### PR TITLE
google-cloud-sdk: kubeconfig: don't store absolute path to gcloud binary

### DIFF
--- a/pkgs/tools/admin/google-cloud-sdk/default.nix
+++ b/pkgs/tools/admin/google-cloud-sdk/default.nix
@@ -36,16 +36,15 @@ in stdenv.mkDerivation rec {
 
   buildInputs = [ python makeWrapper ];
 
-  phases = [ "installPhase" "fixupPhase" ];
+  doBuild = false;
+
 
   installPhase = ''
-    mkdir -p "$out"
-    tar -xzf "$src" -C "$out" google-cloud-sdk
+    mkdir -p $out/google-cloud-sdk
+    cp -R * .install $out/google-cloud-sdk/
 
-    mkdir $out/google-cloud-sdk/lib/surface/alpha
+    mkdir -p $out/google-cloud-sdk/lib/surface/{alpha,beta}
     cp ${./alpha__init__.py} $out/google-cloud-sdk/lib/surface/alpha/__init__.py
-
-    mkdir $out/google-cloud-sdk/lib/surface/beta
     cp ${./beta__init__.py} $out/google-cloud-sdk/lib/surface/beta/__init__.py
 
     # create wrappers with correct env
@@ -68,8 +67,8 @@ in stdenv.mkDerivation rec {
     disable_update_check = true" >> $out/google-cloud-sdk/properties
 
     # setup bash completion
-    mkdir -p "$out/etc/bash_completion.d/"
-    mv "$out/google-cloud-sdk/completion.bash.inc" "$out/etc/bash_completion.d/gcloud.inc"
+    mkdir -p $out/etc/bash_completion.d
+    mv $out/google-cloud-sdk/completion.bash.inc $out/etc/bash_completion.d/gcloud.inc
 
     # This directory contains compiled mac binaries. We used crcmod from
     # nixpkgs instead.

--- a/pkgs/tools/admin/google-cloud-sdk/default.nix
+++ b/pkgs/tools/admin/google-cloud-sdk/default.nix
@@ -38,6 +38,9 @@ in stdenv.mkDerivation rec {
 
   doBuild = false;
 
+  patches = [
+    ./gcloud-path.patch
+  ];
 
   installPhase = ''
     mkdir -p $out/google-cloud-sdk

--- a/pkgs/tools/admin/google-cloud-sdk/gcloud-path.patch
+++ b/pkgs/tools/admin/google-cloud-sdk/gcloud-path.patch
@@ -1,0 +1,47 @@
+From b69fee70154a861637c82e98e18be01bbb96423b Mon Sep 17 00:00:00 2001
+From: Florian Klink <flokli@flokli.de>
+Date: Wed, 12 Jun 2019 17:03:09 +0200
+Subject: [PATCH] kubeconfig: don't store absolute path to gcloud binary
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The `gcloud beta container clusters get-credentials $cluster \
+--region $region --project $project`
+command can be used to write kubectl config files.
+
+In that file, normally the absolute path to the `gcloud` binary is
+stored.
+
+This is a bad idea in NixOS. We might eventually garbage-collect that
+specific gcloud binary - and in general, would expect a nix-shell
+provided gcloud to be used.
+
+In its current state, token renewal would just start to break with the
+following error message:
+
+Unable to connect to the server: error executing access token command "/nix/store/…/gcloud config config-helper --format=json": err=fork/exec /nix/store/…/gcloud: no such file or directory output= stderr=
+
+Avoid this by storing just `gcloud` inside `cmd-path`, which causes
+kubectl to lookup the gcloud command from $PATH, which is more likely to
+keep working.
+---
+ lib/googlecloudsdk/api_lib/container/kubeconfig.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/googlecloudsdk/api_lib/container/kubeconfig.py b/lib/googlecloudsdk/api_lib/container/kubeconfig.py
+index 4330988d6..37424b841 100644
+--- a/lib/googlecloudsdk/api_lib/container/kubeconfig.py
++++ b/lib/googlecloudsdk/api_lib/container/kubeconfig.py
+@@ -255,7 +255,7 @@ def _AuthProvider(name='gcp'):
+       raise Error(SDK_BIN_PATH_NOT_FOUND)
+     cfg = {
+         # Command for gcloud credential helper
+-        'cmd-path': os.path.join(sdk_bin_path, bin_name),
++        'cmd-path': bin_name,
+         # Args for gcloud credential helper
+         'cmd-args': 'config config-helper --format=json',
+         # JSONpath to the field that is the raw access token
+-- 
+2.21.0
+


### PR DESCRIPTION
###### Motivation for this change
I got bitten too often by a hardcoded and disappearing path to `gcloud` in the kubectl config.

This PR fixes the google-cloud-sdk derivation to allow to apply patches on top of it, then patches google-cloud-sdk to not store absolute paths in configuration files.

Description from that patch:

> The `gcloud beta container clusters get-credentials $cluster \
> --region $region --project $project`
> command can be used to write kubectl config files.
> 
> In that file, normally the absolute path to the `gcloud` binary is
> stored.
> 
> This is a bad idea in NixOS. We might eventually garbage-collect that
> specific gcloud binary - and in general, would expect a nix-shell
> provided gcloud to be used.
> 
> In its current state, token renewal would just start to break with the
> following error message:
> 
> Unable to connect to the server: error executing access token command "/nix/store/…/gcloud config config-helper --format=json": err=fork/exec /nix/store/…/gcloud: no such file or directory output= stderr=
> 
> Avoid this by storing just `gcloud` inside `cmd-path`, which causes
> kubectl to lookup the gcloud command from $PATH, which is more likely to
> keep working.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- x ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @arianvp 