### PR TITLE
kallisto: 0.43.1 -> 0.46.0

### DIFF
--- a/pkgs/applications/science/biology/kallisto/default.nix
+++ b/pkgs/applications/science/biology/kallisto/default.nix
@@ -1,25 +1,28 @@
-{ stdenv, fetchFromGitHub, cmake, hdf5, zlib }:
+{ stdenv, fetchFromGitHub, autoconf, cmake, hdf5, zlib }:
 
 stdenv.mkDerivation rec {
   pname = "kallisto";
-  version = "0.43.1";
+  version = "0.46.0";
 
   src = fetchFromGitHub {
     repo = "kallisto";
     owner = "pachterlab";
     rev = "v${version}";
-    sha256 = "04697pf7jvy7vw126s1rn09q4iab9223jvb1nb0jn7ilwkq7pgwz";
+    sha256 = "09vgdqwpigl4x3sdw5vjfyknsllkli339mh8xapbf7ldm0jldfn9";
   };
 
-  nativeBuildInputs = [ cmake ];
-  
+  nativeBuildInputs = [ autoconf cmake ];
+
   buildInputs = [ hdf5 zlib ];
 
+  # Parallel build fails in some cases: https://github.com/pachterlab/kallisto/issues/160
+  enableParallelBuilding = false;
+
   meta = with stdenv.lib; {
-    description = "kallisto is a program for quantifying abundances of transcripts from RNA-Seq data";
-    homepage = https://pachterlab.github.io/kallisto;
+    description = "Kallisto is a program for quantifying abundances of transcripts from RNA-Seq data";
+    homepage = "https://pachterlab.github.io/kallisto";
     license = licenses.bsd2;
     platforms = platforms.linux;
-    maintainers = [ maintainers.arcadio ];
+    maintainers = with maintainers; [ arcadio ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
