### PR TITLE
caddy: add command line options

### DIFF
--- a/nixos/modules/services/web-servers/caddy.nix
+++ b/nixos/modules/services/web-servers/caddy.nix
@@ -36,6 +36,36 @@ in {
       type = types.string;
       description = "Email address (for Let's Encrypt certificate)";
     };
+    
+    httpPort = mkOption {
+      default = "80";
+      type = types.string;
+      description = ''Default port to use for HTTP (default "80")'';
+    };
+    
+    httpsPort = mkOption {
+      default = "443";
+      type = types.string;
+      description = ''Default port to use for HTTPS (default "443")'';
+    };
+    
+    port = mkOption {
+      default = "2015";
+      type = types.string;
+      description = ''Default port (default "2015")'';
+    };
+    
+    http2 = mkOption {
+      default = true;
+      type = types.bool;
+      description = "Use HTTP/2 (default true)";
+    };
+    
+    cpu = mkOption {
+      default = "100%";
+      type = types.string;
+      description = ''CPU cap (default "100%")'';
+    };
 
     agree = mkOption {
       default = false;
@@ -71,7 +101,8 @@ in {
       serviceConfig = {
         ExecStart = ''
           ${cfg.package.bin}/bin/caddy -root=/var/tmp -conf=${configFile} \
-            -ca=${cfg.ca} -email=${cfg.email} ${optionalString cfg.agree "-agree"}
+            -ca=${cfg.ca} -email=${cfg.email} ${optionalString cfg.agree "-agree"} -http-port=${cfg.httpPort} \
+            -https-port=${cfg.httpsPort} -port=${cfg.port} -http2=${cfg.http2} -cpu=${cfg.cpu} 
         '';
         ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
         Type = "simple";


### PR DESCRIPTION
Nixos' caddy release doesn't currently allow changing some command line options.

###### Motivation for this change

Nixos' caddy release doesn't currently allow changing some command line options.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
