### PR TITLE
fetchers: use a meaningful name

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -99,7 +99,7 @@ let
     inherit (sources) pathType pathIsDirectory cleanSourceFilter
       cleanSource sourceByRegex sourceFilesBySuffices
       commitIdFromGitRepo cleanSourceWith pathHasContext
-      canCleanSource;
+      canCleanSource sourceName;
     inherit (modules) evalModules closeModules unifyModuleSyntax
       applyIfFunction unpackSubmodule packSubmodule mergeModules
       mergeModules' mergeOptionDecls evalOptionValue mergeDefinitions

--- a/lib/sources.nix
+++ b/lib/sources.nix
@@ -101,4 +101,13 @@ rec {
   pathHasContext = builtins.hasContext or (lib.hasPrefix builtins.storeDir);
 
   canCleanSource = src: src ? _isLibCleanSourceWith || !(pathHasContext (toString src));
+
+  sourceName = repo: rev: let
+    baseRevision = baseNameOf rev;
+    baseName = baseNameOf repo;
+    isHash = rev: null != builtins.match "[0-9a-z]{30,}" rev;
+    shortRev = if isHash baseRevision
+      then lib.substring 0 10 baseRevision
+      else lib.removePrefix "-" (lib.removePrefix baseName baseRevision);
+  in "${baseName}-${shortRev}-source";
 }

--- a/pkgs/build-support/fetchbitbucket/default.nix
+++ b/pkgs/build-support/fetchbitbucket/default.nix
@@ -1,6 +1,6 @@
-{ fetchzip }:
+{ lib, fetchzip }:
 
-{ owner, repo, rev, name ? "source"
+{ owner, repo, rev, name ? (lib.sourceName repo rev)
 , ... # For hash agility
 }@args: fetchzip ({
   inherit name;

--- a/pkgs/build-support/fetchgithub/default.nix
+++ b/pkgs/build-support/fetchgithub/default.nix
@@ -1,6 +1,6 @@
 { lib, fetchgit, fetchzip }:
 
-{ owner, repo, rev, name ? "source"
+{ owner, repo, rev, name ? (lib.sourceName repo rev)
 , fetchSubmodules ? false, private ? false
 , githubBase ? "github.com", varPrefix ? null
 , ... # For hash agility

--- a/pkgs/build-support/fetchgitlab/default.nix
+++ b/pkgs/build-support/fetchgitlab/default.nix
@@ -1,7 +1,7 @@
 { fetchzip, lib }:
 
 # gitlab example
-{ owner, repo, rev, domain ? "gitlab.com", name ? "source", group ? null
+{ owner, repo, rev, domain ? "gitlab.com", name ? (lib.sourceName repo rev), group ? null
 , ... # For hash agility
 }@args: fetchzip ({
   inherit name;

--- a/pkgs/build-support/fetchrepoorcz/default.nix
+++ b/pkgs/build-support/fetchrepoorcz/default.nix
@@ -1,7 +1,7 @@
-{ fetchzip }:
+{ lib, fetchzip }:
 
 # gitweb example, snapshot support is optional in gitweb
-{ repo, rev, name ? "source"
+{ repo, rev, name ? (lib.sourceName repo rev)
 , ... # For hash agility
 }@args: fetchzip ({
   inherit name;

--- a/pkgs/build-support/fetchsavannah/default.nix
+++ b/pkgs/build-support/fetchsavannah/default.nix
@@ -1,7 +1,7 @@
-{ fetchzip }:
+{ lib, fetchzip }:
 
 # cgit example, snapshot support is optional in cgit
-{ repo, rev, name ? "source"
+{ repo, rev, name ? (lib.sourceName repo rev)
 , ... # For hash agility
 }@args: fetchzip ({
   inherit name;

--- a/pkgs/build-support/fetchzip/default.nix
+++ b/pkgs/build-support/fetchzip/default.nix
@@ -11,12 +11,9 @@
   stripRoot ? true
 , url
 , extraPostFetch ? ""
-, name ? "source"
 , ... } @ args:
 
 (fetchurl ({
-  inherit name;
-
   recursiveHash = true;
 
   downloadToTemp = true;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This adds a meaningful name to source packages fetched with fetch*
helper functions.  The idea is to guess a good name based on the repo
name and the revision. When the revision is a hash, it is truncated to
length 10.

To get an idea of the generated names, please look at
https://gist.github.com/layus/7b176dd31b87a30be274d6de40f658b8. This was
generated with nox-review and also hints at the massive rebuild incurred.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---