### PR TITLE
systemd: point to commit id instead of branch name

### DIFF
--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "NixOS";
     repo = "systemd";
-    rev = "nixos-v${version}";
+    rev = "5c20aab77900f478fd380ab189787d80e4a35963";
     sha256 = "0ldyhfxdy4qlgygvpc92wp0qp6p1c9y3rnm77zwbkga48x60d9i8";
   };
 


### PR DESCRIPTION
branch names are mutable, and with
https://github.com/NixOS/systemd/pull/29 being merged in, the nixos-v242
branch advanced from 5c20aab77900f478fd380ab189787d80e4a35963 to
40eb070cb309ec09def0ecdeaf7514c702200835, causing systemd's
fetchFromGitHub to fail with a sha256sum mismatch (when not relying on
the cache).

Fix this, by pointing systemd.src to the commit id before the branch
advancement. This won't cause a rebuild, as the sha256 stayed the same.

Fast-forwarding systemd to 40eb070cb309ec09def0ecdeaf7514c702200835 will
be done in https://github.com/NixOS/nixpkgs/pull/63784 , which also uses
the commit id, and not a branch name for rev.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
