### PR TITLE
rls: fix darwin build

### DIFF
--- a/pkgs/development/tools/rust/rls/default.nix
+++ b/pkgs/development/tools/rust/rls/default.nix
@@ -19,6 +19,9 @@ rustPlatform.buildRustPackage rec {
   # a nightly compiler is required unless we use this cheat code.
   RUSTC_BOOTSTRAP=1;
 
+  # rls-rustc links to rustc_private crates
+  CARGO_BUILD_RUSTFLAGS = if stdenv.isDarwin then "-C rpath" else null;
+
   nativeBuildInputs = [ pkgconfig cmake ];
   buildInputs = [ openssh openssl curl zlib libiconv ]
     ++ (stdenv.lib.optionals stdenv.isDarwin [ CoreFoundation Security ]);
@@ -27,6 +30,11 @@ rustPlatform.buildRustPackage rec {
   preCheck = ''
     # client tests are flaky
     rm tests/client.rs
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/rls --version
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/tools/rust/rls/default.nix
+++ b/pkgs/development/tools/rust/rls/default.nix
@@ -5,16 +5,16 @@
 rustPlatform.buildRustPackage rec {
   pname = "rls";
   # with rust 1.x you can only build rls version 1.x.y
-  version = "1.35.0";
+  version = "1.36.0";
 
   src = fetchFromGitHub {
     owner = "rust-lang";
     repo = pname;
     rev = version;
-    sha256 = "1l3fvlgfzri8954nbwqxqghjy5wa8p1aiml12r1lqs92dh0g192f";
+    sha256 = "1mclv0admxv48pndyqghxc4nf1amhbd700cgrzjshf9jrnffxmrn";
   };
 
-  cargoSha256 = "0v96ndys6bv5dfjg01chrqrqjc57qqfjw40n6vppi9bpw0f6wkf5";
+  cargoSha256 = "1yli9540510xmzqnzfi3p6rh23bjqsviflqw95a0fawf2rnj8sin";
 
   # a nightly compiler is required unless we use this cheat code.
   RUSTC_BOOTSTRAP=1;


### PR DESCRIPTION
##### Motivation for this change

[Fixes broken darwin builds](https://hydra.nixos.org/build/94805508).

caveat: I'm not really sure why `-C rpath` isn't needed on Linux, `rustlib/` is just magically getting added to rpath on linux but not on darwin?

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
