### PR TITLE
pythonPackages.jpylyzer: init at 1.18.0, use to enable openjpeg tests

### DIFF
--- a/pkgs/development/libraries/openjpeg/generic.nix
+++ b/pkgs/development/libraries/openjpeg/generic.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, cmake, pkgconfig
-, libpng, libtiff, lcms2
+, libpng, libtiff, lcms2, jpylyzer
 , mj2Support ? true # MJ2 executables
 , jpwlLibSupport ? true # JPWL library & executables
 , jpipLibSupport ? false # JPIP library & executables
@@ -8,7 +8,7 @@
 , openjpegJarSupport ? false # Openjpeg jar (Java)
 , jp3dSupport ? true # # JP3D comp
 , thirdPartySupport ? false # Third party libraries - OFF: only build when found, ON: always build
-, testsSupport ? false
+, testsSupport ? true
 , jdk ? null
 # Inherit generics
 , branch, version, revision, sha256, patches ? [], extraFlags ? [], ...
@@ -61,6 +61,13 @@ stdenv.mkDerivation rec {
     ++ optional (openjpegJarSupport || jpipLibSupport) jdk;
 
   propagatedBuildInputs = [ libpng libtiff lcms2 ];
+
+  doCheck = testsSupport;
+  checkPhase = ''
+    substituteInPlace ../tools/ctest_scripts/travis-ci.cmake \
+      --replace "JPYLYZER_EXECUTABLE=" "JPYLYZER_EXECUTABLE=\"${jpylyzer}/bin/jpylyzer\" # "
+    OPJ_SOURCE_DIR=.. ctest -S ../tools/ctest_scripts/travis-ci.cmake
+  '';
 
   passthru = {
     incDir = "openjpeg-${branch}";

--- a/pkgs/development/python-modules/jpylyzer/default.nix
+++ b/pkgs/development/python-modules/jpylyzer/default.nix
@@ -1,0 +1,30 @@
+{ stdenv
+, fetchFromGitHub
+, buildPythonPackage
+, six
+}:
+
+buildPythonPackage rec {
+  pname = "jpylyzer";
+  version = "1.18.0";
+
+  src = fetchFromGitHub {
+    owner = "openpreserve";
+    repo = pname;
+    rev = version;
+    sha256 = "0vhrq15l6jd5fm6vj7mczjzjpl2ph1dk8jp89dw4vlccky8660ll";
+  };
+
+  propagatedBuildInputs = [ six ];
+
+  # there don't appear to be any in-tree tests as such, but the builder's automatic
+  # runner seems to be upset by the project layout
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "JP2 (JPEG 2000 Part 1) image validator and properties extractor";
+    homepage = "https://jpylyzer.openpreservation.org/";
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ ris ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3931,6 +3931,8 @@ in
 
   jpegrescan = callPackage ../applications/graphics/jpegrescan { };
 
+  jpylyzer = with pythonPackages; toPythonApplication jpylyzer;
+
   jq = callPackage ../development/tools/jq { };
 
   jo = callPackage ../development/tools/jo { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2191,6 +2191,8 @@ in {
 
   JPype1 = callPackage ../development/python-modules/JPype1 {};
 
+  jpylyzer = callPackage ../development/python-modules/jpylyzer {};
+
   josepy = callPackage ../development/python-modules/josepy {};
 
   jsbeautifier = callPackage ../development/python-modules/jsbeautifier {};


### PR DESCRIPTION
###### Motivation for this change
`jpylyzer` is a "JP2 (JPEG 2000 Part 1) image validator and properties extractor". Added as a python library and application.

`openjpeg` uses this in its test suite. It seems to me it would be useful to enable the tests for `openjpeg`, with it being one of those packages with a huge list of reverse dependencies, making `nox-review` a far less convenient proxy for checking an `openjpeg` package's correctness.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
