### PR TITLE
emacs: Silence compiler warnings in site-start.el

### DIFF
--- a/pkgs/applications/editors/emacs/site-start.el
+++ b/pkgs/applications/editors/emacs/site-start.el
@@ -1,6 +1,7 @@
+;; -*- lexical-binding: t; -*-
 (defun nix--profile-paths ()
-  "Returns a list of all paths in the NIX_PROFILES environment
-variable, ordered from more-specific (the user profile) to the
+  "Return a list of all paths in NIX_PROFILES.
+The list is ordered from more-specific (the user profile) to the
 least specific (the system profile)"
   (reverse (split-string (or (getenv "NIX_PROFILES") ""))))
 
@@ -23,6 +24,7 @@ least specific (the system profile)"
 
 
 ;;; Make `woman' find the man pages
+(defvar woman-manpath)
 (eval-after-load 'woman
   '(setq woman-manpath
          (append (mapcar (lambda (x) (concat x "/share/man/"))
@@ -30,6 +32,7 @@ least specific (the system profile)"
                  woman-manpath)))
 
 ;;; Make tramp work for remote NixOS machines
+(defvar tramp-remote-path)
 (eval-after-load 'tramp-sh
   ;; TODO: We should also add the other `NIX_PROFILES' to this path.
   ;; However, these are user-specific, so we would need to discover
@@ -42,6 +45,7 @@ least specific (the system profile)"
 ;;; the current file:
 ;;; from: /nix/store/<hash>-emacs-<version>/share/emacs/site-lisp/site-start.el
 ;;; to:   /nix/store/<hash>-emacs-<version>/share/emacs/<version>/src/
+(defvar find-function-C-source-directory)
 (let ((emacs
        (file-name-directory                      ; .../emacs/
         (directory-file-name                     ; .../emacs/site-lisp


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Remove compiler warnings from nixOS's site-start.el

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
