### PR TITLE
pythonPackages.seekpath: mark as broken

### DIFF
--- a/pkgs/development/python-modules/seekpath/default.nix
+++ b/pkgs/development/python-modules/seekpath/default.nix
@@ -7,7 +7,7 @@ buildPythonPackage rec {
   src = fetchPypi {
     inherit pname version;
     sha256 = "b61dadba82acc0838402981b7944155adc092b114ca81f53f61b1d498a512e3a";
-  };  
+  };
 
   LC_ALL = "en_US.utf-8";
 
@@ -17,8 +17,9 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "A module to obtain and visualize band paths in the Brillouin zone of crystal structures.";
-    homepage = https://github.com/giovannipizzi/seekpath;
+    homepage = "https://github.com/giovannipizzi/seekpath";
     license = licenses.mit;
+    broken = true; # seekpath.test_paths_hpkot.TestPaths3D_HPKOT testMethod=test_oI2Y fails
     maintainers = with maintainers; [ psyanticy ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
it's breaking a few other packages

<details> <summary> Long log </summary>

```
builder for '/nix/store/ha7m938bngggxm9n0k0dgczk2j454l59-python2.7-seekpath-1.8.4.drv' failed with exit code 1; last 10 log lines:
    File "/build/seekpath-1.8.4/seekpath/test_paths_hpkot.py", line 366, in base_test
      self.assertEqual(res['bravais_lattice_extended'], ext_bravais)
  AssertionError: 'oI3' != 'oI2'

  ----------------------------------------------------------------------
  Ran 69 tests in 1.138s

  FAILED (failures=1, skipped=2)
  Test failed: <unittest.runner.TextTestResult run=69 errors=0 failures=1>
  error: Test failed: <unittest.runner.TextTestResult run=69 errors=0 failures=1>
builder for '/nix/store/ihi4s44w9fbidxjfkgrgcnxfz9xjh2n8-python3.7-aiohttp-2.3.10.drv' failed with exit code 1; last 6 log lines:
  unpacking sources
  unpacking source archive /nix/store/5dzzs2c8hhrmychljldmjrkgcf3hilgd-aiohttp-2.3.10.tar.gz
  source root is aiohttp-2.3.10
  setting SOURCE_DATE_EPOCH to timestamp 1517564845 of file aiohttp-2.3.10/setup.cfg
  patching sources
  substitute(): ERROR: file 'pytest.ini' does not exist
cannot build derivation '/nix/store/z6zlh6hgj2088zvfwzcjdy03yl3j2p9m-python3.7-pytest-aiohttp-0.3.0.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/1ba1k9sxgs5sy17jxgxvvvr1r7dmgpvl-python3.7-aiohttp-jinja2-0.15.0.drv': 2 dependencies couldn't be built
cannot build derivation '/nix/store/w5kizcvjky785w5w41yifyvndhgijd7c-appdaemon-3.0.5.drv': 2 dependencies couldn't be built
```

</details>

I tried to fix, but.. not really sure if the package is actually in an invalid state or not, so I'm just marking it broken.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
