### PR TITLE
pythonPackages.hdbscan: fix build by applying upstream patch

### DIFF
--- a/pkgs/development/python-modules/hdbscan/default.nix
+++ b/pkgs/development/python-modules/hdbscan/default.nix
@@ -6,6 +6,7 @@
 , scipy
 , scikitlearn
 , fetchPypi
+, fetchpatch
 }:
 
 buildPythonPackage rec {
@@ -16,6 +17,15 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "263e9f34db63eec217d50f2ca3e65049c065775dc4095b5ee817824cd2b5b51b";
   };
+
+  patches = [
+    # Fix Tests. Drop in release >0.8.20
+    (fetchpatch {
+      name = "test-rsl-missing-import.patch";
+      url = https://github.com/scikit-learn-contrib/hdbscan/commit/e40ccef139e56e38adf7bd6912cd63efd97598f9.patch;
+      sha256 = "0cfq4ja7j61h2zwd1jw5gagcz2sg18kjnx29sb0bwa13wfw6fip0";
+    })
+  ];
 
   checkInputs = [ nose ];
 


### PR DESCRIPTION
###### Motivation for this change
Simple missing import in one of the test modules

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
