### PR TITLE
mullvad-vpn: init at 2019.5

### DIFF
--- a/pkgs/applications/networking/mullvad-vpn/default.nix
+++ b/pkgs/applications/networking/mullvad-vpn/default.nix
@@ -1,0 +1,93 @@
+{ stdenv, makeWrapper, fetchurl, dpkg
+, alsaLib, atk, cairo, cups, dbus, expat, fontconfig, freetype
+, gdk_pixbuf, glib, gnome2, pango, nspr, nss, gtk3
+, xorg, autoPatchelfHook, systemd, libnotify
+}:
+
+let deps = [
+    alsaLib
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    fontconfig
+    freetype
+    gdk_pixbuf
+    glib
+    gnome2.GConf
+    pango
+    gtk3
+    libnotify
+    xorg.libX11
+    xorg.libXScrnSaver
+    xorg.libXcomposite
+    xorg.libXcursor
+    xorg.libXdamage
+    xorg.libXext
+    xorg.libXfixes
+    xorg.libXi
+    xorg.libXrandr
+    xorg.libXrender
+    xorg.libXtst
+    xorg.libxcb
+    nspr
+    nss
+    systemd
+  ];
+
+in
+
+stdenv.mkDerivation rec {
+  pname = "mullvad-vpn";
+  version = "2019.5";
+
+  src = fetchurl {
+    url = "https://www.mullvad.net/media/app/MullvadVPN-${version}_amd64.deb";
+    sha256 = "542a93521906cd5e97075c9f3e9088c19562b127556a3de151e25bc66b11fe0b";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    dpkg
+  ];
+
+  buildInputs = deps;
+
+  dontBuild = true;
+  dontConfigure = true;
+
+  unpackPhase = "dpkg-deb -x $src .";
+
+  runtimeDependencies = [ systemd.lib libnotify ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/mullvad $out/bin
+
+    mv usr/share/* $out/share
+    mv usr/bin/* $out/bin
+    mv opt/Mullvad\ VPN/* $out/share/mullvad
+
+    sed -i 's|\/opt\/Mullvad.*VPN|'$out'/bin|g' $out/share/applications/mullvad-vpn.desktop
+    sed -i 's|\/opt\/Mullvad.*VPN/resources|'$out'/bin|g' $out/share/mullvad/resources/mullvad-daemon.service
+
+    ln -s $out/share/mullvad/mullvad-vpn $out/bin/mullvad-vpn
+    ln -s $out/share/mullvad/resources/mullvad-daemon $out/bin/mullvad-daemon
+
+    mkdir -p $out/etc/systemd/system
+    ln -s $out/share/mullvad/resources/mullvad-daemon.service $out/etc/systemd/system/mullvad-daemon.service
+
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/mullvad/mullvadvpn-app";
+    description = "Client for Mullvad VPN";
+    changelog = "https://github.com/mullvad/mullvadvpn-app/blob/${version}/CHANGELOG.md";
+    license = licenses.gpl3;
+    platforms = [ "x86_64-linux" ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14347,6 +14347,8 @@ in
 
   morty = callPackage ../servers/web-apps/morty { };
 
+  mullvad-vpn = callPackage ../applications/networking/mullvad-vpn { };
+
   myserver = callPackage ../servers/http/myserver { };
 
   nas = callPackage ../servers/nas { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

There is no package for the Mullvad VPN client currently. I use this often and perhaps others do as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

It mostly fits the CONTRIBUTING document, except that `meta.maintainers` is not set, as I'm not sure what to set it to.

---
