### PR TITLE
kops: restructure package to maintain multiple versions in the future

### DIFF
--- a/pkgs/applications/networking/cluster/kops/default.nix
+++ b/pkgs/applications/networking/cluster/kops/default.nix
@@ -1,44 +1,57 @@
-{ stdenv, buildGoPackage, fetchFromGitHub, go-bindata }:
+{ stdenv, lib, buildGoPackage, fetchFromGitHub, go-bindata }:
 
-buildGoPackage rec {
-  name = "kops-${version}";
-  version = "1.12.1";
-
+let
   goPackagePath = "k8s.io/kops";
 
-  src = fetchFromGitHub {
-    rev = version;
-    owner = "kubernetes";
-    repo = "kops";
-    sha256 = "09rmgazdrmnh1lqaayzfbn0ld7mbj9whihs9ijv5gf6si9p0ml9y";
-  };
+  generic = { version, sha256, ...}@attrs:
+    let attrs' = builtins.removeAttrs attrs ["version" "sha256"] ; in
+      buildGoPackage {
+        name = "kops-${version}";
 
-  buildInputs = [go-bindata];
-  subPackages = ["cmd/kops"];
+        inherit goPackagePath;
 
-  buildFlagsArray = ''
-    -ldflags=
-        -X k8s.io/kops.Version=${version}
-        -X k8s.io/kops.GitVersion=${version}
-  '';
+        src = fetchFromGitHub {
+          rev = version;
+          owner = "kubernetes";
+          repo = "kops";
+          inherit sha256;
+        };
 
-  preBuild = ''
-    (cd go/src/k8s.io/kops
-     go-bindata -o upup/models/bindata.go -pkg models -prefix upup/models/ upup/models/...)
-  '';
+        buildInputs = [go-bindata];
+        subPackages = ["cmd/kops"];
 
-  postInstall = ''
-    mkdir -p $bin/share/bash-completion/completions
-    mkdir -p $bin/share/zsh/site-functions
-    $bin/bin/kops completion bash > $bin/share/bash-completion/completions/kops
-    $bin/bin/kops completion zsh > $bin/share/zsh/site-functions/_kops
-  '';
+        buildFlagsArray = ''
+          -ldflags=
+              -X k8s.io/kops.Version=${version}
+              -X k8s.io/kops.GitVersion=${version}
+        '';
 
-  meta = with stdenv.lib; {
-    description = "Easiest way to get a production Kubernetes up and running";
-    homepage = https://github.com/kubernetes/kops;
-    license = licenses.asl20;
-    maintainers = with maintainers; [offline zimbatm];
-    platforms = platforms.unix;
+        preBuild = ''
+          (cd go/src/k8s.io/kops
+           go-bindata -o upup/models/bindata.go -pkg models -prefix upup/models/ upup/models/...)
+        '';
+
+        postInstall = ''
+          mkdir -p $bin/share/bash-completion/completions
+          mkdir -p $bin/share/zsh/site-functions
+          $bin/bin/kops completion bash > $bin/share/bash-completion/completions/kops
+          $bin/bin/kops completion zsh > $bin/share/zsh/site-functions/_kops
+        '';
+
+        meta = with stdenv.lib; {
+          description = "Easiest way to get a production Kubernetes up and running";
+          homepage = https://github.com/kubernetes/kops;
+          license = licenses.asl20;
+          maintainers = with maintainers; [offline zimbatm];
+          platforms = platforms.unix;
+        };
+      } // attrs';
+in rec {
+
+  mkKops = generic;
+
+  kops_1_12 = mkKops {
+    version = "1.12.2";
+    sha256 = "0937crwifnld7r5pf5gvab9ibmf8k44dafr9y3hld2p01ijrari1";
   };
 }

--- a/pkgs/applications/networking/cluster/kops/default.nix
+++ b/pkgs/applications/networking/cluster/kops/default.nix
@@ -51,7 +51,7 @@ in rec {
   mkKops = generic;
 
   kops_1_12 = mkKops {
-    version = "1.12.2";
-    sha256 = "0937crwifnld7r5pf5gvab9ibmf8k44dafr9y3hld2p01ijrari1";
+    version = "1.12.3";
+    sha256 = "0rpbaz54l5v1z7ab5kpxcb4jyakkl5ysgz1sxajqmw2d6dvf7xly";
   };
 }

--- a/pkgs/applications/networking/cluster/kops/default.nix
+++ b/pkgs/applications/networking/cluster/kops/default.nix
@@ -54,4 +54,9 @@ in rec {
     version = "1.12.3";
     sha256 = "0rpbaz54l5v1z7ab5kpxcb4jyakkl5ysgz1sxajqmw2d6dvf7xly";
   };
+
+  kops_1_13 = mkKops {
+    version = "1.13.0";
+    sha256 = "04kbbg3gqzwzzzq1lmnpw2gqky3pfwfk7pc0laxv2yssk9wac5k1";
+  };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23638,8 +23638,9 @@ in
   inherit (callPackage ../applications/networking/cluster/kops {})
     mkKops
     kops_1_12
+    kops_1_13
     ;
-  kops = kops_1_12;
+  kops = kops_1_13;
 
   lguf-brightness = callPackage ../misc/lguf-brightness { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23635,7 +23635,11 @@ in
 
   kontemplate = callPackage ../applications/networking/cluster/kontemplate { };
 
-  kops = callPackage ../applications/networking/cluster/kops { };
+  inherit (callPackage ../applications/networking/cluster/kops {})
+    mkKops
+    kops_1_12
+    ;
+  kops = kops_1_12;
 
   lguf-brightness = callPackage ../misc/lguf-brightness { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

kops versions are bound to the version of the kubernetes cluster they
are targeted to maintain (kops 1.12 -> k8s 1.12, kops 1.13 -> k8s 1.13,
etc). Upgrading kops should therefore be done very deliberately
as it may affect the cluster it is working with in drastic ways.
This change introduces the ability to maintain multiple versions of
kops in nixpkgs, giving the users the ability to pin it to their target
cluster version when installing

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
