### PR TITLE
lesspass-cli: init at 9.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2237,6 +2237,11 @@
     github = "izorkin";
     name = "Yurii Izorkin";
   };
+  jasoncarr = {
+    email = "jcarr250@gmail.com";
+    github = "jasoncarr0";
+    name = "Jason Carr";
+  };
   j-keck = {
     email = "jhyphenkeck@gmail.com";
     github = "j-keck";

--- a/pkgs/tools/security/lesspass-cli/default.nix
+++ b/pkgs/tools/security/lesspass-cli/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, python3, fetchFromGitHub }:
+
+let
+  inherit (python3.pkgs) buildPythonApplication pytest mock pexpect;
+in
+buildPythonApplication rec {
+  pname = "lesspass-cli";
+  version = "9.0.0";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = version;
+    sha256 = "1mdv0c0fn4d72iigy8hz4s7kf7q3pg4gjjadxwxyjwsalapnsapk";
+  };
+  sourceRoot = "source/cli";
+
+  # some tests are designed to run against code in the source directory - adapt to run against
+  # *installed* code
+  postPatch = ''
+    for f in tests/test_functional.py tests/test_interaction.py ; do
+      substituteInPlace $f --replace "lesspass/core.py" "-m lesspass.core"
+    done
+  '';
+
+  checkInputs = [ pytest mock pexpect ];
+  checkPhase = ''
+    mv lesspass lesspass.hidden  # ensure we're testing against *installed* package
+    pytest tests
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Stateless password manager";
+    homepage = https://lesspass.com;
+    maintainers = with maintainers; [ jasoncarr ];
+    license = licenses.gpl3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -810,6 +810,8 @@ in
 
   lastpass-cli = callPackage ../tools/security/lastpass-cli { };
 
+  lesspass-cli = callPackage ../tools/security/lesspass-cli { };
+
   pacparser = callPackage ../tools/networking/pacparser { };
 
   pass = callPackage ../tools/security/pass { };


### PR DESCRIPTION
###### Motivation for this change

Adding LessPass CLI tool

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
