### PR TITLE
terraform-providers: bump versions

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/data.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/data.nix
@@ -4,15 +4,15 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-acme";
-      version = "1.1.2";
-      sha256  = "1l77pckiwa72lwbwbqkjzy6m9xsgp13spmzc80gfl4q0gd3d46an";
+      version = "1.3.4";
+      sha256  = "1kam9mwgqh31f1m8kn86bkdi4ccfj5h38f80g3frrla4p2zw9l55";
     };
   alicloud =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-alicloud";
-      version = "1.41.0";
-      sha256  = "0bl24mgk0rangwwbz43ybymcivn3kjjg35rrvv7ashvhmx58qcf8";
+      version = "1.47.0";
+      sha256  = "0w2shy850lp63y036xzhznr94dpyf5b369cddz7laycapknyzd39";
     };
   archive =
     {
@@ -39,36 +39,36 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-aws";
-      version = "2.9.0";
-      sha256  = "1gkw60ihc2b3qhb110m0mckfvb21lqgx4vc4x249mfxxk25i26s7";
+      version = "2.15.0";
+      sha256  = "0ms4x6ri4zi25jnp47f5vg6xj9xmz7jya0y0gbc4kdmy0nwdw8f9";
     };
   azuread =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-azuread";
-      version = "0.3.1";
-      sha256  = "1bs4m9hwdag58by49zsjpys3xvxg98nq8qims17mc82pbsz6mpag";
+      version = "0.4.0";
+      sha256  = "01s2qrabmydgnilkwis76ccx1sv8bkna3nbxn6ra75jvgh3q7d5d";
     };
   azurerm =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-azurerm";
-      version = "1.27.1";
-      sha256  = "0lxa84j9kzinblz7zp4gizizj0sy0vidkjvgnb99sr3861rak1x5";
+      version = "1.30.1";
+      sha256  = "0zxvj6k1xs151dik8yhjl31r563dsc7iykv32g10w5szyigvxqfd";
     };
   azurestack =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-azurestack";
-      version = "0.6.0";
-      sha256  = "0lh0an3bz3kh2s6ncadikivr08fj8cvq7zm20csmjbgwgicq4gl8";
+      version = "0.7.0";
+      sha256  = "0vlppfnwl0r4xf2fl405d93s0kxanh52h1chz04a95x2dcclvx69";
     };
   bigip =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-bigip";
-      version = "0.12.2";
-      sha256  = "0pplv5hi1kjli0jpya12crb5dkc6bkzvm8094rwhjbxb4f65ca5d";
+      version = "0.12.3";
+      sha256  = "1zlwk7jp5r45b3rwkxsq9mqf4nym3ifx56vhcvyc9a3w25s0ss8p";
     };
   bitbucket =
     {
@@ -109,8 +109,8 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-cloudflare";
-      version = "1.13.0";
-      sha256  = "01fgcycn5g53cx32xcgrpcpvjxwb8w11hs0f7s2bhg6cq0v9higj";
+      version = "1.15.0";
+      sha256  = "0mb771dw5fw2s6jd63sybwza49axyj9967fl454m3sznhpl96y8z";
     };
   cloudscale =
     {
@@ -123,22 +123,22 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-cloudstack";
-      version = "0.2.0";
-      sha256  = "1v46da55a8a0hnw319swz3pkd62afy7hdwzybxmp48hxh1i6af74";
+      version = "0.3.0";
+      sha256  = "0zmyww6z3j839ydlmv254hr8gcsixng4lcvmiwkhxb3hj1nw8hcw";
     };
   cobbler =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-cobbler";
-      version = "1.0.1";
-      sha256  = "1z0iijfrbbdrgszvc7jlcr4105zragbc0iq8x48vi24yipqgf5a8";
+      version = "1.1.0";
+      sha256  = "08ljqibfi6alpvv8f7pzvjl2k4w6br6g6ac755x4xw4ycrr24xw9";
     };
   consul =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-consul";
