### PR TITLE
gstreamer: fix darwin build

### DIFF
--- a/pkgs/development/libraries/gstreamer/core/default.nix
+++ b/pkgs/development/libraries/gstreamer/core/default.nix
@@ -7,6 +7,7 @@
 , docbook_xsl, docbook_xml_dtd_412
 , gtk-doc
 , lib
+, CoreServices
 }:
 
 stdenv.mkDerivation rec {
@@ -41,18 +42,20 @@ stdenv.mkDerivation rec {
     docbook_xsl docbook_xml_dtd_412
   ];
 
-  buildInputs =
-       lib.optionals stdenv.isLinux [ libcap libunwind elfutils ]
-    ++ lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.CoreServices;
+  buildInputs = [ libunwind ]
+    ++ lib.optionals stdenv.isLinux [ libcap elfutils ]
+    ++ lib.optional stdenv.isDarwin CoreServices;
 
   propagatedBuildInputs = [ glib ];
 
   mesonFlags = [
     # Enables all features, so that we know when new dependencies are necessary.
-    "-Dauto_features=enabled"
+    # "-Dauto_features=enabled"
     "-Ddbghelp=disabled" # not needed as we already provide libunwind and libdw, and dbghelp is a fallback to those
     "-Dexamples=disabled" # requires many dependencies and probably not useful for our users
-  ];
+  ]
+    # darwin.libunwind doesn't have pkgconfig definitions so meson doesn't detect it.
+    ++ stdenv.lib.optional stdenv.isDarwin "-DHAVE_UNWIND=1";
 
   postInstall = ''
     for prog in "$dev/bin/"*; do

--- a/pkgs/development/libraries/gstreamer/default.nix
+++ b/pkgs/development/libraries/gstreamer/default.nix
@@ -1,7 +1,7 @@
-{ callPackage }:
+{ callPackage, CoreServices }:
 
 rec {
-  gstreamer = callPackage ./core { };
+  gstreamer = callPackage ./core { inherit CoreServices; };
 
   gstreamermm = callPackage ./gstreamermm { };
 

--- a/pkgs/development/libraries/gstreamer/legacy/gstreamer/default.nix
+++ b/pkgs/development/libraries/gstreamer/legacy/gstreamer/default.nix
@@ -1,5 +1,5 @@
 { fetchurl, fetchpatch, stdenv, autoreconfHook
-, perl, bison2, flex, pkgconfig, glib, libxml2, libintl
+, perl, bison2, flex, pkgconfig, glib, libxml2, libintl, libunwind
 }:
 
 stdenv.mkDerivation rec {
@@ -16,6 +16,7 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [ autoreconfHook flex perl pkgconfig libintl bison2 glib ];
+  buildInputs = stdenv.lib.optional stdenv.isDarwin libunwind;
   propagatedBuildInputs = [ glib libxml2 ];
 
   patches = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10671,6 +10671,7 @@ in
 
   gst_all_1 = recurseIntoAttrs(callPackage ../development/libraries/gstreamer {
     callPackage = newScope { libav = pkgs.ffmpeg_4; };
+    inherit (darwin.apple_sdk.frameworks) CoreServices;
   });
 
   gstreamer = callPackage ../development/libraries/gstreamer/legacy/gstreamer { };


### PR DESCRIPTION
###### Motivation for this change

Another fix to unblock `qt5.qtmultimedia` #63617.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---