### PR TITLE
pythonPackages.caffe: fix caffe python bindings

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -537,6 +537,15 @@
     github = "averelld";
     name = "averelld";
   };
+  avitex = {
+    email = "theavitex@gmail.com";
+    github = "avitex";
+    name = "avitex";
+    keys = [{
+      longkeyid = "rsa4096/0x8B366C443CABE942";
+      fingerprint = "271E 136C 178E 06FA EA4E  B854 8B36 6C44 3CAB E942";
+    }];
+  };
   avnik = {
     email = "avn@avnik.info";
     github = "avnik";

--- a/pkgs/applications/science/math/caffe/default.nix
+++ b/pkgs/applications/science/math/caffe/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
   cmakeFlags =
     # It's important that caffe is passed the major and minor version only because that's what
     # boost_python expects
-    [ (if pythonSupport then "-Dpython_version=3${python.pythonVersion}" else "-DBUILD_python=OFF")
+    [ (if pythonSupport then "-Dpython_version=${python.pythonVersion}" else "-DBUILD_python=OFF")
       "-DBLAS=open"
     ] ++ (if cudaSupport then [
            "-DCUDA_ARCH_NAME=All"

--- a/pkgs/applications/science/math/caffe/default.nix
+++ b/pkgs/applications/science/math/caffe/default.nix
@@ -73,9 +73,17 @@ stdenv.mkDerivation rec {
                 ++ lib.optionals stdenv.isDarwin [ Accelerate CoreGraphics CoreVideo ]
                 ;
 
-  propagatedBuildInputs = lib.optional pythonSupport python.pkgs.protobuf;
+  propagatedBuildInputs = lib.optionals pythonSupport (
+    # requirements.txt
+    let pp = python.pkgs; in ([
+      pp.numpy pp.scipy pp.scikitimage pp.h5py
+      pp.matplotlib pp.ipython pp.networkx pp.nose
+      pp.pandas pp.dateutil pp.protobuf pp.gflags
+      pp.pyyaml pp.pillow pp.six
+    ] ++ lib.optional leveldbSupport pp.leveldb)
+  );
 
-  outputs = [ "bin" "out"];
+  outputs = [ "bin" "out" ];
   propagatedBuildOutputs = []; # otherwise propagates out -> bin cycle
 
   patches = [

--- a/pkgs/applications/science/math/caffe/python.patch
+++ b/pkgs/applications/science/math/caffe/python.patch
@@ -64,7 +64,7 @@ index 4a5bac47..be026d43 100644
 -  if(PYTHONLIBS_FOUND AND NUMPY_FOUND AND Boost_PYTHON_FOUND)
 +  find_package(NumPy 1.7.1)
 +  find_package(Boost 1.46 REQUIRED COMPONENTS python@major@@minor@)
-+  if(PYTHONLIBS_FOUND AND NUMPY_FOUND AND BOOST_PYTHON@major@@minor@_FOUND)
++  if(PYTHONLIBS_FOUND AND NUMPY_FOUND AND Boost_PYTHON@major@@minor@_FOUND)
      set(HAVE_PYTHON TRUE)
      if(BUILD_python_layer)
        list(APPEND Caffe_DEFINITIONS PRIVATE -DWITH_PYTHON_LAYER)


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fixes #63191 

cc @jb55

I have not tested with python 2 fully, only confirmed the python 3 bindings are now working (though I will, when I get time).
If you'd like to add me as a maintainer, I'm happy to review future problems

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
