### PR TITLE
beignet: 1.3.2 -> unstable-2018.08.20

### DIFF
--- a/pkgs/development/libraries/beignet/clang_llvm.patch
+++ b/pkgs/development/libraries/beignet/clang_llvm.patch
@@ -47,16 +47,3 @@ index a148321..96cafb8 100644
    set(CLANG_LIBRARIES ${CLANG_LIBRARIES} ${CLANG_LIB})
  	unset(CLANG_LIB CACHE)
  endmacro()
-diff --git a/./CMakeLists.txt b/../Beignet-1.1.2-Source_new/CMakeLists.txt
-index 88985d7..01bca9e 100644
---- a/./CMakeLists.txt
-+++ b/../Beignet-1.1.2-Source_new/CMakeLists.txt
-@@ -205,7 +205,7 @@ IF(OCLIcd_FOUND)
-     "intel-beignet.icd.in"
-     "${ICD_FILE_NAME}"
-   )
--  install (FILES ${CMAKE_CURRENT_BINARY_DIR}/${ICD_FILE_NAME} DESTINATION /etc/OpenCL/vendors)
-+  install (FILES ${CMAKE_CURRENT_BINARY_DIR}/${ICD_FILE_NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/etc/OpenCL/vendors)
- ELSE(OCLIcd_FOUND)
-   MESSAGE(STATUS "Looking for OCL ICD header file - not found")
- ENDIF(OCLIcd_FOUND)

--- a/pkgs/development/libraries/beignet/default.nix
+++ b/pkgs/development/libraries/beignet/default.nix
@@ -1,5 +1,5 @@
 { stdenv
-, fetchurl
+, fetchFromGitHub
 , cmake
 , pkgconfig
 , clang-unwrapped
@@ -19,11 +19,13 @@
 
 stdenv.mkDerivation rec {
   name = "beignet-${version}";
-  version = "1.3.2";
+  version = "unstable-2018.08.20";
 
-  src = fetchurl {
-    url = "https://01.org/sites/default/files/${name}-source.tar.gz"; 
-    sha256 = "0hqb04jhjjslnmi3fnpzphanz84zywwkyw2sjr1k5qlx2jxfsmf5";
+  src = fetchFromGitHub {
+    owner  = "intel";
+    repo   = "beignet";
+    rev    = "fc5f430cb7b7a8f694d86acbb038bd5b38ec389c";
+    sha256 = "1z64v69w7f52jrskh1jfyh1x46mzfhjrqxj9hhgzh3xxv9yla32h";
   };
 
   patches = [ ./clang_llvm.patch ];
@@ -31,6 +33,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   postPatch = ''
+    substituteInPlace CMakeLists.txt --replace /etc/OpenCL/vendors "\''${CMAKE_INSTALL_PREFIX}/etc/OpenCL/vendors"
     patchShebangs src/git_sha1.sh
   '';
 
@@ -101,8 +104,8 @@ stdenv.mkDerivation rec {
     homepage = https://cgit.freedesktop.org/beignet/;
     description = "OpenCL Library for Intel Ivy Bridge and newer GPUs";
     longDescription = ''
-      The package provides an open source implementation of the OpenCL specification for Intel GPUs. 
-      It supports the Intel OpenCL runtime library and compiler. 
+      The package provides an open source implementation of the OpenCL specification for Intel GPUs.
+      It supports the Intel OpenCL runtime library and compiler.
     '';
     license = licenses.lgpl21Plus;
     maintainers = with maintainers; [ artuuge zimbatm ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9929,7 +9929,7 @@ in
   belr = callPackage ../development/libraries/belr { };
 
   beignet = callPackage ../development/libraries/beignet {
-    inherit (llvmPackages_39) llvm clang-unwrapped;
+    inherit (llvmPackages_6) llvm clang-unwrapped;
   };
 
   belle-sip = callPackage ../development/libraries/belle-sip { };


### PR DESCRIPTION
Update ```beignet``` to the latest (yet abandoned an year ago) version, mainly for Coffee Lake support
See https://github.com/NixOS/nixpkgs/pull/55583#issuecomment-499558877
cc @gloaming @7c6f434c 

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

list of available OpenCL devices on ThinkPad P52, all work:
![](http://i.imgur.com/jr0K03f.png)