### PR TITLE
xpra: 2.5 -> 2.5.2, mark winswitch broken as discussed

### DIFF
--- a/pkgs/tools/X11/winswitch/default.nix
+++ b/pkgs/tools/X11/winswitch/default.nix
@@ -38,6 +38,7 @@ let
     doCheck = false;
 
     meta.platforms = stdenv.lib.platforms.linux;
+    meta.broken = true; # Needs older XPRA? See https://github.com/NixOS/nixpkgs/pull/58151#issuecomment-491594198
   };
 in stdenv.lib.overrideDerivation base (b: {
   postFixup = b.postFixup + ''

--- a/pkgs/tools/X11/xpra/default.nix
+++ b/pkgs/tools/X11/xpra/default.nix
@@ -14,11 +14,11 @@ let
   xf86videodummy = callPackage ./xf86videodummy { };
 in buildPythonApplication rec {
   pname = "xpra";
-  version = "2.5";
+  version = "2.5.2";
 
   src = fetchurl {
     url = "https://xpra.org/src/${pname}-${version}.tar.xz";
-    sha256 = "0q6c7ijgpp2wk6jlh0pzqki1w60i36wyl2zfwkg0gpdh40ypab3x";
+    sha256 = "1zbh2990crrxp02c554yh30f0s9znm6iiiklkw8vpxrlmdv1z8ks";
   };
 
   patches = [

--- a/pkgs/tools/X11/xpra/fix-paths.patch
+++ b/pkgs/tools/X11/xpra/fix-paths.patch
@@ -1,14 +1,5 @@
 --- a/setup.py
 +++ b/setup.py
-@@ -1885,7 +1885,7 @@
-     if OSX:
-         pycairo = "py3cairo"
-     else:
--        pycairo = "pycairo"
-+        pycairo = "py3cairo"
-     cython_add(Extension("xpra.client.gtk3.cairo_workaround",
-                 ["xpra/client/gtk3/cairo_workaround.pyx"],
-                 **pkgconfig(pycairo)
 @@ -2363,10 +2363,7 @@
      v4l2_pkgconfig = pkgconfig()
      #fuly warning: cython makes this difficult,


### PR DESCRIPTION
###### Motivation for this change

See previous xpra PR: https://github.com/NixOS/nixpkgs/pull/58151

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x]  other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---