### PR TITLE
zabbix: adding zabbix proxy support

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -513,6 +513,7 @@
   ./services/monitoring/uptime.nix
   ./services/monitoring/vnstat.nix
   ./services/monitoring/zabbix-agent.nix
+  ./services/monitoring/zabbix-proxy.nix
   ./services/monitoring/zabbix-server.nix
   ./services/network-filesystems/beegfs.nix
   ./services/network-filesystems/cachefilesd.nix

--- a/nixos/modules/services/monitoring/zabbix-proxy.nix
+++ b/nixos/modules/services/monitoring/zabbix-proxy.nix
@@ -1,0 +1,133 @@
+# Zabbix proxy daemon.
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.zabbixProxy;
+
+  stateDir = "/run/zabbix";
+
+  logDir = "/var/log/zabbix";
+
+  libDir = "/var/lib/zabbix";
+
+  pidFile = "${stateDir}/zabbix_proxy.pid";
+
+  configFile = pkgs.writeText "zabbix_proxy.conf"
+    ''
+      Server = ${cfg.server}
+
+      LogFile = ${logDir}/zabbix_proxy
+
+      PidFile = ${pidFile}
+
+      ${optionalString (cfg.dbServer != "localhost") ''
+        DBHost = ${cfg.dbServer}
+      ''}
+
+      DBName = zabbix
+
+      DBUser = zabbix
+
+      ${optionalString (cfg.dbPassword != "") ''
+        DBPassword = ${cfg.dbPassword}
+      ''}
+
+      ${config.services.zabbixProxy.extraConfig}
+    '';
+
+  useLocalPostgres = cfg.dbServer == "localhost" || cfg.dbServer == "";
+
+in
+
+{
+
+  ###### interface
+
+  options = {
+
+    services.zabbixProxy.enable = mkOption {
+      default = false;
+      type = types.bool;
+      description = ''
+        Whether to run the Zabbix proxy on this machine.
+      '';
+    };
+
+    services.zabbixProxy.server = mkOption {
+       default = "127.0.0.1";
+       description = ''
+         The IP address or hostname of the Zabbix server to connect to.
+       '';
+    };
+
+    services.zabbixProxy.dbServer = mkOption {
+      default = "localhost";
+      type = types.str;
+      description = ''
+        Hostname or IP address of the database server.
+        Use an empty string ("") to use peer authentication.
+      '';
+    };
+
+    services.zabbixProxy.dbPassword = mkOption {
+      default = "";
+      type = types.str;
+      description = "Password used to connect to the database server.";
+    };
+
+    services.zabbixProxy.extraConfig = mkOption {
+      default = "";
+      type = types.lines;
+      description = ''
+        Configuration that is injected verbatim into the configuration file.
+      '';
+    };
+
+  };
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+
+    services.postgresql.enable = useLocalPostgres;
+
+    users.users = singleton
+      { name = "zabbix";
+        uid = config.ids.uids.zabbix;
+        description = "Zabbix daemon user";
+      };
+
+    systemd.services."zabbix-proxy" =
+      { description = "Zabbix Proxy";
+
+        wantedBy = [ "multi-user.target" ];
+        after = optional useLocalPostgres "postgresql.service";
+
+        preStart =
+          ''
+            mkdir -m 0755 -p ${stateDir} ${logDir} ${libDir}
+            chown zabbix ${stateDir} ${logDir} ${libDir}
+
+            if ! test -e "${libDir}/db-created"; then
+                ${pkgs.su}/bin/su -s "$SHELL" ${config.services.postgresql.superUser} -c '${pkgs.postgresql}/bin/createuser --no-superuser --no-createdb --no-createrole zabbix' || true
+                ${pkgs.su}/bin/su -s "$SHELL" ${config.services.postgresql.superUser} -c '${pkgs.postgresql}/bin/createdb --owner zabbix zabbix' || true
+                cat ${pkgs.zabbix.server}/share/zabbix/db/schema/postgresql.sql | ${pkgs.su}/bin/su -s "$SHELL" zabbix -c '${pkgs.postgresql}/bin/psql zabbix'
+                touch "${libDir}/db-created"
+            fi
+          '';
+
+        path = [ pkgs.nettools ];
+
+        serviceConfig.ExecStart = "@${pkgs.zabbix.proxy}/sbin/zabbix_proxy zabbix_proxy --config ${configFile}";
+        serviceConfig.Type = "forking";
+        serviceConfig.Restart = "always";
+        serviceConfig.RestartSec = 2;
+        serviceConfig.PIDFile = pidFile;
+      };
+
+  };
+
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -262,5 +262,6 @@ in
   xrdp = handleTest ./xrdp.nix {};
   xss-lock = handleTest ./xss-lock.nix {};
   yabar = handleTest ./yabar.nix {};
