### PR TITLE
new:  python-modules/tinytag at 1.2.2

### DIFF
--- a/pkgs/development/python-modules/tinytag/default.nix
+++ b/pkgs/development/python-modules/tinytag/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchPypi, substituteAll, python3Packages }:
+
+python3Packages.buildPythonPackage rec {
+  version = "1.2.2";
+  pname = "tinytag";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256:0r2pazrqq9lxy3an7vvafc6whglnawx2mi8x75gnrr56a02xpr8h";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    twine
+  ];
+
+  # No tests
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Read music meta data and length of MP3, OGG, OPUS, MP4, M4A, FLAC, WMA and Wave files with python 2 or 3";
+    homepage = "https://github.com/devsnd/tinytag";
+    license = licenses.mit;
+    maintainers = [ maintainers.deepfire ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -977,6 +977,8 @@ in {
 
   tableaudocumentapi = callPackage ../development/python-modules/tableaudocumentapi { };
 
+  tinytag = callPackage ../development/python-modules/tinytag {};
+
   trueskill = callPackage ../development/python-modules/trueskill { };
 
   trustme = callPackage ../development/python-modules/trustme {};


### PR DESCRIPTION
###### Motivation for this change
Adds a python tagging library.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
