### PR TITLE
bazel: fix nix-hacks.patch with the latest version of Bazel

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/bash-tools-test.nix
+++ b/pkgs/development/tools/build-managers/bazel/bash-tools-test.nix
@@ -31,6 +31,7 @@ let
 
   testBazel = bazelTest {
     name = "bazel-test-bash-tools";
+    bazelPkg = bazel;
     inherit workspaceDir;
 
     bazelScript = ''

--- a/pkgs/development/tools/build-managers/bazel/nix-hacks.patch
+++ b/pkgs/development/tools/build-managers/bazel/nix-hacks.patch
@@ -1,33 +1,35 @@
 diff -Naur a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
---- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java	1980-01-01 00:00:00.000000000 -0500
-+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java	2018-01-18 08:17:22.420459162 -0500
-@@ -287,21 +287,8 @@
-           markerData.put(key, value);
-         }
-       }
--      boolean result = false;
--      if (markerRuleKey.equals(ruleKey)) {
--        result = handler.verifyMarkerData(rule, markerData, env);
--        if (env.valuesMissing()) {
+--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java	2019-06-12 20:39:37.420705161 -0700
++++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java	2019-06-12 20:44:18.894429744 -0700
+@@ -428,24 +428,7 @@
+       try {
+         content = FileSystemUtils.readContent(markerPath, StandardCharsets.UTF_8);
+         String markerRuleKey = readMarkerFile(content, markerData);
+-        boolean verified = false;
+-        if (Preconditions.checkNotNull(ruleKey).equals(markerRuleKey)
+-            && Objects.equals(
+-                markerData.get(MANAGED_DIRECTORIES_MARKER),
+-                this.markerData.get(MANAGED_DIRECTORIES_MARKER))) {
+-          verified = handler.verifyMarkerData(rule, markerData, env);
+-          if (env.valuesMissing()) {
+-            return null;
+-          }
+-        }
+-
+-        if (verified) {
+           return new Fingerprint().addString(content).digestAndReset();
+-        } else {
+-          // So that we are in a consistent state if something happens while fetching the repository
+-          markerPath.delete();
 -          return null;
 -        }
--      }
- 
--      if (result) {
--        return new Fingerprint().addString(content).digestAndReset();
--      } else {
--        // So that we are in a consistent state if something happens while fetching the repository
--        markerPath.delete();
--        return null;
--      }
-+      return new Fingerprint().addString(content).digestAndReset();
- 
-     } catch (IOException e) {
-       throw new RepositoryFunctionException(e, Transience.TRANSIENT);
+       } catch (IOException e) {
+         throw new RepositoryFunctionException(e, Transience.TRANSIENT);
+       }
 diff -Naur a/src/main/java/com/google/devtools/build/lib/shell/JavaSubprocessFactory.java b/src/main/java/com/google/devtools/build/lib/shell/JavaSubprocessFactory.java
---- a/src/main/java/com/google/devtools/build/lib/shell/JavaSubprocessFactory.java	1980-01-01 00:00:00.000000000 -0500
-+++ b/src/main/java/com/google/devtools/build/lib/shell/JavaSubprocessFactory.java	2018-01-18 08:17:53.274877980 -0500
-@@ -129,7 +129,6 @@
+--- a/src/main/java/com/google/devtools/build/lib/shell/JavaSubprocessFactory.java	2019-06-12 20:39:37.538708196 -0700
++++ b/src/main/java/com/google/devtools/build/lib/shell/JavaSubprocessFactory.java	2019-06-12 20:44:18.863429602 -0700
+@@ -146,7 +146,6 @@
      ProcessBuilder builder = new ProcessBuilder();
      builder.command(params.getArgv());
      if (params.getEnv() != null) {

--- a/pkgs/development/tools/build-managers/bazel/python-bin-path-test.nix
+++ b/pkgs/development/tools/build-managers/bazel/python-bin-path-test.nix
@@ -41,6 +41,7 @@ let
   testBazel = bazelTest {
     name = "bazel-test-builtin-rules";
     inherit workspaceDir;
+    bazelPkg = bazel;
     bazelScript = ''
       ${bazel}/bin/bazel \
         run \


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The build is failing if `enableNixHacks = true;`.

**NOTE**: This PR should be squashed when merging.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
