### PR TITLE
libgdata: 0.17.9 -> 0.17.10

### DIFF
--- a/pkgs/development/libraries/libgdata/default.nix
+++ b/pkgs/development/libraries/libgdata/default.nix
@@ -1,20 +1,69 @@
-{ stdenv, fetchurl, pkgconfig, intltool, libxml2, glib, json-glib, gcr
-, gobject-introspection, liboauth, gnome3, p11-kit, openssl, uhttpmock }:
+{ stdenv
+, fetchurl
+, pkgconfig
+, meson
+, ninja
+, vala
+, gettext
+, libxml2
+, glib
+, json-glib
+, gcr
+, gobject-introspection
+, liboauth
+, gnome3
+, p11-kit
+, openssl
+, uhttpmock
+, libsoup
+}:
 
 stdenv.mkDerivation rec {
   pname = "libgdata";
-  version = "0.17.9";
+  version = "0.17.10";
+
+  outputs = [ "out" "dev" "installedTests" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0fj54yqxdapdppisqm1xcyrpgcichdmipq0a0spzz6009ikzgi45";
+    sha256 = "04mh2p5x2iidfx0d1cablxbi3hvna8cmlddc1mm4387n0grx3ly1";
   };
 
-  nativeBuildInputs = [ pkgconfig intltool gobject-introspection ];
+  patches = [
+    ./installed-tests-path.patch
+  ];
 
-  buildInputs = [ gnome3.libsoup libxml2 glib liboauth gcr gnome3.gnome-online-accounts p11-kit openssl uhttpmock ];
+  nativeBuildInputs = [
+    gettext
+    gobject-introspection
+    meson
+    ninja
+    pkgconfig
+    vala
+  ];
 
-  propagatedBuildInputs = [ json-glib ];
+  buildInputs = [
+    gcr
+    glib
+    gnome3.gnome-online-accounts
+    liboauth
+    libsoup
+    libxml2
+    openssl
+    p11-kit
+    uhttpmock
+  ];
+
+  propagatedBuildInputs = [
+    json-glib
+  ];
+
+  mesonFlags = [
+    "-Dgtk_doc=false"
+    "-Dinstalled_test_bindir=${placeholder ''installedTests''}/libexec"
+    "-Dinstalled_test_datadir=${placeholder ''installedTests''}/share"
+    "-Dinstalled_tests=true"
+  ];
 
   passthru = {
     updateScript = gnome3.updateScript {
@@ -26,7 +75,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "GData API library";
     homepage = https://wiki.gnome.org/Projects/libgdata;
-    maintainers = with maintainers; [ raskin lethalman ];
+    maintainers = with maintainers; [ raskin lethalman ] ++ gnome3.maintainers;
     platforms = platforms.linux;
     license = licenses.lgpl21Plus;
   };

--- a/pkgs/development/libraries/libgdata/installed-tests-path.patch
+++ b/pkgs/development/libraries/libgdata/installed-tests-path.patch
@@ -1,0 +1,94 @@
+diff --git a/gdata/tests/meson.build b/gdata/tests/meson.build
+index 52154e7a..1a44d1d8 100644
+--- a/gdata/tests/meson.build
++++ b/gdata/tests/meson.build
+@@ -1,5 +1,12 @@
+-tests_execdir = gdata_libexecdir / 'installed-tests' / gdata_name
+-tests_metadir = gdata_datadir / 'installed-tests' / gdata_name
++tests_bindir = get_option('installed_test_bindir') / 'installed-tests' / gdata_name
++if tests_bindir == ''
++    test_bindir = gdata_libexecdir / 'installed-tests' / gdata_name
++endif
++
++tests_datadir = get_option('installed_test_datadir') / 'installed-tests' / gdata_name
++if tests_datadir == ''
++    tests_datadir = gdata_datadir / 'installed-tests' / gdata_name
++endif
+ 
+ tests_sources = files(
+   'common.c',
+@@ -48,7 +55,7 @@ foreach test_name, extra_args: tests
+     dependencies: common_deps + extra_args.get('dependencies', []),
+     sources: tests_sources,
+     install: install_tests,
+-    install_dir: tests_execdir,
++    install_dir: tests_bindir,
+   )
+ 
+   test(
+@@ -63,7 +70,7 @@ if install_tests
+   foreach test_name, extra_args: tests
+     tests_conf = {
+       'TEST_TYPE': 'session',
+-      'TEST_ABS_PATH': gdata_prefix / tests_execdir / test_name,
++      'TEST_ABS_PATH': tests_bindir / test_name,
+     }
+ 
+     configure_file (
+@@ -71,13 +78,13 @@ if install_tests
+       output: test_name + '.test',
+       configuration: tests_conf,
+       install: true,
+-      install_dir: tests_metadir,
++      install_dir: tests_datadir,
+     )
+   endforeach
+ 
+   install_subdir(
+     'traces',
+-    install_dir: tests_execdir,
++    install_dir: tests_bindir,
+   )
+ 
+   test_data = [
+@@ -96,6 +103,6 @@ if install_tests
+ 
+   install_data(
+     test_data,
+-    install_dir: tests_execdir,
++    install_dir: tests_bindir,
+   )
+ endif
+diff --git a/meson.build b/meson.build
+index 7d2f5254..bed3e189 100644
+--- a/meson.build
++++ b/meson.build
+@@ -20,9 +20,9 @@ gdata_api_version_minor = 0
+ 
+ # Define the install directories
+ gdata_prefix = get_option('prefix')
+-gdata_datadir = get_option('datadir')
+-gdata_libexecdir = get_option('libexecdir')
+-gdata_includedir = get_option('includedir')
++gdata_datadir = gdata_prefix / get_option('datadir')
++gdata_libexecdir = gdata_prefix / get_option('libexecdir')
++gdata_includedir = gdata_prefix / get_option('includedir')
+ 
+ gdata_include_subdir = gdata_name / 'gdata'
+ 
+diff --git a/meson_options.txt b/meson_options.txt
+index 25cc6b55..6fc2cfa3 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -43,3 +43,11 @@ option('vapi',
+   type: 'boolean',
+   value: true,
+   description: 'Enable creation of vapi files')
++
++option('installed_test_datadir', type: 'string',
++  value: '',
++  description: 'Installation directory for data files in tests')
++
++option('installed_test_bindir', type: 'string',
++  value: '',
++  description: 'Installation directory for binary files in tests')


### PR DESCRIPTION
###### Motivation for this change
* Meson!
* intiltool -> gettext
* multi-outputs
* installed tests

https://gitlab.gnome.org/GNOME/libgdata/blob/0.17.10/NEWS

Installed Tests are here but I didn't have time to actually add the NixOS test and have it working.
Additionally this had to go to staging because we needed Meson `>= 0.50.0`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
