### PR TITLE
Update deepin packages

### DIFF
--- a/pkgs/desktops/deepin/dde-api/default.nix
+++ b/pkgs/desktops/deepin/dde-api/default.nix
@@ -25,7 +25,7 @@
 buildGoPackage rec {
   name = "${pname}-${version}";
   pname = "dde-api";
-  version = "3.18.3";
+  version = "3.18.4.1";
 
   goPackagePath = "pkg.deepin.io/dde/api";
 
@@ -33,7 +33,7 @@ buildGoPackage rec {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "0sbzjpjy2d7j22v5sw3mf472lcnsy81n2rgly87k79r5gk9x89ar";
+    sha256 = "0bcjp5ijwa4wmx6p43lik6vjlb7d5rk7nf8xl495i3yk9x70wyfa";
   };
 
   goDeps = ./deps.nix;

--- a/pkgs/desktops/deepin/dde-api/deps.nix
+++ b/pkgs/desktops/deepin/dde-api/deps.nix
@@ -32,8 +32,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/disintegration/imaging";
-      rev = "061e8a750a4db9667cdf9e2af7f4029ba506cb3b";
-      sha256 = "13fkknwz2iby5rdzv9sgam6p27zdgxis3sxgyls9sdir5lbhjhm7";
+      rev = "465faf0892b5c7b3325643b0e47282e1331672e7";
+      sha256 = "1z9rkphmqgyphznl53pp1gmf0dfrfrmr95bx46p422ldml26c5a0";
     };
   }
   {
@@ -41,8 +41,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/fogleman/gg";
-      rev = "72436a171bf31757dc87fb8fa9f7485307350307";
-      sha256 = "116ysxj7nv9zw5ff75p2mriwf6fx4qzdik9za8cy0l0vih78qvjq";
+      rev = "f194ddec6f45226fc9e1b4a61b7237f186edd543";
+      sha256 = "095g5hpqvpy5w9l4kb65cif013snsvlbw6sgln0kwdix0z099j3i";
     };
   }
   {
@@ -77,8 +77,8 @@
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/image";
-      rev = "6d32002ffd7577f23673706728e1c510698cecb1";
-      sha256 = "03jzn07kfgdzzm4785xngcksv9ix6q1lf12b8j91flc0v7swsd1b";
+      rev = "7e034cad644213bc79b336b52fce73624259aeca";
+      sha256 = "04n4yi0p2yjv8sr9dmnzwc2k6hvzzvl6jdq2xd043kvjwzk583va";
     };
   }
   {
@@ -86,8 +86,8 @@
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/net";
-      rev = "f4e77d36d62c17c2336347bb2670ddbd02d092b7";
-      sha256 = "0avjnglqqg9ya0cbhp23m4namykii219kxjywxn4cd7pfcc5arha";
+      rev = "3b0461eec859c4b73bb64fdc8285971fd33e3938";
+      sha256 = "0l00c8l0a8xnv6qdpwfzxxsr58jggacgzdrwiprrfx2xqm37b6d5";
     };
   }
   {

--- a/pkgs/desktops/deepin/dde-calendar/default.nix
+++ b/pkgs/desktops/deepin/dde-calendar/default.nix
@@ -1,22 +1,22 @@
-{ stdenv, fetchFromGitHub, pkgconfig, qmake, qttools,
+{ stdenv, fetchFromGitHub, pkgconfig, cmake, qttools,
   deepin-gettext-tools, dtkcore, dtkwidget, deepin
 }:
 
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "dde-calendar";
-  version = "1.2.6";
+  version = "1.2.10";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "0k973rv0prvr7cg1xwg7kr14fkx13aslhiqc3q7vpakfk53qsw4n";
+    sha256 = "00aqx24jccf88vvkpb9svyjz8knrqyjgd0152psf9dxc9q13f61h";
   };
 
   nativeBuildInputs = [
+    cmake
     pkgconfig
-    qmake
     qttools
     deepin-gettext-tools
     deepin.setupHook

--- a/pkgs/desktops/deepin/dde-daemon/default.nix
+++ b/pkgs/desktops/deepin/dde-daemon/default.nix
@@ -9,7 +9,7 @@
 buildGoPackage rec {
   name = "${pname}-${version}";
   pname = "dde-daemon";
-  version = "3.27.1";
+  version = "3.27.2.5";
 
   goPackagePath = "pkg.deepin.io/dde/daemon";
 
@@ -17,7 +17,7 @@ buildGoPackage rec {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "1rbv7fals2bwhalw1hh3swmrdzclqbhny782shnrwqv53235xda3";
+    sha256 = "117yhsb0axwblncyj02fhcyl4b7jl7vvh1bbx08bscih5lnvjihx";
   };
 
   patches = [

--- a/pkgs/desktops/deepin/dde-daemon/deps.nix
+++ b/pkgs/desktops/deepin/dde-daemon/deps.nix
@@ -77,8 +77,8 @@
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/image";
-      rev = "6d32002ffd7577f23673706728e1c510698cecb1";
-      sha256 = "03jzn07kfgdzzm4785xngcksv9ix6q1lf12b8j91flc0v7swsd1b";
+      rev = "7e034cad644213bc79b336b52fce73624259aeca";
+      sha256 = "04n4yi0p2yjv8sr9dmnzwc2k6hvzzvl6jdq2xd043kvjwzk583va";
     };
   }
   {
@@ -86,8 +86,8 @@
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/net";
-      rev = "f4e77d36d62c17c2336347bb2670ddbd02d092b7";
-      sha256 = "0avjnglqqg9ya0cbhp23m4namykii219kxjywxn4cd7pfcc5arha";
+      rev = "3b0461eec859c4b73bb64fdc8285971fd33e3938";
+      sha256 = "0l00c8l0a8xnv6qdpwfzxxsr58jggacgzdrwiprrfx2xqm37b6d5";
     };
   }
   {

--- a/pkgs/desktops/deepin/dde-dock/default.nix
+++ b/pkgs/desktops/deepin/dde-dock/default.nix
@@ -8,13 +8,13 @@ let
 unwrapped = stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "dde-dock";
-  version = "4.9.9";
+  version = "4.10.3";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "0vscm808q63bbl84q9l3vhhd8mw86wfjdh55rvyj42qpa5q4mvlz";
+    sha256 = "17iy78r0frpv42g521igfdcgdklbifzig1wzxq2nl14fq0bgxg4v";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/deepin/dde-file-manager/default.nix
+++ b/pkgs/desktops/deepin/dde-file-manager/default.nix
@@ -11,13 +11,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "dde-file-manager";
-  version = "4.8.6.2";
+  version = "4.8.6.4";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "1qw9slssvy6c4j9czyqrhlr3pq6hzxybb86darja2vka84zmvwip";
+    sha256 = "1m0ykw5a91rm5xcah8bzk21xsambqvncj8104ihdhf9h0z9kdmm2";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/deepin/dde-polkit-agent/default.nix
+++ b/pkgs/desktops/deepin/dde-polkit-agent/default.nix
@@ -4,13 +4,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "dde-polkit-agent";
-  version = "0.2.6";
+  version = "0.2.10";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "1ih78sxhnn6hbx9mzhalx95dk18f217mjbvymf8dky2vkmw8vnmx";
+    sha256 = "0syg121slpd6d9xpifgcf85lg9ca0k96cl1g3rjvsmczs2d2ffgf";
   };
 
   nativeBuildInputs = [
@@ -25,10 +25,6 @@ stdenv.mkDerivation rec {
     dtkcore
     dtkwidget
     polkit-qt
-  ];
-
-  patches = [
-    ./dde-polkit-agent.plugins-dir.patch
   ];
 
   postPatch = ''

--- a/pkgs/desktops/deepin/dde-qt-dbus-factory/default.nix
+++ b/pkgs/desktops/deepin/dde-qt-dbus-factory/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "dde-qt-dbus-factory";
-  version = "1.1.1";
+  version = "1.1.5";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "1b2i5m6fzkga72hbl85v2rng3qq53di39p7jj2f119wmlfbyp2vg";
+    sha256 = "1jzfblsmnfpgym95mmbd8mjkk8wqqfb0kz6n6fy742hmqlzrpsj7";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/deepin/dde-session-ui/default.nix
+++ b/pkgs/desktops/deepin/dde-session-ui/default.nix
@@ -6,13 +6,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "dde-session-ui";
-  version = "4.9.6";
+  version = "4.9.11";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "1wk5mjv1g9my80cxpcycqkm2gjc5r5rrcpxmsl06w4g2c19k50x1";
+    sha256 = "16nrlqw8p9s4ncypg4q2df9xpg37y6hqcjn0zmrsfnc5j3i0z82a";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/deepin/deepin-anything/default.nix
+++ b/pkgs/desktops/deepin/deepin-anything/default.nix
@@ -4,13 +4,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "deepin-anything";
-  version = "0.0.7";
+  version = "0.1.0";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "1qggqjjqz2y51pag0v5qniv6763mgrmzjmr7248xx2paw3a923vk";
+    sha256 = "1kvyffrii4b012f6ld1ih14qrn7gg5cxbdpbkac0wxb22hnz0azm";
   };
 
   outputs = [ "out" "modsrc" ];

--- a/pkgs/desktops/deepin/deepin-desktop-base/default.nix
+++ b/pkgs/desktops/deepin/deepin-desktop-base/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "deepin-desktop-base";
-  version = "2019.04.24";
+  version = "2019.06.19";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "0mdfjkyjrccxlsg05mf80qcw8v5srlp80rvjkpnnbhfscq1fnpgn";
+    sha256 = "1r158x4z4qalv4q1ni3aln05krdzblvr7y6wyciwl7cr5ag1i1jy";
   };
 
   nativeBuildInputs = [ deepin.setupHook ];

