### PR TITLE
discord-{ptb,canary}: init; add `update-discord`

### DIFF
--- a/maintainers/scripts/update-discord
+++ b/maintainers/scripts/update-discord
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# script to generate `pkgs/networking/instant-messengers/discord/default.nix`
+
+set -e
+exec >${1:?usage: $0 <output-file>}
+
+cat <<EOF
+{ branch ? "stable", pkgs }:
+
+let
+  inherit (pkgs) callPackage fetchurl;
+in {
+EOF
+
+for branch in "" ptb canary; do
+    url=$(curl -sI "https://discordapp.com/api/download${branch:+/}${branch}?platform=linux&format=tar.gz" | grep -oP 'location: \K\S+')
+    version=${url##https://dl*.discordapp.net/apps/linux/}
+    version=${version%%/*.tar.gz}
+    echo "  ${branch:-stable} = callPackage ./base.nix {"
+    echo "    pname = \"discord${branch:+-}${branch}\";"
+    case $branch in
+        "") suffix="" ;;
+        ptb) suffix="PTB" ;;
+        canary) suffix="Canary" ;;
+    esac
+    echo "    binaryName = \"Discord${suffix}\";"
+    echo "    desktopName = \"Discord${suffix:+ }${suffix}\";"
+    echo "    version = \"${version}\";"
+    echo "    src = fetchurl {"
+    echo "      url = \"${url}\";"
+    echo "      sha256 = \"$(nix-prefetch-url "$url")\";"
+    echo "    };"
+    echo "  };"
+done
+
+echo "}.\${branch}"

--- a/pkgs/applications/networking/instant-messengers/discord/base.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/base.nix
@@ -1,0 +1,61 @@
+{ pname, version, src, binaryName, desktopName
+, stdenv, fetchurl, makeDesktopItem, wrapGAppsHook
+, alsaLib, atk, at-spi2-atk, at-spi2-core, cairo, cups, dbus, expat, fontconfig, freetype
+, gdk_pixbuf, glib, gtk3, libnotify, libX11, libXcomposite, libXcursor, libXdamage, libuuid
+, libXext, libXfixes, libXi, libXrandr, libXrender, libXtst, nspr, nss, libxcb
+, pango, systemd, libXScrnSaver, libcxx, libpulseaudio }:
+
+let
+  inherit binaryName;
+in stdenv.mkDerivation rec {
+  inherit pname version src;
+
+  nativeBuildInputs = [ wrapGAppsHook ];
+
+  dontWrapGApps = true;
+
+  libPath = stdenv.lib.makeLibraryPath [
+    libcxx systemd libpulseaudio
+    stdenv.cc.cc alsaLib atk at-spi2-atk at-spi2-core cairo cups dbus expat fontconfig freetype
+    gdk_pixbuf glib gtk3 libnotify libX11 libXcomposite libuuid
+    libXcursor libXdamage libXext libXfixes libXi libXrandr libXrender
+    libXtst nspr nss libxcb pango systemd libXScrnSaver
+   ];
+
+  installPhase = ''
+    mkdir -p $out/{bin,opt/${binaryName},share/pixmaps}
+    mv * $out/opt/${binaryName}
+
+    chmod +x $out/opt/${binaryName}/${binaryName}
+    patchelf --set-interpreter ${stdenv.cc.bintools.dynamicLinker} \
+        $out/opt/${binaryName}/${binaryName}
+
+    wrapProgram $out/opt/${binaryName}/${binaryName} \
+        "''${gappsWrapperArgs[@]}" \
+        --prefix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}/" \
+        --prefix LD_LIBRARY_PATH : ${libPath}
+
+    ln -s $out/opt/${binaryName}/${binaryName} $out/bin/
+    ln -s $out/opt/${binaryName}/discord.png $out/share/pixmaps/${binaryName}.png
+
+    ln -s "${desktopItem}/share/applications" $out/share/
+  '';
+
+  desktopItem = makeDesktopItem {
+    name = pname;
+    exec = binaryName;
+    icon = pname;
+    inherit desktopName;
+    genericName = meta.description;
+    categories = "Network;InstantMessaging;";
+  };
+
+  meta = with stdenv.lib; {
+    description = "All-in-one cross-platform voice and text chat for gamers";
+    homepage = "https://discordapp.com/";
+    downloadPage = "https://discordapp.com/download";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ ldesgoui MP2E tadeokondrak ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/applications/networking/instant-messengers/discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/default.nix
@@ -1,64 +1,36 @@
-{ stdenv, fetchurl, makeDesktopItem, wrapGAppsHook
-, alsaLib, atk, at-spi2-atk, cairo, cups, dbus, expat, fontconfig, freetype, gdk_pixbuf
-, glib, gtk3, libnotify, libX11, libXcomposite, libXcursor, libXdamage, libuuid
-, libXext, libXfixes, libXi, libXrandr, libXrender, libXtst, nspr, nss, libxcb
-, pango, systemd, libXScrnSaver, libcxx, libpulseaudio }:
+{ branch ? "stable", pkgs }:
 
-stdenv.mkDerivation rec {
-  pname = "discord";
-  version = "0.0.9";
-
-  src = fetchurl {
-    url = "https://cdn.discordapp.com/apps/linux/${version}/${pname}-${version}.tar.gz";
-    sha256 = "1i0f8id10rh2fx381hx151qckvvh8hbznfsfav8w0dfbd1bransf";
-  };
-
-  nativeBuildInputs = [ wrapGAppsHook ];
-
-  dontWrapGApps = true;
-
-  libPath = stdenv.lib.makeLibraryPath [
-    libcxx systemd libpulseaudio
-    stdenv.cc.cc alsaLib atk at-spi2-atk cairo cups dbus expat fontconfig freetype
-    gdk_pixbuf glib gtk3 libnotify libX11 libXcomposite libuuid
-    libXcursor libXdamage libXext libXfixes libXi libXrandr libXrender
-    libXtst nspr nss libxcb pango systemd libXScrnSaver
-   ];
-
-  installPhase = ''
-    mkdir -p $out/{bin,opt/discord,share/pixmaps}
-    mv * $out/opt/discord
-
-    chmod +x $out/opt/discord/Discord
-    patchelf --set-interpreter ${stdenv.cc.bintools.dynamicLinker} \
-             $out/opt/discord/Discord
-
-    wrapProgram $out/opt/discord/Discord \
-        "''${gappsWrapperArgs[@]}" \
-        --prefix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}/" \
-        --prefix LD_LIBRARY_PATH : ${libPath}
-
-    ln -s $out/opt/discord/Discord $out/bin/
-    ln -s $out/opt/discord/discord.png $out/share/pixmaps
-
-    ln -s "${desktopItem}/share/applications" $out/share/
-  '';
-
-  desktopItem = makeDesktopItem {
-    name = pname;
-    exec = "Discord";
-    icon = pname;
+let
+  inherit (pkgs) callPackage fetchurl;
+in {
+  stable = callPackage ./base.nix {
+    pname = "discord";
+    binaryName = "Discord";
     desktopName = "Discord";
-    genericName = meta.description;
-    categories = "Network;InstantMessaging;";
+    version = "0.0.9";
+    src = fetchurl {
+      url = "https://dl.discordapp.net/apps/linux/0.0.9/discord-0.0.9.tar.gz";
+      sha256 = "1i0f8id10rh2fx381hx151qckvvh8hbznfsfav8w0dfbd1bransf";
+    };
   };
-
-  meta = with stdenv.lib; {
-    description = "All-in-one cross-platform voice and text chat for gamers";
-    homepage = https://discordapp.com/;
-    downloadPage = "https://github.com/crmarsh/discord-linux-bugs";
-    license = licenses.unfree;
-    maintainers = [ maintainers.ldesgoui maintainers.MP2E ];
-    platforms = [ "x86_64-linux" ];
+  ptb = callPackage ./base.nix {
+    pname = "discord-ptb";
+    binaryName = "DiscordPTB";
+    desktopName = "Discord PTB";
+    version = "0.0.15";
+    src = fetchurl {
+      url = "https://dl-ptb.discordapp.net/apps/linux/0.0.15/discord-ptb-0.0.15.tar.gz";
+      sha256 = "0znqb0a3yglgx7a9ypkb81jcm8kqgc6559zi7vfqn02zh15gqv6a";
+    };
   };
-}
+  canary = callPackage ./base.nix {
+    pname = "discord-canary";
+    binaryName = "DiscordCanary";
+    desktopName = "Discord Canary";
+    version = "0.0.83";
+    src = fetchurl {
+      url = "https://dl-canary.discordapp.net/apps/linux/0.0.83/discord-canary-0.0.83.tar.gz";
+      sha256 = "100a61x71cgyfm0xk4qdlbp1v41089jy7lajksbpy4y7him6bg2s";
+    };
+  };
+}.${branch}

--- a/pkgs/applications/networking/instant-messengers/discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/default.nix
@@ -5,61 +5,60 @@
 , pango, systemd, libXScrnSaver, libcxx, libpulseaudio }:
 
 stdenv.mkDerivation rec {
+  pname = "discord";
+  version = "0.0.9";
 
-    pname = "discord";
-    version = "0.0.9";
+  src = fetchurl {
+    url = "https://cdn.discordapp.com/apps/linux/${version}/${pname}-${version}.tar.gz";
+    sha256 = "1i0f8id10rh2fx381hx151qckvvh8hbznfsfav8w0dfbd1bransf";
+  };
 
-    src = fetchurl {
-        url = "https://cdn.discordapp.com/apps/linux/${version}/${pname}-${version}.tar.gz";
-        sha256 = "1i0f8id10rh2fx381hx151qckvvh8hbznfsfav8w0dfbd1bransf";
-    };
+  nativeBuildInputs = [ wrapGAppsHook ];
 
-    nativeBuildInputs = [ wrapGAppsHook ];
+  dontWrapGApps = true;
 
-    dontWrapGApps = true;
+  libPath = stdenv.lib.makeLibraryPath [
+    libcxx systemd libpulseaudio
+    stdenv.cc.cc alsaLib atk at-spi2-atk cairo cups dbus expat fontconfig freetype
+    gdk_pixbuf glib gtk3 libnotify libX11 libXcomposite libuuid
+    libXcursor libXdamage libXext libXfixes libXi libXrandr libXrender
+    libXtst nspr nss libxcb pango systemd libXScrnSaver
+   ];
 
-    libPath = stdenv.lib.makeLibraryPath [
-        libcxx systemd libpulseaudio
-        stdenv.cc.cc alsaLib atk at-spi2-atk cairo cups dbus expat fontconfig freetype
-        gdk_pixbuf glib gtk3 libnotify libX11 libXcomposite libuuid
-        libXcursor libXdamage libXext libXfixes libXi libXrandr libXrender
-        libXtst nspr nss libxcb pango systemd libXScrnSaver
-     ];
+  installPhase = ''
+    mkdir -p $out/{bin,opt/discord,share/pixmaps}
+    mv * $out/opt/discord
 
-    installPhase = ''
-        mkdir -p $out/{bin,opt/discord,share/pixmaps}
-        mv * $out/opt/discord
+    chmod +x $out/opt/discord/Discord
+    patchelf --set-interpreter ${stdenv.cc.bintools.dynamicLinker} \
+             $out/opt/discord/Discord
 
-        chmod +x $out/opt/discord/Discord
-        patchelf --set-interpreter ${stdenv.cc.bintools.dynamicLinker} \
-                 $out/opt/discord/Discord
+    wrapProgram $out/opt/discord/Discord \
+        "''${gappsWrapperArgs[@]}" \
+        --prefix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}/" \
+        --prefix LD_LIBRARY_PATH : ${libPath}
 
-        wrapProgram $out/opt/discord/Discord \
-          "''${gappsWrapperArgs[@]}" \
-          --prefix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}/" \
-          --prefix LD_LIBRARY_PATH : ${libPath}
+    ln -s $out/opt/discord/Discord $out/bin/
+    ln -s $out/opt/discord/discord.png $out/share/pixmaps
 
-        ln -s $out/opt/discord/Discord $out/bin/
-        ln -s $out/opt/discord/discord.png $out/share/pixmaps
+    ln -s "${desktopItem}/share/applications" $out/share/
+  '';
 
-        ln -s "${desktopItem}/share/applications" $out/share/
-        '';
+  desktopItem = makeDesktopItem {
+    name = pname;
+    exec = "Discord";
+    icon = pname;
+    desktopName = "Discord";
+    genericName = meta.description;
+    categories = "Network;InstantMessaging;";
+  };
 
-    desktopItem = makeDesktopItem {
-      name = pname;
-      exec = "Discord";
-      icon = pname;
-      desktopName = "Discord";
-      genericName = meta.description;
-      categories = "Network;InstantMessaging;";
-    };
-
-    meta = with stdenv.lib; {
-        description = "All-in-one cross-platform voice and text chat for gamers";
-        homepage = https://discordapp.com/;
-        downloadPage = "https://github.com/crmarsh/discord-linux-bugs";
-        license = licenses.unfree;
-        maintainers = [ maintainers.ldesgoui maintainers.MP2E ];
-        platforms = [ "x86_64-linux" ];
-    };
+  meta = with stdenv.lib; {
+    description = "All-in-one cross-platform voice and text chat for gamers";
+    homepage = https://discordapp.com/;
+    downloadPage = "https://github.com/crmarsh/discord-linux-bugs";
+    license = licenses.unfree;
+    maintainers = [ maintainers.ldesgoui maintainers.MP2E ];
+    platforms = [ "x86_64-linux" ];
+  };
 }

--- a/pkgs/applications/networking/instant-messengers/discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/default.nix
@@ -27,10 +27,10 @@ in {
     pname = "discord-canary";
     binaryName = "DiscordCanary";
     desktopName = "Discord Canary";
-    version = "0.0.83";
+    version = "0.0.84";
     src = fetchurl {
-      url = "https://dl-canary.discordapp.net/apps/linux/0.0.83/discord-canary-0.0.83.tar.gz";
-      sha256 = "100a61x71cgyfm0xk4qdlbp1v41089jy7lajksbpy4y7him6bg2s";
+      url = "https://dl-canary.discordapp.net/apps/linux/0.0.84/discord-canary-0.0.84.tar.gz";
+      sha256 = "1s4m7qvwyb0zglgdcixfnp5asachkybfafbmr74c7zrb0scl80s1";
     };
   };
 }.${branch}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24108,7 +24108,20 @@ in
 
   togglesg-download = callPackage ../tools/misc/togglesg-download { };
 
-  discord = callPackage ../applications/networking/instant-messengers/discord { };
+  discord = import ../applications/networking/instant-messengers/discord {
+    branch = "stable";
+    inherit pkgs;
+  };
+
+  discord-ptb = import ../applications/networking/instant-messengers/discord {
+    branch = "ptb";
+    inherit pkgs;
+  };
+
+  discord-canary = import ../applications/networking/instant-messengers/discord {
+    branch = "canary";
+    inherit pkgs;
+  };
 
   golden-cheetah = libsForQt56.callPackage ../applications/misc/golden-cheetah {};
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I wanted to use `discord-canary`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Since discord-canary updates very often, I've added a script that regenerates the `default.nix` file.