### PR TITLE
[19.03] nomachine-client: 6.5.6 -> 6.7.6

### DIFF
--- a/pkgs/tools/admin/nomachine-client/default.nix
+++ b/pkgs/tools/admin/nomachine-client/default.nix
@@ -1,10 +1,10 @@
 { stdenv, lib, file, fetchurl, makeWrapper,
   autoPatchelfHook, jsoncpp, libpulseaudio }:
 let
-  versionMajor = "6.5";
-  versionMinor = "6";
-  versionBuild_x86_64 = "9";
-  versionBuild_i686 = "8";
+  versionMajor = "6.6";
+  versionMinor = "8";
+  versionBuild_x86_64 = "5";
+  versionBuild_i686 = "5";
 in
   stdenv.mkDerivation rec {
     pname = "nomachine-client";
@@ -14,12 +14,12 @@ in
       if stdenv.hostPlatform.system == "x86_64-linux" then
         fetchurl {
           url = "https://download.nomachine.com/download/${versionMajor}/Linux/nomachine_${version}_${versionBuild_x86_64}_x86_64.tar.gz";
-          sha256 = "07lg5yadxpl5qfvvh067b3kxd8hm3xv95ralm2pyjl4lw6aql46p";
+          sha256 = "0hsx1nd9m1l35pj4jri88jib1hgf2wh1f42s650y2br2h6bhaixs";
         }
       else if stdenv.hostPlatform.system == "i686-linux" then
         fetchurl {
           url = "https://download.nomachine.com/download/${versionMajor}/Linux/nomachine_${version}_${versionBuild_i686}_i686.tar.gz";
-          sha256 = "1a23isw09vicazkrypq0kxbb8qy2i4vxiarrgz5xmasjhiy5999a";
+          sha256 = "1hrp8s17pcqkb4jcnayx81qmm7c1njjp69fkpyqgcnv9vshias1b";
         }
       else
         throw "NoMachine client is not supported on ${stdenv.hostPlatform.system}";

--- a/pkgs/tools/admin/nomachine-client/default.nix
+++ b/pkgs/tools/admin/nomachine-client/default.nix
@@ -1,10 +1,10 @@
 { stdenv, lib, file, fetchurl, makeWrapper,
   autoPatchelfHook, jsoncpp, libpulseaudio }:
 let
-  versionMajor = "6.6";
-  versionMinor = "8";
-  versionBuild_x86_64 = "5";
-  versionBuild_i686 = "5";
+  versionMajor = "6.7";
+  versionMinor = "6";
+  versionBuild_x86_64 = "11";
+  versionBuild_i686 = "11";
 in
   stdenv.mkDerivation rec {
     pname = "nomachine-client";
@@ -14,12 +14,12 @@ in
       if stdenv.hostPlatform.system == "x86_64-linux" then
         fetchurl {
           url = "https://download.nomachine.com/download/${versionMajor}/Linux/nomachine_${version}_${versionBuild_x86_64}_x86_64.tar.gz";
-          sha256 = "0hsx1nd9m1l35pj4jri88jib1hgf2wh1f42s650y2br2h6bhaixs";
+          sha256 = "1mka0a7p03y53zsf0srrcj4f7sigda5vndrwqhr0vncc2qws03k0";
         }
       else if stdenv.hostPlatform.system == "i686-linux" then
         fetchurl {
           url = "https://download.nomachine.com/download/${versionMajor}/Linux/nomachine_${version}_${versionBuild_i686}_i686.tar.gz";
-          sha256 = "1hrp8s17pcqkb4jcnayx81qmm7c1njjp69fkpyqgcnv9vshias1b";
+          sha256 = "1g94s65bp99nfmzvwv1wasvjhgjbfg9jkc089qimi0lvr8ajabkx";
         }
       else
         throw "NoMachine client is not supported on ${stdenv.hostPlatform.system}";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Backport of #62727 as requested by the maintainer.

cc @talyz for testing

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
