### PR TITLE
freeciv_gtk: use gtk3

### DIFF
--- a/pkgs/games/freeciv/default.nix
+++ b/pkgs/games/freeciv/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, zlib, bzip2, pkgconfig, curl, lzma, gettext, libiconv
 , sdlClient ? true, SDL, SDL_mixer, SDL_image, SDL_ttf, SDL_gfx, freetype, fluidsynth
-, gtkClient ? false, gtk2
+, gtkClient ? false, gtk3
 , server ? true, readline
 , enableSqlite ? true, sqlite
 }:
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
 
   buildInputs = [ zlib bzip2 curl lzma gettext libiconv ]
     ++ optionals sdlClient [ SDL SDL_mixer SDL_image SDL_ttf SDL_gfx freetype fluidsynth ]
-    ++ optionals gtkClient [ gtk2 ]
+    ++ optionals gtkClient [ gtk3 ]
     ++ optional server readline
     ++ optional enableSqlite sqlite;
 


### PR DESCRIPTION
##### Motivation for this change

Switching from GTK2 to GTK3.

* Improves the zoom handling on Linux/Wayland.
* Fixes a segfault on MacOS.
* Looks nicer (subjective).

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
