### PR TITLE
keybase: add git-remote-keybase to build

### DIFF
--- a/pkgs/tools/security/keybase/default.nix
+++ b/pkgs/tools/security/keybase/default.nix
@@ -8,7 +8,7 @@ buildGoPackage rec {
   version = "4.0.0";
 
   goPackagePath = "github.com/keybase/client";
-  subPackages = [ "go/keybase" ];
+  subPackages = [ "go/keybase" "go/kbfs/kbfsgit/git-remote-keybase" ];
 
   dontRenameImports = true;
 


### PR DESCRIPTION
###### Motivation for this change

The base package of `keybase` provides just the `keybase` binary. Keybase also provides a [git remote helper](https://git-scm.com/docs/git-remote-helpers) binary under [`go/kbfs/kbfsgit/git-remote-keybase`](https://github.com/keybase/client/tree/master/go/kbfs/kbfsgit/git-remote-keybase) that allows users to clone encrypted repositories using the `keybase://...` scheme. 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

```
$ nix-build -A keybase
$ /nix/store/wzbhqizqizn6riink0nk6brlhfiys92z-keybase-4.0.0-bin/bin/git-remote-keybase
Usage:
  git-remote-keybase -version

To run against remote KBFS servers:
  git-remote-keybase     [-debug]
    [-bserver=host:port] [-mdserver=host:port]
    [-log-to-file] [-log-file=path/to/file] [-clean-bcache-cap=0] <remote> [keybase://<repo>]
[...snip...]
$ nix-env -f . -iA keybase
installing 'keybase-4.0.0'
building '/nix/store/bx1bwr3qb4fqvpbk3kmz7w0sx0hk4a6i-user-environment.drv'...
created 5 symlinks in user environment
$ git clone keybase://team/[snip]
Cloning into 'gatewayV2'...
Initializing Keybase... done.
Syncing with Keybase... done.
Counting: 1.79 MB... done.
Cryptographic cloning: (100.00%) 1.79/1.79 MB... done.