### PR TITLE
rust: fix building in debug mode

### DIFF
--- a/doc/languages-frameworks/rust.section.md
+++ b/doc/languages-frameworks/rust.section.md
@@ -64,6 +64,14 @@ When the `Cargo.lock`, provided by upstream, is not in sync with the
 added in `cargoPatches` will also be prepended to the patches in `patches` at
 build-time.
 
+Any binaries and libraries built will be copied into `$out/lib` and `$out/bin`
+as part of the provided `installPhase`, and Rust packages will also run
+`cargo test` as part of their `checkPhase` by default. Customizations to the
+derivation can find Cargo's build outputs in `$releaseDir` and should not rely
+on assumptions regarding the location of any other target directory in order to
+remain compatible with cross builds.
+
+
 ## Compiling Rust crates using Nix instead of Cargo
 
 ### Simple operation

--- a/pkgs/applications/altcoins/zcash/librustzcash/default.nix
+++ b/pkgs/applications/altcoins/zcash/librustzcash/default.nix
@@ -15,7 +15,7 @@ rustPlatform.buildRustPackage rec {
 
   installPhase = ''
     mkdir -p $out/lib
-    cp target/release/librustzcash.a $out/lib/
+    cp $releaseDir/librustzcash.a $out/lib/
     mkdir -p $out/include
     cp include/librustzcash.h $out/include/
   '';

--- a/pkgs/applications/misc/alacritty/default.nix
+++ b/pkgs/applications/misc/alacritty/default.nix
@@ -76,16 +76,16 @@ in buildRustPackage rec {
 
   outputs = [ "out" "terminfo" ];
 
-  postBuild = lib.optionalString stdenv.isDarwin "make app";
+  postBuild = lib.optionalString stdenv.isDarwin "make app RELEASE_DIR=$releaseDir";
 
   installPhase = ''
     runHook preInstall
 
-    install -D target/release/alacritty $out/bin/alacritty
+    install -D $releaseDir/alacritty $out/bin/alacritty
 
   '' + (if stdenv.isDarwin then ''
     mkdir $out/Applications
-    cp -r target/release/osx/Alacritty.app $out/Applications/Alacritty.app
+    cp -r $releaseDir/osx/Alacritty.app $out/Applications/Alacritty.app
   '' else ''
     install -D extra/linux/alacritty.desktop -t $out/share/applications/
     install -D extra/logo/alacritty-term.svg $out/share/icons/hicolor/scalable/apps/Alacritty.svg

--- a/pkgs/applications/networking/dyndns/cfdyndns/default.nix
+++ b/pkgs/applications/networking/dyndns/cfdyndns/default.nix
@@ -18,7 +18,7 @@ buildRustPackage rec {
 
   installPhase = ''
     mkdir -p $out/bin
-    cp -p target/release/cfdyndns $out/bin/
+    cp -p $releaseDir/cfdyndns $out/bin/
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/version-management/git-and-tools/git-ignore/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-ignore/default.nix
@@ -24,7 +24,7 @@ buildRustPackage rec {
   outputs = [ "out" "man" ];
   preFixup = ''
     mkdir -p "$man/man/man1"
-    cp target/release/build/git-ignore-*/out/git-ignore.1 "$man/man/man1/"
+    cp $releaseDir/build/git-ignore-*/out/git-ignore.1 "$man/man/man1/"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/window-managers/wtftw/default.nix
+++ b/pkgs/applications/window-managers/wtftw/default.nix
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage rec {
   installPhase = ''
     mkdir -p $out/bin
     mkdir -p $out/share/xsessions
-    cp -p target/release/wtftw $out/bin/
+    cp -p $releaseDir/wtftw $out/bin/
     echo "[Desktop Entry]
       Name=wtftw
       Exec=$out/bin/wtftw

--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -103,7 +103,7 @@ in stdenv.mkDerivation (args // {
       "CC_${stdenv.hostPlatform.config}"="${ccForHost}" \
       "CXX_${stdenv.hostPlatform.config}"="${cxxForHost}" \
       cargo build \
-        --${buildType} \
+        ${stdenv.lib.optionalString (buildType != "debug") "--${buildType}"} \
         --target ${stdenv.hostPlatform.config} \
         --frozen ${concatStringsSep " " cargoBuildFlags}
     )

--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -108,13 +108,6 @@ in stdenv.mkDerivation (args // {
         --frozen ${concatStringsSep " " cargoBuildFlags}
     )
 
-    # rename the output dir to a architecture independent one
-    mapfile -t targets < <(find "$NIX_BUILD_TOP" -type d | grep '${releaseDir}$')
-    for target in "''${targets[@]}"; do
-      rm -rf "$target/../../${buildType}"
-      ln -srf "$target" "$target/../../"
-    done
-
     runHook postBuild
   '';
 

--- a/pkgs/development/tools/rust/racerd/default.nix
+++ b/pkgs/development/tools/rust/racerd/default.nix
@@ -22,7 +22,7 @@ buildRustPackage rec {
 
   installPhase = ''
     mkdir -p $out/bin
-    cp -p target/release/racerd $out/bin/
+    cp -p $releaseDir/racerd $out/bin/
     wrapProgram $out/bin/racerd --set RUST_SRC_PATH "$RUST_SRC_PATH"
   '';
 

--- a/pkgs/tools/misc/fd/default.nix
+++ b/pkgs/tools/misc/fd/default.nix
@@ -16,11 +16,11 @@ rustPlatform.buildRustPackage rec {
   preFixup = ''
     install -Dm644 "$src/doc/fd.1" "$out/man/man1/fd.1"
 
-    install -Dm644 target/release/build/fd-find-*/out/fd.bash \
+    install -Dm644 $releaseDir/build/fd-find-*/out/fd.bash \
       "$out/share/bash-completion/completions/fd.bash"
-    install -Dm644 target/release/build/fd-find-*/out/fd.fish \
+    install -Dm644 $releaseDir/build/fd-find-*/out/fd.fish \
       "$out/share/fish/vendor_completions.d/fd.fish"
-    install -Dm644 target/release/build/fd-find-*/out/_fd \
+    install -Dm644 $releaseDir/build/fd-find-*/out/_fd \
       "$out/share/zsh/site-functions/_fd"
   '';
 

--- a/pkgs/tools/misc/lsd/default.nix
+++ b/pkgs/tools/misc/lsd/default.nix
@@ -14,9 +14,9 @@ rustPlatform.buildRustPackage rec {
   cargoSha256 = "095jf63jyd485fk8pl7grvycn7pkwnxdm5lwkmfl9p46m8q1qqr2";
 
   preFixup = ''
-    install -Dm644 -t $out/share/zsh/site-functions/ target/release/build/lsd-*/out/_lsd
-    install -Dm644 -t $out/share/fish/vendor_completions.d/ target/release/build/lsd-*/out/lsd.fish
-    install -Dm644 -t $out/share/bash-completion/completions/ target/release/build/lsd-*/out/lsd.bash
+    install -Dm644 -t $out/share/zsh/site-functions/ $releaseDir/build/lsd-*/out/_lsd
+    install -Dm644 -t $out/share/fish/vendor_completions.d/ $releaseDir/build/lsd-*/out/lsd.fish
+    install -Dm644 -t $out/share/bash-completion/completions/ $releaseDir/build/lsd-*/out/lsd.bash
   '';
 
   # Some tests fail, but Travis ensures a proper build

--- a/pkgs/tools/networking/tox-node/default.nix
+++ b/pkgs/tools/networking/tox-node/default.nix
@@ -24,7 +24,7 @@ buildRustPackage rec {
   installPhase = ''
     runHook preInstall
 
-    install -D target/release/tox-node $out/bin/tox-node
+    install -D $releaseDir/tox-node $out/bin/tox-node
 
     runHook postInstall
   '';

--- a/pkgs/tools/text/ripgrep/default.nix
+++ b/pkgs/tools/text/ripgrep/default.nix
@@ -24,11 +24,11 @@ rustPlatform.buildRustPackage rec {
 
   preFixup = ''
     mkdir -p "$out/man/man1"
-    cp target/release/build/ripgrep-*/out/rg.1 "$out/man/man1/"
+    cp $releaseDir/build/ripgrep-*/out/rg.1 "$out/man/man1/"
 
     mkdir -p "$out/share/"{bash-completion/completions,fish/vendor_completions.d,zsh/site-functions}
-    cp target/release/build/ripgrep-*/out/rg.bash "$out/share/bash-completion/completions/"
-    cp target/release/build/ripgrep-*/out/rg.fish "$out/share/fish/vendor_completions.d/"
+    cp $releaseDir/build/ripgrep-*/out/rg.bash "$out/share/bash-completion/completions/"
+    cp $releaseDir/build/ripgrep-*/out/rg.fish "$out/share/fish/vendor_completions.d/"
     cp "$src/complete/_rg" "$out/share/zsh/site-functions/"
   '';
 


### PR DESCRIPTION
###### Motivation for this change

#56540 broke a few things regarding rust builds and did not have the intended effect:

- bdd3c3fdcb11416d2e2ef459c2e28caa2235f0f3 intended to support debug builds, but passes an invalid `--debug` flag to `cargo build`
- 60761e65ba38280ce19e1d7e3c4ffd883212a96c intended to make sense of cargo target directories, but breaks cargo.
  1. it deletes `$CARGO_TARGET_DIR/debug`, and symlinking/moving `$CARGO_TARGET_DIR/x86_64-unknown-linux-gnu/debug` to it, assuming they're redundant?
  2. this is an incorrect change, as cargo seems to produce and use both directories for different purposes? Each directory has its own lock file, which cargo attempts to use. When both lock files are symlinked to be the same thing, cargo will deadlock itself.
  3. this prevents `cargo test` from working, the only reason it happens to work now is because this step mangles the release directory, while the default `checkPhase` builds tests in debug mode. Changing `buildType` to `debug` or using `cargo test --release` instead will expose the deadlock.
  4. buildRustPackage provides `releaseDir` for this, anything that hard-codes target/release are messy hm...
      - messageformat=json stuff could maybe be used to find binary paths for packaging purposes instead? This is a a rather annoying and [long-standing](https://github.com/rust-lang/cargo/issues/3670) [limitation](https://github.com/rust-lang/cargo/issues/1924) of cargo.

cc @illegalprime @Ericson2314

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
  - will try this soon, it might take a while..?
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---