### PR TITLE
squashfsTools: fix 4k-align patch regression

### DIFF
--- a/pkgs/tools/filesystems/squashfs/default.nix
+++ b/pkgs/tools/filesystems/squashfs/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
     # This patch adds an option to pad filesystems (increasing size) in
     # exchange for better chunking / binary diff calculation.
-    ./squashfs-tools-4.3-4k-align.patch
+    ./squashfs-tools-4.4-4k-align.patch
   ] ++ stdenv.lib.optional stdenv.isDarwin ./darwin.patch;
 
   buildInputs = [ zlib xz zstd ]

--- a/pkgs/tools/filesystems/squashfs/squashfs-tools-4.4-4k-align.patch
+++ b/pkgs/tools/filesystems/squashfs/squashfs-tools-4.4-4k-align.patch
@@ -16,24 +16,20 @@ increased_size = (number_of_unfragmented_files_in_image + number of fragments) *
 
 The 4k alignment can be enabled by flag '-4k-align'
 ---
- squashfs-tools/mksquashfs.c | 16 ++++++++++++++++
- 1 file changed, 16 insertions(+)
-
-diff --git a/squashfs-tools/mksquashfs.c b/squashfs-tools/mksquashfs.c
-index 8b1376f..683973d 100644
---- a/squashfs-tools/mksquashfs.c
-+++ b/squashfs-tools/mksquashfs.c
-@@ -99,6 +99,8 @@ int old_exclude = TRUE;
+diff -u a/squashfs-tools/mksquashfs.c b/squashfs-tools/mksquashfs.c
+--- a/squashfs-tools/mksquashfs.c	2019-07-06 15:50:22.214873176 +0000
++++ b/squashfs-tools/mksquashfs.c	2019-07-06 15:51:22.244802582 +0000
+@@ -100,7 +100,9 @@
  int use_regex = FALSE;
  int nopad = FALSE;
  int exit_on_error = FALSE;
- static off_t squashfs_start_offset = 0;
 +int do_4k_align = FALSE;
+ static off_t squashfs_start_offset = 0;
 +#define ALIGN_UP(bytes, size) (bytes = (bytes + size - 1) & ~(size - 1))
-
+ 
  long long global_uid = -1, global_gid = -1;
-
-@@ -1513,6 +1515,9 @@ void unlock_fragments()
+ 
+@@ -1495,6 +1497,9 @@
  	 * queue at this time.
  	 */
  	while(!queue_empty(locked_fragment)) {
@@ -41,9 +37,9 @@ index 8b1376f..683973d 100644
 +		if(do_4k_align)
 +			ALIGN_UP(bytes, 4096);
  		write_buffer = queue_get(locked_fragment);
- 		frg = write_buffer->block;
+ 		frg = write_buffer->block;	
  		size = SQUASHFS_COMPRESSED_SIZE_BLOCK(fragment_table[frg].size);
-@@ -2420,6 +2420,9 @@
+@@ -2414,6 +2419,9 @@
  	compressed_size = SQUASHFS_COMPRESSED_SIZE_BLOCK(c_byte);
  	write_buffer->size = compressed_size;
  	if(fragments_locked == FALSE) {
@@ -53,18 +49,18 @@ index 8b1376f..683973d 100644
  		fragment_table[file_buffer->block].size = c_byte;
  		fragment_table[file_buffer->block].start_block = bytes;
  		write_buffer->block = bytes;
-@@ -2761,6 +2769,10 @@ int write_file_blocks(squashfs_inode *inode, struct dir_ent *dir_ent,
+@@ -2728,6 +2736,10 @@
  	long long sparse = 0;
  	struct file_buffer *fragment_buffer = NULL;
-
+ 
 +	// 4k align the start of each file.
 +	if(do_4k_align)
 +		ALIGN_UP(bytes, 4096);
 +
  	if(pre_duplicate(read_size))
  		return write_file_blocks_dup(inode, dir_ent, read_buffer, dup);
-
-@@ -4692,6 +4704,7 @@ void write_filesystem_tables(struct squashfs_super_block *sBlk, int nopad)
+ 
+@@ -4808,6 +4820,7 @@
  		"compressed", no_fragments ? "no" : noF ? "uncompressed" :
  		"compressed", no_xattrs ? "no" : noX ? "uncompressed" :
  		"compressed", noI || noId ? "uncompressed" : "compressed");
@@ -72,7 +68,7 @@ index 8b1376f..683973d 100644
  	printf("\tduplicates are %sremoved\n", duplicate_checking ? "" :
  		"not ");
  	printf("Filesystem size %.2f Kbytes (%.2f Mbytes)\n", bytes / 1024.0,
-@@ -5346,6 +5359,8 @@ print_compressor_options:
+@@ -5570,6 +5583,8 @@
  			root_name = argv[i];
  		} else if(strcmp(argv[i], "-version") == 0) {
  			VERSION();
@@ -81,7 +77,7 @@ index 8b1376f..683973d 100644
  		} else {
  			ERROR("%s: invalid option\n\n", argv[0]);
  printOptions:
-@@ -5387,6 +5402,7 @@ printOptions:
+@@ -5613,6 +5628,7 @@
  			ERROR("\t\t\tdirectory containing that directory, "
  				"rather than the\n");
  			ERROR("\t\t\tcontents of the directory\n");
@@ -89,5 +85,3 @@ index 8b1376f..683973d 100644
  			ERROR("\nFilesystem filter options:\n");
  			ERROR("-p <pseudo-definition>\tAdd pseudo file "
  				"definition\n");
---
-2.14.1.480.gb18f417b89-goog (previously; hand-patched by charles-dyfis-net)


### PR DESCRIPTION
###### Motivation for this change

In #49200, an option to use 4k-aligned squashfs blocks was incorporated. Originally developed by Google, this makes it easy to build squashfs images which tools such as casync/desync/etc. can effectively chunk for easier distribution.

In 2aafeedd15e33491f637a20baf5b1b3b4fd5b4a3, this patch stopped being successfully applied. I haven't yet determined how this didn't break the build outright, but many of the strings inserted by the patch existed nowhere in the binary at all, and several components *would* have failed to apply, had it actually been attempted.

In this PR, the patch is updated to apply correctly on top of squashfs 4.4 as modified by the other patches previously applied.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after) *no change; 34038808 both before and after*
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
