### PR TITLE
betterlockscreen: add missing runtime dependencies

### DIFF
--- a/pkgs/misc/screensavers/betterlockscreen/default.nix
+++ b/pkgs/misc/screensavers/betterlockscreen/default.nix
@@ -1,6 +1,6 @@
 {
   stdenv, makeWrapper, fetchFromGitHub,
-  imagemagick, i3lock-color, xdpyinfo, xrandr, bc, feh
+  imagemagick, i3lock-color, xdpyinfo, xrandr, bc, feh, procps, xrdb
 }:
 
 stdenv.mkDerivation rec {
@@ -18,11 +18,11 @@ stdenv.mkDerivation rec {
 
   patches = [ ./replace-i3lock.patch ];
 
-  installPhase = 
-    let 
-      PATH = 
+  installPhase =
+    let
+      PATH =
         stdenv.lib.makeBinPath
-        [imagemagick i3lock-color xdpyinfo xrandr bc feh];
+        [imagemagick i3lock-color xdpyinfo xrandr bc feh procps xrdb];
     in ''
       mkdir -p $out/bin
       cp betterlockscreen $out/bin/betterlockscreen

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18470,7 +18470,9 @@ in
 
   i3lock-pixeled = callPackage ../misc/screensavers/i3lock-pixeled { };
 
-  betterlockscreen = callPackage ../misc/screensavers/betterlockscreen { };
+  betterlockscreen = callPackage ../misc/screensavers/betterlockscreen {
+    inherit (xorg) xrdb;
+  };
 
   i3minator = callPackage ../tools/misc/i3minator { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The motivation for this change is to add missing runtime dependencies on:

 1. procps (pidof)
 2. xrdb

These dependencies may not be missing when using betterlockscreen from an environment such as the "system path", but they can be witnessed as missing from within a pure nix-shell, for example.

## Example 1

```
[nix-shell:~]$ betterlockscreen -u /home/emmanuel/Media/Images/backgrounds/current.jpg
Got 1366x768 /home/emmanuel/.cache/i3lock/1366x768
/nix/store/kv7qjbzpn8nsa0rhyw1czy4wjdic88d1-betterlockscreen-3.0.1/bin/.betterlockscreen-wrapped: line 141: xrdb: command not found
/nix/store/kv7qjbzpn8nsa0rhyw1czy4wjdic88d1-betterlockscreen-3.0.1/bin/.betterlockscreen-wrapped: line 141: xrdb: command not found
/nix/store/kv7qjbzpn8nsa0rhyw1czy4wjdic88d1-betterlockscreen-3.0.1/bin/.betterlockscreen-wrapped: line 141: xrdb: command not found
/nix/store/kv7qjbzpn8nsa0rhyw1czy4wjdic88d1-betterlockscreen-3.0.1/bin/.betterlockscreen-wrapped: line 141: xrdb: command not found
```
## Example 2

```
[nix-shell:~]$ betterlockscreen -l dimblur
Got 1366x768 /home/emmanuel/.cache/i3lock/1366x768
/nix/store/kv7qjbzpn8nsa0rhyw1czy4wjdic88d1-betterlockscreen-3.0.1/bin/.betterlockscreen-wrapped: line 70: pidof: command not found
/nix/store/kv7qjbzpn8nsa0rhyw1czy4wjdic88d1-betterlockscreen-3.0.1/bin/.betterlockscreen-wrapped: line 95: pidof: command not found
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] ~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after) - before:  148788144 after: 155766472 
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
