### PR TITLE
Fix Numpy on PyPy

### DIFF
--- a/pkgs/development/python-modules/numpy/default.nix
+++ b/pkgs/development/python-modules/numpy/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchPypi, python, buildPythonPackage, gfortran, pytest, blas, writeTextFile }:
+{ lib, fetchPypi, python, buildPythonPackage, gfortran, pytest, blas, writeTextFile, isPyPy }:
 
 let
   blasImplementation = lib.nameFromURL blas.name "-";
@@ -44,6 +44,8 @@ in buildPythonPackage rec {
   '';
 
   enableParallelBuilding = true;
+
+  doCheck = !isPyPy; # numpy 1.16+ hits a bug in pypy's ctypes, using either numpy or pypy HEAD fixes this (https://github.com/numpy/numpy/issues/13807)
 
   checkPhase = ''
     runHook preCheck

--- a/pkgs/development/python-modules/pytest/default.nix
+++ b/pkgs/development/python-modules/pytest/default.nix
@@ -1,6 +1,6 @@
 { stdenv, buildPythonPackage, pythonOlder, fetchPypi, attrs, hypothesis, py
 , setuptools_scm, setuptools, six, pluggy, funcsigs, isPy3k, more-itertools
-, atomicwrites, mock, writeText, pathlib2, wcwidth, packaging
+, atomicwrites, mock, writeText, pathlib2, wcwidth, packaging, isPyPy
 }:
 buildPythonPackage rec {
   version = "4.6.3";
@@ -22,6 +22,7 @@ buildPythonPackage rec {
     ++ stdenv.lib.optionals (!isPy3k) [ funcsigs ]
     ++ stdenv.lib.optionals (pythonOlder "3.6") [ pathlib2 ];
 
+  doCheck = !isPyPy; # https://github.com/pytest-dev/pytest/issues/3460
   checkPhase = ''
     runHook preCheck
     $out/bin/py.test -x testing/ -k "not test_collect_pyargs_with_testpaths"


### PR DESCRIPTION
###### Motivation for this change
Numpy works on PyPy as of October 2017, but tests fail for some of its dependencies. I applied a patch from Gentoo, and disabled tests on Numpy for PyPy (due to Numpy 1.16+ hitting a PyPy bug, which is fixed in both Numpy and PyPy HEAD, but not a release). For some reason most of the dependencies are getting built locally, but this built fine before I rebased it, so I'll check if it builds in the morning.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
