### PR TITLE
 papirus-icon-theme: 20190501 -> 20190521 

### DIFF
--- a/pkgs/data/icons/papirus-icon-theme/default.nix
+++ b/pkgs/data/icons/papirus-icon-theme/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchFromGitHub, gtk3 }:
 
 stdenv.mkDerivation rec {
-  name = "papirus-icon-theme-${version}";
+  pname = "papirus-icon-theme";
   version = "20190521";
 
   src = fetchFromGitHub {
     owner = "PapirusDevelopmentTeam";
-    repo = "papirus-icon-theme";
+    repo = pname;
     rev = version;
     sha256 = "192s14bf2ni46jkiifbsl82qy1miy8fnxs2fpqwf6s6jlv9x4zxs";
   };

--- a/pkgs/data/icons/papirus-icon-theme/default.nix
+++ b/pkgs/data/icons/papirus-icon-theme/default.nix
@@ -30,5 +30,6 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl3;
     # darwin gives hash mismatch in source, probably because of file names differing only in case
     platforms = platforms.linux;
+    maintainers = with maintainers; [ romildo ];
   };
 }

--- a/pkgs/data/icons/papirus-icon-theme/default.nix
+++ b/pkgs/data/icons/papirus-icon-theme/default.nix
@@ -28,6 +28,7 @@ stdenv.mkDerivation rec {
     description = "Papirus icon theme";
     homepage = https://github.com/PapirusDevelopmentTeam/papirus-icon-theme;
     license = licenses.lgpl3;
-    platforms = platforms.all;
+    # darwin gives hash mismatch in source, probably because of file names differing only in case
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/data/icons/papirus-icon-theme/default.nix
+++ b/pkgs/data/icons/papirus-icon-theme/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "papirus-icon-theme-${version}";
-  version = "20190501";
+  version = "20190521";
 
   src = fetchFromGitHub {
     owner = "PapirusDevelopmentTeam";
     repo = "papirus-icon-theme";
     rev = version;
-    sha256 = "1sdzbvlzzg42vqahjqcsj6v87y1xhchw7bgiv8jgwd2n4l3gg2zy";
+    sha256 = "192s14bf2ni46jkiifbsl82qy1miy8fnxs2fpqwf6s6jlv9x4zxs";
   };
 
   nativeBuildInputs = [ gtk3 ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

- papirus-icon-theme: 20190501 -> [20190521](https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/releases/tag/20190521)
- papirus-icon-theme: use pname instead of name
- papirus-icon-theme: restrict to linux platforms
- papirus-icon-theme: add maintainer

Supersedes https://github.com/NixOS/nixpkgs/pull/62494.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).