### PR TITLE
matrix-synapse: fix documentation

### DIFF
--- a/nixos/doc/manual/configuration/matrix.xml
+++ b/nixos/doc/manual/configuration/matrix.xml
@@ -95,7 +95,7 @@ in {
 
         # forward all Matrix API calls to the synapse Matrix homeserver
         locations."/_matrix" = {
-          proxyPass = "http://[::1]:8008";
+          proxyPass = "http://[::1]:8008/_matrix";
         };
       };
     };


### PR DESCRIPTION
cc @jtojnar @florianjacob from the `git blame`.

My synapse deployment would work properly only with this change, but pinging you to check whether you have the same thing or it's some other configuration difference that forced me to add that. :)