### PR TITLE
nixos/openvpn: support setting IP forwarding

### DIFF
--- a/nixos/modules/services/networking/openvpn.nix
+++ b/nixos/modules/services/networking/openvpn.nix
@@ -78,6 +78,14 @@ in
 
   options = {
 
+    services.openvpn.enableForwarding = mkOption {
+      default = false;
+      type = types.bool;
+      description = ''
+        Set up IP forwarding on the host.
+      '';
+      };
+
     services.openvpn.servers = mkOption {
       default = {};
 
@@ -210,6 +218,8 @@ in
     environment.systemPackages = [ openvpn ];
 
     boot.kernelModules = [ "tun" ];
+
+    boot.kernel.sysctl = lib.mkIf cfg.enableForwarding { "net.ipv4.ip_forward" = true; };
 
   };
 


### PR DESCRIPTION
###### Motivation for this change

IP forwarding is needed for many of the OpenVPN use cases, so make it configurable through the openvpn module.

Been using this for ages here.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

