### PR TITLE
pythonPackages.z3c_checkversions: init at 1.1

### DIFF
--- a/pkgs/development/python-modules/z3c-checkversions/default.nix
+++ b/pkgs/development/python-modules/z3c-checkversions/default.nix
@@ -1,0 +1,30 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, python
+, zc_buildout
+, zope_testrunner
+}:
+
+buildPythonPackage rec {
+  pname = "z3c-checkversions";
+  version = "1.1";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "z3c.checkversions";
+    sha256 = "b45bd22ae01ed60933694fb5abede1ff71fe8ffa79b37082b2fcf38a2f0dec9d";
+  };
+
+  propagatedBuildInputs = [ zc_buildout ];
+  checkInputs = [ zope_testrunner ];
+  checkPhase = ''
+    ${python.interpreter} -m zope.testrunner --test-path=src []
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/zopefoundation/z3c.checkversions;
+    description = "Find newer package versions on PyPI";
+    license = licenses.zpl21;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1454,6 +1454,8 @@ in {
 
   zc_buildout221 = callPackage ../development/python-modules/buildout { };
 
+  z3c-checkversions = callPackage ../development/python-modules/z3c-checkversions { };
+
   bunch = callPackage ../development/python-modules/bunch { };
 
   can = callPackage ../development/python-modules/can {};


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