-      version = "2.3.0";
-      sha256  = "06b6yjmaq7sq26kfsqxlxmz5mnr1xsn1vywndh14grqwg6zmsrl6";
+      version = "2.5.0";
+      sha256  = "1nmldxn4y87fyb308dajjzcyvxrr6ka5nicyw84a8s7pixzbqh6q";
     };
   datadog =
     {
@@ -151,8 +151,8 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-digitalocean";
-      version = "1.3.0";
-      sha256  = "1bi482s6s3v7sqknwwchscwwncwrhr4jl4gl4l25bngp1kd7cp7i";
+      version = "1.4.0";
+      sha256  = "0a01768ncgmk1vrh2ir86s9iab1s5x8ciaz3fysgcgp9snh8yz4w";
     };
   dme =
     {
@@ -179,8 +179,8 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-docker";
-      version = "1.1.1";
-      sha256  = "0bqwdx8hb7bym4hh01a0n1zrgb1081rvn0qawck712wz0jkzv1r3";
+      version = "1.2.0";
+      sha256  = "1w69kjlrgy4397c9nz3llqsqcjzchwqw1ksw4wg34xnnq20pd4ql";
     };
   dyn =
     {
@@ -200,78 +200,78 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-fastly";
-      version = "0.6.0";
-      sha256  = "1z9qrqcib2rxy8s4glb4ggdkqcq7rwphiclsr1zncyly2n6887yj";
+      version = "0.6.1";
+      sha256  = "1p4j1n2x2y0n1kslfx62fx60v8b1acqv78gns1a5i0vgnnmmqcaj";
     };
   flexibleengine =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-flexibleengine";
-      version = "1.5.0";
-      sha256  = "17dksrqkh35wf0clqcd4v6ggmzc7xmrw8q7q0qa9n9zqyg1zibqk";
+      version = "1.6.0";
+      sha256  = "0vz68nhpy93zsdssxzr41flrwhjqh7wcjrc4nklg6kmr99n6jcc6";
     };
   github =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-github";
-      version = "2.0.0";
-      sha256  = "1lvizak27qxgggp5xb15s8f504cjgr633889cv2jsr2rn64z4jv5";
+      version = "2.1.0";
+      sha256  = "05ca0vw6s7q40zcs50mr6k2swwx3a3njd4dxdz00qki58hgb87y6";
     };
   gitlab =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-gitlab";
-      version = "1.3.0";
-      sha256  = "0lh1v20msahcfjc22v7yf1cwinaq0zy2m8f7sl5jfn294j9nbam8";
+      version = "2.2.0";
+      sha256  = "0iz5ggjkcip86cz2zmsryad34hly542grwzlm5rvpcmfw5csjadw";
     };
   google =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-google";
-      version = "2.6.0";
-      sha256  = "0y93hfwhzbk7dl7cw5lw2gwf5hdbc7rs9gh10b39vxgv9jrj4kqv";
+      version = "2.8.0";
+      sha256  = "1r4x7l20w8wb6a356vx71lra466p7hfww1jyv0bg7z1f015qs91l";
     };
   google-beta =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-google-beta";
-      version = "2.6.0";
-      sha256  = "1bm3nrv2pa6mf6l4vn5b0hads7bhp67bnhc5y72yingfky7kva5h";
+      version = "2.8.0";
+      sha256  = "16ml6sd3g4wzcgm5qaphfyq3lcy33p8nmcahxrhrcvwnwl0kw5bs";
     };
   grafana =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-grafana";
-      version = "1.3.0";
-      sha256  = "1gyma31iv05nfy9jrd8zlkls35fbrxx4nrh56gdgwchv054rxzff";
+      version = "1.4.0";
+      sha256  = "1y41yhp82phgw83frkgrjzpymsys2abvdwa1n905rz7i15ybasqc";
     };
   hcloud =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-hcloud";
