### PR TITLE
networkmanager_strongswan: 1.4.4 -> 1.4.5

### DIFF
--- a/pkgs/tools/networking/network-manager/strongswan.nix
+++ b/pkgs/tools/networking/network-manager/strongswan.nix
@@ -4,11 +4,11 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "NetworkManager-strongswan";
-  version = "1.4.4";
+  version = "1.4.5";
 
   src = fetchurl {
     url = "https://download.strongswan.org/NetworkManager/${name}.tar.bz2";
-    sha256 = "1xhj5cipwbihf0cna8lpicpz7cd8fgkagpmg0xvj6pshymm5jbcd";
+    sha256 = "015xcj42pd84apa0j0n9r3fhldp42mj72dqvl2xf4r9gwg5nhfrl";
   };
 
   buildInputs = [ networkmanager strongswanNM libsecret gtk3 gnome3.networkmanagerapplet ];


### PR DESCRIPTION
###### Motivation for this change

TODO:
* [ ] Confirm working on appropriate setup(s).
* [ ] check release notes's mentions of compat or issues

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---