### PR TITLE
pulseaudio-modules-bt: Patch default settings for AAC encoding

### DIFF
--- a/pkgs/applications/audio/pulseaudio-modules-bt/default.nix
+++ b/pkgs/applications/audio/pulseaudio-modules-bt/default.nix
@@ -35,6 +35,7 @@ in stdenv.mkDerivation rec {
 
   patches = [
     ./fix-install-path.patch
+    ./fix-aac-defaults.patch
   ];
 
   nativeBuildInputs = [

--- a/pkgs/applications/audio/pulseaudio-modules-bt/fix-aac-defaults.patch
+++ b/pkgs/applications/audio/pulseaudio-modules-bt/fix-aac-defaults.patch
@@ -1,0 +1,15 @@
+diff --git a/src/modules/bluetooth/a2dp/a2dp_aac.c b/src/modules/bluetooth/a2dp/a2dp_aac.c
+index 394a7a0..cf5abaf 100644
+--- a/src/modules/bluetooth/a2dp/a2dp_aac.c
++++ b/src/modules/bluetooth/a2dp/a2dp_aac.c
+@@ -90,8 +90,8 @@ pa_aac_encoder_init(pa_a2dp_source_read_cb_t read_cb, pa_a2dp_source_read_buf_fr
+     info->read_pcm = read_cb;
+     info->read_buf_free = free_cb;
+     info->aacenc_handle_opened = false;
+-    info->aac_enc_bitrate_mode = 5;
+-    info->aac_afterburner = false;
++    info->aac_enc_bitrate_mode = 0;
++    info->aac_afterburner = true;
+     info->force_pa_fmt = PA_SAMPLE_INVALID;
+     return true;
+ }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
The upstream defaults result in audibly worse quality than simply
relying on the builtin SBC codec, making it somewhat useless. Attempt
to fix this by setting saner defaults.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
