### PR TITLE
vagrant: 2.2.3 -> 2.2.5

### DIFF
--- a/pkgs/development/tools/vagrant/default.nix
+++ b/pkgs/development/tools/vagrant/default.nix
@@ -4,9 +4,9 @@
 let
   # NOTE: bumping the version and updating the hash is insufficient;
   # you must use bundix to generate a new gemset.nix in the Vagrant source.
-  version = "2.2.3";
+  version = "2.2.5";
   url = "https://github.com/hashicorp/vagrant/archive/v${version}.tar.gz";
-  sha256 = "1j00glqn8b1zsgqg2nyk5as405a6s6vclswg2ri0a229hnsiabvs";
+  sha256 = "0a228f5185b24b72efcc5a3924f86fa9fabab6f7562c3c63c1d9d239aa72a7b1";
 
   deps = bundlerEnv rec {
     name = "${pname}-${version}";

--- a/pkgs/development/tools/vagrant/gemset.nix
+++ b/pkgs/development/tools/vagrant/gemset.nix
@@ -1,20 +1,13 @@
 {
-  addressable = {
-    dependencies = ["public_suffix"];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "0bcm2hchn897xjhqj9zzsxf3n9xhddymj4lsclz508f4vw3av46l";
-      type = "gem";
-    };
-    version = "2.6.0";
-  };
   bcrypt_pbkdf = {
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0cj4k13c7qvvck7y25i3xarvyqq8d27vl61jddifkc7llnnap1hv";
+      sha256 = "02vssr285m7kpsr47jdmzbar1h1d0mnkmyrpr1zg828isfmwii35";
       type = "gem";
     };
-    version = "1.0.0";
+    version = "1.0.1";
   };
   builder = {
     source = {
@@ -34,21 +27,14 @@
     version = "0.6.3";
   };
   concurrent-ruby = {
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1ixcx9pfissxrga53jbdpza85qd5f6b5nq1sfqa9rnfq82qnlbp1";
+      sha256 = "1x07r23s7836cpp5z9yrlbpljcxpax14yw4fy4bnp6crhr6x24an";
       type = "gem";
     };
-    version = "1.1.4";
-  };
-  crack = {
-    dependencies = ["safe_yaml"];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "0abb0fvgw00akyik1zxnq7yv391va148151qxdghnzngv66bl62k";
-      type = "gem";
-    };
-    version = "0.4.3";
+    version = "1.1.5";
   };
   diff-lcs = {
     source = {
@@ -60,12 +46,14 @@
   };
   domain_name = {
     dependencies = ["unf"];
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0abdlwb64ns7ssmiqhdwgl27ly40x2l27l8hs8hn0z4kb3zd2x3v";
+      sha256 = "0lcqjsmixjp52bnlgzh4lg9ppsk52x9hpwdjd53k8jnbah2602h0";
       type = "gem";
     };
-    version = "0.5.20180417";
+    version = "0.5.20190701";
   };
   ed25519 = {
     source = {
@@ -83,30 +71,26 @@
     };
     version = "2.7.0";
   };
-  fake_ftp = {
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "0rn7lxdk3sqc2i4v2c5k25b9ca1qnkdf32nv04y760aml9mszwf7";
-      type = "gem";
-    };
-    version = "0.1.1";
-  };
   ffi = {
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0j8pzj8raxbir5w5k6s7a042sb5k02pg0f8s4na1r5lan901j00p";
+      sha256 = "06mvxpjply8qh4j3fj9wh08kdzwkbnvsiysh0vrhlk5cwxzjmblh";
       type = "gem";
     };
-    version = "1.10.0";
+    version = "1.11.1";
   };
   gssapi = {
     dependencies = ["ffi"];
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0j93nsf9j57p7x4aafalvjg8hia2mmqv3aky7fmw2ck5yci343ix";
+      sha256 = "13l6pqbfrx3vv7cw26nq9p8rnyp9br31gaz85q32wx6hnzfcriwh";
       type = "gem";
     };
-    version = "1.2.0";
+    version = "1.3.0";
   };
   gyoku = {
     dependencies = ["builder"];
@@ -116,14 +100,6 @@
       type = "gem";
     };
     version = "1.3.1";
