### PR TITLE
NTPSec

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -546,6 +546,11 @@ lib.mapAttrs (n: v: v // { shortName = n; }) {
     fullName = "Non-Profit Open Software License 3.0";
   };
 
+  ntp = spdx {
+    spdxId = "NTP";
+    fullName = "NTP License";
+  };
+
   ocamlpro_nc = {
     fullName = "OCamlPro Non Commercial license version 1";
     url = "https://alt-ergo.ocamlpro.com/http/alt-ergo-2.2.0/OCamlPro-Non-Commercial-License.pdf";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2384,6 +2384,15 @@
     githubId = 1176131;
     name = "George Whewell";
   };
+  georgyo = {
+    email = "georgyo@gmail.com";
+    github = "georgyo";
+    name = "George Shammas";
+    keys = [{
+      longkeyid = "rsa4096/0x82BB70D541AE2DB4";
+      fingerprint = "D0CF 440A A703 E0F9 73CB  A078 82BB 70D5 41AE 2DB4";
+    }];
+  };
   gerschtli = {
     email = "tobias.happ@gmx.de";
     github = "Gerschtli";

--- a/pkgs/tools/networking/ntpsec/default.nix
+++ b/pkgs/tools/networking/ntpsec/default.nix
@@ -1,0 +1,70 @@
+{ stdenv, lib, fetchurl, 
+  wafHook, pkgconfig, gnum4,
+  asciidoc, libxslt, docbook_xsl,
+  bison, openssl_1_1, libbsd,
+  coreutils, pythonPackages, pps-tools,
+  libcap ? null, libseccomp ? null,
+}:
+
+assert stdenv.isLinux -> libcap != null;
+assert stdenv.isLinux -> libseccomp != null;
+
+let
+  python = pythonPackages.python;
+
+  withSeccomp = stdenv.isLinux && (stdenv.isi686 || stdenv.isx86_64);
+in
+
+stdenv.mkDerivation rec {
+  name = "ntpsec-${version}";
+  version = "1.1.7";
+
+  src = fetchurl {
+    url = "https://ftp.ntpsec.org/pub/releases/ntpsec-${version}.tar.gz";
+    sha256 = "12rrx8d6y52vp0ibiy9plvyn8w8c9cs4mhrv6whwrz1jv473xss8";
+  };
+
+  patches = [
+    ./skip-decodenetnum-tests.patch
+  ];
+
+  preBuild = ''
+    substituteInPlace ./ntpclients/ntpleapfetch \
+      --replace cat ${coreutils}/bin/cat \
+      --replace basename ${coreutils}/bin/basename \
+      --replace chmod ${coreutils}/bin/chmod
+  '';
+
+  wafConfigureFlags = [
+    "--sysconfdir=/etc"
+    "--localstatedir=/var"
+    "--refclock=all"
+    "--enable-leap-smear"
+    "--python=${python}/bin/python"
+  ]
+    ++ stdenv.lib.optional withSeccomp "--enable-seccomp";
+
+
+  nativeBuildInputs = [ pkgconfig wafHook gnum4
+    asciidoc docbook_xsl libxslt
+    python pythonPackages.wrapPython
+  ];
+
+  buildInputs = [ libbsd bison openssl_1_1 python ]
+    ++ lib.optional withSeccomp libseccomp
+    ++ lib.optionals stdenv.isLinux [ pps-tools libcap ];
+
+  postFixup = ''
+    wrapPythonPrograms
+  '';
+
+  hardeningEnable = [ "pie" ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://www.ntpsec.org/";
+    description = "A secure, hardened, and improved implementation of Network Time Protocol derived from NTP Classic";
+    license = with licenses; [ cc-by-40 bsd2 bsd3 mit ntp ];
+    maintainers = [ maintainers.georgyo ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/networking/ntpsec/skip-decodenetnum-tests.patch
+++ b/pkgs/tools/networking/ntpsec/skip-decodenetnum-tests.patch
@@ -1,0 +1,37 @@
+From c3707ef882cbb52a26db4b7d2e677a728b370773 Mon Sep 17 00:00:00 2001
+From: George Shammas <george@shamm.as>
+Date: Fri, 22 Feb 2019 19:28:51 -0500
+Subject: [PATCH] skip decodenetnum tests
+
+---
+ tests/common/tests_main.c | 1 -
+ tests/wscript             | 1 -
+ 2 files changed, 2 deletions(-)
+
+diff --git a/tests/common/tests_main.c b/tests/common/tests_main.c
+index 3f4da1d7e..02d33c16e 100644
+--- a/tests/common/tests_main.c
++++ b/tests/common/tests_main.c
+@@ -43,7 +43,6 @@ static void RunAllTests(void)
+ 	RUN_TEST_GROUP(calendar);
+ 	RUN_TEST_GROUP(clocktime);
+ 	RUN_TEST_GROUP(endian);
+-	RUN_TEST_GROUP(decodenetnum);
+ 	RUN_TEST_GROUP(dolfptoa);
+ 	RUN_TEST_GROUP(hextolfp);
+ 	RUN_TEST_GROUP(lfpfunc);
+diff --git a/tests/wscript b/tests/wscript
+index 8f46ef9a3..726da9568 100644
+--- a/tests/wscript
++++ b/tests/wscript
+@@ -38,7 +38,6 @@ def build(ctx):
+         "libntp/ntp_endian.c",
+         "libntp/ntp_random.c",
+         "libntp/clocktime.c",
+-        "libntp/decodenetnum.c",
+         "libntp/dolfptoa.c",
+         "libntp/hextolfp.c",
+         "libntp/lfpfunc.c",
+-- 
+2.19.2
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5115,6 +5115,8 @@ in
     libcap = if stdenv.isLinux then libcap else null;
   };
 
+  ntpsec = callPackage ../tools/networking/ntpsec { };
+
   numdiff = callPackage ../tools/text/numdiff { };
 
   numlockx = callPackage ../tools/X11/numlockx { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

NTPSec is fork of ntpd, and there for a  drop in replacement of it. It includes numerous security fixes and improvements, as well as implementations of secure time protocols such as NTS.

Instead of creating a new ntpsec service configuration, I decided it would be better to just reuse the existing ntp configuration, and add a few more customizations to that that one.

This is my first time trying to upstream a nix package, please feel free to point out anything I can do better.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions (archlinux)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
