### PR TITLE
iceshelf: init at unstable-2019-07-03

### DIFF
--- a/pkgs/tools/backup/iceshelf/default.nix
+++ b/pkgs/tools/backup/iceshelf/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, lib, fetchFromGitHub, git, awscli, python3 }:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "iceshelf";
+  version = "unstable-2019-07-03";
+
+  format = "other";
+
+	src = fetchFromGitHub {
+		owner = "mrworf";
+		repo = pname;
+		rev = "26768dde3fc54fa412e523eb8f8552e866b4853b";
+		sha256 = "08rcbd14vn7312rmk2hyvdzvhibri31c4r5lzdrwb1n1y9q761qm";
+  };
+
+  propagatedBuildInputs = [
+    git
+    awscli
+    python3.pkgs.python-gnupg
+  ];
+
+	installPhase = ''
+		mkdir -p $out/bin $out/share/doc/${pname} $out/${python3.sitePackages}
+    cp -v iceshelf iceshelf-restore $out/bin
+    cp -v iceshelf.sample.conf $out/share/doc/${pname}/
+    cp -rv modules $out/${python3.sitePackages}
+	'';
+
+  meta = with lib; {
+    description = "A simple tool to allow storage of signed, encrypted, incremental backups using Amazon's Glacier storage";
+    license = licenses.lgpl2;
+    homepage = "https://github.com/mrworf/iceshelf";
+    maintainers = with maintainers; [ mmahut ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3702,6 +3702,8 @@ in
 
   icecast = callPackage ../servers/icecast { };
 
+  iceshelf = callPackage ../tools/backup/iceshelf { };
+
   darkice = callPackage ../tools/audio/darkice { };
 
   deco = callPackage ../applications/misc/deco { };


### PR DESCRIPTION
###### Motivation for this change

iceshelf: init at unstable-2019-07-03

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
