### PR TITLE
openjfx11: init at 11.0.3+1

### DIFF
--- a/pkgs/development/compilers/openjdk/11.nix
+++ b/pkgs/development/compilers/openjdk/11.nix
@@ -4,6 +4,7 @@
 , libjpeg, giflib
 , setJavaClassPath
 , minimal ? false
+, enableJavaFX ? true, openjfx
 , enableGnome2 ? true, gtk3, gnome_vfs, glib, GConf
 }:
 
@@ -68,6 +69,7 @@ let
     ''
     + lib.optionalString (architecture == "amd64") " \"--with-jvm-features=zgc\""
     + lib.optionalString minimal " \"--enable-headless-only\""
+    + lib.optionalString (!minimal && enableJavaFX) " \"--with-import-modules=${openjfx}\""
     + ");"
     # https://bugzilla.redhat.com/show_bug.cgi?id=1306558
     # https://github.com/JetBrains/jdk8u/commit/eaa5e0711a43d64874111254d74893fa299d5716

--- a/pkgs/development/compilers/openjdk/openjfx/11.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/11.nix
@@ -1,0 +1,110 @@
+{ stdenv, fetchurl, writeText, openjdk, bootjdk, gradleGen, pkgconfig, perl, cmake, gperf
+, gtk2, gtk3, libXtst, libXxf86vm, glib, alsaLib, ffmpeg, python, ruby }:
+
+let
+  major = "11";
+  update = ".0.3";
+  build = "1";
+  repover = "${major}${update}+${build}";
+  gradle_ = (gradleGen.override {
+    jdk = bootjdk;
+  }).gradle_4_10;
+
+  makePackage = args: stdenv.mkDerivation ({
+    version = "${major}${update}-${repover}";
+
+    src = fetchurl {
+      url = "http://hg.openjdk.java.net/openjfx/${major}/rt/archive/${repover}.tar.gz";
+      sha256 = "1h7qsylr7rnwnbimqjyn3whszp9kv4h3gpicsrb3mradxc9yv194";
+    };
+
+    buildInputs = [ gtk2 gtk3 libXtst libXxf86vm glib alsaLib ffmpeg ];
+    nativeBuildInputs = [ gradle_ perl pkgconfig cmake gperf python ruby ];
+
+    dontUseCmakeConfigure = true;
+
+    config = writeText "gradle.properties" (''
+      CONF = Release
+      JDK_HOME = ${bootjdk}/lib/openjdk
+    '' + args.gradleProperties or "");
+
+    buildPhase = ''
+      runHook preBuild
+
+      export GRADLE_USER_HOME=$(mktemp -d)
+      ln -s $config gradle.properties
+      export NIX_CFLAGS_COMPILE="$(pkg-config --cflags glib-2.0) $NIX_CFLAGS_COMPILE"
+      gradle --no-daemon $gradleFlags sdk
+
+      runHook postBuild
+    '';
+  } // args);
+
+  # Fake build to pre-download deps into fixed-output derivation.
+  # We run nearly full build because I see no other way to download everything that's needed.
+  # Anyone who knows a better way?
+  deps = makePackage {
+    pname = "openjfx-deps";
+
+    # perl code mavenizes pathes (com.squareup.okio/okio/1.13.0/a9283170b7305c8d92d25aff02a6ab7e45d06cbe/okio-1.13.0.jar -> com/squareup/okio/okio/1.13.0/okio-1.13.0.jar)
+    installPhase = ''
+      find $GRADLE_USER_HOME -type f -regex '.*\.\(jar\|pom\)' \
+        | perl -pe 's#(.*/([^/]+)/([^/]+)/([^/]+)/[0-9a-f]{30,40}/([^/\s]+))$# ($x = $2) =~ tr|\.|/|; "install -Dm444 $1 \$out/$x/$3/$4/$5" #e' \
+        | sh
+      rm -rf $out/tmp
+    '';
+
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+    outputHash =
+      # Downloaded AWT jars differ by platform.
+      if stdenv.system == "x86_64-linux" then "0d4msxswdav1xsfkpr0qd3xgqkcbxzf47v1zdy5jmg5w4bs6a78a"
+      else if stdenv.system == "i686-linux" then "0mjlyf6jvbis7nrm5d394sjv4hjw6k3753hr1nwdxk8skwc3ry08"
+      else throw "Unsupported platform";
+  };
+
+in makePackage {
+  pname = "openjfx-modular-sdk";
+
+  gradleProperties = ''
+    COMPILE_MEDIA = true
+    COMPILE_WEBKIT = true
+  '';
+
+  preBuild = ''
+    swtJar="$(find ${deps} -name org.eclipse.swt\*.jar)"
+    substituteInPlace build.gradle \
+      --replace 'mavenCentral()' 'mavenLocal(); maven { url uri("${deps}") }' \
+      --replace 'name: SWT_FILE_NAME' "files('$swtJar')"
+  '';
+
+  installPhase = ''
+    cp -r build/modular-sdk $out
+  '';
+
+  stripDebugList = [ "." ];
+
+  postFixup = ''
+    # Remove references to bootstrap.
+    find "$out" -name \*.so | while read lib; do
+      new_refs="$(patchelf --print-rpath "$lib" | sed -E 's,:?${bootjdk}[^:]*,,')"
+      patchelf --set-rpath "$new_refs" "$lib"
+    done
+
+    # Test to make sure that we don't depend on the bootstrap
+    if grep -q -r '${bootjdk}' "$out"; then
+      echo "Extraneous references to ${bootjdk} detected" >&2
+      exit 1
+    fi
+  '';
+
+  passthru.deps = deps;
+
+  meta = with stdenv.lib; {
+    homepage = http://openjdk.java.net/projects/openjfx/;
+    license = openjdk.meta.license;
+    description = "The next-generation Java client toolkit.";
+    maintainers = with maintainers; [ abbradar ];
+    platforms = openjdk.meta.platforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7668,6 +7668,14 @@ in
 
   bootjdk = callPackage ../development/compilers/openjdk/bootstrap.nix { version = "10"; };
 
+  openjfx11 =
+    if stdenv.isDarwin then
+      null
+    else
+      callPackage ../development/compilers/openjdk/openjfx/11.nix {
+        openjdk = openjdk11;
+      };
+
   openjdk8 =
     if stdenv.isDarwin then
       callPackage ../development/compilers/openjdk/darwin/8.nix { }
@@ -7682,6 +7690,7 @@ in
       callPackage ../development/compilers/openjdk/darwin/11.nix { }
     else
       callPackage ../development/compilers/openjdk/11.nix {
+        openjfx = openjfx11;
         inherit (gnome2) GConf gnome_vfs;
       };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

JavaFX (modern Java GUI framework) support in our GUI OpenJDK build. This allows for running JavaFX applications on NixOS. I don't know if any way to split it from OpenJDK and install it separately (perhaps via a symlink farm) exists; this is a [documented way to integrate OpenJFX](https://wiki.openjdk.java.net/display/OpenJFX/Building+OpenJFX#BuildingOpenJFX-IntegrationwithOpenJDK).

Before:
```
/nix/store/wkd27f2vi5vfx6c8cb0gcjaaxmhcfk4v-openjdk-11.0.3-ga	 637.7M
```
After:
```
/nix/store/vm1hzj1gs67xb0rqxndjrwvhxqz4j03y-openjdk-11.0.3-ga	 859.2M
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

OpenJFX 8 is quite a bit different so it's subject to future work.