### PR TITLE
github-release: 0.6.2 -> 0.7.2

### DIFF
--- a/pkgs/development/tools/github/github-release/default.nix
+++ b/pkgs/development/tools/github/github-release/default.nix
@@ -1,26 +1,26 @@
-{ stdenv, fetchurl }:
+{ stdenv, system, fetchurl }:
 
 let
-  linuxPredicate = stdenv.hostPlatform.system == "x86_64-linux";
-  bsdPredicate = stdenv.hostPlatform.system == "x86_64-freebsd";
-  darwinPredicate = stdenv.hostPlatform.system == "x86_64-darwin";
+  linuxPredicate = system == "x86_64-linux";
+  bsdPredicate = system == "x86_64-freebsd";
+  darwinPredicate = system == "x86_64-darwin";
   metadata = assert linuxPredicate || bsdPredicate || darwinPredicate;
     if linuxPredicate then
       { arch = "linux-amd64";
-        sha256 = "0b3h0d0qsrjx99kcd2cf71xijh44wm5rpm2sr54snh3f7macj2p1";
+        sha256 = "0p0qj911nmmdj0r7wx3363gid8g4bm3my6mj3d6s4mwgh9lfisiz";
         archiveBinaryPath = "linux/amd64"; }
     else if bsdPredicate then
       { arch = "freebsd-amd64";
-        sha256 = "1yydm4ndkh80phiwk41kcf6pizvwrfhsfk3jwrrgr42wsnkkgj0q";
+        sha256 = "0g618y9n39j11l1cbhyhwlbl2gv5a2a122c1dps3m2wmv7yzq5hk";
         archiveBinaryPath = "freebsd/amd64"; }
     else
       { arch = "darwin-amd64";
-        sha256 = "1dj74cf1ahihia2dr9ii9ky0cpmywn42z2iq1vkbrrcggjvyrnlf";
+        sha256 = "0l623fgnsix0y3f960bwx3dgnrqaxs21w5652kvaaal7dhnlgmwj";
         archiveBinaryPath = "darwin/amd64"; };
 in stdenv.mkDerivation rec {
   shortname = "github-release";
   name = "${shortname}-${version}";
-  version = "0.6.2";
+  version = "0.7.2";
 
   src = fetchurl {
     url = "https://github.com/aktau/github-release/releases/download/v${version}/${metadata.arch}-${shortname}.tar.bz2";


### PR DESCRIPTION
###### Motivation for this change
Update repology entry

I was able to test the x64-linux binary, but not the others. Trusting the maintainer to have released valid binaries.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
$ nix path-info -Sh /nix/store/xndx4xnvzlxywvdsx3xjwac3vpcqqxq2-github-release-0.6.2
/nix/store/xndx4xnvzlxywvdsx3xjwac3vpcqqxq2-github-release-0.6.2           7.3M

$ nix path-info -Sh ./result
/nix/store/sh3pzyy2mksrg85g6vijjnl9pxd8i2p8-github-release-0.7.2           7.4M