### PR TITLE
python3Packages.ez_setup: init at 0.9.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1985,6 +1985,11 @@
     github = "gridaphobe";
     name = "Eric Seidel";
   };
+  BadDecisionsAlex = {
+    email = "Alex.Ameen.TX@gmail.com";
+    github = "BadDecisionsAlex";
+    name = "Alex Ameen";
+  };
   guibert = {
     email = "david.guibert@gmail.com";
     github = "dguibert";

--- a/pkgs/development/python-modules/ez_setup/default.nix
+++ b/pkgs/development/python-modules/ez_setup/default.nix
@@ -1,0 +1,23 @@
+{ stdenv
+, fetchPypi
+, buildPythonPackage
+}:
+buildPythonPackage rec {
+
+  pname = "ez_setup";
+  version = "0.9";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "303c5b17d552d1e3fb0505d80549f8579f557e13d8dc90e5ecef3c07d7f58642";
+  };
+
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/ActiveState/ez_setup";
+    license = licenses.psfl;
+    description = "Yet another Python setup tool.";
+  };
+
+}

--- a/pkgs/development/python-modules/ez_setup/default.nix
+++ b/pkgs/development/python-modules/ez_setup/default.nix
@@ -18,6 +18,7 @@ buildPythonPackage rec {
     homepage = "https://github.com/ActiveState/ez_setup";
     license = licenses.psfl;
     description = "Yet another Python setup tool.";
+    maintainers = with maintainers; [ BadDecisionsAlex ];
   };
 
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1988,6 +1988,8 @@ in {
 
   ezdxf = callPackage ../development/python-modules/ezdxf {};
 
+  ez_setup = callPackage ../development/python-modules/ez_setup { };
+
   facebook-sdk = callPackage ../development/python-modules/facebook-sdk { };
 
   face_recognition = callPackage ../development/python-modules/face_recognition { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Required package for a project.

###### Things done

Added python package "ex_setup"

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
