### PR TITLE
sccache: init at 0.2.8

### DIFF
--- a/pkgs/development/tools/misc/sccache/default.nix
+++ b/pkgs/development/tools/misc/sccache/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, cargo, rustc, rustPlatform, pkgconfig, glib, openssl }:
+
+rustPlatform.buildRustPackage rec {
+  version = "0.2.8";
+  name = "sccache-${version}";
+
+  src = fetchFromGitHub {
+    owner = "mozilla";
+    repo = "sccache";
+    rev = version;
+    sha256 = "08v8s24q6246mdjzl5lirqg0csxcmd17szmw4lw373hvq4xvf0yk";
+  };
+  cargoSha256 = "1lafzin92h1hb1hqmbrsxja44nj8mpbsxhwcjr6rf5yrclgwmcxj";
+  cargoBuildFlags = [ "--features=all" ];
+  nativeBuildInputs = [
+    pkgconfig cargo rustc
+  ];
+  buildInputs = [
+    openssl
+  ];
+  # Tests fail because of client server setup which is not possible inside the pure environment,
+  # see https://github.com/mozilla/sccache/issues/460
+  checkPhase = null;
+
+  meta = with stdenv.lib; {
+    description = "Ccache with Cloud Storage";
+    homepage = https://github.com/mozilla/sccache;
+    maintainers = with maintainers; [ doronbehar ];
+    license = licenses.asl20;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/tools/misc/sccache/default.nix
+++ b/pkgs/development/tools/misc/sccache/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cargo, rustc, rustPlatform, pkgconfig, glib, openssl }:
+{ stdenv, fetchFromGitHub, cargo, rustc, rustPlatform, pkgconfig, glib, openssl, darwin }:
 
 rustPlatform.buildRustPackage rec {
   version = "0.2.8";
@@ -17,7 +17,7 @@ rustPlatform.buildRustPackage rec {
   ];
   buildInputs = [
     openssl
-  ];
+  ] ++ stdenv.lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Security;
   # Tests fail because of client server setup which is not possible inside the pure environment,
   # see https://github.com/mozilla/sccache/issues/460
   checkPhase = null;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24135,6 +24135,8 @@ in
 
   iterm2 = callPackage ../applications/misc/iterm2 {};
 
+  sccache = callPackage ../development/tools/misc/sccache { };
+
   sequeler = callPackage ../applications/misc/sequeler { };
 
   sequelpro = callPackage ../applications/misc/sequelpro {};


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This is the beginning of a new compiler cache support for NixOS, starting with the bare package. As discussed here: https://discourse.nixos.org/t/use-sccache-for-rust-compilation-cache/3228 . Currently tests are disabled due to https://github.com/mozilla/sccache/issues/460 .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)) - not applicable.
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"` - non depend.
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---