### PR TITLE
Resilio sync configuration fix and NixOS test

### DIFF
--- a/nixos/modules/services/networking/resilio.nix
+++ b/nixos/modules/services/networking/resilio.nix
@@ -30,12 +30,12 @@ let
     download_limit = cfg.downloadLimit;
     upload_limit = cfg.uploadLimit;
     lan_encrypt_data = cfg.encryptLAN;
-  } // optionalAttrs cfg.enableWebUI {
+  } // optionalAttrs (cfg.directoryRoot != "") { directory_root = cfg.directoryRoot; }
+    // optionalAttrs cfg.enableWebUI {
     webui = { listen = "${cfg.httpListenAddr}:${toString cfg.httpListenPort}"; } //
       (optionalAttrs (cfg.httpLogin != "") { login = cfg.httpLogin; }) //
       (optionalAttrs (cfg.httpPass != "") { password = cfg.httpPass; }) //
-      (optionalAttrs (cfg.apiKey != "") { api_key = cfg.apiKey; }) //
-      (optionalAttrs (cfg.directoryRoot != "") { directory_root = cfg.directoryRoot; });
+      (optionalAttrs (cfg.apiKey != "") { api_key = cfg.apiKey; });
   } // optionalAttrs (sharedFoldersRecord != []) {
     shared_folders = sharedFoldersRecord;
   }));

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -267,6 +267,7 @@ in
   radicale = handleTest ./radicale.nix {};
   redis = handleTest ./redis.nix {};
   redmine = handleTest ./redmine.nix {};
+  resilio = handleTest ./resilio.nix {};
   restic = handleTest ./restic.nix {};
   roundcube = handleTest ./roundcube.nix {};
   rspamd = handleTest ./rspamd.nix {};

--- a/nixos/tests/resilio.nix
+++ b/nixos/tests/resilio.nix
@@ -1,0 +1,32 @@
+import ./make-test-python.nix ({ pkgs, lib, ...}:
+let
+  user = "admin";
+  password = "password";
+  port = 10000;
+in with lib; {
+  name = "resilio";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ danieldk ];
+  };
+
+  nodes = {
+    resilio = { config, pkgs, ... }: {
+      services.resilio = {
+        enable = true;
+        enableWebUI = true;
+        deviceName = "nixos-test";
+        directoryRoot = "/tmp/resilio";
+        httpListenPort = port;
+        httpLogin = user;
+        httpPass = password;
+      };
+    };
+  };
+
+  testScript = ''
+    resilio.wait_for_unit("resilio")
+    resilio.wait_for_open_port(${toString port})
+    resilio.succeed("curl -i 'http://localhost:${toString port}/' | grep -q 'Location: /gui/'")
+    resilio.succeed("curl --fail --user '${user}:${password}' http://localhost:${toString port}/gui/")
+  '';
+})


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This change bundles two commits:

- The first commit fixes an error in the configuration when `directoryRoot` is used. The option was placed in the wrong section for current versions of Resilio Sync.
- The second commit adds tests for Resilio Sync. This test would have caught the configuration error solved in the first commit.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
