### PR TITLE
brave: Add libpulseaudio

### DIFF
--- a/pkgs/applications/networking/browsers/brave/default.nix
+++ b/pkgs/applications/networking/browsers/brave/default.nix
@@ -16,6 +16,7 @@
 , gnome3
 , gsettings-desktop-schemas
 , gtk3
+, libpulseaudio
 , libuuid
 , libX11
 , libXcomposite
@@ -55,6 +56,7 @@ rpath = lib.makeLibraryPath [
   glib
   gnome2.GConf
   gtk3
+  libpulseaudio
   libX11
   libXScrnSaver
   libXcomposite


### PR DESCRIPTION
###### Motivation for this change
Fixes #63966

###### Things done
```
$ nix path-info -S /nix/store/h51l8lmwnmm779sp97zwrq0wciymraw2-brave-0.65.118/
/nix/store/h51l8lmwnmm779sp97zwrq0wciymraw2-brave-0.65.118        640199928

$ nix path-info -S /nix/store/n4v5f7is0fnlq205lbnpnpkp9rrlr6kk-brave-0.65.118
/nix/store/n4v5f7is0fnlq205lbnpnpkp9rrlr6kk-brave-0.65.118        646592456
```
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
