### PR TITLE
nodePackages.tedicross: 0.8.7 -> 0.9.1

### DIFF
--- a/pkgs/development/node-packages/default-v10.nix
+++ b/pkgs/development/node-packages/default-v10.nix
@@ -91,7 +91,7 @@ nodePackages // {
     buildInputs = [ pkgs.automake pkgs.autoconf nodePackages.node-gyp-build ];
   };
 
-  tedicross = nodePackages."tedicross-git+https://github.com/TediCross/TediCross.git#v0.8.7".override {
+  tedicross = nodePackages."tedicross-git+https://github.com/TediCross/TediCross.git#v0.9.1".override {
     nativeBuildInputs = [ pkgs.makeWrapper ];
     postInstall = ''
       makeWrapper '${nodejs}/bin/node' "$out/bin/tedicross" \

--- a/pkgs/development/node-packages/node-packages-v10.json
+++ b/pkgs/development/node-packages/node-packages-v10.json
@@ -108,7 +108,7 @@
 , "stackdriver-statsd-backend"
 , "svgo"
 , "swagger"
-, { "tedicross": "git+https://github.com/TediCross/TediCross.git#v0.8.7" }
+, { "tedicross": "git+https://github.com/TediCross/TediCross.git#v0.9.1" }
 , "tern"
 , "textlint"
 , "textlint-plugin-latex"

--- a/pkgs/development/node-packages/node-packages-v10.nix
+++ b/pkgs/development/node-packages/node-packages-v10.nix
@@ -13,31 +13,31 @@ let
         sha512 = "t4WmWoGV9gyzypwG3y3JlcK2t8fKLtvzBA7xEoFTj9SMPvOuLsf13uh4ikK0RRaaa9RPPWLgFUdOyIRaQvCpwQ==";
       };
     };
-    "@angular-devkit/architect-0.800.1" = {
+    "@angular-devkit/architect-0.800.6" = {
       name = "_at_angular-devkit_slash_architect";
       packageName = "@angular-devkit/architect";
-      version = "0.800.1";
+      version = "0.800.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.800.1.tgz";
-        sha512 = "zDueOtGo8q9zAUWL2baLIwc5hlLkNtSr5ud1yTuhS4EmYbXJOvV2BPyXx4d77iL+SK4AMG/FyDsi1ZUxXubHIA==";
+        url = "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.800.6.tgz";
+        sha512 = "946ceRci/1yx09g8iRvULLoVihcB2RW9nhpCCMum4L9wheip8t4FWso3pd3JtPQGJV9dmsnwPzR9s12bncmj3g==";
       };
     };
-    "@angular-devkit/core-8.0.1" = {
+    "@angular-devkit/core-8.0.6" = {
       name = "_at_angular-devkit_slash_core";
       packageName = "@angular-devkit/core";
-      version = "8.0.1";
+      version = "8.0.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@angular-devkit/core/-/core-8.0.1.tgz";
-        sha512 = "GQtspR2umZeuTUDTLy2dpUstvQfK7oAwE0o+rWSa8mx0DyhYssrfBbvfE4GzUzKp6OSz1sbZAatSO+iimZjbQw==";
+        url = "https://registry.npmjs.org/@angular-devkit/core/-/core-8.0.6.tgz";
+        sha512 = "gbKEVsQuYqBJPzgaxEitvs0aN9NwmUHhTkum28mRyPbS3witay/q8+3ls48M2W+98Da/PQbfndxFY4OCa+qHEA==";
       };
     };
-    "@angular-devkit/schematics-8.0.1" = {
+    "@angular-devkit/schematics-8.0.6" = {
       name = "_at_angular-devkit_slash_schematics";
       packageName = "@angular-devkit/schematics";
-      version = "8.0.1";
+      version = "8.0.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-8.0.1.tgz";
-        sha512 = "AbE/Gt0h/6pGu/sQ2oMXZo5ZMDeUhkdU32Nq5styh+B5nVXzGuZK4CGqyDNttdnzebhHt4Bi5ZtF2Avlwt+KEA==";
+        url = "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-8.0.6.tgz";
+        sha512 = "FGPcVKxNvtdFB0A6oHyxtWeugL83nW+kPATlAimgh1hu7TCP94dDpflCV9o/lgZlH817xTYXrhToXJaMZSnDPw==";
       };
     };
     "@apollographql/apollo-tools-0.3.7" = {
@@ -814,13 +814,13 @@ let
         sha512 = "il+/XdNw01i93+M9J9u4T7/e/Ue/vWfNZE4IRUQjplu2Mqb/AFTDimkw2tdEdSH50wuQXZAbXSql0UphQke+vA==";
       };
     };
-    "@babel/polyfill-7.2.5" = {
+    "@babel/polyfill-7.4.4" = {
       name = "_at_babel_slash_polyfill";
       packageName = "@babel/polyfill";
-      version = "7.2.5";
+      version = "7.4.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.2.5.tgz";
-        sha512 = "8Y/t3MWThtMLYr0YNC/Q76tqN1w30+b0uQMeFUYauG2UGTR19zyUtFrAzT23zNtBxPp+LbE5E/nwV/q/r3y6ug==";
+        url = "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.4.4.tgz";
+        sha512 = "WlthFLfhQQhh+A2Gn5NSFl0Huxz36x86Jn+E9OW7ibK8edKPq+KLy4apM1yDpQ8kJOVi1OVjpP4vSDLdrI04dg==";
       };
     };
     "@babel/preset-env-7.3.4" = {
@@ -877,15 +877,6 @@ let
         sha512 = "sn51H88GRa00+ZoMqCVgOphmswG4b7mhf9VOB0LUBAieykq2GnRFerlN+JQkO/ntT7wz4jaHNSRPg9IdMPEUkA==";
       };
     };
-    "@babel/runtime-7.3.1" = {
-      name = "_at_babel_slash_runtime";
-      packageName = "@babel/runtime";
-      version = "7.3.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.1.tgz";
-        sha512 = "7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==";
-      };
-    };
     "@babel/runtime-7.3.4" = {
       name = "_at_babel_slash_runtime";
       packageName = "@babel/runtime";
@@ -902,6 +893,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.5.tgz";
         sha512 = "TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==";
+      };
+    };
+    "@babel/runtime-corejs2-7.4.5" = {
+      name = "_at_babel_slash_runtime-corejs2";
+      packageName = "@babel/runtime-corejs2";
+      version = "7.4.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.4.5.tgz";
+        sha512 = "5yLuwzvIDecKwYMzJtiarky4Fb5643H3Ao5jwX0HrMR5oM5mn2iHH9wSZonxwNK0oAjAFUQAiOd4jT7/9Y2jMQ==";
       };
     };
     "@babel/template-7.2.2" = {
@@ -994,15 +994,6 @@ let
         sha512 = "O/IyiB5pfztCdmxQZg0/xeq5w+YiP3gtJz8d4We2EpLPKzbDVjOrtfLKYgVfm6Ya6mbvDge1uLkSRwaoVCWKnA==";
       };
     };
-    "@cnakazawa/watch-1.0.3" = {
-      name = "_at_cnakazawa_slash_watch";
-      packageName = "@cnakazawa/watch";
-      version = "1.0.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz";
-        sha512 = "r5160ogAvGyHsal38Kux7YYtodEKOj89RGb28ht1jh3SJb08VwRwAKKJL0bGb04Zd/3r9FL3BFIc3bBidYffCA==";
-      };
-    };
     "@comandeer/babel-plugin-banner-4.1.0" = {
       name = "_at_comandeer_slash_babel-plugin-banner";
       packageName = "@comandeer/babel-plugin-banner";
@@ -1084,6 +1075,42 @@ let
         sha512 = "Ce3xE2JvTSEbASFbRbA1gAIcMcZWdS2yUYRaQbeM0nbOzaZrUYfa3ePtcriYRZOZmr+CkKA+zbjhvTpIOAYVcw==";
       };
     };
+    "@evocateur/libnpmaccess-3.1.0" = {
+      name = "_at_evocateur_slash_libnpmaccess";
+      packageName = "@evocateur/libnpmaccess";
+      version = "3.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@evocateur/libnpmaccess/-/libnpmaccess-3.1.0.tgz";
+        sha512 = "bfrqZ0v+Il5TJBsgF2oyepeJg34K2pBItapzP+UT1QMIGpUh/Zc1pQql4jrafamZTqP3ZvdJxaElat8B5K3ICA==";
+      };
+    };
+    "@evocateur/libnpmpublish-1.2.0" = {
+      name = "_at_evocateur_slash_libnpmpublish";
+      packageName = "@evocateur/libnpmpublish";
+      version = "1.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@evocateur/libnpmpublish/-/libnpmpublish-1.2.0.tgz";
+        sha512 = "sezhX9FSnPIyrBBvxVocVJVO1uIWPczf6rOmUZSntCWfQMraO8pWTFlDJbroFqPbEqFFHf3eyw8NQ0Eb7OLd1g==";
+      };
+    };
+    "@evocateur/npm-registry-fetch-3.9.1" = {
+      name = "_at_evocateur_slash_npm-registry-fetch";
+      packageName = "@evocateur/npm-registry-fetch";
+      version = "3.9.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@evocateur/npm-registry-fetch/-/npm-registry-fetch-3.9.1.tgz";
+        sha512 = "6v1bHbcAypQ+te/1RGSNL4JkK6mcMtcZrUusqo5iKRtYSAig9UJXlOaCcBR+eLywt2DQMNpEwAj24jwWDX5G/w==";
+      };
+    };
+    "@evocateur/pacote-9.6.0" = {
+      name = "_at_evocateur_slash_pacote";
+      packageName = "@evocateur/pacote";
+      version = "9.6.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@evocateur/pacote/-/pacote-9.6.0.tgz";
+        sha512 = "nKx8EPxXhzqNfePbqC6603z7Kkf6GBS2q+SNGtBS/bCgS5Q+p3OVR6MXKOkpvC3WHse98W2WLu8QaV9axtfxyw==";
+      };
+    };
     "@gulp-sourcemaps/identity-map-1.0.2" = {
       name = "_at_gulp-sourcemaps_slash_identity-map";
       packageName = "@gulp-sourcemaps/identity-map";
@@ -1120,22 +1147,40 @@ let
         sha512 = "HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==";
       };
     };
-    "@hapi/joi-15.0.3" = {
-      name = "_at_hapi_slash_joi";
-      packageName = "@hapi/joi";
-      version = "15.0.3";
+    "@hapi/hoek-8.0.1" = {
+      name = "_at_hapi_slash_hoek";
+      packageName = "@hapi/hoek";
+      version = "8.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@hapi/joi/-/joi-15.0.3.tgz";
-        sha512 = "z6CesJ2YBwgVCi+ci8SI8zixoj8bGFn/vZb9MBPbSyoxsS2PnWYjHcyTM17VLK6tx64YVK38SDIh10hJypB+ig==";
+        url = "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.0.1.tgz";
+        sha512 = "cctMYH5RLbElaUpZn3IJaUj9QNQD8iXDnl7xNY6KB1aFD2ciJrwpo3kvZowIT75uA+silJFDnSR2kGakALUymg==";
       };
     };
-    "@hapi/topo-3.1.0" = {
+    "@hapi/joi-15.1.0" = {
+      name = "_at_hapi_slash_joi";
+      packageName = "@hapi/joi";
+      version = "15.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.0.tgz";
+        sha512 = "n6kaRQO8S+kepUTbXL9O/UOL788Odqs38/VOfoCrATDtTvyfiO3fgjlSRaNkHabpTLgM7qru9ifqXlXbXk8SeQ==";
+      };
+    };
+    "@hapi/marker-1.0.0" = {
+      name = "_at_hapi_slash_marker";
+      packageName = "@hapi/marker";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@hapi/marker/-/marker-1.0.0.tgz";
+        sha512 = "JOfdekTXnJexfE8PyhZFyHvHjt81rBFSAbTIRAhF2vv/2Y1JzoKsGqxH/GpZJoF7aEfYok8JVcAHmSz1gkBieA==";
+      };
+    };
+    "@hapi/topo-3.1.2" = {
       name = "_at_hapi_slash_topo";
       packageName = "@hapi/topo";
-      version = "3.1.0";
+      version = "3.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.0.tgz";
-        sha512 = "gZDI/eXOIk8kP2PkUKjWu9RW8GGVd2Hkgjxyr/S7Z+JF+0mr7bAlbw+DkTRxnD580o8Kqxlnba9wvqp5aOHBww==";
+        url = "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.2.tgz";
+        sha512 = "r+aumOqJ5QbD6aLPJWqVjMAPsx5pZKz+F5yPqXZ/WWG9JTtHbQqlzrJoknJ0iJxLj9vlXtmpSdjlkszseeG8OA==";
       };
     };
     "@iarna/toml-2.2.3" = {
@@ -1147,22 +1192,22 @@ let
         sha512 = "FmuxfCuolpLl0AnQ2NHSzoUKWEJDFl63qXjzdoWBVyFCXzMGm1spBzk7LeHNoVCiWCF7mRVms9e6jEV9+MoPbg==";
       };
     };
-    "@ionic/cli-framework-2.0.1" = {
+    "@ionic/cli-framework-2.1.1" = {
       name = "_at_ionic_slash_cli-framework";
       packageName = "@ionic/cli-framework";
-      version = "2.0.1";
+      version = "2.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ionic/cli-framework/-/cli-framework-2.0.1.tgz";
-        sha512 = "4ZIbKJg5LTKE8xNUIZCZnX/VrsuKQbdPdeQ8HTkuxUotqT2ceAExuq2r8LLQ4nquRvUZGwJdGF+1w2UwZlg8yA==";
+        url = "https://registry.npmjs.org/@ionic/cli-framework/-/cli-framework-2.1.1.tgz";
+        sha512 = "2CMTAgX9Xu8SBdp72mZkgHGbmqdYrX7yL1R37V6FRzjjeVqF13/m7OMGbDz4PugJ5FDI48y/O97bL4PpKhQV4Q==";
       };
     };
-    "@ionic/discover-2.0.1" = {
+    "@ionic/discover-2.0.2" = {
       name = "_at_ionic_slash_discover";
       packageName = "@ionic/discover";
-      version = "2.0.1";
+      version = "2.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ionic/discover/-/discover-2.0.1.tgz";
-        sha512 = "ADGcv+JY7+cc20l3D0/EOAMnWkALwmlimFrms8DsDwCX4zLOpIB8sHuLfteNEwUFMFDgkHs543WdrkeGbEz/AA==";
+        url = "https://registry.npmjs.org/@ionic/discover/-/discover-2.0.2.tgz";
+        sha512 = "W4AMv6bmJzKtAz92m7XA+6rCkvO/9Q6+BJzrO9KD3qIt4rIH//CZP05yFK79XlqI3Vt4Ke0GsqBDuEfgBXaN/Q==";
       };
     };
     "@ionic/utils-array-1.0.1" = {
@@ -1174,13 +1219,13 @@ let
         sha512 = "XqGhwcGS5XwXpQbGi1K97UY1bBZLYlj/DQ5HVE6551C6QF6PRM8WAlpKs4m4Y1MZ5FRLbZOSykcx6q4mlFF5FA==";
       };
     };
-    "@ionic/utils-fs-2.0.1" = {
+    "@ionic/utils-fs-2.0.3" = {
       name = "_at_ionic_slash_utils-fs";
       packageName = "@ionic/utils-fs";
-      version = "2.0.1";
+      version = "2.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ionic/utils-fs/-/utils-fs-2.0.1.tgz";
-        sha512 = "dwsa9puttLOlLoAa6sZQRqQIp/TIqmxECun8Ec/AnL0hfeFvpyq5MOjo/3rkq2Oq5bEiZr5ppe8hGEpl8pVx7Q==";
+        url = "https://registry.npmjs.org/@ionic/utils-fs/-/utils-fs-2.0.3.tgz";
+        sha512 = "vTZ7ckBWAPyhOQ/EQKtQK2WdTaNdOJHtHLebOoFLy0Bl/fWlqNAaaLfc9IXkp+eGwYBmpa9t48bHjiHtF1IT5Q==";
       };
     };
     "@ionic/utils-network-1.0.1" = {
@@ -1210,22 +1255,22 @@ let
         sha512 = "kEAte96A5xBA0wJX35ykHERgc4KkYS4Xiq7XsSMo3inBbN2rNUkRIzC+aFM3IFeNKtCqgNgh7t9LczvLDEzdiQ==";
       };
     };
-    "@ionic/utils-stream-1.0.1" = {
+    "@ionic/utils-stream-2.0.0" = {
       name = "_at_ionic_slash_utils-stream";
       packageName = "@ionic/utils-stream";
-      version = "1.0.1";
+      version = "2.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ionic/utils-stream/-/utils-stream-1.0.1.tgz";
-        sha512 = "EIprRexxL+s1J8u6cvJrigDXpRTRUwrobBETxJ9DL8KFLhv3HOVcwRFtiP08mm4l3SCfQtrbi4tMCX/KssVLFQ==";
+        url = "https://registry.npmjs.org/@ionic/utils-stream/-/utils-stream-2.0.0.tgz";
+        sha512 = "xUMsvW6/5R3NpWJD6wkT/324PQ2RU9if9b4SjBgrSBrgKWEiwXopz6JihjRwh1Xq2qn5MiV+2eXSgpq5jnhX0w==";
       };
     };
-    "@ionic/utils-subprocess-1.0.1" = {
+    "@ionic/utils-subprocess-1.0.3" = {
       name = "_at_ionic_slash_utils-subprocess";
       packageName = "@ionic/utils-subprocess";
-      version = "1.0.1";
+      version = "1.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ionic/utils-subprocess/-/utils-subprocess-1.0.1.tgz";
-        sha512 = "JsNLpxoMWIkUhAiQpff+Fzn6+Fl8SvXFglqqBq4E0sKLVuVRDhzD+5JDUKqDO7q+crQhRZbDTRVM+GFsi7ZGgg==";
+        url = "https://registry.npmjs.org/@ionic/utils-subprocess/-/utils-subprocess-1.0.3.tgz";
+        sha512 = "JX65/RBWM/25k0Cum61aFalpcWCymX0uDf7B3rBT7ptzuEdawOrA2ho0t3J4wXgCqmHy+Pq0woaAqwg8rccDKw==";
       };
     };
     "@ionic/utils-terminal-1.0.1" = {
@@ -1246,13 +1291,13 @@ let
         sha512 = "CNVsCrMge/jq6DCT5buNZ8PACY9RTvPJbCNoIcndfkJOCsNxOx9dnc5qw4pHZdHi8GS6l3qlgkuFKp33iD8J2Q==";
       };
     };
-    "@lerna/add-3.14.0" = {
+    "@lerna/add-3.15.0" = {
       name = "_at_lerna_slash_add";
       packageName = "@lerna/add";
-      version = "3.14.0";
+      version = "3.15.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/add/-/add-3.14.0.tgz";
-        sha512 = "Sa79Ju6HqF3heSVpBiYPNrGtuS56U/jMzVq4CcVvhNwB34USLrzJJncGFVcfnuUvsjKeFJv+jHxUycHeRE8XYw==";
+        url = "https://registry.npmjs.org/@lerna/add/-/add-3.15.0.tgz";
+        sha512 = "+KrG4GFy/6FISZ+DwWf5Fj5YB4ESa4VTnSn/ujf3VEda6dxngHPN629j+TcPbsdOxUYVah+HuZbC/B8NnkrKpQ==";
       };
     };
     "@lerna/batch-packages-3.14.0" = {
@@ -1264,49 +1309,49 @@ let
         sha512 = "RlBkQVNTqk1qvn6PFWiWNiskllUHh6tXbTVm43mZRNd+vhAyvrQC8RWJxH0ECVvnFAt9rSNGRIVbEJ31WnNQLg==";
       };
     };
-    "@lerna/bootstrap-3.14.0" = {
+    "@lerna/bootstrap-3.15.0" = {
       name = "_at_lerna_slash_bootstrap";
       packageName = "@lerna/bootstrap";
-      version = "3.14.0";
+      version = "3.15.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/bootstrap/-/bootstrap-3.14.0.tgz";
-        sha512 = "AvnuDp8b0kX4zZgqD3v7ItPABhUsN5CmTEvZBD2JqM+xkQKhzCfz5ABcHEwDwOPWnNQmtH+/2iQdwaD7xBcAXw==";
+        url = "https://registry.npmjs.org/@lerna/bootstrap/-/bootstrap-3.15.0.tgz";
+        sha512 = "4AxsPKKbgj2Ju03qDddQTpOHvpqnwd0yaiEU/aCcWv/4tDTe79NqUne2Z3+P2WZY0Zzb8+nUKcskwYBMTeq+Mw==";
       };
     };
-    "@lerna/changed-3.14.1" = {
+    "@lerna/changed-3.15.0" = {
       name = "_at_lerna_slash_changed";
       packageName = "@lerna/changed";
-      version = "3.14.1";
+      version = "3.15.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/changed/-/changed-3.14.1.tgz";
-        sha512 = "G0RgYL/WLTFzbezRBLUO2J0v39EvgZIO5bHHUtYt7zUFSfzapkPfvpdpBj+5JlMtf0B2xfxwTk+lSA4LVnbfmA==";
+        url = "https://registry.npmjs.org/@lerna/changed/-/changed-3.15.0.tgz";
+        sha512 = "Hns1ssI9T9xOTGVc7PT2jUaqzsSkxV3hV/Y7iFO0uKTk+fduyTwGTHU9A/ybQ/xi/9iaJbvaXyjxKiGoEnzmhg==";
       };
     };
-    "@lerna/check-working-tree-3.14.1" = {
+    "@lerna/check-working-tree-3.14.2" = {
       name = "_at_lerna_slash_check-working-tree";
       packageName = "@lerna/check-working-tree";
-      version = "3.14.1";
+      version = "3.14.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/check-working-tree/-/check-working-tree-3.14.1.tgz";
-        sha512 = "ae/sdZPNh4SS+6c4UDuWP/QKbtIFAn/TvKsPncA1Jdo0PqXLBlug4DzkHTGkvZ5F0nj+0JrSxYteInakJV99vg==";
+        url = "https://registry.npmjs.org/@lerna/check-working-tree/-/check-working-tree-3.14.2.tgz";
+        sha512 = "7safqxM/MYoAoxZxulUDtIJIbnBIgo0PB/FHytueG+9VaX7GMnDte2Bt1EKa0dz2sAyQdmQ3Q8ZXpf/6JDjaeg==";
       };
     };
-    "@lerna/child-process-3.13.3" = {
+    "@lerna/child-process-3.14.2" = {
       name = "_at_lerna_slash_child-process";
       packageName = "@lerna/child-process";
-      version = "3.13.3";
+      version = "3.14.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/child-process/-/child-process-3.13.3.tgz";
-        sha512 = "3/e2uCLnbU+bydDnDwyadpOmuzazS01EcnOleAnuj9235CU2U97DH6OyoG1EW/fU59x11J+HjIqovh5vBaMQjQ==";
+        url = "https://registry.npmjs.org/@lerna/child-process/-/child-process-3.14.2.tgz";
+        sha512 = "xnq+W5yQb6RkwI0p16ZQnrn6HkloH/MWTw4lGE1nKsBLAUbmSU5oTE93W1nrG0X3IMF/xWc9UYvNdUGMWvZZ4w==";
       };
     };
-    "@lerna/clean-3.14.0" = {
+    "@lerna/clean-3.15.0" = {
       name = "_at_lerna_slash_clean";
       packageName = "@lerna/clean";
-      version = "3.14.0";
+      version = "3.15.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/clean/-/clean-3.14.0.tgz";
-        sha512 = "wEuAqOS9VMqh2C20KD63IySzyEnyVDqDI3LUsXw+ByUf9AJDgEHv0TCOxbDjDYaaQw1tjSBNZMyYInNeoASwhA==";
+        url = "https://registry.npmjs.org/@lerna/clean/-/clean-3.15.0.tgz";
+        sha512 = "D1BN7BnJk6YjrSR7E7RiCmWiFVWDo3L+OSe6zDq6rNNYexPBtSi2JOCeF/Dibi3jd2luVu0zkVpUtuEEdPiD+A==";
       };
     };
     "@lerna/cli-3.13.0" = {
@@ -1318,31 +1363,31 @@ let
         sha512 = "HgFGlyCZbYaYrjOr3w/EsY18PdvtsTmDfpUQe8HwDjXlPeCCUgliZjXLOVBxSjiOvPeOSwvopwIHKWQmYbwywg==";
       };
     };
-    "@lerna/collect-uncommitted-3.14.1" = {
+    "@lerna/collect-uncommitted-3.14.2" = {
       name = "_at_lerna_slash_collect-uncommitted";
       packageName = "@lerna/collect-uncommitted";
-      version = "3.14.1";
+      version = "3.14.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/collect-uncommitted/-/collect-uncommitted-3.14.1.tgz";
-        sha512 = "hQ67S+nlSJwsPylXbWlrQSZUcWa8tTNIdcMd9OY4+QxdJlZUG7CLbWSyaxi0g11WdoRJHT163mr9xQyAvIVT1A==";
+        url = "https://registry.npmjs.org/@lerna/collect-uncommitted/-/collect-uncommitted-3.14.2.tgz";
+        sha512 = "4EkQu4jIOdNL2BMzy/N0ydHB8+Z6syu6xiiKXOoFl0WoWU9H1jEJCX4TH7CmVxXL1+jcs8FIS2pfQz4oew99Eg==";
       };
     };
-    "@lerna/collect-updates-3.14.0" = {
+    "@lerna/collect-updates-3.14.2" = {
       name = "_at_lerna_slash_collect-updates";
       packageName = "@lerna/collect-updates";
-      version = "3.14.0";
+      version = "3.14.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/collect-updates/-/collect-updates-3.14.0.tgz";
-        sha512 = "siRHo2atAwj5KpKVOo6QTVIYDYbNs7dzTG6ow9VcFMLKX5shuaEyFA22Z3LmnxQ3sakVFdgvvVeediEz6cM3VA==";
+        url = "https://registry.npmjs.org/@lerna/collect-updates/-/collect-updates-3.14.2.tgz";
+        sha512 = "+zSQ2ZovH8Uc0do5dR+sk8VvRJc6Xl+ZnJJGESIl17KSpEw/lVjcOyt6f3BP+WHn+iSOjMWcGvUVA601FIEdZw==";
       };
     };
-    "@lerna/command-3.14.0" = {
+    "@lerna/command-3.15.0" = {
       name = "_at_lerna_slash_command";
       packageName = "@lerna/command";
-      version = "3.14.0";
+      version = "3.15.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/command/-/command-3.14.0.tgz";
-        sha512 = "PtFi5EtXB2VuSruoLsjfZdus56d7oKlZAI4iSRoaS/BBxE2Wyfn7//vW7Ow4hZCzuqb9tBcpDq+4u2pdXN1d2Q==";
+        url = "https://registry.npmjs.org/@lerna/command/-/command-3.15.0.tgz";
+        sha512 = "dZqr4rKFN+veuXakIQ1DcGUpzBgcWKaYFNN4O6/skOdVQaEfGefzo1sZET+q7k/BkypxkhXHXpv5UqqSuL/EHQ==";
       };
     };
     "@lerna/conventional-commits-3.14.0" = {
@@ -1354,13 +1399,13 @@ let
         sha512 = "hGZ2qQZ9uEGf2eeIiIpEodSs9Qkkf/2uYEtNT7QN1RYISPUh6/lKGBssc5dpbCF64aEuxmemWLdlDf1ogG6++w==";
       };
     };
-    "@lerna/create-3.14.0" = {
+    "@lerna/create-3.15.0" = {
       name = "_at_lerna_slash_create";
       packageName = "@lerna/create";
-      version = "3.14.0";
+      version = "3.15.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/create/-/create-3.14.0.tgz";
-        sha512 = "J4PeGnzVBOSV7Cih8Uhv9xIauljR9bGcfSDN9aMzFtJhSX0xFXNvmnpXRORp7xNHV2lbxk7mNxRQxzR9CQRMuw==";
+        url = "https://registry.npmjs.org/@lerna/create/-/create-3.15.0.tgz";
+        sha512 = "doXGt0HTwTQl8GkC2tOrraA/5OWbz35hJqi7Dsl3Fl0bAxiv9XmF3LykHFJ+YTDHfGpdoJ8tKu66f/VKP16G0w==";
       };
     };
     "@lerna/create-symlink-3.14.0" = {
@@ -1372,40 +1417,40 @@ let
         sha512 = "Kw51HYOOi6UfCKncqkgEU1k/SYueSBXgkNL91FR8HAZH7EPSRTEtp9mnJo568g0+Hog5C+3cOaWySwhHpRG29A==";
       };
     };
-    "@lerna/describe-ref-3.13.3" = {
+    "@lerna/describe-ref-3.14.2" = {
       name = "_at_lerna_slash_describe-ref";
       packageName = "@lerna/describe-ref";
-      version = "3.13.3";
+      version = "3.14.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/describe-ref/-/describe-ref-3.13.3.tgz";
-        sha512 = "5KcLTvjdS4gU5evW8ESbZ0BF44NM5HrP3dQNtWnOUSKJRgsES8Gj0lq9AlB2+YglZfjEftFT03uOYOxnKto4Uw==";
+        url = "https://registry.npmjs.org/@lerna/describe-ref/-/describe-ref-3.14.2.tgz";
+        sha512 = "qa5pzDRK2oBQXNjyRmRnN7E8a78NMYfQjjlRFB0KNHMsT6mCiL9+8kIS39sSE2NqT8p7xVNo2r2KAS8R/m3CoQ==";
       };
     };
-    "@lerna/diff-3.14.0" = {
+    "@lerna/diff-3.15.0" = {
       name = "_at_lerna_slash_diff";
       packageName = "@lerna/diff";
-      version = "3.14.0";
+      version = "3.15.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/diff/-/diff-3.14.0.tgz";
-        sha512 = "H6FSj0jOiQ6unVCwOK6ReT5uZN6ZIn/j/cx4YwuOtU3SMcs3UfuQRIFNeKg/tKmOcQGd39Mn9zDhmt3TAYGROA==";
+        url = "https://registry.npmjs.org/@lerna/diff/-/diff-3.15.0.tgz";
+        sha512 = "N1Pr0M554Bt+DlVoD+DXWGh92gcq6G9icn8sH5GSqfwi0XCpPNJ2i1BNEZpUQ6ulLWOMa1YHR4PypPxecRGBjA==";
       };
     };
-    "@lerna/exec-3.14.0" = {
+    "@lerna/exec-3.15.0" = {
       name = "_at_lerna_slash_exec";
       packageName = "@lerna/exec";
-      version = "3.14.0";
+      version = "3.15.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/exec/-/exec-3.14.0.tgz";
-        sha512 = "cNFO8hWsBVLeqVQ7LsQ4rYKbbQ2eN+Ne+hWKTlUQoyRbYzgJ22TXhjKR6IMr68q0xtclcDlasfcNO+XEWESh0g==";
+        url = "https://registry.npmjs.org/@lerna/exec/-/exec-3.15.0.tgz";
+        sha512 = "YuXPd64TNG9wbb3lRvyMARQbdlbMZ1bJZ+GCm0enivnIWUyg0qtBDcfPY2dWpIgOif04zx+K/gmOX4lCaGM4UQ==";
       };
     };
-    "@lerna/filter-options-3.14.0" = {
+    "@lerna/filter-options-3.14.2" = {
       name = "_at_lerna_slash_filter-options";
       packageName = "@lerna/filter-options";
-      version = "3.14.0";
+      version = "3.14.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/filter-options/-/filter-options-3.14.0.tgz";
-        sha512 = "ZmNZK9m8evxHc+2ZnDyCm8XFIKVDKpIASG1wtizr3R14t49fuYE7nR+rm4t82u9oSSmER8gb8bGzh0SKZme/jg==";
+        url = "https://registry.npmjs.org/@lerna/filter-options/-/filter-options-3.14.2.tgz";
+        sha512 = "Ct8oYvRttbYB9JalngHhirb8o9ZVyLm5a9MpXNevXoHiu6j0vNhI19BQCwNnrL6wZvEHJnzPuUl/jO23tWxemg==";
       };
     };
     "@lerna/filter-packages-3.13.0" = {
@@ -1435,13 +1480,22 @@ let
         sha512 = "EgSim24sjIjqQDC57bgXD9l22/HCS93uQBbGpkzEOzxAVzEgpZVm7Fm1t8BVlRcT2P2zwGnRadIvxTbpQuDPTg==";
       };
     };
-    "@lerna/github-client-3.13.3" = {
+    "@lerna/github-client-3.14.2" = {
       name = "_at_lerna_slash_github-client";
       packageName = "@lerna/github-client";
-      version = "3.13.3";
+      version = "3.14.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/github-client/-/github-client-3.13.3.tgz";
-        sha512 = "fcJkjab4kX0zcLLSa/DCUNvU3v8wmy2c1lhdIbL7s7gABmDcV0QZq93LhnEee3VkC9UpnJ6GKG4EkD7eIifBnA==";
+        url = "https://registry.npmjs.org/@lerna/github-client/-/github-client-3.14.2.tgz";
+        sha512 = "+2Xh7t4qVmXiXE2utPnh5T7YwSltG74JP7c+EiooRY5+3zjh9MpPOcTKxVY3xKclzpsyXMohk2KpTF4tzA5rrg==";
+      };
+    };
+    "@lerna/gitlab-client-3.15.0" = {
+      name = "_at_lerna_slash_gitlab-client";
+      packageName = "@lerna/gitlab-client";
+      version = "3.15.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@lerna/gitlab-client/-/gitlab-client-3.15.0.tgz";
+        sha512 = "OsBvRSejHXUBMgwWQqNoioB8sgzL/Pf1pOUhHKtkiMl6aAWjklaaq5HPMvTIsZPfS6DJ9L5OK2GGZuooP/5c8Q==";
       };
     };
     "@lerna/global-options-3.13.0" = {
@@ -1453,49 +1507,49 @@ let
         sha512 = "SlZvh1gVRRzYLVluz9fryY1nJpZ0FHDGB66U9tFfvnnxmueckRQxLopn3tXj3NU1kc3QANT2I5BsQkOqZ4TEFQ==";
       };
     };
-    "@lerna/has-npm-version-3.13.3" = {
+    "@lerna/has-npm-version-3.14.2" = {
       name = "_at_lerna_slash_has-npm-version";
       packageName = "@lerna/has-npm-version";
-      version = "3.13.3";
+      version = "3.14.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/has-npm-version/-/has-npm-version-3.13.3.tgz";
-        sha512 = "mQzoghRw4dBg0R9FFfHrj0TH0glvXyzdEZmYZ8Isvx5BSuEEwpsryoywuZSdppcvLu8o7NAdU5Tac8cJ/mT52w==";
+        url = "https://registry.npmjs.org/@lerna/has-npm-version/-/has-npm-version-3.14.2.tgz";
+        sha512 = "cG+z5bB8JPd5f+nT2eLN2LmKg06O11AxlnUxgw2W7cLyc7cnsmMSp/rxt2JBMwW2r4Yn+CLLJIRwJZ2Es8jFSw==";
       };
     };
-    "@lerna/import-3.14.0" = {
+    "@lerna/import-3.15.0" = {
       name = "_at_lerna_slash_import";
       packageName = "@lerna/import";
-      version = "3.14.0";
+      version = "3.15.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/import/-/import-3.14.0.tgz";
-        sha512 = "j8z/m85FX1QYPgl5TzMNupdxsQF/NFZSmdCR19HQzqiVKC8ULGzF30WJEk66+KeZ94wYMSakINtYD+41s34pNQ==";
+        url = "https://registry.npmjs.org/@lerna/import/-/import-3.15.0.tgz";
+        sha512 = "4GKQgeTXBTwMbZNkYyPdQIVA41HIISD7D6XRNrDaG0falUfvoPsknijQPCBmGqeh66u1Fcn2+4lkL3OCTj2FMg==";
       };
     };
-    "@lerna/init-3.14.0" = {
+    "@lerna/init-3.15.0" = {
       name = "_at_lerna_slash_init";
       packageName = "@lerna/init";
-      version = "3.14.0";
+      version = "3.15.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/init/-/init-3.14.0.tgz";
-        sha512 = "X3PQkQZds5ozA1xiarmVzAK6LPLNK3bBu24Api0w2KJXO7Ccs9ob/VcGdevZuzqdJo1Xg2H6oBhEqIClU9Uqqw==";
+        url = "https://registry.npmjs.org/@lerna/init/-/init-3.15.0.tgz";
+        sha512 = "VOqH6kFbFtfUbXxhSqXKY6bjnVp9nLuLRI6x9tVHOANX2LmSlXm17OUGBnNt+eM4uJLuiUsAR8nTlpCiz//lPQ==";
       };
     };
-    "@lerna/link-3.14.0" = {
+    "@lerna/link-3.15.0" = {
       name = "_at_lerna_slash_link";
       packageName = "@lerna/link";
-      version = "3.14.0";
+      version = "3.15.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/link/-/link-3.14.0.tgz";
-        sha512 = "xlwQhWTVOZrgAuoONY3/OIBWehDfZXmf5qFhnOy7lIxByRhEX5Vwx0ApaGxHTv3Flv7T+oI4s8UZVq5F6dT8Aw==";
+        url = "https://registry.npmjs.org/@lerna/link/-/link-3.15.0.tgz";
+        sha512 = "yKHuifADINobvDOLljBGkVGpVwy6J3mg5p9lQXBdOLXBoIKC8o/UKBR9JvZMFvT/Iy6zn6FPy1v5lz9iU1Ib0Q==";
       };
     };
-    "@lerna/list-3.14.0" = {
+    "@lerna/list-3.15.0" = {
       name = "_at_lerna_slash_list";
       packageName = "@lerna/list";
-      version = "3.14.0";
+      version = "3.15.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/list/-/list-3.14.0.tgz";
-        sha512 = "Gp+9gaIkBfXBwc9Ng0Y74IEfAqpQpLiXwOP4IOpdINxOeDpllhMaYP6SzLaMvrfSyHRayM7Cq5/PRnHkXQ5uuQ==";
+        url = "https://registry.npmjs.org/@lerna/list/-/list-3.15.0.tgz";
+        sha512 = "8SvxnlfAnbEzQDf2NL0IxWyUuqWTykF9cHt5/f5TOzgESClpaOkDtqwh/UlE8nVTzWMnxnQUPQi3UTKyJD3i3g==";
       };
     };
     "@lerna/listable-3.14.0" = {
@@ -1525,40 +1579,40 @@ let
         sha512 = "Jg2kANsGnhg+fbPEzE0X9nX5oviEAvWj0nYyOkcE+cgWuT7W0zpnPXC4hA4C5IPQGhwhhh0IxhWNNHtjTuw53g==";
       };
     };
-    "@lerna/npm-dist-tag-3.14.0" = {
+    "@lerna/npm-dist-tag-3.15.0" = {
       name = "_at_lerna_slash_npm-dist-tag";
       packageName = "@lerna/npm-dist-tag";
-      version = "3.14.0";
+      version = "3.15.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/npm-dist-tag/-/npm-dist-tag-3.14.0.tgz";
-        sha512 = "DEyYEdufTGIC6E4RTJUsYPgqlz1Bs/XPeEQ5fd+ojWnICevj7dRrr2DfHucPiUCADlm2jbAraAQc3QPU0dXRhw==";
+        url = "https://registry.npmjs.org/@lerna/npm-dist-tag/-/npm-dist-tag-3.15.0.tgz";
+        sha512 = "lnbdwc4Ebs7/EI9fTIgbH3dxXnP+SuCcGhG7P5ZjOqo67SY09sRZGcygEzabpvIwXvKpBF8vCd4xxzjnF2u+PA==";
       };
     };
-    "@lerna/npm-install-3.13.3" = {
+    "@lerna/npm-install-3.14.2" = {
       name = "_at_lerna_slash_npm-install";
       packageName = "@lerna/npm-install";
-      version = "3.13.3";
+      version = "3.14.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/npm-install/-/npm-install-3.13.3.tgz";
-        sha512 = "7Jig9MLpwAfcsdQ5UeanAjndChUjiTjTp50zJ+UZz4CbIBIDhoBehvNMTCL2G6pOEC7sGEg6sAqJINAqred6Tg==";
+        url = "https://registry.npmjs.org/@lerna/npm-install/-/npm-install-3.14.2.tgz";
+        sha512 = "JYJJRtLETrGpcQZa8Rj16vbye399RqnaXmJlZuZ2twjJ2DYVYtwkfsGEOdvdaKw5KVOEpWcAxBA9OMmKQtCLQw==";
       };
     };
-    "@lerna/npm-publish-3.14.0" = {
+    "@lerna/npm-publish-3.15.0" = {
       name = "_at_lerna_slash_npm-publish";
       packageName = "@lerna/npm-publish";
-      version = "3.14.0";
+      version = "3.15.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/npm-publish/-/npm-publish-3.14.0.tgz";
-        sha512 = "ShG0qEnGkWxtjQvIRATgm/CzeoVaSyyoNRag5t8gDSR/r2u9ux72oROKQUEaE8OwcTS4rL2cyBECts8XMNmyYw==";
+        url = "https://registry.npmjs.org/@lerna/npm-publish/-/npm-publish-3.15.0.tgz";
+        sha512 = "G7rcNcSGjG0La8eHPXDvCvoNXbwNnP6XJ+GPh3CH5xiR/nikfLOa+Bfm4ytdjVWWxnKfCT4qyMTCoV1rROlqQQ==";
       };
     };
-    "@lerna/npm-run-script-3.13.3" = {
+    "@lerna/npm-run-script-3.14.2" = {
       name = "_at_lerna_slash_npm-run-script";
       packageName = "@lerna/npm-run-script";
-      version = "3.13.3";
+      version = "3.14.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/npm-run-script/-/npm-run-script-3.13.3.tgz";
-        sha512 = "qR4o9BFt5hI8Od5/DqLalOJydnKpiQFEeN0h9xZi7MwzuX1Ukwh3X22vqsX4YRbipIelSFtrDzleNVUm5jj0ow==";
+        url = "https://registry.npmjs.org/@lerna/npm-run-script/-/npm-run-script-3.14.2.tgz";
+        sha512 = "LbVFv+nvAoRTYLMrJlJ8RiakHXrLslL7Jp/m1R18vYrB8LYWA3ey+nz5Tel2OELzmjUiemAKZsD9h6i+Re5egg==";
       };
     };
     "@lerna/otplease-3.14.0" = {
@@ -1579,22 +1633,22 @@ let
         sha512 = "7ZnQ9nvUDu/WD+bNsypmPG5MwZBwu86iRoiW6C1WBuXXDxM5cnIAC1m2WxHeFnjyMrYlRXM9PzOQ9VDD+C15Rg==";
       };
     };
-    "@lerna/pack-directory-3.14.0" = {
+    "@lerna/pack-directory-3.14.2" = {
       name = "_at_lerna_slash_pack-directory";
       packageName = "@lerna/pack-directory";
-      version = "3.14.0";
+      version = "3.14.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/pack-directory/-/pack-directory-3.14.0.tgz";
-        sha512 = "E9PmC1oWYjYN8Z0Oeoj7X98NruMg/pcdDiRxnwJ5awnB0d/kyfoquHXCYwCQQFCnWUfto7m5lM4CSostcolEVQ==";
+        url = "https://registry.npmjs.org/@lerna/pack-directory/-/pack-directory-3.14.2.tgz";
+        sha512 = "b3LnJEmIml3sDj94TQT8R+kVyrDlmE7Su0WwcBYZDySXPMSZ38WA2/2Xjy/EWhXlFxp/nUJKyUG78nDrZ/00Uw==";
       };
     };
-    "@lerna/package-3.13.0" = {
+    "@lerna/package-3.14.2" = {
       name = "_at_lerna_slash_package";
       packageName = "@lerna/package";
-      version = "3.13.0";
+      version = "3.14.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/package/-/package-3.13.0.tgz";
-        sha512 = "kSKO0RJQy093BufCQnkhf1jB4kZnBvL7kK5Ewolhk5gwejN+Jofjd8DGRVUDUJfQ0CkW1o6GbUeZvs8w8VIZDg==";
+        url = "https://registry.npmjs.org/@lerna/package/-/package-3.14.2.tgz";
+        sha512 = "YR/+CzYdufJYfsUlrfuhTjA35iSZpXK7mVOZmeR9iRWhSaqesm4kq2zfxm9vCpZV2oAQQZOwi4eo5h0rQBtdiw==";
       };
     };
     "@lerna/package-graph-3.14.0" = {
@@ -1615,13 +1669,13 @@ let
         sha512 = "Ap3Z/dNhqQuSrKmK+JmzYvQYI2vowxHvUVxZJiDVilW8dyNnxkCsYFmkuZytk5sxVz4VeGLNPS2RSsU5eeSS+Q==";
       };
     };
-    "@lerna/project-3.13.1" = {
+    "@lerna/project-3.15.0" = {
       name = "_at_lerna_slash_project";
       packageName = "@lerna/project";
-      version = "3.13.1";
+      version = "3.15.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/project/-/project-3.13.1.tgz";
-        sha512 = "/GoCrpsCCTyb9sizk1+pMBrIYchtb+F1uCOn3cjn9yenyG/MfYEnlfrbV5k/UDud0Ei75YBLbmwCbigHkAKazQ==";
+        url = "https://registry.npmjs.org/@lerna/project/-/project-3.15.0.tgz";
+        sha512 = "eNGUWiMbQ9kh9kGkomtMnsLypS0rfLqxKgZP2+VnNVtIXjnLv4paeTm+1lkL+naNJUwhnpMk2NSLEeoxT/20QA==";
       };
     };
     "@lerna/prompt-3.13.0" = {
@@ -1633,13 +1687,13 @@ let
         sha512 = "P+lWSFokdyvYpkwC3it9cE0IF2U5yy2mOUbGvvE4iDb9K7TyXGE+7lwtx2thtPvBAfIb7O13POMkv7df03HJeA==";
       };
     };
-    "@lerna/publish-3.14.1" = {
+    "@lerna/publish-3.15.0" = {
       name = "_at_lerna_slash_publish";
       packageName = "@lerna/publish";
-      version = "3.14.1";
+      version = "3.15.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/publish/-/publish-3.14.1.tgz";
-        sha512 = "p+By/P84XJkndBzrmcnVLMcFpGAE+sQZCQK4e3aKQrEMLDrEwXkWt/XJxzeQskPxInFA/7Icj686LOADO7p0qg==";
+        url = "https://registry.npmjs.org/@lerna/publish/-/publish-3.15.0.tgz";
+        sha512 = "6tRRBJ8olLSXfrUsR4f7vSfx0cT1oPi6/v06yI3afDSsUX6eQ3ooZh7gMY4RWmd+nM/IJHTUzhlKF6WhTvo+9g==";
       };
     };
     "@lerna/pulse-till-done-3.13.0" = {
@@ -1669,22 +1723,22 @@ let
         sha512 = "Lc0USSFxwDxUs5JvIisS8JegjA6SHSAWJCMvi2osZx6wVRkEDlWG2B1JAfXUzCMNfHoZX0/XX9iYZ+4JIpjAtg==";
       };
     };
-    "@lerna/rimraf-dir-3.13.3" = {
+    "@lerna/rimraf-dir-3.14.2" = {
       name = "_at_lerna_slash_rimraf-dir";
       packageName = "@lerna/rimraf-dir";
-      version = "3.13.3";
+      version = "3.14.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/rimraf-dir/-/rimraf-dir-3.13.3.tgz";
-        sha512 = "d0T1Hxwu3gpYVv73ytSL+/Oy8JitsmvOYUR5ouRSABsmqS7ZZCh5t6FgVDDGVXeuhbw82+vuny1Og6Q0k4ilqw==";
+        url = "https://registry.npmjs.org/@lerna/rimraf-dir/-/rimraf-dir-3.14.2.tgz";
+        sha512 = "eFNkZsy44Bu9v1Hrj5Zk6omzg8O9h/7W6QYK1TTUHeyrjTEwytaNQlqF0lrTLmEvq55sviV42NC/8P3M2cvq8Q==";
       };
     };
-    "@lerna/run-3.14.0" = {
+    "@lerna/run-3.15.0" = {
       name = "_at_lerna_slash_run";
       packageName = "@lerna/run";
-      version = "3.14.0";
+      version = "3.15.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/run/-/run-3.14.0.tgz";
-        sha512 = "kGGFGLYPKozAN07CSJ7kOyLY6W3oLCQcxCathg1isSkBqQH29tWUg8qNduOlhIFLmnq/nf1JEJxxoXnF6IRLjQ==";
+        url = "https://registry.npmjs.org/@lerna/run/-/run-3.15.0.tgz";
+        sha512 = "KQBkzZYoEKmzILKjbjsm1KKVWFBXwAdwzqJWj/lfxxd3V5LRF8STASk8aiw8bSpB0bUL9TU/pbXakRxiNzjDwQ==";
       };
     };
     "@lerna/run-lifecycle-3.14.0" = {
@@ -1714,22 +1768,22 @@ let
         sha512 = "y+KBpC1YExFzGynovt9MY4O/bc3RrJaKeuXieiPfKGKxrdtmZe/r33oj/xePTXZq65jnw3SaU3H8S5CrrdkwDg==";
       };
     };
-    "@lerna/symlink-binary-3.14.0" = {
+    "@lerna/symlink-binary-3.14.2" = {
       name = "_at_lerna_slash_symlink-binary";
       packageName = "@lerna/symlink-binary";
-      version = "3.14.0";
+      version = "3.14.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/symlink-binary/-/symlink-binary-3.14.0.tgz";
-        sha512 = "AHFb4NlazxYmC+7guoamM3laIRbMSeKERMooKHJ7moe0ayGPBWsCGOH+ZFKZ+eXSDek+FnxdzayR3wf8B3LkTg==";
+        url = "https://registry.npmjs.org/@lerna/symlink-binary/-/symlink-binary-3.14.2.tgz";
+        sha512 = "tqMwuWi6z1da0AFFbleWyu3H9fqayiV50rjj4anFTfayel9jSjlA1xPG+56sGIP6zUUNuUSc9kLh7oRRmlauoA==";
       };
     };
-    "@lerna/symlink-dependencies-3.14.0" = {
+    "@lerna/symlink-dependencies-3.14.2" = {
       name = "_at_lerna_slash_symlink-dependencies";
       packageName = "@lerna/symlink-dependencies";
-      version = "3.14.0";
+      version = "3.14.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/symlink-dependencies/-/symlink-dependencies-3.14.0.tgz";
-        sha512 = "kuSXxwAWiVZqFcXfUBKH4yLUH3lrnGyZmCYon7UnZitw3AK3LQY7HvV2LNNw/oatfjOAiKhPBxnYjYijKiV4oA==";
+        url = "https://registry.npmjs.org/@lerna/symlink-dependencies/-/symlink-dependencies-3.14.2.tgz";
+        sha512 = "Ox7WKXnHZ7IwWlejcCq3n0Hd/yMLv8AwIryhvWxM/RauAge+ML4wg578SsdCyKob8ecgm/R0ytHiU06j81iL1w==";
       };
     };
     "@lerna/timer-3.13.0" = {
@@ -1750,13 +1804,13 @@ let
         sha512 = "SiJP75nwB8GhgwLKQfdkSnDufAaCbkZWJqEDlKOUPUvVOplRGnfL+BPQZH5nvq2BYSRXsksXWZ4UHVnQZI/HYA==";
       };
     };
-    "@lerna/version-3.14.1" = {
+    "@lerna/version-3.15.0" = {
       name = "_at_lerna_slash_version";
       packageName = "@lerna/version";
-      version = "3.14.1";
+      version = "3.15.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/version/-/version-3.14.1.tgz";
-        sha512 = "H/jykoxVIt4oDEYkBgwDfO5dmZFl3G6vP1UEttRVP1FIkI+gCN+olby8S0Qd8XprDuR5OrLboiDWQs3p7nJhLw==";
+        url = "https://registry.npmjs.org/@lerna/version/-/version-3.15.0.tgz";
+        sha512 = "vReYX1NMXZ9PwzTZm97wAl/k3bmRnRZhnQi3mq/m49xTnDavq7p4sbUdFpvu8cVZNKnYS02pNIVGHrQw+K8ZCw==";
       };
     };
     "@lerna/write-log-file-3.13.0" = {
@@ -1777,58 +1831,58 @@ let
         sha512 = "bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==";
       };
     };
-    "@node-red/editor-api-0.20.5" = {
+    "@node-red/editor-api-0.20.6" = {
       name = "_at_node-red_slash_editor-api";
       packageName = "@node-red/editor-api";
-      version = "0.20.5";
+      version = "0.20.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@node-red/editor-api/-/editor-api-0.20.5.tgz";
-        sha512 = "UPVrqqoz2LLP1LVF0BZs1sAqQL1z7bYeF3JTx93Jxl6OFKOvH9NDn0DXMVbaxatANdfNu0PZ8E++oW2c5kj59A==";
+        url = "https://registry.npmjs.org/@node-red/editor-api/-/editor-api-0.20.6.tgz";
+        sha512 = "uJH2KBHolrST4rxPsxAbRLtU/Em/ZBZQ7Ukqd8373Mn3ujo9RzdyvUvrVQZKzw5SAbE4y9HIHe21Tuuthx8rKQ==";
       };
     };
-    "@node-red/editor-client-0.20.5" = {
+    "@node-red/editor-client-0.20.6" = {
       name = "_at_node-red_slash_editor-client";
       packageName = "@node-red/editor-client";
-      version = "0.20.5";
+      version = "0.20.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@node-red/editor-client/-/editor-client-0.20.5.tgz";
-        sha512 = "ujuCM1FdkL3bUOsiQJyLs7MGyjKFcy8F7fFMfev8P+JEa558WeGr/Va0paexMe6h7YEu3zq8r7U/EK/lgIXHZA==";
+        url = "https://registry.npmjs.org/@node-red/editor-client/-/editor-client-0.20.6.tgz";
+        sha512 = "5PANZPrVfwlmDGwD6XmASfF0Pxht+XsumVgp/P7Ml0RQch0JT1F0Fl+BW60EleYpQY1Rh/mA5Wk/jnMacy0lRQ==";
       };
     };
-    "@node-red/nodes-0.20.5" = {
+    "@node-red/nodes-0.20.6" = {
       name = "_at_node-red_slash_nodes";
       packageName = "@node-red/nodes";
-      version = "0.20.5";
+      version = "0.20.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@node-red/nodes/-/nodes-0.20.5.tgz";
-        sha512 = "aAf0rBsfkOi113J/7w2YxAt0jtq0Qg4AsIU2M3ggO1h+JUkZkKvmvxhZTKkBF5j/EGuLb00++n0z/cMkERfLPA==";
+        url = "https://registry.npmjs.org/@node-red/nodes/-/nodes-0.20.6.tgz";
+        sha512 = "r/j3+m19zQ+52mtySLGKILc2ac6bRjMj+JjLYyrC1JAdwEBFMLbfl5fRWTRCs2h1Bjp8uRGay1Hgik689Qyv/w==";
       };
     };
-    "@node-red/registry-0.20.5" = {
+    "@node-red/registry-0.20.6" = {
       name = "_at_node-red_slash_registry";
       packageName = "@node-red/registry";
-      version = "0.20.5";
+      version = "0.20.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@node-red/registry/-/registry-0.20.5.tgz";
-        sha512 = "OlyO6MZWlQmEVTSewgPOrdKOnkwBKnUSNeJ9eg/0AZirL9PG2Q+7/8ViwW2qWvNqt5TqImmg3kmnOZ1zteaB4g==";
+        url = "https://registry.npmjs.org/@node-red/registry/-/registry-0.20.6.tgz";
+        sha512 = "8jMk6BksooxbWf7p1Otei6NZgv/e5zW4CG0R5RxeodFhR15bzvFY6GrYAS9IToVv11EZHo0e+y9NHOnBAwJwaw==";
       };
     };
-    "@node-red/runtime-0.20.5" = {
+    "@node-red/runtime-0.20.6" = {
       name = "_at_node-red_slash_runtime";
       packageName = "@node-red/runtime";
-      version = "0.20.5";
+      version = "0.20.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@node-red/runtime/-/runtime-0.20.5.tgz";
-        sha512 = "pUMRfeO8K1fDFYagAZfE4jzdnQqJdjYl4efKOP9CblLE3VFKn58xs+r1TsdaXZoUkuspllGNEkTXtOqqJw9bzw==";
+        url = "https://registry.npmjs.org/@node-red/runtime/-/runtime-0.20.6.tgz";
+        sha512 = "NAAuttS3FZ7XmE+WPu9lDeHyXEORRgr8X3hpj0L1U7rSzzHK5g3MG/wDLonZgcCRfB843FQmdiAe7jXGxCAHfg==";
       };
     };
-    "@node-red/util-0.20.5" = {
+    "@node-red/util-0.20.6" = {
       name = "_at_node-red_slash_util";
       packageName = "@node-red/util";
-      version = "0.20.5";
+      version = "0.20.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@node-red/util/-/util-0.20.5.tgz";
-        sha512 = "oTRVjGWBs4K1n26CrRs4ts9MBzrdqr04yVZ4Z5Cg/NOynK+Had+nPDFZyD575U0Yaj6H3IVickDvG2FBw+tlxw==";
+        url = "https://registry.npmjs.org/@node-red/util/-/util-0.20.6.tgz";
+        sha512 = "pMQwsaSg7jVZl6hkhQpx5xxqJN/lu4BO7Lz4rmq+Z3qE0OGpSypremAWJn7zrmkpmLplkO3w3MKmDHYTD/NLUQ==";
       };
     };
     "@nodelib/fs.stat-1.1.3" = {
@@ -1840,13 +1894,13 @@ let
         sha512 = "shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==";
       };
     };
-    "@octokit/endpoint-5.1.4" = {
+    "@octokit/endpoint-5.2.0" = {
       name = "_at_octokit_slash_endpoint";
       packageName = "@octokit/endpoint";
-      version = "5.1.4";
+      version = "5.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.1.4.tgz";
-        sha512 = "DypS8gbbcc9rlOCDW0wV9a+B18+ylduj6PpxeE+qa3IK1h5b0eW4CKj5pxxXWOZUYhEKwgOnh3+Q+Y/hx/bOPw==";
+        url = "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.2.0.tgz";
+        sha512 = "g4r1MKr8GJ8qubJQp3HP3JrxDY+ZeVqjYBTgtu1lPEDLhfQDY6rOhyZOoHKOw+gaIF6aAcmuvPPNZUro2OwmOg==";
       };
     };
     "@octokit/plugin-enterprise-rest-2.2.2" = {
@@ -1858,31 +1912,31 @@ let
         sha512 = "CTZr64jZYhGWNTDGlSJ2mvIlFsm9OEO3LqWn9I/gmoHI4jRBp4kpHoFYNemG4oA75zUAcmbuWblb7jjP877YZw==";
       };
     };
-    "@octokit/request-4.1.0" = {
+    "@octokit/request-4.1.1" = {
       name = "_at_octokit_slash_request";
       packageName = "@octokit/request";
-      version = "4.1.0";
+      version = "4.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@octokit/request/-/request-4.1.0.tgz";
-        sha512 = "RvpQAba4i+BNH0z8i0gPRc1ShlHidj4puQjI/Tno6s+Q3/Mzb0XRSHJiOhpeFrZ22V7Mwjq1E7QS27P5CgpWYA==";
+        url = "https://registry.npmjs.org/@octokit/request/-/request-4.1.1.tgz";
+        sha512 = "LOyL0i3oxRo418EXRSJNk/3Q4I0/NKawTn6H/CQp+wnrG1UFLGu080gSsgnWobhPo5BpUNgSQ5BRk5FOOJhD1Q==";
       };
     };
-    "@octokit/request-error-1.0.2" = {
+    "@octokit/request-error-1.0.4" = {
       name = "_at_octokit_slash_request-error";
       packageName = "@octokit/request-error";
-      version = "1.0.2";
+      version = "1.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.0.2.tgz";
-        sha512 = "T9swMS/Vc4QlfWrvyeSyp/GjhXtYaBzCcibjGywV4k4D2qVrQKfEMPy8OxMDEj7zkIIdpHwqdpVbKCvnUPqkXw==";
+        url = "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.0.4.tgz";
+        sha512 = "L4JaJDXn8SGT+5G0uX79rZLv0MNJmfGa4vb4vy1NnpjSnWDLJRy6m90udGwvMmavwsStgbv2QNkPzzTCMmL+ig==";
       };
     };
-    "@octokit/rest-16.27.3" = {
+    "@octokit/rest-16.28.2" = {
       name = "_at_octokit_slash_rest";
       packageName = "@octokit/rest";
-      version = "16.27.3";
+      version = "16.28.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@octokit/rest/-/rest-16.27.3.tgz";
-        sha512 = "WWH/SHF4kus6FG+EAfX7/JYH70EjgFYa4AAd2Lf1hgmgzodhrsoxpXPSZliZ5BdJruZPMP7ZYaPoTrYCCKYzmQ==";
+        url = "https://registry.npmjs.org/@octokit/rest/-/rest-16.28.2.tgz";
+        sha512 = "csuYiHvJ1P/GFDadVn0QhwO83R1+YREjcwCY7ZIezB6aJTRIEidJZj+R7gAkUhT687cqYb4cXTZsDVu9F+Fmug==";
       };
     };
     "@parcel/fs-1.11.0" = {
@@ -2020,22 +2074,22 @@ let
         sha1 = "a777360b5b39a1a2e5106f8e858f2fd2d060c570";
       };
     };
-    "@schematics/angular-8.0.1" = {
+    "@schematics/angular-8.0.6" = {
       name = "_at_schematics_slash_angular";
       packageName = "@schematics/angular";
-      version = "8.0.1";
+      version = "8.0.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@schematics/angular/-/angular-8.0.1.tgz";
-        sha512 = "/FyFJbHuxWfvVgTBSnEa0fiDgeLhAmfK7NeT8Owj2xDAqvVMxfSxupfdr7a9cDr82WImW09SX7PUlv2EomcGLA==";
+        url = "https://registry.npmjs.org/@schematics/angular/-/angular-8.0.6.tgz";
+        sha512 = "F0/MrbvrJQJIjt0GwEkmf9PZUX0xQlCjlDcH6U7yBni0/+R5Gd5g3G0f12fsSa2iAwpwrLkKpiQluj29eFituQ==";
       };
     };
-    "@schematics/update-0.800.1" = {
+    "@schematics/update-0.800.6" = {
       name = "_at_schematics_slash_update";
       packageName = "@schematics/update";
-      version = "0.800.1";
+      version = "0.800.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@schematics/update/-/update-0.800.1.tgz";
-        sha512 = "1Bnn6RJ7tzlaZRpvE6oQl7oem0zMMtNn2ygiMb2FxW97FHvW4hLIDrP31V3s5n8Ku+RBFMgr1z1P+GBZnbaubg==";
+        url = "https://registry.npmjs.org/@schematics/update/-/update-0.800.6.tgz";
+        sha512 = "vrzGIJtMiwLWl96+aJXMYrPgPtktLRpY8ZiNnlLm3pMDmeg08uButRh/pQGt02HuO/apTNJ5g0bmG8K5wS4I5A==";
       };
     };
     "@sindresorhus/is-0.14.0" = {
@@ -2056,13 +2110,22 @@ let
         sha512 = "ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==";
       };
     };
-    "@snyk/dep-graph-1.4.1" = {
+    "@snyk/composer-lockfile-parser-1.0.2" = {
+      name = "_at_snyk_slash_composer-lockfile-parser";
+      packageName = "@snyk/composer-lockfile-parser";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@snyk/composer-lockfile-parser/-/composer-lockfile-parser-1.0.2.tgz";
+        sha512 = "kFzMajJLgWYsRTD+j1B79RckP1nYolM3UU9wJAo6VjvaBJ1R8E6IXmz0lEJBwK2zXM4EPrgk41ZqmoQS3hselQ==";
+      };
+    };
+    "@snyk/dep-graph-1.8.1" = {
       name = "_at_snyk_slash_dep-graph";
       packageName = "@snyk/dep-graph";
-      version = "1.4.1";
+      version = "1.8.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@snyk/dep-graph/-/dep-graph-1.4.1.tgz";
-        sha512 = "7L096NNuNggcSjyOlITaU17n0dz0J4K4WpIHvatP4K0kIbhxolil1QbJF/+xKMRpW6OuaXILiP0hp7szhkEIzQ==";
+        url = "https://registry.npmjs.org/@snyk/dep-graph/-/dep-graph-1.8.1.tgz";
+        sha512 = "cWqJwuiU1+9hL0Fd/qgq0DYeWM/6mqPIa/B0yoEsHD8nR/IPFgalVvMbOSdPKeApvi/AxDzcRxr8tfqHJ7aq2w==";
       };
     };
     "@snyk/gemfile-1.2.0" = {
@@ -2074,94 +2137,94 @@ let
         sha512 = "nI7ELxukf7pT4/VraL4iabtNNMz8mUo7EXlqCFld8O5z6mIMLX9llps24iPpaIZOwArkY3FWA+4t+ixyvtTSIA==";
       };
     };
-    "@starptech/expression-parser-0.8.17" = {
+    "@starptech/expression-parser-0.9.0" = {
       name = "_at_starptech_slash_expression-parser";
       packageName = "@starptech/expression-parser";
-      version = "0.8.17";
+      version = "0.9.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@starptech/expression-parser/-/expression-parser-0.8.17.tgz";
-        sha512 = "7oLWJjPNHaMgGcYIh/rbbmhrXyexHFOj5btztXbFuLjkHc5CmNc1Jhov0jF8rGMkRVwBoHpE1qR2fx4G+383eA==";
+        url = "https://registry.npmjs.org/@starptech/expression-parser/-/expression-parser-0.9.0.tgz";
+        sha512 = "a4CFSYZ3klnflR/rkvN87T2r/n+RxfMhDaZlrWYBaCHcbPhX+2THWyKAn82vT6Ari3SPp3XOsTqUZK4Vx2qcTA==";
       };
     };
-    "@starptech/hast-util-from-webparser-0.8.17" = {
+    "@starptech/hast-util-from-webparser-0.9.0" = {
       name = "_at_starptech_slash_hast-util-from-webparser";
       packageName = "@starptech/hast-util-from-webparser";
-      version = "0.8.17";
+      version = "0.9.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@starptech/hast-util-from-webparser/-/hast-util-from-webparser-0.8.17.tgz";
-        sha512 = "zj5+X2qQltKbI+uYNz1DmkvVGnzZ/2XJOtWqeqeYrhDOtkEFbousifaFMCdTxvwFmGe/WusrO7rV6KtjqhDRjA==";
+        url = "https://registry.npmjs.org/@starptech/hast-util-from-webparser/-/hast-util-from-webparser-0.9.0.tgz";
+        sha512 = "evqGr0KOXB27vu/KiNv6gmd/ggygzwYvINVsCWF6GAd1SFQNS4Vz2wv4tmiktX6rcr6Qq+jBwVXvVwe60d5Z3g==";
       };
     };
-    "@starptech/prettyhtml-0.8.17" = {
+    "@starptech/prettyhtml-0.9.0" = {
       name = "_at_starptech_slash_prettyhtml";
       packageName = "@starptech/prettyhtml";
-      version = "0.8.17";
+      version = "0.9.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@starptech/prettyhtml/-/prettyhtml-0.8.17.tgz";
-        sha512 = "T+5vztw3S/kstOAR/IaF0pRASS+iZxsUR538/4eZmPgoa9haAx9lYZF9wYD2kP81RewhktipOKJbhbbxliVRVA==";
+        url = "https://registry.npmjs.org/@starptech/prettyhtml/-/prettyhtml-0.9.0.tgz";
+        sha512 = "GekZtpBSdlFo732AxrpO7W8ue1dEZdpMK0kNHD/NVDBNU/50/D0NJ72FD2HKLh0Aune9uK+x8b+9MbBFJ2JT9A==";
       };
     };
-    "@starptech/prettyhtml-formatter-0.8.17" = {
+    "@starptech/prettyhtml-formatter-0.9.0" = {
       name = "_at_starptech_slash_prettyhtml-formatter";
       packageName = "@starptech/prettyhtml-formatter";
-      version = "0.8.17";
+      version = "0.9.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@starptech/prettyhtml-formatter/-/prettyhtml-formatter-0.8.17.tgz";
-        sha512 = "+fZcpa54Yxox4jN+nqnL2gJRrGA7XbbknsecxiYl8m9h51zgrmq+RhWlwxosMreFH3mEGdwuLAj1tumm9kpAZQ==";
+        url = "https://registry.npmjs.org/@starptech/prettyhtml-formatter/-/prettyhtml-formatter-0.9.0.tgz";
+        sha512 = "uyG90dzyERExzQg7VTYJm3uBs6hIW81MDvqACgiFgmaafTrveKebJxAZpkbkAgTesvNmApM2I0b5Tu4OKHmaKQ==";
       };
     };
-    "@starptech/prettyhtml-hast-to-html-0.8.17" = {
+    "@starptech/prettyhtml-hast-to-html-0.9.0" = {
       name = "_at_starptech_slash_prettyhtml-hast-to-html";
       packageName = "@starptech/prettyhtml-hast-to-html";
-      version = "0.8.17";
+      version = "0.9.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@starptech/prettyhtml-hast-to-html/-/prettyhtml-hast-to-html-0.8.17.tgz";
-        sha512 = "WXVMJ60ra2Z/X91fXKLqBuCIJ+Xpc9PHSQ90ilzjocvziqKXkBGwio3oLjj/UKDSsh/gUZLsaTkXKFNFg/zx3w==";
+        url = "https://registry.npmjs.org/@starptech/prettyhtml-hast-to-html/-/prettyhtml-hast-to-html-0.9.0.tgz";
+        sha512 = "PcMRqtwXBDsliBC6nesNlDaO0a4uqC2uwfqbz/1VRaFVEInudMQ00fbRjv3Fql5C2YZ1MObMwre/+W7UDuzcIw==";
       };
     };
-    "@starptech/prettyhtml-hastscript-0.8.17" = {
+    "@starptech/prettyhtml-hastscript-0.9.0" = {
       name = "_at_starptech_slash_prettyhtml-hastscript";
       packageName = "@starptech/prettyhtml-hastscript";
-      version = "0.8.17";
+      version = "0.9.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@starptech/prettyhtml-hastscript/-/prettyhtml-hastscript-0.8.17.tgz";
-        sha512 = "MP3/gjrzxcKQEVYv+IxRbRZ6vhCAePUQ5BzkrkBvRM3fZwXMo5ZrnBf06Nq5JuNf/sgMv0hKoOkXbx0E3uiNkg==";
+        url = "https://registry.npmjs.org/@starptech/prettyhtml-hastscript/-/prettyhtml-hastscript-0.9.0.tgz";
+        sha512 = "ifXB3oqZl5LMMaFuQvfUYF0e+XdGDeQoIzFQYdA59cJ+RgjGdsjgFMmvkW+kxZwMWRYyAsLsYuJ19UfIWO8ymQ==";
       };
     };
-    "@starptech/prettyhtml-sort-attributes-0.8.17" = {
+    "@starptech/prettyhtml-sort-attributes-0.9.0" = {
       name = "_at_starptech_slash_prettyhtml-sort-attributes";
       packageName = "@starptech/prettyhtml-sort-attributes";
-      version = "0.8.17";
+      version = "0.9.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@starptech/prettyhtml-sort-attributes/-/prettyhtml-sort-attributes-0.8.17.tgz";
-        sha512 = "S28N5WCN2Wv8U6vpxJXf8sV4lu9hU2dnHJQSUkZP6M1W7HNkD/254Bn1vTJuwvHU5NWSQ3QxmzBe/TWlz9GAhg==";
+        url = "https://registry.npmjs.org/@starptech/prettyhtml-sort-attributes/-/prettyhtml-sort-attributes-0.9.0.tgz";
+        sha512 = "jj4btXkDU0dnY8llM6Cv+6arqVIjfaHhrfLnaaiVdLLb02f1eazMIr8+4jfK0Dol4Bfg3AC3RIYAyu2Kd7FF6g==";
       };
     };
-    "@starptech/rehype-minify-whitespace-0.8.17" = {
+    "@starptech/rehype-minify-whitespace-0.9.0" = {
       name = "_at_starptech_slash_rehype-minify-whitespace";
       packageName = "@starptech/rehype-minify-whitespace";
-      version = "0.8.17";
+      version = "0.9.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@starptech/rehype-minify-whitespace/-/rehype-minify-whitespace-0.8.17.tgz";
-        sha512 = "hrrgNAYknfHw9lBWO0+qHtJJs0zMHwTOCIBTCk2FGyeg+SEKh4dJdNRUfujPkH5qNj7skTUHWtOKL5PaWRT64w==";
+        url = "https://registry.npmjs.org/@starptech/rehype-minify-whitespace/-/rehype-minify-whitespace-0.9.0.tgz";
+        sha512 = "z4CL6TCdHyXVZGU6I632Un5g2MmIsYhnsYVerAW4DKf3Zyc5Nam2U+wVdbE2nLqTInDUpUr4vmzksD8tHsY9Ew==";
       };
     };
-    "@starptech/rehype-webparser-0.8.17" = {
+    "@starptech/rehype-webparser-0.9.0" = {
       name = "_at_starptech_slash_rehype-webparser";
       packageName = "@starptech/rehype-webparser";
-      version = "0.8.17";
+      version = "0.9.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@starptech/rehype-webparser/-/rehype-webparser-0.8.17.tgz";
-        sha512 = "8GklGO1DSCyFqQKl8ZyL0mu3LDIc3DN1w8vj28EYxUinAGUWCGyaimC7QDyvs4hK75XM1NddPzR0fFBlBOXn1g==";
+        url = "https://registry.npmjs.org/@starptech/rehype-webparser/-/rehype-webparser-0.9.0.tgz";
+        sha512 = "Ndv/excuCjdRIUWtzD5YQMvuZudMvjtYmNhLllzYEzMq6+nkPrhaORuUNihDG1SYZI260CXV1khDTGqPc581Yg==";
       };
     };
-    "@starptech/webparser-0.8.17" = {
+    "@starptech/webparser-0.9.0" = {
       name = "_at_starptech_slash_webparser";
       packageName = "@starptech/webparser";
-      version = "0.8.17";
+      version = "0.9.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@starptech/webparser/-/webparser-0.8.17.tgz";
-        sha512 = "St95Jolws0W5NVB+OS0w84Tgu9BHlb+JPltSWD4lDwVIwv7x1lVHdat52AwHQdHPzUY2xGOz1g7Gdb5jSTTk3A==";
+        url = "https://registry.npmjs.org/@starptech/webparser/-/webparser-0.9.0.tgz";
+        sha512 = "QEC1yjpsOtj3leNCWZGirAyVCN7WJDH+rUhfMVGQuLEfoJNKK66t/UWAOrXeGxR2jdU5IffAGnqZIHbFMX6SNw==";
       };
     };
     "@szmarczak/http-timer-1.1.2" = {
@@ -2281,6 +2344,15 @@ let
         sha512 = "jOdnI/3qTpHABjM5cx1Hc0sKsPoYCp+DP/GJRGtDlPd7fiV9oXGGIcjW/ZOxLIvjGz8MA+uMZI9metHlgqbgwQ==";
       };
     };
+    "@types/agent-base-4.2.0" = {
+      name = "_at_types_slash_agent-base";
+      packageName = "@types/agent-base";
+      version = "4.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@types/agent-base/-/agent-base-4.2.0.tgz";
+        sha512 = "8mrhPstU+ZX0Ugya8tl5DsDZ1I5ZwQzbL/8PA0z8Gj0k9nql7nkaMzmPVLj+l/nixWaliXi+EBiLA8bptw3z7Q==";
+      };
+    };
     "@types/bluebird-3.5.27" = {
       name = "_at_types_slash_bluebird";
       packageName = "@types/bluebird";
@@ -2353,22 +2425,22 @@ let
         sha512 = "EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==";
       };
     };
-    "@types/express-4.16.1" = {
+    "@types/express-4.17.0" = {
       name = "_at_types_slash_express";
       packageName = "@types/express";
-      version = "4.16.1";
+      version = "4.17.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/express/-/express-4.16.1.tgz";
-        sha512 = "V0clmJow23WeyblmACoxbHBu2JKlE5TiIme6Lem14FnPW9gsttyHtk6wq7njcdIWH1njAaFgR8gW09lgY98gQg==";
+        url = "https://registry.npmjs.org/@types/express/-/express-4.17.0.tgz";
+        sha512 = "CjaMu57cjgjuZbh9DpkloeGxV45CnMGlVd+XpG7Gm9QgVrd7KFq+X4HY0vM+2v0bczS48Wg7bvnMY5TN+Xmcfw==";
       };
     };
-    "@types/express-serve-static-core-4.16.6" = {
+    "@types/express-serve-static-core-4.16.7" = {
       name = "_at_types_slash_express-serve-static-core";
       packageName = "@types/express-serve-static-core";
-      version = "4.16.6";
+      version = "4.16.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.6.tgz";
-        sha512 = "8wr3CA/EMybyb6/V8qvTRKiNkPmgUA26uA9XWD6hlA0yFDuqi4r2L0C2B0U2HAYltJamoYJszlkaWM31vrKsHg==";
+        url = "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.7.tgz";
+        sha512 = "847KvL8Q1y3TtFLRTXcVakErLJQgdpFSaq+k043xefz9raEf0C7HalpSY7OW5PyjCnY8P7bPW5t/Co9qqp+USg==";
       };
     };
     "@types/glob-7.1.1" = {
@@ -2407,22 +2479,22 @@ let
         sha512 = "tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==";
       };
     };
-    "@types/node-10.14.8" = {
+    "@types/node-10.14.10" = {
       name = "_at_types_slash_node";
       packageName = "@types/node";
-      version = "10.14.8";
+      version = "10.14.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/node/-/node-10.14.8.tgz";
-        sha512 = "I4+DbJEhLEg4/vIy/2gkWDvXBOOtPKV9EnLhYjMoqxcRW+TTZtUftkHktz/a8suoD5mUL7m6ReLrkPvSsCQQmw==";
+        url = "https://registry.npmjs.org/@types/node/-/node-10.14.10.tgz";
+        sha512 = "V8wj+w2YMNvGuhgl/MA5fmTxgjmVHVoasfIaxMMZJV6Y8Kk+Ydpi1z2whoShDCJ2BuNVoqH/h1hrygnBxkrw/Q==";
       };
     };
-    "@types/node-12.0.4" = {
+    "@types/node-12.0.10" = {
       name = "_at_types_slash_node";
       packageName = "@types/node";
-      version = "12.0.4";
+      version = "12.0.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/node/-/node-12.0.4.tgz";
-        sha512 = "j8YL2C0fXq7IONwl/Ud5Kt0PeXw22zGERt+HSSnwbKOJVsAGkEz3sFCYwaF9IOuoG1HOtE0vKCj6sXF7Q0+Vaw==";
+        url = "https://registry.npmjs.org/@types/node/-/node-12.0.10.tgz";
+        sha512 = "LcsGbPomWsad6wmMNv7nBLw7YYYyfdYcz6xryKYQhx89c3XXan+8Q6AJ43G5XDIaklaVkK3mE4fCb0SBvMiPSQ==";
       };
     };
     "@types/node-6.14.6" = {
@@ -2468,6 +2540,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.2.tgz";
         sha512 = "/BZ4QRLpH/bNYgZgwhKEh+5AsboDBcUdlBYgzoLX0fpj3Y2gp6EApyOlM3bK53wQS/OE1SrdSYBAbux2D1528Q==";
+      };
+    };
+    "@types/sinon-7.0.11" = {
+      name = "_at_types_slash_sinon";
+      packageName = "@types/sinon";
+      version = "7.0.11";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@types/sinon/-/sinon-7.0.11.tgz";
+        sha512 = "6ee09Ugx6GyEr0opUIakmxIWFNmqYPjkqa3/BuxCBokA0klsOLPgMD5K4q40lH7/yZVuJVzOfQpd7pipwjngkQ==";
       };
     };
     "@types/superagent-3.8.2" = {
@@ -2533,31 +2614,31 @@ let
         sha512 = "wn1L8pmQnotfftHOYm0VeXs2+cQTySd73uhWXwyO6pT0ehjqlY5c2RTipClmFF3Q+YCYjwlNpsV650F3l1tV8w==";
       };
     };
-    "@vue/cli-ui-3.8.0" = {
+    "@vue/cli-ui-3.8.4" = {
       name = "_at_vue_slash_cli-ui";
       packageName = "@vue/cli-ui";
-      version = "3.8.0";
+      version = "3.8.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@vue/cli-ui/-/cli-ui-3.8.0.tgz";
-        sha512 = "guIWGEFGI4xm9CIJjFzWy74TjiZjblmLA6pmYMCYVKLRgHF0cUSK5o8P4shPkR7xVTM6Bu/7bGDxc6ZUhjbF4g==";
+        url = "https://registry.npmjs.org/@vue/cli-ui/-/cli-ui-3.8.4.tgz";
+        sha512 = "1l85jynu5883zxhdQP8Or34Ltfiq0IZKUjYS0kkPpaScyjYpXlsRp4z397gxJ4ueeU5GKChJdHluFjfKnDgiiA==";
       };
     };
-    "@vue/cli-ui-addon-webpack-3.8.0" = {
+    "@vue/cli-ui-addon-webpack-3.8.4" = {
       name = "_at_vue_slash_cli-ui-addon-webpack";
       packageName = "@vue/cli-ui-addon-webpack";
-      version = "3.8.0";
+      version = "3.8.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@vue/cli-ui-addon-webpack/-/cli-ui-addon-webpack-3.8.0.tgz";
-        sha512 = "81mEy0ul8V0dDvUPWyn2tu3bveFYy6bHRNjuPK/DaZYirxgft8gxihA+JnlWhKL09Sa4E5d0ez95jEW0ts25Uw==";
+        url = "https://registry.npmjs.org/@vue/cli-ui-addon-webpack/-/cli-ui-addon-webpack-3.8.4.tgz";
+        sha512 = "YqWZxlwkSaKPNEkc0KpGq+pV9ywx5cCnzx8duQ3tYHelcPs4aKjO0qzuKJnKB6q0+goEXXVZwYi9P2WQ2YDOEA==";
       };
     };
-    "@vue/cli-ui-addon-widgets-3.8.0" = {
+    "@vue/cli-ui-addon-widgets-3.8.4" = {
       name = "_at_vue_slash_cli-ui-addon-widgets";
       packageName = "@vue/cli-ui-addon-widgets";
-      version = "3.8.0";
+      version = "3.8.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@vue/cli-ui-addon-widgets/-/cli-ui-addon-widgets-3.8.0.tgz";
-        sha512 = "AlgFxTIdrF7O/+1YX2ZUB7xnSTo2bDa35e1jYzLmUugKvV6a66jl67dcK27IPvBFJTPqjuDyeVcg7QwCGotRRw==";
+        url = "https://registry.npmjs.org/@vue/cli-ui-addon-widgets/-/cli-ui-addon-widgets-3.8.4.tgz";
+        sha512 = "aCuaEnSY6qvRJh9pOLIX5gCvJ96jbHWqsGY02NZkXLW2kqShuIm+YYenSx0dCi8cH+Mlh4McCX1LeBRKBDpO6A==";
       };
     };
     "@webassemblyjs/ast-1.8.1" = {
@@ -2893,13 +2974,22 @@ let
         sha512 = "w0U0pD4EhlnvRyeJzBqaVSJAo9w/ce7/WPogeXLzGkO6hzhr4GnQIZ4W4uUt5b9ooAaXPtnXlj0gzsXEOUNYMg==";
       };
     };
-    "@wry/context-0.4.2" = {
+    "@wry/context-0.4.4" = {
       name = "_at_wry_slash_context";
       packageName = "@wry/context";
-      version = "0.4.2";
+      version = "0.4.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@wry/context/-/context-0.4.2.tgz";
-        sha512 = "P3IsTHNeQLVjy3Bi9eiyqUwSu4Hai9vpzgueJai8wfibr6JPjyM9KVi2b7uixk1py7aGyOU15cBNvD/l1eZ2eg==";
+        url = "https://registry.npmjs.org/@wry/context/-/context-0.4.4.tgz";
+        sha512 = "LrKVLove/zw6h2Md/KZyWxIkFM6AoyKp71OqpH9Hiip1csjPVoD3tPxlbQUNxEnHENks3UGgNpSBCAfq9KWuag==";
+      };
+    };
+    "@wry/equality-0.1.9" = {
+      name = "_at_wry_slash_equality";
+      packageName = "@wry/equality";
+      version = "0.1.9";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@wry/equality/-/equality-0.1.9.tgz";
+        sha512 = "mB6ceGjpMGz1ZTza8HYnrPGos2mC6So4NhS1PtZ8s4Qt0K7fBiIGhpSxUbQmhwcSWE3no+bYxmI2OL6KuXYmoQ==";
       };
     };
     "@xtuc/ieee754-1.2.0" = {
@@ -3235,13 +3325,13 @@ let
         sha512 = "OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==";
       };
     };
-    "adbkit-2.11.0" = {
+    "adbkit-2.11.1" = {
       name = "adbkit";
       packageName = "adbkit";
-      version = "2.11.0";
+      version = "2.11.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/adbkit/-/adbkit-2.11.0.tgz";
-        sha512 = "j2vUhEeZmCiqBP+p77CpPWQTcT20rOmSmRHFUTZUwUpxzeCd3fXop4NAGYztSY9/FNU4bT/qqvYQ4EZKuCXhfA==";
+        url = "https://registry.npmjs.org/adbkit/-/adbkit-2.11.1.tgz";
+        sha512 = "hDTiRg9NX3HQt7WoDAPCplUpvzr4ZzQa2lq7BdTTJ/iOZ6O7YNAs6UYD8sFAiBEcYHDRIyq3cm9sZP6uZnhvXw==";
       };
     };
     "adbkit-logcat-1.1.0" = {
@@ -3262,13 +3352,13 @@ let
         sha1 = "f291be701a2efc567a63fc7aa6afcded31430be1";
       };
     };
-    "addons-linter-1.6.1" = {
+    "addons-linter-1.10.0" = {
       name = "addons-linter";
       packageName = "addons-linter";
-      version = "1.6.1";
+      version = "1.10.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/addons-linter/-/addons-linter-1.6.1.tgz";
-        sha512 = "3+N8cskdXHpId0dhfsldgbYGXamtgfGywvU4oPVb1M7imG3pHFoK+VcAr/kPk1VeYGkSmBl2LxnwGHcw1ERvmA==";
+        url = "https://registry.npmjs.org/addons-linter/-/addons-linter-1.10.0.tgz";
+        sha512 = "2i2qSayVPx4h1Aa2ZTdQlpgmjcCNIHZ4AJQS8V/QsBXIdmXl+Djmeyr096bjaC3Usq0rZfYhGgFdwR1dgHVItw==";
       };
     };
     "addr-to-ip-port-1.5.1" = {
@@ -3449,15 +3539,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/ajv/-/ajv-6.5.3.tgz";
         sha512 = "LqZ9wY+fx3UMiiPd741yB2pj3hhil+hQc8taf4o2QGRFpWgZ2V5C8HA165DY9sS3fJwsk7uT7ZlFEyC3Ig3lLg==";
-      };
-    };
-    "ajv-6.9.1" = {
-      name = "ajv";
-      packageName = "ajv";
-      version = "6.9.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/ajv/-/ajv-6.9.1.tgz";
-        sha512 = "XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==";
       };
     };
     "ajv-errors-1.0.1" = {
@@ -3658,13 +3739,13 @@ let
         sha512 = "cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==";
       };
     };
-    "ansi-escapes-4.1.0" = {
+    "ansi-escapes-4.2.0" = {
       name = "ansi-escapes";
       packageName = "ansi-escapes";
-      version = "4.1.0";
+      version = "4.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.1.0.tgz";
-        sha512 = "2VY/iCUZTDLD/qxptS3Zn3c6k2MeIbYqjRXqM8T5oC7N2mMjh3xIU3oYru6cHGbldFa9h5i8N0fP65UaUqrMWA==";
+        url = "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.2.0.tgz";
+        sha512 = "0+VX4uhi8m3aNbzoqKmkAVOEj6uQzcUHXoFPkKjhZPTpGRUBqVh930KbB6PS4zIyDZccphlLIYlu8nsjFzkXwg==";
       };
     };
     "ansi-gray-0.1.1" = {
@@ -3775,6 +3856,15 @@ let
         sha512 = "VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==";
       };
     };
+    "ansi-styles-4.0.0" = {
+      name = "ansi-styles";
+      packageName = "ansi-styles";
+      version = "4.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.0.0.tgz";
+        sha512 = "8zjUtFJ3db/QoPXuuEMloS2AUf79/yeyttJ7Abr3hteopJu9HK8vsgGviGUMq+zyA6cZZO6gAyZoMTF6TgaEjA==";
+      };
+    };
     "ansi-to-html-0.6.11" = {
       name = "ansi-to-html";
       packageName = "ansi-to-html";
@@ -3865,40 +3955,40 @@ let
         sha1 = "ee49736b639b4f108b6e9e626c6da99306b41692";
       };
     };
-    "apollo-cache-1.3.1" = {
+    "apollo-cache-1.3.2" = {
       name = "apollo-cache";
       packageName = "apollo-cache";
-      version = "1.3.1";
+      version = "1.3.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.3.1.tgz";
-        sha512 = "BJ/Mehr3u6XCaHYSmgZ6DM71Fh30OkW6aEr828WjHvs+7i0RUuP51/PM7K6T0jPXtuw7UbArFFPZZsNgXnyyJA==";
+        url = "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.3.2.tgz";
+        sha512 = "+KA685AV5ETEJfjZuviRTEImGA11uNBp/MJGnaCvkgr+BYRrGLruVKBv6WvyFod27WEB2sp7SsG8cNBKANhGLg==";
       };
     };
-    "apollo-cache-control-0.7.1" = {
+    "apollo-cache-control-0.7.4" = {
       name = "apollo-cache-control";
       packageName = "apollo-cache-control";
-      version = "0.7.1";
+      version = "0.7.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.7.1.tgz";
-        sha512 = "3h1TEoMnzex6IIiFb5Ja3owTyLwT5YzK69cRgrSpSscdpYc3ID4KVs0Ht9cbOUmb/L/UKtYVkRC8KeVAYmHEjQ==";
+        url = "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.7.4.tgz";
+        sha512 = "TVACHwcEF4wfHo5H9FLnoNjo0SLDo2jPW+bXs9aw0Y4Z2UisskSAPnIYOqUPnU8SoeNvs7zWgbLizq11SRTJtg==";
       };
     };
-    "apollo-cache-inmemory-1.6.1" = {
+    "apollo-cache-inmemory-1.6.2" = {
       name = "apollo-cache-inmemory";
       packageName = "apollo-cache-inmemory";
-      version = "1.6.1";
+      version = "1.6.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-cache-inmemory/-/apollo-cache-inmemory-1.6.1.tgz";
-        sha512 = "c/WJjh9MTWcdussCTjLKufpPjTx3qOFkBPHIDOOpQ+U0B7K1PczPl9N0LaC4ir3wAWL7s4A0t2EKtoR+6UP92g==";
+        url = "https://registry.npmjs.org/apollo-cache-inmemory/-/apollo-cache-inmemory-1.6.2.tgz";
+        sha512 = "AyCl3PGFv5Qv1w4N9vlg63GBPHXgMCekZy5mhlS042ji0GW84uTySX+r3F61ZX3+KM1vA4m9hQyctrEGiv5XjQ==";
       };
     };
-    "apollo-client-2.6.1" = {
+    "apollo-client-2.6.3" = {
       name = "apollo-client";
       packageName = "apollo-client";
-      version = "2.6.1";
+      version = "2.6.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-client/-/apollo-client-2.6.1.tgz";
-        sha512 = "Tb6ZthPZUHlGqeoH1WC8Qg/tLnkk9H5+xj4e5nzOAC6dCOW3pVU9tYXscrWdmZ65UDUg1khvTNjrQgPhdf4aTQ==";
+        url = "https://registry.npmjs.org/apollo-client/-/apollo-client-2.6.3.tgz";
+        sha512 = "DS8pmF5CGiiJ658dG+mDn8pmCMMQIljKJSTeMNHnFuDLV0uAPZoeaAwVFiAmB408Ujqt92oIZ/8yJJAwSIhd4A==";
       };
     };
     "apollo-codegen-0.20.2" = {
@@ -3982,22 +4072,22 @@ let
         sha512 = "SVXxJyKlWguuDjxkY/WGlC/ykdsTmPxSF0z8FenagcQ91aPURXzXP1ZDz5PbamY+0iiCRubazkxtTQw4GWTFPg==";
       };
     };
-    "apollo-engine-reporting-1.2.1" = {
+    "apollo-engine-reporting-1.3.5" = {
       name = "apollo-engine-reporting";
       packageName = "apollo-engine-reporting";
-      version = "1.2.1";
+      version = "1.3.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-engine-reporting/-/apollo-engine-reporting-1.2.1.tgz";
-        sha512 = "DVXZhz/nSZR4lphakjb1guAD0qJ7Wm1PVtZEBjN097cnOor4XSOzQlPfTaYtVuhlxUKUuCx1syiBbOuV8sKqXg==";
+        url = "https://registry.npmjs.org/apollo-engine-reporting/-/apollo-engine-reporting-1.3.5.tgz";
+        sha512 = "pSwjPgXK/elFsR22LXALtT3jI4fpEpeTNTHgNwLVLohaolusMYgBc/9FnVyFWFfMFS9k+3RmfeQdHhZ6T7WKFQ==";
       };
     };
-    "apollo-engine-reporting-protobuf-0.3.0" = {
+    "apollo-engine-reporting-protobuf-0.3.1" = {
       name = "apollo-engine-reporting-protobuf";
       packageName = "apollo-engine-reporting-protobuf";
-      version = "0.3.0";
+      version = "0.3.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-engine-reporting-protobuf/-/apollo-engine-reporting-protobuf-0.3.0.tgz";
-        sha512 = "PYowpx/E+TJT/8nKpp3JmJuKh3x1SZcxDF6Cquj0soV205TUpFFCZQMi91i5ACiEp2AkYvM/GDBIrw+rfIwzTg==";
+        url = "https://registry.npmjs.org/apollo-engine-reporting-protobuf/-/apollo-engine-reporting-protobuf-0.3.1.tgz";
+        sha512 = "Ui3nPG6BSZF8BEqxFs6EkX6mj2OnFLMejxEHSOdM82bakyeouCGd7J0fiy8AD6liJoIyc4X7XfH4ZGGMvMh11A==";
       };
     };
     "apollo-env-0.5.1" = {
@@ -4009,40 +4099,40 @@ let
         sha512 = "fndST2xojgSdH02k5hxk1cbqA9Ti8RX4YzzBoAB4oIe1Puhq7+YlhXGXfXB5Y4XN0al8dLg+5nAkyjNAR2qZTw==";
       };
     };
-    "apollo-graphql-0.3.1" = {
+    "apollo-graphql-0.3.3" = {
       name = "apollo-graphql";
       packageName = "apollo-graphql";
-      version = "0.3.1";
+      version = "0.3.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.3.1.tgz";
-        sha512 = "tbhtzNAAhNI34v4XY9OlZGnH7U0sX4BP1cJrUfSiNzQnZRg1UbQYZ06riHSOHpi5RSndFcA9LDM5C1ZKKOUeBg==";
+        url = "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.3.3.tgz";
+        sha512 = "t3CO/xIDVsCG2qOvx2MEbuu4b/6LzQjcBBwiVnxclmmFyAxYCIe7rpPlnLHSq7HyOMlCWDMozjoeWfdqYSaLqQ==";
       };
     };
-    "apollo-link-1.2.11" = {
+    "apollo-link-1.2.12" = {
       name = "apollo-link";
       packageName = "apollo-link";
-      version = "1.2.11";
+      version = "1.2.12";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.11.tgz";
-        sha512 = "PQvRCg13VduLy3X/0L79M6uOpTh5iHdxnxYuo8yL7sJlWybKRJwsv4IcRBJpMFbChOOaHY7Og9wgPo6DLKDKDA==";
+        url = "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.12.tgz";
+        sha512 = "fsgIAXPKThyMVEMWQsUN22AoQI+J/pVXcjRGAShtk97h7D8O+SPskFinCGEkxPeQpE83uKaqafB2IyWdjN+J3Q==";
       };
     };
-    "apollo-link-context-1.0.17" = {
+    "apollo-link-context-1.0.18" = {
       name = "apollo-link-context";
       packageName = "apollo-link-context";
-      version = "1.0.17";
+      version = "1.0.18";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-link-context/-/apollo-link-context-1.0.17.tgz";
-        sha512 = "W5UUfHcrrlP5uqJs5X1zbf84AMXhPZGAqX/7AQDgR6wY/7//sMGfJvm36KDkpIeSOElztGtM9z6zdPN1NbT41Q==";
+        url = "https://registry.npmjs.org/apollo-link-context/-/apollo-link-context-1.0.18.tgz";
+        sha512 = "aG5cbUp1zqOHHQjAJXG7n/izeMQ6LApd/whEF5z6qZp5ATvcyfSNkCfy3KRJMMZZ3iNfVTs6jF+IUA8Zvf+zeg==";
       };
     };
-    "apollo-link-http-common-0.2.13" = {
+    "apollo-link-http-common-0.2.14" = {
       name = "apollo-link-http-common";
       packageName = "apollo-link-http-common";
-      version = "0.2.13";
+      version = "0.2.14";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-link-http-common/-/apollo-link-http-common-0.2.13.tgz";
-        sha512 = "Uyg1ECQpTTA691Fwx5e6Rc/6CPSu4TB4pQRTGIpwZ4l5JDOQ+812Wvi/e3IInmzOZpwx5YrrOfXrtN8BrsDXoA==";
+        url = "https://registry.npmjs.org/apollo-link-http-common/-/apollo-link-http-common-0.2.14.tgz";
+        sha512 = "v6mRU1oN6XuX8beVIRB6OpF4q1ULhSnmy7ScnHnuo1qV6GaFmDcbdvXqxIkAV1Q8SQCo2lsv4HeqJOWhFfApOg==";
       };
     };
     "apollo-link-persisted-queries-0.2.2" = {
@@ -4063,13 +4153,13 @@ let
         sha512 = "xMPcAfuiPVYXaLwC6oJFIZrKgV3GmdO31Ag2eufRoXpvT0AfJZjdaPB4450Nu9TslHRePN9A3quxNueILlQxlw==";
       };
     };
-    "apollo-link-ws-1.0.17" = {
+    "apollo-link-ws-1.0.18" = {
       name = "apollo-link-ws";
       packageName = "apollo-link-ws";
-      version = "1.0.17";
+      version = "1.0.18";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-link-ws/-/apollo-link-ws-1.0.17.tgz";
-        sha512 = "0PKgahM2BOcUiI3QSJMYXOoUylWKzar5NTZLgMLEW4K/CczOTzC4CTXvKMjh/cx57Jto/U2xzKRy9BEoNfnK5Q==";
+        url = "https://registry.npmjs.org/apollo-link-ws/-/apollo-link-ws-1.0.18.tgz";
+        sha512 = "nrWh9m7k1FQw1AK1GB1VTJS0o01cpsP2RYmTAh2j+P4lL2/72WgsblhbuF+yA1/jsgVrzg6xa+TNw3UwgGp3+g==";
       };
     };
     "apollo-server-caching-0.4.0" = {
@@ -4081,13 +4171,13 @@ let
         sha512 = "GTOZdbLhrSOKYNWMYgaqX5cVNSMT0bGUTZKV8/tYlyYmsB6ey7l6iId3Q7UpHS6F6OR2lstz5XaKZ+T3fDfPzQ==";
       };
     };
-    "apollo-server-core-2.6.1" = {
+    "apollo-server-core-2.6.7" = {
       name = "apollo-server-core";
       packageName = "apollo-server-core";
-      version = "2.6.1";
+      version = "2.6.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.6.1.tgz";
-        sha512 = "jO2BtcP7ozSSK5qtw1gGDwO66WSNtzhvpDJD7erkA9byv8Z0jB2QIPNWN6iaj311LaPahM05k+8hMIhFy9oHWg==";
+        url = "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.6.7.tgz";
+        sha512 = "HfOGLvEwPgDWTvd3ZKRPEkEnICKb7xadn1Mci4+auMTsL/NVkfpjPa8cdzubi/kS2/MvioIn7Bg74gmiSLghGQ==";
       };
     };
     "apollo-server-env-2.4.0" = {
@@ -4108,31 +4198,31 @@ let
         sha512 = "rUvzwMo2ZQgzzPh2kcJyfbRSfVKRMhfIlhY7BzUfM4x6ZT0aijlgsf714Ll3Mbf5Fxii32kD0A/DmKsTecpccw==";
       };
     };
-    "apollo-server-express-2.6.1" = {
+    "apollo-server-express-2.6.7" = {
       name = "apollo-server-express";
       packageName = "apollo-server-express";
-      version = "2.6.1";
+      version = "2.6.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.6.1.tgz";
-        sha512 = "TVu68LVp+COMGOXuxc0OFeCUQiPApxy7Isv2Vk85nikZV4t4FXlODB6PrRKf5rfvP31dvGsfE6GHPJTLLbKfyg==";
+        url = "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.6.7.tgz";
+        sha512 = "qbCQM+8LxXpwPNN5Sdvcb+Sne8zuCORFt25HJtPJRkHlyBUzOd7JA7SEnUn5e2geTiiGoVIU5leh+++C51udTw==";
       };
     };
-    "apollo-server-plugin-base-0.5.1" = {
+    "apollo-server-plugin-base-0.5.6" = {
       name = "apollo-server-plugin-base";
       packageName = "apollo-server-plugin-base";
-      version = "0.5.1";
+      version = "0.5.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.5.1.tgz";
-        sha512 = "UejnBk6XDqYQ+Ydkbm+gvlOzP+doQA8glVUULs8rCi0/MshsFSsBVl6rtzruELDBVgZhJgGsd4pUexcvNc3aZA==";
+        url = "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.5.6.tgz";
+        sha512 = "wJvcPqfm/kiBwY5JZT85t2A4pcHv24xdQIpWMNt1zsnx77lIZqJmhsc22eSUSrlnYqUMXC4XMVgSUfAO4oI9wg==";
       };
     };
-    "apollo-tracing-0.7.1" = {
+    "apollo-tracing-0.7.3" = {
       name = "apollo-tracing";
       packageName = "apollo-tracing";
-      version = "0.7.1";
+      version = "0.7.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.7.1.tgz";
-        sha512 = "1BYQua+jCWFkZZJP0/rSpzY4XbLLbCrRHCYu8sJn0RCH/hs34BMdFXscS9uSglgIpXwUAIafgsU0hAVCrJjbTw==";
+        url = "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.7.3.tgz";
+        sha512 = "H6fSC+awQGnfDyYdGIB0UQUhcUC3n5Vy+ujacJ0bY6R+vwWeZOQvu7wRHNjk/rbOSTLCo9A0OcVX7huRyu9SZg==";
       };
     };
     "apollo-upload-client-10.0.1" = {
@@ -4144,13 +4234,13 @@ let
         sha512 = "K6WnuYQi0RRTNO+aSPVjoUWXp4QSr+eoKU4fE0OKQp25XRF2oXl2cTLs+Q4Nk0wOIHM76YGdo/IHtzuNR7jO+A==";
       };
     };
-    "apollo-utilities-1.3.1" = {
+    "apollo-utilities-1.3.2" = {
       name = "apollo-utilities";
       packageName = "apollo-utilities";
-      version = "1.3.1";
+      version = "1.3.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.1.tgz";
-        sha512 = "P5cJ75rvhm9hcx9V/xCW0vlHhRd0S2icEcYPoRYNTc5djbynpuO+mQuJ4zMHgjNDpvvDxDfZxXTJ6ZUuJZodiQ==";
+        url = "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.2.tgz";
+        sha512 = "JWNHj8XChz7S4OZghV6yc9FNnzEXj285QYp/nLNh943iObycI5GTDO3NGR9Dth12LRrSFMeDOConPfPln+WGfg==";
       };
     };
     "app-builder-5.2.0" = {
@@ -4459,6 +4549,15 @@ let
         sha1 = "eff52e3758249d33be402b8bb8e564bb2b5d4031";
       };
     };
+    "array-differ-3.0.0" = {
+      name = "array-differ";
+      packageName = "array-differ";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz";
+        sha512 = "THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==";
+      };
+    };
     "array-each-1.0.1" = {
       name = "array-each";
       packageName = "array-each";
@@ -4666,6 +4765,15 @@ let
         sha1 = "9a34410e4f4e3da23dea375be5be70f24778ec39";
       };
     };
+    "array-union-2.1.0" = {
+      name = "array-union";
+      packageName = "array-union";
+      version = "2.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz";
+        sha512 = "HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==";
+      };
+    };
     "array-uniq-1.0.3" = {
       name = "array-uniq";
       packageName = "array-uniq";
@@ -4864,13 +4972,13 @@ let
         sha512 = "ky/YVYCbtVAS8TdMIaTiPFHwEpRB5z1hctepJplTr3UW5q8TDrpIMCILyk8pmLxGtn2KCtC/lSn7zOsaI7nzDw==";
       };
     };
-    "ast-types-0.13.1" = {
+    "ast-types-0.13.2" = {
       name = "ast-types";
       packageName = "ast-types";
-      version = "0.13.1";
+      version = "0.13.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ast-types/-/ast-types-0.13.1.tgz";
-        sha512 = "b+EeK0WlzrSmpMw5jktWvQGxblpWnvMrV+vOp69RLjzGiHwWV0vgq75DPKtUjppKni3yWwSW8WLGV3Ch/XIWcQ==";
+        url = "https://registry.npmjs.org/ast-types/-/ast-types-0.13.2.tgz";
+        sha512 = "uWMHxJxtfj/1oZClOxDEV1sQ1HCDkA4MG8Gr69KKeBjEVH0R84WlejZ0y2DcwyBlpAEMltmVYkVgqfLFb2oyiA==";
       };
     };
     "ast-types-0.9.6" = {
@@ -4990,13 +5098,22 @@ let
         sha512 = "H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==";
       };
     };
-    "async-done-1.3.1" = {
+    "async-3.0.1" = {
+      name = "async";
+      packageName = "async";
+      version = "3.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/async/-/async-3.0.1.tgz";
+        sha512 = "ZswD8vwPtmBZzbn9xyi8XBQWXH3AvOQ43Za1KWYq7JeycrZuUYzx01KvHcVbXltjqH4y0MWrQ33008uLTqXuDw==";
+      };
+    };
+    "async-done-1.3.2" = {
       name = "async-done";
       packageName = "async-done";
-      version = "1.3.1";
+      version = "1.3.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/async-done/-/async-done-1.3.1.tgz";
-        sha512 = "R1BaUeJ4PMoLNJuk+0tLJgjmEqVsdN118+Z8O+alhnQDQgy0kmD5Mqi0DNEmMx2LM0Ed5yekKu+ZXYvIHceicg==";
+        url = "https://registry.npmjs.org/async-done/-/async-done-1.3.2.tgz";
+        sha512 = "uYkTP8dw2og1tu1nmza1n1CMW0qb8gWWlwqMmLb7MhBVs4BXrFziT6HXUd+/RlRA/i4H9AkofYloUbs1fwMqlw==";
       };
     };
     "async-each-1.0.3" = {
@@ -5116,13 +5233,13 @@ let
         sha512 = "TG+5YFiaKQ6CZiSQsosGMJ/IJzwMZ4V/rSdEXlD6+DwKyv8OyeUcprq34kp4yuS6bfQYXhxBC2Vm8PWo+iKBGQ==";
       };
     };
-    "atomic-file-2.0.0" = {
+    "atomic-file-2.0.1" = {
       name = "atomic-file";
       packageName = "atomic-file";
-      version = "2.0.0";
+      version = "2.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/atomic-file/-/atomic-file-2.0.0.tgz";
-        sha512 = "8acsmdYLYCzawXHRV+ryvRppE6dkkPrSywy6wiCzjp2T0wX4rzxw1tJbPgUgZPdi3OQ3AMvvZ3Anrnq6bERvLg==";
+        url = "https://registry.npmjs.org/atomic-file/-/atomic-file-2.0.1.tgz";
+        sha512 = "9JCWojeLDF8UhEv2UJlLlPGsLEs+EBnfB+kOhsvmFI2QilVrnIsAwr7YnF8lLEVuxB+HxFhvGK+ax0Y8Eh/BKA==";
       };
     };
     "attach-ware-1.1.1" = {
@@ -5161,13 +5278,13 @@ let
         sha1 = "00f35b2d27ac91b1f0d3ef2084c98cf1d1f0adc3";
       };
     };
-    "aws-sdk-2.469.0" = {
+    "aws-sdk-2.485.0" = {
       name = "aws-sdk";
       packageName = "aws-sdk";
-      version = "2.469.0";
+      version = "2.485.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.469.0.tgz";
-        sha512 = "VaIrO3aBX83gKkBPk9xM0RHmu7fmq76kaF0SqbsWlPImgxc5foJ4rBlRMMlmeNogFZZ/XTQdI+gkFDVosV14Ig==";
+        url = "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.485.0.tgz";
+        sha512 = "VTmsIPrf9yblghjM5P7hCUG9ysYB+m67mo6/laWeJeGWLxePwtfvVAjhmmXkOJIv0JFSwNfJJ5KpI3Mtu0avsQ==";
       };
     };
     "aws-sign2-0.6.0" = {
@@ -5854,13 +5971,13 @@ let
         sha1 = "199fd661702a0e7b7dcae6e0698bb089c52f6d78";
       };
     };
-    "base64-url-2.2.1" = {
+    "base64-url-2.2.2" = {
       name = "base64-url";
       packageName = "base64-url";
-      version = "2.2.1";
+      version = "2.2.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/base64-url/-/base64-url-2.2.1.tgz";
-        sha512 = "RWaW1M7+pLUikK1bnGyiDe1oY2BKOtbS30Ua1pSAH41st59qDxi/XiggjVhHVPIejXY1eqJ21W3uxHtZpM6KQw==";
+        url = "https://registry.npmjs.org/base64-url/-/base64-url-2.2.2.tgz";
+        sha512 = "JMAkNo3MJ7GG2CHPVMiGPrzGQizUcVE9qvCU6pxQln4aYZZgYM6BJHXbawDegSoryvsKGrK3FuBO9IuGWErRLQ==";
       };
     };
     "base64id-0.1.0" = {
@@ -6052,13 +6169,13 @@ let
         sha1 = "159a49b9a9714c1fb102f2e0ed1906fab6a450f4";
       };
     };
-    "big-integer-1.6.43" = {
+    "big-integer-1.6.44" = {
       name = "big-integer";
       packageName = "big-integer";
-      version = "1.6.43";
+      version = "1.6.44";
       src = fetchurl {
-        url = "https://registry.npmjs.org/big-integer/-/big-integer-1.6.43.tgz";
-        sha512 = "9dULc9jsKmXl0Aeunug8wbF+58n+hQoFjqClN7WeZwGLh0XJUWyJJ9Ee+Ep+Ql/J9fRsTVaeThp8MhiCCrY0Jg==";
+        url = "https://registry.npmjs.org/big-integer/-/big-integer-1.6.44.tgz";
+        sha512 = "7MzElZPTyJ2fNvBkPxtFQ2fWIkVmuzw41+BZHSzpEq3ymB2MfeKp1+yXl/tS75xCx+WnyV+yb0kp+K1C3UNwmQ==";
       };
     };
     "big.js-5.2.2" = {
@@ -6167,15 +6284,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz";
         sha512 = "p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==";
-      };
-    };
-    "binwrap-0.2.1" = {
-      name = "binwrap";
-      packageName = "binwrap";
-      version = "0.2.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/binwrap/-/binwrap-0.2.1.tgz";
-        sha512 = "kILc2+zMfFEv66/NLfO2GIpmWRPE8hL68fv+o5A94OlN9AIIG4zernpgn9bpPAImb5t4QwFxnqAGSyP1+tGKrA==";
       };
     };
     "bitfield-0.1.0" = {
@@ -6817,22 +6925,13 @@ let
         sha512 = "Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==";
       };
     };
-    "browserslist-4.6.1" = {
+    "browserslist-4.6.3" = {
       name = "browserslist";
       packageName = "browserslist";
-      version = "4.6.1";
+      version = "4.6.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/browserslist/-/browserslist-4.6.1.tgz";
-        sha512 = "1MC18ooMPRG2UuVFJTHFIAkk6mpByJfxCrnUyvSlu/hyQSFHMrlhM02SzNuCV+quTP4CKmqtOMAIjrifrpBJXQ==";
-      };
-    };
-    "bser-2.0.0" = {
-      name = "bser";
-      packageName = "bser";
-      version = "2.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz";
-        sha1 = "9ac78d3ed5d915804fd87acb158bc797147a1719";
+        url = "https://registry.npmjs.org/browserslist/-/browserslist-4.6.3.tgz";
+        sha512 = "CNBqTCq22RKM8wKJNowcqihHJ4SkI8CGeK7KOR9tPboXUuS5Zk5lQgzzTbs4oxD8x+6HUshZUa2OyNI9lR93bQ==";
       };
     };
     "btoa-lite-1.0.0" = {
@@ -7249,13 +7348,13 @@ let
         sha1 = "3fb410c7e91558eb1ab22a82834577aa6bd61d42";
       };
     };
-    "cacache-11.3.2" = {
+    "cacache-11.3.3" = {
       name = "cacache";
       packageName = "cacache";
-      version = "11.3.2";
+      version = "11.3.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/cacache/-/cacache-11.3.2.tgz";
-        sha512 = "E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==";
+        url = "https://registry.npmjs.org/cacache/-/cacache-11.3.3.tgz";
+        sha512 = "p8WcneCytvzPxhDvYp31PD039vi77I12W+/KfR9S8AZbaiARFBCpsPJS+9uhWfeBfeAtW7o/4vt3MUqLkbY6nA==";
       };
     };
     "cache-base-1.0.1" = {
@@ -7276,13 +7375,13 @@ let
         sha1 = "0d808801b6342ad33c91df9d0b44dc09b91e5c3d";
       };
     };
-    "cacheable-request-6.0.0" = {
+    "cacheable-request-6.1.0" = {
       name = "cacheable-request";
       packageName = "cacheable-request";
-      version = "6.0.0";
+      version = "6.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.0.0.tgz";
-        sha512 = "2N7AmszH/WPPpl5Z3XMw1HAP+8d+xugnKQAeKvxFZ/04dbT/CAznqwbl+7eSr3HkwdepNwtb2yx3CAMQWvG01Q==";
+        url = "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz";
+        sha512 = "Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==";
       };
     };
     "cached-path-relative-1.0.2" = {
@@ -7465,22 +7564,13 @@ let
         sha512 = "bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==";
       };
     };
-    "caniuse-lite-1.0.30000973" = {
+    "caniuse-lite-1.0.30000978" = {
       name = "caniuse-lite";
       packageName = "caniuse-lite";
-      version = "1.0.30000973";
+      version = "1.0.30000978";
       src = fetchurl {
-        url = "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000973.tgz";
-        sha512 = "/F3t/Yo8LEdRSEPCmI15fLu5vepVh9UCg/9inJXF5AAfW7xRRJkbaM2ut52iRMQMnGCLQouLbFdbOA+VEFOIsg==";
-      };
-    };
-    "capture-exit-2.0.0" = {
-      name = "capture-exit";
-      packageName = "capture-exit";
-      version = "2.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz";
-        sha512 = "PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==";
+        url = "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000978.tgz";
+        sha512 = "H6gK6kxUzG6oAwg/Jal279z8pHw0BzrpZfwo/CA9FFm/vA0l8IhDfkZtepyJNE2Y4V6Dp3P3ubz6czby1/Mgsw==";
       };
     };
     "capture-stack-trace-1.0.1" = {
@@ -7618,15 +7708,6 @@ let
         sha1 = "a8115c55e4a702fe4d150abd3872822a7e09fc98";
       };
     };
-    "chalk-2.1.0" = {
-      name = "chalk";
-      packageName = "chalk";
-      version = "2.1.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz";
-        sha512 = "LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==";
-      };
-    };
     "chalk-2.3.1" = {
       name = "chalk";
       packageName = "chalk";
@@ -7726,6 +7807,15 @@ let
         sha1 = "c0a1d2f3a7092e03774bfa83f14c0fc5790a8667";
       };
     };
+    "charset-1.0.1" = {
+      name = "charset";
+      packageName = "charset";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/charset/-/charset-1.0.1.tgz";
+        sha512 = "6dVyOOYjpfFcL1Y4qChrAoQLRHvj2ziyhcm0QJlhOcAhykL/k1kTUPbeo+87MNRTRdk2OIIsIXbuF3x2wi5EXg==";
+      };
+    };
     "charwise-3.0.1" = {
       name = "charwise";
       packageName = "charwise";
@@ -7780,13 +7870,13 @@ let
         sha1 = "a9baa860a3f9b595a6b81b1a86873121ed3a269e";
       };
     };
-    "cheerio-1.0.0-rc.2" = {
+    "cheerio-1.0.0-rc.3" = {
       name = "cheerio";
       packageName = "cheerio";
-      version = "1.0.0-rc.2";
+      version = "1.0.0-rc.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz";
-        sha1 = "4b9f53a81b27e4d5dac31c0ffd0cfa03cc6830db";
+        url = "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz";
+        sha512 = "0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==";
       };
     };
     "cherow-1.6.9" = {
@@ -7832,15 +7922,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz";
         sha1 = "798e689778151c8076b4b360e5edd28cda2bb468";
-      };
-    };
-    "chokidar-2.1.2" = {
-      name = "chokidar";
-      packageName = "chokidar";
-      version = "2.1.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/chokidar/-/chokidar-2.1.2.tgz";
-        sha512 = "IwXUx0FXc5ibYmPC2XeEj5mpXoV66sR+t3jqu2NS2GYwCktt3KF1/Qqjws/NkegajBA4RbZ5+DDwlOiJsxDHEg==";
       };
     };
     "chokidar-2.1.6" = {
@@ -7933,13 +8014,13 @@ let
         sha1 = "04a106672c18b085ab774d983dfa3ea138f22205";
       };
     };
-    "chunk-store-stream-3.0.1" = {
+    "chunk-store-stream-4.0.0" = {
       name = "chunk-store-stream";
       packageName = "chunk-store-stream";
-      version = "3.0.1";
+      version = "4.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/chunk-store-stream/-/chunk-store-stream-3.0.1.tgz";
-        sha512 = "GA1NIFDZKElhkjiO6QOyzfK1QbUt6M3gFhUU/aR05JYaDqXbU5d7U92cLvGKdItJEDfojky6NQefy5VL5PpDBA==";
+        url = "https://registry.npmjs.org/chunk-store-stream/-/chunk-store-stream-4.0.0.tgz";
+        sha512 = "hmtlqMozj1LbZlEpTBXL3YrBsLz4nJEXVihrSbe6ugfxH/Yae5JvUCXQwpWI7VELjXX0GyZK3ajQDBX/r30zBw==";
       };
     };
     "ci-info-1.6.0" = {
@@ -8122,13 +8203,13 @@ let
         sha512 = "1QL4544moEsDVH9T/l6Cemov/37iv1RtoKf7NJ04A60+4MREXNfx/QvavbH6QoGdsD4N4Mwy49cmaINR/o2mdg==";
       };
     };
-    "cli-spinners-2.1.0" = {
+    "cli-spinners-2.2.0" = {
       name = "cli-spinners";
       packageName = "cli-spinners";
-      version = "2.1.0";
+      version = "2.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.1.0.tgz";
-        sha512 = "8B00fJOEh1HPrx4fo5eW16XmE1PcL1tGpGrxy63CXGP9nHdPBN63X75hA1zhvQuhVztJWLqV58Roj2qlNM7cAA==";
+        url = "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.2.0.tgz";
+        sha512 = "tgU3fKwzYjiLEQgPMD9Jt+JjHVL9kW93FiIMX/l7rivvOD4/LL0Mf7gda3+4U2KJBloybwgj5KEoQgGRioMiKQ==";
       };
     };
     "cli-table-0.3.1" = {
@@ -9643,13 +9724,13 @@ let
         sha512 = "hTNYHUJT5YyMa1cQQE1naGyU6Eh5D5Jl33sMnCh3+q15ZwWTL/TOy3k8+mUvjTp8bwhO5eECGKULYoVO+fp9ZA==";
       };
     };
-    "cordova-common-3.1.0" = {
+    "cordova-common-3.2.0" = {
       name = "cordova-common";
       packageName = "cordova-common";
-      version = "3.1.0";
+      version = "3.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/cordova-common/-/cordova-common-3.1.0.tgz";
-        sha512 = "J2MM1ioyLlBYdwdXH40OZL4hN7XEBOfurddKYifF4aTkb2PkbeM+KVORt53eyU+8ScA0QmRLuTG0EM55eLms0A==";
+        url = "https://registry.npmjs.org/cordova-common/-/cordova-common-3.2.0.tgz";
+        sha512 = "EvlQ6PirfR65hGDoQvsluW00uSS2MTVIRKQ3c1Xvsddx7D5T5JgF3fHWkGik/Y/8yNcpI0zI2NcJyie2z/ak2A==";
       };
     };
     "cordova-create-2.0.0" = {
@@ -9706,31 +9787,31 @@ let
         sha512 = "HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==";
       };
     };
-    "core-js-3.1.3" = {
+    "core-js-3.1.4" = {
       name = "core-js";
       packageName = "core-js";
-      version = "3.1.3";
+      version = "3.1.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/core-js/-/core-js-3.1.3.tgz";
-        sha512 = "PWZ+ZfuaKf178BIAg+CRsljwjIMRV8MY00CbZczkR6Zk5LfkSkjGoaab3+bqRQWVITNZxQB7TFYz+CFcyuamvA==";
+        url = "https://registry.npmjs.org/core-js/-/core-js-3.1.4.tgz";
+        sha512 = "YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ==";
       };
     };
-    "core-js-compat-3.1.3" = {
+    "core-js-compat-3.1.4" = {
       name = "core-js-compat";
       packageName = "core-js-compat";
-      version = "3.1.3";
+      version = "3.1.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.1.3.tgz";
-        sha512 = "EP018pVhgwsKHz3YoN1hTq49aRe+h017Kjz0NQz3nXV0cCRMvH3fLQl+vEPGr4r4J5sk4sU3tUC7U1aqTCeJeA==";
+        url = "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.1.4.tgz";
+        sha512 = "Z5zbO9f1d0YrJdoaQhphVAnKPimX92D6z8lCGphH89MNRxlL1prI9ExJPqVwP0/kgkQCv8c4GJGT8X16yUncOg==";
       };
     };
-    "core-js-pure-3.1.3" = {
+    "core-js-pure-3.1.4" = {
       name = "core-js-pure";
       packageName = "core-js-pure";
-      version = "3.1.3";
+      version = "3.1.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.1.3.tgz";
-        sha512 = "k3JWTrcQBKqjkjI0bkfXS0lbpWPxYuHWfMMjC1VDmzU4Q58IwSbuXSo99YO/hUHlw/EB4AlfA2PVxOGkrIq6dA==";
+        url = "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.1.4.tgz";
+        sha512 = "uJ4Z7iPNwiu1foygbcZYJsJs1jiXrTTCvxfLDXNhI/I+NHbSIEyr548y4fcsCEyWY0XgfAG/qqaunJ1SThHenA==";
       };
     };
     "core-util-is-1.0.2" = {
@@ -9823,13 +9904,13 @@ let
         sha512 = "fmvV4caBnofhPe8kOcitBwSn2f39QLjnAnGq3gO9dfd75mUytzKNZB1hde6QHunW2Rt+OwuBOMc3i1tNElbszA==";
       };
     };
-    "cpy-7.2.0" = {
+    "cpy-7.3.0" = {
       name = "cpy";
       packageName = "cpy";
-      version = "7.2.0";
+      version = "7.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/cpy/-/cpy-7.2.0.tgz";
-        sha512 = "CUYi9WYd7vdtEcq1NKqiS/yY2WdaDCNOBA/AoTQHVJzlpJMqctB8py9JrHgGIft6TgO5m8ZidI4l1ZD+RMr/wA==";
+        url = "https://registry.npmjs.org/cpy/-/cpy-7.3.0.tgz";
+        sha512 = "auvDu6h/J+cO1uqV40ymL/VoPM0+qPpNGaNttTzkYVXO/+GeynuyAK/MwFcWgU/P82ezcZw7RaN34CIIWajKLA==";
       };
     };
     "crc-0.2.0" = {
@@ -9857,15 +9938,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/crc/-/crc-3.3.0.tgz";
         sha1 = "fa622e1bc388bf257309082d6b65200ce67090ba";
-      };
-    };
-    "crc-3.4.4" = {
-      name = "crc";
-      packageName = "crc";
-      version = "3.4.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/crc/-/crc-3.4.4.tgz";
-        sha1 = "9da1e980e3bd44fc5c93bf5ab3da3378d85e466b";
       };
     };
     "crc-3.8.0" = {
@@ -9922,13 +9994,13 @@ let
         sha512 = "MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==";
       };
     };
-    "create-torrent-3.33.0" = {
+    "create-torrent-4.0.0" = {
       name = "create-torrent";
       packageName = "create-torrent";
-      version = "3.33.0";
+      version = "4.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/create-torrent/-/create-torrent-3.33.0.tgz";
-        sha512 = "KMd0KuvwVUg1grlRd5skG9ZkSbBYDDkAjDUMLnvxdRn0rL7ph3IwoOk7I8u1yLX4HYjGiLVlWYO55YWNNPjJFA==";
+        url = "https://registry.npmjs.org/create-torrent/-/create-torrent-4.0.0.tgz";
+        sha512 = "16JQRuPJWAntC4p+k6EFMxKatqzQOKv037aAun6Comomizlg9fOoBiIhxC/QCQfJFmGIfnT6HMOEa6da5xUmsg==";
       };
     };
     "creato-1.0.5" = {
@@ -9940,13 +10012,13 @@ let
         sha512 = "bneB5jF+I0XNe4d3E6PYszPRb+5S8B3UQ3hDlY6ZSkfEU34RKqCfbUodxwwJn8DhmPYiuefEqEGxvstXEwXuUA==";
       };
     };
-    "cron-1.7.0" = {
+    "cron-1.7.1" = {
       name = "cron";
       packageName = "cron";
-      version = "1.7.0";
+      version = "1.7.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/cron/-/cron-1.7.0.tgz";
-        sha512 = "I7S7ES2KZtKPfBTGJ5Brc6X23apE71fgYU/PC5ayh8R6VhECpqvTLe/LTkwAEN3ERFzNKXlWzh/PkwsGg3vkDQ==";
+        url = "https://registry.npmjs.org/cron/-/cron-1.7.1.tgz";
+        sha512 = "gmMB/pJcqUVs/NklR1sCGlNYM7TizEw+1gebz20BMc/8bTm/r7QUp3ZPSPlG8Z5XRlvb7qhjEjq/+bdIfUCL2A==";
       };
     };
     "cross-env-5.2.0" = {
@@ -9965,15 +10037,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/cross-fetch/-/cross-fetch-2.2.2.tgz";
         sha1 = "a47ff4f7fc712daba8f6a695a11c948440d45723";
-      };
-    };
-    "cross-spawn-4.0.0" = {
-      name = "cross-spawn";
-      packageName = "cross-spawn";
-      version = "4.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.0.tgz";
-        sha1 = "8254774ab4786b8c5b3cf4dfba66ce563932c252";
       };
     };
     "cross-spawn-5.0.1" = {
@@ -10163,15 +10226,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz";
         sha512 = "jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==";
-      };
-    };
-    "css-selector-parser-1.3.0" = {
-      name = "css-selector-parser";
-      packageName = "css-selector-parser";
-      version = "1.3.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-1.3.0.tgz";
-        sha1 = "5f1ad43e2d8eefbfdc304fcd39a521664943e3eb";
       };
     };
     "css-selector-tokenizer-0.7.1" = {
@@ -10444,13 +10498,13 @@ let
         sha1 = "988df33feab191ef799a61369dd76c17adf957ea";
       };
     };
-    "cuss-1.15.0" = {
+    "cuss-1.16.0" = {
       name = "cuss";
       packageName = "cuss";
-      version = "1.15.0";
+      version = "1.16.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/cuss/-/cuss-1.15.0.tgz";
-        sha512 = "Pll6Kqz5G4t+3tpnTtmUqJASVDm468TgVHPwhMJzVmyf7xz7g73lShPHCIurzjU0v+ASbcVv22q/auDlTHqqoA==";
+        url = "https://registry.npmjs.org/cuss/-/cuss-1.16.0.tgz";
+        sha512 = "VtYrZxNqRWLd/z3a57ezUv9WLR0l0n0qmYA5O9QBepliUWlEvRgBUnfZO6bZK29KocssaZ6ks7EistDLYPFWhA==";
       };
     };
     "custom-error-instance-2.1.1" = {
@@ -10516,13 +10570,13 @@ let
         sha1 = "1b33792e11e914a2fd6d6ed6447464444e5fa640";
       };
     };
-    "d-1.0.0" = {
+    "d-1.0.1" = {
       name = "d";
       packageName = "d";
-      version = "1.0.0";
+      version = "1.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/d/-/d-1.0.0.tgz";
-        sha1 = "754bb5bfe55451da69a58b94d45f4c5b0462d58f";
+        url = "https://registry.npmjs.org/d/-/d-1.0.1.tgz";
+        sha512 = "m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==";
       };
     };
     "dag-map-1.0.2" = {
@@ -10759,13 +10813,13 @@ let
         sha1 = "01aa9c401edd92750514470b8266390c66c67318";
       };
     };
-    "debounce-1.1.0" = {
+    "debounce-1.2.0" = {
       name = "debounce";
       packageName = "debounce";
-      version = "1.1.0";
+      version = "1.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/debounce/-/debounce-1.1.0.tgz";
-        sha512 = "ZQVKfRVlwRfD150ndzEK8M90ABT+Y/JQKs4Y7U4MXdpuoUkkrr4DwKbVux3YjylA5bUMUj0Nc3pMxPJX6N2QQQ==";
+        url = "https://registry.npmjs.org/debounce/-/debounce-1.2.0.tgz";
+        sha512 = "mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg==";
       };
     };
     "debounced-seeker-1.0.0" = {
@@ -10912,13 +10966,13 @@ let
         sha1 = "f6534d15148269b20352e7bee26f501f9a191290";
       };
     };
-    "decamelize-2.0.0" = {
+    "decamelize-3.2.0" = {
       name = "decamelize";
       packageName = "decamelize";
-      version = "2.0.0";
+      version = "3.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz";
-        sha512 = "Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==";
+        url = "https://registry.npmjs.org/decamelize/-/decamelize-3.2.0.tgz";
+        sha512 = "4TgkVUsmmu7oCSyGBm5FvfMoACuoh9EOidm7V5/J2X2djAwwt57qb3F2KMP2ITqODTCSwb+YRV+0Zqrv18k/hw==";
       };
     };
     "decamelize-keys-1.1.0" = {
@@ -11119,15 +11173,6 @@ let
         sha512 = "R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==";
       };
     };
-    "deepmerge-3.1.0" = {
-      name = "deepmerge";
-      packageName = "deepmerge";
-      version = "3.1.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/deepmerge/-/deepmerge-3.1.0.tgz";
-        sha512 = "/TnecbwXEdycfbsM2++O3eGiatEFHjjNciHEwJclM+T5Kd94qD1AP+2elP/Mq0L5b9VZJao5znR01Mz6eX8Seg==";
-      };
-    };
     "deepmerge-3.2.0" = {
       name = "deepmerge";
       packageName = "deepmerge";
@@ -11135,6 +11180,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/deepmerge/-/deepmerge-3.2.0.tgz";
         sha512 = "6+LuZGU7QCNUnAJyX8cIrlzoEgggTM6B7mm+znKOX4t5ltluT9KLjN6g61ECMS0LTsLW7yDpNoxhix5FZcrIow==";
+      };
+    };
+    "deepmerge-3.3.0" = {
+      name = "deepmerge";
+      packageName = "deepmerge";
+      version = "3.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/deepmerge/-/deepmerge-3.3.0.tgz";
+        sha512 = "GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA==";
       };
     };
     "default-browser-id-1.0.4" = {
@@ -11218,13 +11272,13 @@ let
         sha512 = "5fMC8ek8alH16QiV0lTCis610D1Zt1+LA4MS4d63JgS32lrCjTFDUFz2ao09/j2I4Bqb5jL4FZYwu7Jz0XO1ww==";
       };
     };
-    "deferred-leveldown-5.0.1" = {
+    "deferred-leveldown-5.1.0" = {
       name = "deferred-leveldown";
       packageName = "deferred-leveldown";
-      version = "5.0.1";
+      version = "5.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-5.0.1.tgz";
-        sha512 = "BXohsvTedWOLkj2n/TY+yqVlrCWa2Zs8LSxh3uCAgFOru7/pjxKyZAexGa1j83BaKloER4PqUyQ9rGPJLt9bqA==";
+        url = "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-5.1.0.tgz";
+        sha512 = "PvDY+BT2ONu2XVRgxHb77hYelLtMYxKSGuWuJJdVRXh9ntqx9GYTFJno/SKAz5xcd+yjQwyQeIZrUPjPvA52mg==";
       };
     };
     "define-properties-1.1.3" = {
@@ -11389,13 +11443,13 @@ let
         sha1 = "00966317b7a12fe92f3cc831f7583af329b86c37";
       };
     };
-    "deprecation-2.0.0" = {
+    "deprecation-2.3.1" = {
       name = "deprecation";
       packageName = "deprecation";
-      version = "2.0.0";
+      version = "2.3.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/deprecation/-/deprecation-2.0.0.tgz";
-        sha512 = "lbQN037mB3VfA2JFuguM5GCJ+zPinMeCrFe+AfSZ6eqrnJA/Fs+EYMnd6Nb2mn9lf2jO9xwEd9o9lic+D4vkcw==";
+        url = "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz";
+        sha512 = "xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==";
       };
     };
     "deps-sort-2.0.0" = {
@@ -11731,13 +11785,13 @@ let
         sha1 = "57ddacb47324ae5f58d2cc0da886db4ce9eeb718";
       };
     };
-    "dispensary-0.30.0" = {
+    "dispensary-0.37.0" = {
       name = "dispensary";
       packageName = "dispensary";
-      version = "0.30.0";
+      version = "0.37.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/dispensary/-/dispensary-0.30.0.tgz";
-        sha512 = "ZZipc2xaDky03RD3s1UJOM6zgygo2ncEzmjuqpPR6pT7jMo0cxH/FTzGarD3Pw2naAsBOXVGG10Fwxth9OrW0g==";
+        url = "https://registry.npmjs.org/dispensary/-/dispensary-0.37.0.tgz";
+        sha512 = "Baqbt8MDkRYQZHB7XEd8iBUP8wRkRLjNWbm16nSDTOIoGvgF4Z8Q9wV1yD72TYjFC0kj1/o3nfPXPiAvWqjC8g==";
       };
     };
     "diveSync-0.3.0" = {
@@ -12271,6 +12325,15 @@ let
         sha512 = "fLf9l1hnwrHI2xn9mEDT7KIi22UDqA2jaCwyCbSUJh9a1V+LEUSL/JO/6TIz/QyuBURWUHrFL5Kg2TtO1bkkog==";
       };
     };
+    "ecstatic-4.1.2" = {
+      name = "ecstatic";
+      packageName = "ecstatic";
+      version = "4.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ecstatic/-/ecstatic-4.1.2.tgz";
+        sha512 = "lnrAOpU2f7Ra8dm1pW0D1ucyUxQIEk8RjFrvROg1YqCV0ueVu9hzgiSEbSyROqXDDiHREdqC4w3AwOTb23P4UQ==";
+      };
+    };
     "ed2curve-0.1.4" = {
       name = "ed2curve";
       packageName = "ed2curve";
@@ -12334,22 +12397,22 @@ let
         sha1 = "590c61156b0ae2f4f0255732a158b266bc56b21d";
       };
     };
-    "ejs-2.6.1" = {
+    "ejs-2.6.2" = {
       name = "ejs";
       packageName = "ejs";
-      version = "2.6.1";
+      version = "2.6.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz";
-        sha512 = "0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ==";
+        url = "https://registry.npmjs.org/ejs/-/ejs-2.6.2.tgz";
+        sha512 = "PcW2a0tyTuPHz3tWyYqtK6r1fZ3gp+3Sop8Ph+ZYN81Ob5rwmbHEzaqs10N3BEsaGTkh/ooniXK+WwszGlc2+Q==";
       };
     };
-    "electron-to-chromium-1.3.147" = {
+    "electron-to-chromium-1.3.176" = {
       name = "electron-to-chromium";
       packageName = "electron-to-chromium";
-      version = "1.3.147";
+      version = "1.3.176";
       src = fetchurl {
-        url = "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.147.tgz";
-        sha512 = "pHE+9S2OMXOLAze6KvKMA9Te56M5e4WIdPPPeZ2JiSNvpXkDrn9FoBot1yeeXMRClWvQGI6vj06kQFqCADrspQ==";
+        url = "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.176.tgz";
+        sha512 = "hsQ/BH6x2iCvJ7WOIbNTAlsT39vsVGIVoJJ9i6ZkGXUE2LdzWsNv0xJI2uZ5/Hkqv1oTTLxAYjbtGKVJzqYbjA==";
       };
     };
     "elegant-spinner-1.0.1" = {
@@ -12379,13 +12442,13 @@ let
         sha1 = "9ac91be6e52fb6e6244c4e54a4ac3ed8ae8e29c0";
       };
     };
-    "elliptic-6.4.1" = {
+    "elliptic-6.5.0" = {
       name = "elliptic";
       packageName = "elliptic";
-      version = "6.4.1";
+      version = "6.5.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz";
-        sha512 = "BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==";
+        url = "https://registry.npmjs.org/elliptic/-/elliptic-6.5.0.tgz";
+        sha512 = "eFOJTMyCYb7xtE/caJ6JJu+bhi67WCYNbkGSknu20pmM8Ke/bqOfdnZWxyoGN26JgfxTbXrsCkEw4KheCT/KGg==";
       };
     };
     "elm-serve-0.4.0" = {
@@ -12395,15 +12458,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/elm-serve/-/elm-serve-0.4.0.tgz";
         sha512 = "NYXzzaJT/zw8v7jzDWGXuvX3/soj+5NTLHxX0n/T6DICbmyDj8kO7rlI2wSKs9UTNjXhZ7quFQEKcgcf/SZksw==";
-      };
-    };
-    "elmi-to-json-0.19.1" = {
-      name = "elmi-to-json";
-      packageName = "elmi-to-json";
-      version = "0.19.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/elmi-to-json/-/elmi-to-json-0.19.1.tgz";
-        sha512 = "O0Z3YsYU9OTb1hTDGORWxi69QjQFEIPfZVq/oc1D5lhL3swduHKY8vdKGuo+WlKVdTas99oNIsgL7yojWdYcsQ==";
       };
     };
     "email-validator-2.0.4" = {
@@ -12542,13 +12596,13 @@ let
         sha512 = "8CIZLDcSKxgzT+zX8ZVfgNbu8Md2wq/iqa1Y7zyVR18QBEAc0Nmzuvj/N5ykSKpfGzjM8qxbaFntLPwnVoUhZw==";
       };
     };
-    "encoding-down-6.0.2" = {
+    "encoding-down-6.1.0" = {
       name = "encoding-down";
       packageName = "encoding-down";
-      version = "6.0.2";
+      version = "6.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/encoding-down/-/encoding-down-6.0.2.tgz";
-        sha512 = "oAEANslmNb64AF4kvHXjTxB7KecwD7X0qf8MffMfhpjP6gjGcnCTOkRgps/1yUNeR4Bhe6ckN6aAzZz+RIYgTw==";
+        url = "https://registry.npmjs.org/encoding-down/-/encoding-down-6.1.0.tgz";
+        sha512 = "pBW1mbuQDHQhQLBtqarX8x2oLynahiOzBY5L/BosNqcstJ8MjpSc3rx1yCUIqb6bUE2vsp3t0BaXS0ZDP1s5pg==";
       };
     };
     "end-of-stream-0.1.5" = {
@@ -12794,13 +12848,13 @@ let
         sha512 = "GvXiDTqLYrORVSCuJCsWHPXF5BFvoWMQA9xX4YVjPT1jyS3aZEHUBwjzxU/6LTPF9ReHgVEbX7IEN5UvSXHw/A==";
       };
     };
-    "epidemic-broadcast-trees-6.3.5" = {
+    "epidemic-broadcast-trees-7.0.0" = {
       name = "epidemic-broadcast-trees";
       packageName = "epidemic-broadcast-trees";
-      version = "6.3.5";
+      version = "7.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/epidemic-broadcast-trees/-/epidemic-broadcast-trees-6.3.5.tgz";
-        sha512 = "FYCOslXU7OBkz8A9FXsykcpgby3WKcRdLTCr1LivLLSU2nzaO/x86jBGNFEZkezZPx9/Z5fDVX8SGQyXLz8WZQ==";
+        url = "https://registry.npmjs.org/epidemic-broadcast-trees/-/epidemic-broadcast-trees-7.0.0.tgz";
+        sha512 = "nm1o1ncxcJvXtLJVoPl4AJFX7Bh0BhPsTC9XhCRWwdRJXp1Ud1DcGpi/6c3sUA/URmyoIc1WONNdub+/AE5vTQ==";
       };
     };
     "err-code-1.1.2" = {
@@ -12965,13 +13019,13 @@ let
         sha1 = "a08cdde84ccdbf34d027a1451bc91d4bcd28a613";
       };
     };
-    "es6-promise-4.2.6" = {
+    "es6-promise-4.2.8" = {
       name = "es6-promise";
       packageName = "es6-promise";
-      version = "4.2.6";
+      version = "4.2.8";
       src = fetchurl {
-        url = "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz";
-        sha512 = "aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q==";
+        url = "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz";
+        sha512 = "HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==";
       };
     };
     "es6-promise-pool-2.5.0" = {
@@ -13019,13 +13073,13 @@ let
         sha1 = "bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77";
       };
     };
-    "es6-weak-map-2.0.2" = {
+    "es6-weak-map-2.0.3" = {
       name = "es6-weak-map";
       packageName = "es6-weak-map";
-      version = "2.0.2";
+      version = "2.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz";
-        sha1 = "5e3ab32251ffd1538a1f8e5ffa1357772f92d96f";
+        url = "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz";
+        sha512 = "p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==";
       };
     };
     "esc-exit-2.0.2" = {
@@ -13145,15 +13199,6 @@ let
         sha512 = "bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==";
       };
     };
-    "eslint-5.13.0" = {
-      name = "eslint";
-      packageName = "eslint";
-      version = "5.13.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/eslint/-/eslint-5.13.0.tgz";
-        sha512 = "nqD5WQMisciZC5EHZowejLKQjWGuFS5c70fxqSKlnDME+oz9zmE8KTlX+lHSg+/5wsC/kf9Q9eMkC8qS3oM2fg==";
-      };
-    };
     "eslint-5.16.0" = {
       name = "eslint";
       packageName = "eslint";
@@ -13161,6 +13206,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/eslint/-/eslint-5.16.0.tgz";
         sha512 = "S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==";
+      };
+    };
+    "eslint-6.0.1" = {
+      name = "eslint";
+      packageName = "eslint";
+      version = "6.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/eslint/-/eslint-6.0.1.tgz";
+        sha512 = "DyQRaMmORQ+JsWShYsSg4OPTjY56u1nCjAmICrE8vLWqyLKxhFXOthwMj1SA8xwfrv0CofLNVnqbfyhwCkaO0w==";
       };
     };
     "eslint-plugin-no-unsafe-innerhtml-1.0.16" = {
@@ -13172,13 +13226,13 @@ let
         sha1 = "7d02878c8e9bf7916b88836d5ac122b42f151932";
       };
     };
-    "eslint-plugin-vue-5.2.2" = {
+    "eslint-plugin-vue-5.2.3" = {
       name = "eslint-plugin-vue";
       packageName = "eslint-plugin-vue";
-      version = "5.2.2";
+      version = "5.2.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-5.2.2.tgz";
-        sha512 = "CtGWH7IB0DA6BZOwcV9w9q3Ri6Yuo8qMjx05SmOGJ6X6E0Yo3y9E/gQ5tuNxg2dEt30tRnBoFTbvtmW9iEoyHA==";
+        url = "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-5.2.3.tgz";
+        sha512 = "mGwMqbbJf0+VvpGR5Lllq0PMxvTdrZ/ZPjmhkacrCHbubJeJOt+T6E3HUzAifa2Mxi7RSdJfC9HFpOeSYVMMIw==";
       };
     };
     "eslint-scope-3.7.1" = {
@@ -13253,15 +13307,6 @@ let
         sha512 = "I5BycZW6FCVIub93TeVY1s7vjhP9CY6cXCznIRfiig7nRviKZYdRnj/sHEWC6A7WE9RDWOFq9+7OsWSYz8qv2w==";
       };
     };
-    "espree-5.0.0" = {
-      name = "espree";
-      packageName = "espree";
-      version = "5.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/espree/-/espree-5.0.0.tgz";
-        sha512 = "1MpUfwsdS9MMoN7ZXqAr9e9UKdVHDcvrJpyx7mm1WuQlx/ygErEQBzgi5Nh5qBHIoYweprhtMkTCb9GhcAIcsA==";
-      };
-    };
     "espree-5.0.1" = {
       name = "espree";
       packageName = "espree";
@@ -13269,6 +13314,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz";
         sha512 = "qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==";
+      };
+    };
+    "espree-6.0.0" = {
+      name = "espree";
+      packageName = "espree";
+      version = "6.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/espree/-/espree-6.0.0.tgz";
+        sha512 = "lJvCS6YbCn3ImT3yKkPe0+tJ+mH6ljhGNjHQH9mRtiO6gjhVAOhVXW1yjnwqGwTkK3bGbye+hb00nFNmu0l/1Q==";
       };
     };
     "esprima-3.1.3" = {
@@ -13559,15 +13613,6 @@ let
         sha512 = "FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==";
       };
     };
-    "exec-sh-0.3.2" = {
-      name = "exec-sh";
-      packageName = "exec-sh";
-      version = "0.3.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.2.tgz";
-        sha512 = "9sLAvzhI5nc8TpuQUh4ahMdCrWT00wPWz7j47/emR5+2qEfoZP5zzUXvx+vdx+H6ohhnsYC31iX04QLYJK8zTg==";
-      };
-    };
     "execa-0.1.1" = {
       name = "execa";
       packageName = "execa";
@@ -13820,15 +13865,6 @@ let
         sha1 = "5cc98f3f5ff84ed835f91cbf0aabd0c7107400af";
       };
     };
-    "express-session-1.15.6" = {
-      name = "express-session";
-      packageName = "express-session";
-      version = "1.15.6";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/express-session/-/express-session-1.15.6.tgz";
-        sha512 = "r0nrHTCYtAMrFwZ0kBzZEXa1vtPVrw0dKvGSrKP4dahwBQ1BJpF2/y1Pp4sCD/0kvxV4zZeclyvfmw0B4RMJQA==";
-      };
-    };
     "express-session-1.16.1" = {
       name = "express-session";
       packageName = "express-session";
@@ -13838,6 +13874,15 @@ let
         sha512 = "pWvUL8Tl5jUy1MLH7DhgUlpoKeVPUTe+y6WQD9YhcN0C5qAhsh4a8feVjiUXo3TFhIy191YGZ4tewW9edbl2xQ==";
       };
     };
+    "express-session-1.16.2" = {
+      name = "express-session";
+      packageName = "express-session";
+      version = "1.16.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/express-session/-/express-session-1.16.2.tgz";
+        sha512 = "oy0sRsdw6n93E9wpCNWKRnSsxYnSDX9Dnr9mhZgqUEEorzcq5nshGYSZ4ZReHFhKQ80WI5iVUUSPW7u3GaKauw==";
+      };
+    };
     "express-urlrewrite-1.2.0" = {
       name = "express-urlrewrite";
       packageName = "express-urlrewrite";
@@ -13845,15 +13890,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/express-urlrewrite/-/express-urlrewrite-1.2.0.tgz";
         sha1 = "8e667b7761ff1c7ffdb0efa05d64035387c823eb";
-      };
-    };
-    "express-ws-4.0.0" = {
-      name = "express-ws";
-      packageName = "express-ws";
-      version = "4.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/express-ws/-/express-ws-4.0.0.tgz";
-        sha512 = "KEyUw8AwRET2iFjFsI1EJQrJ/fHeGiJtgpYgEWG3yDv4l/To/m3a2GaYfeGyB3lsWdvbesjF5XCMx+SVBgAAYw==";
       };
     };
     "ext-list-2.2.2" = {
@@ -14234,22 +14270,13 @@ let
         sha512 = "sfFuP4X0hzrbGKjAUNXYvNqsZ5F6ohx/dZ9I0KQud/aiZNwg263r5L9yGB0clvXHCkzXh5W3t7RSHchggYIFmA==";
       };
     };
-    "faye-websocket-0.11.1" = {
+    "faye-websocket-0.11.3" = {
       name = "faye-websocket";
       packageName = "faye-websocket";
-      version = "0.11.1";
+      version = "0.11.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz";
-        sha1 = "f0efe18c4f56e4f40afc7e06c719fd5ee6188f38";
-      };
-    };
-    "fb-watchman-2.0.0" = {
-      name = "fb-watchman";
-      packageName = "fb-watchman";
-      version = "2.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz";
-        sha1 = "54e9abf7dfa2f26cd9b1636c588c1afc05de5d58";
+        url = "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz";
+        sha512 = "D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==";
       };
     };
     "fd-lock-1.0.2" = {
@@ -14567,15 +14594,6 @@ let
         sha512 = "Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==";
       };
     };
-    "find-elm-dependencies-2.0.1" = {
-      name = "find-elm-dependencies";
-      packageName = "find-elm-dependencies";
-      version = "2.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/find-elm-dependencies/-/find-elm-dependencies-2.0.1.tgz";
-        sha512 = "KBxPjc7J1CLw90jVateMKvMYMROZRTR7/QT2I3MxT+7I6KuUQUMNUFuS/eQXQnMnyElGKQ1iyPbe7GnEuYnFXw==";
-      };
-    };
     "find-index-0.1.1" = {
       name = "find-index";
       packageName = "find-index";
@@ -14583,15 +14601,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz";
         sha1 = "675d358b2ca3892d795a1ab47232f8b6e2e0dde4";
-      };
-    };
-    "find-parent-dir-0.3.0" = {
-      name = "find-parent-dir";
-      packageName = "find-parent-dir";
-      version = "0.3.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz";
-        sha1 = "33c44b429ab2b2f0646299c5f9f718f376ff8d54";
       };
     };
     "find-up-1.1.2" = {
@@ -14711,22 +14720,13 @@ let
         sha1 = "1bdecdb8e083c0664b91945581577a43a9f31d70";
       };
     };
-    "firstline-1.2.0" = {
-      name = "firstline";
-      packageName = "firstline";
-      version = "1.2.0";
+    "first-chunk-stream-3.0.0" = {
+      name = "first-chunk-stream";
+      packageName = "first-chunk-stream";
+      version = "3.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/firstline/-/firstline-1.2.0.tgz";
-        sha1 = "c9f4886e7f7fbf0afc12d71941dce06b192aea05";
-      };
-    };
-    "firstline-1.2.1" = {
-      name = "firstline";
-      packageName = "firstline";
-      version = "1.2.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/firstline/-/firstline-1.2.1.tgz";
-        sha1 = "b88673c42009f8821fac2926e99720acee924fae";
+        url = "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-3.0.0.tgz";
+        sha512 = "LNRvR4hr/S8cXXkIY5pTgVP7L3tq6LlYWcg9nWBuW7o1NMxKZo6oOVa/6GIekMGI0Iw7uC+HWimMe9u/VAeKqw==";
       };
     };
     "fkill-5.3.0" = {
@@ -14819,13 +14819,13 @@ let
         sha512 = "4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw==";
       };
     };
-    "flatted-2.0.0" = {
+    "flatted-2.0.1" = {
       name = "flatted";
       packageName = "flatted";
-      version = "2.0.0";
+      version = "2.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz";
-        sha512 = "R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==";
+        url = "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz";
+        sha512 = "a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==";
       };
     };
     "flatten-0.0.1" = {
@@ -14855,13 +14855,13 @@ let
         sha512 = "ougBA2q6Rn9sZrjZQ9r5pTFxCotlGouySpD2yRIuq5AYwwfIT8HHhVMeSwrN5qJayjHINLJyrnsSkkPCZyfMrQ==";
       };
     };
-    "flow-parser-0.100.0" = {
+    "flow-parser-0.102.0" = {
       name = "flow-parser";
       packageName = "flow-parser";
-      version = "0.100.0";
+      version = "0.102.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/flow-parser/-/flow-parser-0.100.0.tgz";
-        sha512 = "4dpz6vfe0rCizZ8czLxrUhAascJspkKDUqINLiKEKCgua91A8hf4f22augPosu1mq9d1hquI+siM8VfDTw+8CA==";
+        url = "https://registry.npmjs.org/flow-parser/-/flow-parser-0.102.0.tgz";
+        sha512 = "lePuMLr6QXv3AwTCl/pnh55YIzHNHHNPl0FW0wuug+tJKSN2UoWFCriANsYNax0Bm0GivHUGQPPQ/GmGgEXbSA==";
       };
     };
     "fluent-ffmpeg-2.1.2" = {
@@ -14873,13 +14873,13 @@ let
         sha1 = "c952de2240f812ebda0aa8006d7776ee2acf7d74";
       };
     };
-    "fluent-syntax-0.10.0" = {
+    "fluent-syntax-0.13.0" = {
       name = "fluent-syntax";
       packageName = "fluent-syntax";
-      version = "0.10.0";
+      version = "0.13.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/fluent-syntax/-/fluent-syntax-0.10.0.tgz";
-        sha512 = "6qRhwQXDTgJjS9DW3IiXZWzUMUPqNPzqh+bZZyUOr6t8xYwkIe+5JONYZuvfvbOUk65paAno0kd8s8kUD2ptNA==";
+        url = "https://registry.npmjs.org/fluent-syntax/-/fluent-syntax-0.13.0.tgz";
+        sha512 = "0Bk1AsliuYB550zr4JV9AYhsETsD3ELXUQzdXGJfIc1Ni/ukAfBdQInDhVMYJUaT2QxoamNslwkYF7MlOrPUwg==";
       };
     };
     "flumecodec-0.0.0" = {
@@ -15125,6 +15125,15 @@ let
         sha512 = "1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==";
       };
     };
+    "form-data-2.4.0" = {
+      name = "form-data";
+      packageName = "form-data";
+      version = "2.4.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/form-data/-/form-data-2.4.0.tgz";
+        sha512 = "4FinE8RfqYnNim20xDwZZE0V2kOs/AuElIjFUbPuegQSaoZM+vUT5FnwSl10KPugH4voTg1bEQlcbCG9ka75TA==";
+      };
+    };
     "format-0.2.2" = {
       name = "format";
       packageName = "format";
@@ -15323,15 +15332,6 @@ let
         sha1 = "9ae1fdd94897798edab76d0918cf42d0c3184fa9";
       };
     };
-    "fs-extra-0.30.0" = {
-      name = "fs-extra";
-      packageName = "fs-extra";
-      version = "0.30.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz";
-        sha1 = "f233ffcc08d4da7d432daa449776989db1df93f0";
-      };
-    };
     "fs-extra-0.6.4" = {
       name = "fs-extra";
       packageName = "fs-extra";
@@ -15384,6 +15384,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz";
         sha512 = "YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==";
+      };
+    };
+    "fs-extra-8.0.1" = {
+      name = "fs-extra";
+      packageName = "fs-extra";
+      version = "8.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/fs-extra/-/fs-extra-8.0.1.tgz";
+        sha512 = "W+XLrggcDzlle47X/XnS7FXrXu9sDo+Ze9zpndeBxdgv88FHLm1HtmkhEwavruS6koanBjp098rUpHs65EmG7A==";
+      };
+    };
+    "fs-extra-8.1.0" = {
+      name = "fs-extra";
+      packageName = "fs-extra";
+      version = "8.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz";
+        sha512 = "yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==";
       };
     };
     "fs-minipass-1.2.6" = {
@@ -15440,15 +15458,6 @@ let
         sha1 = "1504ad2523158caa40db4a2787cb01411994ea4f";
       };
     };
-    "fsevents-1.2.4" = {
-      name = "fsevents";
-      packageName = "fsevents";
-      version = "1.2.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz";
-        sha512 = "z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==";
-      };
-    };
     "fsevents-1.2.9" = {
       name = "fsevents";
       packageName = "fsevents";
@@ -15456,15 +15465,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz";
         sha512 = "oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==";
-      };
-    };
-    "fsevents-2.0.1" = {
-      name = "fsevents";
-      packageName = "fsevents";
-      version = "2.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/fsevents/-/fsevents-2.0.1.tgz";
-        sha512 = "p+CXqK/iLvDESUWdn3NA3JVO9HxdfI+iXx8xR3DqWgKZvQNiEVpAyUQo0lmwz8rqksb4xaGerG291xuwwhX2kA==";
       };
     };
     "fsevents-2.0.7" = {
@@ -15782,6 +15782,15 @@ let
         sha512 = "GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==";
       };
     };
+    "get-stream-5.1.0" = {
+      name = "get-stream";
+      packageName = "get-stream";
+      version = "5.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz";
+        sha512 = "EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==";
+      };
+    };
     "get-uri-2.0.3" = {
       name = "get-uri";
       packageName = "get-uri";
@@ -15899,13 +15908,13 @@ let
         sha1 = "7f51b804924d6c603fc142e3302998d4e0b4d906";
       };
     };
-    "git-rev-sync-1.9.1" = {
+    "git-rev-sync-1.12.0" = {
       name = "git-rev-sync";
       packageName = "git-rev-sync";
-      version = "1.9.1";
+      version = "1.12.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/git-rev-sync/-/git-rev-sync-1.9.1.tgz";
-        sha1 = "a0c2e3dd392abcf6b76962e27fc75fb3223449ce";
+        url = "https://registry.npmjs.org/git-rev-sync/-/git-rev-sync-1.12.0.tgz";
+        sha1 = "4468406c7e6c3ba4cf4587999e1adb28d9d1af55";
       };
     };
     "git-semver-tags-2.0.3" = {
@@ -16041,15 +16050,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz";
         sha1 = "211bafaf49e525b8cd93260d14ab136152b3f57a";
-      };
-    };
-    "glob-7.1.1" = {
-      name = "glob";
-      packageName = "glob";
-      version = "7.1.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz";
-        sha1 = "805211df04faaf1c63a3600306cdf5ade50b2ec8";
       };
     };
     "glob-7.1.2" = {
@@ -16206,6 +16206,15 @@ let
         sha512 = "sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==";
       };
     };
+    "global-modules-2.0.0" = {
+      name = "global-modules";
+      packageName = "global-modules";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz";
+        sha512 = "NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==";
+      };
+    };
     "global-prefix-1.0.2" = {
       name = "global-prefix";
       packageName = "global-prefix";
@@ -16213,6 +16222,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz";
         sha1 = "dbf743c6c14992593c655568cb66ed32c0122ebe";
+      };
+    };
+    "global-prefix-3.0.0" = {
+      name = "global-prefix";
+      packageName = "global-prefix";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz";
+        sha512 = "awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==";
       };
     };
     "global-tunnel-ng-2.7.1" = {
@@ -16395,13 +16413,13 @@ let
         sha1 = "0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658";
       };
     };
-    "graceful-fs-4.1.15" = {
+    "graceful-fs-4.2.0" = {
       name = "graceful-fs";
       packageName = "graceful-fs";
-      version = "4.1.15";
+      version = "4.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz";
-        sha512 = "6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==";
+        url = "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz";
+        sha512 = "jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==";
       };
     };
     "graceful-readlink-1.0.1" = {
@@ -16458,22 +16476,22 @@ let
         sha512 = "QZ5BL8ZO/B20VA8APauGBg3GyEgZ19eduvpLWoq5x7gMmWnHoy8rlQWPLmWgFvo1yNgjSEFMesmS4R6pPr7xog==";
       };
     };
-    "graphql-14.3.1" = {
+    "graphql-14.4.1" = {
       name = "graphql";
       packageName = "graphql";
-      version = "14.3.1";
+      version = "14.4.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/graphql/-/graphql-14.3.1.tgz";
-        sha512 = "FZm7kAa3FqKdXy8YSSpAoTtyDFMIYSpCDOr+3EqlI1bxmtHu+Vv/I2vrSeT1sBOEnEniX3uo4wFhFdS/8XN6gA==";
+        url = "https://registry.npmjs.org/graphql/-/graphql-14.4.1.tgz";
+        sha512 = "g4HUH26CohlMjaHneXMAtvG3QtO6peJIUTFxrPW4g5LNnXkUuFoBI6Bk1c14Q5kW8+FyjM/tTbePTgpiVB/2hQ==";
       };
     };
-    "graphql-anywhere-4.2.3" = {
+    "graphql-anywhere-4.2.4" = {
       name = "graphql-anywhere";
       packageName = "graphql-anywhere";
-      version = "4.2.3";
+      version = "4.2.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/graphql-anywhere/-/graphql-anywhere-4.2.3.tgz";
-        sha512 = "kJiwe/I8rm+GivwwMmlVCLS3cneNXwqEyUIdo9npjEI0NtGBSNJnt8KNww7A450JvO/v+ubM5zQMh1e9LjTnBg==";
+        url = "https://registry.npmjs.org/graphql-anywhere/-/graphql-anywhere-4.2.4.tgz";
+        sha512 = "rN6Op5vle0Ucqo8uOVPuFzRz1L/MB+ZVa+XezhFcQ6iP13vy95HOXRysrRtWcu2kQQTLyukSGmfU08D8LXWSIw==";
       };
     };
     "graphql-cli-prepare-1.4.19" = {
@@ -16512,13 +16530,22 @@ let
         sha512 = "bOufkkog0cSfHJ9gVD3Wy+KHmkSTHWcFfPaV/NVpIvfJx15gU0/CzuC6lcTjioWmn+UGzYdoqmP7OrJAWT57sw==";
       };
     };
-    "graphql-extensions-0.7.1" = {
+    "graphql-extensions-0.7.4" = {
       name = "graphql-extensions";
       packageName = "graphql-extensions";
-      version = "0.7.1";
+      version = "0.7.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.7.1.tgz";
-        sha512 = "4NkAz/f0j5a1DSPl3V77OcesBmwhHz56Soj0yTImlcDdRv9knyO2e+ehi1TIeKBOyIKS7d3A7zqOW/4ieGxlVA==";
+        url = "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.7.4.tgz";
+        sha512 = "Ly+DiTDU+UtlfPGQkqmBX2SWMr9OT3JxMRwpB9K86rDNDBTJtG6AE2kliQKKE+hg1+945KAimO7Ep+YAvS7ywg==";
+      };
+    };
+    "graphql-extensions-0.7.6" = {
+      name = "graphql-extensions";
+      packageName = "graphql-extensions";
+      version = "0.7.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.7.6.tgz";
+        sha512 = "RV00O3YFD1diehvdja180BlKOGWgeigr/8/Wzr6lXwLcFtk6FecQC/7nf6oW1qhuXczHyNjt/uCr0WWbWq6mYg==";
       };
     };
     "graphql-import-0.4.5" = {
@@ -16602,13 +16629,13 @@ let
         sha512 = "jApXqWBzNXQ8jYa/HLkZJaVw9jgwNqZkywa2zfFn16Iv1Zb7ELNHkJaXHR7Quvd5SIGsy6Ny7SUKATgnu05uEg==";
       };
     };
-    "graphql-tools-4.0.4" = {
+    "graphql-tools-4.0.5" = {
       name = "graphql-tools";
       packageName = "graphql-tools";
-      version = "4.0.4";
+      version = "4.0.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/graphql-tools/-/graphql-tools-4.0.4.tgz";
-        sha512 = "chF12etTIGVVGy3fCTJ1ivJX2KB7OSG4c6UOJQuqOHCmBQwTyNgCDuejZKvpYxNZiEx7bwIjrodDgDe9RIkjlw==";
+        url = "https://registry.npmjs.org/graphql-tools/-/graphql-tools-4.0.5.tgz";
+        sha512 = "kQCh3IZsMqquDx7zfIGWBau42xe46gmqabwYkpPlCLIjcEY1XK+auP7iGRD9/205BPyoQdY8hT96MPpgERdC9Q==";
       };
     };
     "graphql-type-json-0.2.4" = {
@@ -16620,13 +16647,13 @@ let
         sha512 = "/tq02ayMQjrG4oDFDRLLrPk0KvJXue0nVXoItBe7uAdbNXjQUu+HYCBdAmPLQoseVzUKKMzrhq2P/sfI76ON6w==";
       };
     };
-    "graphql-upload-8.0.6" = {
+    "graphql-upload-8.0.7" = {
       name = "graphql-upload";
       packageName = "graphql-upload";
-      version = "8.0.6";
+      version = "8.0.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/graphql-upload/-/graphql-upload-8.0.6.tgz";
-        sha512 = "cBRALMOvGBm2AD6M61b1QbSmKfCLXvgV+Z3wXT2JS1EQwGWQ1g5/sby4J/cpwAaGnq5P2eGp+N3HQI9cSn9Jfg==";
+        url = "https://registry.npmjs.org/graphql-upload/-/graphql-upload-8.0.7.tgz";
+        sha512 = "gi2yygbDPXbHPC7H0PNPqP++VKSoNoJO4UrXWq4T0Bi4IhyUd3Ycop/FSxhx2svWIK3jdXR/i0vi91yR1aAF0g==";
       };
     };
     "gray-matter-2.1.1" = {
@@ -17547,6 +17574,15 @@ let
         sha512 = "uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==";
       };
     };
+    "http-errors-1.7.3" = {
+      name = "http-errors";
+      packageName = "http-errors";
+      version = "1.7.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz";
+        sha512 = "ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==";
+      };
+    };
     "http-headers-3.0.2" = {
       name = "http-headers";
       packageName = "http-headers";
@@ -17565,13 +17601,13 @@ let
         sha1 = "29691b6fc58f4f7e81a3605dca82682b068e4430";
       };
     };
-    "http-parser-js-0.5.0" = {
+    "http-parser-js-0.4.10" = {
       name = "http-parser-js";
       packageName = "http-parser-js";
-      version = "0.5.0";
+      version = "0.4.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.0.tgz";
-        sha512 = "cZdEF7r4gfRIq7ezX9J0T+kQmJNOub71dWbgAXVHDct80TKP4MCETtZQ31xyv38UwgzkWPYF/Xc0ge55dW9Z9w==";
+        url = "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.10.tgz";
+        sha1 = "92c9c1374c35085f75db359ec56cc257cbb93fa4";
       };
     };
     "http-proxy-1.17.0" = {
@@ -17745,13 +17781,13 @@ let
         sha1 = "d96c92732076f072711b6b10fd7d4f65ad8ee23d";
       };
     };
-    "i18next-15.0.9" = {
+    "i18next-15.1.0" = {
       name = "i18next";
       packageName = "i18next";
-      version = "15.0.9";
+      version = "15.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/i18next/-/i18next-15.0.9.tgz";
-        sha512 = "IdVj7DqErUuMbGuj2dFT431T7zKlmDci63eae6pNA/bMwgBZKT74/KnwHXE0WH7ivo2EV/LNme4pP4Yw6vB79w==";
+        url = "https://registry.npmjs.org/i18next/-/i18next-15.1.0.tgz";
+        sha512 = "7cCrVn/BcoSOGJwTilAjGgWWzUDg4scTLX1sIBMWq6QjYYBrT+ChSAvmgVyQxkHinaIcswC04XK6l15RxM4Dkg==";
       };
     };
     "iconv-lite-0.4.11" = {
@@ -18132,6 +18168,15 @@ let
         sha1 = "633c2c83e3da42a502f52466022480f4208261de";
       };
     };
+    "inherits-2.0.4" = {
+      name = "inherits";
+      packageName = "inherits";
+      version = "2.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz";
+        sha512 = "k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==";
+      };
+    };
     "ini-1.1.0" = {
       name = "ini";
       packageName = "ini";
@@ -18274,6 +18319,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/inquirer/-/inquirer-6.3.1.tgz";
         sha512 = "MmL624rfkFt4TG9y/Jvmt8vdmOo836U7Y0Hxr2aFk3RelZEGX4Igk0KabWrcaaZaTv9uzglOqWh1Vly+FAWAXA==";
+      };
+    };
+    "inquirer-6.4.1" = {
+      name = "inquirer";
+      packageName = "inquirer";
+      version = "6.4.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/inquirer/-/inquirer-6.4.1.tgz";
+        sha512 = "/Jw+qPZx4EDYsaT6uz7F4GJRNFMRdKNeUZw3ZnKV8lyuUgz/YWRCSUAJMZSVhSq4Ec0R2oYnyi6b3d4JXcL5Nw==";
       };
     };
     "inquirer-autocomplete-prompt-1.0.1" = {
@@ -19491,13 +19545,13 @@ let
         sha1 = "4b0da1442104d1b336340e80797e865cf39f7d72";
       };
     };
-    "is-valid-domain-0.0.9" = {
+    "is-valid-domain-0.0.11" = {
       name = "is-valid-domain";
       packageName = "is-valid-domain";
-      version = "0.0.9";
+      version = "0.0.11";
       src = fetchurl {
-        url = "https://registry.npmjs.org/is-valid-domain/-/is-valid-domain-0.0.9.tgz";
-        sha512 = "IeK/VigfxtjHCrNTY2/Lwed7Gp1VWPRSqtJ4GcaDUJ20AxmsL9Saoz96Q/yvf+y5N8zCjJb9HrA3vUlL8tk5Zg==";
+        url = "https://registry.npmjs.org/is-valid-domain/-/is-valid-domain-0.0.11.tgz";
+        sha512 = "N+XmAifLwbpAf6d5GM5DliNOZZrq2wnmdsAuhM2gyVaKAoJQIBz4emiPC4cnh4cIGiIqg0QvAa7sCpvGkN4WCg==";
       };
     };
     "is-valid-glob-1.0.0" = {
@@ -19617,13 +19671,13 @@ let
         sha512 = "8cJBL5tTd2OS0dM4jz07wQd5g0dCCqIhUxPIGtZfa5L6hWlvV5MHTITy/DBAsF+Oe2LS1X3krBUhNwaGUWpWxw==";
       };
     };
-    "isbinaryfile-4.0.0" = {
+    "isbinaryfile-4.0.1" = {
       name = "isbinaryfile";
       packageName = "isbinaryfile";
-      version = "4.0.0";
+      version = "4.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.0.tgz";
-        sha512 = "RBtmso6l2mCaEsUvXngMTIjg3oheXo0MgYzzfT6sk44RYggPnm9fT+cQJAmzRnJIxPHXg9FZglqDJGW28dvcqA==";
+        url = "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.1.tgz";
+        sha512 = "bvJxbNWm72dy/1+qeBm9F8wUM4siDnlzid7NN5Ib4nQcc0tNIx/YWgEih1ZRHXr8xVbpGk1ccLlA9gOSlyx3gw==";
       };
     };
     "isemail-3.2.0" = {
@@ -19734,13 +19788,13 @@ let
         sha512 = "yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA==";
       };
     };
-    "iterare-1.1.2" = {
+    "iterare-1.2.0" = {
       name = "iterare";
       packageName = "iterare";
-      version = "1.1.2";
+      version = "1.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/iterare/-/iterare-1.1.2.tgz";
-        sha512 = "25rVYmj/dDvTR6zOa9jY1Ihd6USLa0J508Ub2iy7Aga+xu9JMbjDds2Uh03ReDGbva/YN3s3Ybi+Do0nOX6wAg==";
+        url = "https://registry.npmjs.org/iterare/-/iterare-1.2.0.tgz";
+        sha512 = "RxMV9p/UzdK0Iplnd8mVgRvNdXlsTOiuDrqMRnDi3wIhbT+JP4xDquAX9ay13R3CH72NBzQ91KWe0+C168QAyQ==";
       };
     };
     "iterators-0.1.0" = {
@@ -19833,13 +19887,13 @@ let
         sha1 = "06d4912255093419477d425633606e0e90782967";
       };
     };
-    "joplin-turndown-4.0.11" = {
+    "joplin-turndown-4.0.15" = {
       name = "joplin-turndown";
       packageName = "joplin-turndown";
-      version = "4.0.11";
+      version = "4.0.15";
       src = fetchurl {
-        url = "https://registry.npmjs.org/joplin-turndown/-/joplin-turndown-4.0.11.tgz";
-        sha512 = "2oiwWX0nKYi1NVcaprSsrXQkYdGoRtPWFmnXdWQnQW44jlgjFV38B4VrgliwX5ZMq7cbx6A9IBwfXcBL2YV2NA==";
+        url = "https://registry.npmjs.org/joplin-turndown/-/joplin-turndown-4.0.15.tgz";
+        sha512 = "68ukx19XFbKtJ5hfPfPX6IDLFZ1+NI+CpxJZyDEXAN5rPkyGXDw9xnEfo1IYRd+fq56upjo5Fn7J1hTCQTVTIA==";
       };
     };
     "joplin-turndown-plugin-gfm-1.0.8" = {
@@ -19957,15 +20011,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz";
         sha512 = "RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==";
-      };
-    };
-    "js-yaml-3.13.0" = {
-      name = "js-yaml";
-      packageName = "js-yaml";
-      version = "3.13.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz";
-        sha512 = "pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==";
       };
     };
     "js-yaml-3.13.1" = {
@@ -20464,13 +20509,13 @@ let
         sha256 = "00016993634d04b6f7eea8fae529b804d5a0b7ed2636361c7546a48b866e9c5c";
       };
     };
-    "junk-2.1.0" = {
+    "junk-3.1.0" = {
       name = "junk";
       packageName = "junk";
-      version = "2.1.0";
+      version = "3.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/junk/-/junk-2.1.0.tgz";
-        sha1 = "f431b4b7f072dc500a5f10ce7f4ec71930e70134";
+        url = "https://registry.npmjs.org/junk/-/junk-3.1.0.tgz";
+        sha512 = "pBxcB3LFc8QVgdggvZWyeys+hnrNWg4OcZIU/1X59k5jQdLBlCsYGRQaz234SqoRLTCgMH00fY0xRJH+F9METQ==";
       };
     };
     "just-debounce-1.0.0" = {
@@ -20806,15 +20851,6 @@ let
         sha1 = "a205383fea322b33b5ae3b18abee0dc2f356ee15";
       };
     };
-    "latest-version-4.0.0" = {
-      name = "latest-version";
-      packageName = "latest-version";
-      version = "4.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/latest-version/-/latest-version-4.0.0.tgz";
-        sha512 = "b4Myk7aQiQJvgssw2O8yITjELdqKRX4JQJUF1IUplgLaA8unv7s+UsAOwH6Q0/a09czSvlxEm306it2LBXrCzg==";
-      };
-    };
     "latest-version-5.1.0" = {
       name = "latest-version";
       packageName = "latest-version";
@@ -21040,13 +21076,13 @@ let
         sha512 = "UxVEfK5WH0u0InR3WxTCSAroiorAGKzXWZT6i+nBjambmvINuXFUsFx2Ai3UIjUUtnyWhluv42jMlzUZCsAk9A==";
       };
     };
-    "level-packager-5.0.1" = {
+    "level-packager-5.0.2" = {
       name = "level-packager";
       packageName = "level-packager";
-      version = "5.0.1";
+      version = "5.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/level-packager/-/level-packager-5.0.1.tgz";
-        sha512 = "tigB8g7xnFE5es2d/OmGJvcJC9S+FQfJnnULSLbPr53/ABPIaCarCxofkwdBhnJxjLZCNvj/Je6luFj/XeuaUQ==";
+        url = "https://registry.npmjs.org/level-packager/-/level-packager-5.0.2.tgz";
+        sha512 = "sJWdeW5tObvTvgP4Xf2psL5CEUsZjDjiTtlcimHp3Ifd4qbmkEGquN82C5ZtC7VpWEiISeUIBtIcCskVzEpvFw==";
       };
     };
     "level-post-1.0.7" = {
@@ -21076,13 +21112,13 @@ let
         sha512 = "SUgSRTWFh3eeiTdIt2a4Fi9TZO5oWzE9uC/Iw8+fVr1sk8x1S2l151UWwSmrMFZB3GxJhZIf4bQ0n+051Cctpw==";
       };
     };
-    "leveldown-5.1.0" = {
+    "leveldown-5.1.1" = {
       name = "leveldown";
       packageName = "leveldown";
-      version = "5.1.0";
+      version = "5.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/leveldown/-/leveldown-5.1.0.tgz";
-        sha512 = "+Ws1IDVSbJRJl/cP/JlapGSmt8xPSvZQpTlYGpyaMQiXtlx/fdMX30K2aHiTLxhLcnAg74D8odBG1Fk12/8SRA==";
+        url = "https://registry.npmjs.org/leveldown/-/leveldown-5.1.1.tgz";
+        sha512 = "4n2R/vEA/sssh5TKtFwM9gshW2tirNoURLqekLRUUzuF+eUBLFAufO8UW7bz8lBbG2jw8tQDF3LC+LcUCc12kg==";
       };
     };
     "levelup-0.19.1" = {
@@ -21103,13 +21139,13 @@ let
         sha512 = "9N10xRkUU4dShSRRFTBdNaBxofz+PGaIZO962ckboJZiNmLuhVT6FZ6ZKAsICKfUBO76ySaYU6fJWX/jnj3Lcg==";
       };
     };
-    "levelup-4.0.1" = {
+    "levelup-4.1.0" = {
       name = "levelup";
       packageName = "levelup";
-      version = "4.0.1";
+      version = "4.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/levelup/-/levelup-4.0.1.tgz";
-        sha512 = "l7KXOkINXHgNqmz0v9bxvRnMCUG4gmShFrzFSZXXhcqFnfvKAW8NerVsTICpZtVhGOMAmhY6JsVoVh/tUPBmdg==";
+        url = "https://registry.npmjs.org/levelup/-/levelup-4.1.0.tgz";
+        sha512 = "+Qhe2/jb5affN7BeFgWUUWVdYoGXO2nFS3QLEZKZynnQyP9xqA+7wgOz3fD8SST2UKpHQuZgjyJjTcB2nMl2dQ==";
       };
     };
     "leven-2.1.0" = {
@@ -21164,24 +21200,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/libnested/-/libnested-1.4.1.tgz";
         sha512 = "7fvNHrU8QTep71gIJuz7z6iBAQULEHJOcIA0MKUlwFrSnntvOvnke+/tnR7ZxyRAQQ303UJXNZBSRz3r0N5tqw==";
-      };
-    };
-    "libnpmaccess-3.0.1" = {
-      name = "libnpmaccess";
-      packageName = "libnpmaccess";
-      version = "3.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/libnpmaccess/-/libnpmaccess-3.0.1.tgz";
-        sha512 = "RlZ7PNarCBt+XbnP7R6PoVgOq9t+kou5rvhaInoNibhPO7eMlRfS0B8yjatgn2yaHIwWNyoJDolC/6Lc5L/IQA==";
-      };
-    };
-    "libnpmpublish-1.1.1" = {
-      name = "libnpmpublish";
-      packageName = "libnpmpublish";
-      version = "1.1.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/libnpmpublish/-/libnpmpublish-1.1.1.tgz";
-        sha512 = "nefbvJd/wY38zdt+b9SHL6171vqBrMtZ56Gsgfd0duEKb/pB8rDT4/ObUQLrHz1tOfht1flt2zM+UGaemzAG5g==";
       };
     };
     "libqp-1.1.0" = {
@@ -21382,13 +21400,13 @@ let
         sha1 = "259933d1327cbaf0fd3662f8fffde36809d84ced";
       };
     };
-    "locutus-2.0.10" = {
+    "locutus-2.0.11" = {
       name = "locutus";
       packageName = "locutus";
-      version = "2.0.10";
+      version = "2.0.11";
       src = fetchurl {
-        url = "https://registry.npmjs.org/locutus/-/locutus-2.0.10.tgz";
-        sha512 = "AZg2kCqrquMJ5FehDsBidV0qHl98NrsYtseUClzjAQ3HFnsDBJTCwGVplSQ82t9/QfgahqvTjaKcZqZkHmS0wQ==";
+        url = "https://registry.npmjs.org/locutus/-/locutus-2.0.11.tgz";
+        sha512 = "C0q1L38lK5q1t+wE0KY21/9szrBHxye6o2z5EJzU+5B79tubNOC+nLAEzTTn1vPUGoUuehKh8kYKqiVUTWRyaQ==";
       };
     };
     "lodash-1.0.2" = {
@@ -22480,13 +22498,13 @@ let
         sha512 = "KJ6zAPIHWo7Xg1jYror6IUDFJBq1bQ4Bi4wAEp2y/0ScjBBVi/g0thr0sUVhuvuXauWzczt7T2QHghPDNnKBuw==";
       };
     };
-    "log4js-4.3.1" = {
+    "log4js-4.4.0" = {
       name = "log4js";
       packageName = "log4js";
-      version = "4.3.1";
+      version = "4.4.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/log4js/-/log4js-4.3.1.tgz";
-        sha512 = "nPGS7w7kBnzNm1j8JycFxwLCbIMae8tHCo0cCdx/khB20Tcod8SZThYEB9E0c27ObcTGA1mlPowaf3hantQ/FA==";
+        url = "https://registry.npmjs.org/log4js/-/log4js-4.4.0.tgz";
+        sha512 = "xwRvmxFsq8Hb7YeS+XKfvCrsH114bXex6mIwJ2+KmYVi23pB3+hlzyGq1JPycSFTJWNLhD/7PCtM0RfPy6/2yg==";
       };
     };
     "logform-2.1.2" = {
@@ -22498,13 +22516,13 @@ let
         sha512 = "+lZh4OpERDBLqjiwDLpAWNQu6KMjnlXH2ByZwCuSqVPJletw0kTWJf5CgSNAUKn1KUkv3m2cUz/LK8zyEy7wzQ==";
       };
     };
-    "loglevel-1.6.2" = {
+    "loglevel-1.6.3" = {
       name = "loglevel";
       packageName = "loglevel";
-      version = "1.6.2";
+      version = "1.6.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/loglevel/-/loglevel-1.6.2.tgz";
-        sha512 = "Jt2MHrCNdtIe1W6co3tF5KXGRkzF+TYffiQstfXa04mrss9IKXzAAXYWak8LbZseAQY03sH2GzMCMU0ZOUc9bg==";
+        url = "https://registry.npmjs.org/loglevel/-/loglevel-1.6.3.tgz";
+        sha512 = "LoEDv5pgpvWgPF4kNYuIp0qqSJVWak/dML0RY74xlzMZiT9w77teNAwKYKWBTYjlokMirg+o3jBwp+vlLrcfAA==";
       };
     };
     "loglevel-colored-level-prefix-1.0.0" = {
@@ -22687,6 +22705,15 @@ let
         sha512 = "G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==";
       };
     };
+    "lowercase-keys-2.0.0" = {
+      name = "lowercase-keys";
+      packageName = "lowercase-keys";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz";
+        sha512 = "tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==";
+      };
+    };
     "lowlight-1.9.2" = {
       name = "lowlight";
       packageName = "lowlight";
@@ -22813,13 +22840,13 @@ let
         sha512 = "mmLbumEYMi5nXReB9js3WGsB8UE6cDBWyIO62Z4DNx6GbRhDxHNjA1MlzSpJ2S2KM1wyiPRA0d19uHWYYvMHjA==";
       };
     };
-    "macos-release-2.2.0" = {
+    "macos-release-2.3.0" = {
       name = "macos-release";
       packageName = "macos-release";
-      version = "2.2.0";
+      version = "2.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/macos-release/-/macos-release-2.2.0.tgz";
-        sha512 = "iV2IDxZaX8dIcM7fG6cI46uNmHUxHE4yN+Z8tKHAW1TBPMZDIKHf/3L+YnOuj/FK9il14UaVdHmiQ1tsi90ltA==";
+        url = "https://registry.npmjs.org/macos-release/-/macos-release-2.3.0.tgz";
+        sha512 = "OHhSbtcviqMPt7yfw5ef5aghS2jzFVKEFyCJndQt2YpSQ9qRVSEv2axSJI1paVThEu+FFGs584h/1YhxjVqajA==";
       };
     };
     "magic-string-0.22.5" = {
@@ -22955,15 +22982,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz";
         sha512 = "pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==";
-      };
-    };
-    "makeerror-1.0.11" = {
-      name = "makeerror";
-      packageName = "makeerror";
-      version = "1.0.11";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz";
-        sha1 = "e01a5c9109f2af79660e4e8b9587790184f5a96c";
       };
     };
     "mamacro-0.0.3" = {
@@ -23245,13 +23263,13 @@ let
         sha1 = "c04891883c28c83602e1d06b05a11037e359b4c8";
       };
     };
-    "mdn-browser-compat-data-0.0.66" = {
+    "mdn-browser-compat-data-0.0.82" = {
       name = "mdn-browser-compat-data";
       packageName = "mdn-browser-compat-data";
-      version = "0.0.66";
+      version = "0.0.82";
       src = fetchurl {
-        url = "https://registry.npmjs.org/mdn-browser-compat-data/-/mdn-browser-compat-data-0.0.66.tgz";
-        sha512 = "Exx+o05KYCltHmY2thfCoufBaHeqbIzqZHQPDtmcC+nkeFG++ONzwddBtgDBAKeI0IFFKqGIbRT1QBRwmk9QKA==";
+        url = "https://registry.npmjs.org/mdn-browser-compat-data/-/mdn-browser-compat-data-0.0.82.tgz";
+        sha512 = "RmC87C45AgXLuNlkrGLCK2wh0zRwpFnnro5jsNxmS90xLCxfKmTLPtqM9cocKFD7Ro9pWmtvkIkRiesGakd1Ig==";
       };
     };
     "mdn-data-1.1.4" = {
@@ -23306,6 +23324,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz";
         sha1 = "8710d7af0aa626f8fffa1ce00168545263255748";
+      };
+    };
+    "media-typer-1.1.0" = {
+      name = "media-typer";
+      packageName = "media-typer";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz";
+        sha512 = "aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==";
       };
     };
     "mediasource-2.3.0" = {
@@ -23677,22 +23704,13 @@ let
         sha512 = "x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==";
       };
     };
-    "mime-2.4.0" = {
+    "mime-2.4.4" = {
       name = "mime";
       packageName = "mime";
-      version = "2.4.0";
+      version = "2.4.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/mime/-/mime-2.4.0.tgz";
-        sha512 = "ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w==";
-      };
-    };
-    "mime-2.4.3" = {
-      name = "mime";
-      packageName = "mime";
-      version = "2.4.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/mime/-/mime-2.4.3.tgz";
-        sha512 = "QgrPRJfE+riq5TPZMcHZOtm8c6K/yYrMbKIoRfapfiGLxS8OTeIfRhUGW5LU7MlRa52KOAGCfUNruqLrIBvWZw==";
+        url = "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz";
+        sha512 = "LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==";
       };
     };
     "mime-db-1.12.0" = {
@@ -23938,13 +23956,13 @@ let
         sha1 = "53d500266cbd09cda9d94c4cf392e60589b5b324";
       };
     };
-    "mixin-deep-1.3.1" = {
+    "mixin-deep-1.3.2" = {
       name = "mixin-deep";
       packageName = "mixin-deep";
-      version = "1.3.1";
+      version = "1.3.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz";
-        sha512 = "8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==";
+        url = "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz";
+        sha512 = "WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==";
       };
     };
     "mixin-object-2.0.1" = {
@@ -24127,13 +24145,13 @@ let
         sha512 = "U4pMLpjT/UzB8d36dxj6Mf1bG9xypEvgbuRIa1fztRXNKKTCAtRxsnFZhNOd7YDFOKtjBgssYGvo4H/Q3ZY1MA==";
       };
     };
-    "mp4-stream-2.0.3" = {
+    "mp4-stream-3.0.0" = {
       name = "mp4-stream";
       packageName = "mp4-stream";
-      version = "2.0.3";
+      version = "3.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/mp4-stream/-/mp4-stream-2.0.3.tgz";
-        sha512 = "5NzgI0+bGakoZEwnIYINXqB3mnewkt3Y7jcvkXsTubnCNUSdM8cpP0Vemxf6FLg0qUN8fydTgNMVAc3QU8B92g==";
+        url = "https://registry.npmjs.org/mp4-stream/-/mp4-stream-3.0.0.tgz";
+        sha512 = "UCvsZaEP2b+Tl2mJOmb+TXdA2f24ggNUadgQkpgvaNDZQNGs6/O8ivFcj9ogf4Bj4R6dbqv18VXUdp16BhXk/A==";
       };
     };
     "mpath-0.2.1" = {
@@ -24215,6 +24233,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz";
         sha512 = "tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==";
+      };
+    };
+    "ms-2.1.2" = {
+      name = "ms";
+      packageName = "ms";
+      version = "2.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz";
+        sha512 = "sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==";
       };
     };
     "msgpack-lite-0.1.26" = {
@@ -24316,6 +24343,15 @@ let
         sha1 = "9c7906a22fb4c02919e2f5f75161b4cdbd4b2a2b";
       };
     };
+    "multimatch-4.0.0" = {
+      name = "multimatch";
+      packageName = "multimatch";
+      version = "4.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/multimatch/-/multimatch-4.0.0.tgz";
+        sha512 = "lDmx79y1z6i7RNx0ZGCPq1bzJ6ZoDDKbvh7jxr9SJcWLkShMzXrHbYVpTdnhNM5MXpDUxCQ4DgqVttVXlBgiBQ==";
+      };
+    };
     "multiparty-2.2.0" = {
       name = "multiparty";
       packageName = "multiparty";
@@ -24388,22 +24424,13 @@ let
         sha512 = "xasv76hl6nr1dEy3lPvy7Ej7K/Lx3O/FCvwge8PeVJpciPPoNCbaANcNiBug3IpdvTveZUcAV0DJzdnUDMesNQ==";
       };
     };
-    "murmur-hash-js-1.0.0" = {
-      name = "murmur-hash-js";
-      packageName = "murmur-hash-js";
-      version = "1.0.0";
+    "multistream-3.0.0" = {
+      name = "multistream";
+      packageName = "multistream";
+      version = "3.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/murmur-hash-js/-/murmur-hash-js-1.0.0.tgz";
-        sha1 = "5041049269c96633c866386960b2f4289e75e5b0";
-      };
-    };
-    "mustache-2.3.2" = {
-      name = "mustache";
-      packageName = "mustache";
-      version = "2.3.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/mustache/-/mustache-2.3.2.tgz";
-        sha512 = "KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ==";
+        url = "https://registry.npmjs.org/multistream/-/multistream-3.0.0.tgz";
+        sha512 = "v1Fx9uhHEpTB725/Kj8YpRCvrLhb20LeABFLw+0dkBkKUUAbDCY6CUUNzGQsJ94ji/p50wBPsRjIQXN1iOwZYA==";
       };
     };
     "mustache-3.0.1" = {
@@ -25121,13 +25148,13 @@ let
         sha512 = "iEOqDAOFl6uN5jZGRj39Jdo8qALzf2HPXtpFso8+BMaDylDrUMYMwhFbfYGgxdnMlsRnxYTwv68kaXEpsHIapg==";
       };
     };
-    "node-abi-2.8.0" = {
+    "node-abi-2.9.0" = {
       name = "node-abi";
       packageName = "node-abi";
-      version = "2.8.0";
+      version = "2.9.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/node-abi/-/node-abi-2.8.0.tgz";
-        sha512 = "1/aa2clS0pue0HjckL62CsbhWWU35HARvBDXcJtYKbYR7LnIutmpxmXbuDMV9kEviD2lP/wACOgWmmwljghHyQ==";
+        url = "https://registry.npmjs.org/node-abi/-/node-abi-2.9.0.tgz";
+        sha512 = "jmEOvv0eanWjhX8dX1pmjb7oJl1U1oR4FOh0b2GnvALwSYoOdU7sj+kLDSAyjo4pfC9aj/IxkloxdLJQhSSQBA==";
       };
     };
     "node-addon-api-1.6.3" = {
@@ -25182,15 +25209,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz";
         sha1 = "5f5665d93351335caabef8f1c554516cf5f1e4e5";
-      };
-    };
-    "node-elm-compiler-5.0.3" = {
-      name = "node-elm-compiler";
-      packageName = "node-elm-compiler";
-      version = "5.0.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/node-elm-compiler/-/node-elm-compiler-5.0.3.tgz";
-        sha512 = "I3CWm/ExYYQ/a9bjB0OL9VsGa3Lmgbb8QOs4y2kEiB/DTkTqkcTaCr/lVyOYjRpgR25TsmOBATscsg6H6aC9Hg==";
       };
     };
     "node-emoji-1.10.0" = {
@@ -25320,13 +25338,13 @@ let
         sha512 = "FAyICv0sIRJxVp3GW5fzgaf9jwwRQxAKDJlmNFUL5hOy+W4X/I5AypyHoq0DXXbo9o/gt79gj++4cMr4jVWE/w==";
       };
     };
-    "node-libs-browser-2.2.0" = {
+    "node-libs-browser-2.2.1" = {
       name = "node-libs-browser";
       packageName = "node-libs-browser";
-      version = "2.2.0";
+      version = "2.2.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.0.tgz";
-        sha512 = "5MQunG/oyOaBdttrL40dA7bUfPORLRWMUJLQtMg7nluxUvk5XwnLdL9twQHFAjRx/y7mIMkLKT9++qPbbk6BZA==";
+        url = "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz";
+        sha512 = "h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==";
       };
     };
     "node-modules-regexp-1.0.0" = {
@@ -25336,15 +25354,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz";
         sha1 = "8d9dbe28964a4ac5712e9131642107c71e90ec40";
-      };
-    };
-    "node-notifier-5.2.1" = {
-      name = "node-notifier";
-      packageName = "node-notifier";
-      version = "5.2.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz";
-        sha512 = "MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==";
       };
     };
     "node-notifier-5.4.0" = {
@@ -25410,13 +25419,13 @@ let
         sha512 = "OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==";
       };
     };
-    "node-red-node-email-1.6.0" = {
+    "node-red-node-email-1.6.2" = {
       name = "node-red-node-email";
       packageName = "node-red-node-email";
-      version = "1.6.0";
+      version = "1.6.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/node-red-node-email/-/node-red-node-email-1.6.0.tgz";
-        sha512 = "RCDEIkXic66G8ySro6wZ777p3Qko6xBDk31xwQThlldhoedm+syRv4tpNh+eLVQDGDpyKkY1K+gUpZQpzmuDKQ==";
+        url = "https://registry.npmjs.org/node-red-node-email/-/node-red-node-email-1.6.2.tgz";
+        sha512 = "px5xvIE649aEAh08hAqnFV/IyqN1EQ9nHsTp8OWvVdNZqfAEcT0O6jjMONN/ur5Az1Uyrc7cA3c+iYmc2yzGMg==";
       };
     };
     "node-red-node-feedparser-0.1.14" = {
@@ -25455,22 +25464,22 @@ let
         sha512 = "+92kgY+SOW6Oq7GfH3x9HC/9YBAg5UmdZBl426nFg0K4x9oegLqCqW2S0/fBAgyDBQQF8eHmn/GjHeO32R0aRg==";
       };
     };
-    "node-red-node-twitter-1.1.4" = {
+    "node-red-node-twitter-1.1.5" = {
       name = "node-red-node-twitter";
       packageName = "node-red-node-twitter";
-      version = "1.1.4";
+      version = "1.1.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/node-red-node-twitter/-/node-red-node-twitter-1.1.4.tgz";
-        sha512 = "mkw8HOosXHMBRdyJkio77vPx4Ls5IY26P5ZyoMWmKMkimXKTnX00DdpmNlkW+dHwMDYq1H66WzFtQhNOdEAbgA==";
+        url = "https://registry.npmjs.org/node-red-node-twitter/-/node-red-node-twitter-1.1.5.tgz";
+        sha512 = "8V4tLL0nM1DOUgEtTOBSTZcLbtZ4Gg4CPFVHiPmLCo2QYTMQ0JdBIYj4pg95LbJbYkV721fqsw1RDsitBfYuCQ==";
       };
     };
-    "node-releases-1.1.23" = {
+    "node-releases-1.1.24" = {
       name = "node-releases";
       packageName = "node-releases";
-      version = "1.1.23";
+      version = "1.1.24";
       src = fetchurl {
-        url = "https://registry.npmjs.org/node-releases/-/node-releases-1.1.23.tgz";
-        sha512 = "uq1iL79YjfYC0WXoHbC/z28q/9pOl8kSHaXdWmAAc8No+bDwqkZbzIJz55g/MUsPgSGm9LZ7QSUbzTcH5tz47w==";
+        url = "https://registry.npmjs.org/node-releases/-/node-releases-1.1.24.tgz";
+        sha512 = "wym2jptfuKowMmkZsfCSTsn8qAVo8zm+UiQA6l5dNqUcpfChZSnS/vbbpOeXczf+VdPhutxh+99lWHhdd6xKzg==";
       };
     };
     "node-request-by-swagger-1.1.4" = {
@@ -25716,6 +25725,15 @@ let
         sha512 = "U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==";
       };
     };
+    "normalize-url-4.3.0" = {
+      name = "normalize-url";
+      packageName = "normalize-url";
+      version = "4.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/normalize-url/-/normalize-url-4.3.0.tgz";
+        sha512 = "0NLtR71o4k6GLP+mr6Ty34c5GA6CMoEsncKJxvQd8NzPxaHRJNnb5gZE8R1XF4CPIS7QPHLJ74IFszwtNVAHVQ==";
+      };
+    };
     "now-and-later-2.0.1" = {
       name = "now-and-later";
       packageName = "now-and-later";
@@ -25734,13 +25752,13 @@ let
         sha1 = "df7c3ed5a277c3f9d4b5d819b05311d10a200ae6";
       };
     };
-    "npm-6.9.1-next.0" = {
+    "npm-6.9.2" = {
       name = "npm";
       packageName = "npm";
-      version = "6.9.1-next.0";
+      version = "6.9.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/npm/-/npm-6.9.1-next.0.tgz";
-        sha512 = "rw/KR5zPIz5VGhhTusLrXRchqteHO+1uRrg0WjDSj6r7uHuaC/mnjbWO0p7i7Td19azWWQtFS3TKBvE/gAfE9w==";
+        url = "https://registry.npmjs.org/npm/-/npm-6.9.2.tgz";
+        sha512 = "b0sEGRYrVdcV/DedLrqV4VMpdMHJbvpt9bopivh4K9RisHFMbj+G6RNbB6lRdr9rpYIoqHG9YP9CYmxdI9k81g==";
       };
     };
     "npm-bundled-1.0.6" = {
@@ -25788,13 +25806,13 @@ let
         sha512 = "zYbhP2k9DbJhA0Z3HKUePUgdB1x7MfIfKssC+WLPFMKTBZKpZh5m13PgexJjCq6KW7j17r0jHWcCpxEqnnncSA==";
       };
     };
-    "npm-packlist-1.4.1" = {
+    "npm-packlist-1.4.3" = {
       name = "npm-packlist";
       packageName = "npm-packlist";
-      version = "1.4.1";
+      version = "1.4.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz";
-        sha512 = "+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==";
+        url = "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.3.tgz";
+        sha512 = "YABl09v5EoSw3uea9/gUfmqPUSbhhv7Qht8f7VKQWzTEEeUr5q+9w3jOvjIZ31v8qmR4UrkwpPvIk43MDevvsg==";
       };
     };
     "npm-path-2.0.4" = {
@@ -26590,13 +26608,13 @@ let
         sha512 = "I9PKfIZC+e4RXZ/qr1RhgyCnGgYX0UEIlXgWnCOVACIvFgaC9rz6Won7xbdhoHrd8IIhV7YEpHjreNUNkqCGkQ==";
       };
     };
-    "optimism-0.9.5" = {
+    "optimism-0.9.6" = {
       name = "optimism";
       packageName = "optimism";
-      version = "0.9.5";
+      version = "0.9.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/optimism/-/optimism-0.9.5.tgz";
-        sha512 = "lNvmuBgONAGrUbj/xpH69FjMOz1d0jvMNoOCKyVynUPzq2jgVlGL4jFYJqrUHzUfBv+jAFSCP61x5UkfbduYJA==";
+        url = "https://registry.npmjs.org/optimism/-/optimism-0.9.6.tgz";
+        sha512 = "bWr/ZP32UgFCQAoSkz33XctHwpq2via2sBvGvO5JIlrU8gaiM0LvoKj3QMle9LWdSKlzKik8XGSerzsdfYLNxA==";
       };
     };
     "optimist-0.2.8" = {
@@ -27103,13 +27121,13 @@ let
         sha512 = "EeHQFFTlEmLrkIQoxbE9w0FuAWHoc1XpthDqnZ/i9keOt701cteyXwAxQFLpVqVjj3feh2TodkihjLaRUtIgLg==";
       };
     };
-    "package-json-6.3.0" = {
+    "package-json-6.4.0" = {
       name = "package-json";
       packageName = "package-json";
-      version = "6.3.0";
+      version = "6.4.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/package-json/-/package-json-6.3.0.tgz";
-        sha512 = "XO7WS3EEXd48vmW633Y97Mh9xuENFiOevI9G+ExfTG/k6xuY9cBd3fxkAoDMSEsNZXasaVJIJ1rD/n7GMf18bA==";
+        url = "https://registry.npmjs.org/package-json/-/package-json-6.4.0.tgz";
+        sha512 = "bd1T8OBG7hcvMd9c/udgv6u5v9wISP3Oyl9Cm7Weop8EFwrtcQDnS2sb6zhwqus2WslSr5wSTIPiTTpxxmPm7Q==";
       };
     };
     "package-json-versionify-1.0.4" = {
@@ -27146,6 +27164,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/pacote/-/pacote-9.5.0.tgz";
         sha512 = "aUplXozRbzhaJO48FaaeClmN+2Mwt741MC6M3bevIGZwdCaP7frXzbUOfOWa91FPHoLITzG0hYaKY363lxO3bg==";
+      };
+    };
+    "pacote-9.5.1" = {
+      name = "pacote";
+      packageName = "pacote";
+      version = "9.5.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pacote/-/pacote-9.5.1.tgz";
+        sha512 = "Zqvczvf/zZ7QNosdE9uTC7SRuvSs9tFqRkF6cJl+2HH7COBnx4BRAGpeXJlrbN+mM0CMHpbi620xdEHhCflghA==";
       };
     };
     "pad-0.0.5" = {
@@ -27616,15 +27643,6 @@ let
         sha1 = "fad9db6ae252f8b088e0c5decd20a7da0c5d9f1e";
       };
     };
-    "path-browserify-0.0.0" = {
-      name = "path-browserify";
-      packageName = "path-browserify";
-      version = "0.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz";
-        sha1 = "a0b870729aae214005b7d5032ec2cbbb0fb4451a";
-      };
-    };
     "path-browserify-0.0.1" = {
       name = "path-browserify";
       packageName = "path-browserify";
@@ -28057,13 +28075,13 @@ let
         sha1 = "2135d6dfa7a358c069ac9b178776288228450ffa";
       };
     };
-    "pino-5.11.1" = {
+    "pino-5.12.6" = {
       name = "pino";
       packageName = "pino";
-      version = "5.11.1";
+      version = "5.12.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/pino/-/pino-5.11.1.tgz";
-        sha512 = "NIua0mGb9Adknq35ONvQmvh93LCUVUjp2+1q1EcvIkJmpJnSd3E5rHVKlKNjzMXFl/z3fI+QA0xXCjPEKNiLvQ==";
+        url = "https://registry.npmjs.org/pino/-/pino-5.12.6.tgz";
+        sha512 = "LM5ug2b27uymIIkaBw54ncF+9DSf8S4z1uzw+Y5I94dRu3Z+lFuB13j0kg1InAeyxy+CsLGnWHKy9+zgTreFOg==";
       };
     };
     "pino-std-serializers-2.4.2" = {
@@ -28337,13 +28355,13 @@ let
         sha512 = "soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==";
       };
     };
-    "postcss-7.0.14" = {
+    "postcss-7.0.16" = {
       name = "postcss";
       packageName = "postcss";
-      version = "7.0.14";
+      version = "7.0.16";
       src = fetchurl {
-        url = "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz";
-        sha512 = "NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==";
+        url = "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz";
+        sha512 = "MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==";
       };
     };
     "postcss-7.0.17" = {
@@ -28760,13 +28778,13 @@ let
         sha512 = "4rgV2hyc/5Pk0XHH4VjJWHRgVjgRbpMfLQjREAhHBtyW1UvTFkjJEsueGYNYYZd9mn97K+1qv0EBwm11zoaSgA==";
       };
     };
-    "prettier-1.17.1" = {
+    "prettier-1.18.2" = {
       name = "prettier";
       packageName = "prettier";
-      version = "1.17.1";
+      version = "1.18.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/prettier/-/prettier-1.17.1.tgz";
-        sha512 = "TzGRNvuUSmPgwivDqkZ9tM/qTGW9hqDKWOE9YHiyQdixlKbv7kvEqsmDPrcHJTKwthU774TQwZXVtaQ/mMsvjg==";
+        url = "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz";
+        sha512 = "OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==";
       };
     };
     "prettier-bytes-1.0.4" = {
@@ -28931,13 +28949,13 @@ let
         sha1 = "150e20b756590ad3f91093f25a4f2ad8bff30ba3";
       };
     };
-    "process-nextick-args-2.0.0" = {
+    "process-nextick-args-2.0.1" = {
       name = "process-nextick-args";
       packageName = "process-nextick-args";
-      version = "2.0.0";
+      version = "2.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz";
-        sha512 = "MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==";
+        url = "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz";
+        sha512 = "3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==";
       };
     };
     "progress-1.1.8" = {
@@ -29264,13 +29282,13 @@ let
         sha1 = "f052a28da70e618917ef0a8ac34c1ae5a68286b3";
       };
     };
-    "psl-1.1.32" = {
+    "psl-1.1.33" = {
       name = "psl";
       packageName = "psl";
-      version = "1.1.32";
+      version = "1.1.33";
       src = fetchurl {
-        url = "https://registry.npmjs.org/psl/-/psl-1.1.32.tgz";
-        sha512 = "MHACAkHpihU/REGGPLj4sEfc/XKW2bheigvHO1dUqjaKigMp1C8+WLQYRGgeKFMsw5PMfegZcaN8IDXK/cD0+g==";
+        url = "https://registry.npmjs.org/psl/-/psl-1.1.33.tgz";
+        sha512 = "LTDP2uSrsc7XCb5lO7A8BI1qYxRe/8EqlRvMeEl6rsnYAqDOl8xHR+8lSAIVfrNaSAlTPTNOCgNjWcoUL3AZsw==";
       };
     };
     "pstree.remy-1.1.7" = {
@@ -29570,13 +29588,13 @@ let
         sha512 = "djlD60A6NGe5goLdP5pgbqzMEiWmk1bInuAzBp0QOH4vDrVwh05YDz6UP8+pOXveKEk8wHVP+rB2jBrK31QMPA==";
       };
     };
-    "pull-many-1.0.8" = {
+    "pull-many-1.0.9" = {
       name = "pull-many";
       packageName = "pull-many";
-      version = "1.0.8";
+      version = "1.0.9";
       src = fetchurl {
-        url = "https://registry.npmjs.org/pull-many/-/pull-many-1.0.8.tgz";
-        sha1 = "3dadd9b6d156c545721bda8d0003dd8eaa06293e";
+        url = "https://registry.npmjs.org/pull-many/-/pull-many-1.0.9.tgz";
+        sha512 = "+jUydDVlj/HsvtDqxWMSsiRq3B0HVo7RhBV4C0p2nZRS3mFTUEu9SPEBN+B5PMaW8KTnblYhTIaKg7oXgGnj4Q==";
       };
     };
     "pull-next-1.0.1" = {
@@ -29714,13 +29732,13 @@ let
         sha1 = "1ee5b6f76fd3b3a49a5afb6ded5c0320acb3cfc7";
       };
     };
-    "pull-stream-3.6.12" = {
+    "pull-stream-3.6.13" = {
       name = "pull-stream";
       packageName = "pull-stream";
-      version = "3.6.12";
+      version = "3.6.13";
       src = fetchurl {
-        url = "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.12.tgz";
-        sha512 = "+LO1XIVyTMmeoH26UHznpgrgX2npTVYccTkMpgk/EyiQjFt1FmoNm+w+/zMLuz9U3bpvT5sSUicMKEe/2JjgEA==";
+        url = "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.13.tgz";
+        sha512 = "enbnbnO+czsPuCq9s9HTTzDzzVQD5TSe60aO3nBioeJ9mevh8RzE4Hxbujo9TReg1fJlmNEL8uyQTUgn8+rSHg==";
       };
     };
     "pull-stringify-2.0.0" = {
@@ -29876,13 +29894,13 @@ let
         sha512 = "XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==";
       };
     };
-    "push-stream-10.0.4" = {
+    "push-stream-10.1.2" = {
       name = "push-stream";
       packageName = "push-stream";
-      version = "10.0.4";
+      version = "10.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/push-stream/-/push-stream-10.0.4.tgz";
-        sha512 = "IrP96RziNzT4UR7ZffM26o2NQ/Dq0dlRi1p8S/HE4+pHF6OaKWS1DyaJevsxJ6Q8bHafLqin6/pwI36FCmiV0w==";
+        url = "https://registry.npmjs.org/push-stream/-/push-stream-10.1.2.tgz";
+        sha512 = "wCDN1KkAWOMXsiV0XxH/CggHqOYeXvyn00t9Zjp5RKsLZ2rzg/lLJIMAVxYLyh79T168W3fBYcG5TRRJAlQr6g==";
       };
     };
     "push-stream-to-pull-stream-1.0.3" = {
@@ -30146,13 +30164,13 @@ let
         sha1 = "eb7e6267548ddedfb899c1b90e57374559cddb7e";
       };
     };
-    "ramda-0.25.0" = {
+    "ramda-0.26.1" = {
       name = "ramda";
       packageName = "ramda";
-      version = "0.25.0";
+      version = "0.26.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ramda/-/ramda-0.25.0.tgz";
-        sha512 = "GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ==";
+        url = "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz";
+        sha512 = "hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==";
       };
     };
     "randexp-0.4.6" = {
@@ -30164,13 +30182,13 @@ let
         sha512 = "80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==";
       };
     };
-    "random-access-file-2.1.2" = {
+    "random-access-file-2.1.3" = {
       name = "random-access-file";
       packageName = "random-access-file";
-      version = "2.1.2";
+      version = "2.1.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/random-access-file/-/random-access-file-2.1.2.tgz";
-        sha512 = "dZo7HEcEPbZ/6XLXC4GXypiWvFbXVkdeMrJTi0B94pBJwddt/AvJh8GaQhso6KGYROGYCI/VWdHbmRDtkwT9pQ==";
+        url = "https://registry.npmjs.org/random-access-file/-/random-access-file-2.1.3.tgz";
+        sha512 = "AE0Z1ywR5gIkzACMC1lCsR6LP8g4ynNm7oYWYdKPSSU6Y3H+mGDJxBqfcV9B9KstfHNemhfX3nYmx99ZC9f/yg==";
       };
     };
     "random-access-memory-3.1.1" = {
@@ -30182,13 +30200,13 @@ let
         sha512 = "Qy1MliJDozZ1A6Hx3UbEnm8PPCfkiG/8CArbnhrxXMx1YRJPWipgPTB9qyhn4Z7WlLvCEqPb6Bd98OayyVuwrA==";
       };
     };
-    "random-access-storage-1.3.0" = {
+    "random-access-storage-1.4.0" = {
       name = "random-access-storage";
       packageName = "random-access-storage";
-      version = "1.3.0";
+      version = "1.4.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/random-access-storage/-/random-access-storage-1.3.0.tgz";
-        sha512 = "pdS9Mcb9TB7oICypPRALlheaSuszuAKmLVEPKJMuYor7R/zDuHh5ALuQoS+ox31XRwQUL+tDwWH2GPdyspwelA==";
+        url = "https://registry.npmjs.org/random-access-storage/-/random-access-storage-1.4.0.tgz";
+        sha512 = "7oszloM/+PdqWp/oFGyL6SeI14liqo8AAisHAZQGkWdHISyAnngKjNPL0JYIazeLxbHPY6oed2yUffowdq/o6A==";
       };
     };
     "random-bytes-1.0.0" = {
@@ -30335,6 +30353,15 @@ let
         sha512 = "4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==";
       };
     };
+    "raw-body-2.4.1" = {
+      name = "raw-body";
+      packageName = "raw-body";
+      version = "2.4.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/raw-body/-/raw-body-2.4.1.tgz";
+        sha512 = "9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==";
+      };
+    };
     "rc-0.4.0" = {
       name = "rc";
       packageName = "rc";
@@ -30362,13 +30389,13 @@ let
         sha512 = "CN9BmvV9Kcl6c4WEZ8w13JFazLYtKnqxxKGKuiCS8yZpUtJFa/nd7PdjVnRBJJ89U3OZfR6DmqOqMvmZ5ZFNMw==";
       };
     };
-    "re-emitter-1.1.3" = {
+    "re-emitter-1.1.4" = {
       name = "re-emitter";
       packageName = "re-emitter";
-      version = "1.1.3";
+      version = "1.1.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/re-emitter/-/re-emitter-1.1.3.tgz";
-        sha1 = "fa9e319ffdeeeb35b27296ef0f3d374dac2f52a7";
+        url = "https://registry.npmjs.org/re-emitter/-/re-emitter-1.1.4.tgz";
+        sha512 = "C0SIXdXDSus2yqqvV7qifnb4NoWP7mEBXJq3axci301mXHCZb8Djwm4hrEZo4UeXRaEnfjH98uQ8EBppk2oNWA==";
       };
     };
     "react-is-16.8.6" = {
@@ -30450,6 +30477,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.2.2.tgz";
         sha512 = "rW3XWUUkhdKmN2JKB4FL563YAgtINifso5KShykufR03nJ5loGFlkUMe1g/yxmqX073SoYYTsgXu7XdDinKZuA==";
+      };
+    };
+    "read-package-tree-5.3.0" = {
+      name = "read-package-tree";
+      packageName = "read-package-tree";
+      version = "5.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.3.0.tgz";
+        sha512 = "Gi64+EWmi4515E1rPR77ae/Ip8cjFQTlsWytSYJj974U0tSnxm67pyXltbDjB1lvLw4dc85HbtidGL1K2c/oxw==";
       };
     };
     "read-pkg-1.1.0" = {
@@ -30578,13 +30614,13 @@ let
         sha512 = "jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==";
       };
     };
-    "readdir-scoped-modules-1.0.2" = {
+    "readdir-scoped-modules-1.1.0" = {
       name = "readdir-scoped-modules";
       packageName = "readdir-scoped-modules";
-      version = "1.0.2";
+      version = "1.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz";
-        sha1 = "9fafa37d286be5d92cbaebdee030dc9b5f406747";
+        url = "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz";
+        sha512 = "asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==";
       };
     };
     "readdirp-2.2.1" = {
@@ -30776,15 +30812,6 @@ let
         sha512 = "odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==";
       };
     };
-    "regenerator-runtime-0.13.1" = {
-      name = "regenerator-runtime";
-      packageName = "regenerator-runtime";
-      version = "0.13.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.1.tgz";
-        sha512 = "5KzMIyPLvfdPmvsdlYsHqITrDfK9k7bmvf97HvHSN4810i254ponbxCQ1NukpRWlu6en2MBWzAlhDExEKISwAA==";
-      };
-    };
     "regenerator-runtime-0.13.2" = {
       name = "regenerator-runtime";
       packageName = "regenerator-runtime";
@@ -30956,13 +30983,13 @@ let
         sha512 = "RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==";
       };
     };
-    "rehype-sort-attribute-values-1.0.1" = {
+    "rehype-sort-attribute-values-2.0.1" = {
       name = "rehype-sort-attribute-values";
       packageName = "rehype-sort-attribute-values";
-      version = "1.0.1";
+      version = "2.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/rehype-sort-attribute-values/-/rehype-sort-attribute-values-1.0.1.tgz";
-        sha512 = "ZbIbqEAqEulXFAJGkL5Ogb+oCd5sOe1Fc/DQPCqsYpOfPyioE6HomqTfDQfNL0LD5ODTZyrj2yigzfjfqJuSGQ==";
+        url = "https://registry.npmjs.org/rehype-sort-attribute-values/-/rehype-sort-attribute-values-2.0.1.tgz";
+        sha512 = "DitR4wnEvYQEFU8pRPwldGMGW76LM29fvz8s7oTYMwZBMSqNFtBr8eAts/I55LODCQm6b4jzdgFQ+/c6v7RmdA==";
       };
     };
     "reinterval-1.1.0" = {
@@ -30992,13 +31019,13 @@ let
         sha1 = "d21c52a72d6061018bcee9f9c9fc106bf7d65287";
       };
     };
-    "relaxed-json-1.0.1" = {
+    "relaxed-json-1.0.3" = {
       name = "relaxed-json";
       packageName = "relaxed-json";
-      version = "1.0.1";
+      version = "1.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/relaxed-json/-/relaxed-json-1.0.1.tgz";
-        sha1 = "7c8d4aa2f095704cd020e32e8099bcae103f0bd4";
+        url = "https://registry.npmjs.org/relaxed-json/-/relaxed-json-1.0.3.tgz";
+        sha512 = "b7wGPo7o2KE/g7SqkJDDbav6zmrEeP4TK2VpITU72J/M949TLe/23y/ZHJo+pskcGM52xIfFoT9hydwmgr1AEg==";
       };
     };
     "remark-3.2.3" = {
@@ -31019,13 +31046,13 @@ let
         sha1 = "cb463bd3dbcb4b99794935eee1cf71d7a8e3068c";
       };
     };
-    "remark-frontmatter-1.3.1" = {
+    "remark-frontmatter-1.3.2" = {
       name = "remark-frontmatter";
       packageName = "remark-frontmatter";
-      version = "1.3.1";
+      version = "1.3.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-1.3.1.tgz";
-        sha512 = "Zj/fDMYnSVgMCeKp8fXIhtMoZq4G6E1dnwfMoO8fVXrm/+oVSiN8YMREtwN2cctgK9EsnYSeS1ExX2hcX/fE1A==";
+        url = "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-1.3.2.tgz";
+        sha512 = "2eayxITZ8rezsXdgcXnYB3iLivohm2V/ZT4Ne8uhua6A4pk6GdLE2ZzJnbnINtD1HRLaTdB7RwF9sgUbMptJZA==";
       };
     };
     "remark-html-2.0.2" = {
@@ -31037,13 +31064,13 @@ let
         sha1 = "592a347bdd3d5881f4f080c98b5b152fb1407a92";
       };
     };
-    "remark-message-control-4.1.1" = {
+    "remark-message-control-4.2.0" = {
       name = "remark-message-control";
       packageName = "remark-message-control";
-      version = "4.1.1";
+      version = "4.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/remark-message-control/-/remark-message-control-4.1.1.tgz";
-        sha512 = "DojJPPeSux/U7aHCN6GUWBgp6F1EQFPUNvnk2gfuGgiMCHVubz/xAC3TkvPaf5w1F0PEGaOEpCtvxJK6O4Kmiw==";
+        url = "https://registry.npmjs.org/remark-message-control/-/remark-message-control-4.2.0.tgz";
+        sha512 = "WXH2t5ljTyhsXlK1zPBLF3iPHbXl58R94phPMreS1xcHWBZJt6Oiu8RtNjy1poZFb3PqKnbYLJeR/CWcZ1bTFw==";
       };
     };
     "remark-parse-1.1.0" = {
@@ -31073,13 +31100,13 @@ let
         sha512 = "b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==";
       };
     };
-    "remark-retext-3.1.2" = {
+    "remark-retext-3.1.3" = {
       name = "remark-retext";
       packageName = "remark-retext";
-      version = "3.1.2";
+      version = "3.1.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/remark-retext/-/remark-retext-3.1.2.tgz";
-        sha512 = "+48KzJdSXvsPupY5pj5AY7oBUSiDOqFPZBKebX5WemrMyIG+RImIt9hgeqelluVDd1kooHen33K/aybTPyoI9g==";
+        url = "https://registry.npmjs.org/remark-retext/-/remark-retext-3.1.3.tgz";
+        sha512 = "UujXAm28u4lnUvtOZQFYfRIhxX+auKI9PuA2QpQVTT7gYk1OgX6o0OUrSo1KOa6GNrFX+OODOtS5PWIHPxM7qw==";
       };
     };
     "remark-stringify-1.1.0" = {
@@ -31136,13 +31163,13 @@ let
         sha1 = "c24bce2a283adad5bc3f58e0d48249b92379d8ef";
       };
     };
-    "render-media-3.1.3" = {
+    "render-media-3.2.0" = {
       name = "render-media";
       packageName = "render-media";
-      version = "3.1.3";
+      version = "3.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/render-media/-/render-media-3.1.3.tgz";
-        sha512 = "K7ziKKlIcgYpAovRsABDiSaNn7TzDDyyuFGpRwM52cloNcajInB6sCxFPUEzOuTJUeyvKCqT/k5INOjpKLCjhQ==";
+        url = "https://registry.npmjs.org/render-media/-/render-media-3.2.0.tgz";
+        sha512 = "JuV0z+jCWxNO2hYX2dE67G4eiKkXaSR+Nep1ya2AOuXF4ht9t6WLkWT2fq3XbbBre+jFYsZB2jZOIX+rRut9aQ==";
       };
     };
     "repeat-element-1.1.3" = {
@@ -31280,13 +31307,13 @@ let
         sha512 = "rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==";
       };
     };
-    "requestretry-3.1.0" = {
+    "requestretry-4.0.0" = {
       name = "requestretry";
       packageName = "requestretry";
-      version = "3.1.0";
+      version = "4.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/requestretry/-/requestretry-3.1.0.tgz";
-        sha512 = "DkvCPK6qvwxIuVA5TRCvi626WHC2rWjF/n7SCQvVHAr2JX9i1/cmIpSEZlmHAo+c1bj9rjaKoZ9IsKwCpTkoXA==";
+        url = "https://registry.npmjs.org/requestretry/-/requestretry-4.0.0.tgz";
+        sha512 = "ST8m0+5FQH2FA+gbzUQyOQjUwHf22kbPQnd6TexveR0p+2UV1YYBg+Roe7BnKQ1Bb/+LtJwwm0QzxK2NA20Cug==";
       };
     };
     "require-directory-2.1.1" = {
@@ -31350,6 +31377,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz";
         sha1 = "4e0d56d6c9662fd31e43011c4b95aa49955421d3";
+      };
+    };
+    "require-uncached-2.0.0" = {
+      name = "require-uncached";
+      packageName = "require-uncached";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/require-uncached/-/require-uncached-2.0.0.tgz";
+        sha512 = "rPv1//BQwg4gzIbpJcKXWIfjDJEtgS8jzbsNoLcdVSE5FpBzKEKKuoG6MfCbLC28ZTv+qlQWC9/K7J5GBGPSMg==";
       };
     };
     "requireg-0.2.2" = {
@@ -31901,15 +31937,6 @@ let
         sha512 = "OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==";
       };
     };
-    "rsvp-4.8.4" = {
-      name = "rsvp";
-      packageName = "rsvp";
-      version = "4.8.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/rsvp/-/rsvp-4.8.4.tgz";
-        sha512 = "6FomvYPfs+Jy9TfXmBpBuMWNH94SgCsZmJKcanySzgNNP6LjWxBvyLTa9KaMfDDM5oxRfrKDB0r/qeRsLwnBfA==";
-      };
-    };
     "run-async-0.1.0" = {
       name = "run-async";
       packageName = "run-async";
@@ -32162,15 +32189,6 @@ let
         sha512 = "jLYV0DORrzY3xaz/S9ydJL6Iz7essZeAfnAavsJ+zsJGZ1MOnsS52yRjU3uF3pJa/lla7+wisp//fxOwOH8SKQ==";
       };
     };
-    "sane-4.1.0" = {
-      name = "sane";
-      packageName = "sane";
-      version = "4.1.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/sane/-/sane-4.1.0.tgz";
-        sha512 = "hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==";
-      };
-    };
     "sanitize-filename-1.6.1" = {
       name = "sanitize-filename";
       packageName = "sanitize-filename";
@@ -32252,13 +32270,13 @@ let
         sha1 = "033d60a3ad20ecf2e00940d14f97823465774335";
       };
     };
-    "secret-handshake-1.1.18" = {
+    "secret-handshake-1.1.20" = {
       name = "secret-handshake";
       packageName = "secret-handshake";
-      version = "1.1.18";
+      version = "1.1.20";
       src = fetchurl {
-        url = "https://registry.npmjs.org/secret-handshake/-/secret-handshake-1.1.18.tgz";
-        sha512 = "uP8s0ALmbJtjLEShGnJ5HHJSM1+TT8hbUme2/H2grw+WbiofSG6kr6AK1HHOmSublCVNFwfggjnWZXnEPTvIwQ==";
+        url = "https://registry.npmjs.org/secret-handshake/-/secret-handshake-1.1.20.tgz";
+        sha512 = "sDtmZDpibGH2ixj3FOmsC3Z/b08eaB2/KAvy2oSp4qvcGdhatBSfb1RdVpwjQl5c3J83WbBo1HSZ7DBtMu43lA==";
       };
     };
     "secret-stack-5.1.1" = {
@@ -32378,15 +32396,6 @@ let
         sha512 = "4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==";
       };
     };
-    "semver-5.6.0" = {
-      name = "semver";
-      packageName = "semver";
-      version = "5.6.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz";
-        sha512 = "RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==";
-      };
-    };
     "semver-5.7.0" = {
       name = "semver";
       packageName = "semver";
@@ -32412,6 +32421,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/semver/-/semver-6.1.1.tgz";
         sha512 = "rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==";
+      };
+    };
+    "semver-6.1.2" = {
+      name = "semver";
+      packageName = "semver";
+      version = "6.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/semver/-/semver-6.1.2.tgz";
+        sha512 = "z4PqiCpomGtWj8633oeAdXm1Kn1W++3T8epkZYnwiVgIYIJ0QHszhInYSJTYxebByQH7KVCEAn8R9duzZW2PhQ==";
       };
     };
     "semver-compare-1.0.0" = {
@@ -32639,13 +32657,13 @@ let
         sha1 = "935d240cdfe0f5805307fdfe967d88942a2cbcf0";
       };
     };
-    "serve-handler-6.0.1" = {
+    "serve-handler-6.0.2" = {
       name = "serve-handler";
       packageName = "serve-handler";
-      version = "6.0.1";
+      version = "6.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/serve-handler/-/serve-handler-6.0.1.tgz";
-        sha512 = "k/im4Fbx96d8VcrJDjrsagNd9Vq18tVYRDDe90rpNO8Mr76KJF/zES5tBZdlLEbhBXjOs36m9Wl+hRCiDnYfmA==";
+        url = "https://registry.npmjs.org/serve-handler/-/serve-handler-6.0.2.tgz";
+        sha512 = "D1zgDpvx9Rgjip6rzY2QBjlZwfr/oiDSg66HipOWkEw1appHn7/mXdVRL6F8+bd1KD117Wch4+4x78OTXQVwDg==";
       };
     };
     "serve-index-1.7.3" = {
@@ -32738,22 +32756,13 @@ let
         sha1 = "4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61";
       };
     };
-    "set-value-0.4.3" = {
+    "set-value-2.0.1" = {
       name = "set-value";
       packageName = "set-value";
-      version = "0.4.3";
+      version = "2.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz";
-        sha1 = "7db08f9d3d22dc7f78e53af3c3bf4666ecdfccf1";
-      };
-    };
-    "set-value-2.0.0" = {
-      name = "set-value";
-      packageName = "set-value";
-      version = "2.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz";
-        sha512 = "hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==";
+        url = "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz";
+        sha512 = "JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==";
       };
     };
     "setimmediate-1.0.5" = {
@@ -33017,13 +33026,13 @@ let
         sha512 = "Wvre/Jq5vgoz31Z9stYWPLn0PqRqmBDpFSdypAnHu5AvRVCYPRYGnvryNLiXu8GOBNDH82J2FRHUGMjjHUpXFw==";
       };
     };
-    "simple-git-1.113.0" = {
+    "simple-git-1.116.0" = {
       name = "simple-git";
       packageName = "simple-git";
-      version = "1.113.0";
+      version = "1.116.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/simple-git/-/simple-git-1.113.0.tgz";
-        sha512 = "i9WVsrK2u0G/cASI9nh7voxOk9mhanWY9eGtWBDSYql6m49Yk5/Fan6uZsDr/xmzv8n+eQ8ahKCoEr8cvU3h+g==";
+        url = "https://registry.npmjs.org/simple-git/-/simple-git-1.116.0.tgz";
+        sha512 = "Pbo3tceqMYy0j3U7jzMKabOWcx5+67GdgQUjpK83XUxGhA+1BX93UPvlWNzbCRoFwd7EJTyDSCC2XCoT4NTLYQ==";
       };
     };
     "simple-markdown-0.4.4" = {
@@ -33044,13 +33053,13 @@ let
         sha1 = "4e421f485ac7b13b08077a4476934d52c5ba3bb3";
       };
     };
-    "simple-peer-9.3.0" = {
+    "simple-peer-9.4.0" = {
       name = "simple-peer";
       packageName = "simple-peer";
-      version = "9.3.0";
+      version = "9.4.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/simple-peer/-/simple-peer-9.3.0.tgz";
-        sha512 = "5dLDfrRomrS2LuZUuH2aO7yTGtHFEl5Eb+8ZzqM0KC0lHcYUyJudUomP9ZY/lPUKBx2broL/Eee9bQ53yycEgQ==";
+        url = "https://registry.npmjs.org/simple-peer/-/simple-peer-9.4.0.tgz";
+        sha512 = "8qF32uq6SSSVXoBq9g31uGqZYupwRD3Ta/QK9fV04U/IbnIS6mictLb8/kjFyLVa3JrD7QYyKrw3nvJJ+lNFDw==";
       };
     };
     "simple-sha1-2.1.2" = {
@@ -33332,6 +33341,15 @@ let
         sha1 = "6541184cc90aeea6c6e7b35e2659082443c66198";
       };
     };
+    "snyk-1.185.5" = {
+      name = "snyk";
+      packageName = "snyk";
+      version = "1.185.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/snyk/-/snyk-1.185.5.tgz";
+        sha512 = "thiYonTVgfcKA0qq//adcCE2Lmnz6vXG7bii7Fuv3sKMjmiHxv6pkguqgEJ/m8gU5KmTXZXoFLewvAqNj/Yqrg==";
+      };
+    };
     "snyk-config-2.2.1" = {
       name = "snyk-config";
       packageName = "snyk-config";
@@ -33350,31 +33368,31 @@ let
         sha512 = "n/LfA7VXjPEcSz2ZfZonT/DPSC89Zs1/HD0inPFN4RLQT3WiQnjqJUXct+D0nWwEVfhLWNc+Y7PLcTjpnZ9R3Q==";
       };
     };
-    "snyk-go-parser-1.3.0" = {
+    "snyk-go-parser-1.3.1" = {
       name = "snyk-go-parser";
       packageName = "snyk-go-parser";
-      version = "1.3.0";
+      version = "1.3.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-go-parser/-/snyk-go-parser-1.3.0.tgz";
-        sha512 = "qXzmvPyehnrqXMqROtM2PqkvRG7AEBPDDOAywxHdumgDgMPOwOQOZj9t94halDlqb3qVTYgNTupox9kg0tqovA==";
+        url = "https://registry.npmjs.org/snyk-go-parser/-/snyk-go-parser-1.3.1.tgz";
+        sha512 = "jrFRfIk6yGHFeipGD66WV9ei/A/w/lIiGqI80w1ndMbg6D6M5pVNbK7ngDTmo4GdHrZDYqx/VBGBsUm2bol3Rg==";
       };
     };
-    "snyk-go-plugin-1.9.0" = {
+    "snyk-go-plugin-1.10.2" = {
       name = "snyk-go-plugin";
       packageName = "snyk-go-plugin";
-      version = "1.9.0";
+      version = "1.10.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-go-plugin/-/snyk-go-plugin-1.9.0.tgz";
-        sha512 = "8keL4KKHZUXHK2R9DSaejzs4/UPokT1LsSLBxNsqxC9PJ8JSfXIErNmUCyZbCraVt3TPUbUyAfIYoekhokMgpQ==";
+        url = "https://registry.npmjs.org/snyk-go-plugin/-/snyk-go-plugin-1.10.2.tgz";
+        sha512 = "k+f/0XgiAfnqK36L3t3EBYyMy8/vVFAU9ctHO5BztaXZXMfkYZpRsJGbvR3c7cVE4n4ruwYQhlKLM8bCuai8SQ==";
       };
     };
-    "snyk-gradle-plugin-2.12.0" = {
+    "snyk-gradle-plugin-2.12.5" = {
       name = "snyk-gradle-plugin";
       packageName = "snyk-gradle-plugin";
-      version = "2.12.0";
+      version = "2.12.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-2.12.0.tgz";
-        sha512 = "9J3wiqbd/CR6MbmqRfmXxvlGdQHo9cINwxsAoLKTErexGMXzlrEUVUiQ5F3XzUNajVCn+Kf9ukZdsLJF3JhA8A==";
+        url = "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-2.12.5.tgz";
+        sha512 = "AmiQQUL0nlY3SjWUSMSmmbp273ETJzsqvk1E8jf+G/Q3mRl9xZ6BkPMebweD/y5d/smoQmr6rKL57OG+OXoi3w==";
       };
     };
     "snyk-module-1.9.1" = {
@@ -33422,13 +33440,13 @@ let
         sha512 = "6m736zGVoeT/zS9KEtlmqTSPEPjAfLe8iYoQ3AwbyxDhzuLY49lTaV67MyZtGwjhi1x4KBe+XOgeWwyf6Avf/A==";
       };
     };
-    "snyk-php-plugin-1.5.3" = {
+    "snyk-php-plugin-1.6.2" = {
       name = "snyk-php-plugin";
       packageName = "snyk-php-plugin";
-      version = "1.5.3";
+      version = "1.6.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-php-plugin/-/snyk-php-plugin-1.5.3.tgz";
-        sha512 = "iZB3UpleLbeOL1D1bNLMFfh5hSflbQnepxmtXxXSD3S+euAhqJTZz/26QrsUIAtLQ2eHl3LfAXGTp6131tWyGw==";
+        url = "https://registry.npmjs.org/snyk-php-plugin/-/snyk-php-plugin-1.6.2.tgz";
+        sha512 = "6QM7HCmdfhuXSNGFgNOVC+GVT1Y2UfBoO+TAeV1uM1CdRGPJziz12F79a1Qyc9YGuiAwmm5DtdatUgKraC8gdA==";
       };
     };
     "snyk-policy-1.13.5" = {
@@ -33440,13 +33458,13 @@ let
         sha512 = "KI6GHt+Oj4fYKiCp7duhseUj5YhyL/zJOrrJg0u6r59Ux9w8gmkUYT92FHW27ihwuT6IPzdGNEuy06Yv2C9WaQ==";
       };
     };
-    "snyk-python-plugin-1.10.1" = {
+    "snyk-python-plugin-1.10.2" = {
       name = "snyk-python-plugin";
       packageName = "snyk-python-plugin";
-      version = "1.10.1";
+      version = "1.10.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.10.1.tgz";
-        sha512 = "1UAYRBTgnHgzPyX/PUAh9Wb9Udp6Q162IAfftK9uhN1o+KVN3RzsP/jeR0MhOXqECu7f4eABUv4rh+bn25/3hw==";
+        url = "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.10.2.tgz";
+        sha512 = "dLswHfVI9Ax8+Ia/onhv1p9S5y+Ie/oELOfpfNApbb0BPTJ5k1c2CQ7WcgQ5/nDRMUOgoKn4VTObaAGmD5or9A==";
       };
     };
     "snyk-resolve-1.0.1" = {
@@ -33467,13 +33485,13 @@ let
         sha512 = "GP3VBrkz1iDDw2q8ftTqppHqzIAxmsUIoXR+FRWDKcipkKHXHJyUmtEo11QVT5fNRV0D0RCsssk2S5CTxTCu6A==";
       };
     };
-    "snyk-sbt-plugin-2.2.0" = {
+    "snyk-sbt-plugin-2.4.2" = {
       name = "snyk-sbt-plugin";
       packageName = "snyk-sbt-plugin";
-      version = "2.2.0";
+      version = "2.4.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-sbt-plugin/-/snyk-sbt-plugin-2.2.0.tgz";
-        sha512 = "me/Su5J0ZVoOag3SrbfezHD6kkFymovGhZ0eK2P3T8607iWAOeGVEIbOXAAwMLSFmv8TpihQeWmnRgrCvPLfKw==";
+        url = "https://registry.npmjs.org/snyk-sbt-plugin/-/snyk-sbt-plugin-2.4.2.tgz";
+        sha512 = "2H49mB31cLYgZRikf0lM3c8L/0rVx5W0umTpE9kjBxCRoO1cnXDipU5Kf+/U73B1hb+g6YDUP9c4zUa/s4nX1A==";
       };
     };
     "snyk-tree-1.0.0" = {
@@ -33917,15 +33935,6 @@ let
         sha1 = "32552aa64b458392a85eab3b0b5ee61527167aeb";
       };
     };
-    "source-map-support-0.5.10" = {
-      name = "source-map-support";
-      packageName = "source-map-support";
-      version = "0.5.10";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.10.tgz";
-        sha512 = "YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==";
-      };
-    };
     "source-map-support-0.5.12" = {
       name = "source-map-support";
       packageName = "source-map-support";
@@ -33933,15 +33942,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz";
         sha512 = "4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==";
-      };
-    };
-    "source-map-support-0.5.3" = {
-      name = "source-map-support";
-      packageName = "source-map-support";
-      version = "0.5.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.3.tgz";
-        sha512 = "eKkTgWYeBOQqFGXRfKabMFdnWepo51vWqEdoeikaEPFiJC7MCU5j2h4+6Q8npkZTeLGbSyecZvRxiSoWl3rh+w==";
       };
     };
     "source-map-url-0.4.0" = {
@@ -34223,13 +34223,13 @@ let
         sha512 = "VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==";
       };
     };
-    "sqlite3-4.0.8" = {
+    "sqlite3-4.0.9" = {
       name = "sqlite3";
       packageName = "sqlite3";
-      version = "4.0.8";
+      version = "4.0.9";
       src = fetchurl {
-        url = "https://registry.npmjs.org/sqlite3/-/sqlite3-4.0.8.tgz";
-        sha512 = "kgwHu4j10KhpCHtx//dejd/tVQot7jc3sw+Sn0vMuKOw0X00Ckyg9VceKgzPyGmmz+zEoYue9tOLriWTvYy0ww==";
+        url = "https://registry.npmjs.org/sqlite3/-/sqlite3-4.0.9.tgz";
+        sha512 = "IkvzjmsWQl9BuBiM4xKpl5X8WCR4w0AeJHRdobCdXZ8dT/lNc1XS6WqvY35N6+YzIIgzSBeY5prdFObID9F9tA==";
       };
     };
     "srt2vtt-1.3.1" = {
@@ -34268,13 +34268,13 @@ let
         sha512 = "ULJhokqDW4a9l7xXKPHwbhLQgRZmEjwdrrXMsPGoVYnvKb9sJuJ8ki9ilBZIs+NmYuAV+H1ffbB2Z4uioBtFYQ==";
       };
     };
-    "ssb-client-4.7.6" = {
+    "ssb-client-4.7.7" = {
       name = "ssb-client";
       packageName = "ssb-client";
-      version = "4.7.6";
+      version = "4.7.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ssb-client/-/ssb-client-4.7.6.tgz";
-        sha512 = "Jy5BSbMpa+ZETcsxQrJuwepsxHurJxbOvtgrIh8HFPI5oA/Jql+xGBfwiy7sa61v695kSdPFlK+yS+nf+iq9ew==";
+        url = "https://registry.npmjs.org/ssb-client/-/ssb-client-4.7.7.tgz";
+        sha512 = "JKB4DzicHXEAzNnEHrp/FJI7LGnLedfmmWaXuSDjpRH0MzGGFw1oir7R5a11pe7gxXJvm1uQZ4mdNz7nJgHyyw==";
       };
     };
     "ssb-config-2.3.9" = {
@@ -34304,13 +34304,13 @@ let
         sha512 = "/4nFP7yj1JD5jrwX9bHG2nipBefl++xXXbNWD14eL+Ohs3X8kdmJeBKnHgiIF7Je4HQOI31OmEIdyyLKum5niQ==";
       };
     };
-    "ssb-ebt-5.6.4" = {
+    "ssb-ebt-5.6.6" = {
       name = "ssb-ebt";
       packageName = "ssb-ebt";
-      version = "5.6.4";
+      version = "5.6.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ssb-ebt/-/ssb-ebt-5.6.4.tgz";
-        sha512 = "ZNqOECzKyFBJW15N8Fl4iY7MGvb1ZTBxBVjcrQy7NydJn8sbHpC7PUU3QnnNgECwzoEWkuxzkn04GHJHJypo3g==";
+        url = "https://registry.npmjs.org/ssb-ebt/-/ssb-ebt-5.6.6.tgz";
+        sha512 = "RY8pY7+CY8g4zQT+/zgIzr3wBIG0SRHCEiMQoiDGOXXgDXPCnQYyhwCyhVqoDKVRK9FCkdOsfB3Vif8q8knwKw==";
       };
     };
     "ssb-friends-3.1.13" = {
@@ -34349,13 +34349,13 @@ let
         sha1 = "9e857d170dff152c53a273eb9004a0a914a106e5";
       };
     };
-    "ssb-keys-7.1.6" = {
+    "ssb-keys-7.1.7" = {
       name = "ssb-keys";
       packageName = "ssb-keys";
-      version = "7.1.6";
+      version = "7.1.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ssb-keys/-/ssb-keys-7.1.6.tgz";
-        sha512 = "DCl6BTz7zy7fElWgok1aBvYBfe6aUzafW1Q7z5WkpgdT8H90oqXe2l5DyTd7k77yyg82uDSjPOKfPAE9eBqfug==";
+        url = "https://registry.npmjs.org/ssb-keys/-/ssb-keys-7.1.7.tgz";
+        sha512 = "Zncn++gtpoF4Wjz/po4Jvt7mCHbQfU6ATljahqf1CprWAio4JBUJnQrUeUlmlTn3f4Tseo0/hoh3vk7Bu6M/Sw==";
       };
     };
     "ssb-links-3.0.8" = {
@@ -34421,13 +34421,13 @@ let
         sha1 = "dfd30cd50eecd8546bd4aa7f06e7c8f501c08118";
       };
     };
-    "ssb-query-2.4.1" = {
+    "ssb-query-2.4.2" = {
       name = "ssb-query";
       packageName = "ssb-query";
-      version = "2.4.1";
+      version = "2.4.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ssb-query/-/ssb-query-2.4.1.tgz";
-        sha512 = "n/WsKn2xvLp2PidaNgInGji1t6te959p1dNBdZ69rhTVOD9oR+YQ4M3z20d70F6XsUgbyFlVMSvvkfRcubVTkg==";
+        url = "https://registry.npmjs.org/ssb-query/-/ssb-query-2.4.2.tgz";
+        sha512 = "w1iQ6DAyY7tvB31WjNRY05+QN9JCa0pZZL287HPpI+/WZQAsNOHc96mSSXH5KRyqm+dp/W/Me/For5kvItoSCA==";
       };
     };
     "ssb-ref-2.13.9" = {
@@ -34808,22 +34808,22 @@ let
         sha1 = "bbf6b39f5f43ec30bc71babcb37557acecf34353";
       };
     };
-    "stream-to-blob-1.0.1" = {
+    "stream-to-blob-1.0.2" = {
       name = "stream-to-blob";
       packageName = "stream-to-blob";
-      version = "1.0.1";
+      version = "1.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/stream-to-blob/-/stream-to-blob-1.0.1.tgz";
-        sha512 = "aRy4neA4rf+qMtLT9fCRLPGWdrsIKtCx4kUdNTIPgPQ2hkHkdxbViVAvABMx9oRM6yCWfngHx6pwXfbYkVuPuw==";
+        url = "https://registry.npmjs.org/stream-to-blob/-/stream-to-blob-1.0.2.tgz";
+        sha512 = "ryeEu3DGMt/095uTShIYGzLbbhZ+tHQtgp5HWEhXALSoc4U1iLSvpReZUdysahnJ3tki80wBBgryqqBzFZ0KaA==";
       };
     };
-    "stream-to-blob-url-2.1.1" = {
+    "stream-to-blob-url-2.1.2" = {
       name = "stream-to-blob-url";
       packageName = "stream-to-blob-url";
-      version = "2.1.1";
+      version = "2.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/stream-to-blob-url/-/stream-to-blob-url-2.1.1.tgz";
-        sha512 = "DKJPEmCmIZoBfGVle9IhSfERiWaN5cuOtmfPxP2dZbLDRZxkBWZ4QbYxEJOSALk1Kf+WjBgedAMO6qkkf7Lmrg==";
+        url = "https://registry.npmjs.org/stream-to-blob-url/-/stream-to-blob-url-2.1.2.tgz";
+        sha512 = "dpfeYUYNodazv7rU+B9DOBj8u+dueXKOWqCy1lzPBxqeVIqq93jVTn68DZoBPLiYXSdsY9AW8D1l1BuxvghqEA==";
       };
     };
     "stream-to-promise-2.2.0" = {
@@ -34862,13 +34862,13 @@ let
         sha1 = "7d8e6b4e03ac4781778f8c79517501bfb0762a9f";
       };
     };
-    "stream-with-known-length-to-buffer-1.0.2" = {
+    "stream-with-known-length-to-buffer-1.0.3" = {
       name = "stream-with-known-length-to-buffer";
       packageName = "stream-with-known-length-to-buffer";
-      version = "1.0.2";
+      version = "1.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/stream-with-known-length-to-buffer/-/stream-with-known-length-to-buffer-1.0.2.tgz";
-        sha512 = "UxSISjxmguvfYzZdq6d4XAjc3gAocqTIOS1CjgwkDkkGT/LMTsIYiV8agIw42IHFFHf8k4lPOoroCCf4W9oqzg==";
+        url = "https://registry.npmjs.org/stream-with-known-length-to-buffer/-/stream-with-known-length-to-buffer-1.0.3.tgz";
+        sha512 = "4Wi2v47HMkNdRWrlFJNlIsrhV6z6nCyVKVAIiq14MAnc7wILEAINmn96IiPWTcXzT8y2S6yfBoX++MUxqiovag==";
       };
     };
     "streamroller-1.0.5" = {
@@ -34934,13 +34934,13 @@ let
         sha1 = "5ea211cd92d228e184294990a6cc97b366a77cb0";
       };
     };
-    "string-kit-0.9.5" = {
+    "string-kit-0.9.6" = {
       name = "string-kit";
       packageName = "string-kit";
-      version = "0.9.5";
+      version = "0.9.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/string-kit/-/string-kit-0.9.5.tgz";
-        sha512 = "qAj69c0UEV7vacaerxuhwD0iXKcCjisK5MIk1mRxlrzw1ILReJCYh5MYrCDSXypnlH0aC7QQGG3ykp37gRH41g==";
+        url = "https://registry.npmjs.org/string-kit/-/string-kit-0.9.6.tgz";
+        sha512 = "roJghJ/i+Wc87mBHLQzR29wVvXQt13H2z9hk0w1WO/jbOLtEPrLgGFR8iia9Dj62Tr3DkhEa0sL9jkvQHNuMEA==";
       };
     };
     "string-length-2.0.0" = {
@@ -35087,6 +35087,15 @@ let
         sha512 = "nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==";
       };
     };
+    "stringify-entities-2.0.0" = {
+      name = "stringify-entities";
+      packageName = "stringify-entities";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/stringify-entities/-/stringify-entities-2.0.0.tgz";
+        sha512 = "fqqhZzXyAM6pGD9lky/GOPq6V4X0SeTAFBl0iXb/BzOegl40gpf/bV3QQP7zULNYvjr6+Dx8SCaDULjVoOru0A==";
+      };
+    };
     "stringify-parameters-0.0.4" = {
       name = "stringify-parameters";
       packageName = "stringify-parameters";
@@ -35186,13 +35195,13 @@ let
         sha1 = "2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3";
       };
     };
-    "strip-bom-buf-1.0.0" = {
+    "strip-bom-buf-2.0.0" = {
       name = "strip-bom-buf";
       packageName = "strip-bom-buf";
-      version = "1.0.0";
+      version = "2.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-1.0.0.tgz";
-        sha1 = "1cb45aaf57530f4caf86c7f75179d2c9a51dd572";
+        url = "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-2.0.0.tgz";
+        sha512 = "gLFNHucd6gzb8jMsl5QmZ3QgnUJmp7qn4uUSHNwEXumAp7YizoGYw19ZUVfuq4aBOQUtyn2k8X/CwzWB73W2lQ==";
       };
     };
     "strip-bom-stream-2.0.0" = {
@@ -35204,13 +35213,13 @@ let
         sha1 = "f87db5ef2613f6968aa545abfe1ec728b6a829ca";
       };
     };
-    "strip-bom-stream-3.0.0" = {
+    "strip-bom-stream-4.0.0" = {
       name = "strip-bom-stream";
       packageName = "strip-bom-stream";
-      version = "3.0.0";
+      version = "4.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-3.0.0.tgz";
-        sha1 = "956bcc5d84430f69256a90ed823765cd858e159c";
+        url = "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-4.0.0.tgz";
+        sha512 = "0ApK3iAkHv6WbgLICw/J4nhwHeDZsBxIIsOD+gHgZICL6SeJ0S9f/WZqemka9cjkTyMN5geId6e8U5WGFAn3cQ==";
       };
     };
     "strip-bom-string-1.0.0" = {
@@ -35447,13 +35456,13 @@ let
         sha512 = "FT3QLMasz0YyCd4uIi5HNe+3t/onxMyEho7C3PSqmti3Twgy2rXT4fmkTz6wRL6bTF4uzPcfkUCa8u4JWHw8Ag==";
       };
     };
-    "superagent-5.0.5" = {
+    "superagent-5.0.9" = {
       name = "superagent";
       packageName = "superagent";
-      version = "5.0.5";
+      version = "5.0.9";
       src = fetchurl {
-        url = "https://registry.npmjs.org/superagent/-/superagent-5.0.5.tgz";
-        sha512 = "5fnihpNqJfDJHxeIkqlXKFDOW5t4WUFV8Ba1erxdWT0RySqjgAW6Hska0xNYEpAfaoMzubn77GROm/XlkssOoQ==";
+        url = "https://registry.npmjs.org/superagent/-/superagent-5.0.9.tgz";
+        sha512 = "aOBxh0xN3nCcaG0oot9apJe77FzzCOsg469l06Nw0gW7p9q0mfyAOhSiCLzHCFxKKCNtTx8cxymqoY2cGUfV8g==";
       };
     };
     "superagent-proxy-2.0.0" = {
@@ -35517,15 +35526,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz";
         sha1 = "65ac0504b3954171d8a64946b2ae3cbb8a5f54f6";
-      };
-    };
-    "supports-color-4.2.0" = {
-      name = "supports-color";
-      packageName = "supports-color";
-      version = "4.2.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/supports-color/-/supports-color-4.2.0.tgz";
-        sha512 = "Ts0Mu/A1S1aZxEJNG88I4Oc9rcZSBFNac5e27yh4j2mqbhZSSzR1Ah79EYwSn9Zuh7lrlGD2cVGzw1RKGzyLSg==";
       };
     };
     "supports-color-4.5.0" = {
@@ -35663,13 +35663,13 @@ let
         sha512 = "e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==";
       };
     };
-    "symbol-tree-3.2.2" = {
+    "symbol-tree-3.2.4" = {
       name = "symbol-tree";
       packageName = "symbol-tree";
-      version = "3.2.2";
+      version = "3.2.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz";
-        sha1 = "ae27db38f660a7ae2e1c3b7d1bc290819b8519e6";
+        url = "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz";
+        sha512 = "9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==";
       };
     };
     "sync-exec-0.6.2" = {
@@ -35717,22 +35717,22 @@ let
         sha512 = "UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==";
       };
     };
-    "table-5.4.0" = {
+    "table-5.4.1" = {
       name = "table";
       packageName = "table";
-      version = "5.4.0";
+      version = "5.4.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/table/-/table-5.4.0.tgz";
-        sha512 = "nHFDrxmbrkU7JAFKqKbDJXfzrX2UBsWmrieXFTGxiI5e4ncg3VqsZeI4EzNmX0ncp4XNGVeoxIWJXfCIXwrsvw==";
+        url = "https://registry.npmjs.org/table/-/table-5.4.1.tgz";
+        sha512 = "E6CK1/pZe2N75rGZQotFOdmzWQ1AILtgYbMAbAjvms0S1l5IDB47zG3nCnFGB/w+7nB3vKofbLXCH7HPBo864w==";
       };
     };
-    "table-layout-0.4.4" = {
+    "table-layout-0.4.5" = {
       name = "table-layout";
       packageName = "table-layout";
-      version = "0.4.4";
+      version = "0.4.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/table-layout/-/table-layout-0.4.4.tgz";
-        sha512 = "uNaR3SRMJwfdp9OUr36eyEi6LLsbcTqTO/hfTsNviKsNeyMBPICJCC7QXRF3+07bAP6FRwA8rczJPBqXDc0CkQ==";
+        url = "https://registry.npmjs.org/table-layout/-/table-layout-0.4.5.tgz";
+        sha512 = "zTvf0mcggrGeTe/2jJ6ECkJHAQPIYEwDoqsiqBjI24mvRmQbInK5jq33fyypaCBxX08hMkfmdOqj6haT33EqWw==";
       };
     };
     "tabtab-1.3.2" = {
@@ -36006,13 +36006,13 @@ let
         sha1 = "458b83887f288fc56d6fffbfad262e26638efa69";
       };
     };
-    "terminal-kit-1.28.0" = {
+    "terminal-kit-1.28.2" = {
       name = "terminal-kit";
       packageName = "terminal-kit";
-      version = "1.28.0";
+      version = "1.28.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/terminal-kit/-/terminal-kit-1.28.0.tgz";
-        sha512 = "nBXgQzGfQSaTZ55vma5WlmhpO7lDvFrjP2JiaX2MtzwxAB3Y5fm9GLqEeXwJo+n+M+7BG8zRthe3d88ET23iZA==";
+        url = "https://registry.npmjs.org/terminal-kit/-/terminal-kit-1.28.2.tgz";
+        sha512 = "j5ve5LRRM2c1sF4qpYvKwtKTS6kxQWZD1cI7r0S0hQkjsSHs3nE4Um5Ig+i15ikVdfgY+vXfJmfhgWmyY49D5Q==";
       };
     };
     "terser-3.17.0" = {
@@ -36481,15 +36481,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/tmp-promise/-/tmp-promise-1.1.0.tgz";
         sha512 = "8+Ah9aB1IRXCnIOxXZ0uFozV1nMU5xiu7hhFVUSxZ3bYu+psD4TzagCzVbexUCgNNGJnsmNDQlS4nG3mTyoNkw==";
-      };
-    };
-    "tmpl-1.0.4" = {
-      name = "tmpl";
-      packageName = "tmpl";
-      version = "1.0.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz";
-        sha1 = "23640dd7b42d00433911140820e5cf440e521dd1";
       };
     };
     "to-absolute-glob-2.0.2" = {
@@ -37059,22 +37050,31 @@ let
         sha512 = "UReOKsrJFGC9tUblgSRWo+BsVNbEd77Cl6WiV/XpMlkifXwNIJbknViCucHvVZkXSC/mcWeRnIGdY7uprcwvdQ==";
       };
     };
-    "ts-invariant-0.4.2" = {
+    "ts-invariant-0.4.4" = {
       name = "ts-invariant";
       packageName = "ts-invariant";
-      version = "0.4.2";
+      version = "0.4.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.2.tgz";
-        sha512 = "PTAAn8lJPEdRBJJEs4ig6MVZWfO12yrFzV7YaPslmyhG7+4MA279y4BXT3f72gXeVl0mC1aAWq2rMX4eKTWU/Q==";
+        url = "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.4.tgz";
+        sha512 = "uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==";
       };
     };
-    "ts-node-8.2.0" = {
+    "ts-node-8.3.0" = {
       name = "ts-node";
       packageName = "ts-node";
-      version = "8.2.0";
+      version = "8.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ts-node/-/ts-node-8.2.0.tgz";
-        sha512 = "m8XQwUurkbYqXrKqr3WHCW310utRNvV5OnRVeISeea7LoCWVcdfeB/Ntl8JYWFh+WRoUAdBgESrzKochQt7sMw==";
+        url = "https://registry.npmjs.org/ts-node/-/ts-node-8.3.0.tgz";
+        sha512 = "dyNS/RqyVTDcmNM4NIBAeDMpsAdaQ+ojdf0GOLqE6nwJOgzEkdRNzJywhDfwnuvB10oa6NLVG1rUJQCpRN7qoQ==";
+      };
+    };
+    "tslib-1.10.0" = {
+      name = "tslib";
+      packageName = "tslib";
+      version = "1.10.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz";
+        sha512 = "qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==";
       };
     };
     "tslib-1.9.3" = {
@@ -37212,6 +37212,15 @@ let
         sha512 = "/XrQjW0e5Z915m1A0qeXD9tSLDmz8zGjR6imhGDme6rMtXYudFpXXhaToKnM52nPPCNdCh6YQsLLkwbbkFvzVA==";
       };
     };
+    "type-1.0.1" = {
+      name = "type";
+      packageName = "type";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/type/-/type-1.0.1.tgz";
+        sha512 = "MAM5dBMJCJNKs9E7JXo4CXRAansRfG0nlJxW7Wf6GZzSOvH31zClSaHdIMWLehe/EGMBkqeC55rrkaOr5Oo7Nw==";
+      };
+    };
     "type-check-0.3.2" = {
       name = "type-check";
       packageName = "type-check";
@@ -37237,6 +37246,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz";
         sha512 = "cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==";
+      };
+    };
+    "type-fest-0.5.2" = {
+      name = "type-fest";
+      packageName = "type-fest";
+      version = "0.5.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/type-fest/-/type-fest-0.5.2.tgz";
+        sha512 = "DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==";
       };
     };
     "type-is-1.5.7" = {
@@ -37302,13 +37320,13 @@ let
         sha512 = "kk80vLW9iGtjMnIv11qyxLqZm20UklzuR2tL0QAnDIygIUIemcZMxlMWudl9OOt76H3ntVzcTiddQ1/pAAJMYg==";
       };
     };
-    "typescript-3.5.1" = {
+    "typescript-3.5.2" = {
       name = "typescript";
       packageName = "typescript";
-      version = "3.5.1";
+      version = "3.5.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/typescript/-/typescript-3.5.1.tgz";
-        sha512 = "64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==";
+        url = "https://registry.npmjs.org/typescript/-/typescript-3.5.2.tgz";
+        sha512 = "7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==";
       };
     };
     "typescript-eslint-parser-16.0.1" = {
@@ -37390,15 +37408,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz";
         sha512 = "8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==";
-      };
-    };
-    "uglify-js-3.5.3" = {
-      name = "uglify-js";
-      packageName = "uglify-js";
-      version = "3.5.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.3.tgz";
-        sha512 = "rIQPT2UMDnk4jRX+w4WO84/pebU2jiLsjgIyrCktYgSvx28enOE3iYQMr+BD1rHiitWnDmpu0cY/LfIEpKcjcw==";
       };
     };
     "uglify-js-3.6.0" = {
@@ -37788,13 +37797,13 @@ let
         sha1 = "198fbdaeba254e788b0efcb630bc11f24a2959e0";
       };
     };
-    "union-value-1.0.0" = {
+    "union-value-1.0.1" = {
       name = "union-value";
       packageName = "union-value";
-      version = "1.0.0";
+      version = "1.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz";
-        sha1 = "5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4";
+        url = "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz";
+        sha512 = "tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==";
       };
     };
     "uniq-1.0.1" = {
@@ -37833,13 +37842,13 @@ let
         sha512 = "Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==";
       };
     };
-    "unique-slug-2.0.1" = {
+    "unique-slug-2.0.2" = {
       name = "unique-slug";
       packageName = "unique-slug";
-      version = "2.0.1";
+      version = "2.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.1.tgz";
-        sha512 = "n9cU6+gITaVu7VGj1Z8feKMmfAjEAQGhwD9fE3zvpRRa0wEIx8ODYkVGfSc94M2OX00tUFV8wH3zYbm1I8mxFg==";
+        url = "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz";
+        sha512 = "zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==";
       };
     };
     "unique-stream-1.0.0" = {
@@ -37957,15 +37966,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.3.tgz";
         sha512 = "CtszTlOjP2sBGYc2zcKA/CvNdTdEs3ozbiJ63IPBxh8iZg42SCCb8m04f8z2+V1aSk5a7BxbZKEdoDjadmBkWA==";
-      };
-    };
-    "unist-util-select-1.5.0" = {
-      name = "unist-util-select";
-      packageName = "unist-util-select";
-      version = "1.5.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/unist-util-select/-/unist-util-select-1.5.0.tgz";
-        sha1 = "a93c2be8c0f653827803b81331adec2aa24cd933";
       };
     };
     "unist-util-stringify-position-1.1.2" = {
@@ -38166,15 +38166,6 @@ let
         sha1 = "d2f0f737d16b0615e72a6935ed04214572d56f97";
       };
     };
-    "unzip-stream-0.3.0" = {
-      name = "unzip-stream";
-      packageName = "unzip-stream";
-      version = "0.3.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/unzip-stream/-/unzip-stream-0.3.0.tgz";
-        sha512 = "NG1h/MdGIX3HzyqMjyj1laBCmlPYhcO4xEy7gEqqzGiSLw7XqDQCnY4nYSn5XSaH8mQ6TFkaujrO8d/PIZN85A==";
-      };
-    };
     "unzipper-0.9.7" = {
       name = "unzipper";
       packageName = "unzipper";
@@ -38182,15 +38173,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/unzipper/-/unzipper-0.9.7.tgz";
         sha512 = "icFtME1RD648v+cjfcUWoky4bHbMTi8nk06nGxH77EPYyEeKaTgT3nRHM/dQ3znGXLi3+OlhYo86zQzNBRdNhw==";
-      };
-    };
-    "upath-1.1.0" = {
-      name = "upath";
-      packageName = "upath";
-      version = "1.1.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz";
-        sha512 = "bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==";
       };
     };
     "upath-1.1.2" = {
@@ -38209,15 +38191,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/update-check/-/update-check-1.5.2.tgz";
         sha512 = "1TrmYLuLj/5ZovwUS7fFd1jMH3NnFDN1y1A8dboedIDt7zs/zJMo6TwwlhYKkSeEwzleeiSBV5/3c9ufAQWDaQ==";
-      };
-    };
-    "update-notifier-2.3.0" = {
-      name = "update-notifier";
-      packageName = "update-notifier";
-      version = "2.3.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/update-notifier/-/update-notifier-2.3.0.tgz";
-        sha1 = "4e8827a6bb915140ab093559d7014e3ebb837451";
       };
     };
     "update-notifier-2.5.0" = {
@@ -38551,6 +38524,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz";
         sha1 = "450d4dc9fa70de732762fbd2d4a28981419a0ccf";
+      };
+    };
+    "util-promisify-2.1.0" = {
+      name = "util-promisify";
+      packageName = "util-promisify";
+      version = "2.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/util-promisify/-/util-promisify-2.1.0.tgz";
+        sha1 = "3c2236476c4d32c5ff3c47002add7c13b9a82a53";
       };
     };
     "util.promisify-1.0.0" = {
@@ -38913,6 +38895,15 @@ let
         sha512 = "y7Y3gH9BsUSdD4KzHsuMaCzRjglXN0W2EcMf0gpvu6+SbsGhMje7xDc8AEoeXy6mIwCKMI6BkjMsRjzQbhMEjQ==";
       };
     };
+    "vfile-4.0.1" = {
+      name = "vfile";
+      packageName = "vfile";
+      version = "4.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/vfile/-/vfile-4.0.1.tgz";
+        sha512 = "lRHFCuC4SQBFr7Uq91oJDJxlnftoTLQ7eKIpMdubhYcVMho4781a8MWXLy3qZrZ0/STD1kRiKc0cQOHm4OkPeA==";
+      };
+    };
     "vfile-find-down-1.0.0" = {
       name = "vfile-find-down";
       packageName = "vfile-find-down";
@@ -38956,6 +38947,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz";
         sha512 = "1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==";
+      };
+    };
+    "vfile-message-2.0.1" = {
+      name = "vfile-message";
+      packageName = "vfile-message";
+      version = "2.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.1.tgz";
+        sha512 = "KtasSV+uVU7RWhUn4Lw+wW1Zl/nW8JWx7JCPps10Y9JRRIDeDXf8wfBLoOSsJLyo27DqMyAi54C6Jf/d6Kr2Bw==";
       };
     };
     "vfile-reporter-1.5.0" = {
@@ -39021,13 +39021,13 @@ let
         sha1 = "2fb1decd4c466aa88b0f9341af33dc1aff2478d5";
       };
     };
-    "videostream-2.6.0" = {
+    "videostream-3.2.0" = {
       name = "videostream";
       packageName = "videostream";
-      version = "2.6.0";
+      version = "3.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/videostream/-/videostream-2.6.0.tgz";
-        sha512 = "nSsullx1BYClJxVSt4Fa+Ulsv0Cf7UwaHq+4LQdLkAUdmqNhY1DlGxXDWVY2gui5XV4FvDiSbXmSbGryMrrUCQ==";
+        url = "https://registry.npmjs.org/videostream/-/videostream-3.2.0.tgz";
+        sha512 = "8+EY2dBxpJti9OBWUHtTn8wZEzyUwX7ldm/rwz8LKsgK+ccGVbTug9F6nyBOehLhifXALCs6Ca+CeYPVGBwobg==";
       };
     };
     "vinyl-0.4.6" = {
@@ -39129,15 +39129,6 @@ let
         sha512 = "DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==";
       };
     };
-    "vm-browserify-0.0.4" = {
-      name = "vm-browserify";
-      packageName = "vm-browserify";
-      version = "0.0.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz";
-        sha1 = "5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73";
-      };
-    };
     "vm-browserify-1.1.0" = {
       name = "vm-browserify";
       packageName = "vm-browserify";
@@ -39174,13 +39165,13 @@ let
         sha512 = "RWkO/c/A7iXhHEy3OuEqkCqavDjpD4NF2Ca8vjai+ZtEYNeHrm1ybTnBYLP4Ft1uXvvaaVtYA9HrDjD6+CUONg==";
       };
     };
-    "vscode-css-languageservice-4.0.2-next.4" = {
+    "vscode-css-languageservice-4.0.2" = {
       name = "vscode-css-languageservice";
       packageName = "vscode-css-languageservice";
-      version = "4.0.2-next.4";
+      version = "4.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-4.0.2-next.4.tgz";
-        sha512 = "k8sRcmzu58Muusx0IkIYWuFaG4VBQsxy6nM+Cken0sY/bemS5cvX2l4g5zRIJTzUHr85sxqkLmUk0n6Ef/asFA==";
+        url = "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-4.0.2.tgz";
+        sha512 = "pTnfXbsME3pl+yDfhUp/mtvPyIJk0Le4zqJxDn56s9GY9LqY0RmkSEh0oHH6D0HXR3Ni6wKosIaqu8a2G0+jdw==";
       };
     };
     "vscode-emmet-helper-1.2.15" = {
@@ -39264,13 +39255,13 @@ let
         sha512 = "GuayqdKZqAwwaCUjDvMTAVRPJOp/SLON3mJ07eGsx/Iq9HjRymhKWztX41rISqDKhHVVyFM+IywICyZDla6U3A==";
       };
     };
-    "vscode-languageserver-5.3.0-next.7" = {
+    "vscode-languageserver-5.3.0-next.8" = {
       name = "vscode-languageserver";
       packageName = "vscode-languageserver";
-      version = "5.3.0-next.7";
+      version = "5.3.0-next.8";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-5.3.0-next.7.tgz";
-        sha512 = "9jPezPNmqmpjqeH8Xl42Y60lkpfEQkwVnHOhj7uemPbgOqfW41Rq86kpS0du+Xo9dTzxK67KhEkXoEcIO0Xy/Q==";
+        url = "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-5.3.0-next.8.tgz";
+        sha512 = "6vUb96wsRfrFqndril3gct/FBCSc24OxFZ2iz7kuEuXvLaIcEVOcSZIqQK8oFN7PdbAIaa9nnIpKSy4Yd15cIw==";
       };
     };
     "vscode-languageserver-protocol-3.14.1" = {
@@ -39282,13 +39273,13 @@ let
         sha512 = "IL66BLb2g20uIKog5Y2dQ0IiigW0XKrvmWiOvc0yXw80z3tMEzEnHjaGAb3ENuU7MnQqgnYJ1Cl2l9RvNgDi4g==";
       };
     };
-    "vscode-languageserver-protocol-3.15.0-next.5" = {
+    "vscode-languageserver-protocol-3.15.0-next.6" = {
       name = "vscode-languageserver-protocol";
       packageName = "vscode-languageserver-protocol";
-      version = "3.15.0-next.5";
+      version = "3.15.0-next.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.0-next.5.tgz";
-        sha512 = "rR7Zo5WZTGSsE9lq7pPSgO+VMhVV8UVq6emrDoQ3x5dUyhLKB2/gbMkGKucQpsKGLtF/NuccCa+3jMsO788HjQ==";
+        url = "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.0-next.6.tgz";
+        sha512 = "/yDpYlWyNs26mM23mT73xmOFsh1iRfgZfBdHmfAxwDKwpQKLoOSqVidtYfxlK/pD3IEKGcAVnT4WXTsguxxAMQ==";
       };
     };
     "vscode-languageserver-protocol-3.6.0" = {
@@ -39318,13 +39309,13 @@ let
         sha512 = "lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A==";
       };
     };
-    "vscode-languageserver-types-3.15.0-next.1" = {
+    "vscode-languageserver-types-3.15.0-next.2" = {
       name = "vscode-languageserver-types";
       packageName = "vscode-languageserver-types";
-      version = "3.15.0-next.1";
+      version = "3.15.0-next.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.15.0-next.1.tgz";
-        sha512 = "R0kzmaI8gOGEoU7b9huYQAzgZzRQ/5Q8HKjsIUdfz0MjXcBZ4tr1ik1So1p1O5kGrI1VTCd22Fw/wI7ECGoIPw==";
+        url = "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.15.0-next.2.tgz";
+        sha512 = "2JkrMWWUi2rlVLSo9OFR2PIGUzdiowEM8NgNYiwLKnXTjpwpjjIrJbNNxDik7Rv4oo9KtikcFQZKXbrKilL/MQ==";
       };
     };
     "vscode-nls-3.2.5" = {
@@ -39453,15 +39444,6 @@ let
         sha512 = "5skcWAUmySj6hkBdH6B6+3ddMjVQYH5Qy9QGbPmN8kVmLteXk+yVXg+yfk1nbX30EYakahLrr8iPcCxJQSCBeg==";
       };
     };
-    "walker-1.0.7" = {
-      name = "walker";
-      packageName = "walker";
-      version = "1.0.7";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz";
-        sha1 = "2f7f9b8fd10d677262b18a884e28d19618e028fb";
-      };
-    };
     "ware-1.3.0" = {
       name = "ware";
       packageName = "ware";
@@ -39478,15 +39460,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/watch/-/watch-1.0.2.tgz";
         sha1 = "340a717bde765726fa0aa07d721e0147a551df0c";
-      };
-    };
-    "watchpack-1.5.0" = {
-      name = "watchpack";
-      packageName = "watchpack";
-      version = "1.5.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/watchpack/-/watchpack-1.5.0.tgz";
-        sha512 = "RSlipNQB1u48cq0wH/BNfCu1tD/cJ8ydFIkNYhp9o+3d+8unClkIovpW5qpFPgmL9OE48wfAnlZydXByWP82AA==";
       };
     };
     "watchpack-1.6.0" = {
@@ -39543,22 +39516,22 @@ let
         sha512 = "YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==";
       };
     };
-    "webpack-4.33.0" = {
+    "webpack-4.35.0" = {
       name = "webpack";
       packageName = "webpack";
-      version = "4.33.0";
+      version = "4.35.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/webpack/-/webpack-4.33.0.tgz";
-        sha512 = "ggWMb0B2QUuYso6FPZKUohOgfm+Z0sVFs8WwWuSH1IAvkWs428VDNmOlAxvHGTB9Dm/qOB/qtE5cRx5y01clxw==";
+        url = "https://registry.npmjs.org/webpack/-/webpack-4.35.0.tgz";
+        sha512 = "M5hL3qpVvtr8d4YaJANbAQBc4uT01G33eDpl/psRTBCfjxFTihdhin1NtAKB1ruDwzeVdcsHHV3NX+QsAgOosw==";
       };
     };
-    "webpack-cli-3.3.2" = {
+    "webpack-cli-3.3.5" = {
       name = "webpack-cli";
       packageName = "webpack-cli";
-      version = "3.3.2";
+      version = "3.3.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.2.tgz";
-        sha512 = "FLkobnaJJ+03j5eplxlI0TUxhGCOdfewspIGuvDVtpOlrAuKMFC57K42Ukxqs1tn8947/PM6tP95gQc0DCzRYA==";
+        url = "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.5.tgz";
+        sha512 = "w0j/s42c5UhchwTmV/45MLQnTVwRoaUTu9fM5LuyOd/8lFoCNCELDogFoecx5NzRUndO0yD/gF2b02XKMnmAWQ==";
       };
     };
     "webpack-core-0.6.9" = {
@@ -39579,13 +39552,13 @@ let
         sha512 = "OiVgSrbGu7NEnEvQJJgdSFPl2qWKkWq5lHMhgiToIiN9w34EBnjYzSYs+VbL5KoYiLNtFFa7BZIKxRED3I32pA==";
       };
     };
-    "websocket-driver-0.7.0" = {
+    "websocket-driver-0.7.3" = {
       name = "websocket-driver";
       packageName = "websocket-driver";
-      version = "0.7.0";
+      version = "0.7.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz";
-        sha1 = "0caf9d2d755d93aee049d4bdd0d3fe2cca2a24eb";
+        url = "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.3.tgz";
+        sha512 = "bpxWlvbbB459Mlipc5GBzzZwhoZgGEZLuqPaR0INBGnPAY1vdBX6hPnoFXiw+3yWxDuHyQjO2oXTMyS8A5haFg==";
       };
     };
     "websocket-extensions-0.1.3" = {
@@ -39606,13 +39579,13 @@ let
         sha512 = "EXy/zXb9kNHI07TIMz1oIUIrPZxQRA8aeJ5XYg5ihV8K4kD1DuA+FY6R96HfdIHzlSzS8HiISAfrm+vVQkZBug==";
       };
     };
-    "webtorrent-0.103.1" = {
+    "webtorrent-0.104.0" = {
       name = "webtorrent";
       packageName = "webtorrent";
-      version = "0.103.1";
+      version = "0.104.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/webtorrent/-/webtorrent-0.103.1.tgz";
-        sha512 = "rqMD8sAaPzrUzEpA6gDEOgcN9Xyz4WGrQiHoVY6HlymLoNSkScMnmnEX1bsdMcIU9iOrnUlghDEW9sJ9jYCmwQ==";
+        url = "https://registry.npmjs.org/webtorrent/-/webtorrent-0.104.0.tgz";
+        sha512 = "5/SXilp8xcs89Ep5TPjC/cF8I5F9sC8KlzhQQrO3i2OrWM88r43Hl8bcK/RT/6tn/BLf2SrOl7C3bYuUgTb90w==";
       };
     };
     "whatwg-encoding-1.0.5" = {
@@ -40020,6 +39993,15 @@ let
         sha512 = "QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==";
       };
     };
+    "wrap-ansi-6.0.0" = {
+      name = "wrap-ansi";
+      packageName = "wrap-ansi";
+      version = "6.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.0.0.tgz";
+        sha512 = "8YwLklVkHe4QNpGFrK6Mxm+BaMY7da6C9GlDED3xs3XwThyJHSbVwg9qC4s1N8tBFcnM1S0s8I390RC6SgGe+g==";
+      };
+    };
     "wrap-fn-0.1.5" = {
       name = "wrap-fn";
       packageName = "wrap-fn";
@@ -40063,6 +40045,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz";
         sha512 = "GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==";
+      };
+    };
+    "write-file-atomic-3.0.0" = {
+      name = "write-file-atomic";
+      packageName = "write-file-atomic";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.0.tgz";
+        sha512 = "EIgkf60l2oWsffja2Sf2AL384dx328c0B+cIYPTQq5q2rOYuDV00/iPFBOUiDKKwKMOhkymH8AidPaRvzfxY+Q==";
       };
     };
     "write-good-0.11.3" = {
@@ -40162,6 +40153,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz";
         sha512 = "GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==";
+      };
+    };
+    "ws-7.0.1" = {
+      name = "ws";
+      packageName = "ws";
+      version = "7.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ws/-/ws-7.0.1.tgz";
+        sha512 = "ILHfMbuqLJvnSgYXLgy4kMntroJpe8hT41dOVWM8bxRuw6TK4mgMp9VJUNsZTEc5Bh+Mbs0DJT4M0N+wBG9l9A==";
       };
     };
     "wtf-8-1.0.0" = {
@@ -40317,15 +40317,6 @@ let
         sha1 = "98b8f651ca30aa624036f127d11cc66dc7b907a3";
       };
     };
-    "xmlbuilder-8.2.2" = {
-      name = "xmlbuilder";
-      packageName = "xmlbuilder";
-      version = "8.2.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz";
-        sha1 = "69248673410b4ba42e1a6136551d2922335aa773";
-      };
-    };
     "xmlbuilder-9.0.7" = {
       name = "xmlbuilder";
       packageName = "xmlbuilder";
@@ -40399,13 +40390,13 @@ let
         sha1 = "52a63e56ca0b84a7f3a5f3d61872f126ad7a5943";
       };
     };
-    "xregexp-4.0.0" = {
+    "xregexp-4.2.4" = {
       name = "xregexp";
       packageName = "xregexp";
-      version = "4.0.0";
+      version = "4.2.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz";
-        sha512 = "PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg==";
+        url = "https://registry.npmjs.org/xregexp/-/xregexp-4.2.4.tgz";
+        sha512 = "sO0bYdYeJAJBcJA8g7MJJX7UrOZIfJPd8U2SC7B2Dd/J24U0aQNoGp33shCaBSWeb0rD5rh6VBUIXOkGal1TZA==";
       };
     };
     "xsalsa20-1.0.2" = {
@@ -40570,15 +40561,6 @@ let
         sha512 = "Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==";
       };
     };
-    "yargs-13.1.0" = {
-      name = "yargs";
-      packageName = "yargs";
-      version = "13.1.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/yargs/-/yargs-13.1.0.tgz";
-        sha512 = "1UhJbXfzHiPqkfXNHYhiz79qM/kZqjTE8yGlEjZa85Q+3+OwcV6NRkV7XOV1W2Eom2bzILeUn55pQYffjVOLAg==";
-      };
-    };
     "yargs-13.2.2" = {
       name = "yargs";
       packageName = "yargs";
@@ -40595,6 +40577,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/yargs/-/yargs-13.2.4.tgz";
         sha512 = "HG/DWAJa1PAnHT9JAhNa8AbAv3FPaiLzioSjCcmuXXhP8MlpHO5vwls4g4j6n30Z74GVQj8Xa62dWVx1QCGklg==";
+      };
+    };
+    "yargs-13.3.0" = {
+      name = "yargs";
+      packageName = "yargs";
+      version = "13.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz";
+        sha512 = "2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==";
       };
     };
     "yargs-3.10.0" = {
@@ -40622,15 +40613,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/yargs/-/yargs-4.7.1.tgz";
         sha1 = "e60432658a3387ff269c028eacde4a512e438dff";
-      };
-    };
-    "yargs-6.6.0" = {
-      name = "yargs";
-      packageName = "yargs";
-      version = "6.6.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz";
-        sha1 = "782ec21ef403345f830a808ca3d513af56065208";
       };
     };
     "yargs-7.1.0" = {
@@ -40678,13 +40660,13 @@ let
         sha512 = "w2LXjoL8oRdRQN+hOyppuXs+V/fVAYtpcrRxZuF7Kt/Oc+Jr2uAcVntaUTNT6w5ihoWfFDpNY8CPx1QskxZ/pw==";
       };
     };
-    "yargs-parser-13.1.0" = {
+    "yargs-parser-13.1.1" = {
       name = "yargs-parser";
       packageName = "yargs-parser";
-      version = "13.1.0";
+      version = "13.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.0.tgz";
-        sha512 = "Yq+32PrijHRri0vVKQEm+ys8mbqWjLiwQkMFNXEENutzLPP0bE4Lcd4iA3OQY5HF+GD3xXxf0MEHb8E4/SA3AA==";
+        url = "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz";
+        sha512 = "oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==";
       };
     };
     "yargs-parser-2.4.1" = {
@@ -40694,15 +40676,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz";
         sha1 = "85568de3cf150ff49fa51825f03a8c880ddcc5c4";
-      };
-    };
-    "yargs-parser-4.2.1" = {
-      name = "yargs-parser";
-      packageName = "yargs-parser";
-      version = "4.2.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz";
-        sha1 = "29cceac0dc4f03c6c87b4a9f217dd18c9f74871c";
       };
     };
     "yargs-parser-5.0.0" = {
@@ -40786,13 +40759,13 @@ let
         sha512 = "L/1PUIReI8cOzAWgmBY64VBCLeH2IEpgtnF3X97BUU6SraQFczeXXIzh6n5idG4jfzMfWRF1lS4zf6wdg7hAbw==";
       };
     };
-    "yeoman-environment-2.3.4" = {
+    "yeoman-environment-2.4.0" = {
       name = "yeoman-environment";
       packageName = "yeoman-environment";
-      version = "2.3.4";
+      version = "2.4.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.3.4.tgz";
-        sha512 = "KLxE5ft/74Qj7h3AsQZv8G6MEEHYJwmD5F99nfOVaep3rBzCtbrJKkdqWc7bDV141Nr8UZZsIXmzc3IcCm6E2w==";
+        url = "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.4.0.tgz";
+        sha512 = "SsvoL0RNAFIX69eFxkUhwKUN2hG1UwUjxrcP+T2ytwdhqC/kHdnFOH2SXdtSN1Ju4aO4xuimmzfRoheYY88RuA==";
       };
     };
     "yn-3.1.0" = {
@@ -40840,13 +40813,13 @@ let
         sha512 = "kQz39uonEjEESwh+qCi83kcC3rZJGh4mrZW7xjkSQYXkq//JZHTtKo+6yuVloTgMtzsIWOJrjIrKvk/dqm0L5g==";
       };
     };
-    "zen-observable-ts-0.8.18" = {
+    "zen-observable-ts-0.8.19" = {
       name = "zen-observable-ts";
       packageName = "zen-observable-ts";
-      version = "0.8.18";
+      version = "0.8.19";
       src = fetchurl {
-        url = "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.18.tgz";
-        sha512 = "q7d05s75Rn1j39U5Oapg3HI2wzriVwERVo4N7uFGpIYuHB9ff02P/E92P9B8T7QVC93jCMHpbXH7X0eVR5LA7A==";
+        url = "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.19.tgz";
+        sha512 = "u1a2rpE13G+jSzrg3aiCqXU5tN2kw41b+cBZGmnc+30YimdkKiDj9bTowcB41eL77/17RF/h+393AuVgShyheQ==";
       };
     };
     "zerr-1.0.4" = {
@@ -40891,17 +40864,17 @@ in
   "@angular/cli" = nodeEnv.buildNodePackage {
     name = "_at_angular_slash_cli";
     packageName = "@angular/cli";
-    version = "8.0.1";
+    version = "8.0.6";
     src = fetchurl {
-      url = "https://registry.npmjs.org/@angular/cli/-/cli-8.0.1.tgz";
-      sha512 = "V8U4jNE9khQd7ykzewTpGcB7AjRhWIGb3opPfYux5umQsVhlhQqj/jVgGMu+kN9Jl7KkjFzQTjsJws7wODP6MA==";
+      url = "https://registry.npmjs.org/@angular/cli/-/cli-8.0.6.tgz";
+      sha512 = "COBpeoXyLt8FiOhsmoEnDfQcm0aTdUSUHsH3zNkVTcyxpRzZVspTDGzxhK0UsCpddXS/MMjJiXph6SJ1el3qaQ==";
     };
     dependencies = [
-      sources."@angular-devkit/architect-0.800.1"
-      sources."@angular-devkit/core-8.0.1"
-      sources."@angular-devkit/schematics-8.0.1"
-      sources."@schematics/angular-8.0.1"
-      sources."@schematics/update-0.800.1"
+      sources."@angular-devkit/architect-0.800.6"
+      sources."@angular-devkit/core-8.0.6"
+      sources."@angular-devkit/schematics-8.0.6"
+      sources."@schematics/angular-8.0.6"
+      sources."@schematics/update-0.800.6"
       sources."@yarnpkg/lockfile-1.1.0"
       sources."JSONStream-1.3.5"
       sources."agent-base-4.3.0"
@@ -40923,7 +40896,7 @@ in
       sources."brace-expansion-1.1.11"
       sources."buffer-from-1.1.1"
       sources."builtins-1.0.3"
-      sources."cacache-11.3.2"
+      sources."cacache-11.3.3"
       sources."caseless-0.12.0"
       sources."chalk-2.4.2"
       sources."chardet-0.7.0"
@@ -40948,7 +40921,7 @@ in
       sources."encoding-0.1.12"
       sources."end-of-stream-1.4.1"
       sources."err-code-1.1.2"
-      sources."es6-promise-4.2.6"
+      sources."es6-promise-4.2.8"
       sources."es6-promisify-5.0.0"
       sources."escape-string-regexp-1.0.5"
       sources."extend-3.0.2"
@@ -40969,7 +40942,7 @@ in
       sources."get-stream-4.1.0"
       sources."getpass-0.1.7"
       sources."glob-7.1.4"
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-flag-3.0.0"
@@ -40993,7 +40966,7 @@ in
       sources."ignore-walk-3.0.1"
       sources."imurmurhash-0.1.4"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."ini-1.3.5"
       sources."inquirer-6.3.1"
       sources."ip-1.1.5"
@@ -41030,7 +41003,7 @@ in
       sources."mississippi-3.0.0"
       sources."mkdirp-0.5.1"
       sources."move-concurrently-1.0.1"
-      sources."ms-2.1.1"
+      sources."ms-2.1.2"
       sources."mute-stream-0.0.7"
       sources."node-fetch-npm-2.0.2"
       (sources."normalize-package-data-2.5.0" // {
@@ -41044,7 +41017,7 @@ in
           sources."semver-5.7.0"
         ];
       })
-      sources."npm-packlist-1.4.1"
+      sources."npm-packlist-1.4.3"
       (sources."npm-pick-manifest-2.2.3" // {
         dependencies = [
           sources."semver-5.7.0"
@@ -41072,12 +41045,12 @@ in
       sources."path-is-absolute-1.0.1"
       sources."path-parse-1.0.6"
       sources."performance-now-2.1.0"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."promise-inflight-1.0.1"
       sources."promise-retry-1.1.1"
       sources."protoduck-5.0.1"
       sources."pseudomap-1.0.2"
-      sources."psl-1.1.32"
+      sources."psl-1.1.33"
       sources."pump-3.0.0"
       (sources."pumpify-1.5.1" // {
         dependencies = [
@@ -41089,7 +41062,7 @@ in
       sources."read-package-json-2.0.13"
       sources."read-package-tree-5.2.2"
       sources."readable-stream-2.3.6"
-      sources."readdir-scoped-modules-1.0.2"
+      sources."readdir-scoped-modules-1.1.0"
       sources."request-2.88.0"
       sources."resolve-1.11.1"
       sources."restore-cursor-2.0.0"
@@ -41147,12 +41120,12 @@ in
           sources."punycode-1.4.1"
         ];
       })
-      sources."tslib-1.9.3"
+      sources."tslib-1.10.0"
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       sources."typedarray-0.0.6"
       sources."unique-filename-1.1.1"
-      sources."unique-slug-2.0.1"
+      sources."unique-slug-2.0.2"
       (sources."universal-analytics-0.4.20" // {
         dependencies = [
           sources."debug-3.2.6"
@@ -41199,7 +41172,7 @@ in
       sources."fs.realpath-1.0.0"
       sources."glob-7.1.4"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
       sources."mkdirp-0.5.1"
@@ -41223,16 +41196,16 @@ in
   azure-functions-core-tools = nodeEnv.buildNodePackage {
     name = "azure-functions-core-tools";
     packageName = "azure-functions-core-tools";
-    version = "2.7.1158";
+    version = "2.7.1373";
     src = fetchurl {
-      url = "https://registry.npmjs.org/azure-functions-core-tools/-/azure-functions-core-tools-2.7.1158.tgz";
-      sha512 = "40RPWifao1FogT0OaDM5/VMik1d+rZ/moMitdzTThuiP1n7RAjUzqoVZSeEbOyijTZG++HBLiaIp2gXFv/Gadw==";
+      url = "https://registry.npmjs.org/azure-functions-core-tools/-/azure-functions-core-tools-2.7.1373.tgz";
+      sha512 = "EC4lgHBgmSoDFjJSIXMWT24Ner3ctUzDBKM0Xz8mX+RlrpIkKHJq7I8EtcGXBWpF4QIAJYbD3sGP/9h6JqI10A==";
     };
     dependencies = [
       sources."agent-base-4.3.0"
       sources."ansi-styles-3.2.1"
       sources."balanced-match-1.0.0"
-      sources."big-integer-1.6.43"
+      sources."big-integer-1.6.44"
       sources."binary-0.3.0"
       sources."bluebird-3.4.7"
       sources."brace-expansion-1.1.11"
@@ -41247,27 +41220,27 @@ in
       sources."core-util-is-1.0.2"
       sources."debug-3.2.6"
       sources."duplexer2-0.1.4"
-      sources."es6-promise-4.2.6"
+      sources."es6-promise-4.2.8"
       sources."es6-promisify-5.0.0"
       sources."escape-string-regexp-1.0.5"
       sources."fs.realpath-1.0.0"
       sources."fstream-1.0.12"
       sources."glob-7.1.3"
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."has-flag-3.0.0"
       sources."https-proxy-agent-2.2.1"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."isarray-1.0.0"
       sources."listenercount-1.0.1"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
       sources."mkdirp-0.5.1"
-      sources."ms-2.1.1"
+      sources."ms-2.1.2"
       sources."once-1.4.0"
       sources."os-tmpdir-1.0.2"
       sources."path-is-absolute-1.0.1"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."progress-2.0.3"
       sources."readable-stream-2.3.6"
       sources."rimraf-2.6.3"
@@ -41376,7 +41349,7 @@ in
       sources."http-signature-1.2.0"
       sources."iconv-lite-0.4.24"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."ini-1.3.5"
       sources."is-fullwidth-code-point-1.0.0"
       sources."is-typedarray-1.0.0"
@@ -41404,7 +41377,7 @@ in
       })
       sources."nan-2.14.0"
       sources."napi-build-utils-1.0.1"
-      sources."node-abi-2.8.0"
+      sources."node-abi-2.9.0"
       sources."noop-logger-0.1.1"
       sources."npmlog-4.1.2"
       sources."number-is-nan-1.0.1"
@@ -41420,8 +41393,8 @@ in
       sources."pn-1.1.0"
       sources."prebuild-install-5.3.0"
       sources."prelude-ls-1.1.2"
-      sources."process-nextick-args-2.0.0"
-      sources."psl-1.1.32"
+      sources."process-nextick-args-2.0.1"
+      sources."psl-1.1.33"
       sources."pump-2.0.1"
       sources."punycode-2.1.1"
       sources."qs-6.5.2"
@@ -41445,7 +41418,7 @@ in
       sources."string_decoder-1.1.1"
       sources."strip-ansi-3.0.1"
       sources."strip-json-comments-2.0.1"
-      sources."symbol-tree-3.2.2"
+      sources."symbol-tree-3.2.4"
       (sources."tar-fs-1.16.3" // {
         dependencies = [
           sources."pump-1.0.3"
@@ -41547,7 +41520,7 @@ in
       sources."find-up-1.1.2"
       (sources."fs-extra-0.26.7" // {
         dependencies = [
-          sources."graceful-fs-4.1.15"
+          sources."graceful-fs-4.2.0"
         ];
       })
       sources."fs.realpath-1.0.0"
@@ -41557,7 +41530,7 @@ in
       sources."hosted-git-info-2.7.1"
       sources."indent-string-2.1.0"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."intersect-1.0.1"
       sources."is-arrayish-0.2.1"
       sources."is-finite-1.0.2"
@@ -41565,17 +41538,17 @@ in
       sources."is-utf8-0.2.1"
       (sources."jsonfile-2.4.0" // {
         dependencies = [
-          sources."graceful-fs-4.1.15"
+          sources."graceful-fs-4.2.0"
         ];
       })
       (sources."klaw-1.3.1" // {
         dependencies = [
-          sources."graceful-fs-4.1.15"
+          sources."graceful-fs-4.2.0"
         ];
       })
       (sources."load-json-file-1.1.0" // {
         dependencies = [
-          sources."graceful-fs-4.1.15"
+          sources."graceful-fs-4.2.0"
         ];
       })
       sources."lodash-4.2.1"
@@ -41603,7 +41576,7 @@ in
       sources."path-parse-1.0.6"
       (sources."path-type-1.1.0" // {
         dependencies = [
-          sources."graceful-fs-4.1.15"
+          sources."graceful-fs-4.2.0"
         ];
       })
       sources."pify-2.3.0"
@@ -41722,7 +41695,7 @@ in
       sources."diffie-hellman-5.0.3"
       sources."domain-browser-1.2.0"
       sources."duplexer2-0.1.4"
-      sources."elliptic-6.4.1"
+      sources."elliptic-6.5.0"
       sources."events-2.1.0"
       sources."evp_bytestokey-1.0.3"
       sources."fs.realpath-1.0.0"
@@ -41737,7 +41710,7 @@ in
       sources."https-browserify-1.0.0"
       sources."ieee754-1.1.13"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."inline-source-map-0.6.2"
       sources."insert-module-globals-7.2.0"
       sources."is-buffer-1.1.6"
@@ -41767,7 +41740,7 @@ in
       sources."path-platform-0.11.15"
       sources."pbkdf2-3.0.17"
       sources."process-0.11.10"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."public-encrypt-4.0.3"
       sources."punycode-1.4.1"
       sources."querystring-0.2.0"
@@ -41812,7 +41785,11 @@ in
           sources."punycode-1.3.2"
         ];
       })
-      sources."util-0.10.4"
+      (sources."util-0.10.4" // {
+        dependencies = [
+          sources."inherits-2.0.3"
+        ];
+      })
       sources."util-deprecate-1.0.2"
       sources."vm-browserify-1.1.0"
       sources."wrappy-1.0.2"
@@ -41951,7 +41928,7 @@ in
       sources."getpass-0.1.7"
       sources."glob-7.1.4"
       sources."got-1.2.2"
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-ansi-1.0.3"
@@ -41961,7 +41938,7 @@ in
       sources."immediate-chunk-store-1.0.8"
       sources."indent-string-2.1.0"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."ini-1.1.0"
       sources."inquirer-0.8.5"
       sources."internal-ip-1.2.0"
@@ -42069,10 +42046,10 @@ in
         ];
       })
       sources."plist-3.0.1"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."promiscuous-0.6.0"
       sources."protobufjs-3.8.2"
-      sources."psl-1.1.32"
+      sources."psl-1.1.33"
       (sources."pump-0.3.5" // {
         dependencies = [
           sources."once-1.2.0"
@@ -42082,13 +42059,13 @@ in
       sources."qap-3.3.1"
       sources."qs-6.5.2"
       sources."query-string-1.0.1"
-      (sources."random-access-file-2.1.2" // {
+      (sources."random-access-file-2.1.3" // {
         dependencies = [
           sources."minimist-0.0.8"
           sources."mkdirp-0.5.1"
         ];
       })
-      sources."random-access-storage-1.3.0"
+      sources."random-access-storage-1.4.0"
       sources."random-iterate-1.0.1"
       sources."randombytes-2.1.0"
       sources."range-parser-1.2.1"
@@ -42097,7 +42074,7 @@ in
           sources."minimist-0.0.10"
         ];
       })
-      sources."re-emitter-1.1.3"
+      sources."re-emitter-1.1.4"
       sources."read-pkg-1.1.0"
       sources."read-pkg-up-1.0.1"
       (sources."read-torrent-1.3.1" // {
@@ -42294,7 +42271,7 @@ in
       sources."lodash-3.10.1"
       sources."log-symbols-2.2.0"
       sources."mimic-fn-1.2.0"
-      sources."ms-2.1.1"
+      sources."ms-2.1.2"
       sources."number-is-nan-1.0.1"
       sources."onetime-2.0.1"
       sources."ora-1.4.0"
@@ -42342,7 +42319,7 @@ in
       sources."fecha-2.3.3"
       sources."follow-redirects-1.7.0"
       sources."http-proxy-1.17.0"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."is-arrayish-0.3.2"
       sources."is-stream-1.1.0"
       sources."isarray-1.0.0"
@@ -42351,9 +42328,9 @@ in
       sources."logform-2.1.2"
       sources."lynx-0.2.0"
       sources."mersenne-0.0.4"
-      sources."ms-2.1.1"
+      sources."ms-2.1.2"
       sources."one-time-0.0.4"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."readable-stream-3.4.0"
       sources."requires-port-1.0.0"
       sources."safe-buffer-5.1.2"
@@ -42397,7 +42374,7 @@ in
       sources."@types/events-3.0.0"
       sources."@types/glob-7.1.1"
       sources."@types/minimatch-3.0.3"
-      sources."@types/node-12.0.4"
+      sources."@types/node-12.0.10"
       sources."abbrev-1.1.1"
       sources."accepts-1.3.7"
       sources."ajv-6.10.0"
@@ -42430,7 +42407,7 @@ in
       })
       sources."base64-js-1.3.0"
       sources."bcrypt-pbkdf-1.0.2"
-      sources."big-integer-1.6.43"
+      sources."big-integer-1.6.44"
       (sources."body-parser-1.19.0" // {
         dependencies = [
           sources."bytes-3.1.0"
@@ -42491,14 +42468,23 @@ in
       sources."cookie-signature-1.0.6"
       sources."copy-descriptor-0.1.1"
       sources."cordova-app-hello-world-4.0.0"
-      sources."cordova-common-3.1.0"
-      sources."cordova-create-2.0.0"
+      sources."cordova-common-3.2.0"
+      (sources."cordova-create-2.0.0" // {
+        dependencies = [
+          sources."fs-extra-7.0.1"
+        ];
+      })
       (sources."cordova-fetch-2.0.1" // {
         dependencies = [
+          sources."fs-extra-7.0.1"
           sources."pify-4.0.1"
         ];
       })
-      sources."cordova-lib-9.0.1"
+      (sources."cordova-lib-9.0.1" // {
+        dependencies = [
+          sources."fs-extra-7.0.1"
+        ];
+      })
       sources."cordova-serve-3.0.0"
       sources."core-util-is-1.0.2"
       sources."create-error-class-3.0.2"
@@ -42592,7 +42578,7 @@ in
       sources."forwarded-0.1.2"
       sources."fragment-cache-0.2.1"
       sources."fresh-0.5.2"
-      sources."fs-extra-7.0.1"
+      sources."fs-extra-8.1.0"
       sources."fs.realpath-1.0.0"
       sources."function-bind-1.1.1"
       sources."get-stream-4.1.0"
@@ -42616,7 +42602,7 @@ in
           sources."get-stream-3.0.0"
         ];
       })
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-1.0.3"
@@ -42629,7 +42615,11 @@ in
         ];
       })
       sources."hosted-git-info-2.7.1"
-      sources."http-errors-1.7.2"
+      (sources."http-errors-1.7.2" // {
+        dependencies = [
+          sources."inherits-2.0.3"
+        ];
+      })
       sources."http-signature-1.2.0"
       sources."iconv-lite-0.4.24"
       sources."ignore-4.0.6"
@@ -42638,10 +42628,10 @@ in
       sources."imurmurhash-0.1.4"
       sources."indent-string-3.2.0"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."ini-1.3.5"
       sources."init-package-json-1.10.3"
-      (sources."inquirer-6.3.1" // {
+      (sources."inquirer-6.4.1" // {
         dependencies = [
           sources."mute-stream-0.0.7"
         ];
@@ -42699,7 +42689,7 @@ in
       sources."loud-rejection-2.1.0"
       sources."lowercase-keys-1.0.1"
       sources."lru-cache-4.1.5"
-      sources."macos-release-2.2.0"
+      sources."macos-release-2.3.0"
       sources."make-dir-1.3.0"
       sources."map-cache-0.2.2"
       sources."map-visit-1.0.0"
@@ -42715,7 +42705,7 @@ in
       sources."mimic-fn-1.2.0"
       sources."minimatch-3.0.4"
       sources."minimist-1.2.0"
-      (sources."mixin-deep-1.3.1" // {
+      (sources."mixin-deep-1.3.2" // {
         dependencies = [
           sources."is-extendable-1.0.1"
         ];
@@ -42786,7 +42776,7 @@ in
       sources."promzard-0.3.0"
       sources."proxy-addr-2.0.5"
       sources."pseudomap-1.0.2"
-      sources."psl-1.1.32"
+      sources."psl-1.1.33"
       sources."pump-3.0.0"
       sources."punycode-2.1.1"
       sources."q-1.5.1"
@@ -42841,7 +42831,7 @@ in
         ];
       })
       sources."serve-static-1.14.1"
-      (sources."set-value-2.0.0" // {
+      (sources."set-value-2.0.1" // {
         dependencies = [
           sources."extend-shallow-2.0.1"
         ];
@@ -42941,17 +42931,12 @@ in
       sources."to-regex-range-2.1.1"
       sources."toidentifier-1.0.0"
       sources."tough-cookie-3.0.1"
-      sources."tslib-1.9.3"
+      sources."tslib-1.10.0"
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       sources."type-is-1.6.18"
       sources."underscore-1.9.1"
-      (sources."union-value-1.0.0" // {
-        dependencies = [
-          sources."extend-shallow-2.0.1"
-          sources."set-value-0.4.3"
-        ];
-      })
+      sources."union-value-1.0.1"
       sources."unique-string-1.0.0"
       sources."universalify-0.1.2"
       sources."unpipe-1.0.0"
@@ -43021,7 +43006,7 @@ in
       sources."@types/events-3.0.0"
       sources."@types/glob-7.1.1"
       sources."@types/minimatch-3.0.3"
-      sources."@types/node-12.0.4"
+      sources."@types/node-12.0.10"
       sources."arr-diff-4.0.0"
       sources."arr-flatten-1.1.0"
       sources."arr-union-3.1.0"
@@ -43070,7 +43055,7 @@ in
       sources."concat-map-0.0.1"
       sources."copy-descriptor-0.1.1"
       sources."cp-file-6.2.0"
-      sources."cpy-7.2.0"
+      sources."cpy-7.3.0"
       sources."currently-unhandled-0.4.1"
       sources."debug-2.6.9"
       sources."decamelize-1.2.0"
@@ -43131,7 +43116,7 @@ in
       })
       sources."glob-to-regexp-0.3.0"
       sources."globby-9.2.0"
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."has-value-1.0.0"
       (sources."has-values-1.0.0" // {
         dependencies = [
@@ -43142,7 +43127,7 @@ in
       sources."ignore-4.0.6"
       sources."indent-string-3.2.0"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."is-accessor-descriptor-1.0.0"
       sources."is-arrayish-0.2.1"
       sources."is-buffer-1.1.6"
@@ -43179,7 +43164,7 @@ in
       sources."micromatch-3.1.10"
       sources."minimatch-3.0.4"
       sources."minimist-options-3.0.2"
-      (sources."mixin-deep-1.3.1" // {
+      (sources."mixin-deep-1.3.2" // {
         dependencies = [
           sources."is-extendable-1.0.1"
         ];
@@ -43233,7 +43218,7 @@ in
       sources."safe-buffer-5.1.2"
       sources."safe-regex-1.1.0"
       sources."semver-5.7.0"
-      (sources."set-value-2.0.0" // {
+      (sources."set-value-2.0.1" // {
         dependencies = [
           sources."extend-shallow-2.0.1"
         ];
@@ -43303,12 +43288,7 @@ in
       sources."to-regex-3.0.2"
       sources."to-regex-range-2.1.1"
       sources."trim-newlines-2.0.0"
-      (sources."union-value-1.0.0" // {
-        dependencies = [
-          sources."extend-shallow-2.0.1"
-          sources."set-value-0.4.3"
-        ];
-      })
+      sources."union-value-1.0.1"
       (sources."unset-value-1.0.0" // {
         dependencies = [
           (sources."has-value-0.3.1" // {
@@ -43354,7 +43334,7 @@ in
       sources."@cycle/run-3.4.0"
       sources."@cycle/time-0.10.1"
       sources."@types/cookiejar-2.1.1"
-      sources."@types/node-12.0.4"
+      sources."@types/node-12.0.10"
       sources."@types/superagent-3.8.2"
       sources."ansi-escapes-3.2.0"
       sources."ansi-regex-2.1.1"
@@ -43380,7 +43360,7 @@ in
       sources."cssauron-1.4.0"
       sources."custom-error-instance-2.1.1"
       sources."cycle-onionify-4.0.0"
-      sources."d-1.0.0"
+      sources."d-1.0.1"
       sources."debug-3.2.6"
       sources."delayed-stream-1.0.0"
       sources."es5-ext-0.10.50"
@@ -43393,12 +43373,12 @@ in
       sources."extend-3.0.2"
       sources."external-editor-2.2.0"
       sources."figures-2.0.0"
-      sources."form-data-2.3.3"
+      sources."form-data-2.4.0"
       sources."formidable-1.2.1"
       sources."has-ansi-2.0.0"
       sources."has-flag-3.0.0"
       sources."iconv-lite-0.4.24"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       (sources."inquirer-3.3.0" // {
         dependencies = [
           sources."ansi-regex-3.0.0"
@@ -43424,14 +43404,14 @@ in
       sources."mime-types-2.1.24"
       sources."mimic-fn-1.2.0"
       sources."minimist-1.2.0"
-      sources."ms-2.1.1"
+      sources."ms-2.1.2"
       sources."mute-stream-0.0.7"
       sources."next-tick-1.0.0"
       sources."object-assign-4.1.1"
       sources."onetime-2.0.1"
       sources."os-tmpdir-1.0.2"
       sources."performance-now-2.1.0"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."pseudomap-1.0.2"
       sources."qs-6.7.0"
       sources."quicktask-1.1.0"
@@ -43463,6 +43443,7 @@ in
       sources."symbol-observable-1.2.0"
       sources."through-2.3.8"
       sources."tmp-0.0.33"
+      sources."type-1.0.1"
       sources."util-deprecate-1.0.2"
       (sources."variable-diff-1.1.0" // {
         dependencies = [
@@ -43525,12 +43506,12 @@ in
       sources."fstream-1.0.12"
       sources."fstream-ignore-1.0.5"
       sources."glob-7.1.4"
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."has-flag-3.0.0"
       sources."hyperquest-2.1.3"
       sources."iconv-lite-0.4.24"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."inquirer-6.2.2"
       sources."is-fullwidth-code-point-2.0.0"
       sources."is-promise-2.1.0"
@@ -43550,7 +43531,7 @@ in
       sources."os-tmpdir-1.0.2"
       sources."path-is-absolute-1.0.1"
       sources."path-key-2.0.1"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."readable-stream-1.1.14"
       sources."restore-cursor-2.0.0"
       sources."rimraf-2.6.3"
@@ -43589,7 +43570,7 @@ in
         ];
       })
       sources."tmp-0.0.33"
-      sources."tslib-1.9.3"
+      sources."tslib-1.10.0"
       sources."uid-number-0.0.6"
       sources."universalify-0.1.2"
       sources."util-deprecate-1.0.2"
@@ -43626,7 +43607,7 @@ in
       sources."cross-spawn-5.1.0"
       sources."escape-string-regexp-1.0.5"
       sources."fs-extra-4.0.3"
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."has-flag-3.0.0"
       sources."isexe-2.0.0"
       sources."jsonfile-4.0.0"
@@ -43918,7 +43899,7 @@ in
       sources."global-4.3.2"
       sources."global-dirs-0.1.1"
       sources."got-6.7.1"
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-1.0.3"
@@ -43955,7 +43936,7 @@ in
       sources."import-lazy-2.1.0"
       sources."imurmurhash-0.1.4"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."ini-1.3.5"
       sources."inspect-custom-symbol-1.1.0"
       sources."ip-1.1.5"
@@ -44025,7 +44006,7 @@ in
       sources."menu-string-1.3.0"
       sources."merkle-tree-stream-3.0.3"
       sources."micromatch-3.1.10"
-      sources."mime-2.4.3"
+      sources."mime-2.4.4"
       sources."mime-db-1.40.0"
       sources."mime-types-2.1.24"
       sources."mimic-response-1.0.1"
@@ -44033,7 +44014,7 @@ in
       sources."minimatch-3.0.4"
       sources."minimist-1.2.0"
       sources."mirror-folder-3.0.0"
-      (sources."mixin-deep-1.3.1" // {
+      (sources."mixin-deep-1.3.2" // {
         dependencies = [
           sources."is-extendable-1.0.1"
         ];
@@ -44043,7 +44024,7 @@ in
           sources."minimist-0.0.8"
         ];
       })
-      sources."ms-2.1.1"
+      sources."ms-2.1.2"
       sources."multi-random-access-2.1.1"
       sources."multicast-dns-7.2.0"
       sources."multistream-2.1.1"
@@ -44100,7 +44081,7 @@ in
       sources."prettier-bytes-1.0.4"
       sources."pretty-hash-1.0.1"
       sources."process-0.5.2"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."progress-string-1.2.2"
       sources."prompt-1.0.0"
       (sources."protocol-buffers-encodings-1.1.0" // {
@@ -44109,13 +44090,13 @@ in
         ];
       })
       sources."pseudomap-1.0.2"
-      sources."psl-1.1.32"
+      sources."psl-1.1.33"
       sources."pump-3.0.0"
       sources."punycode-2.1.1"
       sources."qs-6.5.2"
-      sources."random-access-file-2.1.2"
+      sources."random-access-file-2.1.3"
       sources."random-access-memory-3.1.1"
-      sources."random-access-storage-1.3.0"
+      sources."random-access-storage-1.4.0"
       sources."randombytes-2.1.0"
       sources."range-parser-1.2.1"
       sources."rc-1.2.8"
@@ -44140,7 +44121,7 @@ in
       sources."safer-buffer-2.1.2"
       sources."semver-5.7.0"
       sources."semver-diff-2.1.0"
-      (sources."set-value-2.0.0" // {
+      (sources."set-value-2.0.1" // {
         dependencies = [
           sources."extend-shallow-2.0.1"
         ];
@@ -44270,12 +44251,7 @@ in
       sources."tweetnacl-0.14.5"
       sources."typedarray-0.0.6"
       sources."uint64be-2.0.2"
-      (sources."union-value-1.0.0" // {
-        dependencies = [
-          sources."extend-shallow-2.0.1"
-          sources."set-value-0.4.3"
-        ];
-      })
+      sources."union-value-1.0.1"
       sources."unique-string-1.0.0"
       sources."unixify-1.0.0"
       sources."unordered-array-remove-1.0.2"
@@ -44399,7 +44375,7 @@ in
       sources."extend-1.2.1"
       sources."extsprintf-1.4.0"
       sources."eyes-0.1.8"
-      sources."faye-websocket-0.11.1"
+      sources."faye-websocket-0.11.3"
       sources."file-uri-to-path-1.0.0"
       sources."finalhandler-0.3.3"
       sources."form-data-0.1.3"
@@ -44408,8 +44384,8 @@ in
       sources."fresh-0.2.4"
       sources."from-0.1.7"
       sources."hiredis-0.4.1"
-      sources."http-parser-js-0.5.0"
-      sources."inherits-2.0.3"
+      sources."http-parser-js-0.4.10"
+      sources."inherits-2.0.4"
       sources."ini-1.3.5"
       sources."ipaddr.js-1.0.5"
       sources."isarray-0.0.1"
@@ -44458,6 +44434,7 @@ in
       sources."readable-stream-1.0.27-1"
       sources."redis-0.12.1"
       sources."reduce-component-1.0.1"
+      sources."safe-buffer-5.1.2"
       sources."send-0.11.1"
       sources."serve-static-1.8.1"
       sources."split-0.3.3"
@@ -44481,7 +44458,7 @@ in
       sources."utils-merge-1.0.0"
       sources."vary-1.0.1"
       sources."verror-1.10.0"
-      sources."websocket-driver-0.7.0"
+      sources."websocket-driver-0.7.3"
       sources."websocket-extensions-0.1.3"
       (sources."winston-0.8.0" // {
         dependencies = [
@@ -44503,10 +44480,10 @@ in
   elasticdump = nodeEnv.buildNodePackage {
     name = "elasticdump";
     packageName = "elasticdump";
-    version = "6.0.1";
+    version = "6.2.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/elasticdump/-/elasticdump-6.0.1.tgz";
-      sha512 = "7xJ/JhwMRBSIt96ZtLqiHMgs/CDL/SW+d+IuM1YwbdL5pC7AsD56RjnxdrZOjKBYjEj6N5L4ZRjbuYiJ8toWtg==";
+      url = "https://registry.npmjs.org/elasticdump/-/elasticdump-6.2.2.tgz";
+      sha512 = "wn6Bu6mHqAWB+TxCGSF95B2/kPIsYaH67KShonesHntjxdQBSIYqbpmDsiNQKCvjbqklIwQb4u6Al5rWwCl/JQ==";
     };
     dependencies = [
       sources."JSONStream-1.3.5"
@@ -44515,7 +44492,7 @@ in
       sources."assert-plus-1.0.0"
       sources."async-2.6.2"
       sources."asynckit-0.4.0"
-      sources."aws-sdk-2.469.0"
+      sources."aws-sdk-2.485.0"
       sources."aws-sign2-0.7.0"
       sources."aws4-1.8.0"
       sources."base64-js-1.3.0"
@@ -44542,7 +44519,7 @@ in
       sources."har-validator-5.1.3"
       sources."http-signature-1.2.0"
       sources."ieee754-1.1.8"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."ini-1.3.5"
       (sources."ip-address-5.8.9" // {
         dependencies = [
@@ -44572,14 +44549,14 @@ in
       sources."oauth-sign-0.9.0"
       sources."optimist-0.6.1"
       sources."performance-now-2.1.0"
-      sources."process-nextick-args-2.0.0"
-      sources."psl-1.1.32"
+      sources."process-nextick-args-2.0.1"
+      sources."psl-1.1.33"
       sources."punycode-1.3.2"
       sources."qs-6.5.2"
       sources."querystring-0.2.0"
       sources."readable-stream-2.3.6"
       sources."request-2.88.0"
-      sources."requestretry-3.1.0"
+      sources."requestretry-4.0.0"
       sources."s3-stream-upload-2.0.2"
       sources."s3signed-0.1.0"
       (sources."s3urls-1.5.2" // {
@@ -44628,392 +44605,6 @@ in
     bypassCache = true;
     reconstructLock = true;
   };
-  elm-doc-preview = nodeEnv.buildNodePackage {
-    name = "elm-doc-preview";
-    packageName = "elm-doc-preview";
-    version = "2.0.3";
-    src = fetchurl {
-      url = "https://registry.npmjs.org/elm-doc-preview/-/elm-doc-preview-2.0.3.tgz";
-      sha512 = "YQZTlFX/DdR2hjJC00nof1hMG4DNeSFbxf45GTVpedPRKZXIZDJI5zeXukGCwD7lPJZIm9gegjqJPXLCCghv8g==";
-    };
-    dependencies = [
-      sources."@cnakazawa/watch-1.0.3"
-      sources."@sindresorhus/is-0.7.0"
-      sources."accepts-1.3.7"
-      sources."ansi-styles-3.2.1"
-      sources."anymatch-2.0.0"
-      sources."arr-diff-4.0.0"
-      sources."arr-flatten-1.1.0"
-      sources."arr-union-3.1.0"
-      sources."array-flatten-1.1.1"
-      sources."array-unique-0.3.2"
-      sources."assign-symbols-1.0.0"
-      sources."async-limiter-1.0.0"
-      sources."atob-2.1.2"
-      (sources."base-0.11.2" // {
-        dependencies = [
-          sources."define-property-1.0.0"
-        ];
-      })
-      sources."body-parser-1.19.0"
-      (sources."braces-2.3.2" // {
-        dependencies = [
-          sources."extend-shallow-2.0.1"
-        ];
-      })
-      sources."bser-2.0.0"
-      sources."bytes-3.1.0"
-      sources."cache-base-1.0.1"
-      (sources."cacheable-request-2.1.4" // {
-        dependencies = [
-          sources."lowercase-keys-1.0.0"
-        ];
-      })
-      sources."capture-exit-2.0.0"
-      sources."chalk-2.4.2"
-      (sources."class-utils-0.3.6" // {
-        dependencies = [
-          sources."define-property-0.2.5"
-          (sources."is-accessor-descriptor-0.1.6" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          (sources."is-data-descriptor-0.1.4" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          sources."is-descriptor-0.1.6"
-          sources."kind-of-5.1.0"
-        ];
-      })
-      sources."clone-response-1.0.2"
-      sources."collection-visit-1.0.0"
-      sources."color-convert-1.9.3"
-      sources."color-name-1.1.3"
-      sources."commander-2.20.0"
-      sources."component-emitter-1.3.0"
-      sources."content-disposition-0.5.3"
-      sources."content-type-1.0.4"
-      sources."cookie-0.4.0"
-      sources."cookie-signature-1.0.6"
-      sources."copy-descriptor-0.1.1"
-      sources."core-util-is-1.0.2"
-      sources."cross-spawn-6.0.5"
-      sources."debug-2.6.9"
-      sources."decode-uri-component-0.2.0"
-      sources."decompress-response-3.3.0"
-      sources."deep-extend-0.6.0"
-      sources."define-property-2.0.2"
-      sources."depd-1.1.2"
-      sources."destroy-1.0.4"
-      sources."duplexer3-0.1.4"
-      sources."ee-first-1.1.1"
-      sources."encodeurl-1.0.2"
-      sources."end-of-stream-1.4.1"
-      sources."escape-html-1.0.3"
-      sources."escape-string-regexp-1.0.5"
-      sources."etag-1.8.1"
-      sources."exec-sh-0.3.2"
-      (sources."execa-1.0.0" // {
-        dependencies = [
-          sources."get-stream-4.1.0"
-        ];
-      })
-      (sources."expand-brackets-2.1.4" // {
-        dependencies = [
-          sources."define-property-0.2.5"
-          sources."extend-shallow-2.0.1"
-          (sources."is-accessor-descriptor-0.1.6" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          (sources."is-data-descriptor-0.1.4" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          sources."is-descriptor-0.1.6"
-          sources."kind-of-5.1.0"
-        ];
-      })
-      sources."express-4.17.1"
-      (sources."express-ws-4.0.0" // {
-        dependencies = [
-          sources."ws-5.2.2"
-        ];
-      })
-      (sources."extend-shallow-3.0.2" // {
-        dependencies = [
-          sources."is-extendable-1.0.1"
-        ];
-      })
-      (sources."extglob-2.0.4" // {
-        dependencies = [
-          sources."define-property-1.0.0"
-          sources."extend-shallow-2.0.1"
-        ];
-      })
-      sources."fb-watchman-2.0.0"
-      (sources."fill-range-4.0.0" // {
-        dependencies = [
-          sources."extend-shallow-2.0.1"
-        ];
-      })
-      sources."finalhandler-1.1.2"
-      sources."for-in-1.0.2"
-      sources."forwarded-0.1.2"
-      sources."fragment-cache-0.2.1"
-      sources."fresh-0.5.2"
-      sources."from2-2.3.0"
-      sources."get-stream-3.0.0"
-      sources."get-value-2.0.6"
-      sources."got-8.3.2"
-      sources."has-flag-3.0.0"
-      sources."has-symbol-support-x-1.4.2"
-      sources."has-to-string-tag-x-1.4.1"
-      sources."has-value-1.0.0"
-      (sources."has-values-1.0.0" // {
-        dependencies = [
-          sources."kind-of-4.0.0"
-        ];
-      })
-      sources."http-cache-semantics-3.8.1"
-      sources."http-errors-1.7.2"
-      sources."iconv-lite-0.4.24"
-      sources."inherits-2.0.3"
-      sources."ini-1.3.5"
-      sources."into-stream-3.1.0"
-      sources."ipaddr.js-1.9.0"
-      sources."is-accessor-descriptor-1.0.0"
-      sources."is-buffer-1.1.6"
-      sources."is-data-descriptor-1.0.0"
-      sources."is-descriptor-1.0.2"
-      sources."is-extendable-0.1.1"
-      (sources."is-number-3.0.0" // {
-        dependencies = [
-          sources."kind-of-3.2.2"
-        ];
-      })
-      sources."is-object-1.0.1"
-      sources."is-plain-obj-1.1.0"
-      sources."is-plain-object-2.0.4"
-      sources."is-retry-allowed-1.1.0"
-      sources."is-stream-1.1.0"
-      sources."is-windows-1.0.2"
-      sources."isarray-1.0.0"
-      sources."isexe-2.0.0"
-      sources."isobject-3.0.1"
-      sources."isurl-1.0.0"
-      sources."json-buffer-3.0.0"
-      sources."keyv-3.0.0"
-      sources."kind-of-6.0.2"
-      sources."latest-version-4.0.0"
-      sources."lowercase-keys-1.0.1"
-      sources."makeerror-1.0.11"
-      sources."map-cache-0.2.2"
-      sources."map-visit-1.0.0"
-      sources."media-typer-0.3.0"
-      sources."merge-descriptors-1.0.1"
-      sources."methods-1.1.2"
-      sources."micromatch-3.1.10"
-      sources."mime-1.6.0"
-      sources."mime-db-1.40.0"
-      sources."mime-types-2.1.24"
-      sources."mimic-response-1.0.1"
-      sources."minimist-1.2.0"
-      (sources."mixin-deep-1.3.1" // {
-        dependencies = [
-          sources."is-extendable-1.0.1"
-        ];
-      })
-      sources."ms-2.0.0"
-      sources."nanomatch-1.2.13"
-      sources."negotiator-0.6.2"
-      sources."nice-try-1.0.5"
-      sources."node-int64-0.4.0"
-      sources."normalize-path-2.1.1"
-      sources."normalize-url-2.0.1"
-      sources."npm-run-path-2.0.2"
-      sources."object-assign-4.1.1"
-      (sources."object-copy-0.1.0" // {
-        dependencies = [
-          sources."define-property-0.2.5"
-          sources."is-accessor-descriptor-0.1.6"
-          sources."is-data-descriptor-0.1.4"
-          (sources."is-descriptor-0.1.6" // {
-            dependencies = [
-              sources."kind-of-5.1.0"
-            ];
-          })
-          sources."kind-of-3.2.2"
-        ];
-      })
-      sources."object-visit-1.0.1"
-      sources."object.pick-1.3.0"
-      sources."on-finished-2.3.0"
-      sources."once-1.4.0"
-      sources."os-tmpdir-1.0.2"
-      sources."p-cancelable-0.4.1"
-      sources."p-finally-1.0.0"
-      sources."p-is-promise-1.1.0"
-      sources."p-timeout-2.0.1"
-      sources."package-json-5.0.0"
-      sources."parseurl-1.3.3"
-      sources."pascalcase-0.1.1"
-      sources."path-key-2.0.1"
-      sources."path-to-regexp-0.1.7"
-      sources."pify-3.0.0"
-      sources."posix-character-classes-0.1.1"
-      sources."prepend-http-2.0.0"
-      sources."process-nextick-args-2.0.0"
-      sources."proxy-addr-2.0.5"
-      sources."pump-3.0.0"
-      sources."qs-6.7.0"
-      sources."query-string-5.1.1"
-      sources."range-parser-1.2.1"
-      sources."raw-body-2.4.0"
-      sources."rc-1.2.8"
-      sources."readable-stream-2.3.6"
-      sources."regex-not-1.0.2"
-      sources."registry-auth-token-3.4.0"
-      sources."registry-url-3.1.0"
-      sources."remove-trailing-separator-1.1.0"
-      sources."repeat-element-1.1.3"
-      sources."repeat-string-1.6.1"
-      sources."resolve-url-0.2.1"
-      sources."responselike-1.0.2"
-      sources."ret-0.1.15"
-      sources."rsvp-4.8.4"
-      sources."safe-buffer-5.1.2"
-      sources."safe-regex-1.1.0"
-      sources."safer-buffer-2.1.2"
-      sources."sane-4.1.0"
-      sources."semver-5.7.0"
-      (sources."send-0.17.1" // {
-        dependencies = [
-          sources."ms-2.1.1"
-        ];
-      })
-      sources."serve-static-1.14.1"
-      (sources."set-value-2.0.0" // {
-        dependencies = [
-          sources."extend-shallow-2.0.1"
-        ];
-      })
-      sources."setprototypeof-1.1.1"
-      sources."shebang-command-1.2.0"
-      sources."shebang-regex-1.0.0"
-      sources."signal-exit-3.0.2"
-      (sources."snapdragon-0.8.2" // {
-        dependencies = [
-          sources."define-property-0.2.5"
-          sources."extend-shallow-2.0.1"
-          (sources."is-accessor-descriptor-0.1.6" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          (sources."is-data-descriptor-0.1.4" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          sources."is-descriptor-0.1.6"
-          sources."kind-of-5.1.0"
-        ];
-      })
-      (sources."snapdragon-node-2.1.1" // {
-        dependencies = [
-          sources."define-property-1.0.0"
-        ];
-      })
-      (sources."snapdragon-util-3.0.1" // {
-        dependencies = [
-          sources."kind-of-3.2.2"
-        ];
-      })
-      sources."sort-keys-2.0.0"
-      sources."source-map-0.5.7"
-      sources."source-map-resolve-0.5.2"
-      sources."source-map-url-0.4.0"
-      sources."split-string-3.1.0"
-      (sources."static-extend-0.1.2" // {
-        dependencies = [
-          sources."define-property-0.2.5"
-          (sources."is-accessor-descriptor-0.1.6" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          (sources."is-data-descriptor-0.1.4" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          sources."is-descriptor-0.1.6"
-          sources."kind-of-5.1.0"
-        ];
-      })
-      sources."statuses-1.5.0"
-      sources."strict-uri-encode-1.1.0"
-      sources."string_decoder-1.1.1"
-      sources."strip-eof-1.0.0"
-      sources."strip-json-comments-2.0.1"
-      sources."supports-color-5.5.0"
-      sources."timed-out-4.0.1"
-      sources."tmp-0.0.33"
-      sources."tmpl-1.0.4"
-      (sources."to-object-path-0.3.0" // {
-        dependencies = [
-          sources."kind-of-3.2.2"
-        ];
-      })
-      sources."to-regex-3.0.2"
-      sources."to-regex-range-2.1.1"
-      sources."toidentifier-1.0.0"
-      sources."type-is-1.6.18"
-      (sources."union-value-1.0.0" // {
-        dependencies = [
-          sources."extend-shallow-2.0.1"
-          sources."set-value-0.4.3"
-        ];
-      })
-      sources."unpipe-1.0.0"
-      (sources."unset-value-1.0.0" // {
-        dependencies = [
-          (sources."has-value-0.3.1" // {
-            dependencies = [
-              sources."isobject-2.1.0"
-            ];
-          })
-          sources."has-values-0.1.4"
-        ];
-      })
-      sources."urix-0.1.0"
-      sources."url-parse-lax-3.0.0"
-      sources."url-to-options-1.0.1"
-      sources."use-3.1.1"
-      sources."util-deprecate-1.0.2"
-      sources."utils-merge-1.0.1"
-      sources."vary-1.1.2"
-      sources."walker-1.0.7"
-      sources."which-1.3.1"
-      sources."wrappy-1.0.2"
-      sources."ws-6.2.1"
-    ];
-    buildInputs = globalBuildInputs;
-    meta = {
-      description = "Elm offline documentation previewer with hot reloading.";
-      homepage = "https://github.com/dmy/elm-doc-preview#readme";
-      license = "SEE LICENSE IN LICENSE.md";
-    };
-    production = true;
-    bypassCache = true;
-    reconstructLock = true;
-  };
   elm-live = nodeEnv.buildNodePackage {
     name = "elm-live";
     packageName = "elm-live";
@@ -45038,7 +44629,7 @@ in
       sources."connect-pushstate-1.1.0"
       sources."cross-spawn-5.0.1"
       sources."crypt-0.0.2"
-      sources."d-1.0.0"
+      sources."d-1.0.1"
       sources."debug-2.6.9"
       sources."default-gateway-2.7.2"
       sources."depd-1.1.2"
@@ -45054,7 +44645,7 @@ in
       sources."es6-iterator-2.0.3"
       sources."es6-promisify-6.0.1"
       sources."es6-symbol-3.1.1"
-      sources."es6-weak-map-2.0.2"
+      sources."es6-weak-map-2.0.3"
       sources."escape-html-1.0.3"
       sources."escape-string-regexp-1.0.5"
       sources."etag-1.8.1"
@@ -45070,7 +44661,7 @@ in
       (sources."follow-redirects-1.7.0" // {
         dependencies = [
           sources."debug-3.2.6"
-          sources."ms-2.1.1"
+          sources."ms-2.1.2"
         ];
       })
       sources."fresh-0.5.2"
@@ -45132,6 +44723,7 @@ in
       sources."supports-color-2.0.0"
       sources."timers-ext-0.1.7"
       sources."to-regex-range-5.0.1"
+      sources."type-1.0.1"
       sources."unpipe-1.0.0"
       sources."url-parse-1.4.3"
       sources."which-1.3.1"
@@ -45160,400 +44752,6 @@ in
     meta = {
       description = "Query for information about values in elm source files.";
       homepage = "https://github.com/ElmCast/elm-oracle#readme";
-      license = "BSD-3-Clause";
-    };
-    production = true;
-    bypassCache = true;
-    reconstructLock = true;
-  };
-  elm-test = nodeEnv.buildNodePackage {
-    name = "elm-test";
-    packageName = "elm-test";
-    version = "0.19.0-rev6";
-    src = fetchurl {
-      url = "https://registry.npmjs.org/elm-test/-/elm-test-0.19.0-rev6.tgz";
-      sha512 = "Qdy9QusZF+eT0203XBiT1Y/UhFeUjcSuyyzf3iyp32dsYpAfcoDTWHjlBVjia1CyvFauESQ4pc81nKaq6snClg==";
-    };
-    dependencies = [
-      sources."ajv-6.10.0"
-      sources."ansi-styles-3.2.1"
-      (sources."anymatch-2.0.0" // {
-        dependencies = [
-          sources."normalize-path-2.1.1"
-        ];
-      })
-      sources."arr-diff-4.0.0"
-      sources."arr-flatten-1.1.0"
-      sources."arr-union-3.1.0"
-      sources."array-unique-0.3.2"
-      sources."asn1-0.2.4"
-      sources."assert-plus-1.0.0"
-      sources."assign-symbols-1.0.0"
-      sources."async-each-1.0.3"
-      sources."asynckit-0.4.0"
-      sources."atob-2.1.2"
-      sources."aws-sign2-0.7.0"
-      sources."aws4-1.8.0"
-      sources."balanced-match-1.0.0"
-      (sources."base-0.11.2" // {
-        dependencies = [
-          sources."define-property-1.0.0"
-        ];
-      })
-      sources."bcrypt-pbkdf-1.0.2"
-      sources."binary-0.3.0"
-      sources."binary-extensions-1.13.1"
-      sources."binwrap-0.2.1"
-      sources."bluebird-3.5.5"
-      sources."brace-expansion-1.1.11"
-      (sources."braces-2.3.2" // {
-        dependencies = [
-          sources."extend-shallow-2.0.1"
-          sources."is-extendable-0.1.1"
-        ];
-      })
-      sources."buffers-0.1.1"
-      sources."cache-base-1.0.1"
-      sources."caseless-0.12.0"
-      sources."chainsaw-0.1.0"
-      sources."chalk-2.1.0"
-      (sources."chokidar-2.1.2" // {
-        dependencies = [
-          sources."fsevents-1.2.9"
-        ];
-      })
-      sources."chownr-1.1.1"
-      (sources."class-utils-0.3.6" // {
-        dependencies = [
-          sources."define-property-0.2.5"
-          (sources."is-accessor-descriptor-0.1.6" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          (sources."is-data-descriptor-0.1.4" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          sources."is-descriptor-0.1.6"
-          sources."kind-of-5.1.0"
-        ];
-      })
-      sources."collection-visit-1.0.0"
-      sources."color-convert-1.9.3"
-      sources."color-name-1.1.3"
-      sources."combined-stream-1.0.8"
-      sources."component-emitter-1.3.0"
-      sources."concat-map-0.0.1"
-      sources."copy-descriptor-0.1.1"
-      sources."core-util-is-1.0.2"
-      sources."cross-spawn-4.0.0"
-      sources."dashdash-1.14.1"
-      sources."debug-2.6.9"
-      sources."decode-uri-component-0.2.0"
-      sources."define-property-2.0.2"
-      sources."delayed-stream-1.0.0"
-      sources."ecc-jsbn-0.1.2"
-      sources."elmi-to-json-0.19.1"
-      sources."escape-string-regexp-1.0.5"
-      (sources."expand-brackets-2.1.4" // {
-        dependencies = [
-          sources."define-property-0.2.5"
-          sources."extend-shallow-2.0.1"
-          (sources."is-accessor-descriptor-0.1.6" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          (sources."is-data-descriptor-0.1.4" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          sources."is-descriptor-0.1.6"
-          sources."is-extendable-0.1.1"
-          sources."kind-of-5.1.0"
-        ];
-      })
-      sources."extend-3.0.2"
-      sources."extend-shallow-3.0.2"
-      (sources."extglob-2.0.4" // {
-        dependencies = [
-          sources."define-property-1.0.0"
-          sources."extend-shallow-2.0.1"
-          sources."is-extendable-0.1.1"
-        ];
-      })
-      sources."extsprintf-1.3.0"
-      sources."fast-deep-equal-2.0.1"
-      sources."fast-json-stable-stringify-2.0.0"
-      (sources."fill-range-4.0.0" // {
-        dependencies = [
-          sources."extend-shallow-2.0.1"
-          sources."is-extendable-0.1.1"
-        ];
-      })
-      (sources."find-elm-dependencies-2.0.1" // {
-        dependencies = [
-          sources."firstline-1.2.0"
-        ];
-      })
-      sources."find-parent-dir-0.3.0"
-      sources."firstline-1.2.1"
-      sources."for-in-1.0.2"
-      sources."forever-agent-0.6.1"
-      sources."form-data-2.3.3"
-      sources."fragment-cache-0.2.1"
-      sources."fs-extra-0.30.0"
-      sources."fs-minipass-1.2.6"
-      sources."fs.realpath-1.0.0"
-      sources."fsevents-1.2.4"
-      sources."get-value-2.0.6"
-      sources."getpass-0.1.7"
-      sources."glob-7.1.1"
-      (sources."glob-parent-3.1.0" // {
-        dependencies = [
-          sources."is-glob-3.1.0"
-        ];
-      })
-      sources."graceful-fs-4.1.15"
-      sources."har-schema-2.0.0"
-      sources."har-validator-5.1.3"
-      sources."has-flag-2.0.0"
-      sources."has-value-1.0.0"
-      (sources."has-values-1.0.0" // {
-        dependencies = [
-          sources."kind-of-4.0.0"
-        ];
-      })
-      sources."http-signature-1.2.0"
-      sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
-      sources."is-accessor-descriptor-1.0.0"
-      sources."is-binary-path-1.0.1"
-      sources."is-buffer-1.1.6"
-      sources."is-data-descriptor-1.0.0"
-      sources."is-descriptor-1.0.2"
-      sources."is-extendable-1.0.1"
-      sources."is-extglob-2.1.1"
-      sources."is-glob-4.0.1"
-      (sources."is-number-3.0.0" // {
-        dependencies = [
-          sources."kind-of-3.2.2"
-        ];
-      })
-      sources."is-plain-object-2.0.4"
-      sources."is-typedarray-1.0.0"
-      sources."is-windows-1.0.2"
-      sources."isarray-1.0.0"
-      sources."isexe-2.0.0"
-      sources."isobject-3.0.1"
-      sources."isstream-0.1.2"
-      sources."jsbn-0.1.1"
-      sources."json-schema-0.2.3"
-      sources."json-schema-traverse-0.4.1"
-      sources."json-stringify-safe-5.0.1"
-      sources."jsonfile-2.4.0"
-      sources."jsprim-1.4.1"
-      sources."kind-of-6.0.2"
-      sources."klaw-1.3.1"
-      sources."lodash-4.17.11"
-      sources."lru-cache-4.1.5"
-      sources."map-cache-0.2.2"
-      sources."map-visit-1.0.0"
-      sources."micromatch-3.1.10"
-      sources."mime-db-1.40.0"
-      sources."mime-types-2.1.24"
-      sources."minimatch-3.0.4"
-      sources."minimist-1.2.0"
-      (sources."minipass-2.3.5" // {
-        dependencies = [
-          sources."yallist-3.0.3"
-        ];
-      })
-      sources."minizlib-1.2.1"
-      sources."mixin-deep-1.3.1"
-      (sources."mkdirp-0.5.1" // {
-        dependencies = [
-          sources."minimist-0.0.8"
-        ];
-      })
-      sources."ms-2.0.0"
-      sources."murmur-hash-js-1.0.0"
-      sources."mustache-2.3.2"
-      sources."nan-2.14.0"
-      sources."nanomatch-1.2.13"
-      sources."node-elm-compiler-5.0.3"
-      sources."normalize-path-3.0.0"
-      sources."oauth-sign-0.9.0"
-      (sources."object-copy-0.1.0" // {
-        dependencies = [
-          sources."define-property-0.2.5"
-          sources."is-accessor-descriptor-0.1.6"
-          sources."is-data-descriptor-0.1.4"
-          (sources."is-descriptor-0.1.6" // {
-            dependencies = [
-              sources."kind-of-5.1.0"
-            ];
-          })
-          sources."kind-of-3.2.2"
-        ];
-      })
-      sources."object-visit-1.0.1"
-      sources."object.pick-1.3.0"
-      sources."once-1.4.0"
-      sources."os-tmpdir-1.0.2"
-      sources."pascalcase-0.1.1"
-      sources."path-dirname-1.0.2"
-      sources."path-is-absolute-1.0.1"
-      sources."performance-now-2.1.0"
-      sources."posix-character-classes-0.1.1"
-      sources."process-nextick-args-2.0.0"
-      sources."pseudomap-1.0.2"
-      sources."psl-1.1.32"
-      sources."punycode-2.1.1"
-      sources."qs-6.5.2"
-      sources."readable-stream-2.3.6"
-      sources."readdirp-2.2.1"
-      sources."regex-not-1.0.2"
-      sources."remove-trailing-separator-1.1.0"
-      sources."repeat-element-1.1.3"
-      sources."repeat-string-1.6.1"
-      sources."request-2.88.0"
-      sources."request-promise-4.2.4"
-      sources."request-promise-core-1.1.2"
-      sources."resolve-url-0.2.1"
-      sources."ret-0.1.15"
-      (sources."rimraf-2.6.3" // {
-        dependencies = [
-          sources."glob-7.1.4"
-        ];
-      })
-      sources."safe-buffer-5.1.2"
-      sources."safe-regex-1.1.0"
-      sources."safer-buffer-2.1.2"
-      (sources."set-value-2.0.0" // {
-        dependencies = [
-          sources."extend-shallow-2.0.1"
-          sources."is-extendable-0.1.1"
-        ];
-      })
-      (sources."snapdragon-0.8.2" // {
-        dependencies = [
-          sources."define-property-0.2.5"
-          sources."extend-shallow-2.0.1"
-          (sources."is-accessor-descriptor-0.1.6" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          (sources."is-data-descriptor-0.1.4" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          sources."is-descriptor-0.1.6"
-          sources."is-extendable-0.1.1"
-          sources."kind-of-5.1.0"
-        ];
-      })
-      (sources."snapdragon-node-2.1.1" // {
-        dependencies = [
-          sources."define-property-1.0.0"
-        ];
-      })
-      (sources."snapdragon-util-3.0.1" // {
-        dependencies = [
-          sources."kind-of-3.2.2"
-        ];
-      })
-      sources."source-map-0.5.7"
-      sources."source-map-resolve-0.5.2"
-      sources."source-map-url-0.4.0"
-      sources."split-1.0.1"
-      sources."split-string-3.1.0"
-      sources."sshpk-1.16.1"
-      (sources."static-extend-0.1.2" // {
-        dependencies = [
-          sources."define-property-0.2.5"
-          (sources."is-accessor-descriptor-0.1.6" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          (sources."is-data-descriptor-0.1.4" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          sources."is-descriptor-0.1.6"
-          sources."kind-of-5.1.0"
-        ];
-      })
-      sources."stealthy-require-1.1.1"
-      sources."string_decoder-1.1.1"
-      sources."supports-color-4.2.0"
-      (sources."tar-4.4.10" // {
-        dependencies = [
-          sources."yallist-3.0.3"
-        ];
-      })
-      (sources."temp-0.8.3" // {
-        dependencies = [
-          sources."rimraf-2.2.8"
-        ];
-      })
-      sources."through-2.3.8"
-      (sources."to-object-path-0.3.0" // {
-        dependencies = [
-          sources."kind-of-3.2.2"
-        ];
-      })
-      sources."to-regex-3.0.2"
-      sources."to-regex-range-2.1.1"
-      (sources."tough-cookie-2.4.3" // {
-        dependencies = [
-          sources."punycode-1.4.1"
-        ];
-      })
-      sources."traverse-0.3.9"
-      sources."tunnel-agent-0.6.0"
-      sources."tweetnacl-0.14.5"
-      (sources."union-value-1.0.0" // {
-        dependencies = [
-          sources."extend-shallow-2.0.1"
-          sources."is-extendable-0.1.1"
-          sources."set-value-0.4.3"
-        ];
-      })
-      (sources."unset-value-1.0.0" // {
-        dependencies = [
-          (sources."has-value-0.3.1" // {
-            dependencies = [
-              sources."isobject-2.1.0"
-            ];
-          })
-          sources."has-values-0.1.4"
-        ];
-      })
-      sources."unzip-stream-0.3.0"
-      sources."upath-1.1.2"
-      sources."uri-js-4.2.2"
-      sources."urix-0.1.0"
-      sources."use-3.1.1"
-      sources."util-deprecate-1.0.2"
-      sources."uuid-3.3.2"
-      sources."verror-1.10.0"
-      sources."which-1.3.1"
-      sources."wrappy-1.0.2"
-      sources."xmlbuilder-8.2.2"
-      sources."yallist-2.1.2"
-    ];
-    buildInputs = globalBuildInputs;
-    meta = {
-      description = "Run elm-test suites.";
-      homepage = "https://github.com/rtfeldman/node-test-runner#readme";
       license = "BSD-3-Clause";
     };
     production = true;
@@ -45632,7 +44830,7 @@ in
       sources."get-stream-3.0.0"
       sources."globals-9.18.0"
       sources."got-7.1.0"
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."has-ansi-3.0.0"
       sources."has-flag-3.0.0"
       sources."has-symbol-support-x-1.4.2"
@@ -45801,10 +44999,10 @@ in
   eslint = nodeEnv.buildNodePackage {
     name = "eslint";
     packageName = "eslint";
-    version = "5.16.0";
+    version = "6.0.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/eslint/-/eslint-5.16.0.tgz";
-      sha512 = "S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==";
+      url = "https://registry.npmjs.org/eslint/-/eslint-6.0.1.tgz";
+      sha512 = "DyQRaMmORQ+JsWShYsSg4OPTjY56u1nCjAmICrE8vLWqyLKxhFXOthwMj1SA8xwfrv0CofLNVnqbfyhwCkaO0w==";
     };
     dependencies = [
       sources."@babel/code-frame-7.0.0"
@@ -45836,7 +45034,7 @@ in
       sources."eslint-scope-4.0.3"
       sources."eslint-utils-1.3.1"
       sources."eslint-visitor-keys-1.0.0"
-      sources."espree-5.0.1"
+      sources."espree-6.0.0"
       sources."esprima-4.0.1"
       sources."esquery-1.0.1"
       sources."esrecurse-4.2.1"
@@ -45849,10 +45047,15 @@ in
       sources."figures-2.0.0"
       sources."file-entry-cache-5.0.1"
       sources."flat-cache-2.0.1"
-      sources."flatted-2.0.0"
+      sources."flatted-2.0.1"
       sources."fs.realpath-1.0.0"
       sources."functional-red-black-tree-1.0.1"
       sources."glob-7.1.4"
+      (sources."glob-parent-3.1.0" // {
+        dependencies = [
+          sources."is-glob-3.1.0"
+        ];
+      })
       sources."globals-11.12.0"
       sources."has-flag-3.0.0"
       sources."iconv-lite-0.4.24"
@@ -45860,13 +45063,15 @@ in
       sources."import-fresh-3.0.0"
       sources."imurmurhash-0.1.4"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
-      (sources."inquirer-6.3.1" // {
+      sources."inherits-2.0.4"
+      (sources."inquirer-6.4.1" // {
         dependencies = [
           sources."strip-ansi-5.2.0"
         ];
       })
+      sources."is-extglob-2.1.1"
       sources."is-fullwidth-code-point-2.0.0"
+      sources."is-glob-4.0.1"
       sources."is-promise-2.1.0"
       sources."isexe-2.0.0"
       sources."js-tokens-4.0.0"
@@ -45879,7 +45084,7 @@ in
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
       sources."mkdirp-0.5.1"
-      sources."ms-2.1.1"
+      sources."ms-2.1.2"
       sources."mute-stream-0.0.7"
       sources."natural-compare-1.4.0"
       sources."nice-try-1.0.5"
@@ -45888,8 +45093,8 @@ in
       sources."optionator-0.8.2"
       sources."os-tmpdir-1.0.2"
       sources."parent-module-1.0.1"
+      sources."path-dirname-1.0.2"
       sources."path-is-absolute-1.0.1"
-      sources."path-is-inside-1.0.2"
       sources."path-key-2.0.1"
       sources."prelude-ls-1.1.2"
       sources."progress-2.0.3"
@@ -45915,7 +45120,7 @@ in
       })
       sources."strip-json-comments-2.0.1"
       sources."supports-color-5.5.0"
-      (sources."table-5.4.0" // {
+      (sources."table-5.4.1" // {
         dependencies = [
           sources."string-width-3.1.0"
           sources."strip-ansi-5.2.0"
@@ -45924,7 +45129,7 @@ in
       sources."text-table-0.2.0"
       sources."through-2.3.8"
       sources."tmp-0.0.33"
-      sources."tslib-1.9.3"
+      sources."tslib-1.10.0"
       sources."type-check-0.3.2"
       sources."uri-js-4.2.2"
       sources."which-1.3.1"
@@ -45945,10 +45150,10 @@ in
   eslint_d = nodeEnv.buildNodePackage {
     name = "eslint_d";
     packageName = "eslint_d";
-    version = "7.3.0";
+    version = "8.0.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/eslint_d/-/eslint_d-7.3.0.tgz";
-      sha512 = "vCP2gYfOiWkXYBtsTFFBCa0nou0leSOhvuUhoDWKedKg3cy4w+ZQoE+4/aGbfLYYnkzxmdiao/vYGMW/BDdi/A==";
+      url = "https://registry.npmjs.org/eslint_d/-/eslint_d-8.0.0.tgz";
+      sha512 = "9I+AC6Y7WTX4J1O3GGg1LqGiDxOUedLxzIxtKSWnD1FP3z2MPQbnWNNycg9Pq/L5B0NlszdaBlajUexZ8qzuag==";
     };
     dependencies = [
       sources."@babel/code-frame-7.0.0"
@@ -45978,11 +45183,11 @@ in
       sources."doctrine-3.0.0"
       sources."emoji-regex-7.0.3"
       sources."escape-string-regexp-1.0.5"
-      sources."eslint-5.16.0"
+      sources."eslint-6.0.1"
       sources."eslint-scope-4.0.3"
       sources."eslint-utils-1.3.1"
       sources."eslint-visitor-keys-1.0.0"
-      sources."espree-5.0.1"
+      sources."espree-6.0.0"
       sources."esprima-4.0.1"
       sources."esquery-1.0.1"
       sources."esrecurse-4.2.1"
@@ -45995,10 +45200,15 @@ in
       sources."figures-2.0.0"
       sources."file-entry-cache-5.0.1"
       sources."flat-cache-2.0.1"
-      sources."flatted-2.0.0"
+      sources."flatted-2.0.1"
       sources."fs.realpath-1.0.0"
       sources."functional-red-black-tree-1.0.1"
       sources."glob-7.1.4"
+      (sources."glob-parent-3.1.0" // {
+        dependencies = [
+          sources."is-glob-3.1.0"
+        ];
+      })
       sources."globals-11.12.0"
       sources."has-flag-3.0.0"
       sources."iconv-lite-0.4.24"
@@ -46006,13 +45216,15 @@ in
       sources."import-fresh-3.0.0"
       sources."imurmurhash-0.1.4"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
-      (sources."inquirer-6.3.1" // {
+      sources."inherits-2.0.4"
+      (sources."inquirer-6.4.1" // {
         dependencies = [
           sources."strip-ansi-5.2.0"
         ];
       })
+      sources."is-extglob-2.1.1"
       sources."is-fullwidth-code-point-2.0.0"
+      sources."is-glob-4.0.1"
       sources."is-promise-2.1.0"
       sources."isexe-2.0.0"
       sources."js-tokens-4.0.0"
@@ -46025,7 +45237,7 @@ in
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
       sources."mkdirp-0.5.1"
-      sources."ms-2.1.1"
+      sources."ms-2.1.2"
       sources."mute-stream-0.0.7"
       sources."nanolru-1.0.0"
       sources."natural-compare-1.4.0"
@@ -46035,8 +45247,8 @@ in
       sources."optionator-0.8.2"
       sources."os-tmpdir-1.0.2"
       sources."parent-module-1.0.1"
+      sources."path-dirname-1.0.2"
       sources."path-is-absolute-1.0.1"
-      sources."path-is-inside-1.0.2"
       sources."path-key-2.0.1"
       sources."path-parse-1.0.6"
       sources."prelude-ls-1.1.2"
@@ -46064,7 +45276,7 @@ in
       })
       sources."strip-json-comments-2.0.1"
       sources."supports-color-5.5.0"
-      (sources."table-5.4.0" // {
+      (sources."table-5.4.1" // {
         dependencies = [
           sources."string-width-3.1.0"
           sources."strip-ansi-5.2.0"
@@ -46073,7 +45285,7 @@ in
       sources."text-table-0.2.0"
       sources."through-2.3.8"
       sources."tmp-0.0.33"
-      sources."tslib-1.9.3"
+      sources."tslib-1.10.0"
       sources."type-check-0.3.2"
       sources."uri-js-4.2.2"
       sources."which-1.3.1"
@@ -46148,7 +45360,7 @@ in
       sources."delayed-stream-1.0.0"
       sources."ecc-jsbn-0.1.2"
       sources."error-ex-1.3.2"
-      sources."es6-promise-4.2.6"
+      sources."es6-promise-4.2.8"
       sources."escape-string-regexp-1.0.5"
       sources."exit-hook-1.1.1"
       sources."extend-3.0.2"
@@ -46163,7 +45375,7 @@ in
       sources."fs-extra-1.0.0"
       sources."get-stdin-4.0.1"
       sources."getpass-0.1.7"
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-ansi-2.0.0"
@@ -46172,7 +45384,7 @@ in
       sources."hosted-git-info-2.7.1"
       sources."http-signature-1.2.0"
       sources."indent-string-2.1.0"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."is-arrayish-0.2.1"
       sources."is-finite-1.0.2"
       sources."is-stream-1.1.0"
@@ -46239,10 +45451,10 @@ in
       sources."pify-2.3.0"
       sources."pinkie-2.0.4"
       sources."pinkie-promise-2.0.1"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."progress-1.1.8"
       sources."promise-phantom-3.1.6"
-      sources."psl-1.1.32"
+      sources."psl-1.1.33"
       sources."punycode-2.1.1"
       sources."qs-6.5.2"
       sources."read-pkg-1.1.0"
@@ -46350,13 +45562,13 @@ in
       sources."generate-function-1.1.0"
       sources."generate-object-property-1.2.0"
       sources."get-stream-3.0.0"
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."has-flag-3.0.0"
       sources."hosted-git-info-2.7.1"
       sources."iconv-lite-0.4.24"
       sources."indent-string-3.2.0"
-      sources."inherits-2.0.3"
-      (sources."inquirer-6.3.1" // {
+      sources."inherits-2.0.4"
+      (sources."inquirer-6.4.1" // {
         dependencies = [
           sources."ansi-regex-4.1.0"
           sources."strip-ansi-5.2.0"
@@ -46422,7 +45634,7 @@ in
           sources."ps-list-4.1.0"
         ];
       })
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."ps-list-5.0.1"
       sources."pseudomap-1.0.2"
       sources."quick-lru-1.1.0"
@@ -46468,7 +45680,7 @@ in
       sources."through2-2.0.5"
       sources."tmp-0.0.33"
       sources."trim-newlines-2.0.0"
-      sources."tslib-1.9.3"
+      sources."tslib-1.10.0"
       sources."util-deprecate-1.0.2"
       sources."validate-npm-package-license-3.0.4"
       sources."which-1.3.1"
@@ -46605,7 +45817,7 @@ in
       sources."glob-7.1.4"
       sources."glob-base-0.3.0"
       sources."glob-parent-2.0.0"
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       (sources."has-value-1.0.0" // {
         dependencies = [
           sources."isobject-3.0.1"
@@ -46623,7 +45835,7 @@ in
       })
       sources."i-0.3.6"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."ini-1.3.5"
       (sources."is-accessor-descriptor-1.0.0" // {
         dependencies = [
@@ -46668,7 +45880,7 @@ in
       sources."micromatch-2.3.11"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.10"
-      (sources."mixin-deep-1.3.1" // {
+      (sources."mixin-deep-1.3.2" // {
         dependencies = [
           sources."is-extendable-1.0.1"
         ];
@@ -46735,7 +45947,7 @@ in
           sources."minimist-1.2.0"
         ];
       })
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       (sources."prompt-0.2.14" // {
         dependencies = [
           sources."utile-0.2.1"
@@ -46813,7 +46025,7 @@ in
       sources."rimraf-2.6.3"
       sources."safe-buffer-5.1.2"
       sources."safe-regex-1.1.0"
-      (sources."set-value-2.0.0" // {
+      (sources."set-value-2.0.1" // {
         dependencies = [
           sources."extend-shallow-2.0.1"
         ];
@@ -46881,12 +46093,7 @@ in
           sources."is-number-3.0.0"
         ];
       })
-      (sources."union-value-1.0.0" // {
-        dependencies = [
-          sources."extend-shallow-2.0.1"
-          sources."set-value-0.4.3"
-        ];
-      })
+      sources."union-value-1.0.1"
       (sources."unset-value-1.0.0" // {
         dependencies = [
           (sources."has-value-0.3.1" // {
@@ -46937,8 +46144,8 @@ in
       sources."lodash.groupby-4.6.0"
       sources."microee-0.0.6"
       sources."minilog-3.1.0"
-      sources."ms-2.1.1"
-      sources."simple-git-1.113.0"
+      sources."ms-2.1.2"
+      sources."simple-git-1.116.0"
       sources."tabtab-git+https://github.com/mixu/node-tabtab.git"
     ];
     buildInputs = globalBuildInputs;
@@ -46979,7 +46186,7 @@ in
       sources."hashlru-2.3.0"
       sources."highlight.js-9.15.8"
       sources."increment-buffer-1.0.1"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."ini-1.3.5"
       sources."ip-1.1.5"
       sources."is-canonical-base64-1.1.1"
@@ -46987,7 +46194,7 @@ in
       sources."is-my-ip-valid-1.0.0"
       sources."is-my-json-valid-2.20.0"
       sources."is-property-1.0.2"
-      sources."is-valid-domain-0.0.9"
+      sources."is-valid-domain-0.0.11"
       sources."json-buffer-2.0.11"
       sources."jsonpointer-4.0.1"
       sources."kvgraph-0.1.0"
@@ -47007,7 +46214,7 @@ in
       })
       sources."moment-2.24.0"
       sources."moo-0.4.3"
-      sources."ms-2.1.1"
+      sources."ms-2.1.2"
       sources."multicb-1.2.2"
       sources."multiserver-3.3.6"
       sources."multiserver-address-1.0.1"
@@ -47055,14 +46262,14 @@ in
       })
       sources."pull-kvdiff-0.0.0"
       sources."pull-looper-1.0.0"
-      sources."pull-many-1.0.8"
+      sources."pull-many-1.0.9"
       sources."pull-paginate-1.0.0"
       sources."pull-pair-1.1.0"
       sources."pull-paramap-1.2.2"
       sources."pull-pushable-2.2.0"
       sources."pull-reader-1.3.1"
       sources."pull-skip-footer-0.1.0"
-      sources."pull-stream-3.6.12"
+      sources."pull-stream-3.6.13"
       (sources."pull-through-1.0.18" // {
         dependencies = [
           sources."looper-3.0.0"
@@ -47076,7 +46283,7 @@ in
       sources."remove-markdown-0.1.0"
       sources."ret-0.1.15"
       sources."safe-buffer-5.1.2"
-      sources."secret-handshake-1.1.18"
+      sources."secret-handshake-1.1.20"
       sources."semver-5.7.0"
       sources."separator-escape-0.0.0"
       sources."sha.js-2.4.5"
@@ -47094,7 +46301,7 @@ in
       sources."split-buffer-1.0.0"
       sources."ssb-avatar-0.2.0"
       sources."ssb-caps-1.0.1"
-      (sources."ssb-client-4.7.6" // {
+      (sources."ssb-client-4.7.7" // {
         dependencies = [
           sources."ssb-config-3.3.1"
         ];
@@ -47103,7 +46310,7 @@ in
       sources."ssb-git-0.5.0"
       sources."ssb-git-repo-2.8.3"
       sources."ssb-issues-1.0.0"
-      sources."ssb-keys-7.1.6"
+      sources."ssb-keys-7.1.7"
       sources."ssb-marked-0.6.0"
       (sources."ssb-mentions-0.1.2" // {
         dependencies = [
@@ -47235,7 +46442,7 @@ in
       sources."ci-info-1.6.0"
       sources."cli-boxes-1.0.0"
       sources."cli-cursor-2.1.0"
-      sources."cli-spinners-2.1.0"
+      sources."cli-spinners-2.2.0"
       sources."cli-width-2.2.0"
       sources."cliui-4.1.0"
       sources."clone-1.0.4"
@@ -47304,7 +46511,7 @@ in
       sources."end-of-stream-1.4.1"
       sources."errno-0.1.7"
       sources."error-ex-1.3.2"
-      sources."es6-promise-4.2.6"
+      sources."es6-promise-4.2.8"
       sources."es6-promisify-5.0.0"
       sources."escape-html-1.0.3"
       sources."escape-string-regexp-1.0.5"
@@ -47325,7 +46532,7 @@ in
       (sources."express-request-proxy-2.2.2" // {
         dependencies = [
           sources."debug-3.2.6"
-          sources."ms-2.1.1"
+          sources."ms-2.1.2"
           sources."path-to-regexp-1.7.0"
         ];
       })
@@ -47358,7 +46565,7 @@ in
       sources."global-modules-1.0.0"
       sources."global-prefix-1.0.2"
       sources."got-6.7.1"
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."graphcool-json-schema-1.2.1"
       (sources."graphcool-yml-0.4.15" // {
         dependencies = [
@@ -47368,10 +46575,10 @@ in
           sources."fast-deep-equal-1.1.0"
           sources."fs-extra-4.0.3"
           sources."json-schema-traverse-0.3.1"
-          sources."ms-2.1.1"
+          sources."ms-2.1.2"
         ];
       })
-      sources."graphql-14.3.1"
+      sources."graphql-14.4.1"
       (sources."graphql-cli-prepare-1.4.19" // {
         dependencies = [
           sources."chalk-2.3.1"
@@ -47397,7 +46604,11 @@ in
       sources."header-case-1.0.1"
       sources."homedir-polyfill-1.0.3"
       sources."hosted-git-info-2.7.1"
-      sources."http-errors-1.7.2"
+      (sources."http-errors-1.7.2" // {
+        dependencies = [
+          sources."inherits-2.0.3"
+        ];
+      })
       (sources."http-proxy-agent-2.1.0" // {
         dependencies = [
           sources."debug-3.1.0"
@@ -47407,7 +46618,7 @@ in
       (sources."https-proxy-agent-2.2.1" // {
         dependencies = [
           sources."debug-3.2.6"
-          sources."ms-2.1.1"
+          sources."ms-2.1.2"
         ];
       })
       sources."iconv-lite-0.4.24"
@@ -47415,7 +46626,7 @@ in
       sources."imurmurhash-0.1.4"
       sources."inflected-2.0.4"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."ini-1.3.5"
       sources."inquirer-6.2.0"
       sources."invert-kv-1.0.0"
@@ -47457,7 +46668,7 @@ in
       (sources."json-schema-ref-parser-3.3.1" // {
         dependencies = [
           sources."debug-3.2.6"
-          sources."ms-2.1.1"
+          sources."ms-2.1.2"
         ];
       })
       sources."json-schema-traverse-0.4.1"
@@ -47467,7 +46678,7 @@ in
       sources."jsonify-0.0.0"
       (sources."jsonwebtoken-8.5.1" // {
         dependencies = [
-          sources."ms-2.1.1"
+          sources."ms-2.1.2"
         ];
       })
       sources."jsprim-1.4.1"
@@ -47586,15 +46797,15 @@ in
           sources."fast-deep-equal-1.1.0"
           sources."fs-extra-7.0.1"
           sources."json-schema-traverse-0.3.1"
-          sources."ms-2.1.1"
+          sources."ms-2.1.2"
         ];
       })
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."protochain-1.0.5"
       sources."proxy-addr-2.0.5"
       sources."prr-1.0.1"
       sources."pseudomap-1.0.2"
-      sources."psl-1.1.32"
+      sources."psl-1.1.33"
       sources."pump-3.0.0"
       sources."punycode-2.1.1"
       sources."qs-6.5.2"
@@ -47697,7 +46908,7 @@ in
       })
       sources."traverse-chain-0.1.0"
       sources."trim-right-1.0.1"
-      sources."tslib-1.9.3"
+      sources."tslib-1.10.0"
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       sources."type-is-1.6.18"
@@ -47903,7 +47114,7 @@ in
       sources."map-cache-0.2.2"
       sources."map-visit-1.0.0"
       sources."micromatch-3.1.10"
-      (sources."mixin-deep-1.3.1" // {
+      (sources."mixin-deep-1.3.2" // {
         dependencies = [
           sources."is-extendable-1.0.1"
         ];
@@ -47947,7 +47158,7 @@ in
       sources."resolve-url-0.2.1"
       sources."ret-0.1.15"
       sources."safe-regex-1.1.0"
-      (sources."set-value-2.0.0" // {
+      (sources."set-value-2.0.1" // {
         dependencies = [
           sources."extend-shallow-2.0.1"
         ];
@@ -48009,12 +47220,7 @@ in
       sources."to-regex-3.0.2"
       sources."to-regex-range-2.1.1"
       sources."unc-path-regex-0.1.2"
-      (sources."union-value-1.0.0" // {
-        dependencies = [
-          sources."extend-shallow-2.0.1"
-          sources."set-value-0.4.3"
-        ];
-      })
+      sources."union-value-1.0.1"
       (sources."unset-value-1.0.0" // {
         dependencies = [
           (sources."has-value-0.3.1" // {
@@ -48080,7 +47286,7 @@ in
       })
       sources."array-unique-0.3.2"
       sources."assign-symbols-1.0.0"
-      sources."async-done-1.3.1"
+      sources."async-done-1.3.2"
       sources."async-each-1.0.3"
       sources."async-settle-1.0.0"
       sources."atob-2.1.2"
@@ -48128,11 +47334,7 @@ in
       sources."clone-2.1.2"
       sources."clone-buffer-1.0.0"
       sources."clone-stats-1.0.0"
-      (sources."cloneable-readable-1.1.3" // {
-        dependencies = [
-          sources."process-nextick-args-2.0.0"
-        ];
-      })
+      sources."cloneable-readable-1.1.3"
       sources."code-point-at-1.1.0"
       sources."collection-map-1.0.0"
       sources."collection-visit-1.0.0"
@@ -48144,7 +47346,7 @@ in
       sources."copy-descriptor-0.1.1"
       sources."copy-props-2.0.4"
       sources."core-util-is-1.0.2"
-      sources."d-1.0.0"
+      sources."d-1.0.1"
       sources."debug-2.6.9"
       sources."decamelize-1.2.0"
       sources."decode-uri-component-0.2.0"
@@ -48164,7 +47366,7 @@ in
       sources."es5-ext-0.10.50"
       sources."es6-iterator-2.0.3"
       sources."es6-symbol-3.1.1"
-      sources."es6-weak-map-2.0.2"
+      sources."es6-weak-map-2.0.3"
       (sources."expand-brackets-2.1.4" // {
         dependencies = [
           sources."define-property-0.2.5"
@@ -48227,7 +47429,7 @@ in
       sources."global-modules-1.0.0"
       sources."global-prefix-1.0.2"
       sources."glogg-1.0.2"
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."gulp-cli-2.2.0"
       sources."gulplog-1.0.0"
       sources."has-symbols-1.0.0"
@@ -48240,7 +47442,7 @@ in
       sources."homedir-polyfill-1.0.3"
       sources."hosted-git-info-2.7.1"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."ini-1.3.5"
       sources."interpret-1.2.0"
       sources."invert-kv-1.0.0"
@@ -48290,7 +47492,7 @@ in
       })
       sources."micromatch-3.1.10"
       sources."minimatch-3.0.4"
-      (sources."mixin-deep-1.3.1" // {
+      (sources."mixin-deep-1.3.2" // {
         dependencies = [
           sources."is-extendable-1.0.1"
         ];
@@ -48344,16 +47546,12 @@ in
       sources."pinkie-promise-2.0.1"
       sources."posix-character-classes-0.1.1"
       sources."pretty-hrtime-1.0.3"
-      sources."process-nextick-args-1.0.7"
+      sources."process-nextick-args-2.0.1"
       sources."pump-2.0.1"
       sources."pumpify-1.5.1"
       sources."read-pkg-1.1.0"
       sources."read-pkg-up-1.0.1"
-      (sources."readable-stream-2.3.6" // {
-        dependencies = [
-          sources."process-nextick-args-2.0.0"
-        ];
-      })
+      sources."readable-stream-2.3.6"
       sources."readdirp-2.2.1"
       sources."rechoir-0.6.2"
       sources."regex-not-1.0.2"
@@ -48376,7 +47574,7 @@ in
       sources."semver-5.7.0"
       sources."semver-greatest-satisfied-range-1.1.0"
       sources."set-blocking-2.0.0"
-      (sources."set-value-2.0.0" // {
+      (sources."set-value-2.0.1" // {
         dependencies = [
           sources."extend-shallow-2.0.1"
         ];
@@ -48455,16 +47653,12 @@ in
       sources."to-regex-3.0.2"
       sources."to-regex-range-2.1.1"
       sources."to-through-2.0.0"
+      sources."type-1.0.1"
       sources."typedarray-0.0.6"
       sources."unc-path-regex-0.1.2"
       sources."undertaker-1.2.1"
       sources."undertaker-registry-1.0.1"
-      (sources."union-value-1.0.0" // {
-        dependencies = [
-          sources."extend-shallow-2.0.1"
-          sources."set-value-0.4.3"
-        ];
-      })
+      sources."union-value-1.0.1"
       sources."unique-stream-2.3.1"
       (sources."unset-value-1.0.0" // {
         dependencies = [
@@ -48559,7 +47753,7 @@ in
       sources."copy-descriptor-0.1.1"
       sources."copy-props-2.0.4"
       sources."core-util-is-1.0.2"
-      sources."d-1.0.0"
+      sources."d-1.0.1"
       sources."debug-2.6.9"
       sources."decamelize-1.2.0"
       sources."decode-uri-component-0.2.0"
@@ -48612,7 +47806,7 @@ in
       sources."global-modules-1.0.0"
       sources."global-prefix-1.0.2"
       sources."glogg-1.0.2"
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."gulplog-1.0.0"
       sources."has-value-1.0.0"
       (sources."has-values-1.0.0" // {
@@ -48622,7 +47816,7 @@ in
       })
       sources."homedir-polyfill-1.0.3"
       sources."hosted-git-info-2.7.1"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."ini-1.3.5"
       sources."interpret-1.2.0"
       sources."invert-kv-1.0.0"
@@ -48683,7 +47877,7 @@ in
           sources."kind-of-6.0.2"
         ];
       })
-      (sources."mixin-deep-1.3.1" // {
+      (sources."mixin-deep-1.3.2" // {
         dependencies = [
           sources."is-extendable-1.0.1"
         ];
@@ -48731,7 +47925,7 @@ in
       sources."pinkie-promise-2.0.1"
       sources."posix-character-classes-0.1.1"
       sources."pretty-hrtime-1.0.3"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."read-pkg-1.1.0"
       sources."read-pkg-up-1.0.1"
       sources."readable-stream-2.3.6"
@@ -48752,7 +47946,7 @@ in
       sources."semver-5.7.0"
       sources."semver-greatest-satisfied-range-1.1.0"
       sources."set-blocking-2.0.0"
-      (sources."set-value-2.0.0" // {
+      (sources."set-value-2.0.1" // {
         dependencies = [
           sources."extend-shallow-2.0.1"
         ];
@@ -48809,14 +48003,10 @@ in
       })
       sources."to-regex-3.0.2"
       sources."to-regex-range-2.1.1"
+      sources."type-1.0.1"
       sources."typedarray-0.0.6"
       sources."unc-path-regex-0.1.2"
-      (sources."union-value-1.0.0" // {
-        dependencies = [
-          sources."extend-shallow-2.0.1"
-          sources."set-value-0.4.3"
-        ];
-      })
+      sources."union-value-1.0.1"
       (sources."unset-value-1.0.0" // {
         dependencies = [
           (sources."has-value-0.3.1" // {
@@ -48908,7 +48098,7 @@ in
       sources."htmlparser2-3.8.3"
       sources."http-signature-1.2.0"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."is-dotfile-1.0.3"
       sources."is-extglob-1.0.0"
       sources."is-glob-2.0.1"
@@ -48936,7 +48126,7 @@ in
       sources."path-is-absolute-1.0.1"
       sources."path-parse-1.0.6"
       sources."performance-now-2.1.0"
-      sources."psl-1.1.32"
+      sources."psl-1.1.33"
       sources."punycode-2.1.1"
       sources."qs-6.5.2"
       sources."readable-stream-1.1.14"
@@ -49026,7 +48216,7 @@ in
           sources."minimist-0.0.8"
         ];
       })
-      sources."ms-2.1.1"
+      sources."ms-2.1.2"
       sources."opener-1.4.3"
       (sources."optimist-0.6.1" // {
         dependencies = [
@@ -49076,14 +48266,14 @@ in
       sources."core-util-is-1.0.2"
       sources."css-color-names-1.0.1"
       sources."dashdash-1.14.1"
-      sources."deepmerge-3.2.0"
+      sources."deepmerge-3.3.0"
       sources."extsprintf-1.4.0"
       sources."fs.realpath-1.0.0"
       sources."fuzzyset.js-0.0.1"
       sources."glob-7.1.4"
       sources."hue-sdk-0.1.0"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."latest-0.2.0"
       sources."lstream-0.0.4"
       sources."minimatch-3.0.4"
@@ -49114,53 +48304,37 @@ in
   ionic = nodeEnv.buildNodePackage {
     name = "ionic";
     packageName = "ionic";
-    version = "5.0.1";
+    version = "5.2.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/ionic/-/ionic-5.0.1.tgz";
-      sha512 = "48v7X8C8OvLN4GdizNJiGpP6/qp9C4V+uP1MXL7zCrcoty4FP4RXbpeBXaZJlrxC9zHxlsPQ/gB/p3e2XINALA==";
+      url = "https://registry.npmjs.org/ionic/-/ionic-5.2.1.tgz";
+      sha512 = "BEsJ5jraMgeqGiGjBhw4hJ5IK135wS4i3zRDda7OtMDyJKb77LHF3P8jyLgH1Yf+/yt7O8Qb5OE0/6bTRiZJaA==";
     };
     dependencies = [
-      sources."@ionic/cli-framework-2.0.1"
-      sources."@ionic/discover-2.0.1"
+      sources."@ionic/cli-framework-2.1.1"
+      sources."@ionic/discover-2.0.2"
       sources."@ionic/utils-array-1.0.1"
-      sources."@ionic/utils-fs-2.0.1"
+      sources."@ionic/utils-fs-2.0.3"
       sources."@ionic/utils-network-1.0.1"
       sources."@ionic/utils-object-1.0.1"
       sources."@ionic/utils-process-1.0.1"
-      sources."@ionic/utils-stream-1.0.1"
-      sources."@ionic/utils-subprocess-1.0.1"
+      sources."@ionic/utils-stream-2.0.0"
+      sources."@ionic/utils-subprocess-1.0.3"
       sources."@ionic/utils-terminal-1.0.1"
       sources."@types/node-8.10.49"
       sources."agent-base-4.3.0"
-      (sources."ansi-align-2.0.0" // {
-        dependencies = [
-          sources."string-width-2.1.1"
-          sources."strip-ansi-4.0.0"
-        ];
-      })
       sources."ansi-escapes-3.2.0"
       sources."ansi-regex-3.0.0"
       sources."ansi-styles-3.2.1"
-      sources."ast-types-0.13.1"
+      sources."ast-types-0.13.2"
       sources."astral-regex-1.0.0"
       sources."async-limiter-1.0.0"
       sources."asynckit-0.4.0"
       sources."balanced-match-1.0.0"
-      (sources."boxen-1.3.0" // {
-        dependencies = [
-          sources."string-width-2.1.1"
-          sources."strip-ansi-4.0.0"
-        ];
-      })
       sources."brace-expansion-1.1.11"
       sources."bytes-3.1.0"
-      sources."camelcase-4.1.0"
-      sources."capture-stack-trace-1.0.1"
       sources."chalk-2.4.2"
       sources."chardet-0.7.0"
       sources."chownr-1.1.1"
-      sources."ci-info-1.6.0"
-      sources."cli-boxes-1.0.0"
       sources."cli-cursor-2.1.0"
       sources."cli-width-2.2.0"
       sources."co-4.6.0"
@@ -49169,31 +48343,30 @@ in
       sources."combined-stream-1.0.8"
       sources."component-emitter-1.3.0"
       sources."concat-map-0.0.1"
-      sources."configstore-3.1.2"
       sources."cookiejar-2.1.2"
       sources."core-util-is-1.0.2"
-      sources."create-error-class-3.0.2"
       (sources."cross-spawn-6.0.5" // {
         dependencies = [
           sources."semver-5.7.0"
         ];
       })
-      sources."crypto-random-string-1.0.0"
       sources."data-uri-to-buffer-2.0.1"
       sources."debug-4.1.1"
-      sources."deep-extend-0.6.0"
       sources."deep-is-0.1.3"
       sources."degenerator-1.0.4"
       sources."delayed-stream-1.0.0"
       sources."depd-1.1.2"
       sources."diff-4.0.1"
-      sources."dot-prop-4.2.0"
-      sources."duplexer2-0.1.4"
-      sources."duplexer3-0.1.4"
+      (sources."duplexer2-0.1.4" // {
+        dependencies = [
+          sources."readable-stream-2.3.6"
+          sources."string_decoder-1.1.1"
+        ];
+      })
       sources."elementtree-0.1.7"
-      sources."emoji-regex-8.0.0"
+      sources."emoji-regex-7.0.3"
       sources."end-of-stream-1.4.1"
-      sources."es6-promise-4.2.6"
+      sources."es6-promise-4.2.8"
       sources."es6-promisify-5.0.0"
       sources."escape-string-regexp-1.0.5"
       sources."escodegen-1.11.1"
@@ -49206,9 +48379,9 @@ in
       sources."fast-levenshtein-2.0.6"
       sources."figures-2.0.0"
       sources."file-uri-to-path-1.0.0"
-      sources."form-data-2.3.3"
+      sources."form-data-2.4.0"
       sources."formidable-1.2.1"
-      sources."fs-extra-7.0.1"
+      sources."fs-extra-8.1.0"
       sources."fs-minipass-1.2.6"
       sources."fs.realpath-1.0.0"
       (sources."ftp-0.3.10" // {
@@ -49219,21 +48392,11 @@ in
         ];
       })
       sources."get-stream-4.1.0"
-      (sources."get-uri-2.0.3" // {
-        dependencies = [
-          sources."readable-stream-3.4.0"
-        ];
-      })
+      sources."get-uri-2.0.3"
       sources."glob-7.1.4"
-      sources."global-dirs-0.1.1"
-      (sources."got-6.7.1" // {
-        dependencies = [
-          sources."get-stream-3.0.0"
-        ];
-      })
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."has-flag-3.0.0"
-      sources."http-errors-1.7.2"
+      sources."http-errors-1.7.3"
       (sources."http-proxy-agent-2.1.0" // {
         dependencies = [
           sources."debug-3.1.0"
@@ -49246,12 +48409,10 @@ in
         ];
       })
       sources."iconv-lite-0.4.24"
-      sources."import-lazy-2.1.0"
       sources."imurmurhash-0.1.4"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
-      sources."ini-1.3.5"
-      (sources."inquirer-6.3.1" // {
+      sources."inherits-2.0.4"
+      (sources."inquirer-6.4.1" // {
         dependencies = [
           (sources."string-width-2.1.1" // {
             dependencies = [
@@ -49261,21 +48422,14 @@ in
         ];
       })
       sources."ip-1.1.5"
-      sources."is-ci-1.2.1"
       sources."is-fullwidth-code-point-2.0.0"
-      sources."is-installed-globally-0.1.0"
-      sources."is-npm-1.0.0"
-      sources."is-obj-1.0.1"
-      sources."is-path-inside-1.0.1"
       sources."is-promise-2.1.0"
-      sources."is-redirect-1.0.0"
-      sources."is-retry-allowed-1.1.0"
       sources."is-stream-1.1.0"
+      sources."is-typedarray-1.0.0"
       sources."is-wsl-1.1.0"
       sources."isarray-1.0.0"
       sources."isexe-2.0.0"
       sources."jsonfile-4.0.0"
-      sources."latest-version-3.1.0"
       (sources."leek-0.0.24" // {
         dependencies = [
           sources."debug-2.6.9"
@@ -49295,13 +48449,16 @@ in
       sources."lodash.isarray-3.0.4"
       sources."lodash.keys-3.1.2"
       sources."lodash.restparam-3.6.1"
-      sources."log-update-3.2.0"
-      sources."lowercase-keys-1.0.1"
+      (sources."log-update-3.2.0" // {
+        dependencies = [
+          sources."string-width-3.1.0"
+          sources."wrap-ansi-5.1.0"
+        ];
+      })
       sources."lru-cache-4.1.5"
-      sources."macos-release-2.2.0"
-      sources."make-dir-1.3.0"
+      sources."macos-release-2.3.0"
       sources."methods-1.1.2"
-      sources."mime-2.4.3"
+      sources."mime-2.4.4"
       sources."mime-db-1.40.0"
       sources."mime-types-2.1.24"
       sources."mimic-fn-1.2.0"
@@ -49318,7 +48475,7 @@ in
           sources."minimist-0.0.8"
         ];
       })
-      sources."ms-2.1.1"
+      sources."ms-2.1.2"
       sources."mute-stream-0.0.7"
       sources."netmask-1.0.6"
       sources."nice-try-1.0.5"
@@ -49336,18 +48493,10 @@ in
         ];
       })
       sources."pac-resolver-3.0.0"
-      (sources."package-json-4.0.1" // {
-        dependencies = [
-          sources."semver-5.7.0"
-        ];
-      })
       sources."path-is-absolute-1.0.1"
-      sources."path-is-inside-1.0.2"
       sources."path-key-2.0.1"
-      sources."pify-3.0.0"
       sources."prelude-ls-1.1.2"
-      sources."prepend-http-1.0.4"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       (sources."proxy-agent-3.1.0" // {
         dependencies = [
           sources."debug-3.2.6"
@@ -49357,11 +48506,8 @@ in
       sources."pseudomap-1.0.2"
       sources."pump-3.0.0"
       sources."qs-6.7.0"
-      sources."raw-body-2.4.0"
-      sources."rc-1.2.8"
-      sources."readable-stream-2.3.6"
-      sources."registry-auth-token-3.4.0"
-      sources."registry-url-3.1.0"
+      sources."raw-body-2.4.1"
+      sources."readable-stream-3.4.0"
       sources."restore-cursor-2.0.0"
       sources."rimraf-2.6.3"
       sources."rsvp-3.6.2"
@@ -49370,12 +48516,7 @@ in
       sources."safe-buffer-5.1.2"
       sources."safer-buffer-2.1.2"
       sources."sax-1.1.4"
-      sources."semver-6.1.1"
-      (sources."semver-diff-2.1.0" // {
-        dependencies = [
-          sources."semver-5.7.0"
-        ];
-      })
+      sources."semver-6.1.2"
       sources."setprototypeof-1.1.1"
       sources."shebang-command-1.2.0"
       sources."shebang-regex-1.0.0"
@@ -49389,32 +48530,29 @@ in
         ];
       })
       sources."source-map-0.6.1"
-      (sources."split2-3.1.1" // {
-        dependencies = [
-          sources."readable-stream-3.4.0"
-        ];
-      })
+      sources."split2-3.1.1"
       sources."ssh-config-1.1.6"
       sources."statuses-1.5.0"
-      sources."stream-combiner2-1.1.1"
+      (sources."stream-combiner2-1.1.1" // {
+        dependencies = [
+          sources."readable-stream-2.3.6"
+          sources."string_decoder-1.1.1"
+        ];
+      })
       (sources."string-width-4.1.0" // {
         dependencies = [
+          sources."emoji-regex-8.0.0"
           sources."is-fullwidth-code-point-3.0.0"
         ];
       })
-      sources."string_decoder-1.1.1"
+      sources."string_decoder-1.2.0"
       (sources."strip-ansi-5.2.0" // {
         dependencies = [
           sources."ansi-regex-4.1.0"
         ];
       })
       sources."strip-eof-1.0.0"
-      sources."strip-json-comments-2.0.1"
-      (sources."superagent-4.1.0" // {
-        dependencies = [
-          sources."readable-stream-3.4.0"
-        ];
-      })
+      sources."superagent-4.1.0"
       (sources."superagent-proxy-2.0.0" // {
         dependencies = [
           sources."debug-3.2.6"
@@ -49426,50 +48564,33 @@ in
           sources."yallist-3.0.3"
         ];
       })
-      (sources."term-size-1.2.0" // {
-        dependencies = [
-          sources."cross-spawn-5.1.0"
-          sources."execa-0.7.0"
-          sources."get-stream-3.0.0"
-        ];
-      })
       sources."through-2.3.8"
       sources."through2-3.0.1"
       sources."thunkify-2.1.2"
-      sources."timed-out-4.0.1"
       sources."tmp-0.0.33"
       sources."toidentifier-1.0.0"
       sources."tree-kill-1.2.1"
-      sources."tslib-1.9.3"
+      sources."tslib-1.10.0"
       sources."type-check-0.3.2"
-      sources."unique-string-1.0.0"
+      sources."typedarray-to-buffer-3.1.5"
       sources."universalify-0.1.2"
       sources."unpipe-1.0.0"
       sources."untildify-4.0.0"
-      sources."unzip-response-2.0.1"
-      sources."update-notifier-2.5.0"
-      sources."url-parse-lax-1.0.0"
       sources."util-deprecate-1.0.2"
       sources."uuid-3.3.2"
       sources."which-1.3.1"
-      (sources."widest-line-2.0.1" // {
-        dependencies = [
-          sources."string-width-2.1.1"
-          sources."strip-ansi-4.0.0"
-        ];
-      })
       sources."windows-release-3.2.0"
       sources."wordwrap-1.0.0"
-      (sources."wrap-ansi-5.1.0" // {
+      (sources."wrap-ansi-6.0.0" // {
         dependencies = [
-          sources."emoji-regex-7.0.3"
-          sources."string-width-3.1.0"
+          sources."ansi-styles-4.0.0"
+          sources."color-convert-2.0.0"
+          sources."color-name-1.1.4"
         ];
       })
       sources."wrappy-1.0.2"
-      sources."write-file-atomic-2.4.3"
-      sources."ws-6.2.1"
-      sources."xdg-basedir-3.0.0"
+      sources."write-file-atomic-3.0.0"
+      sources."ws-7.0.1"
       sources."xregexp-2.0.0"
       sources."yallist-2.1.2"
     ];
@@ -49523,7 +48644,7 @@ in
       sources."glob-6.0.4"
       sources."imap-0.8.19"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."isarray-0.0.1"
       sources."isstream-0.1.2"
       sources."minimatch-3.0.4"
@@ -49662,8 +48783,8 @@ in
       sources."glob-7.1.4"
       sources."has-flag-3.0.0"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
-      sources."iterare-1.1.2"
+      sources."inherits-2.0.4"
+      sources."iterare-1.2.0"
       (sources."jaeger-client-3.15.0" // {
         dependencies = [
           sources."opentracing-0.13.0"
@@ -49714,10 +48835,10 @@ in
   joplin = nodeEnv.buildNodePackage {
     name = "joplin";
     packageName = "joplin";
-    version = "1.0.139";
+    version = "1.0.140";
     src = fetchurl {
-      url = "https://registry.npmjs.org/joplin/-/joplin-1.0.139.tgz";
-      sha512 = "sIXGKP0gMiVf41G8AR9i3Bh3XJB86SCvBlIiW/6A9xspM52VK0TRYveTy07Z1+k97xnxJm/f6Opu6OdYn1Y2ug==";
+      url = "https://registry.npmjs.org/joplin/-/joplin-1.0.140.tgz";
+      sha512 = "+Amc5prSJzN96pXObO5MfbLTfUB7MaMe0Qo+ac99eAX0PGzcbmelVLOeBpEyPu4XaDkaFiN5F+XtKzncVBTyWg==";
     };
     dependencies = [
       sources."@cronvel/get-pixels-3.3.1"
@@ -49754,6 +48875,7 @@ in
       sources."async-limiter-1.0.0"
       sources."async-mutex-0.1.3"
       sources."asynckit-0.4.0"
+      sources."atob-2.1.2"
       sources."aws-sign2-0.7.0"
       sources."aws4-1.8.0"
       sources."balanced-match-1.0.0"
@@ -49786,6 +48908,7 @@ in
       sources."console-control-strings-1.1.0"
       sources."core-util-is-1.0.2"
       sources."crypt-0.0.2"
+      sources."css-2.2.4"
       sources."cssom-0.3.6"
       sources."cssstyle-1.2.2"
       sources."cwise-compiler-1.1.3"
@@ -49796,6 +48919,7 @@ in
         ];
       })
       sources."debug-3.2.6"
+      sources."decode-uri-component-0.2.0"
       sources."decompress-response-3.3.0"
       sources."deep-extend-0.6.0"
       sources."deep-is-0.1.3"
@@ -49838,7 +48962,7 @@ in
       sources."for-each-property-0.0.4"
       sources."for-each-property-deep-0.0.3"
       sources."forever-agent-0.6.1"
-      sources."form-data-2.3.3"
+      sources."form-data-2.4.0"
       sources."format-0.2.2"
       sources."fs-constants-1.0.0"
       sources."fs-copy-file-sync-1.1.1"
@@ -49855,7 +48979,7 @@ in
       sources."getpass-0.1.7"
       sources."github-from-package-0.0.0"
       sources."glob-7.1.4"
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-ansi-2.0.0"
@@ -49877,7 +49001,7 @@ in
       })
       sources."image-type-3.1.0"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."ini-1.3.5"
       (sources."inspect-function-0.2.2" // {
         dependencies = [
@@ -49922,7 +49046,7 @@ in
       })
       sources."isarray-1.0.0"
       sources."isstream-0.1.2"
-      sources."joplin-turndown-4.0.11"
+      sources."joplin-turndown-4.0.15"
       sources."joplin-turndown-plugin-gfm-1.0.8"
       sources."jpeg-js-0.1.2"
       sources."js-tokens-4.0.0"
@@ -49953,7 +49077,7 @@ in
       sources."markdown-it-8.4.2"
       sources."md5-2.2.1"
       sources."mdurl-1.0.1"
-      sources."mime-2.4.3"
+      sources."mime-2.4.4"
       sources."mime-db-1.40.0"
       sources."mime-types-2.1.24"
       sources."mimic-response-1.0.1"
@@ -49963,7 +49087,7 @@ in
       sources."minizlib-1.2.1"
       sources."mkdirp-0.5.1"
       sources."moment-2.24.0"
-      sources."ms-2.1.1"
+      sources."ms-2.1.2"
       sources."nan-2.14.0"
       sources."napi-build-utils-1.0.1"
       sources."ndarray-1.0.18"
@@ -49971,7 +49095,7 @@ in
       sources."needle-2.4.0"
       sources."nextgen-events-1.1.1"
       sources."no-case-2.3.2"
-      (sources."node-abi-2.8.0" // {
+      (sources."node-abi-2.9.0" // {
         dependencies = [
           sources."semver-5.7.0"
         ];
@@ -49988,7 +49112,7 @@ in
       sources."noop-logger-0.1.1"
       sources."nopt-4.0.1"
       sources."npm-bundled-1.0.6"
-      sources."npm-packlist-1.4.1"
+      sources."npm-packlist-1.4.3"
       sources."npmlog-4.1.2"
       sources."number-is-nan-1.0.1"
       sources."nwsapi-2.1.4"
@@ -50025,10 +49149,10 @@ in
         ];
       })
       sources."prelude-ls-1.1.2"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."promise-7.3.1"
       sources."proper-lockfile-2.0.1"
-      sources."psl-1.1.32"
+      sources."psl-1.1.33"
       sources."pump-2.0.1"
       sources."punycode-2.1.1"
       sources."q-1.1.2"
@@ -50045,16 +49169,21 @@ in
       sources."reduce-flatten-1.0.1"
       sources."redux-3.7.2"
       sources."relateurl-0.2.7"
-      sources."request-2.88.0"
+      (sources."request-2.88.0" // {
+        dependencies = [
+          sources."form-data-2.3.3"
+        ];
+      })
       sources."request-promise-core-1.1.2"
       sources."request-promise-native-1.0.7"
       sources."requires-port-1.0.0"
+      sources."resolve-url-0.2.1"
       sources."retry-0.10.1"
       sources."rimraf-2.6.3"
       sources."safe-buffer-5.1.2"
       sources."safer-buffer-2.1.2"
       sources."sax-1.2.4"
-      sources."semver-6.1.1"
+      sources."semver-6.1.2"
       sources."server-destroy-1.0.1"
       sources."set-blocking-2.0.0"
       sources."setimmediate-1.0.5"
@@ -50070,13 +49199,15 @@ in
         ];
       })
       sources."source-map-0.6.1"
+      sources."source-map-resolve-0.5.2"
+      sources."source-map-url-0.4.0"
       sources."split-skip-0.0.2"
       sources."sprintf-js-1.1.2"
-      sources."sqlite3-4.0.8"
+      sources."sqlite3-4.0.9"
       sources."sshpk-1.16.1"
       sources."stealthy-require-1.1.1"
       sources."strict-uri-encode-1.1.0"
-      sources."string-kit-0.9.5"
+      sources."string-kit-0.9.6"
       sources."string-padding-1.0.2"
       sources."string-to-stream-1.1.1"
       (sources."string-width-1.0.2" // {
@@ -50098,9 +49229,9 @@ in
       sources."strip-json-comments-2.0.1"
       sources."supports-color-5.5.0"
       sources."symbol-observable-1.2.0"
-      sources."symbol-tree-3.2.2"
+      sources."symbol-tree-3.2.4"
       sources."syswide-cas-5.3.0"
-      sources."table-layout-0.4.4"
+      sources."table-layout-0.4.5"
       sources."tar-4.4.10"
       (sources."tar-fs-1.16.3" // {
         dependencies = [
@@ -50114,7 +49245,7 @@ in
           sources."q-0.9.7"
         ];
       })
-      sources."terminal-kit-1.28.0"
+      sources."terminal-kit-1.28.2"
       (sources."tkwidgets-0.5.26" // {
         dependencies = [
           sources."is-fullwidth-code-point-2.0.0"
@@ -50146,6 +49277,7 @@ in
       sources."unpack-string-0.0.2"
       sources."upper-case-1.1.3"
       sources."uri-js-4.2.2"
+      sources."urix-0.1.0"
       sources."url-parse-1.4.7"
       sources."util-deprecate-1.0.2"
       sources."uuid-3.3.2"
@@ -50201,7 +49333,7 @@ in
       sources."catharsis-0.8.10"
       sources."entities-1.1.2"
       sources."escape-string-regexp-2.0.0"
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."js2xmlparser-4.0.0"
       sources."klaw-3.0.0"
       sources."linkify-it-2.1.0"
@@ -50260,7 +49392,7 @@ in
       sources."glob-7.1.4"
       sources."htmlparser2-3.8.3"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."isarray-0.0.1"
       sources."lodash-4.17.11"
       sources."minimatch-3.0.4"
@@ -50318,7 +49450,7 @@ in
       sources."fs.realpath-1.0.0"
       sources."glob-7.1.4"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."ini-1.3.5"
       sources."lru-cache-4.1.5"
       sources."minimatch-3.0.4"
@@ -50418,10 +49550,10 @@ in
       sources."delayed-stream-1.0.0"
       sources."esprima-4.0.1"
       sources."extend-3.0.2"
-      sources."form-data-2.3.3"
+      sources."form-data-2.4.0"
       sources."formidable-1.2.1"
       sources."graphlib-2.1.7"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."isarray-1.0.0"
       sources."js-yaml-3.13.1"
       sources."lodash-4.17.11"
@@ -50429,10 +49561,10 @@ in
       sources."mime-1.6.0"
       sources."mime-db-1.40.0"
       sources."mime-types-2.1.24"
-      sources."ms-2.1.1"
+      sources."ms-2.1.2"
       sources."native-promise-only-0.8.1"
       sources."path-loader-1.0.10"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."punycode-2.1.1"
       sources."qs-6.7.0"
       sources."readable-stream-2.3.6"
@@ -50481,9 +49613,10 @@ in
       sources."body-parser-1.19.0"
       sources."boxen-3.2.0"
       sources."bytes-3.1.0"
-      (sources."cacheable-request-6.0.0" // {
+      (sources."cacheable-request-6.1.0" // {
         dependencies = [
-          sources."get-stream-4.1.0"
+          sources."get-stream-5.1.0"
+          sources."lowercase-keys-2.0.0"
         ];
       })
       sources."camelcase-5.3.1"
@@ -50558,7 +49691,7 @@ in
           sources."get-stream-4.1.0"
         ];
       })
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-flag-3.0.0"
@@ -50571,7 +49704,6 @@ in
       sources."imurmurhash-0.1.4"
       sources."inherits-2.0.3"
       sources."ini-1.3.5"
-      sources."invert-kv-2.0.0"
       sources."ipaddr.js-1.9.0"
       sources."is-ci-2.0.0"
       sources."is-fullwidth-code-point-2.0.0"
@@ -50596,7 +49728,6 @@ in
       sources."jsprim-1.4.1"
       sources."keyv-3.1.0"
       sources."latest-version-5.1.0"
-      sources."lcid-2.0.0"
       sources."locate-path-3.0.0"
       sources."lodash-4.17.11"
       sources."lodash-id-0.14.0"
@@ -50604,9 +49735,7 @@ in
       sources."lowercase-keys-1.0.1"
       sources."lru-cache-4.1.5"
       sources."make-dir-1.3.0"
-      sources."map-age-cleaner-0.1.3"
       sources."media-typer-0.3.0"
-      sources."mem-4.3.0"
       sources."merge-descriptors-1.0.1"
       (sources."method-override-3.0.0" // {
         dependencies = [
@@ -50617,36 +49746,25 @@ in
       sources."mime-1.6.0"
       sources."mime-db-1.40.0"
       sources."mime-types-2.1.24"
-      sources."mimic-fn-2.1.0"
       sources."mimic-response-1.0.1"
       sources."minimist-1.2.0"
       sources."morgan-1.9.1"
       sources."ms-2.0.0"
       sources."nanoid-2.0.3"
       sources."negotiator-0.6.2"
-      sources."nice-try-1.0.5"
-      sources."normalize-url-3.3.0"
+      sources."normalize-url-4.3.0"
       sources."npm-run-path-2.0.2"
       sources."oauth-sign-0.9.0"
       sources."object-assign-4.1.1"
       sources."on-finished-2.3.0"
       sources."on-headers-1.0.2"
       sources."once-1.4.0"
-      (sources."os-locale-3.1.0" // {
-        dependencies = [
-          sources."cross-spawn-6.0.5"
-          sources."execa-1.0.0"
-          sources."get-stream-4.1.0"
-        ];
-      })
       sources."p-cancelable-1.1.0"
-      sources."p-defer-1.0.0"
       sources."p-finally-1.0.0"
-      sources."p-is-promise-2.1.0"
       sources."p-limit-2.2.0"
       sources."p-locate-3.0.0"
       sources."p-try-2.2.0"
-      sources."package-json-6.3.0"
+      sources."package-json-6.4.0"
       sources."parseurl-1.3.3"
       sources."path-exists-3.0.0"
       sources."path-is-inside-1.0.2"
@@ -50659,7 +49777,7 @@ in
       sources."prepend-http-2.0.0"
       sources."proxy-addr-2.0.5"
       sources."pseudomap-1.0.2"
-      sources."psl-1.1.32"
+      sources."psl-1.1.33"
       sources."pump-3.0.0"
       sources."punycode-2.1.1"
       sources."qs-6.7.0"
@@ -50678,9 +49796,13 @@ in
       sources."responselike-1.0.2"
       sources."safe-buffer-5.1.2"
       sources."safer-buffer-2.1.2"
-      sources."semver-5.7.0"
+      sources."semver-6.1.2"
       sources."semver-compare-1.0.0"
-      sources."semver-diff-2.1.0"
+      (sources."semver-diff-2.1.0" // {
+        dependencies = [
+          sources."semver-5.7.0"
+        ];
+      })
       (sources."send-0.17.1" // {
         dependencies = [
           sources."ms-2.1.1"
@@ -50737,8 +49859,8 @@ in
       sources."xdg-basedir-3.0.0"
       sources."y18n-4.0.0"
       sources."yallist-2.1.2"
-      sources."yargs-13.2.4"
-      sources."yargs-parser-13.1.0"
+      sources."yargs-13.3.0"
+      sources."yargs-parser-13.1.1"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -50885,11 +50007,11 @@ in
       })
       sources."fill-range-4.0.0"
       sources."finalhandler-1.1.2"
-      sources."flatted-2.0.0"
+      sources."flatted-2.0.1"
       (sources."follow-redirects-1.7.0" // {
         dependencies = [
           sources."debug-3.2.6"
-          sources."ms-2.1.1"
+          sources."ms-2.1.2"
         ];
       })
       sources."for-in-1.0.2"
@@ -50904,7 +50026,7 @@ in
           sources."is-glob-3.1.0"
         ];
       })
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       (sources."has-binary2-1.0.3" // {
         dependencies = [
           sources."isarray-2.0.1"
@@ -50952,10 +50074,10 @@ in
       sources."jsonfile-4.0.0"
       sources."kind-of-3.2.2"
       sources."lodash-4.17.11"
-      (sources."log4js-4.3.1" // {
+      (sources."log4js-4.4.0" // {
         dependencies = [
           sources."debug-4.1.1"
-          sources."ms-2.1.1"
+          sources."ms-2.1.2"
         ];
       })
       sources."lru-cache-4.1.5"
@@ -50970,12 +50092,12 @@ in
           sources."kind-of-6.0.2"
         ];
       })
-      sources."mime-2.4.3"
+      sources."mime-2.4.4"
       sources."mime-db-1.40.0"
       sources."mime-types-2.1.24"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.10"
-      (sources."mixin-deep-1.3.1" // {
+      (sources."mixin-deep-1.3.2" // {
         dependencies = [
           sources."is-extendable-1.0.1"
         ];
@@ -51007,7 +50129,7 @@ in
       sources."path-dirname-1.0.2"
       sources."path-is-absolute-1.0.1"
       sources."posix-character-classes-0.1.1"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."pseudomap-1.0.2"
       sources."qjobs-1.2.0"
       sources."qs-6.7.0"
@@ -51032,7 +50154,7 @@ in
       sources."safe-buffer-5.1.2"
       sources."safe-regex-1.1.0"
       sources."safer-buffer-2.1.2"
-      sources."set-value-2.0.0"
+      sources."set-value-2.0.1"
       sources."setprototypeof-1.1.1"
       (sources."snapdragon-0.8.2" // {
         dependencies = [
@@ -51078,7 +50200,7 @@ in
       (sources."streamroller-1.0.5" // {
         dependencies = [
           sources."debug-3.2.6"
-          sources."ms-2.1.1"
+          sources."ms-2.1.2"
         ];
       })
       sources."string_decoder-1.1.1"
@@ -51096,11 +50218,7 @@ in
       sources."toidentifier-1.0.0"
       sources."type-is-1.6.18"
       sources."ultron-1.1.1"
-      (sources."union-value-1.0.0" // {
-        dependencies = [
-          sources."set-value-0.4.3"
-        ];
-      })
+      sources."union-value-1.0.1"
       sources."universalify-0.1.2"
       sources."unpipe-1.0.0"
       (sources."unset-value-1.0.0" // {
@@ -51168,10 +50286,10 @@ in
       sources."glob-7.1.4"
       sources."glob-parent-3.1.0"
       sources."glob-stream-6.1.0"
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."has-symbols-1.0.0"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."is-absolute-1.0.0"
       sources."is-buffer-1.1.6"
       sources."is-extglob-2.1.1"
@@ -51195,7 +50313,7 @@ in
       sources."ordered-read-streams-1.0.1"
       sources."path-dirname-1.0.2"
       sources."path-is-absolute-1.0.1"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."pump-2.0.1"
       sources."pumpify-1.5.1"
       sources."readable-stream-2.3.6"
@@ -51322,7 +50440,7 @@ in
       sources."http-signature-1.2.0"
       sources."i-0.3.6"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."ini-1.3.5"
       sources."invert-kv-1.0.0"
       sources."is-fullwidth-code-point-1.0.0"
@@ -51392,7 +50510,7 @@ in
       sources."pkginfo-0.4.1"
       sources."prelude-ls-1.1.2"
       sources."prompt-1.0.0"
-      sources."psl-1.1.32"
+      sources."psl-1.1.33"
       sources."pump-3.0.0"
       sources."punycode-2.1.1"
       sources."qs-6.5.2"
@@ -51426,7 +50544,7 @@ in
       sources."strip-ansi-3.0.1"
       sources."strip-eof-1.0.0"
       sources."supports-color-5.5.0"
-      sources."symbol-tree-3.2.2"
+      sources."symbol-tree-3.2.4"
       sources."tough-cookie-2.5.0"
       sources."tr46-0.0.3"
       sources."tunnel-agent-0.6.0"
@@ -51490,87 +50608,104 @@ in
   lerna = nodeEnv.buildNodePackage {
     name = "lerna";
     packageName = "lerna";
-    version = "3.14.1";
+    version = "3.15.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/lerna/-/lerna-3.14.1.tgz";
-      sha512 = "lQxmGeEECjOMI3pRh2+I6jazoEWhEfvZNIs7XaX71op33AVwyjlY/nQ1GJGrPhxYBuQnlPgH0vH/nC/lcLaVkw==";
+      url = "https://registry.npmjs.org/lerna/-/lerna-3.15.0.tgz";
+      sha512 = "kRIQ3bgzkmew5/WZQ0C9WjH0IUf3ZmTNnBwTHfXgLkVY7td0lbwMQFD7zehflUn0zG4ou54o/gn+IfjF0ti/5A==";
     };
     dependencies = [
-      sources."@lerna/add-3.14.0"
+      (sources."@evocateur/libnpmaccess-3.1.0" // {
+        dependencies = [
+          sources."aproba-2.0.0"
+        ];
+      })
+      (sources."@evocateur/libnpmpublish-1.2.0" // {
+        dependencies = [
+          sources."aproba-2.0.0"
+        ];
+      })
+      (sources."@evocateur/npm-registry-fetch-3.9.1" // {
+        dependencies = [
+          sources."lru-cache-4.1.5"
+        ];
+      })
+      sources."@evocateur/pacote-9.6.0"
+      sources."@lerna/add-3.15.0"
       sources."@lerna/batch-packages-3.14.0"
-      sources."@lerna/bootstrap-3.14.0"
-      sources."@lerna/changed-3.14.1"
-      sources."@lerna/check-working-tree-3.14.1"
-      sources."@lerna/child-process-3.13.3"
-      sources."@lerna/clean-3.14.0"
+      sources."@lerna/bootstrap-3.15.0"
+      sources."@lerna/changed-3.15.0"
+      sources."@lerna/check-working-tree-3.14.2"
+      sources."@lerna/child-process-3.14.2"
+      sources."@lerna/clean-3.15.0"
       sources."@lerna/cli-3.13.0"
-      sources."@lerna/collect-uncommitted-3.14.1"
-      sources."@lerna/collect-updates-3.14.0"
-      sources."@lerna/command-3.14.0"
+      sources."@lerna/collect-uncommitted-3.14.2"
+      sources."@lerna/collect-updates-3.14.2"
+      sources."@lerna/command-3.15.0"
       sources."@lerna/conventional-commits-3.14.0"
-      sources."@lerna/create-3.14.0"
+      sources."@lerna/create-3.15.0"
       sources."@lerna/create-symlink-3.14.0"
-      sources."@lerna/describe-ref-3.13.3"
-      sources."@lerna/diff-3.14.0"
-      sources."@lerna/exec-3.14.0"
-      sources."@lerna/filter-options-3.14.0"
+      sources."@lerna/describe-ref-3.14.2"
+      sources."@lerna/diff-3.15.0"
+      sources."@lerna/exec-3.15.0"
+      sources."@lerna/filter-options-3.14.2"
       sources."@lerna/filter-packages-3.13.0"
       sources."@lerna/get-npm-exec-opts-3.13.0"
       sources."@lerna/get-packed-3.13.0"
-      sources."@lerna/github-client-3.13.3"
+      sources."@lerna/github-client-3.14.2"
+      sources."@lerna/gitlab-client-3.15.0"
       sources."@lerna/global-options-3.13.0"
-      sources."@lerna/has-npm-version-3.13.3"
-      sources."@lerna/import-3.14.0"
-      sources."@lerna/init-3.14.0"
-      sources."@lerna/link-3.14.0"
-      sources."@lerna/list-3.14.0"
+      sources."@lerna/has-npm-version-3.14.2"
+      sources."@lerna/import-3.15.0"
+      sources."@lerna/init-3.15.0"
+      sources."@lerna/link-3.15.0"
+      sources."@lerna/list-3.15.0"
       sources."@lerna/listable-3.14.0"
       sources."@lerna/log-packed-3.13.0"
       sources."@lerna/npm-conf-3.13.0"
-      sources."@lerna/npm-dist-tag-3.14.0"
-      sources."@lerna/npm-install-3.13.3"
-      sources."@lerna/npm-publish-3.14.0"
-      sources."@lerna/npm-run-script-3.13.3"
+      sources."@lerna/npm-dist-tag-3.15.0"
+      sources."@lerna/npm-install-3.14.2"
+      sources."@lerna/npm-publish-3.15.0"
+      sources."@lerna/npm-run-script-3.14.2"
       sources."@lerna/otplease-3.14.0"
       sources."@lerna/output-3.13.0"
-      sources."@lerna/pack-directory-3.14.0"
-      sources."@lerna/package-3.13.0"
+      sources."@lerna/pack-directory-3.14.2"
+      sources."@lerna/package-3.14.2"
       sources."@lerna/package-graph-3.14.0"
       sources."@lerna/prerelease-id-from-version-3.14.0"
-      sources."@lerna/project-3.13.1"
+      sources."@lerna/project-3.15.0"
       sources."@lerna/prompt-3.13.0"
-      sources."@lerna/publish-3.14.1"
+      sources."@lerna/publish-3.15.0"
       sources."@lerna/pulse-till-done-3.13.0"
       sources."@lerna/query-graph-3.14.0"
       sources."@lerna/resolve-symlink-3.13.0"
-      sources."@lerna/rimraf-dir-3.13.3"
-      sources."@lerna/run-3.14.0"
+      sources."@lerna/rimraf-dir-3.14.2"
+      sources."@lerna/run-3.15.0"
       sources."@lerna/run-lifecycle-3.14.0"
       sources."@lerna/run-parallel-batches-3.13.0"
       sources."@lerna/run-topologically-3.14.0"
-      sources."@lerna/symlink-binary-3.14.0"
-      sources."@lerna/symlink-dependencies-3.14.0"
+      sources."@lerna/symlink-binary-3.14.2"
+      sources."@lerna/symlink-dependencies-3.14.2"
       sources."@lerna/timer-3.13.0"
       sources."@lerna/validation-error-3.13.0"
-      sources."@lerna/version-3.14.1"
+      sources."@lerna/version-3.15.0"
       sources."@lerna/write-log-file-3.13.0"
       sources."@mrmlnc/readdir-enhanced-2.2.1"
       sources."@nodelib/fs.stat-1.1.3"
-      (sources."@octokit/endpoint-5.1.4" // {
+      (sources."@octokit/endpoint-5.2.0" // {
         dependencies = [
           sources."is-plain-object-3.0.0"
           sources."isobject-4.0.0"
         ];
       })
       sources."@octokit/plugin-enterprise-rest-2.2.2"
-      (sources."@octokit/request-4.1.0" // {
+      (sources."@octokit/request-4.1.1" // {
         dependencies = [
           sources."is-plain-object-3.0.0"
           sources."isobject-4.0.0"
         ];
       })
-      sources."@octokit/request-error-1.0.2"
-      sources."@octokit/rest-16.27.3"
+      sources."@octokit/request-error-1.0.4"
+      sources."@octokit/rest-16.28.2"
       sources."JSONStream-1.3.5"
       sources."abbrev-1.1.1"
       sources."agent-base-4.3.0"
@@ -51621,7 +50756,7 @@ in
       sources."builtins-1.0.3"
       sources."byline-5.0.0"
       sources."byte-size-4.0.4"
-      sources."cacache-11.3.2"
+      sources."cacache-11.3.3"
       sources."cache-base-1.0.1"
       sources."call-me-maybe-1.0.1"
       sources."caller-callsite-2.0.0"
@@ -51691,7 +50826,7 @@ in
       sources."conventional-changelog-preset-loader-2.1.1"
       (sources."conventional-changelog-writer-4.0.6" // {
         dependencies = [
-          sources."semver-6.1.1"
+          sources."semver-6.1.2"
           sources."through2-3.0.1"
         ];
       })
@@ -51717,7 +50852,11 @@ in
       sources."dargs-4.1.0"
       sources."dashdash-1.14.1"
       sources."dateformat-3.0.3"
-      sources."debug-2.6.9"
+      (sources."debug-3.1.0" // {
+        dependencies = [
+          sources."ms-2.0.0"
+        ];
+      })
       sources."debuglog-1.0.1"
       sources."decamelize-1.2.0"
       (sources."decamelize-keys-1.1.0" // {
@@ -51727,12 +50866,13 @@ in
       })
       sources."decode-uri-component-0.2.0"
       sources."dedent-0.7.0"
-      sources."deepmerge-3.2.0"
+      sources."deepmerge-3.3.0"
       sources."defaults-1.0.3"
+      sources."define-properties-1.1.3"
       sources."define-property-2.0.2"
       sources."delayed-stream-1.0.0"
       sources."delegates-1.0.0"
-      sources."deprecation-2.0.0"
+      sources."deprecation-2.3.1"
       sources."detect-indent-5.0.0"
       sources."dezalgo-1.0.3"
       sources."dir-glob-2.0.0"
@@ -51744,7 +50884,9 @@ in
       sources."end-of-stream-1.4.1"
       sources."err-code-1.1.2"
       sources."error-ex-1.3.2"
-      sources."es6-promise-4.2.6"
+      sources."es-abstract-1.13.0"
+      sources."es-to-primitive-1.2.0"
+      sources."es6-promise-4.2.8"
       sources."es6-promisify-5.0.0"
       sources."escape-string-regexp-1.0.5"
       sources."esprima-4.0.1"
@@ -51752,6 +50894,7 @@ in
       sources."execa-1.0.0"
       (sources."expand-brackets-2.1.4" // {
         dependencies = [
+          sources."debug-2.6.9"
           sources."define-property-0.2.5"
           sources."extend-shallow-2.0.1"
           (sources."is-accessor-descriptor-0.1.6" // {
@@ -51766,6 +50909,7 @@ in
           })
           sources."is-descriptor-0.1.6"
           sources."kind-of-5.1.0"
+          sources."ms-2.0.0"
         ];
       })
       sources."extend-3.0.2"
@@ -51807,6 +50951,7 @@ in
       sources."fs-minipass-1.2.6"
       sources."fs-write-stream-atomic-1.0.10"
       sources."fs.realpath-1.0.0"
+      sources."function-bind-1.1.1"
       (sources."gauge-2.7.4" // {
         dependencies = [
           sources."is-fullwidth-code-point-1.0.0"
@@ -51824,6 +50969,7 @@ in
           sources."load-json-file-1.1.0"
           sources."map-obj-1.0.1"
           sources."meow-3.7.0"
+          sources."minimist-1.2.0"
           sources."parse-json-2.2.0"
           sources."path-exists-2.1.0"
           sources."path-type-1.1.0"
@@ -51849,7 +50995,7 @@ in
       })
       (sources."git-semver-tags-2.0.3" // {
         dependencies = [
-          sources."semver-6.1.1"
+          sources."semver-6.1.2"
         ];
       })
       sources."git-up-4.0.1"
@@ -51859,7 +51005,7 @@ in
       sources."glob-parent-3.1.0"
       sources."glob-to-regexp-0.3.0"
       sources."globby-8.0.2"
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       (sources."handlebars-4.1.2" // {
         dependencies = [
           sources."source-map-0.6.1"
@@ -51867,7 +51013,9 @@ in
       })
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
+      sources."has-1.0.3"
       sources."has-flag-3.0.0"
+      sources."has-symbols-1.0.0"
       sources."has-unicode-2.0.1"
       sources."has-value-1.0.0"
       (sources."has-values-1.0.0" // {
@@ -51877,18 +51025,9 @@ in
       })
       sources."hosted-git-info-2.7.1"
       sources."http-cache-semantics-3.8.1"
-      (sources."http-proxy-agent-2.1.0" // {
-        dependencies = [
-          sources."debug-3.1.0"
-        ];
-      })
+      sources."http-proxy-agent-2.1.0"
       sources."http-signature-1.2.0"
-      (sources."https-proxy-agent-2.2.1" // {
-        dependencies = [
-          sources."debug-3.2.6"
-          sources."ms-2.1.1"
-        ];
-      })
+      sources."https-proxy-agent-2.2.1"
       sources."humanize-ms-1.2.1"
       sources."iconv-lite-0.4.24"
       sources."iferr-0.1.5"
@@ -51903,10 +51042,10 @@ in
       sources."imurmurhash-0.1.4"
       sources."indent-string-3.2.0"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."ini-1.3.5"
       sources."init-package-json-1.10.3"
-      (sources."inquirer-6.3.1" // {
+      (sources."inquirer-6.4.1" // {
         dependencies = [
           sources."ansi-regex-4.1.0"
           sources."strip-ansi-5.2.0"
@@ -51917,8 +51056,10 @@ in
       sources."is-accessor-descriptor-1.0.0"
       sources."is-arrayish-0.2.1"
       sources."is-buffer-1.1.6"
+      sources."is-callable-1.1.4"
       sources."is-ci-1.2.1"
       sources."is-data-descriptor-1.0.0"
+      sources."is-date-object-1.0.1"
       sources."is-descriptor-1.0.2"
       sources."is-directory-0.3.1"
       sources."is-extendable-0.1.1"
@@ -51935,8 +51076,10 @@ in
       sources."is-plain-obj-1.1.0"
       sources."is-plain-object-2.0.4"
       sources."is-promise-2.1.0"
+      sources."is-regex-1.0.4"
       sources."is-ssh-1.3.1"
       sources."is-stream-1.1.0"
+      sources."is-symbol-1.0.2"
       sources."is-text-path-2.0.0"
       sources."is-typedarray-1.0.0"
       sources."is-utf8-0.2.1"
@@ -51956,16 +51099,6 @@ in
       sources."jsprim-1.4.1"
       sources."kind-of-6.0.2"
       sources."lcid-2.0.0"
-      (sources."libnpmaccess-3.0.1" // {
-        dependencies = [
-          sources."aproba-2.0.0"
-        ];
-      })
-      (sources."libnpmpublish-1.1.1" // {
-        dependencies = [
-          sources."aproba-2.0.0"
-        ];
-      })
       sources."load-json-file-4.0.0"
       sources."locate-path-3.0.0"
       sources."lodash-4.17.11"
@@ -51979,13 +51112,16 @@ in
       sources."lodash.templatesettings-4.1.0"
       sources."lodash.uniq-4.5.0"
       sources."loud-rejection-1.6.0"
-      sources."lru-cache-5.1.1"
-      sources."macos-release-2.2.0"
+      (sources."lru-cache-5.1.1" // {
+        dependencies = [
+          sources."yallist-3.0.3"
+        ];
+      })
+      sources."macos-release-2.3.0"
       sources."make-dir-1.3.0"
       (sources."make-fetch-happen-4.0.1" // {
         dependencies = [
           sources."lru-cache-4.1.5"
-          sources."yallist-2.1.2"
         ];
       })
       sources."map-age-cleaner-0.1.3"
@@ -51997,31 +51133,35 @@ in
           sources."mimic-fn-2.1.0"
         ];
       })
-      sources."meow-4.0.1"
+      (sources."meow-4.0.1" // {
+        dependencies = [
+          sources."minimist-1.2.0"
+        ];
+      })
       sources."merge2-1.2.3"
       sources."micromatch-3.1.10"
       sources."mime-db-1.40.0"
       sources."mime-types-2.1.24"
       sources."mimic-fn-1.2.0"
       sources."minimatch-3.0.4"
-      sources."minimist-1.2.0"
+      sources."minimist-0.0.8"
       sources."minimist-options-3.0.2"
-      sources."minipass-2.3.5"
+      (sources."minipass-2.3.5" // {
+        dependencies = [
+          sources."yallist-3.0.3"
+        ];
+      })
       sources."minizlib-1.2.1"
       sources."mississippi-3.0.0"
-      (sources."mixin-deep-1.3.1" // {
+      (sources."mixin-deep-1.3.2" // {
         dependencies = [
           sources."is-extendable-1.0.1"
         ];
       })
-      (sources."mkdirp-0.5.1" // {
-        dependencies = [
-          sources."minimist-0.0.8"
-        ];
-      })
+      sources."mkdirp-0.5.1"
       sources."modify-values-1.0.1"
       sources."move-concurrently-1.0.1"
-      sources."ms-2.0.0"
+      sources."ms-2.1.2"
       sources."multimatch-2.1.0"
       sources."mute-stream-0.0.7"
       sources."nanomatch-1.2.13"
@@ -52040,14 +51180,8 @@ in
       sources."npm-bundled-1.0.6"
       sources."npm-lifecycle-2.1.1"
       sources."npm-package-arg-6.1.0"
-      sources."npm-packlist-1.4.1"
+      sources."npm-packlist-1.4.3"
       sources."npm-pick-manifest-2.2.3"
-      (sources."npm-registry-fetch-3.9.0" // {
-        dependencies = [
-          sources."lru-cache-4.1.5"
-          sources."yallist-2.1.2"
-        ];
-      })
       sources."npm-run-path-2.0.2"
       sources."npmlog-4.1.2"
       sources."number-is-nan-1.0.1"
@@ -52066,16 +51200,14 @@ in
           sources."kind-of-3.2.2"
         ];
       })
+      sources."object-keys-1.1.1"
       sources."object-visit-1.0.1"
+      sources."object.getownpropertydescriptors-2.0.3"
       sources."object.pick-1.3.0"
       sources."octokit-pagination-methods-1.1.0"
       sources."once-1.4.0"
       sources."onetime-2.0.1"
-      (sources."optimist-0.6.1" // {
-        dependencies = [
-          sources."minimist-0.0.10"
-        ];
-      })
+      sources."optimist-0.6.1"
       sources."os-homedir-1.0.2"
       sources."os-locale-3.1.0"
       sources."os-name-3.1.0"
@@ -52093,7 +51225,6 @@ in
       sources."p-reduce-1.0.0"
       sources."p-try-2.2.0"
       sources."p-waterfall-1.0.0"
-      sources."pacote-9.5.0"
       sources."parallel-transform-1.1.0"
       sources."parse-github-repo-url-1.4.1"
       sources."parse-json-4.0.0"
@@ -52120,7 +51251,7 @@ in
         ];
       })
       sources."posix-character-classes-0.1.1"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."promise-inflight-1.0.1"
       sources."promise-retry-1.1.1"
       sources."promzard-0.3.0"
@@ -52128,7 +51259,7 @@ in
       sources."protocols-1.4.7"
       sources."protoduck-5.0.1"
       sources."pseudomap-1.0.2"
-      sources."psl-1.1.32"
+      sources."psl-1.1.33"
       sources."pump-3.0.0"
       (sources."pumpify-1.5.1" // {
         dependencies = [
@@ -52142,7 +51273,7 @@ in
       sources."read-1.0.7"
       sources."read-cmd-shim-1.0.1"
       sources."read-package-json-2.0.13"
-      sources."read-package-tree-5.2.2"
+      sources."read-package-tree-5.3.0"
       sources."read-pkg-3.0.0"
       (sources."read-pkg-up-3.0.0" // {
         dependencies = [
@@ -52154,7 +51285,7 @@ in
         ];
       })
       sources."readable-stream-2.3.6"
-      sources."readdir-scoped-modules-1.0.2"
+      sources."readdir-scoped-modules-1.1.0"
       sources."redent-2.0.0"
       sources."regex-not-1.0.2"
       sources."repeat-element-1.1.3"
@@ -52183,7 +51314,7 @@ in
       sources."safer-buffer-2.1.2"
       sources."semver-5.7.0"
       sources."set-blocking-2.0.0"
-      (sources."set-value-2.0.0" // {
+      (sources."set-value-2.0.1" // {
         dependencies = [
           sources."extend-shallow-2.0.1"
         ];
@@ -52196,6 +51327,7 @@ in
       sources."smart-buffer-4.0.2"
       (sources."snapdragon-0.8.2" // {
         dependencies = [
+          sources."debug-2.6.9"
           sources."define-property-0.2.5"
           sources."extend-shallow-2.0.1"
           (sources."is-accessor-descriptor-0.1.6" // {
@@ -52210,6 +51342,7 @@ in
           })
           sources."is-descriptor-0.1.6"
           sources."kind-of-5.1.0"
+          sources."ms-2.0.0"
         ];
       })
       (sources."snapdragon-node-2.1.1" // {
@@ -52272,9 +51405,17 @@ in
       sources."strip-bom-3.0.0"
       sources."strip-eof-1.0.0"
       sources."strip-indent-2.0.0"
-      sources."strong-log-transformer-2.1.0"
+      (sources."strong-log-transformer-2.1.0" // {
+        dependencies = [
+          sources."minimist-1.2.0"
+        ];
+      })
       sources."supports-color-5.5.0"
-      sources."tar-4.4.10"
+      (sources."tar-4.4.10" // {
+        dependencies = [
+          sources."yallist-3.0.3"
+        ];
+      })
       sources."temp-dir-1.0.0"
       sources."temp-write-3.4.0"
       sources."text-extensions-2.0.0"
@@ -52296,7 +51437,7 @@ in
       sources."tr46-1.0.1"
       sources."trim-newlines-2.0.0"
       sources."trim-off-newlines-1.0.1"
-      sources."tslib-1.9.3"
+      sources."tslib-1.10.0"
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       sources."typedarray-0.0.6"
@@ -52307,14 +51448,9 @@ in
       })
       sources."uid-number-0.0.6"
       sources."umask-1.1.0"
-      (sources."union-value-1.0.0" // {
-        dependencies = [
-          sources."extend-shallow-2.0.1"
-          sources."set-value-0.4.3"
-        ];
-      })
+      sources."union-value-1.0.1"
       sources."unique-filename-1.1.1"
-      sources."unique-slug-2.0.1"
+      sources."unique-slug-2.0.2"
       sources."universal-user-agent-2.1.0"
       sources."universalify-0.1.2"
       (sources."unset-value-1.0.0" // {
@@ -52332,6 +51468,7 @@ in
       sources."url-template-2.0.8"
       sources."use-3.1.1"
       sources."util-deprecate-1.0.2"
+      sources."util-promisify-2.1.0"
       sources."uuid-3.3.2"
       sources."validate-npm-package-license-3.0.4"
       sources."validate-npm-package-name-3.0.0"
@@ -52356,7 +51493,7 @@ in
       sources."write-pkg-3.2.0"
       sources."xtend-4.0.1"
       sources."y18n-4.0.0"
-      sources."yallist-3.0.3"
+      sources."yallist-2.1.2"
       sources."yargs-12.0.5"
       sources."yargs-parser-11.1.1"
     ];
@@ -52402,7 +51539,7 @@ in
       sources."forever-agent-0.6.1"
       sources."form-data-2.3.3"
       sources."getpass-0.1.7"
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."http-signature-1.2.0"
@@ -52423,7 +51560,7 @@ in
       sources."performance-now-2.1.0"
       sources."promise-7.3.1"
       sources."prr-1.0.1"
-      sources."psl-1.1.32"
+      sources."psl-1.1.33"
       sources."punycode-2.1.1"
       sources."qs-6.5.2"
       sources."request-2.88.0"
@@ -52579,7 +51716,7 @@ in
           sources."is-extendable-0.1.1"
         ];
       })
-      sources."faye-websocket-0.11.1"
+      sources."faye-websocket-0.11.3"
       (sources."fill-range-4.0.0" // {
         dependencies = [
           sources."extend-shallow-2.0.1"
@@ -52598,7 +51735,7 @@ in
           sources."is-glob-3.1.0"
         ];
       })
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."has-value-1.0.0"
       (sources."has-values-1.0.0" // {
         dependencies = [
@@ -52606,9 +51743,9 @@ in
         ];
       })
       sources."http-auth-3.1.3"
-      sources."http-errors-1.7.2"
-      sources."http-parser-js-0.5.0"
-      sources."inherits-2.0.3"
+      sources."http-errors-1.7.3"
+      sources."http-parser-js-0.4.10"
+      sources."inherits-2.0.4"
       sources."is-accessor-descriptor-1.0.0"
       sources."is-binary-path-1.0.1"
       sources."is-buffer-1.1.6"
@@ -52635,7 +51772,7 @@ in
       sources."mime-1.6.0"
       sources."mime-db-1.40.0"
       sources."mime-types-2.1.24"
-      sources."mixin-deep-1.3.1"
+      sources."mixin-deep-1.3.2"
       sources."morgan-1.9.1"
       sources."ms-2.0.0"
       sources."nan-2.14.0"
@@ -52667,7 +51804,7 @@ in
       sources."path-is-absolute-1.0.1"
       sources."pause-stream-0.0.11"
       sources."posix-character-classes-0.1.1"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."proxy-middleware-0.15.0"
       sources."range-parser-1.2.1"
       sources."readable-stream-2.3.6"
@@ -52688,10 +51825,11 @@ in
       (sources."serve-index-1.9.1" // {
         dependencies = [
           sources."http-errors-1.6.3"
+          sources."inherits-2.0.3"
           sources."setprototypeof-1.1.0"
         ];
       })
-      (sources."set-value-2.0.0" // {
+      (sources."set-value-2.0.1" // {
         dependencies = [
           sources."extend-shallow-2.0.1"
           sources."is-extendable-0.1.1"
@@ -52761,11 +51899,9 @@ in
       sources."to-regex-3.0.2"
       sources."to-regex-range-2.1.1"
       sources."toidentifier-1.0.0"
-      (sources."union-value-1.0.0" // {
+      (sources."union-value-1.0.1" // {
         dependencies = [
-          sources."extend-shallow-2.0.1"
           sources."is-extendable-0.1.1"
-          sources."set-value-0.4.3"
         ];
       })
       sources."unix-crypt-td-js-1.0.0"
@@ -52787,7 +51923,7 @@ in
       sources."utils-merge-1.0.1"
       sources."uuid-3.3.2"
       sources."vary-1.1.2"
-      sources."websocket-driver-0.7.0"
+      sources."websocket-driver-0.7.3"
       sources."websocket-extensions-0.1.3"
     ];
     buildInputs = globalBuildInputs;
@@ -52942,7 +52078,7 @@ in
       sources."github-slugger-1.2.1"
       sources."glob-base-0.3.0"
       sources."glob-parent-2.0.0"
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       (sources."has-binary2-1.0.3" // {
@@ -53033,7 +52169,7 @@ in
       sources."mime-db-1.40.0"
       sources."mime-types-2.1.24"
       sources."minimist-1.2.0"
-      (sources."mixin-deep-1.3.1" // {
+      (sources."mixin-deep-1.3.2" // {
         dependencies = [
           sources."is-extendable-1.0.1"
         ];
@@ -53086,9 +52222,9 @@ in
       sources."performance-now-2.1.0"
       sources."posix-character-classes-0.1.1"
       sources."preserve-0.2.0"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."proxy-addr-2.0.5"
-      sources."psl-1.1.32"
+      sources."psl-1.1.33"
       sources."punycode-2.1.1"
       sources."qs-6.7.0"
       (sources."randomatic-3.1.1" // {
@@ -53172,7 +52308,7 @@ in
         ];
       })
       sources."serve-static-1.14.1"
-      (sources."set-value-2.0.0" // {
+      (sources."set-value-2.0.1" // {
         dependencies = [
           sources."extend-shallow-2.0.1"
         ];
@@ -53206,7 +52342,7 @@ in
       (sources."socket.io-2.2.0" // {
         dependencies = [
           sources."debug-4.1.1"
-          sources."ms-2.1.1"
+          sources."ms-2.1.2"
         ];
       })
       sources."socket.io-adapter-1.1.1"
@@ -53266,12 +52402,7 @@ in
       sources."tweetnacl-0.14.5"
       sources."type-is-1.6.18"
       sources."uc.micro-1.0.6"
-      (sources."union-value-1.0.0" // {
-        dependencies = [
-          sources."extend-shallow-2.0.1"
-          sources."set-value-0.4.3"
-        ];
-      })
+      sources."union-value-1.0.1"
       sources."unpipe-1.0.0"
       (sources."unset-value-1.0.0" // {
         dependencies = [
@@ -53397,7 +52528,7 @@ in
       sources."@types/events-3.0.0"
       sources."@types/glob-7.1.1"
       sources."@types/minimatch-3.0.3"
-      sources."@types/node-12.0.4"
+      sources."@types/node-12.0.10"
       sources."@webassemblyjs/ast-1.8.5"
       sources."@webassemblyjs/floating-point-hex-parser-1.8.5"
       sources."@webassemblyjs/helper-api-error-1.8.5"
@@ -53590,7 +52721,7 @@ in
       sources."browserify-rsa-4.0.1"
       sources."browserify-sign-4.0.4"
       sources."browserify-zlib-0.2.0"
-      sources."browserslist-4.6.1"
+      sources."browserslist-4.6.3"
       sources."buffer-5.2.1"
       sources."buffer-alloc-1.2.0"
       sources."buffer-alloc-unsafe-1.1.0"
@@ -53600,7 +52731,7 @@ in
       sources."buffer-xor-1.0.3"
       sources."builtin-modules-2.0.0"
       sources."builtin-status-codes-3.0.0"
-      sources."cacache-11.3.2"
+      sources."cacache-11.3.3"
       (sources."cache-base-1.0.1" // {
         dependencies = [
           sources."isobject-3.0.1"
@@ -53613,7 +52744,7 @@ in
       })
       sources."call-me-maybe-1.0.1"
       sources."camelcase-5.3.1"
-      sources."caniuse-lite-1.0.30000973"
+      sources."caniuse-lite-1.0.30000978"
       sources."caw-2.0.1"
       (sources."chalk-2.4.2" // {
         dependencies = [
@@ -53662,11 +52793,11 @@ in
         ];
       })
       sources."cli-cursor-2.1.0"
-      sources."cli-spinners-2.1.0"
-      (sources."cliui-4.1.0" // {
+      sources."cli-spinners-2.2.0"
+      (sources."cliui-5.0.0" // {
         dependencies = [
-          sources."ansi-regex-3.0.0"
-          sources."strip-ansi-4.0.0"
+          sources."ansi-regex-4.1.0"
+          sources."strip-ansi-5.2.0"
         ];
       })
       sources."clone-2.1.2"
@@ -53674,7 +52805,6 @@ in
       sources."clone-response-1.0.2"
       sources."clone-stats-1.0.0"
       sources."cloneable-readable-1.1.3"
-      sources."code-point-at-1.1.0"
       sources."collection-visit-1.0.0"
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
@@ -53691,12 +52821,12 @@ in
       sources."copy-concurrently-1.0.5"
       sources."copy-descriptor-0.1.1"
       sources."core-js-2.6.9"
-      (sources."core-js-compat-3.1.3" // {
+      (sources."core-js-compat-3.1.4" // {
         dependencies = [
-          sources."semver-6.1.1"
+          sources."semver-6.1.2"
         ];
       })
-      sources."core-js-pure-3.1.3"
+      sources."core-js-pure-3.1.4"
       sources."core-util-is-1.0.2"
       sources."create-ecdh-4.0.3"
       sources."create-hash-1.2.0"
@@ -53772,8 +52902,9 @@ in
       })
       sources."duplexer3-0.1.4"
       sources."duplexify-3.7.1"
-      sources."electron-to-chromium-1.3.147"
-      sources."elliptic-6.4.1"
+      sources."electron-to-chromium-1.3.176"
+      sources."elliptic-6.5.0"
+      sources."emoji-regex-7.0.3"
       sources."emojis-list-2.1.0"
       sources."end-of-stream-1.4.1"
       sources."enhanced-resolve-4.1.0"
@@ -53875,7 +53006,7 @@ in
       sources."fill-range-2.2.4"
       sources."find-cache-dir-2.1.0"
       sources."find-up-2.1.0"
-      (sources."findup-sync-2.0.0" // {
+      (sources."findup-sync-3.0.0" // {
         dependencies = [
           sources."arr-diff-4.0.0"
           sources."array-unique-0.3.2"
@@ -53906,7 +53037,7 @@ in
             ];
           })
           sources."is-extglob-2.1.1"
-          sources."is-glob-3.1.0"
+          sources."is-glob-4.0.1"
           (sources."is-number-3.0.0" // {
             dependencies = [
               sources."kind-of-3.2.2"
@@ -53928,7 +53059,7 @@ in
       sources."fs-write-stream-atomic-1.0.10"
       sources."fs.realpath-1.0.0"
       sources."fsevents-1.2.9"
-      sources."get-caller-file-1.0.3"
+      sources."get-caller-file-2.0.5"
       sources."get-proxy-2.1.0"
       sources."get-stream-3.0.0"
       sources."get-value-2.0.6"
@@ -53936,7 +53067,12 @@ in
       sources."glob-base-0.3.0"
       sources."glob-parent-2.0.0"
       sources."glob-to-regexp-0.3.0"
-      sources."global-modules-1.0.0"
+      (sources."global-modules-2.0.0" // {
+        dependencies = [
+          sources."global-prefix-3.0.0"
+          sources."kind-of-6.0.2"
+        ];
+      })
       sources."global-prefix-1.0.2"
       sources."globals-11.12.0"
       (sources."globby-8.0.2" // {
@@ -53948,14 +53084,19 @@ in
       (sources."got-9.6.0" // {
         dependencies = [
           sources."@sindresorhus/is-0.14.0"
-          sources."cacheable-request-6.0.0"
+          (sources."cacheable-request-6.1.0" // {
+            dependencies = [
+              sources."get-stream-5.1.0"
+              sources."lowercase-keys-2.0.0"
+            ];
+          })
           sources."get-stream-4.1.0"
           sources."http-cache-semantics-4.0.3"
-          sources."normalize-url-3.3.0"
+          sources."normalize-url-4.3.0"
           sources."p-cancelable-1.1.0"
         ];
       })
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."graceful-readlink-1.0.1"
       sources."has-ansi-2.0.0"
       sources."has-flag-3.0.0"
@@ -53988,9 +53129,8 @@ in
       sources."ignore-3.3.10"
       sources."import-local-2.0.0"
       sources."imurmurhash-0.1.4"
-      sources."indexof-0.0.1"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."ini-1.3.5"
       sources."interpret-1.2.0"
       sources."into-stream-3.1.0"
@@ -54019,7 +53159,7 @@ in
       sources."is-extendable-0.1.1"
       sources."is-extglob-1.0.0"
       sources."is-finite-1.0.2"
-      sources."is-fullwidth-code-point-1.0.0"
+      sources."is-fullwidth-code-point-2.0.0"
       sources."is-glob-2.0.1"
       sources."is-module-1.0.0"
       sources."is-natural-number-4.0.1"
@@ -54100,7 +53240,7 @@ in
       sources."minimatch-3.0.4"
       sources."minimist-1.2.0"
       sources."mississippi-3.0.0"
-      (sources."mixin-deep-1.3.1" // {
+      (sources."mixin-deep-1.3.2" // {
         dependencies = [
           sources."is-extendable-1.0.1"
         ];
@@ -54111,7 +53251,7 @@ in
         ];
       })
       sources."move-concurrently-1.0.1"
-      sources."ms-2.1.1"
+      sources."ms-2.1.2"
       sources."multistream-2.1.1"
       sources."nan-2.14.0"
       (sources."nanomatch-1.2.13" // {
@@ -54129,13 +53269,13 @@ in
       })
       sources."nice-try-1.0.5"
       sources."node-fetch-2.6.0"
-      (sources."node-libs-browser-2.2.0" // {
+      (sources."node-libs-browser-2.2.1" // {
         dependencies = [
           sources."buffer-4.9.1"
           sources."punycode-1.4.1"
         ];
       })
-      sources."node-releases-1.1.23"
+      sources."node-releases-1.1.24"
       sources."normalize-package-data-2.5.0"
       sources."normalize-path-2.1.1"
       (sources."normalize-url-2.0.1" // {
@@ -54201,7 +53341,7 @@ in
       sources."parse-json-2.2.0"
       sources."parse-passwd-1.0.0"
       sources."pascalcase-0.1.1"
-      sources."path-browserify-0.0.0"
+      sources."path-browserify-0.0.1"
       sources."path-dirname-1.0.2"
       sources."path-exists-3.0.0"
       sources."path-is-absolute-1.0.1"
@@ -54229,7 +53369,7 @@ in
       sources."prettier-1.15.1"
       sources."private-0.1.8"
       sources."process-0.11.10"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."progress-2.0.3"
       sources."promise-inflight-1.0.1"
       sources."proto-list-1.2.4"
@@ -54345,7 +53485,11 @@ in
           sources."slash-2.0.0"
         ];
       })
-      sources."resolve-dir-1.0.1"
+      (sources."resolve-dir-1.0.1" // {
+        dependencies = [
+          sources."global-modules-1.0.0"
+        ];
+      })
       sources."resolve-from-3.0.0"
       sources."resolve-url-0.2.1"
       sources."responselike-1.0.2"
@@ -54373,7 +53517,7 @@ in
       sources."semver-5.7.0"
       sources."serialize-javascript-1.7.0"
       sources."set-blocking-2.0.0"
-      (sources."set-value-2.0.0" // {
+      (sources."set-value-2.0.1" // {
         dependencies = [
           sources."extend-shallow-2.0.1"
         ];
@@ -54451,11 +53595,10 @@ in
       sources."stream-http-2.8.3"
       sources."stream-shift-1.0.0"
       sources."strict-uri-encode-1.1.0"
-      (sources."string-width-2.1.1" // {
+      (sources."string-width-3.1.0" // {
         dependencies = [
-          sources."ansi-regex-3.0.0"
-          sources."is-fullwidth-code-point-2.0.0"
-          sources."strip-ansi-4.0.0"
+          sources."ansi-regex-4.1.0"
+          sources."strip-ansi-5.2.0"
         ];
       })
       sources."string_decoder-1.1.1"
@@ -54496,7 +53639,7 @@ in
       })
       sources."trim-repeated-1.0.0"
       sources."trim-right-1.0.1"
-      sources."tslib-1.9.3"
+      sources."tslib-1.10.0"
       sources."tty-browserify-0.0.0"
       sources."tunnel-agent-0.6.0"
       sources."typedarray-0.0.6"
@@ -54505,14 +53648,9 @@ in
       sources."unicode-match-property-ecmascript-1.0.4"
       sources."unicode-match-property-value-ecmascript-1.1.0"
       sources."unicode-property-aliases-ecmascript-1.0.5"
-      (sources."union-value-1.0.0" // {
-        dependencies = [
-          sources."extend-shallow-2.0.1"
-          sources."set-value-0.4.3"
-        ];
-      })
+      sources."union-value-1.0.1"
       sources."unique-filename-1.1.1"
-      sources."unique-slug-2.0.1"
+      sources."unique-slug-2.0.2"
       (sources."unset-value-1.0.0" // {
         dependencies = [
           (sources."has-value-0.3.1" // {
@@ -54535,15 +53673,19 @@ in
       sources."url-parse-lax-3.0.0"
       sources."url-to-options-1.0.1"
       sources."use-3.1.1"
-      sources."util-0.11.1"
+      (sources."util-0.11.1" // {
+        dependencies = [
+          sources."inherits-2.0.3"
+        ];
+      })
       sources."util-deprecate-1.0.2"
       sources."v8-compile-cache-2.0.3"
       sources."validate-npm-package-license-3.0.4"
       sources."vinyl-2.2.0"
-      sources."vm-browserify-0.0.4"
+      sources."vm-browserify-1.1.0"
       sources."watchpack-1.6.0"
       sources."wcwidth-1.0.1"
-      (sources."webpack-4.33.0" // {
+      (sources."webpack-4.35.0" // {
         dependencies = [
           sources."arr-diff-4.0.0"
           sources."array-unique-0.3.2"
@@ -54585,9 +53727,9 @@ in
           sources."ms-2.0.0"
         ];
       })
-      (sources."webpack-cli-3.3.2" // {
+      (sources."webpack-cli-3.3.5" // {
         dependencies = [
-          sources."supports-color-5.5.0"
+          sources."supports-color-6.1.0"
         ];
       })
       (sources."webpack-core-0.6.9" // {
@@ -54610,25 +53752,28 @@ in
         ];
       })
       sources."worker-farm-1.7.0"
-      (sources."wrap-ansi-2.1.0" // {
+      (sources."wrap-ansi-5.1.0" // {
         dependencies = [
-          sources."string-width-1.0.2"
+          sources."ansi-regex-4.1.0"
+          sources."ansi-styles-3.2.1"
+          sources."strip-ansi-5.2.0"
         ];
       })
       sources."wrappy-1.0.2"
       sources."xtend-4.0.1"
       sources."y18n-4.0.0"
       sources."yallist-3.0.3"
-      (sources."yargs-12.0.5" // {
+      (sources."yargs-13.2.4" // {
         dependencies = [
           sources."find-up-3.0.0"
           sources."locate-path-3.0.0"
           sources."p-limit-2.2.0"
           sources."p-locate-3.0.0"
           sources."p-try-2.2.0"
+          sources."require-main-filename-2.0.0"
         ];
       })
-      sources."yargs-parser-11.1.1"
+      sources."yargs-parser-13.1.1"
       sources."yauzl-2.10.0"
     ];
     buildInputs = globalBuildInputs;
@@ -54717,11 +53862,11 @@ in
       sources."marked-0.6.2"
       sources."mime-db-1.40.0"
       sources."mime-types-2.1.24"
-      sources."ms-2.1.1"
+      sources."ms-2.1.2"
       sources."oauth-sign-0.9.0"
       sources."performance-now-2.1.0"
       sources."progress-2.0.3"
-      sources."psl-1.1.32"
+      sources."psl-1.1.33"
       sources."punycode-2.1.1"
       sources."qs-6.5.2"
       sources."request-2.88.0"
@@ -54940,7 +54085,7 @@ in
           sources."source-map-0.6.1"
         ];
       })
-      sources."d-1.0.0"
+      sources."d-1.0.1"
       (sources."dashdash-1.14.1" // {
         dependencies = [
           sources."assert-plus-1.0.0"
@@ -54951,7 +54096,7 @@ in
       (sources."debug-fabulous-1.1.0" // {
         dependencies = [
           sources."debug-3.2.6"
-          sources."ms-2.1.1"
+          sources."ms-2.1.2"
         ];
       })
       sources."decamelize-1.2.0"
@@ -54984,7 +54129,7 @@ in
       sources."es5-ext-0.10.50"
       sources."es6-iterator-2.0.3"
       sources."es6-symbol-3.1.1"
-      sources."es6-weak-map-2.0.2"
+      sources."es6-weak-map-2.0.3"
       sources."escape-string-regexp-1.0.5"
       sources."event-emitter-0.3.5"
       (sources."expand-brackets-2.1.4" // {
@@ -55043,7 +54188,7 @@ in
       sources."fragment-cache-0.2.1"
       (sources."fs-mkdirp-stream-1.0.0" // {
         dependencies = [
-          sources."graceful-fs-4.1.15"
+          sources."graceful-fs-4.2.0"
           sources."readable-stream-2.3.6"
           sources."string_decoder-1.1.1"
           sources."through2-2.0.5"
@@ -55098,7 +54243,7 @@ in
       })
       (sources."gulp-sourcemaps-2.6.4" // {
         dependencies = [
-          sources."graceful-fs-4.1.15"
+          sources."graceful-fs-4.2.0"
           sources."readable-stream-2.3.6"
           sources."source-map-0.6.1"
           sources."string_decoder-1.1.1"
@@ -55115,7 +54260,7 @@ in
           sources."extend-shallow-1.1.4"
           sources."glob-7.1.4"
           sources."glob-stream-6.1.0"
-          sources."graceful-fs-4.1.15"
+          sources."graceful-fs-4.2.0"
           sources."kind-of-1.1.0"
           sources."minimatch-3.0.4"
           sources."ordered-read-streams-1.0.1"
@@ -55166,7 +54311,7 @@ in
       sources."image-size-0.5.5"
       sources."indx-0.2.3"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."ini-1.3.5"
       sources."interpret-1.2.0"
       sources."is-absolute-1.0.0"
@@ -55217,7 +54362,7 @@ in
       sources."lead-1.0.0"
       (sources."less-2.7.3" // {
         dependencies = [
-          sources."graceful-fs-4.1.15"
+          sources."graceful-fs-4.2.0"
         ];
       })
       sources."liftoff-2.5.0"
@@ -55260,7 +54405,7 @@ in
       sources."mime-types-2.1.24"
       sources."minimatch-2.0.10"
       sources."minimist-1.2.0"
-      (sources."mixin-deep-1.3.1" // {
+      (sources."mixin-deep-1.3.2" // {
         dependencies = [
           sources."is-extendable-1.0.1"
         ];
@@ -55315,7 +54460,7 @@ in
       sources."plugin-error-1.0.1"
       sources."posix-character-classes-0.1.1"
       sources."pretty-hrtime-1.0.3"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."promise-7.3.1"
       sources."prr-1.0.1"
       (sources."pump-2.0.1" // {
@@ -55361,7 +54506,7 @@ in
       sources."safer-buffer-2.1.2"
       sources."semver-4.3.6"
       sources."sequencify-0.0.7"
-      (sources."set-value-2.0.0" // {
+      (sources."set-value-2.0.1" // {
         dependencies = [
           sources."extend-shallow-2.0.1"
         ];
@@ -55460,7 +54605,8 @@ in
       sources."tough-cookie-2.3.4"
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
-      sources."typescript-3.5.1"
+      sources."type-1.0.1"
+      sources."typescript-3.5.2"
       (sources."uglify-js-3.4.9" // {
         dependencies = [
           sources."source-map-0.6.1"
@@ -55468,12 +54614,7 @@ in
       })
       sources."uglify-to-browserify-1.0.2"
       sources."unc-path-regex-0.1.2"
-      (sources."union-value-1.0.0" // {
-        dependencies = [
-          sources."extend-shallow-2.0.1"
-          sources."set-value-0.4.3"
-        ];
-      })
+      sources."union-value-1.0.1"
       sources."unique-stream-1.0.0"
       (sources."unset-value-1.0.0" // {
         dependencies = [
@@ -55507,7 +54648,7 @@ in
         dependencies = [
           sources."clone-2.1.2"
           sources."clone-stats-1.0.0"
-          sources."graceful-fs-4.1.15"
+          sources."graceful-fs-4.2.0"
           sources."vinyl-2.2.0"
         ];
       })
@@ -55582,7 +54723,7 @@ in
       sources."has-symbols-1.0.0"
       sources."he-1.2.0"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."invert-kv-2.0.0"
       sources."is-buffer-2.0.3"
       sources."is-callable-1.1.4"
@@ -55696,10 +54837,10 @@ in
       sources."delayed-stream-1.0.0"
       sources."esprima-4.0.1"
       sources."extend-3.0.2"
-      sources."form-data-2.3.3"
+      sources."form-data-2.4.0"
       sources."formidable-1.2.1"
       sources."graphlib-2.1.7"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."isarray-1.0.0"
       sources."js-yaml-3.13.1"
       (sources."json-refs-3.0.13" // {
@@ -55712,10 +54853,10 @@ in
       sources."mime-1.6.0"
       sources."mime-db-1.40.0"
       sources."mime-types-2.1.24"
-      sources."ms-2.1.1"
+      sources."ms-2.1.2"
       sources."native-promise-only-0.8.1"
       sources."path-loader-1.0.10"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."punycode-2.1.1"
       sources."qs-6.7.0"
       sources."readable-stream-2.3.6"
@@ -55857,14 +54998,14 @@ in
       sources."gauge-2.7.4"
       sources."getpass-0.1.7"
       sources."glob-7.1.4"
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-unicode-2.0.1"
       sources."hosted-git-info-2.7.1"
       sources."http-signature-1.2.0"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."ini-1.3.5"
       sources."is-fullwidth-code-point-1.0.0"
       sources."is-typedarray-1.0.0"
@@ -55919,9 +55060,9 @@ in
       sources."path-is-absolute-1.0.1"
       sources."path-parse-1.0.6"
       sources."performance-now-2.1.0"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."proto-list-1.2.4"
-      sources."psl-1.1.32"
+      sources."psl-1.1.33"
       sources."punycode-2.1.1"
       sources."qs-6.5.2"
       sources."readable-stream-2.3.6"
@@ -55931,7 +55072,7 @@ in
       sources."rimraf-2.6.3"
       sources."safe-buffer-5.1.2"
       sources."safer-buffer-2.1.2"
-      sources."semver-6.1.1"
+      sources."semver-6.1.2"
       sources."set-blocking-2.0.0"
       sources."signal-exit-3.0.2"
       sources."slasp-0.0.4"
@@ -55980,10 +55121,10 @@ in
   node-gyp = nodeEnv.buildNodePackage {
     name = "node-gyp";
     packageName = "node-gyp";
-    version = "4.0.0";
+    version = "5.0.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/node-gyp/-/node-gyp-4.0.0.tgz";
-      sha512 = "2XiryJ8sICNo6ej8d0idXDEMKfVfFK7kekGCtJAuelGsYHQxhj13KTf95swTCN2dZ/4lTfZ84Fu31jqJEEgjWA==";
+      url = "https://registry.npmjs.org/node-gyp/-/node-gyp-5.0.1.tgz";
+      sha512 = "D68549U6EDVJLrAkSOZCWX/nmlYo0eCX2dYZoTOOZJ7bEIFrSE/MQgsgMFBKjByJ323hNzkifw2OuT3A5bR5mA==";
     };
     dependencies = [
       sources."abbrev-1.1.1"
@@ -56010,6 +55151,7 @@ in
       sources."delayed-stream-1.0.0"
       sources."delegates-1.0.0"
       sources."ecc-jsbn-0.1.2"
+      sources."env-paths-1.0.0"
       sources."extend-3.0.2"
       sources."extsprintf-1.3.0"
       sources."fast-deep-equal-2.0.1"
@@ -56021,13 +55163,13 @@ in
       sources."gauge-2.7.4"
       sources."getpass-0.1.7"
       sources."glob-7.1.4"
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-unicode-2.0.1"
       sources."http-signature-1.2.0"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."is-fullwidth-code-point-1.0.0"
       sources."is-typedarray-1.0.0"
       sources."isarray-1.0.0"
@@ -56051,13 +55193,10 @@ in
       sources."oauth-sign-0.9.0"
       sources."object-assign-4.1.1"
       sources."once-1.4.0"
-      sources."os-homedir-1.0.2"
-      sources."os-tmpdir-1.0.2"
-      sources."osenv-0.1.5"
       sources."path-is-absolute-1.0.1"
       sources."performance-now-2.1.0"
-      sources."process-nextick-args-2.0.0"
-      sources."psl-1.1.32"
+      sources."process-nextick-args-2.0.1"
+      sources."psl-1.1.33"
       sources."punycode-2.1.1"
       sources."qs-6.5.2"
       sources."readable-stream-2.3.6"
@@ -56145,7 +55284,7 @@ in
       sources."base64-js-0.0.8"
       sources."bcrypt-pbkdf-1.0.2"
       sources."biased-opener-0.2.8"
-      sources."big-integer-1.6.43"
+      sources."big-integer-1.6.44"
       sources."block-stream-0.0.9"
       sources."body-parser-1.19.0"
       sources."boom-2.10.1"
@@ -56209,7 +55348,7 @@ in
         ];
       })
       sources."glob-5.0.15"
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."har-schema-1.0.5"
       sources."har-validator-4.2.1"
       sources."has-unicode-2.0.1"
@@ -56298,7 +55437,7 @@ in
       sources."pinkie-2.0.4"
       sources."pinkie-promise-2.0.1"
       sources."plist-1.2.0"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."proxy-addr-2.0.5"
       sources."punycode-1.4.1"
       sources."qs-6.7.0"
@@ -56448,7 +55587,7 @@ in
       sources."iconv-lite-0.4.24"
       sources."ignore-walk-3.0.1"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."ini-1.3.5"
       sources."is-fullwidth-code-point-1.0.0"
       sources."isarray-1.0.0"
@@ -56457,11 +55596,11 @@ in
       sources."minipass-2.3.5"
       sources."minizlib-1.2.1"
       sources."mkdirp-0.5.1"
-      sources."ms-2.1.1"
+      sources."ms-2.1.2"
       sources."needle-2.4.0"
       sources."nopt-4.0.1"
       sources."npm-bundled-1.0.6"
-      sources."npm-packlist-1.4.1"
+      sources."npm-packlist-1.4.3"
       sources."npmlog-4.1.2"
       sources."number-is-nan-1.0.1"
       sources."object-assign-4.1.1"
@@ -56470,7 +55609,7 @@ in
       sources."os-tmpdir-1.0.2"
       sources."osenv-0.1.5"
       sources."path-is-absolute-1.0.1"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       (sources."rc-1.2.8" // {
         dependencies = [
           sources."minimist-1.2.0"
@@ -56581,7 +55720,7 @@ in
       sources."crypto-random-string-1.0.0"
       (sources."debug-3.2.6" // {
         dependencies = [
-          sources."ms-2.1.1"
+          sources."ms-2.1.2"
         ];
       })
       sources."decode-uri-component-0.2.0"
@@ -56637,7 +55776,7 @@ in
       })
       sources."global-dirs-0.1.1"
       sources."got-6.7.1"
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."has-flag-3.0.0"
       sources."has-value-1.0.0"
       (sources."has-values-1.0.0" // {
@@ -56648,7 +55787,7 @@ in
       sources."ignore-by-default-1.0.1"
       sources."import-lazy-2.1.0"
       sources."imurmurhash-0.1.4"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."ini-1.3.5"
       sources."is-accessor-descriptor-1.0.0"
       sources."is-binary-path-1.0.1"
@@ -56687,7 +55826,7 @@ in
       sources."micromatch-3.1.10"
       sources."minimatch-3.0.4"
       sources."minimist-1.2.0"
-      sources."mixin-deep-1.3.1"
+      sources."mixin-deep-1.3.2"
       sources."ms-2.0.0"
       sources."nan-2.14.0"
       sources."nanomatch-1.2.13"
@@ -56719,7 +55858,7 @@ in
       sources."pify-3.0.0"
       sources."posix-character-classes-0.1.1"
       sources."prepend-http-1.0.4"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."pseudomap-1.0.2"
       sources."pstree.remy-1.1.7"
       sources."rc-1.2.8"
@@ -56737,7 +55876,7 @@ in
       sources."safe-regex-1.1.0"
       sources."semver-5.7.0"
       sources."semver-diff-2.1.0"
-      (sources."set-value-2.0.0" // {
+      (sources."set-value-2.0.1" // {
         dependencies = [
           sources."extend-shallow-2.0.1"
           sources."is-extendable-0.1.1"
@@ -56818,11 +55957,9 @@ in
           sources."debug-2.6.9"
         ];
       })
-      (sources."union-value-1.0.0" // {
+      (sources."union-value-1.0.1" // {
         dependencies = [
-          sources."extend-shallow-2.0.1"
           sources."is-extendable-0.1.1"
-          sources."set-value-0.4.3"
         ];
       })
       sources."unique-string-1.0.0"
@@ -56862,23 +55999,24 @@ in
   node-red = nodeEnv.buildNodePackage {
     name = "node-red";
     packageName = "node-red";
-    version = "0.20.5";
+    version = "0.20.6";
     src = fetchurl {
-      url = "https://registry.npmjs.org/node-red/-/node-red-0.20.5.tgz";
-      sha512 = "kF95ob7BZSiS1rOuy/QqATVHKCN6tDyybLHiqXYgSGgBcrsE+raYGhQcpS5DaCffl4GecYTNl0ijk6gle2ObXQ==";
+      url = "https://registry.npmjs.org/node-red/-/node-red-0.20.6.tgz";
+      sha512 = "YOtehXlxCtMBXMTEjj4OWrY6MXhpgBPEZGeqhl7Y0Pglg+ZNeDmAqa/9KkFkQ0YlVbcDSTN/mmhevuzE/K8aMA==";
     };
     dependencies = [
       sources."@babel/runtime-7.4.5"
-      sources."@node-red/editor-api-0.20.5"
-      sources."@node-red/editor-client-0.20.5"
-      (sources."@node-red/nodes-0.20.5" // {
+      sources."@node-red/editor-api-0.20.6"
+      sources."@node-red/editor-client-0.20.6"
+      (sources."@node-red/nodes-0.20.6" // {
         dependencies = [
-          sources."iconv-lite-0.4.24"
+          sources."cookie-0.4.0"
+          sources."media-typer-1.1.0"
         ];
       })
-      sources."@node-red/registry-0.20.5"
-      sources."@node-red/runtime-0.20.5"
-      sources."@node-red/util-0.20.5"
+      sources."@node-red/registry-0.20.6"
+      sources."@node-red/runtime-0.20.6"
+      sources."@node-red/util-0.20.6"
       sources."abbrev-1.1.1"
       sources."accepts-1.3.7"
       sources."addressparser-1.0.1"
@@ -56914,7 +56052,7 @@ in
           sources."string_decoder-1.1.1"
         ];
       })
-      sources."body-parser-1.18.3"
+      sources."body-parser-1.19.0"
       sources."boolbase-1.0.0"
       sources."brace-expansion-1.1.11"
       sources."buffer-from-1.1.1"
@@ -56925,7 +56063,7 @@ in
           sources."string_decoder-0.10.31"
         ];
       })
-      sources."bytes-3.0.0"
+      sources."bytes-3.1.0"
       (sources."callback-stream-1.1.0" // {
         dependencies = [
           sources."readable-stream-2.3.6"
@@ -56938,7 +56076,7 @@ in
       sources."clone-2.1.2"
       sources."code-point-at-1.1.0"
       sources."combined-stream-1.0.8"
-      sources."commander-2.19.0"
+      sources."commander-2.20.0"
       sources."commist-1.1.0"
       sources."concat-map-0.0.1"
       (sources."concat-stream-1.6.2" // {
@@ -56948,18 +56086,17 @@ in
         ];
       })
       sources."console-control-strings-1.1.0"
-      sources."content-disposition-0.5.2"
+      sources."content-disposition-0.5.3"
       sources."content-type-1.0.4"
       sources."cookie-0.3.1"
       sources."cookie-parser-1.4.4"
       sources."cookie-signature-1.0.6"
       sources."core-util-is-1.0.2"
       sources."cors-2.8.5"
-      sources."crc-3.4.4"
-      sources."cron-1.7.0"
+      sources."cron-1.7.1"
       sources."css-select-1.2.0"
       sources."css-what-2.1.3"
-      sources."d-1.0.0"
+      sources."d-1.0.1"
       sources."dashdash-1.14.1"
       sources."debug-2.6.9"
       sources."deep-extend-0.6.0"
@@ -56994,7 +56131,7 @@ in
       sources."es5-ext-0.10.50"
       sources."es6-iterator-2.0.3"
       sources."es6-map-0.1.5"
-      sources."es6-promise-4.2.6"
+      sources."es6-promise-4.2.8"
       sources."es6-promisify-5.0.0"
       sources."es6-set-0.1.5"
       sources."es6-symbol-3.1.1"
@@ -57002,12 +56139,16 @@ in
       sources."esprima-4.0.1"
       sources."etag-1.8.1"
       sources."event-emitter-0.3.5"
-      (sources."express-4.16.4" // {
+      (sources."express-4.17.1" // {
         dependencies = [
-          sources."statuses-1.4.0"
+          sources."cookie-0.4.0"
         ];
       })
-      sources."express-session-1.15.6"
+      (sources."express-session-1.16.1" // {
+        dependencies = [
+          sources."depd-2.0.0"
+        ];
+      })
       sources."extend-3.0.2"
       sources."extsprintf-1.3.0"
       sources."fast-deep-equal-2.0.1"
@@ -57018,16 +56159,12 @@ in
           sources."string_decoder-1.1.1"
         ];
       })
-      (sources."finalhandler-1.1.1" // {
-        dependencies = [
-          sources."statuses-1.4.0"
-        ];
-      })
+      sources."finalhandler-1.1.2"
       sources."forever-agent-0.6.1"
       sources."form-data-2.3.3"
       sources."forwarded-0.1.2"
       sources."fresh-0.5.2"
-      sources."fs-extra-7.0.1"
+      sources."fs-extra-8.0.1"
       sources."fs-minipass-1.2.6"
       sources."fs.notify-0.0.4"
       sources."fs.realpath-1.0.0"
@@ -57041,7 +56178,7 @@ in
           sources."string_decoder-1.1.1"
         ];
       })
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-unicode-2.0.1"
@@ -57050,16 +56187,16 @@ in
       sources."help-me-1.1.0"
       sources."html-to-text-5.1.1"
       sources."htmlparser2-3.10.1"
-      sources."http-errors-1.6.3"
+      sources."http-errors-1.7.2"
       sources."http-signature-1.2.0"
       (sources."https-proxy-agent-2.2.1" // {
         dependencies = [
           sources."debug-3.2.6"
-          sources."ms-2.1.1"
+          sources."ms-2.1.2"
         ];
       })
-      sources."i18next-15.0.9"
-      sources."iconv-lite-0.4.23"
+      sources."i18next-15.1.0"
+      sources."iconv-lite-0.4.24"
       sources."ignore-walk-3.0.1"
       (sources."imap-0.8.19" // {
         dependencies = [
@@ -57084,7 +56221,7 @@ in
       sources."is-windows-1.0.2"
       sources."isarray-1.0.0"
       sources."isstream-0.1.2"
-      sources."js-yaml-3.13.0"
+      sources."js-yaml-3.13.1"
       sources."jsbn-0.1.1"
       sources."json-schema-0.2.3"
       sources."json-schema-traverse-0.4.1"
@@ -57095,11 +56232,7 @@ in
       sources."jsprim-1.4.1"
       sources."leven-2.1.0"
       sources."libbase64-1.0.3"
-      (sources."libmime-4.1.1" // {
-        dependencies = [
-          sources."iconv-lite-0.4.24"
-        ];
-      })
+      sources."libmime-4.1.1"
       sources."libqp-1.1.0"
       sources."linkify-it-2.1.0"
       sources."lodash-4.17.11"
@@ -57122,7 +56255,6 @@ in
       sources."lru-cache-4.1.5"
       (sources."mailparser-2.7.1" // {
         dependencies = [
-          sources."iconv-lite-0.4.24"
           sources."nodemailer-6.1.1"
         ];
       })
@@ -57135,7 +56267,7 @@ in
       })
       sources."merge-descriptors-1.0.1"
       sources."methods-1.1.2"
-      sources."mime-2.4.0"
+      sources."mime-2.4.4"
       sources."mime-db-1.40.0"
       sources."mime-types-2.1.24"
       sources."minimatch-3.0.4"
@@ -57168,7 +56300,7 @@ in
       (sources."needle-2.4.0" // {
         dependencies = [
           sources."debug-3.2.6"
-          sources."ms-2.1.1"
+          sources."ms-2.1.2"
         ];
       })
       sources."negotiator-0.6.2"
@@ -57178,16 +56310,16 @@ in
           sources."semver-5.7.0"
         ];
       })
-      sources."node-red-node-email-1.6.0"
+      sources."node-red-node-email-1.6.2"
       sources."node-red-node-feedparser-0.1.14"
       sources."node-red-node-rbe-0.2.4"
       sources."node-red-node-sentiment-0.1.3"
       sources."node-red-node-tail-0.0.2"
-      sources."node-red-node-twitter-1.1.4"
+      sources."node-red-node-twitter-1.1.5"
       sources."nodemailer-6.2.1"
       sources."nopt-4.0.1"
       sources."npm-bundled-1.0.6"
-      sources."npm-packlist-1.4.1"
+      sources."npm-packlist-1.4.3"
       sources."npmlog-4.1.2"
       sources."nth-check-1.0.2"
       sources."number-is-nan-1.0.1"
@@ -57223,10 +56355,10 @@ in
       sources."pause-0.0.1"
       sources."performance-now-2.1.0"
       sources."poplib-0.1.7"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."proxy-addr-2.0.5"
       sources."pseudomap-1.0.2"
-      sources."psl-1.1.32"
+      sources."psl-1.1.33"
       sources."pump-3.0.0"
       (sources."pumpify-1.5.1" // {
         dependencies = [
@@ -57234,32 +56366,36 @@ in
         ];
       })
       sources."punycode-2.1.1"
-      sources."qs-6.5.2"
+      sources."qs-6.7.0"
       sources."random-bytes-1.0.0"
       sources."range-parser-1.2.1"
-      sources."raw-body-2.3.3"
+      sources."raw-body-2.4.0"
       sources."rc-1.2.8"
       sources."readable-stream-3.4.0"
       sources."regenerator-runtime-0.13.2"
       sources."reinterval-1.1.0"
       sources."remove-trailing-separator-1.1.0"
-      sources."request-2.88.0"
+      (sources."request-2.88.0" // {
+        dependencies = [
+          sources."qs-6.5.2"
+        ];
+      })
       sources."retry-0.6.1"
       sources."rimraf-2.6.3"
       sources."safe-buffer-5.1.2"
       sources."safer-buffer-2.1.2"
       sources."sax-1.2.4"
-      sources."semver-6.0.0"
-      (sources."send-0.16.2" // {
+      sources."semver-6.1.1"
+      (sources."send-0.17.1" // {
         dependencies = [
-          sources."mime-1.4.1"
-          sources."statuses-1.4.0"
+          sources."mime-1.6.0"
+          sources."ms-2.1.1"
         ];
       })
       sources."sentiment-2.1.0"
-      sources."serve-static-1.13.2"
+      sources."serve-static-1.14.1"
       sources."set-blocking-2.0.0"
-      sources."setprototypeof-1.1.0"
+      sources."setprototypeof-1.1.1"
       sources."signal-exit-3.0.2"
       sources."source-map-0.6.1"
       sources."split2-2.2.0"
@@ -57287,6 +56423,7 @@ in
       sources."through2-filter-3.0.0"
       sources."tlds-1.203.1"
       sources."to-absolute-glob-2.0.2"
+      sources."toidentifier-1.0.0"
       (sources."tough-cookie-2.4.3" // {
         dependencies = [
           sources."punycode-1.4.1"
@@ -57295,10 +56432,11 @@ in
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       sources."twitter-ng-0.6.2"
+      sources."type-1.0.1"
       sources."type-is-1.6.18"
       sources."typedarray-0.0.6"
       sources."uc.micro-1.0.6"
-      sources."uglify-js-3.5.3"
+      sources."uglify-js-3.6.0"
       sources."uid-safe-2.1.5"
       sources."uid2-0.0.3"
       sources."ultron-1.1.1"
@@ -57347,10 +56485,10 @@ in
   npm = nodeEnv.buildNodePackage {
     name = "npm";
     packageName = "npm";
-    version = "6.9.0";
+    version = "6.9.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/npm/-/npm-6.9.0.tgz";
-      sha512 = "91V+zB5hDxO+Jyp2sUKS7juHlIM95dGQxTeQtmZI1nAI/7kjWXFipPrtwwKjhyKmV4GsS2LzJhrxRjGWsU9z/w==";
+      url = "https://registry.npmjs.org/npm/-/npm-6.9.2.tgz";
+      sha512 = "b0sEGRYrVdcV/DedLrqV4VMpdMHJbvpt9bopivh4K9RisHFMbj+G6RNbB6lRdr9rpYIoqHG9YP9CYmxdI9k81g==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -57435,7 +56573,7 @@ in
       sources."has-unicode-2.0.1"
       sources."http-signature-1.2.0"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."ini-1.1.0"
       sources."is-fullwidth-code-point-1.0.0"
       sources."is-typedarray-1.0.0"
@@ -57475,9 +56613,9 @@ in
       sources."osenv-0.0.3"
       sources."path-is-absolute-1.0.1"
       sources."performance-now-2.1.0"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."proto-list-1.2.4"
-      sources."psl-1.1.32"
+      sources."psl-1.1.33"
       sources."punycode-2.1.1"
       sources."qs-6.5.2"
       sources."readable-stream-2.3.6"
@@ -57534,24 +56672,39 @@ in
   npm-check-updates = nodeEnv.buildNodePackage {
     name = "npm-check-updates";
     packageName = "npm-check-updates";
-    version = "3.1.10";
+    version = "3.1.12";
     src = fetchurl {
-      url = "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-3.1.10.tgz";
-      sha512 = "qs4aYg3IbsHbzVyG/4bapgkuflkHj2yAR36ES7fSvDKs3NBotkAWpiaQ9JUbXgqSZwLuvusxBaZgpYlM3fMZSw==";
+      url = "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-3.1.12.tgz";
+      sha512 = "kf8pS7BDBh1yf+ZHxuGBC3bSuHd5okSBBZfNHKkAfV1Pd2DUWcNSILNZhIU54wlZ7au3w4BP9pHJ6Qll/DhI8A==";
     };
     dependencies = [
       sources."@sindresorhus/is-0.14.0"
       sources."@szmarczak/http-timer-1.1.2"
+      sources."JSONStream-1.3.5"
       sources."agent-base-4.3.0"
+      sources."agentkeepalive-3.5.2"
       sources."ansi-align-3.0.0"
       sources."ansi-regex-2.1.1"
       sources."ansi-styles-3.2.1"
+      sources."aproba-1.2.0"
       sources."argparse-1.0.10"
+      sources."balanced-match-1.0.0"
       sources."bluebird-3.5.5"
       sources."boxen-3.2.0"
-      sources."cacheable-request-6.0.0"
+      sources."brace-expansion-1.1.11"
+      sources."buffer-from-1.1.1"
+      sources."builtins-1.0.3"
+      sources."cacache-11.3.3"
+      (sources."cacheable-request-6.1.0" // {
+        dependencies = [
+          sources."get-stream-5.1.0"
+          sources."http-cache-semantics-4.0.3"
+          sources."lowercase-keys-2.0.0"
+        ];
+      })
       sources."camelcase-5.3.1"
       sources."chalk-2.4.2"
+      sources."chownr-1.1.1"
       sources."ci-info-2.0.0"
       sources."cint-8.2.1"
       sources."cli-boxes-2.2.0"
@@ -57561,19 +56714,35 @@ in
       sources."color-name-1.1.3"
       sources."colors-1.0.3"
       sources."commander-2.20.0"
-      sources."config-chain-1.1.12"
+      sources."concat-map-0.0.1"
+      sources."concat-stream-1.6.2"
       sources."configstore-4.0.0"
-      sources."cross-spawn-5.1.0"
+      sources."copy-concurrently-1.0.5"
+      sources."core-util-is-1.0.2"
+      (sources."cross-spawn-5.1.0" // {
+        dependencies = [
+          sources."lru-cache-4.1.5"
+          sources."yallist-2.1.2"
+        ];
+      })
       sources."crypto-random-string-1.0.0"
-      sources."debug-3.2.6"
+      sources."cyclist-0.2.2"
+      (sources."debug-3.1.0" // {
+        dependencies = [
+          sources."ms-2.0.0"
+        ];
+      })
       sources."decompress-response-3.3.0"
       sources."deep-extend-0.6.0"
       sources."defer-to-connect-1.0.2"
       sources."dot-prop-4.2.0"
       sources."duplexer3-0.1.4"
+      sources."duplexify-3.7.1"
       sources."emoji-regex-7.0.3"
+      sources."encoding-0.1.12"
       sources."end-of-stream-1.4.1"
-      sources."es6-promise-4.2.6"
+      sources."err-code-1.1.2"
+      sources."es6-promise-4.2.8"
       sources."es6-promisify-5.0.0"
       sources."escape-string-regexp-1.0.5"
       sources."esprima-4.0.1"
@@ -57583,21 +56752,37 @@ in
         ];
       })
       sources."fast-diff-1.2.0"
+      sources."figgy-pudding-3.5.1"
       sources."find-up-4.0.0"
-      sources."get-proxy-2.1.0"
+      sources."flush-write-stream-1.1.1"
+      sources."from2-2.3.0"
+      sources."fs-minipass-1.2.6"
+      sources."fs-write-stream-atomic-1.0.10"
+      sources."fs.realpath-1.0.0"
+      sources."genfun-5.0.0"
       sources."get-stdin-7.0.0"
       sources."get-stream-4.1.0"
+      sources."glob-7.1.4"
       sources."global-dirs-0.1.1"
       sources."got-9.6.0"
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."has-ansi-2.0.0"
       sources."has-flag-3.0.0"
       sources."has-yarn-2.1.0"
-      sources."http-cache-semantics-4.0.3"
+      sources."hosted-git-info-2.7.1"
+      sources."http-cache-semantics-3.8.1"
+      sources."http-proxy-agent-2.1.0"
       sources."https-proxy-agent-2.2.1"
+      sources."humanize-ms-1.2.1"
+      sources."iconv-lite-0.4.24"
+      sources."iferr-0.1.5"
+      sources."ignore-walk-3.0.1"
       sources."import-lazy-2.1.0"
       sources."imurmurhash-0.1.4"
+      sources."inflight-1.0.6"
+      sources."inherits-2.0.4"
       sources."ini-1.3.5"
+      sources."ip-1.1.5"
       sources."is-ci-2.0.0"
       sources."is-fullwidth-code-point-2.0.0"
       sources."is-installed-globally-0.1.0"
@@ -57606,23 +56791,42 @@ in
       sources."is-path-inside-1.0.1"
       sources."is-stream-1.1.0"
       sources."is-yarn-global-0.3.0"
+      sources."isarray-1.0.0"
       sources."isexe-2.0.0"
       sources."jju-1.4.0"
       sources."js-yaml-3.13.1"
       sources."json-buffer-3.0.0"
+      sources."json-parse-better-errors-1.0.2"
       sources."json-parse-helpfulerror-1.0.3"
-      sources."json5-1.0.1"
+      (sources."json5-1.0.1" // {
+        dependencies = [
+          sources."minimist-1.2.0"
+        ];
+      })
+      sources."jsonparse-1.3.1"
       sources."keyv-3.1.0"
       sources."kleur-3.0.3"
       sources."latest-version-5.1.0"
       sources."locate-path-5.0.0"
       sources."lodash-4.17.11"
       sources."lowercase-keys-1.0.1"
-      sources."lru-cache-4.1.5"
+      sources."lru-cache-5.1.1"
       sources."make-dir-1.3.0"
+      (sources."make-fetch-happen-4.0.1" // {
+        dependencies = [
+          sources."lru-cache-4.1.5"
+          sources."yallist-2.1.2"
+        ];
+      })
       sources."mimic-response-1.0.1"
-      sources."minimist-1.2.0"
-      sources."ms-2.1.1"
+      sources."minimatch-3.0.4"
+      sources."minimist-0.0.8"
+      sources."minipass-2.3.5"
+      sources."minizlib-1.2.1"
+      sources."mississippi-3.0.0"
+      sources."mkdirp-0.5.1"
+      sources."move-concurrently-1.0.1"
+      sources."ms-2.1.2"
       sources."nested-error-stacks-2.0.1"
       (sources."node-alias-1.0.4" // {
         dependencies = [
@@ -57631,43 +56835,93 @@ in
           sources."supports-color-2.0.0"
         ];
       })
-      sources."normalize-url-3.3.0"
-      sources."npm-conf-1.1.3"
+      sources."node-fetch-npm-2.0.2"
+      (sources."normalize-package-data-2.5.0" // {
+        dependencies = [
+          sources."semver-5.7.0"
+        ];
+      })
+      sources."normalize-url-4.3.0"
+      sources."npm-bundled-1.0.6"
+      (sources."npm-package-arg-6.1.0" // {
+        dependencies = [
+          sources."semver-5.7.0"
+        ];
+      })
+      sources."npm-packlist-1.4.3"
+      (sources."npm-pick-manifest-2.2.3" // {
+        dependencies = [
+          sources."semver-5.7.0"
+        ];
+      })
+      (sources."npm-registry-fetch-3.9.0" // {
+        dependencies = [
+          sources."lru-cache-4.1.5"
+          sources."yallist-2.1.2"
+        ];
+      })
       sources."npm-run-path-2.0.2"
       sources."object-assign-4.1.1"
       sources."object-keys-1.1.1"
       sources."once-1.4.0"
+      sources."os-homedir-1.0.2"
+      sources."os-tmpdir-1.0.2"
+      sources."osenv-0.1.5"
       sources."p-cancelable-1.1.0"
       sources."p-finally-1.0.0"
       sources."p-limit-2.2.0"
       sources."p-locate-4.1.0"
       sources."p-try-2.2.0"
-      (sources."package-json-6.3.0" // {
+      sources."package-json-6.4.0"
+      (sources."pacote-9.5.1" // {
         dependencies = [
           sources."semver-5.7.0"
         ];
       })
+      sources."parallel-transform-1.1.0"
       sources."path-exists-3.0.0"
+      sources."path-is-absolute-1.0.1"
       sources."path-is-inside-1.0.2"
       sources."path-key-2.0.1"
       sources."path-parse-1.0.6"
       sources."pify-3.0.0"
       sources."prepend-http-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."progress-2.0.3"
+      sources."promise-inflight-1.0.1"
+      sources."promise-retry-1.1.1"
       sources."prompts-2.1.0"
-      sources."proto-list-1.2.4"
+      sources."protoduck-5.0.1"
       sources."pseudomap-1.0.2"
       sources."pump-3.0.0"
-      sources."rc-1.2.8"
+      (sources."pumpify-1.5.1" // {
+        dependencies = [
+          sources."pump-2.0.1"
+        ];
+      })
+      (sources."rc-1.2.8" // {
+        dependencies = [
+          sources."minimist-1.2.0"
+        ];
+      })
       sources."rc-config-loader-2.0.3"
+      sources."readable-stream-2.3.6"
       sources."registry-auth-token-3.4.0"
       sources."registry-url-5.1.0"
       sources."require-from-string-2.0.2"
-      sources."requireg-0.2.2"
-      sources."resolve-1.7.1"
+      (sources."requireg-0.2.2" // {
+        dependencies = [
+          sources."resolve-1.7.1"
+        ];
+      })
+      sources."resolve-1.11.1"
       sources."responselike-1.0.2"
+      sources."retry-0.10.1"
+      sources."rimraf-2.6.3"
+      sources."run-queue-1.0.3"
       sources."safe-buffer-5.1.2"
-      sources."semver-6.1.1"
+      sources."safer-buffer-2.1.2"
+      sources."semver-6.1.2"
       (sources."semver-diff-2.1.0" // {
         dependencies = [
           sources."semver-5.7.0"
@@ -57678,24 +56932,48 @@ in
       sources."shebang-regex-1.0.0"
       sources."signal-exit-3.0.2"
       sources."sisteransi-1.0.0"
+      sources."smart-buffer-4.0.2"
+      sources."socks-2.3.2"
+      (sources."socks-proxy-agent-4.0.2" // {
+        dependencies = [
+          sources."agent-base-4.2.1"
+        ];
+      })
       sources."spawn-please-0.3.0"
+      sources."spdx-correct-3.1.0"
+      sources."spdx-exceptions-2.2.0"
+      sources."spdx-expression-parse-3.0.0"
+      sources."spdx-license-ids-3.0.4"
       sources."sprintf-js-1.0.3"
+      sources."ssri-6.0.1"
+      sources."stream-each-1.2.3"
+      sources."stream-shift-1.0.0"
       (sources."string-width-3.1.0" // {
         dependencies = [
           sources."ansi-regex-4.1.0"
           sources."strip-ansi-5.2.0"
         ];
       })
+      sources."string_decoder-1.1.1"
       sources."strip-ansi-3.0.1"
       sources."strip-eof-1.0.0"
       sources."strip-json-comments-2.0.1"
       sources."supports-color-5.5.0"
+      sources."tar-4.4.10"
       sources."term-size-1.2.0"
+      sources."through-2.3.8"
+      sources."through2-2.0.5"
       sources."to-readable-stream-1.0.0"
       sources."type-fest-0.3.1"
+      sources."typedarray-0.0.6"
+      sources."unique-filename-1.1.1"
+      sources."unique-slug-2.0.2"
       sources."unique-string-1.0.0"
       sources."update-notifier-3.0.0"
       sources."url-parse-lax-3.0.0"
+      sources."util-deprecate-1.0.2"
+      sources."validate-npm-package-license-3.0.4"
+      sources."validate-npm-package-name-3.0.0"
       sources."which-1.3.1"
       (sources."widest-line-2.0.1" // {
         dependencies = [
@@ -57707,7 +56985,9 @@ in
       sources."wrappy-1.0.2"
       sources."write-file-atomic-2.4.3"
       sources."xdg-basedir-3.0.0"
-      sources."yallist-2.1.2"
+      sources."xtend-4.0.1"
+      sources."y18n-4.0.0"
+      sources."yallist-3.0.3"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -57736,7 +57016,7 @@ in
       sources."fs.realpath-1.0.0"
       sources."glob-7.1.2"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."lodash-4.17.5"
       sources."lokijs-1.5.3"
       sources."minimatch-3.0.4"
@@ -57786,7 +57066,7 @@ in
       sources."balanced-match-1.0.0"
       sources."base64-js-0.0.8"
       sources."bencode-2.0.1"
-      sources."big-integer-1.6.43"
+      sources."big-integer-1.6.44"
       sources."bitfield-0.1.0"
       (sources."bittorrent-dht-6.4.2" // {
         dependencies = [
@@ -57856,7 +57136,7 @@ in
       sources."get-browser-rtc-1.0.2"
       sources."get-stdin-4.0.1"
       sources."glob-7.1.4"
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."has-ansi-2.0.0"
       sources."has-flag-3.0.0"
       sources."hat-0.0.3"
@@ -57866,7 +57146,7 @@ in
       sources."immediate-chunk-store-1.0.8"
       sources."indent-string-2.1.0"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."ini-1.3.5"
       (sources."inquirer-5.2.0" // {
         dependencies = [
@@ -57905,7 +57185,7 @@ in
       sources."magnet-uri-5.2.4"
       sources."map-obj-1.0.1"
       sources."meow-3.7.0"
-      sources."mime-2.4.3"
+      sources."mime-2.4.4"
       sources."mimic-fn-1.2.0"
       sources."mimic-response-1.0.1"
       sources."minimatch-3.0.4"
@@ -57959,20 +57239,20 @@ in
       sources."pinkie-2.0.4"
       sources."pinkie-promise-2.0.1"
       sources."plist-1.2.0"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."pump-2.0.1"
-      (sources."random-access-file-2.1.2" // {
+      (sources."random-access-file-2.1.3" // {
         dependencies = [
           sources."minimist-0.0.8"
           sources."mkdirp-0.5.1"
         ];
       })
-      sources."random-access-storage-1.3.0"
+      sources."random-access-storage-1.4.0"
       sources."random-iterate-1.0.1"
       sources."randombytes-2.1.0"
       sources."range-parser-1.2.1"
       sources."rc-1.2.8"
-      sources."re-emitter-1.1.3"
+      sources."re-emitter-1.1.4"
       sources."read-pkg-1.1.0"
       sources."read-pkg-up-1.0.1"
       sources."readable-stream-2.3.6"
@@ -58243,7 +57523,7 @@ in
       sources."get-browser-rtc-1.0.2"
       sources."getpass-0.1.7"
       sources."glob-7.1.4"
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       (sources."has-binary-0.1.7" // {
@@ -58253,14 +57533,14 @@ in
       })
       sources."has-cors-1.1.0"
       sources."hat-0.0.3"
-      sources."http-errors-1.7.2"
+      sources."http-errors-1.7.3"
       sources."http-signature-1.2.0"
       sources."iconv-lite-0.4.11"
       sources."ieee754-1.1.13"
       sources."immediate-chunk-store-1.0.8"
       sources."indexof-0.0.1"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."ip-1.1.5"
       sources."ip-set-1.0.2"
       sources."ipaddr.js-1.0.5"
@@ -58352,14 +57632,14 @@ in
       sources."peer-wire-swarm-0.12.2"
       sources."pend-1.2.0"
       sources."performance-now-2.1.0"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."proxy-addr-1.0.10"
-      sources."psl-1.1.32"
+      sources."psl-1.1.33"
       sources."pump-1.0.3"
       sources."punycode-2.1.1"
       sources."qs-6.5.2"
-      sources."random-access-file-2.1.2"
-      sources."random-access-storage-1.3.0"
+      sources."random-access-file-2.1.3"
+      sources."random-access-storage-1.4.0"
       sources."random-bytes-1.0.0"
       sources."random-iterate-1.0.1"
       sources."randombytes-2.1.0"
@@ -58370,7 +57650,7 @@ in
           sources."iconv-lite-0.4.13"
         ];
       })
-      sources."re-emitter-1.1.3"
+      sources."re-emitter-1.1.4"
       sources."read-torrent-1.3.1"
       sources."readable-stream-2.3.6"
       sources."remove-trailing-separator-1.1.0"
@@ -58518,10 +57798,10 @@ in
   pnpm = nodeEnv.buildNodePackage {
     name = "pnpm";
     packageName = "pnpm";
-    version = "3.4.1";
+    version = "3.5.3";
     src = fetchurl {
-      url = "https://registry.npmjs.org/pnpm/-/pnpm-3.4.1.tgz";
-      sha512 = "XjKIe2sh817ssTHDGaobbi9YGoiUp+rYfJ3zeuptv2GQNnJ+1e+SHx4uPe2OkXzw9qcnK3VHPjS8+1lSSW7BKQ==";
+      url = "https://registry.npmjs.org/pnpm/-/pnpm-3.5.3.tgz";
+      sha512 = "4gBUaY+IiuJLmoqP3QEtqxmFzY4yqbpnYx7WFrv0Aoy9zR6oneI4429KEO5G3rX+P3jF/OuYdVZ8E59URgD0ag==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -58754,7 +58034,7 @@ in
           sources."pako-1.0.10"
         ];
       })
-      sources."browserslist-4.6.1"
+      sources."browserslist-4.6.3"
       (sources."buffer-4.9.1" // {
         dependencies = [
           sources."isarray-1.0.0"
@@ -58770,7 +58050,7 @@ in
       sources."caller-path-2.0.0"
       sources."callsites-2.0.0"
       sources."caniuse-api-3.0.0"
-      sources."caniuse-lite-1.0.30000973"
+      sources."caniuse-lite-1.0.30000978"
       sources."caseless-0.12.0"
       sources."chalk-2.4.2"
       sources."chokidar-2.1.6"
@@ -58907,8 +58187,8 @@ in
       sources."ecc-jsbn-0.1.2"
       sources."editorconfig-0.15.3"
       sources."ee-first-1.1.1"
-      sources."electron-to-chromium-1.3.147"
-      sources."elliptic-6.4.1"
+      sources."electron-to-chromium-1.3.176"
+      sources."elliptic-6.5.0"
       sources."encodeurl-1.0.2"
       sources."entities-1.1.2"
       sources."error-ex-1.3.2"
@@ -58965,7 +58245,7 @@ in
       })
       sources."glob-to-regexp-0.3.0"
       sources."globals-11.12.0"
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."grapheme-breaker-0.3.2"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
@@ -58998,7 +58278,7 @@ in
           sources."readable-stream-3.4.0"
         ];
       })
-      sources."http-errors-1.7.2"
+      sources."http-errors-1.7.3"
       sources."http-signature-1.2.0"
       sources."https-browserify-1.0.0"
       sources."iconv-lite-0.4.24"
@@ -59006,9 +58286,8 @@ in
       sources."ieee754-1.1.13"
       sources."import-fresh-2.0.0"
       sources."indexes-of-1.0.1"
-      sources."indexof-0.0.1"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."ini-1.3.5"
       sources."invariant-2.2.4"
       sources."is-absolute-url-2.1.0"
@@ -59109,7 +58388,7 @@ in
       sources."minimalistic-crypto-utils-1.0.1"
       sources."minimatch-3.0.4"
       sources."minimist-1.2.0"
-      (sources."mixin-deep-1.3.1" // {
+      (sources."mixin-deep-1.3.2" // {
         dependencies = [
           sources."is-extendable-1.0.1"
         ];
@@ -59119,7 +58398,7 @@ in
           sources."minimist-0.0.8"
         ];
       })
-      sources."ms-2.1.1"
+      sources."ms-2.1.2"
       sources."nan-2.14.0"
       (sources."nanomatch-1.2.13" // {
         dependencies = [
@@ -59132,12 +58411,12 @@ in
       sources."nice-try-1.0.5"
       sources."node-addon-api-1.6.3"
       sources."node-forge-0.7.6"
-      (sources."node-libs-browser-2.2.0" // {
+      (sources."node-libs-browser-2.2.1" // {
         dependencies = [
           sources."punycode-1.4.1"
         ];
       })
-      sources."node-releases-1.1.23"
+      sources."node-releases-1.1.24"
       sources."nopt-4.0.1"
       sources."normalize-html-whitespace-0.2.0"
       sources."normalize-path-3.0.0"
@@ -59169,7 +58448,7 @@ in
       sources."parse5-4.0.0"
       sources."parseurl-1.3.3"
       sources."pascalcase-0.1.1"
-      sources."path-browserify-0.0.0"
+      sources."path-browserify-0.0.1"
       sources."path-dirname-1.0.2"
       sources."path-is-absolute-1.0.1"
       sources."path-key-2.0.1"
@@ -59251,10 +58530,10 @@ in
       sources."prelude-ls-1.1.2"
       sources."private-0.1.8"
       sources."process-0.11.10"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."proto-list-1.2.4"
       sources."pseudomap-1.0.2"
-      sources."psl-1.1.32"
+      sources."psl-1.1.33"
       sources."public-encrypt-4.0.3"
       sources."punycode-2.1.1"
       sources."q-1.5.1"
@@ -59322,11 +58601,12 @@ in
               sources."ms-2.0.0"
             ];
           })
+          sources."ms-2.1.1"
         ];
       })
       sources."serialize-to-js-1.2.2"
       sources."serve-static-1.14.1"
-      sources."set-value-2.0.0"
+      sources."set-value-2.0.1"
       sources."setimmediate-1.0.5"
       sources."setprototypeof-1.1.1"
       sources."sha.js-2.4.11"
@@ -59382,7 +58662,7 @@ in
       })
       sources."supports-color-5.5.0"
       sources."svgo-1.2.2"
-      sources."symbol-tree-3.2.2"
+      sources."symbol-tree-3.2.4"
       sources."terser-3.17.0"
       sources."through2-2.0.5"
       sources."timers-browserify-2.0.10"
@@ -59419,11 +58699,7 @@ in
       sources."unicode-match-property-value-ecmascript-1.1.0"
       sources."unicode-property-aliases-ecmascript-1.0.5"
       sources."unicode-trie-0.3.1"
-      (sources."union-value-1.0.0" // {
-        dependencies = [
-          sources."set-value-0.4.3"
-        ];
-      })
+      sources."union-value-1.0.1"
       sources."uniq-1.0.1"
       sources."uniqs-2.0.0"
       sources."unquote-1.1.1"
@@ -59447,7 +58723,11 @@ in
         ];
       })
       sources."use-3.1.1"
-      sources."util-0.11.1"
+      (sources."util-0.11.1" // {
+        dependencies = [
+          sources."inherits-2.0.3"
+        ];
+      })
       sources."util-deprecate-1.0.2"
       sources."util.promisify-1.0.0"
       sources."uuid-3.3.2"
@@ -59455,7 +58735,7 @@ in
       sources."vendors-1.0.3"
       sources."verror-1.10.0"
       sources."vlq-0.2.3"
-      sources."vm-browserify-0.0.4"
+      sources."vm-browserify-1.1.0"
       sources."w3c-hr-time-1.0.1"
       sources."wcwidth-1.0.1"
       sources."webidl-conversions-4.0.2"
@@ -59483,10 +58763,10 @@ in
   prettier = nodeEnv.buildNodePackage {
     name = "prettier";
     packageName = "prettier";
-    version = "1.17.1";
+    version = "1.18.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/prettier/-/prettier-1.17.1.tgz";
-      sha512 = "TzGRNvuUSmPgwivDqkZ9tM/qTGW9hqDKWOE9YHiyQdixlKbv7kvEqsmDPrcHJTKwthU774TQwZXVtaQ/mMsvjg==";
+      url = "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz";
+      sha512 = "OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -59588,7 +58868,7 @@ in
       sources."diffie-hellman-5.0.3"
       sources."domain-browser-1.2.0"
       sources."duplexer2-0.1.4"
-      sources."elliptic-6.4.1"
+      sources."elliptic-6.5.0"
       sources."es6-promise-3.3.1"
       sources."events-2.1.0"
       sources."evp_bytestokey-1.0.3"
@@ -59598,7 +58878,7 @@ in
       sources."get-assigned-identifiers-1.2.0"
       sources."glob-7.1.4"
       sources."globule-1.2.1"
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."has-1.0.3"
       sources."hash-base-3.0.4"
       sources."hash.js-1.1.7"
@@ -59607,7 +58887,7 @@ in
       sources."https-browserify-1.0.0"
       sources."ieee754-1.1.13"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."inline-source-map-0.6.2"
       (sources."insert-module-globals-7.2.0" // {
         dependencies = [
@@ -59660,7 +58940,7 @@ in
       sources."path-platform-0.11.15"
       sources."pbkdf2-3.0.17"
       sources."process-0.11.10"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."public-encrypt-4.0.3"
       sources."punycode-1.4.1"
       sources."querystring-0.2.0"
@@ -59716,7 +58996,11 @@ in
           sources."punycode-1.3.2"
         ];
       })
-      sources."util-0.10.4"
+      (sources."util-0.10.4" // {
+        dependencies = [
+          sources."inherits-2.0.3"
+        ];
+      })
       sources."util-deprecate-1.0.2"
       sources."vm-browserify-1.1.0"
       sources."which-1.3.1"
@@ -59757,10 +59041,10 @@ in
       sources."esprima-3.1.3"
       sources."esprima-fb-13001.1001.0-dev-harmony-fb"
       sources."glob-5.0.15"
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."iconv-lite-0.4.24"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       (sources."jstransform-10.1.0" // {
         dependencies = [
           sources."source-map-0.1.31"
@@ -59814,7 +59098,7 @@ in
       sources."has-ansi-2.0.0"
       sources."i-0.3.6"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."isstream-0.1.2"
       sources."minimatch-3.0.4"
       sources."minimist-1.2.0"
@@ -59940,7 +59224,7 @@ in
       sources."har-validator-5.1.3"
       sources."http-auth-2.0.7"
       sources."http-signature-1.2.0"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."is-typedarray-1.0.0"
       sources."isarray-0.0.1"
       sources."isstream-0.1.2"
@@ -59955,7 +59239,7 @@ in
       sources."mime-db-1.40.0"
       sources."mime-types-2.1.24"
       sources."mkdirp-0.3.5"
-      sources."ms-2.1.1"
+      sources."ms-2.1.2"
       sources."multiparty-2.2.0"
       sources."negotiator-0.3.0"
       sources."node-swt-0.1.1"
@@ -59971,7 +59255,7 @@ in
       })
       sources."pause-0.0.1"
       sources."performance-now-2.1.0"
-      sources."psl-1.1.32"
+      sources."psl-1.1.33"
       sources."punycode-2.1.1"
       sources."qs-0.6.5"
       sources."range-parser-0.0.4"
@@ -60048,7 +59332,7 @@ in
           sources."isobject-3.0.1"
         ];
       })
-      sources."base64-url-2.2.1"
+      sources."base64-url-2.2.2"
       sources."bash-color-0.0.4"
       sources."binary-extensions-1.13.1"
       sources."binary-search-1.3.5"
@@ -60132,7 +59416,7 @@ in
       sources."decompress-response-3.3.0"
       sources."deep-equal-1.0.1"
       sources."deep-extend-0.6.0"
-      sources."deferred-leveldown-5.0.1"
+      sources."deferred-leveldown-5.1.0"
       sources."define-properties-1.1.3"
       (sources."define-property-2.0.2" // {
         dependencies = [
@@ -60149,9 +59433,9 @@ in
       sources."elegant-spinner-1.0.1"
       sources."emoji-named-characters-1.0.2"
       sources."emoji-server-1.0.0"
-      sources."encoding-down-6.0.2"
+      sources."encoding-down-6.1.0"
       sources."end-of-stream-1.4.1"
-      sources."epidemic-broadcast-trees-6.3.5"
+      sources."epidemic-broadcast-trees-7.0.0"
       sources."errno-0.1.7"
       sources."es-abstract-1.13.0"
       sources."es-to-primitive-1.2.0"
@@ -60192,7 +59476,7 @@ in
       })
       (sources."flumeview-reduce-1.3.16" // {
         dependencies = [
-          (sources."atomic-file-2.0.0" // {
+          (sources."atomic-file-2.0.1" // {
             dependencies = [
               sources."flumecodec-0.0.1"
             ];
@@ -60215,7 +59499,7 @@ in
       sources."glob-base-0.3.0"
       sources."glob-parent-2.0.0"
       sources."globby-4.1.0"
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."has-1.0.3"
       sources."has-ansi-2.0.0"
       sources."has-network-0.0.1"
@@ -60244,7 +59528,7 @@ in
       sources."immediate-3.2.3"
       sources."increment-buffer-1.0.1"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."ini-1.3.5"
       sources."int53-1.0.0"
       sources."ip-1.1.5"
@@ -60291,7 +59575,7 @@ in
       sources."is-regex-1.0.4"
       sources."is-symbol-1.0.2"
       sources."is-typedarray-1.0.0"
-      sources."is-valid-domain-0.0.9"
+      sources."is-valid-domain-0.0.11"
       sources."is-windows-1.0.2"
       sources."isarray-1.0.0"
       sources."isexe-2.0.0"
@@ -60309,7 +59593,7 @@ in
         ];
       })
       sources."level-js-4.0.1"
-      sources."level-packager-5.0.1"
+      sources."level-packager-5.0.2"
       sources."level-post-1.0.7"
       (sources."level-sublevel-6.6.5" // {
         dependencies = [
@@ -60333,12 +59617,12 @@ in
           sources."string_decoder-0.10.31"
         ];
       })
-      (sources."leveldown-5.1.0" // {
+      (sources."leveldown-5.1.1" // {
         dependencies = [
           sources."node-gyp-build-4.1.0"
         ];
       })
-      sources."levelup-4.0.1"
+      sources."levelup-4.1.0"
       sources."libnested-1.4.1"
       sources."libsodium-0.7.4"
       sources."libsodium-wrappers-0.7.4"
@@ -60360,7 +59644,7 @@ in
       sources."mimic-response-1.0.1"
       sources."minimatch-3.0.4"
       sources."minimist-1.2.0"
-      (sources."mixin-deep-1.3.1" // {
+      (sources."mixin-deep-1.3.2" // {
         dependencies = [
           sources."is-extendable-1.0.1"
         ];
@@ -60379,7 +59663,7 @@ in
       (sources."multiserver-3.3.6" // {
         dependencies = [
           sources."debug-4.1.1"
-          sources."ms-2.1.1"
+          sources."ms-2.1.2"
         ];
       })
       sources."multiserver-address-1.0.1"
@@ -60413,7 +59697,7 @@ in
       sources."ncp-2.0.0"
       sources."nearley-2.16.0"
       sources."nice-try-1.0.5"
-      sources."node-abi-2.8.0"
+      sources."node-abi-2.9.0"
       sources."node-gyp-build-3.9.0"
       sources."non-private-ip-1.4.4"
       sources."noop-logger-0.1.1"
@@ -60476,7 +59760,7 @@ in
       sources."prebuild-install-5.2.5"
       sources."preserve-0.2.0"
       sources."private-box-0.3.0"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."promisize-1.1.2"
       sources."prr-1.0.1"
       sources."pull-abortable-4.0.0"
@@ -60514,7 +59798,7 @@ in
           sources."looper-4.0.0"
         ];
       })
-      sources."pull-many-1.0.8"
+      sources."pull-many-1.0.9"
       sources."pull-next-1.0.1"
       sources."pull-notify-0.1.1"
       sources."pull-pair-1.1.0"
@@ -60529,7 +59813,7 @@ in
       sources."pull-reader-1.3.1"
       sources."pull-sink-through-0.0.0"
       sources."pull-sort-1.0.2"
-      sources."pull-stream-3.6.12"
+      sources."pull-stream-3.6.13"
       sources."pull-stringify-2.0.0"
       sources."pull-through-1.0.18"
       sources."pull-traverse-1.0.3"
@@ -60547,7 +59831,7 @@ in
       sources."pull-write-file-0.2.4"
       sources."pull-ws-3.3.2"
       sources."pump-2.0.1"
-      sources."push-stream-10.0.4"
+      sources."push-stream-10.1.2"
       sources."push-stream-to-pull-stream-1.0.3"
       sources."railroad-diagrams-1.0.0"
       sources."randexp-0.4.6"
@@ -60632,17 +59916,17 @@ in
       sources."rwlock-5.0.0"
       sources."safe-buffer-5.1.2"
       sources."safe-regex-1.1.0"
-      sources."secret-handshake-1.1.18"
+      sources."secret-handshake-1.1.20"
       (sources."secret-stack-5.1.1" // {
         dependencies = [
           sources."debug-4.1.1"
-          sources."ms-2.1.1"
+          sources."ms-2.1.2"
         ];
       })
       sources."semver-5.7.0"
       sources."separator-escape-0.0.0"
       sources."set-blocking-2.0.0"
-      (sources."set-value-2.0.0" // {
+      (sources."set-value-2.0.1" // {
         dependencies = [
           sources."extend-shallow-2.0.1"
         ];
@@ -60698,11 +59982,11 @@ in
       (sources."ssb-blobs-1.2.1" // {
         dependencies = [
           sources."debug-4.1.1"
-          sources."ms-2.1.1"
+          sources."ms-2.1.2"
         ];
       })
       sources."ssb-caps-1.0.1"
-      (sources."ssb-client-4.7.6" // {
+      (sources."ssb-client-4.7.7" // {
         dependencies = [
           sources."ssb-config-3.3.1"
         ];
@@ -60721,12 +60005,12 @@ in
           sources."nan-2.12.1"
         ];
       })
-      sources."ssb-ebt-5.6.4"
+      sources."ssb-ebt-5.6.6"
       sources."ssb-friends-3.1.13"
-      sources."ssb-keys-7.1.6"
+      sources."ssb-keys-7.1.7"
       sources."ssb-links-3.0.8"
       sources."ssb-msgs-5.2.0"
-      (sources."ssb-query-2.4.1" // {
+      (sources."ssb-query-2.4.2" // {
         dependencies = [
           sources."flumeview-query-7.1.1"
           sources."map-filter-reduce-3.2.2"
@@ -60802,12 +60086,7 @@ in
       sources."ultron-1.0.2"
       sources."unherit-1.1.2"
       sources."unified-2.1.4"
-      (sources."union-value-1.0.0" // {
-        dependencies = [
-          sources."extend-shallow-2.0.1"
-          sources."set-value-0.4.3"
-        ];
-      })
+      sources."union-value-1.0.1"
       sources."unist-util-is-3.0.0"
       sources."unist-util-visit-1.4.1"
       sources."unist-util-visit-parents-2.1.2"
@@ -60856,10 +60135,10 @@ in
   semver = nodeEnv.buildNodePackage {
     name = "semver";
     packageName = "semver";
-    version = "6.1.1";
+    version = "6.1.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/semver/-/semver-6.1.1.tgz";
-      sha512 = "rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==";
+      url = "https://registry.npmjs.org/semver/-/semver-6.1.2.tgz";
+      sha512 = "z4PqiCpomGtWj8633oeAdXm1Kn1W++3T8epkZYnwiVgIYIJ0QHszhInYSJTYxebByQH7KVCEAn8R9duzZW2PhQ==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -60874,10 +60153,10 @@ in
   serve = nodeEnv.buildNodePackage {
     name = "serve";
     packageName = "serve";
-    version = "11.0.1";
+    version = "11.0.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/serve/-/serve-11.0.1.tgz";
-      sha512 = "kmcR5jOumMcmoDVJk7izj2Gnz+ql4K3Xq1g0l4XX598lLYvbXgfS1oeTgckPVGzsk0MU/dBPHiolRgH0fI7c5g==";
+      url = "https://registry.npmjs.org/serve/-/serve-11.0.2.tgz";
+      sha512 = "TjjjwUdPU+STkUyxvZFtkWOTRXdNDNMfot9Z/f97eEeyjPAV69o1TmJrNAlDbvpPu1JEjCoWiGCjkel7kWNF4A==";
     };
     dependencies = [
       sources."@zeit/schemas-2.6.0"
@@ -60945,7 +60224,7 @@ in
       sources."registry-auth-token-3.3.2"
       sources."registry-url-3.1.0"
       sources."safe-buffer-5.1.2"
-      (sources."serve-handler-6.0.1" // {
+      (sources."serve-handler-6.0.2" // {
         dependencies = [
           sources."mime-db-1.33.0"
           sources."mime-types-2.1.18"
@@ -61075,11 +60354,15 @@ in
           sources."entities-1.0.0"
         ];
       })
-      sources."http-errors-1.7.2"
+      (sources."http-errors-1.7.2" // {
+        dependencies = [
+          sources."inherits-2.0.3"
+        ];
+      })
       sources."http-signature-1.2.0"
       sources."iconv-lite-0.4.24"
       sources."indexof-0.0.1"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."ipaddr.js-1.9.0"
       sources."irc-replies-2.0.1"
       sources."is-typedarray-1.0.0"
@@ -61119,7 +60402,7 @@ in
       sources."pause-stream-0.0.11"
       sources."performance-now-2.1.0"
       sources."proxy-addr-2.0.5"
-      sources."psl-1.1.32"
+      sources."psl-1.1.33"
       sources."punycode-2.1.1"
       sources."qs-6.7.0"
       sources."range-parser-1.2.1"
@@ -61300,7 +60583,7 @@ in
       sources."for-in-1.0.2"
       sources."fragment-cache-0.2.1"
       sources."get-value-2.0.6"
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."graceful-readlink-1.0.1"
       sources."has-value-1.0.0"
       (sources."has-values-1.0.0" // {
@@ -61308,7 +60591,7 @@ in
           sources."kind-of-4.0.0"
         ];
       })
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."is-accessor-descriptor-1.0.0"
       sources."is-buffer-1.1.6"
       sources."is-data-descriptor-1.0.0"
@@ -61328,7 +60611,7 @@ in
       sources."map-cache-0.2.2"
       sources."map-visit-1.0.0"
       sources."micromatch-3.1.10"
-      (sources."mixin-deep-1.3.1" // {
+      (sources."mixin-deep-1.3.2" // {
         dependencies = [
           sources."is-extendable-1.0.1"
         ];
@@ -61352,7 +60635,7 @@ in
       sources."object.pick-1.3.0"
       sources."pascalcase-0.1.1"
       sources."posix-character-classes-0.1.1"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."readable-stream-2.3.6"
       sources."readdirp-2.2.1"
       sources."regex-not-1.0.2"
@@ -61362,7 +60645,7 @@ in
       sources."ret-0.1.15"
       sources."safe-buffer-5.1.2"
       sources."safe-regex-1.1.0"
-      (sources."set-value-2.0.0" // {
+      (sources."set-value-2.0.1" // {
         dependencies = [
           sources."extend-shallow-2.0.1"
         ];
@@ -61424,12 +60707,7 @@ in
       })
       sources."to-regex-3.0.2"
       sources."to-regex-range-2.1.1"
-      (sources."union-value-1.0.0" // {
-        dependencies = [
-          sources."extend-shallow-2.0.1"
-          sources."set-value-0.4.3"
-        ];
-      })
+      sources."union-value-1.0.1"
       (sources."unset-value-1.0.0" // {
         dependencies = [
           (sources."has-value-0.3.1" // {
@@ -61488,7 +60766,7 @@ in
       sources."glob-6.0.4"
       sources."http-signature-0.11.0"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."isarray-1.0.0"
       sources."jodid25519-1.0.2"
       sources."jsbn-0.1.1"
@@ -61514,7 +60792,7 @@ in
       sources."once-1.4.0"
       sources."path-is-absolute-1.0.1"
       sources."precond-0.2.3"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."qs-3.1.0"
       sources."readable-stream-2.3.6"
       (sources."restify-4.0.3" // {
@@ -61600,28 +60878,32 @@ in
   snyk = nodeEnv.buildNodePackage {
     name = "snyk";
     packageName = "snyk";
-    version = "1.173.1";
+    version = "1.185.5";
     src = fetchurl {
-      url = "https://registry.npmjs.org/snyk/-/snyk-1.173.1.tgz";
-      sha512 = "ZqA2qMzsxjm6Q+arSuxnqNvCl8EhZpPBaVgRae3lyajaBssuwz4HmGb5fv86DnKJCDq/Ib+GKtzXTlBZT+s+Zw==";
+      url = "https://registry.npmjs.org/snyk/-/snyk-1.185.5.tgz";
+      sha512 = "thiYonTVgfcKA0qq//adcCE2Lmnz6vXG7bii7Fuv3sKMjmiHxv6pkguqgEJ/m8gU5KmTXZXoFLewvAqNj/Yqrg==";
     };
     dependencies = [
-      sources."@snyk/dep-graph-1.4.1"
+      sources."@snyk/composer-lockfile-parser-1.0.2"
+      sources."@snyk/dep-graph-1.8.1"
       sources."@snyk/gemfile-1.2.0"
+      sources."@types/agent-base-4.2.0"
       sources."@types/debug-4.1.4"
-      sources."@types/node-8.10.49"
+      sources."@types/events-3.0.0"
+      sources."@types/node-12.0.10"
+      sources."@types/sinon-7.0.11"
       sources."@yarnpkg/lockfile-1.1.0"
       sources."abbrev-1.1.1"
       sources."agent-base-4.3.0"
       sources."ansi-align-2.0.0"
-      sources."ansi-escapes-4.1.0"
+      sources."ansi-escapes-4.2.0"
       sources."ansi-regex-3.0.0"
       sources."ansi-styles-3.2.1"
       sources."ansicolors-0.3.2"
       sources."archy-1.0.0"
       sources."argparse-1.0.10"
       sources."asap-2.0.6"
-      sources."ast-types-0.13.1"
+      sources."ast-types-0.13.2"
       sources."async-1.5.2"
       sources."balanced-match-1.0.0"
       (sources."boxen-1.3.0" // {
@@ -61663,7 +60945,11 @@ in
         ];
       })
       sources."crypto-random-string-1.0.0"
-      sources."data-uri-to-buffer-2.0.1"
+      (sources."data-uri-to-buffer-2.0.1" // {
+        dependencies = [
+          sources."@types/node-8.10.49"
+        ];
+      })
       sources."debug-3.2.6"
       sources."decamelize-1.2.0"
       sources."deep-extend-0.6.0"
@@ -61676,7 +60962,7 @@ in
       sources."duplexer3-0.1.4"
       sources."email-validator-2.0.4"
       sources."end-of-stream-1.4.1"
-      sources."es6-promise-4.2.6"
+      sources."es6-promise-4.2.8"
       sources."es6-promisify-5.0.0"
       sources."escape-string-regexp-1.0.5"
       sources."escodegen-1.11.1"
@@ -61712,11 +60998,11 @@ in
           sources."get-stream-3.0.0"
         ];
       })
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."graphlib-2.1.7"
       sources."has-flag-3.0.0"
       sources."hosted-git-info-2.7.1"
-      sources."http-errors-1.7.2"
+      sources."http-errors-1.7.3"
       (sources."http-proxy-agent-2.1.0" // {
         dependencies = [
           sources."debug-3.1.0"
@@ -61729,9 +61015,9 @@ in
       sources."import-lazy-2.1.0"
       sources."imurmurhash-0.1.4"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."ini-1.3.5"
-      (sources."inquirer-6.3.1" // {
+      (sources."inquirer-6.4.1" // {
         dependencies = [
           sources."ansi-escapes-3.2.0"
         ];
@@ -61784,7 +61070,7 @@ in
       sources."lodash.set-4.3.2"
       sources."lowercase-keys-1.0.1"
       sources."lru-cache-4.1.5"
-      sources."macos-release-2.2.0"
+      sources."macos-release-2.3.0"
       sources."make-dir-1.3.0"
       sources."mimic-fn-1.2.0"
       sources."minimatch-3.0.4"
@@ -61794,7 +61080,7 @@ in
           sources."for-in-0.1.8"
         ];
       })
-      sources."ms-2.1.1"
+      sources."ms-2.1.2"
       sources."mute-stream-0.0.7"
       sources."nconf-0.10.0"
       sources."needle-2.4.0"
@@ -61803,6 +61089,7 @@ in
       sources."normalize-url-3.3.0"
       sources."npm-run-path-2.0.2"
       sources."number-is-nan-1.0.1"
+      sources."object-hash-1.3.1"
       sources."once-1.4.0"
       sources."onetime-2.0.1"
       sources."opn-5.5.0"
@@ -61827,14 +61114,14 @@ in
       sources."pify-3.0.0"
       sources."prelude-ls-1.1.2"
       sources."prepend-http-1.0.4"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."promise-7.3.1"
       sources."protocols-1.4.7"
       sources."proxy-agent-3.1.0"
       sources."proxy-from-env-1.0.0"
       sources."pseudomap-1.0.2"
       sources."pump-3.0.0"
-      sources."raw-body-2.4.0"
+      sources."raw-body-2.4.1"
       sources."rc-1.2.8"
       (sources."readable-stream-3.4.0" // {
         dependencies = [
@@ -61850,7 +61137,7 @@ in
       sources."safer-buffer-2.1.2"
       sources."sax-1.2.4"
       sources."secure-keys-1.0.0"
-      sources."semver-6.1.1"
+      sources."semver-6.1.2"
       (sources."semver-diff-2.1.0" // {
         dependencies = [
           sources."semver-5.7.0"
@@ -61873,32 +61160,40 @@ in
           sources."debug-4.1.1"
         ];
       })
-      sources."snyk-go-parser-1.3.0"
-      (sources."snyk-go-plugin-1.9.0" // {
+      sources."snyk-go-parser-1.3.1"
+      (sources."snyk-go-plugin-1.10.2" // {
         dependencies = [
           sources."debug-4.1.1"
         ];
       })
-      (sources."snyk-gradle-plugin-2.12.0" // {
+      (sources."snyk-gradle-plugin-2.12.5" // {
         dependencies = [
           sources."debug-4.1.1"
         ];
       })
       sources."snyk-module-1.9.1"
-      sources."snyk-mvn-plugin-2.3.0"
+      (sources."snyk-mvn-plugin-2.3.0" // {
+        dependencies = [
+          sources."tslib-1.9.3"
+        ];
+      })
       sources."snyk-nodejs-lockfile-parser-1.13.0"
       sources."snyk-nuget-plugin-1.10.0"
       sources."snyk-paket-parser-1.4.3"
-      sources."snyk-php-plugin-1.5.3"
+      sources."snyk-php-plugin-1.6.2"
       sources."snyk-policy-1.13.5"
-      sources."snyk-python-plugin-1.10.1"
+      sources."snyk-python-plugin-1.10.2"
       sources."snyk-resolve-1.0.1"
       (sources."snyk-resolve-deps-4.0.3" // {
         dependencies = [
           sources."semver-5.7.0"
         ];
       })
-      sources."snyk-sbt-plugin-2.2.0"
+      (sources."snyk-sbt-plugin-2.4.2" // {
+        dependencies = [
+          sources."tslib-1.9.3"
+        ];
+      })
       sources."snyk-tree-1.0.0"
       sources."snyk-try-require-1.3.1"
       sources."socks-2.3.2"
@@ -61941,9 +61236,10 @@ in
       sources."tmp-0.0.33"
       sources."toidentifier-1.0.0"
       sources."toml-3.0.0"
-      sources."tslib-1.9.3"
+      sources."tree-kill-1.2.1"
+      sources."tslib-1.10.0"
       sources."type-check-0.3.2"
-      sources."type-fest-0.3.1"
+      sources."type-fest-0.5.2"
       sources."unique-string-1.0.0"
       sources."unpipe-1.0.0"
       sources."unzip-response-2.0.1"
@@ -62035,7 +61331,7 @@ in
       sources."isarray-2.0.1"
       sources."mime-db-1.40.0"
       sources."mime-types-2.1.24"
-      sources."ms-2.1.1"
+      sources."ms-2.1.2"
       sources."negotiator-0.6.2"
       sources."object-component-0.0.3"
       sources."parseqs-0.0.5"
@@ -62092,7 +61388,7 @@ in
       sources."ci-info-1.6.0"
       sources."cli-boxes-1.0.0"
       sources."cli-cursor-2.1.0"
-      sources."cli-spinners-2.1.0"
+      sources."cli-spinners-2.2.0"
       sources."clone-1.0.4"
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
@@ -62114,7 +61410,7 @@ in
       sources."draftlog-1.0.12"
       sources."duplexer3-0.1.4"
       sources."error-ex-1.3.2"
-      sources."es6-promise-4.2.6"
+      sources."es6-promise-4.2.8"
       sources."es6-promisify-5.0.0"
       sources."escape-string-regexp-1.0.5"
       sources."execa-0.7.0"
@@ -62122,7 +61418,7 @@ in
       sources."get-stream-3.0.0"
       sources."global-dirs-0.1.1"
       sources."got-6.7.1"
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."has-flag-3.0.0"
       sources."hosted-git-info-2.7.1"
       sources."http-proxy-agent-2.1.0"
@@ -62515,7 +61811,7 @@ in
       })
       sources."finalhandler-1.1.2"
       sources."for-in-1.0.2"
-      sources."form-data-2.3.3"
+      sources."form-data-2.4.0"
       sources."formidable-1.2.1"
       sources."fragment-cache-0.2.1"
       sources."fresh-0.5.2"
@@ -62532,7 +61828,7 @@ in
       })
       sources."global-dirs-0.1.1"
       sources."got-6.7.1"
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       (sources."graphlib-2.1.7" // {
         dependencies = [
           sources."lodash-4.17.11"
@@ -62552,13 +61848,13 @@ in
           sources."kind-of-4.0.0"
         ];
       })
-      sources."http-errors-1.7.2"
+      sources."http-errors-1.7.3"
       sources."iconv-lite-0.4.8"
       sources."ignore-by-default-1.0.1"
       sources."import-lazy-2.1.0"
       sources."imurmurhash-0.1.4"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."ini-1.3.5"
       sources."inquirer-0.10.1"
       sources."is-accessor-descriptor-1.0.0"
@@ -62658,7 +61954,7 @@ in
       sources."mime-types-2.1.24"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
-      sources."mixin-deep-1.3.1"
+      sources."mixin-deep-1.3.2"
       sources."mkdirp-0.5.1"
       (sources."mocha-2.5.3" // {
         dependencies = [
@@ -62682,7 +61978,7 @@ in
       (sources."nodemon-1.19.1" // {
         dependencies = [
           sources."debug-3.2.6"
-          sources."ms-2.1.1"
+          sources."ms-2.1.2"
           sources."supports-color-5.5.0"
         ];
       })
@@ -62721,7 +62017,7 @@ in
       (sources."path-loader-1.0.10" // {
         dependencies = [
           sources."debug-3.2.6"
-          sources."ms-2.1.1"
+          sources."ms-2.1.2"
           sources."qs-6.7.0"
           sources."superagent-3.8.3"
         ];
@@ -62734,7 +62030,7 @@ in
       sources."pify-3.0.0"
       sources."posix-character-classes-0.1.1"
       sources."prepend-http-1.0.4"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."pseudomap-1.0.2"
       sources."pstree.remy-1.1.7"
       sources."punycode-2.1.1"
@@ -62777,7 +62073,7 @@ in
         ];
       })
       sources."serve-static-1.14.1"
-      (sources."set-value-2.0.0" // {
+      (sources."set-value-2.0.1" // {
         dependencies = [
           sources."extend-shallow-2.0.1"
           sources."is-extendable-0.1.1"
@@ -62901,11 +62197,9 @@ in
         ];
       })
       sources."undefsafe-2.0.2"
-      (sources."union-value-1.0.0" // {
+      (sources."union-value-1.0.1" // {
         dependencies = [
-          sources."extend-shallow-2.0.1"
           sources."is-extendable-0.1.1"
-          sources."set-value-0.4.3"
         ];
       })
       sources."unique-string-1.0.0"
@@ -62958,17 +62252,17 @@ in
     bypassCache = true;
     reconstructLock = true;
   };
-  "tedicross-git+https://github.com/TediCross/TediCross.git#v0.8.7" = nodeEnv.buildNodePackage {
+  "tedicross-git+https://github.com/TediCross/TediCross.git#v0.9.1" = nodeEnv.buildNodePackage {
     name = "tedicross";
     packageName = "tedicross";
-    version = "0.8.7";
+    version = "0.9.1";
     src = fetchgit {
       url = "https://github.com/TediCross/TediCross.git";
-      rev = "80ec2189cbda51eec9f3cd3f7f551b7a71474d38";
-      sha256 = "886069ecc5eedf0371b948e8ff66e7f2943c85fe7cfdaa7183e1a3572d55852b";
+      rev = "ccd9826ac7b9cc0529972f7ac40f8bf5c8c30f04";
+      sha256 = "14bb8749a748699f383109af25e88b732bfeef15d80dff77adba9e746d7e06f9";
     };
     dependencies = [
-      sources."@types/node-12.0.4"
+      sources."@types/node-12.0.10"
       sources."ajv-6.10.0"
       sources."ansi-regex-4.1.0"
       sources."ansi-styles-3.2.1"
@@ -62991,7 +62285,6 @@ in
       sources."color-name-1.1.3"
       sources."combined-stream-1.0.8"
       sources."core-util-is-1.0.2"
-      sources."cross-spawn-6.0.5"
       sources."dashdash-1.14.1"
       sources."debug-4.1.1"
       sources."decamelize-1.2.0"
@@ -62999,9 +62292,7 @@ in
       sources."discord.js-11.5.1"
       sources."ecc-jsbn-0.1.2"
       sources."emoji-regex-7.0.3"
-      sources."end-of-stream-1.4.1"
       sources."esprima-4.0.1"
-      sources."execa-1.0.0"
       sources."extend-3.0.2"
       sources."extsprintf-1.3.0"
       sources."fast-deep-equal-2.0.1"
@@ -63010,16 +62301,12 @@ in
       sources."forever-agent-0.6.1"
       sources."form-data-2.3.3"
       sources."get-caller-file-2.0.5"
-      sources."get-stream-4.1.0"
       sources."getpass-0.1.7"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."http-signature-1.2.0"
-      sources."invert-kv-2.0.0"
       sources."is-fullwidth-code-point-2.0.0"
-      sources."is-stream-1.1.0"
       sources."is-typedarray-1.0.0"
-      sources."isexe-2.0.0"
       sources."isstream-0.1.2"
       sources."js-yaml-3.13.1"
       sources."jsbn-0.1.1"
@@ -63027,49 +62314,32 @@ in
       sources."json-schema-traverse-0.4.1"
       sources."json-stringify-safe-5.0.1"
       sources."jsprim-1.4.1"
-      sources."lcid-2.0.0"
       sources."locate-path-3.0.0"
       sources."long-4.0.0"
-      sources."map-age-cleaner-0.1.3"
-      sources."mem-4.3.0"
-      sources."mime-2.4.3"
+      sources."mime-2.4.4"
       sources."mime-db-1.40.0"
       sources."mime-types-2.1.24"
-      sources."mimic-fn-2.1.0"
       sources."moment-2.24.0"
-      sources."ms-2.1.1"
-      sources."nice-try-1.0.5"
+      sources."ms-2.1.2"
       sources."node-fetch-2.6.0"
-      sources."npm-run-path-2.0.2"
       sources."oauth-sign-0.9.0"
-      sources."once-1.4.0"
-      sources."os-locale-3.1.0"
-      sources."p-defer-1.0.0"
-      sources."p-finally-1.0.0"
-      sources."p-is-promise-2.1.0"
       sources."p-limit-2.2.0"
       sources."p-locate-3.0.0"
       sources."p-try-2.2.0"
       sources."path-exists-3.0.0"
-      sources."path-key-2.0.1"
       sources."performance-now-2.1.0"
       sources."prism-media-0.0.3"
-      sources."psl-1.1.32"
-      sources."pump-3.0.0"
+      sources."psl-1.1.33"
       sources."punycode-2.1.1"
       sources."qs-6.5.2"
-      sources."ramda-0.25.0"
+      sources."ramda-0.26.1"
       sources."request-2.88.0"
       sources."require-directory-2.1.1"
       sources."require-main-filename-2.0.0"
       sources."safe-buffer-5.1.2"
       sources."safer-buffer-2.1.2"
       sources."sandwich-stream-2.0.2"
-      sources."semver-5.7.0"
       sources."set-blocking-2.0.0"
-      sources."shebang-command-1.2.0"
-      sources."shebang-regex-1.0.0"
-      sources."signal-exit-3.0.2"
       sources."simple-markdown-0.4.4"
       sources."snekfetch-3.6.4"
       sources."sprintf-js-1.0.3"
@@ -63080,7 +62350,6 @@ in
       })
       sources."string-width-3.1.0"
       sources."strip-ansi-5.2.0"
-      sources."strip-eof-1.0.0"
       sources."telegraf-3.30.1"
       sources."telegram-typings-3.6.1"
       (sources."tough-cookie-2.4.3" // {
@@ -63093,14 +62362,12 @@ in
       sources."uri-js-4.2.2"
       sources."uuid-3.3.2"
       sources."verror-1.10.0"
-      sources."which-1.3.1"
       sources."which-module-2.0.0"
       sources."wrap-ansi-5.1.0"
-      sources."wrappy-1.0.2"
       sources."ws-6.2.1"
       sources."y18n-4.0.0"
-      sources."yargs-13.2.4"
-      sources."yargs-parser-13.1.0"
+      sources."yargs-13.3.0"
+      sources."yargs-parser-13.1.1"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -63131,16 +62398,16 @@ in
       sources."errno-0.1.7"
       sources."fs.realpath-1.0.0"
       sources."glob-7.1.4"
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."isarray-1.0.0"
       sources."memory-fs-0.3.0"
       sources."minimatch-3.0.4"
       sources."object-assign-4.1.1"
       sources."once-1.4.0"
       sources."path-is-absolute-1.0.1"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."prr-1.0.1"
       sources."readable-stream-2.3.6"
       sources."resolve-from-2.0.0"
@@ -63228,13 +62495,13 @@ in
       sources."function-bind-1.1.1"
       sources."get-stdin-5.0.1"
       sources."glob-7.1.4"
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."has-1.0.3"
       sources."has-ansi-2.0.0"
       sources."has-symbols-1.0.0"
       sources."hosted-git-info-2.7.1"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."interop-require-1.0.0"
       sources."is-alphabetical-1.0.3"
       sources."is-alphanumerical-1.0.3"
@@ -63273,7 +62540,7 @@ in
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
       sources."mkdirp-0.5.1"
-      sources."ms-2.1.1"
+      sources."ms-2.1.2"
       sources."normalize-package-data-2.5.0"
       sources."number-is-nan-1.0.1"
       sources."object-assign-4.1.1"
@@ -63295,7 +62562,7 @@ in
       sources."pinkie-promise-2.0.1"
       sources."pluralize-2.0.0"
       sources."prelude-ls-1.1.2"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       (sources."rc-config-loader-2.0.3" // {
         dependencies = [
           sources."debug-3.2.6"
@@ -63313,7 +62580,7 @@ in
         ];
       })
       sources."readable-stream-2.3.6"
-      sources."remark-frontmatter-1.3.1"
+      sources."remark-frontmatter-1.3.2"
       sources."remark-parse-5.0.0"
       sources."repeat-string-1.6.1"
       sources."replace-ext-1.0.0"
@@ -63484,7 +62751,7 @@ in
       sources."cross-spawn-5.1.0"
       sources."crypto-random-string-1.0.0"
       sources."currently-unhandled-0.4.1"
-      sources."cuss-1.15.0"
+      sources."cuss-1.16.0"
       sources."debug-0.8.1"
       sources."decamelize-1.2.0"
       sources."deep-extend-0.6.0"
@@ -63511,7 +62778,7 @@ in
       sources."glob-7.1.4"
       sources."global-dirs-0.1.1"
       sources."got-6.7.1"
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."has-flag-3.0.0"
       sources."hosted-git-info-2.7.1"
       sources."ignore-3.3.10"
@@ -63519,7 +62786,7 @@ in
       sources."imurmurhash-0.1.4"
       sources."indent-string-2.1.0"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."ini-1.3.5"
       sources."is-alphabetical-1.0.3"
       sources."is-alphanumerical-1.0.3"
@@ -63600,7 +62867,7 @@ in
       sources."pinkie-promise-2.0.1"
       sources."pluralize-7.0.0"
       sources."prepend-http-1.0.4"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."pseudomap-1.0.2"
       sources."pump-1.0.3"
       sources."pump-chain-1.0.0"
@@ -63612,10 +62879,10 @@ in
       sources."redent-1.0.0"
       sources."registry-auth-token-3.4.0"
       sources."registry-url-3.1.0"
-      sources."remark-frontmatter-1.3.1"
-      sources."remark-message-control-4.1.1"
+      sources."remark-frontmatter-1.3.2"
+      sources."remark-message-control-4.2.0"
       sources."remark-parse-4.0.0"
-      sources."remark-retext-3.1.2"
+      sources."remark-retext-3.1.3"
       sources."repeat-string-1.6.1"
       sources."repeating-2.0.1"
       sources."replace-ext-1.0.0"
@@ -63769,14 +63036,14 @@ in
   textlint-rule-diacritics = nodeEnv.buildNodePackage {
     name = "textlint-rule-diacritics";
     packageName = "textlint-rule-diacritics";
-    version = "0.0.2";
+    version = "1.0.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/textlint-rule-diacritics/-/textlint-rule-diacritics-0.0.2.tgz";
-      sha1 = "9998d2bcd9218edfc8d783db5a49948ca077b612";
+      url = "https://registry.npmjs.org/textlint-rule-diacritics/-/textlint-rule-diacritics-1.0.0.tgz";
+      sha512 = "hhJvDZzhV+sKD7walPQ4VmWkBw5o1T/lFLRsoDsAJF+LYhD89R5/L4yFVtxFRUkP9VZ5cvoUIPkYjZvkPEawTA==";
     };
     dependencies = [
       sources."match-casing-1.0.2"
-      sources."strip-json-comments-2.0.1"
+      sources."strip-json-comments-3.0.1"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -63801,10 +63068,10 @@ in
       sources."buffer-from-1.1.1"
       sources."concat-stream-1.6.2"
       sources."core-util-is-1.0.2"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."isarray-1.0.0"
       sources."object-assign-4.1.1"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."readable-stream-2.3.6"
       sources."safe-buffer-5.1.2"
       sources."sentence-splitter-2.3.2"
@@ -63839,9 +63106,9 @@ in
       sources."concat-stream-1.6.2"
       sources."core-util-is-1.0.2"
       sources."flatmap-0.0.3"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."isarray-1.0.0"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."readable-stream-2.3.6"
       sources."safe-buffer-5.1.2"
       sources."sentence-splitter-2.3.2"
@@ -63883,7 +63150,7 @@ in
       sources."function-bind-1.1.1"
       sources."has-1.0.3"
       sources."has-symbols-1.0.0"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."is-callable-1.1.4"
       sources."is-date-object-1.0.1"
       sources."is-regex-1.0.4"
@@ -63892,7 +63159,7 @@ in
       sources."object-assign-4.1.1"
       sources."object-keys-1.1.1"
       sources."object.values-1.1.0"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."readable-stream-2.3.6"
       sources."safe-buffer-5.1.2"
       sources."sentence-splitter-3.0.11"
@@ -63918,17 +63185,14 @@ in
   textlint-rule-period-in-list-item = nodeEnv.buildNodePackage {
     name = "textlint-rule-period-in-list-item";
     packageName = "textlint-rule-period-in-list-item";
-    version = "0.3.0";
+    version = "0.3.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/textlint-rule-period-in-list-item/-/textlint-rule-period-in-list-item-0.3.0.tgz";
-      sha512 = "yHTu24dDU8XPxEpQ6NJc4i8OYKiqHmch4XHCvzfrz8nsWaaIa82h5fDiUsMrzEctlXiWcbmNk6Sxbhq+UnHOvg==";
+      url = "https://registry.npmjs.org/textlint-rule-period-in-list-item/-/textlint-rule-period-in-list-item-0.3.1.tgz";
+      sha512 = "P96DkBVAymn/qCdzGVT4751xdxF4R7yY7Nj2jLkRxakEAOttU+YRLcSiHsIcVsH/3KoZW7pRdOLlMy5AUWw5rA==";
     };
     dependencies = [
       sources."array.prototype.find-2.1.0"
-      sources."boolbase-1.0.0"
       sources."check-ends-with-period-1.0.1"
-      sources."css-selector-parser-1.3.0"
-      sources."debug-2.6.9"
       sources."define-properties-1.1.3"
       sources."emoji-regex-6.5.1"
       sources."end-with-1.0.2"
@@ -63941,15 +63205,12 @@ in
       sources."is-date-object-1.0.1"
       sources."is-regex-1.0.4"
       sources."is-symbol-1.0.2"
-      sources."ms-2.0.0"
-      sources."nth-check-1.0.2"
       sources."object-keys-1.1.1"
-      sources."unist-util-select-1.5.0"
     ];
     buildInputs = globalBuildInputs;
     meta = {
       description = "textlint rule that check with or without period in list item.";
-      homepage = https://github.com/azu/textlint-rule-period-in-list-item;
+      homepage = https://github.com/textlint-rule/textlint-rule-period-in-list-item;
       license = "MIT";
     };
     production = true;
@@ -64092,10 +63353,10 @@ in
   three = nodeEnv.buildNodePackage {
     name = "three";
     packageName = "three";
-    version = "0.105.2";
+    version = "0.106.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/three/-/three-0.105.2.tgz";
-      sha512 = "L3Al37k4g3hVbgFFS251UVtIc25chhyN0/RvXzR0C+uIBToV6EKDG+MZzEXm9L2miGUVMK27W46/VkP6WUZXMg==";
+      url = "https://registry.npmjs.org/three/-/three-0.106.2.tgz";
+      sha512 = "4Tlx43uoxnIaZFW2Bzkd1rXsatvVHEWAZJy8LuE+s6Q8c66ogNnhfq1bHiBKPAnXP230LD11H/ScIZc2LZMviA==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -64173,7 +63434,7 @@ in
         ];
       })
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."is-absolute-0.1.7"
       sources."is-relative-0.1.3"
       sources."isarray-1.0.0"
@@ -64209,7 +63470,7 @@ in
       sources."once-1.3.2"
       sources."path-is-absolute-1.0.1"
       sources."precond-0.2.3"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."pseudomap-1.0.2"
       sources."read-1.0.7"
       sources."readable-stream-2.3.6"
@@ -64335,7 +63596,7 @@ in
       sources."strip-ansi-3.0.1"
       sources."supports-color-2.0.0"
       sources."temp-0.8.3"
-      sources."tslib-1.9.3"
+      sources."tslib-1.10.0"
       sources."wordwrap-0.0.3"
     ];
     buildInputs = globalBuildInputs;
@@ -64374,10 +63635,10 @@ in
   typescript = nodeEnv.buildNodePackage {
     name = "typescript";
     packageName = "typescript";
-    version = "3.5.1";
+    version = "3.5.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/typescript/-/typescript-3.5.1.tgz";
-      sha512 = "64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==";
+      url = "https://registry.npmjs.org/typescript/-/typescript-3.5.2.tgz";
+      sha512 = "7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -64402,7 +63663,7 @@ in
       sources."commander-2.20.0"
       sources."crypto-random-string-1.0.0"
       sources."fs-extra-7.0.1"
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."jsonfile-4.0.0"
       sources."p-debounce-1.0.0"
       sources."temp-dir-1.0.0"
@@ -64580,7 +63841,7 @@ in
           sources."statuses-1.4.0"
         ];
       })
-      (sources."express-session-1.16.1" // {
+      (sources."express-session-1.16.2" // {
         dependencies = [
           sources."depd-2.0.0"
         ];
@@ -64595,6 +63856,7 @@ in
       sources."eyes-0.1.8"
       sources."fast-deep-equal-2.0.1"
       sources."fast-json-stable-stringify-2.0.0"
+      sources."fast-safe-stringify-2.0.6"
       (sources."finalhandler-1.1.1" // {
         dependencies = [
           sources."statuses-1.4.0"
@@ -64613,7 +63875,7 @@ in
       sources."getmac-1.4.6"
       sources."getpass-0.1.7"
       sources."glob-7.1.4"
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       (sources."has-binary2-1.0.3" // {
@@ -64691,7 +63953,7 @@ in
           sources."semver-5.7.0"
         ];
       })
-      sources."npm-6.9.1-next.0"
+      sources."npm-6.9.2"
       (sources."npm-package-arg-6.1.0" // {
         dependencies = [
           sources."semver-5.7.0"
@@ -64741,10 +64003,10 @@ in
       sources."path-to-regexp-0.1.7"
       sources."pause-0.0.1"
       sources."performance-now-2.1.0"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."proxy-addr-2.0.5"
       sources."pseudomap-1.0.2"
-      sources."psl-1.1.32"
+      sources."psl-1.1.33"
       sources."pump-3.0.0"
       sources."punycode-2.1.1"
       sources."qs-6.7.0"
@@ -64791,7 +64053,7 @@ in
       (sources."socket.io-2.2.0" // {
         dependencies = [
           sources."debug-4.1.1"
-          sources."ms-2.1.1"
+          sources."ms-2.1.2"
         ];
       })
       sources."socket.io-adapter-1.1.1"
@@ -64819,13 +64081,14 @@ in
       sources."strip-ansi-3.0.1"
       sources."strip-eof-1.0.0"
       sources."strip-json-comments-2.0.1"
-      (sources."superagent-5.0.5" // {
+      (sources."superagent-5.0.9" // {
         dependencies = [
           sources."component-emitter-1.3.0"
           sources."debug-4.1.1"
-          sources."mime-2.4.3"
-          sources."ms-2.1.1"
+          sources."mime-2.4.4"
+          sources."ms-2.1.2"
           sources."readable-stream-3.4.0"
+          sources."semver-6.1.2"
         ];
       })
       sources."temp-0.9.0"
@@ -64877,7 +64140,7 @@ in
           sources."strip-ansi-5.2.0"
         ];
       })
-      sources."yargs-parser-13.1.0"
+      sources."yargs-parser-13.1.1"
       sources."yeast-0.1.2"
     ];
     buildInputs = globalBuildInputs;
@@ -65064,7 +64327,7 @@ in
       sources."git-clone-0.1.0"
       sources."glob-7.1.4"
       sources."got-6.7.1"
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."graceful-readlink-1.0.1"
       sources."gray-matter-2.1.1"
       sources."handlebars-4.1.2"
@@ -65083,9 +64346,9 @@ in
       sources."iconv-lite-0.4.24"
       sources."ieee754-1.1.13"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."ini-1.3.5"
-      sources."inquirer-6.3.1"
+      sources."inquirer-6.4.1"
       sources."is-3.3.0"
       sources."is-extendable-0.1.1"
       sources."is-fullwidth-code-point-2.0.0"
@@ -65154,9 +64417,9 @@ in
       sources."pinkie-2.0.4"
       sources."pinkie-promise-2.0.1"
       sources."prepend-http-1.0.4"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."proto-list-1.2.4"
-      sources."psl-1.1.32"
+      sources."psl-1.1.33"
       sources."punycode-2.1.1"
       sources."qs-6.5.2"
       sources."read-metadata-1.0.0"
@@ -65209,7 +64472,7 @@ in
         ];
       })
       sources."trim-repeated-1.0.0"
-      sources."tslib-1.9.3"
+      sources."tslib-1.10.0"
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       sources."uglify-js-3.6.0"
@@ -65247,10 +64510,10 @@ in
   "@vue/cli" = nodeEnv.buildNodePackage {
     name = "_at_vue_slash_cli";
     packageName = "@vue/cli";
-    version = "3.8.2";
+    version = "3.8.4";
     src = fetchurl {
-      url = "https://registry.npmjs.org/@vue/cli/-/cli-3.8.2.tgz";
-      sha512 = "owV/G5EmcgjO97cPwJSet2WGhWs30OQ/gWXqxDJNMqA7V+3pm/hc9Cn80yFa9bes3wehZJb72iUTOCeiytENPg==";
+      url = "https://registry.npmjs.org/@vue/cli/-/cli-3.8.4.tgz";
+      sha512 = "4853iVYjlYrIi/ilMlm3VJfmv8K+KbQEkI9Wb0/hsy2EZEek/zBEgAKZQwAYD52HpVQZ9Y/RSuzle2UwvRdbOQ==";
     };
     dependencies = [
       sources."@akryum/winattr-3.0.0"
@@ -65344,8 +64607,13 @@ in
       sources."@babel/types-7.4.4"
       sources."@hapi/address-2.0.0"
       sources."@hapi/hoek-6.2.4"
-      sources."@hapi/joi-15.0.3"
-      sources."@hapi/topo-3.1.0"
+      sources."@hapi/joi-15.1.0"
+      sources."@hapi/marker-1.0.0"
+      (sources."@hapi/topo-3.1.2" // {
+        dependencies = [
+          sources."@hapi/hoek-8.0.1"
+        ];
+      })
       sources."@mrmlnc/readdir-enhanced-2.2.1"
       sources."@nodelib/fs.stat-1.1.3"
       sources."@protobufjs/aspromise-1.1.2"
@@ -65363,26 +64631,27 @@ in
       sources."@types/connect-3.4.32"
       sources."@types/cors-2.8.5"
       sources."@types/events-3.0.0"
-      sources."@types/express-4.16.1"
-      sources."@types/express-serve-static-core-4.16.6"
+      sources."@types/express-4.17.0"
+      sources."@types/express-serve-static-core-4.16.7"
       sources."@types/glob-7.1.1"
       sources."@types/long-4.0.0"
       sources."@types/mime-2.0.1"
       sources."@types/minimatch-3.0.3"
-      sources."@types/node-12.0.4"
+      sources."@types/node-12.0.10"
       sources."@types/range-parser-1.2.3"
       sources."@types/serve-static-1.13.2"
       sources."@types/ws-6.0.1"
       sources."@types/zen-observable-0.8.0"
       sources."@vue/cli-shared-utils-3.8.0"
-      (sources."@vue/cli-ui-3.8.0" // {
+      (sources."@vue/cli-ui-3.8.4" // {
         dependencies = [
           sources."clone-2.1.2"
         ];
       })
-      sources."@vue/cli-ui-addon-webpack-3.8.0"
-      sources."@vue/cli-ui-addon-widgets-3.8.0"
-      sources."@wry/context-0.4.2"
+      sources."@vue/cli-ui-addon-webpack-3.8.4"
+      sources."@vue/cli-ui-addon-widgets-3.8.4"
+      sources."@wry/context-0.4.4"
+      sources."@wry/equality-0.1.9"
       sources."abbrev-1.1.1"
       sources."accepts-1.3.7"
       sources."aggregate-error-3.0.0"
@@ -65396,38 +64665,38 @@ in
           sources."normalize-path-2.1.1"
         ];
       })
-      sources."apollo-cache-1.3.1"
-      sources."apollo-cache-control-0.7.1"
-      sources."apollo-cache-inmemory-1.6.1"
-      sources."apollo-client-2.6.1"
+      sources."apollo-cache-1.3.2"
+      (sources."apollo-cache-control-0.7.4" // {
+        dependencies = [
+          sources."graphql-extensions-0.7.4"
+        ];
+      })
+      sources."apollo-cache-inmemory-1.6.2"
+      sources."apollo-client-2.6.3"
       sources."apollo-datasource-0.5.0"
-      sources."apollo-engine-reporting-1.2.1"
-      sources."apollo-engine-reporting-protobuf-0.3.0"
+      sources."apollo-engine-reporting-1.3.5"
+      sources."apollo-engine-reporting-protobuf-0.3.1"
       sources."apollo-env-0.5.1"
-      sources."apollo-graphql-0.3.1"
-      (sources."apollo-link-1.2.11" // {
-        dependencies = [
-          sources."ts-invariant-0.3.3"
-        ];
-      })
-      sources."apollo-link-context-1.0.17"
-      (sources."apollo-link-http-common-0.2.13" // {
-        dependencies = [
-          sources."ts-invariant-0.3.3"
-        ];
-      })
+      sources."apollo-graphql-0.3.3"
+      sources."apollo-link-1.2.12"
+      sources."apollo-link-context-1.0.18"
+      sources."apollo-link-http-common-0.2.14"
       sources."apollo-link-persisted-queries-0.2.2"
       sources."apollo-link-state-0.4.2"
-      sources."apollo-link-ws-1.0.17"
+      sources."apollo-link-ws-1.0.18"
       sources."apollo-server-caching-0.4.0"
-      sources."apollo-server-core-2.6.1"
+      sources."apollo-server-core-2.6.7"
       sources."apollo-server-env-2.4.0"
       sources."apollo-server-errors-2.3.0"
-      sources."apollo-server-express-2.6.1"
-      sources."apollo-server-plugin-base-0.5.1"
-      sources."apollo-tracing-0.7.1"
+      sources."apollo-server-express-2.6.7"
+      sources."apollo-server-plugin-base-0.5.6"
+      (sources."apollo-tracing-0.7.3" // {
+        dependencies = [
+          sources."graphql-extensions-0.7.4"
+        ];
+      })
       sources."apollo-upload-client-10.0.1"
-      sources."apollo-utilities-1.3.1"
+      sources."apollo-utilities-1.3.2"
       sources."arg-4.1.0"
       sources."argparse-1.0.10"
       sources."arr-diff-4.0.0"
@@ -65468,12 +64737,14 @@ in
       (sources."body-parser-1.19.0" // {
         dependencies = [
           sources."debug-2.6.9"
+          sources."http-errors-1.7.2"
+          sources."inherits-2.0.3"
         ];
       })
       sources."boxen-1.3.0"
       sources."brace-expansion-1.1.11"
       sources."braces-2.3.2"
-      sources."browserslist-4.6.1"
+      sources."browserslist-4.6.3"
       sources."buffer-5.2.1"
       sources."buffer-alloc-1.2.0"
       sources."buffer-alloc-unsafe-1.1.0"
@@ -65486,7 +64757,7 @@ in
       sources."cache-base-1.0.1"
       sources."call-me-maybe-1.0.1"
       sources."camelcase-4.1.0"
-      sources."caniuse-lite-1.0.30000973"
+      sources."caniuse-lite-1.0.30000978"
       sources."capture-stack-trace-1.0.1"
       sources."caseless-0.12.0"
       sources."caw-2.0.1"
@@ -65514,7 +64785,7 @@ in
       sources."clean-stack-2.1.0"
       sources."cli-boxes-1.0.0"
       sources."cli-cursor-2.1.0"
-      sources."cli-spinners-2.1.0"
+      sources."cli-spinners-2.2.0"
       sources."cli-width-2.2.0"
       sources."clipboard-2.0.4"
       sources."clone-1.0.4"
@@ -65536,9 +64807,9 @@ in
       sources."cookie-0.4.0"
       sources."cookie-signature-1.0.6"
       sources."copy-descriptor-0.1.1"
-      sources."core-js-3.1.3"
-      sources."core-js-compat-3.1.3"
-      sources."core-js-pure-3.1.3"
+      sources."core-js-3.1.4"
+      sources."core-js-compat-3.1.4"
+      sources."core-js-pure-3.1.4"
       sources."core-util-is-1.0.2"
       sources."cors-2.8.5"
       sources."create-error-class-3.0.2"
@@ -65553,7 +64824,7 @@ in
       sources."dashdash-1.14.1"
       (sources."debug-4.1.1" // {
         dependencies = [
-          sources."ms-2.1.1"
+          sources."ms-2.1.2"
         ];
       })
       sources."decode-uri-component-0.2.0"
@@ -65577,7 +64848,7 @@ in
         ];
       })
       sources."deep-extend-0.6.0"
-      sources."deepmerge-3.2.0"
+      sources."deepmerge-3.3.0"
       sources."defaults-1.0.3"
       sources."define-properties-1.1.3"
       sources."define-property-2.0.2"
@@ -65601,8 +64872,8 @@ in
       sources."easy-stack-1.0.0"
       sources."ecc-jsbn-0.1.2"
       sources."ee-first-1.1.1"
-      sources."ejs-2.6.1"
-      sources."electron-to-chromium-1.3.147"
+      sources."ejs-2.6.2"
+      sources."electron-to-chromium-1.3.176"
       sources."encodeurl-1.0.2"
       sources."end-of-stream-1.4.1"
       sources."entities-1.1.2"
@@ -65683,7 +64954,7 @@ in
       })
       sources."find-up-3.0.0"
       sources."fkill-6.2.0"
-      sources."flow-parser-0.100.0"
+      sources."flow-parser-0.102.0"
       sources."for-in-1.0.2"
       sources."forever-agent-0.6.1"
       sources."form-data-2.3.3"
@@ -65723,20 +64994,20 @@ in
       })
       sources."good-listener-1.2.2"
       sources."got-6.7.1"
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."graceful-readlink-1.0.1"
-      sources."graphql-14.3.1"
-      (sources."graphql-anywhere-4.2.3" // {
+      sources."graphql-14.4.1"
+      (sources."graphql-anywhere-4.2.4" // {
         dependencies = [
           sources."ts-invariant-0.3.3"
         ];
       })
-      sources."graphql-extensions-0.7.1"
+      sources."graphql-extensions-0.7.6"
       sources."graphql-subscriptions-1.1.0"
       sources."graphql-tag-2.10.1"
-      sources."graphql-tools-4.0.4"
+      sources."graphql-tools-4.0.5"
       sources."graphql-type-json-0.2.4"
-      sources."graphql-upload-8.0.6"
+      sources."graphql-upload-8.0.7"
       sources."growly-1.3.0"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
@@ -65753,7 +65024,7 @@ in
       })
       sources."hash.js-1.1.7"
       sources."homedir-polyfill-1.0.3"
-      sources."http-errors-1.7.2"
+      sources."http-errors-1.7.3"
       sources."http-signature-1.2.0"
       sources."iconv-lite-0.4.24"
       sources."ieee754-1.1.13"
@@ -65764,9 +65035,9 @@ in
       sources."imurmurhash-0.1.4"
       sources."indent-string-3.2.0"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."ini-1.3.5"
-      sources."inquirer-6.3.1"
+      sources."inquirer-6.4.1"
       sources."into-stream-2.0.1"
       sources."invariant-2.2.4"
       sources."ipaddr.js-1.9.0"
@@ -65805,7 +65076,7 @@ in
       sources."is-windows-1.0.2"
       sources."is-wsl-1.1.0"
       sources."isarray-1.0.0"
-      sources."isbinaryfile-4.0.0"
+      sources."isbinaryfile-4.0.1"
       sources."isexe-2.0.0"
       sources."isobject-3.0.1"
       sources."isstream-0.1.2"
@@ -65838,7 +65109,6 @@ in
       sources."locate-path-3.0.0"
       sources."lodash-4.17.11"
       sources."lodash.clonedeep-4.5.0"
-      sources."lodash.isequal-4.5.0"
       sources."lodash.merge-4.6.1"
       sources."lodash.sortby-4.7.0"
       sources."log-symbols-2.2.0"
@@ -65869,7 +65139,7 @@ in
       sources."minimalistic-assert-1.0.1"
       sources."minimatch-3.0.4"
       sources."minimist-1.2.0"
-      (sources."mixin-deep-1.3.1" // {
+      (sources."mixin-deep-1.3.2" // {
         dependencies = [
           sources."is-extendable-1.0.1"
         ];
@@ -65907,7 +65177,7 @@ in
           sources."semver-5.7.0"
         ];
       })
-      (sources."node-releases-1.1.23" // {
+      (sources."node-releases-1.1.24" // {
         dependencies = [
           sources."semver-5.7.0"
         ];
@@ -65915,7 +65185,7 @@ in
       (sources."nodemon-1.19.1" // {
         dependencies = [
           sources."debug-3.2.6"
-          sources."ms-2.1.1"
+          sources."ms-2.1.2"
           sources."semver-5.7.0"
         ];
       })
@@ -65947,7 +65217,7 @@ in
       sources."once-1.4.0"
       sources."onetime-2.0.1"
       sources."open-6.3.0"
-      sources."optimism-0.9.5"
+      sources."optimism-0.9.6"
       sources."ora-3.4.0"
       sources."os-tmpdir-1.0.2"
       sources."p-finally-1.0.0"
@@ -65993,23 +65263,28 @@ in
       sources."prismjs-1.16.0"
       sources."private-0.1.8"
       sources."process-exists-3.1.0"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."proto-list-1.2.4"
       (sources."protobufjs-6.8.8" // {
         dependencies = [
-          sources."@types/node-10.14.8"
+          sources."@types/node-10.14.10"
         ];
       })
       sources."proxy-addr-2.0.5"
       sources."ps-list-4.1.0"
       sources."pseudomap-1.0.2"
-      sources."psl-1.1.32"
+      sources."psl-1.1.33"
       sources."pstree.remy-1.1.7"
       sources."pump-3.0.0"
       sources."punycode-2.1.1"
       sources."qs-6.7.0"
       sources."range-parser-1.2.1"
-      sources."raw-body-2.4.0"
+      (sources."raw-body-2.4.0" // {
+        dependencies = [
+          sources."http-errors-1.7.2"
+          sources."inherits-2.0.3"
+        ];
+      })
       sources."rc-1.2.8"
       sources."readable-stream-2.3.6"
       sources."readdirp-2.2.1"
@@ -66068,7 +65343,7 @@ in
         ];
       })
       sources."select-1.1.2"
-      sources."semver-6.1.1"
+      sources."semver-6.1.2"
       (sources."semver-diff-2.1.0" // {
         dependencies = [
           sources."semver-5.7.0"
@@ -66085,7 +65360,7 @@ in
         ];
       })
       sources."serve-static-1.14.1"
-      sources."set-value-2.0.0"
+      sources."set-value-2.0.1"
       sources."setprototypeof-1.1.1"
       sources."sha.js-2.4.11"
       sources."shebang-command-1.2.0"
@@ -66226,13 +65501,13 @@ in
       })
       sources."trim-repeated-1.0.0"
       sources."trim-right-1.0.1"
-      sources."ts-invariant-0.4.2"
-      sources."ts-node-8.2.0"
-      sources."tslib-1.9.3"
+      sources."ts-invariant-0.4.4"
+      sources."ts-node-8.3.0"
+      sources."tslib-1.10.0"
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       sources."type-is-1.6.18"
-      sources."typescript-3.5.1"
+      sources."typescript-3.5.2"
       sources."unbzip2-stream-1.3.3"
       (sources."undefsafe-2.0.2" // {
         dependencies = [
@@ -66243,11 +65518,7 @@ in
       sources."unicode-match-property-ecmascript-1.0.4"
       sources."unicode-match-property-value-ecmascript-1.1.0"
       sources."unicode-property-aliases-ecmascript-1.0.5"
-      (sources."union-value-1.0.0" // {
-        dependencies = [
-          sources."set-value-0.4.3"
-        ];
-      })
+      sources."union-value-1.0.1"
       sources."unique-string-1.0.0"
       sources."universalify-0.1.2"
       sources."unpipe-1.0.0"
@@ -66297,7 +65568,7 @@ in
       sources."yauzl-2.10.0"
       sources."yn-3.1.0"
       sources."zen-observable-0.8.14"
-      sources."zen-observable-ts-0.8.18"
+      sources."zen-observable-ts-0.8.19"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -66312,26 +65583,26 @@ in
   vue-language-server = nodeEnv.buildNodePackage {
     name = "vue-language-server";
     packageName = "vue-language-server";
-    version = "0.0.56";
+    version = "0.0.57";
     src = fetchurl {
-      url = "https://registry.npmjs.org/vue-language-server/-/vue-language-server-0.0.56.tgz";
-      sha512 = "Tble0PmW2FXF85OKxa6pBagKBdFCLCxCuskIPtmK13mSETIChWdRsaAPJyCpG/NLR/hwObt5EjNdMt/sTk7VhA==";
+      url = "https://registry.npmjs.org/vue-language-server/-/vue-language-server-0.0.57.tgz";
+      sha512 = "o0CSn0HJdo1/ASh2nY9MZh/dZrq+U+fVfIL4XDL/VRMrFAyr9pPmhT9/pdRZlHPN46r05UhBfGQXnbeOOssguA==";
     };
     dependencies = [
       sources."@babel/code-frame-7.0.0"
       sources."@babel/highlight-7.0.0"
       sources."@emmetio/extract-abbreviation-0.1.6"
-      sources."@starptech/expression-parser-0.8.17"
-      sources."@starptech/hast-util-from-webparser-0.8.17"
-      sources."@starptech/prettyhtml-0.8.17"
-      sources."@starptech/prettyhtml-formatter-0.8.17"
-      sources."@starptech/prettyhtml-hast-to-html-0.8.17"
-      sources."@starptech/prettyhtml-hastscript-0.8.17"
-      sources."@starptech/prettyhtml-sort-attributes-0.8.17"
-      sources."@starptech/rehype-minify-whitespace-0.8.17"
-      sources."@starptech/rehype-webparser-0.8.17"
-      sources."@starptech/webparser-0.8.17"
-      sources."@types/node-12.0.4"
+      sources."@starptech/expression-parser-0.9.0"
+      sources."@starptech/hast-util-from-webparser-0.9.0"
+      sources."@starptech/prettyhtml-0.9.0"
+      sources."@starptech/prettyhtml-formatter-0.9.0"
+      sources."@starptech/prettyhtml-hast-to-html-0.9.0"
+      sources."@starptech/prettyhtml-hastscript-0.9.0"
+      sources."@starptech/prettyhtml-sort-attributes-0.9.0"
+      sources."@starptech/rehype-minify-whitespace-0.9.0"
+      sources."@starptech/rehype-webparser-0.9.0"
+      sources."@starptech/webparser-0.9.0"
+      sources."@types/node-12.0.10"
       sources."@types/unist-2.0.3"
       sources."@types/vfile-3.0.2"
       sources."@types/vfile-message-1.0.1"
@@ -66500,7 +65771,7 @@ in
           sources."ignore-4.0.6"
         ];
       })
-      (sources."eslint-plugin-vue-5.2.2" // {
+      (sources."eslint-plugin-vue-5.2.3" // {
         dependencies = [
           sources."debug-4.1.1"
           sources."espree-4.1.0"
@@ -66537,7 +65808,7 @@ in
       sources."fill-range-2.2.4"
       sources."find-up-2.1.0"
       sources."flat-cache-2.0.1"
-      sources."flatted-2.0.0"
+      sources."flatted-2.0.1"
       sources."fn-name-2.0.1"
       sources."for-in-1.0.2"
       sources."for-own-0.1.5"
@@ -66555,7 +65826,7 @@ in
       sources."global-dirs-0.1.1"
       sources."globals-11.12.0"
       sources."got-6.7.1"
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."gridsome-helper-json-1.0.3"
       sources."has-1.0.3"
       (sources."has-ansi-2.0.0" // {
@@ -66601,9 +65872,9 @@ in
       sources."imurmurhash-0.1.4"
       sources."indent-string-3.2.0"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."ini-1.3.5"
-      (sources."inquirer-6.3.1" // {
+      (sources."inquirer-6.4.1" // {
         dependencies = [
           sources."ansi-regex-4.1.0"
           sources."strip-ansi-5.2.0"
@@ -66692,7 +65963,7 @@ in
       sources."lodash.merge-4.6.1"
       sources."lodash.rest-4.0.5"
       sources."lodash.unescape-4.0.1"
-      sources."loglevel-1.6.2"
+      sources."loglevel-1.6.3"
       (sources."loglevel-colored-level-prefix-1.0.0" // {
         dependencies = [
           sources."ansi-regex-2.1.1"
@@ -66722,7 +65993,7 @@ in
       sources."minimatch-3.0.4"
       sources."minimist-1.2.0"
       sources."minimist-options-3.0.2"
-      (sources."mixin-deep-1.3.1" // {
+      (sources."mixin-deep-1.3.2" // {
         dependencies = [
           sources."is-extendable-1.0.1"
         ];
@@ -66733,7 +66004,7 @@ in
         ];
       })
       sources."mout-0.5.0"
-      sources."ms-2.1.1"
+      sources."ms-2.1.2"
       sources."mute-stream-0.0.7"
       sources."nan-2.14.0"
       (sources."nanomatch-1.2.13" // {
@@ -66818,7 +66089,7 @@ in
       sources."prelude-ls-1.1.2"
       sources."prepend-http-1.0.4"
       sources."preserve-0.2.0"
-      sources."prettier-1.17.1"
+      sources."prettier-1.18.2"
       (sources."prettier-eslint-8.8.2" // {
         dependencies = [
           sources."acorn-5.7.3"
@@ -66848,7 +66119,7 @@ in
         ];
       })
       sources."pretty-format-23.6.0"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."progress-2.0.3"
       sources."property-information-5.1.0"
       sources."proto-list-1.2.4"
@@ -66934,7 +66205,7 @@ in
       sources."regexpp-2.0.1"
       sources."registry-auth-token-3.4.0"
       sources."registry-url-3.1.0"
-      sources."rehype-sort-attribute-values-1.0.1"
+      sources."rehype-sort-attribute-values-2.0.1"
       (sources."remark-5.1.0" // {
         dependencies = [
           sources."unified-4.2.1"
@@ -66942,7 +66213,11 @@ in
         ];
       })
       sources."remark-parse-1.1.0"
-      sources."remark-stringify-1.1.0"
+      (sources."remark-stringify-1.1.0" // {
+        dependencies = [
+          sources."stringify-entities-1.3.2"
+        ];
+      })
       sources."remove-trailing-separator-1.1.0"
       sources."repeat-element-1.1.3"
       sources."repeat-string-1.6.1"
@@ -66971,7 +66246,7 @@ in
       sources."semver-5.7.0"
       sources."semver-diff-2.1.0"
       sources."set-blocking-1.0.0"
-      (sources."set-value-2.0.0" // {
+      (sources."set-value-2.0.1" // {
         dependencies = [
           sources."extend-shallow-2.0.1"
         ];
@@ -67042,7 +66317,7 @@ in
       })
       sources."string-width-2.1.1"
       sources."string_decoder-1.1.1"
-      sources."stringify-entities-1.3.2"
+      sources."stringify-entities-2.0.0"
       sources."strip-ansi-4.0.0"
       sources."strip-bom-3.0.0"
       sources."strip-eof-1.0.0"
@@ -67067,7 +66342,7 @@ in
       sources."stylus-supremacy-2.12.7"
       sources."supports-color-5.5.0"
       sources."symbol-0.2.3"
-      (sources."table-5.4.0" // {
+      (sources."table-5.4.1" // {
         dependencies = [
           sources."ansi-regex-4.1.0"
           sources."string-width-3.1.0"
@@ -67086,33 +66361,37 @@ in
           sources."is-number-3.0.0"
         ];
       })
-      sources."to-vfile-5.0.3"
+      (sources."to-vfile-5.0.3" // {
+        dependencies = [
+          sources."vfile-3.0.1"
+        ];
+      })
       sources."trim-0.0.1"
       sources."trim-newlines-2.0.0"
       sources."trim-trailing-lines-1.1.2"
       sources."trough-1.0.4"
-      sources."tslib-1.9.3"
+      sources."tslib-1.10.0"
       sources."type-check-0.3.2"
       sources."typedarray-0.0.6"
-      sources."typescript-3.5.1"
+      sources."typescript-3.5.2"
       (sources."typescript-eslint-parser-16.0.1" // {
         dependencies = [
           sources."semver-5.5.0"
         ];
       })
       sources."unherit-1.1.2"
-      sources."unified-7.1.0"
+      (sources."unified-7.1.0" // {
+        dependencies = [
+          sources."vfile-3.0.1"
+        ];
+      })
       (sources."unified-engine-6.0.1" // {
         dependencies = [
           sources."to-vfile-4.0.0"
+          sources."vfile-3.0.1"
         ];
       })
-      (sources."union-value-1.0.0" // {
-        dependencies = [
-          sources."extend-shallow-2.0.1"
-          sources."set-value-0.4.3"
-        ];
-      })
+      sources."union-value-1.0.1"
       sources."unique-string-1.0.0"
       sources."unist-util-find-1.0.1"
       sources."unist-util-inspect-4.1.4"
@@ -67147,7 +66426,12 @@ in
       sources."user-home-2.0.0"
       sources."util-deprecate-1.0.2"
       sources."validate-npm-package-license-3.0.4"
-      sources."vfile-3.0.1"
+      (sources."vfile-4.0.1" // {
+        dependencies = [
+          sources."unist-util-stringify-position-2.0.1"
+          sources."vfile-message-2.0.1"
+        ];
+      })
       sources."vfile-location-2.0.5"
       sources."vfile-message-1.1.1"
       (sources."vfile-reporter-5.1.2" // {
@@ -67157,20 +66441,16 @@ in
       })
       sources."vfile-sort-2.2.1"
       sources."vfile-statistics-1.1.3"
-      (sources."vscode-css-languageservice-4.0.2-next.4" // {
-        dependencies = [
-          sources."vscode-languageserver-types-3.14.0"
-        ];
-      })
+      sources."vscode-css-languageservice-4.0.2"
       (sources."vscode-emmet-helper-1.2.15" // {
         dependencies = [
           sources."vscode-languageserver-types-3.14.0"
         ];
       })
       sources."vscode-jsonrpc-4.1.0-next.2"
-      sources."vscode-languageserver-5.3.0-next.7"
-      sources."vscode-languageserver-protocol-3.15.0-next.5"
-      sources."vscode-languageserver-types-3.15.0-next.1"
+      sources."vscode-languageserver-5.3.0-next.8"
+      sources."vscode-languageserver-protocol-3.15.0-next.6"
+      sources."vscode-languageserver-types-3.15.0-next.2"
       sources."vscode-nls-4.1.1"
       sources."vscode-textbuffer-1.0.0"
       sources."vscode-uri-1.0.8"
@@ -67438,10 +66718,10 @@ in
   webpack = nodeEnv.buildNodePackage {
     name = "webpack";
     packageName = "webpack";
-    version = "4.33.0";
+    version = "4.35.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/webpack/-/webpack-4.33.0.tgz";
-      sha512 = "ggWMb0B2QUuYso6FPZKUohOgfm+Z0sVFs8WwWuSH1IAvkWs428VDNmOlAxvHGTB9Dm/qOB/qtE5cRx5y01clxw==";
+      url = "https://registry.npmjs.org/webpack/-/webpack-4.35.0.tgz";
+      sha512 = "M5hL3qpVvtr8d4YaJANbAQBc4uT01G33eDpl/psRTBCfjxFTihdhin1NtAKB1ruDwzeVdcsHHV3NX+QsAgOosw==";
     };
     dependencies = [
       sources."@webassemblyjs/ast-1.8.5"
@@ -67517,7 +66797,7 @@ in
       sources."buffer-from-1.1.1"
       sources."buffer-xor-1.0.3"
       sources."builtin-status-codes-3.0.0"
-      sources."cacache-11.3.2"
+      sources."cacache-11.3.3"
       sources."cache-base-1.0.1"
       sources."chokidar-2.1.6"
       sources."chownr-1.1.1"
@@ -67564,7 +66844,7 @@ in
       sources."diffie-hellman-5.0.3"
       sources."domain-browser-1.2.0"
       sources."duplexify-3.7.1"
-      sources."elliptic-6.4.1"
+      sources."elliptic-6.5.0"
       sources."emojis-list-2.1.0"
       sources."end-of-stream-1.4.1"
       sources."enhanced-resolve-4.1.0"
@@ -67627,7 +66907,7 @@ in
           sources."is-glob-3.1.0"
         ];
       })
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."has-value-1.0.0"
       (sources."has-values-1.0.0" // {
         dependencies = [
@@ -67641,9 +66921,8 @@ in
       sources."ieee754-1.1.13"
       sources."iferr-0.1.5"
       sources."imurmurhash-0.1.4"
-      sources."indexof-0.0.1"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."is-accessor-descriptor-1.0.0"
       sources."is-binary-path-1.0.1"
       sources."is-buffer-1.1.6"
@@ -67683,7 +66962,7 @@ in
       sources."minimatch-3.0.4"
       sources."minimist-1.2.0"
       sources."mississippi-3.0.0"
-      (sources."mixin-deep-1.3.1" // {
+      (sources."mixin-deep-1.3.2" // {
         dependencies = [
           sources."is-extendable-1.0.1"
         ];
@@ -67698,7 +66977,7 @@ in
       sources."nan-2.14.0"
       sources."nanomatch-1.2.13"
       sources."neo-async-2.6.1"
-      (sources."node-libs-browser-2.2.0" // {
+      (sources."node-libs-browser-2.2.1" // {
         dependencies = [
           sources."punycode-1.4.1"
         ];
@@ -67729,7 +67008,7 @@ in
       sources."parallel-transform-1.1.0"
       sources."parse-asn1-5.1.4"
       sources."pascalcase-0.1.1"
-      sources."path-browserify-0.0.0"
+      sources."path-browserify-0.0.1"
       sources."path-dirname-1.0.2"
       sources."path-exists-3.0.0"
       sources."path-is-absolute-1.0.1"
@@ -67738,7 +67017,7 @@ in
       sources."pkg-dir-3.0.0"
       sources."posix-character-classes-0.1.1"
       sources."process-0.11.10"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."promise-inflight-1.0.1"
       sources."prr-1.0.1"
       sources."public-encrypt-4.0.3"
@@ -67769,7 +67048,7 @@ in
       sources."schema-utils-1.0.0"
       sources."semver-5.7.0"
       sources."serialize-javascript-1.7.0"
-      (sources."set-value-2.0.0" // {
+      (sources."set-value-2.0.1" // {
         dependencies = [
           sources."extend-shallow-2.0.1"
         ];
@@ -67858,17 +67137,12 @@ in
       })
       sources."to-regex-3.0.2"
       sources."to-regex-range-2.1.1"
-      sources."tslib-1.9.3"
+      sources."tslib-1.10.0"
       sources."tty-browserify-0.0.0"
       sources."typedarray-0.0.6"
-      (sources."union-value-1.0.0" // {
-        dependencies = [
-          sources."extend-shallow-2.0.1"
-          sources."set-value-0.4.3"
-        ];
-      })
+      sources."union-value-1.0.1"
       sources."unique-filename-1.1.1"
-      sources."unique-slug-2.0.1"
+      sources."unique-slug-2.0.2"
       (sources."unset-value-1.0.0" // {
         dependencies = [
           (sources."has-value-0.3.1" // {
@@ -67888,9 +67162,13 @@ in
         ];
       })
       sources."use-3.1.1"
-      sources."util-0.11.1"
+      (sources."util-0.11.1" // {
+        dependencies = [
+          sources."inherits-2.0.3"
+        ];
+      })
       sources."util-deprecate-1.0.2"
-      sources."vm-browserify-0.0.4"
+      sources."vm-browserify-1.1.0"
       sources."watchpack-1.6.0"
       (sources."webpack-sources-1.3.0" // {
         dependencies = [
@@ -67916,13 +67194,13 @@ in
   webpack-cli = nodeEnv.buildNodePackage {
     name = "webpack-cli";
     packageName = "webpack-cli";
-    version = "3.3.2";
+    version = "3.3.5";
     src = fetchurl {
-      url = "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.2.tgz";
-      sha512 = "FLkobnaJJ+03j5eplxlI0TUxhGCOdfewspIGuvDVtpOlrAuKMFC57K42Ukxqs1tn8947/PM6tP95gQc0DCzRYA==";
+      url = "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.5.tgz";
+      sha512 = "w0j/s42c5UhchwTmV/45MLQnTVwRoaUTu9fM5LuyOd/8lFoCNCELDogFoecx5NzRUndO0yD/gF2b02XKMnmAWQ==";
     };
     dependencies = [
-      sources."ansi-regex-3.0.0"
+      sources."ansi-regex-4.1.0"
       sources."ansi-styles-3.2.1"
       sources."arr-diff-4.0.0"
       sources."arr-flatten-1.1.0"
@@ -67943,7 +67221,11 @@ in
       })
       sources."cache-base-1.0.1"
       sources."camelcase-5.3.1"
-      sources."chalk-2.4.2"
+      (sources."chalk-2.4.2" // {
+        dependencies = [
+          sources."supports-color-5.5.0"
+        ];
+      })
       (sources."class-utils-0.3.6" // {
         dependencies = [
           sources."define-property-0.2.5"
@@ -67961,8 +67243,7 @@ in
           sources."kind-of-5.1.0"
         ];
       })
-      sources."cliui-4.1.0"
-      sources."code-point-at-1.1.0"
+      sources."cliui-5.0.0"
       sources."collection-visit-1.0.0"
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
@@ -67975,6 +67256,7 @@ in
       sources."decode-uri-component-0.2.0"
       sources."define-property-2.0.2"
       sources."detect-file-1.0.0"
+      sources."emoji-regex-7.0.3"
       sources."emojis-list-2.1.0"
       sources."end-of-stream-1.4.1"
       sources."enhanced-resolve-4.1.0"
@@ -68017,15 +67299,19 @@ in
         ];
       })
       sources."find-up-3.0.0"
-      sources."findup-sync-2.0.0"
+      sources."findup-sync-3.0.0"
       sources."for-in-1.0.2"
       sources."fragment-cache-0.2.1"
-      sources."get-caller-file-1.0.3"
+      sources."get-caller-file-2.0.5"
       sources."get-stream-4.1.0"
       sources."get-value-2.0.6"
-      sources."global-modules-1.0.0"
+      (sources."global-modules-2.0.0" // {
+        dependencies = [
+          sources."global-prefix-3.0.0"
+        ];
+      })
       sources."global-prefix-1.0.2"
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."has-flag-3.0.0"
       sources."has-value-1.0.0"
       (sources."has-values-1.0.0" // {
@@ -68035,7 +67321,7 @@ in
       })
       sources."homedir-polyfill-1.0.3"
       sources."import-local-2.0.0"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."ini-1.3.5"
       sources."interpret-1.2.0"
       sources."invert-kv-2.0.0"
@@ -68045,8 +67331,8 @@ in
       sources."is-descriptor-1.0.2"
       sources."is-extendable-0.1.1"
       sources."is-extglob-2.1.1"
-      sources."is-fullwidth-code-point-1.0.0"
-      sources."is-glob-3.1.0"
+      sources."is-fullwidth-code-point-2.0.0"
+      sources."is-glob-4.0.1"
       (sources."is-number-3.0.0" // {
         dependencies = [
           sources."kind-of-3.2.2"
@@ -68071,7 +67357,7 @@ in
       sources."micromatch-3.1.10"
       sources."mimic-fn-2.1.0"
       sources."minimist-1.2.0"
-      (sources."mixin-deep-1.3.1" // {
+      (sources."mixin-deep-1.3.2" // {
         dependencies = [
           sources."is-extendable-1.0.1"
         ];
@@ -68080,7 +67366,6 @@ in
       sources."nanomatch-1.2.13"
       sources."nice-try-1.0.5"
       sources."npm-run-path-2.0.2"
-      sources."number-is-nan-1.0.1"
       (sources."object-copy-0.1.0" // {
         dependencies = [
           sources."define-property-0.2.5"
@@ -68110,7 +67395,7 @@ in
       sources."path-key-2.0.1"
       sources."pkg-dir-3.0.0"
       sources."posix-character-classes-0.1.1"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."prr-1.0.1"
       sources."pump-3.0.0"
       sources."readable-stream-2.3.6"
@@ -68118,9 +67403,13 @@ in
       sources."repeat-element-1.1.3"
       sources."repeat-string-1.6.1"
       sources."require-directory-2.1.1"
-      sources."require-main-filename-1.0.1"
+      sources."require-main-filename-2.0.0"
       sources."resolve-cwd-2.0.0"
-      sources."resolve-dir-1.0.1"
+      (sources."resolve-dir-1.0.1" // {
+        dependencies = [
+          sources."global-modules-1.0.0"
+        ];
+      })
       sources."resolve-from-3.0.0"
       sources."resolve-url-0.2.1"
       sources."ret-0.1.15"
@@ -68128,7 +67417,7 @@ in
       sources."safe-regex-1.1.0"
       sources."semver-5.7.0"
       sources."set-blocking-2.0.0"
-      (sources."set-value-2.0.0" // {
+      (sources."set-value-2.0.1" // {
         dependencies = [
           sources."extend-shallow-2.0.1"
         ];
@@ -68185,15 +67474,11 @@ in
           sources."kind-of-5.1.0"
         ];
       })
-      (sources."string-width-2.1.1" // {
-        dependencies = [
-          sources."is-fullwidth-code-point-2.0.0"
-        ];
-      })
+      sources."string-width-3.1.0"
       sources."string_decoder-1.1.1"
-      sources."strip-ansi-4.0.0"
+      sources."strip-ansi-5.2.0"
       sources."strip-eof-1.0.0"
-      sources."supports-color-5.5.0"
+      sources."supports-color-6.1.0"
       sources."tapable-1.1.3"
       (sources."to-object-path-0.3.0" // {
         dependencies = [
@@ -68202,12 +67487,7 @@ in
       })
       sources."to-regex-3.0.2"
       sources."to-regex-range-2.1.1"
-      (sources."union-value-1.0.0" // {
-        dependencies = [
-          sources."extend-shallow-2.0.1"
-          sources."set-value-0.4.3"
-        ];
-      })
+      sources."union-value-1.0.1"
       (sources."unset-value-1.0.0" // {
         dependencies = [
           (sources."has-value-0.3.1" // {
@@ -68224,17 +67504,11 @@ in
       sources."v8-compile-cache-2.0.3"
       sources."which-1.3.1"
       sources."which-module-2.0.0"
-      (sources."wrap-ansi-2.1.0" // {
-        dependencies = [
-          sources."ansi-regex-2.1.1"
-          sources."string-width-1.0.2"
-          sources."strip-ansi-3.0.1"
-        ];
-      })
+      sources."wrap-ansi-5.1.0"
       sources."wrappy-1.0.2"
       sources."y18n-4.0.0"
-      sources."yargs-12.0.5"
-      sources."yargs-parser-11.1.1"
+      sources."yargs-13.2.4"
+      sources."yargs-parser-13.1.1"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -68249,10 +67523,10 @@ in
   webtorrent-cli = nodeEnv.buildNodePackage {
     name = "webtorrent-cli";
     packageName = "webtorrent-cli";
-    version = "1.12.3";
+    version = "2.0.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/webtorrent-cli/-/webtorrent-cli-1.12.3.tgz";
-      sha512 = "NnBAGkD64CRsl9edM9q0QU+ku6nCX32nM0U+YC8Gs/36c8y+5m9Tya3mWIux3oZKZ54yGiVtnok4tUpqDE5tMA==";
+      url = "https://registry.npmjs.org/webtorrent-cli/-/webtorrent-cli-2.0.0.tgz";
+      sha512 = "ohJpPjMtLMjsxi3Cgj+xmGTkuM6Eb58Ik5Esd/xsMSrgXI9IEwbSnlT4D1/FTypCrjDbWVdl68u0zNeTNiQ5FQ==";
     };
     dependencies = [
       sources."addr-to-ip-port-1.5.1"
@@ -68266,21 +67540,21 @@ in
       (sources."bittorrent-dht-9.0.0" // {
         dependencies = [
           sources."debug-3.2.6"
-          sources."ms-2.1.1"
+          sources."ms-2.1.2"
         ];
       })
       sources."bittorrent-peerid-1.3.0"
       (sources."bittorrent-protocol-3.0.1" // {
         dependencies = [
           sources."debug-3.2.6"
-          sources."ms-2.1.1"
+          sources."ms-2.1.2"
           sources."readable-stream-2.3.6"
         ];
       })
       (sources."bittorrent-tracker-9.11.0" // {
         dependencies = [
           sources."debug-4.1.1"
-          sources."ms-2.1.1"
+          sources."ms-2.1.2"
           sources."simple-get-3.0.3"
         ];
       })
@@ -68304,16 +67578,13 @@ in
       sources."bytebuffer-3.5.5"
       sources."castv2-0.1.9"
       sources."castv2-client-1.2.0"
+      sources."charset-1.0.1"
       (sources."chromecasts-1.9.1" // {
         dependencies = [
           sources."mime-1.6.0"
         ];
       })
-      (sources."chunk-store-stream-3.0.1" // {
-        dependencies = [
-          sources."readable-stream-2.3.6"
-        ];
-      })
+      sources."chunk-store-stream-4.0.0"
       sources."clivas-0.2.0"
       sources."closest-to-2.0.0"
       sources."colour-0.7.1"
@@ -68325,7 +67596,7 @@ in
         ];
       })
       sources."core-util-is-1.0.2"
-      sources."create-torrent-3.33.0"
+      sources."create-torrent-4.0.0"
       sources."debug-2.6.9"
       sources."decompress-response-3.3.0"
       sources."defined-1.0.0"
@@ -68336,11 +67607,8 @@ in
       })
       sources."dns-packet-1.3.1"
       sources."dns-txt-2.0.2"
-      (sources."ecstatic-3.3.2" // {
-        dependencies = [
-          sources."mime-1.6.0"
-        ];
-      })
+      sources."ecstatic-4.1.2"
+      sources."ee-first-1.1.1"
       sources."elementtree-0.1.7"
       sources."end-of-stream-1.4.1"
       sources."executable-4.1.1"
@@ -68362,15 +67630,16 @@ in
       sources."he-1.2.0"
       sources."immediate-chunk-store-2.0.0"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."ip-1.1.5"
       sources."ip-set-1.0.2"
       sources."ipaddr.js-1.9.0"
       sources."is-ascii-1.0.0"
       sources."is-file-1.0.0"
       sources."is-typedarray-1.0.0"
+      sources."is-wsl-1.1.0"
       sources."isarray-1.0.0"
-      sources."junk-2.1.0"
+      sources."junk-3.1.0"
       sources."k-bucket-5.0.0"
       (sources."k-rpc-5.0.0" // {
         dependencies = [
@@ -68391,7 +67660,7 @@ in
       sources."mdns-js-packet-0.2.0"
       sources."mediasource-2.3.0"
       sources."memory-chunk-store-1.3.0"
-      sources."mime-2.4.3"
+      sources."mime-2.4.4"
       sources."mimic-response-1.0.1"
       sources."minimatch-3.0.4"
       sources."minimist-1.2.0"
@@ -68402,30 +67671,23 @@ in
       })
       sources."moment-2.24.0"
       sources."mp4-box-encoding-1.3.0"
-      (sources."mp4-stream-2.0.3" // {
-        dependencies = [
-          sources."readable-stream-2.3.6"
-        ];
-      })
+      sources."mp4-stream-3.0.0"
       sources."ms-2.0.0"
       (sources."multicast-dns-6.2.3" // {
         dependencies = [
           sources."thunky-1.0.3"
         ];
       })
-      (sources."multistream-2.1.1" // {
-        dependencies = [
-          sources."readable-stream-2.3.6"
-        ];
-      })
+      sources."multistream-3.0.0"
       sources."netmask-1.0.6"
       sources."network-address-1.1.2"
       sources."next-event-1.0.0"
       sources."node-gyp-build-3.7.0"
       sources."node-ssdp-2.9.1"
       sources."nodebmc-0.0.7"
+      sources."on-finished-2.3.0"
       sources."once-1.4.0"
-      sources."open-0.0.5"
+      sources."opn-6.0.0"
       sources."optjs-3.2.2"
       sources."package-json-versionify-1.0.4"
       sources."parse-numeric-range-0.0.2"
@@ -68443,22 +67705,22 @@ in
         ];
       })
       sources."prettier-bytes-1.0.4"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."protobufjs-3.8.2"
       sources."pump-3.0.0"
       sources."qap-3.3.1"
-      sources."random-access-file-2.1.2"
-      sources."random-access-storage-1.3.0"
+      sources."random-access-file-2.1.3"
+      sources."random-access-storage-1.4.0"
       sources."random-iterate-1.0.1"
       sources."randombytes-2.1.0"
       sources."range-parser-1.2.1"
       sources."range-slice-stream-2.0.0"
       sources."readable-stream-3.4.0"
       sources."record-cache-1.1.0"
-      (sources."render-media-3.1.3" // {
+      (sources."render-media-3.2.0" // {
         dependencies = [
-          sources."debug-3.2.6"
-          sources."ms-2.1.1"
+          sources."debug-4.1.1"
+          sources."ms-2.1.2"
         ];
       })
       sources."rimraf-2.6.3"
@@ -68471,10 +67733,10 @@ in
       sources."semver-5.1.1"
       sources."simple-concat-1.0.0"
       sources."simple-get-2.8.1"
-      (sources."simple-peer-9.3.0" // {
+      (sources."simple-peer-9.4.0" // {
         dependencies = [
           sources."debug-4.1.1"
-          sources."ms-2.1.1"
+          sources."ms-2.1.2"
           sources."readable-stream-2.3.6"
         ];
       })
@@ -68482,15 +67744,15 @@ in
       (sources."simple-websocket-7.2.0" // {
         dependencies = [
           sources."debug-3.2.6"
-          sources."ms-2.1.1"
+          sources."ms-2.1.2"
           sources."readable-stream-2.3.6"
         ];
       })
       sources."speedometer-1.1.0"
       sources."split-1.0.1"
-      sources."stream-to-blob-1.0.1"
-      sources."stream-to-blob-url-2.1.1"
-      sources."stream-with-known-length-to-buffer-1.0.2"
+      sources."stream-to-blob-1.0.2"
+      sources."stream-to-blob-url-2.1.2"
+      sources."stream-with-known-length-to-buffer-1.0.3"
       sources."string2compact-1.3.0"
       sources."string_decoder-1.1.1"
       sources."thirty-two-1.0.2"
@@ -68500,7 +67762,7 @@ in
       (sources."torrent-discovery-9.1.1" // {
         dependencies = [
           sources."debug-3.2.6"
-          sources."ms-2.1.1"
+          sources."ms-2.1.2"
         ];
       })
       sources."torrent-piece-2.0.0"
@@ -68511,22 +67773,22 @@ in
       sources."unordered-array-remove-1.0.2"
       sources."upnp-device-client-1.0.2"
       sources."upnp-mediarenderer-client-1.2.4"
-      sources."url-join-2.0.5"
+      sources."url-join-4.0.0"
       (sources."ut_metadata-3.3.0" // {
         dependencies = [
           sources."debug-3.2.6"
-          sources."ms-2.1.1"
+          sources."ms-2.1.2"
         ];
       })
       sources."ut_pex-1.2.1"
       sources."utf-8-validate-5.0.2"
       sources."util-deprecate-1.0.2"
-      sources."videostream-2.6.0"
+      sources."videostream-3.2.0"
       sources."vlc-command-1.1.2"
-      (sources."webtorrent-0.103.1" // {
+      (sources."webtorrent-0.104.0" // {
         dependencies = [
           sources."debug-4.1.1"
-          sources."ms-2.1.1"
+          sources."ms-2.1.2"
           sources."simple-get-3.0.3"
         ];
       })
@@ -68551,85 +67813,93 @@ in
   web-ext = nodeEnv.buildNodePackage {
     name = "web-ext";
     packageName = "web-ext";
-    version = "3.0.0";
+    version = "3.1.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/web-ext/-/web-ext-3.0.0.tgz";
-      sha512 = "pUT2YYSnECH/SqKXB0m92HWzAAOt97wJpkSHu7AddyxzclN3R9A2IHq+KUzaXEjiwWzVs/+yUOSpmuwCDouNNg==";
+      url = "https://registry.npmjs.org/web-ext/-/web-ext-3.1.0.tgz";
+      sha512 = "uuJRuAJFHJqHKkfHcZcSPb0ceOsVf/EoLJHynAgFOMxCIPAjbnq7gWT2e792hTpQEMXZE7XsXIeXwqogjLxofA==";
     };
     dependencies = [
       sources."@babel/code-frame-7.0.0"
       sources."@babel/highlight-7.0.0"
-      sources."@babel/polyfill-7.2.5"
-      sources."@babel/runtime-7.3.1"
+      sources."@babel/polyfill-7.4.4"
+      sources."@babel/runtime-7.4.5"
+      sources."@babel/runtime-corejs2-7.4.5"
       sources."@cliqz-oss/firefox-client-0.3.1"
       sources."@cliqz-oss/node-firefox-connect-1.2.1"
-      sources."@types/node-12.0.4"
+      sources."@sindresorhus/is-0.14.0"
+      sources."@snyk/composer-lockfile-parser-1.0.2"
+      sources."@snyk/dep-graph-1.8.1"
+      sources."@snyk/gemfile-1.2.0"
+      sources."@szmarczak/http-timer-1.1.2"
+      sources."@types/agent-base-4.2.0"
+      sources."@types/debug-4.1.4"
+      sources."@types/events-3.0.0"
+      sources."@types/minimatch-3.0.3"
+      sources."@types/node-12.0.10"
+      sources."@types/sinon-7.0.11"
+      sources."@yarnpkg/lockfile-1.1.0"
       sources."JSONSelect-0.2.1"
+      sources."abbrev-1.1.1"
       sources."acorn-5.7.3"
       (sources."acorn-jsx-3.0.1" // {
         dependencies = [
           sources."acorn-3.3.0"
         ];
       })
-      sources."adbkit-2.11.0"
+      sources."adbkit-2.11.1"
       sources."adbkit-logcat-1.1.0"
       sources."adbkit-monkey-1.0.1"
-      (sources."addons-linter-1.6.1" // {
+      sources."addons-linter-1.10.0"
+      sources."adm-zip-0.4.13"
+      (sources."agent-base-4.3.0" // {
         dependencies = [
-          sources."ansi-regex-4.1.0"
-          sources."camelcase-5.3.1"
-          sources."decamelize-1.2.0"
-          sources."es6-promisify-6.0.1"
-          sources."get-caller-file-2.0.5"
-          sources."is-fullwidth-code-point-2.0.0"
-          sources."regenerator-runtime-0.13.1"
-          sources."require-main-filename-2.0.0"
-          sources."source-map-support-0.5.10"
-          sources."string-width-3.1.0"
-          sources."strip-ansi-5.2.0"
-          sources."yargs-13.1.0"
-          sources."yargs-parser-13.1.0"
+          sources."es6-promise-4.2.8"
+          sources."es6-promisify-5.0.0"
         ];
       })
-      sources."adm-zip-0.4.13"
-      sources."ajv-6.9.1"
+      sources."ajv-6.10.0"
       sources."ajv-keywords-1.5.1"
       sources."ajv-merge-patch-4.1.0"
       sources."ansi-align-2.0.0"
-      sources."ansi-escapes-3.2.0"
+      sources."ansi-escapes-4.2.0"
       sources."ansi-regex-2.1.1"
       sources."ansi-styles-3.2.1"
+      sources."ansicolors-0.3.2"
       sources."any-promise-1.3.0"
       sources."anymatch-2.0.0"
       (sources."archiver-2.1.1" // {
         dependencies = [
           sources."async-2.6.2"
+          sources."isarray-1.0.0"
           sources."readable-stream-2.3.6"
           sources."string_decoder-1.1.1"
         ];
       })
       (sources."archiver-utils-1.3.0" // {
         dependencies = [
+          sources."isarray-1.0.0"
           sources."readable-stream-2.3.6"
           sources."string_decoder-1.1.1"
         ];
       })
+      sources."archy-1.0.0"
       sources."argparse-1.0.10"
       sources."arr-diff-4.0.0"
       sources."arr-flatten-1.1.0"
       sources."arr-union-3.1.0"
-      sources."array-differ-1.0.0"
+      sources."array-differ-3.0.0"
       sources."array-filter-0.0.1"
       sources."array-from-2.1.1"
       sources."array-map-0.0.0"
       sources."array-reduce-0.0.0"
-      sources."array-union-1.0.2"
-      sources."array-uniq-1.0.3"
+      sources."array-union-2.1.0"
       sources."array-unique-0.3.2"
-      sources."arrify-1.0.1"
+      sources."arrify-2.0.1"
+      sources."asap-2.0.6"
       sources."asn1-0.2.4"
       sources."assert-plus-1.0.0"
       sources."assign-symbols-1.0.0"
+      sources."ast-types-0.13.2"
       sources."astral-regex-1.0.0"
       sources."async-0.2.10"
       sources."async-each-1.0.3"
@@ -68666,18 +67936,22 @@ in
       sources."binary-extensions-1.13.1"
       (sources."bl-1.2.2" // {
         dependencies = [
+          sources."isarray-1.0.0"
           sources."readable-stream-2.3.6"
           sources."string_decoder-1.1.1"
         ];
       })
       sources."bluebird-2.9.34"
       sources."boolbase-1.0.0"
-      sources."boxen-1.3.0"
+      (sources."boxen-1.3.0" // {
+        dependencies = [
+          sources."camelcase-4.1.0"
+        ];
+      })
       sources."brace-expansion-1.1.11"
       (sources."braces-2.3.2" // {
         dependencies = [
           sources."extend-shallow-2.0.1"
-          sources."is-extendable-0.1.1"
         ];
       })
       sources."buffer-5.2.1"
@@ -68688,26 +67962,34 @@ in
       sources."buffer-fill-1.0.0"
       sources."buffer-from-1.1.1"
       sources."bunyan-1.8.12"
+      sources."bytes-3.1.0"
       sources."cache-base-1.0.1"
+      (sources."cacheable-request-6.1.0" // {
+        dependencies = [
+          sources."get-stream-5.1.0"
+          sources."lowercase-keys-2.0.0"
+          sources."normalize-url-4.3.0"
+        ];
+      })
       (sources."caller-path-0.1.0" // {
         dependencies = [
           sources."callsites-0.2.0"
         ];
       })
       sources."callsites-3.1.0"
-      sources."camelcase-4.1.0"
+      sources."camelcase-5.3.1"
       sources."capture-stack-trace-1.0.1"
       sources."caseless-0.12.0"
       sources."chalk-2.4.2"
       sources."chardet-0.7.0"
-      sources."cheerio-1.0.0-rc.2"
+      sources."cheerio-1.0.0-rc.3"
       (sources."chokidar-2.1.6" // {
         dependencies = [
           sources."fsevents-1.2.9"
           sources."normalize-path-3.0.0"
-          sources."upath-1.1.2"
         ];
       })
+      sources."ci-info-1.6.0"
       sources."circular-json-0.3.3"
       (sources."class-utils-0.3.6" // {
         dependencies = [
@@ -68729,13 +68011,15 @@ in
       sources."cli-boxes-1.0.0"
       sources."cli-cursor-2.1.0"
       sources."cli-width-2.2.0"
-      (sources."cliui-4.1.0" // {
+      (sources."cliui-3.2.0" // {
         dependencies = [
-          sources."ansi-regex-3.0.0"
-          sources."strip-ansi-4.0.0"
+          sources."is-fullwidth-code-point-1.0.0"
+          sources."string-width-1.0.2"
         ];
       })
       sources."clone-1.0.4"
+      sources."clone-deep-0.3.0"
+      sources."clone-response-1.0.2"
       sources."co-4.6.0"
       sources."code-point-at-1.1.0"
       sources."collection-visit-1.0.0"
@@ -68749,6 +68033,7 @@ in
       sources."component-emitter-1.3.0"
       (sources."compress-commons-1.2.2" // {
         dependencies = [
+          sources."isarray-1.0.0"
           sources."readable-stream-2.3.6"
           sources."string_decoder-1.1.1"
         ];
@@ -68756,6 +68041,7 @@ in
       sources."concat-map-0.0.1"
       (sources."concat-stream-1.6.2" // {
         dependencies = [
+          sources."isarray-1.0.0"
           sources."readable-stream-2.3.6"
           sources."string_decoder-1.1.1"
         ];
@@ -68767,39 +68053,60 @@ in
       sources."crc-3.8.0"
       (sources."crc32-stream-2.0.0" // {
         dependencies = [
+          sources."isarray-1.0.0"
           sources."readable-stream-2.3.6"
           sources."string_decoder-1.1.1"
         ];
       })
       sources."create-error-class-3.0.2"
-      sources."cross-spawn-6.0.5"
+      (sources."cross-spawn-6.0.5" // {
+        dependencies = [
+          sources."semver-5.7.0"
+        ];
+      })
       sources."crx-parser-0.1.2"
       sources."crypto-random-string-1.0.0"
       sources."css-select-1.2.0"
       sources."css-what-2.1.3"
-      sources."d-1.0.0"
+      sources."d-1.0.1"
       sources."dashdash-1.14.1"
-      sources."debounce-1.1.0"
+      (sources."data-uri-to-buffer-2.0.1" // {
+        dependencies = [
+          sources."@types/node-8.10.49"
+        ];
+      })
+      sources."debounce-1.2.0"
       sources."debug-2.6.9"
-      sources."decamelize-2.0.0"
+      (sources."decamelize-3.2.0" // {
+        dependencies = [
+          sources."xregexp-4.2.4"
+        ];
+      })
       sources."decode-uri-component-0.2.0"
+      sources."decompress-response-3.3.0"
       sources."deep-equal-1.0.1"
       sources."deep-extend-0.6.0"
       sources."deep-is-0.1.3"
       sources."deepcopy-0.6.3"
-      sources."deepmerge-3.1.0"
+      sources."deepmerge-3.2.0"
       sources."defaults-1.0.3"
+      sources."defer-to-connect-1.0.2"
       sources."define-property-2.0.2"
-      sources."delayed-stream-1.0.0"
-      (sources."dispensary-0.30.0" // {
+      (sources."degenerator-1.0.4" // {
         dependencies = [
-          sources."async-2.6.2"
-          sources."decamelize-1.2.0"
-          sources."source-map-support-0.5.12"
-          sources."yargs-12.0.5"
+          sources."esprima-3.1.3"
         ];
       })
-      sources."doctrine-2.1.0"
+      sources."delayed-stream-1.0.0"
+      sources."depd-1.1.2"
+      sources."diff-4.0.1"
+      (sources."dispensary-0.37.0" // {
+        dependencies = [
+          sources."async-3.0.1"
+        ];
+      })
+      sources."dockerfile-ast-0.0.16"
+      sources."doctrine-3.0.0"
       sources."dom-serializer-0.1.1"
       sources."domelementtype-1.3.1"
       sources."domhandler-2.4.2"
@@ -68809,6 +68116,7 @@ in
       sources."duplexer3-0.1.4"
       sources."ecc-jsbn-0.1.2"
       sources."ecdsa-sig-formatter-1.0.11"
+      sources."email-validator-2.0.4"
       sources."emoji-regex-7.0.3"
       sources."encoding-0.1.12"
       sources."end-of-stream-1.4.1"
@@ -68819,22 +68127,25 @@ in
       sources."es6-iterator-2.0.3"
       sources."es6-map-0.1.5"
       sources."es6-promise-2.3.0"
-      (sources."es6-promisify-5.0.0" // {
-        dependencies = [
-          sources."es6-promise-4.2.6"
-        ];
-      })
+      sources."es6-promisify-6.0.1"
       sources."es6-set-0.1.5"
       sources."es6-symbol-3.1.1"
-      sources."es6-weak-map-2.0.2"
+      sources."es6-weak-map-2.0.3"
       sources."escape-string-regexp-1.0.5"
+      (sources."escodegen-1.11.1" // {
+        dependencies = [
+          sources."esprima-3.1.3"
+        ];
+      })
       sources."escope-3.6.0"
-      (sources."eslint-5.13.0" // {
+      (sources."eslint-5.16.0" // {
         dependencies = [
           sources."ansi-regex-3.0.0"
           sources."debug-4.1.1"
-          sources."ms-2.1.1"
+          sources."ms-2.1.2"
+          sources."semver-5.7.0"
           sources."strip-ansi-4.0.0"
+          sources."strip-json-comments-2.0.1"
         ];
       })
       (sources."eslint-plugin-no-unsafe-innerhtml-1.0.16" // {
@@ -68845,38 +68156,46 @@ in
           sources."ansi-styles-2.2.1"
           sources."chalk-1.1.3"
           sources."cli-cursor-1.0.2"
+          sources."doctrine-2.1.0"
           sources."eslint-3.19.0"
           sources."espree-3.5.4"
           sources."figures-1.7.0"
+          sources."file-entry-cache-2.0.0"
+          sources."flat-cache-1.3.4"
           sources."globals-9.18.0"
           sources."ignore-3.3.10"
           sources."inquirer-0.12.0"
-          sources."is-fullwidth-code-point-2.0.0"
+          sources."is-fullwidth-code-point-1.0.0"
           sources."onetime-1.1.0"
           sources."progress-1.1.8"
+          sources."require-uncached-1.0.3"
+          sources."resolve-from-1.0.1"
           sources."restore-cursor-1.0.1"
           sources."run-async-0.1.0"
           sources."slice-ansi-0.0.4"
           sources."string-width-1.0.2"
           sources."strip-ansi-4.0.0"
+          sources."strip-json-comments-2.0.1"
           sources."supports-color-2.0.0"
           (sources."table-3.8.3" // {
             dependencies = [
+              sources."is-fullwidth-code-point-2.0.0"
               sources."string-width-2.1.1"
             ];
           })
+          sources."write-0.2.1"
         ];
       })
       sources."eslint-scope-4.0.3"
       sources."eslint-utils-1.3.1"
       sources."eslint-visitor-keys-1.0.0"
-      (sources."espree-5.0.0" // {
+      (sources."espree-5.0.1" // {
         dependencies = [
           sources."acorn-6.1.1"
           sources."acorn-jsx-5.0.1"
         ];
       })
-      sources."esprima-3.1.3"
+      sources."esprima-4.0.1"
       sources."esquery-1.0.1"
       sources."esrecurse-4.2.1"
       sources."estraverse-4.2.0"
@@ -68900,18 +68219,24 @@ in
             ];
           })
           sources."is-descriptor-0.1.6"
-          sources."is-extendable-0.1.1"
           sources."kind-of-5.1.0"
         ];
       })
       sources."extend-3.0.2"
-      sources."extend-shallow-3.0.2"
-      sources."external-editor-3.0.3"
+      (sources."extend-shallow-3.0.2" // {
+        dependencies = [
+          sources."is-extendable-1.0.1"
+        ];
+      })
+      (sources."external-editor-3.0.3" // {
+        dependencies = [
+          sources."tmp-0.0.33"
+        ];
+      })
       (sources."extglob-2.0.4" // {
         dependencies = [
           sources."define-property-1.0.0"
           sources."extend-shallow-2.0.1"
-          sources."is-extendable-0.1.1"
         ];
       })
       sources."extsprintf-1.3.0"
@@ -68923,11 +68248,11 @@ in
       sources."fast-safe-stringify-2.0.6"
       sources."fd-slicer-1.1.0"
       sources."figures-2.0.0"
-      sources."file-entry-cache-2.0.0"
+      sources."file-entry-cache-5.0.1"
+      sources."file-uri-to-path-1.0.0"
       (sources."fill-range-4.0.0" // {
         dependencies = [
           sources."extend-shallow-2.0.1"
-          sources."is-extendable-0.1.1"
         ];
       })
       sources."find-up-3.0.0"
@@ -68936,23 +68261,26 @@ in
           sources."async-2.5.0"
         ];
       })
-      (sources."first-chunk-stream-2.0.0" // {
-        dependencies = [
-          sources."readable-stream-2.3.6"
-          sources."string_decoder-1.1.1"
-        ];
-      })
-      sources."flat-cache-1.3.4"
+      sources."first-chunk-stream-3.0.0"
+      sources."flat-cache-2.0.1"
       sources."flatstr-1.0.12"
-      sources."fluent-syntax-0.10.0"
+      sources."flatted-2.0.1"
+      sources."fluent-syntax-0.13.0"
       sources."for-in-1.0.2"
+      sources."for-own-1.0.0"
       sources."forever-agent-0.6.1"
       sources."form-data-2.3.3"
       sources."fragment-cache-0.2.1"
       sources."fs-constants-1.0.0"
       sources."fs-extra-4.0.3"
       sources."fs.realpath-1.0.0"
-      sources."fsevents-2.0.1"
+      sources."fsevents-2.0.7"
+      (sources."ftp-0.3.10" // {
+        dependencies = [
+          sources."readable-stream-1.1.14"
+          sources."string_decoder-0.10.31"
+        ];
+      })
       sources."functional-red-black-tree-1.0.1"
       (sources."fx-runner-1.0.10" // {
         dependencies = [
@@ -68963,18 +68291,26 @@ in
       })
       sources."generate-function-2.3.1"
       sources."generate-object-property-1.2.0"
-      sources."get-caller-file-1.0.3"
+      sources."get-caller-file-2.0.5"
       sources."get-stream-4.1.0"
+      (sources."get-uri-2.0.3" // {
+        dependencies = [
+          sources."debug-4.1.1"
+          sources."ms-2.1.2"
+        ];
+      })
       sources."get-value-2.0.6"
       sources."getpass-0.1.7"
       sources."gettext-parser-1.1.0"
-      (sources."git-rev-sync-1.9.1" // {
+      (sources."git-rev-sync-1.12.0" // {
         dependencies = [
           sources."graceful-fs-4.1.11"
           sources."shelljs-0.7.7"
         ];
       })
-      sources."glob-7.1.3"
+      sources."git-up-4.0.1"
+      sources."git-url-parse-11.1.2"
+      sources."glob-7.1.4"
       (sources."glob-parent-3.1.0" // {
         dependencies = [
           sources."is-glob-3.1.0"
@@ -68987,8 +68323,9 @@ in
           sources."get-stream-3.0.0"
         ];
       })
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."graceful-readlink-1.0.1"
+      sources."graphlib-2.1.7"
       sources."growly-1.3.0"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
@@ -69001,47 +68338,73 @@ in
           sources."kind-of-4.0.0"
         ];
       })
+      sources."has-yarn-2.1.0"
       sources."hosted-git-info-2.7.1"
       sources."htmlparser2-3.10.1"
+      sources."http-cache-semantics-4.0.3"
+      sources."http-errors-1.7.3"
+      (sources."http-proxy-agent-2.1.0" // {
+        dependencies = [
+          sources."debug-3.1.0"
+        ];
+      })
       sources."http-signature-1.2.0"
+      (sources."https-proxy-agent-2.2.1" // {
+        dependencies = [
+          sources."debug-3.2.6"
+          sources."ms-2.1.2"
+        ];
+      })
       sources."iconv-lite-0.4.24"
       sources."ieee754-1.1.13"
       sources."ignore-4.0.6"
+      sources."immediate-3.0.6"
       sources."import-fresh-3.0.0"
       sources."import-lazy-2.1.0"
       sources."imurmurhash-0.1.4"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."ini-1.3.5"
-      (sources."inquirer-6.3.1" // {
+      (sources."inquirer-6.4.1" // {
         dependencies = [
+          sources."ansi-escapes-3.2.0"
           sources."ansi-regex-4.1.0"
           sources."strip-ansi-5.2.0"
         ];
       })
       sources."interpret-1.2.0"
-      sources."invert-kv-2.0.0"
+      sources."invert-kv-1.0.0"
+      sources."ip-1.1.5"
       sources."is-absolute-0.1.7"
-      sources."is-accessor-descriptor-1.0.0"
+      (sources."is-accessor-descriptor-1.0.0" // {
+        dependencies = [
+          sources."kind-of-6.0.2"
+        ];
+      })
       sources."is-arrayish-0.2.1"
       sources."is-binary-path-1.0.1"
       sources."is-buffer-1.1.6"
-      sources."is-data-descriptor-1.0.0"
-      sources."is-descriptor-1.0.2"
-      sources."is-extendable-1.0.1"
+      sources."is-ci-1.2.1"
+      (sources."is-data-descriptor-1.0.0" // {
+        dependencies = [
+          sources."kind-of-6.0.2"
+        ];
+      })
+      (sources."is-descriptor-1.0.2" // {
+        dependencies = [
+          sources."kind-of-6.0.2"
+        ];
+      })
+      sources."is-extendable-0.1.1"
       sources."is-extglob-2.1.1"
-      sources."is-fullwidth-code-point-1.0.0"
+      sources."is-fullwidth-code-point-2.0.0"
       sources."is-glob-4.0.1"
       sources."is-installed-globally-0.1.0"
       sources."is-mergeable-object-1.1.0"
       sources."is-my-ip-valid-1.0.0"
       sources."is-my-json-valid-2.20.0"
       sources."is-npm-1.0.0"
-      (sources."is-number-3.0.0" // {
-        dependencies = [
-          sources."kind-of-3.2.2"
-        ];
-      })
+      sources."is-number-3.0.0"
       sources."is-obj-1.0.1"
       sources."is-path-inside-1.0.1"
       sources."is-plain-object-2.0.4"
@@ -69051,12 +68414,14 @@ in
       sources."is-relative-0.1.3"
       sources."is-resolvable-1.1.0"
       sources."is-retry-allowed-1.1.0"
+      sources."is-ssh-1.3.1"
       sources."is-stream-1.1.0"
       sources."is-typedarray-1.0.0"
       sources."is-utf8-0.2.1"
       sources."is-windows-1.0.2"
       sources."is-wsl-1.1.0"
-      sources."isarray-1.0.0"
+      sources."is-yarn-global-0.3.0"
+      sources."isarray-0.0.1"
       sources."isexe-2.0.0"
       sources."isobject-3.0.1"
       sources."isstream-0.1.2"
@@ -69064,12 +68429,9 @@ in
       sources."jetpack-id-1.0.0"
       sources."js-select-0.6.0"
       sources."js-tokens-4.0.0"
-      (sources."js-yaml-3.13.1" // {
-        dependencies = [
-          sources."esprima-4.0.1"
-        ];
-      })
+      sources."js-yaml-3.13.1"
       sources."jsbn-0.1.1"
+      sources."json-buffer-3.0.0"
       sources."json-merge-patch-0.2.3"
       sources."json-parse-better-errors-1.0.2"
       sources."json-schema-0.2.3"
@@ -69082,32 +68444,41 @@ in
       sources."jsonpointer-4.0.1"
       (sources."jsonwebtoken-8.2.1" // {
         dependencies = [
-          sources."ms-2.1.1"
+          sources."ms-2.1.2"
         ];
       })
       sources."jsprim-1.4.1"
-      sources."jszip-2.6.1"
-      sources."jwa-1.4.1"
-      sources."jws-3.2.2"
-      sources."kind-of-6.0.2"
-      sources."latest-version-3.1.0"
-      (sources."lazystream-1.0.0" // {
+      (sources."jszip-3.2.1" // {
         dependencies = [
+          sources."isarray-1.0.0"
           sources."readable-stream-2.3.6"
           sources."string_decoder-1.1.1"
         ];
       })
-      sources."lcid-2.0.0"
-      sources."levn-0.3.0"
-      (sources."load-json-file-1.1.0" // {
+      sources."jwa-1.4.1"
+      sources."jws-3.2.2"
+      sources."keyv-3.1.0"
+      sources."kind-of-3.2.2"
+      sources."latest-version-3.1.0"
+      sources."lazy-cache-0.2.7"
+      (sources."lazystream-1.0.0" // {
         dependencies = [
-          sources."parse-json-2.2.0"
-          sources."pify-2.3.0"
-          sources."strip-bom-2.0.0"
+          sources."isarray-1.0.0"
+          sources."readable-stream-2.3.6"
+          sources."string_decoder-1.1.1"
         ];
       })
+      sources."lcid-1.0.0"
+      sources."levn-0.3.0"
+      sources."lie-3.3.0"
       sources."locate-path-3.0.0"
       sources."lodash-4.17.11"
+      sources."lodash.assign-4.2.0"
+      sources."lodash.assignin-4.2.0"
+      sources."lodash.clone-4.5.0"
+      sources."lodash.clonedeep-4.5.0"
+      sources."lodash.flatten-4.4.0"
+      sources."lodash.get-4.4.2"
       sources."lodash.includes-4.3.0"
       sources."lodash.isboolean-3.0.3"
       sources."lodash.isinteger-4.0.4"
@@ -69115,26 +68486,42 @@ in
       sources."lodash.isplainobject-4.0.6"
       sources."lodash.isstring-4.0.1"
       sources."lodash.once-4.1.1"
+      sources."lodash.set-4.3.2"
       sources."lodash.sortby-4.7.0"
       sources."lowercase-keys-1.0.1"
       sources."lru-cache-4.1.5"
+      sources."macos-release-2.3.0"
       sources."make-dir-1.3.0"
       sources."map-age-cleaner-0.1.3"
       sources."map-cache-0.2.2"
       sources."map-visit-1.0.0"
-      sources."mdn-browser-compat-data-0.0.66"
+      sources."mdn-browser-compat-data-0.0.82"
       (sources."mem-4.3.0" // {
         dependencies = [
           sources."mimic-fn-2.1.0"
         ];
       })
-      sources."micromatch-3.1.10"
+      (sources."micromatch-3.1.10" // {
+        dependencies = [
+          sources."kind-of-6.0.2"
+        ];
+      })
       sources."mime-db-1.40.0"
       sources."mime-types-2.1.24"
       sources."mimic-fn-1.2.0"
+      sources."mimic-response-1.0.1"
       sources."minimatch-3.0.4"
       sources."minimist-1.2.0"
-      sources."mixin-deep-1.3.1"
+      (sources."mixin-deep-1.3.2" // {
+        dependencies = [
+          sources."is-extendable-1.0.1"
+        ];
+      })
+      (sources."mixin-object-2.0.1" // {
+        dependencies = [
+          sources."for-in-0.1.8"
+        ];
+      })
       (sources."mkdirp-0.5.1" // {
         dependencies = [
           sources."minimist-0.0.8"
@@ -69142,7 +68529,7 @@ in
       })
       sources."moment-2.24.0"
       sources."ms-2.0.0"
-      sources."multimatch-2.1.0"
+      sources."multimatch-4.0.0"
       sources."mute-stream-0.0.7"
       (sources."mv-2.1.1" // {
         dependencies = [
@@ -69152,15 +68539,41 @@ in
       })
       sources."mz-2.7.0"
       sources."nan-2.14.0"
-      sources."nanomatch-1.2.13"
+      (sources."nanomatch-1.2.13" // {
+        dependencies = [
+          sources."kind-of-6.0.2"
+        ];
+      })
       sources."natural-compare-1.4.0"
       sources."natural-compare-lite-1.4.0"
+      (sources."nconf-0.10.0" // {
+        dependencies = [
+          sources."async-1.5.2"
+          sources."camelcase-2.1.1"
+          sources."decamelize-1.2.0"
+          sources."is-fullwidth-code-point-1.0.0"
+          sources."os-locale-1.4.0"
+          sources."string-width-1.0.2"
+          sources."yargs-3.32.0"
+        ];
+      })
       sources."ncp-2.0.0"
+      (sources."needle-2.4.0" // {
+        dependencies = [
+          sources."debug-3.2.6"
+          sources."ms-2.1.2"
+        ];
+      })
       sources."neo-async-2.6.1"
+      sources."netmask-1.0.6"
       sources."next-tick-1.0.0"
       sources."nice-try-1.0.5"
       sources."node-forge-0.7.6"
-      sources."node-notifier-5.2.1"
+      (sources."node-notifier-5.4.0" // {
+        dependencies = [
+          sources."semver-5.7.0"
+        ];
+      })
       (sources."nomnom-1.8.1" // {
         dependencies = [
           sources."ansi-styles-1.0.0"
@@ -69168,8 +68581,8 @@ in
           sources."strip-ansi-0.1.1"
         ];
       })
-      sources."normalize-package-data-2.5.0"
       sources."normalize-path-2.1.1"
+      sources."normalize-url-3.3.0"
       sources."npm-run-path-2.0.2"
       sources."nth-check-1.0.2"
       sources."number-is-nan-1.0.1"
@@ -69185,29 +68598,49 @@ in
               sources."kind-of-5.1.0"
             ];
           })
-          sources."kind-of-3.2.2"
         ];
       })
+      sources."object-hash-1.3.1"
       sources."object-visit-1.0.1"
       sources."object.pick-1.3.0"
       sources."once-1.4.0"
       sources."onetime-2.0.1"
-      sources."opn-5.3.0"
+      sources."opn-5.5.0"
       sources."optionator-0.8.2"
       sources."os-homedir-1.0.2"
-      sources."os-locale-3.1.0"
+      (sources."os-locale-3.1.0" // {
+        dependencies = [
+          sources."invert-kv-2.0.0"
+          sources."lcid-2.0.0"
+        ];
+      })
+      sources."os-name-3.1.0"
       sources."os-shim-0.1.3"
       sources."os-tmpdir-1.0.2"
+      sources."p-cancelable-1.1.0"
       sources."p-defer-1.0.0"
       sources."p-finally-1.0.0"
       sources."p-is-promise-2.1.0"
       sources."p-limit-2.2.0"
       sources."p-locate-3.0.0"
       sources."p-try-2.2.0"
-      sources."package-json-4.0.1"
+      (sources."pac-proxy-agent-3.0.0" // {
+        dependencies = [
+          sources."debug-3.2.6"
+          sources."ms-2.1.2"
+        ];
+      })
+      sources."pac-resolver-3.0.0"
+      (sources."package-json-4.0.1" // {
+        dependencies = [
+          sources."semver-5.7.0"
+        ];
+      })
       sources."pako-1.0.10"
       sources."parent-module-1.0.1"
       sources."parse-json-4.0.0"
+      sources."parse-path-4.0.1"
+      sources."parse-url-5.0.1"
       sources."parse5-3.0.3"
       sources."pascalcase-0.1.1"
       sources."path-dirname-1.0.2"
@@ -69216,22 +68649,15 @@ in
       sources."path-is-inside-1.0.2"
       sources."path-key-2.0.1"
       sources."path-parse-1.0.6"
-      (sources."path-type-1.1.0" // {
-        dependencies = [
-          sources."pify-2.3.0"
-        ];
-      })
       sources."pend-1.2.0"
       sources."performance-now-2.1.0"
       sources."pify-3.0.0"
-      sources."pinkie-2.0.4"
-      sources."pinkie-promise-2.0.1"
-      sources."pino-5.11.1"
+      sources."pino-5.12.6"
       sources."pino-std-serializers-2.4.2"
       sources."pluralize-1.2.1"
       sources."po2json-0.4.5"
       sources."posix-character-classes-0.1.1"
-      (sources."postcss-7.0.14" // {
+      (sources."postcss-7.0.16" // {
         dependencies = [
           sources."supports-color-6.1.0"
         ];
@@ -69243,54 +68669,57 @@ in
           sources."deepmerge-2.2.1"
         ];
       })
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."progress-2.0.3"
+      sources."promise-7.3.1"
+      sources."protocols-1.4.7"
+      (sources."proxy-agent-3.1.0" // {
+        dependencies = [
+          sources."debug-3.2.6"
+          sources."ms-2.1.2"
+        ];
+      })
+      sources."proxy-from-env-1.0.0"
       sources."pseudomap-1.0.2"
-      sources."psl-1.1.32"
+      sources."psl-1.1.33"
       sources."pump-3.0.0"
       sources."punycode-2.1.1"
       sources."qs-6.5.2"
       sources."quick-format-unescaped-3.0.2"
-      sources."rc-1.2.8"
-      sources."read-pkg-1.1.0"
-      (sources."read-pkg-up-1.0.1" // {
+      sources."raw-body-2.4.1"
+      (sources."rc-1.2.8" // {
         dependencies = [
-          sources."find-up-1.1.2"
-          sources."path-exists-2.1.0"
+          sources."strip-json-comments-2.0.1"
         ];
       })
       sources."readable-stream-3.4.0"
       (sources."readdirp-2.2.1" // {
         dependencies = [
+          sources."isarray-1.0.0"
           sources."readable-stream-2.3.6"
           sources."string_decoder-1.1.1"
         ];
       })
       (sources."readline2-1.0.1" // {
         dependencies = [
+          sources."is-fullwidth-code-point-1.0.0"
           sources."mute-stream-0.0.5"
         ];
       })
       sources."rechoir-0.6.2"
-      sources."regenerator-runtime-0.12.1"
+      sources."regenerator-runtime-0.13.2"
       sources."regex-not-1.0.2"
       sources."regexpp-2.0.1"
       sources."registry-auth-token-3.4.0"
       sources."registry-url-3.1.0"
-      (sources."relaxed-json-1.0.1" // {
-        dependencies = [
-          sources."ansi-styles-2.2.1"
-          sources."chalk-1.1.3"
-          sources."supports-color-2.0.0"
-        ];
-      })
+      sources."relaxed-json-1.0.3"
       sources."remove-trailing-separator-1.1.0"
       sources."repeat-element-1.1.3"
       sources."repeat-string-1.6.1"
       sources."request-2.88.0"
       sources."require-directory-2.1.1"
-      sources."require-main-filename-1.0.1"
-      (sources."require-uncached-1.0.3" // {
+      sources."require-main-filename-2.0.0"
+      (sources."require-uncached-2.0.0" // {
         dependencies = [
           sources."resolve-from-1.0.1"
         ];
@@ -69298,6 +68727,7 @@ in
       sources."resolve-1.11.1"
       sources."resolve-from-4.0.0"
       sources."resolve-url-0.2.1"
+      sources."responselike-1.0.2"
       sources."restore-cursor-2.0.0"
       sources."ret-0.1.15"
       sources."rimraf-2.6.3"
@@ -69309,16 +68739,27 @@ in
       sources."safe-regex-1.1.0"
       sources."safer-buffer-2.1.2"
       sources."sax-1.2.4"
-      sources."semver-5.6.0"
-      sources."semver-diff-2.1.0"
-      sources."set-blocking-2.0.0"
-      (sources."set-value-2.0.0" // {
+      sources."secure-keys-1.0.0"
+      sources."semver-6.1.1"
+      (sources."semver-diff-2.1.0" // {
         dependencies = [
-          sources."extend-shallow-2.0.1"
-          sources."is-extendable-0.1.1"
+          sources."semver-5.7.0"
         ];
       })
+      sources."set-blocking-2.0.0"
+      sources."set-immediate-shim-1.0.1"
+      (sources."set-value-2.0.1" // {
+        dependencies = [
+          sources."extend-shallow-2.0.1"
+        ];
+      })
+      sources."setprototypeof-1.1.1"
       sources."sha.js-2.4.11"
+      (sources."shallow-clone-0.1.2" // {
+        dependencies = [
+          sources."kind-of-2.0.1"
+        ];
+      })
       sources."shebang-command-1.2.0"
       sources."shebang-regex-1.0.0"
       sources."shell-quote-1.6.1"
@@ -69328,6 +68769,8 @@ in
         dependencies = [
           sources."ajv-5.5.2"
           sources."es6-error-4.0.0"
+          sources."es6-promise-4.2.8"
+          sources."es6-promisify-5.0.0"
           sources."fast-deep-equal-1.1.0"
           sources."har-validator-5.0.3"
           sources."json-schema-traverse-0.3.1"
@@ -69341,11 +68784,8 @@ in
         ];
       })
       sources."signal-exit-3.0.2"
-      (sources."slice-ansi-2.1.0" // {
-        dependencies = [
-          sources."is-fullwidth-code-point-2.0.0"
-        ];
-      })
+      sources."slice-ansi-2.1.0"
+      sources."smart-buffer-4.0.2"
       (sources."snapdragon-0.8.2" // {
         dependencies = [
           sources."define-property-0.2.5"
@@ -69361,7 +68801,6 @@ in
             ];
           })
           sources."is-descriptor-0.1.6"
-          sources."is-extendable-0.1.1"
           sources."kind-of-5.1.0"
           sources."source-map-0.5.7"
         ];
@@ -69371,21 +68810,113 @@ in
           sources."define-property-1.0.0"
         ];
       })
-      (sources."snapdragon-util-3.0.1" // {
+      sources."snapdragon-util-3.0.1"
+      (sources."snyk-1.185.5" // {
         dependencies = [
-          sources."kind-of-3.2.2"
+          sources."ansi-regex-4.1.0"
+          sources."debug-3.2.6"
+          sources."ms-2.1.2"
+          sources."strip-ansi-5.2.0"
+          sources."update-notifier-2.5.0"
+        ];
+      })
+      (sources."snyk-config-2.2.1" // {
+        dependencies = [
+          sources."debug-3.2.6"
+          sources."ms-2.1.2"
+        ];
+      })
+      (sources."snyk-docker-plugin-1.25.1" // {
+        dependencies = [
+          sources."debug-4.1.1"
+          sources."ms-2.1.2"
+        ];
+      })
+      sources."snyk-go-parser-1.3.1"
+      (sources."snyk-go-plugin-1.10.2" // {
+        dependencies = [
+          sources."debug-4.1.1"
+          sources."ms-2.1.2"
+          sources."tmp-0.0.33"
+        ];
+      })
+      (sources."snyk-gradle-plugin-2.12.5" // {
+        dependencies = [
+          sources."debug-4.1.1"
+          sources."ms-2.1.2"
+          sources."tmp-0.0.33"
+        ];
+      })
+      (sources."snyk-module-1.9.1" // {
+        dependencies = [
+          sources."debug-3.2.6"
+          sources."ms-2.1.2"
+        ];
+      })
+      (sources."snyk-mvn-plugin-2.3.0" // {
+        dependencies = [
+          sources."tslib-1.9.3"
+        ];
+      })
+      sources."snyk-nodejs-lockfile-parser-1.13.0"
+      (sources."snyk-nuget-plugin-1.10.0" // {
+        dependencies = [
+          sources."debug-3.2.6"
+          sources."ms-2.1.2"
+        ];
+      })
+      sources."snyk-paket-parser-1.4.3"
+      sources."snyk-php-plugin-1.6.2"
+      (sources."snyk-policy-1.13.5" // {
+        dependencies = [
+          sources."debug-3.2.6"
+          sources."ms-2.1.2"
+        ];
+      })
+      (sources."snyk-python-plugin-1.10.2" // {
+        dependencies = [
+          sources."tmp-0.0.33"
+        ];
+      })
+      (sources."snyk-resolve-1.0.1" // {
+        dependencies = [
+          sources."debug-3.2.6"
+          sources."ms-2.1.2"
+        ];
+      })
+      (sources."snyk-resolve-deps-4.0.3" // {
+        dependencies = [
+          sources."debug-3.2.6"
+          sources."ms-2.1.2"
+          sources."semver-5.7.0"
+        ];
+      })
+      (sources."snyk-sbt-plugin-2.4.2" // {
+        dependencies = [
+          sources."tslib-1.9.3"
+        ];
+      })
+      sources."snyk-tree-1.0.0"
+      (sources."snyk-try-require-1.3.1" // {
+        dependencies = [
+          sources."debug-3.2.6"
+          sources."ms-2.1.2"
+        ];
+      })
+      sources."socks-2.3.2"
+      (sources."socks-proxy-agent-4.0.2" // {
+        dependencies = [
+          sources."agent-base-4.2.1"
+          sources."es6-promise-4.2.8"
+          sources."es6-promisify-5.0.0"
         ];
       })
       sources."sonic-boom-0.7.4"
       sources."source-map-0.6.1"
       sources."source-map-resolve-0.5.2"
-      sources."source-map-support-0.5.3"
+      sources."source-map-support-0.5.12"
       sources."source-map-url-0.4.0"
       sources."spawn-sync-1.0.15"
-      sources."spdx-correct-3.1.0"
-      sources."spdx-exceptions-2.2.0"
-      sources."spdx-expression-parse-3.0.0"
-      sources."spdx-license-ids-3.0.4"
       sources."split-0.3.3"
       sources."split-string-3.1.0"
       sources."sprintf-js-1.0.3"
@@ -69407,6 +68938,7 @@ in
           sources."kind-of-5.1.0"
         ];
       })
+      sources."statuses-1.5.0"
       sources."stream-parser-0.3.1"
       sources."stream-to-array-2.3.0"
       (sources."stream-to-promise-2.2.0" // {
@@ -69418,32 +68950,33 @@ in
       (sources."string-width-2.1.1" // {
         dependencies = [
           sources."ansi-regex-3.0.0"
-          sources."is-fullwidth-code-point-2.0.0"
           sources."strip-ansi-4.0.0"
         ];
       })
       sources."string_decoder-1.2.0"
       sources."strip-ansi-3.0.1"
       sources."strip-bom-3.0.0"
-      sources."strip-bom-buf-1.0.0"
-      sources."strip-bom-stream-3.0.0"
+      sources."strip-bom-buf-2.0.0"
+      sources."strip-bom-stream-4.0.0"
       sources."strip-eof-1.0.0"
-      sources."strip-json-comments-2.0.1"
+      sources."strip-json-comments-3.0.1"
       sources."supports-color-5.5.0"
-      (sources."table-5.4.0" // {
+      (sources."table-5.4.1" // {
         dependencies = [
           sources."ansi-regex-4.1.0"
-          sources."is-fullwidth-code-point-2.0.0"
           sources."string-width-3.1.0"
           sources."strip-ansi-5.2.0"
         ];
       })
       (sources."tar-stream-1.6.2" // {
         dependencies = [
+          sources."isarray-1.0.0"
           sources."readable-stream-2.3.6"
           sources."string_decoder-1.1.1"
         ];
       })
+      sources."temp-dir-1.0.0"
+      sources."tempfile-2.0.0"
       (sources."term-size-1.2.0" // {
         dependencies = [
           sources."cross-spawn-5.1.0"
@@ -69452,19 +68985,20 @@ in
         ];
       })
       sources."text-table-0.2.0"
+      sources."then-fs-2.0.0"
       sources."thenify-3.3.0"
       sources."thenify-all-1.6.0"
       sources."through-2.3.8"
+      sources."thunkify-2.1.2"
       sources."timed-out-4.0.1"
-      sources."tmp-0.0.33"
+      sources."tmp-0.1.0"
       sources."to-buffer-1.1.1"
-      (sources."to-object-path-0.3.0" // {
-        dependencies = [
-          sources."kind-of-3.2.2"
-        ];
-      })
+      sources."to-object-path-0.3.0"
+      sources."to-readable-stream-1.0.0"
       sources."to-regex-3.0.2"
       sources."to-regex-range-2.1.1"
+      sources."toidentifier-1.0.0"
+      sources."toml-3.0.0"
       sources."tosource-1.0.0"
       (sources."tough-cookie-2.4.3" // {
         dependencies = [
@@ -69473,21 +69007,19 @@ in
       })
       sources."tr46-1.0.1"
       sources."traverse-0.4.6"
-      sources."tslib-1.9.3"
+      sources."tree-kill-1.2.1"
+      sources."tslib-1.10.0"
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
+      sources."type-1.0.1"
       sources."type-check-0.3.2"
+      sources."type-fest-0.5.2"
       sources."typedarray-0.0.6"
       sources."underscore-1.6.0"
-      (sources."union-value-1.0.0" // {
-        dependencies = [
-          sources."extend-shallow-2.0.1"
-          sources."is-extendable-0.1.1"
-          sources."set-value-0.4.3"
-        ];
-      })
+      sources."union-value-1.0.1"
       sources."unique-string-1.0.0"
       sources."universalify-0.1.2"
+      sources."unpipe-1.0.0"
       (sources."unset-value-1.0.0" // {
         dependencies = [
           (sources."has-value-0.3.1" // {
@@ -69496,11 +69028,32 @@ in
             ];
           })
           sources."has-values-0.1.4"
+          sources."isarray-1.0.0"
         ];
       })
       sources."unzip-response-2.0.1"
-      sources."upath-1.1.0"
-      sources."update-notifier-2.3.0"
+      sources."upath-1.1.2"
+      (sources."update-notifier-3.0.0" // {
+        dependencies = [
+          sources."ansi-align-3.0.0"
+          sources."ansi-regex-4.1.0"
+          sources."boxen-3.2.0"
+          sources."ci-info-2.0.0"
+          sources."cli-boxes-2.2.0"
+          sources."configstore-4.0.0"
+          sources."got-9.6.0"
+          sources."is-ci-2.0.0"
+          sources."is-npm-3.0.0"
+          sources."latest-version-5.1.0"
+          sources."package-json-6.4.0"
+          sources."prepend-http-2.0.0"
+          sources."registry-url-5.1.0"
+          sources."string-width-3.1.0"
+          sources."strip-ansi-5.2.0"
+          sources."type-fest-0.3.1"
+          sources."url-parse-lax-3.0.0"
+        ];
+      })
       sources."uri-js-4.2.2"
       sources."urix-0.1.0"
       sources."url-parse-lax-1.0.0"
@@ -69508,9 +69061,9 @@ in
       sources."user-home-2.0.0"
       sources."util-deprecate-1.0.2"
       sources."uuid-3.3.2"
-      sources."validate-npm-package-license-3.0.4"
       sources."verror-1.10.0"
-      sources."watchpack-1.5.0"
+      sources."vscode-languageserver-types-3.14.0"
+      sources."watchpack-1.6.0"
       sources."wcwidth-1.0.1"
       sources."webidl-conversions-4.0.2"
       sources."whatwg-url-7.0.0"
@@ -69518,41 +69071,38 @@ in
       sources."which-1.3.1"
       sources."which-module-2.0.0"
       sources."widest-line-2.0.1"
+      sources."window-size-0.1.4"
+      sources."windows-release-3.2.0"
       sources."winreg-0.0.12"
       sources."wordwrap-1.0.0"
       (sources."wrap-ansi-2.1.0" // {
         dependencies = [
+          sources."is-fullwidth-code-point-1.0.0"
           sources."string-width-1.0.2"
         ];
       })
       sources."wrappy-1.0.2"
-      sources."write-0.2.1"
+      sources."write-1.0.3"
       sources."write-file-atomic-2.4.3"
       sources."xdg-basedir-3.0.0"
       sources."xml2js-0.4.19"
       sources."xmlbuilder-9.0.7"
-      sources."xmldom-0.1.27"
-      sources."xregexp-4.0.0"
+      sources."xregexp-2.0.0"
       sources."xtend-4.0.1"
-      sources."y18n-4.0.0"
+      sources."y18n-3.2.1"
       sources."yallist-2.1.2"
-      (sources."yargs-6.6.0" // {
+      (sources."yargs-13.2.4" // {
         dependencies = [
-          sources."camelcase-3.0.0"
-          sources."cliui-3.2.0"
-          sources."decamelize-1.2.0"
-          sources."invert-kv-1.0.0"
-          sources."lcid-1.0.0"
-          sources."os-locale-1.4.0"
-          sources."string-width-1.0.2"
-          sources."which-module-1.0.0"
-          sources."y18n-3.2.1"
-          sources."yargs-parser-4.2.1"
+          sources."ansi-regex-4.1.0"
+          sources."cliui-5.0.0"
+          sources."string-width-3.1.0"
+          sources."strip-ansi-5.2.0"
+          sources."wrap-ansi-5.1.0"
+          sources."y18n-4.0.0"
         ];
       })
-      (sources."yargs-parser-11.1.1" // {
+      (sources."yargs-parser-13.1.1" // {
         dependencies = [
-          sources."camelcase-5.3.1"
           sources."decamelize-1.2.0"
         ];
       })
@@ -69560,10 +69110,12 @@ in
       (sources."zip-dir-1.0.2" // {
         dependencies = [
           sources."async-1.5.2"
+          sources."jszip-2.6.1"
         ];
       })
       (sources."zip-stream-1.2.0" // {
         dependencies = [
+          sources."isarray-1.0.0"
           sources."readable-stream-2.3.6"
           sources."string_decoder-1.1.1"
         ];
@@ -69790,6 +69342,7 @@ in
       sources."encodeurl-1.0.2"
       sources."env-paths-1.0.0"
       sources."error-ex-1.3.2"
+      sources."es6-promise-4.2.8"
       sources."escape-string-regexp-1.0.5"
       (sources."execa-0.6.3" // {
         dependencies = [
@@ -69867,7 +69420,7 @@ in
       sources."global-tunnel-ng-2.7.1"
       sources."globby-8.0.2"
       sources."got-8.3.2"
-      sources."graceful-fs-4.1.15"
+      sources."graceful-fs-4.2.0"
       sources."grouped-queue-0.3.3"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
@@ -69896,9 +69449,9 @@ in
       sources."imurmurhash-0.1.4"
       sources."indent-string-3.2.0"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."ini-1.3.5"
-      sources."inquirer-6.3.1"
+      sources."inquirer-6.4.1"
       (sources."insight-0.10.1" // {
         dependencies = [
           sources."chardet-0.4.2"
@@ -69973,7 +69526,7 @@ in
         ];
       })
       sources."locate-path-2.0.0"
-      sources."locutus-2.0.10"
+      sources."locutus-2.0.11"
       sources."lodash-4.17.11"
       sources."lodash.debounce-4.0.8"
       sources."lodash.pad-4.5.1"
@@ -70005,7 +69558,7 @@ in
       sources."mimic-response-1.0.1"
       sources."minimatch-3.0.4"
       sources."minimist-1.2.0"
-      (sources."mixin-deep-1.3.1" // {
+      (sources."mixin-deep-1.3.2" // {
         dependencies = [
           sources."is-extendable-1.0.1"
         ];
@@ -70099,10 +69652,10 @@ in
       sources."pkg-up-2.0.0"
       sources."posix-character-classes-0.1.1"
       sources."prepend-http-2.0.0"
-      sources."process-nextick-args-2.0.0"
+      sources."process-nextick-args-2.0.1"
       sources."proto-list-1.2.4"
       sources."pseudomap-1.0.2"
-      sources."psl-1.1.32"
+      sources."psl-1.1.33"
       sources."punycode-2.1.1"
       sources."qs-6.5.2"
       sources."query-string-5.1.1"
@@ -70159,7 +69712,7 @@ in
       sources."semver-regex-1.0.0"
       sources."semver-truncate-1.1.2"
       sources."set-immediate-shim-1.0.1"
-      (sources."set-value-2.0.0" // {
+      (sources."set-value-2.0.1" // {
         dependencies = [
           sources."extend-shallow-2.0.1"
         ];
@@ -70300,18 +69853,13 @@ in
       sources."to-regex-range-2.1.1"
       sources."tough-cookie-2.5.0"
       sources."trim-newlines-1.0.0"
-      sources."tslib-1.9.3"
+      sources."tslib-1.10.0"
       sources."tunnel-0.0.6"
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       sources."twig-1.13.3"
       sources."typedarray-0.0.6"
-      (sources."union-value-1.0.0" // {
-        dependencies = [
-          sources."extend-shallow-2.0.1"
-          sources."set-value-0.4.3"
-        ];
-      })
+      sources."union-value-1.0.1"
       sources."unique-string-1.0.0"
       (sources."unset-value-1.0.0" // {
         dependencies = [
@@ -70366,10 +69914,10 @@ in
         ];
       })
       sources."yeoman-doctor-3.0.3"
-      (sources."yeoman-environment-2.3.4" // {
+      (sources."yeoman-environment-2.4.0" // {
         dependencies = [
           sources."debug-3.2.6"
-          sources."ms-2.1.1"
+          sources."ms-2.1.2"
           sources."strip-ansi-4.0.0"
         ];
       })


### PR DESCRIPTION
#### Motivation for this change

This upgrades `nodePackages.tedicross` to the latest release.
Tested and confirmed to work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
