### PR TITLE
stow: 2.2.2 -> 2.3.0

### DIFF
--- a/pkgs/tools/misc/stow/default.nix
+++ b/pkgs/tools/misc/stow/default.nix
@@ -1,17 +1,26 @@
-{ stdenv, fetchurl, perl, perlPackages }:
+{ stdenv, fetchurl, perl, perlPackages, makeWrapper }:
 
 let
-  version = "2.2.2";
+  pname = "stow";
+  version = "2.3.0";
 in
 stdenv.mkDerivation {
-  name = "stow-${version}";
+  name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnu/stow/stow-${version}.tar.bz2";
-    sha256 = "1zd6g9cm3whvy5f87j81j4npl7q6kxl25f7z7p9ahiqfjqs200m0";
+    sha256 = "1fnn83wwx3yaxpqkq8xyya3aiibz19fwrfj30nsiikm7igmwgiv5";
   };
 
-  buildInputs = with perlPackages; [ perl IOStringy TestOutput ];
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = with perlPackages; [ perl IOStringy TestOutput HashMerge Clone CloneChoose ];
+
+  postFixup = ''
+    wrapProgram "$out"/bin/stow \
+    --set PERL5LIB "$out/lib/perl5/site_perl:${with perlPackages; makePerlPath [
+      HashMerge Clone CloneChoose
+    ]}"
+  '';
 
   doCheck = true;
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update stow to latest release `2.3.0`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
