### PR TITLE
rambox-pro: 1.1.2 -> 1.1.4

### DIFF
--- a/pkgs/applications/networking/instant-messengers/rambox/pro.nix
+++ b/pkgs/applications/networking/instant-messengers/rambox/pro.nix
@@ -2,25 +2,18 @@
 
 stdenv.mkDerivation rec {
   pname = "rambox-pro";
-  version = "1.1.2";
+  version = "1.1.4";
 
   dontBuild = true;
   dontStrip = true;
 
-  buildInputs = [ nss xorg.libxkbfile ];
+  buildInputs = [ nss xorg.libXext xorg.libxkbfile xorg.libXScrnSaver ];
   nativeBuildInputs = [ autoPatchelfHook makeWrapper nodePackages.asar ];
 
   src = fetchurl {
     url = "https://github.com/ramboxapp/download/releases/download/v${version}/RamboxPro-${version}-linux-x64.tar.gz";
-    sha256 = "0rrfpl371hp278b02b9b6745ax29yrdfmxrmkxv6d158jzlv0dlr";
+    sha256 = "0vwh3km3h46bgynd10s8ijl3aj5sskzncdj14h3k7h4sibd8r71a";
   };
-
-  postPatch = ''
-    substituteInPlace resources/app.asar.unpacked/node_modules/ad-block/vendor/depot_tools/create-chromium-git-src \
-      --replace "/usr/bin/env -S bash -e" "${stdenv.shell}"
-    substituteInPlace resources/app.asar.unpacked/node_modules/ad-block/node_modules/bloom-filter-cpp/vendor/depot_tools/create-chromium-git-src \
-      --replace "/usr/bin/env -S bash -e" "${stdenv.shell}"
-  '';
 
   installPhase = ''
     mkdir -p $out/bin $out/opt/RamboxPro $out/share/applications


### PR DESCRIPTION
###### Motivation for this change
Upgraded the rambox-pro package I previously created from 1.1.2 to 1.1.4 and added necessary changes to accomplish this.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
