### PR TITLE
bazel: fix the compilation of .proto on Darwin

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/cpp-test.nix
+++ b/pkgs/development/tools/build-managers/bazel/cpp-test.nix
@@ -1,0 +1,49 @@
+{
+  bazel
+, bazelTest
+, bazel-examples
+, gccStdenv
+, lib
+, runLocal
+, runtimeShell
+, writeScript
+, writeText
+}:
+
+let
+
+  toolsBazel = writeScript "bazel" ''
+    #! ${runtimeShell}
+
+    export CXX='${gccStdenv.cc}/bin/g++'
+    export LD='${gccStdenv.cc}/bin/ld'
+    export CC='${gccStdenv.cc}/bin/gcc'
+
+    # XXX: hack for macosX, this flags disable bazel usage of xcode
+    # See: https://github.com/bazelbuild/bazel/issues/4231
+    export BAZEL_USE_CPP_ONLY_TOOLCHAIN=1
+
+    exec "$BAZEL_REAL" "$@"
+  '';
+
+  workspaceDir = runLocal "our_workspace" {} (''
+    cp -r ${bazel-examples}/cpp-tutorial/stage3 $out
+    find $out -type d -exec chmod 755 {} \;
+  ''
+  + (lib.optionalString gccStdenv.isDarwin ''
+    mkdir $out/tools
+    cp ${toolsBazel} $out/tools/bazel
+  ''));
+
+  testBazel = bazelTest {
+    name = "bazel-test-cpp";
+    inherit workspaceDir;
+    bazelPkg = bazel;
+    bazelScript = ''
+      ${bazel}/bin/bazel \
+        build --verbose_failures \
+          //...
+    '';
+  };
+
+in testBazel

--- a/pkgs/development/tools/build-managers/bazel/protobuf-test.nix
+++ b/pkgs/development/tools/build-managers/bazel/protobuf-test.nix
@@ -1,0 +1,144 @@
+{
+  bazel
+, bazelTest
+, fetchFromGitHub
+, fetchurl
+, gccStdenv
+, lib
+, runLocal
+, runtimeShell
+, writeScript
+, writeText
+}:
+
+let
+  com_google_protobuf = fetchFromGitHub {
+    owner = "protocolbuffers";
+    repo = "protobuf";
+    rev = "v3.7.0";
+    sha256 = "0nlxif4cajqllsj2vdh7zp14ag48fb8lsa64zmq8625q9m2lcmdh";
+  };
+
+  bazel_skylib = fetchFromGitHub {
+    owner = "bazelbuild";
+    repo = "bazel-skylib";
+    rev = "f83cb8dd6f5658bc574ccd873e25197055265d1c";
+    sha256 = "091fb0ky0956wgv8gghy9ay3yfx6497mb72qvibf0y9dllmxyn9l";
+  };
+
+  net_zlib = fetchurl rec {
+    url = "https://zlib.net/zlib-1.2.11.tar.gz";
+    sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1";
+
+    passthru.sha256 = sha256;
+  };
+
+  WORKSPACE = writeText "WORKSPACE" ''
+    workspace(name = "our_workspace")
+
+    load("//:proto-support.bzl", "protobuf_deps")
+    protobuf_deps()
+  '';
+
+  protoSupport = writeText "proto-support.bzl" ''
+    """Load dependencies needed to compile the protobuf library as a 3rd-party consumer."""
+
+    load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+    def protobuf_deps():
+        """Loads common dependencies needed to compile the protobuf library."""
+
+        if "zlib" not in native.existing_rules():
+            # proto_library, cc_proto_library, and java_proto_library rules implicitly
+            # depend on @com_google_protobuf for protoc and proto runtimes.
+            # This statement defines the @com_google_protobuf repo.
+            native.local_repository(
+                name = "com_google_protobuf",
+                path = "${com_google_protobuf}",
+            )
+            native.local_repository(
+                name = "bazel_skylib",
+                path = "${bazel_skylib}",
+            )
+
+            native.bind(
+                name = "zlib",
+                actual = "@net_zlib//:zlib",
+            )
+            http_archive(
+                name = "net_zlib",
+                build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
+                sha256 = "${net_zlib.sha256}",
+                strip_prefix = "zlib-1.2.11",
+                urls = ["file://${net_zlib}"],
+            )
+  '';
+
+  personProto = writeText "person.proto" ''
+    syntax = "proto3";
+
+    message Person {
+      string name = 1;
+      int32 id = 2;
+      string email = 3;
+    }
+  '';
+
+  personBUILD = writeText "BUILD" ''
+    proto_library(
+        name = "person_proto",
+        srcs = ["person.proto"],
+        visibility = ["//visibility:public"],
+    )
+
+    java_proto_library(
+        name = "person_java_proto",
+        deps = [":person_proto"],
+    )
+
+    cc_proto_library(
+        name = "person_cc_proto",
+        deps = [":person_proto"],
+    )
+  '';
+
+  toolsBazel = writeScript "bazel" ''
+    #! ${runtimeShell}
+
+    export CXX='${gccStdenv.cc}/bin/g++'
+    export LD='${gccStdenv.cc}/bin/ld'
+    export CC='${gccStdenv.cc}/bin/gcc'
+
+    # XXX: hack for macosX, this flags disable bazel usage of xcode
+    # See: https://github.com/bazelbuild/bazel/issues/4231
+    export BAZEL_USE_CPP_ONLY_TOOLCHAIN=1
+
+    exec "$BAZEL_REAL" "$@"
+  '';
+
+  workspaceDir = runLocal "our_workspace" {} (''
+    mkdir $out
+    cp ${WORKSPACE} $out/WORKSPACE
+    touch $out/BUILD.bazel
+    cp ${protoSupport} $out/proto-support.bzl
+    mkdir $out/person
+    cp ${personProto} $out/person/person.proto
+    cp ${personBUILD} $out/person/BUILD.bazel
+  ''
+  + (lib.optionalString gccStdenv.isDarwin ''
+    mkdir $out/tools
+    cp ${toolsBazel} $out/tools/bazel
+  ''));
+
+  testBazel = bazelTest {
+    name = "bazel-test-protocol-buffers";
+    inherit workspaceDir;
+    bazelPkg = bazel;
+    bazelScript = ''
+      ${bazel}/bin/bazel \
+        build --verbose_failures \
+          //person:person_proto
+    '';
+  };
+
+in testBazel

