### PR TITLE
viking: 1.6.2 -> 1.7

### DIFF
--- a/pkgs/applications/misc/viking/default.nix
+++ b/pkgs/applications/misc/viking/default.nix
@@ -1,19 +1,21 @@
 { fetchurl, stdenv, makeWrapper, pkgconfig, intltool, gettext, gtk2, expat, curl
 , gpsd, bc, file, gnome-doc-utils, libexif, libxml2, libxslt, scrollkeeper
-, docbook_xml_dtd_412, gexiv2, sqlite, gpsbabel, expect, hicolor-icon-theme }:
+, docbook_xml_dtd_412, gexiv2, sqlite, gpsbabel, expect, hicolor-icon-theme
+, geoclue2, liboauth }:
 
 stdenv.mkDerivation rec {
   name = "viking-${version}";
-  version = "1.6.2";
+  version = "1.7";
 
   src = fetchurl {
     url = "mirror://sourceforge/viking/viking/viking-${version}.tar.bz2";
-    sha256 = "09kq0sxs2czps0d6xzgkkp41746v44ip63m72qvfs7rsrnqj7qnz";
+    sha256 = "092q2dv0rcz12nh2js1z1ralib1553dmzy9pdrvz9nv2vf61wybw";
   };
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ makeWrapper intltool gettext gtk2 expat curl gpsd bc file gnome-doc-utils
     libexif libxml2 libxslt scrollkeeper docbook_xml_dtd_412 gexiv2 sqlite hicolor-icon-theme
+    geoclue2 liboauth
   ];
 
   configureFlags = [ "--disable-scrollkeeper --disable-mapnik" ];


### PR DESCRIPTION
###### Motivation for this change

[Viking 1.7 - released 2019-01-21](https://github.com/viking-gps/viking/releases/tag/Viking-1.7)

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
