### PR TITLE
pythonPackages.bcrypt: add missing libffi dependency

### DIFF
--- a/pkgs/development/python-modules/bcrypt/default.nix
+++ b/pkgs/development/python-modules/bcrypt/default.nix
@@ -1,23 +1,24 @@
-{ stdenv, buildPythonPackage, isPyPy, fetchPypi
+{ lib, buildPythonPackage, isPyPy, fetchPypi
+, libffi
 , cffi, pycparser, mock, pytest, py, six }:
 
-with stdenv.lib;
-
 buildPythonPackage rec {
-  version = "3.1.6";
   pname = "bcrypt";
+  version = "3.1.6";
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "44636759d222baa62806bbceb20e96f75a015a6381690d1bc2eda91c01ec02ea";
   };
-  buildInputs = [ pycparser mock pytest py ];
-  propagatedBuildInputs = [ six ] ++ optional (!isPyPy) cffi;
 
-  meta = {
-    maintainers = with maintainers; [ domenkozar ];
+  buildInputs = [ libffi pycparser mock pytest py ];
+
+  propagatedBuildInputs = [ six ] ++ lib.optional (!isPyPy) cffi;
+
+  meta = with lib; {
     description = "Modern password hashing for your software and your servers";
-    license = licenses.asl20;
     homepage = https://github.com/pyca/bcrypt/;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ domenkozar ];
   };
 }


### PR DESCRIPTION

###### Motivation for this change

Broke HA without the libffi dependency

Cc: @fridh @dotlambda 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
