### PR TITLE
picolisp: fix help functionality

### DIFF
--- a/pkgs/development/interpreters/picolisp/default.nix
+++ b/pkgs/development/interpreters/picolisp/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jdk, makeWrapper }:
+{ stdenv, fetchurl, jdk, w3m, makeWrapper }:
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
@@ -33,6 +33,7 @@ stdenv.mkDerivation rec {
 
 
     makeWrapper $out/bin/picolisp $out/bin/pil \
+      --prefix PATH : ${w3m}/bin \
       --add-flags "$out/lib/picolisp/lib.l" \
       --add-flags "@lib/misc.l" \
       --add-flags "@lib/btree.l" \


### PR DESCRIPTION
Currently, trying to use help results in something like this:

```
: (help 'db)
========================================
w3m: Can't exec
=======================================
```

By including `w3m` as an input, the behaviour changes to:

```
: (help 'db)
========================================
(db 'sym 'cls ['hook] 'any ['sym 'any ..]) -> sym | NIL
Returns a database object of class cls, where the values for the sym arguments
correspond to the any arguments. If a matching object cannot be found, NIL is
returned. sym, cls and hook should specify a tree for cls or one of its
superclasses. See also aux, collect, request, fetch, init and step.

========================================
-> db
```

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
