### PR TITLE
bazel-watcher: fix the build

### DIFF
--- a/pkgs/development/tools/bazel-watcher/default.nix
+++ b/pkgs/development/tools/bazel-watcher/default.nix
@@ -1,5 +1,6 @@
 { buildBazelPackage
 , fetchFromGitHub
+, fetchpatch
 , git
 , go
 , python
@@ -7,7 +8,19 @@
 }:
 
 let
-  patches = [ ./use-go-in-path.patch ];
+  patches = [
+    ./use-go-in-path.patch
+
+    # update rules_go to fix the build. Remove these when updating past 0.10.3
+    (fetchpatch {
+      url = "https://github.com/bazelbuild/bazel-watcher/commit/686130f50cea274f7453f6abc8c5249654047462.patch";
+      sha256 = "0rzs01sfiinl5d3dq9sx1bhl8kkzppdwh964fr7bzafqcxv5llmb";
+    })
+    (fetchpatch {
+      url = "https://github.com/bazelbuild/bazel-watcher/commit/18bdb44832ccc533e0ab3923ef80060eeb24582d.patch";
+      sha256 = "0k5hvlxlg4n092d53cbfxqqhzc6f1jv4licdhhi1dhckkhb4sdk6";
+    })
+  ];
 in
 buildBazelPackage rec {
   name = "bazel-watcher-${version}";
@@ -49,7 +62,7 @@ buildBazelPackage rec {
       sed -e '/^FILE:@bazel_gazelle_go_repository_tools.*/d' -i $bazelOut/external/\@*.marker
     '';
 
-    sha256 = "1ck1rsg5msd77abs889nl2n2i3jlah4d4vjz5wbsb3jyhzn8n5ny";
+    sha256 = "01d4m4kb2mhz8fxl9apzsdq0pd7i79w3q49x51rwa524caml9zfv";
   };
 
   buildAttrs = {

--- a/pkgs/development/tools/bazel-watcher/default.nix
+++ b/pkgs/development/tools/bazel-watcher/default.nix
@@ -6,6 +6,9 @@
 , stdenv
 }:
 
+let
+  patches = [ ./use-go-in-path.patch ];
+in
 buildBazelPackage rec {
   name = "bazel-watcher-${version}";
   version = "0.10.3";
@@ -22,11 +25,10 @@ buildBazelPackage rec {
   bazelTarget = "//ibazel";
 
   fetchAttrs = {
+    inherit patches;
+
     preBuild = ''
       patchShebangs .
-
-      # tell rules_go to use the Go binary found in the PATH
-      sed -e 's:go_register_toolchains():go_register_toolchains(go_version = "host"):g' -i WORKSPACE
     '';
 
     preInstall = ''
@@ -51,11 +53,10 @@ buildBazelPackage rec {
   };
 
   buildAttrs = {
+    inherit patches;
+
     preBuild = ''
       patchShebangs .
-
-      # tell rules_go to use the Go binary found in the PATH
-      sed -e 's:go_register_toolchains():go_register_toolchains(go_version = "host"):g' -i WORKSPACE
     '';
 
     installPhase = ''

--- a/pkgs/development/tools/bazel-watcher/use-go-in-path.patch
+++ b/pkgs/development/tools/bazel-watcher/use-go-in-path.patch
@@ -1,0 +1,13 @@
+diff --git a/WORKSPACE b/WORKSPACE
+index 51273b6..fcf9ffb 100644
+--- a/WORKSPACE
++++ b/WORKSPACE
+@@ -61,7 +61,7 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_depe
+ 
+ go_rules_dependencies()
+ 
+-go_register_toolchains()
++go_register_toolchains(go_version = "host")
+ 
+ load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
+ 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Bazel is currently broken on master, this PR fixes it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

closes #63838