### PR TITLE
megasync: init at 4.1.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3278,6 +3278,11 @@
     github = "michelk";
     name = "Michel Kuhlmann";
   };
+  michojel = {
+    email = "mic.liamg@gmail.com";
+    github = "michojel";
+    name = "Michal Minář";
+  };
   mickours = {
     email = "mickours@gmail.com<";
     github = "mickours";

--- a/pkgs/applications/misc/megasync/default.nix
+++ b/pkgs/applications/misc/megasync/default.nix
@@ -1,0 +1,143 @@
+{ lib
+, stdenv
+, autoconf
+, automake
+, bash
+, bashInteractive
+, c-ares
+, cryptopp
+, curl
+, doxygen
+, fetchFromGitHub
+, hicolor-icon-theme
+, libmediainfo
+, libraw
+, libsodium
+, libtool
+, libuv
+, libzen
+, lsb-release
+, makeDesktopItem
+, pkgconfig
+, qt5
+, sqlite
+, swig
+, unzip
+, wget
+, enableFFmpeg   ? true, ffmpeg  ? ffmpeg
+}:
+
+assert enableFFmpeg   -> ffmpeg != null;
+
+stdenv.mkDerivation rec {
+  name = "megasync-${version}";
+  version = "4.1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "meganz";
+    repo = "MEGAsync";
+    rev = "v${version}_Linux";
+    sha256 = "0lc228q3s9xp78dxjn22g6anqlsy1hi7a6yfs4q3l6gyfc3qcxl2";
+    fetchSubmodules = true;
+  };
+
+  desktopItem = makeDesktopItem {
+    name = "megasync";
+    exec = "megasync";
+    icon = "megasync";
+    comment = meta.description;
+    desktopName = "MEGASync";
+    genericName = "File Synchronizer";
+    categories = "Network;FileTransfer;";
+    startupNotify = "false";
+  };
+
+  nativeBuildInputs = [
+    autoconf
+    automake
+    doxygen
+    lsb-release
+    pkgconfig
+    qt5.qmake
+    qt5.qttools
+    swig
+  ];
+  buildInputs = [
+    c-ares
+    cryptopp
+    curl
+    #freeimage    # unreferenced
+    hicolor-icon-theme
+    libmediainfo
+    libraw
+    libsodium
+    libtool
+    libuv
+    libzen
+    qt5.qtbase
+    qt5.qtsvg
+    sqlite
+    unzip
+    wget
+  ] ++ stdenv.lib.optionals enableFFmpeg   [ ffmpeg ];
+
+  patchPhase = ''
+    for file in $(find src/ -type f \( -iname configure -o -iname \*.sh  \) ); do
+      substituteInPlace "$file" \
+        --replace "/bin/bash" "${bashInteractive}/bin/bash"
+    done
+  '';
+
+  preConfigure = ''
+    cd src/MEGASync/mega
+    ./autogen.sh
+  '';
+
+  configureScript = "./configure";
+
+  configureFlags = [
+          "--disable-examples"
+          "--disable-java"
+          "--disable-php"
+          "--enable-chat"
+          "--with-cares"
+          "--with-cryptopp"
+          "--with-curl"
+          "--without-freeimage"  # unreferenced even when found
+          "--without-readline"
+          "--without-termcap"
+          "--with-sodium"
+          "--with-sqlite"
+          "--with-zlib"
+    ] ++ stdenv.lib.optionals enableFFmpeg ["--with-ffmpeg"];
+
+  # TODO: unless overriden, qmake is called instead ??
+  configurePhase = ''
+    runHook preConfigure
+    ./configure ${toString configureFlags}
+    runHook postConfigure
+  '';
+
+  postConfigure = "cd ../..";
+
+  preBuild = ''
+    qmake CONFIG+="release" MEGA.pro
+    lrelease MEGASync/MEGASync.pro
+  '';
+
+  # TODO: install bindings
+  installPhase = ''
+    mkdir -p $out/share/icons
+    install -Dm 755 MEGASync/megasync $out/bin/megasync
+    cp -r ${desktopItem}/share/applications $out/share
+    cp MEGASync/gui/images/uptodate.svg $out/share/icons/megasync.svg
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Easy automated syncing between your computers and your MEGA Cloud Drive";
+    homepage    = https://mega.nz/;
+    license     = licenses.free;
+    platforms   = [ "i686-linux" "x86_64-linux" ];
+    maintainers = [ maintainers.michojel ];
+  };
+}

--- a/pkgs/applications/misc/megasync/install-megasync.patch
+++ b/pkgs/applications/misc/megasync/install-megasync.patch
@@ -1,0 +1,21 @@
+Index: source/src/MEGASync/MEGASync.pro
+===================================================================
+--- source.orig/src/MEGASync/MEGASync.pro
++++ source/src/MEGASync/MEGASync.pro
+@@ -28,11 +28,11 @@ unix:!macx {
+     TARGET = megasync
+ 
+ #    Uncomment the following if "make install" doesn't copy megasync in /usr/bin directory
+-#    isEmpty(PREFIX) {
+-#        PREFIX = /usr
+-#    }
+-#    target.path = $$PREFIX/bin
+-#    INSTALLS += target
++    isEmpty(PREFIX) {
++        PREFIX = /usr
++    }
++    target.path = $$PREFIX/bin
++    INSTALLS += target
+ }
+ else {
+     TARGET = MEGAsync

--- a/pkgs/applications/misc/megasync/noinstall-distro-version.patch
+++ b/pkgs/applications/misc/megasync/noinstall-distro-version.patch
@@ -1,0 +1,13 @@
+Index: source/src/MEGASync/platform/platform.pri
+===================================================================
+--- source.orig/src/MEGASync/platform/platform.pri
++++ source/src/MEGASync/platform/platform.pri
+@@ -37,7 +37,7 @@ unix:!macx {
+     system(command -v lsb_release): version.commands = lsb_release -rs > $$version.target
+ 	version.files = $$version.target
+ 
+-	INSTALLS += distro version
++	# INSTALLS += distro version
+ 
+     QT += dbus
+     SOURCES += $$PWD/linux/LinuxPlatform.cpp \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1695,6 +1695,8 @@ in
 
   massren = callPackage ../tools/misc/massren { };
 
+  megasync = callPackage ../applications/misc/megasync { };
+
   meritous = callPackage ../games/meritous { };
 
   opendune = callPackage ../games/opendune { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---