### PR TITLE
treewide: fix malformed homepage URLs

### DIFF
--- a/pkgs/servers/headphones/default.nix
+++ b/pkgs/servers/headphones/default.nix
@@ -27,7 +27,7 @@ python2.pkgs.buildPythonApplication rec {
   meta = with stdenv.lib; {
     description = "Automatic music downloader for SABnzbd";
     license     = licenses.gpl3;
-    homepage    = https:/github.com/rembo10/headphones;
+    homepage    = "https://github.com/rembo10/headphones";
     maintainers = with stdenv.lib.maintainers; [ rembo10 ];
   };
 }

--- a/pkgs/servers/sickbeard/default.nix
+++ b/pkgs/servers/sickbeard/default.nix
@@ -29,7 +29,7 @@ in stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "PVR & episode guide that downloads and manages all your TV shows";
     license     = licenses.gpl3;
-    homepage    = https:/github.com/midgetspy/Sick-Beard;
+    homepage    = "https://github.com/midgetspy/Sick-Beard";
     maintainers = with stdenv.lib.maintainers; [ ];
   };
 }

--- a/pkgs/servers/sickbeard/sickgear.nix
+++ b/pkgs/servers/sickbeard/sickgear.nix
@@ -29,7 +29,7 @@ in stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "The most reliable stable TV fork of the great Sick-Beard to fully automate TV enjoyment with innovation";
     license     = licenses.gpl3;
-    homepage    = https:/github.com/SickGear/SickGear;
+    homepage    = "https://github.com/SickGear/SickGear";
     maintainers = with stdenv.lib.maintainers; [ ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
