### PR TITLE
fuse-overlayfs: 0.3 -> 0.4

### DIFF
--- a/pkgs/tools/filesystems/fuse-overlayfs/default.nix
+++ b/pkgs/tools/filesystems/fuse-overlayfs/default.nix
@@ -1,14 +1,14 @@
 { stdenv, lib, fetchFromGitHub, autoreconfHook, pkgconfig, fuse3 }:
 
 stdenv.mkDerivation rec {
-  name = "fuse-overlayfs-${version}";
-  version = "0.3";
+  pname = "fuse-overlayfs";
+  version = "0.4";
 
   src = fetchFromGitHub {
     owner = "containers";
-    repo = "fuse-overlayfs";
+    repo = pname;
     rev = "v${version}";
-    sha256 = "1cch2j397hydrhh62faqa663vas75qbmylqd06fk6nafasa3ri0l";
+    sha256 = "1hm1swgv9fi4kdwqssb6rh83i62qyfzv0yrh0z73kwrwdbqbg8m9";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---