### PR TITLE
luarocks: 3.0.4 -> 3.1.3

### DIFF
--- a/pkgs/development/tools/misc/luarocks/darwin-3.0.x.patch
+++ b/pkgs/development/tools/misc/luarocks/darwin-3.0.x.patch
@@ -1,20 +1,17 @@
-diff --git a/src/luarocks/core/cfg.lua b/src/luarocks/core/cfg.lua
-index f93e67a..2eb2db9 100644
---- a/src/luarocks/core/cfg.lua
-+++ b/src/luarocks/core/cfg.lua
-@@ -425,9 +425,9 @@ local function make_defaults(lua_version, target_cpu, platforms, home)
+diff --git i/src/luarocks/core/cfg.lua w/src/luarocks/core/cfg.lua
+index c5af5a2..1949fdc 100644
+--- i/src/luarocks/core/cfg.lua
++++ w/src/luarocks/core/cfg.lua
+@@ -425,7 +425,7 @@ local function make_defaults(lua_version, target_cpu, platforms, home)
        defaults.external_lib_extension = "dylib"
        defaults.arch = "macosx-"..target_cpu
        defaults.variables.LIBFLAG = "-bundle -undefined dynamic_lookup -all_load"
--      defaults.variables.STAT = "/usr/bin/stat"
-+      defaults.variables.STAT = "stat"
-       defaults.variables.STATFLAG = "-f '%A'"
 -      local version = util.popen_read("sw_vers -productVersion")
 +      local version = "10.10"
        version = tonumber(version and version:match("^[^.]+%.([^.]+)")) or 3
        if version >= 10 then
           version = 8
-@@ -436,8 +436,8 @@ local function make_defaults(lua_version, target_cpu, platforms, home)
+@@ -434,8 +434,8 @@ local function make_defaults(lua_version, target_cpu, platforms, home)
        else
           defaults.gcc_rpath = false
        end


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`- I ran this command but I don't think all Lua packages were rebuild so I'm not sure about this one.
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Also: Updated `darwin.patch` for new version of the patched file.

---
