### PR TITLE
dockerTools: use skopeo on the right platform

### DIFF
--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -1,37 +1,41 @@
 {
-  symlinkJoin,
+  cacert,
+  callPackage,
+  closureInfo,
   coreutils,
   docker,
   e2fsprogs,
   findutils,
   go,
-  jshon,
   jq,
+  jshon,
   lib,
-  pkgs,
-  pigz,
+  moreutils,
   nix,
-  runCommand,
+  pigz,
+  referencesByPopularity,
   rsync,
+  runCommand,
+  runtimeShell,
   shadow,
+  skopeo,
+  stdenv,
   storeDir ? builtins.storeDir,
+  substituteAll,
+  symlinkJoin,
   utillinux,
   vmTools,
   writeReferencesToFile,
-  referencesByPopularity,
   writeScript,
   writeText,
-  closureInfo,
-  substituteAll,
-  runtimeShell
 }:
 
 # WARNING: this API is unstable and may be subject to backwards-incompatible changes in the future.
 
 rec {
 
-  examples = import ./examples.nix {
-    inherit pkgs buildImage pullImage shadowSetup buildImageWithNixDb;
+  examples = callPackage ./examples.nix {
+    inherit buildImage pullImage shadowSetup buildImageWithNixDb;
   };
 
   pullImage = let
@@ -57,13 +61,13 @@ rec {
       inherit imageDigest;
       imageName = finalImageName;
       imageTag = finalImageTag;
-      impureEnvVars = pkgs.stdenv.lib.fetchers.proxyImpureEnvVars;
+      impureEnvVars = stdenv.lib.fetchers.proxyImpureEnvVars;
       outputHashMode = "flat";
       outputHashAlgo = "sha256";
       outputHash = sha256;
 
-      nativeBuildInputs = lib.singleton (pkgs.skopeo);
-      SSL_CERT_FILE = "${pkgs.cacert.out}/etc/ssl/certs/ca-bundle.crt";
+      nativeBuildInputs = lib.singleton skopeo;
+      SSL_CERT_FILE = "${cacert.out}/etc/ssl/certs/ca-bundle.crt";
 
       sourceURL = "docker://${imageName}@${imageDigest}";
       destNameTag = "${finalImageName}:${finalImageTag}";
@@ -156,7 +160,8 @@ rec {
     postMount ? "",
     postUmount ? ""
   }:
-    vmTools.runInLinuxVM (
+  let
+    result = vmTools.runInLinuxVM (
       runCommand name {
         preVM = vmTools.createEmptyImage {
           size = diskSize;
@@ -166,8 +171,6 @@ rec {
 
         nativeBuildInputs = [ utillinux e2fsprogs jshon rsync jq ];
       } ''
-      rm -rf $out
-
       mkdir disk
       mkfs /dev/${vmTools.hd}
       mount /dev/${vmTools.hd} disk
@@ -250,6 +253,12 @@ rec {
 
       ${postUmount}
       '');
+    in
+    runCommand name {} ''
+      mkdir -p $out
+      cd ${result}
+      cp layer.tar json VERSION $out
+    '';
 
   exportImage = { name ? fromImage.name, fromImage, fromImageName ? null, fromImageTag ? null, diskSize ? 1024 }:
     runWithOverlay {
@@ -489,7 +498,7 @@ rec {
         (cd layer; ${extraCommandsScript})
 
         echo "Packing layer..."
-        mkdir $out
+        mkdir -p $out
         tar -C layer --hard-dereference --sort=name --mtime="@$SOURCE_DATE_EPOCH" -cf $out/layer.tar .
 
         # Compute the tar checksum and add it to the output json.
@@ -670,7 +679,7 @@ rec {
                   extraCommands;
         };
       result = runCommand "docker-image-${baseName}.tar.gz" {
-        nativeBuildInputs = [ jshon pigz coreutils findutils jq ];
+        nativeBuildInputs = [ jshon pigz coreutils findutils jq moreutils ];
         # Image name and tag must be lowercase
         imageName = lib.toLower name;
         imageTag = if tag == null then "" else lib.toLower tag;
@@ -784,7 +793,7 @@ rec {
           # originally this used `sed -i "1i$layerID" layer-list`, but
           # would fail if layer-list was completely empty.
           echo "$layerID/layer.tar"
-        ) | ${pkgs.moreutils}/bin/sponge layer-list
+        ) | sponge layer-list
 
         # Create image json and image manifest
         imageJson=$(cat ${baseJson} | jq ". + {\"rootfs\": {\"diff_ids\": [], \"type\": \"layers\"}}")


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

When building a Docker image using any one of the `dockerTools` in `pkgsCross`, a `skopeo` on the host platform is chosen and usually this leads to unrecognised Exec format. This PR fixes this issue by assigning the right build packages on the build platform.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
