### PR TITLE
[r19.03] expat: add patch for CVE-2018-20843

### DIFF
--- a/pkgs/development/libraries/expat/default.nix
+++ b/pkgs/development/libraries/expat/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, fetchpatch }:
 
 stdenv.mkDerivation rec {
   name = "expat-2.2.6";
@@ -7,6 +7,15 @@ stdenv.mkDerivation rec {
     url = "mirror://sourceforge/expat/${name}.tar.bz2";
     sha256 = "1wl1x93b5w457ddsdgj0lh7yjq4q6l7wfbgwhagkc8fm2qkkrd0p";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2018-20843.patch";
+      url = "https://github.com/libexpat/libexpat/commit/11f8838bf99ea0a6f0b76f9760c43704d00c4ff6.patch";
+      sha256 = "1i7bq9sp2k5348dvbfv26bprzv6ka1abf0j5ixjaff9alndm4f19";
+      stripLen = 1;
+    })
+  ];
 
   outputs = [ "out" "dev" ]; # TODO: fix referrers
   outputBin = "dev";


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2018-20843

Aimed at `staging-19.03` due to the number of rebuilds - which incidentally looks like it's a bit overdue for a merge.

`master` already has a version bump in `staging`.

Obviously haven't `nox-review`ed this because :scream: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
