### PR TITLE
pythonPackages.channels_redis: init at 2.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1985,6 +1985,11 @@
     github = "gridaphobe";
     name = "Eric Seidel";
   };
+  BadDecisionsAlex = {
+    email = "Alex.Ameen.TX@gmail.com";
+    github = "BadDecisionsAlex";
+    name = "Alex Ameen";
+  };
   guibert = {
     email = "david.guibert@gmail.com";
     github = "dguibert";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1985,6 +1985,11 @@
     github = "gridaphobe";
     name = "Eric Seidel";
   };
+  BadDecisionsAlex = {
+    email = "Alex.Ameen.TX@gmail.com";
+    github = "BadDecisionsAlex";
+    name = "Alex Ameen";
+  };
   guibert = {
     email = "david.guibert@gmail.com";
     github = "dguibert";
@@ -3015,6 +3020,11 @@
     email = "Marc.Fontaine@gmx.de";
     github = "MarcFontaine";
     name = "Marc Fontaine";
+  };
+  magenbluten = {
+    email = "magenbluten@codemonkey.cc";
+    github = "magenbluten";
+    name = "magenbluten";
   };
   magnetophon = {
     email = "bart@magnetophon.nl";

--- a/pkgs/development/python-modules/aioredis/default.nix
+++ b/pkgs/development/python-modules/aioredis/default.nix
@@ -1,4 +1,4 @@
-{ lib
+{ stdenv
 , fetchPypi
 , buildPythonPackage
 , hiredis-py, hiredis, async-timeout
@@ -23,10 +23,11 @@ buildPythonPackage rec {
   ];
   doCheck = false;
 
-  meta = with lib; {
+  meta = with stdenv.lib; {
     homepage = "http://github.com/django/channels_redis";
     license = licenses.mit;
     description = "asyncio (PEP 3156) Redis client library.";
+    maintainers = [ BadDecisionsAlex ];
   };
 
 }

--- a/pkgs/development/python-modules/aioredis/default.nix
+++ b/pkgs/development/python-modules/aioredis/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+, hiredis-py, hiredis, async-timeout
+}:
+buildPythonPackage rec {
+
+  pname = "aioredis";
+  version = "1.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "84d62be729beb87118cf126c20b0e3f52d7a42bb7373dc5bcdd874f26f1f251a";
+  };
+
+  buildInputs = [
+    hiredis
+  ];
+
+  propagatedBuildInputs = [
+    hiredis-py
+    async-timeout
+  ];
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "http://github.com/django/channels_redis";
+    license = licenses.mit;
+    description = "asyncio (PEP 3156) Redis client library.";
+  };
+
+}

--- a/pkgs/development/python-modules/channels_redis/default.nix
+++ b/pkgs/development/python-modules/channels_redis/default.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, fetchPypi
+, buildPythonPackage
+, redis, msgpack, channels, aioredis
+}:
+buildPythonPackage rec {
+
+  pname = "channels_redis";
+  version = "2.4.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "b7ccbcb2fd4e568c08c147891b26db59aa25d88b65af826ce7f70c815cfb91bc";
+  };
+
+  propagatedBuildInputs = [
+    redis
+    aioredis
+    msgpack
+    channels
+  ];
+
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = "http://github.com/django/channels_redis";
+    license = licenses.bsdOriginal;
+    description = "A Django Channels channel layer that uses Redis as its backing store";
+    maintainers = with maintainers; [ BadDecisionsAlex ];
+  };
+
+}

--- a/pkgs/development/python-modules/hiredis-py/default.nix
+++ b/pkgs/development/python-modules/hiredis-py/default.nix
@@ -18,6 +18,7 @@ buildPythonPackage {
     homepage = "http://github.com/redis/hiredis-py";
     license = licenses.bsdOriginal;
     description = "Python extension that wraps protocol parsing code in hiredis. It primarily speeds up parsing of multi bulk replies.";
+    maintainers = with maintainers; [ BadDecisionsAlex ];
   };
 
 }

--- a/pkgs/development/python-modules/hiredis-py/default.nix
+++ b/pkgs/development/python-modules/hiredis-py/default.nix
@@ -1,0 +1,23 @@
+{ stdenv
+, fetchurl
+, buildPythonPackage
+}:
+buildPythonPackage {
+
+  pname = "hiredis-py";
+  version = "1.0.0";
+
+  src = fetchurl {
+    url = "https://files.pythonhosted.org/packages/9e/e0/c160dbdff032ffe68e4b3c576cba3db22d8ceffc9513ae63368296d1bcc8/hiredis-1.0.0.tar.gz";
+    sha256 = "e97c953f08729900a5e740f1760305434d62db9f281ac351108d6c4b5bf51795";
+  };
+
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = "http://github.com/redis/hiredis-py";
+    license = licenses.bsdOriginal;
+    description = "Python extension that wraps protocol parsing code in hiredis. It primarily speeds up parsing of multi bulk replies.";
+  };
+
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -177,6 +177,8 @@ in {
 
   aioamqp = callPackage ../development/python-modules/aioamqp { };
 
+  aioredis = callPackage ../development/python-modules/aioredis { };
+
   ansicolor = callPackage ../development/python-modules/ansicolor { };
 
   anytree = callPackage ../development/python-modules/anytree {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1309,6 +1309,8 @@ in {
 
   channels = callPackage ../development/python-modules/channels {};
 
+  channels_redis = callPackage ../development/python-modules/channels_redis { };
+
   cheroot = callPackage ../development/python-modules/cheroot {};
 
   chevron = callPackage ../development/python-modules/chevron {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -480,6 +480,8 @@ in {
 
   helper = callPackage ../development/python-modules/helper { };
 
+  hiredis-py = callPackage ../development/python-modules/hiredis-py { };
+
   histbook = callPackage ../development/python-modules/histbook { };
 
   hdmedians = callPackage ../development/python-modules/hdmedians { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Required for project.

###### Things done

Added "Channels Redis" python module.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
