### PR TITLE
nixos/mysql: fix mysql test after #63862

### DIFF
--- a/nixos/modules/services/databases/mysql.nix
+++ b/nixos/modules/services/databases/mysql.nix
@@ -319,7 +319,9 @@ in
           ExecStart = "${mysql}/bin/mysqld --defaults-file=/etc/my.cnf ${mysqldOptions} $_WSREP_NEW_CLUSTER $_WSREP_START_POSITION";
           ExecStartPost =
             let
-              setupScript = pkgs.writeShellScript "mysql-setup" ''
+              setupScript = pkgs.writeScript "mysql-setup" ''
+                #!${pkgs.runtimeShell} -e
+
                 ${optionalString (!hasNotify) ''
                   # Wait until the MySQL server is available for use
                   count=0

--- a/nixos/tests/mysql.nix
+++ b/nixos/tests/mysql.nix
@@ -29,10 +29,10 @@ import ./make-test.nix ({ pkgs, ...} : {
         users.users.testuser = { };
         services.mysql.enable = true;
         services.mysql.initialScript = pkgs.writeText "mariadb-init.sql" ''
-          echo "ALTER USER root@localhost IDENTIFIED WITH unix_socket;"
-          echo "DELETE FROM mysql.user WHERE password = ''' AND plugin = ''';"
-          echo "DELETE FROM mysql.user WHERE user = ''';"
-          echo "FLUSH PRIVILEGES;"
+          ALTER USER root@localhost IDENTIFIED WITH unix_socket;
+          DELETE FROM mysql.user WHERE password = ''' AND plugin = ''';
+          DELETE FROM mysql.user WHERE user = ''';
+          FLUSH PRIVILEGES;
         '';
         services.mysql.ensureDatabases = [ "testdb" ];
         services.mysql.ensureUsers = [{


### PR DESCRIPTION
@aanderse @flokli 

I took another look at the mysql test and noticed the initialScript printing a syntax error.

###### Motivation for this change
Fix mysql test after #63862 introduced non-functional initialScript.
###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
