### PR TITLE
xastir: 2.1.0 -> 2.1.2

### DIFF
--- a/pkgs/applications/misc/xastir/default.nix
+++ b/pkgs/applications/misc/xastir/default.nix
@@ -1,23 +1,23 @@
 { stdenv, fetchFromGitHub, autoreconfHook
-, curl, db, gdal, libgeotiff
+, curl, db, libgeotiff
 , libXpm, libXt, motif, pcre
 , perl, proj, rastermagick, shapelib
 }:
 
 stdenv.mkDerivation rec {
   pname = "xastir";
-  version = "2.1.0";
+  version = "2.1.2";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "Release-${version}";
-    sha256 = "16zsgy3589snawr8f1fa22ymvpnjy6njvxmsck7q8p2xmmz2ry7r";
+    sha256 = "1xfzd2m4l0zbb96ak2pniffxdrs9lax0amkxfgdsnyg8x5j0xcxm";
   };
 
   buildInputs = [
     autoreconfHook
-    curl db gdal libgeotiff
+    curl db libgeotiff
     libXpm libXt motif pcre
     perl proj rastermagick shapelib
   ];


### PR DESCRIPTION
Version 2.1.2 is compatible with recent versions of proj (see #63134)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
