### PR TITLE
bluez: CVE-2018-10910

### DIFF
--- a/pkgs/os-specific/linux/bluez/default.nix
+++ b/pkgs/os-specific/linux/bluez/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, dbus, glib, alsaLib,
-  python3, readline, udev, libical, systemd,
+  python3, readline, udev, libical, systemd, fetchpatch,
   enableWiimote ? false, enableMidi ? false, enableSixaxis ? false }:
 
 stdenv.mkDerivation rec {
@@ -23,7 +23,19 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" "test" ];
 
-  patches = [ ./bluez-5.37-obexd_without_systemd-1.patch ];
+  patches = [
+    ./bluez-5.37-obexd_without_systemd-1.patch
+    (fetchpatch {
+      url = "https://git.kernel.org/pub/scm/bluetooth/bluez.git/patch/?id=1880b299086659844889cdaf687133aca5eaf102";
+      name = "CVE-2018-10910-1.patch";
+      sha256 = "17spsxza27gif8jpxk7360ynvwii1llfdfwg35rwywjjmvww0qj4";
+    })
+    (fetchpatch {
+      url = "https://git.kernel.org/pub/scm/bluetooth/bluez.git/patch/?id=9213ff7642a33aa481e3c61989ad60f7985b9984";
+      name = "CVE-2018-10910-2.patch";
+      sha256 = "0j7klbhym64yhn86dbsmybqmwx47bviyyhx931izl1p29z2mg8hn";
+    })
+  ];
 
   postConfigure = ''
     substituteInPlace tools/hid2hci.rules \


### PR DESCRIPTION
###### Motivation for this change

Fixes #61951.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
