### PR TITLE
lib: add applyOptional field to options, use it in mkAliasOptionModule (fixes #63693)

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -327,7 +327,9 @@ rec {
       # function to the merged value.  This allows options to yield a
       # value computed from the definitions.
       value =
-        if !res.isDefined then
+        if opt.applyOptional or false then
+          opt.apply res.optionalValue
+        else if !res.isDefined then
           throw "The option `${showOption loc}' is used but not defined."
         else if opt ? apply then
           opt.apply res.mergedValue
@@ -719,6 +721,7 @@ rec {
         inherit visible;
         description = "Alias of <option>${showOption to}</option>.";
         apply = x: use (toOf config);
+        applyOptional = true;
       });
       config = mkMerge [
         {

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -42,6 +42,11 @@ rec {
     type ? null,
     # Function that converts the option value to something else.
     apply ? null,
+    # Whether the apply function should be applied even if the option
+    # isn't defined. If `applyOptional' is true, the function is applied
+    # to an optional value, i.e. an empty attrset or an attrset with
+    # a single attribute `value'.
+    applyOptional ? false,
     # Whether the option is for NixOS developers only.
     internal ? null,
     # Whether the option shows up in the manual.


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This fixes #63693.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
