### PR TITLE
Fix misuses of overrideCC

### DIFF
--- a/pkgs/tools/package-management/dpkg/default.nix
+++ b/pkgs/tools/package-management/dpkg/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
   '';
 
   buildInputs = [ perl zlib bzip2 xz ];
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper perl ];
 
   postInstall =
     ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -671,7 +671,7 @@ in
 
   apt = callPackage ../tools/package-management/apt {
     # include/c++/6.4.0/cstdlib:75:25: fatal error: stdlib.h: No such file or directory
-    stdenv = overrideCC stdenv gcc5;
+    stdenv = overrideCC stdenv buildPackages.gcc5;
   };
 
   apt-dater = callPackage ../tools/package-management/apt-dater { };
@@ -2805,7 +2805,7 @@ in
   exa = callPackage ../tools/misc/exa { };
 
   exempi = callPackage ../development/libraries/exempi {
-    stdenv = if stdenv.isi686 then overrideCC stdenv gcc6 else stdenv;
+    stdenv = if stdenv.isi686 then overrideCC stdenv buildPackages.gcc6 else stdenv;
   };
 
   execline = skawarePackages.execline;
@@ -3081,7 +3081,7 @@ in
   fusuma = callPackage ../tools/inputmethods/fusuma {};
 
   fdbPackages = dontRecurseIntoAttrs (callPackage ../servers/foundationdb {
-    stdenv49 = overrideCC stdenv gcc49;
+    stdenv49 = overrideCC stdenv buildPackages.gcc49;
   });
 
   inherit (fdbPackages)
@@ -3250,7 +3250,7 @@ in
   gnash = callPackage ../misc/gnash { };
 
   gnaural = callPackage ../applications/audio/gnaural {
-    stdenv = overrideCC stdenv gcc49;
+    stdenv = overrideCC stdenv buildPackages.gcc49;
   };
 
   gnirehtet = callPackage ../tools/networking/gnirehtet { };
