### PR TITLE
gappa: update and add Coq support library

### DIFF
--- a/pkgs/applications/science/logic/gappa/default.nix
+++ b/pkgs/applications/science/logic/gappa/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, gmp, mpfr, boost }:
 
 stdenv.mkDerivation {
-  name = "gappa-1.2";
+  name = "gappa-1.3.5";
 
   src = fetchurl {
-    url = https://gforge.inria.fr/frs/download.php/file/34787/gappa-1.2.0.tar.gz;
-    sha256 = "03hfzmaf5jm54sjpbks20q7qixpmagrfbnyyc276vgmiyslk4dkh";
+    url = https://gforge.inria.fr/frs/download.php/file/38044/gappa-1.3.5.tar.gz;
+    sha256 = "0q1wdiwqj6fsbifaayb1zkp20bz8a1my81sqjsail577jmzwi07w";
   };
 
   buildInputs = [ gmp mpfr boost.dev ];

--- a/pkgs/development/coq-modules/gappalib/default.nix
+++ b/pkgs/development/coq-modules/gappalib/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl, which, coq, flocq }:
+
+stdenv.mkDerivation {
+  name = "coq${coq.coq-version}-gappalib-1.4.1";
+  src = fetchurl {
+    url = https://gforge.inria.fr/frs/download.php/file/37917/gappalib-coq-1.4.1.tar.gz;
+    sha256 = "0d3f23a871haglg8hq1jgxz3y5nryiwy12b5xfnfjn279jfqqjw4";
+  };
+
+  nativeBuildInputs = [ which ];
+  buildInputs = [ coq coq.ocamlPackages.ocaml ];
+  propagatedBuildInputs = [ flocq ];
+
+  configurePhase = "./configure --libdir=$out/lib/coq/${coq.coq-version}/user-contrib/Gappa";
+  buildPhase = "./remake";
+  installPhase = "./remake install";
+
+  meta = {
+    description = "Coq support library for Gappa";
+    license = stdenv.lib.licenses.lgpl21;
+    homepage = http://gappa.gforge.inria.fr/;
+    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    inherit (coq.meta) platforms;
+  };
+
+  passthru = {
+    compatibleCoqVersions = stdenv.lib.flip stdenv.lib.versionAtLeast "8.7";
+  };
+
+}

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -28,6 +28,7 @@ let
       equations = callPackage ../development/coq-modules/equations { };
       fiat_HEAD = callPackage ../development/coq-modules/fiat/HEAD.nix {};
       flocq = callPackage ../development/coq-modules/flocq {};
+      gappalib = callPackage ../development/coq-modules/gappalib {};
       heq = callPackage ../development/coq-modules/heq {};
       HoTT = callPackage ../development/coq-modules/HoTT {};
       interval = callPackage ../development/coq-modules/interval {};


### PR DESCRIPTION
###### Motivation for this change

Use up-to-date gappa from Coq.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
