### PR TITLE
docker-containers: More container options, and tweaks to launch logic

### DIFF
--- a/nixos/modules/virtualisation/docker-containers.nix
+++ b/nixos/modules/virtualisation/docker-containers.nix
@@ -38,8 +38,9 @@ let
           '';
           example = literalExample ''
             [
-              "/dev/dvb:/dev/dvb"
+              "/dev/dvb"
               "/dev/dri:/dev/dri:r"
+              "/dev/sdb:/dev/sdb:rw"
             ]
           '';
         };

--- a/nixos/modules/virtualisation/docker-containers.nix
+++ b/nixos/modules/virtualisation/docker-containers.nix
@@ -123,7 +123,7 @@ let
             <link xlink:href="https://docs.docker.com/engine/reference/run/#network-settings">
             Docker engine documentation</link>
           '';
-          example = "host"
+          example = "host";
         };
 
         ports = mkOption {

--- a/nixos/modules/virtualisation/docker-containers.nix
+++ b/nixos/modules/virtualisation/docker-containers.nix
@@ -65,7 +65,12 @@ let
 
         hostname = mkOption {
           type = with types; nullOr str;
-          description = "Set the hostname inside the container. Not required if using Host networking.";
+          description = ''
+            Set the hostname inside the container.
+            If this is not set, the container will assume a hostname corresponding
+            to its engine ID, or the host's hostname if using host networking
+            (see the "network" option)
+          '';
           default = null;
           example = "MyFancyDockerContainer";
         };
@@ -219,7 +224,7 @@ let
           default = [];
           description = "Extra options for <command>docker run</command>.";
           example = literalExample ''
-            ["--network=host"]
+            ["--cpus 1"]
           '';
         };
       };

--- a/nixos/modules/virtualisation/docker-containers.nix
+++ b/nixos/modules/virtualisation/docker-containers.nix
@@ -71,15 +71,22 @@ let
         };
 
         labels = mkOption {
-          type = with types; listOf str;
-          default = [];
+          type = with types; attrsOf str;
+          default = {};
           description = ''
-            Labels that should be set on this container.
+            Labels that should be applied to this container.
 
             For more details on labels, refer to the
             <link xlink:href="https://docs.docker.com/config/labels-custom-metadata/">
             Docker documentation</link>
           '';
+          example = literalExample ''
+            {
+              "traefik.port" = "80";
+              "traefik.enable" = "true"
+              "mylabel.container.is-cool" = "true";
+            }
+        '';
         };
 
         log-driver = mkOption {
@@ -239,7 +246,7 @@ let
           ++ (mapAttrsToList (k: v: "-e ${escapeShellArg k}=${escapeShellArg v}") container.environment)
           ++ optional (container.hostname != null)
           "-h ${escapeShellArg container.hostname}"
-          ++ map (l: "-l ${escapeShellArg l}") container.labels
+          ++ (mapAttrsToList (k: v: "-l ${escapeShellArg k}=${escapeShellArg v}") container.labels)
           ++ map (p: "-p ${escapeShellArg p}") container.ports
           ++ optional (container.user != null) "-u ${escapeShellArg container.user}"
           ++ map (v: "-v ${escapeShellArg v}") container.volumes


### PR DESCRIPTION
Extends #55179

###### Motivation for this change
I needed to be able to set some extra flags for my personal server, and instead of adding loads of extra cruft to the `extraFlags` field, I decided to just add new options for them.

The options I have added are 
- `devices` (for device nodes like `/dev/dvb`)
- `hostname` (for when you really need to change the container's internal hostname)
- `labels` (for labelling containers, especially useful with træfik's docker mode)
- `network` (for explicitely defining the primary network to join, see below)

I'm open to suggestions as to whether some of these should be done in a different way, especially with regards to whether `devices` should be an attribute set (though if that's the case, should other similars like `volumes` change as well?).

I've also added some changes to how the container is launched. Previously, systemd called `docker run --rm`, which pulls the image if it doesn't already exist, creates the container, starts it (attached to stdout), then removes it when the container closes.
With my tweaked logic, `docker pull` and `docker create` are now ExecStartPre steps, and `docker start -n` actually launches the container. I feel this is better for a couple of reasons:
- the ExecStart command does one thing and one thing alone, launching the container
- I was experimenting with changes to allow nix-defined software networks, and doing it this way around lets us inject other commands between container creation and container launch, which is mandatory to support this - docker only lets you join containers to _extra_ networks by doing `docker network connect` _after_ the container has been initialised, not _while_ you're creating it. (I'm not ready to commit this support yet, fwiw)


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
