### PR TITLE
luaPackages.luaexpat: Downgrade to fix prosody issue and match typical distros

### DIFF
--- a/maintainers/scripts/luarocks-packages.csv
+++ b/maintainers/scripts/luarocks-packages.csv
@@ -40,7 +40,7 @@ luadbi-mysql,,,,,
 luadbi-postgresql,,,,,
 luadbi-sqlite3,,,,,
 luaevent,,,,,
-luaexpat,,,,,flosse
+luaexpat,,,1.3.0-1,,arobyn flosse
 luaffi,,http://luarocks.org/dev,,,
 luafilesystem,,,1.7.0-2,,flosse vcunat
 luaossl,,,,lua5_1,vcunat

--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -867,19 +867,19 @@ luaevent = buildLuarocksPackage {
 };
 luaexpat = buildLuarocksPackage {
   pname = "luaexpat";
-  version = "1.3.3-1";
+  version = "1.3.0-1";
 
   src = fetchurl {
-    url    = https://luarocks.org/luaexpat-1.3.3-1.src.rock;
-    sha256 = "0ahpfnby9qqgj22bajmrqvqq70nx19388lmjm9chljfzszy0hndm";
+    url    = https://luarocks.org/luaexpat-1.3.0-1.src.rock;
+    sha256 = "15jqz5q12i9zvjyagzwz2lrpzya64mih8v1hxwr0wl2gsjh86y5a";
   };
-  disabled = (luaOlder "5.0");
+  disabled = (luaOlder "5.1");
   propagatedBuildInputs = [ lua ];
 
   meta = with stdenv.lib; {
     homepage = "http://www.keplerproject.org/luaexpat/";
     description = "XML Expat parsing";
-    maintainers = with maintainers; [ flosse ];
+    maintainers = with maintainers; [ arobyn flosse ];
     license = {
       fullName = "MIT/X11";
     };


### PR DESCRIPTION
###### Motivation for this change
Matches version used on most distros. Fixes an issue with prosody. Detailed reasoning behind this can be found [here](https://github.com/NixOS/nixpkgs/pull/63108#issuecomment-504015507). As mentioned there, I'm tracking the prosody issue for it, so if some suitable resolution arises there I'll PR an update and remove the version specifier in `luarocks-packages.csv`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
