### PR TITLE
libelf: Add patch to prevent -Wundef warnings.

### DIFF
--- a/pkgs/development/libraries/libelf/default.nix
+++ b/pkgs/development/libraries/libelf/default.nix
@@ -12,6 +12,9 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./dont-hardcode-ar.patch
+    # Fix warnings from preprocessor instructions.
+    # https://github.com/NixOS/nixpkgs/issues/59929
+    ./preprocessor-warnings.patch
   ];
 
   doCheck = true;

--- a/pkgs/development/libraries/libelf/preprocessor-warnings.patch
+++ b/pkgs/development/libraries/libelf/preprocessor-warnings.patch
@@ -1,0 +1,264 @@
+diff --git a/lib/elf_repl.h b/lib/elf_repl.h
+index c5cf90f..7e1e8df 100644
+--- a/lib/elf_repl.h
++++ b/lib/elf_repl.h
+@@ -45,7 +45,7 @@ typedef __libelf_u32_t		Elf32_Word;
+ #define ELF32_FSZ_SWORD		4
+ #define ELF32_FSZ_WORD		4
+ 
+-#if __LIBELF64
++#if defined(__LIBELF64)
+ 
+ typedef __libelf_u64_t		Elf64_Addr;
+ typedef __libelf_u16_t		Elf64_Half;
+@@ -93,7 +93,7 @@ typedef struct {
+     Elf32_Half		e_shstrndx;
+ } Elf32_Ehdr;
+ 
+-#if __LIBELF64
++#if defined(__LIBELF64)
+ typedef struct {
+     unsigned char	e_ident[EI_NIDENT];
+     Elf64_Half		e_type;
+@@ -307,7 +307,7 @@ typedef struct {
+     Elf32_Word		sh_entsize;
+ } Elf32_Shdr;
+ 
+-#if __LIBELF64
++#if defined(__LIBELF64)
+ typedef struct {
+     Elf64_Word		sh_name;
+     Elf64_Word		sh_type;
+@@ -434,7 +434,7 @@ typedef struct {
+     Elf32_Half		st_shndx;
+ } Elf32_Sym;
+ 
+-#if __LIBELF64
++#if defined(__LIBELF64)
+ typedef struct {
+     Elf64_Word		st_name;
+     unsigned char	st_info;
+@@ -457,7 +457,7 @@ typedef struct {
+ #define ELF32_ST_TYPE(i)	((i)&0xf)
+ #define ELF32_ST_INFO(b,t)	(((b)<<4)+((t)&0xf))
+ 
+-#if __LIBELF64
++#if defined(__LIBELF64)
+ #define ELF64_ST_BIND(i)	((i)>>4)
+ #define ELF64_ST_TYPE(i)	((i)&0xf)
+ #define ELF64_ST_INFO(b,t)	(((b)<<4)+((t)&0xf))
+@@ -495,7 +495,7 @@ typedef struct {
+  * Macros for manipulating st_other
+  */
+ #define ELF32_ST_VISIBILITY(o)	((o)&0x3)
+-#if __LIBELF64
++#if defined(__LIBELF64)
+ #define ELF64_ST_VISIBILITY(o)	((o)&0x3)
+ #endif /* __LIBELF64 */
+ 
+@@ -521,7 +521,7 @@ typedef struct {
+     Elf32_Sword		r_addend;
+ } Elf32_Rela;
+ 
+-#if __LIBELF64
++#if defined(__LIBELF64)
+ typedef struct {
+     Elf64_Addr		r_offset;
+     Elf64_Xword		r_info;
+@@ -541,7 +541,7 @@ typedef struct {
+ #define ELF32_R_TYPE(i)		((unsigned char)(i))
+ #define ELF32_R_INFO(s,t)	(((s)<<8)+(unsigned char)(t))
+ 
+-#if __LIBELF64
++#if defined(__LIBELF64)
+ #define ELF64_R_SYM(i)		((Elf64_Xword)(i)>>32)
+ #define ELF64_R_TYPE(i)		((i)&0xffffffffL)
+ #define ELF64_R_INFO(s,t)	(((Elf64_Xword)(s)<<32)+((t)&0xffffffffL))
+@@ -556,7 +556,7 @@ typedef struct {
+     Elf32_Word		n_type;		/* descriptor type */
+ } Elf32_Nhdr;
+ 
+-#if __LIBELF64
++#if defined(__LIBELF64)
+ /* Solaris and GNU use this layout.  Be compatible. */
+ /* XXX: Latest ELF specs say it's 64-bit!!! */
+ typedef struct {
+@@ -587,7 +587,7 @@ typedef struct {
+     Elf32_Word		p_align;
+ } Elf32_Phdr;
+ 
+-#if __LIBELF64
++#if defined(__LIBELF64)
+ typedef struct {
+     Elf64_Word		p_type;
+     Elf64_Word		p_flags;
+@@ -654,7 +654,7 @@ typedef struct {
+     } d_un;
+ } Elf32_Dyn;
+ 
+-#if __LIBELF64
++#if defined(__LIBELF64)
+ typedef struct {
+     Elf64_Sxword	d_tag;
+     union {
+@@ -798,7 +798,7 @@ typedef struct {
+     Elf32_Half		si_flags;
+ } Elf32_Syminfo;
+ 
+-#if __LIBELF64
++#if defined(__LIBELF64)
+ typedef struct {
+     Elf64_Half		si_boundto;
+     Elf64_Half		si_flags;
+@@ -863,7 +863,7 @@ typedef struct {
+ 
+ typedef Elf32_Half	Elf32_Versym;
+ 
+-#if __LIBELF64
++#if defined(__LIBELF64)
+ 
+ typedef struct {
+     Elf64_Half		vd_version;
+@@ -933,7 +933,7 @@ typedef Elf64_Half	Elf64_Versym;
+ /*
+  * Move section
+  */
+-#if __LIBELF64
++#if defined(__LIBELF64)
+ 
+ typedef struct {
+     Elf32_Lword		m_value;
+@@ -973,7 +973,7 @@ typedef struct {
+     } c_un;
+ } Elf32_Cap;
+ 
+-#if __LIBELF64
++#if defined(__LIBELF64)
+ 
+ typedef struct {
+     Elf64_Xword     	c_tag;
+diff --git a/lib/gelf.h b/lib/gelf.h
+index 5af0558..98a759c 100644
+--- a/lib/gelf.h
++++ b/lib/gelf.h
+@@ -22,15 +22,15 @@
+ #ifndef _GELF_H
+ #define _GELF_H
+ 
+-#if __LIBELF_INTERNAL__
++#if defined(__LIBELF_INTERNAL__)
+ #include <libelf.h>
+ #else /* __LIBELF_INTERNAL__ */
+ #include <libelf/libelf.h>
+ #endif /* __LIBELF_INTERNAL__ */
+ 
+-#if __LIBELF_NEED_LINK_H
++#if defined(__LIBELF_NEED_LINK_H)
+ #include <link.h>
+-#elif __LIBELF_NEED_SYS_LINK_H
++#elif defined(__LIBELF_NEED_SYS_LINK_H)
+ #include <sys/link.h>
+ #endif /* __LIBELF_NEED_LINK_H */
+ 
+@@ -46,7 +46,7 @@ extern "C" {
+ # endif /* __STDC__ || defined(__cplusplus) */
+ #endif /* __P */
+ 
+-#if !__LIBELF64
++#if !defined(__LIBELF64)
+ 
+ #error "GElf is not supported on this system."
+ 
+@@ -71,7 +71,7 @@ typedef Elf64_Sym	GElf_Sym;
+ /*
+  * Symbol versioning
+  */
+-#if __LIBELF_SYMBOL_VERSIONS
++#if defined(__LIBELF_SYMBOL_VERSIONS)
+ typedef Elf64_Verdef	GElf_Verdef;
+ typedef Elf64_Verneed	GElf_Verneed;
+ typedef Elf64_Verdaux	GElf_Verdaux;
+diff --git a/lib/libelf.h b/lib/libelf.h
+index 3ebd0f3..788482d 100644
+--- a/lib/libelf.h
++++ b/lib/libelf.h
+@@ -25,7 +25,7 @@
+ #include <stddef.h>	/* for size_t */
+ #include <sys/types.h>
+ 
+-#if __LIBELF_INTERNAL__
++#if defined(__LIBELF_INTERNAL__)
+ #include <sys_elf.h>
+ #else /* __LIBELF_INTERNAL__ */
+ #include <libelf/sys_elf.h>
+@@ -224,7 +224,7 @@ extern Elf_Data *elf32_xlatetom __P((Elf_Data *__dst, const Elf_Data *__src,
+  */
+ extern long elf32_checksum __P((Elf *__elf));
+ 
+-#if __LIBELF64
++#if defined(__LIBELF64)
+ /*
+  * 64-bit ELF functions
+  * Not available on all platforms
+diff --git a/lib/sys_elf.h.in b/lib/sys_elf.h.in
+index b71a20d..722051b 100644
+--- a/lib/sys_elf.h.in
++++ b/lib/sys_elf.h.in
+@@ -68,7 +68,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ #ifdef __LIBELF_HEADER_ELF_H
+ # include __LIBELF_HEADER_ELF_H
+ #else /* __LIBELF_HEADER_ELF_H */
+-# if __LIBELF_INTERNAL__
++# if defined(__LIBELF_INTERNAL__)
+ #  include <elf_repl.h>
+ # else /* __LIBELF_INTERNAL__ */
+ #  include <libelf/elf_repl.h>
+@@ -92,7 +92,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ #  define STN_UNDEF	0
+ # endif /* STN_UNDEF */
+ 
+-# if __LIBELF64
++# if defined(__LIBELF64)
+ 
+ #  ifndef ELF64_FSZ_ADDR
+ #   define ELF64_FSZ_ADDR	8
+@@ -116,7 +116,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ #   define ELF64_R_INFO(s,t)	(((Elf64_Xword)(s)<<32)+((t)&0xffffffffL))
+ #  endif /* ELF64_R_SYM */
+ 
+-#  if __LIBELF64_LINUX
++#  if defined(__LIBELF64_LINUX)
+ typedef __libelf_u64_t	Elf64_Addr;
+ typedef __libelf_u16_t	Elf64_Half;
+ typedef __libelf_u64_t	Elf64_Off;
+diff --git a/lib/sys_elf.h.w32 b/lib/sys_elf.h.w32
+index 0f93c55..7360104 100644
+--- a/lib/sys_elf.h.w32
++++ b/lib/sys_elf.h.w32
+@@ -68,7 +68,7 @@
+ #ifdef __LIBELF_HEADER_ELF_H
+ # include __LIBELF_HEADER_ELF_H
+ #else /* __LIBELF_HEADER_ELF_H */
+-# if __LIBELF_INTERNAL__
++# if defined(__LIBELF_INTERNAL__)
+ #  include <elf_repl.h>
+ # else /* __LIBELF_INTERNAL__ */
+ #  include <libelf/elf_repl.h>
+@@ -92,7 +92,7 @@
+ #  define STN_UNDEF	0
+ # endif /* STN_UNDEF */
+ 
+-# if __LIBELF64
++# if defined(__LIBELF64)
+ 
+ #  ifndef ELF64_FSZ_ADDR
+ #   define ELF64_FSZ_ADDR	8
+@@ -116,7 +116,7 @@
+ #   define ELF64_R_INFO(s,t)	(((Elf64_Xword)(s)<<32)+((t)&0xffffffffL))
+ #  endif /* ELF64_R_SYM */
+ 
+-#  if __LIBELF64_LINUX
++#  if defined(__LIBELF64_LINUX)
+ typedef __libelf_u64_t	Elf64_Addr;
+ typedef __libelf_u16_t	Elf64_Half;
+ typedef __libelf_u64_t	Elf64_Off;


### PR DESCRIPTION
The Linux kernel includes libelf headers with -Wundef and -Werror enabled, resulting in an error when the headers are found through -I as opposed to -isystem.

Fixes https://github.com/NixOS/nixpkgs/issues/59929

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Tested doing the things in the linked issue and confirmed the issue is gone with this patch. Note that this included a rebuild of various things including gcc.

Note that the libelf upstream site is dead.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
