### PR TITLE
gnome3.gnome-contacts: fix build

### DIFF
--- a/pkgs/desktops/gnome-3/core/gnome-contacts/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-contacts/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, gettext, fetchurl, evolution-data-server
+{ stdenv, gettext, fetchurl, evolution-data-server, fetchpatch
 , pkgconfig, libxslt, docbook_xsl, docbook_xml_dtd_42, python3, gtk3, glib, cheese
 , libchamplain, clutter-gtk, geocode-glib, gnome-desktop, gnome-online-accounts
 , wrapGAppsHook, folks, libxml2, gnome3, telepathy-glib
@@ -29,6 +29,18 @@ in stdenv.mkDerivation rec {
 
   mesonFlags = [
     "-Dtelepathy=true"
+  ];
+
+  patches = [
+    # Fixes build with libhandy >= 0.0.10
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/gnome-contacts/commit/c5eee38cd2556403a640a0a4c11d36cbf9a5a798.patch";
+      sha256 = "0s2cl7z6b0x3ky4y28yyxc9x5zp4r3vqmvbhz5m2fm6830fyjg13";
+    })
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/gnome-contacts/commit/1f1500ca01098ffda6392f5ec9ce3a29a48a84b1.patch";
+      sha256 = "082zaaj2l5cgr2qy145x8yknja87r0vpigrhidal40041kd5nldg";
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
ibhandy 0.0.10 added a HeaderBar type, which means this
clashes with that of Gtk. Apply upstream patch that fixes this.

Instigated by
* 48044cda54265ec69d3988bf4d06199b920c212b

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
GNOME3 test failure https://hydra.nixos.org/build/95718709

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