-      version = "1.9.0";
-      sha256  = "08ag1xwn6vj4w8kz37z8hsi8lkvfwkw5n8wjb5c03g9yva1j85yx";
+      version = "1.10.0";
+      sha256  = "18m2smpwcjp49wnylplrnlhfjrmim1qpvn1z70lwvb49liv8ldwf";
     };
   hedvig =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-hedvig";
-      version = "1.0.3";
-      sha256  = "0kqnbd78m4r97b5w7skkpcnhc0bqh2cky7q0inhdhsb7gvivz1b1";
+      version = "1.0.4";
+      sha256  = "0y6brzznxp8khdfbnpmnbjqf140411z0pvnp88p8mj2kmbk7kkjd";
     };
   helm =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-helm";
-      version = "0.9.1";
-      sha256  = "189w8zz2fv0qfggzxmppaw8814c7kylgb11m1r9mqii3phsgnlz1";
+      version = "0.10.0";
+      sha256  = "09qxpgdljkfbyn1ihki2pp2m9wxmrxvp91d1myinml466jylxjar";
     };
   heroku =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-heroku";
-      version = "1.9.0";
-      sha256  = "1qabhf2qm7ba5jw6hclkcp2pw8c39ggrqkhhqg0bh03h220rl22x";
+      version = "2.0.0";
+      sha256  = "161pc6s4ifzi58cx32sdk9nan4kz6gn3mch1pnmp03f6390s2pcm";
     };
   http =
     {
@@ -284,8 +284,8 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-huaweicloud";
-      version = "1.4.0";
-      sha256  = "018b57cndl72vjlijwvjx64rxjgimcqq1f6dxdny3wj1j4i0h4fi";
+      version = "1.6.0";
+      sha256  = "03f92mq4ydfwnxh0v4sm6brllxw6m7kh8j19md9aq0wxcwr5wp6q";
     };
   icinga2 =
     {
@@ -298,22 +298,22 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-ignition";
-      version = "1.0.1";
-      sha256  = "1j9rgwrb4bnm8a44rg3d9fry46wlpfkwxxpkpw9y6l24php0qxh8";
+      version = "1.1.0";
+      sha256  = "0vpjbb70wnlrvw7z2zc92fbisgjk49ivdmv10ahyqlgvc23js5va";
     };
   influxdb =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-influxdb";
-      version = "1.1.0";
-      sha256  = "1mxvc3pwzgj7r79a5vz8n489xny12wa75zpppgh7948fy8m8b23f";
+      version = "1.2.0";
+      sha256  = "1nldywbwg5lgzhlq8hmisv63riipd0aaa4p5ya6qvx5cnj5yhsx8";
     };
   kubernetes =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-kubernetes";
-      version = "1.6.2";
-      sha256  = "14jql78a1rw1wl97myry29lgmqkcdn44qgmzjrfky958afnkgiig";
+      version = "1.7.0";
+      sha256  = "0chr6v47398a3cvff9lwx4ffahcwv7fmzs6kjjqaidb1cv60d039";
     };
   librato =
     {
@@ -361,15 +361,15 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-mysql";
-      version = "1.5.1";
-      sha256  = "0i5s62z3cdg3mhahf09nyw8l2hcx6d7jp3hr3n8rcjwj3ajj8qis";
+      version = "1.6.0";
+      sha256  = "1kgldnrdz0mr99arxf85n8xbbxm96b5mg732c6zs38dgcq63mypx";
     };
   netlify =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-netlify";
-      version = "0.1.0";
-      sha256  = "1lf66nzqcgzjwvh1lv2jp8gcj6apdanlinci5pri8mgv5r1pv40l";
+      version = "0.3.0";
+      sha256  = "0mmbli6d3fbpyvvdfsg32f1w83g8ga3x21b36rgmx3mn156r7yij";
     };
   newrelic =
     {
@@ -382,15 +382,15 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-nomad";
-      version = "1.3.0";
-      sha256  = "06kq0qkrgnj7z13xrgb9shid356m55mz0hkdbm4vfz3fx863mvl3";
+      version = "1.4.0";
+      sha256  = "04dh7gas6viny6bkx89fkwmxrw101b8bmw14m2mzfkxn70cl2na4";
     };
   ns1 =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-ns1";
