### PR TITLE
pythonPackages.redis-py: init at 3.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1985,6 +1985,11 @@
     github = "gridaphobe";
     name = "Eric Seidel";
   };
+  BadDecisionsAlex = {
+    email = "Alex.Ameen.TX@gmail.com";
+    github = "BadDecisionsAlex";
+    name = "Alex Ameen";
+  };
   guibert = {
     email = "david.guibert@gmail.com";
     github = "dguibert";
@@ -3015,11 +3020,6 @@
     email = "Marc.Fontaine@gmx.de";
     github = "MarcFontaine";
     name = "Marc Fontaine";
-  };
-  magenbluten = {
-    email = "magenbluten@codemonkey.cc";
-    github = "magenbluten";
-    name = "magenbluten";
   };
   magnetophon = {
     email = "bart@magnetophon.nl";

--- a/pkgs/development/python-modules/redis-py/default.nix
+++ b/pkgs/development/python-modules/redis-py/default.nix
@@ -26,6 +26,7 @@ buildPythonPackage rec {
     description = "Python client for Redis key-value store";
     homepage = "https://pypi.python.org/pypi/redis/";
     license = licenses.mit;
+    maintainers = with maintainers; [ BadDecisionsAlex ];
   };
 
 }

--- a/pkgs/development/python-modules/redis-py/default.nix
+++ b/pkgs/development/python-modules/redis-py/default.nix
@@ -1,0 +1,31 @@
+{ stdenv
+, fetchPypi
+, buildPythonPackage
+}:
+
+buildPythonPackage rec {
+
+  pname = "redis-py";
+  version = "3.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "7ba8612bbfd966dea8c62322543fed0095da2834dbd5a7c124afbc617a156aa7";
+  };
+
+  # Tests require a running redis
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    # Note: this is ALMOST identical to the existing 'pythonPackages.redis'
+    #       package; except that the module name was modified to accomodate
+    #       other modules which use this alternative name. I believe that the
+    #       rationale on the part of other developers was that 'redis' was an
+    #       innapropriate name because it does not properly distinguish itself
+    #       from the actual 'redis' executable.
+    description = "Python client for Redis key-value store";
+    homepage = "https://pypi.python.org/pypi/redis/";
+    license = licenses.mit;
+  };
+
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4268,6 +4268,8 @@ in {
 
   redis = callPackage ../development/python-modules/redis { };
 
+  redis-py = callPackages ../development/python-modules/redis-py { };
+
   rednose = callPackage ../development/python-modules/rednose { };
 
   reikna = callPackage ../development/python-modules/reikna { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Required for a project.
This is a nearly identical copy of `pythonPackages.redis` which uses a different module name "redis-py". There seems to have been disagreement among users of the module, some of whom believed that the name "redis" did not properly distinguish itself from the actual application "redis". In any case other modules that I required need the module to use "redis-py" as it's name.

###### Things done

A copy of 'pythonPackages.redis' was made and renamed. The proper license was also added.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
