### PR TITLE
bazel: add update script to update srcDeps from WORKSPACE file

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/src-deps.json
+++ b/pkgs/development/tools/build-managers/bazel/src-deps.json
@@ -1,0 +1,386 @@
+{
+    "0.16.2.zip": {
+        "name": "0.16.2.zip",
+        "sha256": "9b72bb0aea72d7cbcfc82a01b1e25bf3d85f791e790ddec16c65e2d906382ee0",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_nodejs/archive/0.16.2.zip",
+            "https://github.com/bazelbuild/rules_nodejs/archive/0.16.2.zip"
+        ]
+    },
+    "2d9566b21fbe405acf5f7bf77eda30df72a4744c.tar.gz": {
+        "name": "2d9566b21fbe405acf5f7bf77eda30df72a4744c.tar.gz",
+        "sha256": "4a1318fed4831697b83ce879b3ab70ae09592b167e5bda8edaff45132d1c3b3f",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/skydoc/archive/2d9566b21fbe405acf5f7bf77eda30df72a4744c.tar.gz",
+            "https://github.com/bazelbuild/skydoc/archive/2d9566b21fbe405acf5f7bf77eda30df72a4744c.tar.gz"
+        ]
+    },
+    "8ccf4f1c351928b55d5dddf3672e3667f6978d60.tar.gz": {
+        "name": "8ccf4f1c351928b55d5dddf3672e3667f6978d60.tar.gz",
+        "sha256": "d868ce50d592ef4aad7dec4dd32ae68d2151261913450fac8390b3fd474bb898",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_sass/archive/8ccf4f1c351928b55d5dddf3672e3667f6978d60.tar.gz",
+            "https://github.com/bazelbuild/rules_sass/archive/8ccf4f1c351928b55d5dddf3672e3667f6978d60.tar.gz"
+        ]
+    },
+    "android_tools_pkg-0.2.tar.gz": {
+        "name": "android_tools_pkg-0.2.tar.gz",
+        "sha256": "04f85f2dd049e87805511e3babc5cea3f5e72332b1627e34f3a5461cc38e815f",
+        "urls": [
+            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.2.tar.gz"
+        ]
+    },
+    "bazel_j2objc": {
+        "name": "bazel_j2objc",
+        "sha256": "a36bac432d0dbd8c98249e484b2b69dd5720afa4abb58711a3c3def1c0bfa21d",
+        "strip_prefix": "j2objc-2.0.3",
+        "urls": [
+            "https://miirror.bazel.build/github.com/google/j2objc/releases/download/2.0.3/j2objc-2.0.3.zip",
+            "https://github.com/google/j2objc/releases/download/2.0.3/j2objc-2.0.3.zip"
+        ]
+    },
+    "bazel_rbe_toolchains": {
+        "name": "bazel_rbe_toolchains",
+        "sha256": "f575778fb1366718f5e1204200ecf35796c558998c15303945d351f0b42669e5",
+        "strip_prefix": "bazel_rbe_toolchains-f50471a57cd05a313a953fa54756db6e8fd93673",
+        "urls": [
+            "https://mirror.bazel.build/github.com/buchgr/bazel_rbe_toolchains/archive/f50471a57cd05a313a953fa54756db6e8fd93673.tar.gz",
+            "https://github.com/buchgr/bazel_rbe_toolchains/archive/f50471a57cd05a313a953fa54756db6e8fd93673.tar.gz"
+        ]
+    },
+    "bazel_skylib": {
+        "name": "bazel_skylib",
+        "sha256": "ba5d15ca230efca96320085d8e4d58da826d1f81b444ef8afccd8b23e0799b52",
+        "strip_prefix": "bazel-skylib-f83cb8dd6f5658bc574ccd873e25197055265d1c",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/archive/f83cb8dd6f5658bc574ccd873e25197055265d1c.tar.gz",
+            "https://github.com/bazelbuild/bazel-skylib/archive/f83cb8dd6f5658bc574ccd873e25197055265d1c.tar.gz"
+        ]
+    },
+    "bazel_toolchains": {
+        "name": "bazel_toolchains",
+        "sha256": "67335b3563d9b67dc2550b8f27cc689b64fadac491e69ce78763d9ba894cc5cc",
+        "strip_prefix": "bazel-toolchains-cddc376d428ada2927ad359211c3e356bd9c9fbb",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/cddc376d428ada2927ad359211c3e356bd9c9fbb.tar.gz",
+            "https://github.com/bazelbuild/bazel-toolchains/archive/cddc376d428ada2927ad359211c3e356bd9c9fbb.tar.gz"
+        ]
+    },
+    "build_bazel_rules_nodejs": {
+        "name": "build_bazel_rules_nodejs",
+        "sha256": "9b72bb0aea72d7cbcfc82a01b1e25bf3d85f791e790ddec16c65e2d906382ee0",
+        "strip_prefix": "rules_nodejs-0.16.2",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_nodejs/archive/0.16.2.zip",
+            "https://github.com/bazelbuild/rules_nodejs/archive/0.16.2.zip"
+        ]
+    },
+    "com_google_googletest": {
+        "name": "com_google_googletest",
+        "sha256": "0fb00ff413f6b9b80ccee44a374ca7a18af7315aea72a43c62f2acd1ca74e9b5",
+        "strip_prefix": "googletest-f13bbe2992d188e834339abe6f715b2b2f840a77",
+        "urls": [
+            "https://mirror.bazel.build/github.com/google/googletest/archive/f13bbe2992d188e834339abe6f715b2b2f840a77.tar.gz",
+            "https://github.com/google/googletest/archive/f13bbe2992d188e834339abe6f715b2b2f840a77.tar.gz"
+        ]
+    },
+    "coverage_output_generator-v1.0.zip": {
+        "name": "coverage_output_generator-v1.0.zip",
+        "sha256": "cc470e529fafb6165b5be3929ff2d99b38429b386ac100878687416603a67889",
+        "urls": [
+            "https://mirror.bazel.build/bazel_coverage_output_generator/releases/coverage_output_generator-v1.0.zip"
+        ]
+    },
+    "desugar_jdk_libs": {
+        "name": "desugar_jdk_libs",
+        "sha256": "fe2e04f91ce8c59d49d91b8102edc6627c6fa2906c1b0e7346f01419ec4f419d",
+        "strip_prefix": "desugar_jdk_libs-e0b0291b2c51fbe5a7cfa14473a1ae850f94f021",
+        "urls": [
+            "https://mirror.bazel.build/github.com/google/desugar_jdk_libs/archive/e0b0291b2c51fbe5a7cfa14473a1ae850f94f021.zip",
+            "https://github.com/google/desugar_jdk_libs/archive/e0b0291b2c51fbe5a7cfa14473a1ae850f94f021.zip"
+        ]
+    },
+    "e0b0291b2c51fbe5a7cfa14473a1ae850f94f021.zip": {
+        "name": "e0b0291b2c51fbe5a7cfa14473a1ae850f94f021.zip",
+        "sha256": "fe2e04f91ce8c59d49d91b8102edc6627c6fa2906c1b0e7346f01419ec4f419d",
+        "urls": [
+            "https://mirror.bazel.build/github.com/google/desugar_jdk_libs/archive/e0b0291b2c51fbe5a7cfa14473a1ae850f94f021.zip",
+            "https://github.com/google/desugar_jdk_libs/archive/e0b0291b2c51fbe5a7cfa14473a1ae850f94f021.zip"
+        ]
+    },
+    "f83cb8dd6f5658bc574ccd873e25197055265d1c.tar.gz": {
+        "name": "f83cb8dd6f5658bc574ccd873e25197055265d1c.tar.gz",
+        "sha256": "ba5d15ca230efca96320085d8e4d58da826d1f81b444ef8afccd8b23e0799b52",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/archive/f83cb8dd6f5658bc574ccd873e25197055265d1c.tar.gz",
+            "https://github.com/bazelbuild/bazel-skylib/archive/f83cb8dd6f5658bc574ccd873e25197055265d1c.tar.gz"
+        ]
+    },
+    "io_bazel_rules_sass": {
+        "name": "io_bazel_rules_sass",
+        "sha256": "d868ce50d592ef4aad7dec4dd32ae68d2151261913450fac8390b3fd474bb898",
+        "strip_prefix": "rules_sass-8ccf4f1c351928b55d5dddf3672e3667f6978d60",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_sass/archive/8ccf4f1c351928b55d5dddf3672e3667f6978d60.tar.gz",
+            "https://github.com/bazelbuild/rules_sass/archive/8ccf4f1c351928b55d5dddf3672e3667f6978d60.tar.gz"
+        ]
+    },
+    "io_bazel_skydoc": {
+        "name": "io_bazel_skydoc",
+        "sha256": "4a1318fed4831697b83ce879b3ab70ae09592b167e5bda8edaff45132d1c3b3f",
+        "strip_prefix": "skydoc-2d9566b21fbe405acf5f7bf77eda30df72a4744c",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/skydoc/archive/2d9566b21fbe405acf5f7bf77eda30df72a4744c.tar.gz",
+            "https://github.com/bazelbuild/skydoc/archive/2d9566b21fbe405acf5f7bf77eda30df72a4744c.tar.gz"
+        ]
+    },
+    "java_tools_javac10_darwin-v3.2.zip": {
+        "name": "java_tools_javac10_darwin-v3.2.zip",
+        "sha256": "1437327179b4284f7082cee0bdc3328f040e62fc5cc59c32f6824b8c520e2b7b",
+        "urls": [
+            "https://mirror.bazel.build/bazel_java_tools/releases/javac10/v3.2/java_tools_javac10_darwin-v3.2.zip"
+        ]
+    },
+    "java_tools_javac10_linux-v3.2.zip": {
+        "name": "java_tools_javac10_linux-v3.2.zip",
+        "sha256": "b93e7c556b01815afb6c248aa73f06b7ec912805bde8898eedac1e20d08f2e67",
+        "urls": [
+            "https://mirror.bazel.build/bazel_java_tools/releases/javac10/v3.2/java_tools_javac10_linux-v3.2.zip"
+        ]
+    },
+    "java_tools_javac10_windows-v3.2.zip": {
+        "name": "java_tools_javac10_windows-v3.2.zip",
+        "sha256": "86d3cc7fa0dc91ccb8f78ae3af8440fe459177e22062043ee4b83d55e6b7dfb0",
+        "urls": [
+            "https://mirror.bazel.build/bazel_java_tools/releases/javac10/v3.2/java_tools_javac10_windows-v3.2.zip"
+        ]
+    },
+    "java_tools_langtools_javac10": {
+        "name": "java_tools_langtools_javac10",
+        "sha256": "e379c71e051eb83e3fc9a08c9b404712707d8920ffcf1e8fd59c844965f0b0dd",
+        "urls": [
+            "https://mirror.bazel.build/bazel_java_tools/jdk_langtools/langtools_jdk10.zip"
+        ]
+    },
+    "java_tools_langtools_javac9": {
+        "name": "java_tools_langtools_javac9",
+        "sha256": "3b6bbc47256acf2f61883901e2d4e3f9b292f5fe154a6912b928805de24cb864",
+        "urls": [
+            "https://mirror.bazel.build/bazel_java_tools/jdk_langtools/langtools_jdk9.zip"
+        ]
+    },
+    "jdk10-server-release-1804.tar.xz": {
+        "name": "jdk10-server-release-1804.tar.xz",
+        "sha256": "b7098b7aaf6ee1ffd4a2d0371a0be26c5a5c87f6aebbe46fe9a92c90583a84be",
+        "urls": [
+            "https://mirror.bazel.build/openjdk.linaro.org/releases/jdk10-server-release-1804.tar.xz"
+        ]
+    },
+    "jdk9-server-release-1708.tar.xz": {
+        "name": "jdk9-server-release-1708.tar.xz",
+        "sha256": "72e7843902b0395e2d30e1e9ad2a5f05f36a4bc62529828bcbc698d54aec6022",
+        "urls": [
+            "https://mirror.bazel.build/openjdk.linaro.org/releases/jdk9-server-release-1708.tar.xz"
+        ]
+    },
+    "openjdk10_linux_archive": {
+        "build_file_content": "java_runtime(name = 'runtime', srcs =  glob(['**']), visibility = ['//visibility:public'])",
+        "name": "openjdk10_linux_archive",
+        "sha256": "b3c2d762091a615b0c1424ebbd05d75cc114da3bf4f25a0dec5c51ea7e84146f",
+        "strip_prefix": "zulu10.2+3-jdk10.0.1-linux_x64",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu10.2+3-jdk10.0.1/zulu10.2+3-jdk10.0.1-linux_x64.tar.gz"
+        ]
+    },
+    "openjdk11_linux_archive": {
+        "build_file_content": "java_runtime(name = 'runtime', srcs =  glob(['**']), visibility = ['//visibility:public'])",
+        "name": "openjdk11_linux_archive",
+        "sha256": "ddb0fd4526089cf1ce2db36282c282263f587a9e8be373fa02f511a12923cc48",
+        "strip_prefix": "zulu11.31.11-ca-jdk11.0.3-linux_x64",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu11.31.11-ca-jdk11.0.3/zulu11.31.11-ca-jdk11.0.3-linux_x64.tar.gz"
+        ]
+    },
+    "openjdk12_linux_archive": {
+        "build_file_content": "java_runtime(name = 'runtime', srcs =  glob(['**']), visibility = ['//visibility:public'])",
+        "name": "openjdk12_linux_archive",
+        "sha256": "529c99841d69e11a85aea967ccfb9d0fd40b98c5b68dbe1d059002655e0a9c13",
+        "strip_prefix": "zulu12.2.3-ca-jdk12.0.1-linux_x64",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu12.2.3-ca-jdk12.0.1/zulu12.2.3-ca-jdk12.0.1-linux_x64.tar.gz"
+        ]
+    },
+    "openjdk9_linux_archive": {
+        "build_file_content": "java_runtime(name = 'runtime', srcs =  glob(['**']), visibility = ['//visibility:public'])",
+        "name": "openjdk9_linux_archive",
+        "sha256": "45f2dfbee93b91b1468cf81d843fc6d9a47fef1f831c0b7ceff4f1eb6e6851c8",
+        "strip_prefix": "zulu9.0.7.1-jdk9.0.7-linux_x64",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu-9.0.7.1-jdk9.0.7/zulu9.0.7.1-jdk9.0.7-linux_x64.tar.gz"
+        ]
+    },
+    "openjdk_linux": {
+        "downloaded_file_path": "zulu-linux.tar.gz",
+        "name": "openjdk_linux",
+        "sha256": "460d8a4f0c0204160b48086e341b22943c9cca471b195340e75b38ae9eb33c1c",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-linux_x64-allmodules-90755145cb6e6418584d8603cd5fa9afbb30aecc-1549209950.tar.gz"
+        ]
+    },
+    "openjdk_linux_aarch64": {
+        "name": "openjdk_linux_aarch64",
+        "sha256": "72e7843902b0395e2d30e1e9ad2a5f05f36a4bc62529828bcbc698d54aec6022",
+        "urls": [
+            "https://mirror.bazel.build/openjdk.linaro.org/releases/jdk9-server-release-1708.tar.xz",
+            "http://openjdk.linaro.org/releases/jdk9-server-release-1708.tar.xz"
+        ]
+    },
+    "openjdk_linux_minimal": {
+        "downloaded_file_path": "zulu-linux-minimal.tar.gz",
+        "name": "openjdk_linux_minimal",
+        "sha256": "5123bc8dd21886761d1fd9ca0fb1898b3372d7243064a070ec81ca9c9d1a6791",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-linux_x64-minimal-524ae2ca2a782c9f15e00f08bd35b3f8ceacbd7f-1556011926.tar.gz"
+        ]
+    },
+    "openjdk_linux_vanilla": {
+        "downloaded_file_path": "zulu-linux-vanilla.tar.gz",
+        "name": "openjdk_linux_vanilla",
+        "sha256": "f3f44b6235508e87b760bf37a49e186cc1fa4e9cd28384c4dbf5a33991921e08",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz"
+        ]
+    },
+    "openjdk_macos": {
+        "downloaded_file_path": "zulu-macos.tar.gz",
+        "name": "openjdk_macos",
+        "sha256": "8fa61d85ca6f657d646fdb50cfc8634987f8f7d8a3250ed39fb7364647633252",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-macosx_x64-allmodules-90755145cb6e6418584d8603cd5fa9afbb30aecc-1549209951.tar.gz"
+        ]
+    },
+    "openjdk_macos_minimal": {
+        "downloaded_file_path": "zulu-macos-minimal.tar.gz",
+        "name": "openjdk_macos_minimal",
+        "sha256": "ac56e44db46fd56ac78b39b6823daed4faa74a2677ac340c7d217f863884ec0f",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-macosx_x64-minimal-524ae2ca2a782c9f15e00f08bd35b3f8ceacbd7f-1556003114.tar.gz"
+        ]
+    },
+    "openjdk_macos_vanilla": {
+        "downloaded_file_path": "zulu-macos-vanilla.tar.gz",
+        "name": "openjdk_macos_vanilla",
+        "sha256": "059f8e3484bf07b63a8f2820d5f528f473eff1befdb1896ee4f8ff06be3b8d8f",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-macosx_x64.zip"
+        ]
+    },
+    "openjdk_win": {
+        "downloaded_file_path": "zulu-win.zip",
+        "name": "openjdk_win",
+        "sha256": "e6ddb361309f8e84eb5fb5ad8b0f5cc031ba3679910139262c31efd8f7579d05",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-win_x64-allmodules-90755145cb6e6418584d8603cd5fa9afbb30aecc-1549209972.zip"
+        ]
+    },
+    "openjdk_win_minimal": {
+        "downloaded_file_path": "zulu-win-minimal.zip",
+        "name": "openjdk_win_minimal",
+        "sha256": "8e5dada6e9ebcc9ce29b4d051449bb95d3ee1e620e166da862224bbf15211f8b",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-win_x64-minimal-524ae2ca2a782c9f15e00f08bd35b3f8ceacbd7f-1556003136.zip"
+        ]
+    },
+    "openjdk_win_vanilla": {
+        "downloaded_file_path": "zulu-win-vanilla.zip",
+        "name": "openjdk_win_vanilla",
+        "sha256": "e1f5b4ce1b9148140fae2fcfb8a96d1c9b7eac5b8df0e13fbcad9b8561284880",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-win_x64.zip"
+        ]
+    },
+    "zulu10.2+3-jdk10.0.1-linux_x64-allmodules.tar.gz": {
+        "name": "zulu10.2+3-jdk10.0.1-linux_x64-allmodules.tar.gz",
+        "sha256": "57fad3602e74c79587901d6966d3b54ef32cb811829a2552163185d5064fe9b5",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu10.2+3-jdk10.0.1/zulu10.2+3-jdk10.0.1-linux_x64-allmodules.tar.gz"
+        ]
+    },
+    "zulu10.2+3-jdk10.0.1-macosx_x64-allmodules.tar.gz": {
+        "name": "zulu10.2+3-jdk10.0.1-macosx_x64-allmodules.tar.gz",
+        "sha256": "e669c9a897413d855b550b4e39d79614392e6fb96f494e8ef99a34297d9d85d3",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu10.2+3-jdk10.0.1/zulu10.2+3-jdk10.0.1-macosx_x64-allmodules.tar.gz"
+        ]
+    },
+    "zulu10.2+3-jdk10.0.1-win_x64-allmodules.zip": {
+        "name": "zulu10.2+3-jdk10.0.1-win_x64-allmodules.zip",
+        "sha256": "c39e7700a8d41794d60985df5a20352435196e78ecbc6a2b30df7be8637bffd5",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu10.2+3-jdk10.0.1/zulu10.2+3-jdk10.0.1-win_x64-allmodules.zip"
+        ]
+    },
+    "zulu11.2.3-jdk11.0.1-linux_x64.tar.gz": {
+        "name": "zulu11.2.3-jdk11.0.1-linux_x64.tar.gz",
+        "sha256": "232b1c3511f0d26e92582b7c3cc363be7ac633e371854ca2f2e9f2b50eb72a75",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu11.2.3-jdk11.0.1/zulu11.2.3-jdk11.0.1-linux_x64.tar.gz"
+        ]
+    },
+    "zulu11.2.3-jdk11.0.1-macosx_x64.tar.gz": {
+        "name": "zulu11.2.3-jdk11.0.1-macosx_x64.tar.gz",
+        "sha256": "1edf366ee821e5db8e348152fcb337b28dfd6bf0f97943c270dcc6747cedb6cb",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu11.2.3-jdk11.0.1/zulu11.2.3-jdk11.0.1-macosx_x64.tar.gz"
+        ]
+    },
+    "zulu11.2.3-jdk11.0.1-win_x64.zip": {
+        "name": "zulu11.2.3-jdk11.0.1-win_x64.zip",
+        "sha256": "8e1e2b8347de6746f3fd1538840dd643201533ab113abc4ed93678e342d28aa3",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu11.2.3-jdk11.0.1/zulu11.2.3-jdk11.0.1-win_x64.zip"
+        ]
+    },
+    "zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz": {
+        "name": "zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz",
+        "sha256": "f3f44b6235508e87b760bf37a49e186cc1fa4e9cd28384c4dbf5a33991921e08",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz"
+        ]
+    },
+    "zulu11.29.3-ca-jdk11.0.2-macosx_x64.zip": {
+        "name": "zulu11.29.3-ca-jdk11.0.2-macosx_x64.zip",
+        "sha256": "059f8e3484bf07b63a8f2820d5f528f473eff1befdb1896ee4f8ff06be3b8d8f",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-macosx_x64.zip"
+        ]
+    },
+    "zulu11.29.3-ca-jdk11.0.2-win_x64.zip": {
+        "name": "zulu11.29.3-ca-jdk11.0.2-win_x64.zip",
+        "sha256": "e1f5b4ce1b9148140fae2fcfb8a96d1c9b7eac5b8df0e13fbcad9b8561284880",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-win_x64.zip"
+        ]
+    },
+    "zulu9.0.7.1-jdk9.0.7-linux_x64-allmodules.tar.gz": {
+        "name": "zulu9.0.7.1-jdk9.0.7-linux_x64-allmodules.tar.gz",
+        "sha256": "f27cb933de4f9e7fe9a703486cf44c84bc8e9f138be0c270c9e5716a32367e87",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu-9.0.7.1-jdk9.0.7/zulu9.0.7.1-jdk9.0.7-linux_x64-allmodules.tar.gz"
+        ]
+    },
+    "zulu9.0.7.1-jdk9.0.7-macosx_x64-allmodules.tar.gz": {
+        "name": "zulu9.0.7.1-jdk9.0.7-macosx_x64-allmodules.tar.gz",
+        "sha256": "404e7058ff91f956612f47705efbee8e175a38b505fb1b52d8c1ea98718683de",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu-9.0.7.1-jdk9.0.7/zulu9.0.7.1-jdk9.0.7-macosx_x64-allmodules.tar.gz"
+        ]
+    },
+    "zulu9.0.7.1-jdk9.0.7-win_x64-allmodules.zip": {
+        "name": "zulu9.0.7.1-jdk9.0.7-win_x64-allmodules.zip",
+        "sha256": "e738829017f107e7a7cd5069db979398ec3c3f03ef56122f89ba38e7374f63ed",
+        "urls": [
+            "https://mirror.bazel.build/openjdk/azul-zulu-9.0.7.1-jdk9.0.7/zulu9.0.7.1-jdk9.0.7-win_x64-allmodules.zip"
+        ]
+    }
+}

