### PR TITLE
mlarchive2maildir: init at 0.0.6

### DIFF
--- a/pkgs/applications/networking/mailreaders/mlarchive2maildir/default.nix
+++ b/pkgs/applications/networking/mailreaders/mlarchive2maildir/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, python3, notmuch }:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "mlarchive2maildir";
+  version = "0.0.6";
+
+  src = python3.pkgs.fetchPypi {
+    inherit pname version;
+    sha256 = "025mv890zsk25cral9cas3qgqdsszh5025khz473zs36innjd0mw";
+  };
+
+  nativeBuildInputs = with python3.pkgs; [ setuptools_scm ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    beautifulsoup4
+    click
+    click-log
+    requests
+    six
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/flokli/mlarchive2maildir;
+    description = "Imports mail from (pipermail) archives into a maildir";
+    license = licenses.mit;
+    maintainers = with maintainers; [ andir flokli ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1705,6 +1705,8 @@ in
 
   mkspiffs-presets = recurseIntoAttrs (callPackages ../tools/filesystems/mkspiffs/presets.nix { });
 
+  mlarchive2maildir = callPackage ../applications/networking/mailreaders/mlarchive2maildir { };
+
   monetdb = callPackage ../servers/sql/monetdb { };
 
   mousetweaks = callPackage ../applications/accessibility/mousetweaks {


### PR DESCRIPTION
This adds mlarchive2maildir, a tool to import mail from (pipermail)
archives into maildir.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
