### PR TITLE
pythonPackages.vsts: init at 0.1.25

### DIFF
--- a/pkgs/development/python-modules/vsts/default.nix
+++ b/pkgs/development/python-modules/vsts/default.nix
@@ -1,0 +1,30 @@
+{ buildPythonPackage
+, lib
+, python
+, fetchPypi
+, msrest
+}:
+
+buildPythonPackage rec {
+  version = "0.1.25";
+  pname = "vsts";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "15sgwqa72ynpahj101r2kc15s3dnsafg5gqx0sz3hnqz29h925ys";
+  };
+
+  propagatedBuildInputs = [ msrest ];
+
+  # Tests are highly impure
+  checkPhase = ''
+    ${python.interpreter} -c 'import vsts.version; print(vsts.version.VERSION)'
+  '';
+
+  meta = with lib; {
+    description = "Python APIs for interacting with and managing Azure DevOps";
+    homepage = https://github.com/microsoft/azure-devops-python-api;
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4558,6 +4558,8 @@ in {
 
   virtualenv = callPackage ../development/python-modules/virtualenv { };
 
+  vsts = callPackage ../development/python-modules/vsts { };
+
   weasyprint = callPackage ../development/python-modules/weasyprint { };
 
   webassets = callPackage ../development/python-modules/webassets { };


### PR DESCRIPTION
###### Motivation for this change
Another dependency for for the `azure-cli` package.

This is the final version for the `vsts` package as it has been rebranded to `azure-devops` for future development.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
$ nix path-info -Sh ./result
/nix/store/njn49gjkdi0c18x48bd9qnfq22rs755i-python3.6-vsts-0.1.25        125.7M

It is a big boi