### PR TITLE
lib: add mapDir and mapDirFiles

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -134,5 +134,6 @@ let
       mergeAttrsByFuncDefaultsClean mergeAttrBy
       fakeSha256 fakeSha512
       nixType imap;
+    inherit (filesystem) filterMapDir mapDirFiles;
   });
 in lib


### PR DESCRIPTION
Adds a function and a convenience function to `lib/filesystems.nix` for mapping a function over a directory.