### PR TITLE
pythonPackages.cli-helpers: 1.2.0 -> 1.2.1

### DIFF
--- a/pkgs/development/python-modules/cli-helpers/default.nix
+++ b/pkgs/development/python-modules/cli-helpers/default.nix
@@ -13,11 +13,11 @@
 
 buildPythonPackage rec {
   pname = "cli_helpers";
-  version = "1.2.0";
+  version = "1.2.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0p9yklddpplncr765h6qrii1dgvvlqxj25n5400dwqas9lmij4fj";
+    sha256 = "0rd194l06aw4612j09b44pgh8b8l4cwmz7xgwsgdj9v8m3m25nwq";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
Noticed it was out of date.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
$ nix path-info -Sh ./result
/nix/store/ixmsj9sdkr4yz6amixg2mvwmh6f6rwca-python3.7-cli_helpers-1.2.0   97.4M

$ nix path-info -Sh ./result
/nix/store/qkgy9i5chxvkw51j3xx9i2b6af5bm6ag-python3.7-cli_helpers-1.2.1   97.4M