### PR TITLE
zsh-you-should-use: init at 1.1.0

### DIFF
--- a/pkgs/shells/zsh/zsh-you-should-use/default.nix
+++ b/pkgs/shells/zsh/zsh-you-should-use/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "zsh-you-should-use";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "MichaelAquilina";
+    repo = pname;
+    rev = version;
+    sha256 = "0fig5ralagi5jajk7gdm52jvwql17qk9cd6j98qsndvckb26a753";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    install -D you-should-use.plugin.zsh $out/share/zsh/plugins/you-should-use/you-should-use.plugin.zsh
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/MichaelAquilina/zsh-you-should-use;
+    license = licenses.gpl3;
+    description = "ZSH plugin that reminds you to use existing aliases for commands you just typed";
+    maintainers = with maintainers; [ ma27 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6987,6 +6987,8 @@ in
 
   zsh-command-time = callPackage ../shells/zsh/zsh-command-time { };
 
+  zsh-you-should-use = callPackage ../shells/zsh/zsh-you-should-use { };
+
   zssh = callPackage ../tools/networking/zssh { };
 
   zstd = callPackage ../tools/compression/zstd { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Simple zsh plugin that reminds you to use existing aliases. With
`oh-my-zsh` it can be installed like this:

``` nix
{
  programs.zsh.ohMyZsh = {
    customPkgs = [ pkgs.zsh-you-should-use ];
    plugins = [ "you-should-use" ];
  };
}
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
