### PR TITLE
bazel: 0.26.1 -> 0.27.0

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -100,10 +100,7 @@ let
   remote_java_tools = stdenv.mkDerivation {
     name = "remote_java_tools_${system}";
 
-    src = fetchurl {
-      url = "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v2.0/java_tools_javac11_${system}-v2.0.zip";
-      sha256 = "074d624fb34441df369afdfd454e75dba821d5d54932fcfee5ba598d17dc1b99";
-    };
+    src = srcDepsSet."java_tools_javac11_${system}-v2.0.zip";
 
     nativeBuildInputs = [ autoPatchelfHook unzip ];
     buildInputs = [ gcc-unwrapped ];

--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -2,7 +2,7 @@
 # this package (through the fixpoint glass)
 , bazel
 , lr, xe, zip, unzip, bash, writeCBin, coreutils
-, which, python, gawk, gnused, gnutar, gnugrep, gzip, findutils
+, which, gawk, gnused, gnutar, gnugrep, gzip, findutils
 # updater
 , python3, writeScript
 # Apple dependencies
@@ -292,8 +292,8 @@ stdenv.mkDerivation rec {
       # Substitute python's stub shebang to plain python path. (see TODO add pr URL)
       # See also `postFixup` where python is added to $out/nix-support
       substituteInPlace src/main/java/com/google/devtools/build/lib/bazel/rules/python/python_stub_template.txt\
-          --replace "/usr/bin/env python" "${python}/bin/python" \
-          --replace "NIX_STORE_PYTHON_PATH" "${python}/bin/python" \
+          --replace "/usr/bin/env python" "${python3}/bin/python" \
+          --replace "NIX_STORE_PYTHON_PATH" "${python3}/bin/python" \
 
       # md5sum is part of coreutils
       sed -i 's|/sbin/md5|md5sum|' \
@@ -374,15 +374,14 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     buildJdk
-    python3 # bazel build requires python3. However we still use python2 for most of the other tasks
-            # This will have to be refactored later.
+    python3
   ];
 
   # when a command can’t be found in a bazel build, you might also
   # need to add it to `defaultShellPath`.
   nativeBuildInputs = [
     zip
-    python
+    python3
     unzip
     makeWrapper
     which
@@ -491,7 +490,7 @@ stdenv.mkDerivation rec {
     echo "${customBash} ${defaultShellPath}" >> $out/nix-support/depends
     # The templates get tar’d up into a .jar,
     # so nix can’t detect python is needed in the runtime closure
-    echo "${python}" >> $out/nix-support/depends
+    echo "${python3}" >> $out/nix-support/depends
   '';
 
   dontStrip = true;

--- a/pkgs/development/tools/build-managers/bazel/src-deps.json
+++ b/pkgs/development/tools/build-managers/bazel/src-deps.json
@@ -23,11 +23,11 @@
             "https://github.com/bazelbuild/rules_sass/archive/8ccf4f1c351928b55d5dddf3672e3667f6978d60.tar.gz"
         ]
     },
-    "android_tools_pkg-0.2.tar.gz": {
-        "name": "android_tools_pkg-0.2.tar.gz",
-        "sha256": "04f85f2dd049e87805511e3babc5cea3f5e72332b1627e34f3a5461cc38e815f",
+    "android_tools_pkg-0.4.tar.gz": {
+        "name": "android_tools_pkg-0.4.tar.gz",
+        "sha256": "331e7706f2bcae8a68057d8ddd3e3f1574bca26c67c65802fc4a8ac6164fa912",
         "urls": [
-            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.2.tar.gz"
+            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.4.tar.gz"
         ]
     },
     "bazel_j2objc": {
@@ -134,25 +134,25 @@
             "https://github.com/bazelbuild/skydoc/archive/2d9566b21fbe405acf5f7bf77eda30df72a4744c.tar.gz"
         ]
     },
-    "java_tools_javac10_darwin-v3.2.zip": {
-        "name": "java_tools_javac10_darwin-v3.2.zip",
-        "sha256": "1437327179b4284f7082cee0bdc3328f040e62fc5cc59c32f6824b8c520e2b7b",
+    "java_tools_javac11_darwin-v2.0.zip": {
+        "name": "java_tools_javac11_darwin-v2.0.zip",
+        "sha256": "0ceb0c9ff91256fe33508306bc9cd9e188dcca38df78e70839d426bdaef67a38",
         "urls": [
-            "https://mirror.bazel.build/bazel_java_tools/releases/javac10/v3.2/java_tools_javac10_darwin-v3.2.zip"
+            "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v2.0/java_tools_javac11_darwin-v2.0.zip"
         ]
     },
-    "java_tools_javac10_linux-v3.2.zip": {
-        "name": "java_tools_javac10_linux-v3.2.zip",
-        "sha256": "b93e7c556b01815afb6c248aa73f06b7ec912805bde8898eedac1e20d08f2e67",
+    "java_tools_javac11_linux-v2.0.zip": {
+        "name": "java_tools_javac11_linux-v2.0.zip",
+        "sha256": "074d624fb34441df369afdfd454e75dba821d5d54932fcfee5ba598d17dc1b99",
         "urls": [
-            "https://mirror.bazel.build/bazel_java_tools/releases/javac10/v3.2/java_tools_javac10_linux-v3.2.zip"
+            "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v2.0/java_tools_javac11_linux-v2.0.zip"
         ]
     },
-    "java_tools_javac10_windows-v3.2.zip": {
-        "name": "java_tools_javac10_windows-v3.2.zip",
-        "sha256": "86d3cc7fa0dc91ccb8f78ae3af8440fe459177e22062043ee4b83d55e6b7dfb0",
+    "java_tools_javac11_windows-v2.0.zip": {
+        "name": "java_tools_javac11_windows-v2.0.zip",
+        "sha256": "2c3fc0ce7d30d60e26f4b8a36e2eadcf9e6a9d5a51b667d3d13b78db53b24251",
         "urls": [
-            "https://mirror.bazel.build/bazel_java_tools/releases/javac10/v3.2/java_tools_javac10_windows-v3.2.zip"
+            "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v2.0/java_tools_javac11_windows-v2.0.zip"
         ]
     },
     "java_tools_langtools_javac10": {
@@ -160,6 +160,13 @@
         "sha256": "e379c71e051eb83e3fc9a08c9b404712707d8920ffcf1e8fd59c844965f0b0dd",
         "urls": [
             "https://mirror.bazel.build/bazel_java_tools/jdk_langtools/langtools_jdk10.zip"
+        ]
+    },
+    "java_tools_langtools_javac11": {
+        "name": "java_tools_langtools_javac11",
+        "sha256": "128a63f39d3f828a761f6afcfe3c6115279336a72ea77f60d7b3acf1841c9acb",
+        "urls": [
+            "https://mirror.bazel.build/bazel_java_tools/jdk_langtools/langtools_jdk11.zip"
         ]
     },
     "java_tools_langtools_javac9": {


### PR DESCRIPTION
- Upgrade to bazel 0.27
- Fixs for newly introduced bin/bash hardcoded reference
- Bazel now references `remote_java_tools_xxx` which contains prebuilt
  binaries. We prefetch them, fix them, and force bazel to use the
  fixed repository.

It also closes #63096

###### Motivation for this change

Bazel upgrade and bug fixing.

Note: instead of fixing #63096 and upgrading to bazel in two separates commits, I've done everything in once. I think it reduce the pull request pressure.

There is no test which proves that I really fixed stuffs, but I'm now able to build rules_haskell with bazel 0.27, which was not possible due to #63096. See https://github.com/tweag/rules_haskell/issues/956

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
