### PR TITLE
linuxptp: init at 2.0

### DIFF
--- a/pkgs/os-specific/linux/linuxptp/default.nix
+++ b/pkgs/os-specific/linux/linuxptp/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchurl, linuxHeaders } :
+
+
+stdenv.mkDerivation rec {
+  pname = "linuxptp";
+  version = "2.0";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/linuxptp/${pname}-${version}.tgz";
+    sha256 = "0zcw8nllla06451r7bfsa31q4z8jj56j67i07l1azm473r0dj90a";
+  };
+
+  postPatch = ''
+    substituteInPlace incdefs.sh --replace \
+       '/usr/include/linux/' "${linuxHeaders}/include/linux/"
+  '';
+
+  makeFlags = [ "prefix=" ];
+
+  preInstall = ''
+    export DESTDIR=$out
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Implementation of the Precision Time Protocol (PTP) according to IEEE standard 1588 for Linux";
+    homepage = "http://linuxptp.sourceforge.net/";
+    maintainers = [ maintainers.markuskowa ];
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1671,6 +1671,8 @@ in
 
   link-grammar = callPackage ../tools/text/link-grammar { };
 
+  linuxptp = callPackage ../os-specific/linux/linuxptp { };
+
   loadwatch = callPackage ../tools/system/loadwatch { };
 
   loccount = callPackage ../development/tools/misc/loccount { };


### PR DESCRIPTION
###### Motvation for this change
Linux command line tools for the precision time protocol (PTP) 

###### Things done
tested `ptp4l` and `phc2sys` on a pair of Xeon systems with HW timestamping.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
