### PR TITLE
nixos/nscd: DynamicUser and other cleanups

### DIFF
--- a/nixos/modules/services/system/nscd.conf
+++ b/nixos/modules/services/system/nscd.conf
@@ -6,6 +6,7 @@
 # fallback to trying to handle the request by itself. Which won't work as glibc
 # is not aware of the path in which the nss modules live.  As a workaround, we
 # have `enable-cache yes` with an explicit ttl of 0
+server-user             nscd
 
 enable-cache            passwd          yes
 positive-time-to-live   passwd          0

--- a/nixos/modules/services/system/nscd.conf
+++ b/nixos/modules/services/system/nscd.conf
@@ -6,7 +6,6 @@
 # fallback to trying to handle the request by itself. Which won't work as glibc
 # is not aware of the path in which the nss modules live.  As a workaround, we
 # have `enable-cache yes` with an explicit ttl of 0
-server-user             nscd
 threads                 1
 paranoia                no
 debug-level             0

--- a/nixos/modules/services/system/nscd.conf
+++ b/nixos/modules/services/system/nscd.conf
@@ -6,46 +6,28 @@
 # fallback to trying to handle the request by itself. Which won't work as glibc
 # is not aware of the path in which the nss modules live.  As a workaround, we
 # have `enable-cache yes` with an explicit ttl of 0
-threads                 1
-paranoia                no
-debug-level             0
 
 enable-cache            passwd          yes
 positive-time-to-live   passwd          0
 negative-time-to-live   passwd          0
-suggested-size          passwd          211
-check-files             passwd          yes
-persistent              passwd          no
 shared                  passwd          yes
 
 enable-cache            group           yes
 positive-time-to-live   group           0
 negative-time-to-live   group           0
-suggested-size          group           211
-check-files             group           yes
-persistent              group           no
 shared                  group           yes
 
 enable-cache            netgroup        yes
 positive-time-to-live   netgroup        0
 negative-time-to-live   netgroup        0
-suggested-size          netgroup        211
-check-files             netgroup        yes
-persistent              netgroup        no
 shared                  netgroup        yes
 
 enable-cache            hosts           yes
 positive-time-to-live   hosts           600
 negative-time-to-live   hosts           0
-suggested-size          hosts           211
-check-files             hosts           yes
-persistent              hosts           no
 shared                  hosts           yes
 
 enable-cache            services        yes
 positive-time-to-live   services        0
 negative-time-to-live   services        0
-suggested-size          services        211
-check-files             services        yes
-persistent              services        no
 shared                  services        yes

--- a/nixos/modules/services/system/nscd.nix
+++ b/nixos/modules/services/system/nscd.nix
@@ -52,6 +52,12 @@ in
           config.environment.etc."nscd.conf".source
         ];
 
