### PR TITLE
python2: backport fix for pyc race condition

### DIFF
--- a/pkgs/development/interpreters/python/cpython/2.7/atomic_pyc.patch
+++ b/pkgs/development/interpreters/python/cpython/2.7/atomic_pyc.patch
@@ -1,0 +1,41 @@
+diff --git a/Lib/py_compile.py b/Lib/py_compile.py
+index 978da73..3559eb9 100644
+--- a/Lib/py_compile.py
++++ b/Lib/py_compile.py
+@@ -120,16 +120,27 @@ def compile(file, cfile=None, dfile=None, doraise=False):
+             return
+     if cfile is None:
+         cfile = file + (__debug__ and 'c' or 'o')
+-    with open(cfile, 'wb') as fc:
+-        fc.write('\0\0\0\0')
+-        if "DETERMINISTIC_BUILD" in os.environ:
++    # Atomically write the pyc/pyo file.  Issue #13146.
++    # id() is used to generate a pseudo-random filename.
++    path_tmp = '{}.{}'.format(cfile, id(cfile))
++    try:
++        with open(path_tmp, 'wb') as fc:
+             fc.write('\0\0\0\0')
+-        else:
+-            wr_long(fc, timestamp)
+-        marshal.dump(codeobject, fc)
+-        fc.flush()
+-        fc.seek(0, 0)
+-        fc.write(MAGIC)
++            if "DETERMINISTIC_BUILD" in os.environ:
++                fc.write('\0\0\0\0')
++            else:
++                wr_long(fc, timestamp)
++            marshal.dump(codeobject, fc)
++            fc.flush()
++            fc.seek(0, 0)
++            fc.write(MAGIC)
++        os.rename(path_tmp, cfile)
++    except OSError:
++        try:
++            os.unlink(path_tmp)
++        except OSError:
++            pass
++        raise
+ 
+ def main(args=None):
+     """Compile several source files.

--- a/pkgs/development/interpreters/python/cpython/2.7/default.nix
+++ b/pkgs/development/interpreters/python/cpython/2.7/default.nix
@@ -79,6 +79,12 @@ let
         sha256 = "0l9rw6r5r90iybdkp3hhl2pf0h0s1izc68h5d3ywrm92pq32wz57";
       })
 
+      # Fix race-condition during pyc creation. Has a slight backwards
+      # incompatible effect: pyc symlinks will now be overridden
+      # (https://bugs.python.org/issue17222). Included in python >= 3.4,
+      # backported in debian since 2013.
+      # https://bugs.python.org/issue13146
+      ./atomic_pyc.patch
     ] ++ optionals (x11Support && stdenv.isDarwin) [
       ./use-correct-tcl-tk-on-darwin.patch
     ] ++ optionals stdenv.isLinux [


### PR DESCRIPTION
###### Motivation for this change

This is python bug https://bugs.python.org/issue13146. Fixed since
python 3.4. It makes pyc creation atomic, preventing a race condition.
The patch has been rebased on our deterministic build patch.

It wasn't backported to python 2.7 because there was a complaint about
changed semantics. Since files are now created in a temporary directory
and then moved, symlinks will be overridden. See
https://bugs.python.org/issue17222.

That is an edge-case however. Ubuntu and debian have backported the fix
in 2013 already, making it mainstream enough for us to adopt.

CC @FRidh. I became aware of this bug while trying to build the py2 version of tensorflow from source with 12 build cores (https://github.com/NixOS/nixpkgs/pull/63616). I have also seen transient test failures for sage on hydra several times that may have been caused by this bug.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
