### PR TITLE
monero: 0.14.0 -> 0.14.1

### DIFF
--- a/pkgs/applications/altcoins/monero-gui/default.nix
+++ b/pkgs/applications/altcoins/monero-gui/default.nix
@@ -25,13 +25,13 @@ in
 
 stdenv.mkDerivation rec {
   name = "monero-gui-${version}";
-  version = "0.14.0.0";
+  version = "0.14.1.0";
 
   src = fetchFromGitHub {
     owner  = "monero-project";
     repo   = "monero-gui";
     rev    = "v${version}";
-    sha256 = "1l4kx2vidr7bpds43jdbwyaz0q1dy7sricpz061ff1fkappbxdh8";
+    sha256 = "0ilx47771faygf97wilm64xnqxgxa3b43q0g9v014npk0qj8pc31";
   };
 
   nativeBuildInputs = [ qmake pkgconfig ];

--- a/pkgs/applications/altcoins/monero-gui/move-log-file.patch
+++ b/pkgs/applications/altcoins/monero-gui/move-log-file.patch
@@ -1,11 +1,12 @@
 diff --git a/main.cpp b/main.cpp
-index 79223c0..e80b317 100644
+index a51568d..5a9f683 100644
 --- a/main.cpp
 +++ b/main.cpp
-@@ -115,6 +115,9 @@ int main(int argc, char *argv[])
+@@ -152,7 +152,9 @@ int main(int argc, char *argv[])
      QCommandLineOption logPathOption(QStringList() << "l" << "log-file",
          QCoreApplication::translate("main", "Log to specified file"),
          QCoreApplication::translate("main", "file"));
+-
 +    logPathOption.setDefaultValue(
 +        QStandardPaths::writableLocation(QStandardPaths::CacheLocation)
 +        + "/monero-wallet-gui.log");

--- a/pkgs/applications/altcoins/monero/default.nix
+++ b/pkgs/applications/altcoins/monero/default.nix
@@ -11,12 +11,12 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name    = "monero-${version}";
-  version = "0.14.0.2";
+  version = "0.14.1.0";
 
   src = fetchgit {
     url    = "https://github.com/monero-project/monero.git";
     rev    = "v${version}";
-    sha256 = "1471iy6c8dfdqcmcwcp0m7fp9xl74dcm5hqlfdfi217abhawfs8k";
+    sha256 = "1wckn566ly98d4whlnsif6zjlpm6nwmrhmmrg0rzr9587vkx57sx";
   };
 
   nativeBuildInputs = [ cmake pkgconfig git ];

--- a/pkgs/applications/altcoins/monero/default.nix
+++ b/pkgs/applications/altcoins/monero/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   src = fetchgit {
     url    = "https://github.com/monero-project/monero.git";
     rev    = "v${version}";
-    sha256 = "1wckn566ly98d4whlnsif6zjlpm6nwmrhmmrg0rzr9587vkx57sx";
+    sha256 = "1asa197fad81jfv12qgaa7y7pdr1r1pda96m9pvivkh4v30cx0nh";
   };
 
   nativeBuildInputs = [ cmake pkgconfig git ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19090,7 +19090,7 @@ in
 
   monero = callPackage ../applications/altcoins/monero {
     inherit (darwin.apple_sdk.frameworks) CoreData IOKit PCSC;
-    boost = boost15x;
+    boost = boost16x;
   };
 
   monero-gui = libsForQt5.callPackage ../applications/altcoins/monero-gui {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19094,7 +19094,7 @@ in
   };
 
   monero-gui = libsForQt5.callPackage ../applications/altcoins/monero-gui {
-    boost = boost15x;
+    boost = boost16x;
   };
 
   xmr-stak = callPackage ../applications/misc/xmr-stak {


### PR DESCRIPTION
###### Motivation for this change
Continuing PR #63700. 
The hash for monero has changed again plus the build was failing and a patch needed to be updated.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using (none)
- [x] Tested execution
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---