### PR TITLE
cargo-generate: init at 0.3.0

### DIFF
--- a/pkgs/development/tools/rust/cargo-generate/default.nix
+++ b/pkgs/development/tools/rust/cargo-generate/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, rustPlatform, Security, openssl, pkgconfig, libiconv, curl }:
+
+rustPlatform.buildRustPackage rec {
+  name = "cargo-generate-${version}";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "ashleygwilliams";
+    repo = "cargo-generate";
+    rev = "v${version}";
+    sha256 = "0n6na6xq4bvs9hc7vc86qqmlrkv824qdmja27b21l2wz3l77r4jb";
+  };
+
+  cargoSha256 = "00fgzh1s63rr1vs3ahra604m81fc4imx3s09brw2y0n46syhwypi";
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [ openssl  ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ Security libiconv curl ];
+
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "cargo, make me a project";
+    homepage = https://github.com/ashleygwilliams/cargo-generate;
+    license = licenses.asl20;
+    maintainers = [ maintainers.turbomack ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8075,6 +8075,9 @@ in
   };
   cargo-sweep = callPackage ../development/tools/rust/cargo-sweep { };
   cargo-xbuild = callPackage ../development/tools/rust/cargo-xbuild { };
+  cargo-generate = callPackage ../development/tools/rust/cargo-generate {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
 
   pyo3-pack = callPackage ../development/tools/rust/pyo3-pack { };
   rainicorn = callPackage ../development/tools/rust/rainicorn { };


### PR DESCRIPTION
###### Motivation for this change
Usefull missing tool

###### Things done
Expression added

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
