### PR TITLE
yder: init at 1.4.5

### DIFF
--- a/pkgs/development/libraries/orcania/default.nix
+++ b/pkgs/development/libraries/orcania/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchFromGitHub, cmake }:
+stdenv.mkDerivation rec {
+  pname = "orcania";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "babelouest";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "11ihbfm7qbqf55wdi7azqx75ggd3l0n8ybyq2ikidffvmg13l4g9";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with stdenv.lib; {
+    description = "Potluck with different functions for different purposes that can be shared among C programs";
+    homepage = "https://github.com/babelouest/orcania";
+    license = licenses.lgpl21;
+    maintainers = with maintainers; [ johnazoidberg ];
+  };
+}

--- a/pkgs/development/libraries/yder/default.nix
+++ b/pkgs/development/libraries/yder/default.nix
@@ -1,4 +1,7 @@
-{ stdenv, lib, fetchFromGitHub, cmake, orcania, systemd, check, subunit }:
+{ stdenv, lib, fetchFromGitHub, cmake, orcania, systemd, check, subunit
+, withSystemd ? stdenv.isLinux
+}:
+assert withSystemd -> systemd != null;
 stdenv.mkDerivation rec {
   pname = "yder";
   version = "1.4.6";
@@ -18,13 +21,13 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  buildInputs = [ orcania ];
+  buildInputs = [ orcania ] ++ lib.optional withSystemd systemd;
 
   checkInputs = [ check subunit ];
 
   cmakeFlags = [
     "-DBUILD_YDER_TESTING=on"
-  ];
+  ] ++ lib.optional (!withSystemd) "-DWITH_JOURNALD=off";
 
   doCheck = true;
 
@@ -37,6 +40,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/babelouest/yder";
     license = licenses.lgpl21;
     maintainers = with maintainers; [ johnazoidberg ];
