### PR TITLE
Revert "Remove amdadlsdk and amdappsdk."

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8664,6 +8664,26 @@ in
 
   ### DEVELOPMENT / MISC
 
+  amdadlsdk = callPackage ../development/misc/amdadl-sdk { };
+
+  amdappsdk26 = amdappsdk.override {
+    version = "2.6";
+  };
+
+  amdappsdk27 = amdappsdk.override {
+    version = "2.7";
+  };
+
+  amdappsdk28 = amdappsdk.override {
+    version = "2.8";
+  };
+
+  amdappsdk = callPackage ../development/misc/amdapp-sdk { };
+
+  amdappsdkFull = amdappsdk.override {
+    samples = true;
+  };
+
   amtk = callPackage ../development/libraries/amtk { };
 
   avrlibc      = callPackage ../development/misc/avr/libc {};


### PR DESCRIPTION
# `git log`

- Revert "Remove amdadlsdk and amdappsdk."

  This reverts commit 08ea7c7ee28a24226c051b467ae0fef0584cfe40.

  This was a part of #61823.

  Firstly, that commit removed those attributes without removing the files
  they refer to, which is strange.

  Secondly, I have a very old but GPGPU-capabale AMD card which doesn't work
  with newer OpenCL infrastructure and hence needs these packages to do GPGPU.

# `nix-instantiate` environment

- Host OS: Linux 4.9, SLNOS 19.09
- Nix: nix-env (Nix) 2.2.2
- Multi-user: yes
- Sandbox: yes
- NIXPKGS_CONFIG:

```nix
{
  checkMeta = true;
  doCheckByDefault = true;
}
```

# `nix-env -qaP` diffs

- On x86_64-linux:
  - New (6):
    - amdadlsdk
    - amdappsdk26
    - amdappsdk27
    - amdappsdk28
    - amdappsdk
    - amdappsdkFull
- On aarch64-linux:
  - New (1):
    - amdadlsdk
- On x86_64-darwin: noop

/cc @ambrop72 @joachifm from that PR