### PR TITLE
pythonPackages.github-webhook: unstable-2016-03-11 to 1.0.2

### DIFF
--- a/pkgs/development/python-modules/github-webhook/default.nix
+++ b/pkgs/development/python-modules/github-webhook/default.nix
@@ -1,28 +1,25 @@
-{ stdenv
-, buildPythonPackage
-, fetchgit
+{ lib, buildPythonPackage, fetchPypi
 , flask
+, six
 }:
 
 buildPythonPackage rec {
   pname = "github-webhook";
-  version = "unstable-2016-03-11";
+  version = "1.0.2";
 
-  # There is a PyPI package but an older one.
-  src = fetchgit {
-    url = "https://github.com/bloomberg/python-github-webhook.git";
-    rev = "ca1855479ee59c4373da5425dbdce08567605d49";
-    sha256 = "0mqwig9281iyzbphp1d21a4pqdrf98vs9k8lqpqx6spzgqaczx5f";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "04jdf595gv97s4br0ym8izca3i6d1nfwcrpi4s26hkvn3czz84sv";
   };
 
-  propagatedBuildInputs = [ flask ];
-  # No tests
+  propagatedBuildInputs = [ flask six ];
+
+  # touches network
   doCheck = false;
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A framework for writing webhooks for GitHub";
+    homepage = "https://github.com/bloomberg/python-github-webhook";
     license = licenses.mit;
-    homepage = https://github.com/bloomberg/python-github-webhook;
   };
-
 }


### PR DESCRIPTION
###### Motivation for this change
Fixes builds for repology :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
