### PR TITLE
libyaml: 0.2.1 -> 0.2.2

### DIFF
--- a/pkgs/development/libraries/libyaml/default.nix
+++ b/pkgs/development/libraries/libyaml/default.nix
@@ -1,30 +1,13 @@
-{ stdenv, fetchurl, fetchpatch }:
+{ stdenv, fetchurl }:
 
-let
-
-  version = "0.2.1";
-
-  # https://github.com/yaml/pyyaml/issues/214
-  p1 = fetchpatch {
-         url = https://github.com/yaml/libyaml/commit/8ee83c0da22fe9aa7dea667be8f899a7e32ffb83.patch;
-         sha256 = "00jh39zww6s4gyhxfmlxwb6lz90nl3p51k5h1qm6z3ymik5vljmz";
-       };
-  p2 = fetchpatch {
-         url = https://github.com/yaml/libyaml/commit/56f4b17221868593d6903ee58d6d679b690cf4df.patch;
-         sha256 = "0najcay1y4kgfpsidj7dnyafnwjbav5jyawhyv215zl9gg3386n0";
-       };
-
-in
-
-stdenv.mkDerivation {
-  name = "libyaml-${version}";
+stdenv.mkDerivation rec {
+  pname = "libyaml";
+  version = "0.2.2";
 
   src = fetchurl {
     url = "https://pyyaml.org/download/libyaml/yaml-${version}.tar.gz";
     sha256 = "1karpcfgacgppa82wm2drcfn2kb6q2wqfykf5nrhy20sci2i2a3q";
   };
-
-  patches = [ p1 p2 ];  # remove when the next release comes out
 
   meta = with stdenv.lib; {
     homepage = https://pyyaml.org/;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
