### PR TITLE
lazydocker: init at 0.5

### DIFF
--- a/pkgs/tools/misc/lazydocker/default.nix
+++ b/pkgs/tools/misc/lazydocker/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "lazydocker";
+  version = "0.5";
+
+  src = fetchFromGitHub {
+    owner = "jesseduffield";
+    repo = "lazydocker";
+    rev = "v${version}";
+    sha256 = "0f062xn58dbci22pg6y4ifcdfs8whzlv2jjprxxk2ygzixrrjwnc";
+  };
+
+  modSha256 = "02n0lg28icy11a2j2rrlmp70blby0kmjas5j48jwh9h9a0yplqic";
+
+  subPackages = [ "." ];
+
+  meta = with stdenv.lib; {
+    description = "A simple terminal UI for both docker and docker-compose";
+    homepage = https://github.com/jesseduffield/lazydocker;
+    license = licenses.mit;
+    maintainers = with maintainers; [ das-g ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -333,6 +333,8 @@ in
     inherit url;
   };
 
+  lazydocker = callPackage ../tools/misc/lazydocker { };
+
   ld-is-cc-hook = makeSetupHook { name = "ld-is-cc-hook"; }
     ../build-support/setup-hooks/ld-is-cc-hook.sh;
 


### PR DESCRIPTION
###### Motivation for this change

Make [lazydocker](https://github.com/jesseduffield/lazydocker) available.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
