### PR TITLE
jetbrains.idea-community: add darwin support

### DIFF
--- a/pkgs/applications/editors/jetbrains/common.nix
+++ b/pkgs/applications/editors/jetbrains/common.nix
@@ -1,4 +1,4 @@
-{ stdenv, makeDesktopItem, makeWrapper, patchelf, p7zip
+{ stdenv, lib, makeDesktopItem, makeWrapper, patchelf, p7zip
 , coreutils, gnugrep, which, git, unzip, libsecret, libnotify
 }:
 
@@ -28,7 +28,7 @@ with stdenv; lib.makeOverridable mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper patchelf p7zip unzip ];
 
-  patchPhase = ''
+  patchPhase = lib.optionalString (!stdenv.isDarwin) ''
       get_file_size() {
         local fname="$1"
         echo $(ls -l $fname | cut -d ' ' -f5)
@@ -63,7 +63,7 @@ with stdenv; lib.makeOverridable mkDerivation rec {
     item=${desktopItem}
 
     makeWrapper "$out/$name/bin/${loName}.sh" "$out/bin/${execName}" \
-      --prefix PATH : "$out/libexec/${name}:${stdenv.lib.makeBinPath [ jdk coreutils gnugrep which git ]}" \
+      --prefix PATH : "$out/libexec/${name}:${lib.optionalString (stdenv.isDarwin) "${jdk}/jdk/Contents/Home/bin:"}${stdenv.lib.makeBinPath [ jdk coreutils gnugrep which git ]}" \
       --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [
         # Some internals want libstdc++.so.6
         stdenv.cc.cc.lib libsecret

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -134,7 +134,7 @@ let
           as IntelliJ.
         '';
         maintainers = with maintainers; [ edwtjo ];
-        platforms = platforms.linux;
+        platforms = platforms.linux ++ platforms.darwin;
       };
     });
 

--- a/pkgs/development/compilers/jetbrains-jdk/default.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/default.nix
@@ -14,6 +14,11 @@ let drv = stdenv.mkDerivation rec {
       url = "https://bintray.com/jetbrains/intellij-jdk/download_file?file_path=jbrsdk-11_0_2-linux-x64-b${version}.tar.gz";
       sha256 = "121yzgvkfx7lq0k9s8wjnhz09a564br5y7zlkxgh191sbm2i7zdi";
     }
+  else if stdenv.hostPlatform.system == "x86_64-darwin" then
+    fetchurl {
+      url = "https://bintray.com/jetbrains/intellij-jdk/download_file?file_path=jbrsdk-11_0_2-osx-x64-b${version}.tar.gz";
+      sha256 = "1ly6kf59knvzbr2pjkc9fqyzfs28pdvnqg5pfffr8zp14xm44zmd";
+    }
   else
     throw "unsupported system: ${stdenv.hostPlatform.system}";
 
@@ -28,20 +33,20 @@ let drv = stdenv.mkDerivation rec {
     jrePath=$out/jre
   '';
 
-  postFixup = ''
+  postFixup = lib.optionalString (!stdenv.isDarwin) ''
     find $out -type f -perm -0100 \
         -exec patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
         --set-rpath "$rpath" {} \;
     find $out -name "*.so" -exec patchelf --set-rpath "$rpath" {} \;
   '';
 
-  rpath = lib.makeLibraryPath ([
+  rpath = lib.optionalString (!stdenv.isDarwin) (lib.makeLibraryPath ([
     stdenv.cc.cc stdenv.cc.libc glib libxml2 libav_0_8 ffmpeg libxslt libGL
     alsaLib fontconfig freetype pango gtk2 cairo gdk-pixbuf atk zlib
     (placeholder "out")
   ] ++ (with xorg; [
     libX11 libXext libXtst libXi libXp libXt libXrender libXxf86vm
-  ])) + ":${placeholder "out"}/lib/jli";
+  ])) + ":${placeholder "out"}/lib/jli");
 
   passthru.home = drv;
 
@@ -61,6 +66,6 @@ let drv = stdenv.mkDerivation rec {
     homepage = "https://bintray.com/jetbrains/intellij-jdk/";
     license = licenses.gpl2;
     maintainers = with maintainers; [ edwtjo ];
-    platforms = with platforms; [ "x86_64-linux" ];
+    platforms = with platforms; [ "x86_64-linux" "x86_64-darwin" ];
   };
 }; in drv


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add darwin support to `jetbrains.idea-community`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
