### PR TITLE
shaarli-material: Mark as broken

### DIFF
--- a/pkgs/servers/web-apps/shaarli/material-theme.nix
+++ b/pkgs/servers/web-apps/shaarli/material-theme.nix
@@ -26,10 +26,13 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
+    # This package has not been updated for the new build process
+    # introduced in 0.10.3 which depends on npm and gulp.
+    broken = true;
     description = "A theme base on Google's Material Design for Shaarli, the superfast delicious clone";
     license = licenses.mit;
     homepage = https://github.com/kalvn/Shaarli-Material;
-    maintainers = with maintainers; [ schneefux ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
shaarli-material is a theme plugin for the shaarli web application.
The version of the theme needs to match shaarli's or else there are server errors, broken scripts and broken styling. shaarli-material is behind by almost a year, so the two versions of shaarli + shaarli-material in the nix store do not work together.
The build process for shaarli-material has changed in 0.10.3 and now depends on npm packages and a gulp script (changelog: https://github.com/kalvn/Shaarli-Material/releases) and I do not know how to update the build recipe for it.
I have not managed to set up a working shaarli + shaarli-material configuration with the prebuilt assets from the GitHub releases page either.

So I'd like to drop the package because it has been unusable for a year, is too difficult to maintain and apparently not used by anyone.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
