### PR TITLE
grsync: init at 1.2.6

### DIFF
--- a/pkgs/applications/misc/grsync/default.nix
+++ b/pkgs/applications/misc/grsync/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchurl, dee, gtk2, intltool, libdbusmenu-gtk2, libunity, pkg-config, rsync }:
+
+stdenv.mkDerivation rec {
+  version = "1.2.6";
+  pname = "grsync";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/grsync/grsync-${version}.tar.gz";
+    sha256 = "06ani65d58p8r3jvxjwpwyqrr07ya3icdqc243nxcrv7bvmarmb6";
+  };
+
+  nativeBuildInputs = [
+    intltool
+    pkg-config
+  ];
+
+  buildInputs = [
+    dee
+    gtk2
+    libdbusmenu-gtk2
+    libunity
+    rsync
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Grsync is used to synchronize folders, files and make backups";
+    homepage = "http://www.opbyte.it/grsync/";
+    license = licenses.gpl1;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.kuznero ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -171,6 +171,8 @@ in
 
   digitalbitbox = libsForQt5.callPackage ../applications/misc/digitalbitbox { };
 
+  grsync = callPackage ../applications/misc/grsync { };
+
   dockerTools = callPackage ../build-support/docker { };
 
   nix-prefetch-docker = callPackage ../build-support/docker/nix-prefetch-docker.nix { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add GRsync (a rsync GUI).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
