### PR TITLE
eksctl: init at 0.1.35

### DIFF
--- a/pkgs/tools/admin/eksctl/default.nix
+++ b/pkgs/tools/admin/eksctl/default.nix
@@ -1,0 +1,40 @@
+{ lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  pname = "eksctl";
+  version = "0.1.35";
+
+  src = fetchFromGitHub {
+    owner = "weaveworks";
+    repo = "eksctl";
+    rev = version;
+    sha256 = "0b3s7vh85k68wawmsdp96q9l4yhikwhyjn1c7cwxys0aia4i8wkv";
+  };
+
+  goPackagePath = "github.com/weaveworks/eksctl";
+
+  subPackages = [ "cmd/eksctl" ];
+
+  buildFlags =
+  ''
+    -ldflags=-s
+    -ldflags=-w
+    -tags netgo
+    -tags release
+  '';
+
+  postInstall =
+  ''
+    mkdir -p "$bin/share/"{bash-completion/completions,zsh/site-functions}
+    $bin/bin/eksctl completion bash > "$bin/share/bash-completion/completions/eksctl"
+    $bin/bin/eksctl completion zsh > "$bin/share/zsh/site-functions/_eksctl"
+  '';
+
+  meta = with lib; {
+    description = "A CLI for Amazon EKS";
+    homepage = "https://github.com/weaveworks/eksctl";
+    license = licenses.asl20;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ xrelkd ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1465,6 +1465,8 @@ in
 
   eggdrop = callPackage ../tools/networking/eggdrop { };
 
+  eksctl = callPackage ../tools/admin/eksctl { };
+
   elementary-xfce-icon-theme = callPackage ../data/icons/elementary-xfce-icon-theme { };
 
   ell = callPackage ../os-specific/linux/ell { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

`eksctl` is a CLI for Amazon EKS 
https://eksctl.io
https://github.com/weaveworks/eksctl

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
