### PR TITLE
Rust 1.36

### DIFF
--- a/pkgs/development/compilers/rust/bootstrap.nix
+++ b/pkgs/development/compilers/rust/bootstrap.nix
@@ -3,16 +3,16 @@
 let
   # Note: the version MUST be one version prior to the version we're
   # building
-  version = "1.34.2";
+  version = "1.35.0";
 
   # fetch hashes by running `print-hashes.sh 1.34.2`
   hashes = {
-    i686-unknown-linux-gnu = "926bafd09eb90ba7d5a0195fcffb8f33dd57e515af4f8987a143459f6b1d3f04";
-    x86_64-unknown-linux-gnu = "2bf6622d980a52832bae141304e96f317c8a1ccd2dfd69a134a14033e6e43c0f";
-    armv7-unknown-linux-gnueabihf = "70d1057fcc133dc3e44377060a00d2f9d3a134e2670963d3f1d93f3dbfa0548e";
-    aarch64-unknown-linux-gnu = "15fc6b7ec121df9d4e42483dd12c677203680bec8c69b6f4f62e5a35a07341a8";
-    i686-apple-darwin = "b9fc44cbb06050975664f1033d1337bb38d5ea73b503a5d3af5409033397be5c";
-    x86_64-apple-darwin = "6fdd4bf7fe26dded0cd57b41ab5f0500a5a99b7bc770523a425e9e34f63d0fd8";
+    i686-unknown-linux-gnu = "05337776b3645e4b8c8c7ced0bcd1615cf9ad1b9c8b3d0f333620e5401e31aee";
+    x86_64-unknown-linux-gnu = "cf600e2273644d8629ed57559c70ca8db4023fd0156346facca9ab3ad3e8f86c";
+    armv7-unknown-linux-gnueabihf = "8f0f32d8ddc6fb7bcb8f50ec5e694078799d93facbf135eec5bd9a8c94d0c11e";
+    aarch64-unknown-linux-gnu = "31e6da56e67838fd2874211ae896a433badf67c13a7b68481f1d5f7dedcc5952";
+    i686-apple-darwin = "6a45ae8db094c5f6c57c5594a00f1a92b08c444a7347a657b4033186d4f08b19";
+    x86_64-apple-darwin = "ac14b1c7dc330dcb53d8641d74ebf9b32aa8b03b9d650bcb9258030d8b10dbd6";
   };
 
   platform =

--- a/pkgs/development/compilers/rust/patches/net-tcp-disable-tests.patch
+++ b/pkgs/development/compilers/rust/patches/net-tcp-disable-tests.patch
@@ -1,6 +1,6 @@
-diff -ru -x '*~' rustc-1.35.0-src-orig/src/libstd/net/tcp.rs rustc-1.35.0-src/src/libstd/net/tcp.rs
---- rustc-1.35.0-src-orig/src/libstd/net/tcp.rs	2019-05-20 14:10:15.000000000 +0200
-+++ rustc-1.35.0-src/src/libstd/net/tcp.rs	2019-06-13 19:59:46.740611889 +0200
+diff -ru rustc-1.36.0-src-orig/src/libstd/net/tcp.rs rustc-1.36.0-src/src/libstd/net/tcp.rs
+--- rustc-1.36.0-src-orig/src/libstd/net/tcp.rs	2019-07-03 10:00:00.000000000 +0200
++++ rustc-1.36.0-src/src/libstd/net/tcp.rs	2019-07-07 11:33:35.378130207 +0200
 @@ -973,6 +973,7 @@
          }
      }
@@ -57,19 +57,16 @@ diff -ru -x '*~' rustc-1.35.0-src-orig/src/libstd/net/tcp.rs rustc-1.35.0-src/sr
      fn clone_while_reading() {
          each_ip(&mut |addr| {
              let accept = t!(TcpListener::bind(&addr));
-@@ -1597,7 +1604,10 @@
+@@ -1597,7 +1604,7 @@
  
-     // FIXME: re-enabled bitrig/openbsd tests once their socket timeout code
+     // FIXME: re-enabled openbsd tests once their socket timeout code
      //        no longer has rounding errors.
--    #[cfg_attr(any(target_os = "bitrig", target_os = "netbsd", target_os = "openbsd"), ignore)]
-+    #[cfg_attr(any(target_os = "bitrig",
-+                   target_os = "netbsd",
-+                   target_os = "openbsd",
-+                   target_os = "macos"), ignore)]
+-    #[cfg_attr(any(target_os = "netbsd", target_os = "openbsd"), ignore)]
++    #[cfg_attr(any(target_os = "netbsd", target_os = "openbsd", target_os = "macos"), ignore)]
      #[cfg_attr(target_env = "sgx", ignore)] // FIXME: https://github.com/fortanix/rust-sgx/issues/31
      #[test]
      fn timeouts() {
-@@ -1643,6 +1653,7 @@
+@@ -1643,6 +1650,7 @@
          drop(listener);
      }
  
@@ -77,7 +74,7 @@ diff -ru -x '*~' rustc-1.35.0-src-orig/src/libstd/net/tcp.rs rustc-1.35.0-src/sr
      #[test]
      #[cfg_attr(target_env = "sgx", ignore)] // FIXME: https://github.com/fortanix/rust-sgx/issues/31
      fn test_read_with_timeout() {
-@@ -1687,6 +1698,7 @@
+@@ -1687,6 +1695,7 @@
          drop(listener);
      }
  
@@ -85,7 +82,7 @@ diff -ru -x '*~' rustc-1.35.0-src-orig/src/libstd/net/tcp.rs rustc-1.35.0-src/sr
      #[test]
      #[cfg_attr(target_env = "sgx", ignore)]
      fn nodelay() {
-@@ -1719,6 +1731,7 @@
+@@ -1719,6 +1728,7 @@
          assert_eq!(ttl, t!(stream.ttl()));
      }
  

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -17,11 +17,11 @@ let
   llvmShared = llvm_7.override { enableSharedLibraries = true; };
 in stdenv.mkDerivation rec {
   pname = "rustc";
-  version = "1.35.0";
+  version = "1.36.0";
 
   src = fetchurl {
     url = "https://static.rust-lang.org/dist/rustc-${version}-src.tar.gz";
-    sha256 = "0bbizy6b7002v1rdhrxrf5gijclbyizdhkglhp81ib3bf5x66kas";
+    sha256 = "06xv2p6zq03lidr0yaf029ii8wnjjqa894nkmrm6s0rx47by9i04";
   };
 
   __darwinAllowLocalNetworking = true;

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -206,6 +206,8 @@ in stdenv.mkDerivation rec {
   # https://github.com/rust-lang/rust/issues/30181
   # enableParallelBuilding = false;
 
+  setupHooks = ./setup-hook.sh;
+
   requiredSystemFeatures = [ "big-parallel" ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/compilers/rust/setup-hook.sh
+++ b/pkgs/development/compilers/rust/setup-hook.sh
@@ -1,0 +1,4 @@
+# Fix 'failed to open: /homeless-shelter/.cargo/.package-cache' in rust 1.36.
+if [[ -z $IN_NIX_SHELL && -z $CARGO_HOME ]]; then
+    export CARGO_HOME=$TMPDIR
+fi


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update Rust from 1.35.0 to 1.36.0.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
