### PR TITLE
michabo: init at 0.1

### DIFF
--- a/pkgs/applications/misc/michabo/default.nix
+++ b/pkgs/applications/misc/michabo/default.nix
@@ -1,0 +1,53 @@
+{ lib
+, mkDerivation
+, makeDesktopItem
+, fetchFromGitLab
+, qmake
+# qt
+, qtbase
+, qtwebsockets
+}:
+
+let
+  desktopItem = makeDesktopItem {
+    type = "Application";
+    name = "Michabo";
+    desktopName = "Michabo";
+    exec = "Michabo";
+  };
+
+in mkDerivation rec {
+  pname = "michabo";
+  version = "0.1";
+
+  src = fetchFromGitLab {
+    domain = "git.pleroma.social";
+    owner = "kaniini";
+    repo = "michabo";
+    rev = "v${version}";
+    sha256 = "0pl4ymdb36r0kwlclfjjp6b1qml3fm9ql7ag5inprny5y8vcjpzn";
+  };
+
+  nativeBuildInputs = [
+    qmake
+  ];
+  buildInputs = [
+    qtbase
+    qtwebsockets
+  ];
+
+  qmakeFlags = [ "michabo.pro" "DESTDIR=${placeholder "out"}/bin" ];
+
+  postInstall = ''
+    ln -s ${desktopItem}/share $out/share
+  '';
+
+  meta = with lib; {
+    description = "A native desktop app for Pleroma and Mastodon servers";
+    homepage = "https://git.pleroma.social/kaniini/michabo";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ fgaz ];
+    platforms = platforms.all;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19365,6 +19365,8 @@ in
 
   mhwaveedit = callPackage ../applications/audio/mhwaveedit {};
 
+  michabo = libsForQt5.callPackage ../applications/misc/michabo { };
+
   mid2key = callPackage ../applications/audio/mid2key { };
 
   midori-unwrapped = callPackage ../applications/networking/browsers/midori { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

A native pleroma/mastodon client: https://git.pleroma.social/kaniini/michabo

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

There's no application icon, as adding it breaks all the in-app icons, as those need to be properly installed too since they use the same filename prefix. I might add it later if it does not get fixed upstream