@@ -3413,7 +3413,7 @@ in
   grpcurl = callPackage ../tools/networking/grpcurl { };
 
   grub = pkgsi686Linux.callPackage ../tools/misc/grub ({
-    stdenv = overrideCC stdenv pkgsi686Linux.gcc6;
+    stdenv = overrideCC stdenv buildPackages.pkgsi686Linux.gcc6;
   } // (config.grub or {}));
 
   trustedGrub = pkgsi686Linux.callPackage ../tools/misc/grub/trusted.nix { };
@@ -6381,7 +6381,7 @@ in
   udptunnel = callPackage ../tools/networking/udptunnel { };
 
   ufraw = callPackage ../applications/graphics/ufraw {
-    stdenv = overrideCC stdenv gcc6; # doesn't build with gcc7
+    stdenv = overrideCC stdenv buildPackages.gcc6; # doesn't build with gcc7
   };
 
   uftrace = callPackage ../development/tools/uftrace { };
@@ -7090,7 +7090,7 @@ in
 
   avian = callPackage ../development/compilers/avian {
     inherit (darwin.apple_sdk.frameworks) CoreServices Foundation;
-    stdenv = if stdenv.cc.isGNU then overrideCC stdenv gcc49 else stdenv;
+    stdenv = if stdenv.cc.isGNU then overrideCC stdenv buildPackages.gcc49 else stdenv;
   };
 
   bigloo = callPackage ../development/compilers/bigloo { };
@@ -7150,7 +7150,7 @@ in
 
   #Use this instead of stdenv to build with clang
   clangStdenv = if stdenv.cc.isClang then stdenv else lowPrio llvmPackages.stdenv;
-  clang-sierraHack-stdenv = overrideCC stdenv clang-sierraHack;
+  clang-sierraHack-stdenv = overrideCC stdenv buildPackages.clang-sierraHack;
   libcxxStdenv = if stdenv.isDarwin then stdenv else lowPrio llvmPackages.libcxxStdenv;
 
   clasp-common-lisp = callPackage ../development/compilers/clasp {
@@ -7229,9 +7229,9 @@ in
     extraBuildInputs = lib.optional stdenv.hostPlatform.isDarwin clang.cc;
   };
 
-  gcc7Stdenv = overrideCC gccStdenv gcc7;
-  gcc8Stdenv = overrideCC gccStdenv gcc8;
-  gcc9Stdenv = overrideCC gccStdenv gcc9;
+  gcc7Stdenv = overrideCC gccStdenv buildPackages.gcc7;
+  gcc8Stdenv = overrideCC gccStdenv buildPackages.gcc8;
+  gcc9Stdenv = overrideCC gccStdenv buildPackages.gcc9;
 
   wrapCCMulti = cc:
     if stdenv.targetPlatform.system == "x86_64-linux" then let
@@ -7268,8 +7268,8 @@ in
   gcc_multi = wrapCCMulti gcc;
   clang_multi = wrapClangMulti clang;
 
-  gccMultiStdenv = overrideCC stdenv gcc_multi;
-  clangMultiStdenv = overrideCC stdenv clang_multi;
+  gccMultiStdenv = overrideCC stdenv buildPackages.gcc_multi;
+  clangMultiStdenv = overrideCC stdenv buildPackages.clang_multi;
   multiStdenv = if stdenv.cc.isClang then clangMultiStdenv else gccMultiStdenv;
 
   gcc_debug = lowPrio (wrapCC (gcc.cc.override {
@@ -7967,7 +7967,7 @@ in
   pforth = callPackage ../development/compilers/pforth {};
 
   picat = callPackage ../development/compilers/picat {
-    stdenv = overrideCC stdenv gcc49;
+    stdenv = overrideCC stdenv buildPackages.gcc49;
   };
 
   ponyc = callPackage ../development/compilers/ponyc {
@@ -8625,7 +8625,7 @@ in
   spidermonkey_38 = callPackage ../development/interpreters/spidermonkey/38.nix ({
     inherit (darwin) libobjc;
   } // (stdenv.lib.optionalAttrs (stdenv.cc.isGNU && stdenv.hostPlatform.isi686) {
-      stdenv = overrideCC stdenv gcc6; # with gcc-7: undefined reference to `__divmoddi4'
+      stdenv = overrideCC stdenv buildPackages.gcc6; # with gcc-7: undefined reference to `__divmoddi4'
   }));
   spidermonkey_52 = callPackage ../development/interpreters/spidermonkey/52.nix { };
   spidermonkey_60 = callPackage ../development/interpreters/spidermonkey/60.nix { };
@@ -8878,7 +8878,7 @@ in
   yacc = bison; # TODO: move to aliases.nix
 
   blackmagic = callPackage ../development/tools/misc/blackmagic {
-    stdenv = overrideCC stdenv gcc6;
+    stdenv = overrideCC stdenv buildPackages.gcc6;
     gcc-arm-embedded = pkgsCross.arm-embedded.buildPackages.gcc;
     binutils-arm-embedded = pkgsCross.arm-embedded.buildPackages.binutils;
   };
@@ -8937,7 +8937,7 @@ in
   # should be owned by user root, group nixbld with permissions 0770.
   ccacheWrapper = makeOverridable ({ extraConfig ? "" }:
      wrapCC (ccache.links extraConfig)) {};
-  ccacheStdenv = lowPrio (overrideCC stdenv ccacheWrapper);
+  ccacheStdenv = lowPrio (overrideCC stdenv buildPackages.ccacheWrapper);
 
   cccc = callPackage ../development/tools/analysis/cccc { };
 
@@ -9103,7 +9103,7 @@ in
   #
   distccWrapper = makeOverridable ({ extraConfig ? "" }:
      wrapCC (distcc.links extraConfig)) {};
-  distccStdenv = lowPrio (overrideCC stdenv distccWrapper);
+  distccStdenv = lowPrio (overrideCC stdenv buildPackages.distccWrapper);
 
   distccMasquerade = if stdenv.isDarwin
     then null
@@ -10922,27 +10922,27 @@ in
     nativeBuildRoot = buildPackages.icu58.override { buildRootOnly = true; };
   } //
     (stdenv.lib.optionalAttrs (stdenv.cc.isGNU && stdenv.hostPlatform.isi686) {
-      stdenv = overrideCC stdenv gcc6; # with gcc-7: undefined reference to `__divmoddi4'
+      stdenv = overrideCC stdenv buildPackages.gcc6; # with gcc-7: undefined reference to `__divmoddi4'
     }));
   icu59 = callPackage ../development/libraries/icu/59.nix ({
     nativeBuildRoot = buildPackages.icu59.override { buildRootOnly = true; };
   } // (stdenv.lib.optionalAttrs (stdenv.cc.isGNU && stdenv.hostPlatform.isi686) {
-      stdenv = overrideCC stdenv gcc6; # with gcc-7: undefined reference to `__divmoddi4'
+      stdenv = overrideCC stdenv buildPackages.gcc6; # with gcc-7: undefined reference to `__divmoddi4'
     }));
   icu60 = callPackage ../development/libraries/icu/60.nix ({
     nativeBuildRoot = buildPackages.icu60.override { buildRootOnly = true; };
   } // (stdenv.lib.optionalAttrs (stdenv.cc.isGNU && stdenv.hostPlatform.isi686) {
-      stdenv = overrideCC stdenv gcc6; # with gcc-7: undefined reference to `__divmoddi4'
+      stdenv = overrideCC stdenv buildPackages.gcc6; # with gcc-7: undefined reference to `__divmoddi4'
     }));
   icu63 = callPackage ../development/libraries/icu/63.nix ({
     nativeBuildRoot = buildPackages.icu63.override { buildRootOnly = true; };
   } // (stdenv.lib.optionalAttrs (stdenv.cc.isGNU && stdenv.hostPlatform.isi686) {
-      stdenv = overrideCC stdenv gcc6; # with gcc-7: undefined reference to `__divmoddi4'
+      stdenv = overrideCC stdenv buildPackages.gcc6; # with gcc-7: undefined reference to `__divmoddi4'
     }));
   icu64 = callPackage ../development/libraries/icu/64.nix ({
     nativeBuildRoot = buildPackages.icu64.override { buildRootOnly = true; };
   } // (stdenv.lib.optionalAttrs (stdenv.cc.isGNU && stdenv.hostPlatform.isi686) {
-      stdenv = overrideCC stdenv gcc6; # with gcc-7: undefined reference to `__divmoddi4'
+      stdenv = overrideCC stdenv buildPackages.gcc6; # with gcc-7: undefined reference to `__divmoddi4'
     }));
 
   icu = icu64;
