### PR TITLE
opera: 60.0.3255.170 -> 62.0.3331.43

### DIFF
--- a/pkgs/applications/networking/browsers/opera/default.nix
+++ b/pkgs/applications/networking/browsers/opera/default.nix
@@ -13,6 +13,7 @@
 , glib
 , gnome2
 , gtk3
+, lib
 , libX11
 , libxcb
 , libXScrnSaver
@@ -39,10 +40,9 @@
 
 let
 
-  mirror = https://get.geo.opera.com/pub/opera/desktop;
-  version = "60.0.3255.170";
+  mirror = "https://get.geo.opera.com/pub/opera/desktop";
 
-  rpath = stdenv.lib.makeLibraryPath [
+  rpath = lib.makeLibraryPath [
 
     # These provide shared libraries loaded when starting. If one is missing,
     # an error is shown in stderr.
@@ -90,13 +90,14 @@ let
     at-spi2-core
   ];
 
-in stdenv.mkDerivation {
+in stdenv.mkDerivation rec {
 
-  name = "opera-${version}";
+  pname = "opera";
+  version = "62.0.3331.43";
 
   src = fetchurl {
-    url = "${mirror}/${version}/linux/opera-stable_${version}_amd64.deb";
-    sha256 = "04bcy9qhrhps3712k229yn58ak2j93wcp613zd6l2zxb8a286991";
+    url = "${mirror}/${version}/linux/${pname}-stable_${version}_amd64.deb";
+    sha256 = "0zylg32zn6blkgy4bwmjzc26i712lwakahvrd24ncpfa8805f7x7";
   };
 
   unpackCmd = "${dpkg}/bin/dpkg-deb -x $curSrc .";
@@ -118,10 +119,10 @@ in stdenv.mkDerivation {
       done
   '';
 
-  meta = {
-    homepage = https://www.opera.com;
+  meta = with lib; {
+    homepage = "https://www.opera.com";
     description = "Web browser";
     platforms = [ "x86_64-linux" ];
-    license = stdenv.lib.licenses.unfree;
+    license = licenses.unfree;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update `opera` to the latest release.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
@GrahamcOfBorg build opera