### PR TITLE
microcodeIntel: 20190514 -> 20190618

### DIFF
--- a/pkgs/os-specific/linux/microcode/intel.nix
+++ b/pkgs/os-specific/linux/microcode/intel.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "microcode-intel";
-  version = "20190514";
+  version = "20190618";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "Intel-Linux-Processor-Microcode-Data-Files";
     rev = "microcode-${version}";
-    sha256 = "1xdxkmsnic191g7kljmrdcvg8vlwiwcrcxy9fnhpqsbsp6mjylv7";
+    sha256 = "0fdhrpxvsq0rm5mzj82gvmfb3lm7mhc9hwvimv7dl1jaidbp6lvs";
   };
 
   nativeBuildInputs = [ iucode-tool libarchive ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The upstream release tag (https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/releases/tag/microcode-20190618) doesn't feature release notes, but e.g. Debian has a changelog entry that reads like this:

```
intel-microcode (3.20190618.1) unstable; urgency=medium

  * New upstream microcode datafile 20190618
    + SECURITY UPDATE
      Implements MDS mitigation (RIDL, Fallout, Zombieload), INTEL-SA-00223
      CVE-2018-12126, CVE-2018-12127, CVE-2018-12130, CVE-2019-11091
      for Sandybridge server and Core-X processors
    + Updated Microcodes:
      sig 0x000206d6, pf_mask 0x6d, 2019-05-21, rev 0x061f, size 18432
      sig 0x000206d7, pf_mask 0x6d, 2019-05-21, rev 0x0718, size 19456
  * Add some missing (minor) changelog entries to 3.20190514.1
  * Reformat 3.20190514.1 changelog entry to match rest of changelog

 -- Henrique de Moraes Holschuh <hmh@debian.org>  Wed, 19 Jun 2019 09:05:54 -0300
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
