### PR TITLE
drawio: init at 10.8.0

### DIFF
--- a/pkgs/applications/graphics/drawio/default.nix
+++ b/pkgs/applications/graphics/drawio/default.nix
@@ -1,0 +1,94 @@
+{ stdenv, lib, fetchurl, rpmextract, autoPatchelfHook, wrapGAppsHook
+
+# Dynamic libraries
+, alsaLib, atk, at-spi2-atk, at-spi2-core, cairo, dbus, cups, expat
+, gdk_pixbuf, glib, gtk3, libX11, libXScrnSaver, libXcomposite, libXcursor
+, libXdamage, libXext, libXfixes, libXi, libXrandr, libXrender, libXtst
+, libxcb, libuuid, nspr, nss, pango
+
+, systemd
+}:
+
+stdenv.mkDerivation rec {
+  pname = "drawio";
+  version = "10.8.0";
+
+  src = fetchurl {
+    url = "https://github.com/jgraph/drawio-desktop/releases/download/v${version}/draw.io-x86_64-${version}.rpm";
+    sha256 = "0c5wymzhbp72x0yhvw7vb4akkdvj97npl9kglk79vqjbzfn5di9k";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    rpmextract
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    alsaLib
+    atk
+    at-spi2-atk
+    at-spi2-core
+    cairo
+    cups
+    dbus
+    expat
+    gdk_pixbuf
+    glib
+    gtk3
+    libX11
+    libXScrnSaver
+    libXcomposite
+    libXcursor
+    libXdamage
+    libXext
+    libXfixes
+    libXi
+    libXrandr
+    libXrender
+    libXtst
+    libxcb
+    libuuid
+    nspr
+    nss
+    pango
+    systemd
+  ];
+
+  runtimeDependencies = [
+    systemd.lib
+  ];
+
+  dontBuild = true;
+  dontConfigure = true;
+
+  unpackPhase = "rpmextract ${src}";
+
+  installPhase = ''
+    mkdir -p $out/share
+    cp -r opt/draw.io $out/share/
+
+    # Application icon
+    mkdir -p $out/share/icons/hicolor
+    cp -r usr/share/icons/hicolor/0x0 $out/share/icons/hicolor/1024x1024
+
+    # XDG desktop item
+    cp -r usr/share/applications $out/share/applications
+
+    # Symlink wrapper
+    mkdir -p $out/bin
+    ln -s $out/share/draw.io/draw.io $out/bin/draw.io
+
+    # Update binary path
+    substituteInPlace $out/share/applications/draw.io.desktop \
+      --replace /opt/draw.io/draw.io $out/bin/draw.io
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A desktop application for creating diagrams";
+    homepage = https://about.draw.io/;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ danieldk ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17434,6 +17434,8 @@ in
 
   dragonfly-reverb = callPackage ../applications/audio/dragonfly-reverb { };
 
+  drawio = callPackage ../applications/graphics/drawio {};
+
   drawpile = libsForQt5.callPackage ../applications/graphics/drawpile { };
   drawpile-server-headless = libsForQt5.callPackage ../applications/graphics/drawpile {
     buildClient = false;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

draw.io is an application for drawing diagrams. This is the (offline)
desktop version of the draw.io web application.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
