### PR TITLE
luaPackages.luadbi: 0.7.1 -> 0.7.2

### DIFF
--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -258,18 +258,23 @@ with self; {
 
   luadbi = buildLuaPackage rec {
     name = "luadbi-${version}";
-    version = "0.7.1";
+    version = "0.7.2";
 
     src = fetchFromGitHub {
       owner = "mwild1";
       repo = "luadbi";
       rev = "v${version}";
-      sha256 = "01i8018zb7w2bhaqglm7cnvbiirgd95b9d07irgz3sci91p08cwp";
+      sha256 = "167ivwmczhp98bxzpz3wdxcfj6vi0a10gpi7rdfjs2rbfwkzqvjh";
     };
 
-    MYSQL_INC="-I${mysql.connector-c}/include/mysql";
+    MYSQL_INC = [ "-I${mysql.connector-c}/include/mysql" ];
+    MYSQL_LDFLAGS= [
+      "-lmysqlclient"
+      "-L${mysql.connector-c}/lib/mysql"
+    ];
 
-    buildInputs = [ mysql.client mysql.connector-c postgresql sqlite ];
+    nativeBuildInputs = [ mysql.client ];
+    buildInputs = [ mysql.connector-c postgresql sqlite ];
 
     preConfigure = stdenv.lib.optionalString stdenv.isDarwin ''
       substituteInPlace Makefile \


### PR DESCRIPTION
###### Motivation for this change
Update lua package luadbi to v0.7.2 and fix worked prosody with mysql database.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
