### PR TITLE
macvim: 7.4.909 -> 8.1.1517

### DIFF
--- a/pkgs/applications/editors/vim/macvim-sparkle.patch
+++ b/pkgs/applications/editors/vim/macvim-sparkle.patch
@@ -1,0 +1,106 @@
+diff --git a/src/MacVim/English.lproj/MainMenu.nib/designable.nib b/src/MacVim/English.lproj/MainMenu.nib/designable.nib
+index bdbcfdb9e..5efc78ab6 100644
+--- a/src/MacVim/English.lproj/MainMenu.nib/designable.nib
++++ b/src/MacVim/English.lproj/MainMenu.nib/designable.nib
+@@ -24,11 +24,6 @@
+                                     <action selector="orderFrontStandardAboutPanel:" target="-2" id="142"/>
+                                 </connections>
+                             </menuItem>
+-                            <menuItem title="Check for Updates…" id="255">
+-                                <connections>
+-                                    <action selector="checkForUpdates:" target="Jqk-qh-n0J" id="Wau-rL-cbn"/>
+-                                </connections>
+-                            </menuItem>
+                             <menuItem isSeparatorItem="YES" id="196">
+                                 <modifierMask key="keyEquivalentModifierMask" command="YES"/>
+                             </menuItem>
+@@ -206,6 +201,5 @@
+                 </menuItem>
+             </items>
+         </menu>
+-        <customObject id="Jqk-qh-n0J" customClass="SUUpdater"/>
+     </objects>
+ </document>
+diff --git a/src/MacVim/English.lproj/Preferences.nib/designable.nib b/src/MacVim/English.lproj/Preferences.nib/designable.nib
+index 889450913..38afc3416 100644
+--- a/src/MacVim/English.lproj/Preferences.nib/designable.nib
++++ b/src/MacVim/English.lproj/Preferences.nib/designable.nib
+@@ -88,14 +88,10 @@
+                     <rect key="frame" x="207" y="208" width="258" height="18"/>
+                     <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                     <string key="toolTip">Checks for updates and presents a dialog box showing the release notes and prompt for whether you want to install the new version.</string>
+-                    <buttonCell key="cell" type="check" title="Check for updates" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="975">
++                    <buttonCell key="cell" type="check" title="Check for updates" bezelStyle="regularSquare" imagePosition="left" alignment="left" enabled="NO" inset="2" id="975">
+                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                         <font key="font" metaFont="system"/>
+                     </buttonCell>
+-                    <connections>
+-                        <action selector="checkForUpdatesChanged:" target="-2" id="YjS-ig-M1j"/>
+-                        <binding destination="58" name="value" keyPath="values.SUCheckAtStartup" id="169"/>
+-                    </connections>
+                 </button>
+                 <textField verticalHuggingPriority="750" id="121">
+                     <rect key="frame" x="209" y="50" width="243" height="58"/>
+@@ -186,16 +182,13 @@
+                     <rect key="frame" x="221" y="188" width="244" height="18"/>
+                     <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                     <string key="toolTip">MacVim will automatically download and install updates without prompting. The updated version will be used the next time MacVim starts.</string>
+-                    <buttonCell key="cell" type="check" title="Automatically install updates" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="GfP-vg-mec">
++                    <buttonCell key="cell" type="check" title="Automatically install updates" bezelStyle="regularSquare" imagePosition="left" alignment="left" enabled="NO" inset="2" id="GfP-vg-mec">
+                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                         <font key="font" metaFont="system"/>
+                         <connections>
+                             <binding destination="58" name="enabled" keyPath="values.SUCheckAtStartup" id="5oY-Gf-XJN"/>
+                         </connections>
+                     </buttonCell>
+-                    <connections>
+-                        <binding destination="58" name="value" keyPath="values.SUAutomaticallyUpdate" id="kyZ-ah-zKf"/>
+-                    </connections>
+                 </button>
+             </subviews>
+             <point key="canvasLocation" x="137.5" y="382"/>
+diff --git a/src/MacVim/MacVim.xcodeproj/project.pbxproj b/src/MacVim/MacVim.xcodeproj/project.pbxproj
+index 648c4290d..c7dd99d1e 100644
+--- a/src/MacVim/MacVim.xcodeproj/project.pbxproj
++++ b/src/MacVim/MacVim.xcodeproj/project.pbxproj
+@@ -66,8 +66,6 @@
+ 		1DFE25A50C527BC4003000F7 /* PSMTabBarControl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D493DB90C52533B00AB718C /* PSMTabBarControl.framework */; };
+ 		52818B031C1C08CE00F59085 /* QLStephen.qlgenerator in Copy QuickLookPlugin */ = {isa = PBXBuildFile; fileRef = 52818AFF1C1C075300F59085 /* QLStephen.qlgenerator */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+ 		528DA66A1426D4F9003380F1 /* macvim-askpass in Copy Scripts */ = {isa = PBXBuildFile; fileRef = 528DA6691426D4EB003380F1 /* macvim-askpass */; };
+-		52A364731C4A5789005757EC /* Sparkle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52A364721C4A5789005757EC /* Sparkle.framework */; };
+-		52A364761C4A57C1005757EC /* Sparkle.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 52A364721C4A5789005757EC /* Sparkle.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+ 		52B7ED9B1C4A4D6900AFFF15 /* dsa_pub.pem in Resources */ = {isa = PBXBuildFile; fileRef = 52B7ED9A1C4A4D6900AFFF15 /* dsa_pub.pem */; };
+ 		8D11072A0486CEB800E47090 /* MainMenu.nib in Resources */ = {isa = PBXBuildFile; fileRef = 29B97318FDCFA39411CA2CEA /* MainMenu.nib */; };
+ 		8D11072B0486CEB800E47090 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 089C165CFE840E0CC02AAC07 /* InfoPlist.strings */; };
+@@ -124,7 +122,6 @@
+ 			dstPath = "";
+ 			dstSubfolderSpec = 10;
+ 			files = (
+-				52A364761C4A57C1005757EC /* Sparkle.framework in Copy Frameworks */,
+ 				1D493DBA0C52534300AB718C /* PSMTabBarControl.framework in Copy Frameworks */,
+ 			);
+ 			name = "Copy Frameworks";
+@@ -250,7 +247,6 @@
+ 		32CA4F630368D1EE00C91783 /* MacVim_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MacVim_Prefix.pch; sourceTree = "<group>"; };
+ 		52818AFA1C1C075300F59085 /* QuickLookStephen.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = QuickLookStephen.xcodeproj; path = qlstephen/QuickLookStephen.xcodeproj; sourceTree = "<group>"; };
+ 		528DA6691426D4EB003380F1 /* macvim-askpass */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "macvim-askpass"; sourceTree = "<group>"; };
+-		52A364721C4A5789005757EC /* Sparkle.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Sparkle.framework; sourceTree = "<group>"; };
+ 		52B7ED9A1C4A4D6900AFFF15 /* dsa_pub.pem */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = dsa_pub.pem; sourceTree = "<group>"; };
+ 		8D1107310486CEB800E47090 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+ 		8D1107320486CEB800E47090 /* MacVim.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MacVim.app; sourceTree = BUILT_PRODUCTS_DIR; };
+@@ -264,7 +260,6 @@
+ 				1DFE25A50C527BC4003000F7 /* PSMTabBarControl.framework in Frameworks */,
+ 				8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */,
+ 				1D8B5A53104AF9FF002E59D5 /* Carbon.framework in Frameworks */,
+-				52A364731C4A5789005757EC /* Sparkle.framework in Frameworks */,
+ 			);
+ 			runOnlyForDeploymentPostprocessing = 0;
+ 		};
+@@ -443,7 +438,6 @@
+ 		29B97323FDCFA39411CA2CEA /* Frameworks */ = {
+ 			isa = PBXGroup;
+ 			children = (
+-				52A364721C4A5789005757EC /* Sparkle.framework */,
+ 				1D8B5A52104AF9FF002E59D5 /* Carbon.framework */,
+ 				1D493DB30C52533B00AB718C /* PSMTabBarControl.xcodeproj */,
+ 				1058C7A0FEA54F0111CA2CBB /* Linked Frameworks */,

--- a/pkgs/applications/editors/vim/macvim.nix
+++ b/pkgs/applications/editors/vim/macvim.nix
@@ -1,55 +1,73 @@
-{ stdenv, fetchFromGitHub, ncurses, gettext
-, pkgconfig, python, ruby, tcl, perl, luajit
+{ stdenv, fetchFromGitHub, runCommand, ncurses, gettext
+, pkgconfig, cscope, ruby, tcl, perl, luajit
 , darwin
+
+, usePython27 ? false
+, python27 ? null, python37 ? null
 }:
+
+let
+  python = if usePython27
+           then { pkg = python27; name = "python"; }
+           else { pkg = python37; name = "python3"; };
+in
+assert python.pkg != null;
+
+let
+  # Building requires a few system tools to be in PATH.
+  # Some of these we could patch into the relevant source files (such as xcodebuild and
+  # qlmanage) but some are used by Xcode itself and we have no choice but to put them in PATH.
+  # Symlinking them in this way is better than just putting all of /usr/bin in there.
+  buildSymlinks = runCommand "macvim-build-symlinks" {} ''
+    mkdir -p $out/bin
+    ln -s /usr/bin/xcrun /usr/bin/xcodebuild /usr/bin/tiffutil /usr/bin/qlmanage $out/bin
+  '';
+in
 
 stdenv.mkDerivation rec {
   name = "macvim-${version}";
 
-  version = "7.4.909";
+  version = "8.1.1517";
 
   src = fetchFromGitHub {
     owner = "macvim-dev";
     repo = "macvim";
-    rev = "75aa7774645adb586ab9010803773bd80e659254";
-    sha256 = "0k04jimbms6zffh8i8fjm2y51q01m5kga2n4djipd3pxij1qy89y";
+    rev = "snapshot-156";
+    sha256 = "17plmqcn49gqwr1km77mkxflrg0f4sn06r3n0fbxa8zcz9zmb1q2";
   };
 
   enableParallelBuilding = true;
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig buildSymlinks ];
   buildInputs = [
-    gettext ncurses luajit ruby tcl perl python
+    gettext ncurses cscope luajit ruby tcl perl python.pkg
   ];
 
-  patches = [ ./macvim.patch ];
+  patches = [ ./macvim.patch ./macvim-sparkle.patch ];
 
+  # The sparkle patch modified the nibs, so we have to recompile them
   postPatch = ''
-    substituteInPlace src/MacVim/mvim --replace "# VIM_APP_DIR=/Applications" "VIM_APP_DIR=$out/Applications"
-
-    # Don't create custom icons.
-    substituteInPlace src/MacVim/icons/Makefile --replace '$(MAKE) -C makeicns' ""
-    substituteInPlace src/MacVim/icons/make_icons.py --replace "dont_create = False" "dont_create = True"
-
-    # Full path to xcodebuild
-    substituteInPlace src/Makefile --replace "xcodebuild" "/usr/bin/xcodebuild"
+    for nib in MainMenu Preferences; do
+      /usr/bin/ibtool --compile src/MacVim/English.lproj/$nib.nib/keyedobjects.nib src/MacVim/English.lproj/$nib.nib
+    done
   '';
 
   configureFlags = [
-      #"--enable-cscope" # TODO: cscope doesn't build on Darwin yet
+      "--enable-cscope"
       "--enable-fail-if-missing"
       "--with-features=huge"
       "--enable-gui=macvim"
       "--enable-multibyte"
       "--enable-nls"
       "--enable-luainterp=dynamic"
-      "--enable-pythoninterp=dynamic"
+      "--enable-${python.name}interp=dynamic"
       "--enable-perlinterp=dynamic"
       "--enable-rubyinterp=dynamic"
       "--enable-tclinterp=yes"
       "--without-local-dir"
       "--with-luajit"
       "--with-lua-prefix=${luajit}"
+      "--with-${python.name}-command=${python.pkg}/bin/${python.name}"
       "--with-ruby-command=${ruby}/bin/ruby"
       "--with-tclsh=${tcl}/bin/tclsh"
       "--with-tlib=ncurses"
@@ -58,8 +76,8 @@ stdenv.mkDerivation rec {
 
   makeFlags = ''PREFIX=$(out) CPPFLAGS="-Wno-error"'';
 
-  # This is unfortunate, but we need to use the same compiler as XCode,
-  # but XCode doesn't provide a way to configure the compiler.
+  # This is unfortunate, but we need to use the same compiler as Xcode,
+  # but Xcode doesn't provide a way to configure the compiler.
   #
   # If you're willing to modify the system files, you can do this:
   #   http://hamelot.co.uk/programming/add-gcc-compiler-to-xcode-6/
@@ -72,10 +90,18 @@ stdenv.mkDerivation rec {
     configureFlagsArray+=(
       "--with-developer-dir=$DEV_DIR"
     )
-  '';
+  ''
+  # For some reason having LD defined causes PSMTabBarControl to fail at link-time as it
+  # passes arguments to ld that it meant for clang.
+  + ''
+    unset LD
+  ''
+  ;
 
   postConfigure = ''
     substituteInPlace src/auto/config.mk --replace "PERL_CFLAGS	=" "PERL_CFLAGS	= -I${darwin.libutil}/include"
+
+    substituteInPlace src/MacVim/vimrc --subst-var-by CSCOPE ${cscope}/bin/cscope
   '';
 
   postInstall = ''
@@ -83,13 +109,11 @@ stdenv.mkDerivation rec {
     cp -r src/MacVim/build/Release/MacVim.app $out/Applications
     rm -rf $out/MacVim.app
 
-    rm $out/bin/{Vimdiff,Vimtutor,Vim,ex,rVim,rview,view}
+    rm $out/bin/*
 
-    cp src/MacVim/mvim $out/bin
     cp src/vimtutor $out/bin
-
-    for prog in "vimdiff" "vi" "vim" "ex" "rvim" "rview" "view"; do
-      ln -s $out/bin/mvim $out/bin/$prog
+    for prog in mvim ex vi vim vimdiff view rvim rvimdiff rview; do
+      ln -s $out/Applications/MacVim.app/Contents/bin/mvim $out/bin/$prog
     done
 
     # Fix rpaths
@@ -97,17 +121,19 @@ stdenv.mkDerivation rec {
     libperl=$(dirname $(find ${perl} -name "libperl.dylib"))
     install_name_tool -add_rpath ${luajit}/lib $exe
     install_name_tool -add_rpath ${tcl}/lib $exe
-    install_name_tool -add_rpath ${python}/lib $exe
+    install_name_tool -add_rpath ${python.pkg}/lib $exe
     install_name_tool -add_rpath $libperl $exe
     install_name_tool -add_rpath ${ruby}/lib $exe
+
+    # Remove manpages from tools we aren't providing
+    find $out/share/man \( -name eVim.1 -or -name xxd.1 \) -delete
   '';
 
   meta = with stdenv.lib; {
-    broken = true; # needs ruby 2.2
     description = "Vim - the text editor - for macOS";
-    homepage    = https://github.com/b4winckler/macvim;
+    homepage    = https://github.com/macvim-dev/macvim;
     license = licenses.vim;
-    maintainers = with maintainers; [ cstrahan ];
+    maintainers = with maintainers; [ cstrahan lilyball ];
     platforms   = platforms.darwin;
   };
 }

--- a/pkgs/applications/editors/vim/macvim.patch
+++ b/pkgs/applications/editors/vim/macvim.patch
@@ -1,65 +1,98 @@
 diff --git a/src/MacVim/MacVim.xcodeproj/project.pbxproj b/src/MacVim/MacVim.xcodeproj/project.pbxproj
-index c384bf7..bf1ce96 100644
+index e519018de..556a4127d 100644
 --- a/src/MacVim/MacVim.xcodeproj/project.pbxproj
 +++ b/src/MacVim/MacVim.xcodeproj/project.pbxproj
-@@ -437,6 +437,8 @@
- /* Begin PBXProject section */
- 		29B97313FDCFA39411CA2CEA /* Project object */ = {
- 			isa = PBXProject;
-+			attributes = {
-+			};
- 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "MacVim" */;
- 			compatibilityVersion = "Xcode 2.4";
- 			developmentRegion = English;
-@@ -632,6 +634,7 @@
- 				INSTALL_PATH = "$(HOME)/Applications";
+@@ -1007,6 +1007,7 @@
+ 				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks";
  				MACOSX_DEPLOYMENT_TARGET = "";
  				ONLY_ACTIVE_ARCH = YES;
 +				OTHER_LDFLAGS = "-headerpad_max_install_names";
+ 				PRODUCT_BUNDLE_IDENTIFIER = org.vim.MacVim;
  				PRODUCT_NAME = MacVim;
  				VERSIONING_SYSTEM = "apple-generic";
- 				WARNING_CFLAGS = "-Wall";
-@@ -662,6 +665,7 @@
- 				INSTALL_PATH = "$(HOME)/Applications";
+@@ -1039,6 +1040,7 @@
+ 				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks";
  				MACOSX_DEPLOYMENT_TARGET = "";
  				ONLY_ACTIVE_ARCH = YES;
 +				OTHER_LDFLAGS = "-headerpad_max_install_names";
+ 				PRODUCT_BUNDLE_IDENTIFIER = org.vim.MacVim;
  				PRODUCT_NAME = MacVim;
  				VERSIONING_SYSTEM = "apple-generic";
- 				WRAPPER_EXTENSION = app;
+diff --git a/src/MacVim/vimrc b/src/MacVim/vimrc
+index 23a06bf37..dfb10fe94 100644
+--- a/src/MacVim/vimrc
++++ b/src/MacVim/vimrc
+@@ -14,35 +14,5 @@ set backspace+=indent,eol,start
+ " translated to English).
+ set langmenu=none
+ 
+-" Python2
+-" MacVim is configured by default to use the pre-installed System python2
+-" version. However, following code tries to find a Homebrew, MacPorts or
+-" an installation from python.org:
+-if exists("&pythondll") && exists("&pythonhome")
+-  if filereadable("/usr/local/Frameworks/Python.framework/Versions/2.7/Python")
+-    " Homebrew python 2.7
+-    set pythondll=/usr/local/Frameworks/Python.framework/Versions/2.7/Python
+-  elseif filereadable("/opt/local/Library/Frameworks/Python.framework/Versions/2.7/Python")
+-    " MacPorts python 2.7
+-    set pythondll=/opt/local/Library/Frameworks/Python.framework/Versions/2.7/Python
+-  elseif filereadable("/Library/Frameworks/Python.framework/Versions/2.7/Python")
+-    " https://www.python.org/downloads/mac-osx/
+-    set pythondll=/Library/Frameworks/Python.framework/Versions/2.7/Python
+-  endif
+-endif
+-
+-" Python3
+-" MacVim is configured by default to use Homebrew python3 version
+-" If this cannot be found, following code tries to find a MacPorts
+-" or an installation from python.org:
+-if exists("&pythonthreedll") && exists("&pythonthreehome") &&
+-      \ !filereadable(&pythonthreedll)
+-  if filereadable("/opt/local/Library/Frameworks/Python.framework/Versions/3.7/Python")
+-    " MacPorts python 3.7
+-    set pythonthreedll=/opt/local/Library/Frameworks/Python.framework/Versions/3.7/Python
+-  elseif filereadable("/Library/Frameworks/Python.framework/Versions/3.7/Python")
+-    " https://www.python.org/downloads/mac-osx/
+-    set pythonthreedll=/Library/Frameworks/Python.framework/Versions/3.7/Python
+-  endif
+-endif
+-
++" Default cscopeprg to the Nix-installed path
++set cscopeprg=@CSCOPE@
 diff --git a/src/Makefile b/src/Makefile
-index 84a93f7..e23196d 100644
+index 32810d0a7..13a05f349 100644
 --- a/src/Makefile
 +++ b/src/Makefile
-@@ -1306,7 +1306,7 @@ MACVIMGUI_SRC	= gui.c gui_beval.c MacVim/gui_macvim.m MacVim/MMBackend.m \
+@@ -1385,7 +1385,7 @@ MACVIMGUI_SRC	= gui.c gui_beval.c MacVim/gui_macvim.m MacVim/MMBackend.m \
  		  MacVim/MacVim.m
- MACVIMGUI_OBJ	= objects/gui.o objects/gui_beval.o objects/pty.o \
+ MACVIMGUI_OBJ	= objects/gui.o objects/gui_beval.o \
  		  objects/gui_macvim.o objects/MMBackend.o objects/MacVim.o
 -MACVIMGUI_DEFS	= -DFEAT_GUI_MACVIM -Wall -Wno-unknown-pragmas -pipe
-+MACVIMGUI_DEFS	= -DMACOS_X_UNIX -DFEAT_GUI_MACVIM -Wall -Wno-unknown-pragmas -pipe
++MACVIMGUI_DEFS	= -DMACOS_X_DARWIN -DFEAT_GUI_MACVIM -Wall -Wno-unknown-pragmas -pipe
  MACVIMGUI_IPATH	=
  MACVIMGUI_LIBS_DIR =
  MACVIMGUI_LIBS1	= -framework Cocoa -framework Carbon
 diff --git a/src/auto/configure b/src/auto/configure
-index cdc0819..8e2fd16 100755
+index 9e6a82f4a..3c6d1a89b 100755
 --- a/src/auto/configure
 +++ b/src/auto/configure
-@@ -5383,10 +5383,7 @@ $as_echo "no" >&6; }
+@@ -5829,10 +5829,7 @@ $as_echo "not found" >&6; }
+ 
+     for path in "${vi_cv_path_mzscheme_pfx}/lib" "${SCHEME_LIB}"; do
+       if test "X$path" != "X"; then
+-	if test "x$MACOS_X" = "xyes"; then
+-	  MZSCHEME_LIBS="-framework Racket"
+-	  MZSCHEME_CFLAGS="-DMZ_PRECISE_GC"
+-	elif test -f "${path}/libmzscheme3m.a"; then
++	if test -f "${path}/libmzscheme3m.a"; then
+ 	  MZSCHEME_LIBS="${path}/libmzscheme3m.a"
+ 	  MZSCHEME_CFLAGS="-DMZ_PRECISE_GC"
+ 	elif test -f "${path}/libracket3m.a"; then
+@@ -6217,23 +6214,6 @@ $as_echo ">>> too old; need Perl version 5.003_01 or later <<<" >&6; }
    fi
  
-   if test "X$vi_cv_path_mzscheme_pfx" != "X"; then
--    if test "x$MACOSX" = "xyes"; then
--      MZSCHEME_LIBS="-framework Racket"
--      MZSCHEME_CFLAGS="-DMZ_PRECISE_GC"
--    elif test -f "${vi_cv_path_mzscheme_pfx}/lib/libmzscheme3m.a"; then
-+    if test -f "${vi_cv_path_mzscheme_pfx}/lib/libmzscheme3m.a"; then
-       MZSCHEME_LIBS="${vi_cv_path_mzscheme_pfx}/lib/libmzscheme3m.a"
-       MZSCHEME_CFLAGS="-DMZ_PRECISE_GC"
-     elif test -f "${vi_cv_path_mzscheme_pfx}/lib/libracket3m.a"; then
-@@ -5731,23 +5728,6 @@ $as_echo ">>> too old; need Perl version 5.003_01 or later <<<" >&6; }
-   fi
- 
-   if test "x$MACOSX" = "xyes"; then
+   if test "x$MACOS_X" = "xyes"; then
 -        dir=/System/Library/Perl
 -    darwindir=$dir/darwin
 -    if test -d $darwindir; then
@@ -80,21 +113,22 @@ index cdc0819..8e2fd16 100755
                  PERL_LIBS=`echo "$PERL_LIBS" | sed -e 's/-arch\ ppc//' -e 's/-arch\ i386//' -e 's/-arch\ x86_64//'`
      PERL_CFLAGS=`echo "$PERL_CFLAGS" | sed -e 's/-arch\ ppc//' -e 's/-arch\ i386//' -e 's/-arch\ x86_64//'`
    fi
-@@ -5954,13 +5934,6 @@ __:
+@@ -6456,13 +6436,7 @@ __:
  eof
  	    	    eval "`cd ${PYTHON_CONFDIR} && make -f "${tmp_mkf}" __ | sed '/ directory /d'`"
  	    rm -f -- "${tmp_mkf}"
--	    if test "x$MACOSX" = "xyes" && ${vi_cv_path_python} -c \
+-	    if test "x$MACOS_X" = "xyes" && test -n "${python_PYTHONFRAMEWORK}" && ${vi_cv_path_python} -c \
 -		"import sys; sys.exit(${vi_cv_var_python_version} < 2.3)"; then
 -	      vi_cv_path_python_plibs="-framework Python"
 -	      if test "x${vi_cv_path_python}" != "x/usr/bin/python" && test -n "${python_PYTHONFRAMEWORKPREFIX}"; then
 -		  vi_cv_path_python_plibs="-F${python_PYTHONFRAMEWORKPREFIX} -framework Python"
 -	      fi
 -	    else
- 	      if test "${vi_cv_var_python_version}" = "1.4"; then
- 		  vi_cv_path_python_plibs="${PYTHON_CONFDIR}/libModules.a ${PYTHON_CONFDIR}/libPython.a ${PYTHON_CONFDIR}/libObjects.a ${PYTHON_CONFDIR}/libParser.a"
- 	      else
-@@ -5979,7 +5952,6 @@ eof
++
+ 	      vi_cv_path_python_plibs="-L${PYTHON_CONFDIR} -lpython${vi_cv_var_python_version}"
+ 	      	      	      	      if test -n "${python_LINKFORSHARED}" && test -n "${python_PYTHONFRAMEWORKPREFIX}"; then
+ 	        python_link_symbol=`echo ${python_LINKFORSHARED} | sed 's/\([^ \t][^ \t]*[ \t][ \t]*[^ \t][^ \t]*\)[ \t].*/\1/'`
+@@ -6477,7 +6451,6 @@ eof
  	      fi
  	      vi_cv_path_python_plibs="${vi_cv_path_python_plibs} ${python_BASEMODLIBS} ${python_LIBS} ${python_SYSLIBS} ${python_LINKFORSHARED}"
  	      	      vi_cv_path_python_plibs=`echo $vi_cv_path_python_plibs | sed s/-ltermcap//`
@@ -102,7 +136,7 @@ index cdc0819..8e2fd16 100755
  
  fi
  
-@@ -6055,13 +6027,6 @@ rm -f core conftest.err conftest.$ac_objext \
+@@ -6556,13 +6529,6 @@ rm -f core conftest.err conftest.$ac_objext \
  $as_echo "no" >&6; }
  	fi
  
@@ -116,11 +150,11 @@ index cdc0819..8e2fd16 100755
  			{ $as_echo "$as_me:${as_lineno-$LINENO}: checking if compile and link flags for Python are sane" >&5
  $as_echo_n "checking if compile and link flags for Python are sane... " >&6; }
  	cflags_save=$CFLAGS
-@@ -6919,11 +6884,7 @@ $as_echo "$tclver - OK" >&6; };
+@@ -7456,11 +7422,7 @@ $as_echo "$tclver - OK" >&6; };
  
        { $as_echo "$as_me:${as_lineno-$LINENO}: checking for location of Tcl include" >&5
  $as_echo_n "checking for location of Tcl include... " >&6; }
--      if test "x$MACOSX" != "xyes"; then
+-      if test "x$MACOS_X" != "xyes"; then
  	tclinc="$tclloc/include $tclloc/include/tcl $tclloc/include/tcl$tclver /usr/local/include /usr/local/include/tcl$tclver /usr/include /usr/include/tcl$tclver"
 -      else
 -		tclinc="/System/Library/Frameworks/Tcl.framework/Headers"
@@ -128,104 +162,63 @@ index cdc0819..8e2fd16 100755
        TCL_INC=
        for try in $tclinc; do
  	if test -f "$try/tcl.h"; then
-@@ -6941,12 +6902,8 @@ $as_echo "<not found>" >&6; }
+@@ -7478,12 +7440,8 @@ $as_echo "<not found>" >&6; }
        if test -z "$SKIP_TCL"; then
  	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for location of tclConfig.sh script" >&5
  $as_echo_n "checking for location of tclConfig.sh script... " >&6; }
