### PR TITLE
firefox: CVE-2019-11708

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
@@ -1,935 +1,935 @@
 {
-  version = "68.0b11";
+  version = "68.0b12";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/ach/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/ach/firefox-68.0b12.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha512 = "5d7c9205c48486ae4dd2154483bfc8a4fc08e2518fcbf90febfdec91f400fe5b6cb25810560deec6c7241b95bb4f716ce60256e826240831420701d0a0f18e69";
+      sha512 = "63b9f627e652b3cd48c33eed8fa04e4c154b0e2dc2f6dd58d43b37a5a4043d2b120b45f24c1e794672bbd4e981d0865fb950c336b6a4201973e4c8b3b4bf1d1c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/af/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/af/firefox-68.0b12.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha512 = "6c446f56004d38b019084a0356858a4a79be1f02647ce27b6f8c2880eef02c145dac93973ba7ad386c78f0c67815222d20d2add2e40b7605387ec77161448e5a";
+      sha512 = "58e69cf58c679b8d7ccd2a06aa61b71f6cd4cdc052e506bed2155519a13127049457a1e47789077ff1bd87dbb81583a60678e230e5c6f1ea7b4386a20e6f26f0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/an/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/an/firefox-68.0b12.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha512 = "2df2379fa950fc297d4974c917689c517b942df34ff3c9bd23b506f3ce580f1813992c2ffae14a5d34fa3835350179637daede30ab801480521b85df6db98e54";
+      sha512 = "51785eb45aed769e65a786661dc89e2044475070da31910e66a567b4f747df8ce694d4a5fc28c9cada0e4a1ab43e553d9ffd9ebf2249bd4ebc523e35312bf944";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/ar/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/ar/firefox-68.0b12.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "4b4412a84608c76e22a3ca2381ee2c02e94840bd90797b67703ad16b267f6321739efcba92e86891303bdf9252b98aacf277ed261f23335cd37f9b734e72825e";
+      sha512 = "79d5044947911e22d2e4a4c563b34a38a8e6972637026cdab4fba359566d1a78163298dbfca544c388918b2d3581fdffa89a9a61449d5d20f1c7e7989aa987c0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/ast/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/ast/firefox-68.0b12.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "82fd0e965c4eb47faa42cced826b43b9031f3c6cb73f0d0905796ab0e5a510c10f349c066d8ab51afa7feab35ace3207d9bcd954877d6e94518e50084f9d537f";
+      sha512 = "ae7cdc0d5dcd7297c9e78f55e36207621b148b8040d074672a64252e681bfcdcff1c17af021a31f3c9d89ae38326cc508f350c6840d77b1480b25e05f1c6b2d2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/az/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/az/firefox-68.0b12.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha512 = "8af492c68ceb231c312ed4eb7a28162713c2adcada606f8af9ce53a3b3afa1d6222cfe424f9424ad7647855b47c1c8638ac018be432b64d88fab7eae81b777d7";
+      sha512 = "c8252fc3fb04008f0cffa43db9983fd741b8bfa04e0fd03d8a293f9cf2eb7a8a7b7b3a6ed14b0fc433aabdb6f106df8c309d83b1a1e60a6539d7fdbc236be092";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/be/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/be/firefox-68.0b12.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "7c701bb35ef3c6df5f32488e18c3c85a30e6c9f1551345df63858f727c584422e9cfe16e57e8da98ef293c352f76f5368be21b2780ab05ba28be71539fc2270f";
+      sha512 = "75784cc6833bb7c988d8b288a8fb64fda53e642fe2c2bce5a525b6aa3a823d409f996d221b90f4445a1ce4d5fbaf0fcdbf6121a2f0e7a0d8106686c9780b192f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/bg/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/bg/firefox-68.0b12.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "ecb712d3f363c2c8ed8ab1f640eb06c53706315426485bfe3fc140e77cfec8d36fa358064b793bf3cc7adbba4b104ef2d7839c478626f1b35c90b04d8f6c3460";
+      sha512 = "38aa22c8739e72594757db7130f34e577b260bc2a61987761348dc356b9d951fba997f5f78084bdef9d8742faf4491e94993fa4e0777913a3c58b28fd3be791b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/bn/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/bn/firefox-68.0b12.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha512 = "9d0cf62c62f0f351a75816fecb60eecffeaedba02a68a270706baf7278c829a85145fb0082acb34b68202336ccc016b3195687e7394c5ba7e0b90572ef9363fc";
+      sha512 = "d6074ab4cd4346774f143406facd7dbee1b3e4d45092a9d61085c6639c9ebc47599b2e8df7dfc79a2a15335a7746f5dce08fac9ebdf082df12f407aff5dc705c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/br/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/br/firefox-68.0b12.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "d9145c41af92e550b84e70996ffa31fe4214c38c4964bf17215b71e17bb896a26acc2f5eeff0c8b6ad574826df0cdfd8e94adb60e04768f2ad6ced5f466d38bf";
+      sha512 = "47377442b5c53424feb7c329f634a1e7da72ef92f152beed1306a602812184f48f9d0d47d22d7f0508a23e27b997685528b80297866668bf04323361f926b255";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/bs/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/bs/firefox-68.0b12.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha512 = "d0c4afdf39f14bd3cfc9e0be6bf54165b4019dc1eade1966b6bd7397839592e74c49d2518ff258115e8a89df51725284b8caf53a50915b83df33914d0b71704b";
+      sha512 = "ab2237624d724a130da9daecdbcbc6f34feb76320000809d227929d35456450e15d45088b809b043c0387843e988b1a3ac155b44a2134c8ff57d8f79c81746d2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/ca/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/ca/firefox-68.0b12.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "6f8891e5a9eada52da1ae58c02ebffee47edb0ccc49a0c99d990101e6eba2653ef1bbcd66cc216e0637667c98199161c847233cde6f7f46fd1ceeb52c426c3d1";
+      sha512 = "559f469319186e63da2da98864f4070414bccefa619a8ff5b8d149e3bb44013fc8a9e29abcf66931ae1cef3b76d0cc1f626f5fe84aa00e7905330609746f1ef6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/cak/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/cak/firefox-68.0b12.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "76ca5c5c985c683f425e0592a8c4721760c619e6efeee86c35eaeabcdd0a366de0adf0f1af2e4130462c1339c666d85b4a5df4aa581813e0b88c1ba6b433a7ca";
+      sha512 = "10ee270b0f201ff6127e1dfaf2e80a4f665ffea5206944d658379582be0169242a2062705cd5588764ed479775efb2f7a476a9618ad8517c90cf36350c587a35";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/cs/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/cs/firefox-68.0b12.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "b4cccc7129343ff7ced9270424c317e4d577adf82d649af602d3181dbdb46c0d0ee806aac03ffed34ce21c9dc05caa90b19ccbdfb971d0c9d6d426dcc2ffd1d0";
+      sha512 = "bb44e9cee3a211a858b87e307494376edf3edfd7c691c5e643b1cf575aca2f6e95987fbecc11355ebeee724c5607f6f938360b3e1ff2157433de22ff3cc18c68";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/cy/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/cy/firefox-68.0b12.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "ea935c15abef1f6f9426249e86485a4857a6459cbea7441c0f1f336c78cbcf91903844b21004a3a9b85e4b182179084055cfa85c0ba394797ef380456c1b2ad3";
+      sha512 = "15be2de82abd5e631c609e034fc267743835a7b35c1afa0ee56c082d3abd3aa293254021141d435004afe7b0dfb48af03247683736de091364476f63635e01da";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/da/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/da/firefox-68.0b12.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "9480f28993dfea90d866abfb385a0034188365dff85b5ce9776229ed58be89d8f94f4fe6774f4f40497447c8fef61c0fce04cd6f6a607195f49df542b334cb76";
+      sha512 = "78ec7abc743c26f48ea5a5232feed7026f9b57992214c007d2486cf19e996a5c074bf972951beca030e534fa1c967af94ba5767d8002bce1089a007926ede8b2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/de/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/de/firefox-68.0b12.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "cb56470113fc4a0344a4d0df5e365992173a9b9925460f86ea7a2b0f88f7aaa05eec59164155190e42ab6a568b5034a19d210b07661d41ee9ca1731449d18b84";
+      sha512 = "be1e4a3466b3d2d442547895623bd055055da4911345567c569f54f098a31b12cdb25a36994796435e1effd7cac2c0f064614c89649faff9b4b7d6223fdd4439";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/dsb/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/dsb/firefox-68.0b12.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "fea741e3964261b8314dfc25d77a49390e091fa04f197ae367ced2a4ba691d9d279e721b22e5d34847f5b89bb76b1f901731d39c009c75f46ab20f81d2b78820";
+      sha512 = "184815dddf4d41ec5d00db47e43004bb8af8cddc694412a81af405da38808e75f7ba1d73f74ebe68409d3e939858ef390eca6829e58bf0739ac9f2552f07171c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/el/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/el/firefox-68.0b12.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "22b737812ce9ced372a43537db992bb441ea00389cbc0f2792718717515459830695d51223b90693a16d7eda84d89ad5440122670f40a23f0d66626a17ccbc33";
+      sha512 = "5ea63e62510babdebf33296a4ed91fea53758c67f5942db663964f04af6f9f96e091d9a423c9558eedf553b4dd69db55e453c1ac99631eae8813581874f9f584";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/en-CA/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/en-CA/firefox-68.0b12.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha512 = "e6aa7e44449e05555430c22f81dd149e9c0bdf41c1619d35ffa892156405b2cc8c9ef85345b35580532654d5bcd076efbf6700ce7a0062a99b1f483c4337e233";
+      sha512 = "af35af203abe32360fb99ff7a913554ef0520c2524f93b5c194cfe080cf2f65247aacf0231cc1b90867737c29b8b385983d0ae0de902bc9f9cf4f0bd67de2b14";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/en-GB/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/en-GB/firefox-68.0b12.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "269a8dc47227c3dc5c47284f12efb721b938ccd7ebc02c00b4d101afd9892c363de9e99395e30395041cb0e9a02249addf701a877dc0a6304da37becc66a1019";
+      sha512 = "145c2b405c4eeaa932720e706246561dd83038a8a21918f2ce1b0012efcac7d0d7d9c3257c2a8b3020197e4a6bb8fa93609a0a04bbc698dac38cff6de13b1b6e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/en-US/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/en-US/firefox-68.0b12.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "7e90373caa8655fd50d4d9519372e667c99d5ff2127f255baab08d46e3863f804c2e8a332a85d04defeedf3453aee339193c34a0022c350ca7291a340eb6eb10";
+      sha512 = "0a2c58bd51c6ef8ab4826130067ed07ba87f81c621d0b5dc3166a366d054e2e71b982fd65e74d83bfb63152d4087e46e07177265c6b44f538953cd961deed5f0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/eo/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/eo/firefox-68.0b12.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha512 = "2668577bed6d51248c476fd88ddfe49109edbd23f872d2ec5052e467b13d11fccfa4e487453cf84eb2c07a4bd7754b6e9cae1dd2d7a42fed98dd0d6a3d6ca596";
+      sha512 = "e26839f4b78cb079016a39f3873380123be4d7ca804c8b15ed59190157a806395513317adafc978dd45bb7571350685774e7eefdce720a14b81b38df5d9ff06f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/es-AR/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/es-AR/firefox-68.0b12.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "937a15160050fa4072037e531b898540748a511705066853ac86e98fb2f814cd139519429eeca21fb73641bd73c76f18c4ec49451bbb6efa25921e9aa92348f3";
+      sha512 = "fc6b5902ee337bb05a3f1c3e4ba9f37e90a8efe650003164d662a3225ece90512a86abe5fddf9c80e2eb30bb1cdef022b03fda53175f9f6fd3ff626d502c5b82";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/es-CL/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/es-CL/firefox-68.0b12.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha512 = "dcd439726e1628608a016e69da2239bc6221f03b69fabeb62686b88ab7178992a13a7d378c08c087c1216ee6010d565d9fdfc713316bc7d3940723e2f5b1b708";
+      sha512 = "12c0ce281867ad4f6c5a190ae11174bcdbe81137a31deb0eeb6997a46826d6f53129394b314d3a0d6bae1d4119498257d34f6ffc5b30568d457b6a6ced186639";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/es-ES/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/es-ES/firefox-68.0b12.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "ec4c9322a48dfd85b84c39dfb020d5530e3477a1949d84de7c68f4c6a4040dab510bdf72708e85f1d9b3120a6b8819b97e7ae4dcd501268744b2cfc06bc937ca";
+      sha512 = "1e30b6695d13c1d11dda43f4f87be9bb5d0115891ddaaab793ec842d4b38ae669cd71db065eaede2fef84235bb4ef6186d2cdd236d310a4b7f27e03a725e410c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/es-MX/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/es-MX/firefox-68.0b12.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha512 = "5be88636a78c4a74c71df859b4833b9896c1699c96a9577df643c6708e50b0768b662bf1bb3fc86170c1dd7f530d89d1addbbaed5ffde829da214338e9d845b7";
+      sha512 = "e60152629eefad15af7af7cbf788119732933911c9c3765a9722aa11617349a4341741b5116e7a4e76d5f5bf3c1f7bf786c3d4b10c2c33ae6cf19950f308a331";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/et/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/et/firefox-68.0b12.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "bdd24e1ad29270d134ed97b50f3c9aa65991d5acfb8b03005747ed7477d4ac6a969ac0c97a82182b25271f0c363c973889e6983ecec2ef2dca7309c0aa43727c";
+      sha512 = "ab4fc13e9c851065fd04f25e4c1e2ee740e6505e903e8c15150eb60b3d7a80af678f7af1a2a508b651d4fbfbc7bd9f5626056df7142806561a00736237cc36ca";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/eu/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/eu/firefox-68.0b12.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "c5e72bd602db21d9acde9df1aeb215f63864c918d61f916baa80c9b1b538ed7d8d11a226d6bf0600f153612158107a01743793d19ad059ee25fdfa5078a7fbe0";
+      sha512 = "46eec787849aaf9cb125e881881a7e0c98f39ac6a5666bf56b54f78e07e1e13bae5308083717cc9ee4e85cbcb6dab60eabf5b3e722507432e0c122bede73c11d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/fa/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/fa/firefox-68.0b12.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha512 = "2817c36e3103b4d764f9bc98daa81185888eabc99c97e2a2bf60a0da93106413a728b6b84d90b36a7a84154472d7238939abf8d4419cf83ecc5a24edd4a7fced";
+      sha512 = "fd595bdb3dfe3bebf04d80499b25386094ab9c594815c93b678c41c551fc5198db60012a66a878d9bfb0f300c731607b7bcce94108a8b44d515b0238d7d30a59";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/ff/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/ff/firefox-68.0b12.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha512 = "98f0b23601041fab292eee44599f8bdd49e38e9fa27df7f15a738c7a2dc618a704355e548e8fa1188a8fa520e04c93aeeda4f20fddafc6705ba12e1c697ae6db";
+      sha512 = "f3a4dc9dc9677064f65e7eca298eada76feee7399537860db48c853946d163b405a1db2c84e58c7be6b1e868ef9e3b09c5058ca7dc0e7c107db072bac2907d5a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/fi/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/fi/firefox-68.0b12.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "0ac0fc1ab65d61cdd172b528254b2ffa1b07e9f88cf841fcb0c8ed3f92835ec201320658357d6ee760a5ad20e852ae30b62232bff34aa4f5343f67d03077f115";
+      sha512 = "ce8ed3b5a3856903db73ef5ea0286126c119a76d44f5dfbe7f8b2261e99046fcaf4f06d07118dc1726d915a5e1ec909a4ca45ad75bdbc3f16b93258a6b987e52";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/fr/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/fr/firefox-68.0b12.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "e453879ea7c52b0fe122251782066a01cae3cbb4b41e55dc6185af2c25b9baa5892f3946c04e4312595b8c96e90705e9d8ba55fe999a5bf0c92fe8686b184c50";
+      sha512 = "75ca1639d5d2be13c186ace6cd9064705827bc63fad48dfbdbe275d1c427ed00b6ce401cfd1c019b46d49453bfce1de51222747f8d7c9ecf373a7898be7993b5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/fy-NL/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/fy-NL/firefox-68.0b12.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "493d5d65aac2dfaff4a0f2c90d12049620a69666fb570dfa0433cf01781e5d8ab51f684f756c860f85c198114261a107b5b63946f85c1ea30d450eb4b7d87ae9";
+      sha512 = "04fb6e2c7c0bf006f45b1d43c543fc43a81063de3dd923a2e72db5d8baf6375251313d00bf960e7e3767f60999884b018bec51a47b92415d6c90218327790da4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/ga-IE/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/ga-IE/firefox-68.0b12.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "f30408252a0d38ee54c2361dd2cb5d7567d6af71cf69fd3de798f2f222617da81895dd670ebd5d5aa12fff754ecbb7db39e0de8f2ded81959b220496e07d74e9";
+      sha512 = "746f3ac13e2d030db89cfee4629c6dcf467a735c124f026e24fd409794bb567730fc50fa4befdf9fa093456d86bd588c9657cd26875683f86d919ed0b3993d18";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/gd/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/gd/firefox-68.0b12.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "febe813e107787b8e504e46f4c66deebf2a3caac393a03bd4ff9b858e7812cc08aecd6d66d7c74c87d797fe2dfde35a0502a0f7c658d6670a9d0eda7f35eaf91";
+      sha512 = "f28e688e388e3a5c587bbc41e58f6af85ef41fe67fa847d6ee257005a783a6e2e19f422d8678b3c44e1e386d088a276ffde8da48feca5acd964a706c7eb94222";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/gl/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/gl/firefox-68.0b12.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "1f7e415ba200af0143525f4a5bf34493f197de86e9bd1814f0bda65eea4610eb8fb4a673363c05d6e3ae6a8d893fc9920145f1cfd89d4986ffee28d4a99b0eac";
+      sha512 = "444c4227c6ade4ff0452e751646a450a0db96f145ff6fdd68f7b58e6aac291ed1313e57003a6084df33d4718e407fa58d0043e6eba5f585da2ed98ea4f40ffab";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/gn/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/gn/firefox-68.0b12.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha512 = "028109af025b4a7ceb90fa682a46ec0e80cadc33ef306a44e9873d859c4758c4f840064c02666f1e8060967c9f31abb8ea2863e9fc9f8597ec102105f17489d5";
+      sha512 = "dbd6a63dde30c979727048957f80d677d9cb3926f64d8783244e28efb167872dce4d6089e818e2b5a044969558395e6f74bb29657aff1424a07711c18f0a1aac";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/gu-IN/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/gu-IN/firefox-68.0b12.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha512 = "311da3ac7daced0c543aa294825fb56b580bf5a0a38f1343eb6020b2f741f65deb1cf656b2f0b3398e333d19700abc854990c00b317cbda87bd7b6c2d7319869";
+      sha512 = "f93f362a8711aeae41c833e32146969d3a931bc26066ab84d4f3f09384022d9ee23b791e6893ce530766443f365bdcb8c732d7ab9ce9c7200a66d6a90da96bf5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/he/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/he/firefox-68.0b12.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "8815717cdd8e0d580687239004ec744dd472b08cb8d18555dffb4ea393973735608914c2f50aba5ba5489ebc04e6976fe2098ba6bf069af9942d0588811ed1eb";
+      sha512 = "96dc618290fc3a6b8d073e57474c2dc5c32e6708be676ed42eb73e0073186c82b110cf63984de43ba6bafebf808da15e4650c34df47d9647b62d8b9290de8dcf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/hi-IN/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/hi-IN/firefox-68.0b12.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha512 = "2f22b1c49cff853afbfa173ddc40ba6853e9074b168dc1937b276b64935a3ada75be699ab3ea3037349eaf0fd03c0300bc43d88b70d1f1de8a9a376599ea04f1";
+      sha512 = "2154a8dd7de9584b03515a750a23fbcf415009907cd6c1e4d08003e0aa6b5683d47554a9ce1222631f12b63abba151480a2a491e686b8c89e5ba22f819ee7c48";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/hr/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/hr/firefox-68.0b12.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "1019e1fd070fed3f25e6ba315920794c1865296362b3527a53b852baad52c97230199d2d9fc673328660da12f10763ee2cb087df9116b3a28a3ecdb2b6938ca8";
+      sha512 = "19315270b79ea8b96457977cbc4f71d2f16359de6e515664aaec9c002f4d537ca5d0d0187eadb6ee2d5112293ffd0e5a0bf156665401bbe569c2bc8d4d712ba3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/hsb/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/hsb/firefox-68.0b12.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "fbfad33f509f91d8489b04aa90a5ef6647f0d7c62b56ea1d96998ec5a24a832e69ee36f71c8bc3523f2d6fa3ce9eac38c0b29caf3a546e1af8c3127cea986f4b";
+      sha512 = "74d86de9290a8f8260301c6a1f5d39b8e18742cc8f2b3f8d282e4093765e4938fce7181bbef81da127cc0fa4b75dfca8cc44de5cbd29e6f56807b049a24a1ef5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/hu/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/hu/firefox-68.0b12.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "a9be554ea619d9bf8a64b91a8cbaa87a001856eb4717be1d72c5ed77f2fa5730507c4173e8aadd12a32c91a33050429889060c49ab2e7ee7c370273b1a685fcf";
+      sha512 = "d5bf23cfa847068d09bd90d8b6fa1494154b65b1ea6323d7c3d275b46f973f8b4a98bab02d4e61706a3fb144009b4b5aed7259124fc36a037926d9372f409adc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/hy-AM/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/hy-AM/firefox-68.0b12.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "1c1c840f1c3b38ea1743592570e3b40b5e2c0863dabc65e3982abe95e01142df23e7e0a80d18d37dfa09b25da32950176ffa8cd34d2a09db6b4047965688688b";
+      sha512 = "70fa78782d08bad09b937718055d2dc89e10ef0dcb8e6d0cf8af07705890818c11550cfd307c54792bd1749499bf1addfe4e89ce0ef35276d4ced93ef75b34e4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/ia/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/ia/firefox-68.0b12.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha512 = "daa79d5423eff166edb8a3de26e06b499eed253e3bd3c8eb6a02115b449a82d30d6efa36b7bf229fbce8e7923f03dae75f658c0263c805bc504602a47f101b91";
+      sha512 = "abc7de0b055056395c57e8b7cfe086ba31a447165230b9012f6e14162237a6c49b7ff2fdbd0db373e3a5cc5e596dcc48b16bcce4932638eb6fe2c99b82ea0023";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/id/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/id/firefox-68.0b12.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "144d1f6311ac11c73fad0d53766d126d458737141b6cda64a0acdbefc6c7754b5c85352b0b877f610367e3444120ea91fe255b25b2e4ad7487ad0b7c26aa209c";
+      sha512 = "55bd13dd322a97af87b506551880017f112fc29a11a175ba6040ed4c1fe672f7ebcbfce0e4cc9b409373bcadfd1dd9327ce53c858a18f4420e5cf366c441874c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/is/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/is/firefox-68.0b12.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "5e13d6dd630c78ef74e579354ddb477d529b9d08e6bfc1e0e01f39f22e406890740b4c286799cb43f6d91bbb06af9ed2a50a5742af7d2bb593c362a3e9f17b35";
+      sha512 = "4f1029f4696fb66d1a407e6b74a9692e916e35dde605bba0aa61864bcf129d12c8f3b58a399e5118cdaa70b62f34b09325273308ff188c98dca7b8eda4851ac0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/it/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/it/firefox-68.0b12.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "1a0d6d3d7c7840cc3a15757be689a5c2f0c68ff748b55dc1a7bf98e9f53bb423ec67fa8848af1d4c626651379f8355b14cd1004b062a2abcaa0bc49bf0756122";
+      sha512 = "3c1f74c2ab991a103783eb78c23c82d6ff0a3d30913ef5bfc3d6ede8772654e8b5f3cab6d5b4cfbd9dace2f8f2ddf1fb542ae57be03179737fddad72812d7d26";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/ja/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/ja/firefox-68.0b12.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "91da92ff85b3290d7e22c013e007da739f1fc5b073bfa9dfc62070b23bef81ade141b879bf9ed6ee679ab0a0d9609ba09f60fd6fc52843e4ff66eac0be30e111";
+      sha512 = "157f40be2e4a41cf91ed4f6b27fb03da9f5f333e79103773879e3f559cb0f10d9947129cc9d09bba93926260cd0b6021ceb780c269b9f4efe73c9da0af03bafb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/ka/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/ka/firefox-68.0b12.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "48851d2cd754d7edd09364c88e9626786357e97918f4dd4082cd2f5cf978249cd5dfc7d6522ef3fd01e3755d55f4e9e4d0dd1e03481dd6d2b6fe4d0bd6a77ebf";
+      sha512 = "ae819155531645b4bfd34fa3f2fcab86ae61cd4efce98dc05325c77cb4c9a9acdfb4c256ac36357575f9826090c92f02d30670dc02efb0e84fd2cd66a71a1cd6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/kab/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/kab/firefox-68.0b12.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "26a657ddcfced8b19eb4efb0d4aaa4b0655bdd8952489b8e5c29c996d7dbf291955594ee20dbcada31638bf204fd3ea480906664c10583a64fabf11df7ca329b";
+      sha512 = "6447fe7826efcdb5e639d88c0ec13fc180f61d4cfc1877bb6f814a305b4480a6481b0403e0656a0c7c10f3595824a85d7755eff197e7b5798288fadd0eb205bd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/kk/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/kk/firefox-68.0b12.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "0f060dd22d6077ceb6dd26e1cccd0efc6d17fce7282821f3d71f73a4a1198b1a5b8c75828ba7faba19e9c2dec9e3ff794523d84aacbbd1f4d8a28bbfa22558a0";
+      sha512 = "f0d272fc030461e6de01c21c3b06d7a8105a81991d7c6347090c85e450a0fe1a44b209b9ffd90c4ade956ba37678398dc4e46640179306bfd2f6b8fcff64dbe8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/km/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/km/firefox-68.0b12.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha512 = "dcf429a1d63173a523693d44fe34c2c7724234a5ada85a11305bd28bc2339ccba037b7c70df658755dd800e8789acf0a842d5c5c325fe976bac0c9b2d93886ad";
+      sha512 = "b8b26fc961738ca0fce723ca41f6bec5d75d18722f7416b93eef2596cc2c01f7831da09b5de305b55c5faae3826382329a2fb0163e1bd79a3b73e00fcaa6c947";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/kn/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/kn/firefox-68.0b12.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha512 = "32f827499114222bf0ab5a9bfd872e6a156be1499f188030828bfad8bfc5ee0b1b8480f39837d3f5052bc838fe352fb1c3753256572eaa6755b8794489388c14";
+      sha512 = "7ba655e207aeba5cf8f734be11f6fd20fa7fc57d0dbfcdf588c70bec224fd23ac2a447c9238ed9559ab612f5f829359254bb88a80851dd4a6ff691ba4d5b39d1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/ko/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/ko/firefox-68.0b12.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "508eb9685a985cd6db97098633707d967bce541ebb0212c15ab88bfcb8c863f65c14fa57849171967ba0e63698039f4df30cd6393ecd26c73e2578574f731fec";
+      sha512 = "1a9480d6f8c9781d401b5b3d98f43b60bf6f0d80121920fdee1ccc6b2339e9c7a96b6fc53214ace7a459e84991cf8d712fc558250158fe10ce7b6b57c40a6172";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/lij/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/lij/firefox-68.0b12.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha512 = "8baaafd82b897863a71b3063a3cb49e385f9dd5f66f0f2d92288feb902519316565249b2e2071d84a64b1f43af427d2d8f0f2df078b3512cecba7c1c42b7b73e";
+      sha512 = "b76d259acf9ce2ec775066f50e68d5821c50b475d870c3c69ef70b66fe2cd14de5f52f47eae6b9e419538c7292149ba301a6c7061cb14eb7b707e5bc8721a557";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/lt/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/lt/firefox-68.0b12.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "b956379293913d9e9ef6ba77b84679fddbeb2c34114427d489d545199d2cf6f082eaa6ec4d6119e4251d0d8e4a8dc91718688280e110555bd35e31a5b485d259";
+      sha512 = "509413d7a37363ba9a57ad6f6389f8c06120480d0d0cb14635b914c0a0026095d522c95f8c6c244b12c048137cbeae240f12c1b35843b00e2c725e37e3a59540";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/lv/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/lv/firefox-68.0b12.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha512 = "8fc15be20cbc818e9f028cbb1efc05eb362f744d8d0d106eee8c7e595e63dd90e829453aad2050808e87892b9cd650b0e22a4919aa4ed00800f89f4dff1d8826";
+      sha512 = "ecb21ab93dca533a2de4b31d48523a6dc83a5901f3824b1cd480152457bfb908a5650f1f9a948713e0e5cfde566157e349f171b1fde5a201dec30877f42f9204";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/mk/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/mk/firefox-68.0b12.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha512 = "3ae9dc885fce911bcc60ebf969df615e12443fa8bcdd35b896fbd1e5f9ebce7664f447104d6ee7fda0d9fc0ae1586023e2a66119337a1a9253df2d62dc049fce";
+      sha512 = "7853fef96ba965febc97c43b9030b50c9a0d3b2f3af31eea2f59ebde3792f6c18eaa207617706dea9c9c24d9d19e1898c357b02b41060ef6b0f79b0c5ef9e8f0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/mr/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/mr/firefox-68.0b12.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha512 = "9cdaf0ed9bcbea75dd6cf7cceffa9d9ab925e75b6b578d4ff89355ce5d41cfb44bc0c331f73d0630322d51596e807162dcdd3e7ddd6283ddfb2abbbc5c9d8643";
+      sha512 = "9b769e0ed3884bb60e7a5d8347bb0cd6af654ffadd7b3f5fcb7f848c859886cb29e276d7e6ce28b56bffed2dc87a9d6722f03e2f0af9b51a657620e57b48dec9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/ms/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/ms/firefox-68.0b12.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "5094bb88d8724bcf6442d0d07b351b3b588afa5577a2766295c0e81fc9b18ec7979aa58c6f046fed5fc1c75e440edac5a281e6e58462f7c0506421f661504338";
+      sha512 = "f076289f7bc5fa8ba644111b306e076103659b8d779faf3dc3c281d9bc7c19498e47babc80795fd20ec8e1c772db984b165418f9e48490c692348de87f1383e8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/my/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/my/firefox-68.0b12.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha512 = "1fc84499232658b759b017245815dfad86ad84e279e89b774c4cfb9b1816383d4ddbb617708e6e848800c7f984a0e0b85b5c2fc6203a3721db22d27a057a2404";
+      sha512 = "d268b850e130543ee45230d3594411d617b5d81bdc85e92464f51772794caa751a95a319a506f3d5e7de2bbaea08fdc86959d167e5f7a29ce050d196b038a447";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/nb-NO/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/nb-NO/firefox-68.0b12.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "33d1db397543604154d5ec40c661c9eb028ba309835d42e5f2c39a3f09544a661d03f9ed7a8f70c832c9a074772811b1d92110c539bc66ef45d2365dd774bcde";
+      sha512 = "f2822fbef945733f249690c30fe06762788455f574696711fa1eaae1decee763ec4d793d0f51702b38c9d87e6697f90a3f81292bc824f2b0d12fdd3643530b60";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/ne-NP/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/ne-NP/firefox-68.0b12.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha512 = "dfa4846df117e176a9f2dd9a5be6dae51b4337e27191828cb712226acd2092595588163e4f782bb6dc3731cfa305076a01d8f4b7c89b85c5c810264a8b873163";
+      sha512 = "f58c8e74f86927afd5cd74b8e502c6fb9366bb2aa85349dade0a0b2ad538c0f2c11c68c305dc6d590bb2d9caa8ccc1b465493a8b1e1df914d437a0f124399330";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/nl/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/nl/firefox-68.0b12.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "e1783dd709f18ba6a561319a8bda01d362b54931fa80a34467befd2064c8f60519b6022b71c3ad85e48f9c15c67d317bab22301ed60a4303d6cf628f96d32bb3";
+      sha512 = "1ddc6e85c68bdc42af08aca251160b720afe535505865adf2990386fd6cf6cc59e1f65ceb36cd3239b12da43897ceac325e69750ea1fb93adbc90e056714990e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/nn-NO/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/nn-NO/firefox-68.0b12.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "5bf6f0160b3d92749d4d30fe1ab452a7c532e1f56f0e88531b608b0a17704153e65df5b1c05dcc53813789e88d0b97e6d6aa71ea1ac1fd96c7c053c50232af36";
+      sha512 = "125ad213464891daad95c54c2354d36c987c9de62b695acdf999cd3b4a3cebd692b780d28307b4381da05f9fba6556d76a5c16e9e0c4ff5c7847511995a17944";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/oc/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/oc/firefox-68.0b12.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha512 = "2292d14df04d23aa51434cd512c8aef72af1e54760df8696dc9db8c3378404310ae2eae8d8a3cb078f144a1d39e0ded4951a54d7fc63f97b3b6588cdc96458c1";
+      sha512 = "9b6d7a9c9e557d9a836aee780ae5c0ef7e81540c6064c183243e55928b32a4f937270ae4b2c21f33e625aba6662a5d0f614167aed728941025115b5a5947834a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/pa-IN/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/pa-IN/firefox-68.0b12.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "3a341967aa6ac5e19e868398a284641c54475bc89c9567a0126a7ccb285f8cd921aed5cd35de8cf7aabf1a00ab1a6aecdc52a02e49520ba2cb4f2eeb92d9edc6";
+      sha512 = "5adbe11d8313d055e58cdc9fc51750b31f8e284403f823e11b72ad9069986647305001a9fd7db737f3943819878b5b9bb70e8c4cde61834ff8bb33e4771399a7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/pl/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/pl/firefox-68.0b12.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "9772fbb01d94be84e6f82d3e68674315d515d7959b6597abd3a3978a5b4370928a2f4421e5420dd4ac45c33d70508013e644a925a09b0a7d408b86106f08649d";
+      sha512 = "c67e75c02e92dcee4e5c2dc71b087ffc3424d18951516a347a4b00c68542a7bb05a81b03dde60f3b4edf6c0add653c72edcbef8db6165811182e9be3ac7cc8d8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/pt-BR/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/pt-BR/firefox-68.0b12.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "9ea9c97c265b8011f88e1d494429c4ed4aaf726db03f0371c97a2b1893fbff89625d04d643bc5b6d3999b870fe6b0f2eabbdb3fee664451177d8e5a3e9cd0525";
+      sha512 = "683165b6c93ec9e0f109b1ba4d24c907cfbc3787136d99307d15abe0e1eed8b6e444ad0b70a352a4aa7c9bcc0d4a09efab48133a9a07797d6e5b2f98e0ee1650";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/pt-PT/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/pt-PT/firefox-68.0b12.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "59ec535ae1939ed04d70662f9d6d2ed2059ab7eaa15aa57c3ed9dfdb8463e2341328d051242e2ef14ae564e78b66a7a5b86908c55202779aa904b27e9599cdcc";
+      sha512 = "ce7367061456c3009e7dd6b4d0a3cf6a1324c3daeb7406020734f63adc169214b9deb26dc37936725d4ca3ed1208d4d81fc5dfdd73d7753b9d64bc8740f76acb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/rm/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/rm/firefox-68.0b12.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "1db1cefed92bac3c4f40636f4fec0c2a23f9e89553f5aca22532e71c7e85458d74d7fdb5a8ce30be2fb59d8d6ecaf507ba56463318eaa8c340fc287040cbf8db";
+      sha512 = "801801eae3a2c51e753dbe1c436d0fd5832c1fc9f0687c04c2a5452f1dbe06435c9619c13f87d6fff2cffd5997469b4fabd8e2d9c917853ac34e3695c1ec223e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/ro/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/ro/firefox-68.0b12.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "0531238a3a87489b94b08338d0facec1a3e22daeef3721f63c11eacbf87328664be5155136935f8e0a9b65b8dc1099ae16fa455673bccf7e88d64179256d74ca";
+      sha512 = "be62b477b0b72b6febb26194604e7be748dd1ed879e3e44e02d430f4feb40b5e50dfa8a5affaa1836fc1ba20cb1aad5fe5482cc870eab83570809ac90994c087";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/ru/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/ru/firefox-68.0b12.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "ad23604f4812b90863fc13c16b4f12aa2eb5bd93f753d86acb64cf41d23c208a4f7184cbca2ac671e8504d1b5c561e4e03eb1cefaa8ecb21745f28184545764b";
+      sha512 = "5943d3f90b1830607619a15cd61493969fe79b7e370934f20de1e63da3cce04fb733fdb9efc8568cdd8ab5fbfe23d67f86be2cb5fe4a9d738688e096ded10f53";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/si/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/si/firefox-68.0b12.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "5bc07458df7ce6f9f75e50d3abb9a922f2aeb6bcc8cff54af0a3c353c195eaea0f46880b5dc6619e9a20afe516c4950d3864a864cf841d118a375bd8edf51e99";
+      sha512 = "d230ff8a7e74efb71424c8c8df2ce1895e44643da96e67f042f1f59a06aa4b3abb8e8c6fa29033196ff6e5cf5ab8792de5d9ec51ae59906c019a6df028ffd436";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/sk/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/sk/firefox-68.0b12.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "faf57e23690e5a9ebf0d216e1a803c3f44d17a85813fdd4dc860846db139a810a8c50a469c7bfd7372028b939a9b2eb4b8f0fa2c290217c8818e9dc386286291";
+      sha512 = "57fdf155d558627c6c80d722574d2361b99fbe692ebef94d53ff52d3cfa33e406339e8c6ac9219c3e4a7de430426aff8be30d5946f7284fdcc50ef514b0c0c70";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/sl/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/sl/firefox-68.0b12.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "61659cf957dbc1187816f2ee20f3f82e6bb3df147d78061724754a23e756bd2518fc07302b54b6235940ceeab849a9253ad7b9508f98dc8329021aa32542c9dd";
+      sha512 = "95f792d6bf63d490d2622156abb2ffb4383252f734738df1b76fc07af60a382d4bff37159ce1887ac411e9637676c24aa6487fc97c1fe8b296aa2971d148f983";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/son/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/son/firefox-68.0b12.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha512 = "54e5bf458dfa2ea77f80fbc8a3c415c1058b17ddce80fc3c93fe2eccf931bbd055a618f5c7723c7d38f478e2140ef3b51d780ae11006731c26303d428c3a78eb";
+      sha512 = "2583e96c5d24231cb3d8b1bb4d9e73c5e6cf73724b10612cc4bff6b2a6d3b7d30321a06221339711293671f8648ec80d48a650e2f18fedc821ce9876136252cb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/sq/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/sq/firefox-68.0b12.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "17d285bc89a8a02ffc1469e54716af988866b730f6cb9288fdc2825579d8d8d480e5387f0e71c1627661c5d906feda865686b328599ad1b71ff2f7ef3083e559";
+      sha512 = "0ae04967e13f3d3e279372001afda687aedf087cb1773047aa3304f36575409a85e91e7076b494d98a78d9524284e80773ed5d87d4856df7407dd0cc384d67fa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/sr/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/sr/firefox-68.0b12.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "002f6452e70ed3a904bc1d27bf1860d1680729d00a850d35e74a343f704a6f71d2598866dfa17b47c94c320bc1ba38ed29eec8bea9d4e5e2dba9a144bc8fda69";
+      sha512 = "8f0dbc4ff9381e66889abf817a484e1b21f72646211d7acdb4b3c6e0fb2af349d436396a8efe8a20ec8357e42bedda4d5811537563849be5ca7c1daf4ab0d23e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/sv-SE/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/sv-SE/firefox-68.0b12.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "71d6cae8c945ddc4deb1f77f32e1f2e1861d8128d14b528027572b6d6475b6f05fc8f8c0767fe5c83e183904b9bfe563befb610597b2531ec5d0ce600d5e8b68";
+      sha512 = "7725e0444d58ba8a2c095511649c45b4fe63ae348cefbb7ac4ef80e3aa776e43de8f9555e5d91074b2a74664c7dc1ad463571efd846735b91ff880ec2ed76d52";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/ta/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/ta/firefox-68.0b12.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha512 = "41f937e15cae9aac8a69325734ade507eb62ed15a7b25dc959cf27c974775e9582f2776642b8c3f53b5760bf4b5ad071aa51fa29d906ec963cc296020d0b5238";
+      sha512 = "952ee81f4d42181c5babc12d0d6abbe9e31d650e3a3957d7d1afcfc54335d1e1b45691fbbb6359a531c73fcf46435fe468bdc87825d42c66b74b64264194fe88";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/te/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/te/firefox-68.0b12.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha512 = "96db56d94392449d8a16d315a7f9f2ab920d10646e8c71ca65f2501e48c563d16ae1734c1f320727f3c3134460507eb8a6a9f737027bbf74b46de4f1b99486d8";
+      sha512 = "de9c9bfa66dc87f2311bf18a15e544391662d36e0f71a72278dee8e24d4cca860f8cfda8f93bd2bd26fc0c3d3992f1603f2e3fd36fbe7a9478390b9535d51e0d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/th/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/th/firefox-68.0b12.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha512 = "ad85371f9e509426f8a1ff4e29d0d25655759bdc1fd57fa7c647a6f8c0287f41adc1613458f972856e6013ad4bc9466be237dbcb587c7ac4838f375a3f301656";
+      sha512 = "d421e5d653b00e290c6acf069c40cf43695b37796bab9a59e7d6c4f9fc4ff22e2d3a9a370a9f6a558c718014cb16a5e0dd05bbec7e1ebab78e50a539bb1a1581";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/tr/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/tr/firefox-68.0b12.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "2246a9339555ada25622ba64ecef1480252c7fcb186ce1807e40687e58155274e9f66742bf55cafa38f711f44de50458315d333e589e497030928f21e31e1e9d";
+      sha512 = "ca4a1f139e8dd4dfee268c0b90778cbf0f9462ae9bc037958cb5b3e0668b902e392ebb5e5dcaf9d72974bf1a5eccb74b079df3e3a81cfad08501cbb39129d2d8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/uk/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/uk/firefox-68.0b12.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "e976d6ec7e846771687f3e91ece27bb4531aca4728906d61b3c7fc52ba441a183e369b4519d37426e18ee2cc9598f06434408e541d6ee13b5e2019174c047b93";
+      sha512 = "e85e9926f59b948f6d9f181a87f8a6096e0ab85c81ca63bd0ccb885eebb05091a11d1c0c583998807b0f153b3de4b76447a2a82a99da9202964971cbfde73ae8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/ur/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/ur/firefox-68.0b12.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha512 = "9d3fe69992f13467183b9eb9a6fc4f38a66207f1903461a223f9c99e9b92a674b7e8f35a2369dd250f7573729b7cb020b4f53f1aaad9dc387d878a63457ccfe6";
+      sha512 = "b1c42f0960b0bcac39b0d3ff2470881bb1d4f69fcdc2d2af3899d8379fc9d949f2b1cba879303e47d5d67122290a82158a12e36a05fe2d41eca3ea68b603973d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/uz/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/uz/firefox-68.0b12.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "7d0125d24df41eeb5f9cd66ce6e5f4831cb215f77a06b551d32388bb36459f6822c66115e3998895304e7f1a058af187e022ab2811760f811cb4dcb8e989d9aa";
+      sha512 = "a862cd7e358d5aed459c93671a0541137c93fdc9687b4caf483ce3cdfddd6964a8e941b92cfa85bc638c7f20a6f2fa219d4e275000eb3452c6a744a95c44ea06";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/vi/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/vi/firefox-68.0b12.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "8700e35063cc323061ec52d78999a068dffa1ff0944eac4a80e6f9eeac938399924a72fee06f21e6b8b79cf7e36f8299c41ad4af66cd042dd86749376f21a02c";
+      sha512 = "0b4cc1154a43446dbf10a796896023ae1d7570dfd9d346cfd05f402954a3f31d803382a7c50e25c0695fd09144f465060cce838e8de144df3fefbed3288358fe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/xh/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/xh/firefox-68.0b12.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha512 = "58aff17b190c2edfbd5f66e5a898d299f97aec6a5316039d7624fd51e36d8f64361398cdfdbd10a836e80c95d58940fd9c7b7b7ec29a635b1d11e4cf77a7ea68";
+      sha512 = "f5c4b78437b9e389cb2a7429d02679280cf9bd8fc7ddba32640221addad8350805c83543588f7567cc19cdcfa2cbf9795a88ed44b3158a7fec9087e2e7815171";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/zh-CN/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/zh-CN/firefox-68.0b12.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "4bd1654232eefb9c71643522f3256f58f8db77741b93a67e55f37548a57698652c1f3d73651dadb34c62d3287a01d635da4900a11a3e39ca498e24a8847ae116";
+      sha512 = "f1c7466c71a9890937bdbda1f17f8813f7cebd7200040338c56c54b40644f47f91bb74ee74734bdf7c2b2343e9445a20098182cdae23876c0c9c4a98e711184f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-x86_64/zh-TW/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-x86_64/zh-TW/firefox-68.0b12.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "39b1624590226fd9bf27994b000484c3aaf8e420c6e76a161f3f8f9062997460bbdf04c43d8b2331a3f2724a956556f6da415cb71b75ffc24c55c71455a8b046";
+      sha512 = "c98e96c1d0d792a378b76deb6222c7cd202c77def3790cdfa30df155b629986c97b11ce025327c0cee8b03cdc8c4c16a938a5060774f1e029bb17c88ff7e9e5f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/ach/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/ach/firefox-68.0b12.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha512 = "f05a409b25ad04201ab9f5bba69f0a853828047d4e0b826eca95ccf79099df8e3d2ad1433cad5efb14683352e076ba138421d43349318dc9097b58984b60973d";
+      sha512 = "be126d8ae1c0998da42006332da3110dcd15a233d1ffef4cbc4f09a4cd2426fb2729e698d7d632fc1ba23b6c1e0ae6d38081aa48a63f9cf738ea6e644273033d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/af/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/af/firefox-68.0b12.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha512 = "88a522349900f923ab5b4aeb7e56c2ad96d06e464cd3cb9276a41ca6d518ab4e755c2081bcff4714d739532fd4608feb3c9b49d9b65e830a64ec7976ea577505";
+      sha512 = "e6bd3df1a3eb81fcf78a570cc62395689a7e2d456051ccdb85a99b5c48966835e58fd52098fe7e75ad1f6fa2d333ca1d4853be2775071077b42679c31ab00590";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/an/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/an/firefox-68.0b12.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha512 = "b7662ed71d44697e4d33a8e73a444eb4185a06a0628bce87fe78a8a767b85c62322a07a0e4c1fd0d7a6e1398084b041727f43e5eca5bc2b360cfd6572dc1bd33";
+      sha512 = "e8590dc16c0047b0d409c60091bddfd4019fee4053ae42c874733e5da0a03a4e170eca053e7dcd3fda70057d7ace4c3014032008c9ebb9ed5c05c8ad57f0daf4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/ar/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/ar/firefox-68.0b12.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "19d139c73d39937fe767c07a26cb10036bd045d08efa06f55543075b94a2598dd4a14542a0fc35a2e8792a3b90122e6bb221e9f5b8176437c54d05500cc06428";
+      sha512 = "7aa355aae3c22329f5769bda023bff2a2bc509e842306421c6728448f55cc675163076ffb76163d56dcac77102e200c78a5221114c6576495d24fca021d54886";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/ast/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/ast/firefox-68.0b12.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "5786f4059c363f4e5ce41e564d1aae7c66cd6d89832e18f7d5833f208c381664ae45cfdc3a6c5ed98c7e0ae9dd07a81833fb3162ccb99475cc5d083d756df8d8";
+      sha512 = "df275d655fde2a2a9c87f77d608bc0ea30807817ce360560e6315b5fb9ad1a06d19399784f13df1be958bcc8cadc84f9ab4e9c2a7672099b23e5c28051b07c01";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/az/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/az/firefox-68.0b12.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha512 = "9be65d715cd3887f45d4e82c66f193739e64f717b578603cae72420a402441afce2849c149a6b51570a43c12c72fe76ae6731b1b59e3c3deb2e2826c4ad366ca";
+      sha512 = "0dda2c6c3c403890c2019ed19e506ce30b86c8d547996d22a3e778c9d519f0368496454b37ddc14c6b7dc4cb3284c17ce2550a57d3ae31b8d4b978c05eaa4b8b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/be/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/be/firefox-68.0b12.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "d49bcc7aa2a51820d2a8d05de7aa931419047a1624e6abd3da276b4c23467ff798451a8cd9c6e301e6e8054a1216a9ae430d887cb8662ee623850c3fff86082f";
+      sha512 = "cfbea537c171b49b866de652ffe26b8ca7e57fe79bb834bbc859781a78505ecd21bfe58194585e60654555a1135295f6bd9efa26e23fa86f9306df9a172a0c0c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/bg/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/bg/firefox-68.0b12.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "4d5aa636e841a136d875a1fdbf55433f22b3ddba8dee1956a9edec74a7d073c567a0f28a5923db3a29c38528984d866857bffb8310c5dc61bf610cbb8a670030";
+      sha512 = "2b4f145666a4e77be1a8af82c1122b6d2a71ad5fa1f2bf8a938f04f7b67619f639ab9170858efd49d7333d2073e40363213f946e161404d3ef250e2f5cd13868";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/bn/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/bn/firefox-68.0b12.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha512 = "83718b79629516ef1f8634dc1ea305dd3b5fe21ceadfa76a9c7df5da08efc2b7065b25b9761f026f215fba9254e7f91e368b71cb217d5e034293e5da317cb26d";
+      sha512 = "c8a1061200871ea00f380f464ded104c757dab2430dd3c416d027a6dfe1c2a1bf97ec6963e6ce2a68f99dd6abef1ba8a0cc978f1387ba0e8dd3793e259abb078";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/br/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/br/firefox-68.0b12.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "cfbc1bbc32fcfb1b997a6083d040e6a05bd4581d27b1f5a1212f5285509dd4c782eb5c9a6070cc3a3f6d923ce40f5bb33f8d7b97b560d80f7494b63796edc3d1";
+      sha512 = "cc40c33af7dcf8258c6d675f392c15da86eeaea27c5c4b27fc2d618b5a7f5cdeb2a2b827134c4fc5f88321d5df5f2d04be088dbf409c51b12538aa6855a7897b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/bs/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/bs/firefox-68.0b12.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha512 = "13ac7530684b01fdf1ed8acb8a365410c9d7331a2420599b7bb6279a82b4c9e79b8e67ee5ac6e7493450e81714706f5ceff31a5c794e2352e59f3d771489cbfa";
+      sha512 = "fd5e9ce9a3f25d01b0a14cf8729b1f44256a279f57211f37af888697f51cdcacead83209c39f126da266d06b6d9fcae30005776da9bcfdcac823f0bd5b91b374";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/ca/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/ca/firefox-68.0b12.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "1702c09018f7e52b8bc9bd6e6241cfc2fc19849c4e24d6c0e91edc72da2fb585dbc00f1e6e689755698bec0e7126ec49e48c2412422f5a7c2a88172c9f6ba020";
+      sha512 = "2fba5d90b6b1c2ed66b6fa8dc52371e77cb1d783acda27c88341c89ead42a8acc6a271daec2b0c0a992b27e2737fc33c26638abdf18ebad64c2d54b2d3e1e84e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/cak/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/cak/firefox-68.0b12.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "4025338d06ae54881cd61590e8db65071c91948c558ca3865d8f472a1250bb1a7c6d754b5570683ad71048934f3052e0ce593cf51f84c634defa819e0c6df306";
+      sha512 = "d9d1ac1370867478bb211b9b51f71f9aafd75745b4553b66cfcc739c2c5f5ac42e2db13d31eaec98877113c0fba9482d4547824917d5f1b8c3e8d43e0045bd8e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/cs/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/cs/firefox-68.0b12.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "7f92a44a9b0af0a22bb823ff7e5d08e42ce9be0d35e11e0bad698d432740e9ac570038096178099c82991ffe80ee7b9f017e643ed050a5afe4d578169e606a8d";
+      sha512 = "703dc733105080287191c1e77a6c969a6b8ae9ba575fbfa572f43c64982c0a957b4319c76712dfcaca2ff6b4e6ae00dbc1f325df2b06261e0cacc75cc279b9a3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/cy/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/cy/firefox-68.0b12.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "517045e4f728094e4a92bfe804d8dae505fd9ce84da144f6130257ad7121b793d90909a3861e358b3a0e8a59e979a33faf3971b55b10d7d59e0058fc0d061cc3";
+      sha512 = "d2e139f9891abad647f8e4cde9283e5a4376dec5ede58ecd27d16cb92a623ca5c5442aebe7ab5ad5726b899b7a90d109350716ccbcf3f645aff46d9167bb8cb7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/da/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/da/firefox-68.0b12.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "ab28b4b4032858280e053c069bbb092a4a93d27f41d243ab51647bc5363e0da220f6d9f1afa9a4197aa9cff5a2b00c2399348799e00838d861c0e3574d50a383";
+      sha512 = "3c6fa6a9112dae40dbf70328af0955a63f1a7c0c2216daf6a3b42a2e6a14f841c6d04e4e294c9e8bf0564afaaf20d9959730fc8b50a491a059955c5e1b2beb99";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/de/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/de/firefox-68.0b12.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "b97f7e9be6f887ab3a894168006ab31938bad13829beb313c838c44492fb14e164ddc8b4a8076120aeb5ab61f86cdc6f4f191775b7817171ed9cdbdf06ad1ab7";
+      sha512 = "dc1c0b8b87a83a6bb2f30beb4da6b3d04a7d0fa0feb734cc207b2b282d3fa55cc5a0bc19d0b9fe430424686b0c785a2f6797210ea7c740c2199cacbfd680500f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/dsb/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/dsb/firefox-68.0b12.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "285baff9216208c5e436df85260c0de5917aa621c4fdbc447a8e9b52b9b1ce25ec9e56fbe6ba4deef1b866308278e578d6189c3287daa0318e24ac25ae8e162b";
+      sha512 = "f7589f38caf59a8acc7d02c026119304443c3016482c47b39613834d93d348f7489364d1fb2efdfb2397ba9a8fe088915531e21b95927d3fac97ec2f07bc6af3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/el/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/el/firefox-68.0b12.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "782455b991864eb295de88acfbf245d0eea7e206c5a8f12d5d45211953c5eb583dd94c9518958d2c06948f6dd0ab9a6626467c4c1d3ace4f5aa70d04ebdd044c";
+      sha512 = "50d0be1514be61facdc660ffe8079defa37cde6f823b47ae498cd1e4536c9f6ced551f82ca8ad08e0be4f0d64b2e8e055a20f3a28b282566c61545aa39994a53";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/en-CA/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/en-CA/firefox-68.0b12.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha512 = "0f5060f65c7d3e13f5bf1e838429b0e7c9e2651cd9919268339ba44c12dfd1de95b7ce7a52cfd80655be5590dd6853bc8c21aebc4211f0e572edf6b1da70aef0";
+      sha512 = "eca93e266ef850971878ee858830f056afe430d5fb6dd45ebf0cc305bbf4ae9d8820154c0c8df596a344c4993ef184e000c9059e068e75064ea53d8c0a2fbd07";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/en-GB/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/en-GB/firefox-68.0b12.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "5d19326c5cb0e083399832a7e9105524bb45a9f90e3bcceb6d846f5dade960392efa74aaa9544be741a50a84a55a35afaa77eeabb37a7db14379e780e2acc396";
+      sha512 = "504c55d0039df0db7cce4cf0346919462fe0ebbe1e36a05ba452b815506d58ad03ed6bfe5e4d347a29a1ee97cbac52158f7939a0c817513e3cc864ad0d80f3fd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/en-US/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/en-US/firefox-68.0b12.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "c7cf6d97d3ed8ec86b27984643e5a3c9f878f197a43b51ac767e7befc33d9902e212cc7a6f766692d7b4a9ac5b7b3faf109822534fae3dbc140bfab7877ad01d";
+      sha512 = "882a4d9edfd71941cf685b0944ec9a4d1dbc7fd847a9bad9ad2f91d84ba0edd025b40529f26d9e9c40707cc82c741e360d1935df3765d1210768967614a416c1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/eo/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/eo/firefox-68.0b12.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha512 = "c02f3f10d7a55df24b8113b857115048ac698e00da71def30d1ce4709cc85044b9832c52bd7ee7a27e93369955e505fa24397303f3cc09fd052fa896568b7501";
+      sha512 = "3fac5b2ec348b453b5710ab58184a8716b98a08da4f7c344690c221c3467c01f92ee21125ce396695358529190a168c2f5ad7d7a6a0b82391e17e94bfacc86d0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/es-AR/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/es-AR/firefox-68.0b12.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "ed4c8a5b4769a040d92caa47985b1b602f5c48d50edafb0cd1dfb12b188ea3fc68875881c6dc4d0872e7cd5e8a632e3ac286feb5ec63c33952848974dda898f9";
+      sha512 = "589d3bc9f2da99d81ed11b2ee353f7dec1fd2f747cd32212ff270f7a1adbc1691e4af76026d1e11e21632a2c976b4b126ec07ae5977209127a99e50e859994bd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/es-CL/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/es-CL/firefox-68.0b12.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha512 = "b93aed5186ba600cb3208ce054b7048bafc15267a947058b42562c2413159a3723e689226a09baf33bd74bea643827e94fff79d2dd6b33c891e41eeca1d73ecc";
+      sha512 = "d0cccd7eb4d8e7593288e5268661075355e528ac6f50bb06bca66995687af703cc15b843641aa41e2d9c34a71444581b151555de083282d857900462fca4a4d4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/es-ES/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/es-ES/firefox-68.0b12.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "2f0fefe408a1cc9ca9a204766cb08c373ccb52a614ff27606b8f4d4379091b37c00f1c268b625b92ad679af6705840969ae4a6402106545125c030f127b77615";
+      sha512 = "c4c39caa2d8e3787bc81a125c3639720c315540f3efd4030f6b16f7be73d7162e9c3f404ecbf9a89918fe522b492e79db9e1983960a0f20e60fd9e5fcf4a6fd6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/es-MX/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/es-MX/firefox-68.0b12.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha512 = "80906e2aaa3ee348864fef97cdeb1b71b41b7ddcf5b746554e732614ea4c21a8dfee9d4fc974c3f51b8122a933ac6610efc9693bec24912b138058b041b3181d";
+      sha512 = "3d385a01ea51929790a6a1e81700aa6fbdd5988b6721b791aa65ead15d20654a7e71cc5595d9a8c9652fa760e07a4b0757115b46e9d9de2b2282d83999ca93d1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/et/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/et/firefox-68.0b12.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "7569efd469dcd5d90845bdaef941374982385c640035007ab7123663d10c479cf032b3a5ffe057ac8b7c663cbba1fc570a68d78f62dafe10234a8d2997823458";
+      sha512 = "e3a278a33d7957326cd0631766d3a4784190c9d3225814ff1fc7f987edbe91fba39dabf2eac7fc95f44ff8eafd46c79254affbaf4d0ade7fc25c9c14366ed4f8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/eu/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/eu/firefox-68.0b12.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "6c0f70c7663963c43795b0ff24589ff80826c1b094b47bd7d4c38d034a0992726ec26f7f32eaf4287b0469c20563464e2030172b55059c283cd15e9e03a3e38f";
+      sha512 = "89790aaae509fa4338abdb92bf2380355f88a71c9246807ebb7099b443bd961fc9dc4190204a72b6d2477e69081724b503a1abc913fab0dd0e1e5e00033dfab5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/fa/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/fa/firefox-68.0b12.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha512 = "8369dba93d0009a7ca98b020b8cbe044083ee155318dfd700318ba69862178ddea43b3e609a3eb10bb9e3b6e201d430e57f02f4d2a3970f687511f1e03ebbbf8";
+      sha512 = "37738b97826f9cf0d1e5364385f4e960487fceea5c27bbb82b43fbb4596ca6e8418edc8f78e6fd323ebdb5472abcd015fd50b345362bdef27ddb172549a9318b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/ff/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/ff/firefox-68.0b12.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha512 = "95b0acd69ffc77959afb2d1868cd093dbf2ba0aef40ac1ce83d56645e46334d2896d66f534f6fd11e75e169ffd4a0f9cc74b27f8f5ef4ad19f04aec212b73028";
+      sha512 = "cb8e50396c862b276678a2fabb80f980fef30d994f53a09359d58604aa0a27eb0b278e5d9a1b1dc7c1fe596a0d3e0313bfcafc44c0d065c4cb3abc5c6034e6e9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/fi/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/fi/firefox-68.0b12.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "c3dbc4f930ef7d39eacfed4f83e382500bf711a737a06b6fbb872c7fe191b5d90d9814201c3c311cb5fa3a7ac6221323784786f2b0923b090e89a51dcb677ca3";
+      sha512 = "99fadaee05f23da102c430d3d1481962b540b71663a219699ec57b2b7342b3531fb3dcfcd506d505364f4c72f3f659140a1169993283683043fbac76cc282eed";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/fr/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/fr/firefox-68.0b12.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "52d1389a31c77fe60e038f63100070b62ccb1374e9c6ba1db5b36dcabb4bf42b951aa45167a5f8452d39891322b61a48690fd1668110fc52092b2967bfdc5f33";
+      sha512 = "70c559e2a9efef7314ee1f029b21e684ca39adf2aef298c613b1fbb93b7b727885b51bebd741eed536d4df4f61e3f63e985257cce79433ab3e6412740486e73e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/fy-NL/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/fy-NL/firefox-68.0b12.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "2e0796fa0bd106541b50c6c935d4b01814410d3cdadfbbf97385f1dc538ab20aa0f480414bae6078ab5b6a16f8919cfd44f1929d78d43c9e054aa7cc97cbe1e8";
+      sha512 = "9935b93db2eca7b29d190cb61e29e249d307efa2475617e4a4885018767bdb7d745380a6ddce2611af94bda34054654de9ef5f61a5cde627900471511bd51f10";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/ga-IE/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/ga-IE/firefox-68.0b12.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "4f8f26071ccfcb1e6198c5bcd5e1babb7da1c0d96d2dbcde8330a794d51028663740273cc915cc2961a73e54c3ced4e9ac8d276d285bcba63eadba839ab7305a";
+      sha512 = "d77f318779d04a6891e4b05f0e17fc76ef8571df1bc87d251b1c00997c9f7736df18fdc98c2a3f91473309dcb2c74df121e300816fc1617efd806a738d4e99d3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/gd/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/gd/firefox-68.0b12.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "30f26bd92cdeaa7de68a08b2d1ac05daf85c4276cb999a5802ffad160de5da52a37edb85c309c709237fb3a8dae16f1a14d2812dbcc547432c259821bf40f370";
+      sha512 = "c960a3557bce3e6aded9454f506ef14eed46695d468199d4dfb5a9bc84314aa171c0b61c3c3972925a881ed5da6d3cdbdf6dd0fce70d2c509cc9d49e6cc74af8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/gl/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/gl/firefox-68.0b12.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "959e8660b1a96fb2a20fec547339031f0079bf4634336937f2afb1f22b5cd614103c0ef85a870cd44c939d16c708366fe55b37e75577625d74ba488374ca7b98";
+      sha512 = "58a0dbf623f87c0fe76384b5407b0681e2ec6418af046a65bc843ab0731d84fa1254244405bdaad92ea03b867c1022cd8359a3f469bbdfabc2d177a2dfd38a3a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/gn/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/gn/firefox-68.0b12.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha512 = "c78d1c5d347e1f8a69ea9c4a254d6893c15ed2a97a8bde70a048b841bcddd625f890285b6ff3689ea14fe6589417d0b3a35610449efbcb7a4dcd571e3688d6ab";
+      sha512 = "1dae8f4d086ca7ae9ce7ebde47d5f11b49768a3c074915735171f851a10aa2ef70bea0701fafc345d777e5cfd5517604744d70e143217426fc3f8a29350904a7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/gu-IN/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/gu-IN/firefox-68.0b12.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha512 = "c52c5039c1a18e8bc1a53c59b148433686189d0045f3c11a0abaf253a9696a801aeb78023bfd7e14c307cb7fdd4851e5c3a39c70846d97d2be116453b038deb4";
+      sha512 = "ee01da06262f1f87093a19f775db4546b2c0a7d2e0a52bf2640e2eb77afab91f36c5134f5e6ba61f0839e366417920727f82066d277bded53d30cfe1bf708841";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/he/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/he/firefox-68.0b12.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "66e9b9850b1536e2a7ad286d42cfc3eb46eac4f2db1b008212534816f6e6cca43f5b6c5eba1753cea4b3c811f19ed72a5ac8bafdd932b446e606f5e62b7f9056";
+      sha512 = "20db236c57f8ef23cada1a4d081c6070141db952986431b6654aaf78f70fdeacf0d50eed7d2b054ef51ff56807ac019efb16a67b47bc9466720a50f07cd59614";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/hi-IN/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/hi-IN/firefox-68.0b12.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha512 = "0b3d3e37a7add1a08d9384ffd093cab584bf79605dbee516e825c7323d4e799b825aa8c4392d26c225e6c65e6737c54de2d69e94014727f70caf76d74a415936";
+      sha512 = "3713350c1cd114dee03fcc74fc4620e56e8f56eafac03fc93e39f3d5bbdd6ad251e9e3b68bf380c1225f4092d607b6624debd37b239853c564a32f5af7ad0edf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/hr/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/hr/firefox-68.0b12.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "a2625a61971dfa5ea6a3f6a8d5d496b590f439bfc778270db6f94daf505c5ccf81987f62d215f434ef92103b0dfe3b22f3442eb12650bbdcb25ef336b28969e2";
+      sha512 = "d7b407331779e0ba9a717b339ce3c0c7ed7977f2d78ffef8889285de4855d50db9a2d23455c81b87620f7235bd1b46259be7694ee05a34c6a80bf3eac172518b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/hsb/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/hsb/firefox-68.0b12.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "34afe9403e38616c9df759f2384eb667b43c03361f208430fc686e8c38ba781ae09805b3aea416973e6bebd84003b12ca8d1d26708e40c49278a40f519f562bc";
+      sha512 = "f0be34fac431045229d9719f7dd8de16d7c47688f8fb403d701e07163376878d82fdd5990cfcd3668d7224569630942c1e0819152d1db397ce25f965decd84c9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/hu/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/hu/firefox-68.0b12.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "2b721601506f427de0e5535a1e1659129597320ac6c2c89d8497779d385f40998add574c1aaee3ef5db2e9b093e9741703ca7c7c80fe031d69d9afb256466d65";
+      sha512 = "acb207fe9c841da3e1d6e0ab80b0a48fe6e8361869be1871bf156f33c99bcafba28a91b4e533a28218416e5a5c5864ff44f7d75ede0deb04c283db252418a164";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/hy-AM/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/hy-AM/firefox-68.0b12.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "6aced6a12ca24101a85f9bed3ff75586043e5091909c5d14c9023d8728fcfe1a2309609a9516a7186f0e40258a183faf976f549686c715f13dc988c70baf0dc5";
+      sha512 = "c8243580e1d4304d9e249ff49e9f14021f886ac29cfaee1b35630f9ac1e7cfec125cd547bee8e645f1c3e709aa834da46a97fddc8fe1eba565ee33818a10a443";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/ia/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/ia/firefox-68.0b12.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha512 = "a16c8e27fc2f663ed503ed53d82debe35154d03d7b5becdbbf74204b16ec91546b9b60bf28085a1c190db63883b9af3d2b97b6cb64c819cf1f351668ba05962f";
+      sha512 = "593f1f384da7f3adc0d945ce87b7196e6b34db416e860c6561a0b4b6e37c2cdb945f26ec465f49caa3da94f2d95230830f8a09a32de6896fd5348aa9ce6dffc1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/id/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/id/firefox-68.0b12.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "1902bfa6579049c7f779e423834811eaa67a2e68c0c9c75319f6732c4a4eccce33d484e8707dc1f6b98963fb2da778c683dd991535606b5ef395960e820ce67b";
+      sha512 = "2c8f939c34c4655173599ac5b5b485695bb3e5aa83e734fea482659d0883e784463d606497de540877bc9121741f9a2fa45fd9842979f348502dca9f148d45e5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/is/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/is/firefox-68.0b12.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "9a9a0eb4a3c677499572126a7bbb257b3d65d7669c6a66430a02cb69aa889549a45334d5642fb313056bf8d2dd8f3b9cab48c93c35684a824c73f0ac62062772";
+      sha512 = "cfebb762b4318c4db863b1a1307cfa59965333d99f6cf78b99927df92741ce8cbf2540b657ce9ab948bca587a80cbc11633033499109addea0f675a2fa9747a0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/it/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/it/firefox-68.0b12.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "7e9bb470e01b787f04ee2c8ad0dff3313b6088c1d5c2c61c7fc286e03355f31f3e2f1cfa2f1e7df4502033a735ac0ca0ebdd9e64556948b3b09783611453ee1e";
+      sha512 = "f2ae7405bc9fda25240a53a731a81724880d0a61f975ecd4e916c46f69648bd09e94f9703cf7f159de3d7578b2a5f114c5abdc7b425540533622a44659fe8580";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/ja/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/ja/firefox-68.0b12.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "038e79b35bb7bc9b308fe76a27a27730b9322ce1fb9456ed898fab290778dde34ee0a7bae35935431dc7722e7166112e50c06db865ca7226d591c28c0ec2cf88";
+      sha512 = "f7084f3dabd2e5cc4029c3840b3ae6cb5de56919076325a5c2789c39794574cdde5ea656d75fc0e0ee2b5600800ea51c3db66431a793362dbe949c49e629bfb3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/ka/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/ka/firefox-68.0b12.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "caa783645b0b2615dc0736830325ba365e0ce6603dc1784243ce46c492ea0b9567d496072e415c3e52bc2fd43362a6e624a64678ca77748c3ac427201d27cc45";
+      sha512 = "9cdbdad908b6c0f292c5bc78a1afdb867b7bccdb43afc524ef3a72a7079587664cb0df58aeb6b3aab3cfb509c0300bf48b3c56e8b6a6ba94e6413f4a4c17a0c6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/kab/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/kab/firefox-68.0b12.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "dbcc0eba3b10bec06a9cc788144ff190f390b3f0dd01c153b6d76ddca9d003a5f0bccc5071fa806e6c74de1c821ea7b95f19e403e7cec15b010ab53a93a70d4d";
+      sha512 = "c2e65f580b84e26addf7f13642b17596d91c24afaac8decd03235dbf6392df083368ad1e7b3a5f44666ff87a8dc6a08bc3030410be8a578164d3140a8743d2b9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/kk/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/kk/firefox-68.0b12.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "cb4dbd9d22b320070423f5cf016604df1886499cca0a397a28ce04cbc306691568dbff3675a829cb87dba32a19eb7ec18488ce129d8f32d137940cdf6f73000f";
+      sha512 = "ae42960c95b5331f5bb93dca24a2a2e9e10ff210fa4d9cc8adc728a67e15dd1e70c57a8e2ba4ba9feb0466268ec7df14cf061aedd30a597a89a46d3f9fb3a313";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/km/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/km/firefox-68.0b12.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha512 = "cc024d09852df790dbc897cc4a3c9490d19801b080b9c83ef8259bcf067fe855be3b2e0cd2d5f810340c38e55f8f27698386cfacd63f66e599a84d12c3e8d3f0";
+      sha512 = "7b4e27a7be3e0d5641fa152e76b878d1fb485579e298e7305934ed4d94ac719e658c32345891be818e03150a417542fae07ebd03db74eeb5e9912a75ec5a0dbc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/kn/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/kn/firefox-68.0b12.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha512 = "39a8b921f1b2640779554300b4f7a62d6316b9c0a5d6555645fed7a5096d02e280d13481de67db6ddbd6b512dcee924abab134bdc79381226a7d119bd523d8b8";
+      sha512 = "9082afa873079ac286dbe1bbd977f6499fb3dd31c9665c6632750de20ca851dda5559aa6b697034367257517dfcd449ee98f253539521c49b3b1d5e4cf2baef3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/ko/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/ko/firefox-68.0b12.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "dfc81f4b2f1ecdb0befe2649a74dd40976d273ddd57a4b89ac7e5f62b6c91438e9872ea4ad9ff02627f3d62f484de483e52451b25c31f1ae99f6f7ee6367fcdd";
+      sha512 = "21d84b384cc16f8b0b62517c355fa438fce255b3d5a7fa77902da2190530c868e46b5a99da059ca5f1306fa58e52471cf7aa85c2d860b8983077d9531a408bbd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/lij/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/lij/firefox-68.0b12.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha512 = "8810b57fe173d20d48521640e7c2395a8a9804e9b392f3817db564b39db84b33824c91772016dc63925eb1e84532789377646413bef4d7ff1b520587774fb927";
+      sha512 = "88104bd633dea730e1291fb3e1be8f63c68be288c86505d5fadf4c51189460b4315408b15d1c30d4a78dafada45687cf4d231c324a2fbb5b1f1c6f0df053fd4f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/lt/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/lt/firefox-68.0b12.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "a408671fbb21b27cbf94f8371bdae85037904732200bf03b617def9dffa05d36546417ae6cfa3564dbb5608ac77830a10215dddcfc2c2468bf91a72ca5102ef5";
+      sha512 = "2b6159e38a3c32f993a9a03e12dcae5198355804b60c262354ccd1976d5c448d133a4e4bfa5fa77040a7811353aceae105afe9e4029e97f88868bb311fdcd64c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/lv/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/lv/firefox-68.0b12.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha512 = "95a8b352d1edc09d33affbb1abdaaa08df6b285a5c538f9d712a223955df27a833b8f02ede0056a7166aa652b23507d826f221d9a3045e8e83404f3cbb562295";
+      sha512 = "6aa7a4e61ab8a08de96b233e98efbd6a558562dd20400b5c905fae5d25e7eedca8732028b5c810611580f250e9fdaec5bed9b6be4ca82a854b218fb50bf29f76";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/mk/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/mk/firefox-68.0b12.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha512 = "f423b6b58813540404ba169f203977f9c1c5c298a15e5073beb605dd2f6bc8127e130b84a8271ec5075494bc5075e0e927824a21b937a78b8b41d543e844a0ff";
+      sha512 = "aea23827fc798c1870bbcf3a1d6305835fbdacbf7b65d3a58cda68d289dcd2abc1552af01c7f81ec2c95953e8a390072fd38bb187083205069c10e049beb5509";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/mr/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/mr/firefox-68.0b12.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha512 = "21635ec05303bfd368d84ff4c1872fedd15ae3d84d096b033c2f9d69c0b33763ddeaa0cf8ac0f7a37cfdd9b0e13871ea4de06ee2ab6b0c0869a9d0cf0820e8ed";
+      sha512 = "a4016ed6ea3c66f3e136e324c370373b79240d021478333f1e75fd5a6041884be5f3984cf769e41e05bb7ba4ab27b3e110b4b60acad2734f57aec1955509756c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/ms/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/ms/firefox-68.0b12.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "8ceb952ca963d925a1ebbfdfbfbc8e8ae1541e6d491b40985624ca170d2a30daafaec6fbdbc8c9c6fe5f519a006946a461d77553f243a7f221ef76e364f0153b";
+      sha512 = "360f51dea75071407513f798b21cd5e45af7f00a6d106550270d8f1cc381e9d93946c0c5d7a5bcf0869c7b552e2a6f217a00a7e33b628e55849298ec71d7ab4f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/my/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/my/firefox-68.0b12.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha512 = "66a8cc0570b24ed840fd14be6f251dda76fcc5b623106f348829ed0ed3cc3a40a5426847e9ab51563c3c90074b405b1f52f2501f8086dec9d5cc7687f7844ccb";
+      sha512 = "500597a8d6728ddecbd535d8d7dafd5a7f462319b2aa8dab159b7c2f6662d4bdb67988e6861ea8e1e8bfaabd1b8ae3e0e281f6c695e21b86f3557299c4f253f7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/nb-NO/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/nb-NO/firefox-68.0b12.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "d82f8c40af4d275691f03a3b5138c12e901cd822f137418823d2b0b5c890ddabb6790d31b57589752ff10475d3bcf0896bd0af79e763bfc9743cd21cfd3f7c10";
+      sha512 = "a42cc16daf51f5820e0fc549131827e9e00fe9da455607c54a069a2ea25cbef0f7d0b831612dbca90763ff94d143ddbf2f3dd795b22f137b167af70f30a27dad";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/ne-NP/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/ne-NP/firefox-68.0b12.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha512 = "55d750f50df07abd557768cc566803886bd4d38f785fc0f04165e48d4cacbb8b7110e6c829c12f5befa025002089b2d3207a8eaee6c154f8fdb1d5f945ad23e9";
+      sha512 = "e279dbf320b862b84cc47ff48422f979080d109f6d5e222c44ff0b7a282a5e2f9c7b8cf90e31a00c62dececb6ed580d15f78126adc1ba5328edaa83bcd2df389";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/nl/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/nl/firefox-68.0b12.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "569b986bc75db8e5e7735d33d8fc357a36e962367f31046afcb4c19a46152569bf1689ab083a603226916c9f977e19d97dbb4076ed2bbdf80b47128a28a6fd75";
+      sha512 = "927e986bb7ac3cb3c0bca70b1731427c47b0c08be95d71017c6e748b837ee5eae4b9240f2c106326f9fe4dc19503e1bdd211ccba4574f10476980083aeb9f6c9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/nn-NO/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/nn-NO/firefox-68.0b12.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "bde4d9de0158f42f7c2e302445e1f9eb0677dec8b9d25c26f7283843933d63951ff8f6f1b5827aba6c1ff6f6e975bca1a8bacac5804d8ddf1f418d2df29e56da";
+      sha512 = "f3f63b23cdfff7d7b7d1a83906afbdaca279eca3bc7bcb0e81844617ae0c682e47de7677e50e9aa255d4153ddc2c71380631ffe9c75467183f9c04ad14fb9a81";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/oc/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/oc/firefox-68.0b12.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha512 = "9aea54dbb28e757f648fbcfb5d2ae26c6f49b0b47ea88bea849d83f9d80422e1131c4873ce5de30c427fc2b09122e63e0253bcd5589973fd4ad27ac848eb091a";
+      sha512 = "ced599f04e78c03c0aff767aa874ae9a16f931a4ccf6fa720eb75fd68dbbf7cfd0a5ff34f5d0ab11570d02d6b9f63f797c41f191e7d00218113eca83cffcd65d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/pa-IN/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/pa-IN/firefox-68.0b12.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "2b73af20dd3449736a0aeb557266b8ed0de9b6bbf5032d81d4452b7fa75bffabf9ea04dab4ee9f9e3276e62b6d5650bdc851553fb589cddceea5054c3d6f3fe0";
+      sha512 = "beca221d503a6b082df8bfe67e9be796c670088e0b3baf30b6e2fb24a9397f10efbe7958461082fb0696ded9b4e4b5b15c77ed57006a76e0c54623cf6f04235e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/pl/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/pl/firefox-68.0b12.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "470bc1f5cd41b29805e60da7e61a73239b669ee9a976588fb8d6125dabceb7da2e4cf40f6f5066f0e4162bb3aa48aefcb99d220b986fd4eee0f59216088c8951";
+      sha512 = "0eca48ee1275ed2bec85bec2c9d0e09ab962c4ee7543441126ff520cd61ac5bc686d1ce006243d652ad4c79fd08be6473b87c0052cda20348a66b5eacec18ca7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/pt-BR/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/pt-BR/firefox-68.0b12.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "a1b6b95cc8d6cd8837e46d15159d2d84591136f32c2c2bfd099146e8a061daebbfccd015c988a6f3df41d1741f4db47dc86336d3e342d33ddde06cd9696b0ed4";
+      sha512 = "0f1b2909355e22bee9812ebe04b2ab9280b892724addca0915b0773592a6598b0aa48543d92a16be39eb1f748f8109594cc129d59d5a74afcfee8ce71ddc7d8a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/pt-PT/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/pt-PT/firefox-68.0b12.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "863323e3ca02995a4501f4105c111a01e19c3a2c41ef2fc3de4a2f17a11d08bd90ee8f02624df47a9271282e9b6c88379a935fc2cc4a8870f2c44e9f209d3ed9";
+      sha512 = "2e8a2d2208825576580a86734f5a77a0d17fdc8ad76bc317a1171bc610eb71f20bb66502cd9158a8afb281ac5e92f8edc9a81592f2df4fbfe2e368acedc241fd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/rm/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/rm/firefox-68.0b12.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "7e21c903e81cfe455b532c397344a6d364f055e15fe22f7b440b1bec5e1ea93e91c4e7e1ca96185775031c9695ae4a237e7480d8f14b79667e52e1fdfda23926";
+      sha512 = "6132cc4dd0ce68b50ed5417842c3f8bdc8deb3243f82cc6160ff657a8d51a73403e6a6f987a7a8fc519806c380754a1fe9eafe804c08a972d05c1fb75c76dbf0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/ro/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/ro/firefox-68.0b12.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "7a677750956dea997ea370db02ea43fbf7b7e9301e04fbc05c18c96ed69fd3084e5ff22d4312c25942cd71a822aa2dcdfcffb43c07d4d678b1b84c861db2b2c1";
+      sha512 = "b7b64b358f847a47831fa7b30a4b1fb2ce5e3dd68252e8516ec255e193d5f2e4f4831bd4649b29ecf8e94e133b9178ae62f13a2bc1d56b93195543d4fffc2a21";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/ru/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/ru/firefox-68.0b12.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "455275e16afe0ad7f43e40ff6c945964551a72b4539dfe899c9e99997cc054ab1afe5fa42d84e05f2c03a323e4363fdfbf5ea85e2b60002e531473b60e8a322c";
+      sha512 = "0c06df6db5060e4c5d7bc1802ffa5b31dc7fcbf041d8ad94ae5d2f02f340ab0a1b8078c0b35822c25fa48b9a48f3e89f15ddb3819f27613d8ac51d3033129bd0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/si/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/si/firefox-68.0b12.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "95efd30705c423dad72114f1ac53d98bdc337d5a5260abefd7aff1b0f7ce4645fc625d3dbcaa98b85dac5b343c61fc55648f16a4f2ac28d01ca235264a67ceb3";
+      sha512 = "ebe76dc51e5ae556152b468084e848d2beebd5b6a2b87efd136db6936492a03085b8207c2928ebb2f5dc003be4fd47e7b330034bbcbf7085663e08348e5580e9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/sk/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/sk/firefox-68.0b12.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "6f817e62714bd91800fdf8c022a4e0ea845d62271e8cfd440f1f5d400284601a5151895cbda7dfdf3e46e1d51674dbd08dc2ceba9111da7c4b495b666a6a5123";
+      sha512 = "e722e0d139da87df2ae9526621379f1e8a23da052bdacc21204cc41b2ee22a316c915cedc8d13c53b63acbd5a5e0693e52a6897fe4c94f33bff8cbc27c4d0f0e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/sl/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/sl/firefox-68.0b12.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "85b57f16e3c191ca81a9d2e8d2a734af73ee9214224a49d5588188331b0d8d382fda6139444bacb8a3b52936e795efeea004d31be483b428afcf8d2601f2ee9b";
+      sha512 = "8ffecbb942625559f6d97ee57d716b97a8cca1110aaecb5759b85aa2f56d65058b08e48b939cd9ec493d709d44cc3083843eebe1e742d6bebaaed15eb9bc4149";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/son/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/son/firefox-68.0b12.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha512 = "3f5e596ffd0dd835db6ac3785e7e42234b7706712f7781acbdc20fde666c6d2610fa0dbfca3ff721f5cb3e38121b8fb732723cc018c773442be523b29e2287ff";
+      sha512 = "bf56d3a90aa862f478c0a858bd307663f1e0bcaf3298e3f3513d0a55a3be3934677778ed16897d477cb27874bfcd9cc7f8965cf5916b48de3425459a04d2d1e7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/sq/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/sq/firefox-68.0b12.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "b7e7dc0570d603807167c33c184bc9b3e97b3e6013e0595d803fc83adf8d329e83c348521cd053e9769257ed7c824374c1d224c5211d7cb9c5fb344f8af3d5ab";
+      sha512 = "5745e225017602257b546b1b08d112292664f46e87a62cbbd46a9fea65db34f24dff61f1473f13927afa33c7c6dd2d9e8e3c3d0bb18c7a6014e45b878c2aecd1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/sr/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/sr/firefox-68.0b12.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "d5f59358f23b5f912fa5f45f764bcd7a4ab3d9033dfdaafc5832bf1debb6330ac40243d4da1184136c325ab44019ff946739c601df953a85c16b33605abda481";
+      sha512 = "90f3ae30892151dca30556aabb3d5ef9f7e2fd85d361d32af4d87516337b8389d8bcf01708477fded9a5cddf58a9f69980fbed68109a36a4892ba3e1e0229df4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/sv-SE/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/sv-SE/firefox-68.0b12.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "546d67e4e0ac504be0063e340f890c126c27b95889a09164d4e59b1ab39ce4e387fb06caabba700df4e5c6cfa016fedba56ad5151cb1d20c5b6d9789556d940a";
+      sha512 = "b9c4453da8a47729a63ed1c67d18d7544cc9a6241a2b9feb246f0ada423086dd72bee3b91a0ef1e335ef15fd1c57ac1937a25b311587ab2470438d8f93076532";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/ta/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/ta/firefox-68.0b12.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha512 = "d1f73f0b3e4f373f6b441f9d4f815e3849e02306b41568b32c64991d45dd583fb9981cb19f402e39af99742921bb1ceffd7956250e05a8eb61e426e65400ec83";
+      sha512 = "99954f03406a823b9662f371d1c6fdbab18d15099b081a4b7ca99517433aa67c22c719efc1fb84baec3e3e25f1286bcf4d876e9494b8b5f92ef921f88c99c57e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/te/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/te/firefox-68.0b12.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha512 = "1c37fcf2135ce3fcd36e49934cd863eff3a5edf649130aba0b7a203e93f6979ecdd9c9464931e811a74e070d56b3ac26bf05e91d3b77d2fb11507751a474db17";
+      sha512 = "420c1b6eabaf6062eaf635625c52a14534dd4646c3c28946ff13a9ac573ffa200d71d29098bb99909747d90e2fa5ff8a316e1785ff45eccc1fd070cf354236d6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/th/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/th/firefox-68.0b12.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha512 = "7fe3a4794a00bfb9c4cdfaba8af78481c7bfb5909e35e5920d2f0ff8618ddefa2e36161618ad9b66927b5b71d3b0e313bd4b70c688aa333edca707c925d2bf28";
+      sha512 = "9e399d3d6c76a27e357f3d5b6a728f6dde409b1575588b55f84b1ee53668928ec1d83a425feeda3dac0198b5ffe15d432d00b9404e13c0cc861f9147fa0b93a9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/tr/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/tr/firefox-68.0b12.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "1b733db0bbcc1a6224801d2d885dd1d561641c3fc949bc0b7318b6c73a44658963ad5a76fd80c5ef5639f99690efb0162be1bf5592767b394aaf18c77a540634";
+      sha512 = "3382250950fe1ea125a3058c633440712f5db3505c92e695708753e8b5f2b89d2a283dc09157c47309d926a0f25662afb1c540d16c15bc2b97cb661cfddc10c7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/uk/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/uk/firefox-68.0b12.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "ece3c515ffb05f32ef1e4576068bbf164a351f2c41adc1e4643bc9ac9969aaa5401ab3321bed983ca93a27a1a49460a3013f022687b40c8b928601c313c62f97";
+      sha512 = "207e86fd3d98316afd63f4c5f10651e9a5c754a3aa2c4c2b50d40eb51048b32806fa631a7559a919b540111f8ca5ed84d038afbb7865de90411d627360b9b979";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/ur/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/ur/firefox-68.0b12.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha512 = "cf0893cbe04c87887f0a69f9bea7aec35070a3705a8840f5914166c3724956785e4f8d8c2bec3396d043adc1342b872d9504890e24ed74628a9abca7ab03cb6a";
+      sha512 = "faab2519f98d53694dc7aa55191a6296f29baff7efc9484790a2a78aa7c6fef09e5a0384fd9235ef32df4d75a0a0a1150a40f6d83f37d487ae9535385ea48210";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/uz/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/uz/firefox-68.0b12.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "13de13904a97e0e91eba345b89fcd9ced021f8c3aa788865c582435869e18aa202b8c089c2724777bd7130160a6b8b77e2c4e93fb538d418a9b5fca79e445c61";
+      sha512 = "b71bbdf0ea3d19038cba328516eba8c49a5a36d29cb0e04151140c7e5b19ea982c7389cd5248d846c760d55f723b11530d050a327a49f3d8cdb371fd283c1a9a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/vi/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/vi/firefox-68.0b12.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "6f7e68742615bf4871dd7892a061d687743bda661803f3eefa016403db0bf2beddf24b3a885c06a6223ba914ad2c052f2902f2fc81229b806a1f7a67f98e4843";
+      sha512 = "d2a27da5ee81c6a46f3e8f4a0d21d37bdfdd1080a8dcc8f43b121c5b4fa6a5a544e8f04a6bea3204c1c8b18604516909a0d8717581d6b2f88a432aa5d04c4aea";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/xh/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/xh/firefox-68.0b12.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha512 = "6ec60da1b2e5edc22882985af97b25249a036a66c8a6a9cecee34614899c9871ee0e61ded4ad1bec12c261d60fcf149f089c1a09021fe5694af58317ca091de0";
+      sha512 = "c52908654b48f79eafc96a5b4f31e13595383dc397564a958fe4ecea444beadaeeac88c1b1c3929005715796a89dca4e3befdfb6d02f4c1503b7e86f1deefde7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/zh-CN/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/zh-CN/firefox-68.0b12.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "710ca56426a69de794531afb25c5e7512c0dd3566fe75e02e7a73a972a8db3f0411d5f15d29747576af45086d50fd0fabff0863379db7c72fa7eb3a2d349f2ee";
+      sha512 = "3fcb1f091af4b37fcdf29ce99299ec02cfa07927f9945bb27be8b97e9374cad28bb2dec9f03aeffd7334e9802f001c520573cc1d34e5670c2476ff16f758347e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b11/linux-i686/zh-TW/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/68.0b12/linux-i686/zh-TW/firefox-68.0b12.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "4b9f02c28e09510c0594fa8c27faf39e15084991ecfa2af68f1e327b4a0facc42358930c81b2f882ecdcfa422e3bb3b4dcea04eead9b09afbf90ece6af60759a";
+      sha512 = "440464d74bb0601ac6d0868a2fce0592a1d49fc029a2bb1782e6758d35e7f7a3961ec0cc60e8b389aaea2dc42703551f7d31e3d1c569e485ccf58bb0e34ba126";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix
@@ -1,935 +1,935 @@
 {
-  version = "68.0b11";
+  version = "68.0b12";
   sources = [
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/ach/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/ach/firefox-68.0b12.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha512 = "b1f8c75338571318731780cc2b70794705164d0b779c404cc6a385f2e247aa640f34e2599d8ae586db8803ea01ae978d9704c309d07a244ae6259e51471677a2";
+      sha512 = "4239de26746d164633b7095da96a837bbd58294a4636d6bd3e4b23cb711f6cb6b1f56f1fd7d30938225f1532117da1d9eace309e2249ca7c6671685d1d9a97d4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/af/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/af/firefox-68.0b12.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha512 = "01a45c3b8c167a292a103233297a89546f33bb7a3c600ce3ba3e95de42fe831c7242c6616ce28150eb1be6f9126fd2a216dce3473310651812b3039a0441a7fc";
+      sha512 = "ed5e3724fa2c88c84b4bf5d4c38613dc99546f952b74ac2e9803f9fc8fb2d5dfc58f8ab34244671eba42adee1ac1e917e578e9625f7206bf3b4b58aa75a5c8aa";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/an/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/an/firefox-68.0b12.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha512 = "e7a6781a01e045cb95b2298903ec7a4da66f92ae1216b71581441ab8c32f3731c3cd2dd5ee7b86fa875835681bdf8134c1cdf3d65f8ae81a46f9faa59f3ad7df";
+      sha512 = "ee87f64673037099dd29fac1d3c545298f4db4d12d0c8809e1f8ea6eddd29210edfb9e20346c0f5f747ba86335e123fd08d5b40b0a6d7ba2f34d4906dfda7f19";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/ar/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/ar/firefox-68.0b12.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "555ab7a472583abf999fa0ce9b06ec5356b3ea78bd63400e67613e6a36ad459142854683a067537765b8498fe18c58204ad694a34cbffc4841ab59836cfb537e";
+      sha512 = "ee2d65b077b464ac1a27e5ff24f33a303ec2a614246cdbf83cf84a7356f1cf3f721f6d804283c9fe2a47ffff1e61688de6129515c5fc833d60f8de2efe370f0c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/ast/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/ast/firefox-68.0b12.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "a7ff56f4c8c549cf42c9f2d0df44084a7606ac93a240dec9d97be2010e374417eb577f2cb8d17c088798b30558ea2312394972c7c8347a611eb2c02ae07cd1f0";
+      sha512 = "e9995774e3349c221f22d09413d6fc30bcb57db262ff311988f596d63702d210b904db5720577c06be4d53e2b95ade7aaa7980b5002ea93c9b9186f108fbb83e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/az/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/az/firefox-68.0b12.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha512 = "8ff93a0b174acdd54a64087ae555f0218af68c2612e1a654ceb01e4a044ada2b4c01316fa3501feb722870980625d01ec8265e392ead0f034f83bf78ea997645";
+      sha512 = "0fe2676b475fce70b5cf325d1044829022599962d1dc144840189f9057623bf575db1cd7cfb8b6d7ccce6588134c91bdf15cc6907fc94f696947a83671cee9b5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/be/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/be/firefox-68.0b12.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "44651e7baf438870cd1a3f3be361c3233e548b72f3e38ad13105cda6db6b837e7f2629954c5e74a8fc957a11bce8b9e3486ca108e9c2525eaae58add64e8f326";
+      sha512 = "ece3b80725f7a2cd2a97778a64f3be788277fcea436151cf5221554a4746e7f9215fbd708f1d7634b974e7716c387c3c8914a5ce3386323c048353cf8aafe039";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/bg/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/bg/firefox-68.0b12.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "2e046a17374d430dfbead853cbbc464e92b240b7c6debdb7f14b5a87eb4c704299f371feb86b5c2f4fb836722a01fb1990097e472ddc1250e524bf06584690a5";
+      sha512 = "5bb8489017dbf8a66aeae34299257afd9849337ab94de9d840db7d408bfefce3959ef08fff6eb2f5f8b3b5878c451b32d9b1ac9b46769149b8dbabeef1b38352";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/bn/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/bn/firefox-68.0b12.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha512 = "d09cceb341e828911c8467fb25863de49a58ce016e1744802a1298ccc612bafdd0587d9891da20a0cea503b35c7cf8d791e2973aa3697e744024347004ca4af2";
+      sha512 = "fc3633d0b2668687410a0163e51eccc67ded362e5e588d53ab2d3ecc804d2e8467a6e935d1eaa696eda720079a82a3c63913803787e33d2b93016d1125f52ae5";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/br/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/br/firefox-68.0b12.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "9cd1e6a8f9ffe2229f2f6a5c77681bb06fcfdf4cab6a07434a6d022825cb39ae3c33fc4bc412dd8000c85878ff323e095921711b4305e375b0aeedda2fba86b4";
+      sha512 = "5e310958d3cabb6911cdcb5403d377baa011be673f3e69a55f4269ad427fd33e13a2b2c674e0bd221589feaeb26b91ac98d7cb9c1d5f718bd7a83c5779ad9e9e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/bs/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/bs/firefox-68.0b12.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha512 = "177576660ea27b1e60d4727ea643b4ecb3d35317050469712bef116b5253c711b359ebb7807d2c3bb6e222327cd7ed31039aaf2c974b0e1a2cf5eb82f4f0ede5";
+      sha512 = "0803e0f91a6696b643e73ea0fddc2e58867a3ad1ef909a8f19aa03aedfb2dc6197dcfab8bd14d0472783d10880e1e23f19720192fc22ad42fac00dc02e4edf0f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/ca/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/ca/firefox-68.0b12.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "0d519401b6d6e464bfb96d4effd30c62e1f1a84d8ddbe2f9d181eac021b18871e1c9beb51b35521cd45b290783fef9860d5371b1f0733b13d5bb63f34ba9c97a";
+      sha512 = "ee6cb26b32ac4a103736432007bb48f41167d52ef89ab27fd2c9764aea4370eb65d88b54a06c37730c3c4c823b02b2519109d9a71d096c9a68a82e86305a01f9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/cak/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/cak/firefox-68.0b12.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "b5a9dd6d4bb0ed1c84a4367ef3fe2d7605ddc5b36f277dd94f85c9cb92891467fdc9c7c674e4560a63bea7220b2d6e3bf3601a8473fa7438b0f999e8b674bc9e";
+      sha512 = "a5547de0ea1ac5c39aa97550159e82c6595241f6079a86bf832c798e3b4f215a6869c1e43e9ab0e1f0d9ddd54133ebc6b0fcd20bad39f5fae9d30ff641c5397d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/cs/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/cs/firefox-68.0b12.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "aff87fe070b04c1d39d9007efc248b268e1bf5902396343d444083fdf7f57704df02de22919f69cc63fdbcad1d2f2b422da5e971a11c992922c67a0509572c54";
+      sha512 = "b4ae0ce992a4aeb6d16ce6f56ce81887557c95bbaa70636e1074c9d3e2766400413cdcc36c0a5994209dad20dba9a6cebe55011eca9295203aeef0a13b74493c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/cy/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/cy/firefox-68.0b12.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "0fc6ef1be3c887d9c74be3b124d4fa471b01fee6c1d9cc05726b94f412b5c3d450143dcf507193adf3fff02d8a3837d0f3fb8a20a075655b6caf9477cc80b592";
+      sha512 = "d1bb65cbeac9c4bb7071a5963cf622d36792b9ca436b89e0d3f6bce3e718c2e6365364d876379ed5cff908a38565f593af236341b9712d54818f1c359a55cf57";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/da/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/da/firefox-68.0b12.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "084cb1f67a0607addc839a5a00211fd468349c420af17526e49a882f57c869de855bb31c48ef16865f9b5eedd98b4387b3d238c357bc57a26fa0697d0934a421";
+      sha512 = "a9b46e51ee7e941414cf6ccc3d9b531ec5e621966515d66f7b0673a7b2be548e8cdc7f783ce0a756e4b50ce2d4b17dcc0dcbdb8c07c97d8ad70a44264155cd69";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/de/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/de/firefox-68.0b12.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "12af25a14b62f4e9456c29ca1fab2b2f4dc974cc46d0af387d5021e9480a8abab18f08cbc75d05a446fd8eabb44a355b2684ef25922b75f1e834f006961c3319";
+      sha512 = "f591e1ffc684f428fbae4b94ce1086a27c9ecea4e9528c18e6dfa8af2a967ff8bfe374984390a6808c2bad656e13adc7cafbb76c862a16f77804d1b4fdfcd29c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/dsb/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/dsb/firefox-68.0b12.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "f4e492da1cff4f4e4b53da28bdfeb1be8d2c493b9d38b8ce9b6e6e4a13bdfb8586e4e2aa01b7b7a650bd2672ea8d30e72584f2dec0919b091d30e38b2c591808";
+      sha512 = "9947092a150bbef82391521ef36dccdcdef9eafe5b5282af5f34d28fc0dd6d173e146ad9ac7f7ee10ca02e4a5ce5099f29939852565c3cac95507f33a8f23e1c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/el/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/el/firefox-68.0b12.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "2a51f47c2dd157d9a63a38a79a158a584f8e2b53dea3f4bbcb0a3218911d768f29e1dacd6e5cf6466c489f4d54342e4d8da69a5e75693c4f0999b50f9e7f7811";
+      sha512 = "a806b3ec254afe96748abf2f9c970e5e5b2ffcb7f7c70e1c4c0c92ed60d493da5cc6b22a5bf78aa1de8c36f5108e4283ed67285d53ebd737d86950c18cce66d7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/en-CA/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/en-CA/firefox-68.0b12.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha512 = "bfdcca30b426836c7dc63ae7c7f11a562074b6e25fd6ec4c0b35facb404ae0a2d986a0dbc5a859856f94fd8eead52de4c995a30b1613e60f6439d54dde3c151b";
+      sha512 = "b3967481f6e7f4e03ab431d8e76ab8bbab286da468897e75a6dceb6ab735f36122ea4ce85867113143019d3750262f705d1f64d59669ee590bf08db409788c09";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/en-GB/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/en-GB/firefox-68.0b12.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "de91e59b9d51d98599487512f7c9dcd1464d4c0da65a9b8cb5c29773e68354f4a3eefadade83d78ed807abac78515f9ec14419a4a97207696177233d9dff3429";
+      sha512 = "7c68680326ecd1d0e7bbd2ccc90d36623434e8019c5bc0968227e15af92b1f07f65767fb2c78a5051538fe79a17bb485b3b697774d938fe3ca876ae3a2e728e8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/en-US/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/en-US/firefox-68.0b12.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "907ea83b79718d78acf79a099237558051b99365b4e0e05d3118bd60d7ffb2e4caa9067cff6d0ab5e2444e2b7f8c998330da55e96d66f43935a564b02b0e27c8";
+      sha512 = "5cab4ea7a8d3a72e6fe1535b21f1b48c2adb183764b71fb230d051b2112ad2466672046faf6b0feffd4b93dd727ac6c824ff420e37901b6e00b6a32b91c830c3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/eo/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/eo/firefox-68.0b12.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha512 = "1ea02ffaaf4c047805d4e600eeb90d53441c93192df406fdfd7d873bba92db596774dce5bfd098d3377f3f7f962848c6f3922b2e31c326bd6f90e50fadaf0f4a";
+      sha512 = "ac913d42212452ce632c86debe61a27d46f682d3fe1c41c61724cb0aaa5ba3b2f63867d0addac46fa3f71d42282dbe3a3e5600990a1dfe611979fafb1c98f4a7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/es-AR/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/es-AR/firefox-68.0b12.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "dcddf401b1380761b94688a8682dfa26323e05ebadd341f34b75db93a3631157833f24f862272d8fe6c4c31c4631dd08629ac9af202b8305ed334e0e98fccd4a";
+      sha512 = "fd003ca892cb26d56f6a3e5553a108c29180310203d095e8cd428a2bf499908c24f8e55077ba443bf9dea6188025e82bb18ebd86fb06e59d3abe83bd1fb23171";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/es-CL/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/es-CL/firefox-68.0b12.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha512 = "c6c422d7986444048b0a838595fdacc22eb2793046b998c0040a151be6f19a08aca2c94a92d0a3d36d33f4ebb198e1564f6ce05832c079599f5529c447196e93";
+      sha512 = "d5144d975a73ab85cef8e271d78f408c7f4f72db7df29c4a7b756fb6134a2a0dec9eb77472f2c980c2e290cea6d59ac9f599e4e946844c0fa0054f79fb201fb2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/es-ES/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/es-ES/firefox-68.0b12.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "0031cecc4801d4fd7f35dfe3a442c40694f904665f368d2800ba24b562f847e7e426782a9bdcc67c8094f3f71f2eda60b466a5efd17461366ee1da88cdfc0c8e";
+      sha512 = "586ef6cff55662f1287cd5ab7926e9f269f8e337432d3708f66e660aad348b88cfa5ca28579c703892695091501cdcda0df18553bfd16ee13c06b26de5581d97";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/es-MX/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/es-MX/firefox-68.0b12.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha512 = "6702ddf8603dd6517285521c268ed63c6ce5dce98035bfe216563187b181062ea06c2e400d8db315f8bd4d482471a982775f92758673ceeb8c66b8f5f636b9de";
+      sha512 = "1a5e2bb5f11d289846214261703fb1b953fbfcf5dde959ef769cb03286bac9a9ef93866000b00828b49c79e4db9aa620327b4f77c3a44f7ccad158a66600cdc3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/et/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/et/firefox-68.0b12.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "03c791edcfb577041563a3439240e92738c9af615d626b41d9da9cd34acdba9156e9556b02e29e695e6c33eb22a2f8bcfa02e0c05107bc9ff5f610911de49e7d";
+      sha512 = "6542fbd6db3f5b41a878ad1172da004407a733c7b6cc19688c1377c24ce5c13ad8e6972d54e02acede345ce948c34b6c164589d452295c0be723145615d2743b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/eu/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/eu/firefox-68.0b12.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "7b91743d88d967978ba9bf22ff07ff3d4c838a17ebbf95133aafe08279f2920b184e736aef966ab3258d44226332044a7e42d7e0550d1f48ef83ec3ad1e51b66";
+      sha512 = "bfce7ce5f0cd03a065ec995f9bbde6a797741b1e9fdb9d7ccc334a8e84deed04dac62e344a05f1ba29f8a9487866520821eb8da02915e2921d0dcaad0922924d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/fa/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/fa/firefox-68.0b12.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha512 = "8615dcd21eb1a47f21dee1e52ad9e1935bfe7c5bea14d044a75240a34ca5911d57c2cbd6c9d4a71ab1439b66860d447d9fc891ce1c80f77a8da9d9f489db06f5";
+      sha512 = "e0e0ef6054925fa5e8987ea9f802311ac80d0290107bc7cbbf8141ae6bd191928cd12a17331edff49ac59673a8ddbe5b35fef6308957e57d6204350ed13b5e97";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/ff/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/ff/firefox-68.0b12.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha512 = "94aa5587c582e3adf2c232b873d3fe2c3ec010f250b5ee30e97166174b8187f8d13784619c13fc203f5fcd36ddfd47d61b7c9af82d929d4b7afcc8896cc0ce10";
+      sha512 = "e224b2d00f272c997ea127f4664e958ae7a7e795965a07beb4ae082549e2f7a866eb5489a7e82240c00fd9f21223d82fbca0f3b708b9c632a98187896c6f1424";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/fi/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/fi/firefox-68.0b12.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "878ab43f0e3cf3d3b84a4182911780f655a1c356638541d8193daeca418c163942f52e0b64a8ddbb9ebbb4702846064707ee1550463f18735fdca6d8c6170b2e";
+      sha512 = "294d654921278d359cf174e28c9cc6cfab1800caf42beee733621ecf3f6b27add20e036b6fc7f7f6fbc6a14acc2ee47865d28f14999e88fa91b5da5248282f8b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/fr/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/fr/firefox-68.0b12.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "54a5614c146cc5e02db18f57e08f25249e5dc08f35ecc4566867ad0dd1488185f2e1d98141c74fda78fd19ae1012ab56d10d2cad4b00d760a8a9703a27109e92";
+      sha512 = "c855b9c5880229379823d5a3486f588cafd654f75cd60ee741e3b1cc3cf84acb200f0a62f7c17d2eea68ff65df83a6b4789b11f027f56d166b05cc45d700ea71";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/fy-NL/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/fy-NL/firefox-68.0b12.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "7189c698fb4b9d5eb9c458ebbfb17f7431948a15a32306b2628886ff9d70fed1392c789ba40785c4517f7dd3f4d4f180f50bd3bb5760b4263cface00fd1eb455";
+      sha512 = "f0086a1455b5f6b0ba116fec9dc3aad31f0165edec2d8ae84258d624142ca1651dd30a8d4d4ccd7441a81b9def479836643ad9ee753eab125d70932c097c1cd9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/ga-IE/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/ga-IE/firefox-68.0b12.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "9e536d0373937bb66b33a098ecc23d099ae0870d51d6aad6635181312c3045c1659fcb0e506818ebed5ec5cd6977432a6adaa43c3a7cd4be29eb9362ef46a429";
+      sha512 = "3488aa241d4eb1af1ae759ee1576fc22e44ba23730b24c78018d5e975b236206d19a1724bcb1b9c28bc3635f3a024f55fc5ddc8211d8803f3a6957e0c3c05011";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/gd/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/gd/firefox-68.0b12.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "cdb637060472e575fbee8165ebc0f35c4695c01a003774672b4b653111017314f1b2e42d7ea2319ff06f4504cec67876a7377fcf0b85b040f31e2df0c56f847f";
+      sha512 = "703b0c668354a90ec5960bd529dd017d5fdb5c014ea9b59b4f8491cdb6612421c22c5e14083074e6d17ad5f4293c7cf5db789ba86cd3ad27997619e6cc95aec2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/gl/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/gl/firefox-68.0b12.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "818f48fe0079c199bada69f0fd596638b8bf1974980ff3c932bc1e801fd904ede30ad6675bbcdae85b05ed7a72b6585f0e3492e8b48224019e1091e47562b308";
+      sha512 = "0412e4011dcda241839eddb2ecff5b3e67399891d8ad3caf5538ed7cacee3fd0e5e5dcdec97b6afa92e50e492c4c3b3fb5169aa4f167f4cca58e2adc8d081b3e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/gn/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/gn/firefox-68.0b12.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha512 = "8416f1eda4a6323d7d64268eab01d73d3bef0ad9829a1402ec1a41fd76afb1bb5f8f919c3efbb9a5eb3535d213ff0bb5179c4ab5b350954c0d815170afb680f8";
+      sha512 = "693aa9153aa73a92b00a56aa331c05f0a09a2c4ef8315cae07a158ae709d9182a07f36722fe2dbf52959fba75cc8494ee81e71a58b69d6a6da8c638381fc746a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/gu-IN/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/gu-IN/firefox-68.0b12.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha512 = "a16f209fda595d79320387530ed8e79ede113187c22e851332b8d2e9354725061c5459696202dc51657348cdd9f3e84f86ac52543f0f04df664c7ac4b3f47df6";
+      sha512 = "df97e1a087a21d7e8f478a50f8993b34d82f3305b3eab3caccfc72927ca9b6f03e431f9b63aef6d044eb1905f1df1fc81c9cd4bfbca4c67a1d2f92d302ca3e20";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/he/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/he/firefox-68.0b12.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "043cbad824f040e60abd2cc412a490cc000a3259705dfacef867c2b929c5254372458fa91d79c1ef37d5a373d7815ac35279bc4e35aa822933dabc5abaffbbfb";
+      sha512 = "aa41c1dff2c5e2f8db9557f1632c1cc0739bc02c606775b602ceef7ea2f9f560bdaeaf3785654aca205c5dc6357c29c7292b1fe756ac8fa0ac2d1d01c15663ce";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/hi-IN/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/hi-IN/firefox-68.0b12.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha512 = "e2f89530caabd445279a69e68bc9a13a75b287c25e2e7a35a51f4862162f6eff5d4efcd9b857dfc5bf36f7efb144efb29e2f97dd53dbca514a1bb904620a4700";
+      sha512 = "53e4d3fc6741dfe72486ed2ca69ec673419d1d6c518de7cf494a7c8c1165a08f6a6113c5c1c7c86b7cc7b2c6e3413eaa790f26397e28dfa86d69bf91120ba02c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/hr/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/hr/firefox-68.0b12.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "b4f4c5839995ee29a846159c1ee766cfd0bb9a532d47bf95315ce037e6eb0b532a339469b141d64f76a11578dac4e489878d6fc3ffadf6625e212081271a4ae9";
+      sha512 = "3c3ea9b770da15c1424a05aff6c87f5699269831c51bbe846caafceeb0a2401201f01cdf4d9cd37b84582b6864a9e53655bbd0f42ad19cb669ca8c28c73a18c8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/hsb/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/hsb/firefox-68.0b12.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "a6727dfc61416c2584330b34768c16be40362bed7040365719f80d35269e3b71ca477aed5431b772b3ba08dea6abfa4bbbe0fd6bed7485b767c7547d2f8f52c5";
+      sha512 = "b1c2285b03472cdf88ac85ea1b623a60d976fef85863e5614c561fcf7e9fa05ddfdbeecb929e01d5508106d51ed2c0c24400b6447bbc357be147e950f0d64339";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/hu/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/hu/firefox-68.0b12.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "18639a0cc33072b4d94652f2b057cc23713024b610bff06964df6f286cd93ffc3a9b952cd8f2d7ba4254eb850f1cd237dee04f9e8ffd028d9ff1e901c6c29573";
+      sha512 = "5a5bb5c7b68af0faa608a9ea8af8cdb0bf8740e77766bfac26cfe25963e6fc8492a88e171e6299cc7c022e2f3d04eaa22df10acfcfd82b42c72bec28466fe449";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/hy-AM/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/hy-AM/firefox-68.0b12.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "6e0da11c764ce4b14b2f6eb58fd4b9c5771dbdbb8b4b89ca1e11053cf94ee8128ce9832c3db202a37451c3ee440902bf7dd114a15aa30e0c1b58fc07b4598f0a";
+      sha512 = "8a3f3d775bb16ca99a58ac819efbf256fc17acc542f7cfc227806b96bdf24ea6ad737a4b749134e00989b7777cb35000dd6b2d78085ed0be3dbe8065f174171b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/ia/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/ia/firefox-68.0b12.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha512 = "a92e686d048356a14842077a112308df8fed5fc4108979443d89400a7b8fe1aadb4122ba4dfc0c2ff24745949a61d1ad9f0954ffe271a7221d01da872f3d0820";
+      sha512 = "7abc1b715852d94a9b5e8e02b7f235d30d0222a297808dc6cc24f9567fccc3478b8c689e133e0595c5c236b0437a6a546776898a683c34cdcab4707968757c68";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/id/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/id/firefox-68.0b12.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "d6edd0846beef764d89c188cd02b66fa41de4d7df68c39ebd0d239daba9b3225e31bc3b88b779d546495b9d9a2ed13e71e493f1e359e375e670a694a93e28072";
+      sha512 = "23ad16f9e5d7ffbaf4ee487c75facf91b0a4fce7ce001e67890f87ac805c8f9f54aa6dfb662bcf3a7536d6fbf1eedc5f393ca6382b89039a1b1945f6544216b8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/is/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/is/firefox-68.0b12.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "b7092112a8d754bbf4878382cde40882a7b7f1b9fe7cdf36ac62627bad350176b8512c28ff682c8c7ed99495d6b6053d698549587242347ad116d794074ff6ff";
+      sha512 = "567af9d4865c9796dd8c7c2c1b564c897c35b387a7da28ff68d45b6a1a0258121a8ea432e6972e7f47d32c64c3bcc99d16f43547afc8faba21512a64e0191d3a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/it/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/it/firefox-68.0b12.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "6014f0f215f869078e73db338ddc25b3ec85ffae0e06db7a211583f5856cb5cb473f3c44c55e91d21739c27ffcf662bd957a664d666cf3375e0b901901fff67d";
+      sha512 = "bf6272b515b54020cc3301136eb134b9ba3943d5b6c97aa7ad92d7b429d69fbaf2abd2af52bf5d111185f0f62cd174a52d89197ba6e22dc7d3a4338acdd737cc";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/ja/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/ja/firefox-68.0b12.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "b6b977092e03f1ef4b9801f543e8961dd65146934c5a80108f518779c2ddcdd16e7962b7d85ac723fa770dc98c78f1c3707d63574282fe72163a8b4dcc89fc22";
+      sha512 = "e60909c2e80c5351f6ca6f00452eef4069b08ddac80aa4d0c2e2dedb2f6a8965fb04e94f0334aae9c8fabf7d611579357251e5931e4cedb5edbff32a6e735539";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/ka/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/ka/firefox-68.0b12.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "3f5f946f76425bc6fce550e51ff369f3d63b7f427a229da39d13eded235aa2579ddad85150a55352b6b95e2e37820e5b15fce755d3613cf33b1e5e809fa1130e";
+      sha512 = "a3f6f68b741f8260adbfdde61fdf6e216c482303f7f10c46355d020db98cc9cc818dec959997384339c1051a5a7eb79371412dbbfbc416ada3c4d291fac70d8e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/kab/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/kab/firefox-68.0b12.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "e58604768c4ef921074cda756c81885bb750e21808c7eb7d2cad36df7ea6c49ae320bb443237d72065722985399a30a8d5368a1207e75d8a8b1a8a53168f24ab";
+      sha512 = "ea01ec4928bbc83cc3801fb166062b5875a039046f80337efb62369ae93fa38e0dc9f8170dcaa9699f98557f9cda1b01d007b720f47157f2217c936481645fb9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/kk/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/kk/firefox-68.0b12.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "fa5bc9a44b72db9c11c248df6b5af287d600841399c40d894400daac863f4fc08fcc0f164b2a766f8d1477fe66202b838661e368b6263ef97d826c00f26aa85d";
+      sha512 = "551281239137022acba3426f790369bcce3d8372afd6bf62f4077fcf640222906461527fc7c339d7a2355a36278007180742af74ec0d27b64b25554057562015";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/km/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/km/firefox-68.0b12.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha512 = "95a02c824a46fa0861cca65ffbb783b8268b479ddfbfdc0a1961cb44d16829b6013783a90b0f6fac8c8ed5dc1fdb0d077b87bcf04e7464aeb176c15bc53b190e";
+      sha512 = "9e3ef62fb17222b701e3f348fa5d48395a1294f762670b214052d0434865c7b10af3550ceb384437009a940241c4851e7dc57ddbd8a745a7b3e4fa3dceb6c346";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/kn/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/kn/firefox-68.0b12.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha512 = "dac6061ed1808f420852570272dbe7099b909609de06a30d62aac1103efde7515bb783db916e85f24652bb77d6b8b733b792f413e03f123f1fd880f7c7523497";
+      sha512 = "654e866b0f4ed8f2c1582ca229e13f4ae3c5db02849e28bcf25993c4154ee436429e16d265be68c08fc1b328ce5f349b13795f9fa1794346679ffad057f4517e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/ko/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/ko/firefox-68.0b12.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "ffdf25a25d2fc83c868eff980a2f1787bf200190b73ed89f29512c05cca070f2e466ab6c0600b90663304cb10ddbae869cc0d9fd70a41bf82025ecc1bc50f2a7";
+      sha512 = "2cd646fc7261ac381a7132b881ae5bc02e351797a5218f4ce4c227dbf55240fec4cb4351d6302c79365376cb8c0b2b1d5b2c331efe0a80bd36b6d786178598b7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/lij/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/lij/firefox-68.0b12.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha512 = "cf5f617f281359bf5698d20bfa942de850b14ac5fd73a89c9681a9926f01ba5d9093e19919fb7d0edfa3169742daa3a3b09331c3ce98bcfca532c568ecd7f0cb";
+      sha512 = "22a5705ee4868520fd2e3148a9327777fdf5d87f459c565a88f266cd0bc0347452dfd7c06c784c6f3428dbfb0f682ec50fc080aa17b4c798455c5f9fb417e59f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/lt/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/lt/firefox-68.0b12.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "62070d8a76d1c2863db370e59724275b7fd6384cfce130ed32ffcfc47f81ad7521bbf967e20074695b26da9b088578bcef65a471552734efb723bf6c5ac12860";
+      sha512 = "b420dba741661ee320a0556edf98617f42a9c8bf3759dd13041b8fdf05e82145f1c4d2b59521719124290918fab53dc2182a123e3f1aaf1ab83cb7d187866f1e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/lv/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/lv/firefox-68.0b12.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha512 = "3a8843df28f0024e999aa0c3b8c27fb49ebf56d1d6268512253b0468d41c3c0d9f79e0f92f1e8b572526c0b2d07772445bb81207ab9d0dc4621e62787a3ddbf1";
+      sha512 = "3ab942e922592771b1c02e93b110e8a757c8bca9061654110d08a2181221d3697a2d385fce484e108bdd44eae4d69043aa02c3781deb297674c2671a87caf874";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/mk/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/mk/firefox-68.0b12.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha512 = "da83cafba31637ca73919fcc95ee5848457ffef6db77141102c7784a3c9bc6b1112f3ad1549d048f797835caaed26ad4301f335cbeb471feadf519700b6ebd7d";
+      sha512 = "f595c839941e6b02a6e312842a0a6effe80acb81d69445b5d3a3ccf559c953de20266343362b87480eaee809c5baf9455f30ecfbd7a148b5a7e753e421b97c97";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/mr/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/mr/firefox-68.0b12.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha512 = "911579cf37dbc86cbe5c265497336e544c88bd25761fa24728e129789648af3bd5e4d838d137927529999a7f9ed7016ace36aa91e3ebba03ef25df12280f4f7e";
+      sha512 = "5e7d0ddbc640ba9e9f31c5754842bcaef5d90501f208a387daf5935a9be9d97ff340bb551c7fc5dd9fef9da7877fd3e6558fec5dec9e0eebf0d7ac5a367aed8f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/ms/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/ms/firefox-68.0b12.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "931d25822cddba59d29a8d2ad8dfaf98329febee9be866e590645942c3cbf450ea420169ee64cff5c24feacfd1be02e3212c2eb7336013e589a5278007cd1e24";
+      sha512 = "7c9c34344989bc919b842dbd02c674fcfd18f1357794a91500f237dd7eb58014e135d4124533726a92db69fc6e69b40d6b1e3bea425a9de649b71134e70d16e3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/my/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/my/firefox-68.0b12.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha512 = "e4ec13456d5379c5be1fd09bc48dc32bb7c8e023d8c1c318f91123649215c39f2e51ab1834a64ea6e6e22b571e207c677b64a427c2d7b350f8f612a713cc2ae9";
+      sha512 = "30e13316e102d857b0a2c257910443cd38cac26b0d6b40e9b352a7c6800dd2890231084b04a9ee32f6eb1bb92a811d5cf54a4c4c19f8edf263d5a890d614953d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/nb-NO/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/nb-NO/firefox-68.0b12.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "291f17a4be45a6921fc555aafdff67745cb926edf3d059e8e979b7ea6768674cf754f602d0aa642d3b3ab109cb3b94e0f1db1817d48d4817a6a0451eb1ba8c0f";
+      sha512 = "c9550a3c280670f8753dbd308737155f34af95e9622dc0201d96d1a1ca6e326797e6f0c9889893c34dd43daed6f6e6bafcd0b8ce2fabef31dea30bc6804dc95e";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/ne-NP/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/ne-NP/firefox-68.0b12.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha512 = "a6c75ce3086966409c39aedb7de7f49ef1b6c2f27370cb1043593a13c9ee215dcd992c207d27373ca528fcc19c5b340c8ac9b299b69c8eaead8fb4c7b598d6ce";
+      sha512 = "82bcd5dbb7e227860e0ac8caacd47a1cc32f1e99664e82e642612c5fbcb7906faa5c853dfa1fc347c4da200064ffdce455935f48d524d0a4c27121d58c1f4bdd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/nl/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/nl/firefox-68.0b12.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "80a2ae9b75784b27bbaa2ffb638c8d882c259525e17a251e854352260db35a3e156e1758811e0aeafc68ef42db9d2afd9246ea635c7015fc517dd2a5091a19a1";
+      sha512 = "9760b1e715752ca64e539570c032ed31c45d336540001dc1b7505c082f2f048b52038c5bdb03138e5e7ce291ff5314909e438974dfc848b66fe864fa9d5e5ac2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/nn-NO/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/nn-NO/firefox-68.0b12.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "ebb165872bc1ff275c02546ceb3ed995acbfb6814dc9ac6f6ce45d927eefbabe88a6bbcfe2991d4239904c36039f9a842f7ba802e57b438155819ba650f81b27";
+      sha512 = "b1712c4d0e87c77a21f1da15ac86407c4e27a8c1a7ad7882e08fd93f6ff24c029181dc14263fde6f27329ea80e3eaab8023d31fa63c90cc4aa7d5f4a43692f17";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/oc/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/oc/firefox-68.0b12.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha512 = "d606702be1112fe01b4738925785c655a8aaa58e4bf9c607f6acbf37f0704c2fef27c41819c7c2a766117e93c4b0a32c29f82b81d512ae7e52d79f61c4b80df3";
+      sha512 = "49b2a7299c9c884d3180513b4e8f325a610c839cca52e8a1b9862a0e759112f1490ce109a7c7fc08aac289adcb73176183d1ff693720737fcfc80296e662ccd6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/pa-IN/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/pa-IN/firefox-68.0b12.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "2eeb889cf62e7e8318231ea29c08e5f0c80533be7fb04d9f7b0511ecdf84469e507f068ed4f2c429bc7cd733c3038f255f841aa809feb83da13b138c39a0aec8";
+      sha512 = "a1cb0f0a3502481a5f88cad6bafb82fa177936db8cbd534be954a15bb185d181d0959abb5b2090de6225bb14741971662aa58a3b362a26b27e2b6f805764c2fe";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/pl/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/pl/firefox-68.0b12.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "d58c88c0bf12382db9dbc39bcbd49748c776a571ac5011577666856f4d390511282217d33f6220862f34841861b69707077d8d9ee92a0ab4b681b37faf8e5f3d";
+      sha512 = "f7207b2839d9c948ea15d9063fac22f16824072a4a102bfc41a7e31962f79bb60fea5de01f0c780942f33ad7066ae7ca1b7a03a7be13a195753b1db3ddba659a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/pt-BR/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/pt-BR/firefox-68.0b12.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "656bf3110042913a5c753835cb357ff1cb66e33814de77494f80ff5f401f3a273d2f3c22f1dab0414b70e5cbedecd4af93ba9538bdd639d7cdeee97aaa69c98f";
+      sha512 = "eefb516a3322efd51b046838a86ddbec5e65a87326f3474876f6e42cfd8bb138d2c5bef32e9a2fccff61c01307c39e7611a83acd40a9e9ddbecc473d4b506ede";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/pt-PT/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/pt-PT/firefox-68.0b12.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "c0721ff7ed233cada1686e3ab407996083b1e021c7322103d24c4ae277a9e088ab85334b90725be59440db0aa151e95b47d7073b5629aea55fe701adb646753a";
+      sha512 = "92f417c004802c422474feb25b69cb6530df5c34f36e1a1a2feb62e87d8202618ad033ccac40465e903d9c85bfa7cf30ca87335e082af6518d6cb114bedc4cff";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/rm/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/rm/firefox-68.0b12.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "285bd524703e09a4b82b1de66514f9eaefcb9751b9ef95a51a7837062581a7d798e28494d46caff2e18c0624010a79670cfaae1c0ceeadf8b0ebb115ac9c5321";
+      sha512 = "04703dda30160f844f8c1475caebd9f604cbbf05f522fbe1aaf841d4a335e295372a4f26c2d07ef24fe07358699450ea13260de1c97e49797f745a484ba11226";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/ro/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/ro/firefox-68.0b12.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "b7127e8452d45e57df5aa8f788f3b773a2a8a2e04e2f7dba589262dc91d9302adb432fdb6522a26b14146bf7aec6e93d5360cfce76293d1725438c7958414505";
+      sha512 = "c4f5a4a4fd04f2536f3bfa303a05bf78c78c0b7b22f4f1d975baf3fb46cd9f7562db151e7c321e4260dcb2efd9bf81e751a6e2ceaff0e3289c5e54932973cff2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/ru/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/ru/firefox-68.0b12.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "2e29c00037cbf7a4775b954c42137369aa92336d32811e622c408b1e7069ae4dd1d2ac77d692c8113f6af37a8a5f3f1349f0e6231ece1a93db3b6ec44949ad10";
+      sha512 = "f2bfeb0c11cac02047c2bc4d29135cf56a4d67eeae45bbce6394a0b496c62fff54b270f23024031c5770cbaedaf8ea95e806effaa0d026434358e5a593c1b4f1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/si/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/si/firefox-68.0b12.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "f3ed0bbd1023131a7052ccd20be645353a9ef395d50a0de5fde76ab88d665ff537692de1349d81c704453e6a12ebeacd3dfd4472594ca5d004bfc3928347e002";
+      sha512 = "f5c50ad106a1c9e4c0182c62c23ca088209fee9b5856aa77d399ace75c3800746c9c79e028dfdadb6094aabc680c129c7510d26d7f258a9c9409630081acbec4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/sk/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/sk/firefox-68.0b12.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "713bea13449f9f447b0a570b5189cfbc49184f5effbee256d665d3eb33352b3421a6e95a47b1dd7768c0cf8b3906705e7bf5ba9982ca2baa7ef81f0990ec16a2";
+      sha512 = "d251454b2078ae1b6ccb5252a9b88a057ae94f747e207832e3e955c15d9a2b17c5cc203cd5fe7c2ec56e1a326d1758c8012948a42f4c9d7cc5ef2c84fdc2f4df";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/sl/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/sl/firefox-68.0b12.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "49a7d532d67b8500e2aecb8164525860b20886a02818f3d4423e61ba626e2d5d2d04ce8062a983e2b80905b1be4eb2d44a65ecaee31a531560e1c138a9951227";
+      sha512 = "a99e992d5b71a22e5e9ca260b0c45942156474ff48da53b5cc02785dd84dbcc381b94e8b2d44d4568656c588c65a49e75c2d8c6257107e345f867df33a3c8c3f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/son/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/son/firefox-68.0b12.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha512 = "9ce44ca3ee7160b819ef4f157a5fd50406d57580da0ef1910fe363d1236610530283aae124a8b673be36b2b82040ae4a5aa1de22e5c7354bdf8e9c1effa1ae92";
+      sha512 = "3669abce71819235bd489ab54e96107508b8c75ed3c29d010e36033c9ec4e6d2a440e1ab41f212d52436129c7d29209223c5cb8bf7a855bc5c0ebbe4e71edb5b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/sq/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/sq/firefox-68.0b12.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "1298a6d3ddb06cb7afc44213d45ad151de93276d3d3f727b0bf01157a18a7ee32c18412e7c7d717ef2acedd7546edaedd95b7f2cb33fcec9d9a6d9642f138646";
+      sha512 = "2f0ac03412be6e5010ad0647c4be28c9edc547ad73baa509bbfc7fdeb478c9c0ad87ef6698fb0d6a60718109a57f5ab58b0ea16a997258c01dfd463ff5cf09b6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/sr/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/sr/firefox-68.0b12.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "efe1ad3230eadf85cfc19715e6055c14edca65b9effe8626651b80a9acdfde6f4e275c1cde9754d63be459f3275d1ac87ee809b3027bdc4c50bc00fac901c352";
+      sha512 = "43c708b130e0319e9fe2ae2fa2162aa1caabb3b41856fba34bf0ca1c2e77da6cac5f7c5fa3e8d07c0480634aa04a38b2a5db07433513710e7b04398e9a3360e1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/sv-SE/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/sv-SE/firefox-68.0b12.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "45396c255c5752b19b1908463c5373b2ed410a28cdd685dab5f5434bd1f79fbc195a39f43e587748d660866cde55df9ad5d5c2ab4547579025a0d7945b1bb2ab";
+      sha512 = "1914a95197db1796ca17e8d8a511ef687329ffbdfcb0dddffc4e1963c1251519b0c120340f730a04171be57f353f5c29e7f3a9c1a7b8c92488a3aeff9bd58d55";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/ta/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/ta/firefox-68.0b12.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha512 = "0e521e84924c331c50d49458584b145be2139ffa7faae3b1b4b82ca9867da2f361f98649d4615e2048260d6cb7fc3daba71e611a527d6f54e6b49c5314bbbe54";
+      sha512 = "af327044ee1c8738f5e65a231af3e0ef74e82491b62445e5a9fd2bea7ed4a05451e46d2cb572b95d025c18616ffa662c3668ab6b1770abba124b976050db9e2b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/te/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/te/firefox-68.0b12.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha512 = "16b83af35436d8882c72b2e9d50b55f67e5a5d824f2ccd8ba23bc782453fe59fe649a2b2c0a90f36de6c53d5112219dc3233543b59b7b26c6c0338ac7784a8cb";
+      sha512 = "51f7975194f153c708e2275992daae1b4435a2e8f159ec344585a9ad759719716fd6d8a1ac10a03dd452faf5a960df2a1b580b74e83df6673a87b562ba6308a8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/th/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/th/firefox-68.0b12.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha512 = "bbeb837646f34501bc1dba80b7189ff2ec0c61ce7dc4d926c09e188804a4dba20c164835792ffdfb88f7ba80260d79700f3f97bc853539f23934033c91035a37";
+      sha512 = "02b651d278898a400474ac59f5def40eedd8c2502d13882e3309256780be13dce4374c75f68d98db3a7555451a5b7d2baf5a7add1733e359ad30fcd4122e0a44";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/tr/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/tr/firefox-68.0b12.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "cce0b1ff1e42b28771db8fdcf146a86571cd7cfb6d9aad662e946ee34a69ed9b535bb96454bdfbf9f8b5add702e1e87f000b2677c27e8e91f44db9206af70f48";
+      sha512 = "bf1e0b7170a86a058f117dc10f8b3f23139a7f7f1b93ccc91619590b9b1fac56f525f5924d6ab331cfec1e0e2b48bbb88b78ba184f7a88cdb2d9fb8d78753979";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/uk/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/uk/firefox-68.0b12.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "41a41e1bb58a73c9cd9d709785d0ecb5c17a1d2d6d03d4bf4446184a61d11ff8325ee4d93c5ba3fdad43f2e955c4bf5318e5b287600ae780fabbf6f082242af3";
+      sha512 = "aa043dd41d2a3b7e670ac81cc0da3aadb1a461fc6957ce40b53e2f2b37de98a5e04146010f49b6d3a63136efe490bfbbfe4676ea353a161e18f009ac5b760e6d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/ur/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/ur/firefox-68.0b12.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha512 = "7e6e8898b0e15ec38ee3224f9c1d32353932240cafa1334cca895bf86c88bea86fd079b16a6e969d1e2534fb010fc8c643b18265e786a837daa9bf84973dfad0";
+      sha512 = "e97b0758d937d9fe31888d4f1c12ce090017a2b9457005d5bebb4eb5b384adc570bf79f7574bf5eb292081763179c16e98d7bb54acdb5f8e494930cb58388035";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/uz/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/uz/firefox-68.0b12.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "caf6f195fe5c8d7a2e1ac064185c2fe1255f862cbdfbae798341b2a6eb8be19e12ab64479ea96498218cc5ab7decfce862630f997d170c90bc8521aa811db5e9";
+      sha512 = "0207ed27cd8507fcc35d18602ea45c0a69384800563d5fbb5e11dc02565912fabfd3343910e7ccd5e4b8270f39498886aa9b42a7ff0b46452c5057c4c4388889";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/vi/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/vi/firefox-68.0b12.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "3278198c4b537c08c4bf32c2536e13d6303a1f174c19a2646b41337fa429d52d64afd43b4455e2e76e35436f63a3c4d3e7a0bad739b972f00ae2b57fb9cf810c";
+      sha512 = "aa6dc56a32f74543d8b2a382cfd5284a977f1242cb54292f09a46d5a2a7ae7d38b74457a7412355e09f5950d82f095ae3ae0fc4a978511a396524e3e0798e281";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/xh/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/xh/firefox-68.0b12.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha512 = "5e5ced53a3a1c01fcb880c9baf909c7d1ef7fc18ddfb1593ba641bb010b3882587f4d736484cd79a0f62672cc93c8eac3854582b15154c8623da45db2d67f643";
+      sha512 = "ac3495cc44f55a5b67cd7f63859349e1433dc6977599a4e2e5195e6920f320732d4f0fe1bb59d4f6124887ae30dce695a120c2427f8b6e6dc5ae33f0ac3f8c39";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/zh-CN/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/zh-CN/firefox-68.0b12.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "0cdc4c0c4bf015d770a8e609b3a8cce1dd9c76f9c5056c82c4e9153fc2410f5e899d7895eb00c259520eab610b0f7ed2ab9fff8eb429403800ae9a59a2ef8c8f";
+      sha512 = "de166a41754eddc1a6b230b72a649c14c7b0a814c4d72d96c916404cc0330e97a1bff136a618e7dde7069d6d7da9419bd0fa74c005319b3150f0a79cddb73568";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-x86_64/zh-TW/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-x86_64/zh-TW/firefox-68.0b12.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "c9f3ce1827291b610e65eacb667a16e53cd32338bf6fb450ce14abf0dcfd7d4167a362825f06e4386e667d0c3e2dd5fdc764e5369e21041832e99dd87f869537";
+      sha512 = "a37b6e0089130c2f9b8b7d45aa09ed3670fe5f35775aa0c4e99b662dcc7f72f7fc20cf97487f1cd154614ef5bb55ce7d911851a0f0c2813f03a82e3f71390701";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/ach/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/ach/firefox-68.0b12.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha512 = "5f24f3e493866bbc27d418e54a39610c36a93909b49c45da80c04414ad0497fcb60bbb06f6abacfbf5eeac093b3c1b31a1bd8041896523a665a5c6b09467f01a";
+      sha512 = "788c3814b6d661faf392d9d16ec8c6d709c9d97f21dd5004f3dccab3d776a3394ff5a5b397069b679dd6f41493dbc284502ebb4eaceafcb7ec7064f28ae816e3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/af/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/af/firefox-68.0b12.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha512 = "2b1ce8305fe859f2ff64b51e047d851b858c45bd4b6661c55865d1af064eeb97338a1ee56e56cdba547c301bc262d0ff6e6eaa615f2b220e7fd0ae12fb19d7e8";
+      sha512 = "9937eeed4840806481a4705235d1316dc7e1330a2046570ff781097ebea5ba4f1f3462c458c90fad163bdaca0226eee541e7475916323ae25b4f554f4bef828a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/an/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/an/firefox-68.0b12.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha512 = "aebc6b601a6f53380aa8f52eb03a06759e67e60588dc30309ecf33d1094be6f274a9b112ac02f764adf1778133368dd423f566e18f8be45aa1fa286a41381159";
+      sha512 = "ed447fd2e4391f82ad2d37453429873170a7277ec9fc3ba935dd55d0529b5208a905bf2852758ed23043ca0f63eedf709596f9aef97d1047960951a9cbfca2c8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/ar/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/ar/firefox-68.0b12.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "98503b8ea0ecf28fc22141dd8275eeb7aa2b40830f0c23cb69b9051283370a48a8a176717677556363f03597584b34ff66e4e803a7f46f5b23a2e316659a64d5";
+      sha512 = "a0ac8fb8b489361eb48cf26d0e9b3b9513cc3f76e38dbe23e44399a3c65c68d8094631656373bac46430572dff54c324a322c3ac6eec3419af2ecd273b7f3e38";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/ast/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/ast/firefox-68.0b12.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "90cef55cc2e8dd3aebc8d8e7df1c2295003bfe5420ccf9547041f8cd41bcf6b08e1fa6fd8ce7461aade2f408432f430546b1ac1435a77cac150431d7d516e100";
+      sha512 = "2efcdac7d506cd1872264e0316bbe02c093f9384301326c8256d2ac6abbd737490a8b93f51a4457c5d4c24485cab5bff149d04bd633164d59b867075c964cdbb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/az/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/az/firefox-68.0b12.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha512 = "4c0130be265d8efd4da137721f433e0fbb8461379fbf301964a3d7895899a1ca650d37a9932eed0173fce4b28a41e843879fcc193423e7ab49907fa78d658b87";
+      sha512 = "b48664a259c88ba408797aa597d5580b52cea58f5d4ac8c3b1cf8939bb8bf90024edaefb38626e83dcb566b766a73e8a6739f518f62776f7a27027b0616b7537";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/be/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/be/firefox-68.0b12.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "1f1fdf0cbe7d0d7f64924380c181c306afd635fd8bc54b1563d562b08dd8c955f32985f8660ab4ed6a7d9a0692570a9574b485788d82d29208a8a3e0ea343725";
+      sha512 = "2e22d3b81946f8ccb95f7431c4505e8120bdf35581708150ec8658fdaecfcac457c2e27d3eff1966ba472ba238b5a145954dc84433c77f626de36897e321c0b9";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/bg/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/bg/firefox-68.0b12.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "f01ee2573d9143f72663c14966368a631d603b948bfc44b3d1e844b7423315c7c3c6f1e42baf2e9e8fe22659523377e91a4d1822770d2183f2f73f4ddede1f8b";
+      sha512 = "c41cfa73a86c653948646b15522abf041c82399bfd22ad9c8bb2e2266cc806617238f3852f7f89bc5fbc748d90f28548cf79e86f44703b06bfab36ffa384acb2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/bn/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/bn/firefox-68.0b12.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha512 = "6ccd5e6e9c893fb89f777ffd2ba64f5f11737a55bccc4f4e7e7d3ec9251d455fe9c7abcf570dee371ab537d23ea9a95c1744d878deb2b711cfc9cc5acaec9891";
+      sha512 = "778d4e60b02ee0f52695c513af3a91e15672397ab60516fe5faa9c0168325ea709314e9b650bc767bc15b721af946925d69e42457f4e821ebf55a5c2dc27b7a2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/br/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/br/firefox-68.0b12.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "bd1a3123e6ea2f53d5741073f2f9f914b96c040de7f4a79f2ba0fcf007ec9c1d540581df5c825dafd9a34ccf215dd7c21541caa0998147f2c7c35e8579d8d7aa";
+      sha512 = "6477cc04626631888fae079b480475520dda775f5e4d9741b82b6bbe8cd0a74845507047fb91ec1d490db77e7f2098bc7798e367aa6ef0687ffe17aca62b9dcc";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/bs/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/bs/firefox-68.0b12.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha512 = "95fefe55ddea9f50a873ff298ac64d6ce02ecad1d308a2da478441b04c18c0877ffdf1f5e675e39ac77890ca988f2ccb059286868abb3f651369cc6b2ed4e598";
+      sha512 = "c51750a16b9da843f9586db8b4c8922a40f946851a52d35b2a52527b6ffcf3ff2535a762168e2af361a374c590d153cdc53cae64521c96ecc51beae88dd00e3f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/ca/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/ca/firefox-68.0b12.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "8468ad9016d138362054c6517d7b93a669967b0708b2867145d431fce8f435d696a06298f685780008109488f0b009ba095f1d5bbd56f37eb7590f72576ba162";
+      sha512 = "3208657a8b81a849bff701a95b04898d32016138ea35f10d1c1a707e53bd66c0f0d94a7e546592c6586d94a7350331bcf20bd78c127bef7f5826c93469727e61";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/cak/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/cak/firefox-68.0b12.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "cf467c3d4302551c17dc3f6f1da1a13a67663022050a8b5ea142c99a96182a4ef0af1d037033ef6b51de91c923d8f8f44904e0e01ac43effc37ec49c7ee6adbc";
+      sha512 = "e0b62c344e89a66f25e7989774983c02d0b31f258054cc71e5b1566f0d6a0e2c834a2a6c596a07ec2a74f47bc149e4c302e7d17cfd26dc4b8de4918474d0a5c8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/cs/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/cs/firefox-68.0b12.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "819daa950318d611ab53202f934d2d69a78283cfdbd1e2f423b55a533f5fceef14850b6022b1e150a3a12fe84c21b21e53a40adc5009dc6dd0bbe2ba9303922a";
+      sha512 = "971ff02141f709092e19e88c21f166dd7f8abee8d7a213a0543902dbe602e5d517ecd028731a49ab5e92cec5abfb084ea5b38824cd2856739dfcb7f8ae2063d7";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/cy/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/cy/firefox-68.0b12.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "2ab81d348255432aeb4e12957f461d4e79dc6e0ddbadf4c848ea179f6ea958b5ee5f85df9bffb4d3f0128348cd088f3f60b10a9154fb4d4d13d5855df922cd78";
+      sha512 = "0956b4b06f09dfb714a0a457387f9e39b47f25ba37300c3f7d506ab6cc7e4c87e48992a38f04018efed84fd76d955e0037abb29c9c93210fd06e05cf1f0ce960";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/da/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/da/firefox-68.0b12.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "b23362c01719661ec09154a3813ac2b5b9fdd1efa517ae72d61dd8be18712a99be27914f5ddd5e8bcfe8796efeb713e50d61aa9c011e720156abdf73e2ac4008";
+      sha512 = "943b0344ab68dfb317fe1fe11deb4af70224de6c5ed34dad4aa5615497bb169a8f815ed2af4c806cf45caa0c1a4ef6df1a9fa7584ae5d3de65574c15727b138c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/de/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/de/firefox-68.0b12.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "50b5e85c7c191af32d885350e1959fb2e86166510f02ba89662eebe876ccf6b3344d1ff0d3e452c1cffbe4986eb0e8b874058cb989003b69b1f2c8965058ef69";
+      sha512 = "097ae1d3f44e296402c706782011f87edc2feff98960aee0e4bf180de99be4b066f849907b90d98f4223a5f7475484e1d03294d09a4b97ba094a1548276c004f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/dsb/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/dsb/firefox-68.0b12.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "92473e411d64af8cddccf77553322dd9334eaa1a278108daf1cf922e18014ed85c1bc2177f26172f8ef4aa5941c89f2cb8c7fdb5f03650be43c1e459c7b0c7b4";
+      sha512 = "c935a2c8c67a81a064f9441d01bbaf515cd981b7edffaca85b901c8837a51bd76615e17f6ba651c4f00199aded533270a3e3572ae932f113a44e4047e974655d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/el/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/el/firefox-68.0b12.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "74ba242c302a0d9b50ac4f05755df7650d48360e82ce5ee1a183b69e6a766e673eb80e903037d44c7558a1bc64bb5d9abeb160b335db8b206635cf12eadfc55a";
+      sha512 = "ae08f0ebf177e0d5a3d1d68037adba15616a300343707b04fbe1e53e369e85d7362a28eae8864391e8463f8812f6d9990a7a56f66b33983fc3561624da79d5b4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/en-CA/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/en-CA/firefox-68.0b12.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha512 = "04329055eb295007004da9e8fdb02fa4489ca00ff48fe4387740958881f8ac182423f16b98005d1dc6dc42d52e0372db064e7974a00e4f7c815c528e3a0b6c18";
+      sha512 = "5b8169dfec0401822ac49f0b6a83d1730b28658f6767c347047d688fe84e09622bdc0320f70506004be66414206b8aea7de7a5fef942d5697fcde71ae2ed7f74";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/en-GB/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/en-GB/firefox-68.0b12.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "02780fc994d19899d6f25e4e979a009d7813bcc59e459ab4519922400858185320624efb35e58a8c8f7e338cf48ff4aaaa029dea17e995391061ccd1021965a3";
+      sha512 = "4a6841b68577dc00131bca9c635243f12ef6df5fd295cf89e9b7aee50abcd765dd08863a49e39e5dee795e1cffde3b48d1719687449d5482f0afbced9dcc8b5b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/en-US/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/en-US/firefox-68.0b12.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "f7d8a43334fa3176405a864c96e1daad59874d0c70afd027d5edf276cebd712c8bc3133645af19e7fb6dc28a6da8edc057f5e3f9a14355338a3d731adbfbfebf";
+      sha512 = "4ec83e426ef77701c024a31695ca10a12a88600d01aaa5c4a979c83ef5ad4ff2b378012989311da15e986da0e1022e8dbb9bdf0e2dcdf194c4b990db61e9416d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/eo/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/eo/firefox-68.0b12.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha512 = "ead225ecd88a3f931a7077a66fc274a74c5cd03992076d869044bfcaefea5a286484b01cd41e06a4ea6ca92cc6ed3a38843d8656cdb0ef5ea39cbb6165a06bd5";
+      sha512 = "731260894548db91a501d12417449a6fc9aea0485258df16470e8517e82e44270eb273113b1c06ec973031d2dd3f920e510b1ab0b7addc2fd19959eaa41431ed";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/es-AR/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/es-AR/firefox-68.0b12.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "55cd336a385c787f784a125679e31dad079c53f803e0a3473462444ca46195ca84491211f4f7644da9583bd3a64ecaf43bd9062eaea1e1ebd4782319c4f3198e";
+      sha512 = "833e51d3ec511302d86599b1e65ae2c551793f7c09397d93665ebb067d9be1b0e6caf2fab67b96d0af70218a913b359271bc8143a080ec671aa1c19762421a7b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/es-CL/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/es-CL/firefox-68.0b12.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha512 = "3eb26a754f7ed282ef96b1c30f231f87ff78d330ce9e16715ec99202bc1ef004c4911ebf4eab32501a5e95670c9f2e961398185410d97127f7a053de932dd5c1";
+      sha512 = "f60869d77f08d4ec67d1e240cce766429324de937d7ab0e36590684c46dd7ee9d81add5529fc721d028ad21fe1666fb94f6256a8485fd954c946c172a74c7fa1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/es-ES/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/es-ES/firefox-68.0b12.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "a7ab59c05a9983c810c11f5cb787f958e15a38c9176e0745c3a5a7e8c6804b67f034e8e6d5f2558eec0065a6aa895665b016c9d44bd5818b7b9235c493dbd3d1";
+      sha512 = "67818179412979b5067fb08cd889ec3036d4270cc322a92b67be0fea402b3fdc22a6ad1eb1c768aa7d9a7f89b0b7f2bada19968903e7f2d85aa4a537cb41a6f4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/es-MX/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/es-MX/firefox-68.0b12.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha512 = "70155e89ff976c7ea4aab46913a05a4eff3aa71ffa020ed5a39165f0f083cfcf81192f3880f9d7319d09e0c6dab4301140c4ce33501aff175f17520382052d35";
+      sha512 = "4b281caff272f08ece0e27ebaf7d7ff5ef26b250a6d33e95f59854386bafea8b5e5fed904dd239f2c4c1473c558c81e15de38fbe4555274c468c30aa2da80476";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/et/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/et/firefox-68.0b12.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "11edb60c3a268d21c7f1a371ecb515a072fe39679c094a161b8f13c11320eebb6e2912621dc3dc2cfb26754a3ff775635c8a5cfa23d9e8cc5d8474fff363f208";
+      sha512 = "f1d15b73184643b3d47fdb9abbfdc0708f808c804bb287bf892bed370262da4170276675d29e2069737459549f9ff593077b3649ef39920607f61f6a3507cd07";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/eu/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/eu/firefox-68.0b12.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "2eb2c5a7b0fc31a7cde85d0abfb69deecab6061beace73c897d3230a570a24c7d776fcf6553287be3ffaf4fb6e62e2033915ffa99999fda1ed2b074bf5a26754";
+      sha512 = "0d21e233e25b8200411328987feaa2868a431f3d3702adb2953d72eee46d521cbbf65d2a33e94d1a10b22a2038261137e6124bc843a2447a2895ff9dc17c7ca1";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/fa/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/fa/firefox-68.0b12.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha512 = "9391c557a991dbf3fac067217498e1693735ac62cef381e4fbfb2d600543307b8c96112eba5de7979623d29171aea5c6d8f870494bd6039b988ce085d4c52c55";
+      sha512 = "27cf9068c191012ffbf32768bcd35b48fdc0d15816f00551e917cc454ad7804094805194d23d7ea216830a91e179b67186627d500f50c0bfdc6449af5a4046e6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/ff/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/ff/firefox-68.0b12.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha512 = "c1917ddb5a787aada8a1baea3a27bef34e225f9f8eb663d0a425a11f3df878b6c89ea08027f8f3170682626d9b858bc9012169bd9cb5c87793496e92a410b9a8";
+      sha512 = "521878b91b8740ad2a7e7607931dba74f5c26e84e1385563d6d2fe6da2228c18cd0bad5379fb5fd41c0b76be4302775b4f02070882dc6c29683fdba6768adeca";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/fi/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/fi/firefox-68.0b12.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "13305132fcd1df53c3e48971ba1dd0930e7292f437e6a28269411bb1fb13467f228131e4bc0be80b47f235abf706e50cf804c7b96f3b7f24d1cdbc94960df545";
+      sha512 = "3a470d7385523a01bcfb443cd462a3c26adf3ed50eb54f0b970f2b084f8bd7a020eb0ffb47c95fa85beb4e25226ed3361f4631d74904fcf2d32c7f15d718b788";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/fr/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/fr/firefox-68.0b12.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "ceaaa7472576985940597626aa6c2d9b2ab3837ce9e9208923f2651d7384eaf185f71cdac8e68ebf4cdf5966bae4129c67ab7f598e754d00f271fba8eecdcfe3";
+      sha512 = "eaaf5b834cc5c71ab901673c0201640d5802773f215062c0472ffadff161fdcb2cfffb70712a8f14b7de2bed06a58f96e795ebe89a8c640e90b13b2bdfa89428";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/fy-NL/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/fy-NL/firefox-68.0b12.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "ec055c40201c9d98603d4587958c36acdb4726c8a6aa2b5e1828697746aa8e0f05c92f5cf1ea7847ba507909c1dd30f9ec36069da6b28e701742d005d22c2c32";
+      sha512 = "37bbb5b9c608fd08ce33d76e39aab5c02d2f3befa1e73e12cc241be0dbc107e13a3f5418b87e2291afa08f6801fb804b9c7b45126abcba40c45a6839e0d3bdfb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/ga-IE/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/ga-IE/firefox-68.0b12.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "d4b2569f1257d1c018bcf74f0f05ac9fd5eedd0f79c6c9c1408d6e66aa1af54942128a9eab9bd693ba4045cfe20d10b0ab79ee780c470bda244b07f256f5a544";
+      sha512 = "09a0b825c831e8dc9bff31c6f9d0c6f08ab56ccd2c680724433dee4af574a0e43604cd1eae54a8728278a7c42d01658e0c511319b1a02ce9e831c96f28fba1e8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/gd/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/gd/firefox-68.0b12.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "86cb346f3db80e02fdb5c3247dba29bd8d19f5f8be7e520b3886bd4728b6707be48fae3e397dc66d181c93b1c2d928a344b3f4a3395bb21aab2ba6707af200a4";
+      sha512 = "22f6fcd27ab973d942ebb4fdc6df4855179fd6fe454401f1338ce36fb62ccdd6722c63fcd3e306d5364ef2aec57738112aad005179a01ef4b200f7cb1cd62ca3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/gl/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/gl/firefox-68.0b12.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "8f787530950db522034774ba786fe54cc905ee5941cbc29685240bccab7dc71672f89033351258f9a2ce9d5ea0a3a92303c327d88d639a7f936d19b6164f7d16";
+      sha512 = "245b8ec2cceb6a4b9b17bd9c50e834994db593614616a3c2b89dad1198107ec36f73544589852c5c11281dc90f3d4dbb5d2364a30afa3e16999d0a054c3dcebd";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/gn/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/gn/firefox-68.0b12.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha512 = "dbbe851f6b05de598c830b18c5dc82af7847a3cc6b312569f1cd2c0f354d84b110f55129fdda3fe4735001cb659cc030bd7373b3a5104075ec460694db042486";
+      sha512 = "6b158020ae5035565b1aaafd211e881d094e3b9077e78fc28e2f380303b8c23b1caa4cd3ea0832201026fceb528a5556dc89f7a7de9298b11184287f1c1dfc45";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/gu-IN/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/gu-IN/firefox-68.0b12.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha512 = "5f5e6dfe68d577d716d067f5a5971f9a68153dc810eda1a3fe106f14e5aed13ae6baf11a125d0157c5afd294a0a1ee25216dda90aa086d609aa1610303e5069a";
+      sha512 = "0bcaf3254813905c546fc229fc8dc384003a0814a09b537d3465cd8cd83b1e9cddae0bf9cad48c4900abc3f76d2842b82119699202f37991b52a016cf8feaf2f";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/he/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/he/firefox-68.0b12.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "599e723778433152eb87795d186354fdf4662b59497cbf367761fce83b900d1632417f47782eb5a2be5b08bb9c725302fb979f650ba8a76eb2d6260b47672a2d";
+      sha512 = "69b9baffff76a335915324214ce98dfb418b0a66e3f1895d6c4f808be6029d239e665e33ebf563694e7f5b8c733b85acdc8e131a2948c92a4ab33d015eea85d2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/hi-IN/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/hi-IN/firefox-68.0b12.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha512 = "1c90171caed4ac54bd3cae4449fb9695c1783a520a91687b77f9a603b8c06ecd8000d343213a87d4753bf21a1ba351c330cce03a186c68fdc83240b235544757";
+      sha512 = "f6a74baf232baa6602e93ccb83d020958630e169f888594237705f9aa2807d502ec3ce705d5fe55e4f89b1bea44133b11b642b011c15329c380eaf6ae19a5b8b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/hr/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/hr/firefox-68.0b12.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "6e2a2d03b16057d93af1d887f9ea479b13f8c044e05478fd518afcd71f60eee1438c2aa6b24e1d7f7bff8584a549c5d0f9fbc3b02a88d3517af4b087d506fa4b";
+      sha512 = "1e8ec2487dc44daa07aebcf0660d18b7aebb04f469b236d2a8f7a49817d5361bccacc15d9549bc44a5673a35e9f93871da6c4b5f8360ed5e19eb5c4775a07161";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/hsb/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/hsb/firefox-68.0b12.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "831ffc498c6497d5e54a969297e9d0ae307efdf2d7202b79c10826561bcc33dbd4c54e463ee5b9adab64683d18065fc5d695ad3c9c299e6be258043e45c2c34d";
+      sha512 = "bee5a0d34206cbac80e9c54026f5a19630173b7725c9223aa00dbced1ed95010d3995ebc4048d6c32db7ea3a28b25d6f86537e13d3e541103c118f847f199ec6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/hu/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/hu/firefox-68.0b12.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "4e4267599304c1d9e90f7e8b28b385686195505b9453518d044b04c132dbfc0bd324596fa118643cbe0e38acf4849974baa06bb2fca61293279c3476decb309d";
+      sha512 = "dc8fbfaa7143b05fec1a16c83cd3c366925b38ddb0c5c8621d5c4cfd7163d0715cf3a75d675f665f35a6fe47397403f810ce71eabaef93d1e27bd4ded74da70d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/hy-AM/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/hy-AM/firefox-68.0b12.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "e4d385f001e9d0f4ba797415b847a53c3f36674fdbb21ec68510d4d9f6bf271f3c1a34e647f78f4bf37cb39169cde9d88371aac9a1e467b40111546d302bcb9b";
+      sha512 = "9e7fb55ec4e3f3ad69a89bca9c50048e7abfe35929b1ce5d0454191ae655c7047a41bb6846b3c12d5098f12ababb2bd6e062cb7cc1eb8605e5d4056880288097";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/ia/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/ia/firefox-68.0b12.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha512 = "15768df1531427686ed663c9a0d085a3888e82fa9c2ab4df78ed418c960d35c75a77fe95d3cc3410c68ba89f75610dc8080cd52ee396a1f02d640424c6698bfe";
+      sha512 = "19ba064d6ec4442291498378ff7db168fe626b912a4f5fe0f7dbd868e0250c958c1189b575315f287c5216842d05963bff10d412f1c5d2850e5f7382b3e94046";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/id/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/id/firefox-68.0b12.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "3a3a1b1ccb2be3db5f358ea8fb07577f568a7ad38600bb159170d60ed011c6a4d24b6daa904f530ef249cadc9ddfa4b77035ac55a4766a4fe177d04d6a82ad36";
+      sha512 = "bdf2a45765ca4b34b35d093b4d8dfa86fae7ec7f54ffee7e52f47e2f25801c5364a1e1174f2f12ff67959d209de8bf423d25bffef7185742af1cc4cb62c499cf";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/is/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/is/firefox-68.0b12.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "ca6655fd260ee63717a6cb59794d75c047194c6f6e59f64082f9ebb3749d948cb5156a81800847a20d9dec28e7c2a6dc6d4d5f434de5f08c458a4d7aefc6c631";
+      sha512 = "196940b279e680ee674b5ac0c8d2744cd60310d11345ef067aa7c0ccc8c7cc9713bca2b2deadf728acc90f26d23ab4938b4d79f6744a4e357b943a6d2872a35c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/it/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/it/firefox-68.0b12.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "e074450be3ae7a2a5ec133108f1fcfbd36c028e341cb66a5bfded62a29a55e2a9e6030a124640227dbc0c915e6c89f52b456039c726816560152ab65e74eaa2d";
+      sha512 = "e42447492b421235810d4746a55777d774c488db6e233507c1c3947ece9902a55eb4390d450eabe4369f65033e9620316cdbfa4bc1dcafcc139e61205083f2b8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/ja/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/ja/firefox-68.0b12.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "7ddfa8464bd6d4d2af15bcc76c3442c0ef8e1accdc972b613e66b5ec01f9131b033d8216bbfa8ae33b08339129ae444658214b682b00bcbbf194c0bdebde748f";
+      sha512 = "ff4d87e5c3d0a4de6725c48c455f59cb8ffc3646da8bf16113845a6eaa6cb5f7ad25cdb1ae9a8cd4d099db6c65352bbebdb534643550af0ebc6ffd6efb82ce5d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/ka/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/ka/firefox-68.0b12.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "ae5d754793c00f90a2b4182ea4a4b1d035aa3912aa0564dcfb5bebef2fe570b8dde1b1174c1ef51e35381fb13a19e736f6277b275b26a2ed9eec7159ed15b34c";
+      sha512 = "5dc95cbb37f035c32442137f713a9e2cce8057b147bc4f410675948cc21e23cab78dbab97b0374fe0ff35caf9d8562832e244086137c40d88b53c8b85ef0c740";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/kab/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/kab/firefox-68.0b12.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "ab0649a0a597177a64d66a04e1af6b4523f029cfd00c11ee3357cae139799ad8de5626683c46c74d54a5d88a2c85499fe539b14c82ea3818a8a75bac896ac037";
+      sha512 = "3d3ef83ab8390f132edc7c574c8daf18946a9a73c9a8348bc4c5a169dd829f634f4ba5c024b91b7598f7f02cafdbf292887bd1d65f657ede7cee9280673246db";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/kk/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/kk/firefox-68.0b12.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "e3c601cbbcc237a8cf1859eae8d50163a8f2e2ab23bea43efaace14442c3c8c4f0e564aff77fe233fd81ca0ebc66bb86fa9e7075959684d4f8327ed7bbe06060";
+      sha512 = "11b1581c79c38bd6b85afb60547dd755725aec25459c57c3a62f668ee5d59999e2f0e1629f9d50fbb68a04765a8134b991508d9a0ee3fccd320f8ade0fc7c030";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/km/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/km/firefox-68.0b12.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha512 = "0968d1d4f4ea27705f639969b52205b19eadd1dc6bea10fefda357cfcea19b75b746087d57a7e0b545fb428effafd46a95c8a1e4b8df811017fceb55ec873087";
+      sha512 = "e28f65d21d1b97fccc46339333465c6f3297ae790883ac78bb32bd3ca18344aae70578addbac7b9660f04fea267354e219d952fac7fb0426350d99f648e13637";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/kn/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/kn/firefox-68.0b12.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha512 = "a82e8837be37a3d56538a1b4647b91bd5dc0e888ca0df6f4c38c4691df34f4adcf6f4f933b061181ead779ff129ba1189fe154238100f9a6e3356422ded28901";
+      sha512 = "0297aa868255f4d391254c8210142b4c31ab9a966eb800d09dbe5fe593af42d68c52d45c73c32edf6988da3c7902ee324e4e026648c075ab67b389f2f595b761";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/ko/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/ko/firefox-68.0b12.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "c835f0725fd66bbe1ab35ae038c2dbab580b115907ffa17982bd17546f44ae58971cc8e2ce9516603e6cb98a6b9c45c26e26444b4ae0838e66b5b20c6a803306";
+      sha512 = "e5f311b43b253954b5e9e22617dde33d34ee08e03e66be4d95e29d5afc48a755e5f686d769ad4ec12498b5a9c46c47c8284cc7b5b0b923bbdce878263fa28233";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/lij/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/lij/firefox-68.0b12.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha512 = "d4e8590beabde244a77f0a05b6bea314257bce85e4468de8ec2fb9456cf62e74a4d3198409fc4590e275d06af72ba71e59a09e7fbf04013e5c94810fec1e68ed";
+      sha512 = "26cc5ba51d71a0d277ad908cbc145c3e04ba4d090b4a41103e2c3dc610914194c46de3ca5e635f1b944308fd697ccfdd68c703944a1eaf0d072e34926ec85ffb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/lt/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/lt/firefox-68.0b12.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "409613c168961c052d243d801dad04becd50ed5bc99ccb67b267acc2a61739f3675efd0503af066ab75a0f493856dd49362385f0197e1cc03cc2fe90db1677f1";
+      sha512 = "cfa6be0944df97db783b827df5349a799d67d5369c37508e4d8fcaee5a2e02b7940f54384afadba3ea36a4f3b56ae621d01b35f6d7c7dc8830da34464671c366";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/lv/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/lv/firefox-68.0b12.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha512 = "b2c364e7cb04638e668e22c43885bda247902106fea4036ce34da7be71bc07649e4d51e6bd736ad83be949678b16becda4176d274f6110ef03464df35e2ae49f";
+      sha512 = "d896152ca7a803bbb80f4108e919addd9a2bb77c78f5a39b521031e703a59fa8874226f87bf2bffc3555620d454b21294839d626c139de6a4ab4639490513268";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/mk/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/mk/firefox-68.0b12.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha512 = "6541a0810c696c39aceef80fdd0d41db025e8132d36ae260af863b40b0b97457918c993caf8ac5009b8c535392e4dc6782947d38fb7b5ee7c7d77941443fbd34";
+      sha512 = "6a7e88217fae55da91c29f8c895cfcf2732dfae0ca009bfd1af0b0b020b7a3d15f58c6e400e8645a1c675958f67257425fd16a7b45d2ca159bcdacca51a0bbe6";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/mr/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/mr/firefox-68.0b12.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha512 = "fc3b70d3e8ec94a84a77969130ddc00f1c477eb821cc3afcc9fd9c1bcd33bbc5b4bb6a4ee832905599ffd03f1eea3b0868e091f5c5ff14f76ce77fca149d18e3";
+      sha512 = "1a8d3b92619df25154cb7564375e41b3321c67e309cbd89bf05015a856e45a36024e406a36d27214c149f5c38d2bf4cf07b8be72af8d5b9d6ae02c91f68a1a9c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/ms/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/ms/firefox-68.0b12.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "659675a62a5c28610f2ca27866e84f8b8d6a4474eaa0696462cd107b3b68239edfbf7f2efa14a697031fde0113b43c0eed23263934df56ce09e6bafc06b64c2b";
+      sha512 = "da5defe18a07f890c53f64ee87926c62c70c23ae568fb18cb15ad9729eb432f141e6f5d3f88336ad3a6c30d6c7ab902ca12a86224470151ea8bdb97956239630";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/my/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/my/firefox-68.0b12.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha512 = "cff3a03d7fe0f4f359fae818f0c849e2c99dd0cf9321992eade4c047c353de80dfb851a61f5837e0a99a1c533bd38d6e3a9b9e385cabeb10e862542f12d7cb29";
+      sha512 = "0eec34d82f3dbe7cc6b4b9292fa90e1bbb547fd225aa15ef3d5cfbca79b1702565f709e4b0d5bdb21b895946856547a676cde13a3aa6076e5d293569fc4d04b4";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/nb-NO/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/nb-NO/firefox-68.0b12.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "3b4ab7ac4076cf3d2b669df00749fd192d4e09536b52a32d694b548e540dc5855f9d90d2f8d9ae40bbe0b49ddfeffeb6401c1f636bd400d1aa392f68ed49935a";
+      sha512 = "53f2979beec2d9aa4d69e87d3ec708092421f91056c563dd555f6258cd50ac3d0ff70a9857372933ff185a5d22f33c42a400c56e0e834e33e1db6ec8a0e2cbca";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/ne-NP/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/ne-NP/firefox-68.0b12.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha512 = "4356893fb4ae5da20b5f8fef428aa72f4eab5dc8e55c5c1be980c62178b00710df7a47d5fd932725ae0a9053f59b988d9657744c5614994a2be8d895b3de87da";
+      sha512 = "2e0bf9610afdb65d9e7bb6605ad2cc55a7e00207cd622650e47e089db1e5bcafcffb4e63d48612b5186d46a933956a23502b0f71a1f4fb02973539b1c0cb5bbb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/nl/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/nl/firefox-68.0b12.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "452196493927e292a06a30edd0ba1f21221f588110198c4ee6cc822771ad0ba7a8b4255aa305764b855c2312e96f6075062362bdcf8c9b262836ba4fcf00ce59";
+      sha512 = "5ba83f18d2d642e55b97d260ab85a0df446c82a17fc10fa8d2fb89df00d0ed8943ac99bc07f28fd8db1e6af41200058c1e90822bbffc39205bab81fff00a8c87";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/nn-NO/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/nn-NO/firefox-68.0b12.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "dbca7b57df661e1f386fcd79825ddbed9fe624a9c0f837012c715a48abfc7ccb72d0f469b52750f6310ca57c3874660402cb997fa6a4ea63561e478eafe4b64a";
+      sha512 = "2d60bef6c729e82a1864c1c420dfd7bbde8922d93f575fa80d5bade425b10b96ea7ed1f00184ec7960f8553ebd56cc54a2c9645d1517da8db97e03b65b2cc700";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/oc/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/oc/firefox-68.0b12.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha512 = "8d4eeae9cd7d2b84a6ba9ed5cfdcf5eba0468b8aa2150d4102d05667cc37bde98d32d27639e7b2bb6b8845d4396e7a70c5fecee2a82cd95eff376ff9132f7b63";
+      sha512 = "67c9724d01749aa132f38a8c5acb7c603b6186b0ff70c693be66dc1c4d5404bed74c8de23bad5e45eebc27e5decfb26733b0c00acd6f2e283780c56d7fa012e2";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/pa-IN/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/pa-IN/firefox-68.0b12.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "effa6e65aa0f2783f9ea43289c8b1cd206df440f37bf4c17eafea1bed74c5fbc424da5bb417cb6dc127bd54273ebf6044594dfd844579d7fe78efee3d91734b4";
+      sha512 = "9b8495348104147f212246414172030bddfddaffaca9615cf701f210ff410d39a0ee3dc78c6a92fe83a35b32e2b18e528db6b6183a5481f8be20c5b93196ff2b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/pl/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/pl/firefox-68.0b12.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "bbae39974e8ed2c688f4d943c8d4e24251051e688ddf3d0fb8d8d579bdb232961d12442b6362824a2062108406a31525ed4627fbf1835a18880f76af95879047";
+      sha512 = "426fb10742be943737a8c1288500ff5b678fc2d29bb3e2bbf2d55221fcce4616be4e86cd8e60356b20f0f5bec51bc5242fea076607ecedcbf3b27bddfacc88ce";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/pt-BR/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/pt-BR/firefox-68.0b12.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "59edfc6f0261d0384b83b65f11923ce029c74277f5807063b78fc076d3c0967c4a2e2f8fd5b1610f715e7697e66c30cddc6fe4e05eb72f49b4bb984996d7d44f";
+      sha512 = "3a288a97dfe69e3fcfa6c48ea4c96a5c5d3cacfb5d6179fa420083961c30ce195d4adad693a981d6409978c938dd6a43f4756d3b62f78fff6f954f917515dc45";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/pt-PT/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/pt-PT/firefox-68.0b12.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "7b7fac0d8d42f5be246aa21dacd70d69abc20787241c5d0ce13df3a6d2438fc18a7788a09320446ea9e8022d9d9990b20adf1331ec6f4c5f005b8a2b280ee9a1";
+      sha512 = "627014dbfe2892da96f76ad180b23126def791bea2a43c431dd418ee6cf4a34edcc352ae710af93f793666aa4e84d88b5b345c341f2b18ad9bdf036797127947";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/rm/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/rm/firefox-68.0b12.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "f72bda141c4598b6c3685d81a99f167844ba7df82470ade3fb5109a5d9ed8888fa6866fd5d6b6e35bd2880a0ca6b41f4bb18c5931bfc2dbde057650c29b9c526";
+      sha512 = "a54cbeb70b2a0d013bc47f9a09cb549a0b9f5352f3a9bf82483a65dbc6f7b57f48d141ceeaaedface0601c0fd9159c2e8b55e21300962b235a36c29682ab8ffb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/ro/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/ro/firefox-68.0b12.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "d18e2dad79296c4ebaed43a97d2a700a3ed0f621260097719962dfe3d89850966a01a7a7f84ed8e57378bb7fb1cf9c18e284e3dc70d9d0f94d6215a12bc04320";
+      sha512 = "e3b894d8e72ea9fdeb99f40e822e731dbd346a468444de95a6782f8b7b97d6d2b36353ca4c02216662804e5e9843dbe410041a6afa8d51cf1dfc777fbd851216";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/ru/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/ru/firefox-68.0b12.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "c29db7070dc70fbf350a998b0495f88fae6dcc193fc99f7034312605f6ca595d5ab727f97282edebd7e60a10fe508c868eb7979c10a2bf353ddcb030170a5a64";
+      sha512 = "2c30a6eceef40e9d0f86172f58f7ac38c3d0bae36c9ca3d0bd262ee1995296b06a38daadfe7a57870623b31aca240e4d1685d6c1513cb297f19e533aa4ff9428";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/si/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/si/firefox-68.0b12.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "903e9393746cd3b6a7d638d25444c9416c85ca226cb29c53b818f70b3ceeaedf60d67e96bdff26af6f65b4a4ff365db8129779d6eba10545870cdddf29ee353c";
+      sha512 = "c05c7bdaf6e986bfeb99872bc8056c11096e1b961ef418ce88b7a8d386c782fc4b2f8d0d0dafac6fb2c0f68db9e1cd27f323c4d36b16175e1901d8908c7b9f3a";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/sk/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/sk/firefox-68.0b12.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "d628978d2fa0dd6c2d2a7347dba7418f1ac3885caa06da2c89f71457888cafeebe461c281305c18d05faf60ed24c3538f108c5d3b681dfa107d7f7d18ed904c7";
+      sha512 = "cdb5a13a02f45f599e3cee55c8d17437fb2190aae81fe9248e02af7eabb967945fdb5eae8e5ecf59c8586f5e5ad32acabb78abf50a31823add459e815beebf3b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/sl/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/sl/firefox-68.0b12.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "0d02a64e2d7f14f005cdaa64ac61ccb65aa475a77de67aacb108636a0c32401e3e80e34fff96555dda14ffbcde36873c76abecc91564ba7e2bf6295bf48fdd27";
+      sha512 = "ef3d0ffaf4eb051a98044057734742c5b615c9e64043af99a1fee36cbd1456494c01f20df8b53c5094b12bb66711e8db4dd7db2223e6a827f9a2c6cdc3fbf55d";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/son/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/son/firefox-68.0b12.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha512 = "701c66690fd8b1ffe250091ca1153a91e0befa24d3c583a7b651569afb10bae91f97b7131d11a383d6fe2b0e1d77a1d45a5631671d74f6d216204e0fd04fccd6";
+      sha512 = "d430041041f703b7367963dfe58cba49b8ca23a50ac70f2dd315d4f2e4e5afe66a3656af08be4046a88e0a06901da722451f6f20740fec9e65fc53a6ebd4f104";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/sq/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/sq/firefox-68.0b12.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "3968c63cafab0e26d7697ca38ea762baf18df8c604f700cd669848c9d7244c2db574cb17ad5ed650d403e625d122ec8a07f2aa519192140e43dd03c000621fda";
+      sha512 = "34042131464d3e29af4d6f9306f8bf20a77a0a1926ecc297a3b587551efcffec5ccf7df82ebbd9cc25cfa9e4598fd15493a8661d61d1ffa9708bf8d706c5e45b";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/sr/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/sr/firefox-68.0b12.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "378a79376c018e03a19cc0565fb47905d94a218e35add149cf6038d0a01d38401b32d84ee272a64bdd692834d93ed59e92886bf4475f1c9fa46d3ca647b02c3d";
+      sha512 = "795dd65257fdf6eb34e822e4ec0b56ad8e1d1536818c7bdae2c4fcd1711fded36ccd168ac22500a071bed37a15e481a4539071b30e9b91159d2ec0f60a428754";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/sv-SE/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/sv-SE/firefox-68.0b12.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "1737f6bbdf52d118c179c4473923077d258ffbb1c58bf4b1a65f469649076ca828c7c0943d0093ab0225bc6700aee7eeb7da1100c354d1cd5782c14898dfc273";
+      sha512 = "a905295f59f638d137f729905872aa9da66b035a5bd63d8717043f4a32ba53ada9835fb7aa613ea0b2252a92ed38a404e533d62d7514a13873a68c40c96a02fb";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/ta/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/ta/firefox-68.0b12.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha512 = "ef61d42bc48b02088f669e24821ed91e9f615371a89e73beaa4127cc6ef03f4ef7c81dbc4de0a0fb0ea7e1c43443fd6849dc8196c656833f726e07596eb77354";
+      sha512 = "c996ac6a419097d2d14400cd050dba33e87ffee5059629f15fd4d666d6abdb02351cb241b03a663fadd85f29a328b311e173d4850d59abf4339a367aa22a94c8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/te/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/te/firefox-68.0b12.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha512 = "1d39d44ecc33d88da7a4ad6769373fcf17bd0165f4145e002f75c9774908aeba30bfa00fe680646aeb127be11ee8c9fa34c2cf108782964c72697553fd3051d1";
+      sha512 = "082d663b14641747a927a23ad9c9e135f2179b958f733e2943267a40600a1b3acfe5b132048b3a4e71879ed292793a5592635de9aed547ece695884a129a598c";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/th/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/th/firefox-68.0b12.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha512 = "1999126c8d4a905e64a82f151a6cdfc60086ae357d9621cac78643a0fba97ea579554aa19f6c391965e713ebb10687e8d1f86796d50460fdf4e3ce68d96a2f2c";
+      sha512 = "f3c45ea9333b25094e153faa4e1faefc9497b04bcccff90b514221671d51e0348fe119a091e6a2c1a867c7e3a5727672a1b153f2101ccf56e5bd223ca8af7fe3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/tr/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/tr/firefox-68.0b12.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "521a9d1c69e66d9e5f7efa4da54d57f4338dde0e04c8f2fc8e31825e734fdda7a8d16464815cfc4e764ddcf060484128b3d0c8554279ce95744fa3e2044c34a8";
+      sha512 = "91e70c57b698a6b4782f64c81a4482cd6046885da0a41a7f1d05b96fd4b10b69681fbb43e302f97d2b4939215f815a68b368b8ee70b1443c29d90410374253db";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/uk/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/uk/firefox-68.0b12.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "de35081f56aece42cb5c0422b1d15b35aecb451fb62d15f6c887d943c2060d884318d1fb090e9891bc8d1556102899c600600ef30a15e60dcda431c44b2cb579";
+      sha512 = "217d3d17cca00530179905c5f0c221380af53f03cc01c152e894eee6bcc58d387db244574d23ac62dfdda160f6fd6065c732c863c5684e85ab32d246af381714";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/ur/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/ur/firefox-68.0b12.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha512 = "387771f43e5453669c05b61436155fbc775f4a0a32b0e68a0d3b5664cf333b1a37864a8e411339004b4035d2566776ce60874f45c3897fdc8bb758a02d6f6516";
+      sha512 = "527871804b234603c95d06fe4c9d9624610aade70ba3985d37f87125a443fb1efd3afa9370b9ab4dadfbade6cc91ed180e830249b0613d366179733fe5f2c2ac";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/uz/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/uz/firefox-68.0b12.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "03f4d140f0c82fe27413a84a8620626ec14976e31fc1c79e6f1f2394c91e9d8b832df6266e29ac5afdad9bd241dffa77dbf5358d82dfc6a5a61d222e44fa577a";
+      sha512 = "35407d10af3148eeb1c62a1e690f5bd83d623afb24151eab254cdd59c19ccdd6f7fe84b9c68136b3f5736fefef31eaaecbf4ee88a4bb38ba93714e6e1a469e96";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/vi/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/vi/firefox-68.0b12.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "2a50359c34505f3a35a387d329c0c01c439769282bd5ad75dfd9b4ab421df43dd0980ec4557f49cf764c0c4d64b9d44269f3bfe60894d1c56d63b21f7a088f90";
+      sha512 = "edd451320a4bb5d670896abc788ba7d845a9ad2eaf235a8aadb13bace36773ce51f31d41b94c363278a9868eabae84186adf7df5902770f12a476145641924d3";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/xh/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/xh/firefox-68.0b12.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha512 = "da2847e60cf7c7a39dfef2073ed314934c2ee44cafe0a0805bfff412a640cca1d16db4707fa09a1f13db4a310a7c34c75f0ef8d7c0d72197750f7a5e6285ae3d";
+      sha512 = "dbc83d9d017ab327dd63a6f42e5fbdfb1d5575c848acc6d8610fa937839e18cf84b43df9ecfbf4cdc6e4390ab24f802a3962e1c58bc09c7ae332aea42b7467c8";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/zh-CN/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/zh-CN/firefox-68.0b12.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "e21a8e9975c87c61752216d995e5701e3b7abdecca40513217bcb141c4237d5247f5c54bbded0105400565762c75f0b184715d9c8c40c2226a04f5fed95a27fa";
+      sha512 = "ca19b51389a339e82332640396cd398ab68651ad3c77fcbc60a6e748400bedd88557a49459e573e02038d69bf95a38eba08760e9cb40d25a0a97354b92cc7052";
     }
-    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b11/linux-i686/zh-TW/firefox-68.0b11.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/devedition/releases/68.0b12/linux-i686/zh-TW/firefox-68.0b12.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "907dd421278548001f8d08f3db0d28e40c3d1aa0a8bdc911db4d0c937ea5d4f019b6907eb447ec6a988060969d1a8e8d630ed35242b7e94d7255d8039c709a9d";
+      sha512 = "8c07654fc7a45d3918d2ce9a7732f7b5feb05cda23280385bf363b907b176c6f3414f05324fed9e384c6e5d63d48030234aa3fcc8c12e240266ba1bf89464c16";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,995 +1,995 @@
 {
-  version = "67.0.3";
+  version = "67.0.4";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/ach/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/ach/firefox-67.0.4.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha512 = "9f75ecd51aeb7422b0017ade4908c9539679b218338e05ea3018b27e0e9ededee35d59fc738f0594cc0278d210c1c658ce3857be72b18fb57b77b83cbc43e40b";
+      sha512 = "242604c1cf23db5dbcd6906170e3f1146e1d56ea443f17ad52133e6bd5fa7febeb025a54e9bc8f6cad7421361d386508912376aa2dd40b6b583a1fc795520a2c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/af/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/af/firefox-67.0.4.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha512 = "c9503156f12103b9a12dd68e32ebf36cb77fcddfb0a6aa833095071f8b1a59bd06f63cfc79bec7a0db08366e2972933f0324faca7ee78abb0ee1a452d39bf621";
+      sha512 = "46f3856b00935d44280c89095617cc48f3d84d29430eba3dbe003b5b20cc612be7c6144c932e683b2926b0961d7759253b233966fbe002c60cb0a5b36d58a76f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/an/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/an/firefox-67.0.4.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha512 = "6d921bb328a0dd91eced77df9e4519db44a2f3cc7e50bef77f1d3c7a3d20564292adaced7ba98b249bffde70862d100b5a5acb7890325335583be64121a8d546";
+      sha512 = "31c70530b2669359458b3a4a8b63cb50abde9f7e77f0d2ac03a8fdfbef57b573a36a80c99a8e87cc7557172f97e8c74c96332501f763b4c137d9d21d783ea74f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/ar/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/ar/firefox-67.0.4.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "8f6a6554b96e674655e86d5a14ba7596a1bc9ec3483ea9caf93763ab2f0d0e4f0bc8ca268067e5740f05d3a03ac262b904c09ca24b21c7b16219ace5e02ec833";
+      sha512 = "11f2689e40ee208a4fe372e09b3f2484ff66f1944f909b08a95c95606b614b829ce13b51ef1ea614dd01fea05f60d629d7546e41b45cccf7ddd863c719e6f0f0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/as/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/as/firefox-67.0.4.tar.bz2";
       locale = "as";
       arch = "linux-x86_64";
-      sha512 = "9a080f3134dad9e046f5c1d32d7a937389b4911831bca1cc747f9b14a457e7d5f06b6bca6e2e092ac12c796d14b3349f1dfbd57782348eca915440258ecd7125";
+      sha512 = "ef8e239ddba2b90444fd06141d9aa480a890da335f308deafda720266fcd7e0fc4fe533fba0b72309eafbff785bf3c1fade5008aad3537c5d6ebf8fdb9908742";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/ast/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/ast/firefox-67.0.4.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "9363ec04824dd722a7716cf1f4408aac43ce11884739935a687c335510de4e9e095cd79dfdfdf6f07334efffe578578e8f85dd390277fd6886179dcf1cc2acd7";
+      sha512 = "bdbbe1339bf7341600a6c6568a24534232f84b3be5a8e7d0b7d02603be4b531afecb59f7eed4087fc143c1687c05da27188d0d7594095ad4a68fb1645c943189";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/az/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/az/firefox-67.0.4.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha512 = "8db6c02bd5c958aa6e7753eb85367c0a11ba96e96b9107b4d313672ff3713fb7ddac0b3348fcd96a2713dd67523cc3825b58bc6e98a323d839d7de4ac016c97f";
+      sha512 = "92dcdc797f853931cb9f7e39ca33cf267d2b92e4c2c1e914527af99089dcfda4d9238d7aea37e2184daae4b3678b76c0d5e59708ee36c2f27c8e702635541d7e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/be/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/be/firefox-67.0.4.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "9cbb9ae13a6d5b453dadeb1d787fec3379698b8aafc41ec9c04217601605071198ab9b19cea5ee3df3204f1d3df397a0fa149a01941591ceef9e2b5ceba4e638";
+      sha512 = "55390415d1a763e63100e3be94c3bd21d33f1045df4118547fd9e92879f6a44e927393ef82d3d65c08cb1689ab5fa171fb4725482741ef0c152ff61734b2277f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/bg/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/bg/firefox-67.0.4.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "2431f7e05852d8ad0e3c83eafee3aedcf0574d1e933b244946650f15b43b9cb0beb35bd215c14d6005b9d37a6dde1755d72bff091e146501d6511a09753f861e";
+      sha512 = "209bd91460775ab2e6d8de5ee18e93bfab3a316ba45fadfe236c7cb3014c59c3c7c05a2a2232ee214dd959b005dc664e8e31fd3c21d0d924740b2d04d637b033";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/bn-BD/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/bn-BD/firefox-67.0.4.tar.bz2";
       locale = "bn-BD";
       arch = "linux-x86_64";
-      sha512 = "589e7b7b5fc2b256303f287c0beae307fb11b8b4329eb30f35a33e5d0e7f18119272eb666a5074dddbc152edf1eec0747eeda66929b0956df0eb0e302eeecdc8";
+      sha512 = "777adaca9943505cba74da7fea7ff6c620d44d12f16b0f8e513680a4d9c00b8a657d6a04b2b23fdcb8ce0cb126a9ffb7d4f983d168858ffa522a2373c42da30c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/bn-IN/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/bn-IN/firefox-67.0.4.tar.bz2";
       locale = "bn-IN";
       arch = "linux-x86_64";
-      sha512 = "edd615a91e8b42732afefb049361efc4dfb704ab0cd59a7f5b918745e3717c7d90df26f0ca0970d07a70317facd48636ec4b421a1d6fbfcccbe725df335ef170";
+      sha512 = "5d5b2f2cfc5ca0ed17da313a052679aa9c9cece912afc660f7d3ebc098a55aff07cc206653570529343b7c3c0a9b3c3be71cc75befbf9f221d0049f90848d3ce";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/br/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/br/firefox-67.0.4.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "ef76f531d225e3c2abe19f07edba5cb2560916546bdbe1a300d43889019599a69aad33d38f28bdd92061627e88ba9269bf6d3834d752b93844c9c6200743741e";
+      sha512 = "6aef5a3e24d4afe68eb852c02442159e41edbad67bdeadffe0cb0e464c733a07f150a4ed45b47765f2891c5b6c625ee6dcbed36ea586dd838e99ec13ebd1521c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/bs/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/bs/firefox-67.0.4.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha512 = "966992bd1f26a725182cb7fc2afbd591d2e394d9bd297c9ff59f31399274ded72e61f4f5fa796b1b07e453cc7f4acf52cbeb2095420396f50da4ede982c1b2ff";
+      sha512 = "37ba7d7c676f703bec7c95281a88a43c2c4e92b6fcb78ab0c11bd5ed6fe166610e3e07c53205438d6f114c9219a67fbff936cbe753d05ecf26e45e259735216e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/ca/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/ca/firefox-67.0.4.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "89c46cac09e7a6e06dbbd44084f03502d72c63eed281075ed46cd6c8d070d7a403120730694677b03643b67b96d099f0401a3962b550e1943306b7f531fb227c";
+      sha512 = "44f8a0d3950182f70adf2a07c0fcba5d0ac6d37566829a8db8eaf0cd5951e43cb45190f7e7d2b756c525c590e10bdeb7c11e349bce50255c3bd6b17eeec4721f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/cak/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/cak/firefox-67.0.4.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "e5c5aa8221ba2c07c3e9ac2562330d6af5077ebaed0b12e687a9a9a6d3301564dfe1f7a68812f4032153ad6264551875fb5a75cad975e74b041382659c509069";
+      sha512 = "1aaa8dc01acc7c72f59ffbea3e391e909bfca8a4444c7cf2642460598eb583f6ea0530efa52044244069c076ff10d22f23362d115a46557eeb9dd6bbbe18ced0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/cs/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/cs/firefox-67.0.4.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "ed9afcf2be0648800cfa4cf9f0769ae8fe5ec849822d6bf4d4fb8edc1c5f20638d3fadaa11b6424aae63716c71f73f38bec51ef0404e51d263dfabb69d370984";
+      sha512 = "109078cc033d14c80ad3a78c6a17f36b1c3717b7d144b619cdd0c4858d05740d2b04da92eaccf8f844206b584fc99a6bc3bd493a06a814157e9f3a130bfc3523";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/cy/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/cy/firefox-67.0.4.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "8eedb5655eacee1fe346a30561396259c8dd147ef0e0c72c52bd34577d86678d0646862a36a2c4af93213364f41699ad99ecc9520b50f78c21635c32a10d9695";
+      sha512 = "391bd48099a9533373ff6abd571c81ee584bd1cebedb6b2c8aef0c16a5d8e7dd54222f31935e98e1e17b66e1eb43b7b0ac65f80fd3638c41341557c1988e2e14";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/da/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/da/firefox-67.0.4.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "37b577a9e6305186974268291c05bc52cddac7bcbe087e8427c288f39b887ae4f1f0ef1641625be8b9a2a55a2846720f6ffa2ca3bbc2e5f0c6900663a8552f9c";
+      sha512 = "f94b5400f504fe72326da70ad3027e3e316b33414c511ca1f72f6c4b0e37761f57115c4e75119c694777d28753dd204b9166f73d365515c6699733035778982e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/de/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/de/firefox-67.0.4.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "7ccf0be3d441473d3294e77cd79d093bf95fcb1740b73ee56377257d9d0f914674d91bcbd1af6b8ae593413ee0bbc75d679153d922c18bf6e0d1475f2274a156";
+      sha512 = "d4d923af91c7fb209e1f2f220ae8c8cb48ee88906da2b10af9addb21820750862b952fd111feb047701f5cc71db8b56380349be1e24c22a42307bc2958d27601";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/dsb/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/dsb/firefox-67.0.4.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "8827e14a56228f5cf7de23823465ce2aebd7a3c14096cb51c9f67f20de9233b6a50d01fbdaf4173a26780dbdbd4f5ab4e0202cc64467c4ad5e67dcbb4ad83e9b";
+      sha512 = "478f25678ee53c9fe0b7725e155249e8781fadd349b476a365c4417f3426b4fae04ea2ba1d39d49ca674442f38bb1bc0bb5992b3506618a3f8172495d8304df1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/el/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/el/firefox-67.0.4.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "164cee7fa8cdd2314c4fe086b947c9f02e4e8e8e512e986e1d8258d4ac162b2b234fbe5f2f954d19e9c81c31f2900118380af4c6374b324327739485549378f9";
+      sha512 = "48906f8582bee9e751ca515e798d1eff390acda3f747885fd27da335be3aaf67d9eaa89a5d51f3d752dfd303041d486fb5147c47a12d1260ce16b4c5d5145dbf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/en-CA/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/en-CA/firefox-67.0.4.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha512 = "77f4b47f3fb1a1350a4a7eb996c1c241e5c34f59b17fd4652e54bae6eec235081bc0bc3a2b06544a9aae1fef2d4156fe9fdc43df73a34f0dcda1b0b2efcb1ea1";
+      sha512 = "4696bb7d8489b1db39e6fcecd7f0863aee3ac7b46ce1ceffd3583a5d0059b1f99345ee99c1d64ec867c276b20745740c5fd82ade24aa05a284b61d132c3b91ca";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/en-GB/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/en-GB/firefox-67.0.4.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "827310ca238fc305a5b65e7a3238d308975f6e19a21bf2882254d257e932c3d35813295c686d8b3a7d4ea67af577e4cd662da5458bdef22fd12952b04e69fcd7";
+      sha512 = "6e11781c6427376994afa642ee2b59c257a57f81b4c2db69be56347f624f22adeff3595c0fc919b82d9a1249f026d7be24706ec192a9ce2f988d9a3184136703";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/en-US/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/en-US/firefox-67.0.4.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "fc6858ccf1388ad502c18b8093beda0e3af14360760b279c91b351b1dcff10898b2829fda389ec486852174a76e3d3489d073ca36e5fcf4cc9da669a15d6be1b";
+      sha512 = "45182265a7fdc3059088502e9f1a9ec6be54a99138d5215f3a46b7e33384e1bdd8d21a5ef5fe5efb99ae3873f146fda9a26c028b114b46bf04c5c3e6812f4913";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/en-ZA/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/en-ZA/firefox-67.0.4.tar.bz2";
       locale = "en-ZA";
       arch = "linux-x86_64";
-      sha512 = "2c8efb64bdaeff4a516a0e4d90c4860c0fb460282bd53e9c5a0861e9d8ea68738a85493db57f506325d24bc2f67159e10e6a40553a3cde5a79e886cd8f9c626a";
+      sha512 = "e0919b61881cbffbf26a58839dc8d5468e2c70edfa2ef0ba35e00a8ec7675edd9053ab2c632b05499b1ffa27275fa5b74c125e04b56cd79740a6fba1cc52119a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/eo/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/eo/firefox-67.0.4.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha512 = "f170dbae4c4a2c6ad9db5e1d5d50ca113d59fb181b2cb02bd0815f1df14e47be299966e2dfbece594527c76acfe42dae68496de2ac3ab024413921217de27425";
+      sha512 = "1c50be0bbbfb74211f958453c938cb5896cbee9d2a891221edfbdbae17726f106ad8da071f067f55fac6988fd6902219033709cb47493b2875348c9a4e734b3f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/es-AR/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/es-AR/firefox-67.0.4.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "3321c50b08b581ed1b44723701a29686845313668232baf71c28601f0ada48892afa164122c3984ed8e82e5d1a8b4be15133e88fc9464469503515630719219c";
+      sha512 = "e1484d5aa03f6be6bcaf366613deaeb1fe40b724a81a3bb101b20d4eb46c64d872c52cdc57a68ac35cabef7e9e4bcb70f83c72cd4d848ebcd4465e4b113fae2a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/es-CL/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/es-CL/firefox-67.0.4.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha512 = "d66fc4f6c72550698a06e85daac6708715670638f638610b2a4418cc8c077a94513bc8f427ffa27915eaeac4735a3a850df6e984c8da259049c08d2a81ae032f";
+      sha512 = "5a61fb2fb1c7bc43ff05be5d75e6ba60f604cecda4b9771b262d9c6b6c2daa710781b84e2d877a003c4e6def1ccf08fdc9d3f6e1c899e2ff05021f298e3b590f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/es-ES/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/es-ES/firefox-67.0.4.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "f3c65b0f7cee99f1f9912fc28bc6098a4bf32dfe77d0d1c1b281c580f76da7604a3baf615e9a8ba8497b31e25a90207343b7430a8515bfa455eacf47f37eb8b6";
+      sha512 = "3a7709301b5611d055c888b737cfcc49b20c9b7289fed3f8c5c5f0273531c2c7ca4fa82e1c9ea38cfdc122f0b75978b5d5a9c5b3fdd5abaac4d7c17b30d2a006";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/es-MX/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/es-MX/firefox-67.0.4.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha512 = "0ee5abefd999e15680072110cee0515eb79960f63addb18d08eda6ff996c079970f9a8dd5a095a674a11972c58b2571609cdce98ba3be0d4397ca880cf1655a3";
+      sha512 = "be4492ddb9bd9b31b67c7cb4583311db2769b42462049c338f9be61fca7013712aae7369b36041560e351b9c7a7d1c6e799cc1423f17846af4dbf1f5d742deef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/et/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/et/firefox-67.0.4.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "237c34a3aba7ce47c457a528c3d3d70a185e6d6cc9fa644065e13c47cb6d683bcebdac1e4ca39122367b8dfe1d02a3a5313127ecc9f368923f76c672020a23b3";
+      sha512 = "edce69aab3f0edb914620a024fcad64a73bbbbe091875b453b82269aa7f24919ff91b1a077af495c0891f20234ab86504571db57f71da7187c399741e65a7959";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/eu/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/eu/firefox-67.0.4.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "106b4c1a1cdadad8bd61e29de8dc2c7a7200bf5d00357cda030f3a5f469ea1794fc40c353131fc856b265b29088190bb10f42ef2e29c433f2e0c2e4aeac86754";
+      sha512 = "612186f2bf70742dc506c73aa6a49715ffab15607413ec2eec6050172f24cfd598facca1caa18f8bd3c872bd768d61a3e7f55a5c7994b687253e8d5e7919aaf9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/fa/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/fa/firefox-67.0.4.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha512 = "92abca1a0c29f635c89f0b1bb51843cf1de48881c5304c10cd6ab430f0e2134c73d495c54759eee95c52eb32e61ec332e7b763f53f88a83a70a3c54261ee3a15";
+      sha512 = "3038cfec8a88eda74b32c14638c001b0bb9bdaf4f4e400a22d2036132659bfaf1d11ae6df0f5722cf5ef4ca14b7a2e2228a10473cadc3d7786b09f7f50016976";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/ff/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/ff/firefox-67.0.4.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha512 = "89421d47b5a8333d1af900bfeea7b134e7924254016510e11c7f38150bf130ab04a120228cf87251e489cc09e1730304107eb58681c7669093509ff422277b02";
+      sha512 = "6601d3508bf587050a4a5314b735f3d63ee059097ad89aa93861e3eea0208fd465bd496d3b0970ebe062fbb7daf2852d3f77aa10b8baeaebcde90f7db3ca37ff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/fi/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/fi/firefox-67.0.4.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "7899f84c6f577bd3ca818ee67be72ad884409a8eaebc6bd212780c55735cb0222edc120cca3a50d8873ae47dfbe18b507e02c908f57802e30e81becd18f36c81";
+      sha512 = "483d8ed081312fddce4702ff2e72e4c4ee9323bae826a60ff1a4a4b78fe6e091e4dabc7874b89fd0e3cecd68644c11d33e0c5941bc414f33de1f3b22c93cf364";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/fr/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/fr/firefox-67.0.4.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "daa663bb72be7339533f39bacc5eca0d6ed1101c168473299661bb685f0fd92ba24c32c3ab8d1fec4dc12bc7e36741317abaaf8dc0c4c948d953225ebb53b253";
+      sha512 = "f6f040446cf1a29023a55d3b7a6a8d8f54b615c5e0bcd39d3b6ec598ac1dbdba50596d1192ef7c33cef6265d2260ae0bcdb71bac36f483877076a6769ade28bf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/fy-NL/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/fy-NL/firefox-67.0.4.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "f68bf03b523e8b68c77ebbd11d99649eac6e3ed2525256a4788d756096e6e4e8dee087c1d30e23f0b5bab3dd4025387d0430a1f421c414f39b07331d9d78b7eb";
+      sha512 = "04c2872a8e50f2aa7fcc98d51597a6b7294892e3059e55042962012da68694df15b6958b8c3ca19dda0bc4f2216b49bf1ec4b8a34ea500cbe21b1d9baa692d01";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/ga-IE/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/ga-IE/firefox-67.0.4.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "d7470bb8b05e5608da39ddc6b6989912b0d4ae1ada25bfc6488bf5e6400d12bf5dbe3d68293088ccb472da5f2b9c15f610b7de887cd0bc616f859a55b96dcafd";
+      sha512 = "54e01fc0f483784a2c70a2745ec8e4c80a71f522977923887ae1b4fe9563d79eff3823026d9ae45f33a8a551dfa36ab571ca775b6a1862c8e604be36584b1ec0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/gd/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/gd/firefox-67.0.4.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "a9daef184f6b2b967159c7a23b6ef3feafdf6b0e608392593b9068798780f49b47d2b956f79d1094cac67adc828ac2bb9f7ad6028044f6f4e8823b28b819784d";
+      sha512 = "c692c2913943c09a8a69bdcface0108d61db14160619be46407d807bcfe3737e8b47bed5ab5f90a056d3fca4c71004f75feace357d6a328a9dc436aa884d6024";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/gl/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/gl/firefox-67.0.4.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "2f181365174afb59ab6cac9dcdc296679a06c9059c473c2213e1e5a8d51db71c42396f4f701082aac7a7967322a177881115102e20adf0bfbbce0464875bdbd7";
+      sha512 = "70df7ef346ed2ad2e1e7e6decc27092fdaad803184b7e58e5a633b0f6922f824904a17f85e7c98c3300ede8d0574974d6b425dee82b917fe0d55d4933fd9ff99";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/gn/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/gn/firefox-67.0.4.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha512 = "7b44172ed4403928a23ce199b29911590c5723bcf06372e2fc3e8d07a696dbb27b87b4c16b10cc028e8da1e353225636fb3040bbd53b2aacb0135ae833435afa";
+      sha512 = "b9f7b5d6cef7c07ed465e4a5d584835e5fa259aac33b9d19fa97fdb2ec86fbde126be0f9e572e1e15aea131dcda6624b7d8a524b13b56615d0566f814ae7f040";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/gu-IN/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/gu-IN/firefox-67.0.4.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha512 = "603bb876c91beff038562703823cb09c9ea0de9392d6eaabc7f6fca4f84e0334c7ef5950aa3f9f1b2d910ebbc8bf6b5907c80073156ff61b008f35c0469cd064";
+      sha512 = "f58051861e6900bb348674631fb9f7a415a72824f518d35948ca44ce6454a9f7fc6c6cad8666f23084edba94158fa45f3e3385eecba2fd966e64869acf5b926a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/he/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/he/firefox-67.0.4.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "a055d4a5d5054e14d08116208ad36d2f1a01d031d0a67e871ec86122b3cd315c8a53eeee6a4973930dba87d4f5c7aeb94c57c3d655794e7878d0d0ee3f22de6c";
+      sha512 = "44146e5c7ddd727ceef7ad24be80d57b820d020103baec8a695a5d11660efbefd29074a550bfaade8fe344e2b984ff853ea739fef60a6fc66fc5ab27ca9894f2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/hi-IN/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/hi-IN/firefox-67.0.4.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha512 = "252dd59cecfd2533aa2d34cdb18b0aff59207dc795d28f51ec7730ea3d5a8566056dc341624a5c1fcc5df13153d05abbe6619ba2243e81ad63351ab80f936b86";
+      sha512 = "07b36ef659a4eed67fee4a8c93db3857b7e676142a42671ff0df002ab63fa2fb2572dfe98ef3b1804ebfbf5aceec855fd684899a7d67b09501a4891f059982c3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/hr/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/hr/firefox-67.0.4.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "b117d5f46139eef8ddd1baeee96d88bcecc585e0f809a368adc015da4b6d8ad0297ce44fb5c133d464eeee9d39ae60b6f934c49d14c791b5d5d5d8b09154b3d8";
+      sha512 = "2409de1ae91130e0034f23fc3bba58c5456eb5ab5dec67b611da8c4c3c70a19d995ed6381ab9c0ca6cd296d247f8a35ea151acd699a5967c6bea926861534774";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/hsb/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/hsb/firefox-67.0.4.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "ba822c24fb6cc39e6966467abcec0ac9bb26002b93499b67744697b2025c3fd52b4e62f45e0b99922fed78df64bd2e6d10a41120e88285d321642fce9edb4562";
+      sha512 = "52cadba3ec438175ab2ca4675db83f3e309464115dd8ced69f3efea29b6b902248257e77749fa3a3c7ae57325cfb57bb0b9fc7b71b8f3509b46f00718c6b4d7d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/hu/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/hu/firefox-67.0.4.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "170f081e7829a5e5fb2878b8c704fa35664f7071aa799346ed91fb9681a1ca8403fd79182801acf6b75332a3b5aea4a2918ee3cc09aac819ceb7f6c41182d5cc";
+      sha512 = "204c7b3b0bcfd44c483bd6d9e5478bf02aab41b8968bd960fc0f656ca2b09e863cc618adf800b409eeda16cad846f66ab1e2f879c4d891a7a60b339b558e6df9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/hy-AM/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/hy-AM/firefox-67.0.4.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "081b899208621b6fc914e91e699cde707cd6e85de04352b2840d86ea6a28cd194cc9f11f5925610cbcc3c1e59766622d47124b0be69501b04eeb2b50d8218e76";
+      sha512 = "70e90d4218c16d0161fe90856040a038af733e4ba42c9de73c39aeea60b34ea508fbce697f8e81155a232913a948f239fde5a103a9a73662e94e491b58ebcac8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/ia/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/ia/firefox-67.0.4.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha512 = "3e28a573c1dfe545773f66a9aba4d0510e3c27a01fcb0bf7f00562ea403221857959fe5645dcd279383c3be6ea0a3cfdf8a745a496fe1eb1542baeceef6abedd";
+      sha512 = "e2fd287beeb581ea5891ba0d8d71e72fa31b31d6ab4309616103eab56fabddcaf2fef51733a078a421c23545399da7f3ae24b6ca90ef2dd42f123150a38dac24";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/id/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/id/firefox-67.0.4.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "2b5eaa66ec8bbe63289062a1a2d7ed896f139d16763bd770fb9d99e85e86bf0e2dd79b66523ac72e76896d6ac8fbad7b006e630eeedb7c3cb30fc2c4f6b1b179";
+      sha512 = "cc7a86b9b1a5801a7929e85c8aa379e3f42ef33cd1b37cc484f4ba339cd048811261dc666d209a30acd10413cf6d788df186624d54a3b95f293b766bd8dc5348";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/is/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/is/firefox-67.0.4.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "39d6562445ac2355c16e5bbdd9d2fe1f7d5a562895864b29ed8577181ca8cb10c04560c29ec9e2be5b24cbf6efd7ca824d701d0053f3b71a9fc30546cf6e1023";
+      sha512 = "c45f90c83e0599c0774b024868a624788418da9506b02eabdacc31fe8ef6d1caf6599981d3e0f2759dd17208e8b2f613565205203a9bf629c91f129c2431c4d5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/it/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/it/firefox-67.0.4.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "09fe88a3838b2fff1e4ddab4fcaa8c18f11b32f7818b45362973b1b7770b4724b687bcae3eef42675814cc008aa2cd40e62aeacd766e0066a3429da313be5819";
+      sha512 = "14ffaf74df4ccdf86cc0695907a5d6a9ef07122a953ead71c6d3c41f532730cfcdff8fc2cdd2c49116ea491cb855f6eb7c9d224e927a50891d237252ac9e5cb2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/ja/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/ja/firefox-67.0.4.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "d3a157cd3709a1b43a35bdbdd418932bd6eeefa18178fbe7af4cbc7fd5ea2dbae6826cbeeddb8e605dc9b88f89ff94da7a58fbaced13430c51bef52be2335f22";
+      sha512 = "eade3b14793f865f03f74fd10902670168d75869a36d10bd6e7baf0ae65b1c5fa3f9fd44d4966f125462a3dc1151260a7965abe8f0152e8047ee1d8a3af31c11";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/ka/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/ka/firefox-67.0.4.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "fb49e54fb07e77727fd76af94403cbd14655dc2dd2776ce38f79d89e50d9a93310d754667abb57a5a43fcf5551cfba5a30aee2e8264b29020a52898b15bece7f";
+      sha512 = "bd58a7bd403583220ca2f8b74936fb7ccd5f38f589a148e1c9fabe679b08d910d501cc511ce4245ea4bc4536e0926a4dfa8696e31498e0dadf8ecf38698cfa27";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/kab/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/kab/firefox-67.0.4.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "75bdde2f55e1c644448459a7f5470c0b3baf179231c6b2f28f97d9f141c4bbf990a56e515362a55285ca743a26bfb0061496bcaa55a7c36f50a8d1d54e0e6505";
+      sha512 = "6302548d66039f68381294b9520188cda6a70b27d6ead2ced4f12ecec12f6437ace80abdda99c61ad120aeb1128f7e90a5cf8779e4c23bfa8b0ea831e14225c1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/kk/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/kk/firefox-67.0.4.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "467d7e02e8b23d4f3c97841c11a93035b9ec6012d01c261e69ef49146784aee2bd8b0a4d603d40e4b8e2beca8ad64ac0895c3cf9bc9455af5f027a84d4e3ab38";
+      sha512 = "9d12b4ad44b2640b4d5c8e98b3ab0fb410c91b37317debe78967524b4fde5cf8b7ef6abf2f7ecf9d86912e3a642af2a1aa619977430c40f697e361a2c8f67928";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/km/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/km/firefox-67.0.4.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha512 = "28dc25ab09b8f65ca85ed73cd246c8208367d16cabbaf931c4a0eedbc3b79e5915d5236049b1d181de5fff4ea4fbda9dacc9dd32638df7a99f3a4e0cbd93485e";
+      sha512 = "289c791203c50133eb07788dd8c37cfd167618520987679c18071d3527ec00891e5528280095659f4e6a92e44ccf1c39a4fa38fa7ff980a443c8a4e83052fc6f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/kn/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/kn/firefox-67.0.4.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha512 = "677bfa5e3e2ecdc9e03c97c34ad5dc74048a86d2cc28544ec30a6d3b874c009f9187033d3bad63f86a19470c1342d6159ab7b1bd0936d24452331535ca88e64f";
+      sha512 = "be8998c94d8d6cf6652be2988d20bcfb09bc62322d295b8e045f2dfeb1eec5493d2b12ab1c9e12a2a86b4e3faa987ba0edf52f69f1e910eda4cdf987ff5ed35b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/ko/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/ko/firefox-67.0.4.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "9b06692144b7dd0a734dfa0831d02a612517a69384da013dedd8e63d3a17edfcf875d9b97bbabe5faa7936f7e0590464290e9fc2f1d8ccf3ac45ec7fd157463a";
+      sha512 = "d2f46ce6787b5baac49bba69e1945ee6cdb7d3ee8f6540c6237a4e007b48a29a398d58e68214659d9d432aeb71bb19a2267e083776f6b3f60ba9359799c41b28";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/lij/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/lij/firefox-67.0.4.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha512 = "42dd372dc1a8684a1a14c60f7d06a4f73b423cf82b4e33d9675c2b97031eaab6d0735256edcbd10aa693a0e2e905cb7224f28ed55d295ee93c1e5cc7eb9969c4";
+      sha512 = "e7177311e672435e86d3b281850d5fc3ccd21c091bfd0388ce29d811ba0de3be687d68a045c197ae5fd6f37224677f538245bbd208cb5a5fcf8e3cc8300ff28f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/lt/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/lt/firefox-67.0.4.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "be0d0c2d386d92e4f446fa350f40056b7e464a2e562279d8695686d9a1f0954d2acecc0e9951d857651ad96686a0a3de8a7e351036c1af3747e8f496cb2201f4";
+      sha512 = "c5961686eab01bf78dcb8912864483e6d97f154604c6721463ef005f61a6bcd0b79a026de2608a07614386357b63c53b4b32efe92f82ca99847bd7f691350bc0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/lv/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/lv/firefox-67.0.4.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha512 = "cadae43d74b3665af99956cf2c143aef32d2958e08b72c293367785ec5c66e3c78d08299ac50f47d826136ed5575ccfc6ecd7e26ba6fe2bc7ff2163cd5ab3482";
+      sha512 = "2db572e52e9404fd2db5f19eaae5166b6459c8dc323e00b3043d76135a2eb83d349236ba0465cf3f57fa981ba338ffb52f9c8fe29197003c9dec3f64a6db39fb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/mai/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/mai/firefox-67.0.4.tar.bz2";
       locale = "mai";
       arch = "linux-x86_64";
-      sha512 = "768c4079fde794c8490574cef21ce7fbcc8b61495feb262443219b73253ac4b6686de7bc09309d088aa6e5dd887f05ff035f404fea49c94a52890f7f4833a2d9";
+      sha512 = "e7e35572de9a505d795e79d4ad9b66c53c283ef74e9fcb7cc48a9cdd41c1e292742f84dbc4260f581078dfb7e3b73890a1eb032c87bd7b3e62608bbc12505221";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/mk/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/mk/firefox-67.0.4.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha512 = "885e5139b0bf6b75296e7be1fcfcf72f035477d8e2844be685f766cea5b8dd7bf9108c58d98172a0fc404c499768df8d40933466c93d83ea3534179e732bc91e";
+      sha512 = "1737e482eabd1a16146e9fa20e24c419af4a8b271c215f5399df961162f34b5029c97afca73921af7605a22013a7434f36cb3e70896840705940f664a57db215";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/ml/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/ml/firefox-67.0.4.tar.bz2";
       locale = "ml";
       arch = "linux-x86_64";
-      sha512 = "93f2a2690a589fd3102fc0a6bb4d4a85dcf71d6467a0031aceab4c3fb1ba102778660b9f36bc706ead8f4f24bc3d0af5a374f8386e0b87b2fe129a2173a4c7b2";
+      sha512 = "6d47977664f7c728faf961cf1ab3cc3c2280b61f53b1854f0094313bf9adf682ac23d948f9d771943fc0e047d5b38cfb661a9cd06dad63b3596642be45b1591a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/mr/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/mr/firefox-67.0.4.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha512 = "fbba5b025bf23c011535a64436d89eaffca89eb5fb1d6fd9b68d24626ffd951a1784ad6cc97d53e27301572b6f4c7ab3530d88dc9e5555ff7490f47dc5a3bb2b";
+      sha512 = "43e4d717641c2d6c0c71cd035467939300c33adeecb0facc4f0576e9eaa25278c136e77d9a27284a90450c6cfd037ae8793acd224170048c52755ad74caaa776";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/ms/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/ms/firefox-67.0.4.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "2b9efe9c34ed6c25e8eaa5eb2962b85b1b32515ace818f0835acbb65eb8c37627b708bea589be82394481a883140161d52f27b5c00e2e6bc5d967380ccbaea0c";
+      sha512 = "a25a69dffe57f289a1a2782a9dc83f255aba7fa91fdba227993528aeb6b2c99c4e3f4002b0054d1493682fdb816b735579815bf2d944460e0dd323ca354c7894";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/my/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/my/firefox-67.0.4.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha512 = "93abbdca560076a213951d81884c1c96e0f60e8b6d33c3537d613e39926385441a08c5c43ef9ac238298fdd40e858e8c0a35cd08f3b20b8c7b82f79a94d5fe05";
+      sha512 = "77f3e770bc9abda2357461c6c730f4e06948875abdd7bd3b9ef6b0caa5b20133c84e7b7123a4fb6bc3d8228a48a341667328690c155eedfae499f316a79854fa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/nb-NO/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/nb-NO/firefox-67.0.4.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "adae2e804ae10bdffd6cca8a82bb1b78ac8fc63d2848c300b7ec943e460db71738106ce756749299141cad204d10799967e2b67a1e3583f4b6897d3b0040d288";
+      sha512 = "78440c8870e68a99e7f7e4604aee99e7bcbc5081361e38351630538d77e8f82da62c4aab3b90b75df561d2a10b7949eb62e28a03ec7c65185dc74127066928a9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/ne-NP/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/ne-NP/firefox-67.0.4.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha512 = "1e856e541808f5158ca84c8b4f95c132429153cf89fbbc8979af8401cab8e57b6d39461760caa070ca1f0cd04fc612b4c17165c3eee53bc79d7d8a34fda28f32";
+      sha512 = "37c7b5f03e09debc7602963c1be733a6b68e77fdd94e06e7e7fae9d40bef703ebf66a615b28a26311fbcef2c9d3838b72f0bf368eedc3f263ce432a77fc73387";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/nl/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/nl/firefox-67.0.4.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "d2ccd137893212c8f1fb47f86165deb7bc06ecd6590c979a5325b6df9472880d726b52920a6e100651ac60d3361294dca49c37dc728c94241983a01319fdac94";
+      sha512 = "297781a85c222f941289404a501f561cec8f74efe653fe474dc160005bd71b554726596577edfcc43ffcb20f6d435f80bf0cfc529504451f83da3a78c8ff89c4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/nn-NO/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/nn-NO/firefox-67.0.4.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "99ec6892187f3574800f4814c804ae95e7bc3ef84263831c23125134ab87f96fbb090022ec7f2e12f927c89685c496aad4d3815483f363d537fb1b0f56138567";
+      sha512 = "0ab591c373e2d79b9a2386a48ffd8da288b88ddbbf3a14916be7040476a094eb8c5e77d169bf30203b66fdd013b18f909fb1c378552f6a54c87fa652b81b2a37";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/oc/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/oc/firefox-67.0.4.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha512 = "cc12b57c7208fa8f17b6f6b69e18b714167a2deef76adf1d7e3382731594bf22419843f9b01c9b6e6fe77466746b08b63a43301c80ece97a02e792942f1912b2";
+      sha512 = "5987b182780f501cd82efebbc570b078a09e23a2da542fd3b3dada15791e112a674b670ce856f80b9240d2fab1429915112c4f6d15e51165ab276a0c8aad1b16";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/or/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/or/firefox-67.0.4.tar.bz2";
       locale = "or";
       arch = "linux-x86_64";
-      sha512 = "8125dda731212b8b030391eb3953832dda82b6c5cfa4b00d8e18aef0b6da16031ffe4aafedc710a8de09108bb4f0a10e812276ce4e298412b2bbf09c6627db6e";
+      sha512 = "564e0169643bc3096686d925c690a70e32dd41c263cf0a43cdeb45058af663c94dc9f794eb88fdf84d7fe35153f80162f47ff3dbebb2f8e76f332ffa29fc1320";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/pa-IN/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/pa-IN/firefox-67.0.4.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "be5384b9b31de32461f385733a10e71494f6ee3cbe066356b83cc96a4d049f3339b269dc32023cb8b1a87563f2f5ecb545dfa4cc7179d5361048b797735a35c3";
+      sha512 = "f2b327bfb199030415747788799105556abcf6186bd8d1de8530eb178ddacc20df75e670f815c95d51eaa6210e353d6ef0e0b156c17d944995caf1ecc11a1552";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/pl/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/pl/firefox-67.0.4.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "aa56ac3e54465953c76ade0126f8502b410bc44639be5869b8a3012536dc00e7b369665eb73d13ca7731aef650dab6c95504164136da4875de7af65e8f46fec3";
+      sha512 = "ca0b43ca5911076e0a22bc19074e634def120944b3a010a05f182b6c30cce841618f0ecde1acac067a1b685989759a50796f8ad2a3688fc432d09a3c245d4501";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/pt-BR/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/pt-BR/firefox-67.0.4.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "8a96760913c2158aea88b2cbac7d9aab0cb570269b63e968dc259d0e31944c394bf5ad5f5083dc619cd62f28b9a217c9764d3c4ed27907d469e050a2c9261a41";
+      sha512 = "81b9c6f031bad7ac993d797eb1a1d0711393c47ab69ed7b4401265f1b0ba462fe8e777ed9283514c9546ea265d98d6773321baa59b81eb0f214d69a98abdc771";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/pt-PT/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/pt-PT/firefox-67.0.4.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "4122263a71a2eb6da062d8caee2d905b0a55a83b859888ca5a6d08016c2c884ec801ab068245fd05b39362966e8896bb3b19fe08dee84c3546a0e9288b7b6103";
+      sha512 = "d653fb7efad8a0fb81dbe31010a9c4ad96b3d0773df8f5bc86a6aa1f03f97826c4be66d3e3806b0a25af7699081c2e8fee26b81fe4768c35677acf6310cbce35";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/rm/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/rm/firefox-67.0.4.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "56b92133f58e1a1711f6cbcf65f161ff3d8f9bcd5927d74c4de9e72680b25a5eda9b398f4985f2258ab95ddc0c4dfeb655198ec727090481897e3372056aedcd";
+      sha512 = "244f2acdf4905714575b21dbfd961b370c9891acf67f79aa1c8c3014a01b549eb18741a9d2dd5df41d5bf8042ac38a506fc08494914ac7b429b9456292400adc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/ro/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/ro/firefox-67.0.4.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "87edefa2897cec715cb1b34c71e3538a4ac76ca0f492a535efc63f7dbf845446dfb5856de41eb02cef6a8eed345b7a64f7e29b0820af0f9c3473dca0ec0ed7ed";
+      sha512 = "365fe04fa3caa16d356514596def6684e4c138a19ba27c43a57f418745870262c781d470101b97e9baec23187e7c779dd6be9aaff491a1cabad0cae064713d2b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/ru/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/ru/firefox-67.0.4.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "3284505bfd4233e47079a7fc1b0ec81b0b0ad7069bde9b015f85f35b227ad1450cb9574e487ac2acefe22b02e78e6793de83a737bf9e16c178a78aa00ca59722";
+      sha512 = "6f23a039207fb9ba69f480e310e5107c3f7d4a595400751a711479138bcdf46de900bf30808164ae3e781b4a016d893e36931b049fc687d96b9000eb6d641c1b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/si/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/si/firefox-67.0.4.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "0f9928897d994d1f021729ebf126f0e319cd714aef5779395d3aab73fa7643ed3cdfee33ca30dcc6f1fe2d6ca00583854b02616e3c1f84748c875ed5e09ea590";
+      sha512 = "cb743b4b6c1cc2b48e1d484503d613a8749e5712778d955ec178a9d922056c46e71c4221fb575e0d66650bc193c6f473b4a4e084743459bb17116252f9328d76";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/sk/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/sk/firefox-67.0.4.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "fe91faf50effc756a48b4f1444be1f607981dbbbe6eec1d1796f337febe4f4ebb0dbc2a1964688deaa12975e791012f4b7e554d267d140c5d3121e3812aeec88";
+      sha512 = "72e512796abfcf9c3a0567a87e34354df9c9d695d955274be130b4499b6e4d7bacfa28ee558c9c93b051361e329bfaccf47bf94119ae4dda19f0a7f1dfd44677";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/sl/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/sl/firefox-67.0.4.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "d9e8363556bd735cac41b8a6c049c7eec32d1d0187e4c9dc92f1b43db97a29712f4675cced2b9df637bb8829de7a11c23b74094905623064e978d2585b8f04b5";
+      sha512 = "f30fcdc67f6733acbc5587e41e819d63b254c40643a2df10e5d492163f4f1a59ab9287f55de96482e3a973d0be84860372074631d7097f39e153e96c96dfe241";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/son/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/son/firefox-67.0.4.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha512 = "998d2b77089e7534cda9a5dc56789fed67cbed7a66325f109193957d27a06a64d484fa822f9ea7b1fd0580eb8359ead6fba1cc81cfc0fef006ac973e3962cb48";
+      sha512 = "8d29fc17b73f0284ffabb03f710d4d4687b7070f381a4cf0af0695e6f5eaf01e403cced9996a728871138f2152c594ec75f227777f721059f61e6cd9e182db1b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/sq/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/sq/firefox-67.0.4.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "aacdba6c2d157ce27862bbb749f78241e9ce1352c915b3b11535cc75140a16ba7caad97da2ff83a6a3fa3025b8c237692a0c066c7002933efc64fc464d96433e";
+      sha512 = "a9ba2d2f7320b432c0427478d60e4c5f5dc0628152845d827ff22b2b5f39bf2c8b2f75855c78c6c13b8f266531a4e7abe7031bce8825741509d4d7e72a40eaa6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/sr/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/sr/firefox-67.0.4.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "71d3e76b6c014887bd07ca9f6276bae4b9a637f6fe6324e97080ffd5633a1abb4a253eed5d1f814a3c9f449bbb331081b5b0441afc71c1c7b561fd128df86379";
+      sha512 = "14b1bdcbcd216ce8fbef761884df3a969821a815616dfcccb9858be52cc8ecabd8874d62b6de7a2960277085cf7b71f24971b987c5005bc89631fe5e84c05d54";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/sv-SE/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/sv-SE/firefox-67.0.4.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "f66112576f89c491b9719ec178a11cab48f73d3fcea962daaee6f8e48262a2dd838ce228db9b18bf815b904b17c7cfed4d4e03ff39ede56aba7fe4c809d830d0";
+      sha512 = "76a9110b775ad84326d4cae80bfc5fd1fcf37e152aa89814ed968adec2592e96e8d7c883c2dc6371542316122ec1df4d18f9f2758f9a1d804cee3f4c390456d5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/ta/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/ta/firefox-67.0.4.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha512 = "c23b0a3450769dc25aa321a10296552a66ab2ab2bfc7626d33968a136fa9c9d4c9980fedf214ec9ba317f45dcc55b538df7de0ffe3813cbac1f5d6d4ab1788b6";
+      sha512 = "e24ac38bd95b430a6753f8a8d8501a8f810979ddd26319c07abb1e32fb23b16904616526a55e4328c72bf7f9d1ffc41aa393c9ae31920e70c196de90e135cc27";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/te/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/te/firefox-67.0.4.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha512 = "d724f3ec95d1a26174818afd5e55b864045007ce9d056025aec1903fb8787e8d90fb43b074734ab66550e18b628a6eccc2ed3b907333a812e4d4c059faacb529";
+      sha512 = "1840c39c580152d4a94997618436c41cfd3d18bd0dc6f2fd76bedad5282cfe0a340b465acd1bdde3d8ae237b6c1a2ceee4c615e25b0c663ff6081de3d16f081a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/th/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/th/firefox-67.0.4.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha512 = "e6729991209f77da79186c2ba607e40f319eb55f72fdcb707f6be84947f58482e3c1a00fcdac93e0681bd1e058ce4e521865dffdb5da1132f4f1f836a45530a3";
+      sha512 = "aad5cd039ec39b3cb67215bd5c90531f9ce8b92ca4dd33da09c9b862fba637fcfb2e2ac77c12e73fedc700d0f12f95eeec3ee6767be44fb853f5174cd477118e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/tr/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/tr/firefox-67.0.4.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "3f6937fd31a6be5c41797df4150c7edd2a1da7d1fd9fd9c062c0a839e4efce452b5f37e06a8bd13b9c770ab5c760c68bf20787343dcc9ff2185d0efa85e653a8";
+      sha512 = "597fdee3a72ffaee8784acf2cf33862f825d7d9d261bb86909f5387ca9ad8ba7099c4d18ac0e7bd8611bb675bf9385a886af7929a90b84a83c659e6922673caa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/uk/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/uk/firefox-67.0.4.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "de221097ced7ef4ad8bfaab9e38b386383640934f93a9d6b43248b47033bed603b6be1bee122b6a1047c21a2980802acd53891e7574773c3a1cdfdc4d34d6971";
+      sha512 = "2937705240b4e95dc0f5dc318f8dcadb1f8ad3a44e010f83778e853328d7313997823ac1f7e72bc693727a535582b81a2346726989086014a761656bc689f5d4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/ur/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/ur/firefox-67.0.4.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha512 = "7c084a22c2183b27a4483a051dd01bc06d43aac46c60521c63f8a1ce4c63296192ccc1f0f70e326d473132dee9590c48bae059264e0878cca0a036b1520d1d5b";
+      sha512 = "4671c428523535497ac2d7a349b7352c71d990884cc4e4836306fac34504eb41c7a04322f972ccdf048853262407b54b9b5877753ce8263eafd12addea7b2bfc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/uz/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/uz/firefox-67.0.4.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "e76be77e14c47374ac9b7b85e4f7b704f33f8e6baabc96440bb04b4ee6333f2755782afa5c390df2a54a5102414c80a66eed2f559ca1c86a1468b24637a54ecb";
+      sha512 = "8762eac0a03b2e4952bf8983746cf4fb6482920e81486e5a68c36b1af09fb72ecc5ee22bdb30edf8ec042441b9e3060c8bc55561350b155f85fca19c0f40a906";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/vi/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/vi/firefox-67.0.4.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "d3d2ef3137e2666a20f0cdae73a7f2a2fbdaaa02248785aa35719224fe5d8df912026aaf5c1f9589e21774c23a88c6e0c98502370d26a59466cadcfa33018851";
+      sha512 = "fb15081b62d0dc05159dde1dc9e1e1dee93caa533990ef02f104a0c8d2699b91392fde2fd20510164640f1491f296bba7cef3b5921b4f199a3fdae1c16884bbf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/xh/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/xh/firefox-67.0.4.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha512 = "b8067b4012fe901844c7666cb48a07927d67bf28193572e5dcc1977ff65c20a93605bc889710d309c0faf4007963f96b976965d3de564bb6726ad31bbc5c970d";
+      sha512 = "245c4818d8deb944def5e3b5e449b235b9fb0819f239737f17a8421a03ef1d987e688dafbd319f2f605c9a8fd041252fd70d533e8d920d51b7ea18cfb85d2c35";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/zh-CN/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/zh-CN/firefox-67.0.4.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "8d4434751ca79653db4a72bb5f74acc1dffd8d6460036b179b85974cbcc1989648cd5fe53a7e10d5f5936bb24a2a72ae045845c75a72a7a5bc4eb6669cf8c23e";
+      sha512 = "fc9af298d18a015d05793e7d39a250f08d8814c7f319eadc69822b544bb588b97b81ceec68d1f2678a914d453038797b8636d783c9eced145d4d99de63c1d82a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-x86_64/zh-TW/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-x86_64/zh-TW/firefox-67.0.4.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "e8efbfaeb83307e0c9fdd1b5619cd319b09ca131eeed3c9e965a2cbe76c528cfbfc4299afa3cc3d7f9a03016babcf0267ac3e98b2b048b4ee80e94a0571c65e5";
+      sha512 = "65eefb2302e28dd7a50236fad1d6e3d3a6e324fd00c3895d9b00e44f89af139f9c56f097ce84e772456f69d33ed260050e153201622692b4fbf2206a02d7e6c6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/ach/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/ach/firefox-67.0.4.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha512 = "fd2c9985a2fed4c60829c9c444f9475ee26c014568ae9919d0d7ba16d3dde3d7c6ebdc644eee8e3e0064e0c441d7a54b35e9d9c7d02d2926b875712cbc991707";
+      sha512 = "1ca913950f33d56bfa4de1a6e64bd16e684f904a0a0409645900d31e0859abb9dcb2818467da52ff69c0414e17918453258856054aea89d5fbde528b790f7f29";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/af/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/af/firefox-67.0.4.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha512 = "ab7371f4452c85d40a7ff48f107fef6555fa9c6ea549da50bce5797681a63b9f351f8cc027bc38432e7e425c653aa1996ac57752165da939f9ef13aa77e978b9";
+      sha512 = "b9ddd1d7a5303ca7003dee0875945c35a825473b4e43162f9db69ff13c1b61dc0f98fbb7be4b761bad69fd89fac1c09f0c793dbd74e9b946088a35166a86393f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/an/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/an/firefox-67.0.4.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha512 = "20c3967f02388cc7b8dfab44401bf7b8f260570842b41f6f520201cedcb7a1de35fd506308f66a148b5d47b428de1b767d1acb73b3346701bc4d1de0ef2e0402";
+      sha512 = "b4e18dce44176993cec5c0a5e6052f0bbc792b2c271681d494851dbe9b899280f5ea685b9241c280709f11362249fa5f296fd9b3d881b3bcc595b9b97b69a059";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/ar/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/ar/firefox-67.0.4.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "c9718d679675b2a8bd317421616353412a55d41aea31c77b21f9b88decbb437b8bf62f44cc08902d76349077ecfa77b2247de91aa8e71fc8cb53c1bba9dcea8d";
+      sha512 = "eb303909cae6777402e57d99edc6759f31d7c50e39e9e1e966d715c1b484e321ee573da3bbbcdf132bd15fe842e5b4fe8f497ddccc766c04eeb05b147df38715";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/as/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/as/firefox-67.0.4.tar.bz2";
       locale = "as";
       arch = "linux-i686";
-      sha512 = "7dcee13dcf541bf0219008e18d7b262b54cc8d0fc64eacd3d5938f93826e1932fcd813e2660450bfbb1aaebcf2c14d9a6d5d1e62186625ebae72a5b9569a6d39";
+      sha512 = "ba48aa6cc90f66f60cd08e1f74bc1a0360103746e6c9b88210a69ad611929dae7473097c3bfb858ba306ee881bcb6f3ebb6fa49817beb1c7a716aa7a9352c836";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/ast/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/ast/firefox-67.0.4.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "f774ee2edcd71a655da14292d2fc9621129845127b78c473736b1514199132871c42b090704bc0207f994b6044ee64cc8368ac30ff715fc5cc0c5a1f183591b2";
+      sha512 = "2350ecc74bb7a5503782aba038941a21c8e9617af6165c5f2cc34760ad09c2a4002670b3e7b361fd3c00c26f17bff2ab95df5f5417bd7be0c2bc8846db3f8d6f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/az/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/az/firefox-67.0.4.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha512 = "27b2ab322b42442c8514fa097adf9be35de274d52f448ade00272912425742d9d7f320ffad7b26608a8f734d1e1b20860198871accf092d50f7a9ec80a677e21";
+      sha512 = "ad5cf8307148b39e485d94bb2f5abb7f5b36ba7cbe5593d72f933c70a1359e56993700757fce0bb0d8ac3ac8c8a1c95c39167f603e8e4db09ed7144e6f12ed35";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/be/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/be/firefox-67.0.4.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "57663527c1c330abb548faf54c59d802d2bf3bae958877b1fcbfcff9dff13f8be4bd8f134460fe6e1e24f2818070dc33e1eaebf0b2334731b00a7e239f20aca6";
+      sha512 = "ebc54fba1a79a88d01b2f9a922a76360ce1c20122f8b3efaee1d3a753f41b6899e642e9bede768f03a6bdda588084975e914e054153853165a3518873487811c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/bg/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/bg/firefox-67.0.4.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "7b376041da3c81c0899330b5ce227cd958d4543c5fb058da6890f3c3d429771ecec157d9e2beb96dd8b9fe80e15e1fb1ab63cc711cb2f4a3ac439b9ca9a3078d";
+      sha512 = "412f23bdf1d3aeab8eb66778cb0bf1021f2303c5805dd7c1c7e9779307683db4fe780b8da645ed5f80f45d312b4a53abc07ea8653a1fad810a2fba9360dda281";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/bn-BD/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/bn-BD/firefox-67.0.4.tar.bz2";
       locale = "bn-BD";
       arch = "linux-i686";
-      sha512 = "cbe583827cb66bb14e75eafdbd0d6b86ca9632d757eee1d62896a5287d89d176f6b0190553d1be5e762a6be3314583a91d3ae501613cd12d6d62b915c7da8c1b";
+      sha512 = "b5452e64b205b93d0192eed48b6f8d863cdc8eb0f73729ddc59b256458320090c5d2f0e9fee39eff8e566bc8e856469048b52a7418d2063147eda2fd0bcd5b0e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/bn-IN/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/bn-IN/firefox-67.0.4.tar.bz2";
       locale = "bn-IN";
       arch = "linux-i686";
-      sha512 = "0f2342f4c87bccaffd7caf7f1c3ebcdbeab3f7ac5fbbb4b7a3dba6ece21d0c1116916cf9440b0caa2a686b4bf790b51ec770e8250a2212e2459afe04dcc8cae3";
+      sha512 = "a26a23dcb510fc3915f89fd74e346f1847e8c58aa65ba03db425d18ef54ed6a332e06e8411780e8d9af75e7f2ad78238683580a37777e1b1a22e0172ad65c600";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/br/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/br/firefox-67.0.4.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "0da1edc57a4c0eaf7a96fd75ffbe1497d4900c377ac32a7fe98b9c365b36d0ce9c7bcc2ff459ea4ea80980256e442b8371533b4cd2875fa301b8f713861d512b";
+      sha512 = "c46d5b2f5c66f4b70c291d3ecf51fe88bcee952fbd4232605b0a9916bbb6e5c55852a82c6634e9d2b94f791a53da6e67f5876caf4bec0b609f7eacf07574fa5e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/bs/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/bs/firefox-67.0.4.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha512 = "8ea43148a8363b4298a615ef83328fb0f8f71b5782d34a0b13401563f56220967d9528fb8be5379fcb1b4fbaacc1f7d9e5f6aa887e80dad3fbc5d804efab183e";
+      sha512 = "342ee4a6cc8daceea892ecedd23fe4765a5718d81279ab86ea61dcbd2ab7cc7dfb50898836116c7a694445c162cfa294c29fe3169a180b8d88256f5826e95013";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/ca/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/ca/firefox-67.0.4.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "5704d8ebc1fc261f456a79a278b31da0bb14ee000ed1efd09e95cbc0f034389905eabc904b5746c17e1aa4618e999d2c5c9a25f375eeda955cb62dba4f334a29";
+      sha512 = "e706802e9a227301b5221b2e210a328577180a93cdaf4d5e9c0ae0011ea2e4bce1d55cac2c9546f38b05a45e41bcaf6cd78d7f96b5236ea3a0ff42a229ad5a80";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/cak/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/cak/firefox-67.0.4.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "1a4d5d0242ba3fa89edd8e0a0f68d30c5ad96a2434317d34573f4d2ae1a229cabb790af39befd1cb04ab498175a776e6f78641624fb405e9128c8f05b94d8526";
+      sha512 = "9d3fcf5d19c0442454b59f2c5e65e4a2e9ceeac737edbb9eb7259e33f9c02e5899df7f2b94eac61e846c98b6253b8a6ab15eaa47befad26ef6384a8dd510098b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/cs/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/cs/firefox-67.0.4.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "4372e02218410bf63415b3f722418f12fee1901bc703cb7f8f79064902926ca16f0b160aa479aae308e7dbca76875de467c4cc011110a8d0019ea7138435bf06";
+      sha512 = "f6926fce90e79da7802cd35578a495e3da7141608e48f2dd2e716c735322f90ae004e49555dec7eb126782e182c337c6987d0b5cf86ffac3513383bb957b43d4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/cy/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/cy/firefox-67.0.4.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "ed2a777bc393652385a2b50406096d30e863ac3a8243d11aafd86115fc869f7ea90a2e14bcdd84cf35f75a08091fcf0cbf1ed51c53fedf110b99b77d77f9623b";
+      sha512 = "2c8cbecfe3cca250ac063257f4965d67bd46a7accca55ba7048a06bff820e0458e9cb8b1a6d47809b49ca6c1963621dffceeea582077f1097ab3e397250db5f9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/da/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/da/firefox-67.0.4.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "647615d238e00ea01924258d2c9311f5b73e4b965fae2690a120c0a8d4dfe16b0ec2ff14bd71e1a78d9b06e40ba0759a475b1013338f47c852126756cdf15d98";
+      sha512 = "98440bc2579f87b3c5179a77b8b63b895275701814c59a6ae53a30f858e97d876bfb7a642c2dff7a2077f602f9edc6dde76f800a49f7da0bd434fc3fa2cc5ca3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/de/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/de/firefox-67.0.4.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "c498765bdea1ccc89c0e4b21ddb42372757a8ce1ea68016338e7655ae4cde91e03888a7a12041e53edddffd89969f45af4d33e477ec1943df45fffb4b3a04f7f";
+      sha512 = "2ed4a49b2b8ff3b450bfa213c63d32248457b1037600dcb02f3b8d3d086cd50953cf5b6c0a38f0aeb454fffe13deeb49e7d730f001989ed09fa5593bf5c341eb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/dsb/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/dsb/firefox-67.0.4.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "9c19822df772b52ca9bea123b898795ae69431d69926f73257622d2e514ddfdd93465636d7ad5978fe0b439dc49f281461a899f28d74b78e3c3777ac9b2456ea";
+      sha512 = "fbe57e3ebc7c5059ece406b32772e3005776861f115542811f72529dfdac2fce98d002838aa60b6bcb57f31b9575cbc732a21ed072618c0ed0178d6a560e90a4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/el/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/el/firefox-67.0.4.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "d4f893d951d4294d40ed58e24a3f07221c636cebcbf417c2301c950c744a535748a894cbc3f5bc558fe3da76e80b180e57445448cc47072031a951340b34ee4b";
+      sha512 = "25f17eef3d6d1b270452349d80ae5b5ecb43506f14efa36bdcabdc4c4cec45080d7cabf95f3d68cb2d0febd27cc2f723a9d1396321b9cad33acce0bf62b599d8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/en-CA/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/en-CA/firefox-67.0.4.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha512 = "b4263cbb96eecf32bffddf0cda878d653faca771b2ef9483a550c74ca94580b8b73daca249e6d0932b471d6ddff06807e4ce696871cc2a4a46b6b1e5d9adf8b7";
+      sha512 = "ecbafedb0e4074be5d8cb390adf3004d6eeb75b9b7e561ff0f161ec8d35882edca50f371366aba033039e940c78d4b9eb2af6a0960694896e2a9900361e2ffa1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/en-GB/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/en-GB/firefox-67.0.4.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "03335799d31a9366511df787e06100d5cf76ab38b8529b8edb47d4d55e9a8e046ff7d018eb03af1594c66dd6a04bab61cfa13f2dc614341934c73912e8a1165d";
+      sha512 = "2337d112409bf0012d2f1bb757c8e7e8678d879fb3bcaf54f47a76efe982d9b7a719cefe607fffc0022440342dc15b837924ff1d22d239fdb5edb5b5b578d76e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/en-US/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/en-US/firefox-67.0.4.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "1983da7f8ddd703ec6f0cf6473f81409ce070525f130f4b9c543ec34adc1dff5c4d5426de02bf7e9444fb7de750f031348616dc9bc4a07d7d83ac5219bae0328";
+      sha512 = "3efdace2379f042860fdf7f39a757816881b552fbbed37c7693fd95b94c04835c5df6891ec2fe7c09b3fa12beacbc9d22e200fd4f7a73350eed8f9c24437b112";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/en-ZA/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/en-ZA/firefox-67.0.4.tar.bz2";
       locale = "en-ZA";
       arch = "linux-i686";
-      sha512 = "3ff9b414aaaf0dba7faeac645c7cdc122e1fdd643bed0aa689deb78d1524f1ee72d2a6d6623119354958ba7bcb2b1b4c2e85353ef1077544ca13faeb861b0488";
+      sha512 = "6c701d87c4606855cae615904d06d35ec8c7f233987ef3ae72212d8624a2696a99fcee66ed151cd2e35775f3addf0b031276e61b17b2d6008c3579a8a639369e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/eo/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/eo/firefox-67.0.4.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha512 = "6040982aa312b4da82a3fce133cc2673750978ee03499c7f9bbed87dd69ed7e60b01ca9143ff444132ede287c83b19904d44c730acdfbafdfd6b07ed4ee08177";
+      sha512 = "58e350ba1d9cd0a3d975c2639271f77be28c61c322cf8509618e4358ccdaf27de1954c9616f0fce0e216bae1ba5e8333d595765733e734c15c301af67764c52e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/es-AR/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/es-AR/firefox-67.0.4.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "eebba32a7a4ebc5202fe9a8286aa03455b275dcc09cd55acdbd355ae09c9dbafe4547b62a5d6e2a7936c47030c459cf6d1ce1bd3bb53a924c5a097fd486a7446";
+      sha512 = "3a6bc52fc479d40f20594121125fdcc9bada9d605ea8434b724f2f3d48df84def2b15b9057b4b11646bbf6810dde063a2469f324c62e126096fe74ac00ed55d7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/es-CL/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/es-CL/firefox-67.0.4.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha512 = "777eafb7fac6db467691c3f9c2c06aa6a0ee54e6e9c163e07f8486307ed4090d42aad078b583a7cacd38fb0b60cae46eefac20eca1a4a43efe1eb3f77a496c61";
+      sha512 = "db035d6ce032905ffde2b70bb66d961e806bdd3103641ff4d4bde6d5a3366baf7dd20326bb8284763ac595b88a8e0ad0070b1c50390f75eabf7103a809cf1ccd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/es-ES/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/es-ES/firefox-67.0.4.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "9a84b881c10f671b49b3a8f154a49a5f66cdb5134328a600a299e050517818492ce33cc1f91d53a3774765054f2dfe644b040a545efe2f9df529412bb6e969ba";
+      sha512 = "44ce9a434905d2272d030d5ce4be09fca6fd4f55b6663f0507ee8c0aee03e4408d26f490c5ffd0cafd5fa6b82c4cd6cde0a8c2a8732e6b2bc662752d53d60721";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/es-MX/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/es-MX/firefox-67.0.4.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha512 = "0304ba74609178fdd16add10b057a7a55979d99abf998f2a1c810b106286ef87a885704c30558a88dc8cc3ab82a2302ffa1def29417f5ce3444e1990baa6cddb";
+      sha512 = "ec0280055da2dcac78c746367fee1d8fb99e032173098f9979023e2c12b8fc03edf2c780ee68cf3e6efca735479e269ae9285ffd9f7873a47825036022b31db7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/et/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/et/firefox-67.0.4.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "744245455ab5aa20bfbb3503425778f8896c6d0e166ae8448678f5e483bf5774faa9144d466b2d976ad09f661dec3f25289bbd378b6abc50016e4265d7cded2c";
+      sha512 = "1115d18b4043600bcb26512b557a34d10bee6c6289b0b0411a26d958d0922c1f52883419f23473aa031748bfa373c35d6949223ce07450910c79bd285b024f67";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/eu/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/eu/firefox-67.0.4.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "4d928166c1a3293f5a6180af040e5bd35a69ea9b38eb80ba863d3fface12c0175bb601c9e4b8fbdefe78478253135dc6e36a992abe72d9924131da608712d769";
+      sha512 = "d279b25565ff56dd4cdb77937a93cf5ed76f7c3a0a3ac207b4915e2a8c810d6a8588de47378e76c1214481bf3006e3d3d5ec4978ab090007fa419fd651d05e2c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/fa/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/fa/firefox-67.0.4.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha512 = "95f1cb3bab6b453f4512386d2232c94a668bab175595ff3ea0c368439510e328b9135e23899f5e66660e887f4672fd11f1bb21998ed55dc2406058a54fb83593";
+      sha512 = "04f23f63a888d0aa7b5fd33dd4e19fcde637d1590c4243c1286f9471286b80cd584edd57290eb2f43e7f92991ef6a22a8e1b5b5b702347f23974121064cd0d73";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/ff/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/ff/firefox-67.0.4.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha512 = "637315f3a303e4c28c9b79b94c63421940550aaa25ceb8fd0b12a09a2c7c7ff66a0561025dd35ce8648171ac235bf3c2e05583cd6c8da8589810900b760db7da";
+      sha512 = "9f799f595f6eb3eb32ee166f87f8ed4dd0faddd11c24b31031f2bc75c471c7692f7c13509bab36c4f9f00370b7e73bf95f0704d58456060ce2ff9eb610d1a090";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/fi/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/fi/firefox-67.0.4.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "5a77a26814fb874aedb5439fc9b01c54b8ecd178c7680ffa3d2dd265aad825214a64261b94837ca56aa9f2d10fa2bf7d96aeb89b5d20d7b03265772bdef55281";
+      sha512 = "bba3768d887c0f01d59396c00017ac3e6ef043d2dc6a535b8735e38a7f864763a5b2aa4ed36732a106ac77a31bc628099d39acae94075c659621a0321b3ea9ee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/fr/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/fr/firefox-67.0.4.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "8144db6de59106142401c115d972814f41c930fef287681460f6dbc19462b7293f93a33af438f04065e5023cb7f7a95dc2e2db9168b2ac8ef1f174a5eb8def85";
+      sha512 = "3ba16ea5681f031d42eb036f9e3c8ddc7df628d365e44ebf10269c7e3e3e4d5bbf6a996e91e132abc793ec521d1151b0426d3bef972c6b8ad74af845393426e6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/fy-NL/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/fy-NL/firefox-67.0.4.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "3def2935f4353f8c77fe857cac6157fd513505b9eaeac5cf1a8dec79a44a0a433895def013886ffefe81c0190af5ba927b3a798acf7c4f58a0328e3041800571";
+      sha512 = "1279fb954b0dc5c2e2ce38e8ddadb88f811c6dc4449d65bf85f6ea62351c64b61d06ee907c68ed85beed25d7727b4c0c70fe6ae056f1f7b13b969713e2106a2e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/ga-IE/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/ga-IE/firefox-67.0.4.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "f8e8befd2ca37ae96adfcb9e97ba53fc7f8ed7151ce4c914856425362a78a196ea4f9fa8bf14e20a433c8acaab295dd3069eb3805f7805a6aba897fa5d2cea7e";
+      sha512 = "4710e9ee57772dea96042153097c29d90ef9dd94836e5eb40d8fe302e42f8be9a2b1315a194955c5990f10f43175ccc1b72772753211fc4e592b15139f1b6ec6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/gd/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/gd/firefox-67.0.4.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "7fefcb8aa2f648ae71a0e59b88c879f2b10b1262d23138c9643ea8eb486fdcf592d86bbb8a6f326163472e180c4e97a8924f850d70f83fe3ffed85e154e871e6";
+      sha512 = "ed40d52447fe066e934db434e700b30bf5f6763c506495363d5fa91cdab1f0fc2a72c30506c574ab80b42aaaed97d2dad0dcd25791be53fbd8d3bdf3f19b367e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/gl/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/gl/firefox-67.0.4.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "b0586f21d3e971151d9b26f1ec20cc8dbdd07ad4f7c8babe1c358da2bfe38f1c47ebdda925cecba2060a6fc9ae0fa3d05fcf62ffa0fba29d2438cf47d0f884e7";
+      sha512 = "7ddb53a5e5c23d794492c82643c5c902f1d4f8c3a87f541c6dc7a409091f06ec3226673fa52430cd28d4ba4378e61731f0199d83e19950d6d69e8b66c4f29e6e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/gn/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/gn/firefox-67.0.4.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha512 = "d739f9e07029ed6d9e96a9d62673a7c0b38cbf43c6c38418861b4adb1404d1c00980ef54addcdd41f7d3ba5a3029e0cba5d6b59acd277c7adb15a15d1a51d2ca";
+      sha512 = "e55c9b6bd2868db442cf160100acd00a746c4dff5a7336384cb3fda3b0feaa3a00b5586a8c0f1c8b6616563dcad44f8ec2d97d073c3dc8f020e6512ccab2b43a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/gu-IN/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/gu-IN/firefox-67.0.4.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha512 = "1c40afa35b524517b39b598e06dc4bdd6e736d7169e4cc3abdcb711d6e96fa69fbcd01ec5c534ccad64bc463d4ac41450635999ee4646d8563fc431ea5585426";
+      sha512 = "d407a0f97c2d70f8e09cc7fc99ef46906edbc377e7bbcfac1ac5410ad653eeb854d0980668b2f23ed62e768d560901f18c390857923715949a0f8f1a0dcd85cf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/he/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/he/firefox-67.0.4.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "9b22250be0559f5ec8798831ee6e638da73485c122cdee43001ab3d9b42a9ca32d51ed5b7113ddd37295e9c279f1271fff5af5d81f27ac5639b7e1466e7ee4e6";
+      sha512 = "aca94bf7da574695d3116202e2df381617d88fc45a3b2ad7a0066452b870faa24e1c1de7dfe2114a33261a623689ce9f09d8498d49987ae2ba1db8f447452cec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/hi-IN/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/hi-IN/firefox-67.0.4.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha512 = "92c9d6993339e132057c1ef05f8f2cc41f0f884a6c52a8df580f9a18f28524c43a392dc99295221d81656e7e944733351d2c3a0d68af0142d39f1694ae0d47d5";
+      sha512 = "4f32f9d92ed40a16e0c64f78d2554bdd8bb383a12eaabf54df224b9f1faa132465dad0182ef2852abeaf5d3d3ca1f3d49e40a4f98400e5f44db40d69c88d4ebe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/hr/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/hr/firefox-67.0.4.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "9aa5cf1052554700663cc0c60c6924f793037402c30e5b88388bdce0a4ac6210998ac11147c4e0a4c4ea3b28e151436dd3e157b85373317c79e58c996a53b6f3";
+      sha512 = "33bdcb0cd147cc3ff33b2be284df267926d9b001ad347630c3d66eab1cf2b874c04d7853f2f36fbfc8680e02673cd254d216a5e2660e2cff37014224269583ba";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/hsb/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/hsb/firefox-67.0.4.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "5fd09b1d2b3e7cebb8f99a8d9983236e52f0d35d812331b60ef595399936aeb47075507d7e695626cc07a7d784c6cad7e8ddd105b064c3c06150efd23876ea54";
+      sha512 = "9ba075a1825fc9ec059b17049c3e1dacc7c78b3ee744a06e748db05df1b46d5bd74e348d887749f01ad5c8d0c3f6bcb5d27fada572fad33d462d9cc80c5357fc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/hu/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/hu/firefox-67.0.4.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "324b72610ed247c6a30a7e73e8c9806f1f22ecd229ae29b92162ccf3a36ad8b6d4bd253a0ebd9c300956488abf753e17e38e7327783b3b46f96801feb0a8fcec";
+      sha512 = "3df7a4a27dfe0366da893297c590b03d9fe4130df6af575cd36cac2d77db2342229274539dbe66b7d3765377ff712a913e988823c512f803a9dbb4fb0148ee06";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/hy-AM/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/hy-AM/firefox-67.0.4.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "f6e90a8f48f72aa05f0009622843d99be5faacb5207d84e6b532b4b7000a2affb8298e5e104d3d0bc47166827f470c8b3f7505de1dfd0c85a80abd79e1014d14";
+      sha512 = "9fe26d24dde3199d9a6aabc8928291c7026b3820805d95ddac852f2b05c008698bb455e71338a42cc8a6a398c2245effccea22e0a85cb1d77c7a8f23b3757c00";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/ia/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/ia/firefox-67.0.4.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha512 = "4c9421f2fcfabb1bace103012ece4758f2007b89633916492a1f2028c5a983e9fc7132d86183b8bb40039934515d4d01a9fe2d22aa23340c839996e8ab0a88fe";
+      sha512 = "5d37b96915afbd0764bc47d64d5b0d0301de97431e1393ba12e0431374fe9e4bbf7b886e0a4c37948d5e2c6aa3c4f02311920d5596828366d00a3831914cce82";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/id/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/id/firefox-67.0.4.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "5775c1ec190920e39bb2473c9970c9b5f4e6438abd6cc00666d73ff67f6e2573afbd1dbc9a2fd7ea6e97704fa8c83ef3f9522565f04ae8f678e30724c186466a";
+      sha512 = "950b9d6ea82dbdbe5220860a2b187e95b06dfe09cd91ccc8689ce9cf44724200e8d75bdfa9a77767ae03931359af3ae817cd86096ccedb20e95b53a332041d7d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/is/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/is/firefox-67.0.4.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "e023e8f1395240fa92c08968e237d871bdaf4f7e9689d7d0a432b083f7278f5d6ae3269ba6a5bebf7b46d28a72ebeba7d8fafe9f3fe35e81dd8761a6d8090026";
+      sha512 = "0d2203891d42930a5ea16f101aca540c6483b0b78f44aa4c4649e63a9378f1ef41b7132a05013a6a09e80aeee17fb0f4636e1e2a16e74eacbe8b9f36b6133615";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/it/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/it/firefox-67.0.4.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "8dc1032932efa85eea759e5309124bb1377e19a494288e4ad94bce2f13197415f7ce774925629d5d3372078f215de694ee91b8e42d3946a6d036fa25a39863e0";
+      sha512 = "be656fbfe88663034e75506607cf853a3a3bee5e225b3ce18b9dc50f7ccd8c44441719e4efedf5e8c85fee3cfabddbd9d1fba5ff64b1b76c2a4d7bccea4e5976";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/ja/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/ja/firefox-67.0.4.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "84c1cc1900a7de07b9ca2267784cddd3536219b1942c834138266cb2f506222c9d25406de42f5e63e6065f680079a6378a58b24c54a37976dc7c99fadc71e0b5";
+      sha512 = "3ab89940a7026b73ee3875f7b1d3907203cd444d60e81f47ffcdf4b7d19defc7ad9ee330a2ae3ecf5bd756839992241c73849ac2c3c78316240ae0c2ee147275";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/ka/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/ka/firefox-67.0.4.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "88c2ed54dcd1c5fef2bfdeb16be80c2d523acc1e3abbb0021bcb5cc47a54404ab736724720ba2c2b7c771413121bc86f27c1ef960764ee0c3c93e1aab652ff7d";
+      sha512 = "6f89d79a6c106be67a7442c0e690eb51d1b1b4c79c6439f05fb47a810690d9a0c3a9827e432b2d913093e3407382a77245860c02886d1d45d5621e513b3b2ef1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/kab/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/kab/firefox-67.0.4.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "0ef587e1e53a954989e884f806557827515f2d04e4da3be15b539a1c8b3b7256ef0b2d36b83afb94f52d6f16cdb7eb40bc164e0724f4dd04d57a2919904f1eb6";
+      sha512 = "def58e13253b056ea526e63d58047711d7c137299fdd63897055ef231f341d64cdeeab6b7092d8cca8ddb1f60547f6dfdb67cec2811df24da2e767ccaafb38e5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/kk/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/kk/firefox-67.0.4.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "7160a038857729f6042af9ad168b3f27596a686bb141668824ad478bc41213471bc7b735b9b1751d35d34acbd72b0c3cfffba832865837e68689e9d35471fdef";
+      sha512 = "03deae4c54d87ad87cc152f8977156cc16997f3a5593d26cfd7950b05bb39fa7392d6b6dccad265700922776f2eb2b4f4e77d790e8eec32e7c7c618a058b0362";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/km/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/km/firefox-67.0.4.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha512 = "f35a181f397fb9dba66f91ec15e7d569bc3ff975ea6a061fca969a1f349eb00dc8aca56b3e9541cbc996a3558a663f272a571de3118e9aec84f1358103516966";
+      sha512 = "bb29597b7d42e7707c5098d811605786a873cc9d74834485a4426aa2898dde727e2cd6ceddad80421605eb9f4e9e17fad739e1469c90c8f71fcd7862b7a93ec2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/kn/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/kn/firefox-67.0.4.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha512 = "71c40e6f2eb495ef431635dd85cd4d09bc470b589965c0b1339a26632dcdfa4cbfda210335d3789edd8a884a2c630d7891a03ee50c675d168e7977db9d57d94c";
+      sha512 = "1264cd2228d0fbc327eb3e3448df8e767c53a24010be21433a318b22e260a72079c7d7edf1762a2ad63b3704c0fd7399cfdab691baccb2841b566556a603c78c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/ko/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/ko/firefox-67.0.4.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "87f6df6f0d5ea21e2d00b207fbdce0cdfef8b160e3674b94e422f18ddcfae69a63045831958cacfd07727ab798b8a215fd20d9495c3627505836c0b41c11d191";
+      sha512 = "5eb15947e5abfca34f90f6fa148eb4457c318cf84e1a48ef381d8142bccd7ec7050da31bf34b78a38d4f76b60bb941d9227d00111a96f2933a023dad8d47708a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/lij/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/lij/firefox-67.0.4.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha512 = "4a009a5e21b36448eea6e66a4b375328d2632b9d1c1ffb9a8dd886fed42f07c87b6a3f0ecdddb446bc91cfe4dfe678d1682ad40a7224b4772fd14069d107f1ac";
+      sha512 = "324d7ca1d7f44eebd2a7f653b8236c9db8f677e5eb01864222330622a7966887a8ca120f622b5268b6a8eac405c3e6a20f767857cdd030d964d10203a18c6127";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/lt/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/lt/firefox-67.0.4.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "7cb2876112d7c988687c3ca29c816d699e8a037e874f7e44f77897c272d3c10746062b33e8f175bf861db4ec28581931c2f102f20cb896d0ecca21e830eeaa18";
+      sha512 = "b8b0608a664c058548b2c0476d8be3b88fc67ef7a4ce3b72245326560445f6016ae41e7b7d3f4220fb70a47c12806a9acf3462615467638de0bc75f6b41a4d2c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/lv/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/lv/firefox-67.0.4.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha512 = "112640788a79ba919401a00ab909a23652d53854c0bc6f0355a550dde5a8965567ad2dfce181a4502d67f411bdc5e87b0dbf77f0c3ed236aba68dc8952898590";
+      sha512 = "b64102c3569d9330689d32a5cce5ff1a4995b05ba9f1f761bfbe2103d51a79375668b11d17aa755839d998256efd82dc0b12395ad1d70f14df2f70cf80288c90";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/mai/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/mai/firefox-67.0.4.tar.bz2";
       locale = "mai";
       arch = "linux-i686";
-      sha512 = "b65dc31fac3f657f7e430abcdad185f3b317ec470b4e52abc5e66aff544c3247f30cc2389b5eecfbcf8fa79cb4ff997cee6d8b7fb1bc25ac3fe944fc67848175";
+      sha512 = "f87d2bcf31c64ed1d33b9387a9ec24ad8862b850704fef7d7eb2ce93209bd6cad05f399b8866d58e399af015aae36d610ff9ad744095ed271875f12e89abefa9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/mk/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/mk/firefox-67.0.4.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha512 = "204ba445f9eb6795f891c4dd7b4910083534e8716e1e3eedd546cb4d22e4572f5203df15ff6bac1aed8337635a0751bf5304d667c39f229c5da660f60303462e";
+      sha512 = "5d086733ac69fc05c8943c27748df82fff1698920457d972ea21b4169bf39b04f6d409bf78febbd68803084bb6836fa9dd8504786a0e076cb3361dd49b1b6f91";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/ml/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/ml/firefox-67.0.4.tar.bz2";
       locale = "ml";
       arch = "linux-i686";
-      sha512 = "a6bd9bfc2920848ab55306312957852f29df1dc4a54d0b66d29947397c6c63a5f7a17e24765247ed5b2aaf199b7e8e8256490a3d2cefa4307e7d87fbaf6fc0cd";
+      sha512 = "6a3b1c5e76c89e820da58997da44ac0282b985ec16be23bef3417f3d1a8995bdf03de59b4cbfd3012f7ffa60c460cb6fddda3b45d87df175c3ffa5e9a2f6fa69";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/mr/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/mr/firefox-67.0.4.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha512 = "43084b4db24c797cbbbd2f1670dfa2c617b148b30e0d132618a2f1031b23a2c46a9c4546b63e46384d468b5e9899ca0f21f12c8b2c40f87be04e034e4214e8f9";
+      sha512 = "77e19235c5f6fca82cdce3f22dee23875212b536fd41ffbd44cee7ded54b64fed67b1965150f6c6487dc49214c42aa9fa9219b5bac9ffdb107bfba8daf3ede58";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/ms/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/ms/firefox-67.0.4.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "c73ebe826324bbf136976709887080c3de41278a465a79a51b586902ef7c32e1ba410facc907827e34e0332be8e9020d112501c9f2ec9c51e80be9405a52b2d7";
+      sha512 = "2438462e98b45df9527247e7010ea4611e35e94562526bbf1932e35d1bdf2ec8b50f8ba601d585cd5efbca535f146ecc3a8ae609b2939af3d9c11f9134d659eb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/my/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/my/firefox-67.0.4.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha512 = "d8efa26ae6c01b7a43eeb0b3dbcad08ab9ff1ce545b88cdc6c47ed2bbc0b19bb240f2887c0ea7202931cb2ab5558a3d8e7a84f997b7b578825874f9c4e5ea628";
+      sha512 = "7ac6bf9bf2fea58434ca4eaee2c4ed7bf0f0299024cfa69207caecb1e91c94484603e0f127791c97f9ac8b5d59e2341a6aba854c4e67e80e6c3086a1eae94868";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/nb-NO/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/nb-NO/firefox-67.0.4.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "cb81f0a9d2aa8e64d783d8e8d7433144f50ace264383891253fb3c1be271b9ae66581543ab7c491204ef398d0ba3712637862d652563abbf0b3c6c1673a849dd";
+      sha512 = "442b1fdd9968f09b42cee1b54166df4eb4eae24cb2115ee9e966ed7590a2a75ff0e2095b83c1edf7463a30cf24118f57c93317dc69ede1aca1052584cc685657";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/ne-NP/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/ne-NP/firefox-67.0.4.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha512 = "fca78c6be150ad5c64a4d10f3358bee3e9203f00a8776fd801b835ed95dc44c847d9f0d1a5396fa6e4d7e9fd3cc1a4aaad3b01da47351bb43fc6f3e7a73ceff4";
+      sha512 = "2d14089dc61a36fedc9583a9aa5215c277b3454e7bbc1b3f4ca3ea48e4456e6bb5993db2f9e8433b7db1f373c46b8ea9834840b61acc1283ac6b5a2608b8018a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/nl/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/nl/firefox-67.0.4.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "eb3ff0a79476c3b0a46de29ffe1b4c8442fdea4ced8a05b6912f55bb70160cb7cf73d3e3738b474b9dfc10d56084df7411e1a0f115a3ae1d5c434619fcc6d33c";
+      sha512 = "7fa6bc5b35d685019b800ec742e420387e732fe4fd60451ebc7e8edbd93848d6697fc850034ece498333c5cbc782404d7b0730bce3f83944c8190832401d2ff0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/nn-NO/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/nn-NO/firefox-67.0.4.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "9751e3970329b26555970b382e18e2599482ceae1fab643df5e9e23ba5de8b5d899c079eb90802afbabd1edd19983f5c36684896d110f60297f46742484b9e65";
+      sha512 = "fd979510d0b3bf2f865af9dff39581d483a82984e845ad59485e61e824d64c3a30b774d8b924974f039b5e2c8a8900c74da1df48bf5b92465f65c0837a1ce5a0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/oc/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/oc/firefox-67.0.4.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha512 = "0cf542343deacd59a3ca1ab96da1ec943a22e8f2cc5eb30e2f522d3465fe42e105bf2d2c14aaff382bc9cfc787b339379d5851c4d872bc80eee09ce05f8675aa";
+      sha512 = "49135cd6bacaf99798eef21670f728c02cac84a2c278b4e0d83bdc5ac36de8c0d568ff5925b55f9869f202c117b20cdf901c52703b5452aa1258d72d811d01c4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/or/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/or/firefox-67.0.4.tar.bz2";
       locale = "or";
       arch = "linux-i686";
-      sha512 = "8b0031d5d17e8c6d7fc15672593b9bc7b132324dddc497e4afdb6ebd1745ad751da6b5bea2813332981ad5d4c74e6c2d4928ff95f3c2e048c7caf207c531e090";
+      sha512 = "83b2b21f39641a80c48e6c7d0659f0dc4df627fd40d86c9e5a80951b83da9a51f31c6d180be3e22314330849ade32e559cf36a3edb10215182906d9d0313b753";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/pa-IN/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/pa-IN/firefox-67.0.4.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "ed086568ff5927a234c9776b146ab9de36a986d08b751c63f4c7ca43e8767c3e66c2909ee157a5b22cc98744b528ab99cbbb2b012029620945bffb58a35fe8c8";
+      sha512 = "930280f01912ab9e83b9bf8fce2f946f7508a20241ee11e83b03ef2fdb078646c485d39e85e9995edf36098a86b6d84b8012da29efd56b44847b50d551ab47f7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/pl/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/pl/firefox-67.0.4.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "3073b5ec8a3bf2ffdac5eb092dc78b61bc151144a5a1d71d947ceb6383df989256c96713fb6d09f5298938cb99b085f87cce43fd1bf214cb934cc3de87d6b490";
+      sha512 = "ad16ee9963517c6c6c3338835b4659d83401db21b843a7799bdbb3ea4a786de5c1995577ed2b66f63e6159481683f8a72d0d7440fea84223fdc2c788c3084c03";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/pt-BR/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/pt-BR/firefox-67.0.4.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "489be74497172a2d449c3b904883d90f134f42ea032a809798537661dc36a9967832a4692c04eb0f522b46b02892d2468d2c0ba4b75bfe45fc65c9dda989c51c";
+      sha512 = "4e0c2772120d3b1c0b231c7ec9dcb331e7095534c1e63a864b46cc1085255f6367a575f214f45e27d3d0ff98bb28d63c945d944aaae2e731436345998824d2a2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/pt-PT/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/pt-PT/firefox-67.0.4.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "70c91b17006b74029e8eb82c2abce8083b2bf252316a798c26307440926f53331687ab930a955d31ba72d7bae3e43a39d8058c978821d8519ca9d593928692d6";
+      sha512 = "60fba6ace4c4ddc5ce7b4f114d415c83d6f6e5464dd0a9c5fc186ae84fc3e9ebcd5ce952a8f8975aa4a43bb5214ccd9525deacac75d2a3a458ab7d89e4ce10b2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/rm/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/rm/firefox-67.0.4.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "92143f9f473f8208188c2a09cde7905d79c961bac7c40ce28d6b2afaaba3e671d62d6424f9861710c0f26da1ad7602e8ff4913c5373b82233a7147cde5a9449b";
+      sha512 = "de6e943eebe7c252e89cf38901a75f900dad2a74ac8ac52c4a89996684e9973e7dad5dbdb51e18b0d57844ca430c2ad19da1e65063397c112336816563a8833a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/ro/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/ro/firefox-67.0.4.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "d4eea316d257a793eb1fc20b9f9526ceb1bbed76771aceb9c276ee634904f7afcbca77c186d5bcedf99035eb6eef61ca12a28b64bc57dc9c589aaf1074f0c21e";
+      sha512 = "4fe9ec3ef4cf67b075d6487671a68eadad07774a2c0b8bfa36193949e0b07e1cc81fa58f6b5d999413d6bd8d5772a8b1cdeed913c9a84a862d9a27db3fed91b2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/ru/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/ru/firefox-67.0.4.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "a084a59ecd2bccc705439d7b0a5c5829d87b6442b06bbfaea9b115e25097f196775043fedac6182406abdbfa630e25e7b6c9b474fe1badd5c3e48e68aab38c4c";
+      sha512 = "ce6d3612868aa36c2c757b4259283577bf147d5a4d642c3b4e3925d6c6dc1c46744173101b692c8eee96e871a64c7871da992e4a8213a8ebe8f5bd443a7863ec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/si/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/si/firefox-67.0.4.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "a9679a0dc2a2051b747c3b2078206836887bd7e0a4dc673786add43d852c8104670867e79f92535944b6639035cca9850ec74ff9113f6e60442743fc5deb9501";
+      sha512 = "c244f4a86f46fac28b38ccddd391b84e5e6d04398efc117a07f9c32486963a62e20dca11666f5f0776e8cd33078ad8861a40352437a53fa889b6e834fbcfade0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/sk/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/sk/firefox-67.0.4.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "c92088a70acf457189fcb030e55d79de8cc02cbfd0d12c4ac00fe8daf2db51857f00761c943f81929734be6aac1aa7753a4967616215882bd5342f7e61c397e4";
+      sha512 = "8dab8f2b5f5e67be82149775ff5985a9c8e5161d562bd56633725baecb0776dd78e6f2c878ffbec9e55cd65140c2bad7413c980eafee31090f70adb3c603a9af";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/sl/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/sl/firefox-67.0.4.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "dfc04638dd051867fc70038fd341943413186eb580ec56f73623e38a7981a98fea0340ae9c4d26e744d54fdab0c46949243220e5e6975e4c7c8522e61eda1c4b";
+      sha512 = "1df3ad4f5edae06926ba0779fc18552936fa07a4471d59e20591fff0ae4e36138277cf563feb128c41d34efb26029db6aa147a4bdcc872918b9c251783a75aec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/son/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/son/firefox-67.0.4.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha512 = "aead3264cb9c51937b6bafcde07771c8c281a32d7319b4298863f87f6902d84012b92543edb4533c8a378beb9c06d24a9ffa84e20d88d3b56a6e3297c273b36f";
+      sha512 = "0ccc7e9e9f74b9ab64584fbed7909baf706345986d788c33ebfd66712602a1d19ed3087da304ce911b8617c2463629309309c4798bbddc6d555630746db39929";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/sq/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/sq/firefox-67.0.4.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "c9da9bb2b49f19c098abca6a7194b2a5bb4b45bf5bdd445a6b35c270a83c11fdc75ecccf38afc95389b1e4429c51ac8a641b6409d267a954e5e9a53527cbbacb";
+      sha512 = "ac47afcbc6311ebf5d5b46c9ed4d1ac5f00581180e365d1d62a7927ebdfbd8a6389e03dbc5887809a5991b5e010eeead964394350aa333d9294ac16ceadaa79c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/sr/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/sr/firefox-67.0.4.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "f358e9c1fbc47ae4cee8f324b7e0433d303c4d2eb61a27caa60cc20974e051e8fab19e5ba4140fe7277ce7aadb57345c311e92b53b5b2fc86676fff77bbcda0c";
+      sha512 = "204059de691624a417f39303060369982e08c21c7a2191b5a838a315319cc944a89a67c79dc2a4908375091bb08dd6e1ac7556e2fe38981af62c460a5dbd070e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/sv-SE/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/sv-SE/firefox-67.0.4.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "eb5f5d553a11b592a60681a6141d5913daa888c04c5b2b359122ee428db7902c39063b1b646f6e9893112710fe14b959163ae7ddaca24cc66212b2dfa0bcfbb2";
+      sha512 = "0a820797f23f6c6df8c2c807d3cbf3e48c6ca644c94f45ac7e7b58d5bc4a0cdb836bd35ea3f5d0dcfc14dab74d3eea2af1b40cd8343f1b47d365fc7eb42d963d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/ta/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/ta/firefox-67.0.4.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha512 = "e6bdb94685ef89be9fe8c1186020c46fe634a60decc5bacc5a0e50d1414ed033fa5d158f1485ce4a4f73444692f884a2bdbb48f00abda42ea36f787c324930c5";
+      sha512 = "77de338d3ad77a0e5616a8c4a15673359c569e53e5568a0b40b6f341d90f2e3bda24db86e9649642e7d69872e05ea766e863c9a333396043764d599d133313b1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/te/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/te/firefox-67.0.4.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha512 = "bef6d38c70f3ca7a2a5d51bd8e34859baecfdf46cc0a664558c5d332d24f435e1bd6244c118470ec2ef7e57d0bf4bd38635aa2d39f2bf7c27093f502724e11d5";
+      sha512 = "95b98e4d5dfceb547bf96b5cb27963c7b3c7786994cc1a6d5aee243311fd7e6c6943dd16d7b063cb773dbeca5262f5ad22413a57e85ab90cd79ca417b4819355";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/th/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/th/firefox-67.0.4.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha512 = "10c71e3eb1687a527d31a28aed315a6b15823bb9548ec1403ac619c33a4d47c9eff7caf4681f0e01a1783dde58126fcda83daf923a702d9dfac176175b02910e";
+      sha512 = "dbe70905a9b04fef460ce0efefcff4a7c16782e8e361ce22c647287625a2d2c088c5fb1942634bbbf9ea000f1f31422c3543028cf07e0cace1a50015feb940f0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/tr/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/tr/firefox-67.0.4.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "e606320cc02ef39080295ea7b208f7a227c4b10dea9773842e7c643755df190e99f1f483385c869a5d5a2cb30c63565042b878df27c7fdbc6bd367d7d7083889";
+      sha512 = "56ae21e90b2d03664e18b3aaad9764613f4bc587088cbc8321d686ee6e4f1f122ff6a973a0bd8e38a49292d74b8181582d62d749033ee48e774c722971693b99";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/uk/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/uk/firefox-67.0.4.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "1330ac941b229a687ee3fd81257fc2cb21dc1b6e3c64bf24cfbc5fa039f6233c17713929894a85a3b975ecf4e9850bf35f607fc10c61751f8d8cf9620f5469d7";
+      sha512 = "3cc450d78f77442c799d5aac7676d46792a6424158a4fafb38fd836281ba8a138b48b9221ac19326ab8f95a60fa2b9bab00d24e4cef2fa362291859b9460ceef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/ur/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/ur/firefox-67.0.4.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha512 = "f710b6e182728666a1b9a3c6c0a72b601cfedd9bf8e8325a34d295bbbf62dc8e9f666d2d9dc248fa1ed0a389329e98166b1292dc88a18bcf7a7276b1eb6551a2";
+      sha512 = "2402744ab2fa8166cd12ac91c8ef7e6bbe1373d6fa7c0da26f0a6fed3b56944b6b021d5e88248b66e40dcfb149004e5790b39bf0c937142b2f00745ad3b14d1e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/uz/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/uz/firefox-67.0.4.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "26a94757976113a458445470a77a71d02ede6507ba6a69cdabd9f33bd67b1dda9f0ed925a55e65c57a25ee30a8226d59cf8cc1be64659a9c4d967816d5c7fceb";
+      sha512 = "98a5a869cc1378ba2fc6d54c3179e739800c7871cac10c00a449e4e4cabb2e35173a4310b62ae8ce689bfa341fd6a4b28b54119399dca3ed308800c793a957d0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/vi/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/vi/firefox-67.0.4.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "5acbe40b582ec92eb5979b72131315c1eb0cf37249a3f417f4cf0298fa15da7192f297688d1f9f5baae0b920c4ab9f3489c7f357e034cc9e56cc0609ad601a25";
+      sha512 = "daa5fa6676f12806e951c329e276c2360cdb17e83163cd2f71fd3400994ca478daee33adf7dd6459c8b825d4693c0755fba3051851e26833324e54d30f8056fb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/xh/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/xh/firefox-67.0.4.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha512 = "a4ea573b98f32a80a79fbf2085f0c96e68285f50085cb723d7e8b5b5bb8c199c0e09c6b87da7a1e5bf60f9672ea5dbfc0e39220fb2bf0d32a056c46e5c72a93c";
+      sha512 = "ab6c0e09eebc112b13efddf7587da524f8afb35683d543e70196a63bd9966b7d2beb05778585aa86d49bc994cf51ed5e985b5b1da1cd6b3819680d9a8fccebd1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/zh-CN/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/zh-CN/firefox-67.0.4.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "0fcfca50579d1d5e7b0edf45ade7f64c1e4fb46956a1cf0e14169bbbba3126eabbbef3808b3960396e55c79db300fca81b85993bea929e8687b7dac506ec4300";
+      sha512 = "a99a71a0f62749844a42664e6222d11b2fb25e0ad5af42eb062b624e8c929593881c8a2821a097dbf32d0ecd34f8c24e58c4dd0830d6f586bf60aafbf5ca8a57";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.3/linux-i686/zh-TW/firefox-67.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0.4/linux-i686/zh-TW/firefox-67.0.4.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "d553617691d38766ecd361c5f79dd03caca1b41ced60254e12cf0c40c093df5d1de1d732b8ee31d38e5af6cb6b96e3583dce93bd30560ac1453dfda8df97d9d1";
+      sha512 = "3399ad8de9c6bc12ecec297e46ba1a0c72e9d0fa95b407f333189aaa7da696bb74b1099791c86b40432246de9359150add28d2810dba535eabe5aa7e0fd74419";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -72,10 +72,10 @@ rec {
 
   firefox-esr-60 = common rec {
     pname = "firefox-esr";
-    ffversion = "60.7.1esr";
+    ffversion = "60.7.2esr";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${ffversion}/source/firefox-${ffversion}.source.tar.xz";
-      sha512 = "23l1sxg50w78zf93296szpyg5mksh18y3ihb4fgdw5qmpxvqsn0aiwwik903gf5fsgbjk0w0gynsy6xdbav862xjkq5j6gvyrr2hzjr";
+      sha512 = "0mw5dgrxd5vj6cngd9v3dy6hzdsg82s0cs9fabhrzrl1dy3pqdkccqqnj9r0hxwmcrdgca3s35i5lwwmlljagq6nyb5q6qv4fzv0n0j";
     };
 
     patches = [

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -17,10 +17,10 @@ rec {
 
   firefox = common rec {
     pname = "firefox";
-    ffversion = "67.0.3";
+    ffversion = "67.0.4";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${ffversion}/source/firefox-${ffversion}.source.tar.xz";
-      sha512 = "218d699mpnb8h6h24l79ar9b2gg0scqj4xwbk7p45x2arhjbhn3wq4pkzq434gcn3a1ybfkqpyifnnpv787kj4mqbdfq3cminj7al67";
+      sha512 = "3krwkc90m320a74vjyzlrxs4jc63cykbmpgisac9kv8m9n0bis5i1yf0dl9n14d9p4p541wvzhqygx7byj6mnvkhbk5b2l0nlvwias2";
     };
 
     patches = [


### PR DESCRIPTION
Here we go again!

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

CVE-2019-11708.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
