### PR TITLE
openalSolf, mpv: fix, enable HRTF support

### DIFF
--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -46,7 +46,7 @@
 , youtubeSupport     ? true,           youtube-dl    ? null
 , archiveSupport     ? false,          libarchive    ? null
 , jackaudioSupport   ? false,          libjack2      ? null
-, openalSupport      ? false,          openalSoft    ? null
+, openalSupport      ? true,          openalSoft    ? null
 , vapoursynthSupport ? false,          vapoursynth   ? null
 }:
 

--- a/pkgs/development/libraries/openal-soft/default.nix
+++ b/pkgs/development/libraries/openal-soft/default.nix
@@ -20,6 +20,14 @@ stdenv.mkDerivation rec {
     sha256 = "0b0g0q1c36nfb289xcaaj3cmyfpiswvvgky3qyalsf9n4dj7vnzi";
   };
 
+  # this will make it find its own data files (e.g. HRTF profiles)
+  # without any other configuration
+  patches = [ ./search-out.patch ];
+  postPatch = ''
+    substituteInPlace Alc/helpers.c \
+      --replace "@OUT@" $out
+  '';
+
   nativeBuildInputs = [ cmake ];
 
   buildInputs = []

--- a/pkgs/development/libraries/openal-soft/search-out.patch
+++ b/pkgs/development/libraries/openal-soft/search-out.patch
@@ -1,0 +1,12 @@
+diff -Nuar a/Alc/helpers.c b/Alc/helpers.c
+--- a/Alc/helpers.c	1970-01-01 00:00:01.000000000 +0000
++++ b/Alc/helpers.c	1970-01-01 00:00:02.000000000 +0000
+@@ -951,6 +951,8 @@
+             }
+         }
+ 
++        DirectorySearch("@OUT@/share", ext, &results);
++
+         alstr_reset(&path);
+     }
+ 


### PR DESCRIPTION
# What? Why?

