### PR TITLE
jsonnet: ship new jsonnetfmt binary

### DIFF
--- a/pkgs/development/compilers/jsonnet/default.nix
+++ b/pkgs/development/compilers/jsonnet/default.nix
@@ -15,12 +15,14 @@ stdenv.mkDerivation rec {
 
   makeFlags = [
     "jsonnet"
+    "jsonnetfmt"
     "libjsonnet.so"
   ];
 
   installPhase = ''
     mkdir -p $out/bin $out/lib $out/include
     cp jsonnet $out/bin/
+    cp jsonnetfmt $out/bin/
     cp libjsonnet*.so $out/lib/
     cp -a include/*.h $out/include/
   '';


### PR DESCRIPTION
###### Motivation for this change
Per https://github.com/google/jsonnet/releases/tag/v0.13.0 `jsonnet fmt` functionality was moved to a separate `jsonnetfmt` binary

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---