### PR TITLE
pythonPackages.myfitnesspal: init at 1.13.3

### DIFF
--- a/pkgs/development/python-modules/measurement/default.nix
+++ b/pkgs/development/python-modules/measurement/default.nix
@@ -1,0 +1,20 @@
+{ lib, fetchPypi, buildPythonPackage, pbr, six, sympy }:
+
+buildPythonPackage rec {
+  pname = "measurement";
+  version = "2.0.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "36ca385ffdccf140a75a7e1d816a4df97a6dd255f16fd2f53dd7ab43632a8835";
+  };
+
+  propagatedBuildInputs = [ pbr six sympy ];
+
+  meta = with lib; {
+    description = "Use and manipulate unit-aware measurement objects in Python";
+    homepage = https://github.com/coddingtonbear/python-measurement;
+    license = licenses.mit;
+    maintainers = with maintainers; [ bhipple ];
+  };
+}

--- a/pkgs/development/python-modules/myfitnesspal/default.nix
+++ b/pkgs/development/python-modules/myfitnesspal/default.nix
@@ -1,0 +1,29 @@
+{ lib, fetchPypi, buildPythonPackage
+, blessed, keyring, keyrings-alt, lxml, measurement, python-dateutil, requests, six
+, mock, nose }:
+
+buildPythonPackage rec {
+  pname = "myfitnesspal";
+  version = "1.13.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "4f785341f0499bad8d3400cfcfffd99b7fcf8aac3971390f8ec3dfaed8361b20";
+  };
+
+  # Remove overly restrictive version constraints on keyring and keyrings.alt
+  postPatch = ''
+    sed -i 's/keyring>=.*/keyring/' requirements.txt
+    sed -i 's/keyrings.alt>=.*/keyrings.alt/' requirements.txt
+  '';
+
+  checkInputs = [ mock nose ];
+  propagatedBuildInputs = [ blessed keyring keyrings-alt lxml measurement python-dateutil requests six ];
+
+  meta = with lib; {
+    description = "Access your meal tracking data stored in MyFitnessPal programatically";
+    homepage = https://github.com/coddingtonbear/python-myfitnesspal;
+    license = licenses.mit;
+    maintainers = with maintainers; [ bhipple ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2470,6 +2470,8 @@ in {
 
   mwlib-rl = callPackage ../development/python-modules/mwlib-rl { };
 
+  myfitnesspal = callPackage ../development/python-modules/myfitnesspal { };
+
   natsort = callPackage ../development/python-modules/natsort { };
 
   naturalsort = callPackage ../development/python-modules/naturalsort { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2454,6 +2454,8 @@ in {
 
   python-mapnik = callPackage ../development/python-modules/python-mapnik { };
 
+  measurement = callPackage ../development/python-modules/measurement {};
+
   midiutil = callPackage ../development/python-modules/midiutil {};
 
   misaka = callPackage ../development/python-modules/misaka {};


### PR DESCRIPTION
###### Motivation for this change
This is a python library for downloading data from the MyFitnessPal API, which is useful for users who want to chart/graph/visualize their data with other tools, such as seaborn or matplotlib.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
