### PR TITLE
trivial-builders: Fix writeShellScript example

### DIFF
--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -143,7 +143,7 @@ rec {
    * Automatically includes interpreter above the contents passed.
    *
    * Example:
-   * # Writes my-file to /nix/store/<store path>/my-file and makes executable.
+   * # Writes my-file to /nix/store/<store path> and makes executable.
    * writeShellScript "my-file"
    *   ''
    *   Contents of File


### PR DESCRIPTION
###### Motivation for this change
`writeShellScript`, similarly to `writeScript`, results in an executable. However the example seems to imply that the script will be written to destination `name` in the result, which is not the case.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
