### PR TITLE
nixos/release-notes: fix bad merge of cargo-vendor entry and formatting

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1909.xml
+++ b/nixos/doc/manual/release-notes/rl-1909.xml
@@ -81,45 +81,45 @@
    </listitem>
    <listitem>
     <para>
-      The options <option>services.prometheus.alertmanager.user</option> and
-      <option>services.prometheus.alertmanager.group</option> have been removed
-      because the alertmanager service is now using systemd's <link
-      xlink:href="http://0pointer.net/blog/dynamic-users-with-systemd.html">
-      DynamicUser mechanism</link> which obviates these options.
+     The options <option>services.prometheus.alertmanager.user</option> and
+     <option>services.prometheus.alertmanager.group</option> have been removed
+     because the alertmanager service is now using systemd's <link
+     xlink:href="http://0pointer.net/blog/dynamic-users-with-systemd.html">
+     DynamicUser mechanism</link> which obviates these options.
     </para>
    </listitem>
    <listitem>
     <para>
-      The NetworkManager systemd unit was renamed back from network-manager.service to
-      NetworkManager.service for better compatibility with other applications expecting this name.
-      The same applies to ModemManager where modem-manager.service is now called ModemManager.service again.
+     The NetworkManager systemd unit was renamed back from network-manager.service to
+     NetworkManager.service for better compatibility with other applications expecting this name.
+     The same applies to ModemManager where modem-manager.service is now called ModemManager.service again.
     </para>
    </listitem>
    <listitem>
     <para>
-      The <option>services.nzbget.configFile</option> and <option>services.nzbget.openFirewall</option>
-      options were removed as they are managed internally by the nzbget. The
-      <option>services.nzbget.dataDir</option> option hadn't actually been used by
-      the module for some time and so was removed as cleanup.
+     The <option>services.nzbget.configFile</option> and <option>services.nzbget.openFirewall</option>
+     options were removed as they are managed internally by the nzbget. The
+     <option>services.nzbget.dataDir</option> option hadn't actually been used by
+     the module for some time and so was removed as cleanup.
     </para>
    </listitem>
    <listitem>
     <para>
-      The <option>services.mysql.pidDir</option> option was removed, as it was only used by the wordpress
-      apache-httpd service to wait for mysql to have started up.
-      This can be accomplished by either describing a dependency on mysql.service (preferred)
-      or waiting for the (hardcoded) <filename>/run/mysqld/mysql.sock</filename> file to appear.
+     The <option>services.mysql.pidDir</option> option was removed, as it was only used by the wordpress
+     apache-httpd service to wait for mysql to have started up.
+     This can be accomplished by either describing a dependency on mysql.service (preferred)
+     or waiting for the (hardcoded) <filename>/run/mysqld/mysql.sock</filename> file to appear.
     </para>
    </listitem>
    <listitem>
     <para>
-      The <option>services.emby.enable</option> module has been removed, see
-      <option>services.jellyfin.enable</option> instead for a free software fork of Emby.
+     The <option>services.emby.enable</option> module has been removed, see
+     <option>services.jellyfin.enable</option> instead for a free software fork of Emby.
 
-      See the Jellyfin documentation:
-      <link xlink:href="https://jellyfin.readthedocs.io/en/latest/administrator-docs/migrate-from-emby/">
-        Migrating from Emby to Jellyfin
-      </link>
+     See the Jellyfin documentation:
+     <link xlink:href="https://jellyfin.readthedocs.io/en/latest/administrator-docs/migrate-from-emby/">
+       Migrating from Emby to Jellyfin
+     </link>
     </para>
    </listitem>
    <listitem>
@@ -136,50 +136,50 @@
    </listitem>
    <listitem>
     <para>
-      Several of the apache subservices have been replaced with full NixOS
-      modules including LimeSurvey and WordPress.
-      These modules can be enabled using the <option>services.limesurvey.enable</option>
-      and <option>services.wordpress.enable</option> options.
+     Several of the apache subservices have been replaced with full NixOS
+     modules including LimeSurvey and WordPress.
+     These modules can be enabled using the <option>services.limesurvey.enable</option>
+     and <option>services.wordpress.enable</option> options.
     </para>
    </listitem>
    <listitem>
