### PR TITLE
melpa-stable-packages: remove unstable packages

### DIFF
--- a/pkgs/applications/editors/emacs-modes/melpa-stable-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/melpa-stable-packages.nix
@@ -207,10 +207,6 @@ self:
       window-numbering = markBroken super.window-numbering;
     };
 
-    melpaStablePackages =
-      removeAttrs (super // overrides)
-      [
-        "lenlen-theme"  # missing dependency: color-theme-solarized
-      ];
+    melpaStablePackages = super // overrides;
   in
     melpaStablePackages // { inherit melpaStablePackages; }


### PR DESCRIPTION
###### Motivation for this change

During the last [melpa-stable-packages update](https://github.com/NixOS/nixpkgs/pull/62784), there was an update script invocation error which resulted in melpa-stable-packages to also include all the unstable packages.

I have re-run the script correctly, so this commit removes all the unstable packages that were accidentally included.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
