### PR TITLE
buildPerlPackage: recognize "#!perl" as shebang

### DIFF
--- a/pkgs/development/perl-modules/generic/builder.sh
+++ b/pkgs/development/perl-modules/generic/builder.sh
@@ -17,7 +17,7 @@ preConfigure() {
             first=$(dd if="$fn" count=2 bs=1 2> /dev/null)
             if test "$first" = "#!"; then
                 echo "patching $fn..."
-                sed -i "$fn" -e "s|^#\!\(.*[ /]perl.*\)$|#\!\1$perlFlags|"
+                sed -i "$fn" -e "s|^#\!\(.*\bperl\b.*\)$|#\!\1$perlFlags|"
             fi
         fi
     done


### PR DESCRIPTION
some packages (for example Catmandu of https://github.com/NixOS/nixpkgs/pull/64137) has files with ```#!perl``` on first line which are not recognized as shebangs