### PR TITLE
trivial-builders: support '/' in writeTextDir

### DIFF
--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -94,17 +94,21 @@ rec {
 
   /*
    * Writes a text file to nix store in a specific directory with no
-   * optional parameters available. Name passed is the destination.
+   * optional parameters available.
    *
    * Example:
-   * # Writes contents of file to /nix/store/<store path>/<name>
+   * # Writes contents of file to /nix/store/<store path>/share/my-file
    * writeTextDir "share/my-file"
    *   ''
    *   Contents of File
    *   '';
    *
   */
-  writeTextDir = name: text: writeTextFile {inherit name text; destination = "/${name}";};
+  writeTextDir = path: text: writeTextFile {
+    inherit text;
+    name = builtins.baseNameOf path;
+    destination = "/${path}";
+  };
 
   /*
    * Writes a text file to /nix/store/<store path> and marks the file as


### PR DESCRIPTION
Before one would get the following error

    nix-repl> pkgs.writeTextDir "share/my-file" "foo"
    error: invalid character '/' in name 'share/my-file'

Fixes #50347

CC @flokli