### PR TITLE
dcm2niix: 1.0.20170130 -> 1.0.20190410

### DIFF
--- a/pkgs/applications/science/biology/dcm2niix/default.nix
+++ b/pkgs/applications/science/biology/dcm2niix/default.nix
@@ -2,21 +2,22 @@
 , fetchFromGitHub
 , cmake
 , libyamlcpp
+, git
 }:
 
 stdenv.mkDerivation rec {
-  version = "1.0.20170130";
+  version = "1.0.20190410";
   name = "dcm2niix-${version}";
 
   src = fetchFromGitHub {
     owner = "rordenlab";
     repo = "dcm2niix";
     rev = "v${version}";
-    sha256 = "1f2nzd8flp1rfn725bi64z7aw3ccxyyygzarxijw6pvgl476i532";
+    sha256 = "1prwpvbi76xlpkhc4kadjhyyx0s71cs30hi6anknhfm6hdyd26ms";
   };
 
   enableParallelBuilding = true;
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake git ];
   buildInputs = [ libyamlcpp ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
