### PR TITLE
timetable: init at 1.0.6

### DIFF
--- a/pkgs/applications/office/timetable/default.nix
+++ b/pkgs/applications/office/timetable/default.nix
@@ -1,0 +1,57 @@
+{ stdenv
+, fetchFromGitHub
+, glib
+, gtk3
+, hicolor-icon-theme
+, json-glib
+, libgee
+, meson
+, ninja
+, pkgconfig
+, pantheon
+, python3
+, wrapGAppsHook
+}:
+
+
+stdenv.mkDerivation rec {
+  pname = "timetable";
+  version = "1.0.6";
+
+  src = fetchFromGitHub {
+    owner = "lainsce";
+    repo = pname;
+    rev = version;
+    sha256 = "080xgp917v6j40qxy0y1iycz01yylbcr8pahx6zd6mpi022ccfv0";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkgconfig
+    pantheon.vala
+    python3
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    glib
+    gtk3
+    hicolor-icon-theme
+    json-glib
+    libgee
+    pantheon.granite
+  ];
+
+  postPatch = ''
+    chmod +x meson/post_install.py
+    patchShebangs meson/post_install.py
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Plot out your own timetable for the week and organize it";
+    homepage = "https://github.com/lainsce/timetable";
+    maintainers = [ maintainers.kjuvi ] ++ pantheon.maintainers;
+    license = licenses.gpl2Plus;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6216,6 +6216,8 @@ in
 
   timetrap = callPackage ../applications/office/timetrap { };
 
+  timetable = callPackage ../applications/office/timetable { };
+
   tzupdate = callPackage ../applications/misc/tzupdate { };
 
   tinc = callPackage ../tools/networking/tinc { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add more curated apps from Elementary OS app store for Pantheon Desktop. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
