### PR TITLE
rustc: 1.34.2 -> 1.35.0

### DIFF
--- a/pkgs/development/compilers/rust/binaryBuild.nix
+++ b/pkgs/development/compilers/rust/binaryBuild.nix
@@ -31,7 +31,8 @@ rec {
       license = [ licenses.mit licenses.asl20 ];
     };
 
-    buildInputs = [ bash ] ++ stdenv.lib.optional stdenv.isDarwin Security;
+    buildInputs = [ bash ]
+      ++ stdenv.lib.optional stdenv.isDarwin Security;
 
     postPatch = ''
       patchShebangs .
@@ -51,17 +52,6 @@ rec {
         patchelf \
           --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
           "$out/bin/cargo"
-      ''}
-
-      ${optionalString (stdenv.isDarwin && bootstrapping) ''
-        install_name_tool -change /usr/lib/libresolv.9.dylib '${darwin.libresolv}/lib/libresolv.9.dylib' "$out/bin/rustc"
-        install_name_tool -change /usr/lib/libresolv.9.dylib '${darwin.libresolv}/lib/libresolv.9.dylib' "$out/bin/rustdoc"
-        install_name_tool -change /usr/lib/libiconv.2.dylib '${darwin.libiconv}/lib/libiconv.2.dylib' "$out/bin/cargo"
-        install_name_tool -change /usr/lib/libresolv.9.dylib '${darwin.libresolv}/lib/libresolv.9.dylib' "$out/bin/cargo"
-        install_name_tool -change /usr/lib/libcurl.4.dylib '${stdenv.lib.getLib curl}/lib/libcurl.4.dylib' "$out/bin/cargo"
-        for f in $out/lib/lib*.dylib; do
-          install_name_tool -change /usr/lib/libresolv.9.dylib '${darwin.libresolv}/lib/libresolv.9.dylib' "$f"
-        done
       ''}
 
       # Do NOT, I repeat, DO NOT use `wrapProgram` on $out/bin/rustc
@@ -85,7 +75,8 @@ rec {
       license = [ licenses.mit licenses.asl20 ];
     };
 
-    buildInputs = [ makeWrapper bash ] ++ stdenv.lib.optional stdenv.isDarwin Security;
+    buildInputs = [ makeWrapper bash ]
+      ++ stdenv.lib.optional stdenv.isDarwin Security;
 
     postPatch = ''
       patchShebangs .
@@ -100,12 +91,6 @@ rec {
         patchelf \
           --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
           "$out/bin/cargo"
-      ''}
-
-      ${optionalString (stdenv.isDarwin && bootstrapping) ''
-        install_name_tool -change /usr/lib/libiconv.2.dylib '${darwin.libiconv}/lib/libiconv.2.dylib' "$out/bin/cargo"
-        install_name_tool -change /usr/lib/libresolv.9.dylib '${darwin.libresolv}/lib/libresolv.9.dylib' "$out/bin/cargo"
-        install_name_tool -change /usr/lib/libcurl.4.dylib '${stdenv.lib.getLib curl}/lib/libcurl.4.dylib' "$out/bin/cargo"
       ''}
 
       wrapProgram "$out/bin/cargo" \

--- a/pkgs/development/compilers/rust/bootstrap.nix
+++ b/pkgs/development/compilers/rust/bootstrap.nix
@@ -3,16 +3,16 @@
 let
   # Note: the version MUST be one version prior to the version we're
   # building
-  version = "1.33.0";
+  version = "1.34.2";
 
