### PR TITLE
wla-dx: git-2017-06-05 -> 9.8

### DIFF
--- a/pkgs/development/compilers/wla-dx/default.nix
+++ b/pkgs/development/compilers/wla-dx/default.nix
@@ -1,17 +1,15 @@
 {stdenv, fetchFromGitHub, cmake}:
 
 stdenv.mkDerivation rec {
-  version = "2017-06-05";
-  name = "wla-dx-git-${version}";
+  pname = "wla-dx";
+  version = "9.8";
 
   src = fetchFromGitHub {
     owner = "vhelin";
     repo = "wla-dx";
-    rev = "ae6843f9711cbc2fa6dd8c200877b40bd2bcad7f";
-    sha256 = "09c2kz12ld97ad41j6r8r65jknllrak1x8r43fgr26x7hdlxz5c6";
+    rev = "v${version}-fix";
+    sha256 = "1dsxhy19nif983lr20vxl099giwzgmzqyh7ass705hkphmwagcv6";
   };
-
-  hardeningDisable = [ "format" ];
 
   installPhase = ''
     mkdir -p $out/bin


### PR DESCRIPTION
Upgrade from an old pinned git commit to the latest official stable release. Additionally, the `hardeningDisable` is no longer required to successfully build.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).