### PR TITLE
plan9port: build everything on Darwin

### DIFF
--- a/pkgs/tools/system/plan9port/default.nix
+++ b/pkgs/tools/system/plan9port/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
       --replace "case Kcmd+'v':" "case 0x16: case Kcmd+'v':"
   '';
 
-  buildInputs = stdenv.lib.optionals (!stdenv.isDarwin) [
+  buildInputs = [
     which perl libX11 fontconfig xorgproto libXt libXext
     freetype # fontsrv wants ft2build.h provides system fonts for acme and sam.
   ];
@@ -59,6 +59,27 @@ stdenv.mkDerivation rec {
 
   NIX_LDFLAGS="-lgcc_s";
   enableParallelBuilding = true;
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/9 rc -c 'echo rc is working.'
+
+    # 9l can find and use its libs
+    cd $TMP
+    cat >test.c <<EOF
+    #include <u.h>
+    #include <libc.h>
+    #include <thread.h>
+    void
+    threadmain(int argc, char **argv)
+    {
+        threadexitsall(nil);
+    }
+    EOF
+    $out/bin/9 9c -o test.o test.c
+    $out/bin/9 9l -o test test.o
+    ./test
+  '';
 
   meta = with stdenv.lib; {
     homepage = https://9fans.github.io/plan9port/;


### PR DESCRIPTION
A commit in 2014 (see #2266) disabled building parts which depended on X11 on Mac OS.  There's no explanation given in the pull request.  In any case, many people install plan9port on Darwin specifically to use the UI components.

Aside from this, the derivation was broken on Mac OS, probably because people put the `which` and `perl` dependencies inside the !isDarwin conditional.  Some programs worked, however the static libraries did not build, so this could not be used as a buildInput to build programs
which need the libraries.  This fixes that.

###### Motivation for this change

Specifically experienced on Mac OS:

* `$out/plan9/bin/rc` was missing.
* `$out/plan9/lib/lib*.a` was missing, preventing `9l` from working.


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS **(Same hash and path size as before)**
   - [x] macOS **(path size 111,256,024 -> 215,351,448)**
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`) **(see note)**
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date **(no docs in this repo)**
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

There's a *lot* of binaries, so I didn't run them all.  I did test the things that I needed that were missing on Mac OS (`rc` and `9l`), and they work.

`nix-review` reported that no packages were built.

This should be safe.

---