### PR TITLE
hostapd: fix hostapd noscan patch url.

### DIFF
--- a/pkgs/os-specific/linux/hostapd/default.nix
+++ b/pkgs/os-specific/linux/hostapd/default.nix
@@ -1,6 +1,5 @@
 { stdenv, fetchurl, pkgconfig, libnl, openssl, sqlite ? null }:
 
-with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "hostapd-${version}";
   version = "2.8";
@@ -50,7 +49,7 @@ stdenv.mkDerivation rec {
     CONFIG_INTERNETWORKING=y
     CONFIG_HS20=y
     CONFIG_ACS=y
-  '' + optionalString (sqlite != null) ''
+  '' + stdenv.lib.optionalString (sqlite != null) ''
     CONFIG_SQLITE=y
   '';
 
@@ -69,7 +68,7 @@ stdenv.mkDerivation rec {
     install -vD hostapd_cli.1 -t $man/share/man/man1
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://hostap.epitest.fi;
     repositories.git = git://w1.fi/hostap.git;
     description = "A user space daemon for access point and authentication servers";

--- a/pkgs/os-specific/linux/hostapd/default.nix
+++ b/pkgs/os-specific/linux/hostapd/default.nix
@@ -1,11 +1,7 @@
 { stdenv, fetchurl, pkgconfig, libnl, openssl, sqlite ? null }:
 
 with stdenv.lib;
-let noScanPatch = fetchurl {
-      url="https://git.telliq.com/gtu/openwrt/raw/master/package/network/services/hostapd/patches/300-noscan.patch";
-      sha256 = "04wg4yjc19wmwk6gia067z99gzzk9jacnwxh5wyia7k5wg71yj5k";
-  };
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   name = "hostapd-${version}";
   version = "2.8";
 
@@ -17,7 +13,13 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ libnl openssl sqlite ];
 
-  patches = [ noScanPatch ];
+  patches = [
+    (fetchurl {
+      # Note: fetchurl seems to be unhappy with openwrt git
+      # server's URLs containing semicolons. Using the github mirror instead.
+      url = "https://raw.githubusercontent.com/openwrt/openwrt/master/package/network/services/hostapd/patches/300-noscan.patch";
+      sha256 = "04wg4yjc19wmwk6gia067z99gzzk9jacnwxh5wyia7k5wg71yj5k";})
+  ];
 
   outputs = [ "out" "man" ];
 


### PR DESCRIPTION
###### Motivation for this change

Something somehow got wrong in #63699; some adjustments made after the
review have been discarded :/ We are using a wrong openwrt upstream.

My apologies.

###### Things done

Changed the noscan patch url to proper openwrt repo.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @flokli 