### PR TITLE
direnv: 2.20.0 -> 2.20.1

### DIFF
--- a/pkgs/tools/misc/direnv/default.nix
+++ b/pkgs/tools/misc/direnv/default.nix
@@ -2,14 +2,14 @@
 
 buildGoPackage rec {
   name = "direnv-${version}";
-  version = "2.20.0";
+  version = "2.20.1";
   goPackagePath = "github.com/direnv/direnv";
 
   src = fetchFromGitHub {
     owner = "direnv";
     repo = "direnv";
     rev = "v${version}";
-    sha256 = "0ds8abwasymbsn9vak2105gczfgka4mz1i6kf1lvc3zm27v55cij";
+    sha256 = "0v8mqxb5g8z9kdnvbwfg39hlb9l3wpb8qwslwgln42k4bs8kg9hs";
   };
 
   postConfigure = ''


### PR DESCRIPTION
###### Motivation for this change
To fix repology showing us as out of date.

2.20.1 was just to fix CI/CD release pipelines, and there were no code changes from 2.20.0

[changes if you want to see for yourself](https://github.com/direnv/direnv/commit/d1dd1f4f70b37f18610b732f7dd0c3494798055d)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
$ nix path-info -Sh /nix/store/d28xkacd6klm63si4f6x36nnf006mwcl-direnv-2.20.0-bin
/nix/store/d28xkacd6klm63si4f6x36nnf006mwcl-direnv-2.20.0-bin      5.8M

$ nix path-info -Sh ./result-bin
/nix/store/xawgj1c3cm1iz8dc79gqlzxdkyg449xr-direnv-2.20.1-bin      5.8M