### PR TITLE
imgcat: 2.3.0 -> 2.3.1

### DIFF
--- a/pkgs/applications/graphics/imgcat/default.nix
+++ b/pkgs/applications/graphics/imgcat/default.nix
@@ -1,25 +1,24 @@
 { stdenv, fetchFromGitHub, autoconf, automake, libtool, ncurses }:
 
 stdenv.mkDerivation rec {
-  name = "imgcat-${version}";
-  version = "2.3.0";
+  pname = "imgcat";
+  version = "2.3.1";
 
-  buildInputs = [ autoconf automake libtool ncurses ];
+  nativeBuildInputs = [ autoconf automake libtool ];
+  buildInputs = [ ncurses ];
 
   preConfigure = ''
     ${autoconf}/bin/autoconf
     sed -i -e "s|-ltermcap|-L ${ncurses}/lib -lncurses|" Makefile
   '';
 
-  preInstall = ''
-    makeFlagsArray=(PREFIX="$out");
-  '';
+  makeFlags = [ "PREFIX=$(out)" ];
 
   src = fetchFromGitHub {
     owner = "eddieantonio";
-    repo = "imgcat";
-    rev = "3d854c72f785dce0eecd9485767a7f972d54890c";
-    sha256 = "0m83c33rzxvs0w214njql2c7q3fg06wnyijch3l2s88i7frl121f";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0frz40rjwi73nx2dlqvmnn56zwr29bmnngfb11hhwr7v58yfajdi";
   };
 
   NIX_CFLAGS_COMPILE = "-Wno-error";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