-      version = "1.3.1";
-      sha256  = "04ibq5dgxqb5lpnvqxg4xkb498w77p2sbjfyy9zj7m5i62xrwg79";
+      version = "1.4.0";
+      sha256  = "1zkmc6flmy48qawaf0l5r72xfwp46c842gd7kg35r06cihc9gavy";
     };
   nsxt =
     {
@@ -417,8 +417,8 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-oci";
-      version = "3.24.1";
-      sha256  = "1yhcxwg3ivrgzasdsf5yq8v6h4j1lprnm881xfm4h1rpq465y1mj";
+      version = "3.29.0-rc1";
+      sha256  = "1rz61qndrrgknkd7bjbgvy28znllipr1v92cn1im43rzsmnz64y3";
     };
   oneandone =
     {
@@ -438,15 +438,15 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-openstack";
-      version = "1.18.0";
-      sha256  = "05sr6vra4fsrysrz7a77vaa5zklhxf4hl8g029y9l1fln7vdpssg";
+      version = "1.19.0";
+      sha256  = "1y9b9h523zflq4z9cwjgfa0l92j4ac5pc1r6vja1aw3gg2ln80x9";
     };
   opentelekomcloud =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-opentelekomcloud";
-      version = "1.8.0";
-      sha256  = "068ap0sw17xmrfvri1yx70qdi8i5h0qhsm9bakm532xjxlgmaxpv";
+      version = "1.9.0";
+      sha256  = "1nq6h6ds2fvxrmyf2v7w8prprl7pp6va8568jf0f775sag51wpl8";
     };
   opsgenie =
     {
@@ -466,36 +466,36 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-ovh";
-      version = "0.3.0";
-      sha256  = "05bzkwa50alh8mpslh64dddp815m8df240w1mmphdmp9rsi6hqp8";
+      version = "0.5.0";
+      sha256  = "07n8ismxbv0gngh4kibqhr4ndqkrg6gxbpj3zl764rrwp54gwgbw";
     };
   packet =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-packet";
-      version = "2.1.0";
-      sha256  = "0hj8av0yry0wsi8fwgs0z9x9jxcnxz8imsanbdsrhb8lsj70n25v";
+      version = "2.2.1";
+      sha256  = "05zhrpynn2yrimlg553f0567b284x51g5yafz29g647vvsqd1rpn";
     };
   pagerduty =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-pagerduty";
-      version = "1.2.1";
-      sha256  = "1b0fbzqalcxngnxk51afxkhs82bj68sjakvb28p0im0x1lblxj0n";
+      version = "1.3.0";
+      sha256  = "1l3rk7c31qafadpg2b0mzvfx7lwwk82vcn489fr35rvmv99zfkh8";
     };
   panos =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-panos";
-      version = "1.5.1";
-      sha256  = "17w4zkc445bpfq6pqx575y5njsak18yca1y2by4chg9d05inphqd";
+      version = "1.5.2";
+      sha256  = "0sycgr4k4dlhxj5klmgg2xcw3xha06332ij8cfzz4xvgdq0xky3j";
     };
   postgresql =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-postgresql";
