### PR TITLE
postgresqlPackages.plv8: 2.3.11 -> 2.3.12

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/plv8.nix
+++ b/pkgs/servers/sql/postgresql/ext/plv8.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "plv8";
-  version = "2.3.11";
+  version = "2.3.12";
 
   nativeBuildInputs = [ perl ];
   buildInputs = [ v8 postgresql ];
@@ -11,26 +11,26 @@ stdenv.mkDerivation rec {
     owner = "plv8";
     repo = "plv8";
     rev = "v${version}";
-    sha256 = "0bv2b8xxdqqhj6nwyc8kwhi5m5i7i1yl078sk3bnnc84b0mnza5x";
+    sha256 = "1yi1ibiibvd0x4z5dm698w32ljrj3yr4j25jm1zkgkwd4ii8y644";
   };
 
-  makeFlags = [ "--makefile=Makefile.shared" ];
+  makefile = "Makefile.shared";
+
+  buildFlags = [ "all" ];
 
   preConfigure = ''
     patchShebangs ./generate_upgrade.sh
   '';
 
-  buildPhase = "make -f Makefile.shared all";
-
   installPhase = ''
-    mkdir -p $out/bin
+    mkdir -p $out/bin    # For buildEnv to setup proper symlinks. See #22653
     install -D plv8*.so                                        -t $out/lib
     install -D {plls,plcoffee,plv8}{--${version}.sql,.control} -t $out/share/postgresql/extension
   '';
 
   meta = with stdenv.lib; {
-    description = "PL/v8 - A Procedural Language in JavaScript powered by V8";
-    homepage = https://pgxn.org/dist/plv8/;
+    description = "V8 Engine Javascript Procedural Language add-on for PostgreSQL";
+    homepage = "https://plv8.github.io/";
     maintainers = with maintainers; [ volth ];
     platforms = platforms.linux;
     license = licenses.postgresql;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Changes: https://github.com/plv8/plv8/compare/v2.3.11...v2.3.12


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
