### PR TITLE
[19.03] gvfs: security fixes

### DIFF
--- a/pkgs/development/libraries/gvfs/default.nix
+++ b/pkgs/development/libraries/gvfs/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, meson, ninja, pkgconfig, gettext, gnome3, dbus
-, glib, libgudev, udisks2, libgcrypt, libcap, polkit
+, glib, libgudev, udisks2, libgcrypt, libcap, polkit, fetchpatch
 , libgphoto2, avahi, libarchive, fuse, libcdio
 , libxml2, libxslt, docbook_xsl, docbook_xml_dtd_42, samba, libmtp
 , gnomeSupport ? false, gnome, gcr, wrapGAppsHook
@@ -17,6 +17,28 @@ in stdenv.mkDerivation rec {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "0nw6mv5qq0d79d72x28db0vwihv4isny6m8q7vdim11ngk10hgwh";
   };
+
+  patches = [
+    # CVE-2019-12448
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/gvfs/commit/a1c2e7ecab0d6457fa2227d92e3569c08516eac5.patch";
+      sha256 = "03fwlpj1vbi80661bbhzv8ddx3czkzv9i1q4h3gqyxi5f1i0xfz4";
+    })
+    # CVE-2019-12447
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/gvfs/commit/0f25dea30d01d920443ab72b0c254560ec40e14c.patch";
+      sha256 = "1p7c48nsx1lkv2qpkyrsm9qfa77xwd28gczwcpv2kbji3ws5qgj5";
+    })
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/gvfs/commit/272e6bdac33309672955e8f8bf1b8f5f1e51fa0a.patch";
+      sha256 = "0zxbhmgqxxw987ag8fh6yjzjn9jl55fqbn814jh9kwrk7x4prx9x";
+    })
+    # CVE-2019-12449
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/gvfs/commit/bed1e9685c9f65f6a3ff3b39dd8547db3e7e77f6.patch";
+      sha256 = "0hfybfaz2gfx3yyw5ymx6q0pqwkx2r1i7gzprfp80bplwslq0d4h";
+    })
+  ];
 
   postPatch = ''
     # patchShebangs requires executable file

--- a/pkgs/development/libraries/gvfs/default.nix
+++ b/pkgs/development/libraries/gvfs/default.nix
@@ -38,6 +38,11 @@ in stdenv.mkDerivation rec {
       url = "https://gitlab.gnome.org/GNOME/gvfs/commit/bed1e9685c9f65f6a3ff3b39dd8547db3e7e77f6.patch";
       sha256 = "0hfybfaz2gfx3yyw5ymx6q0pqwkx2r1i7gzprfp80bplwslq0d4h";
     })
+    # CVE-2019-12795
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/gvfs/commit/e3808a1b4042761055b1d975333a8243d67b8bfe.patch";
+      sha256 = "1lx6yxykx24mnq5izijqk744zj6rgww6ba76z0qjal4y0z3gsdqp";
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
See commits

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
