### PR TITLE
qtpbfimageplugin: init at 1.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4686,6 +4686,11 @@
     github = "sigma";
     name = "Yann Hodique";
   };
+  sikmir = {
+    email = "sikmir@gmail.com";
+    github = "sikmir";
+    name = "Nikolay Korotkiy";
+  };
   simonvandel = {
     email = "simon.vandel@gmail.com";
     github = "simonvandel";

--- a/pkgs/development/libraries/qtpbfimageplugin/default.nix
+++ b/pkgs/development/libraries/qtpbfimageplugin/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchFromGitHub, qmake, qtbase, protobuf }:
+
+stdenv.mkDerivation rec {
+  pname = "qtpbfimageplugin";
+  version = "1.4";
+
+  src = fetchFromGitHub {
+    owner = "tumic0";
+    repo = "QtPBFImagePlugin";
+    rev = version;
+    sha256 = "0d39i7rmhrmm2df49gd47zm37gnz3fmyr6hfc6hhzvk08jb6956r";
+  };
+
+  nativeBuildInputs = [ qmake ];
+  buildInputs = [ qtbase protobuf ];
+
+  postPatch = ''
+    # Fix plugin dir
+    substituteInPlace pbfplugin.pro \
+      --replace "\$\$[QT_INSTALL_PLUGINS]" "$out/$qtPluginPrefix"
+
+    # Fix darwin build
+    substituteInPlace pbfplugin.pro \
+      --replace '$$PROTOBUF/lib/libprotobuf-lite.a' '${protobuf}/lib/libprotobuf-lite.dylib'
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Qt image plugin for displaying Mapbox vector tiles";
+    longDescription = ''
+      QtPBFImagePlugin is a Qt image plugin that enables applications capable of
+      displaying raster MBTiles maps or raster XYZ online maps to also display PBF
+      vector tiles without (almost) any application modifications.
+    '';
+    homepage = https://github.com/tumic0/QtPBFImagePlugin;
+    license = licenses.lgpl3;
+    maintainers = [ maintainers.sikmir ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12987,6 +12987,8 @@ in
 
   qtkeychain = callPackage ../development/libraries/qtkeychain { };
 
+  qtpbfimageplugin = libsForQt5.callPackage ../development/libraries/qtpbfimageplugin { };
+
   qtscriptgenerator = callPackage ../development/libraries/qtscriptgenerator { };
 
   quesoglc = callPackage ../development/libraries/quesoglc { };


### PR DESCRIPTION
###### Motivation for this change

Optional dependency for [gpxsee](https://github.com/NixOS/nixpkgs/tree/master/pkgs/applications/misc/gpxsee) that enables support for PBF vector maps.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
