### PR TITLE
Improve composability of mkShell

### DIFF
--- a/pkgs/build-support/mkshell/default.nix
+++ b/pkgs/build-support/mkshell/default.nix
@@ -25,6 +25,7 @@ let
     "nativeBuildInputs"
     "propagatedBuildInputs"
     "propagatedNativeBuildInputs"
+    "shellHook"
   ];
 in
 
@@ -36,6 +37,9 @@ stdenv.mkDerivation ({
   nativeBuildInputs = mergeInputs "nativeBuildInputs";
   propagatedBuildInputs = mergeInputs "propagatedBuildInputs";
   propagatedNativeBuildInputs = mergeInputs "propagatedNativeBuildInputs";
+
+  shellHook = lib.concatStringsSep "\n" (lib.catAttrs "shellHook"
+    (lib.reverseList inputsFrom ++ [attrs]));
 
   nobuildPhase = ''
     echo

--- a/pkgs/build-support/mkshell/default.nix
+++ b/pkgs/build-support/mkshell/default.nix
@@ -11,13 +11,8 @@
   ...
 }@attrs:
 let
-  mergeInputs = name:
-    let
-      op = item: sum: sum ++ item."${name}" or [];
-      nul = [];
-      list = [attrs] ++ inputsFrom;
-    in
-      lib.foldr op nul list;
+  mergeInputs = name: lib.concatLists (lib.catAttrs name
+    ([attrs] ++ inputsFrom));
 
   rest = builtins.removeAttrs attrs [
     "inputsFrom"


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This improves the composability of `mkShell` in two ways: 

* `shellHook` is now also composed. For example running the following expression with `nix-shell`:

```nix
let
  pkgs = import <nixpkgs> {};

  shell1 = pkgs.mkShell {
    shellHook = ''
      echo shell1
    '';
  };

  shell2 = pkgs.mkShell {
    shellHook = ''
      echo shell2
    '';
  };

  shell3 = pkgs.mkShell {
    inputsFrom = [ shell1 shell2 ];
    shellHook = ''
      echo shell3
    '';
  };
in shell3
```

will now result in:

```
shell2
shell1
shell3
```

Note that packages in the front of `inputsFrom` have precedence over packages in the back. The outermost `mkShell` has precedence over all.

* `mergeInputs` will now result in a more sensible order of `$PATH`. For example running following with `nix-shell`:

```nix
let
  pkgs = import <nixpkgs> {};

  shell1 = pkgs.mkShell {
    buildInputs = [ pkgs.htop ];
  };

  shell2 = pkgs.mkShell {
    buildInputs = [ pkgs.hello ];
  };

  shell3 = pkgs.mkShell {
    inputsFrom = [ shell1 shell2 ];
    buildInputs = [ pkgs.tree ];
  };

in shell3
```

results in the following `$PATH`:

```
$ echo $PATH
...
/nix/store/yifq4bikf7m07160bpia7z48ciqddbfi-tree-1.8.0/bin:
/nix/store/vhxqk81234ivqw1a7j200a1c69k8mywi-htop-2.2.0/bin:
/nix/store/n9vm3m58y1n3rg3mlll17wanc9hln58k-hello-2.10/bin
...
```

Previously the order was:

```
/nix/store/n9vm3m58y1n3rg3mlll17wanc9hln58k-hello-2.10/bin
/nix/store/vhxqk81234ivqw1a7j200a1c69k8mywi-htop-2.2.0/bin:
/nix/store/yifq4bikf7m07160bpia7z48ciqddbfi-tree-1.8.0/bin:
```

The new order makes more sense because it allows to override `$PATH` in the outermost `mkShell` and this order is consistent with the `shellHook` precedence.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
