### PR TITLE
makemkv: 1.14.3 -> 1.14.4

### DIFF
--- a/pkgs/applications/video/makemkv/default.nix
+++ b/pkgs/applications/video/makemkv/default.nix
@@ -4,7 +4,7 @@
 
 stdenv.mkDerivation rec {
   name = "makemkv-${ver}";
-  ver = "1.14.3";
+  ver = "1.14.4";
   builder = ./builder.sh;
 
   # Using two URLs as the first one will break as soon as a new version is released
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
       "http://www.makemkv.com/download/makemkv-bin-${ver}.tar.gz"
       "http://www.makemkv.com/download/old/makemkv-bin-${ver}.tar.gz"
     ];
-    sha256 = "1d1b7rppbxx2b9p1smf0nlgp47j8b1z8d7q0v82kwr4qxaa0xcg0";
+    sha256 = "0vmmvldmwmq9g202abblj6l15kb8z3b0c6mcc03f30s2yci6ij33";
   };
 
   src_oss = fetchurl {
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
       "http://www.makemkv.com/download/makemkv-oss-${ver}.tar.gz"
       "http://www.makemkv.com/download/old/makemkv-oss-${ver}.tar.gz"
     ];
-    sha256 = "1jgyp6qs8r0z26258mvyg9dx7qqqdqrdsziw6m24ka77zpfg4b12";
+    sha256 = "0n1nlq17dxcbgk9xqf7nv6zykvh91yhsjqdhq55947wc11fxjqa0";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Changes:

- Support for AACS v70
- Many small improvements

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
