### PR TITLE
pythonPackages.robotframework-sshlibrary: init at 3.3.0

### DIFF
--- a/pkgs/development/python-modules/robotframework-sshlibrary/default.nix
+++ b/pkgs/development/python-modules/robotframework-sshlibrary/default.nix
@@ -1,0 +1,29 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, robotframework
+, paramiko
+, scp
+}:
+
+buildPythonPackage rec {
+  version = "3.3.0";
+  pname = "robotframework-sshlibrary";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "fc5b5db63cf63a937bd4ada1a8b7508ec8a75d9454fa75e6410cbe72fd718de9";
+  };
+
+  # unit tests are impure
+  doCheck = false;
+
+  propagatedBuildInputs = [ robotframework paramiko scp ];
+
+  meta = with stdenv.lib; {
+    description = "SSHLibrary is a Robot Framework test library for SSH and SFTP";
+    homepage = https://github.com/robotframework/SSHLibrary;
+    license = licenses.asl20;
+  };
+
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4302,6 +4302,8 @@ in {
 
   robotframework-selenium2library = callPackage ../development/python-modules/robotframework-selenium2library { };
 
+  robotframework-sshlibrary = callPackage ../development/python-modules/robotframework-sshlibrary { };
+
   robotframework-tools = callPackage ../development/python-modules/robotframework-tools { };
 
   robotstatuschecker = callPackage ../development/python-modules/robotstatuschecker { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Included all the fixes from the previous pull request.
https://github.com/NixOS/nixpkgs/pull/62943

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