--	if test "x$MACOSX" != "xyes"; then
+-	if test "x$MACOS_X" != "xyes"; then
  	  tclcnf=`echo $tclinc | sed s/include/lib/g`
  	  tclcnf="$tclcnf `echo $tclinc | sed s/include/lib64/g`"
 -	else
 -	  	  tclcnf="/System/Library/Frameworks/Tcl.framework"
 -	fi
  	for try in $tclcnf; do
- 	  if test -f $try/tclConfig.sh; then
+ 	  if test -f "$try/tclConfig.sh"; then
  	    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $try/tclConfig.sh" >&5
-@@ -7120,10 +7077,6 @@ $as_echo "$rubyhdrdir" >&6; }
+@@ -7673,10 +7631,6 @@ $as_echo "$rubyhdrdir" >&6; }
  	if test -f "$rubylibdir/$librubya"; then
  	  librubyarg="$librubyarg"
  	  RUBY_LIBS="$RUBY_LIBS -L$rubylibdir"
--        elif test -d "/System/Library/Frameworks/Ruby.framework"; then
+-        elif test "$vi_cv_path_ruby" = "/usr/bin/ruby" -a -d "/System/Library/Frameworks/Ruby.framework"; then
 -                        RUBY_LIBS="-framework Ruby"
--                        RUBY_CFLAGS="-DRUBY_VERSION=$rubyversion"
+-                        RUBY_CFLAGS="$RUBY_CFLAGS -DRUBY_VERSION=$rubyversion"
 -            librubyarg=
  	fi
  
  	if test "X$librubyarg" != "X"; then
