### PR TITLE
brave: 0.61.50 -> 0.65.118

### DIFF
--- a/pkgs/applications/networking/browsers/brave/default.nix
+++ b/pkgs/applications/networking/browsers/brave/default.nix
@@ -14,6 +14,7 @@
 , glib
 , gnome2
 , gnome3
+, gsettings-desktop-schemas
 , gtk3
 , libuuid
 , libX11
@@ -37,114 +38,118 @@
 , wrapGAppsHook
 }:
 
-let rpath = lib.makeLibraryPath [
-    alsaLib
-    at-spi2-atk
-    at-spi2-core
-    atk
-    cairo
-    cups
-    dbus
-    expat
-    fontconfig
-    freetype
-    gdk_pixbuf
-    glib
-    gnome2.GConf
-    gtk3
-    libX11
-    libXScrnSaver
-    libXcomposite
-    libXcursor
-    libXdamage
-    libXext
-    libXfixes
-    libXi
-    libXrandr
-    libXrender
-    libXtst
-    libuuid
-    nspr
-    nss
-    pango
-    udev
-    xdg_utils
-    xorg.libxcb
-    zlib
+let
+
+rpath = lib.makeLibraryPath [
+  alsaLib
+  at-spi2-atk
+  at-spi2-core
+  atk
+  cairo
+  cups
+  dbus
+  expat
+  fontconfig
+  freetype
+  gdk_pixbuf
+  glib
+  gnome2.GConf
+  gtk3
+  libX11
+  libXScrnSaver
+  libXcomposite
+  libXcursor
+  libXdamage
+  libXext
+  libXfixes
+  libXi
+  libXrandr
+  libXrender
+  libXtst
+  libuuid
+  nspr
+  nss
+  pango
+  udev
+  xdg_utils
+  xorg.libxcb
+  zlib
 ];
 
+in
 
-in stdenv.mkDerivation rec {
-    pname = "brave";
-    version = "0.61.50";
+stdenv.mkDerivation rec {
+  pname = "brave";
+  version = "0.65.118";
 
-    src = fetchurl {
-        url = "https://github.com/brave/brave-browser/releases/download/v${version}/brave-browser_${version}_amd64.deb";
-        sha256 = "1lbajxnxqkd422rckfjm65pwwzl66v7anq4jrzxi29d5x7abl3c1";
-    };
+  src = fetchurl {
+    url = "https://github.com/brave/brave-browser/releases/download/v${version}/brave-browser_${version}_amd64.deb";
+    sha256 = "13bihzf4yfgn01nrw780swhmcdh8gq71jqilhbi04jn1h1pbm3wg";
+  };
 
-    dontConfigure = true;
-    dontBuild = true;
-    dontPatchELF = true;
+  dontConfigure = true;
+  dontBuild = true;
+  dontPatchELF = true;
 
-    nativeBuildInputs = [ dpkg wrapGAppsHook ];
+  nativeBuildInputs = [ dpkg wrapGAppsHook ];
 
-    buildInputs = [ glib gnome3.gsettings_desktop_schemas gnome3.adwaita-icon-theme ];
+  buildInputs = [ glib gsettings-desktop-schemas gnome3.adwaita-icon-theme ];
 
-    unpackPhase = "dpkg-deb --fsys-tarfile $src | tar -x --no-same-permissions --no-same-owner";
+  unpackPhase = "dpkg-deb --fsys-tarfile $src | tar -x --no-same-permissions --no-same-owner";
 
-    installPhase = ''
-        mkdir -p $out $out/bin
+  installPhase = ''
+      mkdir -p $out $out/bin
 
-        cp -R usr/share $out
-        cp -R opt/ $out/opt
+      cp -R usr/share $out
+      cp -R opt/ $out/opt
 
-        export BINARYWRAPPER=$out/opt/brave.com/brave/brave-browser
+      export BINARYWRAPPER=$out/opt/brave.com/brave/brave-browser
 
-        # Fix path to bash in $BINARYWRAPPER
-        substituteInPlace $BINARYWRAPPER \
-            --replace /bin/bash ${stdenv.shell}
+      # Fix path to bash in $BINARYWRAPPER
+      substituteInPlace $BINARYWRAPPER \
+          --replace /bin/bash ${stdenv.shell}
 
-        ln -sf $BINARYWRAPPER $out/bin/brave
+      ln -sf $BINARYWRAPPER $out/bin/brave
 
-        patchelf \
-            --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-            --set-rpath "${rpath}" $out/opt/brave.com/brave/brave
+      patchelf \
+          --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+          --set-rpath "${rpath}" $out/opt/brave.com/brave/brave
 
-        # Fix paths
-        substituteInPlace $out/share/applications/brave-browser.desktop \
-            --replace /usr/bin/brave-browser $out/bin/brave
-        substituteInPlace $out/share/gnome-control-center/default-apps/brave-browser.xml \
-            --replace /opt/brave.com $out/opt/brave.com
-        substituteInPlace $out/share/menu/brave-browser.menu \
-            --replace /opt/brave.com $out/opt/brave.com
-        substituteInPlace $out/opt/brave.com/brave/default-app-block \
-            --replace /opt/brave.com $out/opt/brave.com
+      # Fix paths
+      substituteInPlace $out/share/applications/brave-browser.desktop \
+          --replace /usr/bin/brave-browser $out/bin/brave
+      substituteInPlace $out/share/gnome-control-center/default-apps/brave-browser.xml \
+          --replace /opt/brave.com $out/opt/brave.com
+      substituteInPlace $out/share/menu/brave-browser.menu \
+          --replace /opt/brave.com $out/opt/brave.com
+      substituteInPlace $out/opt/brave.com/brave/default-app-block \
+          --replace /opt/brave.com $out/opt/brave.com
 
-        # Correct icons location
-        icon_sizes=("16" "22" "24" "32" "48" "64" "128" "256")
+      # Correct icons location
+      icon_sizes=("16" "22" "24" "32" "48" "64" "128" "256")
 
-        for icon in ''${icon_sizes[*]}
-        do
-            mkdir -p $out/share/icons/hicolor/$icon\x$icon/apps
-            ln -s $out/opt/brave.com/brave/product_logo_$icon.png $out/share/icons/hicolor/$icon\x$icon/apps/brave-browser.png
-        done
+      for icon in ''${icon_sizes[*]}
+      do
+          mkdir -p $out/share/icons/hicolor/$icon\x$icon/apps
+          ln -s $out/opt/brave.com/brave/product_logo_$icon.png $out/share/icons/hicolor/$icon\x$icon/apps/brave-browser.png
+      done
 
-        # Replace xdg-settings and xdg-mime
-        ln -sf ${xdg_utils}/bin/xdg-settings $out/opt/brave.com/brave/xdg-settings
-        ln -sf ${xdg_utils}/bin/xdg-mime $out/opt/brave.com/brave/xdg-mime
+      # Replace xdg-settings and xdg-mime
+      ln -sf ${xdg_utils}/bin/xdg-settings $out/opt/brave.com/brave/xdg-settings
+      ln -sf ${xdg_utils}/bin/xdg-mime $out/opt/brave.com/brave/xdg-mime
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://brave.com/";
+    description = "Privacy-oriented browser for Desktop and Laptop computers";
+    changelog = "https://github.com/brave/brave-browser/blob/v${version}/CHANGELOG.md";
+    longDescription = ''
+      Brave browser blocks the ads and trackers that slow you down,
+      chew up your bandwidth, and invade your privacy. Brave lets you
+      contribute to your favorite creators automatically.
     '';
-
-    meta = with stdenv.lib; {
-        homepage = "https://brave.com/";
-        description = "Privacy-oriented browser for Desktop and Laptop computers";
-        longDescription = ''
-          Brave browser blocks the ads and trackers that slow you down,
-          chew up your bandwidth, and invade your privacy. Brave lets you
-          contribute to your favorite creators automatically.
-        '';
-        license = licenses.mpl20;
-        maintainers = [ maintainers.uskudnik ];
-        platforms = [ "x86_64-linux" ];
-    };
+    license = licenses.mpl20;
+    maintainers = [ maintainers.uskudnik ];
+    platforms = [ "x86_64-linux" ];
+  };
 }


### PR DESCRIPTION
Also corrects indentation and adds changelog meta attribute.

https://github.com/brave/brave-browser/blob/v0.65.118/CHANGELOG.md

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Fixes https://github.com/NixOS/nixpkgs/issues/63032 though the more subtle issue here is that the version information for this package at [repology](https://repology.org/project/brave/versions) is incorrect.
Where `0.67.72` is reported as the latest but it should be tracking stable releases at `0.65.x`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
