### PR TITLE
nixos/captive-browser: fix module

### DIFF
--- a/nixos/modules/programs/captive-browser.nix
+++ b/nixos/modules/programs/captive-browser.nix
@@ -15,6 +15,8 @@ in
       package = mkOption {
         type = types.package;
         default = pkgs.captive-browser;
+        defaultText = "pkgs.captive-browser";
+        description = "Which package to use for captive-browser";
       };
 
       interface = mkOption {
@@ -35,7 +37,7 @@ in
                                          ''http://cache.nixos.org/''
                                        ];
         description = ''
-          the shell (/bin/sh) command executed once the proxy starts.
+          The shell (/bin/sh) command executed once the proxy starts.
           When browser exits, the proxy exits. An extra env var PROXY is available.
 
           Here, we use a separate Chrome instance in Incognito mode, so that
@@ -51,7 +53,7 @@ in
       dhcp-dns = mkOption {
         type = types.str;
         description = ''
-          the shell (/bin/sh) command executed to obtain the DHCP
+          The shell (/bin/sh) command executed to obtain the DHCP
           DNS server address. The first match of an IPv4 regex is used.
           IPv4 only, because let's be real, it's a captive portal.
         '';
@@ -61,6 +63,16 @@ in
         type = types.str;
         default = "localhost:1666";
         description = ''the listen address for the SOCKS5 proxy server'';
+      };
+
+      bindInterface = mkOption {
+        default = true;
+        type = types.bool;
+        description = ''
+          Binds <package>captive-browser</package> to the network interface declared in
+          <literal>cfg.interface</literal>. This can be used to avoid collisions
+          with private subnets.
+        '';
       };
     };
   };
@@ -99,7 +111,9 @@ in
                                                   browser = """${cfg.browser}"""
                                                   dhcp-dns = """${cfg.dhcp-dns}"""
                                                   socks5-addr = """${cfg.socks5-addr}"""
-                                                  bind-device = """${cfg.interface}"""
+                                                  ${optionalString cfg.bindInterface ''
+                                                    bind-device = """${cfg.interface}"""
+                                                  ''}
                                                 ''}
                         exec ${cfg.package}/bin/captive-browser
                       '';


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Fixes the broken metrics evaluation which was caused by a `trace`
warning in stdout which confused `jq` in `pkgs/top-level/metrics.nix`.

Also made the `bind-device` feature optional as suggested after the
merge.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
