### PR TITLE
kodi: 18.1 -> 18.3

### DIFF
--- a/pkgs/applications/video/kodi/default.nix
+++ b/pkgs/applications/video/kodi/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, autoconf, automake, libtool, makeWrapper
+{ stdenv, lib, fetchurl, fetchFromGitHub, autoconf, automake, libtool, makeWrapper, linuxHeaders
 , pkgconfig, cmake, gnumake, yasm, python2Packages
 , libgcrypt, libgpgerror, libunistring
 , boost, avahi, lame, autoreconfHook
@@ -42,20 +42,35 @@ assert usbSupport   -> libusb != null && ! udevSupport; # libusb won't be used i
 assert vdpauSupport -> libvdpau != null;
 assert useWayland -> wayland != null && wayland-protocols != null && waylandpp != null && libxkbcommon != null;
 
-# TODO for Kodi 18.0
-# - check if dbus support PR has been merged and add dbus as a buildInput
-
 let
-  kodiReleaseDate = "20190129";
-  kodiVersion = "18.1";
+  kodiReleaseDate = "20190627";
+  kodiVersion = "18.3";
   rel = "Leia";
 
   kodi_src = fetchFromGitHub {
     owner  = "xbmc";
     repo   = "xbmc";
     rev    = "${kodiVersion}-${rel}";
-    sha256 = "1w26aqvzxv4c70gcd1vw1pldapsc2xcacwq9b7dqx5m44j0zx1dc";
+    sha256 = "18fbl5hs3aqccrn0m3x7hp95wlafjav0yvrwmb5q3gj24mwf6jld";
   };
+
+  cmakeProto = fetchurl {
+    url = "https://raw.githubusercontent.com/pramsey/libght/ca9b1121c352ea10170636e170040e1af015bad1/cmake/modules/CheckPrototypeExists.cmake";
+    sha256  = "1zai82gm5x55n3xvdv7mns3ja6a2k81x9zz0nk42j6s2yb0fkjxh";
+  };
+
+  cmakeProtoPatch = ''
+    # get rid of windows headers as they will otherwise be found first
+    rm -rf msvc
+
+    cp ${cmakeProto} cmake/${cmakeProto.name}
+    # we need to enable support for C++ for check_prototype_exists to do its thing
+    substituteInPlace CMakeLists.txt --replace 'LANGUAGES C' 'LANGUAGES C CXX'
+    if [ -f cmake/CheckHeadersSTDC.cmake ]; then
+      sed -i cmake/CheckHeadersSTDC.cmake \
+        -e '7iinclude(CheckPrototypeExists)'
+    fi
+  '';
 
   kodiDependency = { name, version, rev, sha256, ... } @attrs:
     let
@@ -83,16 +98,25 @@ let
     nativeBuildInputs = [ cmake nasm pkgconfig ];
   };
 
-  # we should be able to build these externally and have kodi reference them as buildInputs.
-  # Doesn't work ATM though so we just use them for the src
-
+  # We can build these externally but FindLibDvd.cmake forces us to build it
+  # them, so we currently just use them for the src.
   libdvdcss = kodiDependency rec {
     name              = "libdvdcss";
     version           = "1.4.2";
     rev               = "${version}-${rel}-Beta-5";
     sha256            = "0j41ydzx0imaix069s3z07xqw9q95k7llh06fc27dcn6f7b8ydyl";
-    buildInputs       = [ libdvdread ];
-    nativeBuildInputs = [ autoreconfHook pkgconfig ];
+    buildInputs       = [ linuxHeaders ];
+    nativeBuildInputs = [ cmake pkgconfig ];
+    postPatch = ''
+      rm -rf msvc
+
+      substituteInPlace config.h.cm \
+        --replace '#cmakedefine O_BINARY "''${O_BINARY}"' '#define O_BINARY 0'
+    '';
+    cmakeFlags = [
+      "-DBUILD_SHARED_LIBS=1"
+      "-DHAVE_LINUX_DVD_STRUCT=1"
+    ];
   };
 
   libdvdnav = kodiDependency rec {
@@ -100,8 +124,12 @@ let
     version           = "6.0.0";
     rev               = "${version}-${rel}-Alpha-3";
     sha256            = "0qwlf4lgahxqxk1r2pzl866mi03pbp7l1fc0rk522sc0ak2s9jhb";
-    buildInputs       = [ libdvdread ];
-    nativeBuildInputs = [ autoreconfHook pkgconfig ];
+    buildInputs       = [ libdvdcss libdvdread ];
+    nativeBuildInputs = [ cmake pkgconfig ];
+    postPatch         = cmakeProtoPatch;
+    postInstall = ''
+      mv $out/lib/liblibdvdnav.so $out/lib/libdvdnav.so
+    '';
   };
 
   libdvdread = kodiDependency rec {
@@ -109,7 +137,10 @@ let
     version           = "6.0.0";
     rev               = "${version}-${rel}-Alpha-3";
     sha256            = "1xxn01mhkdnp10cqdr357wx77vyzfb5glqpqyg8m0skyi75aii59";
-    nativeBuildInputs = [ autoreconfHook pkgconfig ];
+    buildInputs       = [ libdvdcss ];
+    nativeBuildInputs = [ cmake pkgconfig ];
+    configureFlags    = [ "--with-libdvdcss" ];
+    postPatch         = cmakeProtoPatch;
   };
 
 in stdenv.mkDerivation rec {
@@ -160,7 +191,7 @@ in stdenv.mkDerivation rec {
       makeWrapper
       which
       pkgconfig gnumake
-      autoconf automake libtool # still needed for some components. Check if that is the case with 18.0
+      autoconf automake libtool # still needed for some components. Check if that is the case with 19.0
     ] ++ lib.optional useWayland [ wayland-protocols ];
 
     cmakeFlags = [


### PR DESCRIPTION
##### Motivation for this change

Upstream update from 18.1 to 18.3 (bug fix release).

There are some minor changes to make the libdvd{css,nav,read} dependencies build as well (now they all do), but the kodi build system requires some changes in order to actually use them instead of force building them during the main kodi build.

Cc: @domenkozar @titanous @edwtjo @sephalon

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
