### PR TITLE
infix: init at 1.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1333,6 +1333,11 @@
     github = "dmjio";
     name = "David Johnson";
   };
+  dmvianna = {
+    email = "dmlvianna@gmail.com";
+    github = "dmvianna";
+    name = "Daniel Vianna";
+  };
   dochang = {
     email = "dochang@gmail.com";
     github = "dochang";

--- a/pkgs/development/python-modules/infix/default.nix
+++ b/pkgs/development/python-modules/infix/default.nix
@@ -1,0 +1,24 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "infix";
+  version = "1.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "a1bfdcf875bc072f41e426d0673f2e3017750743bb90cc725fffb292eb09648c";
+  };
+
+  doCheck = true;
+
+  meta = with lib; {
+    homepage = "https://github.com/borntyping/python-infix";
+    description = "A decorator that allows functions to be used as infix functions";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dmvianna ];
+  };
+}
+

--- a/pkgs/development/python-modules/pytest-testmon/default.nix
+++ b/pkgs/development/python-modules/pytest-testmon/default.nix
@@ -1,0 +1,33 @@
+{ pkgs
+, lib
+, pythonPackages
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-testmon";
+  version = "0.9.16";
+  disabled = pythonOlder "3.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "df00594e55f8f8f826e0e345dc23863ebac066eb749f8229c515a0373669c5bb";
+  };
+
+  doCheck = false; # tests written in Python 2; library compiles and runs properly otherwise.
+  buildInputs = with pkgs; [ glibcLocales ];
+  propagatedBuildInputs = with pythonPackages; [ pytest coverage ];
+  preConfigure = ''
+    export LC_ALL="en_US.UTF-8"
+  '';
+  
+  meta = with lib; {
+    homepage = "https://github.com/tarpas/pytest-testmon/";
+    description = "This is a py.test plug-in which automatically selects and re-executes only tests affected by recent changes";
+    license = licenses.mit;
+    maintainers = [ maintainers.dmvianna ];
+  };
+}
+

--- a/pkgs/development/python-modules/pytest-watch/default.nix
+++ b/pkgs/development/python-modules/pytest-watch/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, pkgs
+, pythonPackages
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-watch";
+  version = "4.2.0";
+  disabled = pythonOlder "3.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "06136f03d5b361718b8d0d234042f7b2f203910d8568f63df2f866b547b3d4b9";
+  };
+
+  doCheck = true;
+  propagatedBuildInputs = with pythonPackages; [ colorama docopt pytest watchdog ];
+  
+  meta = with lib; {
+    homepage = "https://github.com/joeyespo/pytest-watch";
+    description = "Local continuous test runner with pytest and watchdog.";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dmvianna ];
+  };
+}
+

--- a/pkgs/development/python-modules/pytest-watch/default.nix
+++ b/pkgs/development/python-modules/pytest-watch/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   
   meta = with lib; {
     homepage = "https://github.com/joeyespo/pytest-watch";
-    description = "Local continuous test runner with pytest and watchdog.";
+    description = "Local continuous test runner with pytest and watchdog";
     license = licenses.mit;
     maintainers = with maintainers; [ dmvianna ];
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -821,6 +821,8 @@ in {
 
   pytest-pylint = callPackage ../development/python-modules/pytest-pylint { };
 
+  pytest-testmon = callPackage ../development/python-modules/pytest-testmon { };
+
   pytest-tornado = callPackage ../development/python-modules/pytest-tornado { };
 
   python-binance = callPackage ../development/python-modules/python-binance { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1624,6 +1624,8 @@ in {
 
   idna = callPackage ../development/python-modules/idna { };
 
+  infix = callPackage ../development/python-modules/infix { };
+
   mahotas = callPackage ../development/python-modules/mahotas { };
 
   MDP = callPackage ../development/python-modules/mdp {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1741,6 +1741,8 @@ in {
 
   pytest-warnings = callPackage ../development/python-modules/pytest-warnings { };
 
+  pytest-watch = callPackage ../development/python-modules/pytest-watch { };
+
   pytestpep8 = callPackage ../development/python-modules/pytest-pep8 { };
 
   pytest-pep257 = callPackage ../development/python-modules/pytest-pep257 { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

New package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
