### PR TITLE
mysql55: fix build under clang 6 (and newer)

### DIFF
--- a/pkgs/servers/sql/mysql/5.5.x.nix
+++ b/pkgs/servers/sql/mysql/5.5.x.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, cmake, bison, ncurses, openssl, readline, zlib, perl
-, cctools, CoreServices }:
+{ stdenv, fetchpatch, fetchurl, cmake, bison, ncurses, openssl
+, readline, zlib, perl, cctools, CoreServices }:
 
 # Note: zlib is not required; MySQL can use an internal zlib.
 
@@ -13,10 +13,17 @@ self = stdenv.mkDerivation rec {
     sha256 = "1mwrzwk9ap09s430fpdkyhvx5j2syd3xj2hyfzvanjphq4xqbrxi";
   };
 
-  patches = if stdenv.isCygwin then [
-    ./5.5.17-cygwin.patch
-    ./5.5.17-export-symbols.patch
-  ] else null;
+  patches =
+    # Minor type error that is a build failure as of clang 6.
+    stdenv.lib.optional stdenv.cc.isClang (fetchpatch {
+      url = "https://svn.freebsd.org/ports/head/databases/mysql55-server/files/patch-sql_sql_partition.cc?rev=469888";
+      extraPrefix = "";
+      sha256 = "09sya27z3ir3xy5mrv3x68hm274594y381n0i6r5s627x71jyszf";
+    }) ++
+    stdenv.lib.optionals stdenv.isCygwin [
+      ./5.5.17-cygwin.patch
+      ./5.5.17-export-symbols.patch
+    ];
 
   preConfigure = stdenv.lib.optional stdenv.isDarwin ''
     ln -s /bin/ps $TMPDIR/ps
@@ -51,7 +58,10 @@ self = stdenv.mkDerivation rec {
     "-DINSTALL_SQLBENCHDIR="
   ];
 
-  NIX_CFLAGS_COMPILE = [ "-fpermissive" ]; # since gcc-7
+  NIX_CFLAGS_COMPILE =
+    stdenv.lib.optionals stdenv.cc.isGNU [ "-fpermissive" ] # since gcc-7
+    ++ stdenv.lib.optionals stdenv.cc.isClang [ "-Wno-c++11-narrowing" ]; # since clang 6
+
   NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isLinux "-lgcc_s";
 
   prePatch = ''
@@ -78,6 +88,6 @@ self = stdenv.mkDerivation rec {
       artistic1 bsd0 bsd2 bsd3 bsdOriginal
       gpl2 lgpl2 lgpl21 mit publicDomain  licenses.zlib
     ];
-    broken = stdenv.isAarch64 && stdenv.isDarwin;
+    broken = stdenv.isAarch64;
   };
 }; in self


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
