### PR TITLE
nixos/deluge: add user/group/openFirewall opts and extraction packages to path

### DIFF
--- a/nixos/tests/deluge.nix
+++ b/nixos/tests/deluge.nix
@@ -8,9 +8,11 @@ import ./make-test.nix ({ pkgs, ...} : {
     simple = {
       services.deluge = {
         enable = true;
-        web.enable = true;
+        web = {
+          enable = true;
+          openFirewall = true;
+        };
       };
-      networking.firewall.allowedTCPPorts = [ 8112 ];
     };
 
     declarative =


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
This PR adds configuration options to the Deluge module that allows
configuration of the user and group that the `deluged` and `delugeweb`
daemons run as. It also adds a `openFirewall` option for the deluge web
interface. Further, it adds extraction utilities used by Deluge's built-in 
"Extractor" plugin to the PATH so that Deluge doesn't error and behave 
strangely when the plugin is enabled and it can't find them.

I've confirmed this works by importing the module in my local configuration.

cc @Infinisil (reviewed the previous change to the Deluge module)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
