### PR TITLE
opendune: support ALSA and pulseaudio (move to SDL2)

### DIFF
--- a/pkgs/games/opendune/default.nix
+++ b/pkgs/games/opendune/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchFromGitHub, SDL, SDL_image, SDL_mixer }:
+{ stdenv, lib, fetchFromGitHub, pkgconfig
+, alsaLib, libpulseaudio, SDL2, SDL2_image, SDL2_mixer }:
 
 # - set the opendune configuration at ~/.config/opendune/opendune.ini:
 #     [opendune]
@@ -16,17 +17,30 @@ stdenv.mkDerivation rec {
     sha256 = "15rvrnszdy3db8s0dmb696l4isb3x2cpj7wcl4j09pdi59pc8p37";
   };
 
-  buildInputs = [ SDL SDL_image SDL_mixer ];
+  configureFlags = [
+    "--with-alsa=${lib.getLib alsaLib}/lib/libasound.so"
+    "--with-pulse=${lib.getLib libpulseaudio}/lib/libpulse.so"
+  ];
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [ alsaLib libpulseaudio SDL2 SDL2_image SDL2_mixer ];
+
+  enableParallelBuilding = true;
 
   installPhase = ''
-    install -m 555 -D bin/opendune $out/bin/opendune
+    runHook preInstall
+
+    install -Dm555 -t $out/bin bin/opendune
+    install -Dm444 -t $out/share/doc/opendune enhancement.txt README.txt
+
+    runHook postInstall
   '';
 
   meta = with stdenv.lib; {
     description = "Dune, Reinvented";
     homepage = https://github.com/OpenDUNE/OpenDUNE;
     license = licenses.gpl2;
-    maintainers = [ maintainers.nand0p ];
-    platforms = platforms.linux;
+    maintainers = with maintainers; [ nand0p ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Add support for ALSA and pulseaudio and move to SDL2.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Cc: @nand0p 
---
