### PR TITLE
kakounePlugins.kak-ansi: init at 0.2.1

### DIFF
--- a/pkgs/applications/editors/kakoune/plugins/default.nix
+++ b/pkgs/applications/editors/kakoune/plugins/default.nix
@@ -3,6 +3,7 @@
 {
   inherit parinfer-rust;
 
+  kak-ansi = pkgs.callPackage ./kak-ansi.nix { };
   kak-auto-pairs = pkgs.callPackage ./kak-auto-pairs.nix { };
   kak-buffers = pkgs.callPackage ./kak-buffers.nix { };
   kak-fzf = pkgs.callPackage ./kak-fzf.nix { };

--- a/pkgs/applications/editors/kakoune/plugins/kak-ansi.nix
+++ b/pkgs/applications/editors/kakoune/plugins/kak-ansi.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "kak-ansi";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "eraserhd";
+    repo = "kak-ansi";
+    rev = "v${version}";
+    sha256 = "0ddjih8hfyf6s4g7y46p1355kklaw1ydzzh61141i0r45wyb2d0d";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share/kak/autoload/plugins/
+    cp kak-ansi-filter $out/bin/
+    # Hard-code path of filter and don't try to build when Kakoune boots
+    sed '
+      /^declare-option.* ansi_filter /i\
+declare-option -hidden str ansi_filter %{'"$out"'/bin/kak-ansi-filter}
+      /^declare-option.* ansi_filter /,/^}/d
+    ' rc/ansi.kak >$out/share/kak/autoload/plugins/ansi.kak
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Kakoune support for rendering ANSI code";
+    homepage = "https://github.com/eraserhd/kak-ansi";
+    license = licenses.unlicense;
+    maintainers = with maintainers; [ eraserhd ];
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

Allow installing kak-ansi from nix.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Package closure size starts at 28,169,192.

Been using this locally on both NixOS and MacOS for a while.

---