### PR TITLE
fbthrift: init at 2019.06.10.00

### DIFF
--- a/pkgs/development/libraries/fbthrift/default.nix
+++ b/pkgs/development/libraries/fbthrift/default.nix
@@ -1,0 +1,50 @@
+{ stdenv, fetchFromGitHub, cmake, bison, boost, libevent, double-conversion
+, fizz, flex, fmt, folly, glog, google-gflags, libiberty, openssl, rsocket-cpp
+, wangle, zlib, zstd }:
+
+stdenv.mkDerivation rec {
+  pname = "fbthrift";
+  version = "2019.06.10.00";
+
+  src = fetchFromGitHub {
+    owner = "facebook";
+    repo = "fbthrift";
+    rev = "v${version}";
+    sha256 = "1fx7awkmsqiy92nsxd78zfpkfvga8xwdhza87kml17v0zspf3b2w";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    bison
+    flex
+  ];
+
+  cmakeFlags = stdenv.lib.optionals stdenv.isDarwin [
+    "-DCMAKE_OSX_DEPLOYMENT_TARGET=10.13" # For aligned allocation
+  ];
+
+  buildInputs = [
+    boost
+    double-conversion
+    fizz
+    fmt
+    folly
+    glog
+    google-gflags
+    libevent
+    libiberty
+    openssl
+    rsocket-cpp
+    wangle
+    zlib
+    zstd
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Facebook's branch of Apache Thrift";
+    homepage = https://github.com/facebook/fbthrift;
+    license = licenses.asl20;
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+    maintainers = with maintainers; [ pierreis ];
+  };
+}