-  # fetch hashes by running `print-hashes.sh 1.33.0`
+  # fetch hashes by running `print-hashes.sh 1.34.2`
   hashes = {
-    i686-unknown-linux-gnu = "c379203687d98e60623aa88c4df4992dd5a9548bc30674b9fc8e671a979e9f3a";
-    x86_64-unknown-linux-gnu = "6623168b9ee9de79deb0d9274c577d741ea92003768660aca184e04fe774393f";
-    armv7-unknown-linux-gnueabihf = "f6f0ec0a98d922c4bfd79703bc9e9eef439ba347453f33608a87cd63c47e7245";
-    aarch64-unknown-linux-gnu = "a308044e4076b62f637313ea803fa0a8f340b0f1b53136856f2c43afcabe5387";
-    i686-apple-darwin = "ed20809d56bbaea041721ce6fc9f10f7ae7a720c5821587f01a537d07a5454b1";
-    x86_64-apple-darwin = "864e7c074a0b88e38883c87c169513d072300bb52e1d320a067bd34cf14f66bd";
+    i686-unknown-linux-gnu = "926bafd09eb90ba7d5a0195fcffb8f33dd57e515af4f8987a143459f6b1d3f04";
+    x86_64-unknown-linux-gnu = "2bf6622d980a52832bae141304e96f317c8a1ccd2dfd69a134a14033e6e43c0f";
+    armv7-unknown-linux-gnueabihf = "70d1057fcc133dc3e44377060a00d2f9d3a134e2670963d3f1d93f3dbfa0548e";
+    aarch64-unknown-linux-gnu = "15fc6b7ec121df9d4e42483dd12c677203680bec8c69b6f4f62e5a35a07341a8";
+    i686-apple-darwin = "b9fc44cbb06050975664f1033d1337bb38d5ea73b503a5d3af5409033397be5c";
+    x86_64-apple-darwin = "6fdd4bf7fe26dded0cd57b41ab5f0500a5a99b7bc770523a425e9e34f63d0fd8";
   };
 
   platform =

--- a/pkgs/development/compilers/rust/patches/net-tcp-disable-tests.patch
+++ b/pkgs/development/compilers/rust/patches/net-tcp-disable-tests.patch
@@ -1,8 +1,7 @@
-diff --git a/src/libstd/net/tcp.rs b/src/libstd/net/tcp.rs
-index 86ecb10edf..626be0a52d 100644
---- a/src/libstd/net/tcp.rs
-+++ b/src/libstd/net/tcp.rs
-@@ -955,6 +955,7 @@ mod tests {
+diff -ru -x '*~' rustc-1.35.0-src-orig/src/libstd/net/tcp.rs rustc-1.35.0-src/src/libstd/net/tcp.rs
+--- rustc-1.35.0-src-orig/src/libstd/net/tcp.rs	2019-05-20 14:10:15.000000000 +0200
++++ rustc-1.35.0-src/src/libstd/net/tcp.rs	2019-06-13 19:59:46.740611889 +0200
+@@ -973,6 +973,7 @@
          }
      }
  
@@ -10,7 +9,7 @@ index 86ecb10edf..626be0a52d 100644
      #[test]
      fn listen_localhost() {
          let socket_addr = next_test_ip4();
-@@ -1013,6 +1014,7 @@ mod tests {
+@@ -1031,6 +1032,7 @@
          })
      }
  
