### PR TITLE
hpmyroom: init at 11.1.0.0508

### DIFF
--- a/pkgs/applications/networking/hpmyroom/default.nix
+++ b/pkgs/applications/networking/hpmyroom/default.nix
@@ -1,0 +1,58 @@
+{ mkDerivation, stdenv, lib, fetchurl, rpmextract, autoPatchelfHook , libuuid
+, libXtst, libXfixes, glib, gst_all_1, alsaLib, freetype, fontconfig , libXext
+, libGL, libpng, libXScrnSaver, libxcb, xorg, libpulseaudio, libdrm
+}:
+mkDerivation rec {
+  pname = "hpmyroom";
+  version = "11.1.0.0508";
+
+  src = fetchurl {
+    url = "https://www.myroom.hpe.com/downloadfiles/${pname}-${version}.x86_64.rpm";
+    sha256 = "1j7mzvf349yxb42m8syh73gpvil01hy1a2wrr0rdzb2ijfnkxyaa";
+  };
+
+  nativeBuildInputs = [
+    rpmextract autoPatchelfHook
+  ];
+
+  buildInputs = [
+    libuuid libXtst libXScrnSaver libXfixes alsaLib freetype fontconfig libXext
+    libGL libpng libxcb libpulseaudio libdrm
+    glib  # For libgobject
+    stdenv.cc.cc  # For libstdc++
+    xorg.libX11
+  ] ++ (with gst_all_1; [ gstreamer gst-plugins-base ]);
+
+  unpackPhase = ''
+    rpmextract $src
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mv usr $out
+
+    runHook postInstall
+  '';
+
+  qtWrapperArgs = [
+    "--prefix QT_XKB_CONFIG_ROOT : '${xorg.xkeyboardconfig}/share/X11/xkb'"
+  ];
+
+  postFixup = ''
+    substituteInPlace $out/share/applications/HP-myroom.desktop \
+      --replace /usr/bin/hpmyroom hpmyroom \
+      --replace Icon=/usr/share/hpmyroom/Resources/MyRoom.png Icon=$out/share/hpmyroom/Resources/MyRoom.png
+
+    ln -s ${libpng}/lib/libpng.so $out/lib/hpmyroom/libpng15.so.15
+  '';
+
+  meta = {
+    description = "Client for HPE's MyRoom web conferencing solution";
+    maintainers = with lib.maintainers; [ johnazoidberg ];
+    license = lib.licenses.unfree;
+    homepage = "https://myroom.hpe.com";
+    # TODO: A Darwin binary is available upstream
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18816,6 +18816,8 @@ in
 
   hpl = callPackage ../tools/misc/hpl { mpi = openmpi; };
 
+  hpmyroom = libsForQt5.callPackage ../applications/networking/hpmyroom { };
+
   ht = callPackage ../applications/editors/ht { };
 
   hubstaff = callPackage ../applications/misc/hubstaff { };


### PR DESCRIPTION
###### Motivation for this change
To join a web conference instantiated by HPE's MyRoom this client can be used.
Everything seems to work, voice chat, screen sharing. It only doesn't show my webcam but I have never used that feature or know how (apart from the "Testing" screen).
Since I can't find a license, I classified it as nonfree and we can't build it with hydra and distribute it in the cache. 

There is a Darwin binary but I don't know how to patchelf there or whether it works there.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
