### PR TITLE
pythonPackages.{hiredis,aioredis,channels_redis,django-crispy-forms,django-filter}: init; Added baddecisionsalex to maintainers.

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -567,6 +567,11 @@
     github = "backuitist";
     name = "Bruno Bieth";
   };
+  BadDecisionsAlex = {
+    email = "Alex.Ameen.TX@gmail.com";
+    github = "BadDecisionsAlex";
+    name = "Alex Ameen";
+  };
   badi = {
     email = "abdulwahidc@gmail.com";
     github = "badi";

--- a/pkgs/development/python-modules/aioredis/default.nix
+++ b/pkgs/development/python-modules/aioredis/default.nix
@@ -1,0 +1,31 @@
+{ stdenv
+, fetchPypi
+, buildPythonPackage
+, hiredis, async-timeout
+}:
+buildPythonPackage rec {
+
+  pname = "aioredis";
+  version = "1.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "84d62be729beb87118cf126c20b0e3f52d7a42bb7373dc5bcdd874f26f1f251a";
+  };
+
+  propagatedBuildInputs = [
+    hiredis
+    async-timeout
+  ];
+
+  # Tests rely on the presence of a redis server.
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = "http://github.com/django/channels_redis";
+    license = licenses.mit;
+    description = "asyncio (PEP 3156) Redis client library.";
+    maintainers = with maintainers; [ BadDecisionsAlex ];
+  };
+
+}

--- a/pkgs/development/python-modules/channels_redis/default.nix
+++ b/pkgs/development/python-modules/channels_redis/default.nix
@@ -1,0 +1,41 @@
+{ stdenv
+, fetchFromGitHub
+, buildPythonPackage
+, redis, msgpack, channels, aioredis, async_generator, pytest
+}:
+buildPythonPackage rec {
+
+  pname = "channels_redis";
+  version = "2.4.0";
+
+  src = fetchFromGitHub {
+    owner = "django";
+    repo = pname;
+    rev = version;
+    sha256 = "05niaqjv790mnrvca26kbnvb50fgnk2zh0k4np60cn6ilp4nl0kc";
+  };
+
+
+  propagatedBuildInputs = [
+    redis
+    aioredis
+    msgpack
+    channels
+  ];
+
+  checkInputs = [ pytest async_generator ];
+  checkPhase = ''
+    # Ensure tests are running against installed packages.
+    mv channels_redis channels_redis.hidden
+    # test_double_receive expects a redis server running.
+    pytest tests/ -k "not test_double_receive"
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "http://github.com/django/channels_redis";
+    license = licenses.bsdOriginal;
+    description = "A Django Channels channel layer that uses Redis as its backing store";
+    maintainers = with maintainers; [ BadDecisionsAlex ];
+  };
+
+}

--- a/pkgs/development/python-modules/django-crispy-forms/default.nix
+++ b/pkgs/development/python-modules/django-crispy-forms/default.nix
@@ -1,0 +1,26 @@
+{ stdenv
+, fetchPypi
+, buildPythonPackage
+}:
+buildPythonPackage rec {
+
+  pname = "django-crispy-forms";
+  version = "1.7.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "5952bab971110d0b86c278132dae0aa095beee8f723e625c3d3fa28888f1675f";
+  };
+
+  # Checks are designed to be run by module's authors not users. Requires
+  # extensive setup of django server.
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = "http://github.com/maraujop/django-crispy-forms";
+    license = licenses.mit;
+    description = "Best way to have Django DRY forms";
+    maintainers = with maintainers; [ BadDecisionsAlex ];
+  };
+
+}

