### PR TITLE
pantheon.switchboard-plug-pantheon-shell: Fix setting lightdm background

### DIFF
--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/pantheon-shell/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/pantheon-shell/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, pantheon, meson, ninja, pkgconfig, vala
 , libgee, granite, gexiv2, elementary-settings-daemon, gtk3, gnome-desktop
-, gala, wingpanel, plank, switchboard, gettext, bamf }:
+, gala, wingpanel, plank, switchboard, gettext, bamf, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "switchboard-plug-pantheon-shell";
@@ -42,6 +42,11 @@ stdenv.mkDerivation rec {
   patches = [
     ./backgrounds.patch # Having https://github.com/elementary/switchboard-plug-pantheon-shell/issues/166 would make this patch uneeded
     ./hardcode-gsettings.patch
+    # Fixes https://github.com/elementary/switchboard-plug-pantheon-shell/issues/172
+    (fetchpatch {
+      url = "https://github.com/elementary/switchboard-plug-pantheon-shell/commit/e4f86df6a6be402db4c979a4b005573618b744d1.patch";
+      sha256 = "0sa8611k6sqg96mnp2plmxd30w6zq76bfwszl8ankr9kwsgyc66y";
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
backports https://github.com/elementary/switchboard-plug-pantheon-shell/commit/e4f86df6a6be402db4c979a4b005573618b744d1

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Setting the lightdm background with the `lightdm-gtk-greeter` was broken.
This patch should have that working as expected.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
