### PR TITLE
rofi: 1.5.3 -> 1.5.4

### DIFF
--- a/pkgs/applications/misc/rofi/default.nix
+++ b/pkgs/applications/misc/rofi/default.nix
@@ -1,15 +1,16 @@
-{ stdenv, fetchurl, autoreconfHook, pkgconfig, libxkbcommon, pango, which, git
+{ stdenv, lib, fetchurl
+, autoreconfHook, pkgconfig, libxkbcommon, pango, which, git
 , cairo, libxcb, xcbutil, xcbutilwm, xcbutilxrm, libstartup_notification
 , bison, flex, librsvg, check
 }:
 
 stdenv.mkDerivation rec {
-  version = "1.5.3";
-  name = "rofi-unwrapped-${version}";
+  pname = "rofi-unwrapped";
+  version = "1.5.4";
 
   src = fetchurl {
-    url = "https://github.com/DaveDavenport/rofi/releases/download/${version}/rofi-${version}.tar.gz";
-    sha256 = "1mskknfnpgmaghplwcyc44qc8swb1f9qiyi67fz9i77jijjpj1lx";
+    url = "https://github.com/davatorium/rofi/releases/download/${version}/rofi-${version}.tar.gz";
+    sha256 = "1g1170zmh5v7slnm1sm2d08jgz6icikf8rm17apm1bjzzyw1lhk7";
   };
 
   preConfigure = ''
@@ -22,11 +23,12 @@ stdenv.mkDerivation rec {
   buildInputs = [ libxkbcommon pango cairo git bison flex librsvg check
     libstartup_notification libxcb xcbutil xcbutilwm xcbutilxrm which
   ];
+
   doCheck = false;
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Window switcher, run dialog and dmenu replacement";
-    homepage = https://github.com/davatorium/rofi;
+    homepage = "https://github.com/davatorium/rofi";
     license = licenses.mit;
     maintainers = with maintainers; [ mbakke ma27 ];
     platforms = with platforms; linux;

--- a/pkgs/applications/misc/rofi/wrapper.nix
+++ b/pkgs/applications/misc/rofi/wrapper.nix
@@ -2,7 +2,9 @@
 
 if theme == null then rofi-unwrapped else
 stdenv.mkDerivation {
-  name = "rofi-${rofi-unwrapped.version}";
+  pname = "rofi";
+  version = rofi-unwrapped.version;
+
   buildInputs = [ makeWrapper ];
   preferLocalBuild = true;
   passthru.unwrapped = rofi-unwrapped;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update `rofi` to the latest release.
- https://github.com/davatorium/rofi/releases/tag/1.5.4

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
