### PR TITLE
pythonPackages.toggl-cli: init at 2.1.0 (and its dependencies)

### DIFF
--- a/pkgs/development/python-modules/inquirer/default.nix
+++ b/pkgs/development/python-modules/inquirer/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, buildPythonPackage, fetchPypi, python-editor, readchar, blessings, pytest, pytestcov, pexpect, pytest-mock }:
+
+buildPythonPackage rec {
+  pname = "inquirer";
+  version = "2.6.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "01lf51y3bxsxkghbdk9hr42yvihpwi2s5zpxnra3bx41r35msvjz";
+  };
+
+  propagatedBuildInputs = [ python-editor readchar blessings ];
+
+  # No real changes in 2.0.0...e0edfa3
+  postPatch = ''
+   substituteInPlace setup.py \
+     --replace "readchar == 2.0.1" "readchar >= 2.0.0"
+  '';
+
+  checkInputs = [ pytest pytestcov pexpect pytest-mock ];
+
+  checkPhase = ''
+    pytest --cov-report=term-missing  --cov inquirer --no-cov-on-fail tests/unit tests/integration
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/magmax/python-inquirer";
+    description = "A collection of common interactive command line user interfaces, based on Inquirer.js";
+    license = licenses.mit;
+    maintainers = [ maintainers.mmahut ];
+  };
+}

--- a/pkgs/development/python-modules/ptable/default.nix
+++ b/pkgs/development/python-modules/ptable/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub, nose }:
+
+buildPythonPackage rec {
+  pname = "ptable";
+  version = "unstable-2019-06-14";
+
+  # https://github.com/kxxoling/PTable/issues/27
+  src = fetchFromGitHub {
+    owner = "kxxoling";
+    repo = "PTable";
+    rev = "bcfdb92811ae1f39e1065f31544710bf87d3bc21";
+    sha256 = "1cj314rp6irlvr0a2c4xffsm2idsb0hzwr38vzz6z3kbhphcb63i";
+  };
+
+  checkInputs = [ nose ];
+
+  checkPhase = ''
+    nosetests --with-coverage --cover-package=prettytable --cover-min-percentage=75
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/kxxoling/PTable";
+    description = "A simple Python library designed to make it quick and easy to represent tabular data in visually appealing ASCII tables";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.mmahut ];
+  };
+}

--- a/pkgs/development/python-modules/readchar/default.nix
+++ b/pkgs/development/python-modules/readchar/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub, flake8, pytest, pytestcov, pexpect }:
+
+buildPythonPackage rec {
+  pname = "readchar";
+  version = "2.0.0";
+
+  # Don't use wheels on PyPI
+  src = fetchFromGitHub {
+    owner = "magmax";
+    repo = "python-${pname}";
+    rev = version;
+    sha256 = "0j1vj4f2j8x5f40rs6h8qplklcxcdbvkkvjpkpmr1xagw05i12bm";
+  };
+
+  nativeBuildInputs = [ flake8 ];
+  checkInputs = [ pytest pytestcov pexpect ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/magmax/python-readchar";
+    description = "Python library to read characters and key strokes";
+    license = licenses.mit;
+    maintainers = [ maintainers.mmahut ];
+  };
+}

--- a/pkgs/development/python-modules/toggl-cli/default.nix
+++ b/pkgs/development/python-modules/toggl-cli/default.nix
@@ -1,0 +1,57 @@
+{ stdenv, buildPythonPackage, fetchPypi, twine, pbr, click, click-completion, validate-email,
+pendulum, ptable, requests, inquirer, pythonOlder, pytest, pytestcov, pytest-mock, faker, factory_boy }:
+
+
+buildPythonPackage rec {
+  pname = "toggl-cli";
+  version = "2.1.0";
+
+  disabled = pythonOlder "3.5";
+
+  src = fetchPypi {
+    pname = "togglCli";
+    inherit version;
+    sha256 = "0iirvvb8772569v28d36bnryksm1qkkw48d48fw26j7ka01qq6mm";
+  };
+
+  postPatch = ''
+   substituteInPlace requirements.txt \
+     --replace "click-completion==0.5.0" "click-completion>=0.5.0" \
+     --replace "pbr==5.1.2" "pbr>=5.1.2" \
+     --replace "inquirer==2.5.1" "inquirer>=2.5.1"
+  '';
+
+  nativeBuildInputs = [ pbr twine ];
+  checkInputs = [ pbr pytest pytestcov pytest-mock faker factory_boy ];
+
+  preCheck = ''
+    export TOGGL_API_TOKEN=your_api_token
+    export TOGGL_PASSWORD=toggl_password
+    export TOGGL_USERNAME=user@example.com
+    '';
+
+  checkPhase = ''
+   runHook preCheck
+   pytest -k "not premium and not TestDateTimeType and not TestDateTimeField" tests/unit --maxfail=20
+   runHook postCheck
+  '';
+
+  propagatedBuildInputs = [
+    click
+    click-completion
+    validate-email
+    pendulum
+    ptable
+    requests
+    inquirer
+    pbr
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://toggl.uhlir.dev/";
+    description = "Command line tool and set of Python wrapper classes for interacting with toggl's API";
+    license = licenses.mit;
+    maintainers = [ maintainers.mmahut ];
+  };
+}
+

--- a/pkgs/development/python-modules/validate-email/default.nix
+++ b/pkgs/development/python-modules/validate-email/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "validate-email";
+  version = "1.3";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "validate_email";
+    sha256 = "1bxffaf5yz2cph8ki55vdvdypbwkvn2xr1firlcy62vqbzf1jivq";
+  };
+
+  # No tests
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/syrusakbary/validate_email";
+    description = "Verify if an email address is valid and really exists";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.mmahut ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -508,6 +508,8 @@ in {
 
   intelhex = callPackage ../development/python-modules/intelhex { };
 
+  inquirer = callPackage ../development/python-modules/inquirer { };
+
   jira = callPackage ../development/python-modules/jira { };
 
   jwcrypto = callPackage ../development/python-modules/jwcrypto { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2471,6 +2471,8 @@ in {
 
   validictory = callPackage ../development/python-modules/validictory { };
 
+  validate-email = callPackage ../development/python-modules/validate-email { };
+
   venusian = callPackage ../development/python-modules/venusian { };
 
   chameleon = callPackage ../development/python-modules/chameleon { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4254,6 +4254,8 @@ in {
 
   readme_renderer = callPackage ../development/python-modules/readme_renderer { };
 
+  readchar = callPackage ../development/python-modules/readchar { };
+
   rivet = disabledIf isPy3k (toPythonModule (pkgs.rivet.override {
     python2 = python;
   }));

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3861,6 +3861,8 @@ in {
     prompt_toolkit = self.prompt_toolkit;
   };
 
+  ptable = callPackage ../development/python-modules/ptable { };
+
   publicsuffix = callPackage ../development/python-modules/publicsuffix {};
 
   py = callPackage ../development/python-modules/py { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -980,6 +980,8 @@ in {
 
   tomlkit = callPackage ../development/python-modules/tomlkit { };
 
+  toggl-cli = callPackage ../development/python-modules/toggl-cli { };
+
   unifi = callPackage ../development/python-modules/unifi { };
 
   uvloop = callPackage ../development/python-modules/uvloop { };


### PR DESCRIPTION
###### Motivation for this change

- pythonPackages.togglCli: init at 2.1.0

And its dependencies:

- pythonPackages.validate_email: init at 1.3
- pythonPackages.readchar: init at 2.0.1
- pythonPackages.inquirer: init at 2.6.3
- pythonPackages.PTable: init at 0.9.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
