### PR TITLE
gelasio: init at unstable-2018-08-13

### DIFF
--- a/pkgs/data/fonts/gelasio/default.nix
+++ b/pkgs/data/fonts/gelasio/default.nix
@@ -1,0 +1,31 @@
+{ lib, fetchFromGitHub }:
+
+let
+  version = "unstable-2018-08-12";
+in fetchFromGitHub {
+  name = "gelasio-${version}";
+  owner = "SorkinType";
+  repo = "Gelasio";
+  rev = "5bced461d54bcf8e900bb3ba69455af35b0d2ff1";
+  sha256 = "0dfskz2vpwsmd88rxqsxf0f01g4f2hm6073afcm424x5gc297n39";
+
+  postFetch = ''
+    tar xf $downloadedFile --strip=1
+    mkdir -p $out/share/fonts/truetype
+    cp *.ttf $out/share/fonts/truetype/
+  '';
+
+  meta = with lib; {
+    description = "a font which is metric-compatible with Microsoft's Georgia";
+    longDescription = ''
+      Gelasio is an original typeface which is metrics compatible with Microsoft's
+      Georgia in its Regular, Bold, Italic and Bold Italic weights. Interpolated
+      Medium, medium Italic, SemiBold and SemiBold Italic have now been added as well.
+    '';
+    homepage = "https://github.com/SorkinType/Gelasio";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ colemickens ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3273,6 +3273,8 @@ in
 
   gdmap = callPackage ../tools/system/gdmap { };
 
+  gelasio = callPackage ../data/fonts/gelasio { };
+
   gen-oath-safe = callPackage ../tools/security/gen-oath-safe { };
 
   genext2fs = callPackage ../tools/filesystems/genext2fs { };


### PR DESCRIPTION
###### Motivation for this change
- package gelasio

EDIT: this is desirable because "Gelasio is a Google font that is metrically comaptible with Georgia".

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
