### PR TITLE
libfsm: init at 0.1pre1869_f70c3c5

### DIFF
--- a/pkgs/development/libraries/libfsm/default.nix
+++ b/pkgs/development/libraries/libfsm/default.nix
@@ -1,0 +1,53 @@
+{ stdenv, fetchFromGitHub
+, bmake
+}:
+
+stdenv.mkDerivation rec {
+  name    = "libfsm-${version}";
+  version = "0.1pre1869_${builtins.substring 0 7 src.rev}";
+
+  src = fetchFromGitHub {
+    owner  = "katef";
+    repo   = "libfsm";
+    rev    = "f70c3c5778a79eeecb52f9fd35c7cbc241db0ed6";
+    sha256 = "1hgv272jdv6dwnsdjajyky537z84q0cwzspw9br46qj51h8gkwvx";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ bmake ];
+  enableParallelBuilding = true;
+
+  # note: build checks value of '$CC' to add some extra cflags, but we don't
+  # necessarily know which 'stdenv' someone chose, so we leave it alone (e.g.
+  # if we use stdenv vs clangStdenv, we don't know which, and CC=cc in all
+  # cases.) it's unclear exactly what should be done if we want those flags,
+  # but the defaults work fine.
+  buildPhase = "PREFIX=$out bmake -r install";
+
+  # fix up multi-output install. we also have to fix the pkgconfig libdir
+  # file; it uses prefix=$out; libdir=${prefix}/lib, which is wrong in
+  # our case; libdir should really be set to the $lib output.
+  installPhase = ''
+    mkdir -p $lib $dev/lib
+
+    mv $out/lib             $lib/lib
+    mv $out/include         $dev/include
+    mv $out/share/pkgconfig $dev/lib/pkgconfig
+    rmdir $out/share
+
+    for x in libfsm.pc libre.pc; do
+      substituteInPlace "$dev/lib/pkgconfig/$x" \
+        --replace 'libdir=''${prefix}/lib' "libdir=$lib/lib"
+    done
+  '';
+
+  outputs = [ "out" "lib" "dev" ];
+
+  meta = with stdenv.lib; {
+    description = "DFA regular expression library & friends";
+    homepage    = "https://github.com/katef/libfsm";
+    license     = licenses.bsd2;
+    platforms   = platforms.unix;
+    maintainers = with maintainers; [ thoughtpolice ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4311,6 +4311,8 @@ in
 
   libfann = callPackage ../development/libraries/libfann { };
 
+  libfsm = callPackage ../development/libraries/libfsm { };
+
   libgaminggear = callPackage ../development/libraries/libgaminggear { };
 
   libhandy = callPackage ../development/libraries/libhandy { };


### PR DESCRIPTION
Signed-off-by: Austin Seipp <as@fastly.com>

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
