### PR TITLE
python3Packages.django-crispy-forms: init at 1.7.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1985,6 +1985,11 @@
     github = "gridaphobe";
     name = "Eric Seidel";
   };
+  BadDecisionsAlex = {
+    email = "Alex.Ameen.TX@gmail.com";
+    github = "BadDecisionsAlex";
+    name = "Alex Ameen";
+  };
   guibert = {
     email = "david.guibert@gmail.com";
     github = "dguibert";

--- a/pkgs/development/python-modules/django-crispy-forms/default.nix
+++ b/pkgs/development/python-modules/django-crispy-forms/default.nix
@@ -1,0 +1,23 @@
+{ stdenv
+, fetchPypi
+, buildPythonPackage
+}:
+buildPythonPackage rec {
+
+  pname = "django-crispy-forms";
+  version = "1.7.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "5952bab971110d0b86c278132dae0aa095beee8f723e625c3d3fa28888f1675f";
+  };
+
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = "http://github.com/maraujop/django-crispy-forms";
+    license = licenses.mit;
+    description = "Best way to have Django DRY forms";
+  };
+
+}

--- a/pkgs/development/python-modules/django-crispy-forms/default.nix
+++ b/pkgs/development/python-modules/django-crispy-forms/default.nix
@@ -18,6 +18,7 @@ buildPythonPackage rec {
     homepage = "http://github.com/maraujop/django-crispy-forms";
     license = licenses.mit;
     description = "Best way to have Django DRY forms";
+    maintainers = with maintainers; [ BadDecisionsAlex ];
   };
 
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2538,6 +2538,8 @@ in {
   django_contrib_comments = callPackage ../development/python-modules/django_contrib_comments { };
 
   django-cors-headers = callPackage ../development/python-modules/django-cors-headers { };
+  
+  django-crispy-forms = callPackage ../development/python-modules/django-crispy-forms { };
 
   django-discover-runner = callPackage ../development/python-modules/django-discover-runner { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Required package for a project.

###### Things done

Added and tested "Django Cripsy Forms" Python Package.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
