### PR TITLE
packr: init at 2.5.1

### DIFF
--- a/pkgs/development/libraries/packr/default.nix
+++ b/pkgs/development/libraries/packr/default.nix
@@ -1,0 +1,25 @@
+{ buildGoModule
+, fetchFromGitHub
+, lib
+}:
+
+buildGoModule rec {
+  pname = "packr";
+  version = "2.5.1";
+
+  src = fetchFromGitHub {
+    owner = "gobuffalo";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "070hpnsr5w1r1cg9wl80cafmhkx4z3s29wq04fa7rk49hmwml4jy";
+  };
+
+  modSha256 = "0xvpk9jjcqac44s4fp0jwpljxvs0ypjwc5qfg0w90s2r7jn50fxn";
+
+  meta = with lib; {
+    description = "The simple and easy way to embed static files into Go binaries";
+    homepage = "https://github.com/gobuffalo/packr";
+    license = licenses.mit;
+    maintainers = with maintainers; [ mmahut ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -244,6 +244,8 @@ in
 
   packer = callPackage ../development/tools/packer { };
 
+  packr = callPackage ../development/libraries/packr { };
+
   pet = callPackage ../development/tools/pet { };
 
   mod = callPackage ../development/tools/mod { };


### PR DESCRIPTION
###### Motivation for this change

packr: init at 2.5.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
