### PR TITLE
nixos/run:Added boot.runOnTmpfs option

### DIFF
--- a/nixos/modules/system/boot/run.nix
+++ b/nixos/modules/system/boot/run.nix
@@ -1,0 +1,41 @@
+{ config, lib, ... }:
+
+with lib;
+
+{
+
+  ###### interface
+
+  options = {
+
+    #TODO:investigate how not to break /run/current-system
+    # boot.cleanRunDir = mkOption {
+    #   type = types.bool;
+    #   default = false;
+    #   description = ''
+    #     Whether to delete all files in <filename>/run</filename> during boot.
+    #   '';
+    # };
+    boot.runOnTmpfs = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+         Whether to mount a tmpfs on <filename>/run</filename> during boot.
+      '';
+    };
+
+  };
+
+  ###### implementation
+
+  config = {
+
+    fileSystems."/run" = mkIf config.boot.runOnTmpfs {
+      fsType="tmpfs";
+    };
+
+    # systemd.tmpfiles.rules = optional config.boot.cleanRunDir "D! /run 1777 root root";
+
+  };
+
+}


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Because if ArchLinux can have `/run` on tmpfs,why can't we?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
