### PR TITLE
Revert "python37Packages.aiorpcx: 0.17.0 -> 0.18.3"

### DIFF
--- a/pkgs/development/python-modules/aiorpcx/default.nix
+++ b/pkgs/development/python-modules/aiorpcx/default.nix
@@ -2,12 +2,12 @@
 
 buildPythonPackage rec {
   pname = "aiorpcx";
-  version = "0.18.3";
+  version = "0.17.0";
 
   src = fetchPypi {
     inherit version;
     pname = "aiorpcX";
-    sha256 = "0k545hc7wl6sh1svydzbv6x7sx5pig2pqkl3yxs9riwmvzawx9xp";
+    sha256 = "14np5r75rs0v45vsv20vbzmnv3qisvm9mdllj1j9s1633cvcik0k";
   };
 
   propagatedBuildInputs = [ attrs ];


### PR DESCRIPTION
This reverts commit 299996bc38da10452680ce1d1e18ab5db07387b7.

###### Motivation for this change

[electrum](https://hydra.nixos.org/job/nixpkgs/trunk/electrum.x86_64-linux) no longer builds as it has not yet released an update that supports version 0.18, and is the only package that depends on aiorpcx.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---