### PR TITLE
octopus: init 0.6.3-beta

### DIFF
--- a/pkgs/applications/science/biology/octopus/default.nix
+++ b/pkgs/applications/science/biology/octopus/default.nix
@@ -1,0 +1,30 @@
+{stdenv, fetchFromGitHub, cmake, boost, gmp, htslib, zlib, lzma, pkg-config}:
+
+stdenv.mkDerivation rec {
+  pname = "octopus";
+  version = "0.6.3-beta";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "luntergroup";
+    repo = "octopus";
+    rev = "v${version}";
+    sha256 = "042fycg8ppld7iajpzq2d8h8wr0nw43zbl57y125sfihryvr373n";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ boost gmp htslib zlib lzma ];
+
+  postInstall = ''
+    mkdir $out/bin
+    mv $out/octopus $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Bayesian haplotype-based mutation calling";
+    license = licenses.mit;
+    homepage = "https://github.com/luntergroup/octopus";
+    maintainers = with maintainers; [ jbedo ];
+    platforms = platforms.x86_64;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22382,6 +22382,8 @@ in
 
   niftyseg = callPackage ../applications/science/biology/niftyseg { };
 
+  octopus-caller = callPackage ../applications/science/biology/octopus { };
+
   paml = callPackage ../applications/science/biology/paml { };
 
   picard-tools = callPackage ../applications/science/biology/picard-tools { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Initial expression for the Octopus variant caller.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
