### PR TITLE
pydot_ng: fix graphviz path and tests (fixes #64461)

### DIFF
--- a/pkgs/development/python-modules/pydot_ng/0001-graphviz_path.patch
+++ b/pkgs/development/python-modules/pydot_ng/0001-graphviz_path.patch
@@ -1,0 +1,130 @@
+diff --git a/pydot_ng/__init__.py b/pydot_ng/__init__.py
+index 70fc198..162d276 100644
+--- a/pydot_ng/__init__.py
++++ b/pydot_ng/__init__.py
+@@ -478,122 +478,9 @@ def find_graphviz():
+     If this fails, it returns None.
+     """
+ 
+-    # Method 1 (Windows only)
+-    if os.sys.platform == 'win32':
+-
+-        HKEY_LOCAL_MACHINE = 0x80000002
+-        KEY_QUERY_VALUE = 0x0001
+-
+-        RegOpenKeyEx = None
+-        RegQueryValueEx = None
+-        RegCloseKey = None
+-
+-        try:
+-            import win32api
+-            RegOpenKeyEx = win32api.RegOpenKeyEx
+-            RegQueryValueEx = win32api.RegQueryValueEx
+-            RegCloseKey = win32api.RegCloseKey
+-
+-        except ImportError:
+-            # Print a messaged suggesting they install these?
+-            pass
+-
+-        try:
+-            import ctypes
+-
+-            def RegOpenKeyEx(key, subkey, opt, sam):
+-                result = ctypes.c_uint(0)
+-                ctypes.windll.advapi32.RegOpenKeyExA(key, subkey, opt, sam,
+-                                                     ctypes.byref(result))
+-                return result.value
+-
+-            def RegQueryValueEx(hkey, valuename):
+-                data_type = ctypes.c_uint(0)
+-                data_len = ctypes.c_uint(1024)
+-                data = ctypes.create_string_buffer(1024)
+-
+-                # this has a return value, which we should probably check
+-                ctypes.windll.advapi32.RegQueryValueExA(
+-                    hkey, valuename, 0, ctypes.byref(data_type),
+-                    data, ctypes.byref(data_len))
+-
+-                return data.value
+-
+-            RegCloseKey = ctypes.windll.advapi32.RegCloseKey
+-
+-        except ImportError:
+-            # Print a messaged suggesting they install these?
+-            pass
+-
+-        if RegOpenKeyEx is not None:
+-            # Get the GraphViz install path from the registry
+-            hkey = None
+-            potentialKeys = [
+-                "SOFTWARE\\ATT\\Graphviz",
+-                "SOFTWARE\\AT&T Research Labs\\Graphviz"]
+-            for potentialKey in potentialKeys:
+-
+-                try:
+-                    hkey = RegOpenKeyEx(
+-                        HKEY_LOCAL_MACHINE,
+-                        potentialKey, 0, KEY_QUERY_VALUE)
+-
+-                    if hkey is not None:
+-                        path = RegQueryValueEx(hkey, "InstallPath")
+-                        RegCloseKey(hkey)
+-
+-                        # The regitry variable might exist, left by
+-                        # old installations but with no value, in those cases
+-                        # we keep searching...
+-                        if not path:
+-                            continue
+-
+-                        # Now append the "bin" subdirectory:
+-                        path = os.path.join(path, "bin")
+-                        progs = __find_executables(path)
+-                        if progs is not None:
+-                            return progs
+-
+-                except Exception:
+-                    pass
+-                else:
+-                    break
+-
+-    # Method 2 (Linux, Windows etc)
+-    if 'PATH' in os.environ:
+-        for path in os.environ['PATH'].split(os.pathsep):
+-            progs = __find_executables(path)
+-            if progs is not None:
+-                return progs
+-
+-    # Method 3 (Windows only)
+-    if os.sys.platform == 'win32':
+-
+-        # Try and work out the equivalent of "C:\Program Files" on this
+-        # machine (might be on drive D:, or in a different language)
+-        if 'PROGRAMFILES' in os.environ:
+-            # Note, we could also use the win32api to get this
+-            # information, but win32api may not be installed.
+-            path = os.path.join(os.environ['PROGRAMFILES'], 'ATT',
+-                                'GraphViz', 'bin')
+-        else:
+-            # Just in case, try the default...
+-            path = r"C:\Program Files\att\Graphviz\bin"
+-
+-        progs = __find_executables(path)
+-
+-        if progs is not None:
+-            return progs
+-
+-    for path in (
+-            '/usr/bin', '/usr/local/bin',
+-            '/opt/local/bin',
+-            '/opt/bin', '/sw/bin', '/usr/share',
+-            '/Applications/Graphviz.app/Contents/MacOS/'):
+-
+-        progs = __find_executables(path)
+-        if progs is not None:
+-            return progs
++    progs = __find_executables(NIX_GRAPHVIZ_PATH)
++    if progs is not None:
++        return progs
+ 
+     # Failed to find GraphViz
+     return None

--- a/pkgs/development/python-modules/pydot_ng/0001-graphviz_path.patch
+++ b/pkgs/development/python-modules/pydot_ng/0001-graphviz_path.patch
@@ -122,7 +122,7 @@ index 70fc198..162d276 100644
 -        progs = __find_executables(path)
 -        if progs is not None:
 -            return progs
-+    progs = __find_executables(NIX_GRAPHVIZ_PATH)
++    progs = __find_executables(@graphviz@)
 +    if progs is not None:
 +        return progs
  

--- a/pkgs/development/python-modules/pydot_ng/default.nix
+++ b/pkgs/development/python-modules/pydot_ng/default.nix
@@ -5,6 +5,7 @@
 , pytest
 , unittest2
 , pkgs
+, mock
 }:
 
 buildPythonPackage rec {
@@ -16,13 +17,18 @@ buildPythonPackage rec {
     sha256 = "8c8073b97aa7030c28118961e2c6c92f046e4cb57aeba7df87146f7baa6530c5";
   };
 
-  buildInputs = [ pytest unittest2 ];
+  patches = [ ./0001-graphviz_path.patch ];
+
+  postPatch =
+    ''
+    substituteInPlace pydot_ng/__init__.py \
+      --replace "NIX_GRAPHVIZ_PATH" "'${pkgs.graphviz}/bin'"
+    '';
+
+  checkInputs = [ pytest unittest2 mock ];
   propagatedBuildInputs = [ pkgs.graphviz pyparsing ];
 
-  checkPhase = ''
-    mkdir test/my_tests
-    py.test test
-  '';
+  checkPhase = "py.test test";
 
   meta = with stdenv.lib; {
     homepage = "https://pypi.python.org/pypi/pydot-ng";

--- a/pkgs/development/python-modules/pydot_ng/default.nix
+++ b/pkgs/development/python-modules/pydot_ng/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
   checkInputs = [ pytest unittest2 mock ];
   propagatedBuildInputs = [ pkgs.graphviz pyparsing ];
 
-  checkPhase = "py.test test";
+  checkPhase = "pytest test";
 
   meta = with stdenv.lib; {
     homepage = "https://pypi.python.org/pypi/pydot-ng";

--- a/pkgs/development/python-modules/pydot_ng/default.nix
+++ b/pkgs/development/python-modules/pydot_ng/default.nix
@@ -17,7 +17,12 @@ buildPythonPackage rec {
     sha256 = "8c8073b97aa7030c28118961e2c6c92f046e4cb57aeba7df87146f7baa6530c5";
   };
 
-  patches = [ ./0001-graphviz_path.patch ];
+  patches = [ 
+    (substituteAll {
+      src = ./0001-graphviz_path.patch;
+      graphviz = "${pkgs.graphviz}/bin";
+    })
+  ];
 
   postPatch =
     ''

--- a/pkgs/development/python-modules/pydot_ng/default.nix
+++ b/pkgs/development/python-modules/pydot_ng/default.nix
@@ -6,6 +6,7 @@
 , unittest2
 , pkgs
 , mock
+, substituteAll
 }:
 
 buildPythonPackage rec {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
This fixes
* An `mkdir` that fails because the directory already exists, in the check phase
* A dependency on the `mock` module
* Substitution of the correct path to graphviz into the source code

The latter is done via a somewhat ugly patch. Happy to try other approaches!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
