### PR TITLE
amiri: init at 0.111

### DIFF
--- a/pkgs/data/fonts/amiri/default.nix
+++ b/pkgs/data/fonts/amiri/default.nix
@@ -1,0 +1,27 @@
+{ lib, fetchzip }:
+
+let
+  version = "0.111";
+
+in fetchzip rec {
+  name = "Amiri-${version}";
+
+  url = "https://github.com/alif-type/amiri/releases/download/${version}/${name}.zip";
+
+  sha256 = "1w3a5na4mazspwy8j2hvpjha10sgd287kamm51p49jcr90cvwbdr";
+
+  postFetch = ''
+    unzip $downloadedFile
+    install -m444 -Dt $out/share/fonts/truetype ${name}/*.ttf
+    install -m444 -Dt $out/share/doc/${name}    ${name}/{*.txt,*.pdf}
+  '';
+
+  meta = with lib; {
+    description = "A classical Arabic typeface in Naskh style";
+    homepage = "https://www.amirifont.org/";
+    license = licenses.ofl;
+    maintainers = [ maintainers.vbgl ];
+    platforms = platforms.all;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16145,6 +16145,8 @@ in
 
   aileron = callPackage ../data/fonts/aileron { };
 
+  amiri = callPackage ../data/fonts/amiri { };
+
   andagii = callPackage ../data/fonts/andagii { };
 
   andika = callPackage ../data/fonts/andika { };


### PR DESCRIPTION
Amiri is a classical Arabic typeface in Naskh style for typesetting books and
other running text.

Homepage: https://www.amirifont.org/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
