### PR TITLE
tor-browser: remove --no-remote option

### DIFF
--- a/pkgs/applications/networking/browsers/tor-browser-bundle/default.nix
+++ b/pkgs/applications/networking/browsers/tor-browser-bundle/default.nix
@@ -299,7 +299,6 @@ stdenv.mkDerivation rec {
       TOR_SOCKS_PORT="\''${TOR_SOCKS_PORT:-}" \
       \
       $self/firefox \
-        -no-remote \
         -profile "\$HOME/TorBrowser/Data/Browser/profile.default" \
         "\$@"
     EOF


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
The `-no-remote` option prevents opening new tabs in an running
tor-browser session. E.g. executing `tor-browser https://example.com`
from the command line always starts a new session regardless of a
running instance

Please note, I have no clue what the original reason was to add the
option `-no-remote`. Maybe this has severe security implications, I
simply don't know.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
