### PR TITLE
ffms: symlink vapoursynth plugin

### DIFF
--- a/pkgs/development/libraries/ffms/default.nix
+++ b/pkgs/development/libraries/ffms/default.nix
@@ -16,6 +16,13 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ zlib ffmpeg ];
 
+  # ffms includes a built-in vapoursynth plugin, see:
+  # https://github.com/FFMS/ffms2#avisynth-and-vapoursynth-plugin
+  postInstall = ''
+    mkdir $out/lib/vapoursynth
+    ln -s $out/lib/libffms2.so $out/lib/vapoursynth/libffms2.so
+  '';
+
   meta = with stdenv.lib; {
     homepage = https://github.com/FFMS/ffms2/;
     description = "Libav/ffmpeg based source library for easy frame accurate access";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

ffms [includes a vapoursynth plugin](https://github.com/FFMS/ffms2#avisynth-and-vapoursynth-plugin), this makes a symlink in the regular location.

As an example, [Arch makes the same symlink in their package](https://git.archlinux.org/svntogit/community.git/tree/trunk/PKGBUILD?h=packages/ffms2#n34).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
