### PR TITLE
deepin.dde-daemon: 3.27.2.5 -> 3.27.2.6; fix some hard coded paths

### DIFF
--- a/pkgs/desktops/deepin/dde-daemon/default.nix
+++ b/pkgs/desktops/deepin/dde-daemon/default.nix
@@ -9,7 +9,7 @@
 buildGoPackage rec {
   name = "${pname}-${version}";
   pname = "dde-daemon";
-  version = "3.27.2.5";
+  version = "3.27.2.6";
 
   goPackagePath = "pkg.deepin.io/dde/daemon";
 
@@ -17,7 +17,7 @@ buildGoPackage rec {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "117yhsb0axwblncyj02fhcyl4b7jl7vvh1bbx08bscih5lnvjihx";
+    sha256 = "14g138h23f1lh1y98pdrfhnph1m7pw8lq8ypiwv9qf3fmdyn35d4";
   };
 
   patches = [

--- a/pkgs/desktops/deepin/dde-daemon/default.nix
+++ b/pkgs/desktops/deepin/dde-daemon/default.nix
@@ -4,7 +4,7 @@
   deepin-wallpapers, deepin-desktop-base, alsaLib, glib, gtk3,
   libgudev, libinput, libnl, librsvg, linux-pam, networkmanager,
   pulseaudio, python3, hicolor-icon-theme, glibc, tzdata, go,
-  deepin, makeWrapper, wrapGAppsHook }:
+  deepin, makeWrapper, xkeyboard_config, wrapGAppsHook }:
 
 buildGoPackage rec {
   name = "${pname}-${version}";
@@ -63,6 +63,7 @@ buildGoPackage rec {
     librsvg
     pulseaudio
     tzdata
+    xkeyboard_config
   ];
 
   postPatch = ''
@@ -70,12 +71,16 @@ buildGoPackage rec {
     patchShebangs network/nm_generator/gen_nm_consts.py
 
     fixPath $out /usr/share/dde/data launcher/manager.go dock/dock_manager_init.go
+    fixPath $out /usr/share/dde-daemon launcher/manager.go gesture/config.go
     fixPath ${networkmanager.dev} /usr/share/gir-1.0/NM-1.0.gir network/nm_generator/Makefile
     fixPath ${glibc.bin} /usr/bin/getconf systeminfo/utils.go
     fixPath ${deepin-desktop-base} /etc/deepin-version systeminfo/version.go accounts/deepinversion.go
     fixPath ${tzdata} /usr/share/zoneinfo timedate/zoneinfo/zone.go
     fixPath ${dde-api} /usr/lib/deepin-api grub2/modify_manger.go accounts/image_blur.go
     fixPath ${deepin-wallpapers} /usr/share/wallpapers appearance/background/list.go accounts/user.go
+    fixPath ${xkeyboard_config} /usr/share/X11/xkb inputdevices/layout_list.go
+
+    # TODO: deepin-system-monitor comes from dde-extra
 
     sed -i -e "s|{DESTDIR}/etc|{DESTDIR}$out/etc|" Makefile
     sed -i -e "s|{DESTDIR}/lib|{DESTDIR}$out/lib|" Makefile


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

- deepin.dde-daemon: 3.27.2.5 -> 3.27.2.6
- deepin.dde-daemon: fix some hard coded paths 

About packaging deepin for NixOS: https://github.com/NixOS/nixpkgs/issues/59023

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).