### PR TITLE
bubblewrap: CVE-2019-12439

### DIFF
--- a/pkgs/tools/admin/bubblewrap/default.nix
+++ b/pkgs/tools/admin/bubblewrap/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, libxslt, docbook_xsl, libcap }:
+{ stdenv, fetchurl, libxslt, docbook_xsl, libcap, fetchpatch }:
 
 stdenv.mkDerivation rec {
   name = "bubblewrap-${version}";
@@ -8,6 +8,14 @@ stdenv.mkDerivation rec {
     url = "https://github.com/projectatomic/bubblewrap/releases/download/v${version}/${name}.tar.xz";
     sha256 = "1y2bdlxnlr84xcbf31lzirc292c5ak9bd2wvcvh4ppsliih6pjny";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/projectatomic/bubblewrap/commit/efc89e3b939b4bde42c10f065f6b7b02958ed50e.patch";
+      name = "CVE-2019-12439.patch";
+      sha256 = "1p2w0ixrr3aca6i26ckmlq8ini4a6kgq53r9f98f7ghvbdlp4dkg";
+    })
+  ];
 
   nativeBuildInputs = [ libcap libxslt docbook_xsl ];
 


### PR DESCRIPTION
###### Motivation for this change

Fixes #63062.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
