### PR TITLE
pythonPackages.msrest: 0.6.7 -> 0.6.8

### DIFF
--- a/pkgs/development/python-modules/msrest/default.nix
+++ b/pkgs/development/python-modules/msrest/default.nix
@@ -18,12 +18,12 @@
 }:
 
 buildPythonPackage rec {
-  version = "0.6.7";
+  version = "0.6.8";
   pname = "msrest";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "07136g3j7zgcvkxki4v6q1p2dm1nzzc28181s8dwic0y4ml8qlq5";
+    sha256 = "0yd43fnmfxkvk3idkyn67ziwjgkwkn261kicr3szjibpqjqcpsf9";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
Noticed it was out of date.

Bug fixes fro serialization with python2 when payloads contain UTF8.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

$ nix path-info -Sh ./result
/nix/store/37i3jk9xgq7lbazvnwx8d86gqrz07klj-python2.7-msrest-0.6.8       107.1M

```
$ nix-review wip
...
[22 built, 58 copied (179.0 MiB), 31.1 MiB DL]
17 package were build:
nixops_1_6_1 python27Packages.azure-cli-core python27Packages.azure-mgmt-common python27Packages.azure-mgmt-compute python27Packages.azure-mgmt-network python27Packages.azure-mgmt-resource python27Packages.azure-mgmt-storage python27Packages.msrest python27Packages.msrestazure python37Packages.azure-cli-core python37Packages.azure-mgmt-common python37Packages.azure-mgmt-compute python37Packages.azure-mgmt-network python37Packages.azure-mgmt-resource python37Packages.azure-mgmt-storage python37Packages.msrest python37Packages.msrestazure
```