### PR TITLE
gnupg: change default keyserver to non-SKS

### DIFF
--- a/pkgs/tools/security/gnupg/22.nix
+++ b/pkgs/tools/security/gnupg/22.nix
@@ -33,7 +33,10 @@ stdenv.mkDerivation rec {
   patches = [
     ./fix-libusb-include-path.patch
   ];
-  postPatch = stdenv.lib.optionalString stdenv.isLinux ''
+  postPatch = ''
+    sed -i 's,hkps://hkps.pool.sks-keyservers.net,hkps://keys.openpgp.org,g' \
+        configure doc/dirmngr.texi doc/gnupg.info-1
+  '' + stdenv.lib.optionalString stdenv.isLinux ''
     sed -i 's,"libpcsclite\.so[^"]*","${stdenv.lib.getLib pcsclite}/lib/libpcsclite.so",g' scd/scdaemon.c
   ''; #" fix Emacs syntax highlighting :-(
 

--- a/pkgs/tools/security/gnupg/22.nix
+++ b/pkgs/tools/security/gnupg/22.nix
@@ -1,5 +1,5 @@
-{ fetchurl, stdenv, pkgconfig, libgcrypt, libassuan, libksba, libgpgerror
-, libiconv, npth, gettext, texinfo, pcsclite, sqlite
+{ fetchurl, fetchpatch, stdenv, pkgconfig, libgcrypt, libassuan, libksba
+, libgpgerror, libiconv, npth, gettext, texinfo, pcsclite, sqlite
 , buildPackages
 
 # Each of the dependencies below are optional.
@@ -32,6 +32,10 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./fix-libusb-include-path.patch
+    (fetchpatch {
+      url = https://files.gnupg.net/file/data/qmxjhc6kuja3orybj7st/PHID-FILE-vvzlnw36427pdnug2amc/file;
+      sha256 = "13snxkmlgmvn0rgxh5k2sgxkp5mbxqiznzm45sw649nvs3ccghq8";
+    })
   ];
   postPatch = ''
     sed -i 's,hkps://hkps.pool.sks-keyservers.net,hkps://keys.openpgp.org,g' \


### PR DESCRIPTION
**I’ve asked the people behind keys.openpgp.org if they’re ready to become a distro default, and am awaiting a definitive answer from them. Until then this PR should not be merged.**

This is a breaking change, but I think it should still be backported to stable because the alternative is leaving people vulnerable.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

See https://gist.github.com/rjhansen/67ab921ffb4084c865b3618d6955275f.

The SKS network is vulnerable to certificate poisoning, which can destroy GnuPG installations. keys.openpgp.org is a new non-SKS keyserver that is resistant to this type of attack.

With such an attack being possible, it is unsafe to use SKS keyservers for almost anything, and so we should protect our users from a now unsafe default. keys.openpgp.org offers some (but not all) functionality of SKS, and is better than nothing.

This default is only present in `gnupg22`. `gnupg20` and `gnupg1orig` are not affected.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---