### PR TITLE
picolisp: include httpGate tool

### DIFF
--- a/pkgs/development/interpreters/picolisp/default.nix
+++ b/pkgs/development/interpreters/picolisp/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jdk, w3m, makeWrapper }:
+{ stdenv, fetchurl, jdk, w3m, openssl, makeWrapper }:
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     url = "https://www.software-lab.de/${name}.tgz";
     sha256 = "0hvgq2vc03bki528jqn95xmvv7mw8xx832spfczhxc16wwbrnrhk";
   };
-  buildInputs = [makeWrapper] ++ optional stdenv.is64bit jdk;
+  buildInputs = [makeWrapper openssl] ++ optional stdenv.is64bit jdk;
   patchPhase = ''
     sed -i "s/which java/command -v java/g" mkAsm
 
@@ -23,6 +23,9 @@ stdenv.mkDerivation rec {
     ''}
   '';
   sourceRoot = ''picoLisp/src${optionalString stdenv.is64bit "64"}'';
+  postBuild = ''
+    cd ../src; make gate
+  '';
   installPhase = ''
     cd ..
 
@@ -30,6 +33,7 @@ stdenv.mkDerivation rec {
     cp -r . "$out/share/picolisp/build-dir"
     ln -s "$out/share/picolisp/build-dir" "$out/lib/picolisp"
     ln -s "$out/lib/picolisp/bin/picolisp" "$out/bin/picolisp"
+    ln -s "$out/lib/picolisp/bin/httpGate" "$out/bin/httpGate"
 
 
     makeWrapper $out/bin/picolisp $out/bin/pil \


### PR DESCRIPTION
https://software-lab.de/doc/httpGate.html

httpGate is a central element of the PicoLisp application server
architecture. Its purpose is to perform the following tasks:

* Provide a single application entry port (e.g. 80 or 443).
* Allow PicoLisp applications to run as non-root.
* Start application servers on demand.
* Handle HTTPS/SSL communication.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
