### PR TITLE
kops: 1.11.1->1.12.1

### DIFF
--- a/pkgs/applications/networking/cluster/kops/default.nix
+++ b/pkgs/applications/networking/cluster/kops/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "kops-${version}";
-  version = "1.11.1";
+  version = "1.12.1";
 
   goPackagePath = "k8s.io/kops";
 
@@ -10,7 +10,7 @@ buildGoPackage rec {
     rev = version;
     owner = "kubernetes";
     repo = "kops";
-    sha256 = "0jia8dhawh786grnbpn64hvsdm6wz5p7hqir01q5xxpd1psnzygj";
+    sha256 = "09rmgazdrmnh1lqaayzfbn0ld7mbj9whihs9ijv5gf6si9p0ml9y";
   };
 
   buildInputs = [go-bindata];


### PR DESCRIPTION
###### Motivation for this change
Package update: https://github.com/kubernetes/kops/releases/tag/1.12.1

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Side note: it would be helpful to have more explicit instructions for how to test. I tried some stuff with `nix-build` before giving up and submitting this without testing.
