### PR TITLE
kubecfg: 0.9.1 -> 0.12.0

### DIFF
--- a/pkgs/applications/networking/cluster/kubecfg/default.nix
+++ b/pkgs/applications/networking/cluster/kubecfg/default.nix
@@ -1,22 +1,22 @@
 { lib, buildGoPackage, fetchFromGitHub, ... }:
 
-let version = "0.9.1"; in
+let version = "0.12.0"; in
 
 buildGoPackage {
   name = "kubecfg-${version}";
 
   src = fetchFromGitHub {
-    owner = "ksonnet";
+    owner = "bitnami";
     repo = "kubecfg";
     rev = "v${version}";
-    sha256 = "010k33arxa4spaq923iazsisxgsaj8c7w4z250y9yrch8xxd74bi";
+    sha256 = "118p1fy6cihswwz03vp62cz8395hgfqd82nmfkw88fx7av23rfhb";
   };
 
-  goPackagePath = "github.com/ksonnet/kubecfg";
+  goPackagePath = "github.com/bitnami/kubecfg";
 
   meta = {
     description = "A tool for managing Kubernetes resources as code";
-    homepage = https://github.com/ksonnet/kubecfg;
+    homepage = https://github.com/bitnami/kubecfg;
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ benley ];
     platforms = lib.platforms.unix;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update kubecfg: 0.9.1 -> 0.12.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
