### PR TITLE
Update lilypond*

### DIFF
--- a/pkgs/misc/lilypond/default.nix
+++ b/pkgs/misc/lilypond/default.nix
@@ -61,6 +61,7 @@ stdenv.mkDerivation {
     license = licenses.gpl3;
     maintainers = with maintainers; [ marcweber yurrriq ];
     platforms = platforms.all;
+    broken = stdenv.isDarwin;
   };
 
   patches = [ ./findlib.patch ];

--- a/pkgs/misc/lilypond/default.nix
+++ b/pkgs/misc/lilypond/default.nix
@@ -1,26 +1,26 @@
-{ stdenv, fetchurl, ghostscript, texinfo, imagemagick, texi2html, guile
+{ stdenv, fetchgit, ghostscript, texinfo, imagemagick, texi2html, guile
 , python2, gettext, flex, perl, bison, pkgconfig, autoreconfHook, dblatex
 , fontconfig, freetype, pango, fontforge, help2man, zip, netpbm, groff
-, fetchsvn, makeWrapper, t1utils
+, makeWrapper, t1utils
 , texlive, tex ? texlive.combine {
     inherit (texlive) scheme-small lh metafont epsf;
   }
 }:
 
-stdenv.mkDerivation rec{
-  majorVersion="2.18";
-  minorVersion="2";
-  version="${majorVersion}.${minorVersion}";
-  name = "lilypond-${version}";
+let
 
-  urwfonts = fetchsvn {
-    url = "http://svn.ghostscript.com/ghostscript/tags/urw-fonts-1.0.7pre44";
-    sha256 = "0al5vdsb66db6yzwi0qgs1dnd1i1fb77cigdjxg8zxhhwf6hhwpn";
-  };
+  version = "2.18.2";
 
-  src = fetchurl {
-    url = "http://download.linuxaudio.org/lilypond/sources/v${majorVersion}/lilypond-${version}.tar.gz";
-    sha256 = "01xs9x2wjj7w9appaaqdhk15r1xvvdbz9qwahzhppfmhclvp779j";
+in
+
+stdenv.mkDerivation {
+  pname = "lilypond";
+  inherit version;
+
+  src = fetchgit {
+    url = "https://git.savannah.gnu.org/r/lilypond.git";
+    rev = "release/${version}-1";
+    sha256 = "0fk045fmmb6fcv7jdvkbqr04qlwnxzwclr2gzx3gja714xy6a76x";
   };
 
   postInstall = ''
@@ -33,7 +33,10 @@ stdenv.mkDerivation rec{
     done
   '';
 
-  configureFlags = [ "--disable-documentation" "--with-ncsb-dir=${urwfonts}"];
+  configureFlags = [
+    "--disable-documentation"
+    "--with-ncsb-dir=${ghostscript}/share/ghostscript/fonts"
+  ];
 
   preConfigure = ''
     sed -e "s@mem=mf2pt1@mem=$PWD/mf/mf2pt1@" -i scripts/build/mf2pt1.pl
@@ -56,7 +59,7 @@ stdenv.mkDerivation rec{
     description = "Music typesetting system";
     homepage = http://lilypond.org/;
     license = licenses.gpl3;
-    maintainers = [ maintainers.marcweber ];
+    maintainers = with maintainers; [ marcweber yurrriq ];
     platforms = platforms.all;
   };
 

--- a/pkgs/misc/lilypond/fonts.nix
+++ b/pkgs/misc/lilypond/fonts.nix
@@ -86,8 +86,8 @@ rec {
   };
   lilyjazz = olpFont {
     fontName = "lilyjazz";
-    rev = "8f1f2dd";
-    sha256 = "0k44dl5hfcn7wn2b6c51mbw6hsb1sprmx95xiabvcbpxnkplbmac";
+    rev = "8fa7d554";
+    sha256 = "1z7px7k2sn7snnj7yfjv0p9axwbn452vn9ww9icmb1249b0d1qry";
   };
   lv-goldenage = olpFont {
     fontName = "lv-goldenage";

--- a/pkgs/misc/lilypond/unstable.nix
+++ b/pkgs/misc/lilypond/unstable.nix
@@ -1,26 +1,23 @@
-{ stdenv, fetchurl, fetchgit, rsync, lilypond, gyre-fonts }:
+{ stdenv, fetchgit, lilypond, ghostscript, gyre-fonts }:
 
-with stdenv.lib;
+let
 
-let urw-fonts = fetchgit {
-  url = "http://git.ghostscript.com/urw-core35-fonts.git";
-  rev = "1f28a6fcd2176256a995db907d9ffe6e1b9b83e9";
-  sha256 = "1nlx95l1pw5lxqp2v0rn9a7lqrsbbhzr0dy3cybk55r4a8awbr2a";
-}; in
+  version = "2.19.83";
 
-overrideDerivation lilypond (p: rec {
-  majorVersion = "2.19";
-  minorVersion = "65";
-  version="${majorVersion}.${minorVersion}";
-  name = "lilypond-${version}";
+in
 
-  src = fetchurl {
-    url = "http://download.linuxaudio.org/lilypond/sources/v${majorVersion}/lilypond-${version}.tar.gz";
-    sha256 = "0k2jy7z58j62c5cv1308ac62d6jri17wip76xrbq8s6jq6jl7phd";
+lilypond.overrideAttrs (oldAttrs: {
+  inherit version;
+
+  src = fetchgit {
+    url = "https://git.savannah.gnu.org/r/lilypond.git";
+    rev = "release/${version}-1";
+    sha256 = "1ycyx9x76d79jh7wlwyyhdjkyrwnhzqpw006xn2fk35s0jrm2iz0";
   };
 
-  configureFlags = [ "--disable-documentation" "--with-urwotf-dir=${urw-fonts}" "--with-texgyre-dir=${gyre-fonts}/share/fonts/truetype/"];
-
-  buildInputs = p.buildInputs ++ [ rsync ];
-
+  configureFlags = [
+    "--disable-documentation"
+    "--with-urwotf-dir=${ghostscript}/share/ghostscript/fonts"
+    "--with-texgyre-dir=${gyre-fonts}/share/fonts/truetype/"
+  ];
 })

--- a/pkgs/misc/lilypond/with-fonts.nix
+++ b/pkgs/misc/lilypond/with-fonts.nix
@@ -4,28 +4,15 @@
 }:
 
 stdenv.lib.appendToName "with-fonts" (symlinkJoin {
-  inherit (lilypond) name version;
+  inherit (lilypond) meta name version ;
 
   paths = [ lilypond ];
 
   buildInputs = [ makeWrapper lndir ];
 
   postBuild = ''
-    local datadir="$out/share/lilypond/${lilypond.version}"
-    local fontsdir="$datadir/fonts"
-
-    install -m755 -d "$fontsdir/otf"
-    install -m755 -d "$fontsdir/svg"
-
-    ${stdenv.lib.concatMapStrings (font: ''
-          lndir -silent "${font}/otf" "$fontsdir/otf"
-          lndir -silent "${font}/svg" "$fontsdir/svg"
-      '') fonts}
-
-      for p in $out/bin/*; do
-          wrapProgram "$p" --set LILYPOND_DATADIR "$datadir"
-      done
+    for p in $out/bin/*; do
+        wrapProgram "$p" --set LILYPOND_DATADIR "$datadir"
+    done
   '';
-
-  inherit (lilypond) meta;
 })

--- a/pkgs/misc/lilypond/with-fonts.nix
+++ b/pkgs/misc/lilypond/with-fonts.nix
@@ -1,35 +1,31 @@
-{ stdenv
-, lndir
-, lilypond
-, openlilylib-fonts
+{ stdenv, lndir, symlinkJoin, makeWrapper
+, lilypond, openlilylib-fonts
 , fonts ? openlilylib-fonts.all
 }:
 
-stdenv.lib.appendToName "with-fonts" (stdenv.mkDerivation {
-  inherit (lilypond) name;
-  phases = "installPhase";
-  buildInputs = fonts;
-  nativeBuildInputs = [ lndir ];
-  installPhase = ''
-    local fontsdir=$out/share/lilypond/${lilypond.version}/fonts
+stdenv.lib.appendToName "with-fonts" (symlinkJoin {
+  inherit (lilypond) name version;
 
-    install -m755 -d $fontsdir/otf
-    install -m755 -d $fontsdir/svg
+  paths = [ lilypond ];
+
+  buildInputs = [ makeWrapper lndir ];
+
+  postBuild = ''
+    local datadir="$out/share/lilypond/${lilypond.version}"
+    local fontsdir="$datadir/fonts"
+
+    install -m755 -d "$fontsdir/otf"
+    install -m755 -d "$fontsdir/svg"
 
     ${stdenv.lib.concatMapStrings (font: ''
-        lndir -silent ${font}/otf $fontsdir/otf
-        lndir -silent ${font}/svg $fontsdir/svg
+          lndir -silent "${font}/otf" "$fontsdir/otf"
+          lndir -silent "${font}/svg" "$fontsdir/svg"
       '') fonts}
 
-      install -m755 -d $out/lib
-      lndir -silent ${lilypond}/lib $out/lib
-      install -m755 -d $out/share
-      lndir -silent ${lilypond}/share $out/share
-
-      install -m755 -Dt $out/bin ${lilypond}/bin/*
-
       for p in $out/bin/*; do
-        substituteInPlace $p --replace "exec -a \"${lilypond}" "exec -a \"$out"
+          wrapProgram "$p" --set LILYPOND_DATADIR "$datadir"
       done
   '';
+
+  inherit (lilypond) meta;
 })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23320,12 +23320,16 @@ in
   lguf-brightness = callPackage ../misc/lguf-brightness { };
 
   lilypond = callPackage ../misc/lilypond { guile = guile_1_8; };
+
   lilypond-unstable = callPackage ../misc/lilypond/unstable.nix { };
+
   lilypond-with-fonts = callPackage ../misc/lilypond/with-fonts.nix {
     lilypond = lilypond-unstable;
   };
 
-  openlilylib-fonts = callPackage ../misc/lilypond/fonts.nix { };
+  openlilylib-fonts = callPackage ../misc/lilypond/fonts.nix {
+    lilypond = lilypond-unstable;
+  };
 
   loop = callPackage ../tools/misc/loop { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
- Rework both to use `fetchgit`
- ~~Use `rsync` in `lilypond` build~~
- Add me as maintainer of `lilypond` (and by extension `lilypond-unstable`)
- Mark `lilypond` broken on darwin (segfault on my machine, been failing on hydra awhile)
- Upgrade `lilypond-stable` from `2.19.65` to `2.19.83`
- Prefer `overrideAttrs` to `overrideDerivation` in `lilypond-unstable`
- Use fonts from `ghostscript` instead of pointing to a nonexistent urw-fonts repo
- Install fonts to the `lilypond` `datadir`
- Update LilyJAZZ font

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
