### PR TITLE
libwhich: 2019-03-20 -> 1.1.0

### DIFF
--- a/pkgs/development/tools/misc/libwhich/default.nix
+++ b/pkgs/development/tools/misc/libwhich/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libwhich";
-  version = "2019-03-20";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "vtjnash";
     repo = pname;
-    rev = "b348872107c77cba50b60475aa8ce2ddba86aac0";
-    sha256 = "0fd8hsdc9b9v83j89mxvisgrz77q9rlxnbzd6j63wq66h95r02r9";
+    rev = "v${version}";
+    sha256 = "0s0pqai61jszmi495k621rdlf288ij67adkz72hwqqarqp54idhb";
   };
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

musl, openbsd support

Also, official release instead of git commit :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---