### PR TITLE
kythe: 0.0.28 -> 0.0.30

### DIFF
--- a/pkgs/development/tools/kythe/default.nix
+++ b/pkgs/development/tools/kythe/default.nix
@@ -1,12 +1,12 @@
 { stdenv, binutils , fetchurl, glibc, ncurses5 }:
 
 stdenv.mkDerivation rec {
-  version = "0.0.28";
-  name = "kythe-${version}";
+  version = "0.0.30";
+  pname = "kythe";
 
   src = fetchurl {
-    url = "https://github.com/google/kythe/releases/download/v0.0.28/kythe-v0.0.28.tar.gz";
-    sha256 = "1qc7cngpxw66m3krpr5x50ns7gb3bpv2bdfzpb5afl12qp0mi6zm";
+    url = "https://github.com/kythe/kythe/releases/download/v${version}/${pname}-v${version}.tar.gz";
+    sha256 = "12bwhqkxfbkh3mm4wfvqflwhmbzpmlhlfykdpy6h7p9ih9ky8w6r";
   };
 
   buildInputs =
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
                 write_entries write_tables entrystream; do
       echo "Patching:" $exe
       patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $exe
-      patchelf --set-rpath "${stdenv.cc.cc.lib}/lib64:${ncurses5}/lib" $exe
+      patchelf --set-rpath "${stdenv.lib.makeLibraryPath [ stdenv.cc.cc ncurses5 ]}" $exe
     done
     cd ../
     cp -R ./ $out


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
