### PR TITLE
nixos/luksroot: Add option to save passphrases.

### DIFF
--- a/nixos/modules/system/boot/luksroot.nix
+++ b/nixos/modules/system/boot/luksroot.nix
@@ -103,6 +103,29 @@ let
         fi
         return 0
     }
+
+    ${optionalString luks.savePassphrases ''
+      saved_passphrases_dir=/run/initrd-saved-passphrases
+
+      init_saved_passphrases_dir() {
+        if [ ! -e "$saved_passphrases_dir" ]; then
+          mkdir "$saved_passphrases_dir"
+          # A ramfs is used here to ensure that the passphrases never get
+          # swapped out. Do NOT remove the mount or replace with tmpfs!
+          mount -t ramfs none "$saved_passphrases_dir"
+          chmod 700 "$saved_passphrases_dir"
+        fi
+      }
+
+      save_passphrase() {
+        local name="$1"
+        local passphrase="$2"
+        local passphrase_file="$saved_passphrases_dir/$name"
+        init_saved_passphrases_dir
+        echo "Saving passphrase for $name to $passphrase_file"
+        echo -n "$passphrase" > "$passphrase_file"
+      }
+    ''}
   '';
 
   preCommands = ''
@@ -189,6 +212,9 @@ let
                   # we don't rm here because we might reuse it for the next device
                 '' else ''
                   rm -f /crypt-ramfs/passphrase
+                ''}
+                ${optionalString luks.savePassphrases ''
+                  save_passphrase ${escapeShellArg "luks-${name}"} "$passphrase"
                 ''}
                 break
             else
@@ -471,6 +497,20 @@ in
         Such setup can be useful if you use <command>cryptsetup
         luksSuspend</command>. Different LUKS devices will still have
         different master keys even when using the same passphrase.
+      '';
+    };
+
+    boot.initrd.luks.savePassphrases = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to save passphrases used to unlock LUKS devices to be
+        available after the initrd completes.
+
+        If enabled, than each passphrase used successfully to unlock a LUKS
+        device will be saved to file
+        <filename>/run/initrd-saved-passphrases/luks-NAME</filename>, where
+        <literal>NAME</literal> is the name of the LUKS device.
       '';
     };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I needed that another LUKS device gets unlocked automatically using the same passphrase that was used to unlock the LUKS device containing the root file system. This adds an option to the initrd which if enabled will save passphrases to `/run/initrd-saved-passphrases` so that they can be used after the initrd to unlock other devices.

Maybe using `/run/keys` (which is already a thing and gets mounted automatically, but not in the initrd) would be more appropriate? Not sure where would be the right place to put the code for doing that, and if it could somehow conflict with the fstab entry.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
