### PR TITLE
conftest: init at 0.7.0

### DIFF
--- a/pkgs/development/tools/conftest/default.nix
+++ b/pkgs/development/tools/conftest/default.nix
@@ -1,0 +1,28 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "conftest";
+  version = "0.7.0";
+
+  src = fetchFromGitHub {
+    owner = "instrumenta";
+    repo = "conftest";
+    rev = "v${version}";
+    sha256 = "0qq2kp9h91rirlhml5vyzmi7rd4v3pkqjk2bn7mvdn578jnwww24";
+  };
+
+  buildFlagsArray = ''
+    -ldflags=
+        -X main.version=${version}
+  '';
+
+  modSha256 = "0c9phka7n2cfi8lf0a3prks2pjna5dgf5lj6az82iklnq4p7177y";
+
+  meta = with lib; {
+    description = "Write tests against structured configuration data";
+    homepage = https://github.com/instrumenta/conftest;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ yurrriq ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -151,6 +151,8 @@ in
 
   cmark = callPackage ../development/libraries/cmark { };
 
+  conftest = callPackage ../development/tools/conftest {};
+
   corgi = callPackage ../development/tools/corgi { };
 
   dhallToNix = callPackage ../build-support/dhall-to-nix.nix {


### PR DESCRIPTION
###### Motivation for this change
Add [conftest](https://github.com/instrumenta/conftest).

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).