### PR TITLE
vivaldi: widevine-support, fixed ffmpeg-support

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -681,6 +681,11 @@
     github = "bergey";
     name = "Daniel Bergey";
   };
+  betaboon = {
+    email = "betaboon@0x80.ninja";
+    github = "betaboon";
+    name = "betaboon";
+  };
   bfortz = {
     email = "bernard.fortz@gmail.com";
     github = "bfortz";

--- a/pkgs/applications/networking/browsers/vivaldi/default.nix
+++ b/pkgs/applications/networking/browsers/vivaldi/default.nix
@@ -9,6 +9,7 @@
 , patchelf, makeWrapper
 , isSnapshot ? false
 , proprietaryCodecs ? false, vivaldi-ffmpeg-codecs ? null
+, enableWidevine ? false, vivaldi-widevine ? null
 }:
 
 let
@@ -51,7 +52,7 @@ in stdenv.mkDerivation rec {
       opt/${vivaldiName}/vivaldi-bin
   '' + stdenv.lib.optionalString proprietaryCodecs ''
     sed -i '/^if \[ "$VIVALDI_FFMPEG_FOUND/i \
-      VIVALDI_FFMPEG_FOUND=YES\nCACHED_FFMPEG=${vivaldi-ffmpeg-codecs}/lib/libffmpeg.so' opt/${vivaldiName}/vivaldi
+      VIVALDI_FFMPEG_FOUND=YES\nCACHED_FFMPEG=${vivaldi-ffmpeg-codecs}/lib/libffmpeg.so' opt/${vivaldiName}/${vivaldiName}
   '' + ''
     echo "Finished patching Vivaldi binaries"
   '';
@@ -76,7 +77,11 @@ in stdenv.mkDerivation rec {
         "$out"/share/icons/hicolor/''${d}x''${d}/apps/vivaldi.png
     done
     wrapProgram "$out/bin/vivaldi" \
-      --suffix XDG_DATA_DIRS : ${gtk3}/share/gsettings-schemas/${gtk3.name}/
+      --suffix XDG_DATA_DIRS : ${gtk3}/share/gsettings-schemas/${gtk3.name}/ \
+      ${stdenv.lib.optionalString enableWidevine "--suffix LD_LIBRARY_PATH : ${libPath}"}
+  '' + stdenv.lib.optionalString enableWidevine ''
+    rm $out/opt/${vivaldiName}/libwidevinecdm.so
+    ln -s ${vivaldi-widevine}/lib/libwidevinecdm.so $out/opt/${vivaldiName}/libwidevinecdm.so
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/networking/browsers/vivaldi/default.nix
+++ b/pkgs/applications/networking/browsers/vivaldi/default.nix
@@ -50,8 +50,8 @@ in stdenv.mkDerivation rec {
       --set-rpath "${libPath}" \
       opt/${vivaldiName}/vivaldi-bin
   '' + stdenv.lib.optionalString proprietaryCodecs ''
-    sed -i '/^VIVALDI_FFMPEG_FOUND/ a \
-    checkffmpeg "${vivaldi-ffmpeg-codecs}/lib/libffmpeg.so"' opt/${vivaldiName}/vivaldi
+    sed -i '/^if \[ "$VIVALDI_FFMPEG_FOUND/i \
+      VIVALDI_FFMPEG_FOUND=YES\nCACHED_FFMPEG=${vivaldi-ffmpeg-codecs}/lib/libffmpeg.so' opt/${vivaldiName}/vivaldi
   '' + ''
     echo "Finished patching Vivaldi binaries"
   '';

--- a/pkgs/applications/networking/browsers/vivaldi/ffmpeg-codecs.nix
+++ b/pkgs/applications/networking/browsers/vivaldi/ffmpeg-codecs.nix
@@ -1,53 +1,32 @@
 { stdenv, fetchurl
-, dbus-glib, gtk3, libexif, libXScrnSaver, ninja, nss
-, pciutils, pkgconfig, python2, xdg_utils, gn, at-spi2-core
+, dpkg
 }:
 
 stdenv.mkDerivation rec {
-  name = "${product}-${version}";
-  product = "vivaldi-ffmpeg-codecs";
-  version = "72.0.3626.122";
+  name = "chromium-codecs-ffmpeg";
+  version = "74.0.3729.169";
 
   src = fetchurl {
-    url = "https://commondatastorage.googleapis.com/chromium-browser-official/chromium-${version}.tar.xz";
-    sha512 = "1477g5dgi4m0zbiqwm9w6jqkmjfmgjlbl3qs9ljldx8bif8my1jbz4hzws954aqxyxdbf5rjpvmrrqqppk5347prvsyl37rbsndaaqf";
+    url = "https://launchpadlibrarian.net/424938057/${name}-extra_${version}-0ubuntu0.16.04.1_amd64.deb";
+    sha256 = "1ls2fshfk08hqsfvbd7p6rp2gv3n0xdy86rdh00wiz5qgl3skfzc";
   };
 
-  buildInputs = [ ];
+  buildInputs = [ dpkg ];
 
-  nativeBuildInputs = [
-    gtk3 libexif libXScrnSaver ninja nss pciutils python2 xdg_utils gn
-    pkgconfig dbus-glib at-spi2-core.dev
-  ];
-
-  patches = [
-  ];
-
-  configurePhase = ''
-    runHook preConfigure
-
-    local args="ffmpeg_branding=\"ChromeOS\" proprietary_codecs=true enable_hevc_demuxing=true use_gnome_keyring=false use_sysroot=false use_gold=false use_allocator=\"none\" linux_use_bundled_binutils=false fatal_linker_warnings=false treat_warnings_as_errors=false enable_nacl=false enable_nacl_nonsfi=false is_clang=false clang_use_chrome_plugins=false is_component_build=true is_debug=false symbol_level=0 use_custom_libcxx=false use_lld=false use_jumbo_build=false"
-    gn gen out/Release -v --args="$args"
-
-    runHook postConfigure
+  unpackPhase = ''
+    dpkg-deb -x $src .
+    find .
   '';
-
-  buildPhase = ''
-    ninja -C out/Release -v libffmpeg.so
-  '';
-
-  dontStrip = true;
 
   installPhase = ''
-    mkdir -p "$out/lib"
-    cp out/Release/libffmpeg.so "$out/lib/libffmpeg.so"
+    install -vD usr/lib/chromium-browser/libffmpeg.so $out/lib/libffmpeg.so
   '';
 
   meta = with stdenv.lib; {
     description = "Additional support for proprietary codecs for Vivaldi";
     homepage    = "https://ffmpeg.org/";
     license     = licenses.lgpl21;
-    maintainers = with maintainers; [ lluchs ];
+    maintainers = with maintainers; [ betaboon lluchs ];
     platforms   = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/applications/networking/browsers/vivaldi/widevine.nix
+++ b/pkgs/applications/networking/browsers/vivaldi/widevine.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchurl
+, unzip
+}:
+
+stdenv.mkDerivation rec {
+  name = "widevine";
+  version = "4.10.1196.0";
+
+  src = fetchurl {
+    url = "https://dl.google.com/widevine-cdm/${version}-linux-x64.zip";
+    sha256 = "01c7nr7d2xs718jymicbk4ipzfx6q253109qv3lk4lryrrhvw14y";
+  };
+
+  buildInputs = [ unzip ];
+
+  unpackPhase = ''
+    unzip $src libwidevinecdm.so
+    find .
+  '';
+
+  installPhase = ''
+    install -vD libwidevinecdm.so $out/lib/libwidevinecdm.so
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Widevine support for Vivaldi";
+    homepage = "https://www.widevine.com";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ betaboon ];
+    platforms   = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19538,6 +19538,8 @@ in
 
   vivaldi-ffmpeg-codecs = callPackage ../applications/networking/browsers/vivaldi/ffmpeg-codecs.nix {};
 
+  vivaldi-widevine = callPackage ../applications/networking/browsers/vivaldi/widevine.nix { };
+
   openmpt123 = callPackage ../applications/audio/openmpt123 { };
 
   opusfile = callPackage ../applications/audio/opusfile { };


### PR DESCRIPTION
###### Motivation for this change
I wanted widevine-support in vivaldi to enable streaming drm-content (eg. netflix)

###### Things done
- updated vivaldi-ffmpeg-codecs
- fixed how ffmpeg-codecs is installed (the way vivaldi detects it has changed)
- packages widevine-cdm from google
- extended vivaldi to allow installing with widevine support


- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
