### PR TITLE
elixir_1_9: init at 1.9.0

### DIFF
--- a/pkgs/development/beam-modules/default.nix
+++ b/pkgs/development/beam-modules/default.nix
@@ -43,6 +43,11 @@ let
         # BEAM-based languages.
         elixir = elixir_1_7;
 
+        elixir_1_9 = lib.callElixir ../interpreters/elixir/1.9.nix {
+          inherit rebar erlang;
+          debugInfo = true;
+        };
+
         elixir_1_8 = lib.callElixir ../interpreters/elixir/1.8.nix {
           inherit rebar erlang;
           debugInfo = true;
@@ -59,11 +64,6 @@ let
         };
 
         elixir_1_5 = lib.callElixir ../interpreters/elixir/1.5.nix {
-          inherit rebar erlang;
-          debugInfo = true;
-        };
-
-        elixir_1_4 = lib.callElixir ../interpreters/elixir/1.4.nix {
           inherit rebar erlang;
           debugInfo = true;
         };

--- a/pkgs/development/interpreters/elixir/1.4.nix
+++ b/pkgs/development/interpreters/elixir/1.4.nix
@@ -1,7 +1,0 @@
-{ mkDerivation }:
-
-mkDerivation rec {
-  version = "1.4.5";
-  sha256 = "18ivcxmh5bak13k3rjy7jjzin57rgb2nffhwnqb2wl7bpi8mrarw";
-  minimumOTPVersion = "18";
-}

--- a/pkgs/development/interpreters/elixir/1.9.nix
+++ b/pkgs/development/interpreters/elixir/1.9.nix
@@ -1,0 +1,7 @@
+{ mkDerivation }:
+
+mkDerivation rec {
+  version = "1.9.0-rc.0";
+  sha256 = "0pid607xbgqghljz2mcgqbjxkxsyq16c60kvnmkq680wk8g5ni72";
+  minimumOTPVersion = "20";
+}

--- a/pkgs/development/interpreters/elixir/1.9.nix
+++ b/pkgs/development/interpreters/elixir/1.9.nix
@@ -1,7 +1,7 @@
 { mkDerivation }:
 
 mkDerivation rec {
-  version = "1.9.0-rc.0";
-  sha256 = "0pid607xbgqghljz2mcgqbjxkxsyq16c60kvnmkq680wk8g5ni72";
+  version = "1.9.0";
+  sha256 = "0yfqh07wjgm10v6acn5pw8l8jndjly5kpzgw4harlj81wcaymlsw";
   minimumOTPVersion = "20";
 }

--- a/pkgs/development/interpreters/elixir/generic-builder.nix
+++ b/pkgs/development/interpreters/elixir/generic-builder.nix
@@ -22,10 +22,8 @@ in
 
     buildInputs = [ erlang rebar makeWrapper ];
 
-    LOCALE_ARCHIVE = stdenv.lib.optionalString stdenv.isLinux
-      "${pkgs.glibcLocales}/lib/locale/locale-archive";
-    LANG = "en_US.UTF-8";
-    LC_TYPE = "en_US.UTF-8";
+    LANG = "C.UTF-8";
+    LC_TYPE = "C.UTF-8";
 
     setupHook = ./setup-hook.sh;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8242,7 +8242,7 @@ in
   inherit (beam.interpreters)
     erlang erlangR18 erlangR19 erlangR20 erlangR21
     erlang_odbc erlang_javac erlang_odbc_javac erlang_nox erlang_basho_R16B02
-    elixir elixir_1_8 elixir_1_7 elixir_1_6 elixir_1_5 elixir_1_4
+    elixir elixir_1_9 elixir_1_8 elixir_1_7 elixir_1_6 elixir_1_5
     lfe lfe_1_2;
 
   inherit (beam.packages.erlang)

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -61,7 +61,7 @@ rec {
     # Other Beam languages. These are built with `beam.interpreters.erlang`. To
     # access for example elixir built with different version of Erlang, use
     # `beam.packages.erlangR19.elixir`.
-    inherit (packages.erlang) elixir elixir_1_8 elixir_1_7 elixir_1_6 elixir_1_5 elixir_1_4;
+    inherit (packages.erlang) elixir elixir_1_9 elixir_1_8 elixir_1_7 elixir_1_6 elixir_1_5;
 
     inherit (packages.erlang) lfe lfe_1_2;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I just prepared this PR.
The use of `C.UTF-8` instead of `glibcLocales - en_US.UTF-8` needs to be tested if it doesn't have any side affects on Elixir.
Should only be merged when Elixir `v1.9.0` is released, as I removed the then deprecated `v1.4`.