### PR TITLE
ocamlPackages.mdx: init at 1.4.0; ocamlPackages.printbox: init at 0.2

### DIFF
--- a/pkgs/development/ocaml-modules/mdx/default.nix
+++ b/pkgs/development/ocaml-modules/mdx/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, buildDunePackage, astring, cmdliner, cppo, fmt, logs, ocaml-migrate-parsetree, ocaml_lwt, pandoc, re }:
+
+buildDunePackage rec {
+  pname = "mdx";
+  version = "1.4.0";
+
+  minimumOCamlVersion = "4.05";
+
+  src = fetchFromGitHub {
+    owner = "realworldocaml";
+    repo = pname;
+    rev = version;
+    sha256 = "0ljd00d261s2wf7cab086asqi39icf9zs4nylni6dldaqb027d4w";
+  };
+
+  nativeBuildInputs = [ cppo ];
+  buildInputs = [ astring cmdliner fmt logs ocaml-migrate-parsetree re ];
+  checkInputs = [ ocaml_lwt pandoc ];
+
+  doCheck = true;
+
+  meta = {
+    homepage = https://github.com/realworldocaml/mdx;
+    description = "Executable OCaml code blocks inside markdown files";
+    license = stdenv.lib.licenses.isc;
+    maintainers = [ stdenv.lib.maintainers.romildo ];
+  };
+}

--- a/pkgs/development/ocaml-modules/printbox/default.nix
+++ b/pkgs/development/ocaml-modules/printbox/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, buildDunePackage, mdx }:
+
+buildDunePackage rec {
+  pname = "printbox";
+  version = "0.2";
+
+  minimumOCamlVersion = "4.05";
+
+  src = fetchFromGitHub {
+    owner = "c-cube";
+    repo = pname;
+    rev = version;
+    sha256 = "16nwwpp13hzlcm9xqfxc558afm3i5s802dkj69l9s2vp04lgms5n";
+  };
+
+  checkInputs = [ mdx ];
+
+  doCheck = true;
+
+  meta = {
+    homepage = https://github.com/c-cube/printbox/;
+    description = "Allows to print nested boxes, lists, arrays, tables in several formats";
+    license = stdenv.lib.licenses.isc;
+    maintainers = [ stdenv.lib.maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -426,6 +426,8 @@ let
 
     markup = callPackage ../development/ocaml-modules/markup { lwt = ocaml_lwt; };
 
+    mdx = callPackage ../development/ocaml-modules/mdx { };
+
     menhir = callPackage ../development/ocaml-modules/menhir { };
 
     merlin = callPackage ../development/tools/ocaml/merlin { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -673,6 +673,8 @@ let
 
     ppx_tools_versioned = callPackage ../development/ocaml-modules/ppx_tools_versioned { };
 
+    printbox = callPackage ../development/ocaml-modules/printbox { };
+
     process = callPackage ../development/ocaml-modules/process { };
 
     ptmap = callPackage ../development/ocaml-modules/ptmap { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add:
- [mdx](https://github.com/realworldocaml/mdx), which allows to execute code blocks inside markdown files
- [printbox](https://github.com/c-cube/printbox), which allows to print nested boxes, lists, arrays, tables in several formats

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).