### PR TITLE
dunst: 1.4.0 -> 1.4.1

### DIFF
--- a/pkgs/applications/misc/dunst/default.nix
+++ b/pkgs/applications/misc/dunst/default.nix
@@ -1,18 +1,18 @@
-{ stdenv, fetchFromGitHub, makeWrapper
+{ stdenv, lib, fetchFromGitHub, makeWrapper
 , pkgconfig, which, perl, libXrandr
 , cairo, dbus, systemd, gdk_pixbuf, glib, libX11, libXScrnSaver
 , libXinerama, libnotify, pango, xorgproto, librsvg, dunstify ? false
 }:
 
 stdenv.mkDerivation rec {
-  name = "dunst-${version}";
-  version = "1.4.0";
+  pname = "dunst";
+  version = "1.4.1";
 
   src = fetchFromGitHub {
     owner = "dunst-project";
     repo = "dunst";
     rev = "v${version}";
-    sha256 = "1rwbylygd88r61yrxc7ckg9svgq8b1i2falr0mk9sabqxzn9050s";
+    sha256 = "0xjj1f2jr1ja5grj6wrx5jjz1sx5fpqnvkw7nqi4452j3nc4p4l2";
   };
 
   nativeBuildInputs = [ perl pkgconfig which systemd makeWrapper ];
@@ -33,19 +33,19 @@ stdenv.mkDerivation rec {
 
   buildFlags = if dunstify then [ "dunstify" ] else [];
 
-  postInstall = stdenv.lib.optionalString dunstify ''
+  postInstall = lib.optionalString dunstify ''
     install -Dm755 dunstify $out/bin
   '' + ''
     wrapProgram $out/bin/dunst \
       --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE"
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Lightweight and customizable notification daemon";
-    homepage = https://dunst-project.org/;
+    homepage = "https://dunst-project.org/";
     license = licenses.bsd3;
     # NOTE: 'unix' or even 'all' COULD work too, I'm not sure
     platforms = platforms.linux;
-    maintainers = [ maintainers.domenkozar ];
+    maintainers = with maintainers; [ domenkozar ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update `dunst` to the latest release.
- https://github.com/dunst-project/dunst/releases/tag/v1.4.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
@GrahamcOfBorg build dunst