### PR TITLE
amp: init at 2019.06.11

### DIFF
--- a/pkgs/applications/editors/amp/default.nix
+++ b/pkgs/applications/editors/amp/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, rustPlatform, openssl, pkgconfig, python3, xorg, cmake, libgit2 }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "amp";
+  # The latest release (0.5.2) does not compile, so we use a git snapshot instead.
+  version = "unstable-2019-06-09";
+
+  src = fetchFromGitHub {
+    owner = "jmacdonald";
+    repo = pname;
+    rev = "2c88e82a88ada8a5fd2620ef225192395a4533a2";
+    sha256 = "0ha1xiabq31s687gkrnszf3zc7b3sfdl79iyg5ygbc49mzvarp8c";
+  };
+
+  cargoSha256 = "1bvj2zg19ak4vi47vjkqlybz011kn5zq1j7zznr76zrryacw4lz1";
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = [ openssl python3 xorg.libxcb libgit2 ];
+
+  # Tests need to write to the theme directory in HOME.
+  preCheck = "export HOME=`mktemp -d`";
+
+  meta = with stdenv.lib; {
+    description = "A modern text editor inspired by Vim";
+    homepage = "https://amp.rs";
+    license = [ licenses.gpl3 ];
+    maintainers = [ maintainers.sb0 ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -532,6 +532,8 @@ in
 
   ammonite = callPackage ../development/tools/ammonite {};
 
+  amp = callPackage ../applications/editors/amp {};
+
   amtterm = callPackage ../tools/system/amtterm {};
 
   analog = callPackage ../tools/admin/analog {};


### PR DESCRIPTION
###### Motivation for this change
Add a package for a nice text editor.

###### Things done
- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
