### PR TITLE
deepin.dde-session-ui: 4.9.11 -> 4.9.12

### DIFF
--- a/pkgs/desktops/deepin/dde-session-ui/default.nix
+++ b/pkgs/desktops/deepin/dde-session-ui/default.nix
@@ -1,18 +1,20 @@
-{ stdenv, fetchFromGitHub, pkgconfig, qmake, qtsvg, qttools,
-  qtx11extras, xkeyboard_config, xorg, lightdm_qt, gsettings-qt,
-  dde-qt-dbus-factory, deepin-gettext-tools, dtkcore, dtkwidget,
-  deepin-desktop-schemas, deepin, hicolor-icon-theme, wrapGAppsHook }:
+{ stdenv, fetchFromGitHub, pkgconfig, qmake, dbus, dde-daemon,
+  dde-qt-dbus-factory, deepin, deepin-desktop-schemas,
+  deepin-gettext-tools, deepin-icon-theme, deepin-wallpapers, dtkcore,
+  dtkwidget, gnugrep, gsettings-qt, hicolor-icon-theme, lightdm_qt,
+  onboard, qtsvg, qttools, qtx11extras, setxkbmap, utillinux, which,
+  xkeyboard_config, xorg, xrandr, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "dde-session-ui";
-  version = "4.9.11";
+  version = "4.9.12";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "16nrlqw8p9s4ncypg4q2df9xpg37y6hqcjn0zmrsfnc5j3i0z82a";
+    sha256 = "00i45xv87wx9cww1d445lg6zjbhda5kki8nhsaav8gf2d4cmwzf4";
   };
 
   nativeBuildInputs = [
@@ -25,34 +27,92 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
+    dbus
+    dde-daemon
     dde-qt-dbus-factory
+    deepin-desktop-schemas
+    deepin-icon-theme
+    deepin-wallpapers
     dtkcore
     dtkwidget
+    gnugrep
     gsettings-qt
+    hicolor-icon-theme
     lightdm_qt
+    onboard
     qtsvg
     qtx11extras
+    setxkbmap
+    utillinux
+    which
+    xkeyboard_config
     xorg.libXcursor
     xorg.libXrandr
     xorg.libXtst
-    xkeyboard_config
-    hicolor-icon-theme
-    deepin-desktop-schemas
+    xrandr
   ];
 
   postPatch = ''
-    searchHardCodedPaths
-    patchShebangs translate_generation.sh
-    patchShebangs translate_desktop.sh
-    sed -i translate_desktop.sh -e "s,/usr/bin/deepin-desktop-ts-convert,deepin-desktop-ts-convert,"
+    searchHardCodedPaths  # debugging
+
+    patchShebangs translate_generation.sh translate_desktop.sh
+
+    substituteInPlace translate_desktop.sh --replace "/usr/bin/deepin-desktop-ts-convert" "deepin-desktop-ts-convert"
+
     find -type f -exec sed -i -e "s,path = /etc,path = $out/etc," {} +
     find -type f -exec sed -i -e "s,path = /usr,path = $out," {} +
-    find -type f -exec sed -i -e "s,Exec=/usr,Exec=$out," {} +
     find -type f -exec sed -i -e "s,/usr/share/dde-session-ui,$out/share/dde-session-ui," {} +
