### PR TITLE
psrecord: init at 1.1

### DIFF
--- a/pkgs/tools/misc/psrecord/default.nix
+++ b/pkgs/tools/misc/psrecord/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonApplication, fetchPypi, psutil, matplotlib, pytest }:
+buildPythonApplication rec {
+  pname = "psrecord";
+  version = "1.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "151rynca97v5wq1drl2yfrqmqil1km72cizn3159c2ip14626mp6";
+  };
+
+  propagatedBuildInputs = [
+    psutil matplotlib
+  ];
+
+  checkInputs = [
+    pytest
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+    pytest psrecord
+    runHook postCheck
+  '';
+
+  meta = {
+    description = "Record the CPU and memory activity of a process";
+    homepage = "https://github.com/astrofrog/psrecord";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ johnazoidberg ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1784,6 +1784,8 @@ in
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  psrecord = python3Packages.callPackage ../tools/misc/psrecord {};
+
   scour = with python3Packages; toPythonApplication scour;
 
   s2png = callPackage ../tools/graphics/s2png { };


### PR DESCRIPTION
###### Motivation for this change
Allows for simple RAM usage measurements, e.g.:
```
psrecord --plot plot.png "nix-env -qa hello"
```

![plot](https://user-images.githubusercontent.com/5307138/60398257-9ae98a00-9b56-11e9-9904-ddad1082e1fd.png)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