-  };
-  hashdiff = {
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "19ykg5pax8798nh1yv71adkx0zzs7gn2rxjj86v7nsw0jba5lask";
-      type = "gem";
-    };
-    version = "0.3.8";
   };
   hashicorp-checkpoint = {
     source = {
@@ -203,12 +179,14 @@
     version = "3.2.2";
   };
   mime-types-data = {
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "07wvp0aw2gjm4njibb70as6rh5hi1zzri5vky1q6jx95h8l56idc";
+      sha256 = "1m00pg19cm47n1qlcxgl91ajh2yq0fszvn1vy8fy0s1jkrp9fw4a";
       type = "gem";
     };
-    version = "3.2018.0812";
+    version = "3.2019.0331";
   };
   multi_json = {
     source = {
@@ -259,22 +237,6 @@
       type = "gem";
     };
     version = "2.6.0";
-  };
-  public_suffix = {
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "08q64b5br692dd3v0a9wq9q5dvycc6kmiqmjbdxkxbfizggsvx6l";
-      type = "gem";
-    };
-    version = "3.0.3";
-  };
-  rake = {
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "01j8fc9bqjnrsxbppncai05h43315vmz9fwg28qdsgcjw9ck1d7n";
-      type = "gem";
-    };
-    version = "12.0.0";
   };
   rb-fsevent = {
     source = {
@@ -338,15 +300,6 @@
     };
     version = "3.5.0";
   };
-  rspec-its = {
-    dependencies = ["rspec-core" "rspec-expectations"];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "1pwphny5jawcm1hda3vs9pjv1cybaxy17dc1s75qd7drrvx697p3";
-      type = "gem";
-    };
-    version = "1.2.0";
-  };
   rspec-mocks = {
     dependencies = ["diff-lcs" "rspec-support"];
     source = {
@@ -381,20 +334,14 @@
     version = "0.6.2";
   };
   rubyzip = {
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1n1lb2sdwh9h27y244hxzg1lrxxg2m53pk1vq7p33bna003qkyrj";
+      sha256 = "1w9gw28ly3zyqydnm8phxchf4ymyjl2r7zf7c12z8kla10cpmhlc";
       type = "gem";
     };
-    version = "1.2.2";
-  };
-  safe_yaml = {
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "1hly915584hyi9q9vgd968x2nsi5yag9jyf5kq60lwzi5scr7094";
-      type = "gem";
-    };
-    version = "1.0.4";
+    version = "1.2.3";
   };
   thor = {
     source = {
@@ -414,15 +361,14 @@
     version = "0.1.4";
   };
   unf_ext = {
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "06p1i6qhy34bpb8q8ms88y6f2kz86azwm098yvcc0nyqk9y729j1";
+      sha256 = "1ll6w64ibh81qwvjx19h8nj7mngxgffg7aigjx11klvf5k2g4nxf";
       type = "gem";
     };
-    version = "0.0.7.5";
-  };
-  vagrant = {
-    dependencies = ["bcrypt_pbkdf" "childprocess" "ed25519" "erubis" "hashicorp-checkpoint" "i18n" "listen" "log4r" "net-scp" "net-sftp" "net-ssh" "rb-kqueue" "rest-client" "ruby_dep" "rubyzip" "vagrant_cloud" "wdm" "winrm" "winrm-elevated" "winrm-fs"];
+    version = "0.0.7.6";
   };
   vagrant-spec = {
     dependencies = ["childprocess" "log4r" "rspec" "thor"];
@@ -452,23 +398,16 @@
     };
     version = "0.1.1";
   };
-  webmock = {
-    dependencies = ["addressable" "crack" "hashdiff"];
+  winrm = {
+    dependencies = ["builder" "erubis" "gssapi" "gyoku" "httpclient" "logging" "nori" "rubyntlm"];
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "04hkcqsmbfnp8g237pisnc834vpgildklicbjbyikqg0bg1rwcy5";
+      sha256 = "19vxrclxc5l8n2agwvv291740s6gna2phg3lkybjb0ldkmpi3sj2";
       type = "gem";
     };
     version = "2.3.2";
-  };
-  winrm = {
-    dependencies = ["builder" "erubis" "gssapi" "gyoku" "httpclient" "logging" "nori" "rubyntlm"];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "0l299w172hl023b3v2vnbx4cqfjq9k2pp8blc1dz8n6g9dc6pk9f";
-      type = "gem";
-    };
-    version = "2.3.1";
   };
   winrm-elevated = {
     dependencies = ["winrm" "winrm-fs"];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fixes #64243.

FYI, it is written:

>  NOTE: bumping the version and updating the hash is insufficient;
> you must use bundix to generate a new gemset.nix in the Vagrant source.

However doing this did work for me:

```
stanislas@nixpsla ~/n/p/d/t/vagrant> (vagrant/update/2.2.5|✚1) ./result/bin/vagrant version
Installed Version: 2.2.5
Latest Version: 2.2.5
 
You're running an up-to-date version of Vagrant!
```

Now, I am interested to know how to update the gems without the Gemfile. I saw https://github.com/NixOS/nixpkgs/pull/47519#issuecomment-425645412 but it's doing weird stuff for me.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @aneeshusa