### PR TITLE
kernel.nix: boot.vesa implies nomodeset

### DIFF
--- a/nixos/modules/system/boot/kernel.nix
+++ b/nixos/modules/system/boot/kernel.nix
@@ -196,7 +196,7 @@ in
     # (so you don't need to reboot to have changes take effect).
     boot.kernelParams =
       [ "loglevel=${toString config.boot.consoleLogLevel}" ] ++
-      optionals config.boot.vesa [ "vga=0x317" ];
+      optionals config.boot.vesa [ "vga=0x317" "nomodeset" ];
 
     boot.kernel.sysctl."kernel.printk" = mkDefault config.boot.consoleLogLevel;
 


### PR DESCRIPTION
Without nomodeset the console is reset to 80x25 after Grub.

###### Motivation for this change

The standard configuration, even with `boot.vesa = true`, results in a tiny virtual console.

###### Things done

Tested this configuration on a VM; did not test this actual change.