+  zabbix-proxy = handleTest ./zabbix-proxy.nix {};
   zookeeper = handleTest ./zookeeper.nix {};
 }

--- a/nixos/tests/zabbix-proxy.nix
+++ b/nixos/tests/zabbix-proxy.nix
@@ -1,0 +1,20 @@
+import ./make-test.nix {
+  name = "zabbix-proxy";
+
+  nodes = {
+    proxy =
+      { pkgs, ... }:
+
+      {
+        services.zabbixProxy.enable = true;
+      };
+  };
+
+  testScript = ''
+    startAll;
+
+    $proxy->waitForUnit("zabbix-proxy.service");
+    $proxy->waitForFile("/run/zabbix/zabbix_proxy.pid");
+    $proxy->waitUntilSucceeds("curl -L localhost:10051 | grep OK");
+  '';
+}

--- a/pkgs/servers/monitoring/zabbix/2.0.nix
+++ b/pkgs/servers/monitoring/zabbix/2.0.nix
@@ -89,4 +89,31 @@ in
     };
   };
 
+  proxy = stdenv.mkDerivation {
+    name = "zabbix-proxy-${version}";
+
+    inherit src preConfigure;
+
+    configureFlags = [
+      "--enable-proxy"
+      "--with-postgresql"
+    ];
+
+    buildInputs = [ postgresql ];
+
+    postInstall = ''
+      mkdir -p $out/share/zabbix/db/schema
+      cp -prvd database/postgresql/schema.sql $out/share/zabbix/db/schema/postgresql.sql
+    '';
+
+    meta = with stdenv.lib; {
+      inherit branch;
+      description = "An enterprise-class open source distributed monitoring solution (client-server proxy)";
+      homepage = https://www.zabbix.com/;
+      license = licenses.gpl2;
+      maintainers = [ maintainers.eelco ];
+      platforms = platforms.linux;
+    };
+  };
+
 }

--- a/pkgs/servers/monitoring/zabbix/2.0.nix
+++ b/pkgs/servers/monitoring/zabbix/2.0.nix
@@ -65,9 +65,9 @@ in
     meta = {
       inherit branch;
       description = "An enterprise-class open source distributed monitoring solution";
-      homepage = https://www.zabbix.com/;
+      homepage = "https://www.zabbix.com/";
       license = "GPL";
-      maintainers = [ stdenv.lib.maintainers.eelco ];
+      maintainers = [ stdenv.lib.maintainers.eelco stdenv.lib.maintainers.mmahut ];
       platforms = stdenv.lib.platforms.linux;
     };
   };
@@ -82,9 +82,9 @@ in
     meta = with stdenv.lib; {
       inherit branch;
       description = "An enterprise-class open source distributed monitoring solution (client-side agent)";
-      homepage = https://www.zabbix.com/;
+      homepage = "https://www.zabbix.com/";
       license = licenses.gpl2;
-      maintainers = [ maintainers.eelco ];
+      maintainers = [ maintainers.eelco maintainers.mmahut ];
       platforms = platforms.linux;
     };
   };
@@ -111,7 +111,7 @@ in
       description = "An enterprise-class open source distributed monitoring solution (client-server proxy)";
       homepage = https://www.zabbix.com/;
       license = licenses.gpl2;
-      maintainers = [ maintainers.eelco ];
+      maintainers = [ maintainers.eelco maintainers.mmahut ];
       platforms = platforms.linux;
     };
   };

