### PR TITLE
fix: #64340 building python wheels in non-standard store

### DIFF
--- a/pkgs/development/interpreters/python/build-python-package-wheel.nix
+++ b/pkgs/development/interpreters/python/build-python-package-wheel.nix
@@ -8,7 +8,7 @@
 attrs // {
   unpackPhase = ''
     mkdir dist
-    cp $src dist/"''${src#*-}"
+    cp "$src" "dist/$(stripHash "$src")"
   '';
 
   # Wheels are pre-compiled


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
This fixes issue #64340 which prevents Python wheels being installed in nix stores that contain at `-`.

I've tested it with
```
nix-build -E 'with import ./default.nix {}; python37.withPackages (p: [p.tensorflow-estimator p.ipython p.tensorflow])'
```
and checked I can import tensorflow. I did *not* test it with a non-standard store path (I don't have access to one easily right now) but am happy to do so.

I'm not sure of the contributing conventions for PRs that don't concern specific packages or nixos modules, happy to make any changes required.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
