### PR TITLE
[r19.03] powerdns: add patches fixing CVE-2019-10162, CVE-2019-10163

### DIFF
--- a/pkgs/servers/dns/powerdns/default.nix
+++ b/pkgs/servers/dns/powerdns/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig
+{ stdenv, fetchurl, pkgconfig, fetchpatch
 , boost, libyamlcpp, libsodium, sqlite, protobuf, botan2, libressl
 , mysql57, postgresql, lua, openldap, geoip, curl, opendbx, unixODBC
 }:
@@ -11,6 +11,19 @@ stdenv.mkDerivation rec {
     url = "https://downloads.powerdns.com/releases/pdns-${version}.tar.bz2";
     sha256 = "11c4r0mbq6ybbihm0jbl9hspb01pj1gi6x3m374liw9jij7dw8b4";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2019-10162-4.1.8-invalidrecords.patch";
+      url = "https://sources.debian.org/data/main/p/pdns/4.1.6-3/debian/patches/CVE-2019-10162-4.1.8-invalidrecords.patch";
+      sha256 = "0960351p20fm0vjd0k5p7bcf2kvnikkzbxzp2wm8bwhcx12jlyll";
+    })
+    (fetchpatch {
+      name = "CVE-2019-10163-4.1.8-busyloop.patch";
+      url = "https://sources.debian.org/data/main/p/pdns/4.1.6-3/debian/patches/CVE-2019-10163-4.1.8-busyloop.patch";
+      sha256 = "0z12frdki1vidskiyin0m6jza88p7535igyj712s5sq8rw5xxz6x";
+    })
+  ];
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change
https://doc.powerdns.com/authoritative/security-advisories/powerdns-advisory-2019-04.html
https://doc.powerdns.com/authoritative/security-advisories/powerdns-advisory-2019-05.html

Debian have conveniently fished out the right patches for these.

~Note: I have **not** yet completed a `nox-review` for this.~ Ok, there aren't any reverse dependencies.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
