### PR TITLE
minecraft-overviewer: init at 0.14.40

### DIFF
--- a/pkgs/games/minecraft-overviewer/default.nix
+++ b/pkgs/games/minecraft-overviewer/default.nix
@@ -1,0 +1,28 @@
+{ buildPythonApplication, pillow, numpy, pkgconfig, fetchurl, lib }:
+
+buildPythonApplication rec {
+  pname = "minecraft-overviewer";
+  version = "0.13.90";
+
+  propagatedBuildInputs = [ pillow numpy ];
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  src = fetchurl {
+    url = "https://overviewer.org/builds/src/131/overviewer-0.13.90.tar.gz";
+    sha256 = "0qlpliby2gypdhn4bfxwdphhjbvabvjy8smhpw24i4zcnqll97ya";
+  };
+
+  preBuild = ''
+    unpackFile ${pillow.src}
+    ln -s Pillow*/src/libImaging/Im*.h .
+    python setup.py build
+  '';
+
+  meta = with lib; {
+    description = "A command-line tool for rendering high-resolution maps of Minecraft worlds";
+    homepage = "https://overviewer.org/";
+    maintainers = with maintainers; [ lheckemann ];
+    license = licenses.gpl3;
+  };
+}

--- a/pkgs/games/minecraft-overviewer/default.nix
+++ b/pkgs/games/minecraft-overviewer/default.nix
@@ -2,15 +2,15 @@
 
 buildPythonApplication rec {
   pname = "minecraft-overviewer";
-  version = "0.13.90";
+  version = "0.14.40";
 
   propagatedBuildInputs = [ pillow numpy ];
 
   nativeBuildInputs = [ pkgconfig ];
 
   src = fetchurl {
-    url = "https://overviewer.org/builds/src/131/overviewer-0.13.90.tar.gz";
-    sha256 = "0qlpliby2gypdhn4bfxwdphhjbvabvjy8smhpw24i4zcnqll97ya";
+    url = "https://overviewer.org/builds/src/42/overviewer-${version}.tar.gz";
+    sha256 = "0881sgr1c57jm9hhjzldbzksxmfvvzcl0isz80byyypg4x6rl22w";
   };
 
   patches = [ ./no-chmod.patch ];

--- a/pkgs/games/minecraft-overviewer/default.nix
+++ b/pkgs/games/minecraft-overviewer/default.nix
@@ -13,6 +13,8 @@ buildPythonApplication rec {
     sha256 = "0qlpliby2gypdhn4bfxwdphhjbvabvjy8smhpw24i4zcnqll97ya";
   };
 
+  patches = [ ./no-chmod.patch ];
+
   preBuild = ''
     unpackFile ${pillow.src}
     ln -s Pillow*/src/libImaging/Im*.h .

--- a/pkgs/games/minecraft-overviewer/no-chmod.patch
+++ b/pkgs/games/minecraft-overviewer/no-chmod.patch
@@ -1,0 +1,45 @@
+commit ffac27719391ac74ef4dcc99f4f97fa4d07b9b80
+Author: Linus Heckemann <steam@bringtnix.sphalerite.tech>
+Date:   Fri Jul 12 21:00:54 2019 +0200
+
+    Disable chmod functionality
+    
+    This allows correct rendering of maps even when Overviewer lives in a
+    read-only location.
+
+diff --git a/overviewer_core/files.py b/overviewer_core/files.py
+index 15647fe..f3c6729 100644
+--- a/overviewer_core/files.py
++++ b/overviewer_core/files.py
+@@ -21,7 +21,7 @@ import logging
+ import stat
+ import errno
+ 
+-default_caps = {"chmod_works": True, "rename_works": True}
++default_caps = {"chmod_works": False, "rename_works": True}
+ 
+ def get_fs_caps(dir_to_test):
+     return {"chmod_works": does_chmod_work(dir_to_test),
+@@ -30,21 +30,7 @@ def get_fs_caps(dir_to_test):
+ 
+ def does_chmod_work(dir_to_test):
+     "Detects if chmod works in a given directory"
+-    # a CIFS mounted FS is the only thing known to reliably not provide chmod
+-
+-    if not os.path.isdir(dir_to_test):
+-        return True
+-
+-    f1 = tempfile.NamedTemporaryFile(dir=dir_to_test)
+-    try:
+-        f1_stat = os.stat(f1.name)
+-        os.chmod(f1.name, f1_stat.st_mode | stat.S_IRUSR)
+-        chmod_works = True
+-        logging.debug("Detected that chmods work in %r" % dir_to_test)
+-    except OSError:
+-        chmod_works = False
+-        logging.debug("Detected that chmods do NOT work in %r" % dir_to_test)
+-    return chmod_works
++    return False
+ 
+ def does_rename_work(dir_to_test):
+     with tempfile.NamedTemporaryFile(dir=dir_to_test) as f1:

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21615,6 +21615,8 @@ in
     minecraft-server_1_13_2
     minecraft-server_1_12_2;
 
+  minecraft-overviewer = python2Packages.callPackage ../games/minecraft-overviewer { };
+
   moon-buggy = callPackage ../games/moon-buggy {};
 
   multimc = libsForQt5.callPackage ../games/multimc { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21615,7 +21615,7 @@ in
     minecraft-server_1_13_2
     minecraft-server_1_12_2;
 
-  minecraft-overviewer = python2Packages.callPackage ../games/minecraft-overviewer { };
+  minecraft-overviewer = python3Packages.callPackage ../games/minecraft-overviewer { };
 
   moon-buggy = callPackage ../games/moon-buggy {};
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
