### PR TITLE
cue: init at 0.0.3

### DIFF
--- a/pkgs/development/tools/cue/default.nix
+++ b/pkgs/development/tools/cue/default.nix
@@ -1,0 +1,27 @@
+{ buildGoModule, fetchgit, stdenv }:
+
+buildGoModule rec {
+  pname = "cue";
+  version = "0.0.3";
+
+  src = fetchgit {
+    url = "https://cue.googlesource.com/cue";
+    rev = "v${version}";
+    sha256 = "1abvvgicr64ssiprkircih2nrbcr1yqxf1qkl21kh0ww1xfp0rw7";
+  };
+
+  modSha256 = "0r5vbplcfq1rsp2jnixq6lfbpcv7grf0q38na76qy7pjb57zikb6";
+
+  subPackages = [ "cmd/cue" ];
+
+  buildFlagsArray = [
+    "-ldflags=-X cuelang.org/go/cmd/cue/cmd.version=${version}"
+  ];
+
+  meta = {
+    description = "A data constraint language which aims to simplify tasks involving defining and using data.";
+    homepage = https://cue.googlesource.com/cue;
+    maintainers = with stdenv.lib.maintainers; [ solson ];
+    license = stdenv.lib.licenses.asl20;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -736,6 +736,8 @@ in
 
   crumbs = callPackage ../applications/misc/crumbs { };
 
+  cue = callPackage ../development/tools/cue { };
+
   deskew = callPackage ../applications/graphics/deskew { };
 
   detect-secrets = python3Packages.callPackage ../development/tools/detect-secrets { };


### PR DESCRIPTION
###### Motivation for this change

Packaging a new development tool, [CUE](https://github.com/cuelang/cue). Despite the 0.0.3 version number, it seems pretty usable.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This is my first time packaging a Go program, so let me know if I'm doing anything poorly.