### PR TITLE
 deepin.dde-control-center: init at 4.10.11

### DIFF
--- a/nixos/modules/services/desktops/deepin/deepin.nix
+++ b/nixos/modules/services/desktops/deepin/deepin.nix
@@ -33,6 +33,7 @@
       environment.systemPackages = [
         pkgs.deepin.dde-api
         pkgs.deepin.dde-calendar
+        pkgs.deepin.dde-control-center
         pkgs.deepin.dde-daemon
         pkgs.deepin.dde-dock
         pkgs.deepin.dde-launcher
@@ -46,6 +47,7 @@
       services.dbus.packages = [
         pkgs.deepin.dde-api
         pkgs.deepin.dde-calendar
+        pkgs.deepin.dde-control-center
         pkgs.deepin.dde-daemon
         pkgs.deepin.dde-dock
         pkgs.deepin.dde-launcher

--- a/pkgs/desktops/deepin/dde-control-center/default.nix
+++ b/pkgs/desktops/deepin/dde-control-center/default.nix
@@ -1,0 +1,112 @@
+{ stdenv, fetchFromGitHub, pkgconfig, cmake, deepin, qttools, qtdeclarative,
+ networkmanager, qtsvg, qtx11extras,  dtkcore, dtkwidget, geoip, gsettings-qt,
+ dde-network-utils, networkmanager-qt, xorg, mtdev, fontconfig, freetype, dde-api,
+ dde-daemon, qt5integration, deepin-desktop-base, deepin-desktop-schemas, dbus,
+ systemd, dde-qt-dbus-factory, qtmultimedia, qtbase, glib, gnome3, which,
+ substituteAll, wrapGAppsHook, tzdata
+}:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "dde-control-center";
+  version = "4.10.11";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "1ip8wjwf0n9q8xnqymzh8lz0j5gcnns976n291np6k5kdh2wqhr5";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    deepin.setupHook
+    pkgconfig
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    dde-api
+    dde-daemon
+    dde-network-utils
+    dde-qt-dbus-factory
+    deepin-desktop-base
+    deepin-desktop-schemas
+    dtkcore
+    dtkwidget
+    fontconfig
+    freetype
+    geoip
+    glib
+    gnome3.networkmanager-l2tp
+    gnome3.networkmanager-openconnect
+    gnome3.networkmanager-openvpn
+    gnome3.networkmanager-vpnc
+    gsettings-qt
+    mtdev
+    networkmanager-qt
+    qt5integration
+    qtbase
+    qtdeclarative
+    qtmultimedia
+    qtsvg
+    qttools
+    qtx11extras
+    xorg.libX11
+    xorg.libXext
+    xorg.libXrandr
+    xorg.libxcb
+  ];
+
+  cmakeFlags = [
+    "-DDISABLE_SYS_UPDATE=YES"
+    "-DDCC_DISABLE_GRUB=YES"
+  ];
+
+  patches = [
+    (substituteAll {
+      src = ./fix-paths.patch;
+      nmcli = "${networkmanager}/bin/nmcli";
+      which = "${which}/bin/which";
+      # not packaged
+      # dman = "${deepin-manual}/bin/dman";
+      inherit tzdata;
+      # exclusive to deepin linux?
+      # allows to synchronize configuration files to cloud networks
+      # deepin_sync = "${deepin-sync}";
+    })
+  ];
+
+  postPatch = ''
+    searchHardCodedPaths
+
+    patchShebangs translate_ts2desktop.sh
+    patchShebangs translate_generation.sh
+    patchShebangs translate_desktop2ts.sh
+
+    fixPath $out /usr dde-control-center-autostart.desktop \
+      com.deepin.dde.ControlCenter.service \
+      src/frame/widgets/utils.h
+
+    substituteInPlace dde-control-center.desktop \
+      --replace "dbus-send" "${dbus}/bin/dbus-send"
+    substituteInPlace com.deepin.controlcenter.addomain.policy \
+      --replace "/bin/systemctl" "${systemd}/bin/systemctl"
+  '';
+
+  postFixup = ''
+    # debuging
+    searchForUnresolvedDLL $out
+    searchHardCodedPaths $out
+  '';
+
+  passthru.updateScript = deepin.updateScript { inherit name; };
+
+  meta = with stdenv.lib; {
+    description = "Control panel of Deepin Desktop Environment";
+    homepage = https://github.com/linuxdeepin/dde-control-center;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ romildo worldofpeace ];
+  };
+}

