### PR TITLE
Update pip tools

### DIFF
--- a/pkgs/development/python-modules/pip-tools/default.nix
+++ b/pkgs/development/python-modules/pip-tools/default.nix
@@ -1,13 +1,12 @@
-{ stdenv, fetchurl, buildPythonPackage, pip, pytest, click, six, first
+{ stdenv, fetchPypi, buildPythonPackage, pip, pytest, click, six, first
 , setuptools_scm, git, glibcLocales, mock }:
 
 buildPythonPackage rec {
   pname = "pip-tools";
   version = "3.3.2";
-  name = pname + "-" + version;
 
-  src = fetchurl {
-    url = "mirror://pypi/p/pip-tools/${name}.tar.gz";
+  src = fetchPypi {
+    inherit pname version;
     sha256 = "100496b15463155f4da3df04c2ca0068677e1ee74d346ebade2d85eef4de8cda";
   };
 

--- a/pkgs/development/python-modules/pip-tools/default.nix
+++ b/pkgs/development/python-modules/pip-tools/default.nix
@@ -3,11 +3,11 @@
 
 buildPythonPackage rec {
   pname = "pip-tools";
-  version = "3.3.2";
+  version = "3.8.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "100496b15463155f4da3df04c2ca0068677e1ee74d346ebade2d85eef4de8cda";
+    sha256 = "1vwh3hx4jrzf51yj9h31nk9ji53lqaq63mlqd7n84hcmfwy3rwz4";
   };
 
   LC_ALL = "en_US.UTF-8";
@@ -16,14 +16,22 @@ buildPythonPackage rec {
 
   disabledTests = stdenv.lib.concatMapStringsSep " and " (s: "not " + s) [
     # Depend on network tests:
+    "test_allow_unsafe_option" #paramaterized, but all fail
+    "test_annotate_option" #paramaterized, but all fail
     "test_editable_package_vcs"
+    "test_editable_top_level_deps_preserved" # can't figure out how to select only one parameter to ignore
+    "test_filter_pip_markers"
     "test_filter_pip_markes"
     "test_generate_hashes_all_platforms"
+    "test_generate_hashes_verbose"
     "test_generate_hashes_with_editable"
+    "test_generate_hashes_with_url"
     "test_generate_hashes_without_interfering_with_each_other"
     "test_get_hashes_local_repository_cache_miss"
     "test_realistic_complex_sub_dependencies"
+    "test_stdin"
     "test_upgrade_packages_option"
+    "test_url_package"
     # Expect specific version of "six":
     "test_editable_package"
     "test_input_file_without_extension"

--- a/pkgs/development/python-modules/pip-tools/default.nix
+++ b/pkgs/development/python-modules/pip-tools/default.nix
@@ -24,6 +24,7 @@ buildPythonPackage rec {
     "test_generate_hashes_with_editable"
     "test_filter_pip_markes"
     "test_get_hashes_local_repository_cache_miss"
+    "test_upgrade_packages_option"
     # Expect specific version of "six":
     "test_editable_package"
     "test_input_file_without_extension"

--- a/pkgs/development/python-modules/pip-tools/default.nix
+++ b/pkgs/development/python-modules/pip-tools/default.nix
@@ -18,12 +18,12 @@ buildPythonPackage rec {
   disabledTests = stdenv.lib.concatMapStringsSep " and " (s: "not " + s) [
     # Depend on network tests:
     "test_editable_package_vcs"
-    "test_generate_hashes_all_platforms"
-    "test_generate_hashes_without_interfering_with_each_other"
-    "test_realistic_complex_sub_dependencies"
-    "test_generate_hashes_with_editable"
     "test_filter_pip_markes"
+    "test_generate_hashes_all_platforms"
+    "test_generate_hashes_with_editable"
+    "test_generate_hashes_without_interfering_with_each_other"
     "test_get_hashes_local_repository_cache_miss"
+    "test_realistic_complex_sub_dependencies"
     "test_upgrade_packages_option"
     # Expect specific version of "six":
     "test_editable_package"


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
