### PR TITLE
alsa-firmware: enable cross compilation

### DIFF
--- a/pkgs/os-specific/linux/alsa-firmware/cross.patch
+++ b/pkgs/os-specific/linux/alsa-firmware/cross.patch
@@ -1,0 +1,347 @@
+--- a/hdsploader/Makefile.am	2015-02-26 20:36:03.000000000 +0800
++++ b/hdsploader/Makefile.am	2019-06-28 00:43:41.557803832 +0800
+@@ -32,5 +32,14 @@
+ 	     tobin.c
+ CLEANFILES = $(dsp_hex_files)
+ 
+-$(dsp_hex_files): tobin
+-	./tobin
++LINK_FOR_BUILD.c = $(CC_FOR_BUILD) $(CFLAGS_FOR_BUILD) $(CPPFLAGS_FOR_BUILD) $(LDFLAGS_FOR_BUILD) $(TARGET_ARCH_FOR_BUILD)
++
++$(tobin_OBJECTS) : CC=$(CC_FOR_BUILD)
++$(tobin_OBJECTS) : CFLAGS=$(CFLAGS_FOR_BUILD)
++$(tobin_OBJECTS) : CPPFLAGS=$(CPPFLAGS_FOR_BUILD)
++
++tobin$(BUILD_EXEEXT): $(tobin_OBJECTS)
++	$(LINK_FOR_BUILD.c) $^ $(LOADLIBES_FOR_BUILD) $(LDLIBS_FOR_BUILD) -o $@
++
++$(dsp_hex_files): tobin$(BUILD_EXEEXT)
++	./$<
+--- a/m4/ax_prog_cc_for_build.m4	2019-06-27 15:50:02.274134717 +0800
++++ b/m4/ax_prog_cc_for_build.m4	2019-06-28 01:32:45.088117432 +0800
+@@ -0,0 +1,125 @@
++# ===========================================================================
++#   https://www.gnu.org/software/autoconf-archive/ax_prog_cc_for_build.html
++# ===========================================================================
++#
++# SYNOPSIS
++#
++#   AX_PROG_CC_FOR_BUILD
++#
++# DESCRIPTION
++#
++#   This macro searches for a C compiler that generates native executables,
++#   that is a C compiler that surely is not a cross-compiler. This can be
++#   useful if you have to generate source code at compile-time like for
++#   example GCC does.
++#
++#   The macro sets the CC_FOR_BUILD and CPP_FOR_BUILD macros to anything
++#   needed to compile or link (CC_FOR_BUILD) and preprocess (CPP_FOR_BUILD).
++#   The value of these variables can be overridden by the user by specifying
++#   a compiler with an environment variable (like you do for standard CC).
++#
++#   It also sets BUILD_EXEEXT and BUILD_OBJEXT to the executable and object
++#   file extensions for the build platform, and GCC_FOR_BUILD to `yes' if
++#   the compiler we found is GCC. All these variables but GCC_FOR_BUILD are
++#   substituted in the Makefile.
++#
++# LICENSE
++#
++#   Copyright (c) 2008 Paolo Bonzini <bonzini@gnu.org>
++#
++#   Copying and distribution of this file, with or without modification, are
++#   permitted in any medium without royalty provided the copyright notice
++#   and this notice are preserved. This file is offered as-is, without any
++#   warranty.
++
++#serial 9
++
++AU_ALIAS([AC_PROG_CC_FOR_BUILD], [AX_PROG_CC_FOR_BUILD])
++AC_DEFUN([AX_PROG_CC_FOR_BUILD], [dnl
++AC_REQUIRE([AC_PROG_CC])dnl
++AC_REQUIRE([AC_PROG_CPP])dnl
++AC_REQUIRE([AC_EXEEXT])dnl
++AC_REQUIRE([AC_CANONICAL_HOST])dnl
++
++dnl Use the standard macros, but make them use other variable names
++dnl
++pushdef([ac_cv_prog_CPP], ac_cv_build_prog_CPP)dnl
++pushdef([ac_cv_prog_gcc], ac_cv_build_prog_gcc)dnl
++pushdef([ac_cv_prog_cc_works], ac_cv_build_prog_cc_works)dnl
++pushdef([ac_cv_prog_cc_cross], ac_cv_build_prog_cc_cross)dnl
++pushdef([ac_cv_prog_cc_g], ac_cv_build_prog_cc_g)dnl
++pushdef([ac_cv_exeext], ac_cv_build_exeext)dnl
++pushdef([ac_cv_objext], ac_cv_build_objext)dnl
++pushdef([ac_exeext], ac_build_exeext)dnl
++pushdef([ac_objext], ac_build_objext)dnl
++pushdef([CC], CC_FOR_BUILD)dnl
++pushdef([CPP], CPP_FOR_BUILD)dnl
++pushdef([CFLAGS], CFLAGS_FOR_BUILD)dnl
++pushdef([CPPFLAGS], CPPFLAGS_FOR_BUILD)dnl
++pushdef([LDFLAGS], LDFLAGS_FOR_BUILD)dnl
++pushdef([host], build)dnl
++pushdef([host_alias], build_alias)dnl
++pushdef([host_cpu], build_cpu)dnl
++pushdef([host_vendor], build_vendor)dnl
++pushdef([host_os], build_os)dnl
++pushdef([ac_cv_host], ac_cv_build)dnl
++pushdef([ac_cv_host_alias], ac_cv_build_alias)dnl
++pushdef([ac_cv_host_cpu], ac_cv_build_cpu)dnl
++pushdef([ac_cv_host_vendor], ac_cv_build_vendor)dnl
++pushdef([ac_cv_host_os], ac_cv_build_os)dnl
++pushdef([ac_cpp], ac_build_cpp)dnl
++pushdef([ac_compile], ac_build_compile)dnl
++pushdef([ac_link], ac_build_link)dnl
++
++save_cross_compiling=$cross_compiling
++save_ac_tool_prefix=$ac_tool_prefix
++cross_compiling=no
++ac_tool_prefix=
++
++AC_PROG_CC
++AC_PROG_CPP
++AC_EXEEXT
++
++ac_tool_prefix=$save_ac_tool_prefix
++cross_compiling=$save_cross_compiling
++
++dnl Restore the old definitions
++dnl
++popdef([ac_link])dnl
++popdef([ac_compile])dnl
++popdef([ac_cpp])dnl
++popdef([ac_cv_host_os])dnl
++popdef([ac_cv_host_vendor])dnl
++popdef([ac_cv_host_cpu])dnl
++popdef([ac_cv_host_alias])dnl
++popdef([ac_cv_host])dnl
++popdef([host_os])dnl
++popdef([host_vendor])dnl
++popdef([host_cpu])dnl
++popdef([host_alias])dnl
++popdef([host])dnl
++popdef([LDFLAGS])dnl
++popdef([CPPFLAGS])dnl
++popdef([CFLAGS])dnl
++popdef([CPP])dnl
++popdef([CC])dnl
++popdef([ac_objext])dnl
++popdef([ac_exeext])dnl
++popdef([ac_cv_objext])dnl
++popdef([ac_cv_exeext])dnl
++popdef([ac_cv_prog_cc_g])dnl
++popdef([ac_cv_prog_cc_cross])dnl
++popdef([ac_cv_prog_cc_works])dnl
++popdef([ac_cv_prog_gcc])dnl
++popdef([ac_cv_prog_CPP])dnl
++
++dnl Finally, set Makefile variables
++dnl
++BUILD_EXEEXT=$ac_build_exeext
++BUILD_OBJEXT=$ac_build_objext
++AC_SUBST(BUILD_EXEEXT)dnl
++AC_SUBST(BUILD_OBJEXT)dnl
++AC_SUBST([CFLAGS_FOR_BUILD])dnl
++AC_SUBST([CPPFLAGS_FOR_BUILD])dnl
++AC_SUBST([LDFLAGS_FOR_BUILD])dnl
++])
+--- a/configure.ac	2019-06-27 23:58:31.045413144 +0800
++++ b/configure.ac	2019-06-28 01:45:36.511771656 +0800
+@@ -1,6 +1,8 @@
+ AC_PREREQ(2.59)
+ AC_INIT(alsa-firmware, 1.0.29)
++AC_CONFIG_MACRO_DIR([m4])
+ AC_PROG_CC
++AC_PROG_CC_FOR_BUILD
+ AC_PROG_INSTALL
+ AC_PROG_LN_S
+ AC_HEADER_STDC
+--- a/vxloader/Makefile.am	2015-02-26 20:36:03.000000000 +0800
++++ b/vxloader/Makefile.am	2019-06-28 01:55:19.525947146 +0800
+@@ -43,5 +43,14 @@
+ hotplugfw_DATA = 
+ endif
+ 
+-%.xlx: %.rbt toxlx
+-	./toxlx < $< > $@
++LINK_FOR_BUILD.c = $(CC_FOR_BUILD) $(CFLAGS_FOR_BUILD) $(CPPFLAGS_FOR_BUILD) $(LDFLAGS_FOR_BUILD) $(TARGET_ARCH_FOR_BUILD)
++
++$(toxlx_OBJECTS) : CC=$(CC_FOR_BUILD)
++$(toxlx_OBJECTS) : CFLAGS=$(CFLAGS_FOR_BUILD)
++$(toxlx_OBJECTS) : CPPFLAGS=$(CPPFLAGS_FOR_BUILD)
++
++toxlx$(BUILD_EXEEXT): $(toxlx_OBJECTS)
++	$(LINK_FOR_BUILD.c) $^ $(LOADLIBES_FOR_BUILD) $(LDLIBS_FOR_BUILD) -o $@
++
++%.xlx: %.rbt toxlx$(BUILD_EXEEXT)
++	./toxlx$(BUILD_EXEEXT) < $< > $@
+--- a/echoaudio/Makefile.am	2015-02-26 20:36:03.000000000 +0800
++++ b/echoaudio/Makefile.am	2019-06-28 02:00:00.579426080 +0800
+@@ -74,33 +74,42 @@
+ hotplugfw_DATA = 
+ endif
+ 
+-$(firmware_files): fw_writer
+-	./fw_writer DSP/LoaderDSP.c loader_dsp.fw
+-	./fw_writer DSP/Darla20DSP.c darla20_dsp.fw
+-	./fw_writer DSP/Gina20DSP.c gina20_dsp.fw
+-	./fw_writer DSP/Layla20DSP.c layla20_dsp.fw
+-	./fw_writer ASIC/LaylaASIC.c layla20_asic.fw
+-	./fw_writer DSP/Darla24DSP.c darla24_dsp.fw
+-	./fw_writer DSP/Gina24DSP.c gina24_301_dsp.fw
+-	./fw_writer ASIC/Gina24ASIC.c gina24_301_asic.fw
+-	./fw_writer DSP/Gina24_361DSP.c gina24_361_dsp.fw
+-	./fw_writer ASIC/Gina24ASIC_361.c gina24_361_asic.fw
+-	./fw_writer DSP/Layla24DSP.c layla24_dsp.fw
+-	./fw_writer ASIC/Layla24_1ASIC.c layla24_1_asic.fw
+-	./fw_writer ASIC/Layla24_2A_ASIC.c layla24_2A_asic.fw
+-	./fw_writer ASIC/Layla24_2S_ASIC.c layla24_2S_asic.fw
+-	./fw_writer DSP/MonaDSP.c mona_301_dsp.fw
+-	./fw_writer ASIC/Mona1ASIC48.c mona_301_1_asic_48.fw
+-	./fw_writer ASIC/Mona1ASIC96.c mona_301_1_asic_96.fw
+-	./fw_writer DSP/Mona361DSP.c mona_361_dsp.fw
+-	./fw_writer ASIC/Mona1ASIC48_361.c mona_361_1_asic_48.fw
+-	./fw_writer ASIC/Mona1ASIC96_361.c mona_361_1_asic_96.fw
+-	./fw_writer ASIC/Mona2ASIC.c mona_2_asic.fw
+-	./fw_writer DSP/MiaDSP.c mia_dsp.fw
+-	./fw_writer DSP/Echo3gDSP.c echo3g_dsp.fw
+-	./fw_writer ASIC/3G_ASIC.c 3g_asic.fw
+-	./fw_writer DSP/IndigoDSP.c indigo_dsp.fw
+-	./fw_writer DSP/IndigoIODSP.c indigo_io_dsp.fw
+-	./fw_writer DSP/IndigoIOxDSP.c indigo_iox_dsp.fw
+-	./fw_writer DSP/IndigoDJDSP.c indigo_dj_dsp.fw
+-	./fw_writer DSP/IndigoDJxDSP.c indigo_djx_dsp.fw
++LINK_FOR_BUILD.c = $(CC_FOR_BUILD) $(CFLAGS_FOR_BUILD) $(CPPFLAGS_FOR_BUILD) $(LDFLAGS_FOR_BUILD) $(TARGET_ARCH_FOR_BUILD)
++
++$(fw_writer_OBJECTS) : CC=$(CC_FOR_BUILD)
++$(fw_writer_OBJECTS) : CFLAGS=$(CFLAGS_FOR_BUILD)
++$(fw_writer_OBJECTS) : CPPFLAGS=$(CPPFLAGS_FOR_BUILD)
++
++fw_writer$(BUILD_EXEEXT): $(tobin_OBJECTS)
++	$(LINK_FOR_BUILD.c) $^ $(LOADLIBES_FOR_BUILD) $(LDLIBS_FOR_BUILD) -o $@
++
++$(firmware_files): fw_writer$(BUILD_EXEEXT)
++	./fw_writer$(BUILD_EXEEXT) DSP/LoaderDSP.c loader_dsp.fw
++	./fw_writer$(BUILD_EXEEXT) DSP/Darla20DSP.c darla20_dsp.fw
++	./fw_writer$(BUILD_EXEEXT) DSP/Gina20DSP.c gina20_dsp.fw
++	./fw_writer$(BUILD_EXEEXT) DSP/Layla20DSP.c layla20_dsp.fw
++	./fw_writer$(BUILD_EXEEXT) ASIC/LaylaASIC.c layla20_asic.fw
++	./fw_writer$(BUILD_EXEEXT) DSP/Darla24DSP.c darla24_dsp.fw
++	./fw_writer$(BUILD_EXEEXT) DSP/Gina24DSP.c gina24_301_dsp.fw
++	./fw_writer$(BUILD_EXEEXT) ASIC/Gina24ASIC.c gina24_301_asic.fw
++	./fw_writer$(BUILD_EXEEXT) DSP/Gina24_361DSP.c gina24_361_dsp.fw
++	./fw_writer$(BUILD_EXEEXT) ASIC/Gina24ASIC_361.c gina24_361_asic.fw
++	./fw_writer$(BUILD_EXEEXT) DSP/Layla24DSP.c layla24_dsp.fw
++	./fw_writer$(BUILD_EXEEXT) ASIC/Layla24_1ASIC.c layla24_1_asic.fw
++	./fw_writer$(BUILD_EXEEXT) ASIC/Layla24_2A_ASIC.c layla24_2A_asic.fw
++	./fw_writer$(BUILD_EXEEXT) ASIC/Layla24_2S_ASIC.c layla24_2S_asic.fw
++	./fw_writer$(BUILD_EXEEXT) DSP/MonaDSP.c mona_301_dsp.fw
++	./fw_writer$(BUILD_EXEEXT) ASIC/Mona1ASIC48.c mona_301_1_asic_48.fw
++	./fw_writer$(BUILD_EXEEXT) ASIC/Mona1ASIC96.c mona_301_1_asic_96.fw
++	./fw_writer$(BUILD_EXEEXT) DSP/Mona361DSP.c mona_361_dsp.fw
++	./fw_writer$(BUILD_EXEEXT) ASIC/Mona1ASIC48_361.c mona_361_1_asic_48.fw
++	./fw_writer$(BUILD_EXEEXT) ASIC/Mona1ASIC96_361.c mona_361_1_asic_96.fw
++	./fw_writer$(BUILD_EXEEXT) ASIC/Mona2ASIC.c mona_2_asic.fw
++	./fw_writer$(BUILD_EXEEXT) DSP/MiaDSP.c mia_dsp.fw
++	./fw_writer$(BUILD_EXEEXT) DSP/Echo3gDSP.c echo3g_dsp.fw
++	./fw_writer$(BUILD_EXEEXT) ASIC/3G_ASIC.c 3g_asic.fw
++	./fw_writer$(BUILD_EXEEXT) DSP/IndigoDSP.c indigo_dsp.fw
++	./fw_writer$(BUILD_EXEEXT) DSP/IndigoIODSP.c indigo_io_dsp.fw
++	./fw_writer$(BUILD_EXEEXT) DSP/IndigoIOxDSP.c indigo_iox_dsp.fw
++	./fw_writer$(BUILD_EXEEXT) DSP/IndigoDJDSP.c indigo_dj_dsp.fw
++	./fw_writer$(BUILD_EXEEXT) DSP/IndigoDJxDSP.c indigo_djx_dsp.fw
+--- a/emu/Makefile.am	2015-02-26 20:36:03.000000000 +0800
++++ b/emu/Makefile.am	2019-06-28 02:01:37.856710042 +0800
+@@ -22,5 +22,14 @@
+ hotplugfw_DATA = 
+ endif
+ 
+-$(firmware_files): fw_writer
+-	./fw_writer
++LINK_FOR_BUILD.c = $(CC_FOR_BUILD) $(CFLAGS_FOR_BUILD) $(CPPFLAGS_FOR_BUILD) $(LDFLAGS_FOR_BUILD) $(TARGET_ARCH_FOR_BUILD)
++
++$(fw_writer_OBJECTS) : CC=$(CC_FOR_BUILD)
++$(fw_writer_OBJECTS) : CFLAGS=$(CFLAGS_FOR_BUILD)
++$(fw_writer_OBJECTS) : CPPFLAGS=$(CPPFLAGS_FOR_BUILD)
++
++fw_writer$(BUILD_EXEEXT): $(tobin_OBJECTS)
++	$(LINK_FOR_BUILD.c) $^ $(LOADLIBES_FOR_BUILD) $(LDLIBS_FOR_BUILD) -o $@
++
++$(firmware_files): fw_writer$(BUILD_EXEEXT)
++	./fw_writer$(BUILD_EXEEXT)
+--- a/maestro3/Makefile.am	2015-02-26 20:36:03.000000000 +0800
++++ b/maestro3/Makefile.am	2019-06-28 02:03:13.704828106 +0800
+@@ -17,5 +17,14 @@
+ hotplugfw_DATA =
+ endif
+ 
+-$(firmware_files): fw_writer
+-	./fw_writer
++LINK_FOR_BUILD.c = $(CC_FOR_BUILD) $(CFLAGS_FOR_BUILD) $(CPPFLAGS_FOR_BUILD) $(LDFLAGS_FOR_BUILD) $(TARGET_ARCH_FOR_BUILD)
++
++$(fw_writer_OBJECTS) : CC=$(CC_FOR_BUILD)
++$(fw_writer_OBJECTS) : CFLAGS=$(CFLAGS_FOR_BUILD)
++$(fw_writer_OBJECTS) : CPPFLAGS=$(CPPFLAGS_FOR_BUILD)
++
++fw_writer$(BUILD_EXEEXT): $(tobin_OBJECTS)
++	$(LINK_FOR_BUILD.c) $^ $(LOADLIBES_FOR_BUILD) $(LDLIBS_FOR_BUILD) -o $@
++
++$(firmware_files): fw_writer$(BUILD_EXEEXT)
++	./fw_writer$(BUILD_EXEEXT)
+--- a/sb16/Makefile.am	2015-02-26 20:36:03.000000000 +0800
++++ b/sb16/Makefile.am	2019-06-28 02:04:37.121743871 +0800
+@@ -18,5 +18,14 @@
+ hotplugfw_DATA =
+ endif
+ 
+-$(firmware_files): fw_writer
+-	./fw_writer
++LINK_FOR_BUILD.c = $(CC_FOR_BUILD) $(CFLAGS_FOR_BUILD) $(CPPFLAGS_FOR_BUILD) $(LDFLAGS_FOR_BUILD) $(TARGET_ARCH_FOR_BUILD)
++
++$(fw_writer_OBJECTS) : CC=$(CC_FOR_BUILD)
++$(fw_writer_OBJECTS) : CFLAGS=$(CFLAGS_FOR_BUILD)
++$(fw_writer_OBJECTS) : CPPFLAGS=$(CPPFLAGS_FOR_BUILD)
++
++fw_writer$(BUILD_EXEEXT): $(tobin_OBJECTS)
++	$(LINK_FOR_BUILD.c) $^ $(LOADLIBES_FOR_BUILD) $(LDLIBS_FOR_BUILD) -o $@
++
++$(firmware_files): fw_writer$(BUILD_EXEEXT)
++	./fw_writer$(BUILD_EXEEXT)
+--- a/wavefront/Makefile.am	2019-06-28 02:07:27.003727160 +0800
++++ b/wavefront/Makefile.am	2019-06-28 02:07:46.477947626 +0800
+@@ -17,5 +17,14 @@
+ hotplugfw_DATA =
+ endif
+ 
+-$(firmware_files): fw_writer
+-	./fw_writer
++LINK_FOR_BUILD.c = $(CC_FOR_BUILD) $(CFLAGS_FOR_BUILD) $(CPPFLAGS_FOR_BUILD) $(LDFLAGS_FOR_BUILD) $(TARGET_ARCH_FOR_BUILD)
++
++$(fw_writer_OBJECTS) : CC=$(CC_FOR_BUILD)
++$(fw_writer_OBJECTS) : CFLAGS=$(CFLAGS_FOR_BUILD)
++$(fw_writer_OBJECTS) : CPPFLAGS=$(CPPFLAGS_FOR_BUILD)
++
++fw_writer$(BUILD_EXEEXT): $(tobin_OBJECTS)
++	$(LINK_FOR_BUILD.c) $^ $(LOADLIBES_FOR_BUILD) $(LDLIBS_FOR_BUILD) -o $@
++
++$(firmware_files): fw_writer$(BUILD_EXEEXT)
++	./fw_writer$(BUILD_EXEEXT)
+--- a/ymfpci/Makefile.am	2015-02-26 20:36:03.000000000 +0800
++++ b/ymfpci/Makefile.am	2019-06-28 02:09:02.487797826 +0800
+@@ -17,5 +17,14 @@
+ hotplugfw_DATA =
+ endif
+ 
+-$(firmware_files): fw_writer
+-	./fw_writer
++LINK_FOR_BUILD.c = $(CC_FOR_BUILD) $(CFLAGS_FOR_BUILD) $(CPPFLAGS_FOR_BUILD) $(LDFLAGS_FOR_BUILD) $(TARGET_ARCH_FOR_BUILD)
++
++$(fw_writer_OBJECTS) : CC=$(CC_FOR_BUILD)
++$(fw_writer_OBJECTS) : CFLAGS=$(CFLAGS_FOR_BUILD)
++$(fw_writer_OBJECTS) : CPPFLAGS=$(CPPFLAGS_FOR_BUILD)
++
++fw_writer$(BUILD_EXEEXT): $(tobin_OBJECTS)
++	$(LINK_FOR_BUILD.c) $^ $(LOADLIBES_FOR_BUILD) $(LDLIBS_FOR_BUILD) -o $@
++
++$(firmware_files): fw_writer$(BUILD_EXEEXT)
++	./fw_writer$(BUILD_EXEEXT)

