### PR TITLE
hostapd: add noscan mode

### DIFF
--- a/nixos/modules/services/networking/hostapd.nix
+++ b/nixos/modules/services/networking/hostapd.nix
@@ -171,6 +171,7 @@ in
         after = [ "sys-subsystem-net-devices-${escapedInterface}.device" ];
         bindsTo = [ "sys-subsystem-net-devices-${escapedInterface}.device" ];
         requiredBy = [ "network-link-${cfg.interface}.service" ];
+        wantedBy = [ "multi-user.target" ];
 
         serviceConfig =
           { ExecStart = "${pkgs.hostapd}/bin/hostapd ${configFile}";

--- a/nixos/modules/services/networking/hostapd.nix
+++ b/nixos/modules/services/networking/hostapd.nix
@@ -30,10 +30,11 @@ let
     ctrl_interface=/run/hostapd
     ctrl_interface_group=${cfg.group}
 
-    ${if cfg.wpa then ''
+    ${optionalString cfg.wpa ''
       wpa=2
       wpa_passphrase=${cfg.wpaPassphrase}
-      '' else ""}
+    ''}
+    ${optionalString cfg.noScan "noscan=1"}
 
     ${cfg.extraConfig}
   '' ;
@@ -66,6 +67,14 @@ in
         example = "wlp2s0";
         description = ''
           The interfaces <command>hostapd</command> will use.
+        '';
+      };
+
+      noScan = mkOption {
+        default = false;
+        description = ''
+          Do not scan for overlapping BSSs in HT40+/- mode.
+          Caution: turning this on will violate regulatory requirements!
         '';
       };
 

--- a/pkgs/os-specific/linux/hostapd/default.nix
+++ b/pkgs/os-specific/linux/hostapd/default.nix
@@ -1,7 +1,11 @@
 { stdenv, fetchurl, pkgconfig, libnl, openssl, sqlite ? null }:
 
 with stdenv.lib;
-stdenv.mkDerivation rec {
+let noScanPatch = fetchurl {
+      url="https://git.telliq.com/gtu/openwrt/raw/master/package/network/services/hostapd/patches/300-noscan.patch";
+      sha256 = "04wg4yjc19wmwk6gia067z99gzzk9jacnwxh5wyia7k5wg71yj5k";
+  };
+in stdenv.mkDerivation rec {
   name = "hostapd-${version}";
   version = "2.8";
 
@@ -12,6 +16,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ libnl openssl sqlite ];
+
+  patches = [ noScanPatch ];
 
   outputs = [ "out" "man" ];
 
@@ -66,7 +72,7 @@ stdenv.mkDerivation rec {
     repositories.git = git://w1.fi/hostap.git;
     description = "A user space daemon for access point and authentication servers";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ phreedom ];
+    maintainers = with maintainers; [ phreedom ninjatrappeur ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Hostapd is preventing us to create any overlapping BSSs in HT40+/- mode.

Not being able to create those overlapping BSSs is basically
preventing us to use 802.11n in any urban area where chances to
overlap with another SSID are extremely high.

###### Things done

Applies OpenWRT's noscan patch to hostapd and the relevant option to
the hostapd module.

This noscan patch adds a new `noscan` option allowing us to create
some overlapping BSSs in HT40+/- mode.

This option is disabled by default, we leave this up to the end
user whether it should be enabled or not.

Not being able to create those overlapping BSSs is basically
preventing us to use 802.11n in any urban area where chances to
overlap with another SSID are extremely high.

The patch we are using is coming from the OpenWRT project. 

This patch is applied to the default hostapd package in both OpenWRT and Archlinux.

Note: The hostapd systemd service was disabled by default, I enabled it in a second commit. Hope not being too sneaky by doing that. If that's the case, don't hesitate to discard the second commit of this PR.

------


- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

--------------

cc @flokli  @Phreedom @Ma27 @bobvanderlinden 