### PR TITLE
bcc: 0.9.0 -> 0.10.0

### DIFF
--- a/pkgs/os-specific/linux/bcc/default.nix
+++ b/pkgs/os-specific/linux/bcc/default.nix
@@ -4,7 +4,7 @@
 }:
 
 python.pkgs.buildPythonApplication rec {
-  version = "0.9.0";
+  version = "0.10.0";
   name = "bcc-${version}";
 
   srcs = [
@@ -12,7 +12,7 @@ python.pkgs.buildPythonApplication rec {
       owner  = "iovisor";
       repo   = "bcc";
       rev    = "v${version}";
-      sha256 = "0gi12bsjaw1d77rx11wkdg4szcydwy55z6mkx558nfvdym0qj7yw";
+      sha256 = "0qbqygj7ia494fbira9ajavvnxlpffx1jlzbb1vsf1wa8h3y4xn1";
       name   = "bcc";
     })
 
@@ -21,8 +21,8 @@ python.pkgs.buildPythonApplication rec {
     (fetchFromGitHub {
       owner  = "libbpf";
       repo   = "libbpf";
-      rev    = "5beb8a2ebffd1045e3edb9b522d6ff5bb477c541";
-      sha256 = "19n6baqj0mbaphzxkpn09m5a7cbij7fxap8ckk488nxqdz7nbsal";
+      rev    = "0e37e0d03ac99987401e4496d3d76d44237b9963";
+      sha256 = "0wjf9dhvqkwiwnygzikamrgmpxgq77h2pxx6mi4pnbw0lxlppivr";
       name   = "libbpf";
     })
   ];


### PR DESCRIPTION
###### Motivation for this change

This upgrade makes bcc execsnoop work on the latest 4.19 kernel.

bcc execsnoop 0.9.0 + Linux 4.19.48: instant kernel panic + reboot; don't test this in production (#62865)

bcc execsnoop 0.9.0 + Linux 4.19.49:

```
# execsnoop                                                     

PCOMM            PID    PPID   RET ARGS
Traceback (most recent call last):
  File "_ctypes/callbacks.c", line 232, in 'calling callback function'
  File "/nix/store/zisijlanfkrw95dkbwcfb2hgi34fkqf5-bcc-0.9.0/lib/python3.7/site-packages/bcc/table.py", line 676, in raw_cb_
    callback(cpu, data, size)
  File "/nix/store/zisijlanfkrw95dkbwcfb2hgi34fkqf5-bcc-0.9.0/share/bcc/tools/.execsnoop-wrapped", line 199, in print_event
    event = b["events"].event(data)
  File "/nix/store/zisijlanfkrw95dkbwcfb2hgi34fkqf5-bcc-0.9.0/lib/python3.7/site-packages/bcc/table.py", line 654, in event
    self._event_class = self._get_event_class()
  File "/nix/store/zisijlanfkrw95dkbwcfb2hgi34fkqf5-bcc-0.9.0/lib/python3.7/site-packages/bcc/table.py", line 625, in _get_event_class
    m = re.match(r"(.*)#(.*)", field)
  File "/nix/store/4w1rxv6wfkv728jzmm6pqq3jsqd4yvi7-python3-3.7.3/lib/python3.7/re.py", line 173, in match
    return _compile(pattern, flags).match(string)
TypeError: cannot use a string pattern on a bytes-like object
```

bcc execsnoop 0.10.0 + Linux 4.19.49: 

```
# execsnoop
PCOMM            PID    PPID   RET ARGS
[lots of good output]
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I haven't tested the other binaries.

cc maintainers @ragnard @Mic92 @thoughtpolice 