+        # We use DynamicUser because in default configurations nscd doesn't
+        # create any files that need to survive restarts. However, in some
+        # configurations, nscd needs to be started as root; it will drop
+        # privileges after all the NSS modules have read their configuration
+        # files. So prefix the ExecStart command with "!" to prevent systemd
+        # from dropping privileges early. See ExecStart in systemd.service(5).
         serviceConfig =
           { ExecStart = "!@${pkgs.glibc.bin}/sbin/nscd nscd";
             Type = "forking";

--- a/nixos/modules/services/system/nscd.nix
+++ b/nixos/modules/services/system/nscd.nix
@@ -55,7 +55,6 @@ in
         serviceConfig =
           { ExecStart = "@${pkgs.glibc.bin}/sbin/nscd nscd";
             Type = "forking";
-            User = "nscd";
             DynamicUser = true;
             RuntimeDirectory = "nscd";
             PIDFile = "/run/nscd/nscd.pid";

--- a/nixos/modules/services/system/nscd.nix
+++ b/nixos/modules/services/system/nscd.nix
@@ -39,11 +39,6 @@ in
   config = mkIf cfg.enable {
     environment.etc."nscd.conf".text = cfg.config;
 
-    users.users.nscd =
-      { isSystemUser = true;
-        description = "Name service cache daemon user";
-      };
-
     systemd.services.nscd =
       { description = "Name Service Cache Daemon";
 
@@ -60,6 +55,8 @@ in
         serviceConfig =
           { ExecStart = "@${pkgs.glibc.bin}/sbin/nscd nscd";
             Type = "forking";
+            User = "nscd";
+            DynamicUser = true;
             RuntimeDirectory = "nscd";
             PIDFile = "/run/nscd/nscd.pid";
             Restart = "always";

--- a/nixos/modules/services/system/nscd.nix
+++ b/nixos/modules/services/system/nscd.nix
@@ -75,15 +75,6 @@ in
                 "${pkgs.glibc.bin}/sbin/nscd --invalidate hosts"
               ];
           };
-
-        # Urgggggh... Nscd forks before opening its socket and writing
-        # its pid. So wait until it's ready.
-        postStart =
-          ''
-            while ! ${pkgs.glibc.bin}/sbin/nscd -g > /dev/null; do
-              sleep 0.2
-            done
-          '';
       };
 
   };

--- a/nixos/modules/services/system/nscd.nix
+++ b/nixos/modules/services/system/nscd.nix
@@ -51,13 +51,6 @@ in
 
         environment = { LD_LIBRARY_PATH = nssModulesPath; };
 
-        preStart =
-          ''
-            mkdir -m 0755 -p /run/nscd
-            rm -f /run/nscd/nscd.pid
-            mkdir -m 0755 -p /var/db/nscd
-          '';
-
         restartTriggers = [
           config.environment.etc.hosts.source
           config.environment.etc."nsswitch.conf".source
@@ -67,6 +60,7 @@ in
         serviceConfig =
           { ExecStart = "@${pkgs.glibc.bin}/sbin/nscd nscd";
             Type = "forking";
+            RuntimeDirectory = "nscd";
             PIDFile = "/run/nscd/nscd.pid";
             Restart = "always";
             ExecReload =

--- a/nixos/modules/services/system/nscd.nix
+++ b/nixos/modules/services/system/nscd.nix
@@ -53,7 +53,7 @@ in
         ];
 
         serviceConfig =
-          { ExecStart = "@${pkgs.glibc.bin}/sbin/nscd nscd";
+          { ExecStart = "!@${pkgs.glibc.bin}/sbin/nscd nscd";
             Type = "forking";
             DynamicUser = true;
             RuntimeDirectory = "nscd";


### PR DESCRIPTION
###### Motivation for this change

I was looking at which users and groups have a `null` value for `uid` or `gid`, and there was only one in a default-configuration `boot.isContainer` build of NixOS: `nscd`. As far as I can tell, that service can use systemd's `DynamicUser` directive instead.

While I was checking that, I found that some very old code in this module doesn't need to exist any more, if I'm not mistaken. So I've included separate commits for those dead-code removals.

###### Things done

I ran:

- `nix-build release.nix -A tests.login.x86_64-linux` (passed)
- `nix-build release.nix -A tests.systemd.x86_64-linux` (passed except the "file system with x-initrd.mount is not unmounted" test fails for me, but it does that without my patches too)

I also built the following expression against this branch and booted it with `systemd-nspawn`:

```
(import <nixpkgs/nixos> {
  configuration = { config, pkgs, ... }: {
    boot.isContainer = true;
    services.mingetty.autologinUser = "root";
  };
}).config.system.build.toplevel
```

Within that container, I verified that:

- `getent` can talk to `nscd`,
- `nscd` is running under a dynamic UID,
- `/run/nscd` and its contents are owned by that UID,
- `/var/db/nscd` doesn't exist but everything still works,
- and the generated `users-groups.json` has no `"uid"` or `"gid"` that is `null`.

---

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).