@@ -12495,7 +12495,7 @@ in
 
   opal = callPackage ../development/libraries/opal {
     ffmpeg = ffmpeg_2;
-    stdenv = overrideCC stdenv gcc6;
+    stdenv = overrideCC stdenv buildPackages.gcc6;
   };
 
   openh264 = callPackage ../development/libraries/openh264 { };
@@ -13505,13 +13505,13 @@ in
   v8_3_14 = callPackage ../development/libraries/v8/3.14.nix {
     inherit (python2Packages) python gyp;
     cctools = darwin.cctools;
-    stdenv = overrideCC stdenv gcc5;
+    stdenv = overrideCC stdenv buildPackages.gcc5;
   };
 
   v8_3_16_14 = callPackage ../development/libraries/v8/3.16.14.nix {
     inherit (python2Packages) python gyp;
     cctools = darwin.cctools;
-    stdenv = if stdenv.isDarwin then stdenv else overrideCC stdenv gcc5;
+    stdenv = if stdenv.isDarwin then stdenv else overrideCC stdenv buildPackages.gcc5;
   };
 
   v8_5_x = callPackage ../development/libraries/v8/5_x.nix ({
@@ -13519,7 +13519,7 @@ in
     icu = icu58; # v8-5.4.232 fails against icu4c-59.1
   } // lib.optionalAttrs stdenv.isLinux {
     # doesn't build with gcc7
-    stdenv = overrideCC stdenv gcc6;
+    stdenv = overrideCC stdenv buildPackages.gcc6;
   });
 
   v8_6_x = v8;
@@ -13527,7 +13527,7 @@ in
     inherit (python2Packages) python;
   } // lib.optionalAttrs stdenv.isLinux {
     # doesn't build with gcc7
-    stdenv = overrideCC stdenv gcc6;
+    stdenv = overrideCC stdenv buildPackages.gcc6;
   };
 
   vaapiIntel = callPackage ../development/libraries/vaapi-intel { };
@@ -13611,7 +13611,7 @@ in
 
   vxl = callPackage ../development/libraries/vxl {
     libpng = libpng12;
-    stdenv = overrideCC stdenv gcc6; # upstream code incompatible with gcc7
+    stdenv = overrideCC stdenv buildPackages.gcc6; # upstream code incompatible with gcc7
   };
 
   wavpack = callPackage ../development/libraries/wavpack { };