--- a/pkgs/desktops/deepin/deepin-desktop-schemas/default.nix
+++ b/pkgs/desktops/deepin/deepin-desktop-schemas/default.nix
@@ -4,13 +4,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "deepin-desktop-schemas";
-  version = "3.13.0";
+  version = "3.13.6";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "0bamjcpmsl8xhw3ksgl11wv5xwcdhrkl1namikfzc4an03sk1rdq";
+    sha256 = "03jqb47kjyb9b43m2yincfjn2i43ma1pn1hddyicrrpg937caa81";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/deepin/deepin-gtk-theme/default.nix
+++ b/pkgs/desktops/deepin/deepin-gtk-theme/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "deepin-gtk-theme";
-  version = "17.10.10";
+  version = "17.10.11";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = "deepin-gtk-theme";
     rev = version;
-    sha256 = "0vwly24cvjwhvda7g3l595vpf99d2z7b2zr0q5kna4df4iql7vn4";
+    sha256 = "0zs6mq70yd1k3d9zm3q6zxnw1md56r4imad5imdxwx58yxdx47fw";
   };
 
   propagatedUserEnvPkgs = [ gtk-engine-murrine ];

--- a/pkgs/desktops/deepin/deepin-icon-theme/default.nix
+++ b/pkgs/desktops/deepin/deepin-icon-theme/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "deepin-icon-theme";
-  version = "15.12.69";
+  version = "15.12.71";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "1y6r2as3acqkq8z1d44c82jfplihscmqc9fgpq1j0anznwcdj73k";
+    sha256 = "12rzzjp906np95ckbxrd4mb345lm198wz69kxy48f8q1zg78q8iw";
   };
 
   nativeBuildInputs = [ gtk3 xcursorgen ];