-diff --git a/src/if_python.c b/src/if_python.c
-index 1d87cac..9d28df0 100644
---- a/src/if_python.c
-+++ b/src/if_python.c
-@@ -55,11 +55,7 @@
- 
- #define PY_SSIZE_T_CLEAN
- 
--#ifdef FEAT_GUI_MACVIM
--# include <Python/Python.h>
--#else
--# include <Python.h>
--#endif
-+#include <Python.h>
- 
- #if !defined(PY_VERSION_HEX) || PY_VERSION_HEX < 0x02050000
- # undef PY_SSIZE_T_CLEAN
-diff --git a/src/if_ruby.c b/src/if_ruby.c
-index 1deb83e..ac23878 100644
---- a/src/if_ruby.c
-+++ b/src/if_ruby.c
-@@ -106,17 +106,9 @@
- # define rb_check_type rb_check_type_stub
- #endif
- 
--#ifdef FEAT_GUI_MACVIM
--# include <Ruby/ruby.h>
--#else
--# include <ruby.h>
--#endif
-+#include <ruby.h>
- #ifdef RUBY19_OR_LATER
--# ifdef FEAT_GUI_MACVIM
--#  include <Ruby/ruby/encoding.h>
--# else
--#  include <ruby/encoding.h>
--# endif
-+# include <ruby/encoding.h>
- #endif
- 
- #undef off_t	/* ruby defines off_t as _int64, Mingw uses long */
 diff --git a/src/vim.h b/src/vim.h
