### PR TITLE
watson: 1.5.2 -> 1.7.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3564,6 +3564,11 @@
     github = "nathan-gs";
     name = "Nathan Bijnens";
   };
+  nathyong = {
+    email = "nathyong@noreply.github.com";
+    github = "nathyong";
+    name = "Nathan Yong";
+  };
   nckx = {
     email = "github@tobias.gr";
     github = "nckx";

--- a/pkgs/applications/office/watson/default.nix
+++ b/pkgs/applications/office/watson/default.nix
@@ -12,10 +12,8 @@ buildPythonApplication rec {
     sha256 = "249313996751f32f38817d424cbf8d74956461df1439f0ee3a962fcc3c77225d";
   };
 
-  # uses tox, test invocation fails
-  doCheck = true;
   checkPhase = ''
-    py.test -vs tests
+    pytest -vs tests
  '';
 
   checkInputs = [ py pytest pytest-datafiles mock pytest-mock pytestrunner ];

--- a/pkgs/applications/office/watson/default.nix
+++ b/pkgs/applications/office/watson/default.nix
@@ -3,11 +3,12 @@
 with pythonPackages;
 
 buildPythonApplication rec {
-  pname = "td-watson";
+  pname = "watson";
   version = "1.7.0";
 
   src = fetchPypi {
-    inherit version pname;
+    inherit version;
+    pname = "td-watson";
     sha256 = "249313996751f32f38817d424cbf8d74956461df1439f0ee3a962fcc3c77225d";
   };
 

--- a/pkgs/applications/office/watson/default.nix
+++ b/pkgs/applications/office/watson/default.nix
@@ -4,11 +4,11 @@ with pythonPackages;
 
 buildPythonApplication rec {
   pname = "td-watson";
-  version = "1.5.2";
+  version = "1.7.0";
 
   src = fetchPypi {
     inherit version pname;
-    sha256 = "6e03d44a9278807fe5245e9ed0943f13ffb88e11249a02655c84cb86260b27c8";
+    sha256 = "249313996751f32f38817d424cbf8d74956461df1439f0ee3a962fcc3c77225d";
   };
 
   # uses tox, test invocation fails
@@ -17,13 +17,6 @@ buildPythonApplication rec {
     py.test -vs tests
  '';
 
-  patches = [
-    (fetchpatch {
-      url = https://github.com/TailorDev/Watson/commit/f5760c71cbc22de4e12ede8f6f7257515a9064d3.patch;
-      sha256 = "0s9h26915ilpbd0qhmvk77r3gmrsdrl5l7dqxj0l5q66fp0z6b0g";
-    })
-  ];
-
   checkInputs = [ py pytest pytest-datafiles mock pytest-mock pytestrunner ];
   propagatedBuildInputs = [ requests click arrow ];
 
@@ -31,6 +24,6 @@ buildPythonApplication rec {
     homepage = https://tailordev.github.io/Watson/;
     description = "A wonderful CLI to track your time!";
     license = licenses.mit;
-    maintainers = with maintainers; [ mguentner ] ;
+    maintainers = with maintainers; [ mguentner nathyong ] ;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update to the latest version on PyPI.

Current nixos-version:
```$ nixos-version
19.03.172927.30a82bba734 (Koi)
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review 63972"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
