### PR TITLE
pythonPackages.azure-cosmos: init at 3.1.0

### DIFF
--- a/pkgs/development/python-modules/azure-cosmos/default.nix
+++ b/pkgs/development/python-modules/azure-cosmos/default.nix
@@ -1,0 +1,28 @@
+{ buildPythonPackage
+, lib
+, fetchPypi
+, six
+, requests
+}:
+
+buildPythonPackage rec {
+  version = "3.1.0";
+  pname = "azure-cosmos";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1955kpn2y16k5mil90bnnyscnh1hyh4d5l5v5b90ms969p61i9zl";
+  };
+
+  propagatedBuildInputs = [ six requests ];
+
+  # requires an active Azure Cosmos service
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Azure Cosmos DB API";
+    homepage = https://github.com/Azure/azure-cosmos-python;
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -254,6 +254,8 @@ in {
 
   azure-common = callPackage ../development/python-modules/azure-common { };
 
+  azure-cosmos = callPackage ../development/python-modules/azure-cosmos { };
+
   azure-mgmt-common = callPackage ../development/python-modules/azure-mgmt-common { };
 
   azure-mgmt-compute = callPackage ../development/python-modules/azure-mgmt-compute { };


### PR DESCRIPTION
###### Motivation for this change
follow up to #63175

This is the currently maintained version of pydocumentdb. 

not related to #60435 separate repo, just similar name.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
$ nix path-info -Sh ./result
/nix/store/2j40nsvfj0ppx35k5lk9mifi4br0lh81-python3.6-azure-cosmos-3.1.0         104.7M