### PR TITLE
bedtools: 2.27.1 -> 2.28.0

### DIFF
--- a/pkgs/applications/science/biology/bedtools/default.nix
+++ b/pkgs/applications/science/biology/bedtools/default.nix
@@ -1,17 +1,17 @@
-{stdenv, fetchFromGitHub, zlib, python}:
+{stdenv, fetchFromGitHub, zlib, python, bzip2, lzma}:
 
 stdenv.mkDerivation rec {
   name = "bedtools-${version}";
-  version = "2.27.1";
+  version = "2.28.0";
 
   src = fetchFromGitHub {
     owner = "arq5x";
     repo = "bedtools2";
     rev = "v${version}";
-    sha256 = "1pk68y052rm2m24yfmy82ms8p6kd6xcqxxgi7n0a1sbh89wllm6s";
+    sha256 = "1266bcn5hgbvysfi6nr4cqxlbxcx7vn7ng8kb0v3gz37qh2zxxw9";
   };
 
-  buildInputs = [ zlib python ];
+  buildInputs = [ zlib python bzip2 lzma ];
   cc = if stdenv.cc.isClang then "clang++" else "g++";
   buildPhase = "make prefix=$out SHELL=${stdenv.shell} CXX=${cc} -j $NIX_BUILD_CORES";
   installPhase = "make prefix=$out SHELL=${stdenv.shell} CXX=${cc} install";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Version bump.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
