### PR TITLE
prometheus-tor-exporter: 0.3 -> 0.4

### DIFF
--- a/pkgs/servers/monitoring/prometheus/tor-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/tor-exporter.nix
@@ -2,7 +2,7 @@
 
 python3Packages.buildPythonApplication rec {
   name = "tor-exporter-${version}";
-  version = "0.3";
+  version = "0.4";
 
   # Just a single .py file to use as the application's main entry point.
   format = "other";
@@ -11,7 +11,7 @@ python3Packages.buildPythonApplication rec {
     rev = "v${version}";
     owner = "atx";
     repo = "prometheus-tor_exporter";
-    sha256 = "0d7pk8s8ya2pm8b4ijbfdniqcbd3vqy15dlhnmaf4wgb51pmm5yv";
+    sha256 = "1gzf42z0cgdqijbi9cwpjkqzkvnabaxkkfa5ac5h27r3pxx3q4n0";
   };
 
   propagatedBuildInputs = with python3Packages; [ prometheus_client stem retrying ];


### PR DESCRIPTION
###### Motivation for this change

This fixes #63831. From the ticket:

The prometheus-tor-exporter gives a stack trace and the following error in the journal:

    stem.OperationFailed: Not running in server mode

This seems to be a "stem 1.7+ compatibility" issue fixed in 0.4.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
