### PR TITLE
libvirt: 5.3.0 -> 5.4.0 + patches for CVE-2019-10161, CVE-2019-10166, CVE-2019-10167 and CVE-2019-10168

### DIFF
--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchgit
-, pkgconfig, makeWrapper, libtool, autoconf, automake
+, pkgconfig, makeWrapper, libtool, autoconf, automake, fetchpatch
 , coreutils, libxml2, gnutls, perl, python2, attr
 , iproute, iptables, readline, lvm2, utillinux, systemd, libpciaccess, gettext
 , libtasn1, ebtables, libgcrypt, yajl, pmutils, libcap_ng, libapparmor
@@ -17,21 +17,45 @@ let
   buildFromTarball = stdenv.isDarwin;
 in stdenv.mkDerivation rec {
   name = "libvirt-${version}";
-  version = "5.3.0";
+  version = "5.4.0";
 
   src =
     if buildFromTarball then
       fetchurl {
         url = "http://libvirt.org/sources/${name}.tar.xz";
-        sha256 = "00f1blazv589cbfc85p4347x68kr45mz1r37z9bkjyw10vavsr45";
+        sha256 = "0ywf8m9yz2hxnic7fylzlmgy4m353r4vv5zsvp89zq5yh4h81yhw";
       }
     else
       fetchgit {
         url = git://libvirt.org/libvirt.git;
         rev = "v${version}";
-        sha256 = "10amj2aibc1cywiwn989n09sdngiw8ghp5jvdr7lwh9wdb0a3r57";
+        sha256 = "1dja1mf295w0sl83zag62c4j55cfbzzfbhdxpkyv2zm3zv0mwdyc";
         fetchSubmodules = true;
       };
+
+  patches = optionals (!stdenv.isDarwin) [
+    (fetchpatch {
+      name = "5.4.0-CVE-2019-10161.patch";
+      url = "https://libvirt.org/git/?p=libvirt.git;a=patch;h=aed6a032cead4386472afb24b16196579e239580";
+      sha256 = "19k9z9xx68nf03igbgy1imxnlp5ppj7cgdbq9kri3s834hkjcygs";
+    })
+  ] ++ [
+    (fetchpatch {
+      name = "5.4.0-CVE-2019-10166.patch";
+      url = "https://libvirt.org/git/?p=libvirt.git;a=patch;h=db0b78457f183e4c7ac45bc94de86044a1e2056a";
+      sha256 = "17pd1rab2mxj4q0vg30vi2gh78mf52ik1p5l12wrghb0wjf7swml";
+    })
+    (fetchpatch {
+      name = "5.4.0-CVE-2019-10167.patch";
+      url = "https://libvirt.org/git/?p=libvirt.git;a=patch;h=8afa68bac0cf99d1f8aaa6566685c43c22622f26";
+      sha256 = "0hgbwk0y2n6ihzjk8vqabhw914axjqgzcb7c5xx893r86c54c0ml";
+    })
+    (fetchpatch {
+      name = "5.4.0-CVE-2019-10168.patch";
+      url = "https://libvirt.org/git/?p=libvirt.git;a=patch;h=bf6c2830b6c338b1f5699b095df36f374777b291";
+      sha256 = "0s4hc3hsjncx1852ndjas1nng9v23pxf4mi1jxcajsqvhw89la0g";
+    })
+  ];
 
   nativeBuildInputs = [ makeWrapper pkgconfig ];
   buildInputs = [

--- a/pkgs/development/python-modules/libvirt/default.nix
+++ b/pkgs/development/python-modules/libvirt/default.nix
@@ -2,12 +2,12 @@
 
 buildPythonPackage rec {
   pname = "libvirt";
-  version = "5.3.0";
+  version = "5.4.0";
 
   src = assert version == libvirt.version; fetchgit {
     url = git://libvirt.org/libvirt-python.git;
     rev = "v${version}";
-    sha256 = "1l2a0gxmf071rd198c1z0ls3idr30i0aarf04bi9v705zdv90sxa";
+    sha256 = "0ja35z90i3m7vsjfpzfm7awkmja3h0150376i5pzmf2q8vp61fi5";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -14674,12 +14674,12 @@ let
   };
 
   SysVirt = buildPerlModule rec {
-    version = "5.3.0";
+    version = "5.4.0";
     name = "Sys-Virt-${version}";
     src = assert version == pkgs.libvirt.version; pkgs.fetchgit {
       url = git://libvirt.org/libvirt-perl.git;
-      rev = "a1e85f96e3897f56e8686e9312c69de764f5a48c"; # there is no "v5.3.0" tag
-      sha256 = "1w80bhsdpcrk99cv355jyhl510a0nawnn9adffwj50a59ka77ihw";
+      rev = "v${version}";
+      sha256 = "0csg10mydcif2l0qf16nlphq6ih5378nk6dk1vznf5bspws2ch7a";
     };
     nativeBuildInputs = [ pkgs.pkgconfig ];
     buildInputs = [ pkgs.libvirt CPANChanges TestPod TestPodCoverage XMLXPath ];


### PR DESCRIPTION
###### Motivation for this change
See also #63909

Multiple recent CVEs for libvirt (CVE-2019-10161, CVE-2019-10166, CVE-2019-10167 and CVE-2019-10168). Commits fixing these have been made to the repo, but no point release seems to be in sight yet, so adding them as patches after a bump to the most recent version.

As in #63909, the fix for CVE-2019-10161 unfortunately breaks the darwin build for me (tested on macos 10.13), so I've conditionally disabled it and will raise it as an issue with upstream.

This includes parallel bumps of `pythonPackages.libvirt` and `perlPackages.SysVirt` as requested in the main `libvirt` package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
