### PR TITLE
kustomize: 2.0.3 -> 3.0.0

### DIFF
--- a/pkgs/development/tools/kustomize/default.nix
+++ b/pkgs/development/tools/kustomize/default.nix
@@ -1,12 +1,13 @@
-{ lib, buildGoPackage, fetchFromGitHub }:
+{ lib, buildGoModule, fetchFromGitHub }:
 
-buildGoPackage rec {
+buildGoModule rec {
   name = "kustomize-${version}";
-  version = "2.0.3";
-  # rev is the 2.0.3 commit, mainly for kustomize version command output
-  rev = "a6f65144121d1955266b0cd836ce954c04122dc8";
+  version = "3.0.0";
+  # rev is the 3.0.0 commit, mainly for kustomize version command output
+  rev = "e0bac6ad192f33d993f11206e24f6cda1d04c4ec";
 
   goPackagePath = "sigs.k8s.io/kustomize";
+  subPackages = [ "cmd/kustomize" ];
 
   buildFlagsArray = let t = "${goPackagePath}/pkg/commands/misc"; in ''
     -ldflags=
@@ -16,11 +17,12 @@ buildGoPackage rec {
   '';
 
   src = fetchFromGitHub {
-    sha256 = "1dfkpx9rllj1bzm5f52bx404kdds3zx1h38yqri9ha3p3pcb1bbb";
+  sha256 = "1ywppn97gfgrwlq1nrj4kdvrdanq5ahqaa636ynyp9yiv9ibziq6";
     rev = "v${version}";
     repo = "kustomize";
     owner = "kubernetes-sigs";
   };
+  modSha256 = "0w8sp73pmj2wqrg7x7z8diglyfq6c6gn9mmck0k1gk90nv7s8rf1";
 
   meta = with lib; {
     description = "Customization of kubernetes YAML configurations";

--- a/pkgs/development/tools/kustomize/default.nix
+++ b/pkgs/development/tools/kustomize/default.nix
@@ -17,11 +17,12 @@ buildGoModule rec {
   '';
 
   src = fetchFromGitHub {
-  sha256 = "1ywppn97gfgrwlq1nrj4kdvrdanq5ahqaa636ynyp9yiv9ibziq6";
+    sha256 = "1ywppn97gfgrwlq1nrj4kdvrdanq5ahqaa636ynyp9yiv9ibziq6";
     rev = "v${version}";
     repo = "kustomize";
     owner = "kubernetes-sigs";
   };
+
   modSha256 = "0w8sp73pmj2wqrg7x7z8diglyfq6c6gn9mmck0k1gk90nv7s8rf1";
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

Bump to latest release : [release notes](https://github.com/kubernetes-sigs/kustomize/blob/master/docs/v3.0.0.md).
This also migrate the package to use `buildGoModule` as it is now using go modules.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
