### PR TITLE
ctypes_sh: init at 1.1

### DIFF
--- a/pkgs/development/libraries/ctypes_sh/default.nix
+++ b/pkgs/development/libraries/ctypes_sh/default.nix
@@ -1,0 +1,28 @@
+{ stdenv
+, fetchFromGitHub
+, autoreconfHook, pkgconfig
+, zlib, libffi, elfutils, libdwarf
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ctypes.sh";
+  version = "1.1";
+
+  src = fetchFromGitHub {
+    owner = "taviso";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "07rqbdxw33h92mllh0srymjjx52mddafs3jyzqpsflq3v0l0dk37";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  buildInputs = [ zlib libffi elfutils libdwarf ];
+
+  meta = with stdenv.lib; {
+    description = "A foreign function interface for bash";
+    homepage = "https://github.com/taviso/ctypes.sh";
+    license = licenses.mit;
+    maintainers = with maintainers; [ tadeokondrak ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10144,6 +10144,8 @@ in
 
   cryptominisat = callPackage ../applications/science/logic/cryptominisat { };
 
+  ctypes_sh = callPackage ../development/libraries/ctypes_sh { };
+
   curlcpp = callPackage ../development/libraries/curlcpp { };
 
   curlpp = callPackage ../development/libraries/curlpp { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Not sure if I should use an underscore or hyphen in the package name, rest of nixpkgs seems to be inconsistent on that