### PR TITLE
luajitPackages: Improve derivation names

### DIFF
--- a/pkgs/development/interpreters/lua-5/build-lua-package.nix
+++ b/pkgs/development/interpreters/lua-5/build-lua-package.nix
@@ -12,7 +12,9 @@ name ? "${attrs.pname}-${attrs.version}"
 , version
 
 # by default prefix `name` e.g. "lua5.2-${name}"
-, namePrefix ? "lua" + lua.luaversion + "-"
+, namePrefix ? if lua.pkgs.isLuaJIT
+               then lua.name + "-"
+               else "lua" + lua.luaversion + "-"
 
 # Dependencies for building the package
 , buildInputs ? []


### PR DESCRIPTION
###### Motivation for this change
`"lua" + lua.luaversion + "-"` resolves to `"lua51-"` for both Lua 5.1 and LuaJIT packages. With this, LuaJIT packages instead get `lua.name + "-"`, which currently resolves to `"luajit-2.1.0-beta3-"`. This makes it easy to distinguish the two package sets in store paths, etc.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
