### PR TITLE
patchwork: 3.11.4 -> 3.14.1

### DIFF
--- a/pkgs/applications/networking/ssb/patchwork/default.nix
+++ b/pkgs/applications/networking/ssb/patchwork/default.nix
@@ -1,46 +1,53 @@
-{
- stdenv,
- appimage-run,
- fetchurl,
- runtimeShell,
- gsettings-desktop-schemas,
- gtk3,
- gobject-introspection,
- wrapGAppsHook,
-}:
+{ appimageTools, symlinkJoin, lib, fetchurl, makeDesktopItem }:
 
-stdenv.mkDerivation rec {
-  # latest version that runs without errors
-  # https://github.com/ssbc/patchwork/issues/972
-  version = "3.11.4";
+let
   pname = "patchwork";
+  version = "3.14.1";
+  name = "${pname}-${version}";
 
   src = fetchurl {
-    url = "https://github.com/ssbc/patchwork/releases/download/v${version}/Patchwork-${version}-linux-x86_64.AppImage";
-    sha256 = "1blsprpkvm0ws9b96gb36f0rbf8f5jgmw4x6dsb1kswr4ysf591s";
+    url = "https://github.com/ssbc/patchwork/releases/download/v${version}/ssb-${pname}-${version}-x86_64.AppImage";
+    sha256 = "01vsldabv9nmbx8kzlgw275zykm72s1dxglnaq4jz5vbysbyn0qd";
   };
 
-  nativeBuildInputs = [ wrapGAppsHook ];
-  buildInputs = [ appimage-run gtk3 gsettings-desktop-schemas gobject-introspection ];
+  binary = appimageTools.wrapType2 {
+    name = "${pname}";
+    inherit src;
+  };
+  # we only use this to extract the icon
+  appimage-contents = appimageTools.extractType2 {
+    inherit name src;
+  };
 
-  unpackPhase = ":";
+  desktopItem = makeDesktopItem {
+    name = "patchwork";
+    exec = "${binary}/bin/patchwork";
+    icon = "ssb-patchwork.png";
+    comment = "Decentralized messaging and sharing app";
+    desktopName = "Patchwork";
+    genericName = "Patchwork";
+    categories = "Network;";
+  };
 
-  installPhase = ''
-    mkdir -p $out/{bin,share}
-    cp $src $out/share/${pname}
-    echo "#!${runtimeShell}" > $out/bin/${pname}
-    echo "${appimage-run}/bin/appimage-run $out/share/${pname}" >> $out/bin/${pname}
-    chmod +x $out/bin/${pname} $out/share/${pname}
-  '';
+in
+  symlinkJoin {
+    inherit name;
+    paths = [ binary ];
 
-  meta = with stdenv.lib; {
-    description = "A decentralized messaging and sharing app built on top of Secure Scuttlebutt (SSB).";
+    postBuild = ''
+      mkdir -p $out/share/pixmaps/ $out/share/applications
+      cp ${appimage-contents}/ssb-patchwork.png $out/share/pixmaps
+      cp ${desktopItem}/share/applications/* $out/share/applications/
+    '';
+
+  meta = with lib; {
+    description = "A decentralized messaging and sharing app built on top of Secure Scuttlebutt (SSB)";
     longDescription = ''
       sea-slang for gossip - a scuttlebutt is basically a watercooler on a ship.
     '';
     homepage = https://www.scuttlebutt.nz/;
     license = licenses.agpl3;
-    maintainers = with maintainers; [ thedavidmeister ];
+    maintainers = with maintainers; [ thedavidmeister ninjatrappeur flokli ];
     platforms = [ "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
This updates patchwork from 3.11.4 to 3.14.1, and uses the `appimageTools`
machinery to extract the AppImage instead of the wrapper used before.

On top of that, we install a `.desktop` file, so its available from the
application menu.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @Infinisil @NinjaTrappeur @thedavidmeister 