### PR TITLE
noah: init at 0.5.1

### DIFF
--- a/pkgs/os-specific/darwin/noah/default.nix
+++ b/pkgs/os-specific/darwin/noah/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, cmake, Hypervisor }:
+
+stdenv.mkDerivation rec {
+  pname = "noah";
+  version = "0.5.1";
+
+  src = fetchFromGitHub {
+    owner = "linux-noah";
+    repo = pname;
+    rev = version;
+    sha256 = "0bivfsgb56kndz61lzjgdcnqlhjikqw89ma0h6f6radyvfzy0vis";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ Hypervisor ];
+
+  meta = with stdenv.lib; {
+    description = "Bash on Ubuntu on macOS";
+    homepage = "https://github.com/linux-noah/noah";
+    license = [ licenses.mit licenses.gpl2 ];
+    maintainers = [ maintainers.marsam ];
+    platforms = platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15690,6 +15690,10 @@ in
 
   nftables = callPackage ../os-specific/linux/nftables { };
 
+  noah = callPackage ../os-specific/darwin/noah {
+    inherit (darwin.apple_sdk.frameworks) Hypervisor;
+  };
+
   numactl = callPackage ../os-specific/linux/numactl { };
 
   numad = callPackage ../os-specific/linux/numad { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add https://github.com/linux-noah/noah

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
