### PR TITLE
protobuf: remove 3.4 and 3.5

### DIFF
--- a/pkgs/development/libraries/protobuf/3.4.nix
+++ b/pkgs/development/libraries/protobuf/3.4.nix
@@ -1,6 +1,0 @@
-{ callPackage, lib, ... }:
-
-lib.overrideDerivation (callPackage ./generic-v3.nix {
-  version = "3.4.1";
-  sha256 = "1lzxmbqlnmi34kymnf399azv86gmdbrf71xiad6wc24bzpkzqybb";
-}) (attrs: { NIX_CFLAGS_COMPILE = "-Wno-error"; })

--- a/pkgs/development/libraries/protobuf/3.5.nix
+++ b/pkgs/development/libraries/protobuf/3.5.nix
@@ -1,6 +1,0 @@
-{ callPackage, lib, ... }:
-
-lib.overrideDerivation (callPackage ./generic-v3.nix {
-  version = "3.5.1.1";
-  sha256 = "1h4xydr5j2zg1888ncn8a1jvqq8fgpgckrmjg6lqzy9jpkvqvfdk";
-}) (attrs: { NIX_CFLAGS_COMPILE = "-Wno-error"; })

--- a/pkgs/development/libraries/protobuf/generic-v3.nix
+++ b/pkgs/development/libraries/protobuf/generic-v3.nix
@@ -40,10 +40,6 @@ mkProtobufDerivation = buildProtobuf: stdenv: stdenv.mkDerivation rec {
 
   dontDisableStatic = true;
 
-  NIX_CFLAGS_COMPILE = with stdenv.lib;
-    # gcc before 6 doesn't know this option
-    optionalString (hasPrefix "gcc-6" stdenv.cc.cc.name) "-Wno-error=misleading-indentation";
-
   meta = {
     description = "Google's data interchange format";
     longDescription =

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12676,8 +12676,6 @@ in
 
   protobuf3_7 = callPackage ../development/libraries/protobuf/3.7.nix { };
   protobuf3_6 = callPackage ../development/libraries/protobuf/3.6.nix { };
-  protobuf3_5 = callPackage ../development/libraries/protobuf/3.5.nix { };
-  protobuf3_4 = callPackage ../development/libraries/protobuf/3.4.nix { };
   protobuf3_1 = callPackage ../development/libraries/protobuf/3.1.nix { };
   protobuf2_5 = callPackage ../development/libraries/protobuf/2.5.nix { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Unless I missed something, protobuf 3.4 and 3.5 are not used in nixpkgs anymore and can be removed.

###### Things done

Remove protobuf 3.4 and 3.5.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
