### PR TITLE
scikits-odes: init at 2.4.0

### DIFF
--- a/pkgs/development/libraries/sundials/3.x.nix
+++ b/pkgs/development/libraries/sundials/3.x.nix
@@ -22,11 +22,13 @@ in stdenv.mkDerivation rec {
     sha256 = "0238r1qnwqz13wcjzfsbcfi8rfnlxcjjmxq2vpf2qf5jgablvna7";
   };
 
-  patches = [ (fetchurl {
-    # https://github.com/LLNL/sundials/pull/19
-    url = "https://github.com/LLNL/sundials/commit/1350421eab6c5ab479de5eccf6af2dcad1eddf30.patch";
-    sha256 = "0g67lixp9m85fqpb9rzz1hl1z8ibdg0ldwq5z6flj5zl8a7cw52l";
-  })];
+  patches = [
+    (fetchurl {
+      # https://github.com/LLNL/sundials/pull/19
+      url = "https://github.com/LLNL/sundials/commit/1350421eab6c5ab479de5eccf6af2dcad1eddf30.patch";
+      sha256 = "0g67lixp9m85fqpb9rzz1hl1z8ibdg0ldwq5z6flj5zl8a7cw52l";
+    })
+  ];
 
   cmakeFlags = [
     "-DEXAMPLES_INSTALL_PATH=${placeholder "out"}/share/examples"

--- a/pkgs/development/libraries/sundials/3.x.nix
+++ b/pkgs/development/libraries/sundials/3.x.nix
@@ -38,7 +38,8 @@ in stdenv.mkDerivation rec {
     "-DLAPACK_LIBRARIES=${liblapackShared}/lib/liblapack${stdenv.hostPlatform.extensions.sharedLibrary};${liblapackShared}/lib/libblas${stdenv.hostPlatform.extensions.sharedLibrary}"
   ];
 
-  doCheck = true;
+  # flaky tests, and patch in https://github.com/LLNL/sundials/pull/21 doesn't apply cleanly for sundials_3
+  doCheck = false;
   checkPhase = "make test";
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/sundials/3.x.nix
+++ b/pkgs/development/libraries/sundials/3.x.nix
@@ -1,0 +1,49 @@
+{ stdenv
+, cmake
+, fetchurl
+, python
+, liblapack
+, gfortran
+, lapackSupport ? true }:
+
+let liblapackShared = liblapack.override {
+  shared = true;
+};
+
+in stdenv.mkDerivation rec {
+  pname = "sundials";
+  version = "3.2.1";
+
+  buildInputs = [ python ] ++ stdenv.lib.optionals (lapackSupport) [ gfortran ];
+  nativeBuildInputs = [ cmake ];
+
+  src = fetchurl {
+    url = "https://computation.llnl.gov/projects/${pname}/download/${pname}-${version}.tar.gz";
+    sha256 = "0238r1qnwqz13wcjzfsbcfi8rfnlxcjjmxq2vpf2qf5jgablvna7";
+  };
+
+  patches = [ (fetchurl {
+    # https://github.com/LLNL/sundials/pull/19
+    url = "https://github.com/LLNL/sundials/commit/1350421eab6c5ab479de5eccf6af2dcad1eddf30.patch";
+    sha256 = "0g67lixp9m85fqpb9rzz1hl1z8ibdg0ldwq5z6flj5zl8a7cw52l";
+  })];
+
+  cmakeFlags = [
+    "-DEXAMPLES_INSTALL_PATH=${placeholder "out"}/share/examples"
+  ] ++ stdenv.lib.optionals (lapackSupport) [
+    "-DSUNDIALS_INDEX_TYPE=int32_t"
+    "-DLAPACK_ENABLE=ON"
+    "-DLAPACK_LIBRARIES=${liblapackShared}/lib/liblapack${stdenv.hostPlatform.extensions.sharedLibrary};${liblapackShared}/lib/libblas${stdenv.hostPlatform.extensions.sharedLibrary}"
+  ];
+
+  doCheck = true;
+  checkPhase = "make test";
+
+  meta = with stdenv.lib; {
+    description = "Suite of nonlinear differential/algebraic equation solvers";
+    homepage    = https://computation.llnl.gov/projects/sundials;
+    platforms   = platforms.all;
+    maintainers = with maintainers; [ flokli idontgetoutmuch ];
+    license     = licenses.bsd3;
+  };
+}

--- a/pkgs/development/libraries/sundials/default.nix
+++ b/pkgs/development/libraries/sundials/default.nix
@@ -15,9 +15,18 @@ stdenv.mkDerivation rec {
     sha256 = "19ca4nmlf6i9ijqcibyvpprxzsdfnackgjs6dw51fq13gg1f2398";
   };
 
+  patches = [ (fetchurl {
+    # https://github.com/LLNL/sundials/pull/19
+    url = "https://github.com/LLNL/sundials/commit/1350421eab6c5ab479de5eccf6af2dcad1eddf30.patch";
+    sha256 = "0g67lixp9m85fqpb9rzz1hl1z8ibdg0ldwq5z6flj5zl8a7cw52l";
+  })];
+
   cmakeFlags = [
     "-DEXAMPLES_INSTALL_PATH=${placeholder "out"}/share/examples"
   ];
+
+  doCheck = true;
+  checkPhase = "make test";
 
   meta = with stdenv.lib; {
     description = "Suite of nonlinear differential/algebraic equation solvers";

--- a/pkgs/development/libraries/sundials/default.nix
+++ b/pkgs/development/libraries/sundials/default.nix
@@ -33,6 +33,8 @@ in stdenv.mkDerivation rec {
       url = "https://github.com/LLNL/sundials/pull/20/commits/2d951bbe1ff7842fcd0dafa28c61b0aa94015f66.patch";
       sha256 = "0lcr6m4lk14yqrxah4rdscpczny5l7m1zpfsjh8bgspadfsgk512";
     })
+    # https://github.com/LLNL/sundials/pull/21
+    ./tests-parallel.patch
   ];
 
   cmakeFlags = [

--- a/pkgs/development/libraries/sundials/default.nix
+++ b/pkgs/development/libraries/sundials/default.nix
@@ -22,11 +22,18 @@ in stdenv.mkDerivation rec {
     sha256 = "19ca4nmlf6i9ijqcibyvpprxzsdfnackgjs6dw51fq13gg1f2398";
   };
 
-  patches = [ (fetchurl {
-    # https://github.com/LLNL/sundials/pull/19
-    url = "https://github.com/LLNL/sundials/commit/1350421eab6c5ab479de5eccf6af2dcad1eddf30.patch";
-    sha256 = "0g67lixp9m85fqpb9rzz1hl1z8ibdg0ldwq5z6flj5zl8a7cw52l";
-  })];
+  patches = [
+    (fetchurl {
+      # https://github.com/LLNL/sundials/pull/19
+      url = "https://github.com/LLNL/sundials/commit/1350421eab6c5ab479de5eccf6af2dcad1eddf30.patch";
+      sha256 = "0g67lixp9m85fqpb9rzz1hl1z8ibdg0ldwq5z6flj5zl8a7cw52l";
+    })
+    (fetchurl {
+      # https://github.com/LLNL/sundials/pull/20
+      url = "https://github.com/LLNL/sundials/pull/20/commits/2d951bbe1ff7842fcd0dafa28c61b0aa94015f66.patch";
+      sha256 = "0lcr6m4lk14yqrxah4rdscpczny5l7m1zpfsjh8bgspadfsgk512";
+    })
+  ];
 
   cmakeFlags = [
     "-DEXAMPLES_INSTALL_PATH=${placeholder "out"}/share/examples"

--- a/pkgs/development/libraries/sundials/default.nix
+++ b/pkgs/development/libraries/sundials/default.nix
@@ -1,27 +1,29 @@
-{ cmake, fetchurl, python, stdenv }:
+{ stdenv
+, cmake
+, fetchurl
+, python }:
 
 stdenv.mkDerivation rec {
-
   pname = "sundials";
   version = "4.1.0";
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ python ];
 
   src = fetchurl {
     url = "https://computation.llnl.gov/projects/${pname}/download/${pname}-${version}.tar.gz";
     sha256 = "19ca4nmlf6i9ijqcibyvpprxzsdfnackgjs6dw51fq13gg1f2398";
   };
 
-  preConfigure = ''
-    export cmakeFlags="-DCMAKE_INSTALL_PREFIX=$out -DEXAMPLES_INSTALL_PATH=$out/share/examples $cmakeFlags"
-  '';
-
-  nativeBuildInputs = [ cmake ];
-  buildInputs = [ python ];
+  cmakeFlags = [
+    "-DEXAMPLES_INSTALL_PATH=${placeholder "out"}/share/examples"
+  ];
 
   meta = with stdenv.lib; {
     description = "Suite of nonlinear differential/algebraic equation solvers";
     homepage    = https://computation.llnl.gov/projects/sundials;
     platforms   = platforms.all;
-    maintainers = [ maintainers.idontgetoutmuch ];
+    maintainers = with maintainers; [ flokli idontgetoutmuch ];
     license     = licenses.bsd3;
   };
 

--- a/pkgs/development/libraries/sundials/tests-parallel.patch
+++ b/pkgs/development/libraries/sundials/tests-parallel.patch
@@ -1,0 +1,45 @@
+diff --git a/config/SundialsAddTest.cmake b/config/SundialsAddTest.cmake
+index e965fed..a7fb1d2 100644
+--- a/config/SundialsAddTest.cmake
++++ b/config/SundialsAddTest.cmake
+@@ -70,7 +70,7 @@ MACRO(SUNDIALS_ADD_TEST NAME EXECUTABLE)
+         "--verbose"
+         "--testname=${NAME}"
+         "--executablename=$<TARGET_FILE:${EXECUTABLE}>"
+-        "--outputdir=${CMAKE_BINARY_DIR}/Testing/output"
++        "--outputdir=${TEST_OUTPUT_DIR}"
+         )
+ 
+       # do not diff the output and answer files
+diff --git a/config/SundialsTesting.cmake b/config/SundialsTesting.cmake
+index 815576a..d91801a 100644
+--- a/config/SundialsTesting.cmake
++++ b/config/SundialsTesting.cmake
+@@ -29,6 +29,13 @@ IF(SUNDIALS_DEVTESTS)
+     ENDIF()
+   ENDIF()
+ 
++  # Directory for test output
++  SET(TEST_OUTPUT_DIR ${PROJECT_BINARY_DIR}/Testing/output)
++
++  IF(NOT EXISTS ${TEST_OUTPUT_DIR})
++    FILE(MAKE_DIRECTORY ${TEST_OUTPUT_DIR})
++  ENDIF()
++
+   # look for the testRunner script in the test directory
+   FIND_PROGRAM(TESTRUNNER testRunner PATHS test)
+   HIDE_VARIABLE(TESTRUNNER)
+diff --git a/test/testRunner b/test/testRunner
+index f450ec2..f1c8deb 100755
+--- a/test/testRunner
++++ b/test/testRunner
+@@ -106,7 +106,8 @@ def main():
+ 
+     # create output directory if necessary
+     if not os.path.exists(outDir):
+-        os.makedirs(outDir)
++        error("Output directory does not exist, it must be created.", outDir)
++        sys.exit(1)
+     elif not os.path.isdir(outDir):
+         error("Output directory exists but is not a directory, it must be deleted.", outDir)
+         sys.exit(1)

--- a/pkgs/development/python-modules/scikits-odes/default.nix
+++ b/pkgs/development/python-modules/scikits-odes/default.nix
@@ -1,0 +1,55 @@
+{ stdenv
+, lib
+, buildPythonPackage
+, fetchFromGitHub
+, fetchurl
+, cython
+, enum34
+, gfortran
+, isPy3k
+, numpy
+, pytest
+, python
+, scipy
+, sundials_3
+}:
+
+buildPythonPackage rec {
+  pname = "scikits.odes";
+  version = "2.4.0-9-g93075ae";
+
+  # we fetch github instead of Pypi, as we want #104 and #105, which don't apply cleanly on 2.4.0
+  src = fetchFromGitHub {
+    owner = "bmcage";
+    repo = "odes";
+    rev = "93075ae25c409f572f13ca7207fada5706f73c73";
+    sha256 = "161rab7hy6r1a9xw1zby9xhnnmxi0zwdpzxfpjkw9651xn2k5xyw";
+  };
+
+  nativeBuildInputs = [
+    gfortran
+    cython
+  ];
+
+  propagatedBuildInputs = [
+    numpy
+    sundials_3
+    scipy
+  ] ++ lib.optionals (!isPy3k) [ enum34 ];
+
+  doCheck = true;
+  checkInputs = [ pytest ];
+
+  checkPhase = ''
+    cd $out/${python.sitePackages}/scikits/odes/tests
+    pytest
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A scikit offering extra ode/dae solvers, as an extension to what is available in scipy";
+    homepage = https://github.com/bmcage/odes;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ flokli idontgetoutmuch ];
+    platforms = [ "aarch64-linux" "x86_64-linux" "x86_64-darwin" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13746,6 +13746,8 @@ in
 
   sundials = callPackage ../development/libraries/sundials { };
 
+  sundials_3 = callPackage ../development/libraries/sundials/3.x.nix { };
+
   sutils = callPackage ../tools/misc/sutils { };
 
   svrcore = callPackage ../development/libraries/svrcore { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4846,6 +4846,8 @@ in {
 
   scikit-build = callPackage ../development/python-modules/scikit-build { };
 
+  scikits-odes = callPackage ../development/python-modules/scikits-odes { };
+
   scikit-optimize = callPackage ../development/python-modules/scikit-optimize { };
 
   scikit-tda = callPackage ../development/python-modules/scikit-tda { };


### PR DESCRIPTION
###### Motivation for this change
This adds `scikits.odes`, a scikit offering extra ode/dae solvers, as an extension to what is available in scipy.

It's not yet compatible with sundials 4.x, so we add `sundials_3`, too.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @idontgetoutmuch 
