### PR TITLE
bundlerApp: Set up passthru properly

### DIFF
--- a/pkgs/development/ruby-modules/bundler-app/default.nix
+++ b/pkgs/development/ruby-modules/bundler-app/default.nix
@@ -36,10 +36,15 @@
 let
   basicEnv = (callPackage ../bundled-common {}) args;
 
-  cmdArgs = removeAttrs args [ "pname" "postBuild" "gemConfig" ] // {
+  cmdArgs = removeAttrs args [ "pname" "postBuild" "gemConfig" "passthru" ] // {
     inherit preferLocalBuild allowSubstitutes; # pass the defaults
 
     buildInputs = buildInputs ++ lib.optional (scripts != []) makeWrapper;
+
+    passthru = basicEnv.passthru // {
+      inherit basicEnv;
+      inherit (basicEnv) env;
+    } // passthru;
   };
 in
   runCommand basicEnv.name cmdArgs ''


### PR DESCRIPTION
###### Motivation for this change
The manual [documents](https://nixos.org/nixpkgs/manual/#sec-language-ruby) both bundlerEnv and bundlerApp as providing `env` and `wrappedRuby` attributes on the resulting derivations. However only bundlerEnv actually had these attributes. Update bundlerApp to provide the same passthru that bundlerEnv does.

Since bundlerApp already let the user provide their own passthru, I've chosen to allow that to take precedence over the default passthru, meaning the user may overwrite `env` or `wrappedRuby` with their own attributes if they choose to do so.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I have not actually tested the impact of this change on the nixpkgs repository. It shouldn't result in rebuilding any `bundlerApp` packages as it only affects `passthru`. I did test the one package I actually care about (the package whose environment I want access to in a `nix-shell`). Given that any manually-provided `passthru` argument will overwrite what I'm adding, this change should be purely additive.