-index 4c93908..edc6bd7 100644
+index cb5be6c97..b703b31cd 100644
 --- a/src/vim.h
 +++ b/src/vim.h
-@@ -308,18 +308,6 @@
- # define UNUSED
+@@ -241,18 +241,6 @@
+ # define SUN_SYSTEM
  #endif
  
--/* if we're compiling in C++ (currently only KVim), the system
+-/* If we're compiling in C++ (currently only KVim), the system
 - * headers must have the correct prototypes or nothing will build.
-- * conversely, our prototypes might clash due to throw() specifiers and
+- * Conversely, our prototypes might clash due to throw() specifiers and
 - * cause compilation failures even though the headers are correct.  For
 - * a concrete example, gcc-3.2 enforces exception specifications, and
 - * glibc-2.2.5 has them in their system headers.
 - */
 -#if !defined(__cplusplus) && defined(UNIX) \
--  && !defined(MACOS_X) /* MACOS_X doesn't yet support osdef.h */
+-	&& !defined(MACOS_X) /* MACOS_X doesn't yet support osdef.h */
 -# include "auto/osdef.h"	/* bring missing declarations in */
 -#endif
 -
- #ifdef __EMX__
- # define    getcwd  _getcwd2
- # define    chdir   _chdir2
+ #ifdef AMIGA
+ # include "os_amiga.h"
+ #endif
 diff --git a/src/vimtutor b/src/vimtutor
