### PR TITLE
pythonPackages.releases: init at 1.6.1

### DIFF
--- a/pkgs/development/python-modules/releases/default.nix
+++ b/pkgs/development/python-modules/releases/default.nix
@@ -1,0 +1,34 @@
+{ buildPythonPackage
+, lib
+, fetchPypi
+, sphinx
+, semantic-version
+}:
+
+buildPythonPackage rec {
+  version = "1.6.1";
+  pname = "releases";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0m6skhfdjmfgwn7f3dhzdwa6sxamy0fzbn319vf42b86mdik26vs";
+  };
+
+  propagatedBuildInputs = [ semantic-version sphinx ];
+
+  # Use compatible sphinx versions
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "sphinx>=1.3,<1.8" "sphinx ~= 1.3"
+  '';
+
+  # Tests excluded from sdist package
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A Sphinx extension for changelog manipulation";
+    homepage = https://github.com/bitprophet/releases;
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -893,6 +893,8 @@ in {
 
   relatorio = callPackage ../development/python-modules/relatorio { };
 
+  releases = callPackage ../development/python-modules/releases { };
+
   reproject = callPackage ../development/python-modules/reproject { };
 
   remotecv = callPackage ../development/python-modules/remotecv { };


### PR DESCRIPTION
###### Motivation for this change
Another indirect dependency of `azure-cli` . Sorry for the PR spam, but until #60435 gets merged, I'm just adding leaf dependencies that aren't in nixpkgs yet.

This is sphinx extension for generating changelogs.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
$ nix path-info -Sh ./result
/nix/store/lp5jrxlr7hbbq6inyl0sbqksr3ifpir6-python3.6-releases-1.6.1     165.4M

most of the size is sphinx ~165.2M