### PR TITLE
nix.binaryCaches: always set https://cache.nixos.org

### DIFF
--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -272,10 +272,12 @@ in
 
       binaryCaches = mkOption {
         type = types.listOf types.str;
-        default = [ https://cache.nixos.org/ ];
         description = ''
           List of binary cache URLs used to obtain pre-built binaries
           of Nix packages.
+
+          By default https://cache.nixos.org/ is added,
+          to override it use <literal>lib.mkForce []</literal>.
         '';
       };
 
@@ -386,6 +388,7 @@ in
   config = {
 
     nix.binaryCachePublicKeys = [ "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=" ];
+    nix.binaryCaches = [ "https://cache.nixos.org/" ];
 
     environment.etc."nix/nix.conf".source = nixConf;
 


### PR DESCRIPTION
There are many support questions when people add a new binary cache
and they suddenly lose nixos substitutions.

Most of the users want to keep that, so we're doing a breaking change.

Previously to disable all binary caches one had to do:

```
  nix.binaryCache = [];
```

Now the same is possible via:

```
  nix.binaryCache = lib.mkForce [];
```

# TODO

- [ ] nixos changelog
- [ ] test