-index 70d9ec7..b565a1a 100755
+index 1e8769b25..47078b0e7 100755
 --- a/src/vimtutor
 +++ b/src/vimtutor
-@@ -16,7 +16,7 @@ seq="vim vim8 vim75 vim74 vim73 vim72 vim71 vim70 vim7 vim6 vi"
+@@ -16,7 +16,7 @@ seq="vim vim81 vim80 vim8 vim74 vim73 vim72 vim71 vim70 vim7 vim6 vi"
  if test "$1" = "-g"; then 
    # Try to use the GUI version of Vim if possible, it will fall back
    # on Vim if Gvim is not installed.
--  seq="gvim gvim8 gvim75 gvim74 gvim73 gvim72 gvim71 gvim70 gvim7 gvim6 $seq"
-+  seq="mvim gvim gvim8 gvim75 gvim74 gvim73 gvim72 gvim71 gvim70 gvim7 gvim6 $seq"
+-  seq="gvim gvim81 gvim80 gvim8 gvim74 gvim73 gvim72 gvim71 gvim70 gvim7 gvim6 $seq"
++  seq="mvim gvim gvim81 gvim80 gvim8 gvim74 gvim73 gvim72 gvim71 gvim70 gvim7 gvim6 $seq"
    shift
  fi
  


### PR DESCRIPTION
###### Motivation for this change

Fix up the macvim package to build again, with the latest snapshot. The patchfile has been recreated by manually reapplying all of the changes from the old patchfile, and the other changes in here were figured out by trial and error (such as the need to unset `LD`).

Also tweak the package to use python37 by default, and add an option to go back to python27 if desired. I'm not actually sure what the most common python configuration is these days, so this was chosen mostly because python3 is supposed to be the future.

Disable Sparkle so the user isn't prompted to update a readonly package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This build is impure. It relies on accessing a few tools from `/usr/bin` (including `xcodebuild`), and it sets the minimum deployment target to the current OS version. I tried patching the latter but that resulted in a bunch of warnings during the build process, so I left it alone. This impurity exists for the current broken package too, of course.

CC @cstrahan