### PR TITLE
gnome3.gnome-user-docs: Add meta attributes

### DIFF
--- a/pkgs/data/documentation/gnome-user-docs/default.nix
+++ b/pkgs/data/documentation/gnome-user-docs/default.nix
@@ -17,4 +17,11 @@ stdenv.mkDerivation rec {
       attrPath = "gnome3.gnome-user-docs";
     };
   };
+
+  meta = {
+    homepage = "https://gitlab.gnome.org/GNOME/gnome-user-docs";
+    description = "GNOME User Documentation";
+    license = stdenv.lib.licenses.cc-by-30;
+    maintainers = gnome3.maintainers;
+  };
 }


### PR DESCRIPTION
###### Motivation for this change
Doesn't have meta attributes (license, homepage).

cc @jtojnar 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
