### PR TITLE
NixOS config option to disable networking entirely

### DIFF
--- a/nixos/modules/config/networking.nix
+++ b/nixos/modules/config/networking.nix
@@ -25,6 +25,16 @@ in
 
   options = {
 
+    networking.enable = mkOption {
+      type = types.bool;
+      default = true;
+      description =
+        ''
+          Whether to enable networking.  Disabling this option
+          also disables all services which require network access.
+        '';
+    };
+
     networking.hosts = lib.mkOption {
       type = types.attrsOf (types.listOf types.str);
       example = literalExample ''
@@ -150,7 +160,7 @@ in
     };
   };
 
-  config = {
+  config = mkIf cfg.enable {
 
     assertions = [{
       assertion = localhostMapped4;

--- a/nixos/modules/config/networking.nix
+++ b/nixos/modules/config/networking.nix
@@ -8,6 +8,12 @@ let
 
   cfg = config.networking;
 
+  upstreamNetworkUnits = [
+    "network.target"
+    "network-pre.target"
+    "network-online.target"
+  ];
+
   localhostMapped4 = cfg.hosts ? "127.0.0.1" && elem "localhost" cfg.hosts."127.0.0.1";
   localhostMapped6 = cfg.hosts ? "::1"       && elem "localhost" cfg.hosts."::1";
 
@@ -213,6 +219,10 @@ in
 
     # Install the proxy environment variables
     environment.sessionVariables = cfg.proxy.envVars;
+
+    systemd.additionalUpstreamSystemUnits = upstreamNetworkUnits;
+
+    systemd.targets.network-online.wantedBy = [ "multi-user.target" ];
 
   };
 

--- a/nixos/modules/services/networking/dnsmasq.nix
+++ b/nixos/modules/services/networking/dnsmasq.nix
@@ -123,7 +123,7 @@ in
           ProtectHome = true;
           Restart = if cfg.alwaysKeepRunning then "always" else "on-failure";
         };
-        restartTriggers = [ config.environment.etc.hosts.source ];
+        restartTriggers = optional ((config.environment.etc).hosts.enable or false) config.environment.etc.hosts.source;
     };
   };
 }

--- a/nixos/modules/services/system/nscd.nix
+++ b/nixos/modules/services/system/nscd.nix
@@ -59,10 +59,9 @@ in
           '';
 
         restartTriggers = [
-          config.environment.etc.hosts.source
           config.environment.etc."nsswitch.conf".source
           config.environment.etc."nscd.conf".source
-        ];
+        ] ++ optional ((config.environment.etc).hosts.enable or false) config.environment.etc.hosts.source;
 
         serviceConfig =
           { ExecStart = "@${pkgs.glibc.bin}/sbin/nscd nscd";

--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -834,7 +834,7 @@ in
 
   };
 
-  config = mkIf config.systemd.network.enable {
+  config = mkIf (config.networking.enable && config.systemd.network.enable) {
 
     systemd.additionalUpstreamSystemUnits = [
       "systemd-networkd.service" "systemd-networkd-wait-online.service"

--- a/nixos/modules/system/boot/resolved.nix
+++ b/nixos/modules/system/boot/resolved.nix
@@ -128,7 +128,7 @@ in
 
   };
 
-  config = mkIf cfg.enable {
+  config = mkIf (config.networking.enable && cfg.enable) {
 
     assertions = [
       { assertion = !config.networking.useHostResolvConf;

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -19,9 +19,6 @@ let
       "exit.target"
       "graphical.target"
       "multi-user.target"
-      "network.target"
-      "network-pre.target"
-      "network-online.target"
       "nss-lookup.target"
       "nss-user-lookup.target"
       "time-sync.target"
@@ -937,7 +934,6 @@ in
     systemd.services.systemd-journald.stopIfChanged = false;
     systemd.targets.local-fs.unitConfig.X-StopOnReconfiguration = true;
     systemd.targets.remote-fs.unitConfig.X-StopOnReconfiguration = true;
-    systemd.targets.network-online.wantedBy = [ "multi-user.target" ];
     systemd.services.systemd-binfmt.wants = [ "proc-sys-fs-binfmt_misc.mount" ];
 
     # Don't bother with certain units in containers.

--- a/nixos/modules/system/boot/timesyncd.nix
+++ b/nixos/modules/system/boot/timesyncd.nix
@@ -23,7 +23,7 @@ with lib;
     };
   };
 
-  config = mkIf config.services.timesyncd.enable {
+  config = mkIf (config.networking.enable && config.services.timesyncd.enable) {
 
     systemd.additionalUpstreamSystemUnits = [ "systemd-timesyncd.service" ];
 

--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -513,11 +513,11 @@ let
 in
 
 {
-  config = mkMerge [
+  config = mkIf cfg.enable (mkMerge [
     bondWarnings
     (mkIf (!cfg.useNetworkd) normalConfig)
     { # Ensure slave interfaces are brought up
       networking.interfaces = genAttrs slaves (i: {});
     }
-  ];
+  ]);
 }

--- a/nixos/modules/tasks/network-interfaces-systemd.nix
+++ b/nixos/modules/tasks/network-interfaces-systemd.nix
@@ -24,7 +24,7 @@ in
 
 {
 
-  config = mkIf cfg.useNetworkd {
+  config = mkIf (cfg.enable && cfg.useNetworkd) {
 
     assertions = [ {
       assertion = cfg.defaultGatewayWindowSize == null;

--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -1,7 +1,6 @@
 { config, options, lib, pkgs, utils, ... }:
 
 with lib;
-with utils;
 
 let
 
@@ -48,7 +47,7 @@ let
 
   # We must escape interfaces due to the systemd interpretation
   subsystemDevice = interface:
-    "sys-subsystem-net-devices-${escapeSystemdPath interface}.device";
+    "sys-subsystem-net-devices-${utils.escapeSystemdPath interface}.device";
 
   addrOpts = v:
     assert v == 4 || v == 6;

--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -920,7 +920,7 @@ in
 
   ###### implementation
 
-  config = {
+  config = mkIf cfg.enable {
 
     warnings = concatMap (i: i.warnings) interfaces;
 


### PR DESCRIPTION
###### Motivation for this change

I've had some success at building single-purpose read-only root filesystem images by heavily customizing NixOS configuration options and package overrides. (I'd like to see NixOS supplant Yocto :smiling_imp:)

But one of the things I couldn't disable was support for networking. I could turn off most individual services, like a DHCP client, but there was still some core stuff wasting space and boot time in my images. Most NixOS users will leave networking enabled, but for specialized applications it's really helpful to just turn it off entirely.

###### Things done

Even after reading [the manual](https://nixos.org/nixos/manual/index.html#sec-running-nixos-tests-interactively) I don't understand how to run the tests. I ran:

```
nix-build tests/networking.nix --arg networkd true
```

I don't know what it would look like if it failed, but I got 12 `result*` symlinks at the end, and spot-checking logs looks okay I guess?

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
