### PR TITLE
system.autoUpgrade: optionally allow rebooting the system on kernel change

### DIFF
--- a/nixos/modules/tasks/auto-upgrade.nix
+++ b/nixos/modules/tasks/auto-upgrade.nix
@@ -57,9 +57,9 @@ let cfg = config.system.autoUpgrade; in
         default = false;
         type = types.bool;
         description = ''
-          Shall the system be rebooted if the new configuration
-          uses a different kernel, kernel modules or initrd
-          than the booted system?
+          Reboot the system into the new generation instead of a switch
+          if the new generation uses a different kernel, kernel modules
+          or initrd than the booted system.
         '';
       };
 
@@ -90,24 +90,20 @@ let cfg = config.system.autoUpgrade; in
 
       path = [ pkgs.coreutils pkgs.gnutar pkgs.xz.bin pkgs.gitMinimal config.nix.package.out ];
 
-      script = ''
-        ${lib.optionalString cfg.allowReboot ''
-          set -euo pipefail
-          T=$(mktemp -d)
-          cd "$T"
-          ${config.system.build.nixos-rebuild}/bin/nixos-rebuild build ${toString cfg.flags}
-          booted="$(readlink /run/booted-system/{initrd,kernel,kernel-modules})"
-          built="$(readlink result/{initrd,kernel,kernel-modules})"
-          cd /tmp
-          rm -rf "$T"
-          if [ "$booted" = "$built" ]; then
-            ${config.system.build.nixos-rebuild}/bin/nixos-rebuild switch ${toString cfg.flags}
-          else
-            ${config.system.build.nixos-rebuild}/bin/nixos-rebuild boot ${toString cfg.flags}
-            /run/current-system/sw/bin/shutdown -r +1
-          fi
-          ''}
-          ${lib.optionalString (!cfg.allowReboot) "${config.system.build.nixos-rebuild}/bin/nixos-rebuild switch ${toString cfg.flags}"}
+      script = let
+          nixos-rebuild = "${config.system.build.nixos-rebuild}/bin/nixos-rebuild";
+        in
+        if cfg.allowReboot then ''
+            ${nixos-rebuild} boot ${toString cfg.flags}
+            booted="$(readlink /run/booted-system/{initrd,kernel,kernel-modules})"
+            built="$(readlink /nix/var/nix/profiles/system/{initrd,kernel,kernel-modules})"
+            if [ "$booted" = "$built" ]; then
+              ${nixos-rebuild} switch ${toString cfg.flags}
+            else
+              /run/current-system/sw/bin/shutdown -r +1
+            fi
+          '' else ''
+            ${nixos-rebuild} switch ${toString cfg.flags}
         '';
 
       startAt = cfg.dates;


### PR DESCRIPTION
###### Motivation for this change

new function for the module: Allows automatic reboots if the new generation uses a different kernel.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
