### PR TITLE
Install postgresql extensions under `$out/share/postgresql`

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/cstore_fdw.nix
+++ b/pkgs/servers/sql/postgresql/ext/cstore_fdw.nix
@@ -18,8 +18,8 @@ stdenv.mkDerivation rec {
     mkdir -p $out/{lib,share/extension}
 
     cp *.so      $out/lib
-    cp *.sql     $out/share/extension
-    cp *.control $out/share/extension
+    cp *.sql     $out/share/postgresql/extension
+    cp *.control $out/share/postgresql/extension
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/servers/sql/postgresql/ext/pg_auto_failover.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_auto_failover.nix
@@ -19,8 +19,8 @@ stdenv.mkDerivation rec {
   installPhase = ''
     install -D -t $out/bin src/bin/pg_autoctl/pg_autoctl
     install -D -t $out/lib src/monitor/pgautofailover.so
-    install -D -t $out/share/extension src/monitor/*.sql
-    install -D -t $out/share/extension src/monitor/pgautofailover.control
+    install -D -t $out/share/postgresql/extension src/monitor/*.sql
+    install -D -t $out/share/postgresql/extension src/monitor/pgautofailover.control
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/servers/sql/postgresql/ext/pg_bigm.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_bigm.nix
@@ -18,8 +18,8 @@ stdenv.mkDerivation rec {
     mkdir -p $out/{lib,share/extension}
 
     cp *.so      $out/lib
-    cp *.sql     $out/share/extension
-    cp *.control $out/share/extension
+    cp *.sql     $out/share/postgresql/extension
+    cp *.control $out/share/postgresql/extension
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/servers/sql/postgresql/ext/pg_cron.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_cron.nix
@@ -18,8 +18,8 @@ stdenv.mkDerivation rec {
     mkdir -p $out/{lib,share/extension}
 
     cp *.so      $out/lib
-    cp *.sql     $out/share/extension
-    cp *.control $out/share/extension
+    cp *.sql     $out/share/postgresql/extension
+    cp *.control $out/share/postgresql/extension
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/servers/sql/postgresql/ext/pg_hll.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_hll.nix
@@ -17,8 +17,8 @@ stdenv.mkDerivation rec {
     mkdir -p $out/{lib,share/extension}
 
     cp *.so      $out/lib
-    cp *.sql     $out/share/extension
-    cp *.control $out/share/extension
+    cp *.sql     $out/share/postgresql/extension
+    cp *.control $out/share/postgresql/extension
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/servers/sql/postgresql/ext/pg_partman.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_partman.nix
@@ -18,9 +18,9 @@ stdenv.mkDerivation rec {
     mkdir -p $out/{lib,share/extension}
 
     cp src/*.so      $out/lib
-    cp updates/*     $out/share/extension
-    cp -r sql/*      $out/share/extension
-    cp *.control     $out/share/extension
+    cp updates/*     $out/share/postgresql/extension
+    cp -r sql/*      $out/share/postgresql/extension
+    cp *.control     $out/share/postgresql/extension
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/servers/sql/postgresql/ext/pg_repack.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_repack.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     install -D bin/pg_repack -t $out/bin/
     install -D lib/pg_repack.so -t $out/lib/
-    install -D lib/{pg_repack--${version}.sql,pg_repack.control} -t $out/share/extension
+    install -D lib/{pg_repack--${version}.sql,pg_repack.control} -t $out/share/postgresql/extension
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/servers/sql/postgresql/ext/pg_similarity.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_similarity.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
   installPhase = ''
     mkdir -p $out/bin   # for buildEnv to setup proper symlinks
     install -D pg_similarity.so -t $out/lib/
-    install -D ./{pg_similarity--unpackaged--1.0.sql,pg_similarity--1.0.sql,pg_similarity.control} -t $out/share/extension
+    install -D ./{pg_similarity--unpackaged--1.0.sql,pg_similarity--1.0.sql,pg_similarity.control} -t $out/share/postgresql/extension
   '';
 
   meta = {

--- a/pkgs/servers/sql/postgresql/ext/pg_topn.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_topn.nix
@@ -17,8 +17,8 @@ stdenv.mkDerivation rec {
     mkdir -p $out/{lib,share/extension}
 
     cp *.so      $out/lib
-    cp *.sql     $out/share/extension
-    cp *.control $out/share/extension
+    cp *.sql     $out/share/postgresql/extension
+    cp *.control $out/share/postgresql/extension
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/servers/sql/postgresql/ext/pgjwt.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgjwt.nix
@@ -14,8 +14,8 @@ stdenv.mkDerivation rec {
   buildPhase = ":";
   installPhase = ''
     mkdir -p $out/bin  # current postgresql extension mechanism in nixos requires bin directory
-    mkdir -p $out/share/extension
-    cp pg*sql *.control $out/share/extension
+    mkdir -p $out/share/postgresql/extension
+    cp pg*sql *.control $out/share/postgresql/extension
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/servers/sql/postgresql/ext/pgroonga.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgroonga.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/bin
     install -D pgroonga.so -t $out/lib/
-    install -D ./{pgroonga-*.sql,pgroonga.control} -t $out/share/extension
+    install -D ./{pgroonga-*.sql,pgroonga.control} -t $out/share/postgresql/extension
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/servers/sql/postgresql/ext/pgrouting.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgrouting.nix
@@ -17,8 +17,8 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/bin # for buildEnv, see https://github.com/NixOS/nixpkgs/issues/22653
     install -D lib/*.so                        -t $out/lib
-    install -D sql/pgrouting--${version}.sql   -t $out/share/extension
-    install -D sql/common/pgrouting.control    -t $out/share/extension
+    install -D sql/pgrouting--${version}.sql   -t $out/share/postgresql/extension
+    install -D sql/common/pgrouting.control    -t $out/share/postgresql/extension
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/servers/sql/postgresql/ext/pgtap.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgtap.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ postgresql perl perlPackages.TAPParserSourceHandlerpgTAP which ];
 
   installPhase = ''
-    install -D {sql/pgtap--${version}.sql,pgtap.control} -t $out/share/extension
+    install -D {sql/pgtap--${version}.sql,pgtap.control} -t $out/share/postgresql/extension
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/servers/sql/postgresql/ext/pipelinedb.nix
+++ b/pkgs/servers/sql/postgresql/ext/pipelinedb.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/bin
     install -D -t $out/lib/ pipelinedb.so
-    install -D -t $out/share/extension {pipelinedb-*.sql,pipelinedb.control}
+    install -D -t $out/share/postgresql/extension {pipelinedb-*.sql,pipelinedb.control}
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/servers/sql/postgresql/ext/plv8.nix
+++ b/pkgs/servers/sql/postgresql/ext/plv8.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/bin
     install -D plv8*.so                                        -t $out/lib
-    install -D {plls,plcoffee,plv8}{--${version}.sql,.control} -t $out/share/extension
+    install -D {plls,plcoffee,plv8}{--${version}.sql,.control} -t $out/share/postgresql/extension
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/servers/sql/postgresql/ext/postgis.nix
+++ b/pkgs/servers/sql/postgresql/ext/postgis.nix
@@ -31,9 +31,9 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
     sed -i 's@/usr/bin/file@${file}/bin/file@' configure
-    configureFlags="--datadir=$out/share --datarootdir=$out/share --bindir=$out/bin --with-gdalconfig=${gdal}/bin/gdal-config --with-jsondir=${json_c.dev}"
+    configureFlags="--datadir=$out/share/postgresql --datarootdir=$out/share/postgresql --bindir=$out/bin --with-gdalconfig=${gdal}/bin/gdal-config --with-jsondir=${json_c.dev}"
 
-    makeFlags="PERL=${perl}/bin/perl datadir=$out/share pkglibdir=$out/lib bindir=$out/bin"
+    makeFlags="PERL=${perl}/bin/perl datadir=$out/share/postgresql pkglibdir=$out/lib bindir=$out/bin"
   '';
   postConfigure = ''
     sed -i "s|@mkdir -p \$(DESTDIR)\$(PGSQL_BINDIR)||g ;

--- a/pkgs/servers/sql/postgresql/ext/tds_fdw.nix
+++ b/pkgs/servers/sql/postgresql/ext/tds_fdw.nix
@@ -15,8 +15,8 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     install -D tds_fdw.so                  -t $out/lib
-    install -D sql/tds_fdw--${version}.sql -t $out/share/extension
-    install -D tds_fdw.control             -t $out/share/extension
+    install -D sql/tds_fdw--${version}.sql -t $out/share/postgresql/extension
+    install -D tds_fdw.control             -t $out/share/postgresql/extension
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/servers/sql/postgresql/ext/temporal_tables.nix
+++ b/pkgs/servers/sql/postgresql/ext/temporal_tables.nix
@@ -17,8 +17,8 @@ stdenv.mkDerivation rec {
     mkdir -p $out/{bin,lib,share/extension}
 
     cp *.so      $out/lib
-    cp *.sql     $out/share/extension
-    cp *.control $out/share/extension
+    cp *.sql     $out/share/postgresql/extension
+    cp *.control $out/share/postgresql/extension
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/servers/sql/postgresql/ext/timescaledb.nix
+++ b/pkgs/servers/sql/postgresql/ext/timescaledb.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   patchPhase = ''
     for x in CMakeLists.txt sql/CMakeLists.txt; do
       substituteInPlace "$x" \
-        --replace 'DESTINATION "''${PG_SHAREDIR}/extension"' "DESTINATION \"$out/share/extension\""
+        --replace 'DESTINATION "''${PG_SHAREDIR}/extension"' "DESTINATION \"$out/share/postgresql/extension\""
     done
 
     for x in src/CMakeLists.txt src/loader/CMakeLists.txt tsl/src/CMakeLists.txt; do

--- a/pkgs/servers/sql/postgresql/ext/tsearch_extras.nix
+++ b/pkgs/servers/sql/postgresql/ext/tsearch_extras.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/bin
     install -D tsearch_extras.so -t $out/lib/
-    install -D ./{tsearch_extras--1.0.sql,tsearch_extras.control} -t $out/share/extension
+    install -D ./{tsearch_extras--1.0.sql,tsearch_extras.control} -t $out/share/postgresql/extension
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Move postgresql extensions from `$out/share` to `$out/share/postgresql`.

Fixes #63805

###### Motivation for this change

Fix broken PostgreSQL with extensions after #62271 moved files from `$out/share` to `$out/share/postgresql`.

###### Things done

I have only tested this for TimescaleDB and PostGIS on NixOS.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---