### PR TITLE
lkl: 2018-08-22 -> 2019-06-20

### DIFF
--- a/pkgs/applications/virtualization/lkl/default.nix
+++ b/pkgs/applications/virtualization/lkl/default.nix
@@ -2,8 +2,9 @@
 , buildPackages }:
 
 stdenv.mkDerivation rec {
-  name = "lkl-2018-08-22";
-  rev  = "5221c547af3d29582703f01049617a6bf9f6232a";
+  pname = "lkl";
+  version = "2019-06-20";
+  rev  = "0a4ebeadad12b94db665b8daf30e44e949a02d90";
 
   outputs = [ "dev" "lib" "out" ];
 
@@ -15,7 +16,7 @@ stdenv.mkDerivation rec {
     inherit rev;
     owner  = "lkl";
     repo   = "linux";
-    sha256 = "1k2plyx40xaphm8zsk2dd1lyv6dhsp7kj6hfmdgiamvl80bjajqy";
+    sha256 = "09y9ci3j0lp3z74h577ng2s9a4n4glqpqndyc9iy6wdqaj764gm6";
   };
 
   # Fix a /usr/bin/env reference in here that breaks sandboxed builds
@@ -58,7 +59,7 @@ stdenv.mkDerivation rec {
       overhead
     '';
     homepage    = https://github.com/lkl/linux/;
-    platforms   = [ "x86_64-linux" "aarch64-linux" ]; # Darwin probably works too but I haven't tested it
+    platforms   = [ "x86_64-linux" "aarch64-linux" "armv7l-linux" "armv6l-linux" ]; # Darwin probably works too but I haven't tested it
     license     = licenses.gpl2;
     maintainers = with maintainers; [ copumpkin ];
   };


### PR DESCRIPTION
Fixes the build on 32-bit ARM, which enables the generation of SD card images
on these platforms.

This fixes #51798 (the original issue was different, but I believe it was left open because the SD image failed to build).
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
