### PR TITLE
bazel: add a test asserting java and java proto

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/java-test.nix
+++ b/pkgs/development/tools/build-managers/bazel/java-test.nix
@@ -1,0 +1,56 @@
+{
+  bazel
+, bazelTest
+, bazel-examples
+, gccStdenv
+, lib
+, openjdk8
+, runLocal
+, runtimeShell
+, writeScript
+, writeText
+}:
+
+let
+
+  toolsBazel = writeScript "bazel" ''
+    #! ${runtimeShell}
+
+    export CXX='${gccStdenv.cc}/bin/g++'
+    export LD='${gccStdenv.cc}/bin/ld'
+    export CC='${gccStdenv.cc}/bin/gcc'
+
+    # XXX: hack for macosX, this flags disable bazel usage of xcode
+    # See: https://github.com/bazelbuild/bazel/issues/4231
+    export BAZEL_USE_CPP_ONLY_TOOLCHAIN=1
+
+    exec "$BAZEL_REAL" "$@"
+  '';
+
+  workspaceDir = runLocal "our_workspace" {} (''
+    cp -r ${bazel-examples}/java-tutorial $out
+    find $out -type d -exec chmod 755 {} \;
+  ''
+  + (lib.optionalString gccStdenv.isDarwin ''
+    mkdir $out/tools
+    cp ${toolsBazel} $out/tools/bazel
+  ''));
+
+  testBazel = bazelTest {
+    name = "bazel-test-cpp";
+    inherit workspaceDir;
+    bazelPkg = bazel;
+    buildInputs = [ openjdk8 ];
+    bazelScript = ''
+      ${bazel}/bin/bazel \
+        run \
+          --host_javabase='@local_jdk//:jdk' \
+          --java_toolchain='@bazel_tools//tools/jdk:toolchain_hostjdk8' \
+          --javabase='@local_jdk//:jdk' \
+          --verbose_failures \
+          //:ProjectRunner
+    '';
+  };
+
+in testBazel
+

--- a/pkgs/development/tools/build-managers/bazel/protobuf-test.nix
+++ b/pkgs/development/tools/build-managers/bazel/protobuf-test.nix
@@ -5,6 +5,7 @@
 , fetchurl
 , gccStdenv
 , lib
+, openjdk8
 , runLocal
 , runtimeShell
 , writeScript
@@ -77,6 +78,8 @@ let
   personProto = writeText "person.proto" ''
     syntax = "proto3";
 
+    package person;
+
     message Person {
       string name = 1;
       int32 id = 2;
@@ -134,10 +137,15 @@ let
     name = "bazel-test-protocol-buffers";
     inherit workspaceDir;
     bazelPkg = bazel;
+    buildInputs = [ openjdk8 ];
     bazelScript = ''
       ${bazel}/bin/bazel \
-        build --verbose_failures \
-          //person:person_proto
+        build \
+          --host_javabase='@local_jdk//:jdk' \
+          --java_toolchain='@bazel_tools//tools/jdk:toolchain_hostjdk8' \
+          --javabase='@local_jdk//:jdk' \
+          --verbose_failures \
+          //...
     '';
   };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add a test asserting working with Java and compiling a Java protobuf.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
