### PR TITLE
gnome-mpv: 0.13 -> 0.16

### DIFF
--- a/pkgs/applications/video/gnome-mpv/appdata-validate.patch
+++ b/pkgs/applications/video/gnome-mpv/appdata-validate.patch
@@ -1,0 +1,11 @@
+--- a/data/meson.build
++++ b/data/meson.build
+@@ -43,7 +43,7 @@ configure_file(
+ 
+ appstream_util = find_program('appstream-util', required: false)
+ if appstream_util.found()
+-  test('Validate appstream file', appstream_util, args: ['validate', appdata])
++  test('Validate appstream file', appstream_util, args: ['validate', '--nonet', appdata])
+ endif
+ 
+ desktop_file_validate = find_program('desktop-file-validate', required: false)

--- a/pkgs/applications/video/gnome-mpv/default.nix
+++ b/pkgs/applications/video/gnome-mpv/default.nix
@@ -4,21 +4,22 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "gnome-mpv-${version}";
-  version = "0.13";
+  pname = "gnome-mpv";
+  version = "0.16";
 
   src = fetchFromGitHub {
-    owner = "gnome-mpv";
-    repo = "gnome-mpv";
-    rev = "0d73b33d60050fd32bf8fae77d831548970a0b69"; # upstream forgot to update appdata
-    # rev = "v${version}";
-    sha256 = "1cjhw3kz163iwj2japhnv354i1lr112xyyfkxw82cwy2554cfim4";
+    owner = "celluloid-player";
+    repo = "celluloid";
+    rev = "v${version}";
+    sha256 = "1fj5mr1dwd07jpnigk7z85xdm6yaf7spbvf60aj3mz12m05b1b2w";
   };
 
   nativeBuildInputs = [ meson ninja python3 appstream-glib gettext pkgconfig desktop-file-utils wrapGAppsHook ];
   buildInputs = [ epoxy glib gtk3 mpv ];
 
-  enableParallelBuilding = true;
+  patches = [
+    ./appdata-validate.patch
+  ];
 
   postPatch = ''
     patchShebangs meson_post_install.py
@@ -35,7 +36,7 @@ stdenv.mkDerivation rec {
       allowing access to mpv's powerful playback capabilities through an
       easy-to-use user interface.
     '';
-    homepage = https://github.com/gnome-mpv/gnome-mpv;
+    homepage = "https://github.com/celluloid-player/celluloid";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
   };


### PR DESCRIPTION
###### Motivation for this change

Updating to newest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
