### PR TITLE
j4-dmenu-desktop: 2.16 -> 2.17

### DIFF
--- a/pkgs/applications/misc/j4-dmenu-desktop/default.nix
+++ b/pkgs/applications/misc/j4-dmenu-desktop/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, cmake, dmenu }:
 
 stdenv.mkDerivation rec {
-  name    = "j4-dmenu-desktop-${version}";
-  version = "2.16";
+  pname = "j4-dmenu-desktop";
+  version = "2.17";
 
   src = fetchFromGitHub {
-    owner  = "enkore";
-    repo   = "j4-dmenu-desktop";
-    rev    = "r${version}";
-    sha256 = "0714cri8bwpimmiirhzrkbri4xi24k0za6i1aw94d3fnblk2dg9f";
+    owner = "enkore";
+    repo = pname;
+    rev = "r${version}";
+    sha256 = "0v23fimkn83dcm5p53y2ymhklff3kwppxhf75sm8xmswrzkixpgc";
   };
 
   postPatch = ''
@@ -18,13 +18,16 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
 
   # tests are fetching an external git repository
-  cmakeFlags = [ "-DNO_TESTS:BOOL=ON" ];
+  cmakeFlags = [
+    "-DWITH_TESTS=OFF"
+    "-DWITH_GIT_CATCH=OFF"
+  ];
 
   meta = with stdenv.lib; {
     description = "A wrapper for dmenu that recognize .desktop files";
-    homepage    = "https://github.com/enkore/j4-dmenu-desktop";
-    license     = licenses.gpl3;
+    homepage = "https://github.com/enkore/j4-dmenu-desktop";
+    license = licenses.gpl3;
     maintainers = with maintainers; [ ericsagnes ];
-    platforms   = with platforms; unix;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
