### PR TITLE
Qt5 + Darwin fixes

### DIFF
--- a/pkgs/development/libraries/qt-5/5.11/qttools.patch
+++ b/pkgs/development/libraries/qt-5/5.11/qttools.patch
@@ -69,3 +69,18 @@ index 4318b16f..d60db4ff 100644
      _qt5_LinguistTools_check_file_exists(${imported_location})
  
      set_target_properties(Qt5::lconvert PROPERTIES
+--- a/src/macdeployqt/shared/shared.cpp
++++ b/src/macdeployqt/shared/shared.cpp
+@@ -1241,6 +1241,12 @@ bool deployQmlImports(const QString &appBundlePath, DeploymentInfo deploymentInf
+     if (!QFile(qmlImportScannerPath).exists())
+         qmlImportScannerPath = QCoreApplication::applicationDirPath() + "/qmlimportscanner";
+ 
++#ifdef NIXPKGS_QMLIMPORTSCANNER
++    // Fallback: Nixpkgs hardcoded path
++    if (!QFile(qmlImportScannerPath).exists())
++        qmlImportScannerPath = NIXPKGS_QMLIMPORTSCANNER;
++#endif
++
+     // Verify that we found a qmlimportscanner binary
+     if (!QFile(qmlImportScannerPath).exists()) {
+         LogError() << "qmlimportscanner not found at" << qmlImportScannerPath;

--- a/pkgs/development/libraries/qt-5/5.12/default.nix
+++ b/pkgs/development/libraries/qt-5/5.12/default.nix
@@ -66,6 +66,7 @@ let
         ./qtwebkit-darwin-no-readline.patch
         ./qtwebkit-darwin-no-qos-classes.patch
       ];
+    qttools = [ ./qttools.patch ];
   };
 
   mkDerivation =

--- a/pkgs/development/libraries/qt-5/5.12/qtbase.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qtbase.patch
@@ -1094,3 +1094,63 @@ index 99d87e2e46..a4eab2aa72 100644
  !!ELSE
      set(imported_location \"$${CMAKE_BIN_DIR}uic$$CMAKE_BIN_SUFFIX\")
  !!ENDIF
+diff --git a/src/corelib/kernel/qcore_mac_p.h b/src/corelib/kernel/qcore_mac_p.h
+index b14a494296..779c4eda95 100644
+--- a/src/corelib/kernel/qcore_mac_p.h
++++ b/src/corelib/kernel/qcore_mac_p.h
+@@ -211,7 +211,7 @@ private:
+ 
+ // --------------------------------------------------------------------------
+ 
+-#if !defined(QT_BOOTSTRAPPED)
++#if 0
+ 
+ QT_END_NAMESPACE
+ #include <os/activity.h>
+@@ -289,7 +289,19 @@ QT_MAC_WEAK_IMPORT(_os_activity_current);
+ 
+ #define QT_APPLE_SCOPED_LOG_ACTIVITY(...) QAppleLogActivity scopedLogActivity = QT_APPLE_LOG_ACTIVITY(__VA_ARGS__).enter();
+ 
+-#endif // !defined(QT_BOOTSTRAPPED)
++#else // !defined(QT_BOOTSTRAPPED)
++
++#define QT_APPLE_LOG_ACTIVITY_WITH_PARENT3(...)
++#define QT_APPLE_LOG_ACTIVITY_WITH_PARENT2(...)
++#define QT_APPLE_LOG_ACTIVITY_WITH_PARENT(...)
++
++#define QT_APPLE_LOG_ACTIVITY2(...)
++#define QT_APPLE_LOG_ACTIVITY1(...)
++#define QT_APPLE_LOG_ACTIVITY(...)
++
++#define QT_APPLE_SCOPED_LOG_ACTIVITY(...)
++
++#endif
+ 
+ // -------------------------------------------------------------------------
+ 
+diff --git a/src/testlib/qappletestlogger.cpp b/src/testlib/qappletestlogger.cpp
+index 2c1005ad80..244147ea7d 100644
+--- a/src/testlib/qappletestlogger.cpp
++++ b/src/testlib/qappletestlogger.cpp
+@@ -43,7 +43,7 @@
+ 
+ QT_BEGIN_NAMESPACE
+ 
+-#if defined(QT_USE_APPLE_UNIFIED_LOGGING)
++#if defined(QT_USE_APPLE_UNIFIED_LOGGING) && 0
+ 
+ using namespace QTestPrivate;
+ 
+diff --git a/src/testlib/qtestlog.cpp b/src/testlib/qtestlog.cpp
+index 1268730cc6..a50e9b0764 100644
+--- a/src/testlib/qtestlog.cpp
++++ b/src/testlib/qtestlog.cpp
+@@ -524,7 +524,7 @@ void QTestLog::addLogger(LogMode mode, const char *filename)
+ #endif
+     }
+ 
+-#if defined(QT_USE_APPLE_UNIFIED_LOGGING)
++#if defined(QT_USE_APPLE_UNIFIED_LOGGING) && 0
+     // Logger that also feeds messages to AUL. It needs to wrap the existing
+     // logger, as it needs to be able to short circuit the existing logger
+     // in case AUL prints to stderr.

--- a/pkgs/development/libraries/qt-5/5.12/qttools.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qttools.patch
@@ -1,0 +1,15 @@
+--- a/src/macdeployqt/shared/shared.cpp
++++ b/src/macdeployqt/shared/shared.cpp
+@@ -1241,6 +1241,12 @@ bool deployQmlImports(const QString &appBundlePath, DeploymentInfo deploymentInf
+     if (!QFile(qmlImportScannerPath).exists())
+         qmlImportScannerPath = QCoreApplication::applicationDirPath() + "/qmlimportscanner";
+ 
++#ifdef NIXPKGS_QMLIMPORTSCANNER
++    // Fallback: Nixpkgs hardcoded path
++    if (!QFile(qmlImportScannerPath).exists())
++        qmlImportScannerPath = NIXPKGS_QMLIMPORTSCANNER;
++#endif
++
+     // Verify that we found a qmlimportscanner binary
+     if (!QFile(qmlImportScannerPath).exists()) {
+         LogError() << "qmlimportscanner not found at" << qmlImportScannerPath;

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation {
           # TODO: move to buildInputs, this should not be propagated.
           AGL AppKit ApplicationServices Carbon Cocoa CoreAudio CoreBluetooth
           CoreLocation CoreServices DiskArbitration Foundation OpenGL
-          darwin.libobjc libiconv
+          darwin.libobjc libiconv MetalKit
         ]
       else
         [

--- a/pkgs/development/libraries/qt-5/modules/qttools.nix
+++ b/pkgs/development/libraries/qt-5/modules/qttools.nix
@@ -1,4 +1,4 @@
-{ qtModule, stdenv, lib, qtbase }:
+{ qtModule, stdenv, lib, qtbase, qtdeclarative }:
 
 with lib;
 
@@ -31,6 +31,9 @@ qtModule {
   ] ++ optionals stdenv.isDarwin [
     "bin/macdeployqt"
   ];
+
+  NIX_CFLAGS_COMPILE =
+    lib.optional stdenv.isDarwin ''-DNIXPKGS_QMLIMPORTSCANNER="${qtdeclarative.dev}/bin/qmlimportscanner"'';
 
   setupHook = ../hooks/qttools-setup-hook.sh;
 }

--- a/pkgs/os-specific/darwin/apple-sdk/default.nix
+++ b/pkgs/os-specific/darwin/apple-sdk/default.nix
@@ -211,6 +211,13 @@ in rec {
           --replace "QuartzCore/../Frameworks/CoreImage.framework/Headers" "CoreImage"
       '';
     });
+
+    MetalKit = stdenv.lib.overrideDerivation super.MetalKit (drv: {
+      installPhase = drv.installPhase + ''
+        mkdir -p $out/include/simd
+        cp ${lib.getDev sdk}/include/simd/*.h $out/include/simd/
+      '';
+    });
   };
 
   bareFrameworks = stdenv.lib.mapAttrs framework (import ./frameworks.nix {

--- a/pkgs/os-specific/darwin/apple-sdk/frameworks.nix
+++ b/pkgs/os-specific/darwin/apple-sdk/frameworks.nix
@@ -74,6 +74,8 @@ with frameworks; with libs; {
   MediaAccessibility      = [ CF CoreGraphics CoreText QuartzCore ];
   MediaToolbox            = [ AudioToolbox AudioUnit CF CoreMedia ];
   Metal                   = [];
+  MetalKit                = [ ModelIO Metal ];
+  ModelIO                 = [ ];
   NetFS                   = [ CF ];
   OSAKit                  = [ Carbon ];
   OpenAL                  = [];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12820,8 +12820,7 @@ in
 
   libsForQt512 = recurseIntoAttrs (lib.makeScope qt512.newScope mkLibsForQt5);
 
-  # TODO bump to 5.12 on darwin once it's not broken
-  qt5 = if stdenv.isDarwin then qt511 else qt512;
+  qt5 = qt512;
   libsForQt5 = if stdenv.isDarwin then libsForQt511 else libsForQt512;
 
   qt5ct = libsForQt5.callPackage ../tools/misc/qt5ct { };


### PR DESCRIPTION
Fixing qt5 and darwin building.

- Support qt5.12
- patch for missing qmlimportscanner in macdeployqt
- add MetalKit

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
