### PR TITLE
nheko: 0.6.3 -> 0.6.4, mtxclient: 0.2.0 -> 0.2.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/nheko/default.nix
+++ b/pkgs/applications/networking/instant-messengers/nheko/default.nix
@@ -1,8 +1,10 @@
 { lib, stdenv, fetchFromGitHub
 , cmake, cmark, lmdb, qt5, qtmacextras, mtxclient
-, boost, spdlog, olm, pkgconfig
+, boost, spdlog, olm, pkgconfig, nlohmann_json
 }:
 
+# These hashes and revisions are based on those from here:
+# https://github.com/Nheko-Reborn/nheko/blob/v0.6.4/deps/CMakeLists.txt#L52
 let
   tweeny = fetchFromGitHub {
     owner = "mobius3";
@@ -20,13 +22,13 @@ let
 in
 stdenv.mkDerivation rec {
   name = "nheko-${version}";
-  version = "0.6.3";
+  version = "0.6.4";
 
   src = fetchFromGitHub {
     owner = "Nheko-Reborn";
     repo = "nheko";
     rev = "v${version}";
-    sha256 = "1h95lixciiq904dnfpwxhyf545yfsrphhwqyvs4yrzdfr9k0cf98";
+    sha256 = "19dkc98l1q4070v6mli4ybqn0ip0za607w39hjf0x8rqdxq45iwm";
   };
 
   # If, on Darwin, you encounter the error
@@ -54,6 +56,7 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     "-DTWEENY_INCLUDE_DIR=.deps/include"
     "-DLMDBXX_INCLUDE_DIR=${lmdbxx}"
+    "-Dnlohmann_json_DIR=${nlohmann_json}/lib/cmake/nlohmann_json"
   ];
 
   nativeBuildInputs = [ cmake pkgconfig ];

--- a/pkgs/development/libraries/mtxclient/default.nix
+++ b/pkgs/development/libraries/mtxclient/default.nix
@@ -3,35 +3,27 @@
 
 stdenv.mkDerivation rec {
   name = "mtxclient-${version}";
-  version = "0.2.0";
+  version = "0.2.1";
 
   src = fetchFromGitHub {
-    owner = "mujx";
+    owner = "Nheko-Reborn";
     repo = "mtxclient";
     rev = "v${version}";
-    sha256 = "19v1qa6mzvc65m7wy7x0g4i24bcg9xk31y1grwvd3zr0l4v6xcgs";
+    sha256 = "0pycznrvj57ff6gbwfn1xj943d2dr4vadl79hii1z16gn0nzxpmj";
   };
 
-  patches = [
-    # remove on the next mtxclient update
-    (fetchpatch {
-      url = "https://github.com/Nheko-Reborn/mtxclient/commit/41314809da7eb17ec00cff1795af6a528c5e904a.diff";
-      sha256 = "17pzrkdhd4jr8xwd7hhyzak880k8yb9nkg3vcbyjfp5si89dha5j";
-    })
+  cmakeFlags = [
+    "-DBUILD_LIB_TESTS=OFF"
+    "-DBUILD_LIB_EXAMPLES=OFF"
+    "-Dnlohmann_json_DIR=${nlohmann_json}/lib/cmake/nlohmann_json"
   ];
-
-  postPatch = ''
-    ln -s ${nlohmann_json}/include/nlohmann/json.hpp include/json.hpp
-  '';
-
-  cmakeFlags = [ "-DBUILD_LIB_TESTS=OFF" "-DBUILD_LIB_EXAMPLES=OFF" ];
 
   nativeBuildInputs = [ cmake pkgconfig ];
   buildInputs = [ boost openssl zlib libsodium olm ];
 
   meta = with stdenv.lib; {
     description = "Client API library for Matrix, built on top of Boost.Asio";
-    homepage = https://github.com/mujx/mtxclient;
+    homepage = https://github.com/Nheko-Reborn/mtxclient;
     license = licenses.mit;
     maintainers = with maintainers; [ fpletz ];
     platforms = platforms.unix;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update package nheko

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"` (Non depend on it)
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

#### Other information

- Updated the URL of mtxclient to use the `Nheko-Reborn` GitHub namspace.
- Made both nheko and mtxclient aware of nlohmann_json with `-Dnlohmann_json_DIR` in `cmakeFlags`.