### PR TITLE
sublime3: fix gksu support

### DIFF
--- a/pkgs/applications/editors/sublime/3/common.nix
+++ b/pkgs/applications/editors/sublime/3/common.nix
@@ -1,12 +1,9 @@
 { buildVersion, x32sha256, x64sha256, dev ? false }:
 
 { fetchurl, stdenv, xorg, glib, glibcLocales, gtk2, gtk3, cairo, pango, libredirect, makeWrapper, wrapGAppsHook
-, pkexecPath ? "/run/wrappers/bin/pkexec", gksuSupport ? false, gksu
-, writeScript, common-updater-scripts, curl, gnugrep
+, gksu, writeScript, common-updater-scripts, curl, gnugrep
 , openssl, bzip2, bash, unzip, zip
 }:
-
-assert gksuSupport -> gksu != null;
 
 let
   pname = "sublimetext3";
@@ -31,8 +28,7 @@ let
       "x64";
 
   libPath = stdenv.lib.makeLibraryPath [ xorg.libX11 glib (if usesGtk2 then gtk2 else gtk3) cairo pango ];
-  redirects = [ "/usr/bin/pkexec=${pkexecPath}" ]
-    ++ stdenv.lib.optional gksuSupport "/usr/bin/gksudo=${gksu}/bin/gksudo";
+  redirects = [ "/usr/bin/gksudo=${gksu}/bin/gksudo" ];
 in let
   binaryPackage = stdenv.mkDerivation {
     pname = "${pname}-bin";

--- a/pkgs/build-support/libredirect/libredirect.c
+++ b/pkgs/build-support/libredirect/libredirect.c
@@ -160,6 +160,19 @@ int posix_spawn(pid_t * pid, const char * path,
     return posix_spawn_real(pid, rewrite(path, buf), file_actions, attrp, argv, envp);
 }
 
+int posix_spawnp(pid_t * pid, const char * path,
+    const posix_spawn_file_actions_t * file_actions,
+    const posix_spawnattr_t * attrp,
+    char * const argv[], char * const envp[])
+{
+    int (*posix_spawnp_real) (pid_t *, const char *,
+        const posix_spawn_file_actions_t *,
+        const posix_spawnattr_t *,
+        char * const argv[], char * const envp[]) = dlsym(RTLD_NEXT, "posix_spawnp");
+    char buf[PATH_MAX];
+    return posix_spawnp_real(pid, rewrite(path, buf), file_actions, attrp, argv, envp);
+}
+
 int execv(const char *path, char *const argv[])
 {
     int (*execv_real) (const char *path, char *const argv[]) = dlsym(RTLD_NEXT, "execv");


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
After bumping sublime3 in #61636 we realized that saving files as root
doesn't work anymore and somehow the paths weren't patched by
`libredirect`.

After some debugging it came out that sublime uses `posix_spawnp(3)` to
start new processes internally which resulted in a broken `execve(2)`
syscall that attempted to use `/usr/bin/gksudo`. Wrapping `posix_spawnp`
appears to fix the problem.

However it seems the use of `pkexec` isn't sufficient anymore and
`gksudo` is required which is why this part has been removed from the
package.

On a side note: it's been decided to remain using `libredirect` rather
than FHS user environments to ensure that it's still possible to edit
global files like `/etc/nixos/configuration.nix`.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
