### PR TITLE
gimp-with-plugins: Fix build errors with exiv2-0.27.1

### DIFF
--- a/pkgs/applications/graphics/gimp/plugins/default.nix
+++ b/pkgs/applications/graphics/gimp/plugins/default.nix
@@ -168,6 +168,9 @@ stdenv.lib.makeScope pkgs.newScope (self: with self; {
     };
 
     buildInputs = with pkgs; [ lensfun exiv2 ];
+    patches = [
+      ./patches/lensfun-Fix-header-files.patch # Needed for exiv2 0.27.1
+    ];
 
     installPhase = "
       installPlugins gimp-lensfun

--- a/pkgs/applications/graphics/gimp/plugins/patches/lensfun-Fix-header-files.patch
+++ b/pkgs/applications/graphics/gimp/plugins/patches/lensfun-Fix-header-files.patch
@@ -1,0 +1,27 @@
+From e9b550d563bf6f1cf8296df2c175ed16c133478f Mon Sep 17 00:00:00 2001
+From: Neil Mayhew <neil_mayhew@users.sourceforge.net>
+Date: Fri, 5 Jul 2019 13:37:39 -0600
+Subject: [PATCH] Change use of exiv2 header files to follow best practices
+Content-Type: text/plain; charset=utf-8
+
+---
+ src/gimplensfun.cpp | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/src/gimplensfun.cpp b/src/gimplensfun.cpp
+index da2a94c..2fe1284 100644
+--- a/src/gimplensfun.cpp
++++ b/src/gimplensfun.cpp
+@@ -31,8 +31,7 @@
+ #include <libgimp/gimp.h>
+ #include <libgimp/gimpui.h>
+ 
+-#include <exiv2/image.hpp>
+-#include <exiv2/exif.hpp>
++#include <exiv2/exiv2.hpp>
+ 
+ #define VERSIONSTR "0.2.5-dev"
+ 
+-- 
+2.22.0
+

--- a/pkgs/applications/graphics/ufraw/0001-Change-use-of-header-files.patch
+++ b/pkgs/applications/graphics/ufraw/0001-Change-use-of-header-files.patch
@@ -1,0 +1,30 @@
+From a9fc8b39010640fd8e931e8d635160430ade57bc Mon Sep 17 00:00:00 2001
+From: Neil Mayhew <neil_mayhew@users.sourceforge.net>
+Date: Fri, 5 Jul 2019 13:08:18 -0600
+Subject: [PATCH 1/2] Change use of header files to follow best practices
+Content-Type: text/plain; charset=utf-8
+
+This also fixes build errors after recent changes to dependencies
+---
+ ufraw_exiv2.cc | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/ufraw_exiv2.cc b/ufraw_exiv2.cc
+index f03011b..9a6ec86 100644
+--- a/ufraw_exiv2.cc
++++ b/ufraw_exiv2.cc
+@@ -15,9 +15,8 @@
+ #include "ufraw.h"
+ 
+ #ifdef HAVE_EXIV2
+-#include <exiv2/image.hpp>
+-#include <exiv2/easyaccess.hpp>
+-#include <exiv2/exif.hpp>
++#include <exiv2/exiv2.hpp>
++#include <iostream>
+ #include <sstream>
+ #include <cassert>
+ 
+-- 
+2.22.0
+

--- a/pkgs/applications/graphics/ufraw/0002-Use-symbolic-error-code.patch
+++ b/pkgs/applications/graphics/ufraw/0002-Use-symbolic-error-code.patch
@@ -1,0 +1,26 @@
+From b85e03dd607fb697f69eb9afb044924f046f9eb3 Mon Sep 17 00:00:00 2001
+From: Neil Mayhew <neil_mayhew@users.sourceforge.net>
+Date: Fri, 5 Jul 2019 13:08:35 -0600
+Subject: [PATCH 2/2] Use symbolic error code
+Content-Type: text/plain; charset=utf-8
+
+---
+ ufraw_exiv2.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ufraw_exiv2.cc b/ufraw_exiv2.cc
+index 9a6ec86..5958b3d 100644
+--- a/ufraw_exiv2.cc
++++ b/ufraw_exiv2.cc
+@@ -66,7 +66,7 @@ extern "C" int ufraw_exif_read_input(ufraw_data *uf)
+         if (exifData.empty()) {
+             std::string error(uf->filename);
+             error += ": No Exif data found in the file";
+-            throw Exiv2::Error(1, error);
++            throw Exiv2::Error(Exiv2::kerErrorMessage, error);
+         }
+ 
+         /* List of tag names taken from exiv2's printSummary() in actions.cpp */
+-- 
+2.22.0
+

--- a/pkgs/applications/graphics/ufraw/default.nix
+++ b/pkgs/applications/graphics/ufraw/default.nix
@@ -20,6 +20,10 @@ stdenv.mkDerivation rec {
     gtk2 gtkimageview bzip2 zlib
     libjpeg libtiff cfitsio exiv2 lcms2 lensfun
   ] ++ stdenv.lib.optional withGimpPlugin gimp;
+  patches = [
+    ./0001-Change-use-of-header-files.patch # Needed for exiv2 0.27.1
+    ./0002-Use-symbolic-error-code.patch    # Needed for exiv2 0.27.1
+  ];
 
   configureFlags = [
     "--enable-extras"


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
