### PR TITLE
olm: Allow building on Darwin

### DIFF
--- a/pkgs/applications/networking/irc/weechat/scripts/weechat-matrix-bridge/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/weechat-matrix-bridge/default.nix
@@ -42,5 +42,9 @@ stdenv.mkDerivation {
     maintainers = with maintainers; [ ma27 ];
     license = licenses.mit; # see https://github.com/torhve/weechat-matrix-protocol-script/blob/0052e7275ae149dc5241226391c9b1889ecc3c6b/matrix.lua#L53
     platforms = platforms.unix;
+
+    # As of 2019-06-30, all of the dependencies are available on macOS but the
+    # package itself does not build.
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/development/libraries/mtxclient/default.nix
+++ b/pkgs/development/libraries/mtxclient/default.nix
@@ -27,5 +27,9 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     maintainers = with maintainers; [ fpletz ];
     platforms = platforms.unix;
+
+    # As of 2019-06-30, all of the dependencies are available on macOS but the
+    # package itself does not build.
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/development/libraries/olm/default.nix
+++ b/pkgs/development/libraries/olm/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     description = "Implements double cryptographic ratchet and Megolm ratchet";
     license = stdenv.lib.licenses.asl20;
     homepage = https://matrix.org/git/olm/about;
-    platforms = stdenv.lib.platforms.linux;
+    platforms = with stdenv.lib.platforms; darwin ++ linux;
   };
 
   src = fetchurl {
@@ -21,6 +21,8 @@ stdenv.mkDerivation rec {
 
   # requires optimisation but memory operations are compiled with -O0
   hardeningDisable = ["fortify"];
+
+  makeFlags = if stdenv.cc.isClang then [ "CC=cc" ] else null;
 
   installFlags = "PREFIX=$(out)";
 }


### PR DESCRIPTION
###### Motivation for this change

Small change to allow the “olm” package to build under Darwin (in addition to Linux).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).