### PR TITLE
installation-device.nix: explain sshd usage, don't include clone-config

### DIFF
--- a/nixos/doc/manual/configuration/profiles/clone-config.xml
+++ b/nixos/doc/manual/configuration/profiles/clone-config.xml
@@ -11,4 +11,11 @@
   creating the image in the first place. As a result it allows users to edit
   and rebuild the live-system.
  </para>
+
+ <para>
+  On images where the installation media also becomes an installation target,
+  copying over <literal>configuration.nix</literal> should be disabled by
+  setting <literal>installer.cloneConfig</literal> to <literal>false</literal>.
+  This is already done in <literal>sd-image.nix</literal>.
+ </para>
 </section>

--- a/nixos/doc/manual/configuration/profiles/installation-device.xml
+++ b/nixos/doc/manual/configuration/profiles/installation-device.xml
@@ -6,33 +6,31 @@
  <title>Installation Device</title>
 
  <para>
-  Provides a basic configuration for installation devices like CDs. This means
-  enabling hardware scans, using the <link linkend="sec-profile-clone-config">
-  Clone Config profile</link> to guarantee
-  <filename>/etc/nixos/configuration.nix</filename> exists (for
-  <command>nixos-rebuild</command> to work), a copy of the Nixpkgs channel
-  snapshot used to create the install media.
+  Provides a basic configuration for installation devices like CDs.
+  This enables redistributable firmware, includes the
+  <link linkend="sec-profile-clone-config">Clone Config profile</link>
+  and a copy of the Nixpkgs channel, so <command>nixos-install</command>
+  works out of the box.
  </para>
-
  <para>
-  Additionally, documentation for <link linkend="opt-documentation.enable">
-  Nixpkgs</link> and <link linkend="opt-documentation.nixos.enable">NixOS
-  </link> are forcefully enabled (to override the
+  Documentation for <link linkend="opt-documentation.enable">Nixpkgs</link>
+  and <link linkend="opt-documentation.nixos.enable">NixOS</link> are
+  forcefully enabled (to override the
   <link linkend="sec-profile-minimal">Minimal profile</link> preference); the
-  NixOS manual is shown automatically on TTY 8, sudo and udisks are disabled.
-  Autologin is enabled as root.
+  NixOS manual is shown automatically on TTY 8, udisks is disabled.
+  Autologin is enabled as <literal>nixos</literal> user, while passwordless
+  login as both <literal>root</literal> and <literal>nixos</literal> is possible.
+  Passwordless <command>sudo</command> is enabled too.
+  <link linkend="opt-networking.wireless.enable">wpa_supplicant</link> is
+  enabled, but configured to not autostart.
+ </para>
+ <para>
+  It is explained how to login, start the ssh server, and if available,
+  how to start the display manager.
  </para>
 
  <para>
-  A message is shown to the user to start a display manager if needed, ssh with
-  <xref linkend="opt-services.openssh.permitRootLogin"/> are enabled (but
-  doesn't autostart). WPA Supplicant is also enabled without autostart.
- </para>
-
- <para>
-  Finally, vim is installed, root is set to not have a password, the kernel is
-  made more silent for remote public IP installs, and several settings are
-  tweaked so that the installer has a better chance of succeeding under
-  low-memory environments.
+  Several settings are tweaked so that the installer has a better chance of
+  succeeding under low-memory environments.
  </para>
 </section>

--- a/nixos/modules/installer/cd-dvd/sd-image.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image.nix
@@ -194,5 +194,9 @@ in
         rm -f /nix-path-registration
       fi
     '';
+
+    # the installation media is also the installation target,
+    # so we don't want to provide the installation configuration.nix.
+    installer.cloneConfig = false;
   };
 }

--- a/nixos/modules/profiles/installation-device.nix
+++ b/nixos/modules/profiles/installation-device.nix
@@ -55,13 +55,16 @@ with lib;
     services.mingetty.autologinUser = "nixos";
 
     # Some more help text.
-    services.mingetty.helpLine =
-      ''
+    services.mingetty.helpLine = ''
+      The "nixos" and "root" accounts have empty passwords.
 
-        The "nixos" and "root" account have empty passwords.  ${
-          optionalString config.services.xserver.enable
-            "Type `sudo systemctl start display-manager' to\nstart the graphical user interface."}
-      '';
+      Type `sudo systemctl start sshd` to start the SSH daemon.
+      You then must set a password for either "root" or "nixos"
+      with `passwd` to be able to login.
+    '' + optionalString config.services.xserver.enable ''
+      Type `sudo systemctl start display-manager' to
+      start the graphical user interface.
+    '';
 
     # Allow sshd to be started manually through "systemctl start sshd".
     services.openssh = {


### PR DESCRIPTION
###### Motivation for this change
The configuration used to build an installation medium isn't really
suitable to be (re)used when building a real system.
    
For example, it enables automatic root login without a password on the
console, installs sshd, but prevents it from starting on boot.
    
This can be very misleading when users try to derive their real system
from it - they should use nixos-generate-config instead, as described in
the manual.

Also update the mingetty helpLine to describe the sshd setup.
  
Closes #63576
Closes #26776




###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
