### PR TITLE
sequoia-tool: init at 0.9.0

### DIFF
--- a/pkgs/tools/security/sequoia-tool/default.nix
+++ b/pkgs/tools/security/sequoia-tool/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitLab, rustPlatform, darwin
+, pkgconfig, capnproto, clang, libclang, nettle, openssl, sqlite }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "sequoia-tool";
+  version = "0.9.0";
+
+  src = fetchFromGitLab {
+    owner = "sequoia-pgp";
+    repo = "sequoia";
+    rev = "v${version}";
+    sha256 = "13dzwdzz33dy2lgnznsv8wqnw2501f2ggrkfwpqy5x6d1kgms8rj";
+  };
+
+  nativeBuildInputs = [ pkgconfig clang libclang ];
+  buildInputs = [ capnproto nettle openssl sqlite ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Security ];
+
+  LIBCLANG_PATH = libclang + "/lib";
+
+  cargoBuildFlags = [ "--package=sequoia-tool" ];
+
+  cargoSha256 = "1zcnkpzcar3a2fk2rn3i3nb70b59ds9fpfa44f15r3aaxajsdhdi";
+
+  meta = with stdenv.lib; {
+    description = "A command-line frontend for Sequoia, an implementation of OpenPGP";
+    homepage = https://sequoia-pgp.org/;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ minijackson ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5813,6 +5813,8 @@ in
 
   seqdiag = with python3Packages; toPythonApplication seqdiag;
 
+  sequoia-tool = callPackage ../tools/security/sequoia-tool { inherit (llvmPackages) libclang; };
+
   sewer = callPackage ../tools/admin/sewer { };
 
   screenfetch = callPackage ../tools/misc/screenfetch { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

A user-friendly PGP tool: https://sequoia-pgp.org/

- The command-line program is actually called "sq" but the Rust package is called "sequoia-tool". I wasn't sure which to choose so I went with the one with the least chance of collision.
- ~~I didn't manage to build it entirely on my laptop because it kept running out of memory / space, so if someone would like to test it locally, or trigger ofborg, I would really appreciate it ^^~~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
