### PR TITLE
terminus-font: enable characters variants switching

### DIFF
--- a/pkgs/data/fonts/terminus-font/default.nix
+++ b/pkgs/data/fonts/terminus-font/default.nix
@@ -1,4 +1,20 @@
-{ stdenv, fetchurl, python3, bdftopcf, mkfontdir, mkfontscale }:
+{ stdenv, fetchurl, python3, bdftopcf, mkfontdir, mkfontscale
+# Some characters are implemented in two variants. See the font homepage
+# for examples. If you want to combine hi2 with dv1 and/or ka2, apply
+# hi2 and then hi2-dv1 and/or hi2-ka2, as mentioned in the README file.
+, ao2Variant ? false      # `a' like `o'
+, br1Variant ? false      # Braille
+, dv1Variant ? false      # ru `dv'
+, ge2Variant ? false      # ru `g'
+, gq2Variant ? false      # quote
+, hi2Variant ? false      # higher upper case letters, digits etc.
+, hi2-dv1Variant ? false  # hi2 and dv1 combo
+, hi2-ka2Variant ? false  # hi2 and ka2 combo
+, ij1Variant ? false      # ru `i'
+, ka2Variant ? false      # ru `k'
+, ll2Variant ? false      # distinct `l' (should pass the il1I test)
+, td1Variant ? false      # center tilde
+}:
 
 stdenv.mkDerivation rec {
   pname = "terminus-font";
@@ -14,7 +30,19 @@ stdenv.mkDerivation rec {
 
   patchPhase = ''
     substituteInPlace Makefile --replace 'fc-cache' '#fc-cache'
-  '';
+    '' + stdenv.lib.optionalString ao2Variant ''patch -p1 -i alt/ao2.diff
+    '' + stdenv.lib.optionalString br1Variant ''patch -p1 -i alt/br1.diff
+    '' + stdenv.lib.optionalString dv1Variant ''patch -p1 -i alt/dv1.diff
+    '' + stdenv.lib.optionalString ge2Variant ''patch -p1 -i alt/ge2.diff
+    '' + stdenv.lib.optionalString gq2Variant ''patch -p1 -i alt/gq2.diff
+    '' + stdenv.lib.optionalString hi2Variant ''patch -p1 -i alt/hi2.diff
+    '' + stdenv.lib.optionalString hi2-dv1Variant ''patch -p1 -i alt/hi2-dv1.diff
+    '' + stdenv.lib.optionalString hi2-ka2Variant ''patch -p1 -i alt/hi2-ka2.diff
+    '' + stdenv.lib.optionalString ij1Variant ''patch -p1 -i alt/ij1.diff
+    '' + stdenv.lib.optionalString ka2Variant ''patch -p1 -i alt/ka2.diff
+    '' + stdenv.lib.optionalString ll2Variant ''patch -p1 -i alt/ll2.diff
+    '' + stdenv.lib.optionalString td1Variant ''patch -p1 -i alt/td1.diff
+    '';
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Terminus font upstream provides patchset for characters variants (see homepage at http://terminus-font.sourceforge.net#variants).

Some alternative variants so common, that e.g. centered tilde is mentioned as "perhaps should be the default".

This PR adds useful ability to switch alternative terminus font variants by Nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
