### PR TITLE
rdesktop: 1.8.3 -> 1.8.6 (security release)

### DIFF
--- a/pkgs/applications/networking/remote/rdesktop/default.nix
+++ b/pkgs/applications/networking/remote/rdesktop/default.nix
@@ -1,18 +1,20 @@
-{stdenv, fetchurl, openssl, libX11, libgssglue, pkgconfig
+{stdenv, fetchFromGitHub, openssl, libX11, libgssglue, pkgconfig, autoreconfHook
 , enableCredssp ? (!stdenv.isDarwin)
 } :
 
 stdenv.mkDerivation (rec {
   pname = "rdesktop";
-  version = "1.8.3";
+  version = "1.8.6";
   name = "${pname}-${version}";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/${pname}/${name}.tar.gz";
-    sha256 = "1r7c1rjmw2xzq8fw0scyb453gy9z19774z1z8ldmzzsfndb03cl8";
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "02sbhnqbasa54c75c86qw9w9h9sxxbnldj7bjv2gvn18lmq5rm20";
   };
 
-  nativeBuildInputs = [pkgconfig];
+  nativeBuildInputs = [pkgconfig autoreconfHook];
   buildInputs = [openssl libX11]
     ++ stdenv.lib.optional enableCredssp libgssglue;
 


### PR DESCRIPTION
###### Motivation for this change
Security release, fixing issue with as-yet-unassigned CVE. Debian are using DSA-4473-1/DLA-1837-1.

https://groups.google.com/forum/#!topic/rdesktop-announce/czgpKDfm2D0

Also switching to github source because they don't seem to be keeping their sourceforge tarballs up to date. This also requires adding a `preConfigure` step and `autoconf`/`automake` build deps.

I think the best thing is to similarly bump 19.03 as there's so little clarity from upstream.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