@@ -13629,7 +13629,7 @@ in
   webkitgtk = callPackage ../development/libraries/webkitgtk {
     harfbuzz = harfbuzzFull;
     inherit (gst_all_1) gst-plugins-base gst-plugins-bad;
-    stdenv = overrideCC stdenv gcc6;
+    stdenv = overrideCC stdenv buildPackages.gcc6;
   };
 
   webkitgtk24x-gtk3 = callPackage ../development/libraries/webkitgtk/2.4.nix {
@@ -14215,8 +14215,8 @@ in
 
   fingerd_bsd = callPackage ../servers/fingerd/bsd-fingerd { };
 
-  firebird = callPackage ../servers/firebird { icu = null; stdenv = overrideCC stdenv gcc5; };
-  firebirdSuper = firebird.override { icu = icu58; superServer = true; stdenv = overrideCC stdenv gcc5; };
+  firebird = callPackage ../servers/firebird { icu = null; stdenv = overrideCC stdenv buildPackages.gcc5; };
+  firebirdSuper = firebird.override { icu = icu58; superServer = true; stdenv = overrideCC stdenv buildPackages.gcc5; };
 
   foswiki = callPackage ../servers/foswiki { };
 
@@ -15190,7 +15190,7 @@ in
   kmscube = callPackage ../os-specific/linux/kmscube { };
 
   kmsxx = callPackage ../development/libraries/kmsxx {
-    stdenv = overrideCC stdenv gcc6;
+    stdenv = overrideCC stdenv buildPackages.gcc6;
   };
 
   latencytop = callPackage ../os-specific/linux/latencytop { };
@@ -16783,7 +16783,7 @@ in
   afterstep = callPackage ../applications/window-managers/afterstep {
     fltk = fltk13;
     gtk = gtk2;
-    stdenv = overrideCC stdenv gcc49;
+    stdenv = overrideCC stdenv buildPackages.gcc49;
   };
 
   agedu = callPackage ../tools/misc/agedu { };
@@ -17024,7 +17024,7 @@ in
 
   blender = callPackage  ../applications/misc/blender {
     pythonPackages = python35Packages;
-    stdenv = overrideCC stdenv gcc6;
+    stdenv = overrideCC stdenv buildPackages.gcc6;
   };
 
   bluefish = callPackage ../applications/editors/bluefish {
@@ -17069,7 +17069,7 @@ in
 
   calf = callPackage ../applications/audio/calf {
       inherit (gnome2) libglade;
-      stdenv = overrideCC stdenv gcc5;
+      stdenv = overrideCC stdenv buildPackages.gcc5;
   };
 
   calcurse = callPackage ../applications/misc/calcurse { };
@@ -18611,7 +18611,7 @@ in
 
   k3d = callPackage ../applications/graphics/k3d {
     inherit (pkgs.gnome2) gtkglext;
-    stdenv = overrideCC stdenv gcc6;
+    stdenv = overrideCC stdenv buildPackages.gcc6;
     boost = boost166.override { enablePython = true; };
   };
 
@@ -19046,7 +19046,7 @@ in
   };
 
   xmr-stak = callPackage ../applications/misc/xmr-stak {
-    stdenvGcc6 = overrideCC stdenv gcc6;
+    stdenvGcc6 = overrideCC stdenv buildPackages.gcc6;
   };
 
   xmrig = callPackage ../applications/misc/xmrig { };
@@ -19334,7 +19334,7 @@ in
   maxlib = callPackage ../applications/audio/pd-plugins/maxlib { };
 
   maxscale = callPackage ../tools/networking/maxscale {
-    stdenv = overrideCC stdenv gcc6;
+    stdenv = overrideCC stdenv buildPackages.gcc6;
   };
 
   pdfdiff = callPackage ../applications/misc/pdfdiff { };
@@ -19445,7 +19445,7 @@ in
   openfx = callPackage ../development/libraries/openfx {};
 
   openimageio = callPackage ../applications/graphics/openimageio {
-    stdenv = overrideCC stdenv gcc6;
+    stdenv = overrideCC stdenv buildPackages.gcc6;
   };
 
   openimageio2 = callPackage ../applications/graphics/openimageio/2.x.nix { };
@@ -19501,7 +19501,7 @@ in
 
   palemoon = callPackage ../applications/networking/browsers/palemoon {
     # https://forum.palemoon.org/viewtopic.php?f=57&t=15296#p111146
-    stdenv = overrideCC stdenv gcc49;
+    stdenv = overrideCC stdenv buildPackages.gcc49;
   };
 
   pamix = callPackage ../applications/audio/pamix { };
@@ -21284,7 +21284,7 @@ in
   arena = callPackage ../games/arena {};
 
   arx-libertatis = callPackage ../games/arx-libertatis {
-    stdenv = overrideCC stdenv gcc6;
+    stdenv = overrideCC stdenv buildPackages.gcc6;
   };
 
   asc = callPackage ../games/asc {
@@ -22288,7 +22288,7 @@ in
   aragorn = callPackage ../applications/science/biology/aragorn { };
 
   archimedes = callPackage ../applications/science/electronics/archimedes {
-    stdenv = overrideCC stdenv gcc49;
+    stdenv = overrideCC stdenv buildPackages.gcc49;
   };
 
   bedtools = callPackage ../applications/science/biology/bedtools { };
@@ -23191,7 +23191,7 @@ in
   dumb = callPackage ../misc/dumb { };
 
   emulationstation = callPackage ../misc/emulators/emulationstation {
-    stdenv = overrideCC stdenv gcc5;
+    stdenv = overrideCC stdenv buildPackages.gcc5;
   };
 
   electricsheep = callPackage ../misc/screensavers/electricsheep { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -671,7 +671,7 @@ in
 
   apt = callPackage ../tools/package-management/apt {
     # include/c++/6.4.0/cstdlib:75:25: fatal error: stdlib.h: No such file or directory
-    stdenv = overrideCC stdenv buildPackages.gcc5;
+    stdenv = gcc5Stdenv;
   };
 
   apt-dater = callPackage ../tools/package-management/apt-dater { };
@@ -2805,7 +2805,7 @@ in
   exa = callPackage ../tools/misc/exa { };
 
   exempi = callPackage ../development/libraries/exempi {
-    stdenv = if stdenv.isi686 then overrideCC stdenv buildPackages.gcc6 else stdenv;
+    stdenv = if stdenv.isi686 then gcc6Stdenv else stdenv;
   };
 
   execline = skawarePackages.execline;
@@ -3081,7 +3081,7 @@ in
   fusuma = callPackage ../tools/inputmethods/fusuma {};
 
   fdbPackages = dontRecurseIntoAttrs (callPackage ../servers/foundationdb {
-    stdenv49 = overrideCC stdenv buildPackages.gcc49;
+    stdenv49 = gcc49Stdenv;
   });
 
   inherit (fdbPackages)
@@ -3250,7 +3250,7 @@ in
   gnash = callPackage ../misc/gnash { };
 
   gnaural = callPackage ../applications/audio/gnaural {
-    stdenv = overrideCC stdenv buildPackages.gcc49;
+    stdenv = gcc49Stdenv;
   };
 
   gnirehtet = callPackage ../tools/networking/gnirehtet { };
@@ -6381,7 +6381,7 @@ in
   udptunnel = callPackage ../tools/networking/udptunnel { };
 
   ufraw = callPackage ../applications/graphics/ufraw {
-    stdenv = overrideCC stdenv buildPackages.gcc6; # doesn't build with gcc7
+    stdenv = gcc6Stdenv; # doesn't build with gcc7
   };
 
   uftrace = callPackage ../development/tools/uftrace { };
@@ -7090,7 +7090,7 @@ in
 
   avian = callPackage ../development/compilers/avian {
     inherit (darwin.apple_sdk.frameworks) CoreServices Foundation;
-    stdenv = if stdenv.cc.isGNU then overrideCC stdenv buildPackages.gcc49 else stdenv;
+    stdenv = if stdenv.cc.isGNU then gcc49Stdenv else stdenv;
   };
 
   bigloo = callPackage ../development/compilers/bigloo { };
@@ -7229,6 +7229,9 @@ in
     extraBuildInputs = lib.optional stdenv.hostPlatform.isDarwin clang.cc;
   };
 
+  gcc49Stdenv = overrideCC gccStdenv buildPackages.gcc49;
+  gcc5Stdenv = overrideCC gccStdenv buildPackages.gcc5;
+  gcc6Stdenv = overrideCC gccStdenv buildPackages.gcc6;
   gcc7Stdenv = overrideCC gccStdenv buildPackages.gcc7;
   gcc8Stdenv = overrideCC gccStdenv buildPackages.gcc8;
   gcc9Stdenv = overrideCC gccStdenv buildPackages.gcc9;
@@ -7803,7 +7806,7 @@ in
   llvmPackages_35 = callPackage ../development/compilers/llvm/3.5 ({
     isl = isl_0_14;
   } // stdenv.lib.optionalAttrs (stdenv.cc.isGNU && stdenv.hostPlatform.isi686) {
-    stdenv = overrideCC stdenv buildPackages.gcc6;
+    stdenv = gcc6Stdenv;
   });
 
   llvmPackages_38 = callPackage ../development/compilers/llvm/3.8 ({
@@ -7811,7 +7814,7 @@ in
     buildLlvmTools = buildPackages.llvmPackages_38.tools;
     targetLlvmLibraries = targetPackages.llvmPackages_38.libraries;
   } // stdenv.lib.optionalAttrs (stdenv.cc.isGNU && stdenv.hostPlatform.isi686) {
-    stdenv = overrideCC stdenv buildPackages.gcc6;
+    stdenv = gcc6Stdenv;
   });
 
   llvmPackages_39 = callPackage ../development/compilers/llvm/3.9 ({
@@ -7819,7 +7822,7 @@ in
     buildLlvmTools = buildPackages.llvmPackages_39.tools;
     targetLlvmLibraries = targetPackages.llvmPackages_39.libraries;
   } // stdenv.lib.optionalAttrs (stdenv.cc.isGNU && stdenv.hostPlatform.isi686) {
-    stdenv = overrideCC stdenv buildPackages.gcc6;
+    stdenv = gcc6Stdenv;
   });
 
   llvmPackages_4 = callPackage ../development/compilers/llvm/4 ({
@@ -7827,7 +7830,7 @@ in
     buildLlvmTools = buildPackages.llvmPackages_4.tools;
     targetLlvmLibraries = targetPackages.llvmPackages_4.libraries;
   } // stdenv.lib.optionalAttrs (stdenv.cc.isGNU && stdenv.hostPlatform.isi686) {
-    stdenv = overrideCC stdenv buildPackages.gcc6;
+    stdenv = gcc6Stdenv;
   });
 
   llvmPackages_5 = callPackage ../development/compilers/llvm/5 ({
@@ -7835,7 +7838,7 @@ in
     buildLlvmTools = buildPackages.llvmPackages_5.tools;
     targetLlvmLibraries = targetPackages.llvmPackages_5.libraries;
   } // stdenv.lib.optionalAttrs (stdenv.cc.isGNU && stdenv.hostPlatform.isi686) {
-    stdenv = overrideCC stdenv buildPackages.gcc6; # with gcc-7: undefined reference to `__divmoddi4'
+    stdenv = gcc6Stdenv; # with gcc-7: undefined reference to `__divmoddi4'
   });
 
   llvmPackages_6 = callPackage ../development/compilers/llvm/6 ({
@@ -7843,7 +7846,7 @@ in
     buildLlvmTools = buildPackages.llvmPackages_6.tools;
     targetLlvmLibraries = targetPackages.llvmPackages_6.libraries;
   } // stdenv.lib.optionalAttrs (stdenv.cc.isGNU && stdenv.hostPlatform.isi686) {
-    stdenv = overrideCC stdenv buildPackages.gcc6; # with gcc-7: undefined reference to `__divmoddi4'
+    stdenv = gcc6Stdenv; # with gcc-7: undefined reference to `__divmoddi4'
   });
 
   llvmPackages_7 = callPackage ../development/compilers/llvm/7 ({
@@ -7851,7 +7854,7 @@ in
     buildLlvmTools = buildPackages.llvmPackages_7.tools;
     targetLlvmLibraries = targetPackages.llvmPackages_7.libraries;
   } // stdenv.lib.optionalAttrs (buildPackages.stdenv.cc.isGNU && stdenv.hostPlatform.isi686) {
-    stdenv = overrideCC stdenv buildPackages.gcc6; # with gcc-7: undefined reference to `__divmoddi4'
+    stdenv = gcc6Stdenv; # with gcc-7: undefined reference to `__divmoddi4'
   });
 
   llvmPackages_8 = callPackage ../development/compilers/llvm/8 ({
@@ -7859,7 +7862,7 @@ in
     buildLlvmTools = buildPackages.llvmPackages_8.tools;
     targetLlvmLibraries = targetPackages.llvmPackages_8.libraries;
   } // stdenv.lib.optionalAttrs (buildPackages.stdenv.cc.isGNU && stdenv.hostPlatform.isi686) {
-    stdenv = overrideCC stdenv buildPackages.gcc6; # with gcc-7: undefined reference to `__divmoddi4'
+    stdenv = gcc6Stdenv; # with gcc-7: undefined reference to `__divmoddi4'
   });
 
   llvmPackages_latest = llvmPackages_8;
