### PR TITLE
localtime: use upstream unit, fix polkit rules

### DIFF
--- a/nixos/modules/services/system/localtime.nix
+++ b/nixos/modules/services/system/localtime.nix
@@ -22,33 +22,16 @@ in {
   config = mkIf cfg.enable {
     services.geoclue2.enable = true;
 
-    # so polkit will pick up the rules
-    environment.systemPackages = [ pkgs.localtime ];
-
-    users.users = [{
-      name = "localtimed";
-      description = "Taskserver user";
-    }];
+    # We use the 'out' output, since localtime has its 'bin' output
+    # first, so that is what we get if we use the derivation bare.
+    # Install the polkit rules.
+    environment.systemPackages = [ pkgs.localtime.out ];
+    # Install the systemd unit.
+    systemd.packages = [ pkgs.localtime.out ];
 
     systemd.services.localtime = {
-      description = "localtime service";
       wantedBy = [ "multi-user.target" ];
-      partOf = [ "geoclue.service "];
-
-      serviceConfig = {
-        Restart                 = "on-failure";
-        # TODO: make it work with dbus
-        #DynamicUser             = true;
-        Nice                    = 10;
-        User                    = "localtimed";
-        PrivateTmp              = "yes";
-        PrivateDevices          = true;
-        PrivateNetwork          = "yes";
-        NoNewPrivileges         = "yes";
-        ProtectSystem           = "strict";
-        ProtectHome             = true;
-        ExecStart               = "${pkgs.localtime}/bin/localtimed";
-      };
+      serviceConfig.Restart = "on-failure";
     };
   };
 }

--- a/pkgs/tools/system/localtime/default.nix
+++ b/pkgs/tools/system/localtime/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, systemd, polkit, fetchFromGitHub, buildGoPackage, m4}:
+{ stdenv, fetchFromGitHub, buildGoPackage, m4 }:
 
 buildGoPackage rec {
   name = "localtime-2017-11-07";
@@ -11,18 +11,17 @@ buildGoPackage rec {
   };
   goPackagePath = "github.com/Stebalien/localtime";
 
-  buildInputs = [ systemd polkit m4 ];
+  buildInputs = [ m4 ];
 
-  makeFlags = [ "PREFIX=$(out)" ];
+  makeFlags = [ "PREFIX=$(out)" "BINDIR=$(bin)/bin" ];
 
   buildPhase = ''
     cd go/src/${goPackagePath}
-    make localtimed
+    make $makeFlags
   '';
 
   installPhase = ''
-    mkdir -p $bin/bin
-    install -Dm555 localtimed $bin/bin
+    make install $makeFlags
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/system/localtime/default.nix
+++ b/pkgs/tools/system/localtime/default.nix
@@ -13,7 +13,10 @@ buildGoPackage rec {
 
   buildInputs = [ m4 ];
 
-  makeFlags = [ "PREFIX=$(out)" "BINDIR=$(bin)/bin" ];
+  makeFlags = [ 
+    "PREFIX=${placeholder "out"}" 
+    "BINDIR=${placeholder "bin"}/bin" 
+  ];
 
   buildPhase = ''
     cd go/src/${goPackagePath}


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Fixes #55288.

`localtime`'s systemd unit and polkit rules weren't being installed since ed473e661533d04d3ed212be837346430c73cc88, which moves it to using `buildGoPackage`. This caused two issues:
- We weren't using `make install`, so we weren't installing all the build products to the output at all.
- `buildGoPackage` puts the `bin` output first, so the bare package references in the module were getting the `bin` output rather than the `out` output, and so wouldn't see the polkit rules anyway.

This PR fixes those issue.s

Along the way, I made us actually use the upstream unit, which works fine in my testing. With these changes and the recent geoclue changes, localtime now actually works on my system.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
