### PR TITLE
xtrace: 1.3.1 -> 1.4.0

### DIFF
--- a/pkgs/tools/X11/xtrace/default.nix
+++ b/pkgs/tools/X11/xtrace/default.nix
@@ -1,31 +1,30 @@
-{ stdenv, autoreconfHook, fetchgit, libX11, xauth, makeWrapper }:
+{ stdenv, autoreconfHook, fetchFromGitLab, libX11, xauth, makeWrapper }:
 
-let version = "1.3.1"; in
-stdenv.mkDerivation {
-  name = "xtrace-${version}";
-  src = fetchgit {
-    url = "git://git.debian.org/xtrace/xtrace.git";
-    rev = "refs/tags/xtrace-1.3.1";
-    sha256 = "1g26hr6rl7bbb9cwqk606nbbapslq3wnsy8j28azrgi8hgfqhjfi";
+stdenv.mkDerivation rec {
+  pname = "xtrace";
+  version = "1.4.0";
+
+  src = fetchFromGitLab rec {
+    domain = "salsa.debian.org";
+    owner = "debian";
+    repo = pname;
+    rev = "xtrace-${version}";
+    sha256 = "1yff6x847nksciail9jly41mv70sl8sadh0m5d847ypbjmxcwjpq";
   };
 
-  nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = [ libX11 makeWrapper ];
+  nativeBuildInputs = [ autoreconfHook makeWrapper ];
+  buildInputs = [ libX11 ];
 
-  preConfigure = ''
-    ./autogen.sh
+  postInstall = ''
+    wrapProgram "$out/bin/xtrace" \
+        --prefix PATH ':' "${xauth}/bin"
   '';
 
-  postInstall =
-    '' wrapProgram "$out/bin/xtrace" \
-         --prefix PATH ':' "${xauth}/bin"
-    '';
-
-  meta = {
-    homepage = http://xtrace.alioth.debian.org/;
+  meta = with stdenv.lib; {
+    homepage = "https://salsa.debian.org/debian/xtrace";
     description = "Tool to trace X11 protocol connections";
-    license = stdenv.lib.licenses.gpl2;
-    maintainers = with stdenv.lib.maintainers; [viric];
-    platforms = with stdenv.lib.platforms; linux;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ viric ];
+    platforms = with platforms; linux;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This one could not be updated automatically anymore. The source
repository has changed.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---