### PR TITLE
oppai-ng: init at 3.2.2

### DIFF
--- a/pkgs/tools/misc/oppai-ng/default.nix
+++ b/pkgs/tools/misc/oppai-ng/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "oppai-ng";
+  version = "3.2.2";
+
+  src = fetchFromGitHub {
+    owner = "Francesco149";
+    repo = pname;
+    rev = version;
+    sha256 = "1cq8kvw33dnafs06j54qgc475jma81g7mh0pmiinybfgzypm4fmx";
+  };
+
+  buildPhase = ''
+    ./build
+    ./libbuild
+  '';
+
+  installPhase = ''
+    install -D oppai $out/bin/oppai
+    install -D oppai.c $out/include/oppai.c
+    install -D liboppai.so $out/lib/liboppai.so
+  '';
+
+  meta = with stdenv.lib; {
+    description = "difficulty and pp calculator for osu!";
+    homepage = "https://github.com/Francesco149/oppai-ng";
+    license = licenses.unlicense;
+    maintainers = with maintainers; [ tadeokondrak ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/tools/misc/oppai-ng/default.nix
+++ b/pkgs/tools/misc/oppai-ng/default.nix
@@ -1,14 +1,16 @@
-{ stdenv, fetchFromGitHub }:
+{ stdenv
+, fetchFromGitHub
+}:
 
 stdenv.mkDerivation rec {
   pname = "oppai-ng";
-  version = "3.2.2";
+  version = "3.2.3";
 
   src = fetchFromGitHub {
     owner = "Francesco149";
     repo = pname;
     rev = version;
-    sha256 = "1cq8kvw33dnafs06j54qgc475jma81g7mh0pmiinybfgzypm4fmx";
+    sha256 = "1wrnpnx1yl0pdzmla4knlpcwy7baamy2wpdypnbdqxrn0zkw7kzk";
   };
 
   buildPhase = ''
@@ -23,7 +25,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "difficulty and pp calculator for osu!";
+    description = "Difficulty and pp calculator for osu!";
     homepage = "https://github.com/Francesco149/oppai-ng";
     license = licenses.unlicense;
     maintainers = with maintainers; [ tadeokondrak ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5053,6 +5053,8 @@ in
     stdenv = clangStdenv;
   };
 
+  oppai-ng = callPackage ../tools/misc/oppai-ng { };
+
   update-resolv-conf = callPackage ../tools/networking/openvpn/update-resolv-conf.nix { };
 
   opae = callPackage ../development/libraries/opae { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
