### PR TITLE
tomcat: CVE-2019-10072

### DIFF
--- a/pkgs/servers/http/tomcat/default.nix
+++ b/pkgs/servers/http/tomcat/default.nix
@@ -44,8 +44,8 @@ in {
 
   tomcat85 = common {
     versionMajor = "8";
-    versionMinor = "5.35";
-    sha256 = "0n6agr2wn8m5mv0asz73hy2194n9rk7mh5wsp2pz7aq0andbhh5s";
+    versionMinor = "5.42";
+    sha256 = "1d90abwwvl0ghr0g0drk48j37wr2zgw74vws9z2rshyzrwgbvgp3";
   };
 
   tomcat9 = common {

--- a/pkgs/servers/http/tomcat/default.nix
+++ b/pkgs/servers/http/tomcat/default.nix
@@ -50,7 +50,7 @@ in {
 
   tomcat9 = common {
     versionMajor = "9";
-    versionMinor = "0.13";
-    sha256 = "1rsrnmkkrbzrj56jk2wh8hrr79kfkk3fz1j0abk3midn1jnbgxxq";
+    versionMinor = "0.21";
+    sha256 = "0nsylbqvky4pf3wpsx3a29b85lvwk91ay37mljk9636qffjj1vjh";
   };
 }


### PR DESCRIPTION
###### Motivation for this change
According to this announcement:
http://mail-archives.us.apache.org/mod_mbox/www-announce/201906.mbox/%3Cca69531a-1592-be7b-60ce-729549c7f812%40apache.org%3E

.. both the 8.5 and 9 versions we have in nixpkgs are vulnerable. I ran the tomcat nixos test with `services.tomcat.package` set to `tomcat85` and `tomcat9`. Both tests passed locally.

Not sure of the severity of the CVE. Perhaps this should be backported to 19.03 as well.

@grahamcofborg build tomcat85 tomcat9

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
