### PR TITLE
Erlang/OTP 22

### DIFF
--- a/pkgs/development/interpreters/erlang/R22.nix
+++ b/pkgs/development/interpreters/erlang/R22.nix
@@ -1,0 +1,11 @@
+{ mkDerivation }:
+
+mkDerivation rec {
+  version = "22.0.4";
+  sha256 = "1aqkhd6nwdn4xp5yz02zbymd4x8ij8fjw9ji8kh860n1a513k9ai";
+
+  prePatch = ''
+    substituteInPlace make/configure.in --replace '`sw_vers -productVersion`' '10.10'
+    substituteInPlace erts/configure.in --replace '-Wl,-no_weak_imports' ""
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8233,7 +8233,7 @@ in
   beam = callPackage ./beam-packages.nix { };
 
   inherit (beam.interpreters)
-    erlang erlangR18 erlangR19 erlangR20 erlangR21
+    erlang erlangR18 erlangR19 erlangR20 erlangR21 erlangR22
     erlang_odbc erlang_javac erlang_odbc_javac erlang_nox erlang_basho_R16B02
     elixir elixir_1_8 elixir_1_7 elixir_1_6 elixir_1_5 elixir_1_4
     lfe lfe_1_2;

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -50,6 +50,15 @@ rec {
       javacSupport = true; odbcSupport = true;
     };
     erlangR21_nox = erlangR21.override { wxSupport = false; };
+    erlangR22 = lib.callErlang ../development/interpreters/erlang/R22.nix {
+      wxGTK = wxGTK30;
+    };
+    erlangR22_odbc = erlangR22.override { odbcSupport = true; };
+    erlangR22_javac = erlangR22.override { javacSupport = true; };
+    erlangR22_odbc_javac = erlangR22.override {
+      javacSupport = true; odbcSupport = true;
+    };
+    erlangR22_nox = erlangR22.override { wxSupport = false; };
 
     # Basho fork, using custom builder.
     erlang_basho_R16B02 = lib.callErlang ../development/interpreters/erlang/R16B02-basho.nix {
@@ -79,6 +88,7 @@ rec {
     erlangR19 = packagesWith interpreters.erlangR19;
     erlangR20 = packagesWith interpreters.erlangR20;
     erlangR21 = packagesWith interpreters.erlangR21;
+    erlangR22 = packagesWith interpreters.erlangR22;
 
   };
 }


### PR DESCRIPTION
~This depends on #63295 being merged.~

###### Motivation for this change

Adding the latest, stable Erlang/OTP release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
