### PR TITLE
python: wxPython: init at 4.0.6

### DIFF
--- a/pkgs/development/python-modules/wxPython/4.0.nix
+++ b/pkgs/development/python-modules/wxPython/4.0.nix
@@ -1,8 +1,11 @@
 { lib
+, stdenv
+, openglSupport ? true
+, libX11
+, pyopengl
 , buildPythonPackage
 , fetchPypi
 , pkgconfig
-, gtk3
 , libjpeg
 , libtiff
 , SDL
@@ -11,6 +14,16 @@
 , freeglut
 , xorg
 , which
+, cairo
+, requests
+, pango
+, pathlib2
+, python
+, doxygen
+, ncurses
+, libpng
+, gstreamer
+, wxGTK
 }:
 
 buildPythonPackage rec {
@@ -22,14 +35,43 @@ buildPythonPackage rec {
     sha256 = "35cc8ae9dd5246e2c9861bb796026bbcb9fb083e4d49650f776622171ecdab37";
   };
 
-  nativeBuildInputs = [
-    pkgconfig
-  ];
+  doCheck = false;
 
-  buildInputs = [
-    gtk3 libjpeg libtiff SDL gst-plugins-base libnotify freeglut xorg.libSM
-    which
-  ];
+  nativeBuildInputs = [ pkgconfig which doxygen wxGTK ];
+
+  buildInputs = [ libjpeg libtiff SDL
+      gst-plugins-base libnotify freeglut xorg.libSM ncurses
+      requests libpng gstreamer libX11
+      pathlib2
+      (wxGTK.gtk)
+  ]
+    ++ lib.optional openglSupport pyopengl;
+
+  hardeningDisable = [ "format" ];
+
+  DOXYGEN = "${doxygen}/bin/doxygen";
+
+  preConfigure = lib.optionalString (!stdenv.isDarwin) ''
+    substituteInPlace wx/lib/wxcairo/wx_pycairo.py \
+      --replace 'cairoLib = None' 'cairoLib = ctypes.CDLL("${cairo}/lib/libcairo.so")'
+    substituteInPlace wx/lib/wxcairo/wx_pycairo.py \
+      --replace '_dlls = dict()' '_dlls = {k: ctypes.CDLL(v) for k, v in [
+        ("gdk",        "${wxGTK.gtk}/lib/libgtk-x11-2.0.so"),
+        ("pangocairo", "${pango.out}/lib/libpangocairo-1.0.so"),
+        ("appsvc",     None)
+      ]}'
+  '';
+
+  buildPhase = ''
+  python build.py -v --use_syswx dox etg --nodoc sip build_py
+  '';
+
+  installPhase = ''
+    ${python.interpreter} setup.py install --skip-build --prefix=$out
+    wrapPythonPrograms
+  '';
+
+  passthru = { inherit wxGTK openglSupport; };
 
 
   meta = {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4660,6 +4660,11 @@ in {
     inherit (pkgs) pkgconfig;
   };
 
+  wxPython_4_0 = callPackage ../development/python-modules/wxPython/4.0.nix {
+    inherit (pkgs) pkgconfig;
+    wxGTK = pkgs.wxGTK30.override { withGtk2 = false; withWebKit = true; };
+  };
+
   xml2rfc = callPackage ../development/python-modules/xml2rfc { };
 
   xmltodict = callPackage ../development/python-modules/xmltodict { };


### PR DESCRIPTION
###### Motivation for this change
add wxPython 4, which is unlisted in python-modules and broken.

###### Things done
Split off from https://github.com/NixOS/nixpkgs/pull/61253 and addressed comments by @veprbl 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
Resolves: #55426