### PR TITLE
luaPackages.bit32: Tiny patch to fix a LuaJIT-incompatible declaration

### DIFF
--- a/pkgs/development/lua-modules/bit32.patch
+++ b/pkgs/development/lua-modules/bit32.patch
@@ -1,0 +1,14 @@
+diff -Naur lua-compat-5.2/c-api/compat-5.2.h lua-compat-5.2-patched/c-api/compat-5.2.h
+--- lua-compat-5.2/c-api/compat-5.2.h	2015-02-19 09:23:42.000000000 +1100
++++ lua-compat-5.2-patched/c-api/compat-5.2.h	2019-06-17 17:58:13.585361793 +1000
+@@ -146,8 +146,10 @@
+ #define lua_pushglobaltable(L) \
+   lua_pushvalue(L, LUA_GLOBALSINDEX)
+ 
++#if !defined(luaL_newlib)
+ #define luaL_newlib(L, l) \
+   (lua_newtable((L)),luaL_setfuncs((L), (l), 0))
++#endif
+ 
+ void luaL_checkversion (lua_State *L);
+ 

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -6,10 +6,12 @@ with super;
   #### manual fixes for generated packages
   ##########################################3
   bit32 = super.bit32.override({
-    disabled = !isLua51;
-    # Theoretically works with luajit, but it does redefine at least one Lua
-    # 5.2 function that Luajit 2.1 provides, see:
-    # https://github.com/LuaJIT/LuaJIT/issues/325
+    # Small patch in order to no longer redefine a Lua 5.2 function that Luajit
+    # 2.1 also provides, see https://github.com/LuaJIT/LuaJIT/issues/325 for
+    # more
+    patches = [
+      ./bit32.patch
+    ];
   });
 
   busted = super.busted.override({


### PR DESCRIPTION
###### Motivation for this change
Makes it build cleanly against LuaJIT.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