--- a/pkgs/servers/monitoring/zabbix/2.2.nix
+++ b/pkgs/servers/monitoring/zabbix/2.2.nix
@@ -101,4 +101,31 @@ in
     };
   };
 
+  proxy = stdenv.mkDerivation {
+    name = "zabbix-proxy-${version}";
+
+    inherit src preConfigure;
+
+    configureFlags = [
+			"--enable-proxy"
+			"--with-postgresql"
+		];
+
+		buildInputs = [ postgresql ];
+
+    postInstall = ''
+      mkdir -p $out/share/zabbix/db/schema
+      cp -prvd database/postgresql/schema.sql $out/share/zabbix/db/schema/postgresql.sql
+    '';
+
+    meta = with stdenv.lib; {
+      inherit branch;
+      description = "An enterprise-class open source distributed monitoring solution (client-server proxy)";
+      homepage = https://www.zabbix.com/;
+      license = licenses.gpl2;
+      maintainers = [ maintainers.eelco ];
+      platforms = platforms.linux;
+    };
+  };
+
 }

--- a/pkgs/servers/monitoring/zabbix/2.2.nix
+++ b/pkgs/servers/monitoring/zabbix/2.2.nix
@@ -77,9 +77,9 @@ in
     meta = {
       inherit branch;
       description = "An enterprise-class open source distributed monitoring solution";
-      homepage = https://www.zabbix.com/;
+      homepage = "https://www.zabbix.com/";
       license = "GPL";
-      maintainers = [ stdenv.lib.maintainers.eelco ];
+      maintainers = [ stdenv.lib.maintainers.eelco stdenv.lib.maintainers.mmahut ];
       platforms = stdenv.lib.platforms.linux;
     };
   };
@@ -94,9 +94,9 @@ in
     meta = with stdenv.lib; {
       inherit branch;
       description = "An enterprise-class open source distributed monitoring solution (client-side agent)";
-      homepage = https://www.zabbix.com/;
+      homepage = "https://www.zabbix.com/";
       license = licenses.gpl2;
-      maintainers = [ maintainers.eelco ];
+      maintainers = [ maintainers.eelco maintainers.mmahut ];
       platforms = platforms.linux;
     };
   };
@@ -121,9 +121,9 @@ in
     meta = with stdenv.lib; {
       inherit branch;
       description = "An enterprise-class open source distributed monitoring solution (client-server proxy)";
-      homepage = https://www.zabbix.com/;
+      homepage = "https://www.zabbix.com/";
       license = licenses.gpl2;
-      maintainers = [ maintainers.eelco ];
+      maintainers = [ maintainers.eelco maintainers.mmahut ];
       platforms = platforms.linux;
     };
   };

--- a/pkgs/servers/monitoring/zabbix/3.4.nix
+++ b/pkgs/servers/monitoring/zabbix/3.4.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pcre, libiconv, openssl }:
+{ stdenv, fetchurl, pcre, libiconv, openssl, postgresql }:
 
 
 let
