### PR TITLE
Backport to 19.03: oraclejdk/jdk8cpu: 8u201 -> 8u211

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk8cpu-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8cpu-linux.nix
@@ -2,13 +2,13 @@
 # jce download url: http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;
 import ./jdk-linux-base.nix {
   productVersion = "8";
-  patchVersion = "201";
-  buildVersion = "09";
-  sha256.i686-linux = "1f9n93zmkggchaxkchp4bqasvxznn96zjci34f52h7v392jkzqac";
-  sha256.x86_64-linux = "0w730v2q0iaxf2lprabwmy7129byrs0hhdbwas575p1xmk00qw6b";
-  sha256.armv7l-linux = "0y6bvq93lsf21v6ca536dpfhkk5ljsj7c6di0qzkban37bivj0si";
-  sha256.aarch64-linux = "1bybysgg9llqzllsmdszmmb73v5az2l1shxn6lxwv3wwiazpf47q";
-  releaseToken = "42970487e3af4f5aa5bca3f542482c60";
+  patchVersion = "211";
+  buildVersion = "12";
+  sha256.i686-linux = "0mdrljs0rw9s4pvaa3sn791nqgdrp8749z3qn80y7hhad74kvsnp";
+  sha256.x86_64-linux = "13b6qk4sn8jdhxa22na9d2aazm4yjh6yxrlxr189gxy3619y9dy0";
+  sha256.armv7l-linux = "1ij1x925k7lyp5f98gy8r0xfr41qhczf2rb74plwwmrccc1k00p5";
+  sha256.aarch64-linux = "041r615qj9qy34a9gxm8968qlmf060ba2as5w97v86mbik4rca05";
+  releaseToken = "478a62b7d4e34b78b671c754eaaf38ab";
   jceName = "jce_policy-8.zip";
   sha256JCE = "0n8b6b8qmwb14lllk2lk1q1ahd3za9fnjigz5xn65mpg48whl0pk";
 }


### PR DESCRIPTION
(cherry picked from commit 9e2ec2a2df26a84c02a8da3c536f4a5cd1092dca)

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

It seems that Oracle Java 8u201 isn't available anymore, so building packages on 19.03 fails. I.e.:

```
> nix run -f channel:nixos-19.03 mediathekview
trace: WARNING: Public updates for Oracle Java SE 8 released after January 2019 will not be available for business, commercial or production use without a commercial license. See https://java.com/en/download/release_notice.jsp for more information.
builder for '/nix/store/l09wp0d9g0l220vmsf8ywyhxfgjcnm4r-jdk-8u201-linux-x64.tar.gz.drv' failed with exit code 1; last 10 log lines:

  trying http://download.oracle.com/otn-pub/java/jdk/8u201-b09/42970487e3af4f5aa5bca3f542482c60/jdk-8u201-linux-x64.tar.gz
    % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                   Dload  Upload   Total   Spent    Left  Speed
    0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  100   531  100   531    0     0    293      0  0:00:01  0:00:01 --:--:--  1206
    0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
    0     0    0     0    0     0      0      0 --:--:--  0:00:05 --:--:--     0
  curl: (22) The requested URL returned error: 404 Not Found
  error: cannot download jdk-8u201-linux-x64.tar.gz from any mirror
cannot build derivation '/nix/store/kbddbimhq843aaj7rcsgh5pkl7sdkibm-oraclejre-8u201.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/j0c270s673klpfi831bv6r5mhxrz5n7c-mediathekview-13.2.1.drv': 1 dependencies couldn't be built
[0 built (1 failed)]
error: build of '/nix/store/j0c270s673klpfi831bv6r5mhxrz5n7c-mediathekview-13.2.1.drv' failed
```

This PR backports the upgrade to 8u211 to the 19.03 channel.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
