### PR TITLE
pythonPackages.django_taggit: fix build, enable tests

### DIFF
--- a/pkgs/development/python-modules/django_taggit/default.nix
+++ b/pkgs/development/python-modules/django_taggit/default.nix
@@ -1,7 +1,11 @@
 { stdenv
 , buildPythonPackage
+, python
 , fetchPypi
 , pythonOlder
+, django
+, mock
+, isort
 }:
 
 buildPythonPackage rec {
@@ -14,7 +18,14 @@ buildPythonPackage rec {
     sha256 = "a21cbe7e0879f1364eef1c88a2eda89d593bf000ebf51c3f00423c6927075dce";
   };
 
-  doCheck = false;
+  propagatedBuildInputs = [ isort django ];
+
+  checkInputs = [ mock ];
+  checkPhase = ''
+    # prove we're running tests against installed package, not build dir
+    rm -r taggit
+    ${python.interpreter} -m django test --settings=tests.settings
+  '';
 
   meta = with stdenv.lib; {
     description = "django-taggit is a reusable Django application for simple tagging";


### PR DESCRIPTION
###### Motivation for this change
New `django_taggit` version wants `django` & `isort` at install time, enabling the tests is simple enough.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
