### PR TITLE
qmapshack: 1.12.3 -> 1.13.0

### DIFF
--- a/pkgs/applications/misc/qmapshack/default.nix
+++ b/pkgs/applications/misc/qmapshack/default.nix
@@ -1,12 +1,12 @@
-{ stdenv, fetchurl, cmake, qtscript, qtwebengine, gdal, proj, routino, quazip }:
+{ stdenv, fetchurl, fetchpatch, cmake, qtscript, qtwebengine, gdal, proj, routino, quazip }:
 
 stdenv.mkDerivation rec {
   name = "qmapshack-${version}";
-  version = "1.12.3";
+  version = "1.13.0";
 
   src = fetchurl {
     url = "https://bitbucket.org/maproom/qmapshack/downloads/${name}.tar.gz";
-    sha256 = "1yp5gw4q4gwiwr9w4dz19am0bhsla9n2l3bdlk98a7f46kxgnkrx";
+    sha256 = "1cv1f718r8vqyk2l6w3alz2aqjvb4msz8705pm9yr5ndi28qyrba";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -15,11 +15,22 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DROUTINO_XML_PATH=${routino}/share/routino"
-    "-DQUAZIP_INCLUDE_DIR=${quazip}/include/quazip"
+    "-DQUAZIP_INCLUDE_DIR=${quazip}/include/quazip5"
     "-DLIBQUAZIP_LIBRARY=${quazip}/lib/libquazip.so"
   ];
 
   enableParallelBuilding = true;
+
+  patches = [
+    (fetchpatch {
+      url = "https://bitbucket.org/maproom/qmapshack/raw/d0b1b595578a83fda981ccc1ff24166fa636ba1d/FindPROJ4.patch";
+      sha256 = "1nx4ax233bnnj478cmjpm5c1qqmyn1navlihf10q6hhbanay9n99";
+    })
+    (fetchpatch {
+      url = "https://bitbucket.org/maproom/qmapshack/raw/d0b1b595578a83fda981ccc1ff24166fa636ba1d/FindQuaZip5.patch";
+      sha256 = "0z1b2dz2zlz685mxgn8bmh1fyhxpf6dzd6jvkkjyk2kvnrdxv3b9";
+    })
+  ];
 
   meta = with stdenv.lib; {
     homepage = https://bitbucket.org/maproom/qmapshack/wiki/Home;


### PR DESCRIPTION
###### Motivation for this change

[Changelog](https://bitbucket.org/maproom/qmapshack/src/default/changelog.txt):

> V 1.13.0
> * Live GPS data
> * Add waypoint summary to project details
> * Route history is buggy and causes data loss when auto-routing is enabled
> * Suppress ascent/descent if wrong
> * Partially: Support for PROJ 6.0.0
> * Add Geocaching Attributes
> * Mega-fancy tour description on screen
> * Project Details: Add track points with additional information to lists
> * Garmin Map: Fixing elevation marks
> * Waypoint: copy coordinate to clipboard

Patches originated from:
* [FindPROJ4.patch](https://bitbucket.org/maproom/qmapshack/src/default/FindPROJ4.patch)
* [FindQuaZip5.patch](https://bitbucket.org/maproom/qmapshack/src/default/FindQuaZip5.patch)

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