-     <para>
-      The option <option>systemd.network.networks.&lt;name&gt;.routes.*.routeConfig.GatewayOnlink</option>
-      was renamed to <option>systemd.network.networks.&lt;name&gt;.routes.*.routeConfig.GatewayOnLink</option>
-      (capital <literal>L</literal>). This follows
-      <link xlink:href="https://github.com/systemd/systemd/commit/9cb8c5593443d24c19e40bfd4fc06d672f8c554c">
-        upstreams renaming
-      </link> of the setting.
-     </para>
+    <para>
+     The option <option>systemd.network.networks.&lt;name&gt;.routes.*.routeConfig.GatewayOnlink</option>
+     was renamed to <option>systemd.network.networks.&lt;name&gt;.routes.*.routeConfig.GatewayOnLink</option>
+     (capital <literal>L</literal>). This follows
+     <link xlink:href="https://github.com/systemd/systemd/commit/9cb8c5593443d24c19e40bfd4fc06d672f8c554c">
+      upstreams renaming
+     </link> of the setting.
+    </para>
    </listitem>
    <listitem>
     <para>
-      As of this release the NixOps feature <literal>autoLuks</literal> is deprecated. It no longer works
-      with our systemd version without manual intervention.
+     As of this release the NixOps feature <literal>autoLuks</literal> is deprecated. It no longer works
+     with our systemd version without manual intervention.
     </para>
     <para>
-      Whenever the usage of the module is detected the evaluation will fail with a message
-      explaining why and how to deal with the situation.
+     Whenever the usage of the module is detected the evaluation will fail with a message
+     explaining why and how to deal with the situation.
     </para>
     <para>
-      A new knob named <literal>nixops.enableDeprecatedAutoLuks</literal>
-      has been introduced to disable the eval failure and to acknowledge the notice was received and read.
-      If you plan on using the feature please note that it might break with subsequent updates.
+     A new knob named <literal>nixops.enableDeprecatedAutoLuks</literal>
+     has been introduced to disable the eval failure and to acknowledge the notice was received and read.
+     If you plan on using the feature please note that it might break with subsequent updates.
     </para>
     <para>
-      Make sure you set the <literal>_netdev</literal> option for each of the file systems referring to block
-      devices provided by the autoLuks module. Not doing this might render the system in a
-      state where it doesn't boot anymore.
+     Make sure you set the <literal>_netdev</literal> option for each of the file systems referring to block
+     devices provided by the autoLuks module. Not doing this might render the system in a
+     state where it doesn't boot anymore.
     </para>
     <para>
-      If you are actively using the <literal>autoLuks</literal> module please let us know in
-      <link xlink:href="https://github.com/NixOS/nixpkgs/issues/62211">issue #62211</link>.
+     If you are actively using the <literal>autoLuks</literal> module please let us know in
+     <link xlink:href="https://github.com/NixOS/nixpkgs/issues/62211">issue #62211</link>.
     </para>
-  </listitem>
-  <listitem>
+   </listitem>
+   <listitem>
     <para>
-      The setopt declarations will be evaluated at the end of <literal>/etc/zshrc</literal>, so any code in <xref linkend="opt-programs.zsh.interactiveShellInit" />,
-      <xref linkend="opt-programs.zsh.loginShellInit" /> and <xref linkend="opt-programs.zsh.promptInit" /> may break if it relies on those options being set.
+     The setopt declarations will be evaluated at the end of <literal>/etc/zshrc</literal>, so any code in <xref linkend="opt-programs.zsh.interactiveShellInit" />,
+     <xref linkend="opt-programs.zsh.loginShellInit" /> and <xref linkend="opt-programs.zsh.promptInit" /> may break if it relies on those options being set.
     </para>
    </listitem>
   </itemizedlist>
@@ -236,36 +236,36 @@
    </listitem>
    <listitem>
     <para>
-      The <literal>hunspellDicts.fr-any</literal> dictionary now ships with <literal>fr_FR.{aff,dic}</literal>
-      which is linked to <literal>fr-toutesvariantes.{aff,dic}</literal>.
-    </para>
-  </listitem>
-  <listitem>
-    <para>
-      The <literal>mysql</literal> service now runs as <literal>mysql</literal>
-      user. Previously, systemd did execute it as root, and mysql dropped privileges
-      itself.
-      This includes <literal>ExecStartPre=</literal> and
-      <literal>ExecStartPost=</literal> phases.
-      To accomplish that, runtime and data directory setup was delegated to
-      RuntimeDirectory and tmpfiles.
+     The <literal>hunspellDicts.fr-any</literal> dictionary now ships with <literal>fr_FR.{aff,dic}</literal>
+     which is linked to <literal>fr-toutesvariantes.{aff,dic}</literal>.
     </para>
    </listitem>
    <listitem>
     <para>
