### PR TITLE
i3-layout-manager: init at unstable-2019-06-19

### DIFF
--- a/pkgs/applications/window-managers/i3/layout-manager.nix
+++ b/pkgs/applications/window-managers/i3/layout-manager.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchFromGitHub, vim, makeWrapper, jq, rofi, xrandr, xdotool, i3, gawk, libnotify }:
+
+let
+  path = stdenv.lib.makeBinPath [ vim jq rofi xrandr xdotool i3 gawk libnotify ];
+in
+
+stdenv.mkDerivation rec {
+  pname = "i3-layout-manager";
+  version = "unstable-2019-06-19";
+
+  src = fetchFromGitHub {
+    owner = "klaxalk";
+    repo = pname;
+    rev = "80ade872bfd70d9c6039024097ceb8c852a2816a";
+    sha256 = "02xhyd737qwni628mjzr9i5v2kga5cq4k8m77bxm1p6kkj84nlmg";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D layout_manager.sh $out/bin/layout_manager
+    wrapProgram $out/bin/layout_manager \
+      --prefix PATH : "${path}"
+
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/klaxalk/i3-layout-manager;
+    description = "Saving, loading and managing layouts for i3wm.";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ ma27 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18430,6 +18430,8 @@ in
 
   i3-easyfocus = callPackage ../applications/window-managers/i3/easyfocus.nix { };
 
+  i3-layout-manager = callPackage ../applications/window-managers/i3/layout-manager.nix { };
+
   i3blocks = callPackage ../applications/window-managers/i3/blocks.nix { };
 
   i3blocks-gaps = callPackage ../applications/window-managers/i3/blocks-gaps.nix { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Simple script which is a wrapper for i3's layout persist functionality[1] that
automates the manual editing of the exported layout JSON.

[1] https://i3wm.org/docs/layout-saving.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
