### PR TITLE
python3.pkgs.scikitlearn: 0.20.3 -> 0.21.2

### DIFF
--- a/pkgs/development/python-modules/scikitlearn/0.20.nix
+++ b/pkgs/development/python-modules/scikitlearn/0.20.nix
@@ -1,43 +1,23 @@
-{ stdenv
-, lib
-, buildPythonPackage
-, fetchPypi
+{ stdenv, buildPythonPackage, fetchPypi
 , gfortran, glibcLocales
 , numpy, scipy, pytest, pillow
-, cython
-, joblib
-, llvmPackages
 }:
+
+# 0.20.x is the last version that maintains python2 compatibility
 
 buildPythonPackage rec {
   pname = "scikit-learn";
-  version = "0.21.2";
+  version = "0.20.3";
   # UnboundLocalError: local variable 'message' referenced before assignment
   disabled = stdenv.isi686;  # https://github.com/scikit-learn/scikit-learn/issues/5534
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1nvj9j16y1hz9gm0qwzpnx2zmz55c63k1fai643migsyll9c7bqa";
+    sha256 = "c503802a81de18b8b4d40d069f5e363795ee44b1605f38bc104160ca3bfe2c41";
   };
 
-  buildInputs = [
-    pillow
-    gfortran
-    glibcLocales
-  ] ++ lib.optionals stdenv.cc.isClang [
-    llvmPackages.openmp
-  ];
-
-  nativeBuildInputs = [
-    cython
-  ];
-
-  propagatedBuildInputs = [
-    numpy
-    scipy
-    numpy.blas
-    joblib
-  ];
+  buildInputs = [ pillow gfortran glibcLocales ];
+  propagatedBuildInputs = [ numpy scipy numpy.blas ];
   checkInputs = [ pytest ];
 
   LC_ALL="en_US.UTF-8";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4393,9 +4393,11 @@ in {
 
   scikitimage = callPackage ../development/python-modules/scikit-image { };
 
-  scikitlearn = callPackage ../development/python-modules/scikitlearn {
-    inherit (pkgs) gfortran glibcLocales;
-  };
+  scikitlearn = let
+    args = { inherit (pkgs) gfortran glibcLocales; };
+  in
+    if isPy3k then callPackage ../development/python-modules/scikitlearn args
+    else callPackage ../development/python-modules/scikitlearn/0.20.nix args;
 
   scikit-bio = callPackage ../development/python-modules/scikit-bio { };
 


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Splits scikitlearn into a python2 (0.20.x) and a python3 (>0.20)
version.

Currently blocked by https://github.com/NixOS/nixpkgs/issues/63573.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
