### PR TITLE
sslsplit: init at 0.5.5

### DIFF
--- a/pkgs/tools/networking/sslsplit/default.nix
+++ b/pkgs/tools/networking/sslsplit/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, openssl, libevent, libpcap, libnet, zlib }:
+
+stdenv.mkDerivation rec {
+  pname = "sslsplit";
+  version = "0.5.5";
+
+  src = fetchFromGitHub {
+    owner = "droe";
+    repo = pname;
+    rev = version;
+    sha256 = "1p43z9ln5rbc76v0j1k3r4nhvfw71hq8jzsallb54z9hvwfvqp3l";
+  };
+
+  buildInputs = [ openssl libevent libpcap libnet zlib ];
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    "OPENSSL_BASE=${openssl.dev}"
+    "LIBEVENT_BASE=${libevent.dev}"
+    "LIBPCAP_BASE=${libpcap}"
+    "LIBNET_BASE=${libnet}"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Transparent SSL/TLS interception";
+    homepage = "https://www.roe.ch/SSLsplit";
+    platforms = platforms.all;
+    maintainers = with maintainers; [ contrun ];
+    license = with licenses; [ bsd2 mit unlicense free ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6433,6 +6433,8 @@ in
 
   ssldump = callPackage ../tools/networking/ssldump { };
 
+  sslsplit = callPackage ../tools/networking/sslsplit { };
+
   sstp = callPackage ../tools/networking/sstp {};
 
   strip-nondeterminism = perlPackages.strip-nondeterminism;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
