### PR TITLE
pythonPackages.python-dotenv: 0.10.2 -> 0.10.3

### DIFF
--- a/pkgs/development/python-modules/python-dotenv/default.nix
+++ b/pkgs/development/python-modules/python-dotenv/default.nix
@@ -1,15 +1,28 @@
-{ lib, buildPythonPackage, fetchPypi, click, ipython }:
+{ lib, buildPythonPackage, fetchPypi, isPy27
+, click
+, ipython
+, pytest
+, sh
+, typing
+}:
 
 buildPythonPackage rec {
   pname = "python-dotenv";
-  version = "0.10.2";
+  version = "0.10.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "6640acd76e6cab84648e4fec16c9d19de6700971f9d91d045e7120622167bfda";
+    sha256 = "0i25gh8wi87l4g0iflp81rlgmps4cdmp90hwypalp7gcbwfxfmzi";
   };
 
-  checkInputs = [ click ipython ];
+  propagatedBuildInputs = [ click ] ++ lib.optionals isPy27 [ typing ];
+
+  checkInputs = [ ipython pytest sh ];
+
+  # cli tests are impure
+  checkPhase = ''
+    pytest tests/ -k 'not cli'
+  '';
 
   meta = with lib; {
     description = "Add .env support to your django/flask apps in development and deployments";


### PR DESCRIPTION
###### Motivation for this change
Noticed this was broken while doing a nix-review of another package, so I updated it as well.

```
builder for '/nix/store/g4i52p8cfidrlvvbwk8f80xir8r89njr-python3.7-python-dotenv-0.10.2.drv' failed with exit code 1; last 10 log lines:
      import pytest
  ModuleNotFoundError: No module named 'pytest'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

$ nix path-info -Sh ./result/
/nix/store/wwf9j8h34sfwlmk26ysf68aikd7yf3sj-python3.7-python-dotenv-0.10.3        99.8M