### PR TITLE
habitat: 0.32.2 -> 0.82.0

### DIFF
--- a/pkgs/applications/networking/cluster/habitat/default.nix
+++ b/pkgs/applications/networking/cluster/habitat/default.nix
@@ -36,6 +36,6 @@ buildRustPackage rec {
     homepage = https://www.habitat.sh;
     license = licenses.asl20;
     maintainers = [ maintainers.boj maintainers.rushmorem ];
-    platforms = [ "x86_64-linux" ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
   };
 }

--- a/pkgs/applications/networking/cluster/habitat/default.nix
+++ b/pkgs/applications/networking/cluster/habitat/default.nix
@@ -16,7 +16,11 @@ buildRustPackage rec {
   cargoSha256 = "04a48drfx6cz4m51iffhr472jb5ar5yfd2588qm5pkhdkmvv6kx2";
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ libsodium libarchive openssl zeromq ];
+  buildInputs = [
+    libsodium libarchive openssl zeromq
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.Security
+  ];
 
   cargoBuildFlags = ["--package hab"];
 

--- a/pkgs/applications/networking/cluster/habitat/default.nix
+++ b/pkgs/applications/networking/cluster/habitat/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, rustPlatform, pkgconfig
+ { stdenv, lib, fetchFromGitHub, rustPlatform, pkgconfig, darwin
 , libsodium, libarchive, openssl, zeromq }:
 
 with rustPlatform;

--- a/pkgs/applications/networking/cluster/habitat/default.nix
+++ b/pkgs/applications/networking/cluster/habitat/default.nix
@@ -1,24 +1,22 @@
 { lib, fetchFromGitHub, rustPlatform, pkgconfig
-, libsodium, libarchive, openssl }:
+, libsodium, libarchive, openssl, zeromq }:
 
 with rustPlatform;
 
 buildRustPackage rec {
   name = "habitat-${version}";
-  version = "0.30.2";
+  version = "0.82.0";
 
   src = fetchFromGitHub {
     owner = "habitat-sh";
     repo = "habitat";
     rev = version;
-    sha256 = "0pqrm85pd9hqn5fwqjbyyrrfh4k7q9mi9qy9hm8yigk5l8mw44y1";
-  };
+    sha256 = "00fq87kygvd6qmf9lclsblrr3c2m1gmfhpfxgzyzwyzgvh84m35k"; };
 
-  cargoSha256 = "1ahfm5agvabqqqgjsyjb95xxbc7mng1mdyclcakwp1m1qdkxx9p0";
-
-  buildInputs = [ libsodium libarchive openssl ];
+  cargoSha256 = "04a48drfx6cz4m51iffhr472jb5ar5yfd2588qm5pkhdkmvv6kx2";
 
   nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ libsodium libarchive openssl zeromq ];
 
   cargoBuildFlags = ["--package hab"];
 
@@ -33,8 +31,7 @@ buildRustPackage rec {
     description = "An application automation framework";
     homepage = https://www.habitat.sh;
     license = licenses.asl20;
-    maintainers = [ maintainers.rushmorem ];
-    platforms = [ "x86_64-linux" "x86_64-darwin" ];
-    broken = true; # mark temporary as broken due git dependencies
+    maintainers = [ maintainers.boj maintainers.rushmorem ];
+    platforms = [ "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

New attempt after closing https://github.com/NixOS/nixpkgs/pull/46138

Fixes the cargoSha256 problem here for habitat: https://github.com/NixOS/nixpkgs/pull/62047

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
