### PR TITLE
go-protobuf: 2018-01-04 -> 1.3.1

### DIFF
--- a/pkgs/development/tools/go-protobuf/default.nix
+++ b/pkgs/development/tools/go-protobuf/default.nix
@@ -1,18 +1,17 @@
-{ stdenv, buildGoPackage, fetchFromGitHub }:
+{ stdenv, buildGoModule, fetchFromGitHub }:
 
-buildGoPackage rec {
+buildGoModule rec {
   name = "go-protobuf-${version}";
-  version = "2018-01-04";
-  rev = "1e59b77b52bf8e4b449a57e6f79f21226d571845";
-
-  goPackagePath = "github.com/golang/protobuf";
+  version = "1.3.1";
 
   src = fetchFromGitHub {
-    inherit rev;
     owner = "golang";
     repo = "protobuf";
-    sha256 = "19bkh81wnp6njg3931wky6hsnnl2d1ig20vfjxpv450sd3k6yys8";
+    rev = "v${version}";
+    sha256 = "15am4s4646qy6iv0g3kkqq52rzykqjhm4bf08dk0fy2r58knpsyl";
   };
+
+  modSha256 = "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5";
 
   meta = with stdenv.lib; {
     homepage    = "https://github.com/golang/protobuf";


### PR DESCRIPTION
###### Motivation for this change

Update to officially released, new version.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
