### PR TITLE
wp-cli: 2.0.1 -> 2.2.0

### DIFF
--- a/pkgs/development/tools/wp-cli/default.nix
+++ b/pkgs/development/tools/wp-cli/default.nix
@@ -1,53 +1,49 @@
-{ stdenv, lib, fetchurl, php, runtimeShell }:
+{ stdenv, lib, fetchurl, writeText, php, makeWrapper }:
 
 let
-  version = "2.0.1";
+  version = "2.2.0";
 
   completion = fetchurl {
     url    = "https://raw.githubusercontent.com/wp-cli/wp-cli/v${version}/utils/wp-completion.bash";
     sha256 = "15d330x6d3fizrm6ckzmdknqg6wjlx5fr87bmkbd5s6a1ihs0g24";
   };
 
+  ini = writeText "php.ini" ''
+    [PHP]
+    memory_limit = -1 ; no limit as composer uses a lot of memory
+
+    [Phar]
+    phar.readonly = Off
+  '';
+
 in stdenv.mkDerivation rec {
-  name = "wp-cli-${version}";
+  pname = "wp-cli";
   inherit version;
 
   src = fetchurl {
-    url    = "https://github.com/wp-cli/wp-cli/releases/download/v${version}/${name}.phar";
-    sha256 = "05lbay4c0477465vv4h8d2j94pk3haz1a7f0ncb127fvxz3a2pcg";
+    url    = "https://github.com/wp-cli/wp-cli/releases/download/v${version}/${pname}-${version}.phar";
+    sha256 = "0s03jbsjwvkcbyss6rvpgw867hiwvk5p4n1qznkghyzi94j8mvki";
   };
+
+  nativeBuildInputs = [ makeWrapper ];
 
   buildCommand = ''
     dir=$out/share/wp-cli
     mkdir -p $out/bin $dir
 
-    cat <<_EOF > $out/bin/wp
-#!${runtimeShell}
+    install -Dm444 ${src}        $dir/wp-cli
+    install -Dm444 ${ini}        $dir/php.ini
+    install -Dm444 ${completion} $out/share/bash-completion/completions/wp
 
-set -euo pipefail
-
-exec ${lib.getBin php}/bin/php \\
-  -c $dir/php.ini \\
-  -f $dir/wp-cli -- "\$@"
-_EOF
-    chmod 0755 $out/bin/wp
-
-    cat <<_EOF > $dir/php.ini
-[PHP]
-memory_limit = -1 ; no limit as composer uses a lot of memory
-
-[Phar]
-phar.readonly = Off
-_EOF
-
-    install -Dm644 ${src}        $dir/wp-cli
-    install -Dm644 ${completion} $out/share/bash-completion/completions/wp
+    makeWrapper ${lib.getBin php}/bin/php $out/bin/wp \
+      --add-flags "-c $dir/php.ini" \
+      --add-flags "-f $dir/wp-cli"
 
     # this is a very basic run test
-    $out/bin/wp --info
+    $out/bin/wp --info >/dev/null
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A command line interface for WordPress";
     homepage    = https://wp-cli.org;
     license     = licenses.mit;


### PR DESCRIPTION

###### Motivation for this change

Regular upgrade.

Also instead of creating our own manual wrapper, just use ```makeWrapper```.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
