### PR TITLE
pythonPackages.soco: 0.16 -> 0.17

### DIFF
--- a/pkgs/development/python-modules/soco/default.nix
+++ b/pkgs/development/python-modules/soco/default.nix
@@ -1,22 +1,28 @@
 { lib, buildPythonPackage, fetchPypi, xmltodict, requests
 
 # Test dependencies
-, pytest_3, pytestcov, coveralls, pylint, flake8, graphviz, mock, sphinx
+, pytest, pytestcov, coveralls, pylint, flake8, graphviz, mock, sphinx
 , sphinx_rtd_theme
 }:
 
 buildPythonPackage rec {
   pname = "soco";
-  version = "0.16";
+  version = "0.17";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "7bed4475e3f134283af1f520a9b2e6ce2a8e69bdc1b58ee68528b3d093972424";
+    sha256 = "15zw6i5z5p8vsa3lp20rjizhv4lzz935r73im0xm6zsl71bsgvj8";
   };
+
+  postPatch = ''
+    # https://github.com/SoCo/SoCo/pull/670
+    substituteInPlace requirements-dev.txt \
+      --replace "pytest-cov>=2.4.0,<2.6" "pytest-cov>=2.4.0"
+  '';
 
   propagatedBuildInputs = [ xmltodict requests ];
   checkInputs = [
-    pytest_3 pytestcov coveralls pylint flake8 graphviz mock sphinx
+    pytest pytestcov coveralls pylint flake8 graphviz mock sphinx
     sphinx_rtd_theme
   ];
 


### PR DESCRIPTION
Now works with latest pytestcov

This transitively fixes beets (fixes https://github.com/NixOS/nixpkgs/issues/64339) which depends on soco, which now doesn't depend on
pytest_3 anymore, which depends on pytestcov_3, which is broken.

An upstream PR for the patch here has been submitted: https://github.com/SoCo/SoCo/pull/670

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
