### PR TITLE
Unp fixes

### DIFF
--- a/pkgs/tools/archivers/unp/default.nix
+++ b/pkgs/tools/archivers/unp/default.nix
@@ -1,7 +1,11 @@
-{ stdenv, lib, fetchurl, makeWrapper, perl, unrar, unzip, gzip, file, extraBackends ? [] }:
+{ stdenv, lib, fetchurl, makeWrapper, perl
+, unzip, gzip, file
+# extractors which are added to unp’s PATH
+, extraBackends ? []
+}:
 
 let
-  runtime_bins =  [ file unrar unzip gzip ] ++ extraBackends;
+  runtime_bins =  [ file unzip gzip ] ++ extraBackends;
 
 in stdenv.mkDerivation rec {
   name = "unp-${version}";

--- a/pkgs/tools/archivers/unp/default.nix
+++ b/pkgs/tools/archivers/unp/default.nix
@@ -1,11 +1,12 @@
 { stdenv, lib, fetchurl, makeWrapper, perl, unrar, unzip, gzip, file, extraBackends ? [] }:
 
-stdenv.mkDerivation rec {
+let
+  runtime_bins =  [ file unrar unzip gzip ] ++ extraBackends;
+
+in stdenv.mkDerivation rec {
   name = "unp-${version}";
   version = "2.0-pre7";
-
-  runtime_bins =  [ file unrar unzip gzip ] ++ extraBackends;
-  buildInputs = [ perl makeWrapper ] ++ runtime_bins;
+  buildInputs = [ perl makeWrapper ];
 
   src = fetchurl {
     # url = "http://http.debian.net/debian/pool/main/u/unp/unp_2.0~pre7+nmu1.tar.bz2";
@@ -18,10 +19,10 @@ stdenv.mkDerivation rec {
   buildPhase = "true";
   installPhase = ''
   mkdir -p $out/bin
-  mkdir -p $out/share/man
-  cp unp $out/bin/
-  cp ucat $out/bin/
-  cp debian/unp.1 $out/share/man
+  mkdir -p $out/share/man/man1
+  install ./unp $out/bin/unp
+  install ./ucat $out/bin/ucat
+  cp debian/unp.1 $out/share/man/man1
 
   wrapProgram $out/bin/unp \
     --prefix PATH : ${lib.makeBinPath runtime_bins}


### PR DESCRIPTION
##### Motivation for this change

`unrar` was in the default build, making unp unfree. Also fixes the manpage (see commits)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @timor 
@GrahamcOfBorg build unp