@@ -7967,7 +7970,7 @@ in
   pforth = callPackage ../development/compilers/pforth {};
 
   picat = callPackage ../development/compilers/picat {
-    stdenv = overrideCC stdenv buildPackages.gcc49;
+    stdenv = gcc49Stdenv;
   };
 
   ponyc = callPackage ../development/compilers/ponyc {
@@ -8625,7 +8628,7 @@ in
   spidermonkey_38 = callPackage ../development/interpreters/spidermonkey/38.nix ({
     inherit (darwin) libobjc;
   } // (stdenv.lib.optionalAttrs (stdenv.cc.isGNU && stdenv.hostPlatform.isi686) {
-      stdenv = overrideCC stdenv buildPackages.gcc6; # with gcc-7: undefined reference to `__divmoddi4'
+      stdenv = gcc6Stdenv; # with gcc-7: undefined reference to `__divmoddi4'
   }));
   spidermonkey_52 = callPackage ../development/interpreters/spidermonkey/52.nix { };
   spidermonkey_60 = callPackage ../development/interpreters/spidermonkey/60.nix { };
@@ -8878,7 +8881,7 @@ in
   yacc = bison; # TODO: move to aliases.nix
 
   blackmagic = callPackage ../development/tools/misc/blackmagic {
-    stdenv = overrideCC stdenv buildPackages.gcc6;
+    stdenv = gcc6Stdenv;
     gcc-arm-embedded = pkgsCross.arm-embedded.buildPackages.gcc;
     binutils-arm-embedded = pkgsCross.arm-embedded.buildPackages.binutils;
   };
