### PR TITLE
pythonPackages.django-sites: fix build, flesh out comments

### DIFF
--- a/pkgs/development/python-modules/django-sites/default.nix
+++ b/pkgs/development/python-modules/django-sites/default.nix
@@ -4,6 +4,23 @@ buildPythonPackage rec {
   pname = "django-sites";
   version = "0.10";
 
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "f6f9ae55a05288a95567f5844222052b6b997819e174f4bde4e7c23763be6fc3";
+  };
+  # LICENSE file appears to be missing from pypi package, but expected by the installer
+  # https://github.com/niwinz/django-sites/issues/11
+  postPatch = ''
+    touch LICENSE
+  '';
+
+  propagatedBuildInputs = [ django ];
+
+  # required files for test don't seem to be included in pypi package, full source for 0.10
+  # version doesn't appear to be present on github
+  # https://github.com/niwinz/django-sites/issues/9
+  doCheck = false;
+
   meta = {
     description = ''
       Alternative implementation of django "sites" framework
@@ -12,14 +29,4 @@ buildPythonPackage rec {
     homepage = https://github.com/niwinz/django-sites;
     license = lib.licenses.bsd3;
   };
-
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "f6f9ae55a05288a95567f5844222052b6b997819e174f4bde4e7c23763be6fc3";
-  };
-
-  propagatedBuildInputs = [ django ];
-
-  # django.core.exceptions.ImproperlyConfigured: Requested settings, but settings are not configured. You must either define the environment variable DJANGO_SETTINGS_MODULE or call settings.configure() before accessing settings.
-  doCheck = false;
 }


### PR DESCRIPTION
###### Motivation for this change
Simple missing `LICENSE` file in pypi package, upstream issue doesn't really look to be going anywhere.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