--- a/pkgs/development/python-modules/django-filter/default.nix
+++ b/pkgs/development/python-modules/django-filter/default.nix
@@ -1,0 +1,42 @@
+{ stdenv
+, fetchPypi, fetchpatch
+, buildPythonPackage, pythonOlder
+, django, python, django-crispy-forms, mock, djangorestframework
+}:
+buildPythonPackage rec {
+
+  pname = "django-filter";
+  version = "2.1.0";
+
+  disabled = pythonOlder "3.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "3dafb7d2810790498895c22a1f31b2375795910680ac9c1432821cbedb1e176d";
+  };
+
+  # Big thanks to `risicle` for helping out with this patch!
+  patches = [ (fetchpatch {
+    name = "fix-dst-test.patch";
+    url = https://github.com/carltongibson/django-filter/pull/1058/commits/9c0b06610dbd5b69a006ae121d383ef49cc70fff.patch;
+    sha256 = "0rrbqxjcwwkcldxi1q38cf2wcl9rgk7yyyc6rxwswi45r9sxihgb";
+  }) ];
+
+  propagatedBuildInputs = [ django ];
+  
+  checkInputs = [
+    djangorestframework
+    mock
+    django-crispy-forms
+  ];
+
+  checkPhase = "${python.interpreter} runtests.py";
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/carltongibson/django-filter/tree/master";
+    license = licenses.bsdOriginal;
+    description = "Django-filter is a reusable Django application for allowing users to filter querysets dynamically.";
+    maintainers = with maintainers; [ BadDecisionsAlex ];
+  };
+
+}

--- a/pkgs/development/python-modules/hiredis/default.nix
+++ b/pkgs/development/python-modules/hiredis/default.nix
@@ -1,0 +1,25 @@
+{ stdenv
+, fetchPypi
+, buildPythonPackage
+, python
+}:
+buildPythonPackage rec {
+
+  pname = "hiredis";
+  version = "1.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "e97c953f08729900a5e740f1760305434d62db9f281ac351108d6c4b5bf51795";
+  };
+  
+  checkPhase = "${python.interpreter} test.py";
+
+  meta = with stdenv.lib; {
+    homepage = "http://github.com/redis/hiredis-py";
+    license = licenses.bsdOriginal;
+    description = "Python extension that wraps protocol parsing code in hiredis. It primarily speeds up parsing of multi bulk replies.";
+    maintainers = with maintainers; [ BadDecisionsAlex ];
+  };
+
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -177,6 +177,8 @@ in {
 
   aioamqp = callPackage ../development/python-modules/aioamqp { };
 
+  aioredis = callPackage ../development/python-modules/aioredis { };
+
   ansicolor = callPackage ../development/python-modules/ansicolor { };
 
   anytree = callPackage ../development/python-modules/anytree {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1311,6 +1311,8 @@ in {
 
   channels = callPackage ../development/python-modules/channels {};
 
+  channels_redis = callPackage ../development/python-modules/channels_redis { };
+
   cheroot = callPackage ../development/python-modules/cheroot {};
 
   chevron = callPackage ../development/python-modules/chevron {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2545,6 +2545,8 @@ in {
 
   django-cors-headers = callPackage ../development/python-modules/django-cors-headers { };
 
+  django-crispy-forms = callPackage ../development/python-modules/django-crispy-forms { };
+
   django-discover-runner = callPackage ../development/python-modules/django-discover-runner { };
 
   django_environ = callPackage ../development/python-modules/django_environ { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -482,6 +482,8 @@ in {
 
   histbook = callPackage ../development/python-modules/histbook { };
 
+  hiredis = callPackage ../development/python-modules/hiredis { };
+
   hdmedians = callPackage ../development/python-modules/hdmedians { };
 
   holoviews = callPackage ../development/python-modules/holoviews { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2555,6 +2555,8 @@ in {
 
   django_extensions = callPackage ../development/python-modules/django-extensions { };
 
+  django-filter = callPackage ../development/python-modules/django-filter { };
+
   django-gravatar2 = callPackage ../development/python-modules/django-gravatar2 { };
 
   django_guardian = callPackage ../development/python-modules/django_guardian { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Required packages for a project at work.

###### Things done

* adding BadDecisionsAlex to maintainer's list.
* pythonPackages.django-filter: init at 2.1.0
* pythonPackages.django-crispy-forms: init at 1.7.2
* pythonPackages.channels_redis: init at 2.4.0
* pythonPackages.aioredis: init at 1.2.0
* pythonPackages.hiredis: init at 1.0.0

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