--- a/pkgs/desktops/deepin/deepin-image-viewer/default.nix
+++ b/pkgs/desktops/deepin/deepin-image-viewer/default.nix
@@ -6,13 +6,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "deepin-image-viewer";
-  version = "1.3.13";
+  version = "1.3.17";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "1ql3li63qiw92jx5jzmx3k115vdn3cjfysja3afjhmfngq1xibmj";
+    sha256 = "0hz4f1kqcycyvggwfzpkblhhha87rqd427hq0mf31jfh5x17ymnh";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/deepin/deepin-menu/default.nix
+++ b/pkgs/desktops/deepin/deepin-menu/default.nix
@@ -4,13 +4,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "deepin-menu";
-  version = "3.4.6";
+  version = "3.4.8";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "1gxf3slqx1s15bjrds29sas7ah6kp8c4pjvzwipncyx6qfgczj2a";
+    sha256 = "09i0ybllymlj7s46pxma5py6x8nknfja4gxn5gj9kpf2c37qsqjc";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/deepin/deepin-movie-reborn/default.nix
+++ b/pkgs/desktops/deepin/deepin-movie-reborn/default.nix
@@ -5,13 +5,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "deepin-movie-reborn";
-  version = "3.2.22.1";
+  version = "3.2.24";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "1qh079j4c2n33z0ykv87af9vfkmdxxrv6dy54wdqdpr7vrhn89gb";
+    sha256 = "16mxym7dm6qk90q2w7xqm62047rq0lirrjmnnpaxshzaww9gngkh";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/desktops/deepin/deepin-screenshot/default.nix
+++ b/pkgs/desktops/deepin/deepin-screenshot/default.nix
@@ -5,13 +5,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "deepin-screenshot";
-  version = "4.1.10";
+  version = "4.2.1";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "00zmmnvm5wv9fkc9fbqs23jsqs1mnr68afl4irj6y287ic0pj61i";
+    sha256 = "16wy1ywp4lm7fg488laqxgxpir745rbpj9z410r6x7krpgjds189";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/deepin/deepin-terminal/default.nix
+++ b/pkgs/desktops/deepin/deepin-terminal/default.nix
@@ -7,13 +7,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "deepin-terminal";
-  version = "3.2.2.1";
+  version = "3.2.6";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = "deepin-terminal";
     rev = version;
