### PR TITLE
nixos/synapse-bt: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -863,6 +863,7 @@
   ./services/torrent/opentracker.nix
   ./services/torrent/peerflix.nix
   ./services/torrent/rtorrent.nix
+  ./services/torrent/synapse-bt.nix
   ./services/torrent/transmission.nix
   ./services/ttys/getty.nix
   ./services/ttys/gpm.nix

--- a/nixos/modules/services/torrent/synapse-bt.nix
+++ b/nixos/modules/services/torrent/synapse-bt.nix
@@ -1,0 +1,117 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.synapse-bt;
+  runtimeDirectory = "/run/synapse-bt";
+  stateDirectory = "/var/lib/synapse-bt";
+in {
+  options = {
+    services.synapse-bt = {
+      enable = mkEnableOption "the Synapse BitTorrent daemon";
+
+      user = mkOption {
+        type = types.str;
+        default = "synapse-bt";
+        description = ''
+          User under which synapse-bt will run.
+        '';
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "synapse-bt";
+        description = ''
+          Group under which synapse-bt will run.
+        '';
+      };
+
+      config = mkOption {
+        type = types.attrs;
+        default = {
+          disk.session = "${stateDirectory}/session";
+          disk.directory = "${stateDirectory}/downloads";
+        };
+        description = ''
+          Configuration for synapse.toml. See
+          <link xlink:href="https://github.com/Luminarys/synapse/blob/${pkgs.synapse-bt.version}/example_config.toml"/>
+          for options.
+
+          Warning: this file will be world-readable in the Nix store,
+          so any authentication setup should be set up in
+          <option>services.synapse-bt.extraConfigPath</option>.
+        '';
+        example = literalExample ''
+          {
+            port = 16943;
+            max_dl = 10;
+            rpc = {
+              port = 8412;
+              local = true;
+            };
+          }
+        '';
+      };
+
+      extraConfigPath = mkOption {
+        type = with types; nullOr str;
+        default = null;
+        description = ''
+          Path to a TOML file that will be appended to the synapse.toml file defined in
+          <option>services.synapse-bt.config</option>.
+
+          This is intended to store authentication info for its RPC interface.
+        '';
+      };
+    };
+  };
+
+  config = let
+    configFile = pkgs.runCommand "synapse.toml" {
+      buildInputs = [ pkgs.remarshal ];
+    } ''
+      remarshal -if json -of toml \
+          < ${pkgs.writeText "synapse.json" (builtins.toJSON cfg.config)} \
+          > $out
+    '';
+  in mkIf cfg.enable {
+    users.users.synapse-bt = mkIf (cfg.user == "synapse-bt") { group = mkDefault cfg.group; };
+    users.groups.synapse-bt = mkIf (cfg.group == "synapse-bt") { };
+
+    # for sycli
+    environment.systemPackages = [ pkgs.synapse-bt ];
+
+    systemd.tmpfiles.rules = []
+      ++ optional
+        (hasAttrByPath [ "disk" "session" ] cfg.config)
+        "d ${cfg.config.disk.session} - ${cfg.user} ${cfg.group} - -"
+      ++ optional
+        (hasAttrByPath [ "disk" "directory" ] cfg.config)
+        "d ${cfg.config.disk.directory} - ${cfg.user} ${cfg.group} - -";
+
+    systemd.services.synapse-bt = {
+      description = "Synapse BitTorrent daemon";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      preStart = ''
+        touch ${runtimeDirectory}/synapse.toml
+        chmod 600 ${runtimeDirectory}/synapse.toml
+        ${pkgs.coreutils}/bin/cat \
+            ${configFile} \
+            ${optionalString (cfg.extraConfigPath != null) cfg.extraConfigPath} \
+            > ${runtimeDirectory}/synapse.toml
+      '';
+      serviceConfig = {
+        User = cfg.user;
+        Group = cfg.group;
+        RuntimeDirectory = "synapse-bt";
+        ExecStart = ''
+          ${pkgs.synapse-bt}/bin/synapse -c ${runtimeDirectory}/synapse.toml
+        '';
+      };
+    };
+  };
+
+  meta.maintainers = with maintainers; [ tadeokondrak ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -370,6 +370,7 @@ in
   sudo = handleTest ./sudo.nix {};
   switchTest = handleTest ./switch-test.nix {};
   sympa = handleTest ./sympa.nix {};
+  synapse-bt = handleTest ./synapse-bt.nix {};
   syncthing = handleTest ./syncthing.nix {};
   syncthing-init = handleTest ./syncthing-init.nix {};
   syncthing-relay = handleTest ./syncthing-relay.nix {};

--- a/nixos/tests/synapse-bt.nix
+++ b/nixos/tests/synapse-bt.nix
@@ -1,0 +1,16 @@
+import ./make-test-python.nix ({ lib, ... }: {
+  name = "synapse-bt";
+
+  meta.maintainers = with lib.maintainers; [ tadeokondrak ];
+
+  machine = { ... }: {
+    services.synapse-bt.enable = true;
+  };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("synapse-bt.service")
+    machine.wait_for_open_port("8412")
+    machine.succeed("sycli list")
+  '';
+})


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Wanted to run this on my server.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This turned out a more complex than I would have liked, and it still isn't plug and play.

I can't figure out a nice way to set default values for `services.synapse-bt.config.disk.{session,directory}`. I'd like to set this up using systemd-tmpfiles, but just using `mkDefault` like that doesn't work. Is setting them in the default value for the option okay?

