### PR TITLE
redeclipse: fix license info

### DIFF
--- a/pkgs/games/redeclipse/default.nix
+++ b/pkgs/games/redeclipse/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
       cp -R -t $out/share/redeclipse/data/ data/*
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "A first person arena shooter, featuring parkour, impulse boosts, and more.";
     longDescription = ''
       Red Eclipse is a fun-filled new take on the first person arena shooter,
@@ -48,10 +48,10 @@ stdenv.mkDerivation rec {
       toward balanced gameplay, with a general theme of agility in a variety of
       environments.
     '';
-    homepage = https://www.redeclipse.net;
-    license = with stdenv.lib.licenses; [ zlib cc-by-sa-30 ];
-    maintainers = with stdenv.lib.maintainers; [ lambda-11235 ];
-    platforms = stdenv.lib.platforms.linux;
+    homepage = "https://www.redeclipse.net";
+    license = with licenses; [ licenses.zlib cc-by-sa-30 ];
+    maintainers = with maintainers; [ lambda-11235 ];
+    platforms = platforms.linux;
     hydraPlatforms = [];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Got tired of seeing output similar to this:
```
$ nix-env -f /home/jon/.cache/nix-review/pr-64225/nixpkgs -qaP --xml --out-path --show-trace --meta
derivation 'redeclipse-1.6.0' has invalid meta attribute 'license'
```
the zlib listed in the license array is getting inherited from the parent scope (the zlib derviation) rather than the license. Looked up zlib license through license attr set to make it unambiguous.

Also quoted url while i was at it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

$ nix path-info -Sh ./result
/nix/store/8grwyzf9fxar54a12rdxzrr9fsnjfazz-redeclipse-1.6.0       1.2G
