### PR TITLE
nixos/cassandra: use cassandra's default cluster name "Test Cluster"

### DIFF
--- a/nixos/modules/services/databases/cassandra.nix
+++ b/nixos/modules/services/databases/cassandra.nix
@@ -71,7 +71,7 @@ in {
     '';
     clusterName = mkOption {
       type = types.str;
-      default = "NixOS Test Cluster";
+      default = "Test Cluster";
       description = ''
         The name of the cluster.
         This setting prevents nodes in one logical cluster from joining


### PR DESCRIPTION
###### Motivation for this change

The change to make the default cluster name "NixOS Test Cluster" in #59179 broke startup of existing clusters that used the previously-default cluster name "Test Cluster":

```
ERROR 23:00:47 Fatal exception during initialization
org.apache.cassandra.exceptions.ConfigurationException: Saved cluster name Test Cluster != configured name NixOS Test Cluster
```

Fixes #63388.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I deployed this to my server and my cassandra 2.2 server started up.

cc @JohnAZoidberg and committer @aanderse and maintainer @cransom 