### PR TITLE
pythonPackages.msrestazure: 0.6.0 -> 0.6.1

### DIFF
--- a/pkgs/development/python-modules/msrest/default.nix
+++ b/pkgs/development/python-modules/msrest/default.nix
@@ -1,6 +1,6 @@
 { lib
 , buildPythonPackage
-, fetchFromGitHub
+, fetchPypi
 , isPy3k
 , requests
 , requests_oauthlib
@@ -18,16 +18,12 @@
 }:
 
 buildPythonPackage rec {
-  version = "0.6.4";
+  version = "0.6.7";
   pname = "msrest";
 
-  # no tests in PyPI tarball
-  # see https://github.com/Azure/msrest-for-python/pull/152
-  src = fetchFromGitHub {
-    owner = "Azure";
-    repo = "msrest-for-python";
-    rev = "v${version}";
-    sha256 = "0ilrc06qq0dw4qqzq1dq2vs6nymc39h19w52dwcyawwfalalnjzi";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "07136g3j7zgcvkxki4v6q1p2dm1nzzc28181s8dwic0y4ml8qlq5";
   };
 
   propagatedBuildInputs = [
@@ -48,6 +44,6 @@ buildPythonPackage rec {
     description = "The runtime library 'msrest' for AutoRest generated Python clients.";
     homepage = "https://azure.microsoft.com/en-us/develop/python/";
     license = licenses.mit;
-    maintainers = with maintainers; [ bendlas ];
+    maintainers = with maintainers; [ bendlas jonringer ];
   };
 }

--- a/pkgs/development/python-modules/msrestazure/default.nix
+++ b/pkgs/development/python-modules/msrestazure/default.nix
@@ -1,25 +1,42 @@
 { pkgs
+, lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
+, isPy3k
 , adal
 , msrest
+, mock
+, httpretty
+, pytest
+, pytest-asyncio
 }:
 
 buildPythonPackage rec {
-  version = "0.6.0";
+  version = "0.6.1";
   pname = "msrestazure";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "06s04f6nng4na2663kc12a3skiaqb631nscjfwpsrx4lzkf8bccr";
+  # Pypi tarball doesnt include tests
+  # see https://github.com/Azure/msrestazure-for-python/pull/133
+  src = fetchFromGitHub {
+    owner = "Azure";
+    repo = "msrestazure-for-python";
+    rev = "v${version}";
+    sha256 = "09swndz57131b8x57mzibnsr1sv0l80pk62p89q99gsd6mvc389c";
   };
 
   propagatedBuildInputs = [ adal msrest ];
+
+  checkInputs = [ httpretty mock pytest ]
+                ++ lib.optional isPy3k [ pytest-asyncio ];
+
+  checkPhase = ''
+    pytest tests/
+  '';
 
   meta = with pkgs.lib; {
     description = "The runtime library 'msrestazure' for AutoRest generated Python clients.";
     homepage = "https://azure.microsoft.com/en-us/develop/python/";
     license = licenses.mit;
-    maintainers = with maintainers; [ bendlas ];
+    maintainers = with maintainers; [ bendlas jonringer ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Noticed it was out of date

Added myself as a maintainer because my day job is working on AzureML now, so I have a reason to keep this up to date. (This package is fundamental to `azure-sdk` and `azure-cli`)

Both packages now run tests. (msrestazure was just collecting `0 tests` before)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
```
$ nix-shell -p nix-review --command "nix-review wip"
...
[17 built, 0.0 MiB DL]
15 package were build:
nixops_1_6_1 python27Packages.azure-mgmt-common python27Packages.azure-mgmt-compute python27Packages.azure-mgmt-network python27Packages.azure-mgmt-resource python27Packages.azure-mgmt-storage python27Packages.msrest python27Packages.msrestazure python37Packages.azure-mgmt-common python37Packages.azure-mgmt-compute python37Packages.azure-mgmt-network python37Packages.azure-mgmt-resource python37Packages.azure-mgmt-storage python37Packages.msrest python37Packages.msrestazure
```

```
$ nix path-info -Sh ./result
/nix/store/xxk7gbny0dh67av8lv3hc6jrh41kngrl-python3.7-msrest-0.6.7       113.1M
```
```
$ nix path-info -Sh ./result
/nix/store/bnczfr25ysqibway86qj6v8gdpf0yx46-python3.6-msrestazure-0.6.1  113.3M
```