### PR TITLE
powerdns: fix build, 4.1.7 -> 4.1.9, fixing CVE-2019-10162, CVE-2019-10163

### DIFF
--- a/pkgs/servers/dns/powerdns/default.nix
+++ b/pkgs/servers/dns/powerdns/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   name = "powerdns-${version}";
-  version = "4.1.7";
+  version = "4.1.9";
 
   src = fetchurl {
     url = "https://downloads.powerdns.com/releases/pdns-${version}.tar.bz2";
-    sha256 = "11c4r0mbq6ybbihm0jbl9hspb01pj1gi6x3m374liw9jij7dw8b4";
+    sha256 = "1dmx37xzg7qckq166jr7swcnw3m9wjh5169844ad59qhspfzflnk";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15879,7 +15879,7 @@ in
 
   semodule-utils = callPackage ../os-specific/linux/semodule-utils { };
 
-  powerdns = callPackage ../servers/dns/powerdns { };
+  powerdns = callPackage ../servers/dns/powerdns { libressl = libressl_2_8; };
 
   dnsdist = callPackage ../servers/dns/dnsdist { };
 


### PR DESCRIPTION
###### Motivation for this change
https://doc.powerdns.com/authoritative/security-advisories/powerdns-advisory-2019-04.html
https://doc.powerdns.com/authoritative/security-advisories/powerdns-advisory-2019-05.html

`powerdns`'s build was broken by the recent default `libressl` switch to 2.9. While we should chase down and fix what's causing that failure, there's the pressing concern of these two CVEs - so I've just switched `powerdns` back to `libressl_2_8` for now, then bumped to 4.1.9.

~Note: I have **not** yet completed a `nox-review` for this.~ Ok, there aren't any reverse dependencies.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
