### PR TITLE
linux: Enable kernel config option for raw HID devices

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -234,6 +234,7 @@ let
       USB_DEBUG = { optional = true; tristate = whenOlder "4.18" "n";};
       USB_EHCI_ROOT_HUB_TT = yes; # Root Hub Transaction Translators
       USB_EHCI_TT_NEWSCHED = yes; # Improved transaction translator scheduling
+      USB_HIDDEV = yes; # USB Raw HID Devices (like monitor controls and Uninterruptable Power Supplies)
     };
 
     # Filesystem options - in particular, enable extended attributes and


### PR DESCRIPTION
###### Motivation for this change

Uninterruptable Power Supplies (accessed via things like `apcupsd` and `apctest`) such as APC's USB models show up as HID devices, but are not explicitely _HID_ devices (and need to be communicated to in RAW). Annoyingly, this requires a non-standard build flag to be set at kernel build time to get them to work, otherwise `apcupsd` just sits and complains about an unavailable UPS.

You also get some relevant scrollback in dmesg:
```
[  890.567023] usb 1-1.1.2: new low-speed USB device number 6 using dwc2
[  890.891728] hid-generic 0003:051D:0002.0002: device has no listeners, quitting
```

###### Things done

Set the `USB_HIDDEV` kernel build flag to `yes`. More information on this flag: https://cateee.net/lkddb/web-lkddb/USB_HIDDEV.html

I'm 99.9% confident that this won't have any adverse effect on any system; it's purely additive, and just exposes these devices on `/dev/usb/hiddevX`. The flag was added way back in 2.6.22 (and even earlier). Willing to be proved wrong.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
