### PR TITLE
galario: init at 1.2.1

### DIFF
--- a/pkgs/development/libraries/galario/default.nix
+++ b/pkgs/development/libraries/galario/default.nix
@@ -1,0 +1,78 @@
+{ stdenv
+, fetchzip
+, fetchFromGitHub
+, cmake
+, fftw
+, fftwFloat
+, enablePython ? false
+, pythonPackages
+, llvmPackages
+}:
+let
+  # CMake recipes are needed to build galario
+  # Build process would usually download them
+  great-cmake-cookoff = fetchzip {
+    url = "https://github.com/UCL/GreatCMakeCookOff/archive/v2.1.9.tar.gz";
+    sha256 = "1yd53b5gx38g6f44jmjk4lc4igs3p25z6616hfb7aq79ly01q0w2";
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "galario";
+  version = "1.2.1";
+
+  src = fetchFromGitHub {
+    owner = "mtazzari";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1akz7md7ly16a89zr880c265habakqdg9sj8iil90klqa0i21w6g";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ fftw fftwFloat ]
+    ++ stdenv.lib.optional enablePython pythonPackages.python
+    ++ stdenv.lib.optional stdenv.isDarwin llvmPackages.openmp
+  ;
+
+  propagatedBuildInputs = stdenv.lib.optional enablePython [
+    pythonPackages.numpy
+    pythonPackages.cython
+    pythonPackages.pytest
+  ];
+
+  checkInputs = stdenv.lib.optional enablePython pythonPackages.scipy;
+
+  preConfigure = ''
+    mkdir -p build/external/src
+    cp -r ${great-cmake-cookoff} build/external/src/GreatCMakeCookOff
+    chmod -R 777 build/external/src/GreatCMakeCookOff
+  '';
+
+  preCheck = ''
+    ${if stdenv.isDarwin then "export DYLD_LIBRARY_PATH=$(pwd)/src/" else "export LD_LIBRARY_PATH=$(pwd)/src/"}
+    ${if enablePython then "sed -i -e 's|^#!.*|#!${stdenv.shell}|' python/py.test.sh" else ""}
+  '';
+
+  doCheck = true;
+
+  postInstall = stdenv.lib.optionalString (stdenv.isDarwin && enablePython) ''
+    install_name_tool -change libgalario.dylib $out/lib/libgalario.dylib $out/lib/python*/site-packages/galario/double/libcommon.so
+    install_name_tool -change libgalario_single.dylib $out/lib/libgalario_single.dylib $out/lib/python*/site-packages/galario/single/libcommon.so
+  '';
+
+  meta = with stdenv.lib; {
+    description = "GPU Accelerated Library for Analysing Radio Interferometer Observations";
+    longDescription = ''
+      Galario is a library that exploits the computing power of modern
+      graphic cards (GPUs) to accelerate the comparison of model
+      predictions to radio interferometer observations. Namely, it
+      speeds up the computation of the synthetic visibilities given a
+      model image (or an axisymmetric brightness profile) and their
+      comparison to the observations.
+    '';
+    homepage = "https://mtazzari.github.io/galario/";
+    license = licenses.lgpl3;
+    maintainers = [ maintainers.smaret ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23028,6 +23028,8 @@ in
 
   fityk = callPackage ../applications/science/misc/fityk { };
 
+  galario = callPackage ../development/libraries/galario { };
+
   gildas = callPackage ../applications/science/astronomy/gildas { };
 
   gplates = callPackage ../applications/science/misc/gplates {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2843,6 +2843,11 @@ in {
 
   futures = callPackage ../development/python-modules/futures { };
 
+  galario = toPythonModule (pkgs.galario.override {
+    enablePython = true;
+    pythonPackages = self;
+  });
+
   gcovr = callPackage ../development/python-modules/gcovr { };
 
   gdal = toPythonModule (pkgs.gdal.override {


### PR DESCRIPTION

###### Motivation for this change

Package [galario](https://github.com/mtazzari/galario/) for Nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
