### PR TITLE
Mptcp tools

### DIFF
--- a/pkgs/os-specific/linux/iproute/mptcp.nix
+++ b/pkgs/os-specific/linux/iproute/mptcp.nix
@@ -1,0 +1,22 @@
+{ stdenv, iproute, fetchFromGitHub }:
+
+iproute.overrideAttrs (oa: rec {
+  pname = "iproute_mptcp";
+  version = "0.95";
+
+  src = fetchFromGitHub {
+    owner = "multipath-tcp";
+    repo = "iproute-mptcp";
+    rev = "mptcp_v${version}";
+    sha256 = "07fihvwlaj0ng8s8sxqhd0a9h1narcnp4ibk88km9cpsd32xv4q3";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/multipath-tcp/iproute-mptcp;
+    description = "IP-Route extensions for MultiPath TCP";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ teto ];
+    priority = 2;
+  };
+})

--- a/pkgs/os-specific/linux/net-tools/mptcp.nix
+++ b/pkgs/os-specific/linux/net-tools/mptcp.nix
@@ -1,0 +1,21 @@
+{ stdenv, nettools, fetchFromGitHub  }:
+
+nettools.overrideAttrs(oa: rec {
+  name = "net-tools-mptcp";
+  version = "0.95";
+
+  src = fetchFromGitHub {
+    owner = "multipath-tcp";
+    repo = "net-tools";
+    rev = "mptcp_v${version}";
+    sha256 = "0i7gr1y699nc7j9qllsx8kicqkpkhw51x4chcmyl5xs06b2mdjri";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/multipath-tcp/net-tools;
+    description = "A set of tools for controlling the network subsystem in Linux";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ teto ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15728,6 +15728,8 @@ in
   nettools = if stdenv.isLinux then callPackage ../os-specific/linux/net-tools { }
              else unixtools.nettools;
 
+  nettools_mptcp = callPackage ../os-specific/linux/net-tools/mptcp.nix { };
+
   nftables = callPackage ../os-specific/linux/nftables { };
 
   noah = callPackage ../os-specific/darwin/noah {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15205,6 +15205,8 @@ in
 
   iproute = callPackage ../os-specific/linux/iproute { };
 
+  iproute_mptcp = callPackage ../os-specific/linux/iproute/mptcp.nix { };
+
   iputils = callPackage ../os-specific/linux/iputils { };
 
   iptables = callPackage ../os-specific/linux/iptables { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
One of the pain point of MPTCP is - because it's not upstream yet - it's kinda hard to configure as standard tools may need to be overriden with their MPTCP fork.
Nix makes it easier.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
