### PR TITLE
windows.mingwrt: fix src url

### DIFF
--- a/pkgs/os-specific/windows/mingwrt/default.nix
+++ b/pkgs/os-specific/windows/mingwrt/default.nix
@@ -4,8 +4,8 @@ stdenv.mkDerivation rec {
   name = "mingwrt-5.0.2";
 
   src = fetchurl {
-    url = "mirror://sourceforge/mingw/MinGW/Base/mingw-rt/${name}-mingw32-src.tar.gz";
-    sha256 = "02pydg1m8y35nxb4k34nlb5c341y2waq76z42mgdzlcf661r91p0";
+    url = "mirror://sourceforge/mingw/MinGW/Base/mingwrt/${name}/${name}-mingw32-src.tar.xz";
+    sha256 = "1vj6f578wcffdmy7zzf7xz1lw57kxjy08j0k1n28f0j4ylrk68vp";
   };
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
