### PR TITLE
nixos/bluetooth: don't install obex tools by default

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2003.xml
+++ b/nixos/doc/manual/release-notes/rl-2003.xml
@@ -199,6 +199,13 @@
       This has led to drastically reduced closed sizes for some rust crates since development dependencies are now in the <literal>lib</literal> output.
     </para>
    </listitem>
+   <listitem>
+    <para>
+     The packages <literal>openobex</literal> and <literal>obexftp</literal>
+     are no loger installed when enabling bluetooth via
+     <option>hardware.bluetooth.enable</option>.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/modules/services/hardware/bluetooth.nix
+++ b/nixos/modules/services/hardware/bluetooth.nix
@@ -72,7 +72,7 @@ in {
       };
     };
 
-    environment.systemPackages = [ bluez-bluetooth pkgs.openobex pkgs.obexftp ];
+    environment.systemPackages = [ bluez-bluetooth ];
 
     environment.etc = singleton {
       source = pkgs.writeText "main.conf" (generators.toINI { } cfg.config + optionalString (cfg.extraConfig != null) cfg.extraConfig);

--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -169,7 +169,7 @@ in
         ++ lib.optional (cfg.phononBackend == "vlc") libsForQt5.phonon-backend-vlc
 
         # Optional hardware support features
-        ++ lib.optionals config.hardware.bluetooth.enable [ bluedevil bluez-qt ]
+        ++ lib.optionals config.hardware.bluetooth.enable [ bluedevil bluez-qt openobex obexftp ]
         ++ lib.optional config.networking.networkmanager.enable plasma-nm
         ++ lib.optional config.hardware.pulseaudio.enable plasma-pa
         ++ lib.optional config.powerManagement.enable powerdevil


### PR DESCRIPTION
###### Motivation for this change
Currently setting `hardware.bluetooth.enable = true` install the OpenOBEX tools along with bluez.
Since sharing files over bluetooth seems pretty uncommon and the packages are more than 200MB I propose we don't install them by default.

---
