### PR TITLE
aarch64: misc. graphical boot fixes

### DIFF
--- a/nixos/modules/installer/cd-dvd/sd-image-aarch64.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image-aarch64.nix
@@ -26,6 +26,11 @@ in
   # Also increase the amount of CMA to ensure the virtual console on the RPi3 works.
   boot.kernelParams = ["cma=32M" "console=ttyS0,115200n8" "console=ttyAMA0,115200n8" "console=tty0"];
 
+  boot.initrd.availableKernelModules = [
+    # Allows early (earlier) modesetting for the Raspberry Pi
+    "vc4" "bcm2835_dma" "i2c_bcm2835"
+  ];
+
   sdImage = {
     populateBootCommands = let
       configTxt = pkgs.writeText "config.txt" ''

--- a/nixos/modules/installer/cd-dvd/sd-image-aarch64.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image-aarch64.nix
@@ -29,6 +29,8 @@ in
   boot.initrd.availableKernelModules = [
     # Allows early (earlier) modesetting for the Raspberry Pi
     "vc4" "bcm2835_dma" "i2c_bcm2835"
+    # Allows early (earlier) modesetting for Allwinner SoCs
+    "sun4i_drm" "sun8i_drm_hdmi" "sun8i_mixer"
   ];
 
   sdImage = {

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -709,6 +709,9 @@ let
       # Bump the maximum number of CPUs to support systems like EC2 x1.*
       # instances and Xeon Phi.
       NR_CPUS = freeform "384";
+    } // optionalAttrs (stdenv.hostPlatform.system == "aarch64-linux") {
+      # Enables support for the Allwinner Display Engine 2.0
+      SUN8I_DE2_CCU = whenAtLeast "4.13" yes;
     };
   };
 in


### PR DESCRIPTION
### Motivation for this change

Two main changes

#### 1. HDMI for Allwinner SoCs

The `SUN8I_DE2_CCU` configuration has been enabled for the Allwinner Display Engine 2.0.

This makes the HDMI output work for Allwinner boards I tried.

#### 2. `availableKernelModules` for early mode setting

This adds the required kernel modules to the initrd so they are available earlier, allowing the modesetting to happen as early as possible. It ends up, both for vc4 and de2 to be right at the tail end of stage-1, but definitely before stage-2 has mounted the filesystems.

This means that on initial boot, it is more obvious that the board isn't hanging during boot, and the user will see the messages from the partition resizing processes, among other boot messages.

### Things done

Tested on:

 * Raspberry Pi 3B
 * Pine A64-LTS
 * Orange Pi Zero Plus2 H5

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ☑️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ☑️ NixOS
   - 🔲 macOS
   - 🔲 other Linux distributions
- 🔲 Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ☑️ Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- ☑️ Tested execution of all binary files (usually in `./result/bin/`)
- ☑️ Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ☑️ Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
