### PR TITLE
mscgen: add darwin to meta.platforms

### DIFF
--- a/pkgs/tools/graphics/mscgen/default.nix
+++ b/pkgs/tools/graphics/mscgen/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation {
       printing.
     '';
 
-    platforms = stdenv.lib.platforms.linux;
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
     maintainers = [ stdenv.lib.maintainers.peti ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

`mscgen` appears to work without issue on darwin, sort of...

I built this without `sandbox = true` and it works fine, but with sandboxing enabled, it fails because it doesn't have permission to write to `/tmp` in:

```c
        static char tmpTemplate[] = "/tmp/mscgenXXXXXX";
        int h;

        outType  = ADRAW_FMT_PNG;
        outImage = tmpTemplate;

        /* Create temporary file */
        h = mkstemp(tmpTemplate);
```

However, looking at the nearby `#ifdef`, this should be an issue on Linux too.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [-] NixOS
   - [x] macOS
   - [-] other Linux distributions
- [-] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
