### PR TITLE
inconsolata-nerdfont: init at 2.0.0

### DIFF
--- a/pkgs/data/fonts/inconsolata-nerdfont/default.nix
+++ b/pkgs/data/fonts/inconsolata-nerdfont/default.nix
@@ -1,0 +1,28 @@
+{ lib, fetchzip }:
+
+let
+  version = "2.0.0";
+in fetchzip {
+  name = "inconsolata-nerdfont-${version}";
+
+  url = "https://github.com/ryanoasis/nerd-fonts/releases/download/v${version}/Inconsolata.zip";
+
+  postFetch = ''
+    mkdir -p $out/share/fonts/inconsolata-nerdfont
+    unzip -j $downloadedFile -d $out/share/fonts/inconsolata-nerdfont
+  '';
+
+  sha256 = "06i1akjblqd038cn5lvz67lwp6afpv31vqcfdihp66qisgbgm4w9";
+
+  meta = with lib; {
+    description = ''
+      Nerd Fonts is a project that attempts to patch as many developer targeted
+      and/or used fonts as possible. The patch is to specifically add a high
+      number of additional glyphs from popular 'iconic fonts' such as Font
+      Awesome, Devicons, Octicons, and others.
+    '';
+    homepage = https://github.com/ryanoasis/nerd-fonts;
+    license = licenses.mit;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/data/fonts/terminus-nerdfont/default.nix
+++ b/pkgs/data/fonts/terminus-nerdfont/default.nix
@@ -1,0 +1,28 @@
+{ lib, fetchzip }:
+
+let
+  version = "2.0.0";
+in fetchzip {
+  name = "terminus-nerdfont-${version}";
+
+  url = "https://github.com/ryanoasis/nerd-fonts/releases/download/v${version}/Terminus.zip";
+
+  postFetch = ''
+    mkdir -p $out/share/fonts/terminus-nerdfont
+    unzip -j $downloadedFile -d $out/share/fonts/terminus-nerdfont
+  '';
+
+  sha256 = "036i1qwwrb0r8hvcjf3h34w0g7mbsmngvrjic98jgikbz3i2f46c";
+
+  meta = with lib; {
+    description = ''
+      Nerd Fonts is a project that attempts to patch as many developer targeted
+      and/or used fonts as possible. The patch is to specifically add a high
+      number of additional glyphs from popular 'iconic fonts' such as Font
+      Awesome, Devicons, Octicons, and others.
+    '';
+    homepage = https://github.com/ryanoasis/nerd-fonts;
+    license = licenses.mit;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16314,7 +16314,10 @@ in
   iconpack-obsidian = callPackage ../data/icons/iconpack-obsidian { };
 
   inconsolata = callPackage ../data/fonts/inconsolata {};
+
   inconsolata-lgc = callPackage ../data/fonts/inconsolata/lgc.nix {};
+
+  inconsolata-nerdfont = callPackage ../data/fonts/inconsolata-nerdfont {};
 
   input-fonts = callPackage ../data/fonts/input-fonts { };
 
@@ -16665,6 +16668,8 @@ in
   terminus_font = callPackage ../data/fonts/terminus-font { };
 
   terminus_font_ttf = callPackage ../data/fonts/terminus-font-ttf { };
+
+  terminus-nerdfont = callPackage ../data/fonts/terminus-nerdfont { };
 
   termtekst = callPackage ../misc/emulators/termtekst { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

nerdfonts-2.0.0 is a 2GB download. Each of these is < 10 MB download. It makes sense to provide separate packages for each font. This prevents issues such as described in #47921.

###### Things done

I build both, installed on my system and checked their presence with font-manager.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
