### PR TITLE
Fix bug. Replace networking.enableIntel2200BGFirmware

### DIFF
--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -189,12 +189,12 @@ sub pciCheck {
     # Can't rely on $module here, since the module may not be loaded
     # due to missing firmware.  Ideally we would check modules.pcimap
     # here.
-    push @attrs, "networking.enableIntel2200BGFirmware = true;" if
+    push @attrs, "hardware.enableRedistributableFirmware = true;" if
         $vendor eq "0x8086" &&
         ($device eq "0x1043" || $device eq "0x104f" || $device eq "0x4220" ||
          $device eq "0x4221" || $device eq "0x4223" || $device eq "0x4224");
 
-    push @attrs, "networking.enableIntel3945ABGFirmware = true;" if
+    push @attrs, "hardware.enableRedistributableFirmware = true;" if
         $vendor eq "0x8086" &&
         ($device eq "0x4229" || $device eq "0x4230" ||
          $device eq "0x4222" || $device eq "0x4227");


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

When running `nixos-install` the error `error: The option networking.enableIntel2200BGFirmware defined in /mnt/etc/nixos/hardware-configuration.nix does not exist` shows up.

To fix this I was told to replace it with `hardware.enableRedistributableFirmware` by @srhb on IRC.

###### Things done

Installed nixos on a laptop.

---
