### PR TITLE
nixos/mosquitto: make the tests run

### DIFF
--- a/nixos/tests/mosquitto.nix
+++ b/nixos/tests/mosquitto.nix
@@ -49,21 +49,40 @@ in rec {
 
   testScript = let
     file = "/tmp/msg";
-    payload = "wootWOOT";
+    sub = args:
+      "(${cmd "sub"} -C 1 ${args} | tee ${file} &)";
   in ''
     startAll;
     $server->waitForUnit("mosquitto.service");
 
     $server->fail("test -f ${file}");
-    $server->execute("(${cmd "sub"} -C 1 | tee ${file} &)");
-
     $client1->fail("test -f ${file}");
-    $client1->execute("(${cmd "sub"} -C 1 | tee ${file} &)");
+    $client2->fail("test -f ${file}");
 
-    $client2->succeed("${cmd "pub"} -m ${payload}");
 
-    $server->succeed("grep -q ${payload} ${file}");
+    # QoS = 0, so only one subscribers should get it
+    $server->execute("${sub "-q 0"}");
 
-    $client1->succeed("grep -q ${payload} ${file}");
+    # we need to give the subscribers some time to connect
+    $client2->execute("sleep 5");
+    $client2->succeed("${cmd "pub"} -m FOO -q 0");
+
+    $server->waitUntilSucceeds("grep -q FOO ${file}");
+    $server->execute("rm ${file}");
+
+
+    # QoS = 1, so both subscribers should get it
+    $server->execute("${sub "-q 1"}");
+    $client1->execute("${sub "-q 1"}");
+
+    # we need to give the subscribers some time to connect
+    $client2->execute("sleep 5");
+    $client2->succeed("${cmd "pub"} -m BAR -q 1");
+
+    $server->waitUntilSucceeds("grep -q BAR ${file}");
+    $server->execute("rm ${file}");
+
+    $client1->waitUntilSucceeds("grep -q BAR ${file}");
+    $client1->execute("rm ${file}");
   '';
 })


### PR DESCRIPTION
###### Motivation for this change

The test would randomly work/not-work due to races between subscribers and publishers.

We are now using a hardcoded 5 second delay, which is *super* ugly but at least it works consistently here.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
