### PR TITLE
plata-theme: 0.8.3 -> 0.8.6

### DIFF
--- a/pkgs/data/themes/plata/default.nix
+++ b/pkgs/data/themes/plata/default.nix
@@ -1,10 +1,11 @@
 { stdenv, fetchFromGitLab, autoreconfHook, pkgconfig, parallel
-, sassc, inkscape, libxml2, gnome2, gdk_pixbuf, librsvg, gtk-engine-murrine
+, sassc, inkscape, libxml2, glib, gdk_pixbuf, librsvg, gtk-engine-murrine
 , cinnamonSupport ? true
 , gnomeFlashbackSupport ? true
 , gnomeShellSupport ? true
 , openboxSupport ? true
 , xfceSupport ? true
+, mateSupport ? true, gtk3 ? null, marco ? null
 , gtkNextSupport ? false
 , plankSupport ? false
 , steamSupport ? false
@@ -16,17 +17,18 @@
 , destructionColor ? null # Tertiary color for 'destructive' buttons (Default: #F44336 = Red500)
 }:
 
+assert mateSupport -> gtk3 != null && marco != null;
 assert telegramSupport -> zip != null;
 
 stdenv.mkDerivation rec {
   pname = "plata-theme";
-  version = "0.8.3";
+  version = "0.8.6";
 
   src = fetchFromGitLab {
     owner = "tista500";
     repo = "plata-theme";
     rev = version;
-    sha256 = "0ibgymdrw91lnng76lb0x55zg6nm9f2vap19wk7qsq3bcw6ny2zi";
+    sha256 = "1iwz6lxnrsxkh3ivz8kilprwca3h8kf09rf33a5r6m7ysgiqvl7j";
   };
 
   preferLocalBuild = true;
@@ -38,8 +40,9 @@ stdenv.mkDerivation rec {
     sassc
     inkscape
     libxml2
-    gnome2.glib.dev
+    glib.dev
   ]
+  ++ stdenv.lib.optionals mateSupport [ gtk3 marco ]
   ++ stdenv.lib.optional telegramSupport zip;
 
   buildInputs = [
@@ -62,6 +65,7 @@ stdenv.mkDerivation rec {
       (enableFeature gnomeShellSupport "gnome")
       (enableFeature openboxSupport "openbox")
       (enableFeature xfceSupport "xfce")
+      (enableFeature mateSupport "mate")
       (enableFeature gtkNextSupport "gtk_next")
       (enableFeature plankSupport "plank")
       (enableFeature steamSupport "airforsteam")

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16572,7 +16572,9 @@ in
 
   plano-theme = callPackage ../data/themes/plano { };
 
-  plata-theme = callPackage ../data/themes/plata {};
+  plata-theme = callPackage ../data/themes/plata {
+    inherit (mate) marco;
+  };
 
   poly = callPackage ../data/fonts/poly { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update `plata-theme` to 0.8.6.

Reintroduce the `mateSupport` option, which requires `mate.marco` and `gtk3` for building. This defaults to `true` to mirror the upstream defaults.

Replace `gnome2.glib` argument with `glib` to fix evaluation when `allowAliases = false`, letting `r-ryantm` update the package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
