### PR TITLE
drm_info: init at 2.1.0

### DIFF
--- a/pkgs/tools/graphics/drm_info/default.nix
+++ b/pkgs/tools/graphics/drm_info/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, meson, ninja, pkgconfig, libdrm, json_c }:
+
+stdenv.mkDerivation rec {
+  pname = "drm_info";
+  version = "2.1.0";
+
+  src = fetchFromGitHub {
+    owner = "ascent12";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1i5bzkgqxjjw34jpj1x1gfdl3sz0sl6i7s787a6mjjslsc5g422l";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkgconfig
+  ];
+
+  buildInputs = [
+    libdrm
+    json_c
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Small utility to dump info about DRM devices";
+    homepage = https://github.com/ascent12/drm_info;
+    license = licenses.mit;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1445,6 +1445,8 @@ in
     gtk = gtk3;
   };
 
+  drm_info = callPackage ../tools/graphics/drm_info { };
+
   dtools = callPackage ../development/tools/dtools { };
 
   dtrx = callPackage ../tools/compression/dtrx { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
