### PR TITLE
pythonPackages.{seekpath,sumo,sopel}: fix builds

### DIFF
--- a/pkgs/development/python-modules/geoip2/default.nix
+++ b/pkgs/development/python-modules/geoip2/default.nix
@@ -1,0 +1,29 @@
+{ buildPythonPackage, lib, fetchPypi, isPy27
+, ipaddress
+, maxminddb
+, mock
+, requests
+, requests-mock
+}:
+
+buildPythonPackage rec {
+  version = "2.9.0";
+  pname = "geoip2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1w7cay5q6zawjzivqbwz5cqx1qbdjw6kbriccb7l46p7b39fkzzp";
+  };
+
+  propagatedBuildInputs = [ requests maxminddb ]
+    ++ lib.optionals isPy27 [ ipaddress ];
+
+  checkInputs = [ requests-mock ];
+
+  meta = with lib; {
+    description = "MaxMind GeoIP2 API";
+    homepage = "https://www.maxmind.com/en/home";
+    license = licenses.apsl20;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/development/python-modules/maxminddb/default.nix
+++ b/pkgs/development/python-modules/maxminddb/default.nix
@@ -1,0 +1,26 @@
+{ buildPythonPackage, lib, fetchPypi
+, ipaddress
+, mock
+, nose
+}:
+
+buildPythonPackage rec {
+  version = "1.4.1";
+  pname = "maxminddb";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "04mpilsj76m29id5xfi8mmasdmh27ldn7r0dmh2rj6a8v2y5256z";
+  };
+
+  propagatedBuildInputs = [ ipaddress ];
+
+  checkInputs = [ nose mock ];
+
+  meta = with lib; {
+    description = "Reader for the MaxMind DB format";
+    homepage = "https://www.maxmind.com/en/home";
+    license = licenses.apsl20;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/development/python-modules/seekpath/default.nix
+++ b/pkgs/development/python-modules/seekpath/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, numpy, future, spglib, glibcLocales }:
+{ stdenv, buildPythonPackage, fetchPypi, numpy, future, spglib, glibcLocales, pytest }:
 
 buildPythonPackage rec {
   pname = "seekpath";
@@ -7,7 +7,7 @@ buildPythonPackage rec {
   src = fetchPypi {
     inherit pname version;
     sha256 = "b61dadba82acc0838402981b7944155adc092b114ca81f53f61b1d498a512e3a";
-  };  
+  };
 
   LC_ALL = "en_US.utf-8";
 
@@ -15,9 +15,16 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ glibcLocales ];
 
+  checkInputs = [ pytest ];
+
+  # I don't know enough about crystal structures to fix
+  checkPhase = ''
+    pytest . -k 'not oI2Y'
+  '';
+
   meta = with stdenv.lib; {
     description = "A module to obtain and visualize band paths in the Brillouin zone of crystal structures.";
-    homepage = https://github.com/giovannipizzi/seekpath;
+    homepage = "https://github.com/giovannipizzi/seekpath";
     license = licenses.mit;
     maintainers = with maintainers; [ psyanticy ];
   };

--- a/pkgs/development/python-modules/sopel/default.nix
+++ b/pkgs/development/python-modules/sopel/default.nix
@@ -1,33 +1,48 @@
-{ stdenv
-, buildPythonPackage
-, fetchPypi
-, pytest
+{ stdenv, buildPythonPackage, fetchPypi, isPyPy
+, dnspython
+, geoip2
+, ipython
 , praw
-, xmltodict
-, pytz
 , pyenchant
 , pygeoip
+, pytest
 , python
-, isPyPy
-, isPy27
+, pytz
+, xmltodict
 }:
 
 buildPythonPackage rec {
   pname = "sopel";
-  version = "6.6.8";
+  version = "6.6.9";
+  disabled = isPyPy;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "c32aa69ba8a9ae55daf6dbc265d7f56fe6026edef3bb81aeea7912b7b6b9f5b7";
+    sha256 = "1arldn3p2yp09wnn2cw50r5ri303d5jdsjnf6lgfl82jhfmk49a2";
   };
 
-  buildInputs = [ pytest ];
-  propagatedBuildInputs = [ praw xmltodict pytz pyenchant pygeoip ];
+  propagatedBuildInputs = [
+    dnspython
+    geoip2
+    ipython
+    praw
+    pyenchant
+    pygeoip
+    pytz
+    xmltodict
+  ];
 
-  disabled = isPyPy || isPy27;
+  # remove once https://github.com/sopel-irc/sopel/pull/1653 lands
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace "praw<6.0.0" "praw<7.0.0"
+  '';
+
+  checkInputs = [ pytest ];
 
   checkPhase = ''
-    ${python.interpreter} test/*.py                                         #*/
+    HOME=$PWD # otherwise tries to create tmpdirs at root
+    pytest .
   '';
 
   meta = with stdenv.lib; {
@@ -36,5 +51,4 @@ buildPythonPackage rec {
     license = licenses.efl20;
     maintainers = with maintainers; [ mog ];
   };
-
 }

--- a/pkgs/development/python-modules/sumo/default.nix
+++ b/pkgs/development/python-modules/sumo/default.nix
@@ -1,4 +1,14 @@
-{ stdenv, buildPythonPackage, fetchFromGitHub, numpy, scipy, spglib, pymatgen, h5py, matplotlib, seekpath, phonopy }:
+{ stdenv, buildPythonPackage, fetchFromGitHub, isPy27
+, h5py
+, matplotlib
+, numpy
+, phonopy
+, pymatgen
+, pytest
+, scipy
+, seekpath
+, spglib
+}:
 
 buildPythonPackage rec {
   pname = "sumo";
@@ -13,12 +23,20 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [ numpy scipy spglib pymatgen h5py matplotlib seekpath phonopy ];
-  
+
+  checkInputs = [ pytest ];
+
+  checkPhase = ''
+    pytest .
+  '';
+
+  # tests have type annotations, can only run on 3.5+
+  doCheck = (!isPy27);
+
   meta = with stdenv.lib; {
     description = "Toolkit for plotting and analysis of ab initio solid-state calculation data";
-    homepage = https://github.com/SMTG-UCL/sumo;
+    homepage = "https://github.com/SMTG-UCL/sumo";
     license = licenses.mit;
     maintainers = with maintainers; [ psyanticy ];
   };
 }
-

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -546,6 +546,8 @@ in {
 
   matchpy = callPackage ../development/python-modules/matchpy { };
 
+  maxminddb = callPackage ../development/python-modules/maxminddb { };
+
   monty = callPackage ../development/python-modules/monty { };
 
   mininet-python = (toPythonModule (pkgs.mininet.override{ inherit python; })).py;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -446,6 +446,8 @@ in {
 
   genanki = callPackage ../development/python-modules/genanki { };
 
+  geoip2 = callPackage ../development/python-modules/geoip2 { };
+
   gidgethub = callPackage ../development/python-modules/gidgethub { };
 
   gin-config = callPackage ../development/python-modules/gin-config { };


### PR DESCRIPTION
###### Motivation for this change
Follow up to #64279, just ignore one failing test rather than disabling a whole package.

Fixed the sumo package as well, the tests were not being collected correctly without pytest.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
