### PR TITLE
way-cooler: Mark as broken

### DIFF
--- a/pkgs/applications/window-managers/way-cooler/default.nix
+++ b/pkgs/applications/window-managers/way-cooler/default.nix
@@ -107,5 +107,6 @@ in symlinkJoin rec {
     maintainers = [ maintainers.miltador ];
     broken = stdenv.hostPlatform.isAarch64; # fails to build wc-bg (on aarch64)
     platforms = platforms.all;
+    broken = true;
   };
 }

--- a/pkgs/applications/window-managers/way-cooler/default.nix
+++ b/pkgs/applications/window-managers/way-cooler/default.nix
@@ -105,7 +105,6 @@ in symlinkJoin rec {
     homepage = http://way-cooler.org/;
     license = with licenses; [ mit ];
     maintainers = [ maintainers.miltador ];
-    broken = stdenv.hostPlatform.isAarch64; # fails to build wc-bg (on aarch64)
     platforms = platforms.all;
     broken = true;
   };


### PR DESCRIPTION
The project is in full-rewrite state, which also breaks backwards
compatibility.
Right now, the project README warns that way-cooler is not usable in its
current state.

Thus mark this as broken, so die-hard users can still use it.

This patch should be reverted as soon as there is a new release.

###### Motivation for this change

Closes https://github.com/NixOS/nixpkgs/issues/63914

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Not tested at all.