### PR TITLE
theft: 0.4.4 -> 0.4.5, fix pkg-config file

### DIFF
--- a/pkgs/development/libraries/theft/default.nix
+++ b/pkgs/development/libraries/theft/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  version = "0.4.4";
+  version = "0.4.5";
   name = "theft-${version}";
 
   src = fetchFromGitHub {
-    owner = "silentbicycle";
-    repo = "theft";
-    rev = "v${version}";
-    sha256 = "1csdhnb10k7vsyd44vjpg430nf6a909wj8af2zawdkbvnxn5wxc4";
+    owner  = "silentbicycle";
+    repo   = "theft";
+    rev    = "v${version}";
+    sha256 = "1n2mkawfl2bpd4pwy3mdzxwlqjjvb5bdrr2x2gldlyqdwbk7qjhd";
   };
 
   preConfigure = "patchShebangs ./scripts/mk_bits_lut";
@@ -17,13 +17,21 @@ stdenv.mkDerivation rec {
   checkTarget = "test";
   
   installFlags = [ "PREFIX=$(out)" ];
-  postInstall = "install -m644 vendor/greatest.h $out/include/";
+
+  # fix the libtheft.pc file to use the right installation
+  # directory. should be fixed upstream, too
+  postInstall = ''
+    install -m644 vendor/greatest.h $out/include/
+
+    substituteInPlace $out/lib/pkgconfig/libtheft.pc \
+      --replace "/usr/local" "$out"
+  '';
   
-  meta = {
+  meta = with stdenv.lib; {
     description = "A C library for property-based testing";
-    platforms = stdenv.lib.platforms.linux;
-    homepage = "https://github.com/silentbicycle/theft/";
-    license = stdenv.lib.licenses.isc;
-    maintainers = [ stdenv.lib.maintainers.kquick ];
+    homepage    = "https://github.com/silentbicycle/theft/";
+    platforms   = platforms.unix;
+    license     = licenses.isc;
+    maintainers = with maintainers; [ kquick thoughtpolice ];
   };
 }


### PR DESCRIPTION
The libtheft.pc file was using prefix=/usr/local for its own relative
-L/-l/-I parameters for GCC, giving incorrect results. (This is really
more of an upstream bug.)

This also adds myself to the maintainer list, and enables builds on
non-Linux platforms.

Signed-off-by: Austin Seipp <as@fastly.com>

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
