### PR TITLE
[19.03] environment.noXlibs: disable gnome3 for pinentry

### DIFF
--- a/nixos/modules/config/no-x-libs.nix
+++ b/nixos/modules/config/no-x-libs.nix
@@ -34,7 +34,7 @@ with lib;
       networkmanager-openvpn = super.networkmanager-openvpn.override { withGnome = false; };
       networkmanager-vpnc = super.networkmanager-vpnc.override { withGnome = false; };
       networkmanager-iodine = super.networkmanager-iodine.override { withGnome = false; };
-      pinentry = super.pinentry_ncurses;
+      pinentry = super.pinentry.override { gtk2 = null; gcr = null; qt = null; };
       gobject-introspection = super.gobject-introspection.override { x11Support = false; };
     }));
   };


### PR DESCRIPTION
Backport of #59051 to release-19.03

cc @delroth @timokau 