### PR TITLE
cmake: 3.13.4 -> 3.14.5

### DIFF
--- a/pkgs/development/tools/build-managers/cmake/default.nix
+++ b/pkgs/development/tools/build-managers/cmake/default.nix
@@ -13,24 +13,20 @@
 assert withQt5 -> useQt4 == false;
 assert useQt4 -> withQt5 == false;
 
-with stdenv.lib;
-
 let
-  os = stdenv.lib.optionalString;
-  majorVersion = "3.13";
-  minorVersion = "4";
-  # from https://cmake.org/files/v3.13/cmake-3.13.4-SHA-256.txt for cmake-3.13.4.tar.gz
-  sha256 = "fdd928fee35f472920071d1c7f1a6a2b72c9b25e04f7a37b409349aef3f20e9b";
-  version = "${majorVersion}.${minorVersion}";
+  lib = stdenv.lib;
+  os = lib.optionalString;
+  version = "3.14.5";
+  # compare with https://cmake.org/files/v${lib.versions.majorMinor version}/cmake-${version}-SHA-256.txt
+  sha256 = "505ae49ebe3c63c595fa5f814975d8b72848447ee13b6613b0f8b96ebda18c06";
 in
 
 stdenv.mkDerivation rec {
-  name = "cmake-${os isBootstrap "boot-"}${os useNcurses "cursesUI-"}${os withQt5 "qt5UI-"}${os useQt4 "qt4UI-"}${version}";
-
-  inherit majorVersion;
+  pname = "cmake${os isBootstrap "-boot"}${os useNcurses "-cursesUI"}${os withQt5 "-qt5UI"}${os useQt4 "-qt4UI"}";
+  inherit version;
 
   src = fetchurl {
-    url = "${meta.homepage}files/v${majorVersion}/cmake-${version}.tar.gz";
+    url = "${meta.homepage}files/v${lib.versions.majorMinor version}/cmake-${version}.tar.gz";
     inherit sha256;
   };
 
@@ -43,7 +39,7 @@ stdenv.mkDerivation rec {
 
     # Derived from https://github.com/libuv/libuv/commit/1a5d4f08238dd532c3718e210078de1186a5920d
     ./libuv-application-services.patch
-  ] ++ optional stdenv.isCygwin ./3.2.2-cygwin.patch;
+  ] ++ lib.optional stdenv.isCygwin ./3.2.2-cygwin.patch;
 
   outputs = [ "out" ];
   setOutputFlags = false;
