### PR TITLE
pythonPackages.hdbscan: fix build

### DIFF
--- a/pkgs/development/python-modules/hdbscan/default.nix
+++ b/pkgs/development/python-modules/hdbscan/default.nix
@@ -6,7 +6,7 @@
 , scipy
 , scikitlearn
 , fetchPypi
-, fetchpatch
+, joblib
 }:
 
 buildPythonPackage rec {
@@ -18,18 +18,10 @@ buildPythonPackage rec {
     sha256 = "5cfdc25375123eb9a72363449979141cc928c1953f220f0f81d7baabcaccec2d";
   };
 
-  patches = [
-    # Fix Tests. Drop in release >0.8.20
-    (fetchpatch {
-      name = "test-rsl-missing-import.patch";
-      url = https://github.com/scikit-learn-contrib/hdbscan/commit/e40ccef139e56e38adf7bd6912cd63efd97598f9.patch;
-      sha256 = "0cfq4ja7j61h2zwd1jw5gagcz2sg18kjnx29sb0bwa13wfw6fip0";
-    })
-  ];
-
   checkInputs = [ nose ];
 
-  propagatedBuildInputs = [ cython numpy scipy scikitlearn ];
+  nativeBuildInputs = [ cython ];
+  propagatedBuildInputs = [ numpy scipy scikitlearn joblib ];
 
   meta = with lib; {
     description = "Hierarchical Density-Based Spatial Clustering of Applications with Noise, a clustering algorithm with a scikit-learn compatible API";


### PR DESCRIPTION
###### Motivation for this change
Newer `hdbscan` came sooner than I was expecting. don't need the upstream patch anymore. Also seems to need `joblib`, added for the benefit of the py27 version, whose `scikitlearn` doesn't include it.

~Won't build until https://github.com/NixOS/nixpkgs/issues/63573 is fixed, hence draft.~
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
