### PR TITLE
blockbook: init at 0.3.1

### DIFF
--- a/pkgs/servers/blockbook/default.nix
+++ b/pkgs/servers/blockbook/default.nix
@@ -1,0 +1,51 @@
+{ buildGoPackage
+, lib
+, fetchFromGitHub
+, rocksdb
+, bzip2
+, zlib
+, packr
+, snappy
+, pkg-config
+, zeromq
+, lz4
+}:
+
+buildGoPackage rec {
+  pname = "blockbook";
+  version = "0.3.1";
+
+  goPackagePath = "blockbook";
+
+  src = fetchFromGitHub {
+    owner = "trezor";
+    repo = "blockbook";
+    rev = "v${version}";
+    sha256 = "0qgd1f3b4vavw55mvpvwvlya39dx1c3kjsc7n46nn7kpc152jv1l";
+  };
+
+  goDeps = ./deps.nix;
+
+  buildInputs = [ bzip2 zlib snappy zeromq lz4 ];
+
+  nativeBuildInputs = [ pkg-config packr ];
+
+  preBuild = ''
+    export CGO_CFLAGS="-I${rocksdb}/include"
+    export CGO_LDFLAGS="-L${rocksdb}/lib -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy -llz4"
+    packr clean && packr
+  '';
+
+  postInstall = ''
+    rm $bin/bin/{scripts,templates,trezor-common}
+  '';
+
+  meta = with lib; {
+    description = "Trezor address/account balance backend";
+    homepage = "https://github.com/trezor/blockbook";
+    license = licenses.agpl3;
+    maintainers = with maintainers; [ mmahut ];
+    platforms = platforms.all;
+  };
+}
+

