### PR TITLE
manual: remind to drop kernels that will get EOL'd

### DIFF
--- a/nixos/doc/manual/development/releases.xml
+++ b/nixos/doc/manual/development/releases.xml
@@ -100,6 +100,16 @@
     </listitem>
     <listitem>
      <para>
+      Remove software that we know we will not be able to support,
+      especially if there is a stable alternative. E.g. Check that our
+      Linux kernels'
+      <link xlink:href="https://www.kernel.org/category/releases.html">
+      projected end-of-life</link> are after our release projected
+      end-of-life
+     </para>
+    </listitem>
+    <listitem>
+     <para>
       Edit changelog at
       <literal>nixos/doc/manual/release-notes/rl-1709.xml</literal> (double
       check desktop versions are noted)

--- a/nixos/doc/manual/development/releases.xml
+++ b/nixos/doc/manual/development/releases.xml
@@ -100,7 +100,7 @@
     </listitem>
     <listitem>
      <para>
-      Remove software that we know we will not be able to support,
+      Remove attributes that we know we will not be able to support,
       especially if there is a stable alternative. E.g. Check that our
       Linux kernels'
       <link xlink:href="https://www.kernel.org/category/releases.html">


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
