### PR TITLE
fail2ban: fix dovecot filter's journalmatch

### DIFF
--- a/pkgs/tools/security/fail2ban/default.nix
+++ b/pkgs/tools/security/fail2ban/default.nix
@@ -21,6 +21,9 @@ pythonPackages.buildPythonApplication {
         --replace /usr/sbin/sendmail sendmail \
         --replace /usr/bin/whois whois
     done
+
+    substituteInPlace config/filter.d/dovecot.conf \
+      --replace dovecot.service dovecot2.service
   '';
 
   doCheck = false;


### PR DESCRIPTION
The dovecot filter config distributed with fail2ban watches for log
entries with a journalmatch filter of "_SYSTEMD_UNIT=dovecot.service",
but NixOS's Dovecot runs as dovecot2.service. Fix the journalmatch
config to match NixOS's Dovecot.


###### Motivation for this change
fail2ban doesn't currently work with dovecot because the upstream config uses a different name for the dovecot systemd service than NixOS.

###### Things done

I'm afraid I am very new to Nix / NixOS and I'm not sure how to test this.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
