### PR TITLE
acpilight: fix build error

### DIFF
--- a/pkgs/misc/acpilight/default.nix
+++ b/pkgs/misc/acpilight/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, python3, udev, coreutils }:
+{ stdenv, fetchgit, python3, coreutils }:
 
 stdenv.mkDerivation rec {
   pname = "acpilight";
@@ -16,9 +16,10 @@ stdenv.mkDerivation rec {
 
   postConfigure = ''
     substituteInPlace 90-backlight.rules --replace /bin ${coreutils}/bin
+    substituteInPlace Makefile --replace udevadm true
   '';
 
-  buildInputs = [ pyenv udev ];
+  buildInputs = [ pyenv ];
 
   makeFlags = [ "DESTDIR=$(out) prefix=" ];
 


### PR DESCRIPTION
###### Motivation for this change

`udevadm trigger` should not run as part of make install. The offending line is [Makefile#17](https://gitlab.com/wavexx/acpilight/blob/master/Makefile#L17), would a patch be more appropriate or is this change fine?

The package doesn't seem to depend on udev beyond providing rules files, it seems like a recent systemd update broke this, [previously it was fine](https://hydra.nixos.org/job/nixpkgs/trunk/acpilight.x86_64-linux) but really shouldn't have been running that command anyway.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---