### PR TITLE
gitkraken: 5.0.4 -> 6.0.0

### DIFF
--- a/pkgs/applications/version-management/gitkraken/default.nix
+++ b/pkgs/applications/version-management/gitkraken/default.nix
@@ -2,7 +2,7 @@
 , libXfixes, atk, gtk3, libXrender, pango, gnome2, gnome3, cairo, freetype, fontconfig
 , libX11, libXi, libxcb, libXext, libXcursor, glib, libXScrnSaver, libxkbfile, libXtst
 , nss, nspr, cups, fetchurl, expat, gdk_pixbuf, libXdamage, libXrandr, dbus
-, dpkg, makeDesktopItem, openssl, wrapGAppsHook, hicolor-icon-theme, at_spi2_atk, libuuid
+, dpkg, makeDesktopItem, openssl, wrapGAppsHook, hicolor-icon-theme, at-spi2-atk, libuuid
 }:
 
 with stdenv.lib;
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
     gnome2.GConf
     libgnome-keyring
     openssl
-    at_spi2_atk
+    at-spi2-atk
     libuuid
   ];
 

--- a/pkgs/applications/version-management/gitkraken/default.nix
+++ b/pkgs/applications/version-management/gitkraken/default.nix
@@ -2,7 +2,7 @@
 , libXfixes, atk, gtk3, libXrender, pango, gnome2, gnome3, cairo, freetype, fontconfig
 , libX11, libXi, libxcb, libXext, libXcursor, glib, libXScrnSaver, libxkbfile, libXtst
 , nss, nspr, cups, fetchurl, expat, gdk_pixbuf, libXdamage, libXrandr, dbus
-, dpkg, makeDesktopItem, openssl, wrapGAppsHook, hicolor-icon-theme
+, dpkg, makeDesktopItem, openssl, wrapGAppsHook, hicolor-icon-theme, at_spi2_atk, libuuid
 }:
 
 with stdenv.lib;
@@ -12,11 +12,11 @@ let
 in
 stdenv.mkDerivation rec {
   name = "gitkraken-${version}";
-  version = "5.0.4";
+  version = "6.0.0";
 
   src = fetchurl {
     url = "https://release.axocdn.com/linux/GitKraken-v${version}.deb";
-    sha256 = "1fq0w8djkcx5jr2pw6izlq5rkwbq3r3f15xr3dmmbz6gjvi3nra0";
+    sha256 = "1ykjdnzl34pqr6dhfnswix44i412c7gcba1pk95a8670wmc29a1f";
   };
 
   libPath = makeLibraryPath [
@@ -53,6 +53,8 @@ stdenv.mkDerivation rec {
     gnome2.GConf
     libgnome-keyring
     openssl
+    at_spi2_atk
+    libuuid
   ];
 
   desktopItem = makeDesktopItem {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
- A new major release for GitKraken is now available

###### Things done
- Bump GitKraken to 6.0.0
- Add new dependency on libuuid (libuuid.so.1) 
- Add new dependency on at_spi2_atk (libatk-bridge-2.0.so.0)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Closure size is slightly larger now
```
$ nix path-info -S /nix/store/b566xa8w0apraw2v826jd6c9sv3h2kxi-gitkraken-5.0.4
/nix/store/b566xa8w0apraw2v826jd6c9sv3h2kxi-gitkraken-5.0.4       706752728

$ nix path-info -S /nix/store/56j0aq1wqf86sv21jr4xhmsxrr1wha8a-gitkraken-6.0.0
/nix/store/56j0aq1wqf86sv21jr4xhmsxrr1wha8a-gitkraken-6.0.0       929702928
```

