### PR TITLE
apparmor: make apparmor cross-compile

### DIFF
--- a/pkgs/os-specific/linux/apparmor/cross.patch
+++ b/pkgs/os-specific/linux/apparmor/cross.patch
@@ -1,0 +1,19 @@
+--- a/parser/libapparmor_re/Makefile	2018-10-14 07:38:06.000000000 +0800
++++ b/parser/libapparmor_re/Makefile	2019-06-28 16:16:33.741916660 +0800
+@@ -10,6 +10,7 @@
+ 
+ TARGET=libapparmor_re.a
+ 
++AR ?= ar
+ CFLAGS ?= -g -Wall -O2 ${EXTRA_CFLAGS} -std=gnu++0x
+ CXXFLAGS := ${CFLAGS} ${INCLUDE_APPARMOR}
+ 
+@@ -22,7 +23,7 @@
+ UNITTESTS = tst_parse
+ 
+ libapparmor_re.a: parse.o expr-tree.o hfa.o chfa.o aare_rules.o
+-	ar ${ARFLAGS} $@ $^
++	${AR} ${ARFLAGS} $@ $^
+ 
+ expr-tree.o: expr-tree.cc expr-tree.h
+ 

--- a/pkgs/os-specific/linux/apparmor/default.nix
+++ b/pkgs/os-specific/linux/apparmor/default.nix
@@ -49,7 +49,9 @@ let
       sha256 = "1m4dx901biqgnr4w4wz8a2z9r9dxyw7wv6m6mqglqwf2lxinqmp4";
     })
     # (alpine patches {1,4,5,6,8} are needed for apparmor 2.11, but not 2.12)
-  ];
+    ] ++ [
+      ./cross.patch
+    ];
 
   # Set to `true` after the next FIXME gets fixed or this gets some
   # common derivation infra. Too much copy-paste to fix one by one.
@@ -185,7 +187,7 @@ let
     '';
     inherit patches;
     postPatch = "cd ./parser";
-    makeFlags = ''LANGS= USE_SYSTEM=1 INCLUDEDIR=${libapparmor}/include'';
+    makeFlags = ''LANGS= USE_SYSTEM=1 INCLUDEDIR=${libapparmor}/include AR=${stdenv.cc.bintools.targetPrefix}ar'';
     installFlags = ''DESTDIR=$(out) DISTRO=unknown'';
 
     inherit doCheck;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

`apparmor` assumes that the archiver always has no target platform prefix, which is not true when cross compiling. This PR fixes this, so that `apparmor-parser` in particular will cross compile.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
