### PR TITLE
gthumb: 3.6.2 -> 3.8.0

### DIFF
--- a/pkgs/applications/graphics/gthumb/default.nix
+++ b/pkgs/applications/graphics/gthumb/default.nix
@@ -1,31 +1,92 @@
-{ stdenv,  fetchurl, gnome3, itstool, libxml2, pkgconfig, intltool,
-  exiv2, libjpeg, libtiff, gst_all_1, libraw, libsoup, libsecret,
-  glib, gtk3, gsettings-desktop-schemas,
-  libchamplain, librsvg, libwebp, json-glib, webkitgtk, lcms2, bison,
-  flex, wrapGAppsHook, shared-mime-info }:
+{ stdenv
+, fetchurl
+, fetchpatch
+, gnome3
+, pkgconfig
+, meson
+, ninja
+, exiv2
+, libjpeg
+, libtiff
+, gst_all_1
+, libraw
+, libsoup
+, libsecret
+, glib
+, gtk3
+, gsettings-desktop-schemas
+, libchamplain
+, librsvg
+, libwebp
+, json-glib
+, webkitgtk
+, lcms2
+, bison
+, flex
+, clutter-gtk
+, wrapGAppsHook
+, shared-mime-info
+, python3
+, desktop-file-utils
+, itstool
+}:
 
 stdenv.mkDerivation rec {
   pname = "gthumb";
-  version = "3.6.2";
+  version = "3.8.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0rjb0bsjhn7nyl5jyjgrypvr6qdr9dc2g586j3lzan96a2vnpgy9";
+    sha256 = "1l2s1facq1r6yvqjqc34aqfzlvb3nhkhn79xisxbbdlgrrxdq52f";
   };
 
-  nativeBuildInputs = [ itstool libxml2 intltool pkgconfig bison flex wrapGAppsHook ];
+  nativeBuildInputs = [
+    bison
+    desktop-file-utils
+    flex
+    itstool
+    meson
+    ninja
+    pkgconfig
+    python3
+    wrapGAppsHook
+  ];
 
   buildInputs = [
-    glib gtk3 gsettings-desktop-schemas gst_all_1.gstreamer gst_all_1.gst-plugins-base
-    exiv2 libjpeg libtiff libraw libsoup libsecret libchamplain
-    librsvg libwebp json-glib webkitgtk lcms2 gnome3.adwaita-icon-theme
+    clutter-gtk
+    exiv2
+    glib
+    gnome3.adwaita-icon-theme
+    gsettings-desktop-schemas
+    gst_all_1.gst-plugins-base
+    gst_all_1.gstreamer
+    gtk3
+    json-glib
+    lcms2
+    libchamplain
+    libjpeg
+    libraw
+    librsvg
+    libsecret
+    libsoup
+    libtiff
+    libwebp
+    webkitgtk
   ];
 
-  enableParallelBuilding = true;
-
-  configureFlags = [
-    "--enable-libchamplain"
+  mesonFlags = [
+    "-Dlibchamplain=true"
   ];
+
+  postPatch = ''
+    chmod +x gthumb/make-gthumb-h.py
+
+    patchShebangs data/gschemas/make-enums.py \
+      gthumb/make-gthumb-h.py \
+      po/make-potfiles-in.py \
+      postinstall.py \
+      gthumb/make-authors-tab.py
+  '';
 
   preFixup = ''
     gappsWrapperArgs+=(--prefix XDG_DATA_DIRS : "${shared-mime-info}/share")
@@ -41,7 +102,7 @@ stdenv.mkDerivation rec {
     homepage = "https://wiki.gnome.org/Apps/Gthumb";
     description = "Image browser and viewer for GNOME";
     platforms = platforms.linux;
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     maintainers = [ maintainers.mimadrid ];
   };
 }


### PR DESCRIPTION
* enable clutter-gtk support
  Upstream defaults to it so we probably should as well.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Fixes build with exiv2 0.27.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
