### PR TITLE
pythonPackages.timew-report: init at 1.0.2

### DIFF
--- a/pkgs/development/python-modules/timew-report/default.nix
+++ b/pkgs/development/python-modules/timew-report/default.nix
@@ -1,0 +1,19 @@
+{ lib, buildPythonPackage, fetchPypi, dateutil }:
+
+buildPythonPackage rec {
+  pname = "timew-report";
+  version = "1.0.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1z94wsq6xnrff2wlywp95p1gpjicply1mxjr8xyjr1n7vkw0fgfc";
+  };
+
+  propagatedBuildInputs = [ dateutil ];
+
+  meta = {
+    description = "An interface for TimeWarrior report data";
+    homepage = https://github.com/lauft/timew-report;
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4789,6 +4789,8 @@ in {
 
   timeout-decorator = callPackage ../development/python-modules/timeout-decorator { };
 
+  timew-report = callPackage ../development/python-modules/timew-report { };
+
   pid = callPackage ../development/python-modules/pid { };
 
   pip2nix = callPackage ../development/python-modules/pip2nix { };


### PR DESCRIPTION
###### Motivation for this change
I'm using timewarrior and with a couple of personal extensions written in python that use this package.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md). (*meta.maintainers is not set*)

---
