### PR TITLE
keybase{,-gui}: 4.0.0 -> 4.1.0

### DIFF
--- a/pkgs/tools/security/keybase/default.nix
+++ b/pkgs/tools/security/keybase/default.nix
@@ -1,20 +1,22 @@
-{ stdenv, lib, buildGoPackage, fetchurl, cf-private
+{ stdenv, lib, buildGoPackage, fetchFromGitHub, cf-private
 , AVFoundation, AudioToolbox, ImageIO, CoreMedia
 , Foundation, CoreGraphics, MediaToolbox
 }:
 
 buildGoPackage rec {
   name = "keybase-${version}";
-  version = "4.0.0";
+  version = "4.1.0";
 
   goPackagePath = "github.com/keybase/client";
   subPackages = [ "go/keybase" ];
 
   dontRenameImports = true;
 
-  src = fetchurl {
-    url = "https://github.com/keybase/client/archive/v${version}.tar.gz";
-    sha256 = "14c0876mxz3xa2k4d665kf8j6k3hc6qybkj0gr4pr9c9gs70cgjh";
+  src = fetchFromGitHub {
+    owner = "keybase";
+    repo = "client";
+    rev = "v${version}";
+    sha256 = "00mxyy4jhdbcvbwabf4yvq4h5mpnlfp2z93gy2266kz6gkd5myzk";
   };
 
   buildInputs = lib.optionals stdenv.isDarwin [

--- a/pkgs/tools/security/keybase/gui.nix
+++ b/pkgs/tools/security/keybase/gui.nix
@@ -4,16 +4,16 @@
 , runtimeShell, gsettings-desktop-schemas }:
 
 let
-  versionSuffix = "20190508150240.6614a49937";
+  versionSuffix = "20190612201656.952fee6c59";
 in
 
 stdenv.mkDerivation rec {
   name = "keybase-gui-${version}";
-  version = "4.0.0"; # Find latest version from https://prerelease.keybase.io/deb/dists/stable/main/binary-amd64/Packages
+  version = "4.1.0"; # Find latest version from https://prerelease.keybase.io/deb/dists/stable/main/binary-amd64/Packages
 
   src = fetchurl {
     url = "https://s3.amazonaws.com/prerelease.keybase.io/linux_binaries/deb/keybase_${version + "-" + versionSuffix}_amd64.deb";
-    sha256 = "1fj92gxwfd6909r79prsq760b9s50js1iip5c01621hz9y39jd6m";
+    sha256 = "0jwxw75yz7sbvfqw2aksa3p7jlcv817743fl59qk6rq1x9ag6qpx";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
#### Motivation for this change
resolves #64248

did a nix-review on NixOS, these are leaf packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

$ nix path-info -Sh ./result
/nix/store/l3m6xv4wkiqdh56zsn13a9ya9ypdm44r-keybase-gui-4.0.0    460.1M
$ nix path-info -Sh ./result
/nix/store/vl37mvjm10sl29w4i8yyrhl6hj5jzxgs-keybase-gui-4.1.0    460.5M

$ nix path-info -Sh ./result-bin
/nix/store/zrfhyqs442knixhfkg3vi8inicqg5v35-keybase-4.0.0-bin     91.0M
$ nix path-info -Sh ./result-bin
/nix/store/ic2861ldxj5q988lj5d044z4bcjfiz8m-keybase-4.1.0-bin     91.6M
