### PR TITLE
prometheus-node-exporter: 0.17.0 -> 0.18.1; set version information

### DIFF
--- a/pkgs/servers/monitoring/prometheus/node-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/node-exporter.nix
@@ -17,6 +17,12 @@ buildGoPackage rec {
   # FIXME: tests fail due to read-only nix store
   doCheck = false;
 
+  buildFlagsArray = ''
+    -ldflags=
+        -X ${goPackagePath}/vendor/github.com/prometheus/common/version.Version=${version}
+        -X ${goPackagePath}/vendor/github.com/prometheus/common/version.Revision=${rev}
+  '';
+
   meta = with stdenv.lib; {
     description = "Prometheus exporter for machine metrics";
     homepage = https://github.com/prometheus/node_exporter;

--- a/pkgs/servers/monitoring/prometheus/node-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/node-exporter.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "node_exporter-${version}";
-  version = "0.17.0";
+  version = "0.18.1";
   rev = "v${version}";
 
   goPackagePath = "github.com/prometheus/node_exporter";
@@ -11,7 +11,7 @@ buildGoPackage rec {
     inherit rev;
     owner = "prometheus";
     repo = "node_exporter";
-    sha256 = "08g4dg6zcr95j88apsxp828jfyx4vq271w1mgkf77c46c16d2nh0";
+    sha256 = "0s3sp1gj86p7npxl38hkgs6ymd3wjjmc5hydyg1b5wh0x3yvpx07";
   };
 
   # FIXME: tests fail due to read-only nix store


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Package update.

Note there are breaking changes, documented in the [upstream release notes][].

The version information has more fields, which the push gateway sets fully: https://github.com/NixOS/nixpkgs/blob/e478e6bdff2f8de59ecebd5e3377d03d5150e8a0/pkgs/servers/monitoring/prometheus/pushgateway.nix#L22-L26

I didn't think the dummy values contributed much, so omitted them.

[upstream release notes]: https://github.com/prometheus/node_exporter/releases/tag/v0.18.0


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---