### PR TITLE
lib/modules: add mkUnset, mkOverrideUnset

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -106,10 +106,10 @@ let
       pushDownProperties dischargeProperties filterOverrides
       sortProperties fixupOptionType mkIf mkAssert mkMerge mkOverride
       mkOptionDefault mkDefault mkForce mkVMOverride mkStrict
-      mkFixStrictness mkOrder mkBefore mkAfter mkAliasDefinitions
-      mkAliasAndWrapDefinitions fixMergeModules mkRemovedOptionModule
-      mkRenamedOptionModule mkMergedOptionModule mkChangedOptionModule
-      mkAliasOptionModule doRename filterModules;
+      mkFixStrictness mkOverrideUnset mkUnset mkOrder mkBefore mkAfter
+      mkAliasDefinitions mkAliasAndWrapDefinitions fixMergeModules
+      mkRemovedOptionModule mkRenamedOptionModule mkMergedOptionModule
+      mkChangedOptionModule mkAliasOptionModule doRename filterModules;
     inherit (options) isOption mkEnableOption mkSinkUndeclaredOptions
       mergeDefaultOption mergeOneOption mergeEqualOption getValues
       getFiles optionAttrSetToDocList optionAttrSetToDocList'

--- a/lib/tests/modules/declare-attrs.nix
+++ b/lib/tests/modules/declare-attrs.nix
@@ -1,0 +1,23 @@
+{ config, lib, ... }:
+
+{
+  options = {
+    attrs = lib.mkOption {
+      type = lib.types.attrsOf lib.types.int;
+    };
+
+    names = lib.mkOption {
+      type = lib.types.str;
+    };
+
+    values = lib.mkOption {
+      type = lib.types.str;
+    };
+  };
+
+  config = {
+    attrs = { alpha = 1; bravo = 2; charlie = 3; };
+    names = toString (lib.attrNames config.attrs);
+    values = toString (lib.attrValues config.attrs);
+  };
+}

--- a/lib/tests/modules/define-attrs-bravo-force.nix
+++ b/lib/tests/modules/define-attrs-bravo-force.nix
@@ -1,0 +1,5 @@
+{ lib, ... }:
+
+{
+  attrs.bravo = lib.mkForce 29;
+}

--- a/lib/tests/modules/define-attrs-bravo-override.nix
+++ b/lib/tests/modules/define-attrs-bravo-override.nix
@@ -1,0 +1,5 @@
+{ lib, ... }:
+
+{
+  attrs.bravo = lib.mkOverride 10 29;
+}

--- a/lib/tests/modules/define-attrs-bravo-overrideUnset.nix
+++ b/lib/tests/modules/define-attrs-bravo-overrideUnset.nix
@@ -1,0 +1,5 @@
+{ lib, ... }:
+
+{
+  attrs.bravo = lib.mkOverrideUnset 10;
+}

--- a/lib/tests/modules/unset-attrs-bravo.nix
+++ b/lib/tests/modules/unset-attrs-bravo.nix
@@ -1,0 +1,5 @@
+{ lib, ... }:
+
+{
+  attrs.bravo = lib.mkUnset;
+}

--- a/nixos/doc/manual/development/option-def.xml
+++ b/nixos/doc/manual/development/option-def.xml
@@ -74,6 +74,15 @@ services.openssh.enable = mkOverride 10 false;
    discarded. The function <varname>mkForce</varname> is equal to
    <varname>mkOverride 50</varname>.
   </para>
+  <para>
+   The function <varname>mkOverrideUnset</varname> can be used instead to
+   remove an attribute that was defined in another module. It also takes a
+   priority, but no replacement value. For convenience,
+   <varname>mkUnset</varname> is equal to <varname>mkOverrideUnset 50</varname>.
+   Note that attempting to unset an attribute with the same priority as a
+   definition for that attribute is an error (unless they are both overridden by
+   a definition with a lower priority).
+  </para>
  </simplesect>
 
  <simplesect xml:id="sec-option-definitions-merging">

--- a/nixos/doc/manual/release-notes/rl-1909.xml
+++ b/nixos/doc/manual/release-notes/rl-1909.xml
@@ -375,6 +375,11 @@
      installer after creating <literal>/var/lib/nextcloud</literal>.
     </para>
    </listitem>
+   <listitem>
+    <para>
+     The <varname>mkOverrideUnset</varname> function and <varname>mkUnset</varname> constant have been added to <varname>lib</varname>.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 </section>


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Using only `mkForce`/`mkOverride`, a module or configuration has no way
of removing an attribute specified elsewhere; the best you could do is
to replace that attribute with a null, empty set, or similar. This may
result in undesired behavior, if a module implementation takes some
action for every attribute in a set, for example.

`mkOverrideUnset` is a function intended to be used like `mkOverride`: a
`config.some.attribute.path = lib.mkOverrideUnset p` means that, if `p`
is the winning priority among all definitions of `some.attribute.path`,
then `some.attribute.path` will not exist at all in the final
configuration values.

`mkUnset` is a shorthand for `mkOverrideUnset 50`, analogous to
`mkForce`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).