### PR TITLE
shadowsocks-libev: 3.2.5 -> 3.3.0

### DIFF
--- a/pkgs/tools/networking/shadowsocks-libev/default.nix
+++ b/pkgs/tools/networking/shadowsocks-libev/default.nix
@@ -5,14 +5,14 @@
 
 stdenv.mkDerivation rec {
   pname = "shadowsocks-libev";
-  version = "3.2.5";
+  version = "3.3.0";
 
   # Git tag includes CMake build files which are much more convenient.
   src = fetchFromGitHub {
     owner = "shadowsocks";
     repo = pname;
     rev = "refs/tags/v${version}";
-    sha256 = "09z20y35zjzsx5fd5cnnxxgbfcrh2bp0z7m15l59wlmlsfp7r2pw";
+    sha256 = "0f6fk7p49b1m78v4ipacbl522nma9b3qzrvihzp2mmsa6j3cysgr";
     fetchSubmodules = true;
   };
 
@@ -21,12 +21,6 @@ stdenv.mkDerivation rec {
                         docbook_xsl libxslt ];
 
   cmakeFlags = [ "-DWITH_STATIC=OFF"  "-DCMAKE_BUILD_WITH_INSTALL_NAME_DIR=ON" ];
-
-  postInstall = ''
-    cp lib/* $out/lib
-    chmod +x $out/bin/*
-    mv $out/pkgconfig $out/lib
-  '';
 
   meta = with stdenv.lib; {
     description = "A lightweight secured SOCKS5 proxy";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
