### PR TITLE
flatpak: Preserve pixbuf path in validate-icon

### DIFF
--- a/pkgs/development/libraries/flatpak/default.nix
+++ b/pkgs/development/libraries/flatpak/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, autoreconfHook, docbook_xml_dtd_412, docbook_xml_dtd_42, docbook_xml_dtd_43, docbook_xsl, which, libxml2
 , gobject-introspection, gtk-doc, intltool, libxslt, pkgconfig, xmlto, appstream-glib, substituteAll, glibcLocales, yacc, xdg-dbus-proxy, p11-kit
 , bubblewrap, bzip2, dbus, glib, gpgme, json-glib, libarchive, libcap, libseccomp, coreutils, gettext, python2, hicolor-icon-theme
-, libsoup, lzma, ostree, polkit, python3, systemd, xorg, valgrind, glib-networking, wrapGAppsHook, gnome3, gsettings-desktop-schemas }:
+, libsoup, lzma, ostree, polkit, python3, systemd, xorg, valgrind, glib-networking, wrapGAppsHook, gnome3, gsettings-desktop-schemas, librsvg }:
 
 stdenv.mkDerivation rec {
   pname = "flatpak";
@@ -45,6 +45,7 @@ stdenv.mkDerivation rec {
     bubblewrap bzip2 dbus gnome3.dconf glib gpgme json-glib libarchive libcap libseccomp
     libsoup lzma ostree polkit python3 systemd xorg.libXau
     gsettings-desktop-schemas glib-networking
+    librsvg # for flatpak-validate-icon
   ];
 
   checkInputs = [ valgrind ];

--- a/pkgs/development/libraries/flatpak/default.nix
+++ b/pkgs/development/libraries/flatpak/default.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation rec {
     ./respect-xml-catalog-files-var.patch
     ./use-flatpak-from-path.patch
     ./unset-env-vars.patch
+    ./validate-icon-pixbuf.patch
   ];
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/flatpak/validate-icon-pixbuf.patch
+++ b/pkgs/development/libraries/flatpak/validate-icon-pixbuf.patch
@@ -1,0 +1,13 @@
+diff --git a/icon-validator/validate-icon.c b/icon-validator/validate-icon.c
+index 6e23d9f2..f0659a78 100644
+--- a/icon-validator/validate-icon.c
++++ b/icon-validator/validate-icon.c
+@@ -193,6 +193,8 @@ rerun_in_sandbox (const char *arg_width,
+     add_args (args, "--setenv", "G_MESSAGES_DEBUG", g_getenv ("G_MESSAGES_DEBUG"), NULL);
+   if (g_getenv ("G_MESSAGES_PREFIXED"))
+     add_args (args, "--setenv", "G_MESSAGES_PREFIXED", g_getenv ("G_MESSAGES_PREFIXED"), NULL);
++  if (g_getenv ("GDK_PIXBUF_MODULE_FILE"))
++    add_args (args, "--setenv", "GDK_PIXBUF_MODULE_FILE", g_getenv ("GDK_PIXBUF_MODULE_FILE"), NULL);
+ 
+   add_args (args, validate_icon, arg_width, arg_height, filename, NULL);
+   g_ptr_array_add (args, NULL);


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Without this, `flatpak-validate-icon` fails on SVG files and I can't build any flatpaks which have SVG icons.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I tested with:

```
$ git checkout 46e1c7f17aafaab18091f8fe04c1586f4ab932af^; nix-build . -A flatpak; ./result/libexec/flatpak-validate-icon --sandbox 16 16 ~/.local/share/flatpak/exports/share/icons/hicolor/symbolic/apps/org.gnome.Boxes-symbolic.svg; echo $?
HEAD is now at 29dc0ba6577 vimPlugins: update (#63119)
/nix/store/5nw27q7hb34a9bd49zdpg44fc8p1kh0k-flatpak-1.2.4
Format not recognized
1
$ git checkout 46e1c7f17aafaab18091f8fe04c1586f4ab932af; nix-build . -A flatpak; ./result/libexec/flatpak-validate-icon --sandbox 16 16 ~/.local/share/flatpak/exports/share/icons/hicolor/symbolic/apps/org.gnome.Boxes-symbolic.svg; echo $?
Previous HEAD position was 29dc0ba6577 vimPlugins: update (#63119)
HEAD is now at 46e1c7f17aa flatpak: Preserve pixbuf path in validate-icon
/nix/store/4a8j3i5k7d0f9skxwwfknsk7czk1ndfv-flatpak-1.2.4
0
```

---