-      version = "0.3.0";
-      sha256  = "0z1xdzl5mn6dxgkgmysq06g3fg9cdlwa59ng42r6kffcbl0mwgfh";
+      version = "0.4.0";
+      sha256  = "0fywq1vzm8fcd0jcvzx1n3jilrk0r6ylqz9r4dwsyc64iqvmrpps";
     };
   powerdns =
     {
@@ -522,8 +522,8 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-rancher";
-      version = "1.2.1";
-      sha256  = "1z0gqchb268w5mw0519fbx4126nkxb9kvvay8vjj287yxdpi5grj";
+      version = "1.3.0";
+      sha256  = "0b62hhb87xqmc1izl5lyk2kvkrkgrjil5z1xwprfdl6yz4fnin0w";
     };
   random =
     {
@@ -543,8 +543,8 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-rundeck";
-      version = "0.1.0";
-      sha256  = "0rp8cgnp8in52g7zkl2lj42hns0g27m8f7l42lhfnv6n2vv5qxcg";
+      version = "0.3.0";
+      sha256  = "10xhj3xxdhbdxq14linqabn8cm0gnnswfwr0r20s1yp7pn36lgkj";
     };
   runscope =
     {
@@ -557,22 +557,22 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-scaleway";
-      version = "1.9.2";
-      sha256  = "0wjkjf4sc3rfxiz3lfw6cfhdn8a7pzmyfw1f2dsp3a6fpa2srbph";
+      version = "1.10.0";
+      sha256  = "0sbcvcd413f53b25piymmh4rfmlmqsxdscpar8gf2dx6mrsacgf0";
     };
   selectel =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-selectel";
-      version = "2.1.0";
-      sha256  = "078pyml9nwv7347yni1h7mjdp8sd4zyccv80mgjn8xh2q208fqpg";
+      version = "2.2.0";
+      sha256  = "1vw49ckcavzq8igc3091mzsqv9garzh1npwdwsyqb9367z5ib39m";
     };
   skytap =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-skytap";
-      version = "0.9.0";
-      sha256  = "15p2rfaqw5iab8fkxcxigp7nxvs4gmgr2v8ysfyjz01mgwidd0rq";
+      version = "0.10.0";
+      sha256  = "1rfyaf8zhcr74mhcjdsm659rzlncyaxvqqqrc1630a3bk4h8p3i1";
     };
   softlayer =
     {
@@ -585,8 +585,8 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-spotinst";
-      version = "1.13.2";
-      sha256  = "1v3vgnspg3g0hvwzfplyvl37jxpc9m6hcsnmw6lkfqr57dy4dhlc";
+      version = "1.13.3";
+      sha256  = "0s75xlw8y3rz1ik11dnh3dzkk1jfklvq3wsf2fam0789z2j1zr1m";
     };
   statuscake =
     {
@@ -613,8 +613,8 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-tencentcloud";
-      version = "1.5.0";
-      sha256  = "04psgirl78klbpzllcvzl510j66jcavxmi9zxnwmmmw128a3dig2";
+      version = "1.9.0";
+      sha256  = "0zgn3ndbcs6dgmz2y8qcns08rbwbfq633rbk6zgfck8pzqw2d2lr";
     };
   terraform =
     {
@@ -627,8 +627,8 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-tfe";
-      version = "0.8.2";
-      sha256  = "0apxf197g4mrxybbx1vrk2i3fnw4cf23aq1wjhks5fkvm4wshgl7";
+      version = "0.9.1";
+      sha256  = "0ww3fm8mgpqmv0ra0zbv560avcla76dkj2qxz9bdwzg7iz8vsj4s";
     };
   tls =
     {
@@ -648,8 +648,8 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-ucloud";
-      version = "1.6.0";
-      sha256  = "0ijksfjqc91gxf45w9h2r024zgyqpr4s7z6snyzxcdbnf8ahs9q0";
+      version = "1.10.1";
+      sha256  = "1c5w2816rf55khs534z780j0r8i6n8gqhkda21i32n9rj8y5clv1";
     };
   ultradns =
     {


### PR DESCRIPTION
I skipped terraform-provider-matchbox and terraform-provider-ansible,
they failed to build:

terraform-provider-ansible
> cannot find package "github.com/hashicorp/terraform/helper/schema" …

terraform-provider-matchbox
> cannot find package "github.com/poseidon/terraform-provider-matchbox/matchbox" …

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
