### PR TITLE
discord-rpc: init at 3.4.0

### DIFF
--- a/pkgs/development/libraries/discord-rpc/default.nix
+++ b/pkgs/development/libraries/discord-rpc/default.nix
@@ -1,0 +1,40 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, rapidjson
+, AppKit
+, buildExamples ? false
+}:
+
+stdenv.mkDerivation rec {
+  pname = "discord-rpc";
+  version = "3.4.0";
+
+  src = fetchFromGitHub {
+    owner = "discordapp";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "04cxhqdv5r92lrpnhxf8702a8iackdf3sfk1050z7pijbijiql2a";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    rapidjson
+  ] ++ stdenv.lib.optional stdenv.isDarwin AppKit;
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=true"
+    "-DBUILD_EXAMPLES=${stdenv.lib.boolToString buildExamples}"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Official library to interface with the Discord client";
+    homepage = "https://github.com/discordapp/discord-rpc";
+    license = licenses.mit;
+    maintainers = with maintainers; [ tadeokondrak ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10274,6 +10274,10 @@ in
 
   directfb = callPackage ../development/libraries/directfb { };
 
+  discord-rpc = callPackage ../development/libraries/discord-rpc {
+    inherit (darwin.apple_sdk.frameworks) AppKit;
+  };
+
   dlib = callPackage ../development/libraries/dlib { };
 
   docopt_cpp = callPackage ../development/libraries/docopt_cpp { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Wanted to use this with ctypes.sh 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
