### PR TITLE
nixos/openldap: fix assertion

### DIFF
--- a/nixos/modules/services/databases/openldap.nix
+++ b/nixos/modules/services/databases/openldap.nix
@@ -237,8 +237,8 @@ in
   config = mkIf cfg.enable {
     assertions = [
       {
-        assertion = cfg.rootpwFile != null || cfg.rootpw != null;
-        message = "Either services.openldap.rootpw or services.openldap.rootpwFile must be set";
+        assertion = cfg.configDir != null || cfg.rootpwFile != null || cfg.rootpw != null;
+        message = "services.openldap: Unless configDir is set, either rootpw or rootpwFile must be set";
       }
     ];
 


### PR DESCRIPTION
###### Motivation for this change

In commit d43dc68db3f414a527cad632a3f1fb868fc1c902, @Mic92 split the rootpw option to allow specifying it in a file kept outside the Nix store, as an alternative to specifying the password directly in the config.

Prior to that, rootpw's type was `str`, but in order to allow both alternatives, it had to become `nullOr str` with a default of `null`. So I can see why this assertion, that either rootpw or rootpwFile are specified, makes sense to add here.

However, these options aren't used if the configDir option is set, so as written this assertion breaks valid configurations, including the configuration used by nixos/tests/ldap.nix.

So this patch fixes the assertion so that it doesn't fire if configDir is set.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
