### PR TITLE
SPAdes: init at 3.13.1

### DIFF
--- a/pkgs/applications/science/biology/spades/default.nix
+++ b/pkgs/applications/science/biology/spades/default.nix
@@ -15,15 +15,12 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  postUnpack = ''
-    sourceRoot=''${sourceRoot}/src
-    echo Source root reset to ''${sourceRoot}
-  '';
+  sourceRoot = "${pname}-${version}/src";
 
   meta = with stdenv.lib; {
     description = "St. Petersburg genome assembler: assembly toolkit containing various assembly pipelines";
     license = licenses.gpl2;
-    homepage = http://cab.spbu.ru/software/spades/;
+    homepage = "http://cab.spbu.ru/software/spades/";
     platforms = platforms.unix;
     maintainers = [ maintainers.bzizou ];
   };

--- a/pkgs/applications/science/biology/spades/default.nix
+++ b/pkgs/applications/science/biology/spades/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl, zlib, bzip2, cmake }:
+
+stdenv.mkDerivation rec {
+  pname = "SPAdes";
+  version = "3.13.1";
+
+  src = fetchurl {
+    url = "http://cab.spbu.ru/files/release${version}/${pname}-${version}.tar.gz";
+    sha256 = "0giayz197lmq2108filkn9izma3i803sb3iskv9hs5snzdr9p8ld";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ zlib bzip2 ];
+
+  doCheck = true;
+
+  postUnpack = ''
+    sourceRoot=''${sourceRoot}/src
+    echo Source root reset to ''${sourceRoot}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "St. Petersburg genome assembler: assembly toolkit containing various assembly pipelines";
+    license = licenses.gpl2;
+    homepage = http://cab.spbu.ru/software/spades/;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.bzizou ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22975,6 +22975,8 @@ in
 
   seaview = callPackage ../applications/science/biology/seaview { };
 
+  SPAdes = callPackage ../applications/science/biology/spades { };
+
   trimal = callPackage ../applications/science/biology/trimal { };
 
   varscan = callPackage ../applications/science/biology/varscan { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Bioinformatic tool used into my laboratory

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
