### PR TITLE
 firefox, firefox-bin: 67.0.1 -> 67.0.2 

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,995 +1,995 @@
 {
-  version = "67.0.1";
+  version = "67.0.2";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/ach/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/ach/firefox-67.0.2.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha512 = "c868018d9c1ae3712fc748f8d8db4b7f11f17ba539ee44453acc948cc68e94ba356ba48631581762e6f328f33153ab84791d8113252b40d6f70eb2cc29264acf";
+      sha512 = "ec8762aaffc4402a61594835b5b813d8593a85dc8e1a87d9efe00d40f629a68b2eeb34ac75641197d16f5c4503beb06ecb6d0a5659c84debcfa9ba4d4d2aec04";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/af/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/af/firefox-67.0.2.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha512 = "8723a7d43474a49c436c66cc196d81c5a2f430f4d98cff542dfbca3c181bfe7a2af2781f59aaa9decda5d660c1bd9bce31a3e53c5ee187764c3c4265d473b71c";
+      sha512 = "a42d7db1d3ea7a1ca17cf5460de619a1c24ae6c1298a0b08e8681b6e3e7f9c7b3da0b6e7b4eb9cb39ad521d2f18ca5ce59f4f5f14c851d58444310d070b2fbec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/an/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/an/firefox-67.0.2.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha512 = "98432b58b2a263134b0331399422a044df7860b4b9d7897a6ee05649ecb7507ea1bebff2b30ce88ef68ecaca751c378f279fac06e0aae1079bfb00a55b94cb64";
+      sha512 = "1189292cca4d4ee4b4153a6eb7d403686ea7235227d0ab71b6a45b246cc324cd3fddd7e643463eabeb809cc7127ebe5fc730b75223d3367c57af489b088f36d9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/ar/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/ar/firefox-67.0.2.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "3c4da65cc4649980943cd73c62e10f8bdd3087ac7de73b7b109a51a055839cacf791e6cfd74f35daae4c10d9baf65aef48682202e3410013a55ce65cd6963f9a";
+      sha512 = "c6b348ee6d3e1544495e7b815b026052251285e0cb8fa92d88758b066c46636c2bd481543e3fcf98c98ffbe05714402940bfa3ee49e20ca42c5b2b63f6b12843";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/as/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/as/firefox-67.0.2.tar.bz2";
       locale = "as";
       arch = "linux-x86_64";
-      sha512 = "6e7236f364aa8800a9f82b1f83969d3fe4c4443861b8b87d5bcada2fe8af91e86fe2b3f512baa5184bb777fea903e00b04280088672368cfa6053d7f1143dac6";
+      sha512 = "6532fec4d57fe325699bdc78d98c97daddc3c4f143729d4db0e949ddf62ed11497363f79a523c97d3545c4ae6a225086e5790ffbe54a994e8a880a24afde52cb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/ast/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/ast/firefox-67.0.2.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "8e722a2335dc017709505179522548bc88ca2eb09710b869243bb12c18eebb99fa29dfcece76385abc9ca7630e7093778fb4bf006d31360488e494654550bd63";
+      sha512 = "732c76f935754b1c08c674ed5cea5181483c3766108c9bc1b7a022248e8226f218c5f111b3cfbd683408b3ca328f9cfd63e65720e85693c5a8184797b3372551";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/az/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/az/firefox-67.0.2.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha512 = "a31007953b96bd66362114a3ab290304e0831575d2d84c02686a3f413bab1bd2685f95931cb21d5e44b07b2be3057452ef8902087b0424ce258140400e99f38c";
+      sha512 = "33310fe5f8dac1921662f9fa1460a653dfca25a8dc3f9d88324503a021b1fc8f980b3cf3e7793ca3cf7051c58fd9688230b1e0bdb277bfdc6f0f6a6825ec6c06";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/be/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/be/firefox-67.0.2.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "380589ee226e1e4acd3bfb263a620fea20e66b71372ec3d0c1fcb8abbab64f98457da45824f6616cef6912a55fa03f0740c48941d82b33e4d8c65bb78863517f";
+      sha512 = "995dd2a26f13aacc9ecda53df04bcccf35dc1685285b24fc3d11c27414e6329aac564879d4de17e5625fa605b614a3f2a7b3ea747ded88432f33af327a80ab9e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/bg/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/bg/firefox-67.0.2.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "6aa4f7a4e3938563bef34e29bf2998a64dc316500db08bacca2fa4494ae6f775ea8f1224fc8ec7ff7bb5b95674d85c7e42a380b1a0448cc79ce8e99d78f4d927";
+      sha512 = "61bfe4c004ea55585afb2115f83992a2a4bbd1edb2e0e005d09e97378419a2ae52b90d27d6f3049b6fc89b669881bead704be0c35f5ec5b8d6cb039d2127c64c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/bn-BD/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/bn-BD/firefox-67.0.2.tar.bz2";
       locale = "bn-BD";
       arch = "linux-x86_64";
-      sha512 = "d08b72dd0ce155f455b9238100ddac8a228ad7800f2974ae3765728c7a5ab4a4c9b53ee1b14a50b6ea5cbd0bc2824d16ad191e1854a1f2e29c8ff9043f052b38";
+      sha512 = "b7621d371e0404d18d075714f758ddf2706b3de883cd8881fda0c720842baa1b30fc7346d3af6fa5bc5c8b2d626555dc21185b0292031472da12be8708d363a2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/bn-IN/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/bn-IN/firefox-67.0.2.tar.bz2";
       locale = "bn-IN";
       arch = "linux-x86_64";
-      sha512 = "53fc8e9dc403be685b3e4923087c074e5e36fb54a29f981b1668fc55958469b8de303e58b22ca1aa2908b87be065b4da2da33c3359f49c11fecc0548fce070a1";
+      sha512 = "603822bebbd1b0fd6c1a47e7a76bd79d666c1198c88c45c7143efd923b75901ddae483d745fab6a47fe9c08a912d12f616d06f6e820f1bf09f5542bee72c32e8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/br/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/br/firefox-67.0.2.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "a5a08f1f19879e48dfa330bcd2ac396d41e357156fdf82d273ed29c0f8e77d7233df3e05f573fc62b29d96c1b2fa499b7598463df5eecbb736f7643ded3be58c";
+      sha512 = "d8afd2275cf8dc30e8b3285d9b04c7462bfa961324c2a65ba84121dc0b39611297930f5bdf7627de570267739592f4b52cfc9efe0af5c8bac6f1ebe465ed29d2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/bs/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/bs/firefox-67.0.2.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha512 = "4bb5097920ba78c9159731565cd34a711e8824572e72c0f92f6482980156297ac9479d63a3663084cc91b023a312e16f460f098d3fbe717fdbd59b7c46556890";
+      sha512 = "104bd65c212fccaea9629d6f799046a663e89ed31182de61707551700237ad23413d80ab916385642b415d35cf1ad613617d34c76f503eb89347f1b19be7a9f2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/ca/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/ca/firefox-67.0.2.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "a97846e487dde9aa7efc3f0727e5f0dc1e0306c618b4044bc0f1b797b5857296db4a7456c3fd79aa11106444b4298b5f6e8453a0ebe9316e0ab95cbaa8fe5e78";
+      sha512 = "39a4fca88ef57289c0584302dd433fae111a4fa28146691868b693f82d9569ec5b5e973ec2da1e8fdd50b5b65c315f0867795ceb85e5d897029fee37d2eae5ee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/cak/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/cak/firefox-67.0.2.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "9a2c76ec6e3822aa56c729959f0e7005c5a8cb9925fa5fc05d37800432b796d4d876d60ce67790aba6ddc0f29d73d95c81605cc8f3a039158eac35834a6b4d96";
+      sha512 = "8b7093b2dbb843c42049082b39bc9677ef06709092d9a6b05d70eb53520c0ecfb8da4789a47c83ed52755a68c5f4fd83b37831d0be99a15b168d5869da21bbae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/cs/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/cs/firefox-67.0.2.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "f2c89c734d7ddc2c5769566991bb3377046932e26673f04138a87e766253a280a5b75f805c0ee571d39acba27dd33241bfd7aa9efd45e29367b55330e14094a3";
+      sha512 = "5eb6e925c7c9147dee853e1e3763161f9fdaad73edd71fac995897af3d3e8d018e2f58880a251c8d09ce06d0a971ecea7d05b0f7e28c2e120460c297d4bc78d6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/cy/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/cy/firefox-67.0.2.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "980f1bfb92ca53888260d451e5149d4db1320d981649665f95cacc236c6dea65ba7e39d845bb4b210f08f2be2abbb5d918796a4672e6a52d2c1dd3ff424776ca";
+      sha512 = "82dd9971cd65249b844ab52241ac86b6e0c2de84c65b7689756564714b85c61e00e591cb9cb892e1c4e75fd6944f191bbbf8920ea18dc2c1adecb5a0d93bdb6d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/da/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/da/firefox-67.0.2.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "4e92280a962d3ad18f2bd2d8951b4880cf14c1c5ef74c35b3fb836ba388ff6fdc35c81a08ae87ab016c34749db0e9031cfacd163eded7c6d4114fcfc1ba40efd";
+      sha512 = "d4f7066ea01d8aaa9ae7dd92d0c7ac8ab10f628c5a9e93244c49d546df7708bfd450f7988e05528d2bdb9f5a6849473be22a4f7cc44754f51d09118731fc9411";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/de/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/de/firefox-67.0.2.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "9f666528e4f4890d4dd5d027ed62222b0f1c8888560365cab63defce34596a5c992bce1df176e6dd6f3b8368688bdfc9d5330b69d36e953593569d2da0d40141";
+      sha512 = "7ab0930126196041cf8b83426d81cf998b9759fb65c123f61efd641502c42b0141fb55086b4ffb99ef5ed9ba50596d70368a0188610a1c78799e26d4904bf4c6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/dsb/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/dsb/firefox-67.0.2.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "e980c6479a724eb5f16fde0adce4be17d471501d6e569f08ad8c3b1b8ec7d8a187e57627ceb1a390a0a51b4accb34161bca935cdd0180531263c72d8887cc95c";
+      sha512 = "901840a64290edd9b9612ae1138d64ad88744bb270cde132cfc79f8be42ba4b59ab3266adf943c61eec6a2c05748cd3fc756862a6080feb62a2a5445f2ddbba8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/el/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/el/firefox-67.0.2.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "373642d255b141f55b856162c744ca6db7bbc2b238f08e8257896a27e09d93dfe9f0de8ed0a2feb11ad8e9dc2f08ec79ac6988bd16882b62f8c3f46bcfc03e91";
+      sha512 = "7b4e51e879f12f2ae5d041d384ceea9ddfc980e8b564dfc9fb601d9c5c71c1614a6ba0675c8bd9bb483c65b5f92b0506dda3a1d1a3e54ea0c4135011e1a471b5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/en-CA/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/en-CA/firefox-67.0.2.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha512 = "4e85ff012b3477580b293cbe9d9617377dc0562a48bb6b890583e2b59f98ac65aca0c9329347eea3e762efa440bf554c514bf58a26a5f0b10e27b02f444852f4";
+      sha512 = "8e96857b18bcd8718440caf5d17398612afb2e4cbf74b3ea13742b79532da4081e2017856c99707b0edd0ffd8791bdac9a5e6c4647edcf6e96637d8cc020cba2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/en-GB/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/en-GB/firefox-67.0.2.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "aac7ac00545c9e8c90acc3e06c5aaf1dfe6995913a67957e08ac5899e70b969a6e2d0395c3aec023a61ae5057ec6023e000846fde5c92134bcabc9746535e41c";
+      sha512 = "51b4d05987aef814b36326066d50f3903c29840bb780b09b7a7c4ea60848d33618e0a40329fb80221e56de4b462824531ae250736d41a5cb498173517a29341b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/en-US/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/en-US/firefox-67.0.2.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "ef86d1feddc368c695aece44d4af655a351e9bc313af5ff1a32928c469fd19eae75e1c9b7f66dadac754b05d8d1cec8e44c468caddf4277b11a9b72f66b2eeaa";
+      sha512 = "70c8b0ab34abbcfa916e5bd5dd687405422f6d2339843d8b332d13efe7aef474064ca49ebe1026585a540c04175af2a1e88224d92506b01012cfc8e173167138";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/en-ZA/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/en-ZA/firefox-67.0.2.tar.bz2";
       locale = "en-ZA";
       arch = "linux-x86_64";
-      sha512 = "ed20b44da68fec92ce529c14edadb351f937e26cfe60f48acce5a5b9c3fca3190eb974891c7db8c3e3524943cc93e8f715859242221ba21a5b9c14a7b95ae827";
+      sha512 = "73ea4fa964fc97c15672eedd5822fc5b83a620780ddd46ae07f851890c16f3c8f0d30f2a5273f4631f04cae8bf0258c9140dd0bb256d38c38c620d4bfdf51a40";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/eo/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/eo/firefox-67.0.2.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha512 = "1fddc64bc09e10c076919e6f1ff0f57adabfc06123f1e12c1455d6468db6bb05e51eb758d621d569d90bcec6fcf349787daed53a9b7932c96bca0c5f7e2eb383";
+      sha512 = "77026c365a103f484daa17d3228eb02f271dd7a3065830ef8b42d30d1f39ba81732b7f9ae35fcd4a1ad7714f3935567ffb6d3aed9bce50da30a1e8b36c4fead8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/es-AR/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/es-AR/firefox-67.0.2.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "48c6513cb062c9ea04249291e383200b9745db20a6660b90f05e039c365402dd7dec35101655d36fd53f5a0223231163e503aab23f54f285eb7d9be8a165a17b";
+      sha512 = "90b14b2873f28f48d49203e9ed1db35a760a5d1bf3dc30b7fdc238a9c8626c54ac9707a4845835cccb0f3aed428574d684e29058dea945cdb2f97274766dd3a9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/es-CL/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/es-CL/firefox-67.0.2.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha512 = "8bc6261da80286004b91fedacff707cd24f1fa56a3cb4b3e37bb21e1439fff082e1fabc806e092b834eab13d4b11c3ebf3933ec21ce4588eb28696fc18f36fe2";
+      sha512 = "58ad3c66ccd087f4c199af647cefd37d41205f2f8faec9dd605aa71c9d6ef9cae64a4a97fe55b5bb8fb862d19c6c41e504608780dafbf365c1306646a72ac125";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/es-ES/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/es-ES/firefox-67.0.2.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "940c2d5a85764e3e9eee63cebecc5b2a2cd9913cbac170cb4ac5179518dfde6182e29f5ca3fe8c0e1459ab0c38887a4e15184743d003cbe4d0b7eda427ca9836";
+      sha512 = "2ef0cf55996424b9430f0241ea68f32e0064583abbf8ea8d7bba181048eebf1e157158fa51c7ed9c8ceb7ae9c9f6df92d2284c3f397d8d912d4ecc8f78d03773";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/es-MX/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/es-MX/firefox-67.0.2.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha512 = "dd5e7056107732aae419cdcfd350f85b0989cd858a096649eb138c6ce9127bbe5c9f5422ea56f7d0c159de0c0401e0a84279ea9411d434e5e093fdadc790dabf";
+      sha512 = "79c45541291ab0e2b67a945c43f22c08fe89306060da60060a8a61fbbcca2538b6ba6a1a5828df4cf9c2cc86b64419281b39c59f5cf12ca61b8f4a831558b452";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/et/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/et/firefox-67.0.2.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "116cabb2d751aad2a37e6e6c3bd43924ff060d86db18edb5a7a97320d38d8a0a095370d47a3a663fb5a79aaac4cde3a1fbdf803b6161823b69b57a1bd9c321f5";
+      sha512 = "362fb9635f292fca9988912a8dbfd335ffa0d43f20461f04960c424b92719fc7347c504549668bb823ba2afef52cb4f9a2852d86f6ba187e9e2c7e2daec3f257";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/eu/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/eu/firefox-67.0.2.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "afdb63e987163babfc5d7d1558cd41ddd412cd4a4dcbf258ad61a1fffbd1d418565012e8ff17ea6c8b9b458e9294d8ce8615e00fcb9b350f0c892543f2e41a58";
+      sha512 = "56f79575438c58e0302fb494433f498ea55892605b30ea30d0208ff700830446ee7f831021a1cafc4f8779cf6aa3340766d2a60c42466259e6273799acf94b01";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/fa/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/fa/firefox-67.0.2.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha512 = "a162164b3f8aa83daf4bc3e2cd278cb34a216bfd4fd066c7750d05a6aabea65592f272f520206c5a0e9a2052555fa718a3bc11fc8701cb85a0bd1bc213197018";
+      sha512 = "2d8ac7fdb95e7704cbf00d18c6a3f0ed1ca08a9badaf1908ae21a1ccc381efb4c3a7f93f99b19b395d0b09bf0bd037b120e1e9b856b8e091bbfc87f37525de3c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/ff/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/ff/firefox-67.0.2.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha512 = "cf770f3a855f358d7c0f62f50bb311b94d6435a3a785c925034ae373b754c76de5f795540a5f5c100506385707df6d577b92c07a4dd426fa5fc764ff3f8754d7";
+      sha512 = "e203accc21c37660b52857a18746b8a22bfa4efef558952e5162a65e3d27805fa005ace1892bab81047bbdaa4e11ad139598c2c9f13f5cfd0fda6fe1b283f3a3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/fi/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/fi/firefox-67.0.2.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "5f00d800c8cdd11b11b24575aef14884d3e0f2aa00d4a52aad0b7f7067a3eaea7f6225834487859d341140d344898f26eca47c29cd4f695103909663bd90f336";
+      sha512 = "2018a2875b08b6a311b1e42c7763218449949d3c5a7f97c995dd3bf6fb73116a32781b44f2d372605b1718f12dbd62aefbfedd3cf976213f215b689b5dda2e1b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/fr/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/fr/firefox-67.0.2.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "1bd08df6555c61dc77c7f90c18ab7199aaf02b8a39dd341408e9280fdfb8c3bffb149b8d2df1f6fa7a11d41c7e6ee5d39502b258b0319e9026faa401f9ff385c";
+      sha512 = "2544525e99b0e8f4013a4cc6a131d687f63e4cd5f634e8a8f3847a51cbd7ab26ea4d7bbe490618e61b82843abc6c6295e89d424a83398cc3e900247cc6503a94";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/fy-NL/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/fy-NL/firefox-67.0.2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "cd518e1191fcddb62293a5668608b152875cb43ece29b993dc87417db059722c9797a9fb9222b46eac24c333e04a619f304d5162d5a52d6a218af5c8fe6933b9";
+      sha512 = "7db8c00d0641843c55696d1ae12e695075209c32b6a4a764246bba4ac1d553d60ee0b3065f4b214a39622b3036b8efc49467bd59067f10a00143997605d16b86";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/ga-IE/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/ga-IE/firefox-67.0.2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "f5b43a60aae12ddf6f2cf75df4b252c7a437a8d0e74a90bacf225d043ed713491b19d666b463a75c6d04020e27cf93047626efc2aaf956596c055809f196ea62";
+      sha512 = "1472c619b85bb324dae529b251f7674bf6efef3b4229e4d9e39310d746f754c97d6a99b00fa3a6f2f3b77ca5bf6e1705455b589a7614ff11237715b935d8d56b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/gd/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/gd/firefox-67.0.2.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "6c9f0d9af45f271076573277fbdd49ffc236bbb1a8d75eb1163a66b884b734596e2f57e1eeadc229d5deebf5db2e87e1b11429debdcd3697891a8e3a6b04b201";
+      sha512 = "a2af23d919a3c5319728017727bb760ba5e1cecbea550e8dd28afac157542c52c1e9294ede4b09b4e8e13b855f460670fb8b9bb27be33381181a2d02176f932b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/gl/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/gl/firefox-67.0.2.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "9142a20aecee5ed787a280feef5205d9cd337d21f64edf9de37d597f703f42bd1e6de2c8568c821df391dcc30f69cc61ba7910ee585835989ce9971ef2d64f14";
+      sha512 = "ae6cfd7f83e8565a59b85e9329ecfe8a8b55891e7967fa31a6586beb62f7387f24329a6488d359d084990a7566f907cae5ed2aca9db0a0cb160732cbf2d9d9dc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/gn/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/gn/firefox-67.0.2.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha512 = "f433147686f92444d01df7dfd68ad26c351d9456834830d9351e0e72b428539f14e7be090209e5ce35e2b6ac51b5b429a57b12ff0c57b867b41d862cb87f6e1c";
+      sha512 = "5dfd75c0c322114c6fe486aed5dc844b205de4fa4358a2b3a66c88ea65ad375dc1055b446838f9c29b0dc81d25cff04a18428c468035bb80188f9f9ad6731176";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/gu-IN/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/gu-IN/firefox-67.0.2.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha512 = "6db70a7d074a1ee8a1e51152de8f3d13b5d036fd54d9aedee47be73b25b044a3cb0ff4a28c265a69065085c2e61f91da170e060c0ea2d9579a606d1201006133";
+      sha512 = "41842c245b997be7f7fbb833d22ded9333e1cbe4bc53c0589ddb0b66658949919eee3bc0f26f4e019de661cd1b97cd96781e936541909cc65ab2a171e1f29f5c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/he/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/he/firefox-67.0.2.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "b2e559f01a2d47bcfd25080bef5c09bc96c33ef6049e4ad6c178fe359a5d5662041843c7bc6ec37e6d7bfc157ac5d59dd24ea87e02c139bcd8fb4d8d0afb6ec6";
+      sha512 = "28b159fa1cbd7168b0025408a6d7f75d9441f8c0bbe3d1a1ebaf61fa066d5709c37ab18771d768d05ff89dc682d494598f3d281c2b99829b8975d2b7adc06432";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/hi-IN/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/hi-IN/firefox-67.0.2.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha512 = "ba7b7e07d9d660bd0f79ffec1f539f56f663af3b5a8aa589b5209ee62b1fd563371a01a883a0e7dd8498442d4d12fe45ec7afd5cbd81212f2fdd0446b00351c7";
+      sha512 = "4dcd82cf0de1a0e2d73e38f0d00801c3f3ab89e41a8fb510d60bf3c2601443ee14c9e801f2a02d3f9b8b1c084542fe7463a20f1041efc06029c1a9c57d176f64";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/hr/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/hr/firefox-67.0.2.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "e91f7eec141e48f721585b5b00ab390076a1a055e60e8de2add55f716a0a1271d031e25e28206acd14d50046a46e515fba5f1937bd7ebf25262f9932caa4954a";
+      sha512 = "7c4c1e5eb202cfa56bcfcd597ea4bf57f0f882814b0fba10776739d8defba3c436d28d3bfd4e9977d19a58c5d1b949ac12a12801a67dabd631a5faca71db3d3c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/hsb/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/hsb/firefox-67.0.2.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "f40e0ce5beabdf0b1bc3aa569864446c0aeb54c0eff2bfd377ec6c1ee473b78f10772f53b3c8c432d328dcda366357860767e235ec26f468f3d94353313c7f20";
+      sha512 = "f098af4aaa9f707a4dd10a405e80e523f39f4dcbdbc9b2ee51e70611fcfe9060cf5ae776e062e299837699c996a65680ac9d1bbb87d53371aa206f7e92c9ccd2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/hu/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/hu/firefox-67.0.2.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "4c2c57098f3490285f50b4995e1800dd1f193ce781a600a08288566bbeb5b6eda59d7f648722494ba00b827341e9aa1920feb49a15437ed87bcc1b69c73e2427";
+      sha512 = "ba960bdc6c0b9f30fee22beda2cd6ccaf7ca21e069a46e7284bf967c80a3e4c3d969ff6ca9d6d637dc65099e41655268b0f64ed801d00fadaac41630707bb5db";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/hy-AM/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/hy-AM/firefox-67.0.2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "85451050240f65d9dae676504576d594678797797cbfceebd7c6c3b287c1e3da00ba8c3dc1ed5fc8055ab066f058d97fb7e88500befe5b1820499cdbfdb2f9a5";
+      sha512 = "39a5e68217c9d43f1cb66733f68cda55078522793132dd90b824f26088c770e60e292a76355314cff8656c591c5c07a5eb4d15af396804b00361cc9d7b612eec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/ia/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/ia/firefox-67.0.2.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha512 = "95d2014c98682cbb59a5d81b9c751a1117cb21ff9d76ec176970b33d17ea2f3e76a99aeb05669d9831e3a7f560293cb3848e7369e1cafa00edb682e2c03fead3";
+      sha512 = "56af9cabbe9b7c9af119e111757a1ab9313142ac7eb3dd1fc6fa433be16e4c583be1731290d1e1a83703638513e0575c5fcfab25b13af2b21b510a9e68d7a140";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/id/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/id/firefox-67.0.2.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "f5a290ab8f5a9366eb184a5177581e84561ded6a76601777db66c2d2560a484502ab789228ccd8374d9c185fa81d88a8e36acee239fac5167ba1fcb2ebba9742";
+      sha512 = "fc36530b67beb5004f01751a20b0aacb9a5ba3b97c08ef27f4c1c37d4c269f01af514ab5786b465750506c18e6ee3f6cdf4b6c5368d7a2f023cda1b88b963e84";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/is/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/is/firefox-67.0.2.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "a8edd686dbb58f058928638568644233917e8bc6128f0d5e93eeea434df0e0bb729a5c464770b2aff71638f220d50fdace949e70dc43876fd979fd5d3e62705e";
+      sha512 = "1676c1a62a2db1824183e3c9e31e5907a3f75e78d142ebad96d644853b2a3f53ae7bf51b439221de1bb949d12ccf7d05b33ddb004b65f9bf5d7f39cba45f7205";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/it/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/it/firefox-67.0.2.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "96d84d920e6cb83f2d68db3b6b4233efa15031b386eb40d9d42d7c0428bfd73367038ee916867ee66195f293f7bd14065109430673d2199acebc3d352a2ff5dc";
+      sha512 = "9e6e5b8c0055bdd64b6f61cfda07dae0cc295a8278107953ac05eca99c4d4f1a5905bea6f583ca86cde3f80282bf04753f9b8e16721b6abfc205d5f9fc461a19";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/ja/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/ja/firefox-67.0.2.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "00ba1fbfa7e17744b4de9dc950c1bcfc98e5e156a4e0bd4bef976d52189835b4a6f84e3f17bb38058f0f4e1800af33aa9de0dfa985653fa756b66a63c5bdc556";
+      sha512 = "4ad489d06459cd17f6658d699f844e877aa5fe8add9f9e0cf36ba3ca551271cc5b572dc4e9cd6b84df8b60c756ea24edc9b9a5f8a6c0f50c2dca1ec93b9f0f7c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/ka/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/ka/firefox-67.0.2.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "08da471802d0baa0de993695ee38ddc0283ae0ae19de09df154050ba0323216a755e32f677473d64cbe38fff653c769efa44a5f26c3d30b8e3dabbe14982e3c8";
+      sha512 = "9148dc40c9b5d75d7eab501de2fd338d3b745ca354ed4cc8e78fe89f92d1d2b82bda9607fbd942bf19c0e44e3925e0800e0e3c4c9992043926c2c611ae42af9e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/kab/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/kab/firefox-67.0.2.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "39b34fad303ec213ce1c50e6859c745767ab1999a60564b9d09740856c47b88a78dc7a567df6ecc02f55949e7f95488c286ce273bb4e8a912f6055126e8281ae";
+      sha512 = "56b594de53230cf5e9ad03c49171a13914675132b2181092359ddbb12eeeff0a34866f501d5b95970514f0f8f9a9aca7a1e4a6bb1c76d2be99eaaa8320628c59";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/kk/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/kk/firefox-67.0.2.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "005837faa89c25888699da347473c2683a31649874caadce3eed3bdf834b16b90bcef0e69cf1acef66fe12af2c4f8245261c0283ec0af6b29a7a416b50bad462";
+      sha512 = "9bd8b2da9ccfa515fd794faefec4c91fe2b0851b0321a523addbc56f2c6110872093ca8146b126e69949bd44ec20e8ad3b63b75da38818457deb03e70330e919";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/km/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/km/firefox-67.0.2.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha512 = "1f6f9cbde351b9ba046916d7cdd2ea64d0a1a641cbecad272248723d6090ace1e27b3562d28989fbb5bde597e9cc13f1824bf87932a41cc0cd4059fafd047216";
+      sha512 = "ada2fe4f9d3901b4b0f90541357bb0b52caed1616c4612c855731715014a1265561f1755fe33b16ec449b75085993935aafe4b8a3755a902602290ffcb79a580";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/kn/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/kn/firefox-67.0.2.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha512 = "5a8366711021c5bbd39bc686717b03567703fed6fb21742028601d26ca691ec92ec3adb6dc1290e1ddbfbe90cb82d04680c575ffc00ba112c55852a736f1388f";
+      sha512 = "0ed21b278d1b31bb9d6f37316f40bbbbfe6ccda5ef5077ec5593fac355fa216bc854070578b2db9805b2c40ab1bb1845f0ecb1405a8d070377741cc770d93ccc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/ko/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/ko/firefox-67.0.2.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "c4ceddbac8a371cf4e206db53fdb00a8b6a2354912d5de6e607d530e6d9b7ab19efbb2631e797408f0856aeba480a63f32cb3a3ea96a426cfd5d7cd3c6eaca38";
+      sha512 = "527d920673b1c38399971648bae3ecf90099d8561737c9003e8bd839f7d7e89f5819d795073ca35ed8f8268eae8b8c3c4357db709f5753f46e86e7cdba14f1e4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/lij/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/lij/firefox-67.0.2.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha512 = "d51780b5bb07c430de3914798bed306d8e08af353ee4010d0536005c94b1efe598a34650dc7cfff89cdc5c41ef9a9f5f4cd8adba9c861727a0a8506adc2d384f";
+      sha512 = "d82a7e8f5d58a1e9f768dcc8dd62d2f759fb2760ad1ed898de0dc7b0261f0406724475842542367db3d9043e5d5bcd0bbf712ecbccf82a10d2ed6c44ef5e2955";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/lt/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/lt/firefox-67.0.2.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "e2fece90a6c84a45b5e4c687d64d996866c4e47bae691888504e803a2fedd17deaddeda4c691b5c42a6ed48cff4cdef141f2c89e4da864e32957d5ba087a93aa";
+      sha512 = "374a97de975b2b641d71489be091306f76ca52f620c5b5f50ffeaa204e23e3b9f463916978b6b0977ba6bc39b616073ce4e15a426de31c48c3fb89f74e5ff063";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/lv/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/lv/firefox-67.0.2.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha512 = "7ec38379878b8178f92e905a62aa8ac3718ad268f12851aac6c08f28358150936cdeb6ce9bb1364c904d933fd87ac628cf6daad5de3a7629f7bd06c0a5167ede";
+      sha512 = "a5dfc9207b1bad2d67a88218a03f9622d8cb25b5e3dc0c5e3d678b17bfdaa662a3c6587b4b6794d679a8f99dfb6af31d3cdb038510ecc33f7c2f12141459af2a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/mai/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/mai/firefox-67.0.2.tar.bz2";
       locale = "mai";
       arch = "linux-x86_64";
-      sha512 = "67af9610fc67f77e06448bd88ffdf3f0ddc0c0a29e8b8b08f2c00dd0e37795fad00aca231fede025090209417b06d08de5b27f70644c200706ae482ca9c758af";
+      sha512 = "928bdef67c7c4f0355c46fe2887a935b58c07e65b70dcb1aa2b9b659256b613a520a8b427d8665b3c07bb00cdf0fb30f70561a843b8eb62aedbc56b8ae90bfed";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/mk/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/mk/firefox-67.0.2.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha512 = "ca774f6b343ab4e2623ddd9a531ad0cd925a810908b25d3f101e12a5f92ca8f5d195ec6316a8bf56afad9676b1154cd94746873f41c02aace459fdc875ee9b5e";
+      sha512 = "2cc563a78bf029c9d64012c2711e20face6d6460658328787f774cb04e3e2478d1aa584688ea32d87efaa06c8902f9db68dd27fe0326ace06f67bc75a4af2723";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/ml/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/ml/firefox-67.0.2.tar.bz2";
       locale = "ml";
       arch = "linux-x86_64";
-      sha512 = "a96457926309cb28a22a984695b4b6afeb1908ff59087251034209bdac035fc511a6e01658dff217a66c023b77bf1d5cbdc770c1c70cd9876164f3d1df00d716";
+      sha512 = "e4e5f9b5174cfa4c98e1855560d155117ea7084ebcef4cac2deae32d10e86d5860d79b08d83407b82a657febf7a68ad3cccdfc6754dc93757e3cdfe9c4540182";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/mr/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/mr/firefox-67.0.2.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha512 = "605e107e1d68398db16f403c95b24b123d9c878c62e0d339b389b28554713ec8b569e1faf2b6c855b59f9273eb040a31ecdecabdb81b6568f12a82fafb583a6e";
+      sha512 = "38b15b6dcc709e0d7df1f3a5d083ed45eaf66e27f44c2547c082b5ee52e78d55cf190a971e6929d68cc397df74caa2b9433b71a02beb05a414af9ea4415855b6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/ms/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/ms/firefox-67.0.2.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "fe831de9c5e71728276feda01996e31168002b4029474cfbc1ad743758b809b4b36b62f4413e29abf84443890a63f771043eaa180d24fa562944173572c18a07";
+      sha512 = "0202ad8c65fa8dd7468c19ad59930864b1e5cbbf6a20af850547e1d40296389f5b49f0406fe3366aa45254cf328234bdf1469948c6dc9ba8ceace29f33847b0d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/my/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/my/firefox-67.0.2.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha512 = "dc01473c556444ebe2d05c1b60bce0cdb96d64a1cbc9d6f76de1d836c0cf371f283d809f3cc99345c826952e7a2959e0468449b5065115f5acf8ad360be2a942";
+      sha512 = "9dc7394730878c6828a4645719567e3083aad9df62492b8713dc65c5faa86f9ccc8a2bd6992b19044ce2eacf426fe43bd16c83169aa36fd43ea7131fe4789647";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/nb-NO/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/nb-NO/firefox-67.0.2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "1b2736ee296161d89a42039e238705858d3d4fea9f20fcaaaadc36bdae052a9284a188d2dbef9d07cf8967ee08b5facb4beb671a66eeb90b1139705a2d7b9174";
+      sha512 = "67722961e89e238f6a27495a6cd19f02cc634f058c3f350ffd3230f08049a486de3ce0b3b2d87a4a050a38f67e75fe0eb98f8e5a48e09cf9c413559835e921dd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/ne-NP/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/ne-NP/firefox-67.0.2.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha512 = "6399d697b59fd06bd1793bbb7b86a25b9e075cf8b786ee78da9f5418391ad45e27a1daaef5777fa83ba15b667c2279c68e4f1c730320805c243ec2d1082c1686";
+      sha512 = "ec582049c29062ae210eb760407ae782df794eaf9803581549c96322312d0c9ff4eb1db8c7a5e3329dcc42eb88d661d10fac35aa218280e163b9cb140f8afbd7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/nl/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/nl/firefox-67.0.2.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "189381a4cade7d3ac0ce34447323b37777c44e4101108d5ceca27a8557bd22d8b3acc8d3fc2f01c34f4e82e8b8f6014da14378e7dcb4d298250423f9f78143b4";
+      sha512 = "67eafd14c297882d2683d77ca06b576b1161d8f83f7d181e3b182933429fa5e2fca2cfdd4ca63ec62a0105fd62c4fd39653986d3c6a3cebdcb949b76101c92e5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/nn-NO/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/nn-NO/firefox-67.0.2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "6a3797f0db08aa19d2b59cccd2a524199b9b7621d34d7f27b7404d604c3bbfe50c4c59c9b189315ecff86bdd1f4d3092810c66dcbd091549a9c3bcc6662f9bc2";
+      sha512 = "6b97328e6402b8c41a0dad0485a707e0316b462c7db0c1a7eb2bf20bf389582aae8195d9d7b25243e86a2ea1ca122f4f4fbb16adad7d67af97d548dec80b7cf5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/oc/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/oc/firefox-67.0.2.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha512 = "50ae2f5685b955904036e92a5289a05bb2d207fe9816260c8840119ad7063ea6ec6d3e0ed117972fcc2779a389e603ff99b2a0cadb0c1c407b4b70728a5a347d";
+      sha512 = "c1fc46c423cb40c46fd573273a64f4765970341597e614f58fd08189247ebcac3f5b0d5c922f44586adf2a67cd058a6564a9a8ddb93467e12ff6c34c1520188d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/or/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/or/firefox-67.0.2.tar.bz2";
       locale = "or";
       arch = "linux-x86_64";
-      sha512 = "e4e0fefe02fe0e6031e3c992fe111987ed328e03488e53839a65ae0baff902047a3b1fbed7b8c863dc9a05a01af291406b4946321e204e537d19a617b5b50688";
+      sha512 = "86ccafb4f087a8d64c7cbac66522ba3e57c4563e5bb8556d92030e7fc3535dce524eda5d88acdec1a1029071ac062f8099a3410030e98a52e374fe3e91ecd207";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/pa-IN/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/pa-IN/firefox-67.0.2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "59233c1964bc89bf1be63f4ce901fa11d48cbcb0d0e93e62f7cfff5abd4617f84044ba6810f39df6902a25f47e0e9845419a0786f1741679b3fc7ac62cf6415b";
+      sha512 = "a9ff382aa059c3039bc7bfc5b2cfc1c1883b26f923d5d665f2789f3ab710e596b57b970bc182624ad68bbb4ffc3ae4edbf8a0d3773d5d4eda9f8a0dc3f36d7d7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/pl/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/pl/firefox-67.0.2.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "225656779445d84eae1da64a185c2f949cfdb086a13475c8ccabda6f1076dc17f1b9874db710edfcdd094d0ec1e9e8e8c9d32f8b2e6f3f80dd9652f1309f5c9d";
+      sha512 = "fba6c16ba8192f0e47dc4c3e3acf09bbbbc7851af9641f13008813cd0109b5e6e77b2e58605a632d32a6be6352b25d725540ca0dfa301f43c4666ab755f16d0b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/pt-BR/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/pt-BR/firefox-67.0.2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "6a910d696e48df058719138e6ea7d0d37095f2a81b7c7ff7c9d418c24760cfb32398b887f0294a25ca4f4beced913119b0c6c4a25e9cb3924e6972286f9da7a3";
+      sha512 = "0b1204b3ff0646df71529f5a5319c9e32ecb844938d2ce7bc30ff62e20eeebb99ba4d34820851ccb00fb68a369bd786e1589f920433838e2e4ca16682419d174";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/pt-PT/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/pt-PT/firefox-67.0.2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "3060be3fe72e23f9c6af6057bcddb70ed48dbeb02632223a1e040f320cfe825d68599f35245a7b9e8b335fb5646738f839244adea38491e04d7d4155cb62f1e9";
+      sha512 = "0c7ad169a660e3d315dcbc5322df0e3fc3f41f35fb8ef39d21aa006c36ea6692fd999ce229fa5e25ffbdd3e7609887c6795e1b3fe4b2679fbbf706e904c9e14a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/rm/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/rm/firefox-67.0.2.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "61e3270320b5ae32a1ba278dd8a60db18db46b558adaafee14d0bc60e2d6fba0a3fe95f6f7b95c19b73e36f6c42f19bb09021ce308448116be479ae5bd0ad04c";
+      sha512 = "9db14295905b73b4c401a6ede5d6e86c10ba9da8c5a0fdaf8984cd800dc2344edf0103ae50234d06984870ac8e0a1aff7190233924b08d9f2eee0981acf2cfa0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/ro/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/ro/firefox-67.0.2.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "97070dc3e1e8919446c6331ba014c21dd54d88d8c775f529bd16acbfe7903cbd10d51337f4129d4547ebce402de228bd4a8a7835150a145b34f0827497e31f8e";
+      sha512 = "48cbed795a07cd92441ea435dc9f51459d7a5e23fc9407dc4eeb0b39dc7d3f8b6807d5d441711b9931f566e527a2a456cc440635e0a1185236ec8938f4dc9b91";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/ru/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/ru/firefox-67.0.2.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "3bdc32fdf089c72377c4c166360320f5c23bc4c451c91cc01bc0925711c88c0f0f1071714d28af323c602ab9ea84ef50270b7f6080adecb974c7dc5fd23658f3";
+      sha512 = "9c4c2d5f6231c7504b67037f6fbe5d8f31aed52da93cc343b2a6bce2a1da75ffc59d0cec2b7992098b4791508fc39d029bcf16ab96dd8ee4c1dd535c8dd81aa8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/si/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/si/firefox-67.0.2.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "6552073a65ae22e140b1c46693526a50c96da4d0ab55de6231915d52b8e402172be7aa27ff5b7d6f7a5128e77006c0c4073c6344fb21708e63cd17a09da238c5";
+      sha512 = "431b4064558cac4dbf459b71614e7287c17c4e48268075dc8bd4158b120fd7fd84f96ca0516ed1291291c04a9fbb82b3df1828134cbb1a59ee76127a09ad8630";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/sk/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/sk/firefox-67.0.2.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "68a204a72b2ff261b09397f1f5b2d82fb3f0e2fa42332cf881198bc8949f185b66c101a0f513eb6849efefa7c717aa013fa5ff4812d10314f8e3e49c77c117ac";
+      sha512 = "9d9a52ec4c769c00a851f1434113706ba6d0fc555709494c014ccc647cf708cb1d8dad9abad4eb2988c5fdb7d0437e79bb01a8aebb7d7a5562f2bdc72f8c5114";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/sl/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/sl/firefox-67.0.2.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "4cb79fceebf60f8fd95b85f537462413f64e1c3559721a1909ab07a10a9621c4c27dcce888e29d4f0c3237acb8956e63253840fe3b3d2e1ded56d4f935e8e6f8";
+      sha512 = "1ff52851d656d0b8cbdb730f09ab374ee0a29fe2eef7e3c1880df03dac07687ac5bd3c8dcbc6893534a86b952e2e0604d625cec3df14e7c70560cf20a38f96a9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/son/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/son/firefox-67.0.2.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha512 = "038bc081026286b08e753077f45931f724805030add5ce4ea92ac50eb59db298b3834cfe4c3899c59fde373c21564dba0b5cbfccda2fcb734aae255ec609d7ff";
+      sha512 = "07288885374781c2164cc23929e86b666e393f5c3e699d18447aac9aa2e3d098208cb806a2e3a5528b3cd40bcb5c5f62a4eb5d17bcf50ab7c44f387b5b153de4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/sq/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/sq/firefox-67.0.2.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "ed6a31b0496f60d2c4def5ef5f343ed57e421c8c628c84610a1b558d454dd7d765307980cfc9f8bf463c7e03987109ee8c342d84e33455fb2fe0f9dcd0f80c4e";
+      sha512 = "8c4cf47a4ba9f4fb9228dcd60ba3a85dea90c353b45092173fcaa7494e5afbb8e92f81151cd02290a9e8d9654ad04da10e53acc39e4a8983f02737883b532c56";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/sr/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/sr/firefox-67.0.2.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "790cc26da2fe7691af2e50640e7458055e1f9e48ca7756fc225341339962f615f48596a10cccc2e5f6a505dac73740efeaab353587cbe19a14d7c8ee1dfece93";
+      sha512 = "54c23457008e84b3995b795f5553d7cc22edcaf50af2bb31e621822d9946115683ac06f22373e64b313b145f707c4269c9291b95fe860e26d2ac4fda0df9a614";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/sv-SE/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/sv-SE/firefox-67.0.2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "b98190c45f637fda39807f40da99afe6ff5aa0029f51d8649144052785b9942e30c7d0b31fc6c55bd0cb56e2275ac3c511e61f1e6d4cc8d0e45e73642150b7c0";
+      sha512 = "551d34b62979e4a27ca152a3560347617100e35b1a9ba357cb17efce619cad6c8b50b222e191ff117a154c5f1db908cebd8d76e5be016b98325a02dd2bdd8c0b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/ta/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/ta/firefox-67.0.2.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha512 = "6a9ac4b44ecc81de9db574334f81c6ae67ea2b578e9d5dbe11710a7809f72a5c408cc776c7def4c400405d86add0e0f54cd238438305badb5b0e4a663819a230";
+      sha512 = "62fdb16d50cd7b17659486fb8b915c605cdd2ec6d8a33bea7a269463044b1943695eed05526f785835afe9f69f12e2aa40b339d6a6d3ee8ed3e622d6dc25f5ce";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/te/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/te/firefox-67.0.2.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha512 = "67afd13cb6e27c266669477e82ea93ef406cfe7b64566fb90665f8461348c12a0ccde36954025c9b605f691d9f1e101a47fb467b02147830900a35ca923a3b9d";
+      sha512 = "c6837f6ea7b023a02b8f7087955dcdd9bcd834d0d4a46eae0cbc05098cee2e039cc053497f686fcad658896697aac60d875eeaf8be12b2cf34403be759cf5f86";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/th/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/th/firefox-67.0.2.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha512 = "d99b4c58e299cc9d37ef0eae150e0e3278721b3c0c6ce217c7effedd3b8e9fba485def0c1cd0c42b48c7cc20721ddbb02380556aa293c1f7c013df5025eaf5ce";
+      sha512 = "53a52d76cd55f0ee8cf2361868a3c2fad174836e5b947c3615410e54dab19e182a4f08a4c9cabb206f684429ebe8c692a3dbae50790ebb617031976a0d210c1a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/tr/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/tr/firefox-67.0.2.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "33aaaf9b93b51289a0b8ffd0896e7275ebef83e8bb8eb907f67a585ad02793de1a3ea3d370465fb5bb401cfbf57f0088350476cdc374a98be6c073cb0724f581";
+      sha512 = "4c48ceff4d62193e22323687e82761b37f810a5bccacd0679eb248d455c7e5b12e0677b496a51df4557c89b6e1dc846d32738a53b1ff8c9176249e39ad8e3064";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/uk/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/uk/firefox-67.0.2.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "802c1a1fff2f734ee20d57a2a23b23d434093648b3bac802f4509e3c8094321ab3e51600a516ef6930d9eef2188f5ebc30eb684c882fb0f38ab94fc3b80a0b31";
+      sha512 = "45a9e335dc561ba8dadb8e15aa1aef620fa64ab0b4bb985b9477542eb457d146ba87b4274890edf3587d45bc6ff0b6b56db01134abf8557c8408d923be8e4a6f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/ur/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/ur/firefox-67.0.2.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha512 = "9e0a5f04a705e674e4d5a4c6e087f1fd8e6abaf6a47086daa838fc0def6fcf93e4eb0183d4214277a56a790e11a29c4ab6ad59bbf7b0cadba11ef1527219365a";
+      sha512 = "c56d697fac3a76209dbf031e88e02d3018ecb3fd811771517d1aaf2619a182238881419fddf08bb68e239438d969d8d53c243f3b204644d8543ec6372bf7f52a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/uz/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/uz/firefox-67.0.2.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "edf763b76602aebb3a77776716ced9429b5a15836b6a9a6db2bea1d491abd94e1bf8cf925f23c18790bc3383dd92d91d0dc8c081bcf3ece24042c0fd8e7549d9";
+      sha512 = "c7abcece9858f3a14c7c470a96fed65820cb417eb99ca7a2ab33abbe1721e4d14c6aa7aaafbe6c5cf283782113fc1d9d8f13cd86b16faef1303f5f0aa3312deb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/vi/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/vi/firefox-67.0.2.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "b60ee821056f890de4d44dc3b20a2c0fab0a892936e3d5f5f77c9e46c7743b841c421b55dce6c69d97f4270c911d5b489d0b61f23101da70c8dd52a0038835b6";
+      sha512 = "6ac3ad94a985f3367673620ea94311c60b0a43f1455dd232b811335f75f78963bf9c2b4e6519436beacb1c40ed3065c320bec048dba925efe8dd2bd3e2458609";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/xh/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/xh/firefox-67.0.2.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha512 = "5a52fb8e49ef6824c2c95bdf472371cb2c95d5c6ee963b704196cb297907b91602ea0306fdad2bfe84716c999976c242a257a4c62b8b4b28211217b7790366d8";
+      sha512 = "c18022115ee3121ec5a29a7778ed7065ec8552e4d65d27d4ab38c31684fcb2169ab9e8158a861abcd27a901b51c006c528d65d8f7d6a8cf00fa990dd310dd2de";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/zh-CN/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/zh-CN/firefox-67.0.2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "73ca694ffddaf5298437af312fc4d13f393aab300a5a3937390766275bcdecedeaba6b751afd67dc31d0a5472568c4fac99ce31856f4f1905739f49d9f81549c";
+      sha512 = "4f2688557972fd281607b25b15636bb2e89bd034d9ac2d647b4fba8e8a258ada3bca32ac80f3f9f49909aae52f7261e5c39981b66d86ea55f058f06c4887e2d4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-x86_64/zh-TW/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-x86_64/zh-TW/firefox-67.0.2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "baa9b532b1e4cdce439838bf5630bdc4d4ae625c4b643098ef1217c7ad34b4d50cef21cc048ab861036ad5be5a9d10ebe1b9c288ac524f17dcbfcd2d4b82d76a";
+      sha512 = "d2263f4c8cef29602c67d01758b18e22d63530f093c8d39b22ed556b2b141e135c94f51087313be8677f20b9fe63930ee983c50691b59498ba904b927c6678f9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/ach/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/ach/firefox-67.0.2.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha512 = "9aa1a72a4b75b506ee0c7c12a0d35acac31c25d777488c7e01aa1f84fb14aee343ad9e9853ef713dbe043fba5a6c3064bbee7ced63fda1bf3e4039d849d9e923";
+      sha512 = "f20d308d540cff62b153c8592eb26f16cf45ddf2554c1076c7239c3a63eaa0bffea91e11ff130ae89432a79159d30c5b501b9577bb6713c135925dccba29c10e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/af/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/af/firefox-67.0.2.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha512 = "074c20c4d78313899e990683d2ba51c251bf3976a6a3f1f7027e9b9f7fbcb1dd38b54bc51c11dd3bec831c7999effbd0548585303a35ada8b5b7ff729b924d75";
+      sha512 = "a2e9c7d9aa7799506aea57c39f7c0a8d40f5e371702bf3cc4ef1b34c59edc4791644f4a27377198b72a7df2070af6c32e1b607b7a11469e1fc680f0aa4bdc042";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/an/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/an/firefox-67.0.2.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha512 = "0b3b62035af0eb3cd52c0d011571b1ef597803a4d6dba2b9981a3d851952b10c8532f5e90e99d2459eaeeac1d4bc8cc45a6bbbbaf34642525aadbe6e6db0fc4d";
+      sha512 = "7a1b8f13cb987587358a193c2242de334a93bc4727fa97566bc62726370217522a5c705324044fbba134752835e5363ef7a21f7b62a2f4a31df8a755b3856ec9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/ar/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/ar/firefox-67.0.2.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "3f393f8d0f8f33675de96fc1987002c90df3b376f395e9abbaa704c46ab35b93ef91e128f9e54e0e3a1d39d6b5e307956c30650874e78332f7eb786848b028be";
+      sha512 = "a17a8a7f7effcb4fd6ba380c6a7405a16d99a9edfd56c33ca60aac0d3d0d1e03017636f5ee6f80d621dd69e16ea2b52796e3e0c299de9d52cd2f4b3c4e10dc62";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/as/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/as/firefox-67.0.2.tar.bz2";
       locale = "as";
       arch = "linux-i686";
-      sha512 = "703cd4f07cbb80fbcd82e810d23e9b84de9c9f2835556afef0fe9777c33196343f1a21a99ab1f4056f4621a5131a6cdcedd408f4446778da5fe618d755f60f25";
+      sha512 = "3e723c42d9796b59237a50413c84d760520706d6ef071218fe512766b662d3d22b8e1228d9fcc91c1a140f3ad4ecd4b57719ebb38f245a5f272536575841e11f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/ast/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/ast/firefox-67.0.2.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "1fc80cfd8a6f26974cce991f58271fa736ad0984e6a4da75ee7891a6c723b4793d4a4e72fe44910b718acaf3ab983b71ad6d2b8ddb1c79facfffdf823332cb7a";
+      sha512 = "59ee42766f8a1c5e5c14103659f5a24a1f7f1e10d81fdbbdfefc968ffecf99a222edb393d933d84581a42d7ef7557d3b7f5c4bed6946d7abecfd190b2d84eaa1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/az/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/az/firefox-67.0.2.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha512 = "c4364e417125cd2cdfa13d6adcbb7d0363868bd956ca1885757071206dc4f85ad2ce0b69c44bc12ac65a16e295ed9e609a6ffef7469ddf8f1d1b4f33e8eae0b6";
+      sha512 = "15ad74a16bfbee2af34c68af24736188a71990b6dfdf319f2911784d85eaa4f5d588d1ac283cfb9535725afcf993375ac886c971197531c449ce5dfd3195f2b8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/be/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/be/firefox-67.0.2.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "3f19c71194c3b99d093df0b444d76a307b54512f992021c99e71d046170022a4083c811ee890556e946cd7a6672b1bae376a7ef9134494baa39e11c1fbaf08fb";
+      sha512 = "869736953ddaa5a6773d9b35f4cf2e2f3c6c2c3cd07fc390a6dd5d496e226693f050746d94e778861a9801d0315ddf9da62b9ad20d4f06043c5a1fb11bdea23d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/bg/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/bg/firefox-67.0.2.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "5e1017761fd9e543c36d4a19e8f0e725bdc680110595a7364b69b24d431a54ab4858f17a99f02ad3ffb7e90ebe615c21c80c2142f4541c55f1f8878f62a18a10";
+      sha512 = "470b3624415c317b06f82cc4dca2a738962acee5cf7fe203b9b01dd92e7d9e7dbc8a8f3a427fc831882bfb1ee11c39e66f2f13eb483f8a9cec5b19bfdedd165a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/bn-BD/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/bn-BD/firefox-67.0.2.tar.bz2";
       locale = "bn-BD";
       arch = "linux-i686";
-      sha512 = "35c2a51f4ae58246f2ce212205ef54284a8aeabe67b47480229220c904c379f9830860939277dafe54b6293a71c357fd696065cab6bf2e08f4986cae2a9b51d6";
+      sha512 = "6ad552eff2dc42ca8ce84b547dc2e4f79ebd1922e95f27737dc6380329d04dd816fd3ae7c0938c2468ca4d00e4fd76b296bfbb0a5251b1c3ce28b8852efe79f2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/bn-IN/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/bn-IN/firefox-67.0.2.tar.bz2";
       locale = "bn-IN";
       arch = "linux-i686";
-      sha512 = "e60380605bbda7f8942fb4181d3b6c69da7558603229861c20ce7a9f1ab77c1f1f75189dd65541798d6b8b27b1722be0d8ed3a7fd5cd68a546f55661309f903b";
+      sha512 = "91e5e4c4e09ab660a3f4fe603dee03217fa663d6d7252491fa0b0d350a6cc6fbda9e4ac95ceddfe3634d9b1117558ef0eacbaa66c1697fa7f1cd7fb46b2c8bf8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/br/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/br/firefox-67.0.2.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "d2a58e9c8970ca5e2c8b76c8e59e4084f9cc12d94603c3daed086e107e195c5b0187ff4cae4c3c1fca43bad9cc0ec8408ff058c9d7ac3f89a998f93dbcabf032";
+      sha512 = "92f9de0e263876a5c322b5f161a97969a657908a06c32a09bbdcc22eed696751f2370881c94bcb46850c31782fd7e1c0a5eed6c717198007ccd808dacf29ced1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/bs/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/bs/firefox-67.0.2.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha512 = "d651e2fdb17d28a05552740337230526b90ab341dde440a91cfaeaf42b73ac728b9004ae8e3fabea3a2e59d3842d681b6d16518919e77e493b26d4437770c672";
+      sha512 = "9019a42b4e97a45e4b4d8196a06253cfcd8216093df4918544f5f85ef6d2fa332808a545bb76151a7badedc684fce1817e4bf322d524fa8f5487dff9e4cfc0a6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/ca/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/ca/firefox-67.0.2.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "91588258072187d2af65140dd788d1ea2cdce3e66090be350d93f9e1606f6eb82ea952e5431815c88d4629cdf5bd446c6ba0a1e5f26b4f83c013c568cdc55d58";
+      sha512 = "80ee22f52d97e8d0c6b18cc766555423b681fcc01bfdf8d52babebf985f44dca59d0405bb792649d3cc3fd7ef9461cb1fcc32fa0f60a6599aeaa27b6fcf05595";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/cak/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/cak/firefox-67.0.2.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "0731080aaea48e016df2bdaec019b3c0bf1b03d2912a801f055bd6bd237b6885753b71b11cb7ea726a6391eefd833434d437de6d51f2cd0be6b3b3911f2693df";
+      sha512 = "3fa0fbcda1d98b4b507e716af052cabc3815321064af2e9e71af10281661bf46833535d9047418b6e5ec6f62c5d79f3739b2a847382332274549cd07c7de09f7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/cs/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/cs/firefox-67.0.2.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "a8bd3e4d8f292928260a993f7352c1ea4ca9e2a86e4c5b24fd29a6b857ccb4a3aa80bcbf7ecf8435a5bf89927b1f6df681d225bb226e2e5d6c76576c44b05916";
+      sha512 = "7432adaf3f484c120ed98919842201d71747d8803fec499aaa5c32343ed7c757df554e9ba7376c48c3c7a39358d9ab6952bd323f17b829895f0646c042f2b518";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/cy/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/cy/firefox-67.0.2.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "bb7ea5154b1b6a860a5308388caac7f6744f7518345bd7291d3a42c08dfcada992466fd560ec3d707b5cacadae8e23ca683b98330a6205c3c9c3ccfb662000b4";
+      sha512 = "bd48af052d2bb0c1d1393cb4994ad9d76aa8d5c5730c442af59e8790ce40095e1d9721da552ed07c5d71f89b8a9ccc8900fab2895bd1239768589a51db7df92b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/da/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/da/firefox-67.0.2.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "7c62c16b29d62b55dc432315667706e4fc4fb15343d79dff6147c9c49c4106ea8a5c0efb0892d41f0c5c92444b0818bb477891f6d86f15ea4d7e74e692446636";
+      sha512 = "320b32e030b6e674763ae01e877a3d665150dac077bbec32281557930fb4b1cb17176c04e4716229e649088f40ffc2eacde7229fec178d34f73f0aacaa89d519";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/de/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/de/firefox-67.0.2.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "350d7ed17dd62cddf6fd75b5522067ba90bd8f17b63cb2e09442d1f8afeecc9aa3ce6dd033e5c26ccad0013d24195d869c8e611e58e089325e72348565e819c9";
+      sha512 = "afd1a42ead4d7b25ecf2e74f06642485eb4885291903d4799a252ef63d555adc847525aaa0670f032a4b36c28b7b14b1ed91ec7c4450816f6d222b1688342079";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/dsb/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/dsb/firefox-67.0.2.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "590d98484c5a26b8597d0d91eb674a6f8ce3dea40b24e4848f468a059f3746cbba2b198239cdf23c658afe7ba353091cf0adcc7ab6e5995c023d0ec0d9055c86";
+      sha512 = "b6984f653dc40135f247e306c3fa30c1719170ad54af5514a0a1eca57292a5f5a0ad918e30ff7fa0553238b34dd2d4d00866665232a8b2c5cc405bcf934feaf3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/el/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/el/firefox-67.0.2.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "67eb4433df99fc0000039c1fce75dfcd3734f7f0eb153b6e2f02bdb2cd403c7ec49aac11ddf33aad3a00e6a06481b89e316704e05171a71f761de75603842c14";
+      sha512 = "69404fed19c796891222b368d46d10edb011e1ba9dd0588a8d855b31bb3b57d15d503348339119e8a6b2509a23201b77a8f53a9a1c86613496a8e4afdc3b9ab6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/en-CA/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/en-CA/firefox-67.0.2.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha512 = "ba27e4c47883c1d0ee39fc9c9d96bfb818040dfceeaf91003176558373932b7ccb23c7a34cfcf13e8763e4e9b7a271e103081a7b4a60bd33f0b9a931089b782a";
+      sha512 = "9c32cc27dd06d2cb119fefb3e860acb05c58a7ef8d4dcc7e6acb0c8d2bf6b9db5685317be04ccc02117b1b25913d5b0d9f8e3ea12afae2f24ecdbafa37eaa74e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/en-GB/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/en-GB/firefox-67.0.2.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "a4628c68314b5c4e102fcc6a1b7fbeb39ae301cea0d0b08f9bd5d8692cc56887dec7f05643583cf1ae62bcb572ff435d4e394d0c09c0e1ec839f351b67b8594b";
+      sha512 = "1a1691555f2f269e42bf63331e7b635fe733651ff2786446f643b1746e48ef3f6f30332b1a3cb9309e183da65f9dfaf9347acfaa852360dbd328d4256c5ecffe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/en-US/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/en-US/firefox-67.0.2.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "242136fd7ba32dee520366427234746e596c278e8a59fea70db08105944b50403c078219ff5f666212a64ee818ea2d68f15b5afce710c6b711ed763ec1e6f17f";
+      sha512 = "06e78c26ce3cd5bdb0c6057606a0e93530511f05ba2b2f35c7d72dc950412ffbfb4ec924bf989578db450bf73748e9e69ab080057e9f4d4e95986c299a46eb78";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/en-ZA/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/en-ZA/firefox-67.0.2.tar.bz2";
       locale = "en-ZA";
       arch = "linux-i686";
-      sha512 = "89c958976906b2b0be42d6efc9492a348cbc0cc81bd316a2496db8b9d0705c2ee894c58b1f6d4143642c40752d110ef89392b1a689e2cf641839c66b650e5d7d";
+      sha512 = "298fd0cf1156c06ba529ac7f5f64ec8c9c0dc98866d0f93305c2adfcc2e9759fb1607a87dac01665978baaeff1786b253d483239f31b93ffb1e612d0da867c04";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/eo/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/eo/firefox-67.0.2.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha512 = "dc9ae524c1e504a18890567c8f43141bd68cd34d0808516b3d9cbb039efa7c5da5ea406218d0cb9ebbadbd75c72479b181b8d7b4804a9bdb77561d1a1b88b426";
+      sha512 = "5b0118acdffb6e23b4aa495b52a76df4f4a045af804eb262e5d30fe8ea18ccfb9205e942b8f8a0a1e899a1116ce9334e0a68bbbfa9229bf82c755616d473c791";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/es-AR/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/es-AR/firefox-67.0.2.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "4b2ece30ad452eacb7fa23f046ff72faf938549e80f794f898d055bc78713b243b726d6839c4398a5a96d04b71512259b341f1227bd3bc9be6c7411ac34cf6d5";
+      sha512 = "326de324c14199db72b8da5fd8b41ae00a759c87d1144156608dd7805c09b2db7458c007eb56c8bea2e539556130f514c7da7cbb690ca0cfd2b7ffb512203579";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/es-CL/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/es-CL/firefox-67.0.2.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha512 = "141b1295ecb2d9f2aa66bb61eae8ad905bdad95cebd23274728194882fdee154e9c68491c55f3938d33b8e85d984d8f79bea20c2f088be223790f07a39708111";
+      sha512 = "ceb38eac9c8e7ea0dfd08b7030bb817fd4163cc323136c6f28b1a1dbdce72af0e52e08940cfe05668ed9bdac9af0eb2fbfbf85cd7b0822da7c3def405066dac3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/es-ES/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/es-ES/firefox-67.0.2.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "74fbbe970da22d4a1bb3522b61787ed00b41d12d5463ab7b61797f7b0f07c8276e1366b23b575eb51ecb1b0a31e8aba2513db7daca25541a19e050f7c0e86f1e";
+      sha512 = "4f6f90b9f4d7faf7ad4357d8b369ccd7f27dc3b91302ed7e0a72e3a2497f5685fd524e5a02afe61c6b22574ea5e49a5e98207d5209b2ebfe0eed2d5e48eb7a03";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/es-MX/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/es-MX/firefox-67.0.2.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha512 = "a4ca6e40c08e4fd3d38840415e43c36db682cde3f5b0e177759d192ef9dfb7365f946ede5e30fedbfa27f07c64696904cbc36895507832390609ef1000e7d075";
+      sha512 = "5e9e1192148674ed5247003d804608fcbe712da60b32b21a5ddf538e6e335037117a133b72208379fb5994a5d4377c52c9c28f9fecd8269f9227066886dd4206";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/et/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/et/firefox-67.0.2.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "36b9d5ff3c88c29c2960b5dce898775b581646f1905a776b95a57288b5545ba132ccf09a1d80a12666936dc63b2d738caf8ba9154181f065959a1169e752b0e5";
+      sha512 = "ce7db1c964fa4a52c043e1e8279e3f16b84a216dd0faa09fa06a602cdf4fda7f856edde9ab250ba27e7fc39f631bb4f22f9f9439f1f177d1b167506b239614e5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/eu/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/eu/firefox-67.0.2.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "b63283de71fa0c871ef779318582959c440a6ad85d85997100db97b6ad4c10f280ffa1250138961aace4cf2549314ca63e637b043ca97483afc087c12c1e12bb";
+      sha512 = "dce4c457ae6b74d571a5adbee15083604b1e900d6cbb2180da82f6401d0c1ddab161b33811680204c5c7eb288077e21985ddcf0718b9b1e82d787399cd76ee1f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/fa/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/fa/firefox-67.0.2.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha512 = "13359faff88883df9d31bd8c023fdb5b829056c4512d0ad93e2045ad4d794f1d979254894b46ca5d3ce65da48db511a60b1abcef2c4f1203d8c04aca5f8a8abe";
+      sha512 = "12385d23ce72f5a788d87cd90e33cdb45d45fa5a0c5b9157078c03200fa4a24a595e1de664390646e44a4abd3735665e05c27c391e95c392a606941e71adced9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/ff/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/ff/firefox-67.0.2.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha512 = "7ab6fa4f4ddc14cdfd0729279ccd70b15ee7897ef99050da12899f51fe1bf3d7dc10c98bd4289ea5e5d37f5008f3d7bc65d7eedea322b7f06773b65158f55058";
+      sha512 = "ceb46d75451d2f3c4f7019541febca272478fd893ff41da6218d3525b1de8feb0d1338a5ab77f25a87ef1d6484386c965bffa91d6580bec9830a23b2a16538dd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/fi/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/fi/firefox-67.0.2.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "ddaa45e8f63d430d71fa1c8ce73dcb94dc825cfadc4ba66a123be26b4724a26618201a232e4145e0cd2890507b51482b496bebf0045fac18efcf71aaadb88c4f";
+      sha512 = "9cca9064afec459cc2649ee0a19a18bf8e91d4afd141c4a83b7ed2e337c6bfe1c68b48ae8175e73b55fa219909161acea7baf885b38ef0304566c3860e4835cf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/fr/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/fr/firefox-67.0.2.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "61db58304811d1682f1d90b8fe72f5532c0714666afa3fda14b20eaf598c69e9ff8e1272889e940fbb59ab9590f505fb8182ea49068831c59250980c8c41e49d";
+      sha512 = "018f5fdd6fedf4bf860b677491593ed10155659d60b2d3af2d0fd187fc790baa1c87e153facd018733e6443074e7003382d7753d056a2cea5b8adb6f299751db";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/fy-NL/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/fy-NL/firefox-67.0.2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "fb06d991e3e1098656fb2cfc4552c848bf39efcad2afd6b3764b12646a1edf4bf6cb74413600a50416899feb27c1c5effa9133341cbf14dfad80310b18aa122f";
+      sha512 = "f010f5b40573dee3108912ff538dd4dec9db1fc1f6817d8f9602a0ace537fa80ac0e684f3f32c006b10bfae8e3e65ab8cd0c25ad35e7f7638121d2f758447f42";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/ga-IE/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/ga-IE/firefox-67.0.2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "1465affa310a6824e7edc77b809f41b966f94b520ce63c10a36d3b604c43c3ade0d6d66c86cd863122fc2849ab5b037c5d3acf7b45eef83fc704085289d6b060";
+      sha512 = "d1333c7139433a4b330ca5d93e6e773f623ffe7c431f4f02dbc64be28f388aeb77fb98eb593c01705849d6ad75c5f3bd74b4beb9b5dc1f95816e1614aad8ac66";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/gd/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/gd/firefox-67.0.2.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "1a77d9844d1aee49b8326c56d1af240b7970e26160c3c49eafad8f1079d1e318e7f8b832ae5d7a028e1d1d1585d8833361ac145343d24b3042576a84acb0ee4f";
+      sha512 = "4f2a6b7a8917a155f8e8c36041695a7f08f561140f554f3ad9cf2e78583aa48d5049080da1bb00f5550918d8d5999ed8960ed5c0b12e98882efded12467ddc69";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/gl/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/gl/firefox-67.0.2.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "a6b8ba633be33220009b4c2b25dd2eeed7cb4d98df352e467f14584b7ec66e13aa20a546a222973a31a3e2458967a98c7ccdfd9f5d88cd44512ee79d1bfdff43";
+      sha512 = "32c88369a8a6028c7a20b708511b508dcc6fc1eeb99a52af4437721dd1299eccf28822343e8934c1a230e6e9bdf84e6a148fe7cc83d9477e65ac51bf477a653b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/gn/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/gn/firefox-67.0.2.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha512 = "f7e8011aeec51f623e017bcb5b562504fdaa79c081854972a9626f22360f4517ed6269463394ba604581809df3d7ed7cecb4f54140960a832e570adab5674c39";
+      sha512 = "e603801478d85d45431147189b84324b6ee04c2be1024a25ec492706dc91e76d13c7ce1da31f96a81e21e6c067efc48a31c5c3a121eedfbbc326545b5997ad3e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/gu-IN/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/gu-IN/firefox-67.0.2.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha512 = "b91d13d217c313ab0fc35e46acca44f9729c5708db71219dbee8ebda272f74a38a73d60cad7b4865121f8dd4cb55b85abd4c6417e5167223dffcd4ddc6c5a17e";
+      sha512 = "0f0c788be9fec191f195d87762e4cb91d8ca3dce4ce35a9da1cc9fa8271456960be6bf67bd8135d7f4036835df48013507233efaebf95244ba158a18cf81cc09";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/he/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/he/firefox-67.0.2.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "13483866dc9268597f74fcfa5a7bc111c65a7ba6e43f90c413c80e1f4269228a2da6cf2f60d39df4d9aea932ece8c0409ffa4406f9f562d79a86d563f31acfd1";
+      sha512 = "5bd2afe767cc81845835983469e5d5661e57131df7d26104d740dcec27026bdbdb02372d8170ac23f67982319fedd3e6449a7f06070ad1957526059528084a43";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/hi-IN/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/hi-IN/firefox-67.0.2.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha512 = "ade837f046c513e69c1122334b65d9aa4dcdb2e3faf1c8321192f76173b404c51bfdc97bb802e91df22dd2ad4342c247450b4a30215e94cd9604efe926034379";
+      sha512 = "69dbc6d78da4d44b86ff571fac073971e4864e66b0153040d29e5161102202297805a8a2f2e6d17074b250ec2782d9a32aca146992ffc0198b9dbb2b96a23761";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/hr/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/hr/firefox-67.0.2.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "f29d24bcc1d2624fadfe22e4ef9ed901799bae60b88808597f4cdfab81f66f3ab5fa273259e640b7ef628c7e638edf33c6bc06d7d883c74fd4d28b9beb4e62e5";
+      sha512 = "a2d0a1293d38a98ad9c3479f8a6cb4ae4da65a3b3c56f5730f175be710a867e15ef83fdd08f1d98df0e409da270de1c3615bffcbcbfa6e6ac1f161fb8694cce0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/hsb/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/hsb/firefox-67.0.2.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "6a771b8ec7e5d035f7964f14077ac9e6dc775c44980607aa4407d7760ed947d78ec8cb46c0b8b3f5c4852eea9da1cfd8d0a15acc2c785f71942a073c54cabeca";
+      sha512 = "0ec1f0c9f7c0e9ef1204b17426db09f623f25cf5816a91753d171732b7b027a44f977a2bd2a38be3c2f22035a69a2438430259636c0b38c1e276f5b6b21661dd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/hu/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/hu/firefox-67.0.2.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "9022917ec678e4c384bde266baba6dc3df58ae3d38ada07d896b6409d51ea74dc3eea29469a236210e2315a5722e0fc78fbdaeba6d0fde550b77a1bd6debff31";
+      sha512 = "7adaac028742223a09c598842de5fcd34524e93b34b602d2307431fc0be651e1e081c06804992e878ecdd100d1ed15b3a83ac664b59709eb7adfb75ed3de76cc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/hy-AM/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/hy-AM/firefox-67.0.2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "00bb4ae4cda93e8b9448db36cc3e61da415dfe544cd9b484192e5686492b0129f5b350aa48e8cbef9bfa843b273c3cbb9f10e108098d2f5eadcc52e848b617a0";
+      sha512 = "01c327f71e7dc09473c8dbbb2fb61d054b85431f15e4ab5b5759508b8a5ffa9c018a17c8fbdd927292a710ded9e49c0223661dc26a0e22f125ab4ff72b85ad9c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/ia/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/ia/firefox-67.0.2.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha512 = "a54a7ddfc99fbc63e4d9d18d15f33498734fd083436bb2909b0902298baf1042e77f8f59bb6e6dfc033e65f2e9c71a310947f4f7ce05062e8754f51644dbc459";
+      sha512 = "5e144cdd7d21cd9c94977ce0b9374e8918f67ef84a0a8f8d58d1ca170fe62456587b1f6d1a208329e3747708b19a3a647adb53eaf28e8f146f1c3deae00fc56a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/id/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/id/firefox-67.0.2.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "747d8532c45efd4311be057131f5a39eb2d8ab8ccaeb4dbf3966c9f2e175a237f5e87f84fe00eef5203f71fe2aca83d182d308d3129b1146a3e6e2c0b2a44199";
+      sha512 = "b1ea8d573395e06421f4c74c796b8fa68260a754eba0642c5685b1acb8d0a13c87ce001a0d7da43167223f1fa556cf24681bfb271840ce7ee3303caf2d355e5d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/is/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/is/firefox-67.0.2.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "d4d98317d4f39c76ea36726e668edf1c2519e70628b3a5ac6482156c854457ef26e0ccf981d31a5b91dccb1af5a87f1c7aed4ce457932e74f2363e5f8fb110e2";
+      sha512 = "07055c68477bf6d27ea708f043bcf0a14da5f37e597c36b369129791ba7373351ee8d109a89faf7e8aa2645a6282bc03c4081d04dfc615d98aa1c45899fa92a4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/it/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/it/firefox-67.0.2.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "6bf4cf809212c12160617a915fc6c0201919177b81925330c63a43f4e370108b4bb6fc6139844f7509367acfef7660eeeef03237cfbb0f9699302186397691c5";
+      sha512 = "da3af727771c5a3cf483b4179d1a7bd51d0aeb3446d04de2bcaa520279f5ed6c442b8ae476d5e5362e7017b97aaebe944e0509652ae0ea116a658f8bc42cdb9c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/ja/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/ja/firefox-67.0.2.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "870c4b627994d0a701cfaed320ea8ec81974954f2faf3a0d3431e9d211c26f3b6cc73b476cbc699116a4c8760aa374030bf8f7a55a2985c0da72f8476cc6ef16";
+      sha512 = "6640a635b112e01e57f36964a986cb62562753a5b598b5e3474d8a4dd6d70350c989d82e4d07ba3c19878617b97981ee8c2477618282089ec49bb933f6057bb4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/ka/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/ka/firefox-67.0.2.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "7775bbdcbaad31acb2bd0151267d30d06ae2510ba20e3a1e9fec8530acf409733f562d7636dae8ee65c076225aeaf5417e1a1148d48bee4ac1eb4faced828a0a";
+      sha512 = "248da01a4a5841bf75af3abaf2c463abf1cdac17b96c1940c4eed6e2c11f0c2c02e5e99869e125024371436298e473d86456fc0ebc28e7cb16b8d233cad5ce9f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/kab/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/kab/firefox-67.0.2.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "154e422d2dd39dda6af42005d2510aa4cafd718d4069378141cba18fe5c1f077700bb73f6421481b77faae9e714f1651a38b904a5e7aacad3c19272d31d49485";
+      sha512 = "9d7c848aef22fe3206fb78f554dcc0a9012b5cbd28924aa29a2145e6fdb985c56318e2b33912493d0d01d1984f8cc8487a3fd924af13b85cfd38cb5744c8fbb9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/kk/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/kk/firefox-67.0.2.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "65d31621804fc3a05ea35a273f8a31c66882d77c4103168098abb3885a45a02f94d31494c29684b22d9a3ef43fc67d05f3bffec6ec53a6d68afd3b9e4cc82585";
+      sha512 = "a94acb2fe325318a5bf6045aee6ad7f5025b53f94615db91dfdf032dfce3f14f8c35aaf9cb1442f47aea808a001323dbff78cdda596d981421d7c7e9fbb2953b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/km/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/km/firefox-67.0.2.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha512 = "8508a0dbc8338f4f306446a50a0dc0c25bfd5cd971462770cb7221bb2eaf433d5e970bc68a4f0b28be58ed959b5778529d8d3600def1bbdfd23bba8efbdaf0a6";
+      sha512 = "a116af962afaaf94c98de70c0ccf8dde414d4bb6e0256d7d69078d2b3b85b44038a0eb5aaff4d6bc630aae2a96ed8f51295fdbb634b1f9b31b2069012d90a9d2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/kn/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/kn/firefox-67.0.2.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha512 = "a3951e200713ab79880b304b9c7ade80f6fdeb558de5854362ed5657efd85b752306dd5f4471e8e9e90ada22c5b1b99e432f9ac2cf0d071ec5f6494b0c2bb6cd";
+      sha512 = "afd57965e63c525fc5384108977465a8b90ab47ea6e1506142d05071fe6f0089588d4ded589995db0a743000b168d22ecbc74aec6e669cdd539620088681b375";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/ko/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/ko/firefox-67.0.2.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "2385405b5b46c2ad06692b47c440d40dd571f7c3c84eb14b7eef4317b983d05c63e26d362d40bab4381455562669a745be6edef2c6c03106f62892288b315470";
+      sha512 = "09f26513b65528b903e6728fbe10738db485abca4472187dcad725f0ca4b77060c059d3b52e68dd932f92ac9f321a27fd6a82d427873dd336f4dc25981d08e9b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/lij/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/lij/firefox-67.0.2.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha512 = "ff14d7416d28205940c4b47bff8d3a938464c1ef4240751adb9cd3655239f94375845eacf3c40de2f28f35e207e12dcffba61cb38161eea22ab1cd0d4e16d371";
+      sha512 = "1b1a24f1a4928bed8ef833655e271e6785ffb9fb7efd5357af12e1b6a1680e07abfcaaeaa43a2aef08e02d802099758a0e689a8af03ecd2790423ca33f62a230";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/lt/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/lt/firefox-67.0.2.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "0227e707fd7da06022965c61e8c30ebe4584a1532ad8d7da8f1228bb506a4abadd40c73a4752d81e3a6bf289363081185a28247c3a6ec90b69cae255b7aeccd2";
+      sha512 = "8ce739bca4653c81788529ba03d9b6bbb253d60c09157a184ffe3c4bcb8819af0c3831d5ed71ce32084c257d17487fc23ccc9841739e9839a62acfa17f14ef36";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/lv/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/lv/firefox-67.0.2.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha512 = "4b15a19ffd61d8518784bc0c0336504de0db52f059f72c88cadd35a9298c6c29b0c27db603c54f3b155289a2dcf5bec6f03c642a9253a93be7ca9df0a8bd6630";
+      sha512 = "84542ae12dc18c6b586b43777ae0f3ef29584bba56d0babc9220c755a010b2ca138894ffe9c566f943c9465938b36a8483f5fa3e61ce750da5c556fa3efbda12";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/mai/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/mai/firefox-67.0.2.tar.bz2";
       locale = "mai";
       arch = "linux-i686";
-      sha512 = "5c087cf79f9789a0bbf09c15cefb98489f4e92cc0ad229cb620571abb4a0373339eae325d51294e0ade233495a6b56dac699fd3a75ce4cf5e338ab748bc4542b";
+      sha512 = "9767bc1057b6194e09c94d7ad96d62d791113bd36ecf518c581127b32ae9baca790fbb39391bff199d6d62fec12cb6fc047d52d70469463dfacaa48a12cae76d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/mk/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/mk/firefox-67.0.2.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha512 = "c7e79d5175ab69601b6b83a6725ccee08aebb956dfed7b6668ad31aef4aef2715687149ec9a5eca8309948d9b5c31927c1d0aa1134bd039c6be528b1353e3a3b";
+      sha512 = "3a7d5eebb65992be8c71998c5c8ddea9fff147492e51781d85aa50dcfe45184911eed787be93097555e71ee7c4dad7df773ab86c10f41121a840c7fc604cc744";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/ml/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/ml/firefox-67.0.2.tar.bz2";
       locale = "ml";
       arch = "linux-i686";
-      sha512 = "39ea6a6cd4e078ecaad5c9bdc2e4a4e61e853bd87ff77c9c3f09383c7e4222022ae0aaec2f6a2ba09ab255c588493fa0f4a219d90fcd57e7d525188278eb761d";
+      sha512 = "15c1407419022c20f95437aad1904e23ae24a2e8b82101b0408f8cea1096d8973c354a98914c927375398e7d643d986c0f79bdea47152b8ee9fe9b14521b66a5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/mr/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/mr/firefox-67.0.2.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha512 = "f10546d51421b0a0566cb035807f0b577bf393724bb1a659b60e3239ec2164bff84e38f7344dfa4b5c264ae5f852882a496551e7e50375a7c0ece299e23ef9a8";
+      sha512 = "d6505da2a2686d4ca08eea71f6eed0079e30479b80bb3563fa8df023d7f9fa0bdc0fcdca4076730506ffeaa12eb76059b2586571ff9a9f09e8be94ffc303e218";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/ms/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/ms/firefox-67.0.2.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "13dfec3a0d9b4702c2b4a36930b026147503e96f529d6dbb572a63c23bfeeebfb6b32c5e3dd164d8b958cf6dcd1f4723ad9559b55e739d0180663eefcc154c20";
+      sha512 = "5758f944f8ffbc464a24496e789eb228ec70fdf1196101a8880376fd04dcb03d3b197605d05cdef45eebdb4c1f48fe4741990fbe7f451c3d14497db748ab80d7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/my/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/my/firefox-67.0.2.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha512 = "27331a17b984970c7dfcbbb70b52ca88415a98423a2e318fc09f47fcbc11a15e4d46b93f4c1ec98df5e05e57498697323e4512c3b351082ab0fee5a295ed61d8";
+      sha512 = "2cf077adc1d37b32c02cc2862fbdb243a5488a89dde7f353ee1f0d74e225cca63aa71d4ef18897ab949ca476b7ad9d6e0b54f686f981fd275180f7de04393398";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/nb-NO/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/nb-NO/firefox-67.0.2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "6aa6cc3c22bc5a2e91fe299a9f8c031968d4cd8b746d7be8746a9406ca76c5fe267eb9c6b6534d4fd3f3a5b0bb58e5e89f83bb498a9cae60cddc1c1f8dd066ee";
+      sha512 = "6e4bf126c03a68ec324da82c840b586f2f64c58b4092b7c16df89529063703060b46d5e419aacb52b494c2125ec7c47fca4fcb31fe61d5385582996d2054c969";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/ne-NP/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/ne-NP/firefox-67.0.2.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha512 = "c94e55287576a50f1e40c42bddb40f7a58bba53232503c8931c0e147950ca72ec26f5a988158530761eadbe50efbd78088373a97e093cbe58660def1613b7f3a";
+      sha512 = "fdb6d568053d6906ff04410a951cea2c82f4c580a56ead4af811f3a974305b03eed4fa03d733b6045cb4359a5ce8423b0cb44701d2b45c1055c12f809d64f4b9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/nl/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/nl/firefox-67.0.2.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "0e2ced803ffe66a5a1265fcd386dc332b2e6f11e4bb8d3f73523f6264236a8e0c0734af57274f4daaee12b192464ff8391af5105fce973140b2b464097df888d";
+      sha512 = "88bfabe393482bb1a3945a945ac3388df79a9c1de386ccafcccd3d5590e9bcd0d105b8200c8bcfed06f3347dac39fc8c17248dfd342b455fd19373184271b18f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/nn-NO/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/nn-NO/firefox-67.0.2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "f164bebab52bcafbeb6421f554882895a4a437884a977a71a036e10e79095be25d70d62fd7de5f8b6f76b3fb123fe879f11afab57dc24b62f913000e1270c48a";
+      sha512 = "e51fae5d29e084b08828233df3b9e74a0b08bc3f1f6f77b7e13848f724ec98f9467213d712cf433928575a2f3a3fb3a8b1134eb0b1d777a8a41fc3eca80af5b5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/oc/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/oc/firefox-67.0.2.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha512 = "dd5bae84f71c8658511145f0055dadf63e1398875ee35073d80d38f8d9d4312ab197fa64d36462caf6f9f3f8d9460f20069ddec603d3f265e3fc9f1f2ce000fe";
+      sha512 = "53fb6a39aa04fc0344de9c4c55b7d04ac081794cff9dfc53cec7bcd6ffaed84f3bb33d626c3e8d78860f1014d8e9a7ec365339745c06a8d9a1d01f570e1c8fed";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/or/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/or/firefox-67.0.2.tar.bz2";
       locale = "or";
       arch = "linux-i686";
-      sha512 = "dbc8f653c70939f9fc7645470662f6f44571c61e3e4c2043f84589a5ef8f06a884f608a9808f0eda778fdd195e38c9e1f25e33a665d6fac05cbaea062ee76c80";
+      sha512 = "b06021935c6a9e3749f4470fcfd80c98271b1fd2be0938783d377a50313f91387bcaa5bee68bbe217a4af63c89dac639a00f1e3b2382b8d3352d5ba7067b69a5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/pa-IN/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/pa-IN/firefox-67.0.2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "a0c22e1b7eeeaff10be4874acdb5dd9057b19196a1ecd73f606a8a5140490db099561d4aab125c90ea87a91a003bf560c26d94049a24ad256a4bf48698e3a4f8";
+      sha512 = "dd2bbedbd02941f6d555beac331da953f54fb2a8d7021d3308a9820aedf505b366917525863d8300ca95bddeb281a15a07b0ea7e866c9efbff63060b2991ddf9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/pl/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/pl/firefox-67.0.2.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "c25686924cab8e24cecdc86fd4e498b3a54e8616ed4ef5f465fbb1be4e8f9391580fb19fb0eac28faa958b2492edba5bc8e8a0a89c5f79f3e54524da386b6b0c";
+      sha512 = "ed450c305893c3af235fa3fc7ccd76abdcf4d3b7845307a98e64c0b864330925b30df66f93a630559c838fe6d919b6aed79d33704513020ac462b2dd81e812f8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/pt-BR/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/pt-BR/firefox-67.0.2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "add60a7e876bc5ed1e27c4a7fea269b2375aed4b50c27f09e73c71f2b454f9df31fbfce5275287ca12aa8772a585cf8d27107b99ddd8f4f7dc8afebc884c1c53";
+      sha512 = "274ebd3f02014253865cf85221e04a1a770837d34395f6f1320fff9f84d91b3d6d216b0de2e9f3756eaffeaa07af14b5cf0fc54c9e4877f2bc2b76ebd9cfc237";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/pt-PT/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/pt-PT/firefox-67.0.2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "cfe6e1110d1b2b426bd6c93ed75631d6e8ea80405339c9d3736d3e38df39d31b982ebc745c3120d840e21fbe2fd4aaf599f721859484c112197f52b0d7fa69fc";
+      sha512 = "a0505e46b48f6e474fd6cb73e77012c2dfc8e1b25a94d4c9ecb56117e73ef43685960c3bc9bea157f81d417c9e0352ea12340a7cf6367ebed42cf2eb790366fa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/rm/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/rm/firefox-67.0.2.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "cf712dc160bce844cb586069ebb2566251054e552f52a3d88065f947e9e238f19bae8e0550e521b54b53cf3d3d0083afdba26cd5bd31b375f62ff8445886bdf9";
+      sha512 = "3b84e39e98b136cf69945c1888731e5d9e47374ca0e0e5b63612cd1b0f9b3080add05fa5a6921805f153810a633aab3b3c431766de4e4522c9f06ce4d6f634ef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/ro/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/ro/firefox-67.0.2.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "8b62528602991eed10bb448b0f705180c32179e8cb863654e2cb506add0a2e0e1e052e832c584cd6bfacd951d42bc5d20989ebe1700e9dc077a18d0720a9a4d3";
+      sha512 = "6ccd439d5e9b564449998c43368a69a5d8db8a52d3bc4b4f680f3bf1430d4b5a5b7b49f62c13ac80f9acd925b93e078a1086649ddf7b3685700089e29e7ff102";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/ru/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/ru/firefox-67.0.2.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "7905a139fc3d045c4abd6942843e70e8696d336693131eb0145c58ce764fee9825ed500c178244b90aa969be4a6d7b8ca67f40240eb426ed34515795da52a3a8";
+      sha512 = "d63d10a66f6a270dd3bcd12ab22af602a5f9a90558b3ddcfecbcc3e58c0497a48be68c92611c1fc0e58674a4664f9e7a0247072787e4227735cdb35578198758";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/si/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/si/firefox-67.0.2.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "df75784f36ebc0af036ad33faa58d664dcda1d38ae65739ecadef86f96e3a2f3ca8951df12fdf5db68e3fdd5749fd8309008fdc75329dc270b86c267e8d7d1ea";
+      sha512 = "39d403829cc1982c64f544feebbbc476bc45866f9b72b0e95f8a9e6aab9437f1d7e4a02a33f155bf33dd128d1257acfe0ba196647cd32f73db18a80b8c67fcef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/sk/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/sk/firefox-67.0.2.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "f3866c218c429b8ce888d576e7edc45a5737ac331a046df7d8dda890e0bbf26604cdb9775d90271d27f727e0122125ec96750cf4a768907521ce362bd26dffcf";
+      sha512 = "47a4638607acf215ebe2e01000f72089dcf269705525a4b866eddf32076a621461ffffae708177bdf52267e348101c06448de8c68814d8897fc044e367e749cc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/sl/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/sl/firefox-67.0.2.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "a6d9c0865feca9c7be0c916fca5a1c95f7dcd9c719ccde1bc7fc7cf1d8fd3c200e63bbb077d51c2106b50f87aef5d25d7860e4b0ab17f4ea6bb4a123a7bad5d6";
+      sha512 = "fee01b2c327b2c67c44ee8bdd6de277a2f4c56e4626ad42fb4bd83e1b42eb8d21e5f4c189584c5e9df4b16749bbc85f52a0ad3751f4f998adb131844419412e4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/son/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/son/firefox-67.0.2.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha512 = "db1e261dcf06c28dc012cc8481638c27b043e1f139fa279e4f5b386dfeb0f50bc622b4719eb2cb1303f51bfce269be9bc4cafa2a414615f0fc1ebd6988be5ebb";
+      sha512 = "72ecfbfca6a40830567e5b7d657d1bd015bd354a01042caa77f268496c500836aa9358707eb1e988ae8a33d7c20daa880adea6f4b4be3df7548f8aea9e41a767";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/sq/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/sq/firefox-67.0.2.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "c22b22e4536f663bab35ae225708007fa3884e6989ba8d1718adc1d7ddf5b5a8d1978e6a3081c06b7c8f0ac85de76e1a5859a7bec1df48353dec1f53ce9bb962";
+      sha512 = "821eaaa3bf2cdb2077aca4ff6fe6380fef6e114e0ee91c262824a859ef04387d0c42723df4eda3422980b2e719a5ecffa660579a2f30d26874115dee39cdb0bf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/sr/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/sr/firefox-67.0.2.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "a199b82892a3c3d6828c1d56accef2c8e21989fd5b7827bab8d90d11d54fd950c71d3111e40994a06404609c70c7e2fec2b4501c3c3bb0f873be44cb1af5ea3d";
+      sha512 = "5c845bc0ccb92a1ca88f2b18f7a57e4372f3d8084898d432cdbe4386cf9cdb94d9c6d210d9c58a05688a0de59fdab3c4f50814f53d67632ee577d9e4b95da380";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/sv-SE/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/sv-SE/firefox-67.0.2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "ab594ddd887ae833bf74dc6b70f4c0f25020261baa4f56182fc173a90af2991f103bfd197706a118cc0db418f31f78b392d6509fe788ca03510ce29a362f8349";
+      sha512 = "ffb3490701ec8dc6cba11f6f47cf744d55ea3a4a49d74a0af58c2cd9feaf3bfd95937c1cf401bd105a1ec31c089eec4f41c582d1a17d05dd4210346074d40d64";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/ta/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/ta/firefox-67.0.2.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha512 = "12c52a221e1e5f797f9b5cbe09bd34d477f7aa041aeb7d8b20a45324a5c9ebf36358e5abab9eebd63f696877af8537a08d4f0ac0aa45521c950a87085840eb91";
+      sha512 = "4287b589b22da8bfee1e1112c1aed8f79b668c992d95ea3913def1eb9c57c1a1bc8e109f99f93b04e100b94303f0b379d6cb569f8d65f925ba6047aa82af9373";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/te/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/te/firefox-67.0.2.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha512 = "9eeef96092912e2bf0208dd1eb6a6fc79a263db51da5085a800076aa58b9f3b8c5da01516f8f08a108e77f02280240fdbe3a20da4300f39c934c242dfa826186";
+      sha512 = "9f2def6472474500d38e2ed7325d22f5af44dadfd8aa713e456df47b38fb2ecbe9a1ef00f1b2e2a35b9e38f9098c532ad53dece54167eb23d0c78d73ceebb812";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/th/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/th/firefox-67.0.2.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha512 = "3f3be2d5171f4eefd24dc25098ac456786dea0d6b99bae5f7239ef00cc1fae2a09893999d22c9ed6a7c5caffb86193e4306e7a229b3e8d2935b4bb49f489ce06";
+      sha512 = "565e37686beedcb51d104d73b1b06a5efa1c651e3a701adcf26f44a692cbce4d3069a5a9f88217f95de5974943d292ecf2d2d39922ffeef07ebfcba984aac28f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/tr/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/tr/firefox-67.0.2.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "daf55b4a04ee9e4fbd71fb4c99a31b7f5b6d32024609b20c323d75a8ec3f76f88388b97fa61d314616dce50c58c1716a1b75269dd599e9d6c208daa6fbe7632b";
+      sha512 = "6c8901310a7352c2f65a65cf59ca8cebdc4db97d6f61f726a6e8b4c8ac21855ead17c5342681d8b8a04cb533d7f00d6891b4366ba846fe5688f633a098c5658b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/uk/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/uk/firefox-67.0.2.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "983addb3688266015fb6dd81f1b28d5e3e6be2c2e98a205ccb536a54e586f684d02977e23990c1637ea4115606345c40b622109e81d9d3c666358d05411a20b7";
+      sha512 = "1f1a3c6955c8b1fd38fb478428fd71ec3c4767cc1950531f28262caecc831c703e4257483e3530771fcc830d03e007476de48e6d36d550e59e2e51fbfb394388";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/ur/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/ur/firefox-67.0.2.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha512 = "c73830b65aad9178232beb85232d51d99c45fd63c8edd0449a10cac28131d1c7ccea9957893fbd675481e3bf104c5d44176001086dd7b5f0185d2bcce16a3430";
+      sha512 = "d10a8381fc0a0cb249fd4fd1bd149368ed460bf2d9c92e28c3403b215dbbaab11bd98f8eec8c96d381ebc6721a3a261ae79ad4471c31ecbe3f5357aa859156f4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/uz/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/uz/firefox-67.0.2.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "31e18f7dc6dd8f2d3e1776a6c1ce15a331c0d6c2e059404f64348452bcdcd7d9323c0922edb2b190816db03ef6d91d50c825e56ae0d6766061a5501bd7818cd7";
+      sha512 = "d46a56a1a272d1d803cb7910875829d25e0630d95befdd92dabbc77f470b65b5e0283738b91e3fbefa34a324131f37eb85fcc99a5a82be59a6c7363b07953f41";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/vi/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/vi/firefox-67.0.2.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "11cbe72844a1b1f98231a4ab5a1e4037021a1a8a1ddd76dbb7819825ae40f2f9184b1de694ebaf751ce8f4814781dbb74033d186eaaa3cfbf19cfab2a98a3251";
+      sha512 = "b83b27030ffd3b8f59c0fee240b87c23af1ea04652587de62d50f29ea267a8e99024ce07449aa8a24ed565368574abcc483a059d8694a75b56370198fead8569";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/xh/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/xh/firefox-67.0.2.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha512 = "4790f698b72776309abcf65842caa79badc943fe65015eb0954c9c982870429f0eb66899c210069a41b464e15278f98e756ce27a2573db2568b38ad5baf9c575";
+      sha512 = "4e04a016a50152d533ac3c2957c7a8254b809e8642a771972b26844ff3cc541d9e016c079f56ce44a1474b8efcf1cfc69ee778cb55acdee7f8ac76a937d92edd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/zh-CN/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/zh-CN/firefox-67.0.2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "68d2d7f8bf4c423f8c81e1fffd08e7753fe1cf3e22be95b6f1fa168dea23c7a04a13fa3406cd1f11cbccdb391e8da4a5ef9d32163b6318a445be8953bb7e75bc";
+      sha512 = "24da20d0c14062827db8cddeb4960390f0afc32e7cac1374282e13f0c8d1ddc14a0a5ad130a22083973da52f26b4a222c77ad7b604293bad6badd8b629649e99";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.1/linux-i686/zh-TW/firefox-67.0.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.2/linux-i686/zh-TW/firefox-67.0.2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "01cbbe12dc54e4f23b124adfe825106054840b06b25f91f7c7540303808505c9d645db56172457bae6852c9c88831f3f4a068e06db404ea6f2db9a67f3c67e1f";
+      sha512 = "dbec0311c4709ebc28b4d13caa822cb4d93409369ce1bca883d70e16ec48447e1ced908ffaeac4d89c8b2313b24a223fa21b31666c82777a7ae33867c3a018d3";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -17,10 +17,10 @@ rec {
 
   firefox = common rec {
     pname = "firefox";
-    ffversion = "67.0.1";
+    ffversion = "67.0.2";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${ffversion}/source/firefox-${ffversion}.source.tar.xz";
-      sha512 = "1cbhlbgni08phqqiqlh1c29kl8b1w2sify4756bm4a01hmhfnhgwfa6v88vhzqy9h4c0045g8g4w14l2521k8w6rcijl1nvh14xdczf";
+      sha512 = "289bhd8ynanb2zpclzaqqyz4082w529kcf3fd7li3k4pn0ayvkxfv4kmmhfz4xxrwsx6f489ffcj9a48ckk1czi9kykvj3i6ni0mnhl";
     };
 
     patches = [


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

- Bug fixes

https://www.mozilla.org/en-US/firefox/67.0.2/releasenotes/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Tested only `firefox-bin`. `firefox` is being built.

---
