### PR TITLE
Python unstable

### DIFF
--- a/pkgs/development/python-modules/Mako/default.nix
+++ b/pkgs/development/python-modules/Mako/default.nix
@@ -4,20 +4,20 @@
 , markupsafe
 , nose
 , mock
-, pytest_3
+, pytest
 , isPyPy
 }:
 
 buildPythonPackage rec {
   pname = "Mako";
-  version = "1.0.10";
+  version = "1.0.12";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "7165919e78e1feb68b4dbe829871ea9941398178fa58e6beedb9ba14acf63965";
+    sha256 = "0cfa65de3a835e87eeca6ac856b3013aade55f49e32515f65d999f91a2324162";
   };
 
-  checkInputs = [ markupsafe nose mock pytest_3 ];
+  checkInputs = [ markupsafe nose mock pytest ];
   propagatedBuildInputs = [ markupsafe ];
 
   doCheck = !isPyPy;  # https://bitbucket.org/zzzeek/mako/issue/238/2-tests-failed-on-pypy-24-25

--- a/pkgs/development/python-modules/antlr4-python2-runtime/default.nix
+++ b/pkgs/development/python-modules/antlr4-python2-runtime/default.nix
@@ -1,0 +1,18 @@
+{ stdenv, fetchPypi, buildPythonPackage, isPy3k }:
+
+buildPythonPackage rec {
+  pname = "antlr4-python2-runtime";
+  version = "4.7.2";
+  disabled = isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "04ljic5wnqpizln8q3c78pqrckz6q5nb433if00j1mlyv2yja22q";
+  };
+
+  meta = {
+    description = "Runtime for ANTLR";
+    homepage = "https://www.antlr.org/";
+    license = stdenv.lib.licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/apipkg/default.nix
+++ b/pkgs/development/python-modules/apipkg/default.nix
@@ -1,5 +1,5 @@
 { stdenv, buildPythonPackage, fetchPypi
-, pytest_3, setuptools_scm }:
+, pytest, setuptools_scm }:
 
 buildPythonPackage rec {
   pname = "apipkg";
@@ -11,7 +11,13 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [ setuptools_scm ];
-  checkInputs = [ pytest_3 ];
+  checkInputs = [ pytest ];
+
+  # Fix pytest 4 support. See: https://github.com/pytest-dev/apipkg/issues/14
+  postPatch = ''
+    substituteInPlace "test_apipkg.py" \
+      --replace "py.test.ensuretemp('test_apipkg')" "py.path.local('test_apipkg')"
+  '';
 
   checkPhase = ''
     py.test
@@ -19,7 +25,7 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "Namespace control and lazy-import mechanism";
-    homepage = https://bitbucket.org/hpk42/apipkg;
+    homepage = "https://github.com/pytest-dev/apipkg";
     license = licenses.mit;
   };
 }

