### PR TITLE
oclgrind: init at 18.3.

### DIFF
--- a/pkgs/development/tools/analysis/oclgrind/default.nix
+++ b/pkgs/development/tools/analysis/oclgrind/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "oclgrind";
-  version = "18.3";
+  version = "18.3"; # see comment in all-packages.nix
 
   src = fetchFromGitHub {
     owner = "jrprice";

--- a/pkgs/development/tools/analysis/oclgrind/default.nix
+++ b/pkgs/development/tools/analysis/oclgrind/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, cmake, llvmPackages, readline, python }:
+
+stdenv.mkDerivation rec {
+  pname = "oclgrind";
+  version = "18.3";
+
+  src = fetchFromGitHub {
+    owner = "jrprice";
+    repo = "oclgrind";
+    rev = "v${version}";
+    sha256 = "0s42z3dg684a0gk8qyx2h08cbh95zkrdaaj9y71rrc5bjsg8197x";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ llvmPackages.llvm llvmPackages.clang-unwrapped readline python ];
+
+  cmakeFlags = [
+    "-DCLANG_ROOT=${llvmPackages.clang-unwrapped}"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "An OpenCL device simulator and debugger";
+    homepage = https://github.com/jrprice/oclgrind;
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ athas ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23761,6 +23761,10 @@ in
 
   sndio = callPackage ../misc/sndio { };
 
+  # Oclgrind 18.3 does not work with newer LLVMs (but HEAD does, so
+  # fix this after next release).
+  oclgrind = callPackage ../development/tools/analysis/oclgrind { llvmPackages = llvmPackages_6; };
+
   opkg = callPackage ../tools/package-management/opkg { };
 
   opkg-utils = callPackage ../tools/package-management/opkg-utils { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Oclgrind is an indispensable Valgrind-like tool for OpenCL programming.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
