### PR TITLE
zaz: init at 1.0.0

### DIFF
--- a/pkgs/games/zaz/default.nix
+++ b/pkgs/games/zaz/default.nix
@@ -1,0 +1,58 @@
+{ stdenv
+, fetchurl
+, pkgconfig
+, SDL
+, SDL_image
+, mesa
+, libtheora
+, libvorbis
+, libogg
+, ftgl
+, freetype
+}:
+
+stdenv.mkDerivation rec {
+  pname = "zaz";
+  version = "1.0.0";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/${pname}/${pname}-${version}.tar.bz2";
+    sha256 = "15q3kxzl71m50byw37dshfsx5wp240ywah19ccmqmqarcldcqcp3";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+  ];
+  buildInputs = [
+    SDL.dev
+    SDL_image
+    mesa
+    libtheora
+    libvorbis.dev
+    libogg
+    ftgl
+    freetype
+  ];
+
+  # Fix SDL include problems
+  NIX_CFLAGS_COMPILE="-I${SDL.dev}/include/SDL -I${SDL_image}/include/SDL";
+  # Fix linking errors
+  makeFlags = [
+    "ZAZ_LIBS+=-lSDL"
+    "ZAZ_LIBS+=-lvorbis"
+    "ZAZ_LIBS+=-ltheora"
+    "ZAZ_LIBS+=-logg"
+    "ZAZ_LIBS+=-ltheoraenc"
+    "ZAZ_LIBS+=-ltheoradec"
+    "ZAZ_LIBS+=-lvorbisfile"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A puzzle game about arranging balls in triplets, like Luxor, Zuma, or Puzzle Bobble";
+    homepage = "http://zaz.sourceforge.net/";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ fgaz ];
+    platforms = platforms.all;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22154,6 +22154,8 @@ in
 
   zangband = callPackage ../games/zangband { };
 
+  zaz = callPackage ../games/zaz { };
+
   zdbsp = callPackage ../games/zdoom/zdbsp.nix { };
 
   zdoom = callPackage ../games/zdoom { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Pretty "famous" foss game (you can find it in most repos)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
