### PR TITLE
pythonPackages.flask-caching: 1.4.0 -> 1.7.2

### DIFF
--- a/pkgs/development/python-modules/flask-caching/default.nix
+++ b/pkgs/development/python-modules/flask-caching/default.nix
@@ -1,28 +1,26 @@
-{ lib, buildPythonPackage, fetchPypi, flask, pytest, pytestcov }:
+{ lib, buildPythonPackage, fetchPypi, flask, pytest, pytestcov, pytest-xprocess }:
 
 buildPythonPackage rec {
   pname = "Flask-Caching";
-  version = "1.4.0";
+  version = "1.7.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "e34f24631ba240e09fe6241e1bf652863e0cff06a1a94598e23be526bc2e4985";
+    sha256 = "17jnnmnpdflv120yhsfbnpick06iias6f2hcxmf1mi1nr35kdqjj";
   };
 
   propagatedBuildInputs = [ flask ];
 
-  checkInputs = [ pytest pytestcov ];
+  checkInputs = [ pytest pytestcov pytest-xprocess ];
 
+  # backend_cache relies on pytest-cache, which is a stale package from 2013
   checkPhase = ''
-    py.test
+    pytest -k 'not backend_cache'
   '';
-
-  # https://github.com/sh4nks/flask-caching/pull/74
-  doCheck = false;
 
   meta = with lib; {
     description = "Adds caching support to your Flask application";
-    homepage = https://github.com/sh4nks/flask-caching;
+    homepage = "https://github.com/sh4nks/flask-caching";
     license = licenses.bsd3;
   };
 }

--- a/pkgs/development/python-modules/pytest-xprocess/default.nix
+++ b/pkgs/development/python-modules/pytest-xprocess/default.nix
@@ -1,0 +1,32 @@
+{ lib, buildPythonPackage, fetchPypi
+, psutil
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-xprocess";
+  version = "0.12.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "06w2acg0shy0vxrmnxpqclimhgfjys5ql5kmmzr7r1lai46x1q2h";
+  };
+
+  propagatedBuildInputs = [ psutil pytest ];
+
+  # Remove test QoL package from install_requires
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "'pytest-cache', " ""
+  '';
+
+  # There's no tests in repo
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Pytest external process plugin";
+    homepage = "https://github.com/pytest-dev";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -855,6 +855,8 @@ in {
 
   pytest-tornado = callPackage ../development/python-modules/pytest-tornado { };
 
+  pytest-xprocess = callPackage ../development/python-modules/pytest-xprocess { };
+
   python-binance = callPackage ../development/python-modules/python-binance { };
 
   python-dbusmock = callPackage ../development/python-modules/python-dbusmock { };


### PR DESCRIPTION
###### Motivation for this change
Just updating packages from repology

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

```
[21 built, 213 copied (153.3 MiB), 27.8 MiB DL]
https://github.com/NixOS/nixpkgs/pull/64435
24 package were build:
buku papis python27Packages.azure-cli-core python27Packages.flask-caching python27Packages.flask-common python27Packages.graphite_api python27Packages.habanero python27Packages.httpbin python27Packages.influxgraph python27Packages.knack python27Packages.pytest-httpbin python27Packages.pytest-xprocess python27Packages.vcrpy python37Packages.azure-cli-core python37Packages.flask-caching python37Packages.flask-common python37Packages.graphite_api python37Packages.habanero python37Packages.httpbin python37Packages.influxgraph python37Packages.knack python37Packages.pytest-httpbin python37Packages.pytest-xprocess python37Packages.vcrpy
```