### PR TITLE
Pyls bumping

### DIFF
--- a/pkgs/development/python-modules/pyls-mypy/default.nix
+++ b/pkgs/development/python-modules/pyls-mypy/default.nix
@@ -5,13 +5,13 @@
 
 buildPythonPackage rec {
   pname = "pyls-mypy";
-  version = "0.1.3";
+  version = "0.1.6";
 
   src = fetchFromGitHub {
     owner = "tomv564";
     repo = "pyls-mypy";
     rev = version;
-    sha256 = "0v7ghcd1715lxlfq304b7xhchp31ahdd89lf6za4n0l59dz74swh";
+    sha256 = "0c1111m9h6f05frkyj6i757q9y2lijpbv8nxmwgp3nqbpkvfnmrk";
   };
 
   disabled = !isPy3k;

--- a/pkgs/development/python-modules/python-language-server/default.nix
+++ b/pkgs/development/python-modules/python-language-server/default.nix
@@ -21,13 +21,13 @@ in
 
 buildPythonPackage rec {
   pname = "python-language-server";
-  version = "0.26.1";
+  version = "0.27.0";
 
   src = fetchFromGitHub {
     owner = "palantir";
     repo = "python-language-server";
     rev = version;
-    sha256 = "003fy8bbvwibnsnyxw1qwg2rxnhbfylqs67ixr6fdnw6mmrzd6fg";
+    sha256 = "158wxj2w880jrab7mi4fb3xqnjhmfixqacxjp7whf7jy3zxqrq38";
   };
 
   # The tests require all the providers, disable otherwise.


### PR DESCRIPTION

###### Motivation for this change
there were some bugs in pyls-mypy (would crash with coc). With this update it looks ok

Pinging @jabranham since he made the last python-language-server update.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
