### PR TITLE
openjpeg: CVE-2019-12973

### DIFF
--- a/pkgs/development/libraries/openjpeg/2.x.nix
+++ b/pkgs/development/libraries/openjpeg/2.x.nix
@@ -13,5 +13,15 @@ callPackage ./generic.nix (args // rec {
 
   patches = [
     ./fix-cmake-config-includedir.patch
+    (fetchpatch {
+      url = "https://github.com/uclouvain/openjpeg/commit/21399f6b7d318fcdf4406d5e88723c4922202aa3.patch";
+      name = "CVE-2019-12973-1.patch";
+      sha256 = "161yvnfbzy2016qqapm0ywfgglgs1v8ljnk6fj8d2bwdh1cxxz8f";
+    })
+    (fetchpatch {
+      url = "https://github.com/uclouvain/openjpeg/commit/3aef207f90e937d4931daf6d411e092f76d82e66.patch";
+      name = "CVE-2019-12973-2.patch";
+      sha256 = "1jkkfw13l7nx4hxdhc7z17f4vfgqcaf09zpl235kypbxx1ygc7vq";
+    })
   ];
 })


### PR DESCRIPTION
###### Motivation for this change

Fixes #64182

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