@@ -10922,27 +10925,27 @@ in
     nativeBuildRoot = buildPackages.icu58.override { buildRootOnly = true; };
   } //
     (stdenv.lib.optionalAttrs (stdenv.cc.isGNU && stdenv.hostPlatform.isi686) {
-      stdenv = overrideCC stdenv buildPackages.gcc6; # with gcc-7: undefined reference to `__divmoddi4'
+      stdenv = gcc6Stdenv; # with gcc-7: undefined reference to `__divmoddi4'
     }));
   icu59 = callPackage ../development/libraries/icu/59.nix ({
     nativeBuildRoot = buildPackages.icu59.override { buildRootOnly = true; };
   } // (stdenv.lib.optionalAttrs (stdenv.cc.isGNU && stdenv.hostPlatform.isi686) {
-      stdenv = overrideCC stdenv buildPackages.gcc6; # with gcc-7: undefined reference to `__divmoddi4'
+      stdenv = gcc6Stdenv; # with gcc-7: undefined reference to `__divmoddi4'
     }));
   icu60 = callPackage ../development/libraries/icu/60.nix ({
     nativeBuildRoot = buildPackages.icu60.override { buildRootOnly = true; };
   } // (stdenv.lib.optionalAttrs (stdenv.cc.isGNU && stdenv.hostPlatform.isi686) {
-      stdenv = overrideCC stdenv buildPackages.gcc6; # with gcc-7: undefined reference to `__divmoddi4'
+      stdenv = gcc6Stdenv; # with gcc-7: undefined reference to `__divmoddi4'
     }));
   icu63 = callPackage ../development/libraries/icu/63.nix ({
     nativeBuildRoot = buildPackages.icu63.override { buildRootOnly = true; };
   } // (stdenv.lib.optionalAttrs (stdenv.cc.isGNU && stdenv.hostPlatform.isi686) {
-      stdenv = overrideCC stdenv buildPackages.gcc6; # with gcc-7: undefined reference to `__divmoddi4'
+      stdenv = gcc6Stdenv; # with gcc-7: undefined reference to `__divmoddi4'
     }));
   icu64 = callPackage ../development/libraries/icu/64.nix ({
     nativeBuildRoot = buildPackages.icu64.override { buildRootOnly = true; };
   } // (stdenv.lib.optionalAttrs (stdenv.cc.isGNU && stdenv.hostPlatform.isi686) {
-      stdenv = overrideCC stdenv buildPackages.gcc6; # with gcc-7: undefined reference to `__divmoddi4'
+      stdenv = gcc6Stdenv; # with gcc-7: undefined reference to `__divmoddi4'
     }));
 
   icu = icu64;