-    sha256 = "08bhdd9q4aqy5yjbpqy918j63c3b2rrdqdkxh3fk258n1fm72gmw";
+    sha256 = "09s5gvzfxfb353kb61x1b6z3h2aqgln3s3mah3f3zkf5y8hrp2pj";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/deepin/dtkcore/default.nix
+++ b/pkgs/desktops/deepin/dtkcore/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "dtkcore";
-  version = "2.0.12.1";
+  version = "2.0.14";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "1akfzkdhgsndm6rlr7snhpznxj0w351v6rr8vvnr6ka2dw75xsl4";
+    sha256 = "0yc6zx8rhzg9mj2brggcsr1jy1pzfvgqy1h305y2dwnx5haazd04";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/deepin/dtkwidget/default.nix
+++ b/pkgs/desktops/deepin/dtkwidget/default.nix
@@ -5,13 +5,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "dtkwidget";
-  version = "2.0.12.3";
+  version = "2.0.14";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "0z71il09gj1frkxfw3av97szh17spr6ss1k07l0prk1s1wm7yyfr";
+    sha256 = "11ws0rl7rhlgwbqd4nqpqxhngf4lcyfrrdq33wzxwdlk33d69i1h";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/deepin/go-dbus-factory/default.nix
+++ b/pkgs/desktops/deepin/go-dbus-factory/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "go-dbus-factory";
-  version = "0.7.0";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "080bcwbq00d91iazgl59cp5ra2x6xkhnc41ipvglvrkibq9zi1a4";
+    sha256 = "06fqyad9f50gcjsjkh7929yyaprahdjhnd0dr4gl2797a7wysl3f";
   };
 
   makeFlags = [ "PREFIX=${placeholder ''out''}" ];

--- a/pkgs/desktops/deepin/go-gir-generator/default.nix
+++ b/pkgs/desktops/deepin/go-gir-generator/default.nix
@@ -4,13 +4,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "go-gir-generator";
-  version = "2.0.1";
+  version = "2.0.2";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "0jdhfnwrpp77893zxljr453w23kahqsdpd8a8i5jp6pyvkdm816j";
+    sha256 = "1ydzll8zlk897iqcihvv6p046p0rzr4qqz2drmz2nx95njp8n03a";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/deepin/qt5dxcb-plugin/default.nix
+++ b/pkgs/desktops/deepin/qt5dxcb-plugin/default.nix
@@ -4,13 +4,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "qt5dxcb-plugin";
-  version = "1.1.27";
+  version = "1.2.2";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "1hs7r17qsqn3hgfjd0scagpj1dqys7i1507vxadfac4h1ahyxaz7";
+    sha256 = "1zvab6qxdr49pmk6mbk7s0md7bx585p32lca0xbg8mrkajz7g8rq";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/deepin/qt5integration/default.nix
+++ b/pkgs/desktops/deepin/qt5integration/default.nix
@@ -5,13 +5,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "qt5integration";
-  version = "0.3.11";
+  version = "0.3.12";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "1p3bnjy449vy5mpxassjv6sr2dp887gsss000szk5s0p1agmydxq";
+    sha256 = "140wb3vcm2ji8jhqdxv8f4shiknia1zk8fssqlp09kzc1cmb4ncy";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update Deepin Desktop Environment packages:

- deepin.dde-calendar: 1.2.6 -> 1.2.10
- deepin.dde-api: 3.18.3 -> 3.18.4.1
- deepin.dde-daemon: 3.27.1 -> 3.27.2.5
- deepin.dde-dock: 4.9.9 -> 4.10.3
- deepin.dde-file-manager: 4.8.6.2 -> 4.8.6.4
- deepin.dde-polkit-agent: 0.2.6 -> 0.2.10
- deepin.dde-qt-dbus-factory: 1.1.1 -> 1.1.5
- deepin.dde-session-ui: 4.9.6 -> 4.9.11
- deepin.deepin-anything: 0.0.7 -> 0.1.0
- deepin.deepin-desktop-base: 2019.04.24 -> 2019.06.19
- deepin.deepin-desktop-schemas: 3.13.0 -> 3.13.6
- deepin.deepin-gtk-theme: 17.10.10 -> 17.10.11
- deepin.deepin-icon-theme: 15.12.69 -> 15.12.71
- deepin.deepin-image-viewer: 1.3.13 -> 1.3.17
- deepin.deepin-menu: 3.4.6 -> 3.4.8
- deepin.deepin-movie-reborn: 3.2.22.1 -> 3.2.24
- deepin.deepin-screenshot: 4.1.10 -> 4.2.1
- deepin.deepin-terminal: 3.2.2.1 -> 3.2.6
- deepin.dtkcore: 2.0.12.1 -> 2.0.14
- deepin.dtkwidget: 2.0.12.3 -> 2.0.14
- deepin.go-dbus-factory: 0.7.0 -> 0.9.0
- deepin.go-gir-generator: 2.0.1 -> 2.0.2
- deepin.qt5dxcb-plugin: 1.1.27 -> 1.2.2
- deepin.qt5integration: 0.3.11 -> 0.3.12

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).