### PR TITLE
[WIP]nixos/firejail:added program.firejail.firecfg option

### DIFF
--- a/nixos/modules/programs/firejail.nix
+++ b/nixos/modules/programs/firejail.nix
@@ -22,7 +22,6 @@ let
   };
 
 in {
-  disabledModules=[<nixpkgs/nixos/modules/programs/firejail.nix>];
   options.programs.firejail = {
     enable = mkEnableOption "firejail";
 

--- a/nixos/modules/programs/firejail.nix
+++ b/nixos/modules/programs/firejail.nix
@@ -22,6 +22,7 @@ let
   };
 
 in {
+  disabledModules=[<nixpkgs/nixos/modules/programs/firejail.nix>];
   options.programs.firejail = {
     enable = mkEnableOption "firejail";
 
@@ -49,9 +50,8 @@ in {
     environment.systemPackages = [ wrappedBins ] ++ optional cfg.firecfg fj;
 
     environment.extraSetup = optionalString cfg.firecfg ''
-      mkdir tmp
-      cp -r $out tmp
-      chroot tmp firecfg
+      SUDO_USER= #TODO:username of the current builder
+      ${fj}/bin/firecfg --bindir=$out
     '';
   };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
The firecfg program already knows how to wrap the correct comands and desktop files

###### Things done
Still work in progress
```
nixos-rebuild build -I nixpkgs=.                                            
building Nix...
building the system configuration...
these derivations will be built:
  /nix/store/j69786fjsxpgv8lbfcck72ar2lgppar1-system-path.drv
  /nix/store/c0496dynbfbjnhwvg8gnk1v5565s7spp-dbus-1.drv
  /nix/store/q6nk3hx6jilcyrqfzkxlirw9x5y8r433-unit-dbus.service.drv
  /nix/store/j86vgqzw8vlr7cqg2j79shczprxl2w68-user-units.drv
  /nix/store/9saqvr99mcbg2s1z8ppcjzfa53b7827z-unit-dbus.service.drv
  /nix/store/d9s25xipg5cszpm2dqzmm44n72ybjnvp-unit-polkit.service.drv
  /nix/store/v1dhqmyk7vpjwf96pwzzg2bc98kckgfr-unit-systemd-fsck-.service.drv
  /nix/store/n7i2b9bgbr50ns9g31dn746wjlsl5qh6-system-units.drv
  /nix/store/v5pl243kw0by169dd0cslgq56p6wy2w8-etc.drv
  /nix/store/561i4mbfabqrlr3ylc813zpz0pqnnd95-nixos-system-nixos-19.09.git.9cc8f88.drv
building '/nix/store/j69786fjsxpgv8lbfcck72ar2lgppar1-system-path.drv'...
created 6818 symlinks in user environment
cp: -r not specified; omitting directory '/nix/store/9p6z02r5bmkzqz87fkbh0llj3iwdynrr-system-path'
builder for '/nix/store/j69786fjsxpgv8lbfcck72ar2lgppar1-system-path.drv' failed with exit code 1
cannot build derivation '/nix/store/c0496dynbfbjnhwvg8gnk1v5565s7spp-dbus-1.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/d9s25xipg5cszpm2dqzmm44n72ybjnvp-unit-polkit.service.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/v1dhqmyk7vpjwf96pwzzg2bc98kckgfr-unit-systemd-fsck-.service.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/9saqvr99mcbg2s1z8ppcjzfa53b7827z-unit-dbus.service.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/q6nk3hx6jilcyrqfzkxlirw9x5y8r433-unit-dbus.service.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/n7i2b9bgbr50ns9g31dn746wjlsl5qh6-system-units.drv': 3 dependencies couldn't be built
cannot build derivation '/nix/store/j86vgqzw8vlr7cqg2j79shczprxl2w68-user-units.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/v5pl243kw0by169dd0cslgq56p6wy2w8-etc.drv': 4 dependencies couldn't be built
cannot build derivation '/nix/store/561i4mbfabqrlr3ylc813zpz0pqnnd95-nixos-system-nixos-19.09.git.9cc8f88.drv': 2 dependencies couldn't be built
error: build of '/nix/store/561i4mbfabqrlr3ylc813zpz0pqnnd95-nixos-system-nixos-19.09.git.9cc8f88.drv' failed
```
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
