### PR TITLE
pythonPackages.azure-devops: init at 5.0.0b8

### DIFF
--- a/pkgs/development/python-modules/azure-devops/default.nix
+++ b/pkgs/development/python-modules/azure-devops/default.nix
@@ -1,0 +1,29 @@
+{ buildPythonPackage
+, lib
+, fetchPypi
+, msrest
+}:
+
+buildPythonPackage rec {
+  version = "5.0.0b8";
+  pname = "azure-devops";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1hssbmg53zkixnr5hj52arwyq2k06jygxm49py88nnlbkkhxhxaf";
+  };
+
+  propagatedBuildInputs = [ msrest ];
+
+  # Tests are highly impure
+  checkPhase = ''
+    python -c 'import azure.devops.version; print(azure.devops.version.VERSION)'
+  '';
+
+  meta = with lib; {
+    description = "Python APIs for interacting with and managing Azure DevOps";
+    homepage = https://github.com/microsoft/azure-devops-python-api;
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -254,6 +254,8 @@ in {
 
   azure-common = callPackage ../development/python-modules/azure-common { };
 
+  azure-devops = callPackage ../development/python-modules/azure-devops { };
+
   azure-mgmt-common = callPackage ../development/python-modules/azure-mgmt-common { };
 
   azure-mgmt-compute = callPackage ../development/python-modules/azure-mgmt-compute { };


### PR DESCRIPTION
###### Motivation for this change
Follow up to #63184

This is the "new" azure-devops package after vsts was rebranded to azure-devops.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
$ nix path-info -Sh ./result
/nix/store/j2xpynp8kxi476vk0rz0q89sqa1cn9wm-python3.6-azure-devops-5.0.0b8       126.1M