### PR TITLE
clojure: 1.10.0.442 -> 1.10.1.462

### DIFF
--- a/pkgs/development/interpreters/clojure/default.nix
+++ b/pkgs/development/interpreters/clojure/default.nix
@@ -1,12 +1,12 @@
-{ stdenv, fetchurl, jdk, rlwrap, makeWrapper }:
+{ stdenv, fetchurl, jdk11, rlwrap, makeWrapper }:
 
 stdenv.mkDerivation rec {
-  name = "clojure-${version}";
-  version = "1.10.0.442";
+  pname = "clojure";
+  version = "1.10.1.462";
 
   src = fetchurl {
     url = "https://download.clojure.org/install/clojure-tools-${version}.tar.gz";
-    sha256 = "147pkid3pvw60gq8vansid3x6wwfy9pqdbla3wfd5qaxqbcrhclw";
+    sha256 = "0mi7fzqvkg2ihigxkkamc742m1iba0yzy8ivciavzmpcnw128sc6";
   };
 
   buildInputs = [ makeWrapper ];
@@ -14,11 +14,11 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "prefix" ];
 
   installPhase = let
-    binPath = stdenv.lib.makeBinPath [ rlwrap jdk ];
+    binPath = stdenv.lib.makeBinPath [ rlwrap jdk11 ];
   in ''
     mkdir -p $prefix/libexec
     cp clojure-tools-${version}.jar $prefix/libexec
-    cp {,example-}deps.edn $prefix
+    cp example-deps.edn $prefix
 
     substituteInPlace clojure --replace PREFIX $prefix
 
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
       offers a software transactional memory system and reactive Agent
       system that ensure clean, correct, multithreaded designs.
     '';
-    maintainers = with maintainers; [ the-kenny ];
+    maintainers = with maintainers; [ jlesquembre ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Updates jdk dependency from 8 to 11. Clojure 1.10.0 added support for
jdk11, and was released with a new develper tool: REBL
(https://github.com/cognitect-labs/REBL-distro). REBL depends on javafx,
currently only supported on Nix by jdk11 (see #63574)

I also added myself as maintainer and removed @the-kenny, I have the impression he is not interested anymore in maintaining this package.
@the-kenny can you let me know if that's ok with you? If my assumption was wrong, I'll update the PR to add you back as maintainer. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
