### PR TITLE
codespell: init at 1.15.0

### DIFF
--- a/pkgs/development/python-modules/codespell/default.nix
+++ b/pkgs/development/python-modules/codespell/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildPythonApplication, fetchPypi, pytest, chardet }:
+buildPythonApplication rec {
+  pname = "codespell";
+  version = "1.15.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0c211rzfgmwls8ab8fj21xp9bhxk6ys3xw8w7chp4arjlifc26wg";
+  };
+
+  checkInputs = [ pytest chardet ];
+  checkPhase = ''
+    # We don't want to be affected by the presence of these
+    rm -r codespell_lib setup.cfg
+    # test_command assumes too much about the execution environment
+    pytest --pyargs codespell_lib.tests -k "not test_command"
+  '';
+
+  meta = {
+    description = "Fix common misspellings in source code";
+    homepage = "https://github.com/codespell-project/codespell";
+    license = with lib.licenses; [ gpl2 cc-by-sa-30 ];
+    maintainers = with lib.maintainers; [ johnazoidberg ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -744,6 +744,8 @@ in
 
   chkcrontab = callPackage ../tools/admin/chkcrontab { };
 
+  codespell = with python3Packages; toPythonApplication codespell;
+
   cozy = callPackage ../applications/audio/cozy-audiobooks { };
 
   ctrtool = callPackage ../tools/archivers/ctrtool { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -474,6 +474,8 @@ in {
 
   cozy = callPackage ../development/python-modules/cozy { };
 
+  codespell = callPackage ../development/python-modules/codespell { };
+
   curio = callPackage ../development/python-modules/curio { };
 
   dendropy = callPackage ../development/python-modules/dendropy { };


### PR DESCRIPTION
###### Motivation for this change
With codespell it's easy to check the spelling of variables and comments in source code.
Hint: Can easily be tried on nixpkgs (`./result/bin/codespell ~/clone/nixpkgs`)- I might open a PR fixing spelling mistakes in nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

`fetchPypi` is preferred for Python projects over `fetchFromGitHub` (or other repo fetchers) because it usually contains the same code but possibly less other unnecessary files for running the program (e.g. documentation), right?
