### PR TITLE
pythonPackages.uproot: 3.4.19 -> 3.7.0

### DIFF
--- a/pkgs/development/python-modules/awkward/default.nix
+++ b/pkgs/development/python-modules/awkward/default.nix
@@ -11,11 +11,11 @@
 
 buildPythonPackage rec {
   pname = "awkward";
-  version = "0.10.3";
+  version = "0.11.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0vq27db5k8cc5jpbdrl531gjhig0f9iy0i7z6ks81lz1a2mkvjik";
+    sha256 = "07m797jc5lpaj6m8469d67l2s43jf8w0mfhy0hfvbfs4mk0cjix0";
   };
 
   nativeBuildInputs = [ pytestrunner ];

--- a/pkgs/development/python-modules/uproot-methods/default.nix
+++ b/pkgs/development/python-modules/uproot-methods/default.nix
@@ -6,15 +6,18 @@
 }:
 
 buildPythonPackage rec {
-  version = "0.4.7";
+  version = "0.7.0";
   pname = "uproot-methods";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "4a00d1db828c44d2ba35801aeff7d1ea890b7dfa337895395e3b06284c14857b";
+    sha256 = "0awxd4p8yr27k4iayc0phw99bxgw04dnd3lb372hj9wjvldm0hzr";
   };
 
   propagatedBuildInputs = [ numpy awkward ];
+
+  # No tests on PyPi
+  doCheck = false;
 
   meta = with stdenv.lib; {
     homepage = https://github.com/scikit-hep/uproot-methods;

--- a/pkgs/development/python-modules/uproot/default.nix
+++ b/pkgs/development/python-modules/uproot/default.nix
@@ -1,5 +1,6 @@
-{ lib, fetchPypi, buildPythonPackage
+{ lib, fetchPypi, buildPythonPackage, isPy27
 , awkward
+, backports_lzma
 , cachetools
 , lz4
 , pytestrunner
@@ -30,7 +31,7 @@ buildPythonPackage rec {
     pytest
     requests
     xxhash
-  ];
+  ] ++ lib.optional isPy27 backports_lzma;
 
   propagatedBuildInputs = [
     numpy

--- a/pkgs/development/python-modules/uproot/default.nix
+++ b/pkgs/development/python-modules/uproot/default.nix
@@ -1,33 +1,48 @@
-{ lib
-, fetchPypi
-, buildPythonPackage
-, numpy
-, uproot-methods
+{ lib, fetchPypi, buildPythonPackage
 , awkward
 , cachetools
-, pythonOlder
+, lz4
 , pytestrunner
 , pytest
 , pkgconfig
-, lz4
 , mock
+, numpy
 , requests
-, backports_lzma
+, uproot-methods
+, xxhash
 }:
 
 buildPythonPackage rec {
   pname = "uproot";
-  version = "3.4.19";
+  version = "3.7.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1df24d1f193b044cc4d6ef98e183a853655b568b7b15173d88b0d2a79e1226da";
+    sha256 = "0glsl57ha0d4pn5q318dmzml7crml1h8yilbhxh768wcs2030s1g";
   };
 
   nativeBuildInputs = [ pytestrunner ];
-  checkInputs = [ pytest pkgconfig lz4 mock requests ]
-    ++ lib.optionals (pythonOlder "3.3") [ backports_lzma ];
-  propagatedBuildInputs = [ numpy cachetools uproot-methods awkward ];
+
+  checkInputs = [
+    lz4
+    mock
+    pkgconfig
+    pytest
+    requests
+    xxhash
+  ];
+
+  propagatedBuildInputs = [
+    numpy
+    cachetools
+    uproot-methods
+    awkward
+  ];
+
+  # skip tests which do network calls
+  checkPhase = ''
+    pytest tests -k 'not hist_in_tree and not branch_auto_interpretation'
+  '';
 
   meta = with lib; {
     homepage = https://github.com/scikit-hep/uproot;


### PR DESCRIPTION
###### Motivation for this change
Noticed it was broken when doing a nix-review of another package.

###### Things done


- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
$ nix path-info -Sh ./result
/nix/store/7cvvcs0j7xh10w2aq1a4852p5yzf25vg-python3.7-uproot-3.7.0       155.5M