### PR TITLE
hy: 0.16.0 -> 0.17.0

### DIFF
--- a/pkgs/development/interpreters/hy/default.nix
+++ b/pkgs/development/interpreters/hy/default.nix
@@ -1,22 +1,13 @@
-{ stdenv, fetchurl, fetchpatch, pythonPackages }:
+{ stdenv, fetchurl, pythonPackages }:
 
 pythonPackages.buildPythonApplication rec {
-  name = "hy-${version}";
-  version = "0.16.0";
+  pname = "hy";
+  version = "0.17.0";
 
-  src = fetchurl {
-    url = "mirror://pypi/h/hy/${name}.tar.gz";
-    sha256 = "00lq38ppikrpyw38fn5iy9iwrsamsv22507cp146dsjbzkwjpzrd";
+  src = pythonPackages.fetchPypi {
+    inherit pname version;
+    sha256 = "1gdbqsirsdxj320wnp7my5awzs1kfs6m4fqmkzbd1zd47qzj0zfi";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "bytecode-error-handling.patch";
-      url = "https://github.com/hylang/hy/commit/57326785b97b7b0a89f6258fe3d04dccdc06cfc0.patch";
-      sha256 = "1lxxs7mxbh0kaaa25b1pbqs9d8asyjnlf2n86qg8hzsv32jfcq92";
-      excludes = [ "AUTHORS" "NEWS.rst" ];
-    })
-  ];
 
   propagatedBuildInputs = with pythonPackages; [
     appdirs
@@ -27,11 +18,11 @@ pythonPackages.buildPythonApplication rec {
     rply
   ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "A LISP dialect embedded in Python";
-    homepage = http://hylang.org/;
-    license = stdenv.lib.licenses.mit;
-    maintainers = [ stdenv.lib.maintainers.nixy ];
-    platforms = stdenv.lib.platforms.all;
+    homepage = "http://hylang.org/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ nixy ];
+    platforms = platforms.all;
   };
 }

--- a/pkgs/development/python-modules/astor/default.nix
+++ b/pkgs/development/python-modules/astor/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "astor";
-  version = "0.7.1";
+  version = "0.8.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "95c30d87a6c2cf89aa628b87398466840f0ad8652f88eb173125a6df8533fb8d";
+    sha256 = "0qkq5bf13fqcwablg0nk7rx83izxdizysd42n26j5wbingcfx9ip";
   };
 
   # disable tests broken with python3.6: https://github.com/berkerpeksag/astor/issues/89


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