-      With the upgrade to systemd version 242 the <literal>systemd-timesyncd</literal>
-      service is no longer using <literal>DynamicUser=yes</literal>. In order for the
-      upgrade to work we rely on an activation script to move the state from the old
-      to the new directory. The older directory (prior <literal>19.09</literal>) was
-      <literal>/var/lib/private/systemd/timesync</literal>.
+     The <literal>mysql</literal> service now runs as <literal>mysql</literal>
+     user. Previously, systemd did execute it as root, and mysql dropped privileges
+     itself.
+     This includes <literal>ExecStartPre=</literal> and
+     <literal>ExecStartPost=</literal> phases.
+     To accomplish that, runtime and data directory setup was delegated to
+     RuntimeDirectory and tmpfiles.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     With the upgrade to systemd version 242 the <literal>systemd-timesyncd</literal>
+     service is no longer using <literal>DynamicUser=yes</literal>. In order for the
+     upgrade to work we rely on an activation script to move the state from the old
+     to the new directory. The older directory (prior <literal>19.09</literal>) was
+     <literal>/var/lib/private/systemd/timesync</literal>.
     </para>
     <para>
-      As long as the <literal>system.config.stateVersion</literal> is below
-      <literal>19.09</literal> the state folder will migrated to its proper location
-      (<literal>/var/lib/systemd/timesync</literal>), if required.
+     As long as the <literal>system.config.stateVersion</literal> is below
+     <literal>19.09</literal> the state folder will migrated to its proper location
+     (<literal>/var/lib/systemd/timesync</literal>), if required.
     </para>
-  </listitem>
-  <listitem>
+   </listitem>
+   <listitem>
     <para>
      The package <literal>avahi</literal> is now built to look up service
      definitions from <literal>/etc/avahi/services</literal> instead of its
@@ -275,32 +275,36 @@
      in the aforementioned directory. See <citerefentry>
      <refentrytitle>avahi.service</refentrytitle><manvolnum>5</manvolnum>
      </citerefentry> for more information on custom service definitions.
-      Since version 0.1.19, <literal>cargo-vendor</literal> honors package
-      includes that are specified in the <filename>Cargo.toml</filename>
-      file of Rust crates. <literal>rustPlatform.buildRustPackage</literal> uses
-      <literal>cargo-vendor</literal> to collect and build dependent crates.
-      Since this change in <literal>cargo-vendor</literal> changes the set of
-      vendored files for most Rust packages, the hash that use used to verify
-      the dependencies, <literal>cargoSha256</literal>, also changes.
-    </para>
-    <para>
-      The <literal>cargoSha256</literal> hashes of all in-tree derivations that
-      use <literal>buildRustPackage</literal> have been updated to reflect this
-      change. However, third-party derivations that use
-      <literal>buildRustPackage</literal> may have to be updated as well.
     </para>
    </listitem>
    <listitem>
     <para>
-      The <literal>consul</literal> package was upgraded past version <literal>1.5</literal>,
-      so its deprecated legacy UI is no longer available.
+     Since version 0.1.19, <literal>cargo-vendor</literal> honors package
+     includes that are specified in the <filename>Cargo.toml</filename>
+     file of Rust crates. <literal>rustPlatform.buildRustPackage</literal> uses
+     <literal>cargo-vendor</literal> to collect and build dependent crates.
+     Since this change in <literal>cargo-vendor</literal> changes the set of
+     vendored files for most Rust packages, the hash that use used to verify
+     the dependencies, <literal>cargoSha256</literal>, also changes.
+    </para>
+    <para>
+     The <literal>cargoSha256</literal> hashes of all in-tree derivations that
+     use <literal>buildRustPackage</literal> have been updated to reflect this
+     change. However, third-party derivations that use
+     <literal>buildRustPackage</literal> may have to be updated as well.
     </para>
    </listitem>
    <listitem>
     <para>
-      The default resample-method for PulseAudio has been changed from the upstream default <literal>speex-float-1</literal>
-      to <literal>speex-float-5</literal>. Be aware that low-powered ARM-based and MIPS-based boards will struggle with this
-      so you'll need to set <option>hardware.pulseaudio.daemon.config.resample-method</option> back to <literal>speex-float-1</literal>.
+     The <literal>consul</literal> package was upgraded past version <literal>1.5</literal>,
+     so its deprecated legacy UI is no longer available.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     The default resample-method for PulseAudio has been changed from the upstream default <literal>speex-float-1</literal>
+     to <literal>speex-float-5</literal>. Be aware that low-powered ARM-based and MIPS-based boards will struggle with this
+     so you'll need to set <option>hardware.pulseaudio.daemon.config.resample-method</option> back to <literal>speex-float-1</literal>.
     </para>
    </listitem>
    <listitem>


### PR DESCRIPTION
Fixes the bad merge of #62935 and fixes the overall formatting of the release notes. The inconsistent indentation has always annoyed me, so I decided to try and convert it all to single space, which seems to be the prevailing style.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
