### PR TITLE
soundtouch: CVE-2018-1000223 CVE-2018-14044 CVE-2018-14045

### DIFF
--- a/pkgs/development/libraries/soundtouch/default.nix
+++ b/pkgs/development/libraries/soundtouch/default.nix
@@ -14,6 +14,11 @@ stdenv.mkDerivation rec {
       name = "CVE-2018-1000223.patch";
       sha256 = "1ji8xrc3qyp9jdycrdv9bwpfpgw63nnd7xwl32sjwbf8v80xpdkp";
     })
+    (fetchpatch {
+      url = "https://gitlab.com/soundtouch/soundtouch/commit/107f2c5d201a4dfea1b7f15c5957ff2ac9e5f260.patch";
+      name = "CVE-2018-14044-CVE-2018-14045.patch";
+      sha256 = "0cfsf527fdbj8vd306d6ijvgsfp81dbkyaq5g2z7pk351qkqd0dw";
+    })
   ];
 
   buildInputs = [ autoconf automake libtool ];

--- a/pkgs/development/libraries/soundtouch/default.nix
+++ b/pkgs/development/libraries/soundtouch/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, autoconf, automake, libtool}:
+{stdenv, fetchurl, autoconf, automake, libtool, fetchpatch}:
 
 stdenv.mkDerivation rec {
   pName = "soundtouch";
@@ -7,6 +7,14 @@ stdenv.mkDerivation rec {
     url = "https://www.surina.net/soundtouch/${name}.tar.gz";
     sha256 = "09cxr02mfyj2bg731bj0i9hh565x8l9p91aclxs8wpqv8b8zf96j";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://gitlab.com/soundtouch/soundtouch/commit/9e02d9b04fda6c1f44336ff00bb5af1e2ffc039e.patch";
+      name = "CVE-2018-1000223.patch";
+      sha256 = "1ji8xrc3qyp9jdycrdv9bwpfpgw63nnd7xwl32sjwbf8v80xpdkp";
+    })
+  ];
 
   buildInputs = [ autoconf automake libtool ];
 


### PR DESCRIPTION
###### Motivation for this change

Fixes #64187.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
