### PR TITLE
snscrape: 0.2.0 -> 0.3.0

### DIFF
--- a/pkgs/development/python-modules/snscrape/default.nix
+++ b/pkgs/development/python-modules/snscrape/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , isPy3k
 , fetchPypi
+, setuptools_scm
 , requests
 , lxml
 , beautifulsoup4
@@ -9,13 +10,13 @@
 
 buildPythonPackage rec {
   pname = "snscrape";
-  version = "0.2.0";
+  version = "0.3.0";
 
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "02mlpzkvpl2mv30cknq6ngw02y7gj2614qikq25ncrpg5vb903d9";
+    sha256 = "1f3lyq06l8s4kcsmwbxcwcxnv6mvz9c3zj70np8vnx149p3zi983";
   };
 
   # There are no tests; make sure the executable works.
@@ -24,6 +25,7 @@ buildPythonPackage rec {
     snscrape --help
   '';
 
+  nativeBuildInputs = [ setuptools_scm ];
   propagatedBuildInputs = [ requests lxml beautifulsoup4 ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

https://github.com/JustAnotherArchivist/snscrape/commits/v0.3.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I tested 0.3.0 on twitter and instagram and it worked, unlike 0.2.0 now.