### PR TITLE
waf: Added support for optional extra tools

### DIFF
--- a/pkgs/development/tools/build-managers/waf/default.nix
+++ b/pkgs/development/tools/build-managers/waf/default.nix
@@ -1,5 +1,11 @@
-{ stdenv, fetchFromGitLab, fetchpatch, python, ensureNewerSourcesForZipFilesHook }:
-
+{ stdenv, fetchFromGitLab, fetchpatch, python, ensureNewerSourcesForZipFilesHook
+# optional list of extra waf tools, e.g. `[ "doxygen" "pytest" ]`
+, withTools ? null
+}:
+let
+  wafToolsArg = with stdenv.lib.strings;
+    optionalString (!isNull withTools) "--tools=\"${concatStringsSep "," withTools}\"";
+in
 stdenv.mkDerivation rec {
   name = "waf-${version}";
   version = "2.0.14";
@@ -24,7 +30,7 @@ stdenv.mkDerivation rec {
     python waf-light configure
   '';
   buildPhase = ''
-    python waf-light build
+    python waf-light build ${wafToolsArg}
   '';
   installPhase = ''
     install waf $out

--- a/pkgs/development/tools/build-managers/waf/default.nix
+++ b/pkgs/development/tools/build-managers/waf/default.nix
@@ -4,7 +4,7 @@
 }:
 let
   wafToolsArg = with stdenv.lib.strings;
-    optionalString (!isNull withTools) "--tools=\"${concatStringsSep "," withTools}\"";
+    optionalString (!isNull withTools) " --tools=\"${concatStringsSep "," withTools}\"";
 in
 stdenv.mkDerivation rec {
   name = "waf-${version}";
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     python waf-light configure
   '';
   buildPhase = ''
-    python waf-light build ${wafToolsArg}
+    python waf-light build${wafToolsArg}
   '';
   installPhase = ''
     install waf $out


### PR DESCRIPTION
The list of tools `withTools` are included as extra tools when building waf.

Example:

    mywaf = callPackage ../development/tools/build-managers/waf {
      python = python3;
      withTools = [ "doxygen" ];
    };

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

waf carries many extra tools (under `waflib/extras`) that are not included by default. This PR enables users to create a waf version with a selection of these extra tools using `withTools` .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions (CentOS 7.4)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
- [x] Tested on local waf project
---