--- a/pkgs/development/python-modules/azure-cli-core/default.nix
+++ b/pkgs/development/python-modules/azure-cli-core/default.nix
@@ -1,0 +1,93 @@
+{ stdenv
+, lib
+, python
+, buildPythonPackage
+, fetchPypi
+, adal
+, antlr4-python3-runtime
+, argcomplete
+, azure-cli-telemetry
+, colorama
+, jmespath
+, humanfriendly
+, knack
+, msrest
+, msrestazure
+, paramiko
+, pygments
+, pyjwt
+, pyopenssl
+, pyyaml
+, requests
+, six
+, tabulate
+, azure-mgmt-resource
+, pyperclip
+, psutil
+, enum34
+, futures
+, antlr4-python2-runtime
+, ndg-httpsclient
+, isPy3k
+}:
+
+buildPythonPackage rec {
+  pname = "azure-cli-core";
+  version = "2.0.66";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0fp6b2x1l9bg07pca7asm80rnjlc4kkm061s3nrb55yj6awsnim5";
+  };
+
+  propagatedBuildInputs = [
+    adal
+    argcomplete
+    azure-cli-telemetry
+    colorama
+    jmespath
+    humanfriendly
+    knack
+    msrest
+    msrestazure
+    paramiko
+    pygments
+    pyjwt
+    pyopenssl
+    pyyaml
+    requests
+    six
+    tabulate
+    azure-mgmt-resource
+    pyperclip
+    psutil
+  ]
+  ++ lib.optionals isPy3k [ antlr4-python3-runtime ]
+  ++ lib.optionals (!isPy3k) [ enum34 futures antlr4-python2-runtime ndg-httpsclient ];
+
+  # Remove overly restrictive version contraints and obsolete namespace setup
+  prePatch = ''
+    substituteInPlace setup.py \
+      --replace "wheel==0.30.0" "wheel" \
+      --replace "azure-mgmt-resource==2.1.0" "azure-mgmt-resource"
+    substituteInPlace setup.cfg \
+      --replace "azure-namespace-package = azure-cli-nspkg" ""
+  '';
+
+  # Prevent these __init__'s from violating PEP420, only needed for python2
+  postInstall = lib.optionalString isPy3k ''
+    rm $out/${python.sitePackages}/azure/__init__.py \
+       $out/${python.sitePackages}/azure/cli/__init__.py
+  '';
+
+  # Tests are not included in sdist package
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = https://github.com/Azure/azure-cli;
+    description = "Next generation multi-platform command line experience for Azure";
+    platforms = platforms.all;
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/development/python-modules/azure-cli-telemetry/default.nix
+++ b/pkgs/development/python-modules/azure-cli-telemetry/default.nix
@@ -1,0 +1,50 @@
+{ stdenv
+, lib
+, buildPythonPackage
+, fetchPypi
+, isPy3k
+, python
+, applicationinsights
+, portalocker
+}:
+
+buildPythonPackage rec {
+  pname = "azure-cli-telemetry";
+  version = "1.0.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "14wmxdsrrlnixaj52q37rrvp9wg5b54gf5wn2z1vq68kxpg1s560";
+  };
+
+  propagatedBuildInputs = [
+    applicationinsights
+    portalocker
+  ];
+
+  # tests are not published to pypi
+  doCheck = false;
+
+  # Remove overly restrictive version contraints and obsolete namespace setup
+  prePatch = ''
+    substituteInPlace setup.py \
+      --replace "applicationinsights>=0.11.1,<0.11.8" "applicationinsights" \
+      --replace "portalocker==1.2.1" "portalocker"
+    substituteInPlace setup.cfg \
+      --replace "azure-namespace-package = azure-cli-nspkg" ""
+  '';
+
+  # Prevent these __init__'s from violating PEP420, only needed for python2
+  postInstall = lib.optionalString isPy3k ''
+    rm $out/${python.sitePackages}/azure/__init__.py \
+       $out/${python.sitePackages}/azure/cli/__init__.py
+  '';
+
+  meta = with lib; {
+    homepage = https://github.com/Azure/azure-cli;
+    description = "Next generation multi-platform command line experience for Azure";
+    platforms = platforms.all;
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/development/python-modules/chardet/default.nix
+++ b/pkgs/development/python-modules/chardet/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, buildPythonPackage, fetchPypi
-, pytest_3, pytestrunner, hypothesis }:
+{ stdenv, buildPythonPackage, fetchPypi, fetchpatch
+, pytest, pytestrunner, hypothesis }:
 
 buildPythonPackage rec {
   pname = "chardet";
@@ -10,7 +10,15 @@ buildPythonPackage rec {
     sha256 = "1bpalpia6r5x1kknbk11p1fzph56fmmnp405ds8icksd3knr5aw4";
   };
 
-  checkInputs = [ pytest_3 pytestrunner hypothesis ];
+  patches = [
+    # Add pytest 4 support. See: https://github.com/chardet/chardet/pull/174
+    (fetchpatch {
+      url = "https://github.com/chardet/chardet/commit/0561ddcedcd12ea1f98b7ddedb93686ed8a5ffa4.patch";
+      sha256 = "1y1xhjf32rdhq9sfz58pghwv794f3w2f2qcn8p6hp4pc8jsdrn2q";
+    })
+  ];
+
+  checkInputs = [ pytest pytestrunner hypothesis ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/chardet/chardet;

--- a/pkgs/development/python-modules/execnet/default.nix
+++ b/pkgs/development/python-modules/execnet/default.nix
@@ -3,21 +3,21 @@
 , buildPythonPackage
 , isPyPy
 , fetchPypi
-, pytest_3
+, pytest
 , setuptools_scm
 , apipkg
 }:
 
 buildPythonPackage rec {
   pname = "execnet";
-  version = "1.5.0";
+  version = "1.6.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "a7a84d5fa07a089186a329528f127c9d73b9de57f1a1131b82bb5320ee651f6a";
+    sha256 = "752a3786f17416d491f833a29217dda3ea4a471fc5269c492eebcee8cc4772d3";
   };
 
-  checkInputs = [ pytest_3 ];
+  checkInputs = [ pytest ];
   nativeBuildInputs = [ setuptools_scm ];
   propagatedBuildInputs = [ apipkg ];
 
@@ -34,15 +34,12 @@ buildPythonPackage rec {
     py.test testing
   '';
 
-  # not yet compatible with pytest 4
-  doCheck = false;
-
   __darwinAllowLocalNetworking = true;
 
   meta = with stdenv.lib; {
     description = "Rapid multi-Python deployment";
     license = licenses.gpl2;
-    homepage = "http://codespeak.net/execnet";
+    homepage = "https://execnet.readthedocs.io/";
     maintainers = with maintainers; [ nand0p ];
   };
 

--- a/pkgs/development/python-modules/importlib-metadata/default.nix
+++ b/pkgs/development/python-modules/importlib-metadata/default.nix
@@ -13,12 +13,12 @@
 
 buildPythonPackage rec {
   pname = "importlib-metadata";
-  version = "0.8";
+  version = "0.18";
 
   src = fetchPypi {
     pname = "importlib_metadata";
     inherit version;
-    sha256 = "b50191ead8c70adfa12495fba19ce6d75f2e0275c14c5a7beb653d6799b512bd";
+    sha256 = "cb6ee23b46173539939964df59d3d72c3e0c1b5d54b84f1d8a7e912fe43612db";
   };
 
   nativeBuildInputs = [ setuptools_scm ];
@@ -27,6 +27,9 @@ buildPythonPackage rec {
     ++ lib.optionals (!isPy3k) [ pathlib2 contextlib2 configparser ];
 
   checkInputs = [ importlib-resources packaging ];
+
+  # Two failing tests: https://gitlab.com/python-devs/importlib_metadata/issues/72
+  doCheck = false;
 
   meta = with lib; {
     description = "Read metadata from Python packages";

--- a/pkgs/development/python-modules/knack/default.nix
+++ b/pkgs/development/python-modules/knack/default.nix
@@ -1,0 +1,55 @@
+{ stdenv
+, lib
+, buildPythonPackage
+, fetchPypi
+, argcomplete
+, colorama
+, jmespath
+, knack
+, pygments
+, pyyaml
+, six
+, tabulate
+, mock
+, vcrpy
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "knack";
+  version = "0.6.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1kxxj9m2mvva9rz11m6pgdg0mi712d28faj4633rl23qa53sh7i8";
+  };
+
+  propagatedBuildInputs = [
+    argcomplete
+    colorama
+    jmespath
+    pygments
+    pyyaml
+    six
+    tabulate
+  ];
+
+  checkInputs = [
+    mock
+    vcrpy
+    pytest
+  ];
+
+  # tries to make a '/homeless-shelter' dir
+  checkPhase = ''
+    pytest -k 'not test_cli_exapp1'
+  '';
+
+  meta = with lib; {
+    homepage = https://github.com/microsoft/knack;
+    description = "A Command-Line Interface framework";
+    platforms = platforms.all;
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/development/python-modules/packaging/default.nix
+++ b/pkgs/development/python-modules/packaging/default.nix
@@ -18,6 +18,9 @@ buildPythonPackage rec {
     py.test tests
   '';
 
+  # Prevent circular dependency
+  doCheck = false;
+
   meta = with stdenv.lib; {
     description = "Core utilities for Python packages";
     homepage = https://github.com/pypa/packaging;

--- a/pkgs/development/python-modules/pluggy/default.nix
+++ b/pkgs/development/python-modules/pluggy/default.nix
@@ -6,11 +6,11 @@
 
 buildPythonPackage rec {
   pname = "pluggy";
-  version = "0.8.1";
+  version = "0.11.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "8ddc32f03971bfdf900a81961a48ccf2fb677cf7715108f85295c67405798616";
+    sha256 = "25a1bc1d148c9a640211872b4ff859878d422bccb59c9965e04eed468a0aa180";
   };
 
   checkPhase = ''
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "Plugin and hook calling mechanisms for Python";
-    homepage = "https://pypi.python.org/pypi/pluggy";
+    homepage = "https://github.com/pytest-dev/pluggy";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ ];
   };

--- a/pkgs/development/python-modules/pluggy/default.nix
+++ b/pkgs/development/python-modules/pluggy/default.nix
@@ -2,15 +2,16 @@
 , lib
 , fetchPypi
 , setuptools_scm
+, importlib-metadata
 }:
 
 buildPythonPackage rec {
   pname = "pluggy";
-  version = "0.11.0";
+  version = "0.12.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "25a1bc1d148c9a640211872b4ff859878d422bccb59c9965e04eed468a0aa180";
+    sha256 = "0825a152ac059776623854c1543d65a4ad408eb3d33ee114dff91e57ec6ae6fc";
   };
 
   checkPhase = ''
@@ -20,7 +21,9 @@ buildPythonPackage rec {
   # To prevent infinite recursion with pytest
   doCheck = false;
 
-  buildInputs = [ setuptools_scm ];
+  nativeBuildInputs = [ setuptools_scm ];
+
+  propagatedBuildInputs = [ importlib-metadata ];
 
   meta = {
     description = "Plugin and hook calling mechanisms for Python";

--- a/pkgs/development/python-modules/psutil/default.nix
+++ b/pkgs/development/python-modules/psutil/default.nix
@@ -6,11 +6,11 @@
 
 buildPythonPackage rec {
   pname = "psutil";
-  version = "5.6.2";
+  version = "5.6.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1v95vb5385qscfdvphv8l2w22bmir3d7yhpi02n58v3mlqy1r3l2";
+    sha256 = "863a85c1c0a5103a12c05a35e59d336e1d665747e531256e061213e2e90f63f3";
   };
 
   # No tests in archive

--- a/pkgs/development/python-modules/psutil/default.nix
+++ b/pkgs/development/python-modules/psutil/default.nix
@@ -6,11 +6,11 @@
 
 buildPythonPackage rec {
   pname = "psutil";
-  version = "5.5.1";
+  version = "5.6.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "045qaqvn6k90bj5bcy259yrwcd2afgznaav3sfhphy9b8ambzkkj";
+    sha256 = "1v95vb5385qscfdvphv8l2w22bmir3d7yhpi02n58v3mlqy1r3l2";
   };
 
   # No tests in archive

--- a/pkgs/development/python-modules/pytest-fixture-config/default.nix
+++ b/pkgs/development/python-modules/pytest-fixture-config/default.nix
@@ -1,18 +1,18 @@
 { stdenv, buildPythonPackage, fetchPypi
-, setuptools-git, pytest_3 }:
+, setuptools-git, pytest }:
 
 buildPythonPackage rec {
   pname = "pytest-fixture-config";
-  version = "1.4.0";
+  version = "1.7.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "839d70343c87d6dda5bca88e3ab06e7b2027998dc1ec452c14d50be5725180a3";
+    sha256 = "13i1qpz22w3x4dmw8vih5jdnbqfqvl7jiqs0dg764s0zf8bp98a1";
   };
 
   nativeBuildInputs = [ setuptools-git ];
 
-  buildInputs = [ pytest_3 ];
+  buildInputs = [ pytest ];
 
   doCheck = false;
 

--- a/pkgs/development/python-modules/pytest-server-fixtures/default.nix
+++ b/pkgs/development/python-modules/pytest-server-fixtures/default.nix
@@ -1,17 +1,17 @@
 { stdenv, buildPythonPackage, fetchPypi
-, pytest_3, pytest-shutil, pytest-fixture-config, psutil
+, pytest, pytest-shutil, pytest-fixture-config, psutil
 , requests, future, retry }:
 
 buildPythonPackage rec {
   pname = "pytest-server-fixtures";
-  version = "1.6.2";
+  version = "1.7.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "c89f9532f62cf851489082ece1ec692b6ed5b0f88f20823bea25e2a963ebee8f";
+    sha256 = "07vdv3y89qzv89ws0y48h92yplqsx208b9cizx80w644dazb398g";
   };
 
-  buildInputs = [ pytest_3 ];
+  buildInputs = [ pytest ];
   propagatedBuildInputs = [ pytest-shutil pytest-fixture-config psutil requests future retry ];
 
   # RuntimeError: Unable to find a free server number to start Xvfb

--- a/pkgs/development/python-modules/pytest-shutil/default.nix
+++ b/pkgs/development/python-modules/pytest-shutil/default.nix
@@ -1,19 +1,19 @@
 { stdenv, lib, isPyPy, buildPythonPackage, fetchPypi
-, pytest_3, cmdline, pytestcov, coverage, setuptools-git, mock, pathpy, execnet
+, pytest, cmdline, pytestcov, coverage, setuptools-git, mock, pathpy, execnet
 , contextlib2, termcolor }:
 
 buildPythonPackage rec {
   pname = "pytest-shutil";
-  version = "1.6.0";
+  version = "1.7.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "efe615b7709637ec8828abebee7fc2ad033ae0f1fc54145f769a8b5e8cc3b4ca";
+    sha256 = "0q8j0ayzmnvlraml6i977ybdq4xi096djhf30n2m1rvnvrhm45nq";
   };
 
-  checkInputs = [ cmdline pytest_3 ];
+  checkInputs = [ cmdline pytest ];
   propagatedBuildInputs = [ pytestcov coverage setuptools-git mock pathpy execnet contextlib2 termcolor ];
-  nativeBuildInputs = [ pytest_3 ];
+  nativeBuildInputs = [ pytest ];
 
   checkPhase = ''
     py.test ${lib.optionalString isPyPy "-k'not (test_run or test_run_integration)'"}

--- a/pkgs/development/python-modules/pytest-virtualenv/default.nix
+++ b/pkgs/development/python-modules/pytest-virtualenv/default.nix
@@ -1,20 +1,20 @@
 { stdenv, buildPythonPackage, fetchPypi
-, pytest_3, pytestcov, mock, cmdline, pytest-fixture-config, pytest-shutil }:
+, pytest, pytestcov, mock, cmdline, pytest-fixture-config, pytest-shutil, virtualenv }:
 
 buildPythonPackage rec {
   pname = "pytest-virtualenv";
-  version = "1.6.0";
+  version = "1.7.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "d281725d10848773cb2b495d1255dd0a42fc9179e34a274c22e1c35837721f19";
+    sha256 = "03w2zz3crblj1p6i8nq17946hbn3zqp9z7cfnifw47hi4a4fww12";
   };
 
-  checkInputs = [ pytest_3 pytestcov mock cmdline ];
-  propagatedBuildInputs = [ pytest-fixture-config pytest-shutil ];
+  checkInputs = [ pytest pytestcov mock cmdline ];
+  propagatedBuildInputs = [ pytest-fixture-config pytest-shutil virtualenv ];
   checkPhase = '' py.test tests/unit '';
 
-  nativeBuildInputs = [ pytest_3 ];
+  nativeBuildInputs = [ pytest ];
 
   meta = with stdenv.lib; {
     description = "Create a Python virtual environment in your test that cleans up on teardown. The fixture has utility methods to install packages and list what’s installed.";

--- a/pkgs/development/python-modules/pytest-xdist/default.nix
+++ b/pkgs/development/python-modules/pytest-xdist/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "pytest-xdist";
-  version = "1.26.1";
+  version = "1.28.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "d03d1ff1b008458ed04fa73e642d840ac69b4107c168e06b71037c62d7813dd4";
+    sha256 = "f83a485293e81fd57c8a5a85a3f12473a532c5ca7dec518857cbb72766bb526c";
   };
 
   nativeBuildInputs = [ setuptools_scm pytest ];

--- a/pkgs/development/python-modules/pytest/default.nix
+++ b/pkgs/development/python-modules/pytest/default.nix
@@ -1,9 +1,9 @@
 { stdenv, buildPythonPackage, pythonOlder, fetchPypi, attrs, hypothesis, py
 , setuptools_scm, setuptools, six, pluggy, funcsigs, isPy3k, more-itertools
-, atomicwrites, mock, writeText, pathlib2
+, atomicwrites, mock, writeText, pathlib2, wcwidth, packaging
 }:
 buildPythonPackage rec {
-  version = "4.2.1";
+  version = "4.6.3";
   pname = "pytest";
 
   preCheck = ''
@@ -13,12 +13,12 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "c2396a15726218a2dfef480861c4ba37bd3952ebaaa5b0fede3fc23fddcd7f8c";
+    sha256 = "4a784f1d4f2ef198fe9b7aef793e9fa1a3b2f84e822d9b3a64a181293a572d45";
   };
 
   checkInputs = [ hypothesis mock ];
   buildInputs = [ setuptools_scm ];
-  propagatedBuildInputs = [ attrs py setuptools six pluggy more-itertools atomicwrites]
+  propagatedBuildInputs = [ attrs py setuptools six pluggy more-itertools atomicwrites wcwidth packaging ]
     ++ stdenv.lib.optionals (!isPy3k) [ funcsigs ]
     ++ stdenv.lib.optionals (pythonOlder "3.6") [ pathlib2 ];
 

--- a/pkgs/development/python-modules/scikit-build/default.nix
+++ b/pkgs/development/python-modules/scikit-build/default.nix
@@ -17,13 +17,14 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ wheel setuptools packaging ];
   checkInputs = [ 
-    cmake ninja cython codecov coverage six virtualenv pathpy
+    cmake ninja cython codecov coverage six pathpy
     pytest pytestcov pytest-mock pytest-virtualenv pytestrunner
     requests flake8
   ];
 
   disabledTests = lib.concatMapStringsSep " and " (s: "not " + s) ([
     "test_hello_develop" # tries setuptools develop install
+    "test_source_distribution" # pip has no way to install missing dependencies
     "test_wheel" # pip has no way to install missing dependencies
     "test_fortran_compiler" # passes if gfortran is available
     "test_install_command" # tries to alter out path

--- a/pkgs/development/python-modules/scikitlearn/default.nix
+++ b/pkgs/development/python-modules/scikitlearn/default.nix
@@ -1,22 +1,23 @@
-{ stdenv, buildPythonPackage, fetchPypi
-, gfortran, glibcLocales
-, numpy, scipy, pytest, pillow
+{ stdenv, buildPythonPackage, fetchPypi, python
+, gfortran, glibcLocales, joblib, pythonOlder
+, numpy, scipy, pytest, pillow, cython
 }:
 
 buildPythonPackage rec {
   pname = "scikit-learn";
-  version = "0.20.3";
+  version = "0.21.2";
   # UnboundLocalError: local variable 'message' referenced before assignment
-  disabled = stdenv.isi686;  # https://github.com/scikit-learn/scikit-learn/issues/5534
+  disabled = stdenv.isi686 || (pythonOlder "3.5");  # https://github.com/scikit-learn/scikit-learn/issues/5534
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "c503802a81de18b8b4d40d069f5e363795ee44b1605f38bc104160ca3bfe2c41";
+    sha256 = "0aafc312a55ebf58073151b9308761a5fcfa45b7f7730cea4b1f066f824c72db";
   };
 
   buildInputs = [ pillow gfortran glibcLocales ];
-  propagatedBuildInputs = [ numpy scipy numpy.blas ];
+  propagatedBuildInputs = [ numpy scipy numpy.blas joblib ];
   checkInputs = [ pytest ];
+  nativeBuildInputs = [ cython ];
 
   LC_ALL="en_US.UTF-8";
 

--- a/pkgs/development/python-modules/txaio/default.nix
+++ b/pkgs/development/python-modules/txaio/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, pytest_3, mock, six, twisted,isPy37 }:
+{ stdenv, buildPythonPackage, fetchPypi, pytest, mock, six, twisted,isPy37 }:
 
 buildPythonPackage rec {
   pname = "txaio";
@@ -9,7 +9,7 @@ buildPythonPackage rec {
     sha256 = "67e360ac73b12c52058219bb5f8b3ed4105d2636707a36a7cdafb56fe06db7fe";
   };
 
-  checkInputs = [ pytest_3 mock ];
+  checkInputs = [ pytest mock ];
 
   propagatedBuildInputs = [ six twisted ];
 
@@ -17,8 +17,8 @@ buildPythonPackage rec {
     py.test -k "not test_sdist"
   '';
 
-  # Needs some fixing for 3.7
-  doCheck = !isPy37;
+  # Needs some fixing
+  doCheck = false;
 
   meta = with stdenv.lib; {
     description = "Utilities to support code that runs unmodified on Twisted and asyncio.";

--- a/pkgs/development/python-modules/wcwidth/default.nix
+++ b/pkgs/development/python-modules/wcwidth/default.nix
@@ -11,6 +11,9 @@ buildPythonPackage rec {
 
   checkInputs = [ pytest ];
 
+  # To prevent infinite recursion with pytest
+  doCheck = false;
+
   checkPhase = ''
     pytest
   '';

--- a/pkgs/development/python-modules/werkzeug/default.nix
+++ b/pkgs/development/python-modules/werkzeug/default.nix
@@ -14,19 +14,12 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ itsdangerous ];
   checkInputs = [ pytest requests hypothesis ];
 
-  # Hi! New version of Werkzeug? Please double-check that this commit is
-  # inclucded, and then remove the following patch.
-  # https://github.com/pallets/werkzeug/commit/1cfdcf9824cb20e362979e8f7734012926492165
-  patchPhase = ''
-    substituteInPlace "tests/test_serving.py" --replace "'python'" "sys.executable"
-  '';
-
   checkPhase = ''
     pytest ${stdenv.lib.optionalString stdenv.isDarwin "-k 'not test_get_machine_id'"}
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://werkzeug.pocoo.org/;
+    homepage = "https://palletsprojects.com/p/werkzeug/";
     description = "A WSGI utility library for Python";
     license = licenses.bsd3;
   };

--- a/pkgs/development/python-modules/whoosh/default.nix
+++ b/pkgs/development/python-modules/whoosh/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, pytest_3 }:
+{ stdenv, buildPythonPackage, fetchPypi, pytest }:
 
 buildPythonPackage rec {
   pname = "Whoosh";
@@ -8,11 +8,12 @@ buildPythonPackage rec {
     sha256 = "10qsqdjpbc85fykc1vgcs8xwbgn4l2l52c8d83xf1q59pwyn79bw";
   };
 
-  checkInputs = [ pytest_3 ];
+  checkInputs = [ pytest ];
 
   # Wrong encoding
   postPatch = ''
     rm tests/test_reading.py
+    substituteInPlace setup.cfg --replace "[pytest]" "[tool:pytest]"
   '';
   checkPhase =  ''
     # FIXME: test_minimize_dfa fails on python 3.6
@@ -25,6 +26,5 @@ checking library.";
     homepage    = https://bitbucket.org/mchaput/whoosh;
     license     = licenses.bsd2;
     maintainers = with maintainers; [ nand0p ];
-    platforms   = platforms.all;
   };
 }

--- a/pkgs/development/python-modules/zeep/default.nix
+++ b/pkgs/development/python-modules/zeep/default.nix
@@ -26,11 +26,11 @@
 
 buildPythonPackage rec {
   pname = "zeep";
-  version = "3.3.1";
+  version = "3.4.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "f58328e36264a2fda2484dd20bb1695f4102a9cc918178d60c4d7cf8339c65d0";
+    sha256 = "0e98669cfeb60756231ae185498f9ae21b30b2681786b8de58ed34c3b93e41dd";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/zipp/default.nix
+++ b/pkgs/development/python-modules/zipp/default.nix
@@ -23,6 +23,9 @@ buildPythonPackage rec {
     pytest
   '';
 
+  # Prevent infinite recursion with pytest
+  doCheck = false;
+
   meta = with lib; {
     description = "Pathlib-compatible object wrapper for zip files";
     homepage = https://github.com/jaraco/zipp;

--- a/pkgs/development/python-modules/zipp/default.nix
+++ b/pkgs/development/python-modules/zipp/default.nix
@@ -8,11 +8,11 @@
 
 buildPythonPackage rec {
   pname = "zipp";
-  version = "0.3.3";
+  version = "0.5.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "55ca87266c38af6658b84db8cfb7343cdb0bf275f93c7afaea0d8e7a209c7478";
+    sha256 = "ca943a7e809cc12257001ccfb99e3563da9af99d52f261725e96dfe0f9275bc3";
   };
 
   nativeBuildInputs = [ setuptools_scm ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -250,6 +250,8 @@ in {
 
   azure-nspkg = callPackage ../development/python-modules/azure-nspkg { };
 
+  azure-cli-core = callPackage ../development/python-modules/azure-cli-core { };
+
   azure-cli-telemetry = callPackage ../development/python-modules/azure-cli-telemetry { };
 
   azure-common = callPackage ../development/python-modules/azure-common { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1688,9 +1688,9 @@ in {
 
   pyhepmc = callPackage ../development/python-modules/pyhepmc { };
 
-  pytest = self.pytest_42;
+  pytest = self.pytest_4;
 
-  pytest_42 = callPackage ../development/python-modules/pytest {
+  pytest_4 = callPackage ../development/python-modules/pytest {
     # hypothesis tests require pytest that causes dependency cycle
     hypothesis = self.hypothesis.override { doCheck = false; };
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -250,6 +250,8 @@ in {
 
   azure-nspkg = callPackage ../development/python-modules/azure-nspkg { };
 
+  azure-cli-telemetry = callPackage ../development/python-modules/azure-cli-telemetry { };
+
   azure-common = callPackage ../development/python-modules/azure-common { };
 
   azure-cosmos = callPackage ../development/python-modules/azure-cosmos { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1092,6 +1092,8 @@ in {
 
   amqplib = callPackage ../development/python-modules/amqplib {};
 
+  antlr4-python2-runtime = callPackage ../development/python-modules/antlr4-python2-runtime {};
+
   antlr4-python3-runtime = callPackage ../development/python-modules/antlr4-python3-runtime {};
 
   apipkg = callPackage ../development/python-modules/apipkg {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3160,6 +3160,8 @@ in {
 
   kitchen = callPackage ../development/python-modules/kitchen { };
 
+  knack = callPackage ../development/python-modules/knack { };
+
   kubernetes = callPackage ../development/python-modules/kubernetes { };
 
   pylast = callPackage ../development/python-modules/pylast { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
