### PR TITLE
pythonPackages.ndg-httpsclient: 0.4.2 -> 0.5.1

### DIFF
--- a/pkgs/development/python-modules/ndg-httpsclient/default.nix
+++ b/pkgs/development/python-modules/ndg-httpsclient/default.nix
@@ -5,7 +5,7 @@
 }:
 
 buildPythonPackage rec {
-  version = "0.4.2";
+  version = "0.5.1";
   pname = "ndg-httpsclient";
 
   propagatedBuildInputs = [ pyopenssl ];
@@ -14,7 +14,7 @@ buildPythonPackage rec {
     owner = "cedadev";
     repo = "ndg_httpsclient";
     rev = version;
-    sha256 = "1kk4knv029j0cicfiv23c1rayc1n3f1j3rhl0527gxiv0qv4jw8h";
+    sha256 = "0lhsgs4am4xyjssng5p0vkfwqncczj1dpa0vss4lrhzq86mnn5rz";
   };
 
   # uses networking


### PR DESCRIPTION
###### Motivation for this change
Noticed it was out of date.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
```
$ nix-shell -p nix-review --command "nix-review wip"
...
[13 built, 110 copied (141.7 MiB), 37.8 MiB DL]
19 package were build:
beets certbot mopidy-gmusic python27Packages.Quandl python27Packages.acme python27Packages.github3_py python27Packages.gmusicapi python27Packages.gpsoauth python27Packages.lektor python27Packages.ndg-httpsclient python37Packages.acme python37Packages.github3_py python37Packages.gmusicapi python37Packages.gplaycli python37Packages.gpsoauth python37Packages.lektor python37Packages.ndg-httpsclient searx simp_le
```

$ nix path-info -Sh /nix/store/688plz0xwdwwmb8srfwkbyy3q68sis32-python2.7-ndg-httpsclient-0.4.2
/nix/store/688plz0xwdwwmb8srfwkbyy3q68sis32-python2.7-ndg-httpsclient-0.4.2      102.7M

$ nix path-info -Sh ./result
/nix/store/7iwm6rmvzdygwpj4hsar6x14w813xrxm-python2.7-ndg-httpsclient-0.5.1      102.7M