-    sed -i global_util/xkbparser.h -e "s,/usr/share/X11/xkb/rules/base.xml,${xkeyboard_config}/share/X11/xkb/rules/base.xml,"
-    sed -i lightdm-deepin-greeter/scripts/lightdm-deepin-greeter -e "s,/usr/bin/lightdm-deepin-greeter,$out/bin/lightdm-deepin-greeter,"
+
+    substituteInPlace dde-osd/dde-osd_autostart.desktop --replace "Exec=/usr/lib/deepin-daemon/dde-osd" "Exec=$out/lib/deepin-daemon/dde-osd"
+    substituteInPlace dde-osd/com.deepin.dde.osd.service --replace "Exec=/usr/lib/deepin-daemon/dde-osd" "Exec=$out/lib/deepin-daemon/dde-osd"
+    substituteInPlace dde-lock/com.deepin.dde.lockFront.service --replace "Exec=/usr/bin/dde-lock" "Exec=$out/bin/dde-lock"
+    substituteInPlace dmemory-warning-dialog/com.deepin.dde.MemoryWarningDialog.service --replace "Exec=/usr/bin/dmemory-warning-dialog" "Exec=$out/bin/dmemory-warning-dialog"
+    substituteInPlace dde-warning-dialog/com.deepin.dde.WarningDialog.service --replace "Exec=/usr/lib/deepin-daemon/dde-warning-dialog" "Exec=$out/lib/deepin-daemon/dde-warning-dialog"
+    substituteInPlace dde-shutdown/com.deepin.dde.shutdownFront.service --replace "Exec=/usr/bin/dde-shutdown" "Exec=$out/bin/dde-shutdown"
+    substituteInPlace dde-welcome/com.deepin.dde.welcome.service --replace "Exec=/usr/lib/deepin-daemon/dde-welcome" "Exec=$out/lib/deepin-daemon/dde-welcome"
+    substituteInPlace session-ui-guardien/session-ui-guardien.desktop --replace "Exec=/usr/bin/session-ui-guardien" "Exec=$out/bin/session-ui-guardien"
+    substituteInPlace lightdm-deepin-greeter/lightdm-deepin-greeter.desktop --replace "Exec=/usr/bin/deepin-greeter" "Exec=$out/bin/deepin-greeter"
+    substituteInPlace misc/applications/deepin-toggle-desktop.desktop.in --replace "Exec=/usr/lib/deepin-daemon/desktop-toggle" "Exec=${dde-daemon}/lib/deepin-daemon/desktop-toggle"
+
+    # Uncomment (and remove space after $) after packaging deepin-system-monitor
+    #substituteInPlace dde-shutdown/view/contentwidget.cpp --replace "/usr/bin/deepin-system-monitor" "$ {deepin-system-monitor}/bin/deepin-system-monitor"
+
+    substituteInPlace dde-offline-upgrader/main.cpp --replace "dbus-send" "${dbus}/bin/dbus-send"
+    substituteInPlace dde-osd/kblayoutindicator.cpp --replace "dbus-send" "${dbus}/bin/dbus-send"
+    substituteInPlace dde-shutdown/view/contentwidget.cpp --replace "/usr/share/backgrounds/deepin" "${deepin-wallpapers}/share/backgrounds/deepin"
+    substituteInPlace dde-welcome/mainwidget.cpp --replace "dbus-send" "${dbus}/bin/dbus-send"
+    substituteInPlace dmemory-warning-dialog/src/buttondelegate.cpp --replace "dbus-send" "${dbus}/bin/dbus-send"
+    substituteInPlace dmemory-warning-dialog/src/buttondelegate.cpp --replace "kill" "${utillinux}/bin/dbus-send"
+    substituteInPlace global_util/xkbparser.h --replace "/usr/share/X11/xkb/rules/base.xml" "${xkeyboard_config}/share/X11/xkb/rules/base.xml"
+    substituteInPlace lightdm-deepin-greeter/deepin-greeter --replace "/etc/deepin/greeters.d" "$out/etc/deepin/greeters.d"
+    substituteInPlace lightdm-deepin-greeter/main.cpp --replace "/usr/share/icons/deepin" "${deepin-icon-theme}/share/icons/deepin"
+    substituteInPlace lightdm-deepin-greeter/scripts/00-xrandr --replace "egrep" "${gnugrep}/bin/egrep"
+    substituteInPlace lightdm-deepin-greeter/scripts/00-xrandr --replace "xrandr" "${xrandr}/bin/xrandr"
+    substituteInPlace lightdm-deepin-greeter/scripts/lightdm-deepin-greeter --replace "/usr/bin/lightdm-deepin-greeter" "$out/bin/lightdm-deepin-greeter"
+    substituteInPlace session-ui-guardien/guardien.cpp --replace "dde-lock" "$out/bin/dde-lock"
+    substituteInPlace session-ui-guardien/guardien.cpp --replace "dde-shutdown" "$out/bin/dde-shutdown"
+    substituteInPlace session-widgets/lockworker.cpp --replace "dde-switchtogreeter" "$out/bin/dde-switchtogreeter"
+    substituteInPlace session-widgets/lockworker.cpp --replace "which" "${which}/bin/which"
+    substituteInPlace session-widgets/userinfo.cpp --replace "/usr/share/wallpapers/deepin" "${deepin-wallpapers}/share/wallpapers/deepin"
+    substituteInPlace widgets/fullscreenbackground.cpp --replace "/usr/share/wallpapers/deepin" "${deepin-wallpapers}/share/wallpapers/deepin"
+    substituteInPlace widgets/kblayoutwidget.cpp --replace "setxkbmap" "${setxkbmap}/bin/setxkbmap"
+    substituteInPlace widgets/virtualkbinstance.cpp --replace "onboard" "${onboard}/bin/onboard"
+
     # fix default background url
-    sed -i widgets/*.cpp boxframe/*.cpp -e 's,/usr/share/backgrounds/default_background.jpg,/usr/share/backgrounds/deepin/desktop.jpg,'
+    substituteInPlace widgets/fullscreenbackground.cpp --replace "/usr/share/backgrounds/default_background.jpg" "${deepin-wallpapers}/share/backgrounds/deepin/desktop.jpg"
+
+    # NOTES
+    # - on deepin linux /usr/share/icons/default/index.theme is controlled by alternatives, without an equivalent mechanism in NixOS
+    # - do not wrap dde-dman-portal related files: it appears it has been removed: https://github.com/linuxdeepin/dde-session-ui/commit/3bd028cf135ad22c784c0146e447ef34a69af768
+  '';
+
+  postFixup = ''
+    # wrapGAppsHook does not work with binaries outside of $out/bin or $out/libexec
+    for binary in $out/lib/deepin-daemon/*; do
+      wrapProgram $binary "''${gappsWrapperArgs[@]}"
+    done
+
+    searchHardCodedPaths $out  # debugging
   '';
 
   passthru.updateScript = deepin.updateScript { inherit name; };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

- Update to version 4.9.12
- Revise hard coded paths
- Wrap binaries in `lib/deepin-daemon/`

About packaging deepin for NixOS: https://github.com/NixOS/nixpkgs/issues/59023

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).