### PR TITLE
datadog-agent: fix extraIntegrations

### DIFF
--- a/nixos/modules/services/monitoring/datadog-agent.nix
+++ b/nixos/modules/services/monitoring/datadog-agent.nix
@@ -42,9 +42,9 @@ let
   # Apply the configured extraIntegrations to the provided agent
   # package. See the documentation of `dd-agent/integrations-core.nix`
   # for detailed information on this.
-  datadogPkg = cfg.package.overrideAttrs(_: {
-    python = (pkgs.datadog-integrations-core cfg.extraIntegrations).python;
-  });
+  datadogPkg = cfg.package.override {
+    pythonPackages = pkgs.datadog-integrations-core cfg.extraIntegrations;
+  };
 in {
   options.services.datadog-agent = {
     enable = mkOption {
@@ -60,7 +60,7 @@ in {
       defaultText = "pkgs.datadog-agent";
       description = ''
         Which DataDog v6 agent package to use. Note that the provided
-        package is expected to have an overridable `python`-attribute
+        package is expected to have an overridable `pythonPackages`-attribute
         which configures the Python environment with the Datadog
         checks.
       '';

--- a/pkgs/tools/networking/dd-agent/datadog-agent.nix
+++ b/pkgs/tools/networking/dd-agent/datadog-agent.nix
@@ -3,6 +3,7 @@
 let
   # keep this in sync with github.com/DataDog/agent-payload dependency
   payloadVersion = "4.7.1";
+  python = pythonPackages.python;
 
 in buildGoPackage rec {
   name = "datadog-agent-${version}";
@@ -26,8 +27,6 @@ in buildGoPackage rec {
   goDeps = ./datadog-agent-deps.nix;
   goPackagePath = "github.com/${owner}/${repo}";
 
-  # Explicitly set this here to allow it to be overridden.
-  python = pythonPackages.python;
 
   nativeBuildInputs = [ pkgconfig makeWrapper ];
   buildInputs = [ systemd ];


### PR DESCRIPTION
The override that builds the custom python for integrations-core was overriding python, but pythonPackages was still being inherited from a call to `datadog-integrations-core {}`, causing service.datadog-agent.extraIntegrations to be ignored.

###### Motivation for this change

`services.datadog-agent.extraIntegrations` failed to include varnish related files from datadogs `integration-core` repo when I tried to include varnish.


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

There isn't an integrated nixos test for datadog, but you can run the daemon and validate scripts without a functional API key or network access (assuming the checks don't need external network access). I used this snippet to validate my varnish change succeeded.

```
import <nixpkgs/nixos/tests/make-test.nix> ({ pkgs, ...} : {
  name = "datadog";

  nodes = {
    machine =
      { ... }:
      {
        imports = [ ../modules/profiles/minimal.nix ];
        services.datadog-agent.enable = true;
        users.groups.varnish.members = [ "datadog" ];
        services.datadog-agent.apiKeyFile = "/dev/null";
        services.datadog-agent.extraIntegrations = {
          varnish = (ps: [ ]);
        };
        services.datadog-agent.checks = {
          varnish = {
            init_config = {};
            instances = [{
              varnishstat = "${pkgs.varnish}/bin/varnishstat";
            }];
          };
        };
        services.varnish.enable = true;
        services.varnish.config = ''
          vcl 4.0;
          backend foo {
            .host = "127.0.0.1";
            .port = "8080";
          }
        '';
      };
    };

    testScript = ''
      startAll;
      $machine->waitForUnit("varnish.service");
      $machine->succeed("sleep 30");
      $machine->fail("journalctl -b -u datadog-agent | grep -q 'Error running check varnish'");
    '';
  })
```