### PR TITLE
elisa: 0.3.0 -> 0.4.2

### DIFF
--- a/pkgs/applications/audio/elisa/default.nix
+++ b/pkgs/applications/audio/elisa/default.nix
@@ -1,26 +1,28 @@
 { mkDerivation, fetchFromGitHub, lib
 , extra-cmake-modules, kdoctools, wrapGAppsHook
 , qtmultimedia, qtquickcontrols2, qtwebsockets
-, kconfig, kcmutils, kcrash, kdeclarative, kfilemetadata, kinit
-, baloo
+, kconfig, kcmutils, kcrash, kdeclarative, kfilemetadata, kinit, kirigami2
+, baloo, vlc
 }:
 
 mkDerivation rec {
-  name = "elisa-${version}";
-  version = "0.3.0";
+  pname = "elisa";
+  version = "0.4.2";
 
   src = fetchFromGitHub {
     owner  = "KDE";
     repo   = "elisa";
     rev    = "v${version}";
-    sha256 = "0bpkr5rp9nfa2wzm6w3xkhsfgf5dbgxbmhckjh9wkxal3mncpkg4";
+    sha256 = "0q098zaajwbpkrarrsdzpjhpsq2nxkqaxwzhr2gjlg08j9vqkpfm";
   };
+
+  buildInputs = [ vlc ];
 
   nativeBuildInputs = [ extra-cmake-modules kdoctools wrapGAppsHook ];
 
   propagatedBuildInputs = [
     qtmultimedia qtquickcontrols2 qtwebsockets
-    kconfig kcmutils kcrash kdeclarative kfilemetadata kinit
+    kconfig kcmutils kcrash kdeclarative kfilemetadata kinit kirigami2
     baloo
   ];
 


### PR DESCRIPTION
###### Motivation for this change

Turns out some people don't have sound. As nothing else depends on elisa and having a media player without sounds is rather pointless, we should backport this.

Fixes #50726

###### Things done


- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
