### PR TITLE
distgen: init at 1.3

### DIFF
--- a/pkgs/development/tools/distgen/default.nix
+++ b/pkgs/development/tools/distgen/default.nix
@@ -1,0 +1,32 @@
+{ lib, python3 }:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "distgen";
+  version = "1.3";
+
+  src = python3.pkgs.fetchPypi {
+    inherit pname version;
+    sha256 = "03jwy08wgp1lp6208vks1hv9g1f3aj45cml6k99mm3nw1jfnlbbq";
+  };
+
+  checkInputs = with python3.pkgs; [
+    pytest
+    mock
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    distro
+    jinja2
+    six
+    pyyaml
+  ];
+
+  checkPhase = "make test-unit PYTHON=${python3.executable}";
+
+  meta = with lib; {
+    description = "Templating system/generator for distributions";
+    license = licenses.gpl2Plus;
+    homepage = "https://distgen.readthedocs.io/";
+    maintainers = with maintainers; [ bachp ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1423,6 +1423,8 @@ in
 
   dislocker = callPackage ../tools/filesystems/dislocker { };
 
+  distgen = callPackage ../development/tools/distgen {};
+
   distrobuilder = callPackage ../tools/virtualization/distrobuilder { };
 
   ditaa = callPackage ../tools/graphics/ditaa { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This tool is mainly used in openshift to build source to image containers.
Building a [source to image container](https://github.com/sclorg/s2i-python-container) required `dg` to be present.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
