### PR TITLE
[r19.03] libvirt: add patches for CVE-2019-10132, CVE-2019-10161, CVE-2019-10166, CVE-2019-10167 & CVE-2019-10168

### DIFF
--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchgit
-, pkgconfig, makeWrapper, libtool, autoconf, automake
+, pkgconfig, makeWrapper, libtool, autoconf, automake, fetchpatch
 , coreutils, libxml2, gnutls, perl, python2, attr
 , iproute, iptables, readline, lvm2, utillinux, systemd, libpciaccess, gettext
 , libtasn1, ebtables, libgcrypt, yajl, pmutils, libcap_ng, libapparmor
@@ -32,6 +32,46 @@ in stdenv.mkDerivation rec {
         sha256 = "0dlpv3v6jpbmgvhpn29ryp0w2a1xny8ciqid8hnlf3klahz9kwz9";
         fetchSubmodules = true;
       };
+
+  patches = [
+    (fetchpatch {
+      name = "4.10.0-CVE-2019-10132-1.patch";
+      url = "https://libvirt.org/git/?p=libvirt.git;a=patch;h=8d12118171a250150f2cb16448c49271a1dcb077";
+      sha256 = "1s8xm0zn63wciaxzrcf5ld9d3r2hn9k31p41addhyrxivgvkvk4d";
+    })
+    (fetchpatch {
+      name = "4.10.0-CVE-2019-10132-2.patch";
+      url = "https://libvirt.org/git/?p=libvirt.git;a=patch;h=a712f01682078f48d3c258bff8cd523ab9100b0d";
+      sha256 = "12wzv190l7gp3fpa1qirgy5l6w674pfpw06jb15gifrwhy7x9j06";
+    })
+    (fetchpatch {
+      name = "4.10.0-CVE-2019-10132-3.patch";
+      url = "https://libvirt.org/git/?p=libvirt.git;a=patch;h=f8d8a7a182c0854fa50d3976077b3a3d8de8980f";
+      sha256 = "08306952a32khl8mkw1xarh084dqp9vxhl6hwm2cmf30zkp8jlff";
+    })
+  ] ++ optionals (!stdenv.isDarwin) [  # this patch appears to be broken on darwin
+    (fetchpatch {
+      name = "4.10.0-CVE-2019-10161.patch";
+      url = "https://libvirt.org/git/?p=libvirt.git;a=patch;h=3572564893d1710beb1862797fe32cc2e9cb1e38";
+      sha256 = "118541d8w1jg92kqzrjhf631f753wncx6xm64jwzhnc096l7swsj";
+    })
+  ] ++ [
+    (fetchpatch {
+      name = "4.10.0-CVE-2019-10166.patch";
+      url = "https://libvirt.org/git/?p=libvirt.git;a=patch;h=3f744efec31959f7643849f6a3708198bcdfc6ae";
+      sha256 = "0alkw14iwcdy32r6g2lm660ss6fax9c1d9l53s5788vkjfw3jnz0";
+    })
+    (fetchpatch {
+      name = "4.10.0-CVE-2019-10167.patch";
+      url = "https://libvirt.org/git/?p=libvirt.git;a=patch;h=d238f132e6e0432a42d3cdff4571730dae3a85eb";
+      sha256 = "0pnvzdhdiqd4hvc5ip59iszahkfrwvf7f99p2v2lb438z9c5bb32";
+    })
+    (fetchpatch {
+      name = "4.10.0-CVE-2019-10168.patch";
+      url = "https://libvirt.org/git/?p=libvirt.git;a=patch;h=09c2635d0deec198de0f250abc2958f2d1c09eaa";
+      sha256 = "0s4hc3hsjncx1852ndjas1nng9v23pxf4mi1jxcajsqvhw89la0g";
+    })
+  ];
 
   nativeBuildInputs = [ makeWrapper pkgconfig ];
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change
Yes, this is indeed every 4.10 commit in the repo _after_ the 4.10.0 release - they don't seem to be in a hurry to release 4.10.1. The fix for CVE-2019-10161 unfortunately breaks the darwin build for me (tested on macos 10.13), so at least having them as separate patches allows me to disable that patch for darwin. I'll open an upstream bug on that once I've also updated/patched `master`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
