### PR TITLE
sage: fix threejs integration

### DIFF
--- a/pkgs/applications/science/math/sage/default.nix
+++ b/pkgs/applications/science/math/sage/default.nix
@@ -33,7 +33,7 @@ let
       # `sagelib`, i.e. all of sage except some wrappers and runtime dependencies
       sagelib = self.callPackage ./sagelib.nix {
         inherit flint ecl arb;
-        inherit sage-src pynac singular;
+        inherit sage-src env-locations pynac singular;
         linbox = pkgs.linbox.override { withSage = true; };
         pkg-config = pkgs.pkgconfig; # not to confuse with pythonPackages.pkgconfig
       };

--- a/pkgs/applications/science/math/sage/patches/threejs-offline.patch
+++ b/pkgs/applications/science/math/sage/patches/threejs-offline.patch
@@ -1,0 +1,64 @@
+diff --git a/build/pkgs/threejs/spkg-src b/build/pkgs/threejs/spkg-src
+index 91780d813c..254b850a24 100755
+--- a/build/pkgs/threejs/spkg-src
++++ b/build/pkgs/threejs/spkg-src
+@@ -20,9 +20,17 @@ URL3="https://raw.githubusercontent.com/mrdoob/three.js/${GIT_VERSION}/LICENSE"
+ echo "Downloading $URL3"
+ curl -OL "$URL3"
+ 
++# Set up directory structure
++
++mkdir build
++mv three.min.js build
++
++mkdir -p examples/js/controls
++mv OrbitControls.js examples/js/controls
++
+ # Package
+-tar czf "$SAGE_ROOT/upstream/threejs-${GIT_VERSION}.tar.gz" 'three.min.js' 'OrbitControls.js' 'LICENSE'
+-rm -rf 'three.min.js' 'OrbitControls.js' 'LICENSE'
++tar czf "$SAGE_ROOT/upstream/threejs-${GIT_VERSION}.tar.gz" build examples 'LICENSE'
++rm -rf 'build' 'examples' 'LICENSE'
+ 
+ # Update package info
+ echo "${GIT_VERSION}" > 'package-version.txt'
+diff --git a/src/sage/repl/rich_output/backend_ipython.py b/src/sage/repl/rich_output/backend_ipython.py
+index 7c27d48a21..8bf4861a35 100644
+--- a/src/sage/repl/rich_output/backend_ipython.py
++++ b/src/sage/repl/rich_output/backend_ipython.py
+@@ -411,10 +411,15 @@ class BackendIPythonCommandline(BackendIPython):
+             sage: backend.threejs_offline_scripts()
+             '...<script ...</script>...'
+         """
+-        from sage.env import SAGE_SHARE
++        from sage.env import THREEJS_DIR
+ 
+-        scripts = [os.path.join(SAGE_SHARE, 'threejs', script)
+-                   for script in ['three.min.js', 'OrbitControls.js']]
++        scripts = [
++            os.path.join(THREEJS_DIR, script)
++            for script in [
++                'build/three.min.js',
++                'examples/js/controls/OrbitControls.js',
++            ]
++        ]
+ 
+         if sys.platform == 'cygwin':
+             import cygwin
+@@ -594,13 +599,13 @@ class BackendIPythonNotebook(BackendIPython):
+             sage: from sage.repl.rich_output.backend_ipython import BackendIPythonNotebook
+             sage: backend = BackendIPythonNotebook()
+             sage: backend.threejs_offline_scripts()
+-            '...<script src="/nbextensions/threejs/three.min...<\\/script>...'
++            '...<script src="/nbextensions/threejs/build/three.min...<\\/script>...'
+         """
+         from sage.repl.rich_output import get_display_manager
+         CDN_scripts = get_display_manager().threejs_scripts(online=True)
+         return """
+-<script src="/nbextensions/threejs/three.min.js"></script>
+-<script src="/nbextensions/threejs/OrbitControls.js"></script>
++<script src="/nbextensions/threejs/build/three.min.js"></script>
++<script src="/nbextensions/threejs/examples/js/controls/OrbitControls.js"></script>
+ <script>
+   if ( !window.THREE ) document.write('{}');
+ </script>

--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -68,6 +68,9 @@ stdenv.mkDerivation rec {
       url = "https://git.sagemath.org/sage.git/patch/?h=c4d966e7cb0c7b87c55d52dc6f46518433a2a0a2";
       sha256 = "0pqbbsx8mriwny422s9mp3z5d095cnam32sm62q4mxk8g8jb9vm9";
     })
+
+    # https://trac.sagemath.org/ticket/28007
+    ./patches/threejs-offline.patch
   ];
 
   # Since sage unfortunately does not release bugfix releases, packagers must

--- a/pkgs/applications/science/math/sage/sagelib.nix
+++ b/pkgs/applications/science/math/sage/sagelib.nix
@@ -1,4 +1,5 @@
 { sage-src
+, env-locations
 , perl
 , buildPythonPackage
 , arb
@@ -125,8 +126,11 @@ buildPythonPackage rec {
     export SAGE_ROOT="$PWD"
     export SAGE_LOCAL="$SAGE_ROOT"
     export SAGE_SHARE="$SAGE_LOCAL/share"
-    export JUPYTER_PATH="$SAGE_LOCAL/jupyter"
 
+    # set locations of dependencies (needed for nbextensions like threejs)
+    . ${env-locations}/sage-env-locations
+
+    export JUPYTER_PATH="$SAGE_LOCAL/jupyter"
     export PATH="$SAGE_ROOT/build/bin:$SAGE_ROOT/src/bin:$PATH"
 
     export SAGE_NUM_THREADS="$NIX_BUILD_CORES"


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Before this it didn't find the correct files. Unfortunately, the
interactive parts of sage are hard to test automatically.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