@@ -30,6 +30,35 @@ in
     meta = with stdenv.lib; {
       inherit branch;
       description = "An enterprise-class open source distributed monitoring solution (client-side agent)";
+      homepage = https://www.zabbix.com/;
+      license = licenses.gpl2;
+      maintainers = [ maintainers.eelco ];
+      platforms = platforms.linux;
+    };
+  };
+
+  proxy = stdenv.mkDerivation {
+    name = "zabbix-proxy-${version}";
+
+    inherit src;
+
+     configureFlags = [
+      "--enable-proxy"
+      "--with-postgresql"
+      "--with-libpcre=${pcre.dev}"
+      "--with-iconv=${libiconv}"
+    ];
+
+    buildInputs = [ postgresql libiconv pcre ];
+
+    postInstall = ''
+      mkdir -p $out/share/zabbix/db/schema
+      cp -pvd database/postgresql/schema.sql $out/share/zabbix/db/schema/postgresql.sql
+    '';
+
+    meta = with stdenv.lib; {
+      inherit branch;
+      description = "An enterprise-class open source distributed monitoring solution (client-server proxy)";
       homepage = https://www.zabbix.com/;
       license = licenses.gpl2;
       maintainers = [ maintainers.eelco ];

--- a/pkgs/servers/monitoring/zabbix/3.4.nix
+++ b/pkgs/servers/monitoring/zabbix/3.4.nix
@@ -30,9 +30,9 @@ in
     meta = with stdenv.lib; {
       inherit branch;
       description = "An enterprise-class open source distributed monitoring solution (client-side agent)";
-      homepage = https://www.zabbix.com/;
+      homepage = "https://www.zabbix.com/";
       license = licenses.gpl2;
-      maintainers = [ maintainers.eelco ];
+      maintainers = [ maintainers.eelco maintainers.mmahut ];
       platforms = platforms.linux;
     };
   };
@@ -59,9 +59,9 @@ in
     meta = with stdenv.lib; {
       inherit branch;
       description = "An enterprise-class open source distributed monitoring solution (client-server proxy)";
-      homepage = https://www.zabbix.com/;
+      homepage = "https://www.zabbix.com/";
       license = licenses.gpl2;
-      maintainers = [ maintainers.eelco ];
+      maintainers = [ maintainers.eelco maintainers.mmahut ];
       platforms = platforms.linux;
     };
   };

--- a/pkgs/servers/monitoring/zabbix/default.nix
+++ b/pkgs/servers/monitoring/zabbix/default.nix
@@ -72,4 +72,30 @@ in
     };
   };
 
+  proxy = stdenv.mkDerivation {
+    name = "zabbix-proxy-${version}";
+
+    inherit src preConfigure;
+
+    configureFlags = [
+      "--enable-proxy"
+      "--with-pgsql"
+    ];
+
+    buildInputs = [ postgresql ];
+
+    postInstall = ''
+      mkdir -p $out/share/zabbix/db/schema
+      cp -prvd create/schema/*.sql $out/share/zabbix/db/schema
+    '';
+
+    meta = with stdenv.lib; {
+      description = "An enterprise-class open source distributed monitoring solution (client-server proxy)";
+      homepage = https://www.zabbix.com/;
+      license = licenses.gpl2;
+      maintainers = [ maintainers.eelco ];
+      platforms = platforms.linux;
+    };
+  };
+
 }

--- a/pkgs/servers/monitoring/zabbix/default.nix
+++ b/pkgs/servers/monitoring/zabbix/default.nix
@@ -49,9 +49,9 @@ in
 
     meta = {
       description = "An enterprise-class open source distributed monitoring solution";
-      homepage = https://www.zabbix.com/;
+      homepage = "https://www.zabbix.com/";
       license = "GPL";
-      maintainers = [ stdenv.lib.maintainers.eelco ];
+      maintainers = [ stdenv.lib.maintainers.eelco stdenv.lib.maintainers.mmahut ];
       platforms = stdenv.lib.platforms.linux;
     };
   };
@@ -65,9 +65,9 @@ in
 
     meta = with stdenv.lib; {
       description = "An enterprise-class open source distributed monitoring solution (client-side agent)";
-      homepage = https://www.zabbix.com/;
+      homepage = "https://www.zabbix.com/";
       license = licenses.gpl2;
-      maintainers = [ maintainers.eelco ];
+      maintainers = [ maintainers.eelco maintainers.mmahut ];
       platforms = platforms.linux;
     };
   };
@@ -91,9 +91,9 @@ in
 
     meta = with stdenv.lib; {
       description = "An enterprise-class open source distributed monitoring solution (client-server proxy)";
-      homepage = https://www.zabbix.com/;
+      homepage = "https://www.zabbix.com/";
       license = licenses.gpl2;
-      maintainers = [ maintainers.eelco ];
+      maintainers = [ maintainers.eelco maintainers.mmahut ];
       platforms = platforms.linux;
     };
   };


### PR DESCRIPTION
###### Motivation for this change

Adding zabbix proxy support by creating a new zabbix proxy module along with zabbix-proxy subpackages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
