### PR TITLE
nixos/release-notes: document changed CargoSha256 hashes

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1909.xml
+++ b/nixos/doc/manual/release-notes/rl-1909.xml
@@ -206,6 +206,24 @@
       RuntimeDirectory and tmpfiles.
     </para>
    </listitem>
+  <listitem>
+    <para>
+      Since version 0.1.19, <literal>cargo-vendor</literal> honors package
+      includes that are specified in the <filename>Cargo.toml</filename>
+      file of Rust crates. <literal>rustPlatform.buildRustPackage</literal> uses
+      <literal>cargo-vendor</literal> to collect and build dependent crates.
+      Since this change in <literal>cargo-vendor</literal> changes the set of
+      vendored files for most Rust packages, the hash that use used to verify
+      the dependencies, <literal>cargoSha256</literal>, also changes.
+    </para>
+
+    <para>
+      The <literal>cargoSha256</literal> hashes of all in-tree derivations that
+      use <literal>buildRustPackage</literal> have been updated to reflect this
+      change. However, third-party derivations that use
+      <literal>buildRustPackage</literal> may have to be updated as well.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 </section>


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

cargoSha256 hashes change as result of changes in cargo-vendor, as
discussed in #60668.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
