### PR TITLE
pg-safeupdate: init at 1.2

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/pg_safeupdate.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_safeupdate.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, postgresql }:
+
+stdenv.mkDerivation rec {
+  pname = "pg-safeupdate";
+  version = "1.2";
+
+  buildInputs = [ postgresql ];
+
+  src = fetchFromGitHub {
+    owner  = "eradman";
+    repo   = pname;
+    rev    = version;
+    sha256 = "010m57jcv5v8pyfm1cqs3a306y750lvnvla9m5d98v5vdx3349jg";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin # for buildEnv, see https://github.com/NixOS/nixpkgs/issues/22653
+    install -D safeupdate.so -t $out/lib
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A simple extension to PostgreSQL that requires criteria for UPDATE and DELETE";
+    homepage    = "https://github.com/eradman/pg-safeupdate";
+    platforms   = postgresql.meta.platforms;
+    license     = licenses.postgresql;
+  };
+}

--- a/pkgs/servers/sql/postgresql/packages.nix
+++ b/pkgs/servers/sql/postgresql/packages.nix
@@ -44,4 +44,6 @@ self: super: {
     pgrouting = super.callPackage ./ext/pgrouting.nix { };
 
     pg_partman = super.callPackage ./ext/pg_partman.nix { };
+
+    pg_safeupdate = super.callPackage ./ext/pg_safeupdate.nix { };
 }


### PR DESCRIPTION
###### Motivation for this change

[pg-safeupdate](https://github.com/eradman/pg-safeupdate) is a simple extension to PostgreSQL that raises an error if UPDATE and DELETE are executed without specifying conditions.

To test this works you can do:
```sql
load 'safeupdate';
create temp table items( id int );
delete from items;
-- ERROR:  21000: DELETE requires a WHERE clause
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