Fixing HRTF (see https://en.wikipedia.org/wiki/Head-related_transfer_function) functionality in `openalSolf` and then enabling it by defeault in `mpv` is the simplest way I found to get proper sound output for media files with more than two channels of audio.

For instance, say you want to properly hear all of the channels of a 5.1 movie while wearing stereo headphones. Applying this patchset makes it magically work in plain simple `mpv` without any hacking with ALSA mapping tables, PulseAudio, jackd, etc.

As a nice bonus, using this also allows to map `mpv` sound output with a HRTF. The default HRTF that comes with `openalSolf` is not particularly awesome, but it works, and it can be easily configured via `~/.alsoftrc` if desired.

# `git log`

- openalSolf: make it search its own $out for data files

  Without those data files HRTF will silently fail to initialize.

  It searches /usr and /usr/local by default but we don't have those paths.
  It also searches XDG_DATA_DIRS but using that requires configuration by the
  user. This patch makes makes it just work.

  How to play with it:

  - Build `mpv` with `openalSoft` support.

  - cat << EOF > ~/.alsoftrc
  [general]
  hrtf = true
  EOF

  - Wear stereo headphones.

  - Play a file with 6 or more channels with `mpv -ao openal $file`, e.g.
    https://archive.org/download/5.1SurroundSoundTestFilesVariousFormatsAACAC3MP4DTSWAV/5.1%20Surround%20Sound%20AAC%20Test.mp4

  - Try `hrtf = false` to hear the difference.

- mpv: enable openal support by default

  See the previous commit.

# `nix-instantiate` environment

- Host OS: Linux 4.9, SLNOS 19.09
- Nix: nix-env (Nix) 2.2.2
- Multi-user: yes
- Sandbox: yes
- NIXPKGS_CONFIG:

```nix
{
  checkMeta = true;
  doCheckByDefault = true;
}
```

# `nix-env -qaP` diffs

- On x86_64-linux:
  - Updated (189):
    - _90secondportraits
    - airwave
    - alienarena
    - allegro
    - allegro5
    - alure
    - andyetitmoves
    - arx-libertatis
    - assaultcube
    - astromenace
    - atanks
    - attract-mode
    - bino3d
    - blackshades
    - blender
    - cgui
    - csfml
    - curseradio
    - deepin.dde-file-manager
    - deepin.deepin-movie-reborn
    - desmume
    - dhewm3
    - digikam
    - digikam5
    - dolphinEmu
    - dolphinEmuMaster
    - duckmarines
    - dumb
    - dwarf_fortress
    - dwarf-fortress
    - dwarf-fortress-packages.dwarf-fortress_0_43_05
    - dwarf-fortress-packages.dwarf-fortress_0_44_05
    - dwarf-fortress-packages.dwarf-fortress_0_44_09
    - dwarf-fortress-packages.dwarf-fortress_0_44_10
    - dwarf-fortress-packages.dwarf-fortress_0_44_11
    - dwarf-fortress-packages.dwarf-fortress-full
    - dwarf-fortress-packages.dwarf-fortress-original
    - dwarf-fortress-packages.dwarf-therapist
    - EmptyEpsilon
    - endless-sky
    - extremetuxracer
    - ffmpeg-full
    - flightgear
    - freealut
    - freeorion
    - fsuae
    - garden-of-coloured-lights
    - gemrb
    - gnome-mpv
    - gzdoom
    - handbrake
    - higan
    - hydron
    - ioquake3
    - kdeApplications.konquest
    - kdeApplications.libkdegames
    - kodiPlugins.steam-launcher
    - libretro.dolphin
    - libsForQt511.libqtav
    - libsForQt5.libqtav
    - linux-steam-integration
    - liquidsoap
    - liquidwar5
    - love
    - love_0_7
    - love_0_8
    - love_0_9
    - love_11
    - lugaru
    - lutris
    - mars
    - megaglest
    - meguca
    - minetest
    - minetestclient_4
    - mosdepth
    - mpc-qt
    - mpv
    - mpv-with-scripts
    - mrrescue
    - naev
    - nim
    - nrpl
    - olive-editor
    - openal
    - openarena
    - openclonk
    - opendungeons
    - openmw
    - openmw-tes3mp
    - openra
    - openraPackages.engines.bleed
    - openraPackages.engines.playtest
    - openraPackages.mods.ca
    - openraPackages.mods.d2
    - openraPackages.mods.dr
    - openraPackages.mods.gen
    - openraPackages.mods.kknd
    - openraPackages.mods.mw
    - openraPackages.mods.ra2
    - openraPackages.mods.raclassic
    - openraPackages.mods.rv
    - openraPackages.mods.sp
    - openraPackages.mods.ss
    - openraPackages.mods.ura
    - openraPackages.mods.yr
    - openrw
    - openspades
    - orthorobot
    - pipelight
    - playonlinux
    - plex-media-player
    - python27Packages.mpv
    - python27Packages.pydub
    - python37Packages.mpv
    - python37Packages.pydub
    - qtox
    - quake3demo
    - quake3game
    - racer
    - rigsofrods
    - rimshot
    - rpcs3
    - scorched3d
    - sfml
    - sienna
    - simgear
    - slade
    - sladeUnstable
    - solarus
    - solarus-quest-editor
    - soundkonverter
    - speed_dreams
    - spring
    - springLobby
    - steam
    - steamcmd
    - steam-run
    - steam-run-native
    - stuntrally
    - superTux
    - superTuxKart
    - tdesktop
    - tdm
    - tome4
    - torcs
    - toxic
    - trigger
    - ue4demos.black_jack
    - ue4demos.blueprint_examples_demo
    - ue4demos.card_game
    - ue4demos.effects_cave_demo
    - ue4demos.elemental_demo
    - ue4demos.landscape_mountains
    - ue4demos.matinee_demo
    - ue4demos.mobile_temple_demo
    - ue4demos.realistic_rendering
    - ue4demos.reflections_subway
    - ue4demos.scifi_hallway_demo
    - ue4demos.shooter_game
    - ue4demos.strategy_game
    - ue4demos.stylized_demo
    - ue4demos.swing_ninja
    - ue4demos.tappy_chicken
    - ue4demos.vehicle_game
    - ultimatestunts
    - unigine-valley
    - urbanterror
    - ut2004demo
    - utox
    - vapor
    - vbam
    - voxelands
    - warsow
    - warsow-engine
    - warzone2100
    - wine
    - wineFull
    - wine-staging
    - wineStaging
    - winetricks
    - wineWowPackages.full
    - yquake2
    - yquake2-all-games
    - yquake2-ctf
    - yquake2-ground-zero
    - yquake2-the-reckoning
    - zdoom
    - zeroad
- On aarch64-linux:
  - Updated (127):
    - _90secondportraits
    - alienarena
    - allegro
    - allegro5
    - alure
    - arx-libertatis
    - assaultcube
    - astromenace
    - atanks
    - attract-mode
    - bino3d
    - blackshades
    - cgui
    - csfml
    - curseradio
    - deepin.dde-file-manager
    - deepin.deepin-movie-reborn
    - desmume
    - dhewm3
    - digikam
    - digikam5
    - duckmarines
    - dumb
    - EmptyEpsilon
    - endless-sky
    - extremetuxracer
    - ffmpeg-full
    - flightgear
    - freealut
    - freeorion
    - garden-of-coloured-lights
    - gemrb
    - gnome-mpv
    - handbrake
    - higan
    - hydron
    - ioquake3
    - kdeApplications.konquest
    - kdeApplications.libkdegames
    - libretro.dolphin
    - libsForQt511.libqtav
    - libsForQt5.libqtav
    - liquidsoap
    - liquidwar5
    - love
    - love_0_7
    - love_0_8
    - love_0_9
    - love_11
    - lugaru
    - mars
    - megaglest
    - meguca
    - minetest
    - minetestclient_4
    - mosdepth
    - mpc-qt
    - mpv
    - mpv-with-scripts
    - mrrescue
    - naev
    - nim
    - olive-editor
    - openal
    - openarena
    - opendungeons
    - openmw
    - openmw-tes3mp
    - openra
    - openraPackages.engines.bleed
    - openraPackages.engines.playtest
    - openraPackages.mods.ca
    - openraPackages.mods.d2
    - openraPackages.mods.dr
    - openraPackages.mods.gen
    - openraPackages.mods.kknd
    - openraPackages.mods.mw
    - openraPackages.mods.ra2
    - openraPackages.mods.raclassic
    - openraPackages.mods.rv
    - openraPackages.mods.sp
    - openraPackages.mods.ss
    - openraPackages.mods.ura
    - openraPackages.mods.yr
    - openrw
    - openspades
    - orthorobot
    - plex-media-player
    - python27Packages.mpv
    - python27Packages.pydub
    - python37Packages.mpv
    - python37Packages.pydub
    - qtox
    - quake3demo
    - quake3game
    - rimshot
    - scorched3d
    - sfml
    - sienna
    - simgear
    - solarus
    - solarus-quest-editor
    - soundkonverter
    - speed_dreams
    - stuntrally
    - superTux
    - superTuxKart
    - tdesktop
    - torcs
    - toxic
    - trigger
    - ultimatestunts
    - urbanterror
    - utox
    - vapor
    - vbam
    - voxelands
    - warsow
    - warsow-engine
    - warzone2100
    - yquake2
    - yquake2-all-games
    - yquake2-ctf
    - yquake2-ground-zero
    - yquake2-the-reckoning
    - zdoom
    - zeroad
- On x86_64-darwin:
  - Updated (20):
    - curseradio
    - freealut
    - gemrb
    - mpc-qt
    - mpv
    - mpv-with-scripts
    - nim
    - openal
    - openrw
    - openspades
    - plex-media-player
    - python27Packages.mpv
    - python37Packages.mpv
    - qtox
    - sfml
    - yquake2
    - yquake2-all-games
    - yquake2-ctf
    - yquake2-ground-zero
    - yquake2-the-reckoning