### PR TITLE
pythonPackages.hidapi: enable on darwin

### DIFF
--- a/pkgs/development/python-modules/hidapi/default.nix
+++ b/pkgs/development/python-modules/hidapi/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, libusb1, udev, fetchPypi, buildPythonPackage, cython }:
+{ stdenv, libusb1, udev, darwin, fetchPypi, buildPythonPackage, cython }:
 
 buildPythonPackage rec {
   pname = "hidapi";
@@ -9,10 +9,13 @@ buildPythonPackage rec {
     sha256 = "e0be1aa6566979266a8fc845ab0e18613f4918cf2c977fe67050f5dc7e2a9a97";
   };
 
-  propagatedBuildInputs = [ libusb1 udev cython ];
+  propagatedBuildInputs =
+    stdenv.lib.optionals stdenv.isLinux [ libusb1 udev ] ++
+    stdenv.lib.optionals stdenv.isDarwin [ darwin.IOKit darwin.apple_sdk.frameworks.CoreFoundation ] ++
+    [ cython ];
 
   # Fix the USB backend library lookup
-  postPatch = ''
+  postPatch = stdenv.lib.optionalString stdenv.isLinux ''
     libusb=${libusb1.dev}/include/libusb-1.0
     test -d $libusb || { echo "ERROR: $libusb doesn't exist, please update/fix this build expression."; exit 1; }
     sed -i -e "s|/usr/include/libusb-1.0|$libusb|" setup.py


### PR DESCRIPTION
###### Motivation for this change

Package is cross-platform, and only uses libusb on linux and bsd.

Is the `with` too messy?

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