--- a/pkgs/development/tools/build-managers/bazel/python-bin-path-test.nix
+++ b/pkgs/development/tools/build-managers/bazel/python-bin-path-test.nix
@@ -45,7 +45,6 @@ let
     bazelScript = ''
       ${bazel}/bin/bazel \
         run \
-          --host_javabase='@local_jdk//:jdk' \
           //python:bin
     '';
   };

--- a/pkgs/development/tools/build-managers/bazel/trim-last-argument-to-gcc-if-empty.patch
+++ b/pkgs/development/tools/build-managers/bazel/trim-last-argument-to-gcc-if-empty.patch
@@ -1,0 +1,37 @@
+From 177b4720d6fbaa7fdd17e5e11b2c79ac8f246786 Mon Sep 17 00:00:00 2001
+From: "Wael M. Nasreddine" <wael.nasreddine@gmail.com>
+Date: Thu, 27 Jun 2019 21:08:51 -0700
+Subject: [PATCH] Trim last argument to gcc if empty, on Darwin
+
+On Darwin, the last argument to GCC is coming up as an empty string.
+This is breaking the build of proto_library targets. However, I was not
+able to reproduce with the example cpp project[0].
+
+This commit removes the last argument if it's an empty string. This is
+not a problem on Linux.
+
+[0]: https://github.com/bazelbuild/examples/tree/master/cpp-tutorial/stage3
+---
+ tools/cpp/osx_cc_wrapper.sh.tpl | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/tools/cpp/osx_cc_wrapper.sh.tpl b/tools/cpp/osx_cc_wrapper.sh.tpl
+index 4c85cd9b6b..6c611e3d25 100644
+--- a/tools/cpp/osx_cc_wrapper.sh.tpl
++++ b/tools/cpp/osx_cc_wrapper.sh.tpl
+@@ -53,7 +53,11 @@ done
+ %{env}
+ 
+ # Call the C++ compiler
+-%{cc} "$@"
++if [[ ${*: -1} = "" ]]; then
++    %{cc} "${@:0:$#}"
++else
++    %{cc} "$@"
++fi
+ 
+ function get_library_path() {
+     for libdir in ${LIB_DIRS}; do
+-- 
+2.19.2
+


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

On Darwin, the last argument to GCC is coming up as an empty string. This is breaking the build of proto_library targets. However, I was not able to reproduce with the example [cpp project](https://github.com/bazelbuild/examples/tree/master/cpp-tutorial/stage3).

This commit patches the cc_wrapper of Bazel that gets installed on
Darwin to remove the last argument if it's an empty string. This is
not a problem on Linux.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @guibou @Profpatsch 