### PR TITLE
waifu2x-converter-cpp: 5.2.4 -> 5.3 + OpenCL support

### DIFF
--- a/pkgs/tools/graphics/waifu2x-converter-cpp/default.nix
+++ b/pkgs/tools/graphics/waifu2x-converter-cpp/default.nix
@@ -1,34 +1,64 @@
-{ cmake, fetchFromGitHub, opencv3, stdenv, opencl-headers
-, cudaSupport ? false, cudatoolkit ? null
+{ stdenv
+, fetchFromGitHub
+, makeWrapper
+
+, cmake
+, cudatoolkit
+, ocl-icd
+, opencl-headers
+, opencv3
+, pkgconfig
+, waifu2x-converter-cpp
+
+, cudaSupport ? false
 }:
+
+with stdenv.lib;
 
 stdenv.mkDerivation rec {
   pname = "waifu2x-converter-cpp";
-  version = "5.2.4";
+  version = "5.3";
 
   src = fetchFromGitHub {
     owner = "DeadSix27";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0r7xcjqbyaa20gsgmjj7645640g3nb2bn1pc1nlfplwlzjxmz213";
+    sha256 = "1i627n34mv73ihd09mlndzdwx8j613l6r8wqs42n42k7yl8naz5i";
   };
-
-  patchPhase = ''
-    # https://github.com/DeadSix27/waifu2x-converter-cpp/issues/123
-    sed -i 's:{"PNG",  false},:{"PNG",  true},:' src/main.cpp
-  '';
-
-  buildInputs = [
-    opencv3 opencl-headers
-  ] ++ stdenv.lib.optional cudaSupport cudatoolkit;
 
   nativeBuildInputs = [ cmake ];
 
-  meta = {
+  buildInputs = [ ocl-icd opencl-headers opencv3 ]
+    ++ optional cudaSupport cudatoolkit;
+
+  patches = [
+  # Handle failed attempt to write to the Nix store
+  # https://github.com/DeadSix27/waifu2x-converter-cpp/pull/184
+    ./erofs.patch
+  # Allow version override
+    ./no-git-version.patch
+  ];
+
+  postPatch = ''
+    sed -i 's,"/system/vendor/lib/libOpenCL.so","${ocl-icd}/lib/libOpenCL.so",' src/modelHandler_OpenCL.cpp
+  '';
+
+  # The build script tries to determine the project version
+  # from the git repo. This doesn't work since Nix discards
+  # .git even when it does a clone.
+  cmakeFlags = [ "-DGIT_TAG=v${version}" ]
+    ++ optional (waifu2x-converter-cpp.doCheck or false) "-DENABLE_TESTS=ON";
+
+  preCheck = ''
+    export LD_LIBRARY_PATH=.:$LD_LIBRARY_PATH
+    ln -s ../models_rgb ./
+  '';
+
+  meta = with stdenv.lib; {
+    homepage    = https://github.com/DeadSix27/waifu2x-converter-cpp;
     description = "Improved fork of Waifu2X C++ using OpenCL and OpenCV";
-    homepage = https://github.com/DeadSix27/waifu2x-converter-cpp;
-    license = stdenv.lib.licenses.mit;
-    maintainers = [ stdenv.lib.maintainers.xzfc ];
-    platforms = stdenv.lib.platforms.linux;
+    license     = licenses.mit;
+    platforms   = platforms.all;
+    maintainers = with maintainers; [ gloaming xzfc ];
   };
 }

--- a/pkgs/tools/graphics/waifu2x-converter-cpp/erofs.patch
+++ b/pkgs/tools/graphics/waifu2x-converter-cpp/erofs.patch
@@ -1,0 +1,21 @@
+diff --git a/src/modelHandler_OpenCL.cpp b/src/modelHandler_OpenCL.cpp
+index 4091308..0140ae4 100644
+--- a/src/modelHandler_OpenCL.cpp
++++ b/src/modelHandler_OpenCL.cpp
+@@ -51,6 +51,7 @@ namespace fs = std::experimental::filesystem;
+ #include <unistd.h>
+ #include <sys/types.h>
+ #include <pwd.h>
++#include <errno.h>
+ #endif
+ 
+ static const char prog[] =
+@@ -510,7 +511,7 @@ namespace w2xc
+ 				if (fp == NULL)
+ 				{
+ #if (defined __linux)
+-						if (errno == 13)
++						if (errno == EACCES || errno == EROFS)
+ 						{
+ 							std::string user_folder("/tmp/.waifu2x");
+ 							char *home_dir = getenv ("HOME");

--- a/pkgs/tools/graphics/waifu2x-converter-cpp/no-git-version.patch
+++ b/pkgs/tools/graphics/waifu2x-converter-cpp/no-git-version.patch
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f48d059..ac2c4e7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -35,10 +35,6 @@ add_definitions(-DBUILD_TS="${TS}")
+ ### Check for Git and aquire version info
+ find_program(FOUND_GIT "git")
+ if (FOUND_GIT STREQUAL "FOUND_GIT-NOTFOUND")
+-	set(GIT_BRANCH "null")
+-	set(GIT_COMMIT_HASH "000000")
+-	set(GIT_TAG "v0.0.0")
+-	message(WARNING "Git not found, using placeholder version: ${GIT_TAG} (${GIT_BRANCH}-${GIT_COMMIT_HASH})")
+ else()
+     execute_process(COMMAND git rev-parse --abbrev-ref HEAD WORKING_DIRECTORY ${CMAKE_SOURCE_DIR} OUTPUT_VARIABLE GIT_BRANCH OUTPUT_STRIP_TRAILING_WHITESPACE)
+ 	execute_process(COMMAND git rev-parse --short HEAD WORKING_DIRECTORY ${CMAKE_SOURCE_DIR} OUTPUT_VARIABLE GIT_COMMIT_HASH OUTPUT_STRIP_TRAILING_WHITESPACE)


### PR DESCRIPTION
Also with working tests and version info.

###### Motivation for this change

OpenCL allows the program to run on AMD GPUs.

###### Things done
`nix path-info -S`:
```
/nix/store/jla4yvh2wsrprfbm4wkrkakk0k62s91s-waifu2x-converter-cpp-5.2.4   199550760
/nix/store/flywi3hjjygvldcsx3ljgqkbx2dz4gsn-waifu2x-converter-cpp-5.3     199771712
```
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
