### PR TITLE
adapta-backgrounds: 0.5.2.3 -> 0.5.3.1

### DIFF
--- a/pkgs/data/misc/adapta-backgrounds/default.nix
+++ b/pkgs/data/misc/adapta-backgrounds/default.nix
@@ -1,23 +1,23 @@
-{ stdenv, fetchFromGitHub, autoreconfHook }:
+{ stdenv, fetchFromGitHub, meson, ninja, pkgconfig, glib }:
 
 stdenv.mkDerivation rec {
-  name = "adapta-backgrounds-${version}";
-  version = "0.5.2.3";
+  pname = "adapta-backgrounds";
+  version = "0.5.3.1";
 
   src = fetchFromGitHub {
     owner = "adapta-project";
     repo = "adapta-backgrounds";
     rev = version;
-    sha256 = "0n0ggcxinja81lasmpviqq3l4jiwb05bs8r5aah1im2zvls1g007";
+    sha256 = "04hmbmzf97rsii8gpwy3wkljy5xhxmlsl34d63s6hfy05knclydj";
   };
 
-  nativeBuildInputs = [ autoreconfHook  ];
+  nativeBuildInputs = [ meson ninja pkgconfig glib ];
 
   meta = with stdenv.lib; {
     description = "Wallpaper collection for adapta-project";
-    homepage = https://github.com/adapta-project/adapta-backgrounds;
+    homepage = "https://github.com/adapta-project/adapta-backgrounds";
     license = with licenses; [ gpl2 cc-by-sa-40 ];
     platforms = platforms.all;
-    maintainers = [ maintainers.romildo ];
+    maintainers = with maintainers; [ romildo ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
