### PR TITLE
Fix Handbrake build on Darwin by turning off GUI support

### DIFF
--- a/pkgs/applications/video/handbrake/default.nix
+++ b/pkgs/applications/video/handbrake/default.nix
@@ -2,10 +2,14 @@
 #
 # Derivation patches HandBrake to use Nix closure dependencies.
 #
+# NOTE: 2019-07-19: This derivation does not currently support the native macOS
+# GUI--it produces the "HandbrakeCLI" CLI version only. In the future it would
+# be nice to add the native GUI (and/or the GTK GUI) as an option too, but that
+# requires invoking the Xcode build system, which is non-trivial for now.
 
 { stdenv, lib, fetchurl,
   # Main build tools
-  python2, pkgconfig, autoconf, automake, cmake, nasm, libtool, m4,
+  python2, pkgconfig, autoconf, automake, cmake, nasm, libtool, m4, lzma,
   # Processing, video codecs, containers
   ffmpeg-full, nv-codec-headers, libogg, x264, x265, libvpx, libtheora,
   # Codecs, audio
@@ -14,19 +18,33 @@
   libiconv, fribidi, fontconfig, freetype, libass, jansson, libxml2, harfbuzz,
   # Optical media
   libdvdread, libdvdnav, libdvdcss, libbluray,
-  useGtk ? true, wrapGAppsHook ? null,
-                 intltool ? null,
-                 glib ? null,
-                 gtk3 ? null,
-                 libappindicator-gtk3 ? null,
-                 libnotify ? null,
-                 gst_all_1 ? null,
-                 dbus-glib ? null,
-                 udev ? null,
-                 libgudev ? null,
-                 hicolor-icon-theme ? null,
+  # Darwin-specific
+  AudioToolbox ? null,
+  Foundation ? null,
+  libobjc ? null,
+  VideoToolbox ? null,
+  # GTK
+  # NOTE: 2019-07-19: The gtk3 package has a transitive dependency on dbus,
+  # which in turn depends on systemd. systemd is not supported on Darwin, so
+  # for now we disable GTK GUI support on Darwin. (It may be possible to remove
+  # this restriction later.)
+  useGtk ? !stdenv.isDarwin, wrapGAppsHook ? null,
+                             intltool ? null,
+                             glib ? null,
+                             gtk3 ? null,
+                             libappindicator-gtk3 ? null,
+                             libnotify ? null,
+                             gst_all_1 ? null,
+                             dbus-glib ? null,
+                             udev ? null,
+                             libgudev ? null,
+                             hicolor-icon-theme ? null,
+  # FDK
   useFdk ? false, fdk_aac ? null
 }:
+
+assert stdenv.isDarwin -> AudioToolbox != null && Foundation != null
+  && libobjc != null && VideoToolbox != null;
 
 stdenv.mkDerivation rec {
   pname = "handbrake";
@@ -45,12 +63,13 @@ stdenv.mkDerivation rec {
     ffmpeg-full libogg libtheora x264 x265 libvpx
     libopus lame libvorbis a52dec speex libsamplerate
     libiconv fribidi fontconfig freetype libass jansson libxml2 harfbuzz
-    libdvdread libdvdnav libdvdcss libbluray
+    libdvdread libdvdnav libdvdcss libbluray lzma
   ] ++ lib.optionals useGtk [
     glib gtk3 libappindicator-gtk3 libnotify
     gst_all_1.gstreamer gst_all_1.gst-plugins-base dbus-glib udev
     libgudev hicolor-icon-theme
   ] ++ lib.optional useFdk fdk_aac
+    ++ lib.optionals stdenv.isDarwin [ AudioToolbox Foundation libobjc VideoToolbox ]
   # NOTE: 2018-12-27: Handbrake supports nv-codec-headers for Linux only,
   # look at ./make/configure.py search "enable_nvenc"
     ++ lib.optional stdenv.isLinux nv-codec-headers;
@@ -66,6 +85,8 @@ stdenv.mkDerivation rec {
 
     substituteInPlace libhb/module.defs \
       --replace /usr/include/libxml2 ${libxml2.dev}/include/libxml2
+    substituteInPlace libhb/module.defs \
+      --replace '$(CONTRIB.build/)include/libxml2' ${libxml2.dev}/include/libxml2
 
     # Force using nixpkgs dependencies
     sed -i '/MODULES += contrib/d' make/include/main.defs
@@ -75,8 +96,9 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--disable-df-fetch"
     "--disable-df-verify"
-    (if useGtk then "--disable-gtk-update-checks" else "--disable-gtk")
-    (if useFdk then "--enable-fdk-aac"            else "")
+    (if useGtk          then "--disable-gtk-update-checks" else "--disable-gtk")
+    (if useFdk          then "--enable-fdk-aac"            else "")
+    (if stdenv.isDarwin then "--disable-xcode"             else "")
   ];
 
   # NOTE: 2018-12-27: Check NixOS HandBrake test if changing

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18990,7 +18990,10 @@ in
 
   lxdvdrip = callPackage ../applications/video/lxdvdrip { };
 
-  handbrake = callPackage ../applications/video/handbrake { };
+  handbrake = callPackage ../applications/video/handbrake {
+    inherit (darwin.apple_sdk.frameworks) AudioToolbox Foundation VideoToolbox;
+    inherit (darwin) libobjc;
+  };
 
   lilyterm = callPackage ../applications/misc/lilyterm {
     inherit (gnome2) vte;


### PR DESCRIPTION
###### Motivation for this change

* **Fix cairo build on macOS** by disabling Xlib support.
* **Fix ffmpeg-full build on macOS** by making sure that the `nvenc` option is not used.
* **Fix handbrake build** by adding a dependency on lzma (for all platforms) and adding some Darwin-specific libraries and patches.
* **Fix mp4v2 build** by building against the C++03 standard. The package has some code that is not valid under the newer standards.
* **Add [video-transcoding](https://github.com/donmelton/video_transcoding),** a set of scripts for transcoding, inspecting, and converting videos.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @codyopel @fuuzetsu @Anton-Latukha @wmertens