### PR TITLE
postgresqlPackages.pg_bigm: init at 1.2

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/pg_bigm.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_bigm.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchurl, postgresql }:
+
+stdenv.mkDerivation rec {
+  pname = "pg_bigm";
+  version = "1.2";
+
+  src = fetchurl {
+    url = "mirror://osdn/pgbigm/66565/${pname}-${version}-20161011.tar.gz";
+    sha256 = "1jp30za4bhwlas0yrhyjs9m03b1sj63km61xnvcbnh0sizyvhwis";
+  };
+
+  buildInputs = [ postgresql ];
+
+  makeFlags = [ "USE_PGXS=1" ];
+
+  installPhase = ''
+    mkdir -p $out/bin    # For buildEnv to setup proper symlinks. See #22653
+    mkdir -p $out/{lib,share/extension}
+
+    cp *.so      $out/lib
+    cp *.sql     $out/share/extension
+    cp *.control $out/share/extension
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Text similarity measurement and index searching based on bigrams";
+    homepage = "https://pgbigm.osdn.jp/";
+    maintainers = [ maintainers.marsam ];
+    platforms = postgresql.meta.platforms;
+    license = licenses.postgresql;
+  };
+}

--- a/pkgs/servers/sql/postgresql/packages.nix
+++ b/pkgs/servers/sql/postgresql/packages.nix
@@ -9,6 +9,8 @@ self: super: {
 
     pg_auto_failover = super.callPackage ./ext/pg_auto_failover.nix { };
 
+    pg_bigm = super.callPackage ./ext/pg_bigm.nix { };
+
     pg_repack = super.callPackage ./ext/pg_repack.nix { };
 
     pg_similarity = super.callPackage ./ext/pg_similarity.nix { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add https://pgbigm.osdn.jp/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
