### PR TITLE
sudo: set secure_path with root-installed software only

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1909.xml
+++ b/nixos/doc/manual/release-notes/rl-1909.xml
@@ -23,6 +23,23 @@
      End of support is planned for end of April 2020, handing over to 20.03.
     </para>
    </listitem>
+
+   <listitem>
+    <para>
+      <command>sudo</command> now defaults to setting a
+      <literal>secure_path</literal> via
+      <option>security.sudo.enableSecurePath</option>. The default
+      secure path includes only software installed by root
+      (<option>security.sudo.securePathEntries</option>).
+      Specifically, this defaults to including the default profile
+      (<filename>/nix/var/nix/profiles/default/bin</filename>), the
+      current system's <option>environment.systemPackages</option>
+      (<filename>/run/current-system/sw/bin</filename>), and setuid
+      wrapped programs in <option>security.wrappers</option>
+      (<filename>/run/wrappers/bin</filename>).
+    </para>
+   </listitem>
+
    <listitem>
     <para>
      PHP now defaults to PHP 7.3, updated from 7.2.


### PR DESCRIPTION
Given the following hypothetical:

> Nix allows any user to install software in to their PATH. A crafty
> person with malicious intent could use Nix to alter the installed
> software of a given user without editing their PATH, and without any
> "writable" user directories in the PATH.

This change explicitly sets sudo's PATH to only include root installed
software. This at least reduces the chances of that hypothetical
coming true.

Tested and seemed to work a treat. Also easy to roll back if it is
unwanted.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
