### PR TITLE
matrix-synapse: 1.0.0 -> 1.1.0

### DIFF
--- a/pkgs/servers/matrix-synapse/default.nix
+++ b/pkgs/servers/matrix-synapse/default.nix
@@ -23,11 +23,11 @@ let
 
 in buildPythonApplication rec {
   pname = "matrix-synapse";
-  version = "1.0.0";
+  version = "1.1.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1n8hv0zd818z4fx39yz6svb07zsbrh8fd6wfmgvhdxhp6p1vl0wq";
+    sha256 = "0bmcpk3b6hlix2dzkwzlqy97ypljipr4bw8rnxm8rlihpd6scrjq";
   };
 
   patches = [

--- a/pkgs/servers/matrix-synapse/homeserver-script.patch
+++ b/pkgs/servers/matrix-synapse/homeserver-script.patch
@@ -1,21 +1,23 @@
 diff --git a/homeserver b/homeserver
 new file mode 120000
-index 0000000..2f1d413
+index 000000000..2f1d41351
 --- /dev/null
 +++ b/homeserver
-@@ -0,0 +1,1 @@
+@@ -0,0 +1 @@
 +synapse/app/homeserver.py
 \ No newline at end of file
 diff --git a/setup.py b/setup.py
-index b00c2af..c7f6e0a 100755
+index 5ce06c898..f1ccd95bc 100755
 --- a/setup.py
 +++ b/setup.py
-@@ -92,6 +92,6 @@ setup(
-     include_package_data=True,
-     zip_safe=False,
-     long_description=long_description,
+@@ -115,6 +115,6 @@ setup(
+         "Programming Language :: Python :: 3.6",
+         "Programming Language :: Python :: 3.7",
+     ],
 -    scripts=["synctl"] + glob.glob("scripts/*"),
 +    scripts=["synctl", "homeserver"] + glob.glob("scripts/*"),
-     cmdclass={'test': TestCommand},
+     cmdclass={"test": TestCommand},
  )
+-- 
+2.22.0
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

@Ralith @fpletz 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
