### PR TITLE
zziplib: CVE-2018-17828

### DIFF
--- a/pkgs/development/libraries/zziplib/default.nix
+++ b/pkgs/development/libraries/zziplib/default.nix
@@ -1,4 +1,4 @@
-{ docbook_xml_dtd_412, fetchurl, stdenv, perl, python2, zip, xmlto, zlib }:
+{ docbook_xml_dtd_412, fetchurl, stdenv, perl, python2, zip, xmlto, zlib, fetchpatch }:
 
 stdenv.mkDerivation rec {
   name = "zziplib-${version}";
@@ -8,6 +8,13 @@ stdenv.mkDerivation rec {
     url = "https://github.com/gdraheim/zziplib/archive/v${version}.tar.gz";
     sha256 = "0i052a7shww0fzsxrdp3rd7g4mbzx7324a8ysbc0br7frpblcql4";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/gdraheim/zziplib/commit/f609ae8971f3c0ce64d38276b778001d0bbfc84b.patch";
+      sha256 = "0p9s5ix7g98ramf66bf501h08whzd7fanfjp11gyz0manzywghp8";
+  })
+  ];
 
   postPatch = ''
     sed -i -e s,--export-dynamic,, configure


### PR DESCRIPTION
(cherry picked from commit f0d386ab9108fba0d0a71b5b323026a8cdf8d7a4)

###### Motivation for this change

Fixes #61961.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
