### PR TITLE
pjsip: 2.8 -> 2.9

### DIFF
--- a/pkgs/applications/networking/pjsip/default.nix
+++ b/pkgs/applications/networking/pjsip/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "pjsip-${version}";
-  version = "2.8";
+  version = "2.9";
 
   src = fetchurl {
     url = "https://www.pjsip.org/release/${version}/pjproject-${version}.tar.bz2";
-    sha256 = "0ybg0113rp3fk49rm2v0pcgqb28h3dv1pdy9594w2ggiz7bhngah";
+    sha256 = "0dm6l8fypkimmzvld35zyykbg957cm5zb4ny3lchgv68amwfz1fi";
   };
 
   buildInputs = [ openssl libsamplerate alsaLib ];

--- a/pkgs/applications/networking/pjsip/default.nix
+++ b/pkgs/applications/networking/pjsip/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "0dm6l8fypkimmzvld35zyykbg957cm5zb4ny3lchgv68amwfz1fi";
   };
 
+  patches = [ ./fix-aarch64.patch ];
+
   buildInputs = [ openssl libsamplerate alsaLib ];
 
   preConfigure = ''

--- a/pkgs/applications/networking/pjsip/fix-aarch64.patch
+++ b/pkgs/applications/networking/pjsip/fix-aarch64.patch
@@ -1,0 +1,13 @@
+--- a/aconfigure
++++ b/aconfigure
+@@ -8945,6 +8945,10 @@
+                                  ac_webrtc_instset=neon
+                                  ac_webrtc_cflags="-DWEBRTC_ARCH_ARMV7 -mfloat-abi=hard -mfpu=neon"
+                                  ;;
++                             arm64*|aarch64*)
++                                 ac_webrtc_instset=neon
++                                 ac_webrtc_cflags="-DWEBRTC_ARCH_ARM64"
++                                 ;;
+                              *)
+                                  ac_webrtc_instset=sse2
+                                  ;;


### PR DESCRIPTION
###### Motivation for this change
Upgrade and make sure it works on aarch64.
Obsoletes and fixes #64111

Builds with `nix-build -A pkgsCross.aarch64-multiplatform.pjsip` and doesn't immediately crash with `qemu-aarch64 ./result/bin/pjsua`. So it should be fine :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
