### PR TITLE
syncplay: 1.6.4 -> 1.6.4a, and upgrade dependency from Qt4 to Qt5

### DIFF
--- a/pkgs/applications/networking/syncplay/default.nix
+++ b/pkgs/applications/networking/syncplay/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, buildPythonApplication, pyside2, shiboken2, twisted, certifi }:
+{ lib, fetchFromGitHub, buildPythonApplication, pyside2, shiboken2, twisted, certifi, qt5 }:
 
 buildPythonApplication rec {
   pname = "syncplay";
@@ -14,8 +14,13 @@ buildPythonApplication rec {
   };
 
   propagatedBuildInputs = [ pyside2 shiboken2 twisted certifi ] ++ twisted.extras.tls;
+  nativeBuildInputs = [ qt5.wrapQtAppsHook ];
 
   makeFlags = [ "DESTDIR=" "PREFIX=$(out)" ];
+
+  postFixup = ''
+    wrapQtApp $out/bin/syncplay
+  '';
 
   meta = with lib; {
     homepage = https://syncplay.pl/;

--- a/pkgs/applications/networking/syncplay/default.nix
+++ b/pkgs/applications/networking/syncplay/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, buildPythonApplication, pyside, twisted, certifi }:
+{ lib, fetchFromGitHub, buildPythonApplication, pyside2, shiboken2, twisted, certifi }:
 
 buildPythonApplication rec {
   pname = "syncplay";
@@ -13,7 +13,7 @@ buildPythonApplication rec {
     sha256 = "0afh2a0l1c3hwgj5q6wy0v5iimg8qcjam3pw7b8mf63lasx6iqk4";
   };
 
-  propagatedBuildInputs = [ pyside twisted certifi ] ++ twisted.extras.tls;
+  propagatedBuildInputs = [ pyside2 shiboken2 twisted certifi ] ++ twisted.extras.tls;
 
   makeFlags = [ "DESTDIR=" "PREFIX=$(out)" ];
 

--- a/pkgs/applications/networking/syncplay/default.nix
+++ b/pkgs/applications/networking/syncplay/default.nix
@@ -2,7 +2,7 @@
 
 buildPythonApplication rec {
   pname = "syncplay";
-  version = "1.6.4";
+  version = "1.6.4a";
 
   format = "other";
 
@@ -10,7 +10,7 @@ buildPythonApplication rec {
     owner = "Syncplay";
     repo = "syncplay";
     rev = "v${version}";
-    sha256 = "0afh2a0l1c3hwgj5q6wy0v5iimg8qcjam3pw7b8mf63lasx6iqk4";
+    sha256 = "0zz4a3vzfg808z1qkqz31z4818wzpfa2lika7wl0jgpmw4zi85ix";
   };
 
   propagatedBuildInputs = [ pyside2 shiboken2 twisted certifi ] ++ twisted.extras.tls;


### PR DESCRIPTION
###### Motivation for this change

It turns out Syncplay has had support for Qt5 for a while, and automatically detects whether it has access to PySide, which binds Qt4, or PySide2, which binds Qt5. By simply updating the dependencies, we can upgrade Syncplay to Qt5.

Technically the upgrade to 1.6.4a is independent, but I figured I might as well do both. If there is any reason to keep a separate Qt4 version of Syncplay around, let me know. cc @enzime

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
