### PR TITLE
hstr: 1.25 -> 2.0

### DIFF
--- a/pkgs/applications/misc/hstr/default.nix
+++ b/pkgs/applications/misc/hstr/default.nix
@@ -1,15 +1,29 @@
-{ stdenv, fetchurl, readline, ncurses }:
+{ stdenv, fetchFromGitHub, readline, ncurses
+, autoreconfHook, pkgconfig, gettext }:
 
 stdenv.mkDerivation rec {
   name    = "hstr-${version}";
-  version = "1.25";
+  version = "2.0";
 
-  src = fetchurl {
-    url = "https://github.com/dvorka/hstr/releases/download/${version}/hh-${version}-src.tgz";
-    sha256 = "10njj0a3s5czv497wk3whka3gxr7vmhabs12vaw7kgb07h4ssnhg";
+  src = fetchFromGitHub {
+    owner  = "dvorka";
+    repo   = "hstr";
+    rev    = version;
+    sha256 = "1y9vsfbg07gbic0daqy569d9pb9i1d07fym3q7a0a99hbng85s20";
   };
 
-  buildInputs = [ readline ncurses ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  buildInputs = [ readline ncurses gettext ];
+
+  configurePhase = ''
+    autoreconf -fvi
+    ./configure
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin/
+    mv src/hstr $out/bin/
+  '';
 
   meta = {
     homepage = https://github.com/dvorka/hstr;


### PR DESCRIPTION
I had to manually implement the `installPhase` because the make setup of the project did not pick up `PREFIX`... or I did something wrong...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
