### PR TITLE
monosat: Fix Linux build

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -137,6 +137,11 @@
     githubId = 2321000;
     name = "Ruslan Babayev";
   };
+  acairncross = {
+    email = "acairncross@gmail.com";
+    github = "acairncross";
+    name = "Aiken Cairncross";
+  };
   acowley = {
     email = "acowley@gmail.com";
     github = "acowley";

--- a/pkgs/applications/science/logic/monosat/default.nix
+++ b/pkgs/applications/science/logic/monosat/default.nix
@@ -39,7 +39,7 @@ let
       platforms   = platforms.unix;
       license     = if includeGplCode then licenses.gpl2 else licenses.mit;
       homepage    = https://github.com/sambayless/monosat;
-      broken = true;
+      maintainers = [ maintainers.acairncross ];
     };
   };
 

--- a/pkgs/applications/science/logic/monosat/default.nix
+++ b/pkgs/applications/science/logic/monosat/default.nix
@@ -8,11 +8,11 @@ with stdenv.lib;
 let
   boolToCmake = x: if x then "ON" else "OFF";
 
-  rev    = "2deeadeff214e975c9f7508bc8a24fa05a1a0c32";
-  sha256 = "09yhym2lxmn3xbhw5fcxawnmvms5jd9fw9m7x2wzil7yvy4vwdjn";
+  rev    = "1.8.0";
+  sha256 = "0q3a8x3iih25xkp2bm842sm2hxlb8hxlls4qmvj7vzwrh4lvsl7b";
 
   pname   = "monosat";
-  version = substring 0 7 sha256;
+  version = rev;
 
   src = fetchFromGitHub {
     owner = "sambayless";
@@ -25,7 +25,11 @@ let
     inherit src;
     buildInputs = [ cmake zlib gmp jdk8 ];
 
-    cmakeFlags = [ "-DJAVA=${boolToCmake includeJava}" "-DGPL=${boolToCmake includeGplCode}" ];
+    cmakeFlags = [
+      "-DBUILD_STATIC=OFF"
+      "-DJAVA=${boolToCmake includeJava}"
+      "-DGPL=${boolToCmake includeGplCode}"
+    ];
 
     postInstall = optionalString includeJava ''
       mkdir -p $out/share/java
@@ -51,18 +55,15 @@ let
 
     propagatedBuildInputs = [ core cython ];
 
-    # This tells setup.py to use cython
+    # This tells setup.py to use cython, which should produce faster bindings
     MONOSAT_CYTHON = true;
 
     # The relative paths here don't make sense for our Nix build
-    # Also, let's use cython since it should produce faster bindings
     # TODO: do we want to just reference the core monosat library rather than copying the
     # shared lib? The current setup.py copies the .dylib/.so...
     postPatch = ''
-
       substituteInPlace setup.py \
-        --replace '../../../../libmonosat.dylib' '${core}/lib/libmonosat.dylib' \
-        --replace '../../../../libmonosat.so'  '${core}/lib/libmonosat.so'
+        --replace 'library_dir = "../../../../"' 'library_dir = "${core}/lib/"'
     '';
   };
 in core


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
The Linux build was broken because the CMake build process for this package builds both static and shared libraries, but the static library dependencies weren't being provided. For some reason this doesn't seem to be a problem for the Darwin build:
Linux: https://hydra.nixos.org/job/nixpkgs/trunk/monosat.x86_64-linux
Darwin: https://hydra.nixos.org/job/nixpkgs/trunk/monosat.x86_64-darwin

The closure size seems large compared to the Darwin build. Is this normal?
`/nix/store/1n2vwa7hc2wr882szg8s4dcajqc46m5b-monosat-09yhym2      511.3M`

~~I'm not sure how to build the accompanying Python package.~~

@copumpkin 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
