### PR TITLE
devpi-server: 4.4.0 -> 4.9.0

### DIFF
--- a/pkgs/development/python-modules/strictyaml/default.nix
+++ b/pkgs/development/python-modules/strictyaml/default.nix
@@ -1,0 +1,29 @@
+{ buildPythonPackage
+, lib
+, fetchPypi
+, ruamel_yaml
+, python-dateutil
+}:
+
+buildPythonPackage rec {
+  version = "1.0.1";
+  pname = "strictyaml";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1baz5zjl1z9dwaczaga1ik1iy1v9zg3acwnpmgghwnk9hw2i1mq6";
+  };
+
+  propagatedBuildInputs = [ ruamel_yaml python-dateutil ];
+
+  # Library tested with external tool
+  # https://hitchdev.com/approach/contributing-to-hitch-libraries/
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Strict, typed YAML parser";
+    homepage = https://hitchdev.com/strictyaml/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/development/tools/devpi-server/default.nix
+++ b/pkgs/development/tools/devpi-server/default.nix
@@ -1,28 +1,40 @@
- { stdenv, pythonPackages, nginx }:
+ { stdenv, python3Packages, nginx }:
 
-pythonPackages.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   name = "${pname}-${version}";
   pname = "devpi-server";
-  version = "4.4.0";
+  version = "4.9.0";
 
-  src = pythonPackages.fetchPypi {
+  src = python3Packages.fetchPypi {
     inherit pname version;
-    sha256 = "0y77kcnk26pfid8vsw07v2k61x9sdl6wbmxg5qxnz3vd7703xpkl";
+    sha256 = "0cx0nv1qqv8lg6p1v8dv5val0dxnc3229c15imibl9wrhrffjbg9";
   };
 
-  propagatedBuildInputs = with pythonPackages;
-    [ devpi-common execnet itsdangerous pluggy waitress pyramid passlib ];
-  checkInputs = with pythonPackages; [ nginx webtest pytest beautifulsoup4 pytest-timeout mock pyyaml ];
-  preCheck = ''
-    # These tests pass with pytest 3.3.2 but not with pytest 3.4.0.
-    sed -i 's/test_basic/noop/' test_devpi_server/test_log.py
-    sed -i 's/test_new/noop/' test_devpi_server/test_log.py
-    sed -i 's/test_thread_run_try_again/noop/' test_devpi_server/test_replica.py
-  '';
+  propagatedBuildInputs = with python3Packages; [
+    appdirs
+    devpi-common
+    execnet
+    itsdangerous
+    passlib
+    pluggy
+    pyramid
+    strictyaml
+    waitress
+  ];
+
+  checkInputs = with python3Packages; [
+    beautifulsoup4
+    mock
+    nginx
+    pytest
+    pytest-flakes
+    pytestpep8
+    webtest
+  ];
+
+  # test_genconfig.py needs devpi-server on PATH
   checkPhase = ''
-    runHook preCheck
-    cd test_devpi_server/
-    PATH=$PATH:$out/bin pytest --slow -rfsxX
+    PATH=$PATH:$out/bin pytest ./test_devpi_server --slow -rfsxX
   '';
 
   meta = with stdenv.lib;{

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5471,6 +5471,8 @@ in {
 
   strict-rfc3339 = callPackage ../development/python-modules/strict-rfc3339 { };
 
+  strictyaml = callPackage ../development/python-modules/strictyaml { };
+
   twilio = callPackage ../development/python-modules/twilio { };
 
   uranium = callPackage ../development/python-modules/uranium { };


### PR DESCRIPTION
###### Motivation for this change
Noticed it was out of date when building a different package.

Bumped the python packages to use 3.7 instead of 2.7.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
$ nix path-info -Sh ./result
/nix/store/771311zs2gmld9xsivg5r0z37h3n2hf1-devpi-server-4.9.0   184.0M