### PR TITLE
cgit: add patch fixing remote DoS

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/cgit/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/cgit/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, openssl, zlib, asciidoc, libxml2, libxslt
+{ stdenv, fetchurl, fetchpatch, openssl, zlib, asciidoc, libxml2, libxslt
 , docbook_xsl, pkgconfig, luajit
 , coreutils, gnused, groff, docutils
 , gzip, bzip2, xz
@@ -21,6 +21,14 @@ stdenv.mkDerivation rec {
     url    = "mirror://kernel/software/scm/git/git-2.18.0.tar.xz";
     sha256 = "14hfwfkrci829a9316hnvkglnqqw1p03cw9k56p4fcb078wbwh4b";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "prevent-dos-limit-path-length.patch";
+      url = "https://git.zx2c4.com/cgit/patch/?id=54c407a74a35d4ee9ffae94cc5bc9096c9f7f54a";
+      sha256 = "1qlbpqsc293lmc9hzwf1j4jr5qlv8cm1r249v3yij5s4wki1595j";
+    })
+  ];
 
   nativeBuildInputs = [ pkgconfig ] ++ [ python wrapPython ];
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change
Issue assigned MGASA-2019-0203 by Mageia.

https://www.openwall.com/lists/oss-security/2019/05/19/3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