-    platforms = platforms.linux;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/yder/default.nix
+++ b/pkgs/development/libraries/yder/default.nix
@@ -17,6 +17,15 @@ stdenv.mkDerivation rec {
     # We set CMAKE_INSTALL_LIBDIR to the absolute path in $out, so
     # prefix and exec_prefix cannot be $out, too
     ./fix-pkgconfig.patch
+
+    # - ORCANIA_LIBRARIES must be set before target_link_libraries is called
+    # - librt is not available, nor needed on Darwin
+    # - The test binary is not linked against all necessary libraries
+    # - Test for journald logging is not systemd specific and fails on darwin
+    # - If the working directory is different from the build directory, the
+    #   dynamic linker can't find libyder
+    # - Return correct error code from y_init_logs when journald is disabled
+    ./fix-darwin.patch
   ];
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/yder/default.nix
+++ b/pkgs/development/libraries/yder/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, lib, fetchFromGitHub, cmake, orcania, systemd, check, subunit }:
+stdenv.mkDerivation rec {
+  pname = "yder";
+  version = "1.4.6";
+
+  src = fetchFromGitHub {
+    owner = "babelouest";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0j46v93vn130gjcr704rkdiibbk3ampzsqb6xdcrn4x115gwyf5i";
+  };
+
+  patches = [
+    # We set CMAKE_INSTALL_LIBDIR to the absolute path in $out, so
+    # prefix and exec_prefix cannot be $out, too
+    ./fix-pkgconfig.patch
+  ];
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ orcania ];
+
+  checkInputs = [ check subunit ];
+
+  cmakeFlags = [
+    "-DBUILD_YDER_TESTING=on"
+  ];
+
+  doCheck = true;
+
+  preCheck = ''
+    export LD_LIBRARY_PATH="$(pwd):$LD_LIBRARY_PATH"
+  '';
+
+  meta = with lib; {
+    description = "Logging library for C applications";
+    homepage = "https://github.com/babelouest/yder";
+    license = licenses.lgpl21;
+    maintainers = with maintainers; [ johnazoidberg ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/yder/fix-darwin.patch
+++ b/pkgs/development/libraries/yder/fix-darwin.patch
@@ -1,0 +1,159 @@
+diff --git i/CMakeLists.txt w/CMakeLists.txt
+index 036ab73..0bab8c7 100644
+--- i/CMakeLists.txt
++++ w/CMakeLists.txt
+@@ -87,33 +87,6 @@ else()
+   set(DISABLE_JOURNALD ON)
+ endif ()
+ 
+-# shared library
+-
+-add_library(yder SHARED ${LIB_SRC})
+-if (NOT MSVC)
+-    set_target_properties(yder PROPERTIES
+-            COMPILE_OPTIONS -Wextra
+-            PUBLIC_HEADER "${INC_DIR}/yder.h;${PROJECT_BINARY_DIR}/yder-cfg.h"
+-            VERSION "${LIBRARY_VERSION}"
+-            SOVERSION "${LIBRARY_SOVERSION}")
+-endif()
+-if (WIN32)
+-    set_target_properties(yder PROPERTIES SUFFIX "-${LIBRARY_VERSION_MAJOR}.dll")
+-endif ()
+-
+-target_link_libraries(yder ${LIBS} ${ORCANIA_LIBRARIES} ${SYSTEMD_LIBRARIES})
+-
+-# static library
+-
+-option(BUILD_STATIC "Build static library." OFF)
+-
+-if (BUILD_STATIC)
+-    add_library(yder_static STATIC ${LIB_SRC})
+-    target_compile_definitions(yder_static PUBLIC -DO_STATIC_LIBRARY)
+-    set_target_properties(yder_static PROPERTIES
+-            OUTPUT_NAME yder)
+-endif ()
+-
+ option (SEARCH_ORCANIA "Search for Orcania library" ON)
+ if (SEARCH_ORCANIA)
+     set(Orcania_FIND_QUIETLY ON) # force to find Orcania quietly
+@@ -145,6 +118,33 @@ else ()
+   set(PKGCONF_REQ_PRIVATE "liborcania")
+ endif ()
+ 
++# shared library
++
++add_library(yder SHARED ${LIB_SRC})
++if (NOT MSVC)
++    set_target_properties(yder PROPERTIES
++            COMPILE_OPTIONS -Wextra
++            PUBLIC_HEADER "${INC_DIR}/yder.h;${PROJECT_BINARY_DIR}/yder-cfg.h"
++            VERSION "${LIBRARY_VERSION}"
++            SOVERSION "${LIBRARY_SOVERSION}")
++endif()
++if (WIN32)
++    set_target_properties(yder PROPERTIES SUFFIX "-${LIBRARY_VERSION_MAJOR}.dll")
++endif ()
++
++target_link_libraries(yder ${LIBS} ${ORCANIA_LIBRARIES} ${SYSTEMD_LIBRARIES})
++
++# static library
++
++option(BUILD_STATIC "Build static library." OFF)
++
++if (BUILD_STATIC)
++    add_library(yder_static STATIC ${LIB_SRC})
++    target_compile_definitions(yder_static PUBLIC -DO_STATIC_LIBRARY)
++    set_target_properties(yder_static PROPERTIES
++            OUTPUT_NAME yder)
++endif ()
++
+ # build yder-cfg.h file
+ configure_file(${INC_DIR}/yder-cfg.h.in ${PROJECT_BINARY_DIR}/yder-cfg.h)
+ set (CMAKE_EXTRA_INCLUDE_FILES ${PROJECT_BINARY_DIR})
+@@ -168,10 +168,9 @@ if (BUILD_YDER_TESTING)
+         set(CMAKE_CTEST_COMMAND ctest -V)
+ 
+         set(TST_DIR ${CMAKE_CURRENT_SOURCE_DIR}/test)
+-        set(LIBS yder ${LIBS} ${CHECK_LIBRARIES})
+         if (NOT WIN32)
+             find_package(Threads REQUIRED)
+-            set(LIBS ${LIBS} ${SUBUNIT_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} m rt)
++            set(LIBS yder ${LIBS} ${SUBUNIT_LIBRARIES} ${ORCANIA_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${CHECK_LIBRARIES} m)
+         endif ()
+ 
+         set(TESTS yder_test)
+@@ -186,7 +185,6 @@ if (BUILD_YDER_TESTING)
+             target_include_directories(${t} PUBLIC ${TST_DIR})
+             target_link_libraries(${t} PUBLIC ${LIBS})
+             add_test(NAME ${t}
+-                    WORKING_DIRECTORY ${TST_DIR}
+                     COMMAND ${t})
+         endforeach ()
+     endif ()
+diff --git i/src/yder.c w/src/yder.c
+index 3122e3f..79e4e70 100644
+--- i/src/yder.c
++++ w/src/yder.c
+@@ -236,11 +236,12 @@ static int y_write_log(const char * app_name,
+       if (cur_mode & Y_LOG_MODE_SYSLOG) {
+         y_write_log_syslog(cur_app_name, level, message);
+       }
+-  #ifndef Y_DISABLE_JOURNALD
++#endif
++
++#if !defined(_WIN32) && !defined(Y_DISABLE_JOURNALD)
+       if (cur_mode & Y_LOG_MODE_JOURNALD) {
+         y_write_log_journald(cur_app_name, level, message);
+       }
+-  #endif
+ #endif
+       if (cur_mode & Y_LOG_MODE_FILE) {
+         y_write_log_file(cur_app_name, now, cur_log_file, level, message);
+@@ -266,18 +267,20 @@ static int y_write_log(const char * app_name,
+  */
+ int y_init_logs(const char * app, const unsigned long init_mode, const unsigned long init_level, const char * init_log_file, const char * message) {
+ #ifdef _WIN32
+-	if (init_mode & Y_LOG_MODE_SYSLOG) {
+-		perror("syslog mode not supported on your architecture");
+-		return 0;
+-  } else if (init_mode & Y_LOG_MODE_JOURNALD) {
+-		perror("journald mode not supported on your architecture");
+-		return 0;
+-	} else {
+-		return y_write_log(app, init_mode, init_level, init_log_file, NULL, NULL, Y_LOG_LEVEL_INFO, message);
+-	}
+-#else
+-  return y_write_log(app, init_mode, init_level, init_log_file, NULL, NULL, Y_LOG_LEVEL_INFO, message);
++  if (init_mode & Y_LOG_MODE_SYSLOG) {
++    perror("syslog mode not supported on your architecture");
++    return 0;
++  }
+ #endif
++
++#if defined(_WIN32) || defined(Y_DISABLE_JOURNALD)
++  if (init_mode & Y_LOG_MODE_JOURNALD) {
++    perror("journald mode not supported on your architecture");
++    return 0;
++  }
++#endif
++
++  return y_write_log(app, init_mode, init_level, init_log_file, NULL, NULL, Y_LOG_LEVEL_INFO, message);
+ }
+ 
+ /**
+diff --git i/test/yder_test.c w/test/yder_test.c
+index a10fd9f..b73fb16 100644
+--- i/test/yder_test.c
++++ w/test/yder_test.c
+@@ -27,7 +27,11 @@ START_TEST(test_yder_init)
+   y_close_logs();
+   ck_assert_int_eq(y_init_logs("test_yder_syslog", Y_LOG_MODE_SYSLOG, Y_LOG_LEVEL_DEBUG, NULL, "third test"), 1);
+   y_close_logs();
++#ifndef Y_DISABLE_JOURNALD
+   ck_assert_int_eq(y_init_logs("test_yder_journald", Y_LOG_MODE_JOURNALD, Y_LOG_LEVEL_DEBUG, NULL, "fourth test"), 1);
++#else
++  ck_assert_int_eq(y_init_logs("test_yder_journald", Y_LOG_MODE_JOURNALD, Y_LOG_LEVEL_DEBUG, NULL, "fourth test"), 0);
++#endif
+   y_close_logs();
+   ck_assert_int_eq(y_init_logs("test_yder_file_fail", Y_LOG_MODE_FILE, Y_LOG_LEVEL_DEBUG, "/nope/nope", "second test"), 0);
+ }

--- a/pkgs/development/libraries/yder/fix-pkgconfig.patch
+++ b/pkgs/development/libraries/yder/fix-pkgconfig.patch
@@ -1,0 +1,9 @@
+--- i/libyder.pc.in
++++ w/libyder.pc.in
+@@ -1,7 +1,5 @@
+-prefix=@CMAKE_INSTALL_PREFIX@
+-exec_prefix=@CMAKE_INSTALL_PREFIX@
+-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
++libdir=@CMAKE_INSTALL_LIBDIR@
++includedir=@CMAKE_INSTALL_INCLUDEDIR@

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13799,6 +13799,8 @@ in
 
   yajl = callPackage ../development/libraries/yajl { };
 
+  yder = callPackage ../development/libraries/yder { };
+
   yojimbo = callPackage ../development/libraries/yojimbo { };
 
   yubioath-desktop = libsForQt5.callPackage ../applications/misc/yubioath-desktop { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12589,6 +12589,8 @@ in
 
   openrct2 = callPackage ../games/openrct2 { };
 
+  orcania = callPackage ../development/libraries/orcania { };
+
   osm-gps-map = callPackage ../development/libraries/osm-gps-map { };
 
   osinfo-db = callPackage ../data/misc/osinfo-db { };


### PR DESCRIPTION
###### Motivation for this change
Is in lots of other repos: https://repology.org/project/yder/versions

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested compilation of all library files
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
