### PR TITLE
sonobuoy: init at 0.15.0

### DIFF
--- a/pkgs/applications/networking/cluster/sonobuoy/default.nix
+++ b/pkgs/applications/networking/cluster/sonobuoy/default.nix
@@ -1,0 +1,43 @@
+{ lib, buildGoPackage, fetchFromGitHub }:
+
+# SHA of ${version} for the tool's help output
+let rev = "7ad367535a6710802085d41e0dbb53df359b9882";
+in
+buildGoPackage rec {
+  pname = "sonobuoy";
+  version = "0.15.0";
+
+  goPackagePath = "github.com/heptio/sonobuoy";
+
+  buildFlagsArray =
+    let t = "${goPackagePath}";
+    in ''
+      -ldflags=
+        -s -X ${t}/pkg/buildinfo.Version=${version}
+           -X ${t}/pkg/buildinfo.GitSHA=${rev}
+           -X ${t}/pkg/buildDate=unknown
+    '';
+
+  src = fetchFromGitHub {
+    sha256 = "0dkmhmr7calk8mkdxfpy3yjzk10ja4gz1jq8pgk3v8rh04f4h1x5";
+    rev = "v${version}";
+    repo = "sonobuoy";
+    owner = "heptio";
+  };
+
+  meta = with lib; {
+    description = ''
+      Diagnostic tool that makes it easier to understand the
+      state of a Kubernetes cluster.
+    '';
+    longDescription = ''
+      Sonobuoy is a diagnostic tool that makes it easier to understand the state of
+      a Kubernetes cluster by running a set of Kubernetes conformance tests in an
+      accessible and non-destructive manner.
+    '';
+
+    homepage = "https://github.com/heptio/sonobuoy";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ carlosdagos ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2657,6 +2657,8 @@ in
 
   sonota = callPackage ../tools/misc/sonota { };
 
+  sonobuoy = callPackage ../applications/networking/cluster/sonobuoy { };
+
   tealdeer = callPackage ../tools/misc/tealdeer { };
 
   teamocil = callPackage ../tools/misc/teamocil { };


### PR DESCRIPTION
###### Motivation for this change

Neat program to run k8s tests 😄 	

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
