### PR TITLE
mpv: fix drm and vulkan support

### DIFF
--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -24,12 +24,15 @@
   , vulkan-headers ? null
   , vulkan-loader ? null
 
+, drmSupport ? stdenv.isLinux
+  , libdrm ? null
+  , mesa   ? null
+
 , alsaSupport        ? stdenv.isLinux, alsaLib       ? null
 , bluraySupport      ? true,           libbluray     ? null
 , bs2bSupport        ? true,           libbs2b       ? null
 , cacaSupport        ? true,           libcaca       ? null
 , cmsSupport         ? true,           lcms2         ? null
-, drmSupport         ? stdenv.isLinux, libdrm        ? null
 , dvdnavSupport      ? stdenv.isLinux, libdvdnav     ? null
 , dvdreadSupport     ? stdenv.isLinux, libdvdread    ? null
 , libpngSupport      ? true,           libpng        ? null
@@ -62,7 +65,7 @@ assert bs2bSupport        -> available libbs2b;
 assert cacaSupport        -> available libcaca;
 assert cddaSupport        -> all available [libcdio libcdio-paranoia];
 assert cmsSupport         -> available lcms2;
-assert drmSupport         -> available libdrm;
+assert drmSupport         -> all available [ libdrm mesa ];
 assert dvdnavSupport      -> available libdvdnav;
 assert dvdreadSupport     -> available libdvdread;
 assert jackaudioSupport   -> available libjack2;
@@ -148,7 +151,6 @@ in stdenv.mkDerivation rec {
     ++ optional bs2bSupport        libbs2b
     ++ optional cacaSupport        libcaca
     ++ optional cmsSupport         lcms2
-    ++ optional drmSupport         libdrm
     ++ optional dvdreadSupport     libdvdread
     ++ optional jackaudioSupport   libjack2
     ++ optional libpngSupport      libpng
@@ -168,6 +170,7 @@ in stdenv.mkDerivation rec {
     ++ optional stdenv.isDarwin    libiconv
     ++ optional stdenv.isLinux     nv-codec-headers
     ++ optionals cddaSupport       [ libcdio libcdio-paranoia ]
+    ++ optionals drmSupport        [ libdrm mesa.dev ]
     ++ optionals dvdnavSupport     [ libdvdnav libdvdnav.libdvdread ]
     ++ optionals waylandSupport    [ wayland wayland-protocols libxkbcommon ]
     ++ optionals x11Support        [ libX11 libXext libGLU_combined libXxf86vm libXrandr ]

--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -20,9 +20,10 @@
   , libcdio-paranoia ? null
 
 , vulkanSupport ? stdenv.isLinux
-  , shaderc ? null
+  , shaderc        ? null
   , vulkan-headers ? null
-  , vulkan-loader ? null
+  , vulkan-loader  ? null
+  , libplacebo     ? null
 
 , drmSupport ? stdenv.isLinux
   , libdrm ? null
@@ -37,12 +38,12 @@
 , dvdreadSupport     ? stdenv.isLinux, libdvdread    ? null
 , libpngSupport      ? true,           libpng        ? null
 , pulseSupport       ? config.pulseaudio or stdenv.isLinux, libpulseaudio ? null
-, rubberbandSupport  ? stdenv.isLinux, rubberband ? null
+, rubberbandSupport  ? stdenv.isLinux, rubberband    ? null
 , screenSaverSupport ? true,           libXScrnSaver ? null
 , sdl2Support        ? true,           SDL2          ? null
 , speexSupport       ? true,           speex         ? null
 , theoraSupport      ? true,           libtheora     ? null
-, vaapiSupport       ? stdenv.isLinux, libva ? null
+, vaapiSupport       ? stdenv.isLinux, libva         ? null
 , vdpauSupport       ? true,           libvdpau      ? null
 , xineramaSupport    ? stdenv.isLinux, libXinerama   ? null
 , xvSupport          ? stdenv.isLinux, libXv         ? null
@@ -95,16 +96,16 @@ let
              "http://www.freehackers.org/~tnagy/release/waf-${wafVersion}" ];
     sha256 = "0j7sbn3w6bgslvwwh5v9527w3gi2sd08kskrgxamx693y0b0i3ia";
   };
-  luaEnv = lua.withPackages(ps: with ps; [ luasocket ]);
+  luaEnv = lua.withPackages (ps: with ps; [ luasocket ]);
 
 in stdenv.mkDerivation rec {
-  name = "mpv-${version}";
+  pname = "mpv";
   version = "0.29.1";
 
   src = fetchFromGitHub {
     owner = "mpv-player";
-    repo  = "mpv";
-    rev    = "v${version}";
+    repo = "mpv";
+    rev = "v${version}";
     sha256 = "138921kx8g6qprim558xin09xximjhsj9ss8b71ifg2m6kclym8m";
   };
 
@@ -174,7 +175,7 @@ in stdenv.mkDerivation rec {
     ++ optionals dvdnavSupport     [ libdvdnav libdvdnav.libdvdread ]
     ++ optionals waylandSupport    [ wayland wayland-protocols libxkbcommon ]
     ++ optionals x11Support        [ libX11 libXext libGLU_combined libXxf86vm libXrandr ]
-    ++ optionals vulkanSupport     [ shaderc vulkan-headers vulkan-loader ]
+    ++ optionals vulkanSupport     [ shaderc vulkan-headers vulkan-loader libplacebo ]
     ++ optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
       CoreFoundation Cocoa CoreAudio
     ]);

--- a/pkgs/development/libraries/libplacebo/default.nix
+++ b/pkgs/development/libraries/libplacebo/default.nix
@@ -1,0 +1,46 @@
+{ stdenv
+, fetchFromGitLab
+, meson
+, ninja
+, pkgconfig
+, vulkan-headers
+, vulkan-loader
+, shaderc
+, glslang
+, lcms2
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libplacebo";
+  version = "1.18.0";
+
+  src = fetchFromGitLab {
+    domain = "code.videolan.org";
+    owner = "videolan";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0ib12i2491piwiz0g5n5izr5jmn5fhwzicq97vfki3r7wrdb54mz";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkgconfig
+  ];
+
+  buildInputs = [
+    vulkan-headers
+    vulkan-loader
+    shaderc
+    glslang
+    lcms2
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Reusable library for GPU-accelerated video/image rendering primitives";
+    homepage = "https://code.videolan.org/videolan/libplacebo";
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ tadeokondrak ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11955,6 +11955,8 @@ in
 
   libphonenumber = callPackage ../development/libraries/libphonenumber { };
 
+  libplacebo = callPackage ../development/libraries/libplacebo { };
+
   libpng = callPackage ../development/libraries/libpng { };
   libpng_apng = libpng.override { apngSupport = true; };
   libpng12 = callPackage ../development/libraries/libpng/12.nix { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Noticed my Vulkan settings in my mpv config weren't doing anything

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
Can someone on Darwin test to see if libplacebo builds on it, and if not, if removing a dependency would fix it (all are optional)?

I was originally going to add libplacebo as only a vulkan dependency (it's required for it), but mpv uses it for more than just vulkan.