### PR TITLE
Add NodeJS v10 to nixos-small channel

### DIFF
--- a/nixos/release-small.nix
+++ b/nixos/release-small.nix
@@ -71,6 +71,7 @@ in rec {
       mysql
       nginx
       nodejs
+      nodejs-10_x
       openssh
       php
       postgresql


### PR DESCRIPTION
v10 is the LTS but it is a breaking change to make it the default on 18.03 so it would be good to add it as build.

This will increase the build time and closure size of nixos-small, but it would be useful for at least my servers.