### PR TITLE
hackage2nix: update broken-packages

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -3650,7 +3650,6 @@ broken-packages:
   - conductive-base
   - conductive-hsc3
   - conductive-song
-  - conduit-algorithms
   - conduit-audio-lame
   - conduit-audio-samplerate
   - conduit-find
@@ -3661,7 +3660,6 @@ broken-packages:
   - conduit-tokenize-attoparsec
   - conduit-vfs
   - conduit-vfs-zip
-  - conduit-zstd
   - conf
   - confcrypt
   - conffmt


### PR DESCRIPTION
conduit-zstd and conduit-algorithms were marked as broken as they depended on "zstd" which was broken until recently (but is now working).

###### Things done

These packages now build cleanly

- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
---
