### PR TITLE
ffado: prevent build tools from leaking into closure

### DIFF
--- a/pkgs/development/libraries/libxmlxx/v3.nix
+++ b/pkgs/development/libraries/libxmlxx/v3.nix
@@ -1,16 +1,15 @@
 { stdenv, fetchurl, pkgconfig, libxml2, glibmm, perl }:
 
 stdenv.mkDerivation rec {
-  name = "libxml++-${maj_ver}.${min_ver}";
-  maj_ver = "3.0";
-  min_ver = "1";
+  pname = "libxml++";
+  version = "3.0.1";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/libxml++/${maj_ver}/${name}.tar.xz";
+    url = "mirror://gnome/sources/libxml++/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "19kik79fmg61nv0by0a5f9wchrcfjwzvih4v2waw01hqflhqvp0r";
   };
 
-  outputs = [ "out" "devdoc" ];
+  outputs = [ "out" "dev" "devdoc" ];
 
   nativeBuildInputs = [ pkgconfig perl ];
 

--- a/pkgs/development/libraries/libxmlxx/v3.nix
+++ b/pkgs/development/libraries/libxmlxx/v3.nix
@@ -9,13 +9,18 @@ stdenv.mkDerivation rec {
     sha256 = "19kik79fmg61nv0by0a5f9wchrcfjwzvih4v2waw01hqflhqvp0r";
   };
 
-  outputs = [ "out" "dev" "devdoc" ];
+  outputs = [ "out" "dev" "doc" "devdoc" ];
 
   nativeBuildInputs = [ pkgconfig perl ];
 
   buildInputs = [ glibmm ];
 
   propagatedBuildInputs = [ libxml2 ];
+
+  postFixup = ''
+    substituteInPlace $dev/lib/pkgconfig/libxml++-3.0.pc \
+      --replace 'docdir=''${datarootdir}' "docdir=$doc/share"
+  '';
 
   meta = with stdenv.lib; {
     homepage = http://libxmlplusplus.sourceforge.net/;

--- a/pkgs/os-specific/linux/ffado/default.nix
+++ b/pkgs/os-specific/linux/ffado/default.nix
@@ -53,6 +53,11 @@ in stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  postInstall = ''
+    # prevent build tools from leaking into closure
+    echo 'See `nix-store --query --tree ${placeholder "out"}`.' > $out/lib/libffado/static_info.txt
+  '';
+
   meta = with stdenv.lib; {
     homepage = http://www.ffado.org;
     description = "FireWire audio drivers";


### PR DESCRIPTION
FFADO stored paths to various build dependencies and libraries like gcc or pyuic5 (from PyQT) in `$out/lib/libffado/static_info.txt`, thus bringing them into the runtime closure.

With Nix, this information is not really critical, as we can find out the exact dependencies from .drv files in Nix store.

This alone reduced the closure size from 914866184B to 132341176B.