### PR TITLE
msp430GccSupport: 1.206 -> 1.207

### DIFF
--- a/pkgs/development/misc/msp430/gcc-support.nix
+++ b/pkgs/development/misc/msp430/gcc-support.nix
@@ -1,13 +1,13 @@
 { stdenvNoCC, fetchzip }:
 
 let
-  mspgccVersion = "6_1_0_0";
-  version = "1.206";
-in stdenvNoCC.mkDerivation {
-  name = "msp430-gcc-support-files-${version}";
+  mspgccVersion = "6_1_1_0";
+in stdenvNoCC.mkDerivation rec {
+  pname = "msp430-gcc-support-files";
+  version = "1.207";
   src = fetchzip {
     url = "http://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSPGCC/${mspgccVersion}/exports/msp430-gcc-support-files-${version}.zip";
-    sha256 = "0h297jms3gkmdcqmfpr3cg6v9wxnms34qbwvwl2fkmrz20vk766q";
+    sha256 = "1gyi9zc5vh9c1lxd22dwvk6b17dcd17hah2rayr062p4l51kzam1";
   };
 
   buildCommand = ''


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update to latest [MSP430-GCC-OPENSOURCE](http://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSPGCC/6_1_1_0/index_FDS.html) release headers.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---