### PR TITLE
pythonPackages.pytricia: unstable-2019-01-16 -> 1.0.0

### DIFF
--- a/pkgs/development/python-modules/pytricia/default.nix
+++ b/pkgs/development/python-modules/pytricia/default.nix
@@ -1,22 +1,23 @@
-{ stdenv
+{ lib
 , buildPythonPackage
-, fetchFromGitHub
+, fetchPypi
 }:
 
 buildPythonPackage rec {
   pname = "pytricia";
-  version = "unstable-2019-01-16";
+  version = "1.0.0";
 
-  src = fetchFromGitHub {
-    owner = "jsommers";
-    repo = pname;
-    rev = "4ba88f68c3125f789ca8cd1cfae156e1464bde87";
-    sha256 = "0qp5774xkm700g35k5c76pck8pdzqlyzbaqgrz76a1yh67s2ri8h";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1nlhmnx2y3x17fcnspl4jargl1q9w8clwr8bqk32b6j5bbh0swy8";
   };
 
-  meta = with stdenv.lib; {
+  # no tests in pypi, and no github releases
+  doCheck = false;
+
+  meta = with lib; {
     description = "A library for fast IP address lookup in Python";
-    homepage = https://github.com/jsommers/pytricia;
+    homepage = "https://github.com/jsommers/pytricia";
     license = with licenses; [ lgpl3Plus ];
     maintainers = with maintainers; [ mkg ];
   };


### PR DESCRIPTION
###### Motivation for this change
Updating "troubled" repology packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

```
$ nix path-info -Sh ./results/pytho*
/nix/store/s6wk8z69xnmh5i2wwbldw58nxrwid5gc-python2.7-pytricia-1.0.0      94.6M
/nix/store/wdsn2lv2khc6c9inzb04af6ph881wvq1-python3.7-pytricia-1.0.0      96.8M
```

```
$ nix-review wip
...
[1 built, 0.0 MiB DL]
2 package were build:
python27Packages.pytricia python37Packages.pytricia
```