### PR TITLE
pythonPackages.django_appconf, pythonPackages.django_compressor: fix build

### DIFF
--- a/pkgs/development/python-modules/django_appconf/default.nix
+++ b/pkgs/development/python-modules/django_appconf/default.nix
@@ -1,17 +1,22 @@
-{ stdenv, buildPythonPackage, fetchPypi, six }:
+{ stdenv, buildPythonPackage, fetchFromGitHub, six, django }:
 buildPythonPackage rec {
   pname = "django-appconf";
   version = "1.0.3";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "35f13ca4d567f132b960e2cd4c832c2d03cb6543452d34e29b7ba10371ba80e3";
+  src = fetchFromGitHub {
+    owner = "django-compressor";
+    repo = "django-appconf";
+    rev = version;
+    sha256 = "06hwbz7362y0la9np3df25mms235fcqgpd2vn0mnf8dri9spzy1h";
   };
 
-  # No tests in archive
-  doCheck = false;
+  propagatedBuildInputs = [ six django ];
 
-  propagatedBuildInputs = [ six ];
+  checkPhase = ''
+    # prove we're running tests against installed package, not build dir
+    rm -r appconf
+    python -m django test --settings="tests.test_settings"
+  '';
 
   meta = with stdenv.lib; {
     description = "A helper class for handling configuration defaults of packaged apps gracefully";

--- a/pkgs/development/python-modules/django_compressor/default.nix
+++ b/pkgs/development/python-modules/django_compressor/default.nix
@@ -8,8 +8,12 @@ buildPythonPackage rec {
       inherit pname version;
       sha256 = "9616570e5b08e92fa9eadc7a1b1b49639cce07ef392fc27c74230ab08075b30f";
     };
+    postPatch = ''
+      substituteInPlace setup.py --replace 'rcssmin == 1.0.6' 'rcssmin' \
+        --replace 'rjsmin == 1.0.12' 'rjsmin'
+    '';
 
-    # Need to setup django testing
+    # requires django-sekizai, which we don't have packaged yet
     doCheck = false;
 
     propagatedBuildInputs = [ rcssmin rjsmin django_appconf ];


### PR DESCRIPTION
###### Motivation for this change
`pythonPackages.django_appconf` needed `django` at install-time, `django_compressor` was being overly strict about its dependency versions. Couldn't enable the test suites unfortunately, but have left better explanations why.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
