### PR TITLE
cloud-nuke: init at 0.1.7

### DIFF
--- a/pkgs/development/tools/cloud-nuke/default.nix
+++ b/pkgs/development/tools/cloud-nuke/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  pname = "cloud-nuke";
+  version = "0.1.7";
+
+  src = fetchFromGitHub {
+    owner = "gruntwork-io";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "054z6v13x55x9l5xnixxxszj8k2wa09b5ld2wq4gm4hc273s2m4k";
+  };
+
+  goPackagePath = "github.com/gruntwork-io/cloud-nuke";
+
+  goDeps = ./deps.nix;
+
+  meta = with lib; {
+    homepage = "https://github.com/gruntwork-io/cloud-nuke";
+    description = "A tool for cleaning up your cloud accounts by nuking (deleting) all resources within it";
+    license = licenses.mit;
+    maintainers = [ maintainers.marsam ];
+  };
+}

--- a/pkgs/development/tools/cloud-nuke/deps.nix
+++ b/pkgs/development/tools/cloud-nuke/deps.nix
@@ -1,0 +1,138 @@
+# file generated from Gopkg.lock using dep2nix (https://github.com/nixcloud/dep2nix)
+[
+  {
+    goPackagePath  = "github.com/aws/aws-sdk-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/aws/aws-sdk-go";
+      rev =  "180cc10e5ff368b86dee226b034af7d1672baec6";
+      sha256 = "0xphkjqhcn8zq7gali0v32kq2xpbnnw1g7r5vr5p763q2z5c436w";
+    };
+  }
+  {
+    goPackagePath  = "github.com/bgentry/speakeasy";
+    fetch = {
+      type = "git";
+      url = "https://github.com/bgentry/speakeasy";
+      rev =  "4aabc24848ce5fd31929f7d1e4ea74d3709c14cd";
+      sha256 = "02dfrj0wyphd3db9zn2mixqxwiz1ivnyc5xc7gkz58l5l27nzp8s";
+    };
+  }
+  {
+    goPackagePath  = "github.com/davecgh/go-spew";
+    fetch = {
+      type = "git";
+      url = "https://github.com/davecgh/go-spew";
+      rev =  "346938d642f2ec3594ed81d874461961cd0faa76";
+      sha256 = "0d4jfmak5p6lb7n2r6yvf5p1zcw0l8j74kn55ghvr7zr7b7axm6c";
+    };
+  }
+  {
+    goPackagePath  = "github.com/fatih/color";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fatih/color";
+      rev =  "570b54cabe6b8eb0bc2dfce68d964677d63b5260";
+      sha256 = "1hw9hgkfzbzqjhy29pqpk20xggxaqjv45wx8yn69488mw5ph7khh";
+    };
+  }
+  {
+    goPackagePath  = "github.com/go-errors/errors";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-errors/errors";
+      rev =  "d98b870cc4e05f1545532a80e9909be8216095b6";
+      sha256 = "1skj4vh9h7c5lk1pw8y6740w2k99z398jl0aasn63x83viqjf1zw";
+    };
+  }
+  {
+    goPackagePath  = "github.com/gruntwork-io/gruntwork-cli";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gruntwork-io/gruntwork-cli";
+      rev =  "94044eeeb0a48b5e8dd52190fa0d0daba53e157f";
+      sha256 = "1x6g2s4f66c4pb8dwvjnj4i70ik43ak2x189v2ys218nz4zkjs74";
+    };
+  }
+  {
+    goPackagePath  = "github.com/jmespath/go-jmespath";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jmespath/go-jmespath";
+      rev =  "0b12d6b5";
+      sha256 = "1vv6hph8j6xgv7gwl9vvhlsaaqsm22sxxqmgmldi4v11783pc1ld";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mattn/go-colorable";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-colorable";
+      rev =  "167de6bfdfba052fa6b2d3664c8f5272e23c9072";
+      sha256 = "1nwjmsppsjicr7anq8na6md7b1z84l9ppnlr045hhxjvbkqwalvx";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mattn/go-isatty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-isatty";
+      rev =  "0360b2af4f38e8d38c7fce2a9f4e702702d73a39";
+      sha256 = "06w45aqz2a6yrk25axbly2k5wmsccv8cspb94bfmz4izvw8h927n";
+    };
+  }
+  {
+    goPackagePath  = "github.com/pmezard/go-difflib";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pmezard/go-difflib";
+      rev =  "792786c7400a136282c1664665ae0a8db921c6c2";
+      sha256 = "0c1cn55m4rypmscgf0rrb88pn58j3ysvc2d0432dp3c6fqg6cnzw";
+    };
+  }
+  {
+    goPackagePath  = "github.com/sirupsen/logrus";
+    fetch = {
+      type = "git";
+      url = "https://github.com/sirupsen/logrus";
+      rev =  "d682213848ed68c0a260ca37d6dd5ace8423f5ba";
+      sha256 = "0nzyqwzx3k7nqfq8q7yv32gaf3ymq3bpwhkmw1hj2zakq5a93d8x";
+    };
+  }
+  {
+    goPackagePath  = "github.com/stretchr/testify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/testify";
+      rev =  "b91bfb9ebec76498946beb6af7c0230c7cc7ba6c";
+      sha256 = "178xyfgsbs40jq406aqj0r67ik1b81gdc28z45nbcw6hfhz82rvl";
+    };
+  }
+  {
+    goPackagePath  = "github.com/urfave/cli";
+    fetch = {
+      type = "git";
+      url = "https://github.com/urfave/cli";
+      rev =  "cfb38830724cc34fedffe9a2a29fb54fa9169cd1";
+      sha256 = "0y6f4sbzkiiwrxbl15biivj8c7qwxnvm3zl2dd3mw4wzg4x10ygj";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev =  "13931e22f9e72ea58bb73048bc752b48c6d4d4ac";
+      sha256 = "1621j82c1hiw4pxjdvaf5qyirwv5c0bqwlrhhna9pnjsgr5pkw33";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev =  "2c42eef0765b9837fbdab12011af7830f55f88f0";
+      sha256 = "0gj9nwryyzf9rn33gl3zm6rxvg1zhrhwi36akipqj37x4g86h3gz";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8961,6 +8961,8 @@ in
 
   cl-launch = callPackage ../development/tools/misc/cl-launch {};
 
+  cloud-nuke = callPackage ../development/tools/cloud-nuke { };
+
   cloudfoundry-cli = callPackage ../development/tools/cloudfoundry-cli { };
 
   coan = callPackage ../development/tools/analysis/coan { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add https://github.com/gruntwork-io/cloud-nuke

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
