### PR TITLE
haskell.compiler.ghcHEAD: 20190115 -> 20190601

### DIFF
--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -27,7 +27,7 @@
 , # Whetherto build terminfo.
   enableTerminfo ? !stdenv.targetPlatform.isWindows
 
-, version ? "8.7.20190115"
+, version ? "8.9.20190601"
 , # What flavour to build. An empty string indicates no
   # specific flavour and falls back to ghc default values.
   ghcFlavour ? stdenv.lib.optionalString (stdenv.targetPlatform != stdenv.hostPlatform)
@@ -89,13 +89,23 @@ stdenv.mkDerivation (rec {
 
   src = fetchgit {
     url = "https://gitlab.haskell.org/ghc/ghc.git/";
-    rev = "c9756dbf1ee58b117ea5c4ded45dea88030efd65";
-    sha256 = "0ja3ivyz4jrqkw6z1mdgsczxaqkjy5vw0nyyqlqr0bqxiw9p8834";
+    rev = "9bc10993bb300d3712b0f13ec6e28621d75d4204";
+    sha256 = "1s7vbinywx8ffj09nxr0h32nggjiqpssrvgmj7820k32w2yi7i8v";
   };
 
   enableParallelBuilding = true;
 
   outputs = [ "out" "doc" ];
+
+  patches = [
+    (fetchpatch rec { # https://github.com/haskell/haddock/issues/900
+     url = "https://patch-diff.githubusercontent.com/raw/haskell/haddock/pull/983.diff";
+     name = "loadpluginsinmodules.diff";
+     sha256 = "0bvvv0zsfq2581zsir97zfkggc1kkircbbajc2fz3b169ycpbha1";
+     extraPrefix = "utils/haddock/";
+     stripLen = 1;
+   })
+  ];
 
   postPatch = "patchShebangs .";
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
I want a recent version for trying out https://gitlab.haskell.org/ghc/ghc/merge_requests/668

I'm not entirely sure on the version naming, I chose 8.9 because 8.8 is branched off already, and HEAD will once become 8.10

I included the patch not propagated in https://github.com/NixOS/nixpkgs/commit/e001b99710cebbbe5f64d2dbac5dbf8f417962a2, because I still ran into https://github.com/haskell/haddock/issues/900 when compiling the polysemy-zoo package, see https://github.com/commercialhaskell/stackage/pull/4562#issuecomment-493898672. Not entirely sure why that patch doesn't appear to be in HEAD.

Since recent times, current ghcHEAD failed in nixpkgs, see https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.haskell.compiler.ghcHEAD.x86_64-linux, but this updated versions builds just fine.

Ping @peti @ryantm @deepfire @Ericson2314 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
