### PR TITLE
ocamlPackages.mlgmpidl: 1.2.8 -> 1.2.10

### DIFF
--- a/pkgs/development/ocaml-modules/mlgmpidl/default.nix
+++ b/pkgs/development/ocaml-modules/mlgmpidl/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "ocaml${ocaml.version}-mlgmpidl-${version}";
-  version = "1.2.8";
+  version = "1.2.10";
   src = fetchFromGitHub {
     owner = "nberth";
     repo = "mlgmpidl";
     rev = version;
-    sha256 = "1csqplyxi5gq6ma7g4la2x20mhz1plmjallsankv0mn0x69zb1id";
+    sha256 = "181vpqx8zdairq645b8qpkzj4fnkb508iavk7sqzskag1s8613qn";
   };
 
   buildInputs = [ perl gmp mpfr ocaml findlib camlidl ];


### PR DESCRIPTION
###### Motivation for this change

Bugfix release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
