### PR TITLE
[r19.03] wireshark: 2.6.6 -> 2.6.9, security release

### DIFF
--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -12,7 +12,7 @@ assert withQt  -> !withGtk && qt5  != null;
 with stdenv.lib;
 
 let
-  version = "2.6.6";
+  version = "2.6.9";
   variant = if withGtk then "gtk" else if withQt then "qt" else "cli";
 
 in stdenv.mkDerivation {
@@ -21,7 +21,7 @@ in stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://www.wireshark.org/download/src/all-versions/wireshark-${version}.tar.xz";
-    sha256 = "0qz8a1ays63712pq1v7nnw7c57zlqkcifq7himfv5nsv0zm36ya8";
+    sha256 = "1gh6a4xiq2ck3rzk5ndhi89ri8ai27xfga5iyqi9548mm6aim30d";
   };
 
   cmakeFlags = [


### PR DESCRIPTION
###### Motivation for this change
Security release(s) fixing multiple issues:

 - https://www.wireshark.org/security/wnpa-sec-2019-06.html CVE-2019-9209
 - https://www.wireshark.org/security/wnpa-sec-2019-07.html CVE-2019-9208
 - https://www.wireshark.org/security/wnpa-sec-2019-08.html CVE-2019-9214
 - https://www.wireshark.org/security/wnpa-sec-2019-09.html CVE-2019-10895
 - https://www.wireshark.org/security/wnpa-sec-2019-10.html CVE-2019-10899
 - https://www.wireshark.org/security/wnpa-sec-2019-14.html CVE-2019-10894
 - https://www.wireshark.org/security/wnpa-sec-2019-15.html CVE-2019-10896
 - https://www.wireshark.org/security/wnpa-sec-2019-17.html CVE-2019-10901
 - https://www.wireshark.org/security/wnpa-sec-2019-18.html CVE-2019-10903
 - https://www.wireshark.org/security/wnpa-sec-2019-19.html (?)

~This probably slipped under the radar because they haven't assigned CVEs for these.~ Oh yes they have.

`nox-review` is happy on non-nixos linux x86_64, on macos 10.13 I only get build failures for packages that already won't build on my machine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
