### PR TITLE
nixos/nix: add support for specifying additional nix paths

### DIFF
--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -358,6 +358,19 @@ in
           The default Nix expression search path, used by the Nix
           evaluator to look up paths enclosed in angle brackets
           (e.g. <literal>&lt;nixpkgs&gt;</literal>).
+
+          If you want to add a non-standard search path and do not want
+          to deal with managing the defaults use <literal>nix.extraNixPath</literal>
+          instead.
+        '';
+      };
+
+      extraNixPath = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        description = ''
+          Like <literal>nix.nixPath</literal> but only appends additional
+          search paths.
         '';
       };
 
@@ -448,7 +461,7 @@ in
 
     # Set up the environment variables for running Nix.
     environment.sessionVariables = cfg.envVars //
-      { NIX_PATH = cfg.nixPath;
+      { NIX_PATH = cfg.nixPath ++ cfg.extraNixPath;
       };
 
     environment.extraInit = optionalString (!isNix20)


### PR DESCRIPTION
It is a common pitfall for NixOS users to declare some additional nix
search paths by setting `nix.nixPath` not noticing that they are
removing the default search paths.

This change introduces the option `nix.extraNixPath` which can be used
to add paths to the list of search paths without overriding the
defaults. Users most likely want to use this since it is less likely
they'll have to resort fiddling the `NIX_PATH` environment variable
themselves in order to repair their system.


/cc @lheckemann @flokli since we just helped a NixOS users at ZuriHack with recovering from such a situation.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nixos/nixpkgs/63201)
<!-- Reviewable:end -->