@@ -12495,7 +12498,7 @@ in
 
   opal = callPackage ../development/libraries/opal {
     ffmpeg = ffmpeg_2;
-    stdenv = overrideCC stdenv buildPackages.gcc6;
+    stdenv = gcc6Stdenv;
   };
 
   openh264 = callPackage ../development/libraries/openh264 { };
@@ -13505,13 +13508,13 @@ in
   v8_3_14 = callPackage ../development/libraries/v8/3.14.nix {
     inherit (python2Packages) python gyp;
     cctools = darwin.cctools;
-    stdenv = overrideCC stdenv buildPackages.gcc5;
+    stdenv = gcc5Stdenv;
   };
 
   v8_3_16_14 = callPackage ../development/libraries/v8/3.16.14.nix {
     inherit (python2Packages) python gyp;
     cctools = darwin.cctools;
-    stdenv = if stdenv.isDarwin then stdenv else overrideCC stdenv buildPackages.gcc5;
+    stdenv = if stdenv.isDarwin then stdenv else gcc5Stdenv;
   };
 
   v8_5_x = callPackage ../development/libraries/v8/5_x.nix ({
@@ -13519,7 +13522,7 @@ in
     icu = icu58; # v8-5.4.232 fails against icu4c-59.1
   } // lib.optionalAttrs stdenv.isLinux {
     # doesn't build with gcc7
-    stdenv = overrideCC stdenv buildPackages.gcc6;
+    stdenv = gcc6Stdenv;
   });
 
   v8_6_x = v8;
@@ -13527,7 +13530,7 @@ in
     inherit (python2Packages) python;
   } // lib.optionalAttrs stdenv.isLinux {
     # doesn't build with gcc7
-    stdenv = overrideCC stdenv buildPackages.gcc6;
+    stdenv = gcc6Stdenv;
   };
 
   vaapiIntel = callPackage ../development/libraries/vaapi-intel { };
@@ -13611,7 +13614,7 @@ in
 
   vxl = callPackage ../development/libraries/vxl {
     libpng = libpng12;
-    stdenv = overrideCC stdenv buildPackages.gcc6; # upstream code incompatible with gcc7
+    stdenv = gcc6Stdenv; # upstream code incompatible with gcc7
   };
 
   wavpack = callPackage ../development/libraries/wavpack { };
