### PR TITLE
nitro_luks: init at 1.0.1

### DIFF
--- a/nixos/modules/system/boot/luksroot.nix
+++ b/nixos/modules/system/boot/luksroot.nix
@@ -389,6 +389,11 @@ let
 
     ${if (luks.yubikeySupport && (yubikey != null)) || (luks.gpgSupport && (gpgCard != null)) then ''
     open_with_hardware
+    '' else ${if (luks.nitrokeySupport) then ''
+       ${nitro_luks} > ${keyFile}
+       if [$? -eq 1]; then
+         open_normally
+       fi
     '' else ''
     open_normally
     ''}

--- a/pkgs/tools/security/libnitrokey/default.nix
+++ b/pkgs/tools/security/libnitrokey/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, makeWrapper, cmake, fetchFromGitHub, hidapi, libusb1, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  name = "libnitrokey-${version}";
+  version = "3.5";
+
+  src = fetchFromGitHub {
+    owner = "Nitrokey";
+    repo = "libnitrokey";
+    rev = "v${version}";
+    sha256 = "1is7ncb19n2hf42vrklnyl1xg1gz2varnkbb16cac4bjjbsn3840";
+    fetchSubmodules = true;
+  };
+
+  buildInputs = [
+    hidapi
+    libusb1
+  ];
+  nativeBuildInputs = [
+    cmake
+    pkgconfig
+    makeWrapper
+  ];
+  cmakeFlags = "-DCMAKE_BUILD_TYPE=Release";
+
+  meta = with stdenv.lib; {
+    description      = "Communicate with Nitrokey devices in a clean and easy manner";
+    homepage         = https://github.com/Nitrokey/libnitrokey;
+    repositories.git = https://github.com/Nitrokey/libnitrokey.git;
+    license          = licenses.gpl3;
+    maintainers      = with maintainers; [ mog ];
+  };
+}

--- a/pkgs/tools/security/nitro_luks/default.nix
+++ b/pkgs/tools/security/nitro_luks/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, makeWrapper, fetchFromGitHub, libnitrokey, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  name = "nitro_luks-${version}";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "mogorman";
+    repo = "nitroluks";
+    rev = "${version}";
+    sha256 ="0s5kgxadyv116iacbagnsp60mnizdavfysm5agqbms0nm7rmzlw9";
+  };
+
+  buildInputs = [
+    libnitrokey
+  ];
+
+  nativeBuildInputs = [
+    pkgconfig
+    makeWrapper
+  ];
+
+  installPhase = ''
+    install -D -m 0755 nitro_luks $out/bin/nitro_luks
+  '';
+
+  meta = with stdenv.lib; {
+    description      = "Use nitrokey to unlock your luks drive on boot";
+    homepage         = https://github.com/mogorman/nitroluks;
+    license          = licenses.gpl3;
+    maintainers      = with maintainers; [ mog ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24211,6 +24211,8 @@ in
 
   xrq = callPackage ../applications/misc/xrq { };
 
+  libnitrokey = callPackage ../tools/security/libnitrokey { };
+  nitro_luks = callPackage ../tools/security/nitro_luks { };
   nitrokey-app = libsForQt5.callPackage ../tools/security/nitrokey-app { };
   nitrokey-udev-rules = callPackage ../tools/security/nitrokey-app/udev-rules.nix { };
 


### PR DESCRIPTION
###### Motivation for this change
I want to unlock my computer with my nitrokey. I don't know if this works as I am not sure of an easy way to build and test this. is there an easy way to build a nixos vm with luks encrypted image?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
