### PR TITLE
winePackages.fonts: init at 4.0

### DIFF
--- a/pkgs/misc/emulators/wine/base.nix
+++ b/pkgs/misc/emulators/wine/base.nix
@@ -114,8 +114,8 @@ stdenv.mkDerivation ((lib.optionalAttrs (buildScript != null) {
   passthru = { inherit pkgArches; };
   meta = {
     inherit version platforms;
-    homepage = http://www.winehq.org/;
-    license = "LGPL";
+    homepage = "https://www.winehq.org/";
+    license = with stdenv.lib.licenses; [ lgpl21Plus ];
     description = "An Open Source implementation of the Windows API on top of X, OpenGL, and Unix";
     maintainers = with stdenv.lib.maintainers; [ avnik raskin bendlas ];
   };

--- a/pkgs/misc/emulators/wine/fonts.nix
+++ b/pkgs/misc/emulators/wine/fonts.nix
@@ -1,0 +1,22 @@
+{ stdenv, lib, callPackage }:
+let src = (callPackage ./sources.nix {}).stable;
+in
+stdenv.mkDerivation {
+  pname = "wine-fonts";
+  inherit (src) version;
+
+  sourceRoot = "wine-${src.version}/fonts";
+  inherit src;
+
+  installPhase = ''
+    install *.ttf -Dt $out/share/fonts/wine
+  '';
+
+  meta = {
+    description = "Microsoft replacement fonts by the Wine project";
+    homepage = "https://wiki.winehq.org/Create_Fonts";
+    license = with lib.licenses; [ lgpl21Plus ];
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ avnik raskin bendlas johnazoidberg ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23918,7 +23918,7 @@ in
     inherit wineBuild;
 
     inherit (callPackage ./wine-packages.nix {})
-      minimal base full stable unstable staging;
+      minimal base full stable unstable staging fonts;
   });
 
   winePackages = recurseIntoAttrs (winePackagesFor (config.wine.build or "wine32"));

--- a/pkgs/top-level/wine-packages.nix
+++ b/pkgs/top-level/wine-packages.nix
@@ -1,6 +1,7 @@
 { stdenv, config, callPackage, wineBuild }:
 
 rec {
+  fonts = callPackage ../misc/emulators/wine/fonts.nix {};
   minimal = callPackage ../misc/emulators/wine {
     wineRelease = config.wine.release or "stable";
     inherit wineBuild;


### PR DESCRIPTION
###### Motivation for this change
> Wine's fonts should be a natural candidate for their own subpackage

https://wiki.winehq.org/Packaging

They are a replacement for some Microsoft fonts not available in other
replacement packages, e.g. Tahoma.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
