### PR TITLE
Add intel-compute-runtime / Intel NEO driver stack

### DIFF
--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -33,6 +33,7 @@ fi
 # GCC prints annoying warnings when they are not needed.
 dontLink=0
 nonFlagArgs=0
+cc1=0
 # shellcheck disable=SC2193
 [[ "@prog@" = *++ ]] && isCpp=1 || isCpp=0
 cppInclude=1
@@ -68,6 +69,8 @@ while (( "$n" < "$nParams" )); do
     elif [[ "$p" != -?* ]]; then
         # A dash alone signifies standard input; it is not a flag
         nonFlagArgs=1
+    elif [ "$p" = -cc1 ]; then
+        cc1=1
     fi
     n+=1
 done
@@ -165,6 +168,14 @@ fi
 if [ "$*" = -v ]; then
     extraAfter=()
     extraBefore=()
+fi
+
+# clang's -cc1 mode is not compatible with most options
+# that we would pass. Rather than trying to pass only
+# options that would work, let's just remove all of them.
+if [ "$cc1" = 1 ]; then
+  extraAfter=()
+  extraBefore=()
 fi
 
 # Optionally print debug info.

--- a/pkgs/development/compilers/intel-graphics-compiler/default.nix
+++ b/pkgs/development/compilers/intel-graphics-compiler/default.nix
@@ -1,0 +1,73 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, pkgconfig
+
+, bison
+, flex
+, llvmPackages_8
+, opencl-clang
+, python
+, spirv-llvm-translator
+
+, buildWithPatches ? true
+}:
+
+let
+  llvmPkgs = llvmPackages_8 // {
+    inherit spirv-llvm-translator;
+  };
+  inherit (llvmPkgs) llvm;
+  inherit (if buildWithPatches then opencl-clang else llvmPkgs) clang clang-unwrapped spirv-llvm-translator;
+  inherit (stdenv.lib) getVersion optional optionals versionOlder versions;
+in
+
+stdenv.mkDerivation rec {
+  pname = "intel-graphics-compiler";
+  version = "1.0.10";
+
+  src = fetchFromGitHub {
+    owner = "intel";
+    repo = "intel-graphics-compiler";
+    rev = "igc-${version}";
+    sha256 = "1yqd2zvvvxxxzb5d3v0f03n0jdivid5l2cj11dw7ff7xz7jwiv2i";
+  };
+
+  nativeBuildInputs = [ clang cmake bison flex llvm python ];
+
+  buildInputs = [ clang opencl-clang spirv-llvm-translator ];
+
+  # checkInputs = [ lit pythonPackages.nose ];
+
+  # FIXME: How do we run the test suite?
+  # https://github.com/intel/intel-graphics-compiler/issues/98
+  doCheck = false;
+
+  # Handholding the braindead build script
+  # We put this in a derivation because the cmake requires an absolute path
+  prebuilds = stdenv.mkDerivation {
+    name = "igc-cclang-prebuilds";
+    phases = [ "installPhase" ];
+    installPhase = ''
+      mkdir $out
+      ln -s ${clang}/bin/clang $out/
+      ln -s clang $out/clang-${versions.major (getVersion clang)}
+      ln -s ${opencl-clang}/lib/* $out/
+      ln -s ${clang-unwrapped}/lib/clang/${getVersion clang}/include/opencl-c.h $out/
+    '';
+  };
+
+  cmakeFlags = [
+    "-DCCLANG_BUILD_PREBUILDS=ON"
+    "-DCCLANG_BUILD_PREBUILDS_DIR=${prebuilds}"
+    "-DIGC_PREFERRED_LLVM_VERSION=${getVersion llvm}"
+  ];
+
+  meta = with stdenv.lib; {
+    homepage    = https://github.com/intel/intel-graphics-compiler;
+    description = "LLVM-based compiler for OpenCL targeting Intel Gen graphics hardware";
+    license     = licenses.mit;
+    platforms   = platforms.all;
+    maintainers = with maintainers; [ gloaming ];
+  };
+}

--- a/pkgs/development/compilers/spirv-llvm-translator/default.nix
+++ b/pkgs/development/compilers/spirv-llvm-translator/default.nix
@@ -1,0 +1,38 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+
+, lit
+, llvm_8
+}:
+
+stdenv.mkDerivation rec {
+  pname = "SPIRV-LLVM-Translator";
+  version = "8.0.1-2";
+
+  src = fetchFromGitHub {
+    owner = "KhronosGroup";
+    repo = "SPIRV-LLVM-Translator";
+    rev = "v${version}";
+    sha256 = "0hxalc3fkliqs61hpr97phbm3qsx4b8vgnlg30aimzr6aas403r5";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ llvm_8 ];
+
+  checkInputs = [ lit ];
+
+  cmakeFlags = [ "-DLLVM_INCLUDE_TESTS=ON" ];
+
+  # FIXME: CMake tries to run "/llvm-lit" which of course doesn't exist
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage    = https://github.com/KhronosGroup/SPIRV-LLVM-Translator;
+    description = "A tool and a library for bi-directional translation between SPIR-V and LLVM IR";
+    license     = licenses.ncsa;
+    platforms   = platforms.all;
+    maintainers = with maintainers; [ gloaming ];
+  };
+}

--- a/pkgs/development/libraries/opencl-clang/default.nix
+++ b/pkgs/development/libraries/opencl-clang/default.nix
@@ -1,0 +1,97 @@
+{ stdenv
+, fetchFromGitHub
+, fetchpatch
+, cmake
+, git
+
+, llvmPackages_8
+, spirv-llvm-translator
+
+, buildWithPatches ? true
+}:
+
+let
+  llvmPkgs = llvmPackages_8 // {
+    inherit spirv-llvm-translator;
+  };
+
+  inherit (stdenv.lib) getVersion;
+
+  addPatches = component: pkg:
+    with builtins; with stdenv.lib;
+    let path = "${passthru.patchesOut}/${component}";
+    in pkg.overrideAttrs (super: {
+      postPatch = (if super ? postPatch then super.postPatch + "\n" else "") + ''
+        for p in ${path}/*
+        do
+          patch -p1 -i "$p"
+        done
+      '';
+    });
+
+  passthru = rec {
+
+    clang-unwrapped = addPatches "clang" llvmPkgs.clang-unwrapped;
+
+    clang = llvmPkgs.clang.override {
+      cc = clang-unwrapped;
+    };
+
+    patchesOut = stdenv.mkDerivation rec {
+      pname = "opencl-clang-patches";
+      inherit (lib) version src patches;
+      installPhase = ''
+        [ -d patches ] && cp -r patches/ $out || mkdir $out
+        mkdir -p $out/clang $out/spirv
+      '';
+    };
+
+    spirv-llvm-translator = addPatches "spirv" llvmPkgs.spirv-llvm-translator;
+
+  };
+
+  lib = let
+    inherit (llvmPkgs) llvm;
+    inherit (if buildWithPatches then passthru else llvmPkgs) clang-unwrapped spirv-llvm-translator;
+  in
+    stdenv.mkDerivation rec {
+      pname = "opencl-clang";
+      version = "unstable-2019-08-16";
+
+      inherit passthru;
+
+      src = fetchFromGitHub {
+        owner = "intel";
+        repo = "opencl-clang";
+        rev = "94af090661d7c953c516c97a25ed053c744a0737";
+        sha256 = "05cg89m62nqjqm705h7gpdz4jd4hiczg8944dcjsvaybrqv3hcm5";
+      };
+
+      patches = [
+      # Build script tries to find Clang OpenCL headers under ${llvm}
+      # Work around it by specifying that directory manually.
+        ./opencl-headers-dir.patch
+      ];
+
+      nativeBuildInputs = [ cmake git ];
+
+      buildInputs = [ clang-unwrapped llvm spirv-llvm-translator ];
+
+      cmakeFlags = [
+        "-DPREFERRED_LLVM_VERSION=${getVersion llvm}"
+        "-DOPENCL_HEADERS_DIR=${clang-unwrapped}/lib/clang/${getVersion clang-unwrapped}/include/"
+
+        "-DLLVMSPIRV_INCLUDED_IN_LLVM=OFF"
+        "-DSPIRV_TRANSLATOR_DIR=${spirv-llvm-translator}"
+      ];
+
+      meta = with stdenv.lib; {
+        homepage    = https://github.com/intel/opencl-clang/;
+        description = "A clang wrapper library with an OpenCL-oriented API and the ability to compile OpenCL C kernels to SPIR-V modules";
+        license     = licenses.ncsa;
+        platforms   = platforms.all;
+        maintainers = with maintainers; [ gloaming ];
+      };
+    };
+in
+  lib

--- a/pkgs/development/libraries/opencl-clang/opencl-headers-dir.patch
+++ b/pkgs/development/libraries/opencl-clang/opencl-headers-dir.patch
@@ -1,0 +1,25 @@
+diff --git a/cl_headers/CMakeLists.txt b/cl_headers/CMakeLists.txt
+index 3dd2ea4..aeae6e9 100644
+--- a/cl_headers/CMakeLists.txt
++++ b/cl_headers/CMakeLists.txt
+@@ -11,12 +11,14 @@ add_custom_command(
+ )
+ endfunction(copy_file)
+ 
+-if(USE_PREBUILT_LLVM)
+-    set(OPENCL_HEADERS_DIR
+-      "${LLVM_LIBRARY_DIRS}/clang/${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.${LLVM_VERSION_PATCH}/include/")
+-else(USE_PREBUILT_LLVM)
+-    set(OPENCL_HEADERS_DIR "${CLANG_SOURCE_DIR}/lib/Headers")
+-endif(USE_PREBUILT_LLVM)
++if(NOT DEFINED OPENCL_HEADERS_DIR)
++  if(USE_PREBUILT_LLVM)
++      set(OPENCL_HEADERS_DIR
++        "${LLVM_LIBRARY_DIRS}/clang/${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.${LLVM_VERSION_PATCH}/include/")
++  else(USE_PREBUILT_LLVM)
++      set(OPENCL_HEADERS_DIR "${CLANG_SOURCE_DIR}/lib/Headers")
++  endif(USE_PREBUILT_LLVM)
++endif()
+ copy_file(${OPENCL_HEADERS_DIR}/opencl-c.h opencl-c.h)
+ 
+ add_custom_target (

--- a/pkgs/os-specific/linux/intel-compute-runtime/default.nix
+++ b/pkgs/os-specific/linux/intel-compute-runtime/default.nix
@@ -1,0 +1,57 @@
+{ stdenv
+, fetchFromGitHub
+, patchelf
+, cmake
+, pkgconfig
+
+, intel-gmmlib
+, intel-graphics-compiler
+, libva
+}:
+
+stdenv.mkDerivation rec {
+  pname = "intel-compute-runtime";
+  version = "19.34.13959";
+
+  src = fetchFromGitHub {
+    owner = "intel";
+    repo = "compute-runtime";
+    rev = version;
+    sha256 = "1m54w5p5pilrkmlmqgvgrsm3d5dqfdr4jai5siq5ccsqj4gnv1wz";
+  };
+
+  # Build script tries to write the ICD to /etc
+  patches = [ ./etc-dir.patch ];
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+
+  buildInputs = [ intel-gmmlib intel-graphics-compiler libva ];
+
+  cmakeFlags = [
+    "-DSKIP_UNIT_TESTS=1"
+
+    "-DIGC_DIR=${intel-graphics-compiler}"
+    "-DETC_DIR=${placeholder "out"}/etc"
+
+    # The install script assumes this path is relative to CMAKE_INSTALL_PREFIX
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+  ];
+
+  postInstall = ''
+    # Avoid clash with intel-ocl
+    mv $out/etc/OpenCL/vendors/intel.icd $out/etc/OpenCL/vendors/intel-neo.icd
+  '';
+
+  postFixup = ''
+    patchelf --set-rpath ${stdenv.lib.makeLibraryPath [ intel-gmmlib intel-graphics-compiler libva ]} \
+      $out/lib/intel-opencl/libigdrcl.so
+  '';
+
+  meta = with stdenv.lib; {
+    homepage    = https://github.com/intel/compute-runtime;
+    description = "Intel Graphics Compute Runtime for OpenCL. Replaces Beignet for Gen8 (Broadwell) and beyond.";
+    license     = licenses.mit;
+    platforms   = platforms.linux;
+    maintainers = with maintainers; [ gloaming ];
+  };
+}

--- a/pkgs/os-specific/linux/intel-compute-runtime/etc-dir.patch
+++ b/pkgs/os-specific/linux/intel-compute-runtime/etc-dir.patch
@@ -1,0 +1,15 @@
+diff --git a/package.cmake b/package.cmake
+index 24960d5..e9a21e7 100644
+--- a/package.cmake
++++ b/package.cmake
+@@ -24,7 +24,9 @@ if(UNIX)
+ 
+   get_os_release_info(os_name os_version)
+ 
+-  if("${os_name}" STREQUAL "clear-linux-os")
++  if(DEFINED ETC_DIR)
++    set(_dir_etc ${ETC_DIR})
++  elseif("${os_name}" STREQUAL "clear-linux-os")
+     # clear-linux-os distribution avoids /etc for distribution defaults.
+     set(_dir_etc "/usr/share/defaults/etc")
+   else()

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7915,6 +7915,8 @@ in
 
   idris = idrisPackages.with-packages [ idrisPackages.base ] ;
 
+  intel-graphics-compiler = callPackage ../development/compilers/intel-graphics-compiler { };
+
   intercal = callPackage ../development/compilers/intercal { };
 
   irony-server = callPackage ../development/tools/irony-server {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15586,6 +15586,8 @@ in
 
   intel2200BGFirmware = callPackage ../os-specific/linux/firmware/intel2200BGFirmware { };
 
+  intel-compute-runtime = callPackage ../os-specific/linux/intel-compute-runtime { };
+
   intel-ocl = callPackage ../os-specific/linux/intel-ocl { };
 
   iomelt = callPackage ../os-specific/linux/iomelt { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8411,6 +8411,8 @@ in
 
   souffle = callPackage ../development/compilers/souffle { };
 
+  spirv-llvm-translator = callPackage ../development/compilers/spirv-llvm-translator { };
+
   sqldeveloper = callPackage ../development/tools/database/sqldeveloper { };
 
   # sqldeveloper_18 needs JavaFX, which currently only is available inside the

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12599,6 +12599,8 @@ in
 
   lzo = callPackage ../development/libraries/lzo { };
 
+  opencl-clang = callPackage ../development/libraries/opencl-clang { };
+
   mapnik = callPackage ../development/libraries/mapnik { };
 
   marisa = callPackage ../development/libraries/marisa {};


### PR DESCRIPTION
###### Motivation for this change
Add `intel-compute-runtime` aka NEO, Intel's new open-source OpenCL GPGPU driver, which replaces Beignet for newer Intel processors.

## TO INSTALL
```
hardware.opengl.extraPackages = with pkgs; [ intel-compute-runtime ];
```
Note that this driver may be installed in parallel with `intel-ocl`. The latter provides an OpenCL device for the CPU, not the iGPU; relative performance may differ depending on workload.

## TODO:
- ~~Update to later versions as much as possible~~
- ~~Finalise changes to `cc-wrapper.sh` and push them into `build-support` on `staging`~~
- ~~Find a way to automatically make gmmlib and IGC available to the driver instead of requiring the user to add them to `opengl.extraPackages`~~
- ~~Assess if there is a saner way to package opencl-clang and its patches~~
- Push .cmake patches upstream?
- ~~Prepare for opencl-clang_8 etc.~~
- Would it make sense to put this under llvmPackages?
- Check and fix tests where possible

## NOTES
- ~~The SPIRV-LLVM-Translator and OpenCL Clang projects have seperate branches and releases depending on LLVM version; I targeted LLVM 7 as that's what we have in release now. On my system I am running these patches rebased onto `release-19.03` and it appears to be working well.~~
- ~~Built largely as per instructions here: https://github.com/JacekDanecki/compute-runtime/wiki/How-to-build-Neo-components-(system-llvm-clang-7)~~
- cc-wrapper.sh has to be modified as the extra options it passes cause Clang to barf with errors about unrecognised flags when attempting to compile with `-cc1`

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @volth @OpenSourceAnarchist