### PR TITLE
franz: use wrapGAppsHook

### DIFF
--- a/pkgs/applications/networking/instant-messengers/franz/default.nix
+++ b/pkgs/applications/networking/instant-messengers/franz/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, autoPatchelfHook, dpkg
+{ stdenv, fetchurl, makeWrapper, wrapGAppsHook, autoPatchelfHook, dpkg
 , xorg, atk, glib, pango, gdk_pixbuf, cairo, freetype, fontconfig, gtk3
 , gnome2, dbus, nss, nspr, alsaLib, cups, expat, udev, libnotify, xdg_utils }:
 
@@ -14,7 +14,7 @@ in stdenv.mkDerivation rec {
   # don't remove runtime deps
   dontPatchELF = true;
 
-  nativeBuildInputs = [ autoPatchelfHook makeWrapper dpkg ];
+  nativeBuildInputs = [ autoPatchelfHook makeWrapper wrapGAppsHook dpkg ];
   buildInputs = (with xorg; [
     libXi libXcursor libXdamage libXrandr libXcomposite libXext libXfixes
     libXrender libX11 libXtst libXScrnSaver
@@ -37,8 +37,12 @@ in stdenv.mkDerivation rec {
       --replace Exec=\"/opt/Franz/franz\" Exec=franz
   '';
 
+  dontWrapGApps = true;
+
   postFixup = ''
-    wrapProgram $out/opt/Franz/franz --prefix PATH : ${xdg_utils}/bin
+    wrapProgram $out/opt/Franz/franz \
+      --prefix PATH : ${xdg_utils}/bin \
+      "''${gappsWrapperArgs[@]}"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
I encountered crashes while opening the file selection dialog. 

```
(franz:11597): GLib-GIO-ERROR **: 14:08:20.102: No GSettings schemas are installed on the system
[1]    11597 trace trap  franz
```

This error is also presented in various other gtk applications (e.g. https://github.com/NixOS/nixpkgs/issues/45286). I used the same trick to fix this error.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
