### PR TITLE
cdrtools: fix for darwin

### DIFF
--- a/pkgs/applications/misc/cdrtools/default.nix
+++ b/pkgs/applications/misc/cdrtools/default.nix
@@ -11,9 +11,7 @@ stdenv.mkDerivation rec {
 
   patches = [ ./fix-paths.patch ];
 
-  buildInputs =
-    stdenv.lib.optionals (!stdenv.isDarwin) [ acl libcap ]
-    ++ stdenv.lib.optionals stdenv.isDarwin [ Carbon IOKit ];
+  buildInputs = if stdenv.isDarwin then [ Carbon IOKit ] else [ acl libcap ];
 
   postPatch = ''
     sed "/\.mk3/d" -i libschily/Targets.man

--- a/pkgs/applications/misc/cdrtools/default.nix
+++ b/pkgs/applications/misc/cdrtools/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, acl, libcap }:
+{ stdenv, fetchurl, acl, libcap, Carbon, IOKit }:
 
 stdenv.mkDerivation rec {
   name = "cdrtools-${version}";
@@ -11,7 +11,9 @@ stdenv.mkDerivation rec {
 
   patches = [ ./fix-paths.patch ];
 
-  buildInputs = [ acl libcap ];
+  buildInputs =
+    stdenv.lib.optionals (!stdenv.isDarwin) [ acl libcap ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ Carbon IOKit ];
 
   postPatch = ''
     sed "/\.mk3/d" -i libschily/Targets.man
@@ -28,7 +30,7 @@ stdenv.mkDerivation rec {
     homepage = https://sourceforge.net/projects/cdrtools/;
     description = "Highly portable CD/DVD/BluRay command line recording software";
     license = with licenses; [ gpl2 lgpl2 cddl ];
-    platforms = platforms.linux;
+    platforms = with platforms; linux ++ darwin;
     # Licensing issues: This package contains code licensed under CDDL, GPL2
     # and LGPL2. There is a debate regarding the legality of distributing this
     # package in binary form.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17175,7 +17175,9 @@ in
     inherit (darwin.apple_sdk.frameworks) Carbon;
   };
 
-  cdrtools = callPackage ../applications/misc/cdrtools { };
+  cdrtools = callPackage ../applications/misc/cdrtools {
+    inherit (darwin.apple_sdk.frameworks) Carbon IOKit;
+  };
 
   centerim = callPackage ../applications/networking/instant-messengers/centerim { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Updated `cdrtools` to compile on darwin. Some recent change to macOS frameworks in nix must have fixed this since I used to not be able to build this at all ( closes #60357 )

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
