### PR TITLE
pythonPackages.black: fix tests in sandbox mode on Darwin

### DIFF
--- a/pkgs/development/python-modules/black/default.nix
+++ b/pkgs/development/python-modules/black/default.nix
@@ -15,6 +15,10 @@ buildPythonPackage rec {
 
   checkInputs =  [ pytest glibcLocales ];
 
+  # Necessary for the tests to pass on Darwin with sandbox enabled.
+  # Black starts a local server and needs to bind a local address.
+  __darwinAllowLocalNetworking = true;
+
   # Don't know why these tests fails
   checkPhase = ''
     LC_ALL="en_US.UTF-8" pytest \


### PR DESCRIPTION
###### Motivation for this change

Fixes #63722

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
