### PR TITLE
[19.03] gnupg: change default keyserver to non-SKS

### DIFF
--- a/pkgs/tools/security/gnupg/0001-dirmngr-Only-use-SKS-pool-CA-for-SKS-pool.patch
+++ b/pkgs/tools/security/gnupg/0001-dirmngr-Only-use-SKS-pool-CA-for-SKS-pool.patch
@@ -1,0 +1,34 @@
+From 1c9cc97e9d47d73763810dcb4a36b6cdf31a2254 Mon Sep 17 00:00:00 2001
+From: Daniel Kahn Gillmor <dkg@fifthhorseman.net>
+Date: Sun, 30 Jun 2019 11:54:35 -0400
+Subject: [PATCH] dirmngr: Only use SKS pool CA for SKS pool
+
+* dirmngr/http.c (http_session_new): when checking whether the
+keyserver is the HKPS pool, check specifically against the pool name,
+as ./configure might have been used to select a different default
+keyserver.  It makes no sense to apply Kristian's certificate
+authority to anything other than the literal host
+hkps.pool.sks-keyservers.net.
+
+Signed-off-by: Daniel Kahn Gillmor <dkg@fifthhorseman.net>
+GnuPG-Bug-Id: 4593
+---
+ dirmngr/http.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/dirmngr/http.c b/dirmngr/http.c
+index 384f2569d..8e5d53939 100644
+--- a/dirmngr/http.c
++++ b/dirmngr/http.c
+@@ -767,7 +767,7 @@ http_session_new (http_session_t *r_session,
+ 
+     is_hkps_pool = (intended_hostname
+                     && !ascii_strcasecmp (intended_hostname,
+-                                          get_default_keyserver (1)));
++                                          "hkps.pool.sks-keyservers.net"));
+ 
+     /* If the user has not specified a CA list, and they are looking
+      * for the hkps pool from sks-keyservers.net, then default to
+-- 
+2.22.0
+

--- a/pkgs/tools/security/gnupg/22.nix
+++ b/pkgs/tools/security/gnupg/22.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, pkgconfig, libgcrypt, libassuan, libksba
+{ fetchurl, fetchpatch, stdenv, pkgconfig, libgcrypt, libassuan, libksba
 , libiconv, npth, gettext, texinfo, pcsclite, sqlite
 
 # Each of the dependencies below are optional.
@@ -30,6 +30,10 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./fix-libusb-include-path.patch
+    (fetchpatch {
+      url = https://files.gnupg.net/file/data/qmxjhc6kuja3orybj7st/PHID-FILE-vvzlnw36427pdnug2amc/file;
+      sha256 = "13snxkmlgmvn0rgxh5k2sgxkp5mbxqiznzm45sw649nvs3ccghq8";
+    })
   ];
   postPatch = ''
     sed -i 's,hkps://hkps.pool.sks-keyservers.net,hkps://keys.openpgp.org,g' \

--- a/pkgs/tools/security/gnupg/22.nix
+++ b/pkgs/tools/security/gnupg/22.nix
@@ -31,7 +31,10 @@ stdenv.mkDerivation rec {
   patches = [
     ./fix-libusb-include-path.patch
   ];
-  postPatch = stdenv.lib.optionalString stdenv.isLinux ''
+  postPatch = ''
+    sed -i 's,hkps://hkps.pool.sks-keyservers.net,hkps://keys.openpgp.org,g' \
+        configure doc/dirmngr.texi doc/gnupg.info-1
+  '' + stdenv.lib.optionalString stdenv.isLinux ''
     sed -i 's,"libpcsclite\.so[^"]*","${stdenv.lib.getLib pcsclite}/lib/libpcsclite.so",g' scd/scdaemon.c
   ''; #" fix Emacs syntax highlighting :-(
 

--- a/pkgs/tools/security/gnupg/22.nix
+++ b/pkgs/tools/security/gnupg/22.nix
@@ -30,10 +30,7 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./fix-libusb-include-path.patch
-    (fetchpatch {
-      url = https://files.gnupg.net/file/data/qmxjhc6kuja3orybj7st/PHID-FILE-vvzlnw36427pdnug2amc/file;
-      sha256 = "13snxkmlgmvn0rgxh5k2sgxkp5mbxqiznzm45sw649nvs3ccghq8";
-    })
+    ./0001-dirmngr-Only-use-SKS-pool-CA-for-SKS-pool.patch
   ];
   postPatch = ''
     sed -i 's,hkps://hkps.pool.sks-keyservers.net,hkps://keys.openpgp.org,g' \


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Backport of #63952. I expect this to be controversial since it is a breaking change, and I know @Ekleog disagrees, so I’m opening this for discussion and to allow the release managers to make the call.

Personally, I think this is the right thing to do. keys.openpgp.org may not support all of SKS’s features, but it’s the only solid way to ensure our users are protected against their GnuPG installations becoming unusable. We could set `import-clean` by default, which protects against the attack iff the attacker has not managed to already get their own key into the user’s key ring, but doing that isn’t exactly difficult, especially if they enable `auto-key-retrieve`.

To summarise our options:

- Do nothing. Almost any interaction with a key server can potentially render a user’s GnuPG installation unusable, requiring surgery or deleting the keyring to be usable again.
- Enable `import-clean` by default. Mitigates the attack _in some cirmcumstances_, but not all by far.
- Switch the default keyserver. Protects against the attack unless the user explicitly configures otherwise. Means that some keyserver features (UID fetching, UID revocation) are no longer available.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
