### PR TITLE
prototool: init at 1.8.0

### DIFF
--- a/pkgs/development/tools/prototool/default.nix
+++ b/pkgs/development/tools/prototool/default.nix
@@ -1,0 +1,33 @@
+{ lib, buildGoModule, fetchFromGitHub, makeWrapper, protobuf }:
+
+buildGoModule rec {
+  pname = "prototool";
+  version = "1.8.0";
+
+  src = fetchFromGitHub {
+    owner = "uber";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0m6g5p3jyf0ja5j9rqmw8mhipdqxk7rcxm0plmh65bxk1n22fzjc";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  modSha256 = "0l4nqb1c1lqqk70l9qwib1azavxlwghi2fv5siwrr5zw4jysz5ml";
+
+  postInstall = ''
+    wrapProgram "$out/bin/prototool" \
+      --prefix PROTOTOOL_PROTOC_BIN_PATH : "${protobuf}/bin/protoc" \
+      --prefix PROTOTOOL_PROTOC_WKT_PATH : "${protobuf}/include"
+  '';
+
+  subPackages = [ "cmd/prototool" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/uber/prototool";
+    description = "Your Swiss Army Knife for Protocol Buffers";
+    maintainers = [ maintainers.marsam ];
+    license = licenses.mit;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15896,6 +15896,8 @@ in
 
   procdump = callPackage ../os-specific/linux/procdump { };
 
+  prototool = callPackage ../development/tools/prototool { };
+
   qemu_kvm = lowPrio (qemu.override { hostCpuOnly = true; });
 
   # See `xenPackages` source for explanations.


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add https://github.com/uber/prototool

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
