### PR TITLE
pythonPackages.wily: init at 1.12.2

### DIFF
--- a/pkgs/development/python-modules/flake8-polyfill/default.nix
+++ b/pkgs/development/python-modules/flake8-polyfill/default.nix
@@ -1,0 +1,20 @@
+{ lib, buildPythonPackage, fetchPypi, flake8 }:
+
+buildPythonPackage rec {
+  pname = "flake8-polyfill";
+  version = "1.0.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1nlf1mkqw856vi6782qcglqhaacb23khk9wkcgn55npnjxshhjz4";
+  };
+
+  propagatedBuildInputs = [ flake8 ];
+
+  meta = with lib; {
+    description = "Polyfill package for Flake8 plugins";
+    homepage = https://radon.readthedocs.org/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ lnl7 ];
+  };
+}

--- a/pkgs/development/python-modules/mando/default.nix
+++ b/pkgs/development/python-modules/mando/default.nix
@@ -1,0 +1,21 @@
+{ lib, buildPythonPackage, fetchPypi, six, pytest }:
+
+buildPythonPackage rec {
+  pname = "mando";
+  version = "0.6.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0q6rl085q1hw1wic52pqfndr0x3nirbxnhqj9akdm5zhq2fv3zkr";
+  };
+
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ six ];
+
+  meta = with lib; {
+    description = "Create Python CLI apps with little to no effort at all!";
+    homepage = https://mando.readthedocs.org/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ lnl7 ];
+  };
+}

--- a/pkgs/development/python-modules/radon/default.nix
+++ b/pkgs/development/python-modules/radon/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, fetchPypi, flake8-polyfill, colorama, mando, future }:
+
+buildPythonPackage rec {
+  pname = "radon";
+  version = "3.0.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0g9bi0qchjd6illda65k59ipf00s2hxvc9bl0sdsirxsx263087f";
+  };
+
+  propagatedBuildInputs = [ flake8-polyfill colorama mando future ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Code Metrics in Python";
+    homepage = https://radon.readthedocs.org/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ lnl7 ];
+  };
+}
+

--- a/pkgs/development/python-modules/wily/default.nix
+++ b/pkgs/development/python-modules/wily/default.nix
@@ -1,0 +1,24 @@
+{ lib, isPy3k, buildPythonPackage, fetchPypi, GitPython
+, tabulate, progress, click, plotly, colorlog, radon, dataclasses
+}:
+
+buildPythonPackage rec {
+  pname = "wily";
+  version = "1.12.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "193bs1h42bl23fca4fsmz3nbp5xj9mc0m9x61bfbfdml1kv10f71";
+  };
+
+  propagatedBuildInputs = [ GitPython tabulate progress click plotly colorlog radon ];
+
+  disabled = !isPy3k;
+
+  meta = with lib; {
+    description = "A command-line application for tracking, reporting on complexity of Python tests and applications";
+    homepage = https://github.com/tonybaloney/wily;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ lnl7 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -438,6 +438,8 @@ in {
 
   filemagic = callPackage ../development/python-modules/filemagic { };
 
+  flake8-polyfill = callPackage ../development/python-modules/flake8-polyfill { };
+
   fuse = callPackage ../development/python-modules/fuse-python {
     inherit (pkgs) fuse pkgconfig;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4296,6 +4296,8 @@ in {
 
   qutip = callPackage ../development/python-modules/qutip { };
 
+  radon = callPackage ../development/python-modules/radon { };
+
   rcssmin = callPackage ../development/python-modules/rcssmin { };
 
   recommonmark = callPackage ../development/python-modules/recommonmark { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5000,6 +5000,8 @@ in {
 
   webtest = callPackage ../development/python-modules/webtest { };
 
+  wily = callPackage ../development/python-modules/wily { };
+
   wsgiproxy2 = callPackage ../development/python-modules/wsgiproxy2 { };
 
   wurlitzer = callPackage ../development/python-modules/wurlitzer { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -542,6 +542,8 @@ in {
 
   macropy = callPackage ../development/python-modules/macropy { };
 
+  mando = callPackage ../development/python-modules/mando { };
+
   mail-parser = callPackage ../development/python-modules/mail-parser { };
 
   manhole = callPackage ../development/python-modules/manhole { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
