### PR TITLE
gitlab: 11.10.4 -> 11.10.5

### DIFF
--- a/pkgs/applications/version-management/gitlab/data.json
+++ b/pkgs/applications/version-management/gitlab/data.json
@@ -1,12 +1,12 @@
 {
   "ce": {
-    "version": "11.10.4",
-    "repo_hash": "02rvf5ikahydswjldzg99k8han051ap7v8h9mcjgrr4xmj301hxm",
-    "deb_hash": "0sigpp5lhg4pl88gsgf7dq2k7mi2wgaz0vdsl25c97w1daw7a60c",
-    "deb_url": "https://packages.gitlab.com/gitlab/gitlab-ce/packages/debian/stretch/gitlab-ce_11.10.4-ce.0_amd64.deb/download.deb",
+    "version": "11.10.5",
+    "repo_hash": "00bkdylcnz171jf8di05ygviplqzssazrfaqpwmbqwdjab2ax4yr",
+    "deb_hash": "1zsg4fhpl07pz76i4yynk38xs7cp9w4jcryxk7larbr25m48q4rb",
+    "deb_url": "https://packages.gitlab.com/gitlab/gitlab-ce/packages/debian/stretch/gitlab-ce_11.10.5-ce.0_amd64.deb/download.deb",
     "owner": "gitlab-org",
     "repo": "gitlab-ce",
-    "rev": "v11.10.4",
+    "rev": "v11.10.5",
     "passthru": {
       "GITALY_SERVER_VERSION": "1.34.1",
       "GITLAB_PAGES_VERSION": "1.5.0",
@@ -15,13 +15,13 @@
     }
   },
   "ee": {
-    "version": "11.10.4",
-    "repo_hash": "06nf94k0ay9kmx060j387hydyf6crv0f1pjb691r3y6s713m6php",
-    "deb_hash": "1g0mlyzm2ikpblmy529wg6az5biiqczpr3kyp2mk4yjkdvg59jjp",
-    "deb_url": "https://packages.gitlab.com/gitlab/gitlab-ee/packages/debian/stretch/gitlab-ee_11.10.4-ee.0_amd64.deb/download.deb",
+    "version": "11.10.5",
+    "repo_hash": "0nla908l3513r87i3x2fa87j48wgykzpf7cqxddnahk98m0wgxvi",
+    "deb_hash": "02ri9b4xd77wqjnd49h5n77aylrb5xlq6xa26xn39kl326isaj41",
+    "deb_url": "https://packages.gitlab.com/gitlab/gitlab-ee/packages/debian/stretch/gitlab-ee_11.10.5-ee.0_amd64.deb/download.deb",
     "owner": "gitlab-org",
     "repo": "gitlab-ee",
-    "rev": "v11.10.4-ee",
+    "rev": "v11.10.5-ee",
     "passthru": {
       "GITALY_SERVER_VERSION": "1.34.1",
       "GITLAB_PAGES_VERSION": "1.5.0",


### PR DESCRIPTION
###### Motivation for this change

Security update to 11.10.5

https://about.gitlab.com/2019/06/03/security-release-gitlab-11-dot-11-dot-1-released/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
