### PR TITLE
cum: init at 0.9.1

### DIFF
--- a/pkgs/applications/misc/cum/default.nix
+++ b/pkgs/applications/misc/cum/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, python3Packages }:
+
+with python3Packages;
+
+buildPythonApplication rec {
+  pname = "cum";
+  version = "0.9.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "15qc6agka2g3kcnpnz0hbjic1s3260cr9bda0rlcyninxs1vndq0";
+  };
+
+  propagatedBuildInputs = [
+    alembic beautifulsoup4 click natsort requests sqlalchemy
+  ];
+
+  # tests seem to fail for `config` not being defined,
+  # but it works once installed
+  doCheck = false;
+
+  # remove the top-level `tests` and `LICENSE` file
+  # they should not be installed, and there can be issues if another package
+  # has a collision (especially with the license file)
+  postInstall = ''
+    rm -rf $out/tests $out/LICENSE
+  '';
+
+  meta = with stdenv.lib; {
+    description = "comic updater, mangafied";
+    homepage = "https://github.com/Hamuko/cum";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ tadeokondrak ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17246,6 +17246,8 @@ in
 
   cubicsdr = callPackage ../applications/radio/cubicsdr { wxGTK = wxGTK31; };
 
+  cum = callPackage ../applications/misc/cum { };
+
   cuneiform = callPackage ../tools/graphics/cuneiform {};
 
   curseradio = callPackage ../applications/audio/curseradio { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
