### PR TITLE
acme-tiny: 2016-03-26 -> 4.0.4

### DIFF
--- a/pkgs/development/python-modules/acme-tiny/default.nix
+++ b/pkgs/development/python-modules/acme-tiny/default.nix
@@ -1,34 +1,26 @@
-{ stdenv, buildPythonPackage, fetchFromGitHub
-, python, openssl }:
+{ stdenv, buildPythonPackage, fetchPypi, setuptools_scm, fusepy, fuse
+, openssl }:
 
 buildPythonPackage rec {
   pname = "acme-tiny";
-  version = "2016-03-26";
+  version = "4.0.4";
 
-  src = fetchFromGitHub {
-    sha256 = "0ngmr3kxcvlqa9mrv3gx0rg4r67xvdjplqfminxliri3ipak853g";
-    rev = "7a5a2558c8d6e5ab2a59b9fec9633d9e63127971";
-    repo = "acme-tiny";
-    owner = "diafygi";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0vqlmvk34jgvgx3qdsh50q7m4aiy02786jyjjcq45dcws7a4f9f1";
   };
 
-  # source doesn't have any python "packaging" as such
-  configurePhase = " ";
-  buildPhase = " ";
-  # the tests are... complex
-  doCheck = false;
-
   patchPhase = ''
-    substituteInPlace acme_tiny.py --replace "openssl" "${openssl.bin}/bin/openssl"
+    substituteInPlace acme_tiny.py --replace '"openssl"' '"${openssl.bin}/bin/openssl"'
+    substituteInPlace tests/monkey.py --replace '"openssl"' '"${openssl.bin}/bin/openssl"'
+    substituteInPlace tests/test_module.py --replace '"openssl"' '"${openssl.bin}/bin/openssl"'
+    substituteInPlace tests/monkey.py --replace /etc/ssl/openssl.cnf ${openssl.out}/etc/ssl/openssl.cnf
   '';
 
-  installPhase = ''
-    mkdir -p $out/${python.sitePackages}/
-    cp acme_tiny.py $out/${python.sitePackages}/
-    mkdir -p $out/bin
-    ln -s $out/${python.sitePackages}/acme_tiny.py $out/bin/acme_tiny
-    chmod +x $out/bin/acme_tiny
-  '';
+  buildInputs = [ setuptools_scm ];
+  checkInputs = [ fusepy fuse ];
+
+  doCheck = false; # seems to hang, not sure
 
   meta = with stdenv.lib; {
     description = "A tiny script to issue and renew TLS certs from Let's Encrypt";


### PR DESCRIPTION
###### Motivation for this change

* fetch from pypi
* nearly fix tests,
  but they seem to hang so leaving disabled for now

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Have not tried actually using this script, sorry.