### PR TITLE
pythonPackages.deap: 1.2.2 -> 1.3.0

### DIFF
--- a/pkgs/development/python-modules/deap/default.nix
+++ b/pkgs/development/python-modules/deap/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "deap";
-  version = "1.2.2";
+  version = "1.3.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "95c63e66d755ec206c80fdb2908851c0bef420ee8651ad7be4f0578e9e909bcf";
+    sha256 = "102r11pxb36xkq5bjv1lpkss77v278f5xdv6lvkbjdvqryydf3yd";
   };
 
   propagatedBuildInputs = [ numpy matplotlib ];
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "DEAP is a novel evolutionary computation framework for rapid prototyping and testing of ideas.";
-    homepage = https://github.com/DEAP/deap;
+    homepage = "https://github.com/DEAP/deap";
     license = licenses.lgpl3;
     maintainers = with maintainers; [ psyanticy ];
   };

--- a/pkgs/development/python-modules/sklearn-deap/default.nix
+++ b/pkgs/development/python-modules/sklearn-deap/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchFromGitHub, numpy, scipy, deap, scikitlearn, python }:
+{ stdenv, buildPythonPackage, fetchFromGitHub, numpy, scipy, deap, scikitlearn, python, isPy3k }:
 
 buildPythonPackage rec {
   pname = "sklearn-deap";
@@ -23,6 +23,7 @@ buildPythonPackage rec {
     homepage = https://github.com/rsteca/sklearn-deap;
     license = licenses.lgpl3;
     maintainers = with maintainers; [ psyanticy ];
+    broken = isPy3k; # https://github.com/rsteca/sklearn-deap/issues/65
   };
 }
 


### PR DESCRIPTION
###### Motivation for this change
Just going through repology at this point and updating packages.

marked sklearn-deap as broken due to https://github.com/rsteca/sklearn-deap/issues/65

pythonPackages.sklearn-deap still works because we fix it at the last supported version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
