### PR TITLE
chrome-export: init at 2.0.2

### DIFF
--- a/pkgs/tools/misc/chrome-export/default.nix
+++ b/pkgs/tools/misc/chrome-export/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub
+, python3
+}:
+
+stdenv.mkDerivation rec {
+  pname = "chrome-export";
+  version = "2.0.2";
+
+  src = fetchFromGitHub {
+    owner = "bdesham";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0p1914wfjggjavw7a0dh2nb7z97z3wrkwrpwxkdc2pj5w5lv405m";
+  };
+
+  buildInputs = [ python3 ];
+
+  dontBuild = true;
+  installPhase = ''
+    mkdir -p $out/bin
+    cp export-chrome-bookmarks export-chrome-history $out/bin
+    mkdir -p $out/share/man/man1
+    cp man_pages/*.1 $out/share/man/man1
+  '';
+  doInstallCheck = true;
+  installCheckPhase = ''
+    bash test/run_tests $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Scripts to save Google Chrome's bookmarks and history as HTML bookmarks files";
+    homepage = "https://github.com/bdesham/chrome-export";
+    license = [ licenses.isc ];
+    maintainers = [ maintainers.bdesham ];
+    platforms = python3.meta.platforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24155,6 +24155,8 @@ in
   vdrPlugins = recurseIntoAttrs (callPackages ../applications/video/vdr/plugins.nix { });
   wrapVdr = callPackage ../applications/video/vdr/wrapper.nix {};
 
+  chrome-export = callPackage ../tools/misc/chrome-export {};
+
   chrome-gnome-shell = callPackage  ../desktops/gnome-3/extensions/chrome-gnome-shell {};
 
   chrome-token-signing = libsForQt5.callPackage ../tools/security/chrome-token-signing {};


### PR DESCRIPTION
###### Motivation for this change

Adds [chrome-export](https://github.com/bdesham/chrome-export), which converts Chrome’s bookmark and history files to the standard HTML bookmarks file format.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
