### PR TITLE
keepassxc: 2.4.1 -> 2.4.3

### DIFF
--- a/pkgs/applications/misc/keepassx/community.nix
+++ b/pkgs/applications/misc/keepassx/community.nix
@@ -32,13 +32,13 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "keepassxc-${version}";
-  version = "2.4.1";
+  version = "2.4.3";
 
   src = fetchFromGitHub {
     owner = "keepassxreboot";
     repo = "keepassxc";
     rev = "${version}";
-    sha256 = "1cbfsfdvb4qw6yb0zl6mymdbphnb7lxbfrc5a8cjmn9w8b09kv6m";
+    sha256 = "1r63bl0cam04rps1bjr107qvwsmay4254nv00gwhh9n45s6cslac";
   };
 
   NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.cc.isClang [

--- a/pkgs/applications/misc/keepassx/darwin.patch
+++ b/pkgs/applications/misc/keepassx/darwin.patch
@@ -1,33 +1,33 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 658548f7..f8f10bdb 100644
+index 74b1a7ff..0a1691df 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -288,6 +288,7 @@ if(MINGW)
+@@ -307,6 +307,7 @@ if(MINGW)
      set(PLUGIN_INSTALL_DIR ".")
      set(DATA_INSTALL_DIR "share")
  elseif(APPLE AND WITH_APP_BUNDLE)
-+	set(CMAKE_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}/Applications")
++    set(CMAKE_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}/Applications")
      set(CMAKE_INSTALL_MANDIR "${PROGNAME}.app/Contents/Resources/man")
      set(CLI_INSTALL_DIR "${PROGNAME}.app/Contents/MacOS")
      set(PROXY_INSTALL_DIR "${PROGNAME}.app/Contents/MacOS")
-@@ -350,12 +351,6 @@ set(CMAKE_AUTORCC ON)
+@@ -369,12 +370,6 @@ set(CMAKE_AUTORCC ON)
  
  if(APPLE)
      set(CMAKE_MACOSX_RPATH TRUE)
 -    find_program(MACDEPLOYQT_EXE macdeployqt HINTS ${Qt5_PREFIX}/bin ENV PATH)
 -    if(NOT MACDEPLOYQT_EXE)
--        message(FATAL_ERROR "macdeployqt is required to build in macOS")
+-        message(FATAL_ERROR "macdeployqt is required to build on macOS")
 -    else()
 -        message(STATUS "Using macdeployqt: ${MACDEPLOYQT_EXE}")
 -    endif()
- endif()
- 
- # Debian sets the the build type to None for package builds.
+ elseif(MINGW)
+     find_program(WINDEPLOYQT_EXE windeployqt HINTS ${Qt5_PREFIX}/bin ENV PATH)
+     if(NOT WINDEPLOYQT_EXE)
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index 110dc606..f9b58818 100644
+index f142f368..0742512d 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -343,11 +343,6 @@ if(APPLE AND WITH_APP_BUNDLE)
+@@ -351,11 +351,6 @@ if(APPLE AND WITH_APP_BUNDLE)
      set(CPACK_PACKAGE_FILE_NAME "${PROGNAME}-${KEEPASSXC_VERSION}")
      include(CPack)
  
@@ -40,10 +40,10 @@ index 110dc606..f9b58818 100644
  
  install(TARGETS ${PROGNAME}
 diff --git a/src/autotype/mac/CMakeLists.txt b/src/autotype/mac/CMakeLists.txt
-index f1c5387f..abf70b48 100644
+index 7427450a..a0a58d71 100644
 --- a/src/autotype/mac/CMakeLists.txt
 +++ b/src/autotype/mac/CMakeLists.txt
-@@ -12,7 +12,6 @@ if(WITH_APP_BUNDLE)
+@@ -8,7 +8,6 @@ if(WITH_APP_BUNDLE)
      add_custom_command(TARGET keepassx-autotype-cocoa
              POST_BUILD
              COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/libkeepassx-autotype-cocoa.so ${PLUGIN_INSTALL_DIR}


### PR DESCRIPTION
Upgrade keepassxc to 2.4.3. Full changelog available at
https://github.com/keepassxreboot/keepassxc/releases/tag/2.4.3.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
