### PR TITLE
pythonPackages.antlr4-python2-runtime: init at 4.7.2

### DIFF
--- a/pkgs/development/python-modules/antlr4-python2-runtime/default.nix
+++ b/pkgs/development/python-modules/antlr4-python2-runtime/default.nix
@@ -1,0 +1,18 @@
+{ stdenv, fetchPypi, buildPythonPackage, isPy3k }:
+
+buildPythonPackage rec {
+  pname = "antlr4-python2-runtime";
+  version = "4.7.2";
+  disabled = isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "04ljic5wnqpizln8q3c78pqrckz6q5nb433if00j1mlyv2yja22q";
+  };
+
+  meta = {
+    description = "Runtime for ANTLR";
+    homepage = "https://www.antlr.org/";
+    license = stdenv.lib.licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1069,6 +1069,8 @@ in {
 
   amqplib = callPackage ../development/python-modules/amqplib {};
 
+  antlr4-python2-runtime = callPackage ../development/python-modules/antlr4-python2-runtime {};
+
   antlr4-python3-runtime = callPackage ../development/python-modules/antlr4-python3-runtime {};
 
   apipkg = callPackage ../development/python-modules/apipkg {};


### PR DESCRIPTION
###### Motivation for this change
Breaking apart #62746 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
$ nix path-info -Sh ./result
/nix/store/1914j8xz98m1fh0zbhck6hc3hc7qx5xf-python2.7-antlr4-python2-runtime-4.7.2        95.4M