@@ -13629,7 +13632,7 @@ in
   webkitgtk = callPackage ../development/libraries/webkitgtk {
     harfbuzz = harfbuzzFull;
     inherit (gst_all_1) gst-plugins-base gst-plugins-bad;
-    stdenv = overrideCC stdenv buildPackages.gcc6;
+    stdenv = gcc6Stdenv;
   };
 
   webkitgtk24x-gtk3 = callPackage ../development/libraries/webkitgtk/2.4.nix {
@@ -14215,8 +14218,8 @@ in
 
   fingerd_bsd = callPackage ../servers/fingerd/bsd-fingerd { };
 
-  firebird = callPackage ../servers/firebird { icu = null; stdenv = overrideCC stdenv buildPackages.gcc5; };
-  firebirdSuper = firebird.override { icu = icu58; superServer = true; stdenv = overrideCC stdenv buildPackages.gcc5; };
+  firebird = callPackage ../servers/firebird { icu = null; stdenv = gcc5Stdenv; };
+  firebirdSuper = firebird.override { icu = icu58; superServer = true; stdenv = gcc5Stdenv; };
 
   foswiki = callPackage ../servers/foswiki { };
 
@@ -15190,7 +15193,7 @@ in
   kmscube = callPackage ../os-specific/linux/kmscube { };
 
   kmsxx = callPackage ../development/libraries/kmsxx {
-    stdenv = overrideCC stdenv buildPackages.gcc6;
+    stdenv = gcc6Stdenv;
   };
 
   latencytop = callPackage ../os-specific/linux/latencytop { };
@@ -16783,7 +16786,7 @@ in
   afterstep = callPackage ../applications/window-managers/afterstep {
     fltk = fltk13;
     gtk = gtk2;
-    stdenv = overrideCC stdenv buildPackages.gcc49;
+    stdenv = gcc49Stdenv;
   };
 
   agedu = callPackage ../tools/misc/agedu { };
@@ -17024,7 +17027,7 @@ in
 
   blender = callPackage  ../applications/misc/blender {
     pythonPackages = python35Packages;
-    stdenv = overrideCC stdenv buildPackages.gcc6;
+    stdenv = gcc6Stdenv;
   };
 
   bluefish = callPackage ../applications/editors/bluefish {
@@ -17069,7 +17072,7 @@ in
 
   calf = callPackage ../applications/audio/calf {
       inherit (gnome2) libglade;
-      stdenv = overrideCC stdenv buildPackages.gcc5;
+      stdenv = gcc5Stdenv;
   };
 
   calcurse = callPackage ../applications/misc/calcurse { };
@@ -18611,7 +18614,7 @@ in
 
   k3d = callPackage ../applications/graphics/k3d {
     inherit (pkgs.gnome2) gtkglext;
-    stdenv = overrideCC stdenv buildPackages.gcc6;
+    stdenv = gcc6Stdenv;
     boost = boost166.override { enablePython = true; };
   };
 
@@ -19046,7 +19049,7 @@ in
   };
 
   xmr-stak = callPackage ../applications/misc/xmr-stak {
-    stdenvGcc6 = overrideCC stdenv buildPackages.gcc6;
+    stdenvGcc6 = gcc6Stdenv;
   };
 
   xmrig = callPackage ../applications/misc/xmrig { };
@@ -19334,7 +19337,7 @@ in
   maxlib = callPackage ../applications/audio/pd-plugins/maxlib { };
 
   maxscale = callPackage ../tools/networking/maxscale {
-    stdenv = overrideCC stdenv buildPackages.gcc6;
+    stdenv = gcc6Stdenv;
   };
 
   pdfdiff = callPackage ../applications/misc/pdfdiff { };
@@ -19445,7 +19448,7 @@ in
   openfx = callPackage ../development/libraries/openfx {};
 
   openimageio = callPackage ../applications/graphics/openimageio {
-    stdenv = overrideCC stdenv buildPackages.gcc6;
+    stdenv = gcc6Stdenv;
   };
 
   openimageio2 = callPackage ../applications/graphics/openimageio/2.x.nix { };
@@ -19501,7 +19504,7 @@ in
 
   palemoon = callPackage ../applications/networking/browsers/palemoon {
     # https://forum.palemoon.org/viewtopic.php?f=57&t=15296#p111146
-    stdenv = overrideCC stdenv buildPackages.gcc49;
+    stdenv = gcc49Stdenv;
   };
 
   pamix = callPackage ../applications/audio/pamix { };
@@ -21284,7 +21287,7 @@ in
   arena = callPackage ../games/arena {};
 
   arx-libertatis = callPackage ../games/arx-libertatis {
-    stdenv = overrideCC stdenv buildPackages.gcc6;
+    stdenv = gcc6Stdenv;
   };
 
   asc = callPackage ../games/asc {
@@ -22288,7 +22291,7 @@ in
   aragorn = callPackage ../applications/science/biology/aragorn { };
 
   archimedes = callPackage ../applications/science/electronics/archimedes {
-    stdenv = overrideCC stdenv buildPackages.gcc49;
+    stdenv = gcc49Stdenv;
   };
 
   bedtools = callPackage ../applications/science/biology/bedtools { };
@@ -23191,7 +23194,7 @@ in
   dumb = callPackage ../misc/dumb { };
 
   emulationstation = callPackage ../misc/emulators/emulationstation {
-    stdenv = overrideCC stdenv buildPackages.gcc5;
+    stdenv = gcc5Stdenv;
   };
 
   electricsheep = callPackage ../misc/screensavers/electricsheep { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
As stated in https://github.com/NixOS/nixpkgs/issues/63293#issuecomment-504464858 `overrideCC` has to be called with a compiler from `buildPackages`, otherwise it breaks cross builds.

###### Things done
- Replace uses of `overrideCC` with indirections to `gccXStdenv`.

Note that I did very limited testing on this. I tried to build `apt` for `raspberryPi` but that fails at some perl library dependency.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
