### PR TITLE
weechat: prevent impure use of system Python

### DIFF
--- a/pkgs/applications/networking/irc/weechat/wrapper.nix
+++ b/pkgs/applications/networking/irc/weechat/wrapper.nix
@@ -15,8 +15,10 @@ let
     availablePlugins = let
         simplePlugin = name: {pluginFile = "${weechat.${name}}/lib/weechat/plugins/${name}.so";};
       in rec {
-        python = {
-          pluginFile = "${weechat.python}/lib/weechat/plugins/python.so";
+        python = (simplePlugin "python") // {
+          extraEnv = ''
+            export PATH="${pythonPackages.python}/bin:$PATH"
+          '';
           withPackages = pkgsFun: (python // {
             extraEnv = ''
               export PYTHONHOME="${pythonPackages.python.withPackages pkgsFun}"


### PR DESCRIPTION
###### Motivation for this change

Weechat was calling the system Python at runtime (see #64167). In my case, this resulted in it crashing pretty much immediately on launch. My solution was to have the wrapper script prepend the Nix-provided-Python’s `bin` directory to the `PATH` before invoking the wrapped Weechat binary.

###### Questions

1. Would the same problem exist for the other script interpreters? We’re currently adding the “right” Python and Perl to the `PATH`, but should I adjust this PR to do the same for TCL, Ruby, Guile, and Lua?
2. ~~While working on this patch I noticed that [the FindPython.cmake file](https://github.com/weechat/weechat/blob/v2.5/cmake/FindPython.cmake) has a couple of stanzas like~~

       find_program(PYTHON_EXECUTABLE
           NAMES python3.7 python3.6 python3.5 python3.4 python3.3 python3.2 python3.1 python3.0 python3 python2.7 python2.6 python2.5 python
           PATHS /usr/bin /usr/local/bin /usr/pkg/bin
       )

    ~~Any idea if this is also a potential source of impurity? Or does Nix’s CMake infrastructure take care of it somehow?~~ I’ve addressed this by adding another commit to the PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @FRidh
Resolves: #37622