### PR TITLE
nvidia-settings: Install desktop file and icon.

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/settings.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/settings.nix
@@ -72,6 +72,17 @@ stdenv.mkDerivation rec {
     ${lib.optionalString (!withGtk3) ''
       rm -f $out/lib/libnvidia-gtk3.so.*
     ''}
+
+    # Install the desktop file and icon.
+    # The template has substitution variables intended to be replaced resulting
+    # in absolute paths. Because absolute paths break after the desktop file is
+    # copied by a desktop environment, make Exec and Icon be just a name.
+    sed -i doc/nvidia-settings.desktop \
+      -e "s|^Exec=.*$|Exec=nvidia-settings|" \
+      -e "s|^Icon=.*$|Icon=nvidia-settings|" \
+      -e "s|__NVIDIA_SETTINGS_DESKTOP_CATEGORIES__|Settings|g"
+    install doc/nvidia-settings.desktop -D -t $out/share/applications/
+    install doc/nvidia-settings.png -D -t $out/share/icons/hicolor/128x128/apps/
   '';
 
   binaryName = if withGtk3 then ".nvidia-settings-wrapped" else "nvidia-settings";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

Tested that an entry appears in Xfce under the Settings group, has the right icon and starts the application.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
