### PR TITLE
[r18.09] graphicsmagick: 1.3.31 -> 1.3.32 (security release)

### DIFF
--- a/pkgs/applications/graphics/graphicsmagick/1.3.32-darwin-png-strlcat-fix.patch
+++ b/pkgs/applications/graphics/graphicsmagick/1.3.32-darwin-png-strlcat-fix.patch
@@ -1,0 +1,42 @@
+# reduced version of commit f30492f40f78d867b43422215057dd21de4ba447
+# from upstream hg repository:
+RegisterPNGImage(): Pass correct size value to strlcat().
+
+diff -r 95c4711e8bee -r f30492f40f78 coders/png.c
+--- a/coders/png.c	Mon Jun 17 07:24:30 2019 -0500
++++ b/coders/png.c	Mon Jun 17 18:54:43 2019 -0500
+@@ -6427,26 +6427,26 @@
+ 
+       *version='\0';
+ #if defined(PNG_LIBPNG_VER_STRING)
+-      (void) strlcat(version,"libpng ",MaxTextExtent);
+-      (void) strlcat(version,PNG_LIBPNG_VER_STRING,MaxTextExtent);
++      (void) strlcat(version,"libpng ",sizeof(version));
++      (void) strlcat(version,PNG_LIBPNG_VER_STRING,sizeof(version));
+ #if (PNG_LIBPNG_VER > 10005)
+       if (LocaleCompare(PNG_LIBPNG_VER_STRING,png_get_header_ver(NULL)) != 0)
+         {
+-          (void) strlcat(version,",",MaxTextExtent);
+-          (void) strlcat(version,png_get_libpng_ver(NULL),MaxTextExtent);
++          (void) strlcat(version,",",sizeof(version));
++          (void) strlcat(version,png_get_libpng_ver(NULL),sizeof(version));
+         }
+ #endif
+ #endif
+ 
+ #if defined(ZLIB_VERSION)
+       if (*version != '\0')
+-        (void) strlcat(version,", ",MaxTextExtent);
+-      (void) strlcat(version,"zlib ",MaxTextExtent);
+-      (void) strlcat(version,ZLIB_VERSION,MaxTextExtent);
++        (void) strlcat(version,", ",sizeof(version));
++      (void) strlcat(version,"zlib ",sizeof(version));
++      (void) strlcat(version,ZLIB_VERSION,sizeof(version));
+       if (LocaleCompare(ZLIB_VERSION,zlib_version) != 0)
+         {
+-          (void) strlcat(version,",",MaxTextExtent);
+-          (void) strlcat(version,zlib_version,MaxTextExtent);
++          (void) strlcat(version,",",sizeof(version));
++          (void) strlcat(version,zlib_version,sizeof(version));
+         }
+ #endif

--- a/pkgs/applications/graphics/graphicsmagick/default.nix
+++ b/pkgs/applications/graphics/graphicsmagick/default.nix
@@ -4,15 +4,16 @@
 
 stdenv.mkDerivation rec {
   name = "graphicsmagick-${version}";
-  version = "1.3.31";
+  version = "1.3.32";
 
   src = fetchurl {
     url = "mirror://sourceforge/graphicsmagick/GraphicsMagick-${version}.tar.xz";
-    sha256 = "0y22740f25qxsqqqg26xqlfp920dm57b7hrgaqmx7azksrcvnsq9";
+    sha256 = "1qclp9i31idpcbbqswmnq2q11lmv0a7cvdb1y72xcky8sshaahmq";
   };
 
   patches = [
     ./disable-popen.patch
+    ./1.3.32-darwin-png-strlcat-fix.patch
   ];
 
   configureFlags = [


### PR DESCRIPTION
###### Motivation for this change
Backport of #64380

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
