### PR TITLE
netdata: 1.11.1 -> 1.15.0

### DIFF
--- a/pkgs/tools/system/netdata/default.nix
+++ b/pkgs/tools/system/netdata/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, autoreconfHook, pkgconfig, zlib, libuuid, libossp_uuid, CoreFoundation, IOKit, lm_sensors }:
 
 stdenv.mkDerivation rec{
-  version = "1.11.1";
+  version = "1.15.0";
   name = "netdata-${version}";
 
   src = fetchurl {
     url = "https://github.com/netdata/netdata/releases/download/v${version}/netdata-v${version}.tar.gz";
-    sha256 = "0djph4586cc14vavj6za6k255lscf3b415dx8k45q3nsc2hb4l01";
+    sha256 = "04frfy08k6m70y3s8j3gvnfnqqd9d5mwj3j6krk9dsh34332abvx";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec{
   postInstall = stdenv.lib.optionalString (!stdenv.isDarwin) ''
     # rename this plugin so netdata will look for setuid wrapper
     mv $out/libexec/netdata/plugins.d/apps.plugin \
-      $out/libexec/netdata/plugins.d/apps.plugin.org
+       $out/libexec/netdata/plugins.d/apps.plugin.org
   '';
 
   preConfigure = ''

--- a/pkgs/tools/system/netdata/no-files-in-etc-and-var.patch
+++ b/pkgs/tools/system/netdata/no-files-in-etc-and-var.patch
@@ -1,14 +1,15 @@
-diff -ruN orig/Makefile.am new/Makefile.am
---- orig/Makefile.am	2018-11-02 08:56:21.000000000 -0500
-+++ new/Makefile.am	2018-11-16 10:30:22.000000000 -0500
-@@ -99,10 +99,10 @@
+diff --git a/Makefile.am b/Makefile.am
+index f2087bb..7a70cfb 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -116,10 +116,10 @@ AM_CFLAGS = \
  	$(NULL)
  
  sbin_PROGRAMS =
--dist_cache_DATA = installer/.keep
--dist_varlib_DATA = installer/.keep
--dist_registry_DATA = installer/.keep
--dist_log_DATA = installer/.keep
+-dist_cache_DATA = packaging/installer/.keep
+-dist_varlib_DATA = packaging/installer/.keep
+-dist_registry_DATA = packaging/installer/.keep
+-dist_log_DATA = packaging/installer/.keep
 +dist_cache_DATA =
 +dist_varlib_DATA =
 +dist_registry_DATA =
@@ -16,64 +17,70 @@ diff -ruN orig/Makefile.am new/Makefile.am
  plugins_PROGRAMS =
  
  LIBNETDATA_FILES = \
-diff -ruN orig/collectors/charts.d.plugin/Makefile.am new/collectors/charts.d.plugin/Makefile.am
---- orig/collectors/charts.d.plugin/Makefile.am	2018-11-02 08:56:21.000000000 -0500
-+++ new/collectors/charts.d.plugin/Makefile.am	2018-11-16 11:16:47.000000000 -0500
-@@ -32,7 +32,6 @@
+diff --git a/collectors/charts.d.plugin/Makefile.am b/collectors/charts.d.plugin/Makefile.am
+index 2989b4b..64de7d6 100644
+--- a/collectors/charts.d.plugin/Makefile.am
++++ b/collectors/charts.d.plugin/Makefile.am
+@@ -32,7 +32,6 @@ dist_charts_DATA = \
  
  userchartsconfigdir=$(configdir)/charts.d
  dist_userchartsconfig_DATA = \
--    $(top_srcdir)/installer/.keep \
+-    .keep \
      $(NULL)
  
  chartsconfigdir=$(libconfigdir)/charts.d
-diff -ruN orig/collectors/node.d.plugin/Makefile.am new/collectors/node.d.plugin/Makefile.am
---- orig/collectors/node.d.plugin/Makefile.am	2018-11-02 08:56:21.000000000 -0500
-+++ new/collectors/node.d.plugin/Makefile.am	2018-11-16 11:16:42.000000000 -0500
-@@ -23,7 +23,6 @@
+diff --git a/collectors/node.d.plugin/Makefile.am b/collectors/node.d.plugin/Makefile.am
+index 3b5a0a5..b7abe01 100644
+--- a/collectors/node.d.plugin/Makefile.am
++++ b/collectors/node.d.plugin/Makefile.am
+@@ -23,7 +23,6 @@ dist_noinst_DATA = \
  
  usernodeconfigdir=$(configdir)/node.d
  dist_usernodeconfig_DATA = \
--    $(top_srcdir)/installer/.keep \
+-    .keep \
      $(NULL)
  
  nodeconfigdir=$(libconfigdir)/node.d
-diff -ruN orig/collectors/python.d.plugin/Makefile.am new/collectors/python.d.plugin/Makefile.am
---- orig/collectors/python.d.plugin/Makefile.am	2018-11-02 08:56:21.000000000 -0500
-+++ new/collectors/python.d.plugin/Makefile.am	2018-11-16 10:56:06.000000000 -0500
-@@ -29,7 +29,6 @@
+diff --git a/collectors/python.d.plugin/Makefile.am b/collectors/python.d.plugin/Makefile.am
+index 652a35d..cf4b2cc 100644
+--- a/collectors/python.d.plugin/Makefile.am
++++ b/collectors/python.d.plugin/Makefile.am
+@@ -29,7 +29,6 @@ dist_python_DATA = \
  
  userpythonconfigdir=$(configdir)/python.d
  dist_userpythonconfig_DATA = \
--    $(top_srcdir)/installer/.keep \
+-    .keep \
      $(NULL)
  
  pythonconfigdir=$(libconfigdir)/python.d
-diff -ruN orig/collectors/statsd.plugin/Makefile.am new/collectors/statsd.plugin/Makefile.am
---- orig/collectors/statsd.plugin/Makefile.am	2018-11-02 08:56:21.000000000 -0500
-+++ new/collectors/statsd.plugin/Makefile.am	2018-11-16 10:53:04.000000000 -0500
-@@ -15,6 +15,5 @@
+diff --git a/collectors/statsd.plugin/Makefile.am b/collectors/statsd.plugin/Makefile.am
+index e63bf98..0f59782 100644
+--- a/collectors/statsd.plugin/Makefile.am
++++ b/collectors/statsd.plugin/Makefile.am
+@@ -14,6 +14,5 @@ dist_statsdconfig_DATA = \
  
  userstatsdconfigdir=$(configdir)/statsd.d
  dist_userstatsdconfig_DATA = \
--    $(top_srcdir)/installer/.keep \
+-    .keep \
      $(NULL)
  
-diff -ruN orig/health/Makefile.am new/health/Makefile.am
---- orig/health/Makefile.am	2018-11-02 08:56:21.000000000 -0500
-+++ new/health/Makefile.am	2018-11-16 10:56:30.000000000 -0500
-@@ -16,7 +16,6 @@
+diff --git a/health/Makefile.am b/health/Makefile.am
+index 62a4c6d..4d651df 100644
+--- a/health/Makefile.am
++++ b/health/Makefile.am
+@@ -16,7 +16,6 @@ dist_noinst_DATA = \
  
  userhealthconfigdir=$(configdir)/health.d
  dist_userhealthconfig_DATA = \
--    $(top_srcdir)/installer/.keep \
+-    .keep \
      $(NULL)
  
  healthconfigdir=$(libconfigdir)/health.d
-diff -ruN orig/system/Makefile.am new/system/Makefile.am
---- orig/system/Makefile.am	2018-11-02 08:56:21.000000000 -0500
-+++ new/system/Makefile.am	2018-11-16 10:29:21.000000000 -0500
-@@ -17,10 +17,6 @@
+diff --git a/system/Makefile.am b/system/Makefile.am
+index b085dca..ccfa588 100644
+--- a/system/Makefile.am
++++ b/system/Makefile.am
+@@ -17,10 +17,6 @@ CLEANFILES = \
  include $(top_srcdir)/build/subst.inc
  SUFFIXES = .in
  


### PR DESCRIPTION
###### Motivation for this change
Update to version 1.15.0

@Mic92 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
