### PR TITLE
bundlerApp: add support for wildcards [WIP]

### DIFF
--- a/pkgs/development/ruby-modules/bundler-app/default.nix
+++ b/pkgs/development/ruby-modules/bundler-app/default.nix
@@ -49,7 +49,7 @@ let
 in
   runCommand basicEnv.name cmdArgs ''
     mkdir -p $out/bin
-    ${(lib.concatMapStrings (x: "ln -s '${basicEnv}/bin/${x}' $out/bin/${x};\n") exes)}
+    ${(lib.concatMapStrings (x: "ln -s ${basicEnv}/bin/${x} $out/bin/;\n") exes)}
     ${(lib.concatMapStrings (s: "makeWrapper $out/bin/$(basename ${s}) $srcdir/${s} " +
                                 "--set BUNDLE_GEMFILE ${basicEnv.confFiles}/Gemfile "+
                                 "--set BUNDLE_PATH ${basicEnv}/${ruby.gemPath} "+


### PR DESCRIPTION
#### Motivation for this change

We currently quote the executable we link to in a ```bundlerApp``` which is neat because it supports files with spaces, but the problem is that we then cannot use wildcards in the ```bundlerApp.exes``` property.

None of the existing ```bundlerApp``` users in nixpkgs has executables with spaces in their names.

Supporting regular wildcards, means we can do stuff like this:
```exes = [ "check-*" "metrics-*" ];``` which is great when one is using a script to automatically package a lot of ruby plugins for sensu.

Cc: @manveru @cstrahan @lilyball 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
