### PR TITLE
soundtouch: 2.0.0 -> 2.1.2

### DIFF
--- a/pkgs/development/libraries/soundtouch/default.nix
+++ b/pkgs/development/libraries/soundtouch/default.nix
@@ -1,22 +1,24 @@
-{stdenv, fetchurl, autoconf, automake, libtool}:
+{stdenv, lib, fetchFromGitLab, autoconf, automake, libtool}:
 
 stdenv.mkDerivation rec {
-  pName = "soundtouch";
-  name = "${pName}-2.0.0";
-  src = fetchurl {
-    url = "https://www.surina.net/soundtouch/${name}.tar.gz";
-    sha256 = "09cxr02mfyj2bg731bj0i9hh565x8l9p91aclxs8wpqv8b8zf96j";
+  pname = "soundtouch";
+  version = "2.1.2";
+
+  src = fetchFromGitLab {
+    owner = pname;
+    repo = pname;
+    rev = version;
+    sha256 = "174wgm3s0inmbnkrlnspxjwm2014qhjhkbdqa5r8rbfi0nzqxzsz";
   };
 
-  buildInputs = [ autoconf automake libtool ];
+  nativeBuildInputs = [ autoconf automake libtool ];
 
   preConfigure = "./bootstrap";
 
-  meta = {
-      description = "A program and library for changing the tempo, pitch and playback rate of audio";
-      homepage = http://www.surina.net/soundtouch/;
-      downloadPage = http://www.surina.net/soundtouch/sourcecode.html;
-      license = stdenv.lib.licenses.lgpl21;
-      platforms = stdenv.lib.platforms.all;
+  meta = with lib; {
+    description = "A program and library for changing the tempo, pitch and playback rate of audio";
+    homepage = "http://www.surina.net/soundtouch/";
+    license = licenses.lgpl21;
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
##### Motivation for this change

Obsoletes #64354.
Fixes #64187.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
