### PR TITLE
meson: enable auto_features by default

### DIFF
--- a/pkgs/applications/audio/ncmpc/default.nix
+++ b/pkgs/applications/audio/ncmpc/default.nix
@@ -15,6 +15,12 @@ stdenv.mkDerivation rec {
   buildInputs = [ glib ncurses mpd_clientlib boost ];
   nativeBuildInputs = [ meson ninja pkgconfig gettext ];
 
+  mesonFlags = [
+    "-Dlirc=disabled"
+    "-Dregex=disabled"
+    "-Ddocumentation=disabled"
+  ];
+
   meta = with stdenv.lib; {
     description = "Curses-based interface for MPD (music player daemon)";
     homepage    = https://www.musicpd.org/clients/ncmpc/;

--- a/pkgs/applications/misc/girara/default.nix
+++ b/pkgs/applications/misc/girara/default.nix
@@ -1,18 +1,33 @@
-{ stdenv, fetchurl, meson, ninja, pkgconfig, glib, gtk, gettext, libiconv, libintl
+{ stdenv, fetchurl, meson, ninja, pkgconfig, check, dbus, xvfb_run, glib, gtk, gettext, libiconv, json_c, libintl
 }:
 
 stdenv.mkDerivation rec {
-  name = "girara-${version}";
+  pname = "girara";
   version = "0.3.2";
 
+  outputs = [ "out" "dev" ];
+
   src = fetchurl {
-    url = "https://pwmt.org/projects/girara/download/${name}.tar.xz";
+    url = "https://pwmt.org/projects/girara/download/${pname}-${version}.tar.xz";
     sha256 = "1kc6n1mxjxa7wvwnqy94qfg8l9jvx9qrvrr2kc7m4g0z20x3a00p";
   };
 
-  nativeBuildInputs = [ meson ninja pkgconfig gettext ];
-  buildInputs = [ libintl libiconv ];
+  nativeBuildInputs = [ meson ninja pkgconfig gettext check dbus xvfb_run ];
+  buildInputs = [ libintl libiconv json_c ];
   propagatedBuildInputs = [ glib gtk ];
+
+  doCheck = true;
+
+  mesonFlags = [
+    "-Ddocs=disabled" # docs do not seem to be installed
+  ];
+
+  checkPhase = ''
+    export NO_AT_BRIDGE=1
+    xvfb-run -s '-screen 0 800x600x24' dbus-run-session \
+      --config-file=${dbus.daemon}/share/dbus-1/session.conf \
+      meson test --print-errorlogs
+  '';
 
   meta = with stdenv.lib; {
     homepage = https://pwmt.org/projects/girara/;

--- a/pkgs/applications/misc/zathura/core/default.nix
+++ b/pkgs/applications/misc/zathura/core/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, meson, ninja, wrapGAppsHook, pkgconfig
 , appstream-glib, desktop-file-utils, python3
-, gtk, girara, gettext, libxml2
+, gtk, girara, gettext, libxml2, check
 , sqlite, glib, texlive, libintl, libseccomp
 , file, librsvg
 , gtk-mac-integration, synctexSupport ? true
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     meson ninja pkgconfig desktop-file-utils python3.pkgs.sphinx
-    gettext wrapGAppsHook libxml2
+    gettext wrapGAppsHook libxml2 check
   ] ++ optional stdenv.isLinux appstream-glib;
 
   buildInputs = [
@@ -41,6 +41,8 @@ stdenv.mkDerivation rec {
   ] ++ optional synctexSupport texlive.bin.core
     ++ optional stdenv.isLinux libseccomp
     ++ optional stdenv.isDarwin gtk-mac-integration;
+
+  doCheck = true;
 
   meta = {
     homepage = https://pwmt.org/projects/zathura/;

--- a/pkgs/desktops/gnome-3/core/evince/default.nix
+++ b/pkgs/desktops/gnome-3/core/evince/default.nix
@@ -104,7 +104,6 @@ stdenv.mkDerivation rec {
       gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-libav ]);
 
   mesonFlags = [
-    "-Dauto_features=enabled"
     "-Dnautilus=false"
     "-Dps=enabled"
     "-Dgtk_doc=false"

--- a/pkgs/desktops/gnome-3/core/gnome-desktop/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-desktop/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, substituteAll, pkgconfig, libxslt, ninja, libX11, gnome3, gtk3, glib
 , gettext, libxml2, xkeyboard_config, isocodes, meson, wayland
-, libseccomp, bubblewrap, gobject-introspection, gtk-doc, docbook_xsl, gsettings-desktop-schemas }:
+, libseccomp, systemd, bubblewrap, gobject-introspection, gtk-doc, docbook_xsl, gsettings-desktop-schemas }:
 
 stdenv.mkDerivation rec {
   name = "gnome-desktop-${version}";
@@ -13,15 +13,13 @@ stdenv.mkDerivation rec {
     sha256 = "0bidx4626x7k2myv6f64qv4fzmxv8v475wibiz19kj8hjfr737q9";
   };
 
-  enableParallelBuilding = true;
-
   nativeBuildInputs = [
     pkgconfig meson ninja gettext libxslt libxml2 gobject-introspection
     gtk-doc docbook_xsl
   ];
   buildInputs = [
     libX11 bubblewrap xkeyboard_config isocodes wayland
-    gtk3 glib libseccomp
+    gtk3 glib libseccomp systemd
   ];
 
   propagatedBuildInputs = [ gsettings-desktop-schemas ];

--- a/pkgs/desktops/gnome-3/core/tracker-miners/default.nix
+++ b/pkgs/desktops/gnome-3/core/tracker-miners/default.nix
@@ -104,7 +104,6 @@ stdenv.mkDerivation rec {
     "-Dfunctional_tests=false"
     "-Ddbus_services=${placeholder "out"}/share/dbus-1/services"
     "-Dsystemd_user_services=${placeholder "out"}/lib/systemd/user"
-    "-Dauto_features=enabled"
   ];
 
   patches = [

--- a/pkgs/development/libraries/spice-gtk/default.nix
+++ b/pkgs/development/libraries/spice-gtk/default.nix
@@ -109,7 +109,6 @@ stdenv.mkDerivation rec {
   PKG_CONFIG_POLKIT_GOBJECT_1_POLICYDIR = "${placeholder "out"}/share/polkit-1/actions";
 
   mesonFlags = [
-    "-Dauto_features=enabled"
     "-Dcelt051=disabled"
     "-Dpulse=disabled" # is deprecated upstream
   ];

--- a/pkgs/development/libraries/spice/default.nix
+++ b/pkgs/development/libraries/spice/default.nix
@@ -77,7 +77,6 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = "-fno-stack-protector";
 
   mesonFlags = [
-    "-Dauto_features=enabled"
     "-Dgstreamer=1.0"
     "-Dcelt051=disabled"
   ];

--- a/pkgs/development/libraries/wlroots/default.nix
+++ b/pkgs/development/libraries/wlroots/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, meson, ninja, pkgconfig
 , wayland, libGL, wayland-protocols, libinput, libxkbcommon, pixman
 , xcbutilwm, libX11, libcap, xcbutilimage, xcbutilerrors, mesa
-, libpng, ffmpeg_4
+, libpng, ffmpeg_4, freerdp
 }:
 
 stdenv.mkDerivation rec {
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     wayland libGL wayland-protocols libinput libxkbcommon pixman
     xcbutilwm libX11 libcap xcbutilimage xcbutilerrors mesa
-    libpng ffmpeg_4
+    libpng ffmpeg_4 freerdp
   ];
 
   mesonFlags = [

--- a/pkgs/development/tools/build-managers/meson/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/meson/setup-hook.sh
@@ -21,7 +21,7 @@ mesonConfigurePhase() {
         -Dwrap_mode=${mesonWrapMode:-nodownload} \
         $mesonFlags"
 
-    mesonFlags="${crossMesonFlags+$crossMesonFlags }--buildtype=${mesonBuildType:-release} $mesonFlags"
+    mesonFlags="${crossMesonFlags+$crossMesonFlags }--buildtype=${mesonBuildType:-plain} $mesonFlags"
 
     echo "meson flags: $mesonFlags ${mesonFlagsArray[@]}"
 

--- a/pkgs/development/tools/build-managers/meson/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/meson/setup-hook.sh
@@ -18,6 +18,7 @@ mesonConfigurePhase() {
         --mandir=${!outputMan}/share/man --infodir=${!outputInfo}/share/info \
         --localedir=${!outputLib}/share/locale \
         -Dauto_features=${mesonAutoFeatures:-enabled} \
+        -Dwrap_mode=${mesonWrapMode:-nodownload} \
         $mesonFlags"
 
     mesonFlags="${crossMesonFlags+$crossMesonFlags }--buildtype=${mesonBuildType:-release} $mesonFlags"

--- a/pkgs/development/tools/build-managers/meson/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/meson/setup-hook.sh
@@ -17,7 +17,7 @@ mesonConfigurePhase() {
         --includedir=${!outputInclude}/include \
         --mandir=${!outputMan}/share/man --infodir=${!outputInfo}/share/info \
         --localedir=${!outputLib}/share/locale \
-        -Dauto_features=disabled \
+        -Dauto_features=${mesonAutoFeatures:-enabled} \
         $mesonFlags"
 
     mesonFlags="${crossMesonFlags+$crossMesonFlags }--buildtype=${mesonBuildType:-release} $mesonFlags"

--- a/pkgs/tools/graphics/grim/default.nix
+++ b/pkgs/tools/graphics/grim/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cairo, libjpeg, meson, ninja, wayland, pkgconfig, wayland-protocols }:
+{ stdenv, fetchFromGitHub, cairo, libjpeg, meson, ninja, wayland, pkgconfig, scdoc, wayland-protocols }:
 
 stdenv.mkDerivation rec {
   pname = "grim";
@@ -15,6 +15,7 @@ stdenv.mkDerivation rec {
     meson
     ninja
     pkgconfig
+    scdoc
   ];
 
   buildInputs = [

--- a/pkgs/tools/misc/wl-clipboard/default.nix
+++ b/pkgs/tools/misc/wl-clipboard/default.nix
@@ -14,7 +14,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ meson ninja pkgconfig wayland-protocols ];
   buildInputs = [ wayland ];
-  mesonFlags = [ "-Dauto_features=enabled" ];
 
   meta = with stdenv.lib; {
     description = "Command-line copy/paste utilities for Wayland";


### PR DESCRIPTION
We disabled them by default when they were introduced in

https://github.com/NixOS/nixpkgs/pull/42994

but enabling them probably makes more sense:

https://github.com/NixOS/nixpkgs/pull/54398
https://github.com/NixOS/nixpkgs/pull/63491

We will probably need to adjust dependencies like in https://github.com/NixOS/nixpkgs/pull/63491 all over the place.