### PR TITLE
netdata: update build config

### DIFF
--- a/nixos/modules/services/monitoring/netdata.nix
+++ b/nixos/modules/services/monitoring/netdata.nix
@@ -8,6 +8,7 @@ let
   wrappedPlugins = pkgs.runCommand "wrapped-plugins" { preferLocalBuild = true; } ''
     mkdir -p $out/libexec/netdata/plugins.d
     ln -s /run/wrappers/bin/apps.plugin $out/libexec/netdata/plugins.d/apps.plugin
+    ln -s /run/wrappers/bin/freeipmi.plugin $out/libexec/netdata/plugins.d/freeipmi.plugin
   '';
 
   plugins = [
@@ -156,6 +157,13 @@ in {
       permissions = "u+rx,g+rx,o-rwx";
     };
 
+    security.wrappers."freeipmi.plugin" = {
+      source = "${pkgs.netdata}/libexec/netdata/plugins.d/freeipmi.plugin.org";
+      capabilities = "cap_dac_override,cap_fowner+ep";
+      owner = cfg.user;
+      group = cfg.group;
+      permissions = "u+rx,g+rx,o-rwx";
+    };
 
     users.users = optional (cfg.user == defaultUser) {
       name = defaultUser;

--- a/pkgs/tools/system/netdata/default.nix
+++ b/pkgs/tools/system/netdata/default.nix
@@ -1,6 +1,16 @@
-{ stdenv, fetchurl, autoreconfHook, pkgconfig, zlib, libuuid, libossp_uuid, CoreFoundation, IOKit, lm_sensors }:
+{ stdenv, fetchurl, autoreconfHook, pkgconfig
+, CoreFoundation, IOKit, libossp_uuid
+, curl, libcap,  libuuid, lm_sensors, zlib
+, withCups ? false, cups
+, withDBengine ? true, libuv, lz4, judy
+, withIpmi ? (!stdenv.isDarwin), freeipmi
+, withNetfilter ? (!stdenv.isDarwin), libmnl, libnetfilter_acct
+, withSsl ? true, openssl
+}:
 
-stdenv.mkDerivation rec{
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
   version = "1.15.0";
   name = "netdata-${version}";
 
@@ -10,20 +20,26 @@ stdenv.mkDerivation rec{
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
-  buildInputs = [ zlib ]
-    ++ (if stdenv.isDarwin then [ libossp_uuid CoreFoundation IOKit ] else [ libuuid ]);
+  buildInputs = [ curl.dev zlib.dev ]
+    ++ optionals stdenv.isDarwin [ CoreFoundation IOKit libossp_uuid ]
+    ++ optionals (!stdenv.isDarwin) [ libcap.dev libuuid.dev ]
+    ++ optionals withCups [ cups ]
+    ++ optionals withDBengine [ libuv lz4.dev judy ]
+    ++ optionals withIpmi [ freeipmi ]
+    ++ optionals withNetfilter [ libmnl libnetfilter_acct ]
+    ++ optionals withSsl [ openssl.dev ];
 
   patches = [
     ./no-files-in-etc-and-var.patch
   ];
 
-  postInstall = stdenv.lib.optionalString (!stdenv.isDarwin) ''
+  postInstall = optionalString (!stdenv.isDarwin) ''
     # rename this plugin so netdata will look for setuid wrapper
     mv $out/libexec/netdata/plugins.d/apps.plugin \
        $out/libexec/netdata/plugins.d/apps.plugin.org
   '';
 
-  preConfigure = ''
+  preConfigure =  optionalString (!stdenv.isDarwin) ''
     substituteInPlace collectors/python.d.plugin/python_modules/third_party/lm_sensors.py \
       --replace 'ctypes.util.find_library("sensors")' '"${lm_sensors.out}/lib/libsensors${stdenv.hostPlatform.extensions.sharedLibrary}"'
   '';
@@ -37,7 +53,7 @@ stdenv.mkDerivation rec{
     rm -r $out/sbin
   '';
 
-  meta = with stdenv.lib; {
+  meta = {
     description = "Real-time performance monitoring tool";
     homepage = https://my-netdata.io/;
     license = licenses.gpl3;

--- a/pkgs/tools/system/netdata/default.nix
+++ b/pkgs/tools/system/netdata/default.nix
@@ -37,6 +37,10 @@ stdenv.mkDerivation rec {
     # rename this plugin so netdata will look for setuid wrapper
     mv $out/libexec/netdata/plugins.d/apps.plugin \
        $out/libexec/netdata/plugins.d/apps.plugin.org
+    ${optionalString withIpmi ''
+      mv $out/libexec/netdata/plugins.d/freeipmi.plugin \
+         $out/libexec/netdata/plugins.d/freeipmi.plugin.org
+    ''}
   '';
 
   preConfigure =  optionalString (!stdenv.isDarwin) ''

--- a/pkgs/tools/system/netdata/default.nix
+++ b/pkgs/tools/system/netdata/default.nix
@@ -6,6 +6,7 @@
 , withIpmi ? (!stdenv.isDarwin), freeipmi
 , withNetfilter ? (!stdenv.isDarwin), libmnl, libnetfilter_acct
 , withSsl ? true, openssl
+, withDebug ? false
 }:
 
 with stdenv.lib;
@@ -32,6 +33,8 @@ stdenv.mkDerivation rec {
   patches = [
     ./no-files-in-etc-and-var.patch
   ];
+
+  NIX_CFLAGS_COMPILE = optional withDebug "-O1 -ggdb -DNETDATA_INTERNAL_CHECKS=1";
 
   postInstall = optionalString (!stdenv.isDarwin) ''
     # rename this plugin so netdata will look for setuid wrapper


### PR DESCRIPTION
###### Motivation for this change
Update build config and add support ipmi, dbengine, netfilter and cups.

cc @Mic92
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
