### PR TITLE
CNVkit: init 0.9.6

### DIFF
--- a/pkgs/development/python-modules/cnvkit/default.nix
+++ b/pkgs/development/python-modules/cnvkit/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, fetchPypi
+, rPackages
+, rWrapper
+, buildPythonPackage
+, biopython
+, numpy
+, scipy
+, pandas
+, matplotlib
+, reportlab
+, pysam
+, future
+, pillow
+, pomegranate
+, pyfaidx
+}:
+
+buildPythonPackage rec {
+  pname = "CNVkit";
+  version = "0.9.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1hj8c98s538i0hg5mrz4bw4v07qmcl51rhxq611rj2nglnc9r25y";
+  };
+
+  propagatedBuildInputs = [
+    biopython
+    numpy
+    scipy
+    pandas
+    matplotlib
+    reportlab
+    pyfaidx
+    pysam
+    future
+    pillow
+    pomegranate
+  ];
+
+  meta = with lib; {
+    homepage = "https://cnvkit.readthedocs.io";
+    description = "A Python library and command-line software toolkit to infer and visualize copy number from high-throughput DNA sequencing data";
+    license = licenses.asl20;
+    maintainers = [ maintainers.jbedo ];
+  };
+}

--- a/pkgs/development/python-modules/pomegranate/default.nix
+++ b/pkgs/development/python-modules/pomegranate/default.nix
@@ -1,17 +1,17 @@
-{ stdenv, buildPythonPackage, fetchFromGitHub, numpy, scipy, cython, networkx, joblib, nose }:
+{ stdenv, buildPythonPackage, fetchFromGitHub, numpy, scipy, cython, networkx, joblib, nose, pyyaml }:
 
 buildPythonPackage rec {
   pname = "pomegranate";
-  version = "0.8.1";
-  
+  version = "0.11.0";
+
   src = fetchFromGitHub {
     repo = pname;
     owner = "jmschrei";
     rev = "v${version}";
-    sha256 = "085nka5bh88bxbd5vl1azyv9cfpp6grz2ngclc85f9kgccac1djr";
+    sha256 = "0gf7z343ag4g7pfccn1sdap3ihkaxrc9ca75awjhmsa2cyqs66df";
   };
 
-  propagatedBuildInputs = [ numpy scipy cython networkx joblib ];
+  propagatedBuildInputs = [ numpy scipy cython networkx joblib pyyaml ];
 
   checkInputs = [ nose ];
 
@@ -20,9 +20,5 @@ buildPythonPackage rec {
     homepage = https://github.com/jmschrei/pomegranate;
     license = licenses.mit;
     maintainers = with maintainers; [ rybern ];
-
-    # "pomegranate does not yet work with networkx 2.0"
-    # see https://github.com/jmschrei/pomegranate/issues/209
-    broken = true; 
   };
 }

--- a/pkgs/development/python-modules/pyfaidx/default.nix
+++ b/pkgs/development/python-modules/pyfaidx/default.nix
@@ -1,0 +1,24 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, six
+}:
+
+buildPythonPackage rec {
+  pname = "pyfaidx";
+  version = "0.5.5.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1akc8hk8rlw7sv07bv1n2r471acvmxwc57gb69frjpcwggf2phls";
+  };
+
+  propagatedBuildInputs = [ six ];
+
+  meta = with lib; {
+    homepage = "https://github.com/mdshw5/pyfaidx";
+    description = "Python classes for indexing, retrieval, and in-place modification of FASTA files using a samtools compatible index";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.jbedo ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -346,6 +346,8 @@ in {
 
   clustershell = callPackage ../development/python-modules/clustershell { };
 
+  cnvkit = callPackage ../development/python-modules/cnvkit { };
+
   cozy = callPackage ../development/python-modules/cozy { };
 
   curio = callPackage ../development/python-modules/curio { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -722,6 +722,8 @@ in {
 
   pyfakefs = callPackage ../development/python-modules/pyfakefs {};
 
+  pyfaidx = callPackage ../development/python-modules/pyfaidx { };
+
   pyfttt = callPackage ../development/python-modules/pyfttt { };
 
   pyftdi = callPackage ../development/python-modules/pyftdi { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Initial CNVkit expression.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
