### PR TITLE
smimesign: init at v0.0.13

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1570,6 +1570,11 @@
     github = "endgame";
     name = "Jack Kelly";
   };
+  enorris = {
+      name = "Eric Norris";
+      email = "erictnorris@gmail.com";
+      github = "ericnorris";
+  };
   enzime = {
     email = "enzime@users.noreply.github.com";
     github = "enzime";

--- a/pkgs/os-specific/darwin/smimesign/default.nix
+++ b/pkgs/os-specific/darwin/smimesign/default.nix
@@ -1,0 +1,26 @@
+{ buildGoModule, fetchFromGitHub, lib }:
+
+buildGoModule rec {
+  name    = "smimesign-${version}";
+  version = "v0.0.13";
+
+  src = fetchFromGitHub {
+    owner  = "github";
+    repo   = "smimesign";
+    rev    = version;
+    sha256 = "0higcg2rdz02c0n50vigg7w7bxc7wlmg1x2ygrbh3iwms5lc74vi";
+  };
+
+  modSha256 = "1k3gnjzblfk14y19zhlvwysx045nbw0xr5nngh7zj1wcqxhhm206";
+
+  buildFlagsArray = "-ldflags=-X main.versionString=${version}";
+
+  meta = with lib; {
+    description = "An S/MIME signing utility for macOS and Windows that is compatible with Git.";
+
+    homepage    = https://github.com/github/smimesign;
+    license     = licenses.mit;
+    platforms   = platforms.darwin;
+    maintainers = [ maintainers.enorris ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15956,6 +15956,8 @@ in
 
   smem = callPackage ../os-specific/linux/smem { };
 
+  smimesign = callPackage ../os-specific/darwin/smimesign { };
+
   speedometer = callPackage ../os-specific/linux/speedometer { };
 
   statik = callPackage ../development/tools/statik { };


### PR DESCRIPTION
###### Motivation for this change

Adding GitHub's https://github.com/github/smimesign. Although this is a `darwin` only package, I believe I have found other examples of this and followed their precedent. Let me know if I should move anything around.

The commit itself is signed by the binary built by Nix.

###### Things done


- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---