--- a/pkgs/development/tools/build-managers/bazel/update-srcDeps.py
+++ b/pkgs/development/tools/build-managers/bazel/update-srcDeps.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+import sys
+import json
+
+if len(sys.argv) == 1:
+    print("usage: ./this-script WORKSPACE", file=sys.stderr)
+    print("Takes the bazel WORKSPACE file and reads all archives into a json dict (by evaling it as python code)", file=sys.stderr)
+    print("Hail Eris.", file=sys.stderr)
+    sys.exit(1)
+
+http_archives = []
+
+# just the kw args are the dict { name, sha256, urls … }
+def http_archive(**kw):
+    http_archives.append(kw)
+# like http_file
+def http_file(**kw):
+    http_archives.append(kw)
+
+# this is inverted from http_archive/http_file and bundles multiple archives
+def distdir_tar(**kw):
+    for archive_name in kw['archives']:
+        http_archives.append({
+            "name": archive_name,
+            "sha256": kw['sha256'][archive_name],
+            "urls": kw['urls'][archive_name]
+        })
+
+# stubs for symbols we are not interested in
+# might need to be expanded if new bazel releases add symbols to the workspace
+def workspace(name): pass
+def load(*args): pass
+def bind(**kw): pass
+def list_source_repository(**kw): pass
+def new_local_repository(**kw): pass
+def local_repository(**kw): pass
+DOC_VERSIONS = []
+def skydoc_repositories(**kw): pass
+def rules_sass_dependencies(**kw): pass
+def node_repositories(**kw): pass
+def sass_repositories(**kw): pass
+def register_execution_platforms(*args): pass
+
+# execute the WORKSPACE like it was python code in this module,
+# using all the function stubs from above.
+with open(sys.argv[1]) as f:
+    exec(f.read())
+
+# transform to a dict with the names as keys
+d = { el['name']: el for el in http_archives }
+
+print(json.dumps(d, sort_keys=True, indent=4))


### PR DESCRIPTION
This adds an automated updater that can “parse” the bazel WORKSPACE file to dump most dependencies into a JSON file, meaning we don’t have to update dependencies by hand (and also don’t forget when updating bazel).

cc @groodt @uri-canva 

After I implemented it, I actually noticed that the bazel build itself doesn’t use these dependencies, only if you want to run the tests afterwards they are needed, and we disabled the tests :( 

So the next step is to move the `installTests` into a different derivation, like we do with `passthru.tests`.

@GrahamcOfBorg build bazel.tests

###### Things done

<!-- Plea check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
