### PR TITLE
opencascade: build with vtk and freeimage, patch for fontconfig support

### DIFF
--- a/pkgs/development/libraries/opencascade/default.nix
+++ b/pkgs/development/libraries/opencascade/default.nix
@@ -1,33 +1,49 @@
-{stdenv, fetchurl, libGLU_combined, tcl, tk, file, libXmu, cmake, libtool, qt4,
-ftgl, freetype}:
+{ stdenv, fetchFromGitHub, fetchpatch, libGL, libGLU, libXmu, cmake, ninja,
+  pkgconfig, fontconfig, freetype, expat, freeimage, vtk }:
 
 stdenv.mkDerivation rec {
-  name = "opencascade-oce-0.18.3";
-  src = fetchurl {
-    url = https://github.com/tpaviot/oce/archive/OCE-0.18.3.tar.gz;
-    sha256 = "0v4ny0qhr5hiialb2ss25bllfnd6j4g7mfxnqfmr1xsjpykxcly5";
+  pname = "opencascade-oce";
+  version = "0.18.3";
+
+  src = fetchFromGitHub {
+    owner = "tpaviot";
+    repo = "oce";
+    rev = "OCE-${version}";
+    sha256 = "17wy8dcf44vqisishv1jjf3cmcxyygqq29y9c3wjdj983qi2hsig";
   };
 
-  buildInputs = [ libGLU_combined tcl tk file libXmu libtool qt4 ftgl freetype cmake ];
+  nativeBuildInputs = [ cmake ninja pkgconfig ];
+  buildInputs = [ libGL libGLU libXmu freetype fontconfig expat freeimage vtk ];
 
-  # Fix for glibc 2.26
+  cmakeFlags = [
+    "-DOCE_INSTALL_PREFIX=${placeholder "out"}"
+    "-DOCE_WITH_FREEIMAGE=ON"
+    "-DOCE_WITH_VTK=ON"
+  ];
+
+  patches = [
+    # Use fontconfig instead of hardcoded directory list
+    # https://github.com/tpaviot/oce/pull/714
+    (fetchpatch {
+      url = "https://github.com/tpaviot/oce/commit/9643432b27fec8974ca0ee15c3c372f5fe8fc069.patch";
+      sha256 = "1wd940rszmh5apcpk5fv6126h8mcjcy4rjifrql5d4ac90v06v4c";
+    })
+    # Fix for glibc 2.26
+    (fetchpatch {
+      url = "https://github.com/tpaviot/oce/commit/3b44656e93270d782009b06ec4be84d2a13f8126.patch";
+      sha256 = "1ccakkcwy5g0184m23x0mnh22i0lk45xm8kgiv5z3pl7nh35dh8k";
+    })
+  ];
+
   postPatch = ''
-    sed -i -e 's/^\( *#include <\)x\(locale.h>\)//' \
-      src/Standard/Standard_CLocaleSentry.hxx
+    # make sure the installed cmake file uses absolute paths for fontconfig
+    substituteInPlace adm/cmake/TKService/CMakeLists.txt \
+      --replace FONTCONFIG_LIBRARIES FONTCONFIG_LINK_LIBRARIES
   '';
-
-  preConfigure = ''
-    cmakeFlags="$cmakeFlags -DOCE_INSTALL_PREFIX=$out"
-  '';
-
-  # https://bugs.freedesktop.org/show_bug.cgi?id=83631
-  NIX_CFLAGS_COMPILE = "-DGLX_GLXEXT_LEGACY";
-
-  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     description = "Open CASCADE Technology, libraries for 3D modeling and numerical simulation";
-    homepage = http://www.opencascade.org/;
+    homepage = "https://github.com/tpaviot/oce";
     maintainers = [ maintainers.viric ];
     platforms = platforms.linux;
     license = licenses.lgpl21;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

OpenCASCADE didn't find any fonts on NixOS, see https://github.com/tpaviot/oce/pull/714

cc maintainer @viric 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
