### PR TITLE
initial vdr plugin xineliboutput-2.1.0

### DIFF
--- a/pkgs/applications/video/vdr/plugins.nix
+++ b/pkgs/applications/video/vdr/plugins.nix
@@ -1,7 +1,8 @@
 { stdenv, fetchurl, fetchgit, vdr, ffmpeg_2, alsaLib, fetchFromGitHub
 , libvdpau, libxcb, xcbutilwm, graphicsmagick, libav, pcre, xorgserver, ffmpeg
-, libiconv, boost, libgcrypt, perl, utillinux, groff, libva, xorg, ncurses }:
-let
+, libiconv, boost, libgcrypt, perl, utillinux, groff, libva, xorg, ncurses
+, callPackage
+}: let
   mkPlugin = name: stdenv.mkDerivation {
     name = "vdr-${vdr.version}-${name}";
     inherit (vdr) src;
@@ -10,6 +11,8 @@ let
     installFlags = [ "DESTDIR=$(out)" ];
   };
 in {
+
+  xineliboutput = callPackage ./xineliboutput {};
 
   skincurses = (mkPlugin "skincurses").overrideAttrs(oldAttr: {
     buildInputs = oldAttr.buildInputs ++ [ ncurses ];

--- a/pkgs/applications/video/vdr/wrapper.nix
+++ b/pkgs/applications/video/vdr/wrapper.nix
@@ -1,5 +1,12 @@
-{ symlinkJoin, lib, makeWrapper, vdr, plugins ? [] }:
-symlinkJoin {
+{ symlinkJoin, lib, makeWrapper, vdr
+, plugins ? []
+}: let
+
+  makeXinePluginPath = l: lib.concatStringsSep ":" (map (p: "${p}/lib/xine/plugins") l);
+
+  requiredXinePlugins = lib.flatten (map (p: p.passthru.requiredXinePlugins or []) plugins);
+
+in symlinkJoin {
 
   name = "vdr-with-plugins-${(builtins.parseDrvName vdr.name).version}";
 
@@ -8,7 +15,9 @@ symlinkJoin {
   nativeBuildInputs = [ makeWrapper ];
 
   postBuild = ''
-    wrapProgram $out/bin/vdr --add-flags "-L $out/lib/vdr --localedir=$out/share/locale"
+    wrapProgram $out/bin/vdr \
+      --add-flags "-L $out/lib/vdr --localedir=$out/share/locale" \
+      --prefix XINE_PLUGIN_PATH ":" ${makeXinePluginPath requiredXinePlugins}
   '';
 
   meta = with vdr.meta; {

--- a/pkgs/applications/video/vdr/xineliboutput/default.nix
+++ b/pkgs/applications/video/vdr/xineliboutput/default.nix
@@ -1,0 +1,63 @@
+{ stdenv, fetchurl, lib, vdr
+, libav, libcap, libvdpau
+, xineLib, libjpeg, libextractor, mesa_noglu, libGLU
+, libX11, libXext, libXrender, libXrandr
+, makeWrapper
+}: let
+  name = "vdr-xineliboutput-2.1.0";
+
+  makeXinePluginPath = l: lib.concatStringsSep ":" (map (p: "${p}/lib/xine/plugins") l);
+
+  self =  stdenv.mkDerivation {
+    inherit name;
+
+    src = fetchurl {
+      name = "src.tgz";
+      url = "https://sourceforge.net/projects/xineliboutput/files/xineliboutput/${name}/${name}.tgz/download";
+      sha256 = "6af99450ad0792bd646c6f4058f6e49541aab8ba3a10e131f82752f4d5ed19de";
+    };
+
+    configurePhase = ''
+      ./configure
+      sed -i config.mak \
+        -e 's,XINEPLUGINDIR=/[^/]*/[^/]*/[^/]*/,XINEPLUGINDIR=/,'
+    '';
+
+    makeFlags = [ "DESTDIR=$(out)" ];
+
+    postFixup = ''
+      for f in $out/bin/*; do
+        wrapProgram $f \
+          --prefix XINE_PLUGIN_PATH ":" "${makeXinePluginPath [ "$out" xineLib ]}"
+      done
+    '';
+
+    nativeBuildInputs = [ makeWrapper ];
+
+    buildInputs = [
+      libav
+      libcap
+      libextractor
+      libjpeg
+      libGLU
+      libvdpau
+      libXext
+      libXrandr
+      libXrender
+      libX11
+      mesa_noglu
+      vdr
+      xineLib
+    ];
+
+    passthru.requiredXinePlugins = [ xineLib self ];
+
+    meta = with lib;{
+      homepage = https://sourceforge.net/projects/xineliboutput/;
+      description = "xine-lib based software output device for VDR.";
+      maintainers = [ maintainers.ck3d ];
+      license = licenses.gpl2;
+      platforms = [ "i686-linux" "x86_64-linux" ];
+    };
+  };
+in self

--- a/pkgs/applications/video/vdr/xineliboutput/default.nix
+++ b/pkgs/applications/video/vdr/xineliboutput/default.nix
@@ -12,13 +12,14 @@
     inherit name;
 
     src = fetchurl {
-      name = "src.tgz";
-      url = "https://sourceforge.net/projects/xineliboutput/files/xineliboutput/${name}/${name}.tgz/download";
-      sha256 = "6af99450ad0792bd646c6f4058f6e49541aab8ba3a10e131f82752f4d5ed19de";
+      url = "mirror://sourceforge/project/xineliboutput/xineliboutput/${name}/${name}.tgz";
+      sha256 = "1phrxpaz8li7z0qy241spawalhcmwkv5hh3gdijbv4h7mm899yba";
     };
 
-    configurePhase = ''
-      ./configure
+    # configure don't accept argument --prefix
+    dontAddPrefix = true;
+
+    postConfigure = ''
       sed -i config.mak \
         -e 's,XINEPLUGINDIR=/[^/]*/[^/]*/[^/]*/,XINEPLUGINDIR=/,'
     '';
@@ -53,11 +54,11 @@
     passthru.requiredXinePlugins = [ xineLib self ];
 
     meta = with lib;{
-      homepage = https://sourceforge.net/projects/xineliboutput/;
-      description = "xine-lib based software output device for VDR.";
+      homepage = "https://sourceforge.net/projects/xineliboutput/";
+      description = "Xine-lib based software output device for VDR";
       maintainers = [ maintainers.ck3d ];
       license = licenses.gpl2;
-      platforms = [ "i686-linux" "x86_64-linux" ];
+      inherit (vdr.meta) platforms;
     };
   };
 in self

--- a/pkgs/development/libraries/xine-lib/default.nix
+++ b/pkgs/development/libraries/xine-lib/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, xorg, alsaLib, libGLU_combined, aalib
+{ stdenv, fetchurl, fetchpatch, pkgconfig, xorg, alsaLib, libGLU_combined, aalib
 , libvorbis, libtheora, speex, zlib, perl, ffmpeg
 , flac, libcaca, libpulseaudio, libmng, libcdio, libv4l, vcdimager
 , libmpcdec
@@ -18,6 +18,14 @@ stdenv.mkDerivation rec {
     xorg.libX11 xorg.libXv xorg.libXinerama xorg.libxcb xorg.libXext
     alsaLib libGLU_combined aalib libvorbis libtheora speex perl ffmpeg flac
     libcaca libpulseaudio libmng libcdio libv4l vcdimager libmpcdec
+  ];
+
+  patches = [
+    (fetchpatch {
+      name = "0001-fix-XINE_PLUGIN_PATH-splitting.patch";
+      url = "https://sourceforge.net/p/xine/mailman/attachment/32394053-5e27-6558-f0c9-49e0da0bc3cc%40gmx.de/1/";
+      sha256 = "0nrsdn7myvjs8fl9rj6k4g1bnv0a84prsscg1q9n49gwn339v5rc";
+    })
   ];
 
   NIX_LDFLAGS = "-lxcb-shm";


### PR DESCRIPTION
Needed to patch package xineLib to fix usage of XINE_PLUGIN_PATH .

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