--- a/pkgs/os-specific/linux/alsa-firmware/default.nix
+++ b/pkgs/os-specific/linux/alsa-firmware/default.nix
@@ -1,12 +1,19 @@
-{stdenv, fetchurl}:
+{ stdenv, buildPackages, autoreconfHook, fetchurl, fetchpatch }:
 
 stdenv.mkDerivation rec {
-  name = "alsa-firmware-1.0.29";
+  name = "alsa-firmware-1.2.1";
 
   src = fetchurl {
     url = "mirror://alsa/firmware/${name}.tar.bz2";
-    sha256 = "0gfcyj5anckjn030wcxx5v2xk2s219nyf99s9m833275b5wz2piw";
+    sha256 = "1aq8z8ajpjvcx7bwhwp36bh5idzximyn77ygk3ifs0my3mbpr8mf";
   };
+
+  patches = [ (fetchpatch {
+    url = "https://github.com/alsa-project/alsa-firmware/commit/a8a478485a999ff9e4a8d8098107d3b946b70288.patch";
+    sha256 = "0zd7vrgz00hn02va5bkv7qj2395a1rl6f8jq1mwbryxs7hiysb78";
+  }) ];
+
+  nativeBuildInputs = [ autoreconfHook buildPackages.stdenv.cc ];
 
   configureFlags = [
     "--with-hotplug-dir=$(out)/lib/firmware"


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The Autoconf and Automake scripts in `alsa-firmware` incorrectly build the firmware writers to the host platform, which leads to incorrect Exec format if they are invoked by these scripts later to transform the firmware blobs. This PR will properly build the writers to the build platform instead.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
