### PR TITLE
grab-site: 2.1.15 -> 2.1.16

### DIFF
--- a/pkgs/tools/backup/grab-site/default.nix
+++ b/pkgs/tools/backup/grab-site/default.nix
@@ -1,14 +1,14 @@
 { stdenv, python3Packages, fetchFromGitHub }:
 
 python3Packages.buildPythonApplication rec {
-  version = "2.1.15";
+  version = "2.1.16";
   name = "grab-site-${version}";
 
   src = fetchFromGitHub {
     rev = "${version}";
     owner = "ArchiveTeam";
     repo = "grab-site";
-    sha256 = "1h3ajsj1c2wlxji1san97vmjd9d97dv0rh0jw1p77irkcvhzfpj8";
+    sha256 = "01n3mi9q593sd2bbmbbp5pn2c3pkwj7iqmy02zbh8ciqskraja4z";
   };
 
   propagatedBuildInputs = with python3Packages; [


### PR DESCRIPTION
###### Motivation for this change

This release fixes an issue with initial URLs being retried forever on failure:

https://github.com/ArchiveTeam/grab-site/commits/master

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
