### PR TITLE
udisks1: mark as broken

### DIFF
--- a/pkgs/os-specific/linux/udisks-glue/default.nix
+++ b/pkgs/os-specific/linux/udisks-glue/default.nix
@@ -19,5 +19,7 @@ stdenv.mkDerivation {
     platforms = stdenv.lib.platforms.linux;
     maintainers = with stdenv.lib.maintainers; [pSub];
     license = stdenv.lib.licenses.bsd2;
+    broken = true;
+    hydraPlatforms = [];
   };
 }

--- a/pkgs/os-specific/linux/udisks/1-default.nix
+++ b/pkgs/os-specific/linux/udisks/1-default.nix
@@ -40,5 +40,7 @@ stdenv.mkDerivation rec {
     description = "A daemon and command-line utility for querying and manipulating storage devices";
     platforms = platforms.linux;
     license = with licenses; [ gpl2 lgpl2Plus ];
+    broken = true;
+    hydraPlatforms = [];
   };
 }


### PR DESCRIPTION
The build has been broken for a long time; udisks1 is also deprecated.