### PR TITLE
lsb-release: Fix/replace with a custom Bash script

### DIFF
--- a/pkgs/os-specific/linux/lsb-release/default.nix
+++ b/pkgs/os-specific/linux/lsb-release/default.nix
@@ -1,4 +1,6 @@
-{ substituteAll, lib }:
+{ substituteAll, lib
+, coreutils, getopt
+}:
 
 substituteAll {
   name = "lsb_release";
@@ -7,6 +9,8 @@ substituteAll {
 
   dir = "bin";
   isExecutable = true;
+
+  inherit coreutils getopt;
 
   meta = with lib; {
     description = "Prints certain LSB (Linux Standard Base) and Distribution information";

--- a/pkgs/os-specific/linux/lsb-release/default.nix
+++ b/pkgs/os-specific/linux/lsb-release/default.nix
@@ -1,34 +1,17 @@
-{ stdenv, fetchurl, perl, coreutils, getopt, makeWrapper }:
+{ substituteAll, lib }:
 
-stdenv.mkDerivation rec {
-  version = "1.4";
-  name = "lsb-release-${version}";
+substituteAll {
+  name = "lsb_release";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/lsb/${name}.tar.gz";
-    sha256 = "0wkiy7ymfi3fh2an2g30raw6yxh6rzf6nz2v90fplbnnz2414clr";
-  };
+  src = ./lsb_release.sh;
 
-  preConfigure = ''
-    substituteInPlace help2man \
-      --replace /usr/bin/perl ${perl}/bin/perl
-  '';
+  dir = "bin";
+  isExecutable = true;
 
-  installFlags = [ "prefix=$(out)" ];
-
-  nativeBuildInputs  = [ makeWrapper perl ];
-
-  buildInputs = [ coreutils getopt ];
-
-  # Ensure utilities used are available
-  preFixup = ''
-    wrapProgram $out/bin/lsb_release --prefix PATH : ${stdenv.lib.makeBinPath [ coreutils getopt ]}
-  '';
-
-  meta = {
+  meta = with lib; {
     description = "Prints certain LSB (Linux Standard Base) and Distribution information";
-    homepage = http://www.linuxfoundation.org/collaborate/workgroups/lsb;
-    license = [ stdenv.lib.licenses.gpl2Plus stdenv.lib.licenses.gpl3Plus ];
-    platforms = stdenv.lib.platforms.linux;
+    license = [ licenses.mit ];
+    maintainers = with maintainers; [ primeos ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/os-specific/linux/lsb-release/lsb_release.sh
+++ b/pkgs/os-specific/linux/lsb-release/lsb_release.sh
@@ -4,7 +4,7 @@ set -o errexit
 set -o nounset
 
 show_help() {
-  cat << EOF
+  @coreutils@/bin/cat << EOF
 Usage: lsb_release [options]
 
 Options:
@@ -29,9 +29,9 @@ codename=0
 all=0
 short=0
 
-getopt --test > /dev/null && rc=$? || rc=$?
+@getopt@/bin/getopt --test > /dev/null && rc=$? || rc=$?
 if [[ $rc -ne 4 ]]; then
-  # This shouldn't happen on any recent GNU system.
+  # This shouldn't happen.
   echo "Warning: Enhanced getopt not supported, please open an issue." >&2
 else
   # Define all short and long options.
@@ -39,11 +39,7 @@ else
   LONG=help,version,id,description,release,codename,all,short
 
   # Parse all options.
-  PARSED=`getopt --options $SHORT --longoptions $LONG --name "$0" -- "$@"`
-  if [[ $? -ne 0 ]]; then
-    # getopt will print an error
-    exit 1
-  fi
+  PARSED=`@getopt@/bin/getopt --options $SHORT --longoptions $LONG --name "$0" -- "$@"`
 
   eval set -- "$PARSED"
 fi

--- a/pkgs/os-specific/linux/lsb-release/lsb_release.sh
+++ b/pkgs/os-specific/linux/lsb-release/lsb_release.sh
@@ -93,7 +93,7 @@ done
 if [[ -e /etc/os-release ]]; then
   . /etc/os-release
 else
-  echo "/etc/os-release is not present. Aborting" >&2
+  echo "Error: /etc/os-release is not present, aborting." >&2
   exit 1
 fi
 
@@ -101,7 +101,7 @@ fi
 if [[ "$version" = "0" ]] && [[ "$id" = "0" ]] && \
    [[ "$description" = "0" ]] && [[ "$release" = "0" ]] && \
    [[ "$codename" = "0" ]] && [[ "$all" = "0" ]]; then
-  echo "No LSB modules are available."
+  echo "No LSB modules are available." >&2
   exit 0
 fi
 
@@ -109,7 +109,7 @@ fi
 # what the original lsb_release used.
 
 if [[ "$all" = "1" ]] || [[ "$version" = "1" ]]; then
-  echo "No LSB modules are available."
+  echo "No LSB modules are available." >&2
 fi
 
 if [[ "$all" = "1" ]] || [[ "$id" = "1" ]]; then
@@ -139,6 +139,3 @@ if [[ "$all" = "1" ]] || [[ "$codename" = "1" ]]; then
   fi
   echo $VERSION_CODENAME
 fi
-
-# Success
-exit 0

--- a/pkgs/os-specific/linux/lsb-release/lsb_release.sh
+++ b/pkgs/os-specific/linux/lsb-release/lsb_release.sh
@@ -112,26 +112,26 @@ if [[ "$all" = "1" ]] || [[ "$id" = "1" ]]; then
   if [[ "$short" = "0" ]]; then
     printf "Distributor ID:\t"
   fi
-  echo $NAME
+  echo "$NAME"
 fi
 
 if [[ "$all" = "1" ]] || [[ "$description" = "1" ]]; then
   if [[ "$short" = "0" ]]; then
     printf "Description:\t"
   fi
-  echo $PRETTY_NAME
+  echo "$PRETTY_NAME"
 fi
 
 if [[ "$all" = "1" ]] || [[ "$release" = "1" ]]; then
   if [[ "$short" = "0" ]]; then
     printf "Release:\t"
   fi
-  echo $VERSION_ID
+  echo "$VERSION_ID"
 fi
 
 if [[ "$all" = "1" ]] || [[ "$codename" = "1" ]]; then
   if [[ "$short" = "0" ]]; then
     printf "Codename:\t"
   fi
-  echo $VERSION_CODENAME
+  echo "$VERSION_CODENAME"
 fi

--- a/pkgs/os-specific/linux/lsb-release/lsb_release.sh
+++ b/pkgs/os-specific/linux/lsb-release/lsb_release.sh
@@ -93,7 +93,7 @@ done
 if [[ -e /etc/os-release ]]; then
   . /etc/os-release
 else
-  echo "/etc/os-release is not present.  Aborting" >&2
+  echo "/etc/os-release is not present. Aborting" >&2
   exit 1
 fi
 

--- a/pkgs/os-specific/linux/lsb-release/lsb_release.sh
+++ b/pkgs/os-specific/linux/lsb-release/lsb_release.sh
@@ -1,0 +1,167 @@
+#! @shell@
+
+# Program name (e.g. /.../nixos-version -> nixos-version)
+# Helps with alternative names like lsb_release
+pname="${0##*/}"
+
+show_help() {
+  cat << EOF
+Usage: $pname [options]
+
+Options:
+  -h, --help         show this help message and exit
+  -v, --version      show LSB modules this system supports
+  -i, --id           show distributor ID
+  -d, --description  show description of this distribution
+  -r, --release      show release number of this distribution
+  --revision, --hash show revision (abbreviated commit hash) of this distribution
+  -c, --codename     show code name of this distribution
+  -a, --all          show all of the above information
+  -s, --short        show requested information in short format
+EOF
+  exit 0
+}
+
+# Potential command-line options.
+version=0
+id=0
+description=0
+release=0
+revision=0
+codename=0
+all=0
+short=0
+
+getopt --test > /dev/null
+if [[ $? -ne 4 ]]; then
+  # This shouldn't happen on any recent GNU system.
+  echo "Enhanced getopt not supported, please open an issue."
+else
+  # Define all short and long options.
+  SHORT=hvidrcas
+  LONG=help,version,id,description,release,revision,hash,codename,all,short
+
+  # Parse all options.
+  PARSED=`getopt --options $SHORT --longoptions $LONG --name "$0" -- "$@"`
+  if [[ $? -ne 0 ]]; then
+    # getopt will print an error
+    exit 1
+  fi
+
+  eval set -- "$PARSED"
+fi
+
+
+# Process each argument, and set the appropriate flag if we recognize it.
+while [[ $# -ge 1 ]]; do
+  case $1 in
+    -v|--version)
+      version=1
+      ;;
+    -i|--id)
+      id=1
+      ;;
+    -d|--description)
+      description=1
+      ;;
+    -r|--release)
+      release=1
+      ;;
+    --revision|--hash)
+      revision=1
+      ;;
+    -c|--codename)
+      codename=1
+      ;;
+    -a|--all)
+      all=1
+      ;;
+    -s|--short)
+      short=1
+      ;;
+    -h|--help)
+      show_help
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      echo "$pname: unrecognized option '$1'"
+      echo "Type '$pname -h' for a list of available options."
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+#  Read our variables.
+if [[ -e /etc/os-release ]]; then
+  . /etc/os-release
+else
+  echo "/etc/os-release is not present.  Aborting" >&2
+  exit 1
+fi
+
+# Default output (depending on the executable name)
+# Stays compatible to nixos-version *and* lsb_release
+if [[ "$version" = "0" ]] && [[ "$id" = "0" ]] && \
+   [[ "$description" = "0" ]] && [[ "$release" = "0" ]] && \
+   [[ "$revision" = "0" ]] && [[ "$codename" = "0" ]] && \
+   [[ "$all" = "0" ]]; then
+  if [[ $pname = "lsb_release" ]]; then
+    echo "No LSB modules are available."
+  else
+    echo $VERSION
+    # was: echo "@nixosVersion@ (@nixosCodeName@)"
+  fi
+  exit 0
+fi
+
+# Now output the data - The order of these was chosen to match
+# what the original lsb_release used.
+
+if [[ "$all" = "1" ]] || [[ "$version" = "1" ]]; then
+  echo "No LSB modules are available."
+fi
+
+if [[ "$all" = "1" ]] || [[ "$id" = "1" ]]; then
+  if [[ "$short" = "0" ]]; then
+    printf "Distributor ID:\t"
+  fi
+  echo $NAME
+fi
+
+if [[ "$all" = "1" ]] || [[ "$description" = "1" ]]; then
+  if [[ "$short" = "0" ]]; then
+    printf "Description:\t"
+  fi
+  echo $PRETTY_NAME
+fi
+
+if [[ "$all" = "1" ]] || [[ "$release" = "1" ]]; then
+  if [[ "$short" = "0" ]]; then
+    printf "Release:\t"
+  fi
+  echo $VERSION_ID
+fi
+
+# TODO: For all (incompatible with lsb_release)?
+if [[ "$all" = "1" ]] || [[ "$revision" = "1" ]]; then
+  if [[ "$short" = "0" ]]; then
+    printf "Revision:\t"
+  fi
+  # Revision comes from: VERSION_ID="16.09.git.effc189" -> effc189
+  echo $(echo $VERSION_ID | rev | cut -d. -f1 | rev)
+  # was: echo "@nixosRevision@"
+fi
+
+if [[ "$all" = "1" ]] || [[ "$codename" = "1" ]]; then
+  if [[ "$short" = "0" ]]; then
+    printf "Codename:\t"
+  fi
+  echo $(echo $VERSION_CODENAME)
+fi
+
+# Success
+exit 0


### PR DESCRIPTION
###### Motivation for this change

See #22729 and #23175.

TODOs:
- [x] Choose a license (I used MIT because Nixpkgs uses it, but we could also use something else)
- [x] Replace cat and getopt with references to the Nix store
- [x] Determine if we want to fallback to other files than `/etc/os-release`
  - Could be nice for non-NixOS systems, but probably problematic to implement as the format of the 
other files is most likely not standardized.
  - We'll skip this for now.
- [x] Verify the output (LGTM, but I might have missed something)
  - Thanks @davidak for checking it as well and posting additional examples
- [x] Verify that the script is secure and robust
  - Note: Some variables are unnecessary quoted (e.g. the ones which are either 0 or 1) and the variables sourced from `/etc/os-releases` are not quoted (but that file should always be owned by root).
  - Should be ok, all important variables are quoted. And this script doesn't run with any elevated privileges.
- ...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
