### PR TITLE
pythonPackages.pydocumentdb: init at 2.3.3

### DIFF
--- a/pkgs/development/python-modules/pydocumentdb/default.nix
+++ b/pkgs/development/python-modules/pydocumentdb/default.nix
@@ -1,0 +1,28 @@
+{ buildPythonPackage
+, lib
+, fetchPypi
+, six
+, requests
+}:
+
+buildPythonPackage rec {
+  version = "2.3.3";
+  pname = "pydocumentdb";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1fcp3g62pc9hpa0r6vdjhaln4h0azywjqfzi8bd4414ja0mxmj3p";
+  };
+
+  propagatedBuildInputs = [ six requests ];
+
+  # requires an active Azure Cosmos service
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Azure Cosmos DB API";
+    homepage = https://github.com/Azure/azure-cosmos-python;
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -704,6 +704,8 @@ in {
 
   pydocstyle = callPackage ../development/python-modules/pydocstyle { };
 
+  pydocumentdb = callPackage ../development/python-modules/pydocumentdb { };
+
   pyexiv2 = disabledIf isPy3k (toPythonModule (callPackage ../development/python-modules/pyexiv2 {}));
 
   py3exiv2 = callPackage ../development/python-modules/py3exiv2 { };


### PR DESCRIPTION
###### Motivation for this change
Dependency for a few other packages i would like to upload here.

This package is now continued on as `azure-cosmos`. `pydocumentdb` is meant to be the package before they moved to a `azure.cosmos` namespace. 

This package should never need a bump.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
$ nix path-info -Sh ./result
/nix/store/ydn3ibyky880424imcq818lvff6y083j-python3.7-pydocumentdb-2.3.3         106.0M
