### PR TITLE
sidequest: init at 0.3.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2415,6 +2415,11 @@
     email = "me@joelt.io";
     name = "Joel Taylor";
   };
+  joepie91 = {
+    email = "admin@cryto.net";
+    name = "Sven Slootweg";
+    github = "joepie91";
+  };
   johanot = {
     email = "write@ownrisk.dk";
     github = "johanot";

--- a/pkgs/applications/misc/sidequest/default.nix
+++ b/pkgs/applications/misc/sidequest/default.nix
@@ -1,0 +1,69 @@
+{ stdenv, lib, fetchurl, buildFHSUserEnv, makeDesktopItem, makeWrapper, atomEnv, libuuid, at-spi2-atk, icu, openssl, zlib }:
+	let
+		pname = "sidequest";
+		version = "0.3.1";
+		
+		desktopItem = makeDesktopItem rec {
+			name = "SideQuest";
+			exec = "SideQuest";
+			desktopName = name;
+			genericName = "VR App Store";
+			categories = "Settings;PackageManager;";
+		};
+
+		sidequest = stdenv.mkDerivation {
+			inherit pname version;
+
+			src = fetchurl {
+				url = "https://github.com/the-expanse/SideQuest/releases/download/${version}/SideQuest-linux-x64.tar.gz";
+				sha256 = "1hj398zzp1x74zhp9rlhqzm9a0ck6zh9bj39g6fpvc38zab5dj1p";
+			};
+
+			buildInputs = [ makeWrapper ];
+
+			buildCommand = ''
+				mkdir -p "$out/lib/SideQuest" "$out/bin"
+				tar -xzf "$src" -C "$out/lib/SideQuest" --strip-components 1
+
+				ln -s "$out/lib/SideQuest/SideQuest" "$out/bin"
+
+				fixupPhase
+
+				# mkdir -p "$out/share/applications"
+				# ln -s "${desktopItem}/share/applications/*" "$out/share/applications"
+
+				patchelf \
+					--set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+					--set-rpath "${atomEnv.libPath}/lib:${lib.makeLibraryPath [libuuid at-spi2-atk]}:$out/lib/SideQuest" \
+					"$out/lib/SideQuest/SideQuest"
+			'';
+		};
+	in buildFHSUserEnv {
+		name = "SideQuest";
+
+		passthru = {
+			inherit pname version;
+
+			meta = with stdenv.lib; {
+				description = "An open app store and side-loading tool for Android-based VR devices such as the Oculus Go, Oculus Quest or Moverio BT 300";
+				homepage = "https://github.com/the-expanse/SideQuest";
+				downloadPage = "https://github.com/the-expanse/SideQuest/releases";
+				license = licenses.mit;
+				maintainers = [ maintainers.joepie91 ];
+				platforms = [ "x86_64-linux" ];
+			};
+		};
+		
+		targetPkgs = pkgs: [
+			sidequest
+			# Needed in the environment on runtime, to make QuestSaberPatch work
+			icu openssl zlib
+		];
+
+		extraInstallCommands = ''
+			mkdir -p "$out/share/applications"
+			ln -s "${desktopItem}/share/applications/*" "$out/share/applications"
+		'';
+
+		runScript = "SideQuest";
+	}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24102,6 +24102,8 @@ in
 
   sequelpro = callPackage ../applications/misc/sequelpro {};
 
+  sidequest = callPackage ../applications/misc/sidequest {};
+
   maphosts = callPackage ../tools/networking/maphosts {};
 
   zimg = callPackage ../development/libraries/zimg { };


### PR DESCRIPTION
###### Motivation for this change

Adds SideQuest, an application store / sideloading tool for the Oculus Quest and some other VR headsets.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Also verified that loading Beat Saber songs works with my Quest (which uses a separate tool, QuestSaberPatch, that is downloaded on runtime). Have not tested other sideloading capabilities with this expression, but if uploading a new Beat Saber APK works, I see no reason why those features shouldn't.

---
