### PR TITLE
vscode-extensions.ms-vscode.cpptools: 0.23.1 -> 0.24.0

### DIFF
--- a/pkgs/misc/vscode-extensions/cpptools/default.nix
+++ b/pkgs/misc/vscode-extensions/cpptools/default.nix
@@ -1,4 +1,7 @@
-{ stdenv, fetchzip, vscode-utils, jq, mono, clang-tools, writeScript, runtimeShell
+{ stdenv, vscode-utils
+, fetchurl, unzip
+, mono, writeScript, runtimeShell
+, jq, clang-tools
 , gdbUseFixed ? true, gdb # The gdb default setting will be fixed to specified. Use version from `PATH` otherwise.
 }:
 
@@ -30,25 +33,37 @@ assert gdbUseFixed -> null != gdb;
 let
   gdbDefaultsTo = if gdbUseFixed then "${gdb}/bin/gdb" else "gdb";
 
-  langComponentBinaries = stdenv.mkDerivation {
+  langComponentBinaries = stdenv.mkDerivation rec {
     name = "cpptools-language-component-binaries";
 
-    src = fetchzip {
+    src = fetchurl {
       # Follow https://go.microsoft.com/fwlink/?linkid=2037608
-      url = "https://download.visualstudio.microsoft.com/download/pr/97ed3eeb-b31e-421c-92dc-4f3a98af301e/069a1e6ab1b4b017853a7e9e08067744/bin_linux.zip";
-      sha256 = "19flm4vcrg89x0b20bd0g45apabzfqgvcpjddnmyk312jc242gmb";
+      url = "https://download.visualstudio.microsoft.com/download/pr/fd05d7fd-b771-4746-9c54-b5b30afcd82e/1f443716d6156a265bf50cb6e53fa999/bin_linux.zip";
+      sha256 = "198xnq709clibjmd8rrv0haniy2m3qvhn89hg9hpj6lvg9lsr7a4";
     };
 
-    patchPhase = ''
-      elfInterpreter="${stdenv.glibc.out}/lib/ld-linux-x86-64.so.2"
-      patchelf --set-interpreter "$elfInterpreter" ./Microsoft.VSCode.CPP.Extension.linux
-      patchelf --set-interpreter "$elfInterpreter" ./Microsoft.VSCode.CPP.IntelliSense.Msvc.linux
-      chmod a+x ./Microsoft.VSCode.CPP.Extension.linux ./Microsoft.VSCode.CPP.IntelliSense.Msvc.linux
+    sourceRoot = name;
+
+    nativeBuildInputs = [ unzip ];
+
+    unpackPhase = ''
+      runHook preUnpack
+      unzip -d $name $src || true
+      runHook postUnpack
     '';
 
     installPhase = ''
+      runHook preInstall
       mkdir -p "$out/bin"
-      find . -mindepth 1 -maxdepth 1 | xargs cp -a -t "$out/bin"
+      cp -a -t "$out/bin" ./bin/*
+      runHook postInstall
+    '';
+
+    postFixup = ''
+      elfInterpreter="$(cat $NIX_CC/nix-support/dynamic-linker)"
+      patchelf --set-interpreter "$elfInterpreter" $out/bin/Microsoft.VSCode.CPP.Extension.linux
+      patchelf --set-interpreter "$elfInterpreter" $out/bin/Microsoft.VSCode.CPP.IntelliSense.Msvc.linux
+      chmod a+x $out/bin/Microsoft.VSCode.CPP.Extension.linux $out/bin/Microsoft.VSCode.CPP.IntelliSense.Msvc.linux
     '';
   };
 
@@ -68,8 +83,8 @@ vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     name = "cpptools";
     publisher = "ms-vscode";
-    version = "0.23.1";
-    sha256 = "08kfzvyl8vgjmhqzpp7pxw0gd87jr5g7z15ag4cpcil4inq4c8k3";
+    version = "0.24.0";
+    sha256 = "0b0rwj3aadd4kf561zpzv95r96dqvhkn7db8d7rz3naaqydz0z8i";
   };
 
   buildInputs = [
@@ -80,15 +95,11 @@ vscode-utils.buildVscodeMarketplaceExtension {
     mv ./package.json ./package_ori.json
 
     # 1. Add activation events so that the extension is functional. This listing is empty when unpacking the extension but is filled at runtime.
-    # 2. Patch `packages.json` so that nix's *gdb* is used as default value for `miDebuggerPath`.
+    # 2. Patch `package.json` so that nix's *gdb* is used as default value for `miDebuggerPath`.
     cat ./package_ori.json | \
       jq --slurpfile actEvts ${./package-activation-events.json} '(.activationEvents) = $actEvts[0]' | \
       jq '(.contributes.debuggers[].configurationAttributes | .attach , .launch | .properties.miDebuggerPath | select(. != null) | select(.default == "/usr/bin/gdb") | .default) = "${gdbDefaultsTo}"' > \
       ./package.json
-
-    # Patch `packages.json` so that nix's *gdb* is used as default value for `miDebuggerPath`.
-    substituteInPlace "./package.json" \
-      --replace "\"default\": \"/usr/bin/gdb\"" "\"default\": \"${gdbDefaultsTo}\""
 
     # Prevent download/install of extensions
     touch "./install.lock"


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
