### PR TITLE
pythonPackages.pycategories: init at 1.2.0

### DIFF
--- a/pkgs/development/python-modules/pycategories/default.nix
+++ b/pkgs/development/python-modules/pycategories/default.nix
@@ -1,0 +1,35 @@
+{ buildPythonPackage
+, callPackage
+, pytestcov
+, fetchPypi
+, lib
+, pytest
+, pythonOlder
+, pytestrunner
+}:
+
+buildPythonPackage rec {
+  pname = "pycategories";
+  version = "1.2.0";
+  disabled = pythonOlder "3.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "bd70ecb5e94e7659e564ea153f0c7673291dc37c526c246800fc08d6c5378099";
+  };
+
+  nativeBuildInputs = [ pytestrunner ];
+
+  # Is private because the author states it's unmaintained
+  # and shouldn't be used in production code
+  propagatedBuildInputs = [ (callPackage ./infix.nix { }) ];
+
+  checkInputs = [ pytest pytestcov ];
+
+  meta = with lib; {
+    homepage = "https://gitlab.com/danielhones/pycategories";
+    description = "Implementation of some concepts from category theory";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dmvianna ];
+  };
+}

--- a/pkgs/development/python-modules/pycategories/infix.nix
+++ b/pkgs/development/python-modules/pycategories/infix.nix
@@ -1,0 +1,23 @@
+{ buildPythonPackage
+, lib
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "infix";
+  version = "1.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "a1bfdcf875bc072f41e426d0673f2e3017750743bb90cc725fffb292eb09648c";
+  };
+
+  # No tests
+  doCheck = false;
+
+  meta = {
+    homepage = "https://github.com/borntyping/python-infix";
+    description = "A decorator that allows functions to be used as infix functions";
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -682,6 +682,8 @@ in {
     inherit (pkgs) pkgconfig;
   };
 
+  pycategories = callPackage ../development/python-modules/pycategories { };
+
   pycangjie = disabledIf (!isPy3k) (callPackage ../development/python-modules/pycangjie {
     inherit (pkgs) pkgconfig;
   });


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add new package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
