### PR TITLE
consul: 1.4.2 -> 1.5.1

### DIFF
--- a/pkgs/servers/consul/default.nix
+++ b/pkgs/servers/consul/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "consul-${version}";
-  version = "1.4.2";
+  version = "1.5.1";
   rev = "v${version}";
 
   goPackagePath = "github.com/hashicorp/consul";
@@ -19,7 +19,7 @@ buildGoPackage rec {
     owner = "hashicorp";
     repo = "consul";
     inherit rev;
-    sha256 = "1nprl9kcb98ikcmk7safji3hl4kfacx0gnh05k8m4ysfz6mr7zri";
+    sha256 = "1rp07qlpclpw4qkim7rimlq582p0phyvln0y2kzah9bi0q209vl8";
   };
 
   preBuild = ''


### PR DESCRIPTION
###### Motivation for this change

Changelogs, read careful for security and compatibility:

* https://github.com/hashicorp/consul/blob/v1.5.1/CHANGELOG.md
* https://github.com/hashicorp/consul/blob/v1.5.0/CHANGELOG.md
  **CVE-2019-9900 and CVE-2019-9901**
* https://github.com/hashicorp/consul/blob/v1.4.5/CHANGELOG.md
* https://github.com/hashicorp/consul/blob/v1.4.4/CHANGELOG.md
  **CVE-2019-9764** (introduced in 1.4.3)
* https://github.com/hashicorp/consul/blob/v1.4.3/CHANGELOG.md

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---