### PR TITLE
More OctoPrint plugins

### DIFF
--- a/pkgs/applications/misc/octoprint/default.nix
+++ b/pkgs/applications/misc/octoprint/default.nix
@@ -15,7 +15,6 @@ let
     packageOverrides = lib.foldr lib.composeExtensions (self: super: { }) ([
       (mkOverride "flask"       "0.10.1" "0wrkavjdjndknhp8ya8j850jq7a1cli4g5a93mg8nh1xz2gq50sc")
       (mkOverride "flask_login" "0.2.11" "1rg3rsjs1gwi2pw6vr9jmhaqm9b3vc9c4hfcsvp4y8agbh7g3mc3")
-      (mkOverride "sarge"       "0.1.4"  "08s8896973bz1gg0pkr592w6g4p6v47bkfvws5i91p9xf8b35yar")
       (mkOverride "tornado"     "4.5.3"  "02jzd23l4r6fswmwxaica9ldlyc2p6q8dk6dyff7j58fmdzf853d")
 
       # Octoprint holds back jinja2 to 2.8.1 due to breaking changes.

--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -123,6 +123,25 @@ let
       };
     };
 
+    touchui = buildPlugin rec {
+      pname = "TouchUI";
+      version = "0.3.13";
+
+      src = fetchFromGitHub {
+        owner = "BillyBlaze";
+        repo = "OctoPrint-${pname}";
+        rev = version;
+        sha256 = "0qk12ysabdzy6cna3l4f8v3qcnppppwxxsjx2i0xn1nd0cv6yzwh";
+      };
+
+      meta = with stdenv.lib; {
+        description = "Touch friendly interface for a small TFT module or phone for OctoPrint";
+        homepage = "https://github.com/BillyBlaze/OctoPrint-TouchUI";
+        license = licenses.agpl3;
+        maintainers = with maintainers; [ gebner ];
+      };
+    };
+
   };
 
 in self

--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -142,6 +142,30 @@ let
       };
     };
 
+    psucontrol = buildPlugin rec {
+      pname = "PSUControl";
+      version = "0.1.8";
+
+      src = fetchFromGitHub {
+        owner = "kantlivelong";
+        repo = "OctoPrint-${pname}";
+        rev = version;
+        sha256 = "0aj38d7b7d5pzmzq841pip18cpg18wy2vrxq2nd13875597y54b8";
+      };
+
+      preConfigure = ''
+        # optional; RPi.GPIO is broken on vanilla kernels
+        sed /RPi.GPIO/d -i requirements.txt
+      '';
+
+      meta = with stdenv.lib; {
+        description = "OctoPrint plugin to control ATX/AUX power supply";
+        homepage = "https://github.com/kantlivelong/OctoPrint-PSUControl";
+        license = licenses.agpl3;
+        maintainers = with maintainers; [ gebner ];
+      };
+    };
+
   };
 
 in self

--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, octoprint, python2Packages }:
+{ stdenv, fetchFromGitHub, octoprint, python2Packages, marlin-calc }:
 
 let
   buildPlugin = args: python2Packages.buildPythonPackage (args // {
@@ -161,6 +161,31 @@ let
       meta = with stdenv.lib; {
         description = "OctoPrint plugin to control ATX/AUX power supply";
         homepage = "https://github.com/kantlivelong/OctoPrint-PSUControl";
+        license = licenses.agpl3;
+        maintainers = with maintainers; [ gebner ];
+      };
+    };
+
+    printtimegenius = buildPlugin rec {
+      pname = "PrintTimeGenius";
+      version = "1.3.1";
+
+      src = fetchFromGitHub {
+        owner = "eyal0";
+        repo = "OctoPrint-${pname}";
+        rev = version;
+        sha256 = "0ijv1nxmikv06a00hqqkqri6wnydqh6lwcx07pmvw6jy706jhy28";
+      };
+
+      preConfigure = ''
+        # PrintTimeGenius ships with marlin-calc binaries for multiple architectures
+        rm */analyzers/marlin-calc*
+        sed 's@"{}.{}".format(binary_base_name, machine)@"${marlin-calc}/bin/marlin-calc"@' -i */analyzers/analyze_progress.py
+      '';
+
+      meta = with stdenv.lib; {
+        description = "Better print time estimation for OctoPrint";
+        homepage = "https://github.com/eyal0/OctoPrint-PrintTimeGenius";
         license = licenses.agpl3;
         maintainers = with maintainers; [ gebner ];
       };

--- a/pkgs/applications/video/mjpg-streamer/default.nix
+++ b/pkgs/applications/video/mjpg-streamer/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "mjpg-streamer-${version}";
-  version = "2016-03-08";
+  version = "unstable-2019-05-24";
 
   src = fetchFromGitHub {
     owner = "jacksonliam";
     repo = "mjpg-streamer";
-    rev = "4060cb64e3557037fd404d10e1c1d076b672e9e8";
-    sha256 = "0g7y832jsz4ylmq9qp2l4fq6bm8l6dhsbi60fr5jfqpx4l0pia8m";
+    rev = "501f6362c5afddcfb41055f97ae484252c85c912";
+    sha256 = "1cl159svfs1zzzrd3zgn4x7qy6751bvlnxfwf5hn5fmg4iszajw7";
   };
 
   prePatch = ''
@@ -23,9 +23,10 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = https://sourceforge.net/projects/mjpg-streamer/;
+    homepage = "https://github.com/jacksonliam/mjpg-streamer";
     description = "MJPG-streamer takes JPGs from Linux-UVC compatible webcams, filesystem or other input plugins and streams them as M-JPEG via HTTP to webbrowsers, VLC and other software";
     platforms = platforms.linux;
     license = licenses.gpl2;
+    maintainers = with maintainers; [ gebner ];
   };
 }

--- a/pkgs/tools/misc/marlin-calc/default.nix
+++ b/pkgs/tools/misc/marlin-calc/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "marlin-calc";
+  version = "2019-06-04";
+
+  src = fetchFromGitHub {
+    owner = "eyal0";
+    repo = "Marlin";
+    rev = "4120d1c72d6c32e9c5cc745c05d20963ba4bbca3";
+    sha256 = "06aly7s4k1r31njm43sbxq9a0127sw43pnaddh92a3cc39rbj2va";
+  };
+
+  buildPhase = ''
+    cd Marlin/src
+    c++ module/planner.cpp module/calc.cpp feature/fwretract.cpp \
+      -O2 -Wall -std=gnu++11 -o marlin-calc
+  '';
+
+  installPhase = ''
+    install -Dm0755 {,$out/bin/}marlin-calc
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/eyal0/Marlin";
+    description = "Marlin 3D printer timing simulator";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ gebner ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1699,6 +1699,8 @@ in
 
   lynis = callPackage ../tools/security/lynis { };
 
+  marlin-calc = callPackage ../tools/misc/marlin-calc {};
+
   mathics = pythonPackages.mathics;
 
   masscan = callPackage ../tools/security/masscan {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

OctoPrint-related updates and plugin additions.

I removed the sarge version override, which silently broke PrintTimeGenius (and also the pip version check in octoprint, but that one doesn't matter).

Tested on a raspberry pi 3b+.

cc maintainer @abbradar 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
