### PR TITLE
parity: 2.4.6 -> 2.4.8, parity-beta: 2.5.1 -> 2.5.3

### DIFF
--- a/pkgs/applications/altcoins/parity/beta.nix
+++ b/pkgs/applications/altcoins/parity/beta.nix
@@ -1,6 +1,6 @@
 let
-  version     = "2.5.1";
-  sha256      = "0nnrgc2qyqqld3znjigryqpg5jaqh3jnmin4a334dbr4jw50dz3d";
-  cargoSha256 = "184vfhsalk5dims3k13zrsv4lmm45a7nm3r0b84g72q7hhbl8pkf";
+  version     = "2.5.3";
+  sha256      = "04z38ba4f1kmaa3d9b4gqz7dwr5blbppnkngw758xdm56772hfmj";
+  cargoSha256 = "03dlzl96g8k02lifymwp1xs0b2mrnj5c1xzpwp014ijqlnzcfgsv";
 in
   import ./parity.nix { inherit version sha256 cargoSha256; }

--- a/pkgs/applications/altcoins/parity/default.nix
+++ b/pkgs/applications/altcoins/parity/default.nix
@@ -1,6 +1,6 @@
 let
-  version     = "2.4.6";
-  sha256      = "0vfq1pyd92n60h9gimn4d5j56xanvl43sgxk9h2kb16amy0mmh3z";
-  cargoSha256 = "04gi9vddahq1q207f83n3wriwdjnmmnby6mq4crdh7yx1p4b26m9";
+  version     = "2.4.8";
+  sha256      = "1kr7hzv27vxa14wafhpaq5a4fv97zh71xjjmwzaqq4gj3k9yj0rm";
+  cargoSha256 = "1yjyk6mhr3ws73aq6h8z5iabvj03ch7mxhkrfdkmhw3cjj0jgx6j";
 in
   import ./parity.nix { inherit version sha256 cargoSha256; }

--- a/pkgs/applications/altcoins/parity/parity.nix
+++ b/pkgs/applications/altcoins/parity/parity.nix
@@ -5,7 +5,7 @@
 
 { stdenv
 , fetchFromGitHub
-, rustPlatform 
+, rustPlatform
 , pkgconfig
 , openssl
 , systemd
@@ -34,7 +34,7 @@ rustPlatform.buildRustPackage rec {
 
   meta = with stdenv.lib; {
     description = "Fast, light, robust Ethereum implementation";
-    homepage = http://parity.io;
+    homepage = "http://parity.io";
     license = licenses.gpl3;
     maintainers = [ maintainers.akru ];
     platforms = platforms.linux;

--- a/pkgs/applications/altcoins/parity/parity.nix
+++ b/pkgs/applications/altcoins/parity/parity.nix
@@ -29,6 +29,8 @@ rustPlatform.buildRustPackage rec {
     systemd.lib systemd.dev openssl openssl.dev
   ];
 
+  cargoBuildFlags = [ "--features final" ];
+
   # test result: FAILED. 80 passed; 12 failed; 0 ignored; 0 measured; 0 filtered out
   doCheck = false;
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update `parity` and `parity-beta` to the latest release.
https://github.com/paritytech/parity-ethereum/releases/tag/v2.4.8
https://github.com/paritytech/parity-ethereum/releases/tag/v2.5.3

cc @akru to review. Thank you!
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
