### PR TITLE
deepin.dde-launcher: init at 4.6.13

### DIFF
--- a/nixos/modules/services/desktops/deepin/deepin.nix
+++ b/nixos/modules/services/desktops/deepin/deepin.nix
@@ -35,6 +35,7 @@
         pkgs.deepin.dde-calendar
         pkgs.deepin.dde-daemon
         pkgs.deepin.dde-dock
+        pkgs.deepin.dde-launcher
         pkgs.deepin.dde-file-manager
         pkgs.deepin.dde-session-ui
         pkgs.deepin.deepin-anything
@@ -47,6 +48,7 @@
         pkgs.deepin.dde-calendar
         pkgs.deepin.dde-daemon
         pkgs.deepin.dde-dock
+        pkgs.deepin.dde-launcher
         pkgs.deepin.dde-file-manager
         pkgs.deepin.dde-session-ui
         pkgs.deepin.deepin-anything

--- a/pkgs/desktops/deepin/dde-launcher/default.nix
+++ b/pkgs/desktops/deepin/dde-launcher/default.nix
@@ -1,0 +1,76 @@
+{ stdenv, fetchFromGitHub, pkgconfig, cmake, dde-qt-dbus-factory,
+  dde-session-ui, deepin, deepin-desktop-schemas, deepin-wallpapers,
+  dtkcore, dtkwidget, gsettings-qt, qtsvg, qttools, qtx11extras,
+  which, xdg_utils, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "dde-launcher";
+  version = "4.6.13";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "1lwwn2qjbd4i7wx18mi8n7hzdh832i3kdadrivr10sbafdank7ky";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkgconfig
+    qttools
+    wrapGAppsHook
+    deepin.setupHook
+  ];
+
+  buildInputs = [
+    dde-qt-dbus-factory
+    dde-session-ui
+    deepin-desktop-schemas
+    deepin-wallpapers
+    dtkcore
+    dtkwidget
+    gsettings-qt
+    qtsvg
+    qtx11extras
+    which
+    xdg_utils
+  ];
+
+  postPatch = ''
+    # debugging
+    searchHardCodedPaths
+
+    substituteInPlace CMakeLists.txt --replace "/usr/share" "$out/share"
+
+    substituteInPlace src/dbusservices/com.deepin.dde.Launcher.service --replace "/usr" "$out"
+
+    substituteInPlace src/historywidget.cpp --replace "xdg-open" "${xdg_utils}/bin/xdg-open"
+    substituteInPlace src/widgets/miniframebottombar.cpp --replace "dde-shutdown" "${dde-session-ui}/bin/dde-shutdown"
+    substituteInPlace src/widgets/miniframerightbar.cpp --replace "which" "${which}/bin/which"
+
+    # Uncomment (and remove space after $) after packaging deepin-manual
+    #substituteInPlace src/sharedeventfilter.cpp --replace "dman" "$ {deepin-manual}/bin/dman"
+
+    for f in src/boxframe/*.cpp; do
+      substituteInPlace $f --replace "/usr/share/backgrounds/default_background.jpg" "${deepin-wallpapers}/share/backgrounds/deepin/desktop.jpg"
+    done
+
+    # note: `dbus-send` path does not need to be hard coded because it is not used for dtkcore >= 2.0.8.0
+  '';
+
+  postFixup = ''
+    # debugging
+    searchHardCodedPaths $out
+  '';
+
+  passthru.updateScript = deepin.updateScript { inherit name; };
+
+  meta = with stdenv.lib; {
+    description = "Deepin Desktop Environment launcher module";
+    homepage = https://github.com/linuxdeepin/dde-launcher;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ romildo ];
+  };
+}

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -12,6 +12,7 @@ let
     dde-daemon = callPackage ./dde-daemon { };
     dde-dock = callPackage ./dde-dock { };
     dde-file-manager = callPackage ./dde-file-manager { };
+    dde-launcher = callPackage ./dde-launcher { };
     dde-network-utils = callPackage ./dde-network-utils { };
     dde-polkit-agent = callPackage ./dde-polkit-agent { };
     dde-qt-dbus-factory = callPackage ./dde-qt-dbus-factory { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add [dde-launcher](https://github.com/linuxdeepin/dde-launcher), the launcher of Deepin Desktop Environment.

About packaging deepin for NixOS: #59023

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).