### PR TITLE
perlPackages.CatalystPluginSmartURI: init at 0.041

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -1669,6 +1669,21 @@ let
     };
   };
 
+  CatalystPluginSmartURI = buildPerlPackage rec {
+    pname = "Catalyst-Plugin-SmartURI";
+    version = "0.041";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/R/RK/RKITOVER/${pname}-${version}.tar.gz";
+      sha256 = "0msz3w2vfdb5w4ixi5llq66xlhm0181gjz9xj8yj0lalk232326b";
+    };
+    checkInputs = [ TestWarnings TimeOut ];
+    propagatedBuildInputs = [ URISmartURI CatalystRuntime ClassC3Componentised ClassLoad Moose ScalarListUtils namespaceclean ];
+    meta = {
+      description = "File storage backend for session data";
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   CatalystPluginStackTrace = buildPerlPackage {
     pname = "Catalyst-Plugin-StackTrace";
     version = "0.12";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -14851,6 +14851,22 @@ let
     };
   };
 
+  URISmartURI = buildPerlPackage rec {
+    pname = "URI-SmartURI";
+    version = "0.032";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/R/RK/RKITOVER/${pname}-${version}.tar.gz";
+      sha256 = "0b2grkmkbnp37q85wj7jpj5zr93vdbisgxlls2vl5q928rwln5zb";
+    };
+    checkInputs = [ TestNoWarnings TestFatal ];
+    propagatedBuildInputs = [ URI FileFindRule ListMoreUtils
+      ClassC3Componentised ClassLoad Moose ScalarListUtils namespaceclean ];
+    meta = {
+      description = "File storage backend for session data";
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   SnowballNorwegian = buildPerlModule {
      pname = "Snowball-Norwegian";
      version = "1.2";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -18462,6 +18462,19 @@ let
     };
   };
 
+  TimeOut = buildPerlPackage rec {
+    pname = "Time-Out";
+    version = "0.11";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/P/PA/PATL/${pname}-${version}.tar.gz";
+      sha256 = "1lhmx1x8j6z1k9vn32bcsw7g44cg22icshnnc37djlnlixlxm5lk";
+    };
+    meta = {
+      description = "Easily timeout long running operations";
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   Tk = buildPerlPackage {
     pname = "Tk";
     version = "804.034";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This package allows Catalyst web projects to use relative URLs instead of absolute URLs. This is specifically interesting to me for Hydra, because using relative URLs allows using Hydra behind a proxy without extra configuration. I've tested Hydra with this package and it works well.

Once this package has been merged for a while, I'll send PRs to both the Hydra repo and to Nixpkgs to add this package as a dependency.

Pinging @volth for review of Perl, @grahamc and @edolstra for relevance to Hydra

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
