### PR TITLE
soapyuhd: 0.3.5 -> 0.3.6

### DIFF
--- a/pkgs/applications/radio/soapyuhd/default.nix
+++ b/pkgs/applications/radio/soapyuhd/default.nix
@@ -3,7 +3,7 @@
 } :
 
 let
-  version = "0.3.5";
+  version = "0.3.6";
 
 in stdenv.mkDerivation {
   name = "soapyuhd-${version}";
@@ -12,7 +12,7 @@ in stdenv.mkDerivation {
     owner = "pothosware";
     repo = "SoapyUHD";
     rev = "soapy-uhd-${version}";
-    sha256 = "07cr4zk42d0l5g03wm7dzl5lmqr104hmzp1fdjqa1z7xq4v9c9b1";
+    sha256 = "11kp5iv21k8lqwjjydzqmcxdgpm6yicw6d3jhzvcvwcavd41crs7";
   };
 
   nativeBuildInputs = [ cmake pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change
Minor update

https://github.com/pothosware/SoapyUHD/blob/master/Changelog.txt

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
