### PR TITLE
minecraft-server: 1.14 -> 1.14.3

### DIFF
--- a/pkgs/games/minecraft-server/default.nix
+++ b/pkgs/games/minecraft-server/default.nix
@@ -1,57 +1,34 @@
 { stdenv, fetchurl, jre }:
+stdenv.mkDerivation rec {
+  name = "minecraft-server-${version}";
+  version = "1.14.3";
 
-let
-  common = { version, sha256, url }:
-    stdenv.mkDerivation (rec {
-      name = "minecraft-server-${version}";
-      inherit version;
-
-      src = fetchurl {
-        inherit url sha256;
-      };
-
-      preferLocalBuild = true;
-
-      installPhase = ''
-        mkdir -p $out/bin $out/lib/minecraft
-        cp -v $src $out/lib/minecraft/server.jar
-
-        cat > $out/bin/minecraft-server << EOF
-        #!/bin/sh
-        exec ${jre}/bin/java \$@ -jar $out/lib/minecraft/server.jar nogui
-        EOF
-
-        chmod +x $out/bin/minecraft-server
-      '';
-
-      phases = "installPhase";
-
-      meta = {
-        description = "Minecraft Server";
-        homepage    = "https://minecraft.net";
-        license     = stdenv.lib.licenses.unfreeRedistributable;
-        platforms   = stdenv.lib.platforms.unix;
-        maintainers = with stdenv.lib.maintainers; [ thoughtpolice tomberek costrouc];
-      };
-    });
-
-in {
-  minecraft-server_1_14 = common {
-    version = "1.14";
-    url    = "https://launcher.mojang.com/v1/objects/f1a0073671057f01aa843443fef34330281333ce/server.jar";
-    sha256 = "671e3d334dd601c520bf1aeb96e49038145172bef16bc6c418e969fd8bf8ff6c";
+  src = fetchurl {
+    url    = "https://launcher.mojang.com/v1/objects/d0d0fe2b1dc6ab4c65554cb734270872b72dadd6/server.jar";
+    sha256 = "0f0v0kqz2v5758551yji1vj6xf43lvbma30v3crz4h7cpzq5c8ll";
   };
 
-  minecraft-server_1_13_2 = common {
-    version = "1.13.2";
-    url    = "https://launcher.mojang.com/v1/objects/3737db93722a9e39eeada7c27e7aca28b144ffa7/server.jar";
-    sha256 = "13h8dxrrgqa1g6sd7aaw26779hcsqsyjm7xm0sknifn54lnamlzz";
-  };
+  preferLocalBuild = true;
 
-  minecraft-server_1_12_2 = common {
-    version = "1.12.2";
-    url = "https://s3.amazonaws.com/Minecraft.Download/versions/1.12.2/minecraft_server.1.12.2.jar";
-    sha256 = "0zhnac6yvkdgdaag0gb0fgrkgizbwrpf7s76yqdiknfswrs947zy";
-  };
+  installPhase = ''
+    mkdir -p $out/bin $out/lib/minecraft
+    cp -v $src $out/lib/minecraft/server.jar
 
+    cat > $out/bin/minecraft-server << EOF
+    #!/bin/sh
+    exec ${jre}/bin/java \$@ -jar $out/lib/minecraft/server.jar nogui
+    EOF
+
+    chmod +x $out/bin/minecraft-server
+  '';
+
+  phases = "installPhase";
+
+  meta = {
+    description = "Minecraft Server";
+    homepage    = "https://minecraft.net";
+    license     = stdenv.lib.licenses.unfreeRedistributable;
+    platforms   = stdenv.lib.platforms.unix;
+    maintainers = with stdenv.lib.maintainers; [ thoughtpolice tomberek costrouc];
+  };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21661,12 +21661,7 @@ in
 
   minecraft = callPackage ../games/minecraft { };
 
-  minecraft-server = minecraft-server_1_14;
-
-  inherit (callPackages ../games/minecraft-server { })
-    minecraft-server_1_14
-    minecraft-server_1_13_2
-    minecraft-server_1_12_2;
+  minecraft-server = callPackage ../games/minecraft-server { };
 
   moon-buggy = callPackage ../games/moon-buggy {};
 


### PR DESCRIPTION
Also removes older versions from the top level of nixpkgs. They can
still be accessed via minecraft-server-versions. This allows leaving
all-packages.nix alone in future server bumps.

cc @thoughtpolice @tomberek @costrouc — would very much appreciate your input on this because it's a minor breaking change.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
