### PR TITLE
nixos/undervolt: fixes ExecStart formatting

### DIFF
--- a/nixos/modules/services/hardware/undervolt.nix
+++ b/nixos/modules/services/hardware/undervolt.nix
@@ -106,18 +106,19 @@ in {
         #     Core or Cache offsets have no effect. It is not possible to set different offsets for
         #     CPU Core and Cache. The CPU will take the smaller of the two offsets, and apply that to
         #     both CPU and Cache. A warning message will be displayed if you attempt to set different offsets.
-        ExecStart = ''
-          ${pkgs.undervolt}/bin/undervolt \
-            ${optionalString cfg.verbose "--verbose"} \
-            ${optionalString (cfg.coreOffset != null) "--core ${cfg.coreOffset}"} \
-            ${optionalString (cfg.coreOffset != null) "--cache ${cfg.coreOffset}"} \
-            ${optionalString (cfg.gpuOffset != null) "--gpu ${cfg.gpuOffset}"} \
-            ${optionalString (cfg.uncoreOffset != null) "--uncore ${cfg.uncoreOffset}"} \
-            ${optionalString (cfg.analogioOffset != null) "--analogio ${cfg.analogioOffset}"} \
-            ${optionalString (cfg.temp != null) "--temp ${cfg.temp}"} \
-            ${optionalString (cfg.tempAc != null) "--temp-ac ${cfg.tempAc}"} \
-            ${optionalString (cfg.tempBat != null) "--temp-bat ${cfg.tempBat}"}
-        '';
+        ExecStart = concatStringsSep " "
+          [
+            "${pkgs.undervolt}/bin/undervolt"
+            (optionalString cfg.verbose "--verbose")
+            (optionalString (cfg.coreOffset != null) "--core ${cfg.coreOffset}")
+            (optionalString (cfg.coreOffset != null) "--cache ${cfg.coreOffset}")
+            (optionalString (cfg.gpuOffset != null) "--gpu ${cfg.gpuOffset}")
+            (optionalString (cfg.uncoreOffset != null) "--uncore ${cfg.uncoreOffset}")
+            (optionalString (cfg.analogioOffset != null) "--analogio ${cfg.analogioOffset}")
+            (optionalString (cfg.temp != null) "--temp ${cfg.temp}")
+            (optionalString (cfg.tempAc != null) "--temp-ac ${cfg.tempAc}")
+            (optionalString (cfg.tempBat != null) "--temp-bat ${cfg.tempBat}")
+          ];
       };
     };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This is my first PR, so not sure if I did some of the testing stuff correctly. `nix-shell -p nix-review --run "nix-review rev  undervolt-fix"` reported "Nothing changed" for example. 

Anyway, with the current `ExecStart` string, the service will fail as `systemd` appears to parse the `Restart=no` option as an argument to `undervolt`. This PR fixes that. 