@@ -52,21 +48,21 @@ stdenv.mkDerivation rec {
 
   buildInputs =
     [ setupHook pkgconfig ]
-    ++ optionals useSharedLibraries [ bzip2 curl expat libarchive xz zlib libuv rhash ]
-    ++ optional useNcurses ncurses
-    ++ optional useQt4 qt4
-    ++ optional withQt5 qtbase;
+    ++ lib.optionals useSharedLibraries [ bzip2 curl expat libarchive xz zlib libuv rhash ]
+    ++ lib.optional useNcurses ncurses
+    ++ lib.optional useQt4 qt4
+    ++ lib.optional withQt5 qtbase;
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
 
-  propagatedBuildInputs = optional stdenv.isDarwin ps;
+  propagatedBuildInputs = lib.optional stdenv.isDarwin ps;
 
   preConfigure = ''
     fixCmakeFiles .
     substituteInPlace Modules/Platform/UnixPaths.cmake \
-      --subst-var-by libc_bin ${getBin stdenv.cc.libc} \
-      --subst-var-by libc_dev ${getDev stdenv.cc.libc} \
-      --subst-var-by libc_lib ${getLib stdenv.cc.libc}
+      --subst-var-by libc_bin ${lib.getBin stdenv.cc.libc} \
+      --subst-var-by libc_dev ${lib.getDev stdenv.cc.libc} \
+      --subst-var-by libc_lib ${lib.getLib stdenv.cc.libc}
     substituteInPlace Modules/FindCxxTest.cmake \
       --replace "$""{PYTHON_EXECUTABLE}" ${stdenv.shell}
     # BUILD_CC and BUILD_CXX are used to bootstrap cmake
@@ -74,9 +70,9 @@ stdenv.mkDerivation rec {
   '';
 
   configureFlags = [
-    "--docdir=share/doc/${name}"
+    "--docdir=share/doc/${pname}${version}"
   ] ++ (if useSharedLibraries then [ "--no-system-jsoncpp" "--system-libs" ] else [ "--no-system-libs" ]) # FIXME: cleanup
-    ++ optional (useQt4 || withQt5) "--qt-gui"
+    ++ lib.optional (useQt4 || withQt5) "--qt-gui"
     ++ [
     "--"
     # We should set the proper `CMAKE_SYSTEM_NAME`.
@@ -87,15 +83,15 @@ stdenv.mkDerivation rec {
     # package being built.
     "-DCMAKE_CXX_COMPILER=${stdenv.cc.targetPrefix}c++"
     "-DCMAKE_C_COMPILER=${stdenv.cc.targetPrefix}cc"
-    "-DCMAKE_AR=${getBin stdenv.cc.bintools.bintools}/bin/${stdenv.cc.targetPrefix}ar"
-    "-DCMAKE_RANLIB=${getBin stdenv.cc.bintools.bintools}/bin/${stdenv.cc.targetPrefix}ranlib"
-    "-DCMAKE_STRIP=${getBin stdenv.cc.bintools.bintools}/bin/${stdenv.cc.targetPrefix}strip"
+    "-DCMAKE_AR=${lib.getBin stdenv.cc.bintools.bintools}/bin/${stdenv.cc.targetPrefix}ar"
+    "-DCMAKE_RANLIB=${lib.getBin stdenv.cc.bintools.bintools}/bin/${stdenv.cc.targetPrefix}ranlib"
+    "-DCMAKE_STRIP=${lib.getBin stdenv.cc.bintools.bintools}/bin/${stdenv.cc.targetPrefix}strip"
   ]
     # Avoid depending on frameworks.
-    ++ optional (!useNcurses) "-DBUILD_CursesDialog=OFF";
+    ++ lib.optional (!useNcurses) "-DBUILD_CursesDialog=OFF";
 
   # make install attempts to use the just-built cmake
-  preInstall = optional (stdenv.hostPlatform != stdenv.buildPlatform) ''
+  preInstall = lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) ''
     sed -i 's|bin/cmake|${buildPackages.cmake}/bin/cmake|g' Makefile
   '';
 
@@ -108,7 +104,7 @@ stdenv.mkDerivation rec {
 
   doCheck = false; # fails
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = http://www.cmake.org/;
     description = "Cross-Platform Makefile Generator";
     platforms = if useQt4 then qt4.meta.platforms else platforms.all;

--- a/pkgs/development/tools/build-managers/cmake/default.nix
+++ b/pkgs/development/tools/build-managers/cmake/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig
+{ stdenv, lib, fetchurl, pkgconfig
 , bzip2, curl, expat, libarchive, xz, zlib, libuv, rhash
 , buildPackages
 # darwin attributes
@@ -13,21 +13,18 @@
 assert withQt5 -> useQt4 == false;
 assert useQt4 -> withQt5 == false;
 
-let
-  lib = stdenv.lib;
-  os = lib.optionalString;
-  version = "3.14.5";
-  # compare with https://cmake.org/files/v${lib.versions.majorMinor version}/cmake-${version}-SHA-256.txt
-  sha256 = "505ae49ebe3c63c595fa5f814975d8b72848447ee13b6613b0f8b96ebda18c06";
-in
-
 stdenv.mkDerivation rec {
-  pname = "cmake${os isBootstrap "-boot"}${os useNcurses "-cursesUI"}${os withQt5 "-qt5UI"}${os useQt4 "-qt4UI"}";
-  inherit version;
+  pname = "cmake"
+          + lib.optionalString isBootstrap "-boot"
+          + lib.optionalString useNcurses "-cursesUI"
+          + lib.optionalString withQt5 "-qt5UI"
+          + lib.optionalString useQt4 "-qt4UI";
+  version = "3.14.5";
 
   src = fetchurl {
     url = "${meta.homepage}files/v${lib.versions.majorMinor version}/cmake-${version}.tar.gz";
-    inherit sha256;
+    # compare with https://cmake.org/files/v${lib.versions.majorMinor version}/cmake-${version}-SHA-256.txt
+    sha256 = "505ae49ebe3c63c595fa5f814975d8b72848447ee13b6613b0f8b96ebda18c06";
   };
 
   patches = [

--- a/pkgs/development/tools/build-managers/cmake/libuv-application-services.patch
+++ b/pkgs/development/tools/build-managers/cmake/libuv-application-services.patch
@@ -24,36 +24,6 @@ diff -ur cmake-3.12.1/Utilities/cmlibuv/CMakeLists.txt cmake-3.12.1-patched/Util
  endif()
  
  if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-diff -ur cmake-3.12.1/Utilities/cmlibuv/src/unix/darwin-proctitle.c cmake-3.12.1-patched/Utilities/cmlibuv/src/unix/darwin-proctitle.c
---- cmake-3.12.1/Utilities/cmlibuv/src/unix/darwin-proctitle.c	2018-08-09 21:14:08.000000000 +0900
-+++ cmake-3.12.1-patched/Utilities/cmlibuv/src/unix/darwin-proctitle.c	2018-08-13 10:01:29.000000000 +0900
-@@ -26,9 +26,7 @@
- #include <stdlib.h>
- #include <string.h>
- 
--#include <TargetConditionals.h>
--
--#if !TARGET_OS_IPHONE
-+#if HAVE_APPLICATIONSERVICES_APPLICATIONSERVICES_H
- # include <CoreFoundation/CoreFoundation.h>
- # include <ApplicationServices/ApplicationServices.h>
- #endif
-@@ -58,7 +56,7 @@
- 
- 
- int uv__set_process_title(const char* title) {
--#if TARGET_OS_IPHONE
-+#if !HAVE_APPLICATIONSERVICES_APPLICATIONSERVICES_H
-   return uv__pthread_setname_np(title);
- #else
-   CFStringRef (*pCFStringCreateWithCString)(CFAllocatorRef,
-@@ -205,5 +203,5 @@
-     dlclose(application_services_handle);
- 
-   return err;
--#endif  /* !TARGET_OS_IPHONE */
-+#endif  /* HAVE_APPLICATIONSERVICES_APPLICATIONSERVICES_H */
- }
 diff -ur cmake-3.12.1/Utilities/cmlibuv/src/unix/fsevents.c cmake-3.12.1-patched/Utilities/cmlibuv/src/unix/fsevents.c
 --- cmake-3.12.1/Utilities/cmlibuv/src/unix/fsevents.c	2018-08-09 21:14:08.000000000 +0900
 +++ cmake-3.12.1-patched/Utilities/cmlibuv/src/unix/fsevents.c	2018-08-13 10:01:29.000000000 +0900

--- a/pkgs/development/tools/build-managers/cmake/search-path.patch
+++ b/pkgs/development/tools/build-managers/cmake/search-path.patch
@@ -38,12 +38,27 @@ diff -ur cmake-3.9.1/Modules/Platform/UnixPaths.cmake cmake-3.9.1-mod/Modules/Pl
 +  @libc_lib@/lib
    )
  
- list(APPEND CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES
--  /usr/include
+ if(CMAKE_SYSROOT_COMPILE)
+   set(_cmake_sysroot_compile "${CMAKE_SYSROOT_COMPILE}")
+ else()
+   set(_cmake_sysroot_compile "${CMAKE_SYSROOT}")
+ endif()
+ 
+ # Default per-language values.  These may be later replaced after
+ # parsing the implicit directory information from compiler output.
+ set(_CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES_INIT
+   ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES}
+-  "${_cmake_sysroot_compile}/usr/include"
 +  @libc_dev@/include
    )
- list(APPEND CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES
--  /usr/include
+ set(_CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES_INIT
+   ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES}
+-  "${_cmake_sysroot_compile}/usr/include"
++  @libc_dev@/include
+   )
+ set(_CMAKE_CUDA_IMPLICIT_INCLUDE_DIRECTORIES_INIT
+   ${CMAKE_CUDA_IMPLICIT_INCLUDE_DIRECTORIES}
+-  "${_cmake_sysroot_compile}/usr/include"
 +  @libc_dev@/include
    )
  


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
https://cmake.org/cmake/help/v3.14/release/3.14.html

###### Things done
Besides the updated version and Hash, I applied these changes to the expression:
- Remove `with stdenv.lib` statement to make the origin of various functions clearer at their call sites.
- Calculate `Major.Minor` from `version`, instead of the other way around. Hopefully making this package auto-updater friendly.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
