### PR TITLE
protoc-gen-doc: init unstable at 2019-04-22

### DIFF
--- a/pkgs/development/tools/protoc-gen-doc/default.nix
+++ b/pkgs/development/tools/protoc-gen-doc/default.nix
@@ -1,0 +1,30 @@
+{ buildGoModule, fetchFromGitHub, lib }:
+
+buildGoModule rec {
+  name = "protoc-gen-doc-unstable-${version}";
+  version = "2019-04-22";
+
+  src = fetchFromGitHub {
+    owner = "pseudomuto";
+    repo = "protoc-gen-doc";
+    rev = "f824a8908ce33f213b2dba1bf7be83384c5c51e8";
+    sha256 = "004axh2gqc4f115mdxxg59d19hph3rr0bq9d08n3nyl315f590kj";
+  };
+
+  modSha256 = "1952ycdkgl00q2s3qmhislhhim15nn6nmlkwbfdvrsfzznqj47rd";
+
+  meta = with lib; {
+    description = "Documentation generator plugin for Google Protocol Buffers";
+    longDescription = ''
+      This is a documentation generator plugin for the Google Protocol Buffers
+      compiler (protoc). The plugin can generate HTML, JSON, DocBook and
+      Markdown documentation from comments in your .proto files.
+
+      It supports proto2 and proto3, and can handle having both in the same
+      context.
+    '';
+    homepage = "https://github.com/pseudomuto/protoc-gen-doc";
+    license = licenses.mit;
+    maintainers = with maintainers; [ kalbasit ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -163,6 +163,8 @@ in
 
   proto-contrib = callPackage ../development/tools/proto-contrib {};
 
+  protoc-gen-doc = callPackage ../development/tools/protoc-gen-doc {};
+
   demoit = callPackage ../servers/demoit { };
 
   diffPlugins = (callPackage ../build-support/plugins.nix {}).diffPlugins;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
