### PR TITLE
xorg.xcalc: 1.0.7 -> 1.1.0

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -1405,11 +1405,11 @@ lib.makeScope newScope (self: with self; {
   }) {};
 
   xcalc = callPackage ({ stdenv, pkgconfig, fetchurl, libX11, libXaw, xorgproto, libXt }: stdenv.mkDerivation {
-    name = "xcalc-1.0.7";
+    name = "xcalc-1.1.0";
     builder = ./builder.sh;
     src = fetchurl {
-      url = mirror://xorg/individual/app/xcalc-1.0.7.tar.bz2;
-      sha256 = "08bzaldi76vrj7350d7b04pq7qa1qhi81x8i806yv42zcp8p3lkh";
+      url = mirror://xorg/individual/app/xcalc-1.1.0.tar.bz2;
+      sha256 = "1sxmlcb0sb3h4z05kl5l0kxnhrc0h8c74p9m3zdc7bv58jaldmym";
     };
     hardeningDisable = [ "bindnow" "relro" ];
     nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -699,4 +699,15 @@ self: super:
       rm $out/bin/xkeystone
     '';
   });
+
+  xcalc = super.xcalc.overrideAttrs (attrs: {
+    configureFlags = attrs.configureFlags or [] ++ [
+      "--with-appdefaultdir=${placeholder "out"}/share/X11/app-defaults"
+    ];
+    nativeBuildInputs = attrs.nativeBuildInputs or [] ++ [ makeWrapper ];
+    postInstall = ''
+      wrapProgram $out/bin/xcalc \
+        --set XAPPLRESDIR ${placeholder "out"}/share/X11/app-defaults
+    '';
+  });
 }

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -28,7 +28,7 @@ mirror://xorg/individual/app/viewres-1.0.5.tar.bz2
 mirror://xorg/individual/app/x11perf-1.6.1.tar.bz2
 mirror://xorg/individual/app/xauth-1.0.10.tar.bz2
 mirror://xorg/individual/app/xbacklight-1.2.2.tar.bz2
-mirror://xorg/individual/app/xcalc-1.0.7.tar.bz2
+mirror://xorg/individual/app/xcalc-1.1.0.tar.bz2
 mirror://xorg/individual/app/xclock-1.0.8.tar.bz2
 mirror://xorg/individual/app/xcmsdb-1.0.5.tar.bz2
 mirror://xorg/individual/app/xcompmgr-1.1.8.tar.bz2


### PR DESCRIPTION
xcalc: ensure "app-defaults" resources are installed+found, works now

###### Motivation for this change

https://lists.x.org/archives/xorg-announce/2019-June/002996.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---