### PR TITLE
wine: Set WINELOADER in wrapper, wrap also wine64.

### DIFF
--- a/pkgs/misc/emulators/wine/base.nix
+++ b/pkgs/misc/emulators/wine/base.nix
@@ -95,10 +95,25 @@ stdenv.mkDerivation ((lib.optionalAttrs (buildScript != null) {
           ((map (links "share/wine/gecko") geckos)
         ++ (map (links "share/wine/mono")  monos))}
   '' + lib.optionalString supportFlags.gstreamerSupport ''
-    for i in wine ; do
-      if [ -e "$out/bin/$i" ]; then
-        wrapProgram "$out/bin/$i" \
+    # Wrapping Wine is tricky.
+    # https://github.com/NixOS/nixpkgs/issues/63170
+    # https://github.com/NixOS/nixpkgs/issues/28486
+    # The main problem is that wine-preloader opens and loads the wine(64) binary, and
+    # breakage occurs if it finds a shell script instead of the real binary. We solve this
+    # by setting WINELOADER to point to the original binary. Additionally, the locations
+    # of the 32-bit and 64-bit binaries must differ only by the presence of "64" at the
+    # end, due to the logic Wine uses to find the other binary (see get_alternate_loader
+    # in dlls/kernel32/process.c). Therefore we do not use wrapProgram which would move
+    # the binaries to ".wine-wrapped" and ".wine64-wrapped", but use makeWrapper directly,
+    # and move the binaries to ".wine" and ".wine64".
+    for i in wine wine64 ; do
+      prog="$out/bin/$i"
+      if [ -e "$prog" ]; then
+        hidden="$(dirname "$prog")/.$(basename "$prog")"
+        mv "$prog" "$hidden"
+        makeWrapper "$hidden" "$prog" \
           --argv0 "" \
+          --set WINELOADER "$hidden" \
           --prefix GST_PLUGIN_SYSTEM_PATH_1_0 ":" "$GST_PLUGIN_SYSTEM_PATH_1_0"
       fi
     done


### PR DESCRIPTION
Fixes #63170. Note that this brings back wrapping of wine64 which was removed in #28486 because the underlying issue is now fixed.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Tested (on 19.03 branch) that with `wineWowPackages.full`:
- `wineboot` populates the `syswow64` directory in addition to `system32` (before this fix `syswow64` was not populated),
- `wine <32-bit-exe>` works,
- `wine <64-bit-exe>` works,
- `wine64 <32-bit-exe>` works,
- `wine64 <64-bit-exe>` works,
- running a 32-bit exe from within a 64-bit program works,
- running a 64-bit exe from within a 32-bit program works.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
