### PR TITLE
curseofwar,curseofwar-sdl: init at 1.2.0

### DIFF
--- a/pkgs/games/curseofwar/default.nix
+++ b/pkgs/games/curseofwar/default.nix
@@ -1,0 +1,41 @@
+{ stdenv
+, fetchFromGitHub
+, fetchpatch
+, ncurses
+, SDL
+}:
+
+stdenv.mkDerivation rec {
+  pname = "curseofwar";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "a-nikolaev";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1bj3lv5vrnwzzkgj31pyf1lzkz10qphvzlfz7a3j4plqkczjq92y";
+  };
+
+  patches = [(fetchpatch {
+    # Pull request #40: https://github.com/a-nikolaev/curseofwar/pull/40
+    name = "prefix-independent-data";
+    url = "https://github.com/fgaz/curseofwar/commit/947dea527b2bf4c6e107b8e9c66f4c4fd775b6f9.patch";
+    sha256 = "0ak5igaxmbavkbl8101xx6gswhwgzm5f6wyplwapgh7cylnclc61";
+  })];
+
+  buildInputs = [
+    ncurses
+    SDL
+  ];
+
+  makeFlags = (if isNull SDL then [] else [ "SDL=yes" ]) ++ [ "PREFIX=$(out)" ];
+
+  meta = with stdenv.lib; {
+    description = "A fast-paced action strategy game";
+    homepage = "https://a-nikolaev.github.io/curseofwar/";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ fgaz ];
+    platforms = platforms.all;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21458,6 +21458,9 @@ in
 
   crrcsim = callPackage ../games/crrcsim {};
 
+  curseofwar = callPackage ../games/curseofwar { SDL = null; };
+  curseofwar-sdl = callPackage ../games/curseofwar { ncurses = null; };
+
   cutemaze = libsForQt5.callPackage ../games/cutemaze {};
 
   cuyo = callPackage ../games/cuyo { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Just a game

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Not sure if it will build on darwin. Could some trusted user run the build?