### PR TITLE
ldh_client

### DIFF
--- a/pkgs/development/python-modules/ldh-client/default.nix
+++ b/pkgs/development/python-modules/ldh-client/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchPypi, wrapGAppsHook, gobject-introspection, pygobject3, click, requests, networkmanager, networkmanager-openvpn}:
+
+buildPythonPackage rec {
+  pname = "ldh_client";
+  version = "0.0.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "19dqnrz2rvv4mc4l41wrnrnnlbls37bjgbfqk12p283g5d4c5xnh";
+  };
+
+  postPatch = ''
+      substituteInPlace "scripts/nm_tunnel_setup.py" --replace "/usr/lib/x86_64-linux-gnu/" "${networkmanager-openvpn}/lib/"
+  '';
+
+  nativeBuildInputs = [ wrapGAppsHook ];
+  propagatedBuildInputs = [ gobject-introspection pygobject3 click requests networkmanager];
+
+  meta = with stdenv.lib; {
+    homepage = https://source.puri.sm/liberty/ldh_client;
+    description = "user-facing command-line client for interacting with a Liberty Deckplan Host (LDH)";
+    license = licenses.agpl3;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -520,6 +520,8 @@ in {
 
   langdetect = callPackage ../development/python-modules/langdetect { };
 
+  ldh-client = callPackage ../development/python-modules/ldh-client { };
+
   libmr = callPackage ../development/python-modules/libmr { };
 
   limitlessled = callPackage ../development/python-modules/limitlessled { };


### PR DESCRIPTION
###### Motivation for this change
ldh_client is a setup helper for https://librem.one currently the program is only useful for auto configuring their vpn connection

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
