### PR TITLE
pythonPackages.sqlalchemy: Add Postgres support

### DIFF
--- a/pkgs/development/python-modules/sqlalchemy/default.nix
+++ b/pkgs/development/python-modules/sqlalchemy/default.nix
@@ -6,6 +6,8 @@
 , mock
 , isPy3k
 , pysqlite
+, withPsycopg2 ? true
+, psycopg2
 }:
 
 buildPythonPackage rec {
@@ -26,6 +28,8 @@ buildPythonPackage rec {
       sha256 = "1x25aj5hqmgjdak4hllya0rf0srr937k1hwaxb24i9ban607hjri";
     })
   ];
+
+  propagatedBuildInputs = lib.optional withPsycopg2 psycopg2;
 
   checkInputs = [
     pytest


### PR DESCRIPTION
This adds a propagated dependency on Psycopg2, which is needed for Postgres support in SQLAlchemy. The dependency can be turned off with a flag. (Although I don't know if it is customary to do this for Python packages, please tell me if there is a better way to do this.)

###### Motivation for this change

Psycopg2 in SQLAlchemy is needed to use Alembic with Postgres, as SQLAlchemy is a dependency of Alembic.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
        I did verify that `alemic` can run against Postgres after this change, but I did not test any other binaries.
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
