### PR TITLE
SDL_gpu: init at 20190124

### DIFF
--- a/pkgs/development/libraries/SDL_gpu/default.nix
+++ b/pkgs/development/libraries/SDL_gpu/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, cmake, SDL2, libGLU }:
+
+stdenv.mkDerivation rec {
+  pname = "SDL_gpu-unstable";
+  version = "2019-01-24";
+
+  src = fetchFromGitHub {
+    owner = "grimfang4";
+    repo = "sdl-gpu";
+    rev = "e3d350b325a0e0d0b3007f69ede62313df46c6ef";
+    sha256 = "0kibcaim01inb6xxn4mr6affn4hm50vz9kahb5k9iz8dmdsrhxy1";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ SDL2 libGLU ];
+
+  cmakeFlags = [
+    "-DSDL_gpu_BUILD_DEMOS=OFF"
+    "-DSDL_gpu_BUILD_TOOLS=OFF"
+    "-DSDL_gpu_BUILD_VIDEO_TEST=OFF"
+    "-DSDL_gpu_BUILD_TESTS=OFF"
+  ];
+
+  patchPhase = ''
+    sed -ie '210s#''${OUTPUT_DIR}/lib#''${CMAKE_INSTALL_LIBDIR}#' src/CMakeLists.txt
+    sed -ie '213s#''${OUTPUT_DIR}/lib#''${CMAKE_INSTALL_LIBDIR}#' src/CMakeLists.txt
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A library for high-performance, modern 2D graphics with SDL written in C";
+    homepage = "https://github.com/grimfang4/sdl-gpu";
+    license = licenses.mit;
+    maintainers = with maintainers; [ pmiddend ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13080,6 +13080,8 @@ in
 
   SDL_gfx = callPackage ../development/libraries/SDL_gfx { };
 
+  SDL_gpu = callPackage ../development/libraries/SDL_gpu { };
+
   SDL_image = callPackage ../development/libraries/SDL_image { };
 
   SDL_mixer = callPackage ../development/libraries/SDL_mixer { };


### PR DESCRIPTION
###### Motivation for this change

I'm using this package with SDL2.

Notes:

  - The library is supposed to work with SDL1 and SDL2. I've only packaged the SDL2 version right now. I'm hoping if somebody still uses SDL1, the derivation will be extended accordingly.
  - I'm aware of the strange `sed` command in the `patchPhase`. Replacing all of the `OUTPUT_DIR` variables isn't necessary and would have broken the build as far as I can ascertain.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