--- a/pkgs/servers/blockbook/deps.nix
+++ b/pkgs/servers/blockbook/deps.nix
@@ -1,0 +1,309 @@
+# file generated from Gopkg.lock using dep2nix (https://github.com/nixcloud/dep2nix)
+[
+  {
+    goPackagePath  = "github.com/Groestlcoin/go-groestl-hash";
+    fetch = {
+      type = "git";
+      url = "https://github.com/Groestlcoin/go-groestl-hash";
+      rev =  "790653ac190c4029ee200e82a8f21b5d1afaf7d6";
+      sha256 = "02davg672v9sz8l7a8s0b8m87154p42hkm5r6pavf4gqziw8bmr4";
+    };
+  }
+  {
+    goPackagePath  = "github.com/beorn7/perks";
+    fetch = {
+      type = "git";
+      url = "https://github.com/beorn7/perks";
+      rev =  "3a771d992973f24aa725d07868b467d1ddfceafb";
+      sha256 = "1l2lns4f5jabp61201sh88zf3b0q793w4zdgp9nll7mmfcxxjif3";
+    };
+  }
+  {
+    goPackagePath  = "github.com/bsm/go-vlq";
+    fetch = {
+      type = "git";
+      url = "https://github.com/bsm/go-vlq";
+      rev =  "ec6e8d4f5f4ec0f6e808ffc7f4dcc7516d4d7d49";
+      sha256 = "13nhgpigaqdvcksi6jrav0rqr5mzqkx3wrsans9ql89nva51r9sz";
+    };
+  }
+  {
+    goPackagePath  = "github.com/martinboehm/btcd";
+    fetch = {
+      type = "git";
+      url = "https://github.com/martinboehm/btcd";
+      rev =  "8e7c0427fee5d4778c5d4eb987150369e3ca1d0e";
+      sha256 = "10fwzl8hzqpsq1rk5iz3xs8hbn3wqans12hszvlxlmm2xb0f6z9b";
+    };
+  }
+  {
+    goPackagePath  = "github.com/btcsuite/btclog";
+    fetch = {
+      type = "git";
+      url = "https://github.com/btcsuite/btclog";
+      rev =  "84c8d2346e9fc8c7b947e243b9c24e6df9fd206a";
+      sha256 = "02dl46wcnfpg9sqvg0ipipkpnd7lrf4fnvb9zy56jqa7mfcwc7wk";
+    };
+  }
+  {
+    goPackagePath  = "github.com/deckarep/golang-set";
+    fetch = {
+      type = "git";
+      url = "https://github.com/deckarep/golang-set";
+      rev =  "1d4478f51bed434f1dadf96dcd9b43aabac66795";
+      sha256 = "01kaqrc5ywbwa46b6lz3db7kkg8q6v383h4lnxds4z3kjglkqaff";
+    };
+  }
+  {
+    goPackagePath  = "github.com/ethereum/go-ethereum";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ethereum/go-ethereum";
+      rev =  "8bbe72075e4e16442c4e28d999edee12e294329e";
+      sha256 = "0q0w0vz85d94wym3xni8y22vly886j6g6zn9hizcww1nanvk4nl6";
+    };
+  }
+  {
+    goPackagePath  = "github.com/go-stack/stack";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-stack/stack";
+      rev =  "259ab82a6cad3992b4e21ff5cac294ccb06474bc";
+      sha256 = "0irkqifyj84cbnq4n66ax2r591id2285diw5hzcz2k3bga8d8lqr";
+    };
+  }
+  {
+    goPackagePath  = "github.com/gobuffalo/packr";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gobuffalo/packr";
+      rev =  "5a2cbb54c4e7d482e3f518c56f1f86f133d5204f";
+      sha256 = "0hs62w1bv96zzfqqmnq18w71v0kmh4qrqpkf2y8qngvwgan761gd";
+    };
+  }
+  {
+    goPackagePath  = "github.com/gogo/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gogo/protobuf";
+      rev =  "1adfc126b41513cc696b209667c8656ea7aac67c";
+      sha256 = "1j7azzlnihcvnd1apw5zr0bz30h7n0gyimqqkgc76vzb1n5dpi7m";
+    };
+  }
+  {
+    goPackagePath  = "github.com/golang/glog";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/glog";
+      rev =  "23def4e6c14b4da8ac2ed8007337bc5eb5007998";
+      sha256 = "0jb2834rw5sykfr937fxi8hxi2zy80sj2bdn9b3jb4b26ksqng30";
+    };
+  }
+  {
+    goPackagePath  = "github.com/golang/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/protobuf";
+      rev =  "925541529c1fa6821df4e44ce2723319eb2be768";
+      sha256 = "1d3zjvhl115l23xakj0014qpjchivlg098h10v5nfirkk1i9f9sa";
+    };
+  }
+  {
+    goPackagePath  = "github.com/golang/snappy";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/snappy";
+      rev =  "553a641470496b2327abcac10b36396bd98e45c9";
+      sha256 = "0kssxnih1l722hx9219c7javganjqkqhvl3i0hp0hif6xm6chvqk";
+    };
+  }
+  {
+    goPackagePath  = "github.com/gorilla/websocket";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gorilla/websocket";
+      rev =  "ea4d1f681babbce9545c9c5f3d5194a789c89f5b";
+      sha256 = "1bhgs2542qs49p1dafybqxfs2qc072xv41w5nswyrknwyjxxs2a1";
+    };
+  }
+  {
+    goPackagePath  = "github.com/martinboehm/bchutil";
+    fetch = {
+      type = "git";
+      url = "https://github.com/martinboehm/bchutil";
+      rev =  "6373f11b6efe1ea81e8713b8788a695b2c144d38";
+      sha256 = "1wp7ixa0n0jj7y9phxm6p3fymc2555fb2k71s91jhis14fil2jim";
+    };
+  }
+  {
+    goPackagePath  = "github.com/martinboehm/btcutil";
+    fetch = {
+      type = "git";
+      url = "https://github.com/martinboehm/btcutil";
+      rev =  "225ed00dbbd5cb8d8b3949a0ee7c9ea540754585";
+      sha256 = "0dn5s6h1524q38glp6fcdws97lyvmchq26dhbd3dqazrq61dhdvy";
+    };
+  }
+  {
+    goPackagePath  = "github.com/juju/errors";
+    fetch = {
+      type = "git";
+      url = "https://github.com/juju/errors";
+      rev =  "c7d06af17c68cd34c835053720b21f6549d9b0ee";
+      sha256 = "1dmj8wkpmkw4z4c7wmnscs4ykrcv7p8lgwb75g5akahwqjaf9zcp";
+    };
+  }
+  {
+    goPackagePath  = "github.com/martinboehm/golang-socketio";
+    fetch = {
+      type = "git";
+      url = "https://github.com/martinboehm/golang-socketio";
+      rev =  "f60b0a8befde091474a624a8ffd81ee9912957b3";
+      sha256 = "1zln03qgzzbkr7zwm7ah1iikjdnipacp60bbg9lzkxsdcw2h1vd5";
+    };
+  }
+  {
+    goPackagePath  = "github.com/matttproud/golang_protobuf_extensions";
+    fetch = {
+      type = "git";
+      url = "https://github.com/matttproud/golang_protobuf_extensions";
+      rev =  "3247c84500bff8d9fb6d579d800f20b3e091582c";
+      sha256 = "12hcych25wf725zxdkpnyx4wa0gyxl8v4m8xmhdmmaki9bbmqd0d";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mr-tron/base58";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mr-tron/base58";
+      rev =  "c1bdf7c52f59d6685ca597b9955a443ff95eeee6";
+      sha256 = "1dq6i8619manxdhb0fwhdm9ar23kx88pc2xwl1pjla9djrgql6a8";
+    };
+  }
+  {
+    goPackagePath  = "github.com/pebbe/zmq4";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pebbe/zmq4";
+      rev =  "5b443b6471cea4b4f9f85025530c04c93233f76a";
+      sha256 = "0vnwlabrlrzszqyfbw4vypalhsxi4l4ywcbjhfhwl1fpvcph5dar";
+    };
+  }
+  {
+    goPackagePath  = "github.com/pkg/errors";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pkg/errors";
+      rev =  "645ef00459ed84a119197bfb8d8205042c6df63d";
+      sha256 = "001i6n71ghp2l6kdl3qq1v2vmghcz3kicv9a5wgcihrzigm75pp5";
+    };
+  }
+  {
+    goPackagePath  = "github.com/prometheus/client_golang";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/client_golang";
+      rev =  "c5b7fccd204277076155f10851dad72b76a49317";
+      sha256 = "1xqny3147g12n4j03kxm8s9mvdbs3ln6i56c655mybrn9jjy48kd";
+    };
+  }
+  {
+    goPackagePath  = "github.com/prometheus/client_model";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/client_model";
+      rev =  "99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c";
+      sha256 = "19y4ywsivhpxj7ikf2j0gm9k3cmyw37qcbfi78n526jxcc7kw998";
+    };
+  }
+  {
+    goPackagePath  = "github.com/prometheus/common";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/common";
+      rev =  "d0f7cd64bda49e08b22ae8a730aa57aa0db125d6";
+      sha256 = "1d4hfbb66xsf0wq317fwhgrwakqzhvryw4d7ip851lwrpql5fqcx";
+    };
+  }
+  {
+    goPackagePath  = "github.com/prometheus/procfs";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/procfs";
+      rev =  "8b1c2da0d56deffdbb9e48d4414b4e674bd8083e";
+      sha256 = "0x128p15h35mgwqxkigfkk1lfrcz9g697ahl8v6xp9kwvcqvjrrf";
+    };
+  }
+  {
+    goPackagePath  = "github.com/rs/cors";
+    fetch = {
+      type = "git";
+      url = "https://github.com/rs/cors";
+      rev =  "feef513b9575b32f84bafa580aad89b011259019";
+      sha256 = "0wjm0yjsnxhnp6924mq8v04srqa8sxrlnd7rkb19h4j6b9zagsik";
+    };
+  }
+  {
+    goPackagePath  = "github.com/schancel/cashaddr-converter";
+    fetch = {
+      type = "git";
+      url = "https://github.com/schancel/cashaddr-converter";
+      rev =  "0a38f5822f795dc3727b4caacc298e02938d9eb1";
+      sha256 = "0d0dsn029yckgjp26vkmg7r476hb6b9ayf2njcgdi648ln8rrad8";
+    };
+  }
+  {
+    goPackagePath  = "github.com/syndtr/goleveldb";
+    fetch = {
+      type = "git";
+      url = "https://github.com/syndtr/goleveldb";
+      rev =  "714f901b98fdb3aa954b4193d8cbd64a28d80cad";
+      sha256 = "0fn70vzqmww5v2xy0lamc319vrmfpza085d196cffhfw0jzw9i18";
+    };
+  }
+  {
+    goPackagePath  = "github.com/tecbot/gorocksdb";
+    fetch = {
+      type = "git";
+      url = "https://github.com/tecbot/gorocksdb";
+      rev =  "214b6b7bc0f06812ab5602fdc502a3e619916f38";
+      sha256 = "1mqpp14z4igr9jip39flpd7nf4rhr3z85y8mg74jjl1yrnwrwsld";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev =  "d6449816ce06963d9d136eee5a56fca5b0616e7e";
+      sha256 = "17dkprbbk84q165275zwhcn0s6pcarigq37zlhsxj23pq2qz3aqy";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev =  "61147c48b25b599e5b561d2e9c4f3e1ef489ca41";
+      sha256 = "1520pdlw9a9s41ad1cf1z6y2ff4j96zbn82qffrxqk02bqlr9f5w";
+    };
+  }
+  {
+    goPackagePath  = "gopkg.in/karalabe/cookiejar.v2";
+    fetch = {
+      type = "git";
+      url = "https://github.com/karalabe/cookiejar";
+      rev =  "8dcd6a7f4951f6ff3ee9cbb919a06d8925822e57";
+      sha256 = "1dbizcklsfn6b5i182nf9pgkk4ac8jnmq8zix73si7x2n53wyb3b";
+    };
+  }
+  {
+    goPackagePath  = "gopkg.in/natefinch/npipe.v2";
+    fetch = {
+      type = "git";
+      url = "https://github.com/natefinch/npipe";
+      rev =  "c1b8fa8bdccecb0b8db834ee0b92fdbcfa606dd6";
+      sha256 = "1qplrvhks05pay169d9lph3hl7apdam4vj1kx3yzik7cphx6b24f";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1050,6 +1050,8 @@ in
 
   blink = callPackage ../applications/networking/instant-messengers/blink { };
 
+  blockbook = callPackage ../servers/blockbook { };
+
   blockhash = callPackage ../tools/graphics/blockhash { };
 
   bluemix-cli = callPackage ../tools/admin/bluemix-cli { };


### PR DESCRIPTION
###### Motivation for this change

init at 0.3.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
