### PR TITLE
texmacs: 1.99.2 -> 1.99.10

### DIFF
--- a/pkgs/applications/editors/texmacs/default.nix
+++ b/pkgs/applications/editors/texmacs/default.nix
@@ -1,7 +1,13 @@
 { stdenv, callPackage,
   fetchurl, guile_1_8, qt4, xmodmap, which, makeWrapper, freetype,
+  libjpeg,
+  sqlite,
   tex ? null,
   aspell ? null,
+  git ? null,
+  python3 ? null,
+  cmake,
+  pkgconfig,
   ghostscriptX ? null,
   extraFonts ? false,
   chineseFonts ? false,
@@ -10,7 +16,7 @@
 
 let
   pname = "TeXmacs";
-  version = "1.99.2";
+  version = "1.99.10";
   common = callPackage ./common.nix {
     inherit tex extraFonts chineseFonts japaneseFonts koreanFonts;
   };
@@ -19,17 +25,38 @@ stdenv.mkDerivation {
   name = "${pname}-${version}";
 
   src = fetchurl {
-    url = "http://www.texmacs.org/Download/ftp/tmftp/source/TeXmacs-${version}-src.tar.gz";
-    sha256 = "0l48g9746igiaxw657shm8g3xxk565vzsviajlrxqyljbh6py0fs";
+    url = "https://www.texmacs.org/Download/ftp/tmftp/source/TeXmacs-${version}-src.tar.gz";
+    sha256 = "1k12bkcik7mv93q0j7q3b77x8s6rmvlb23s3v7nnzdwjxlp5lph2";
   };
 
-  buildInputs = [ guile_1_8 qt4 makeWrapper ghostscriptX freetype ];
+  cmakeFlags = [
+    # Texmacs' cmake build as of writing defaults to Qt5,
+    # but we haven't updated to that yet.
+    "-DTEXMACS_GUI=Qt4"
+  ];
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = [
+    guile_1_8
+    qt4
+    makeWrapper
+    ghostscriptX
+    freetype
+    libjpeg
+    sqlite
+    git
+    python3
+  ];
   NIX_LDFLAGS = [ "-lz" ];
 
   postInstall = "wrapProgram $out/bin/texmacs --suffix PATH : " +
         (if ghostscriptX == null then "" else "${ghostscriptX}/bin:") +
         (if aspell == null then "" else "${aspell}/bin:") +
         (if tex == null then "" else "${tex}/bin:") +
+        (if git == null then "" else "${git}/bin:") +
+        (if python3 == null then "" else "${python3}/bin:") +
         "${xmodmap}/bin:${which}/bin";
 
   inherit (common) postPatch;


### PR DESCRIPTION
Packaging changes:

* Switch from autoconf to cmake.
  Fixes error
    ```
    checking for guile-config... guile-config
    sh: =~: unknown operand
    ./configure: ./configure.lineno: line 8057: syntax error: bad substitution
    ```
  that appared with the new version.
* Also add new dependencies for new features: git, python
  * (fixes all "missing" errors in cmake's output)
* Stay at Qt4 for now to not introduce too many changes
  * Upgrading to Qt5 in the future is feasible (#33248); it builds
  * I'm not doing it here because Qt5 apps apparently don't run yet on non-NixOS

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

New release with new features!

https://github.com/texmacs/texmacs/releases/tag/v1.99.10

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - I ran texmacs on Ubuntu 16.04 in `nix-shell`, it worked as expected
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