--- a/pkgs/desktops/deepin/dde-control-center/fix-paths.patch
+++ b/pkgs/desktops/deepin/dde-control-center/fix-paths.patch
@@ -1,0 +1,65 @@
+diff --git a/src/frame/frame.cpp b/src/frame/frame.cpp
+index 90d06f8..7cdad04 100644
+--- a/src/frame/frame.cpp
++++ b/src/frame/frame.cpp
+@@ -375,7 +375,7 @@ void Frame::keyPressEvent(QKeyEvent *e)
+ #ifdef QT_DEBUG
+     case Qt::Key_Escape:        qApp->quit();                               break;
+ #endif
+-    case Qt::Key_F1:            QProcess::startDetached("dman", QStringList("dde"));  break;
++    case Qt::Key_F1:            QProcess::startDetached("@dman@", QStringList("dde"));  break;
+     default:;
+     }
+ }
+diff --git a/src/frame/modules/datetime/timezone_dialog/timezone.cpp b/src/frame/modules/datetime/timezone_dialog/timezone.cpp
+index 3dd4aad..5f1b363 100644
+--- a/src/frame/modules/datetime/timezone_dialog/timezone.cpp
++++ b/src/frame/modules/datetime/timezone_dialog/timezone.cpp
+@@ -46,7 +46,7 @@ namespace installer {
+ namespace {
+ 
+ // Absolute path to zone.tab file.
+-const char kZoneTabFile[] = "/usr/share/zoneinfo/zone.tab";
++const char kZoneTabFile[] = "@tzdata@/share/zoneinfo/zone.tab";
+ 
+ // Absolute path to backward timezone file.
+ const char kTimezoneAliasFile[] = "/timezone_alias";
+diff --git a/src/frame/modules/network/connectionvpneditpage.cpp b/src/frame/modules/network/connectionvpneditpage.cpp
+index e292865..95c5a2b 100644
+--- a/src/frame/modules/network/connectionvpneditpage.cpp
++++ b/src/frame/modules/network/connectionvpneditpage.cpp
+@@ -215,7 +215,7 @@ void ConnectionVpnEditPage::exportConnConfig()
+     qDebug() << Q_FUNC_INFO << args;
+ 
+     QProcess p;
+-    p.start("nmcli", args);
++    p.start("@nmcli@", args);
+     p.waitForFinished();
+     qDebug() << p.readAllStandardOutput();
+     qDebug() << p.readAllStandardError();
+diff --git a/src/frame/modules/network/vpnpage.cpp b/src/frame/modules/network/vpnpage.cpp
+index 521a603..450d1a6 100644
+--- a/src/frame/modules/network/vpnpage.cpp
++++ b/src/frame/modules/network/vpnpage.cpp
+@@ -224,7 +224,7 @@ void VpnPage::importVPN()
+     qDebug() << args;
+ 
+     QProcess p;
+-    p.start("nmcli", args);
++    p.start("@nmcli@", args);
+     p.waitForFinished();
+     const auto stat = p.exitCode();
+     const QString output = p.readAllStandardOutput();
+diff --git a/src/frame/modules/sync/syncworker.cpp b/src/frame/modules/sync/syncworker.cpp
+index 3f929bf..6f240d9 100644
+--- a/src/frame/modules/sync/syncworker.cpp
++++ b/src/frame/modules/sync/syncworker.cpp
+@@ -24,7 +24,7 @@ SyncWorker::SyncWorker(SyncModel *model, QObject *parent)
+ 
+     m_model->setSyncIsValid(
+         QProcess::execute(
+-            "which", QStringList() << "/usr/lib/deepin-sync-daemon/deepin-sync-daemon") ==
++            "@which@", QStringList() << "@deepin_sync@/lib/deepin-sync-daemon/deepin-sync-daemon") ==
+             0 &&
+         valueByQSettings<bool>(DCC_CONFIG_FILES, "CloudSync", "AllowCloudSync", false));
+ }

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -9,6 +9,7 @@ let
     dbus-factory = callPackage ./dbus-factory { };
     dde-api = callPackage ./dde-api { };
     dde-calendar = callPackage ./dde-calendar { };
+    dde-control-center = callPackage ./dde-control-center { };
     dde-daemon = callPackage ./dde-daemon { };
     dde-dock = callPackage ./dde-dock { };
     dde-file-manager = callPackage ./dde-file-manager { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Get #59023 going for 19.09 :fireworks: 

I've left the redshift functionality unpatched because it looked too impure for NixOS.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