--- a/pkgs/development/libraries/fizz/default.nix
+++ b/pkgs/development/libraries/fizz/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchFromGitHub, cmake, boost, libevent, double-conversion, glog
+, google-gflags, libiberty, openssl, folly, libsodium, gtest, zlib }:
+
+stdenv.mkDerivation rec {
+  pname = "fizz";
+  version = "2019.06.10.00";
+
+  src = fetchFromGitHub {
+    owner = "facebookincubator";
+    repo = "fizz";
+    rev = "v${version}";
+    sha256 = "1v7ry6yl6xnpr01ix25v4m19n69finkl7412594sbvssdfvvg2lb";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  cmakeDir = "../fizz";
+  NIX_LDFLAGS = "-lz";
+
+  buildInputs = [
+    boost
+    double-conversion
+    folly
+    glog
+    google-gflags
+    gtest
+    libevent
+    libiberty
+    libsodium
+    openssl
+    zlib
+  ];
+
+  meta = with stdenv.lib; {
+    description = "C++14 implementation of the TLS-1.3 standard";
+    homepage = https://github.com/facebookincubator/fizz;
+    license = licenses.bsd3;
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+    maintainers = with maintainers; [ pierreis ];
+  };
+}

--- a/pkgs/development/libraries/fmt/default.nix
+++ b/pkgs/development/libraries/fmt/default.nix
@@ -13,6 +13,11 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
+  postInstall = ''
+      substituteInPlace $out/lib/cmake/fmt/fmt-targets.cmake \
+          --replace "\''${_IMPORT_PREFIX}/include" "$dev/include"
+    '';
+
   nativeBuildInputs = [ cmake ];
 
   cmakeFlags = [

--- a/pkgs/development/libraries/folly/default.nix
+++ b/pkgs/development/libraries/folly/default.nix
@@ -2,14 +2,14 @@
 , google-gflags, libiberty, openssl }:
 
 stdenv.mkDerivation rec {
-  name = "folly-${version}";
-  version = "2019.05.27.00";
+  pname = "folly";
+  version = "2019.06.10.00";
 
   src = fetchFromGitHub {
     owner = "facebook";
     repo = "folly";
     rev = "v${version}";
-    sha256 = "00xacaziqllps069xzg7iz68rj5hr8mj3rbi4shkrr9jq51y9ikj";
+    sha256 = "1lli9a01ypna6kcw00mapknjb4cdrgiggn1rsj1ayji1fwmcyyfn";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -24,8 +24,6 @@ stdenv.mkDerivation rec {
     libiberty
     openssl
   ];
-
-  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     description = "An open-source C++ library developed and used at Facebook";

--- a/pkgs/development/libraries/rsocket-cpp/default.nix
+++ b/pkgs/development/libraries/rsocket-cpp/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub, cmake, boost, libevent, double-conversion, glog
+, google-gflags, openssl, folly }:
+
+stdenv.mkDerivation rec {
+  pname = "rsocket-cpp";
+  version = "2019-06-13";
+
+  src = fetchFromGitHub {
+    owner = "rsocket";
+    repo = "rsocket-cpp";
+    rev = "14106e93e9e78d86247778bdb1b8ce41f42cd101";
+    sha256 = "0wlpvpfdysa80y0iw87zx3a74mqy11g570gfj26b3l1j55rbw7nk";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  cmakeFlags = [
+    "-DBUILD_EXAMPLES=off"
+    "-DBUILD_TESTS=off"
+  ];
+
+  buildInputs = [
+    double-conversion
+    folly
+    glog
+    google-gflags
+    openssl
+  ];
+
+  meta = with stdenv.lib; {
+    description = "C++ implementation of RSocket";
+    homepage = https://github.com/rsocket/rsocket-cpp;
+    license = licenses.bsd3;
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+    maintainers = with maintainers; [ pierreis ];
+  };
+}

--- a/pkgs/development/libraries/wangle/default.nix
+++ b/pkgs/development/libraries/wangle/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, fetchFromGitHub, cmake, boost, libevent, double-conversion, glog
+, google-gflags, openssl, fizz, folly, gtest }:
+
+stdenv.mkDerivation rec {
+  pname = "wangle";
+  version = "2019.06.10.00";
+
+  src = fetchFromGitHub {
+    owner = "facebook";
+    repo = "wangle";
+    rev = "v${version}";
+    sha256 = "034callgv3n09hcmd6bs2lxvfs1db6654g2ihj1zg6y03az9ijy0";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  cmakeDir = "../wangle";
+
+  cmakeFlags = stdenv.lib.optionals stdenv.isDarwin [
+    "-DBUILD_TESTS=off" # Tests fail on Darwin due to missing utimensat
+    "-DCMAKE_OSX_DEPLOYMENT_TARGET=10.13" # For aligned allocation
+  ];
+
+  buildInputs = [
+    boost
+    double-conversion
+    fizz
+    folly
+    gtest
+    glog
+    google-gflags
+    libevent
+    openssl
+  ];
+
+  meta = with stdenv.lib; {
+    description = "An open-source C++ networking library";
+    longDescription = ''
+      Wangle is a framework providing a set of common client/server
+      abstractions for building services in a consistent, modular, and
+      composable way.
+    '';
+    homepage = https://github.com/facebook/wangle;
+    license = licenses.asl20;
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+    maintainers = with maintainers; [ pierreis ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10388,6 +10388,8 @@ in
 
   folly = callPackage ../development/libraries/folly { };
 
+  wangle = callPackage ../development/libraries/wangle { };
+
   folks = callPackage ../development/libraries/folks { };
 
   makeFontsConf = let fontconfig_ = fontconfig; in {fontconfig ? fontconfig_, fontDirectories}:

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10384,6 +10384,8 @@ in
 
   fontconfig-ultimate = callPackage ../development/libraries/fontconfig-ultimate {};
 
+  fbthrift = callPackage ../development/libraries/fbthrift { };
+
   fizz = callPackage ../development/libraries/fizz { };
 
   folly = callPackage ../development/libraries/folly { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10388,6 +10388,8 @@ in
 
   folly = callPackage ../development/libraries/folly { };
 
+  rsocket-cpp = callPackage ../development/libraries/rsocket-cpp { };
+
   wangle = callPackage ../development/libraries/wangle { };
 
   folks = callPackage ../development/libraries/folks { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10384,6 +10384,8 @@ in
 
   fontconfig-ultimate = callPackage ../development/libraries/fontconfig-ultimate {};
 
+  fizz = callPackage ../development/libraries/fizz { };
+
   folly = callPackage ../development/libraries/folly { };
 
   folks = callPackage ../development/libraries/folks { };


### PR DESCRIPTION
###### Motivation for this change

Added Fbthrift library and its dependencies

**New packages**:

1. Fbthrift (v2019.06.10.00)
2. Fizz (v2019.06.10.00)
3. Wangle (v2019.06.10.00)
4. rsocket-cpp (git master)

**Updated packages**

1. Folly (v2019.05.27.00 >> v2019.06.10.00)

**Fixed packages**

1. Fixed fmt cmake manifest generation


###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
