### PR TITLE
journalwatch: fix pytest checks

### DIFF
--- a/pkgs/tools/system/journalwatch/default.nix
+++ b/pkgs/tools/system/journalwatch/default.nix
@@ -20,14 +20,10 @@ buildPythonPackage rec {
 
 
   doCheck = true;
-
+  checkInputs = [ pytest ];
   checkPhase = ''
-    pytest test_journalwatch.py
-  '';
-
-  buildInputs = [
     pytest
-  ];
+  '';
 
   propagatedBuildInputs = [
     systemd


### PR DESCRIPTION
(cherry picked from commit ee20ba83144551497fcecedca277f5de32e81c0c)

Reason: The more strict dependency handling of buildPythonPackage in
19.03 uncovered the error of having pytest as buildInput instead of
checkInput, which leads to a broken package on 19.03.

(Backport of relevant commit from #59424)
