### PR TITLE
trompeloeil: init at 34

### DIFF
--- a/pkgs/development/libraries/trompeloeil/default.nix
+++ b/pkgs/development/libraries/trompeloeil/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, cmake }:
+
+stdenv.mkDerivation rec {
+  name = "trompeloeil-${version}";
+  version = "34";
+
+  src = fetchFromGitHub {
+    owner = "rollbear";
+    repo = "trompeloeil";
+    rev = "v${version}";
+    sha256 = "0mj3zni18kfm04jrqjaa1p6ii5q0dz6qdm3hi57z9lzygaxbdc97";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with stdenv.lib; {
+    description = "Header only C++14 mocking framework";
+    homepage = "https://github.com/rollbear/trompeloeil";
+    license = licenses.boost;
+    maintainers = [ maintainers.bjornfor ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2663,6 +2663,8 @@ in
 
   tridactyl-native = callPackage ../tools/networking/tridactyl-native { };
 
+  trompeloeil = callPackage ../development/libraries/trompeloeil { };
+
   uudeview = callPackage ../tools/misc/uudeview { };
 
   uutils-coreutils = callPackage ../tools/misc/uutils-coreutils {


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Motivation for this change
Trompeloeil is a header only C++14 mocking framework.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
