### PR TITLE
openssh: use ssh-keysign from PATH

### DIFF
--- a/pkgs/tools/networking/openssh/default.nix
+++ b/pkgs/tools/networking/openssh/default.nix
@@ -50,6 +50,8 @@ stdenv.mkDerivation rec {
         url = https://github.com/openssh/openssh-portable/commit/6010c0303a422a9c5fa8860c061bf7105eb7f8b2.patch;
         sha256 = "0q27i9ymr97yb628y44qi4m11hk5qikb1ji1vhvax8hp18lwskds";
       })
+
+      ./ssh-keysign.patch
     ]
     ++ optional withGssapiPatches (assert withKerberos; gssapiPatch);
 

--- a/pkgs/tools/networking/openssh/ssh-keysign.patch
+++ b/pkgs/tools/networking/openssh/ssh-keysign.patch
@@ -1,0 +1,29 @@
+diff --git a/pathnames.h b/pathnames.h
+index cb44caa4..354fdf05 100644
+--- a/pathnames.h
++++ b/pathnames.h
+@@ -124,7 +124,7 @@
+ 
+ /* Location of ssh-keysign for hostbased authentication */
+ #ifndef _PATH_SSH_KEY_SIGN
+-#define _PATH_SSH_KEY_SIGN		"/usr/libexec/ssh-keysign"
++#define _PATH_SSH_KEY_SIGN		"ssh-keysign"
+ #endif
+ 
+ /* Location of ssh-pkcs11-helper to support keys in tokens */
+diff --git a/sshconnect2.c b/sshconnect2.c
+index dffee90b..e9a86e59 100644
+--- a/sshconnect2.c
++++ b/sshconnect2.c
+@@ -1879,7 +1879,7 @@ ssh_keysign(struct ssh *ssh, struct sshkey *key, u_char **sigp, size_t *lenp,
+ 		closefrom(sock + 1);
+ 		debug3("%s: [child] pid=%ld, exec %s",
+ 		    __func__, (long)getpid(), _PATH_SSH_KEY_SIGN);
+-		execl(_PATH_SSH_KEY_SIGN, _PATH_SSH_KEY_SIGN, (char *)NULL);
++		execlp(_PATH_SSH_KEY_SIGN, _PATH_SSH_KEY_SIGN, (char *)NULL);
+ 		fatal("%s: exec(%s): %s", __func__, _PATH_SSH_KEY_SIGN,
+ 		    strerror(errno));
+ 	}
+-- 
+2.22.0
+


### PR DESCRIPTION
###### Motivation for this change

ssh-keysign is used for host-based authentication, and is designed to be used
as SUID-root program. OpenSSH defaults to referencing it from libexec, which
cannot be made SUID in Nix.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---