### PR TITLE
llvm_7,8: disable libpfm on aarch64

### DIFF
--- a/pkgs/development/compilers/llvm/7/llvm.nix
+++ b/pkgs/development/compilers/llvm/7/llvm.nix
@@ -15,7 +15,9 @@
 , debugVersion ? false
 , enableManpages ? false
 , enableSharedLibraries ? true
-, enablePFM ? !stdenv.isDarwin
+, enablePFM ? !(stdenv.isDarwin
+  || stdenv.isAarch64 # broken for Ampere eMAG 8180 (c2.large.arm on Packet) #56245
+  )
 , enablePolly ? false
 }:
 

--- a/pkgs/development/compilers/llvm/8/llvm.nix
+++ b/pkgs/development/compilers/llvm/8/llvm.nix
@@ -14,7 +14,9 @@
 , debugVersion ? false
 , enableManpages ? false
 , enableSharedLibraries ? true
-, enablePFM ? !stdenv.isDarwin
+, enablePFM ? !(stdenv.isDarwin
+  || stdenv.isAarch64 # broken for Ampere eMAG 8180 (c2.large.arm on Packet) #56245
+)
 , enablePolly ? false
 }:
 


### PR DESCRIPTION
See https://github.com/nixos/nixpkgs/issues/56245

Testing: 0 ..
FAIL: LLVM-Unit :: tools/llvm-exegesis/./LLVMExegesisTests/PerfHelperTest.FunctionalTest (2933 of 27000)
******************** TEST 'LLVM-Unit :: tools/llvm-exegesis/./LLVMExegesisTests/PerfHelperTest.FunctionalTest' FAILED ********************
Note: Google Test filter = PerfHelperTest.FunctionalTest
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from PerfHelperTest
[ RUN      ] PerfHelperTest.FunctionalTest
/build/llvm/unittests/tools/llvm-exegesis/PerfHelperTest.cpp:37: Failure
      Expected: CallbackEventName
            Which is: ""
            To be equal to: "CYCLES:u"
            /build/llvm/unittests/tools/llvm-exegesis/PerfHelperTest.cpp:38: Failure
            Value of: CallbackEventNameFullyQualifed
            Expected: isn't empty
              Actual: ""
              [  FAILED  ] PerfHelperTest.FunctionalTest (3 ms)
              [----------] 1 test from PerfHelperTest (3 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (3 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] PerfHelperTest.FunctionalTest

 1 FAILED TEST
 invalid event attribute - cannot create event CYCLES:u

********************
Testing: 0 .. 10.. 20.. 30.. 40.. 50.. 60.. 70.. 80.. 90..

1 warning(s) in tests.
Testing Time: 108.19s
********************
Failing Tests (1):
    LLVM-Unit :: tools/llvm-exegesis/./LLVMExegesisTests/PerfHelperTest.FunctionalTest

  Expected Passes    : 25609
    Expected Failures  : 141
      Unsupported Tests  : 1249
        Unexpected Failures: 1
        make[3]: *** [CMakeFiles/check-all.dir/build.make:58: CMakeFiles/check-all] Error 1
        make[3]: Leaving directory '/build/llvm/build'
        make[2]: *** [CMakeFiles/Makefile2:365: CMakeFiles/check-all.dir/all] Error 2
        make[2]: Leaving directory '/build/llvm/build'
        make[1]: *** [CMakeFiles/Makefile2:372: CMakeFiles/check-all.dir/rule] Error 2
        make[1]: Leaving directory '/build/llvm/build'
        make: *** [Makefile:251: check-all] Error 2
        builder for '/nix/store/4kq72x6ahrigryr6yjjj7c7ayqy8z2sl-llvm-7.0.1.drv' failed with exit code 2Testing: 0 ..
        FAIL: LLVM-Unit :: tools/llvm-exegesis/./LLVMExegesisTests/PerfHelperTest.FunctionalTest (2933 of 27000)
        ******************** TEST 'LLVM-Unit :: tools/llvm-exegesis/./LLVMExegesisTests/PerfHelperTest.FunctionalTest' FAILED ********************
        Note: Google Test filter = PerfHelperTest.FunctionalTest
        [==========] Running 1 test from 1 test case.
        [----------] Global test environment set-up.
        [----------] 1 test from PerfHelperTest
        [ RUN      ] PerfHelperTest.FunctionalTest
        /build/llvm/unittests/tools/llvm-exegesis/PerfHelperTest.cpp:37: Failure
              Expected: CallbackEventName
                    Which is: ""
                    To be equal to: "CYCLES:u"
                    /build/llvm/unittests/tools/llvm-exegesis/PerfHelperTest.cpp:38: Failure
                    Value of: CallbackEventNameFullyQualifed
                    Expected: isn't empty
                      Actual: ""
                      [  FAILED  ] PerfHelperTest.FunctionalTest (3 ms)
                      [----------] 1 test from PerfHelperTest (3 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (3 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] PerfHelperTest.FunctionalTest

 1 FAILED TEST
 invalid event attribute - cannot create event CYCLES:u

********************
Testing: 0 .. 10.. 20.. 30.. 40.. 50.. 60.. 70.. 80.. 90..

1 warning(s) in tests.
Testing Time: 108.19s
********************
Failing Tests (1):
    LLVM-Unit :: tools/llvm-exegesis/./LLVMExegesisTests/PerfHelperTest.FunctionalTest

  Expected Passes    : 25609
    Expected Failures  : 141
      Unsupported Tests  : 1249
        Unexpected Failures: 1
        make[3]: *** [CMakeFiles/check-all.dir/build.make:58: CMakeFiles/check-all] Error 1
        make[3]: Leaving directory '/build/llvm/build'
        make[2]: *** [CMakeFiles/Makefile2:365: CMakeFiles/check-all.dir/all] Error 2
        make[2]: Leaving directory '/build/llvm/build'
        make[1]: *** [CMakeFiles/Makefile2:372: CMakeFiles/check-all.dir/rule] Error 2
        make[1]: Leaving directory '/build/llvm/build'
        make: *** [Makefile:251: check-all] Error 2
        builder for '/nix/store/4kq72x6ahrigryr6yjjj7c7ayqy8z2sl-llvm-7.0.1.drv' failed with exit code 2

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