@@ -18,7 +17,7 @@ index 86ecb10edf..626be0a52d 100644
      #[test]
      fn read_eof() {
          each_ip(&mut |addr| {
-@@ -1032,6 +1034,7 @@ mod tests {
+@@ -1050,6 +1052,7 @@
          })
      }
  
@@ -26,7 +25,7 @@ index 86ecb10edf..626be0a52d 100644
      #[test]
      fn write_close() {
          each_ip(&mut |addr| {
-@@ -1058,6 +1061,7 @@ mod tests {
+@@ -1076,6 +1079,7 @@
          })
      }
  
@@ -34,7 +33,7 @@ index 86ecb10edf..626be0a52d 100644
      #[test]
      fn multiple_connect_serial() {
          each_ip(&mut |addr| {
-@@ -1080,6 +1084,7 @@ mod tests {
+@@ -1098,6 +1102,7 @@
          })
      }
  
@@ -42,7 +41,7 @@ index 86ecb10edf..626be0a52d 100644
      #[test]
      fn multiple_connect_interleaved_greedy_schedule() {
          const MAX: usize = 10;
-@@ -1116,6 +1121,7 @@ mod tests {
+@@ -1134,6 +1139,7 @@
      }
  
      #[test]
@@ -50,7 +49,7 @@ index 86ecb10edf..626be0a52d 100644
      fn multiple_connect_interleaved_lazy_schedule() {
          const MAX: usize = 10;
          each_ip(&mut |addr| {
-@@ -1394,6 +1400,7 @@ mod tests {
+@@ -1467,6 +1473,7 @@
      }
  
      #[test]
@@ -58,7 +57,7 @@ index 86ecb10edf..626be0a52d 100644
      fn clone_while_reading() {
          each_ip(&mut |addr| {
              let accept = t!(TcpListener::bind(&addr));
-@@ -1504,7 +1511,10 @@ mod tests {
+@@ -1597,7 +1604,10 @@
  
      // FIXME: re-enabled bitrig/openbsd tests once their socket timeout code
      //        no longer has rounding errors.
@@ -67,30 +66,30 @@ index 86ecb10edf..626be0a52d 100644
 +                   target_os = "netbsd",
 +                   target_os = "openbsd",
 +                   target_os = "macos"), ignore)]
+     #[cfg_attr(target_env = "sgx", ignore)] // FIXME: https://github.com/fortanix/rust-sgx/issues/31
      #[test]
      fn timeouts() {
-         let addr = next_test_ip4();
-@@ -1591,6 +1601,7 @@ mod tests {
+@@ -1643,6 +1653,7 @@
          drop(listener);
      }
  
 +    #[cfg_attr(target_os = "macos", ignore)]
      #[test]
+     #[cfg_attr(target_env = "sgx", ignore)] // FIXME: https://github.com/fortanix/rust-sgx/issues/31
+     fn test_read_with_timeout() {
+@@ -1687,6 +1698,7 @@
+         drop(listener);
+     }
+ 
++    #[cfg_attr(target_os = "macos", ignore)]
+     #[test]
+     #[cfg_attr(target_env = "sgx", ignore)]
      fn nodelay() {
-         let addr = next_test_ip4();
-@@ -1605,6 +1616,7 @@ mod tests {
-         assert_eq!(false, t!(stream.nodelay()));
+@@ -1719,6 +1731,7 @@
+         assert_eq!(ttl, t!(stream.ttl()));
      }
  
 +    #[cfg_attr(target_os = "macos", ignore)]
      #[test]
-     fn ttl() {
-         let ttl = 100;
-@@ -1642,6 +1654,7 @@ mod tests {
-         }
-     }
- 
-+    #[cfg_attr(target_os = "macos", ignore)]
-     #[test]
-     fn peek() {
-         each_ip(&mut |addr| {
+     #[cfg_attr(target_env = "sgx", ignore)]
+     fn set_nonblocking() {

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -17,11 +17,11 @@ let
   llvmShared = llvm_7.override { enableSharedLibraries = true; };
 in stdenv.mkDerivation rec {
   pname = "rustc";
-  version = "1.34.2";
+  version = "1.35.0";
 
   src = fetchurl {
     url = "https://static.rust-lang.org/dist/rustc-${version}-src.tar.gz";
-    sha256 = "0mig0prkmlnpbba1cmi17vlsl88ikv5pi26zjy2kcr64l62lm6n6";
+    sha256 = "0bbizy6b7002v1rdhrxrf5gijclbyizdhkglhp81ib3bf5x66kas";
   };
 
   __darwinAllowLocalNetworking = true;

--- a/pkgs/development/tools/rust/rustfmt/default.nix
+++ b/pkgs/development/tools/rust/rustfmt/default.nix
@@ -2,13 +2,13 @@
 
 rustPlatform.buildRustPackage rec {
   name = "rustfmt-${version}";
-  version = "1.2.1";
+  version = "1.2.2";
 
   src = fetchFromGitHub {
     owner = "rust-lang";
     repo = "rustfmt";
     rev = "v${version}";
-    sha256 = "153pas7d5fchkmiw6mkbhn75lv3y69k85spzmm5i4lqnq7f0yqap";
+    sha256 = "1k9p6sp8q87flx9vzg46880ir7likvbydai3g6q76278h86rn0v8";
   };
 
   cargoSha256 = "08x6vy5v2vgrk3gsw3qcvv52a7hifsgcsnsg1phlk1ikaff21y4z";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
