### PR TITLE
Backport "Improve composability of mkShell" to release-19.03

### DIFF
--- a/pkgs/build-support/mkshell/default.nix
+++ b/pkgs/build-support/mkshell/default.nix
@@ -11,13 +11,8 @@
   ...
 }@attrs:
 let
-  mergeInputs = name:
-    let
-      op = item: sum: sum ++ item."${name}" or [];
-      nul = [];
-      list = [attrs] ++ inputsFrom;
-    in
-      lib.foldr op nul list;
+  mergeInputs = name: lib.concatLists (lib.catAttrs name
+    ([attrs] ++ inputsFrom));
 
   rest = builtins.removeAttrs attrs [
     "inputsFrom"

--- a/pkgs/build-support/mkshell/default.nix
+++ b/pkgs/build-support/mkshell/default.nix
@@ -20,6 +20,7 @@ let
     "nativeBuildInputs"
     "propagatedBuildInputs"
     "propagatedNativeBuildInputs"
+    "shellHook"
   ];
 in
 
@@ -31,6 +32,9 @@ stdenv.mkDerivation ({
   nativeBuildInputs = mergeInputs "nativeBuildInputs";
   propagatedBuildInputs = mergeInputs "propagatedBuildInputs";
   propagatedNativeBuildInputs = mergeInputs "propagatedNativeBuildInputs";
+
+  shellHook = lib.concatStringsSep "\n" (lib.catAttrs "shellHook"
+    (lib.reverseList inputsFrom ++ [attrs]));
 
   nobuildPhase = ''
     echo


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Backport of https://github.com/NixOS/nixpkgs/pull/63701 to `release-19.03`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
