### PR TITLE
ocamlPackages.bistro: init at 0.4.0

### DIFF
--- a/pkgs/development/ocaml-modules/bistro/default.nix
+++ b/pkgs/development/ocaml-modules/bistro/default.nix
@@ -1,0 +1,27 @@
+{ lib, fetchFromGitHub, buildDunePackage
+, core, lwt ? ocaml_lwt, ocaml_lwt, ocamlgraph, rresult, tyxml
+}:
+
+buildDunePackage rec {
+  pname = "bistro";
+  version = "0.4.0";
+  src = fetchFromGitHub {
+    owner = "pveber";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0bxnggm4nkyl2iqwj4f5afw8lj5miq2rqsc9qfrlmg4g4rr3zh1c";
+  };
+
+  buildInputs = [ lwt ocamlgraph rresult tyxml ];
+
+  propagatedBuildInputs = [ core ];
+
+  minimumOCamlVersion = "4.04";
+
+  meta = {
+    inherit (src.meta) homepage;
+    description = "Build and execute typed scientific workflows";
+    maintainers = [ lib.maintainers.vbgl ];
+    license = lib.licenses.gpl2;
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -63,6 +63,8 @@ let
 
     bigstringaf = callPackage ../development/ocaml-modules/bigstringaf { };
 
+    bistro = callPackage ../development/ocaml-modules/bistro { };
+
     bitstring = callPackage ../development/ocaml-modules/bitstring { };
 
     bitv = callPackage ../development/ocaml-modules/bitv { };


### PR DESCRIPTION
###### Motivation for this change

[bistro](https://github.com/pveber/bistro) is an OCaml library to build and run computations represented by a collection of interdependent scripts, as is often found in applied research (especially computational biology).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
