### PR TITLE
nixos/phpfpm: Remove usage of undefined variable fpmCfg

### DIFF
--- a/nixos/modules/services/web-servers/phpfpm/default.nix
+++ b/nixos/modules/services/web-servers/phpfpm/default.nix
@@ -65,8 +65,8 @@ in {
 
             phpPackage = mkOption {
               type = types.package;
-              default = fpmCfg.phpPackage;
-              defaultText = "config.services.phpfpm.phpPackage";
+              default = pkgs.php;
+              defaultText = "pkgs.php";
               description = ''
                 The PHP package to use for running this PHP-FPM pool.
               '';
@@ -74,10 +74,9 @@ in {
 
             phpOptions = mkOption {
               type = types.lines;
-              default = fpmCfg.phpOptions;
-              defaultText = "config.services.phpfpm.phpOptions";
+              default = "";
               description = ''
-                "Options appended to the PHP configuration file <filename>php.ini</filename> used for this PHP-FPM pool."
+                Options appended to the PHP configuration file <filename>php.ini</filename> used for this PHP-FPM pool.
               '';
             };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

```
error: undefined variable 'fpmCfg' at /nix/store/pnlg9bycirawpry9gx99yfnymszzlki5-source/nixos/modules/services/web-servers/phpfpm/default.nix:77:25
```

cc @Izorkin 

This seems to have been introduced in #63156

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
