### PR TITLE
dbus: 1.12.14 -> 1.12.16

### DIFF
--- a/pkgs/development/libraries/dbus/default.nix
+++ b/pkgs/development/libraries/dbus/default.nix
@@ -6,8 +6,8 @@ assert x11Support -> libX11 != null
                   && libSM != null;
 
 let
-  version = "1.12.14";
-  sha256 = "13aca7gzgl7z1dfdipfs23773w8n6z01d4rj5kmssv4gms8c5ya4";
+  version = "1.12.16";
+  sha256 = "107ckxaff1cv4q6kmfdi2fb1nlsv03312a7kf6lb4biglhpjv8jl";
 
 self = stdenv.mkDerivation {
     name = "dbus-${version}";


### PR DESCRIPTION
###### Motivation for this change

https://gitlab.freedesktop.org/dbus/dbus/blob/dbus-1.12.16/NEWS

It's short and explains the CVE a bit, including below:

> CVE-2019-12749: Do not attempt to carry out DBUS_COOKIE_SHA1
> authentication for identities that differ from the user running the
> DBusServer. Previously, a local attacker could manipulate symbolic
> links in their own home directory to bypass authentication and connect
> to a DBusServer with elevated privileges. The standard system and
> session dbus-daemons in their default configuration were immune to this
> attack because they did not allow DBUS_COOKIE_SHA1, but third-party
> users of DBusServer such as Upstart could be vulnerable.   Thanks to Joe
> Vennix of Apple Information Security.   (dbus#269, Simon McVittie)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---