### PR TITLE
gnome3.tracker-miners: enable auto_features

### DIFF
--- a/pkgs/desktops/gnome-3/core/tracker-miners/default.nix
+++ b/pkgs/desktops/gnome-3/core/tracker-miners/default.nix
@@ -1,17 +1,54 @@
-{ stdenv, fetchurl, substituteAll, intltool, itstool, libxslt, gexiv2, tracker
-, meson, ninja, pkgconfig, vala, wrapGAppsHook, bzip2, dbus, evolution-data-server
-, exempi, flac, giflib, glib, gnome3, gst_all_1, icu, json-glib, libcue, libexif
-, libgrss, libgsf, libiptcdata, libjpeg, libpng, libseccomp, libsoup, libtiff, libuuid
-, libvorbis, libxml2, poppler, taglib, upower, totem-pl-parser }:
+{ stdenv
+, fetchurl
+, substituteAll
+, intltool
+, itstool
+, libxslt
+, gexiv2
+, tracker
+, meson
+, ninja
+, pkgconfig
+, vala
+, wrapGAppsHook
+, bzip2
+, dbus
+, evolution-data-server
+, exempi
+, flac
+, giflib
+, glib
+, gnome3
+, gst_all_1
+, icu
+, json-glib
+, libcue
+, libexif
+, libgrss
+, libgsf
+, libgxps
+, libiptcdata
+, libjpeg
+, libosinfo
+, libpng
+, libseccomp
+, libsoup
+, libtiff
+, libuuid
+, libvorbis
+, libxml2
+, poppler
+, taglib
+, upower
+, totem-pl-parser
+}:
 
-let
+stdenv.mkDerivation rec {
   pname = "tracker-miners";
-in stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
   version = "2.2.2";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "0kk5xaajamb8jlm6cfdbc2m3axzr6bnph84m7697xmb0pkg8hdiw";
   };
 
@@ -46,8 +83,10 @@ in stdenv.mkDerivation rec {
     libexif
     libgrss
     libgsf
+    libgxps
     libiptcdata
     libjpeg
+    libosinfo
     libpng
     libseccomp
     libsoup
@@ -65,6 +104,7 @@ in stdenv.mkDerivation rec {
     "-Dfunctional_tests=false"
     "-Ddbus_services=${placeholder "out"}/share/dbus-1/services"
     "-Dsystemd_user_services=${placeholder "out"}/lib/systemd/user"
+    "-Dauto_features=enabled"
   ];
 
   patches = [


### PR DESCRIPTION
When tracker-miners switched from booleans to features, we were no longer building majority of the miners, since we disable auto_features by default.

cc @worldofpeace

- [x] built in sandbox on NixOS