### PR TITLE
sourcetrail: 2019.1.11 -> 2019.2.39

### DIFF
--- a/pkgs/development/tools/sourcetrail/default.nix
+++ b/pkgs/development/tools/sourcetrail/default.nix
@@ -1,18 +1,18 @@
 { stdenv, fetchurl, autoPatchelfHook
-, zlib, expat, dbus, openssl}:
+, zlib, expat, dbus, openssl, python3 }:
 
 stdenv.mkDerivation rec {
   name = "sourcetrail-${version}";
-  version = "2019.1.11";
+  version = "2019.2.39";
 
   src = fetchurl {
     name = "sourtrail.tar.gz";
     url = "https://www.sourcetrail.com/downloads/${version}/linux/64bit";
-    sha256 = "09f3qdgdqg6dlai43050qh4iv1d4j43isk81q68swalpnvjn72w0";
+    sha256 = "13kzfnsb5lf9v6bqw41qljp5bgz2rd3w163r6xg59hzd3dv8f90q";
   };
 
   nativeBuildInputs = [ autoPatchelfHook ];
-  buildInputs = [ zlib expat dbus stdenv.cc.cc openssl ];
+  buildInputs = [ zlib expat dbus stdenv.cc.cc openssl python3 ];
 
   installPhase = ''
     runHook preInstall
@@ -38,28 +38,30 @@ stdenv.mkDerivation rec {
       --replace /usr/bin/ $out/bin/
 
     cat <<EOF > $out/bin/sourcetrail
-      #! ${stdenv.shell} -e
+    #! ${stdenv.shell} -e
 
-      # XXX: Sourcetrail somehow copies the initial config files into the home
-      # directory without write permissions. We currently just copy them
-      # ourselves to work around this problem.
-      setup_config() {
-        local src dst
+    # XXX: Sourcetrail somehow copies the initial config files into the home
+    # directory without write permissions. We currently just copy them
+    # ourselves to work around this problem.
+    setup_config() {
+      local src dst
 
-        [ ! -d ~/.config/sourcetrail ] && mkdir -p ~/.config/sourcetrail
-        for src in $out/opt/data/fallback/*; do
-          dst=~/.config/sourcetrail/"\$(basename "\$src")"
-          if [ ! -e "\$dst" ]; then
-            cp -r "\$src" "\$dst"
-          fi
-        done
+      [ ! -d ~/.config/sourcetrail ] && mkdir -p ~/.config/sourcetrail
+      for src in $out/opt/data/fallback/*; do
+        dst=~/.config/sourcetrail/"\$(basename "\$src")"
+        if [ ! -e "\$dst" ]; then
+          cp -r "\$src" "\$dst"
+        fi
+      done
 
-        chmod -R u+w ~/.config/sourcetrail
-      }
+      chmod -R u+w ~/.config/sourcetrail
+    }
 
-      [ -d "\$HOME" ] && setup_config
-      exec "$out/opt/Sourcetrail.sh" "\$@"
+    [ -d "\$HOME" ] && setup_config
+    export PATH="\$PATH:${python3}/bin"
+    exec "$out/opt/Sourcetrail.sh" "\$@"
     EOF
+
     chmod +x $out/bin/sourcetrail
 
     runHook postInstall


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
- update to newer version
- enable python indexing

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
