### PR TITLE
radiotray-ng: 0.2.5 -> 0.2.6

### DIFF
--- a/pkgs/applications/audio/radiotray-ng/default.nix
+++ b/pkgs/applications/audio/radiotray-ng/default.nix
@@ -39,14 +39,14 @@ let
   pythonInputs = with python2.pkgs; [ python2 lxml ];
 in
 stdenv.mkDerivation rec {
-  name = "radiotray-ng-${version}";
-  version = "0.2.5";
+  pname = "radiotray-ng";
+  version = "0.2.6";
 
   src = fetchFromGitHub {
     owner = "ebruck";
     repo = "radiotray-ng";
     rev = "v${version}";
-    sha256 = "1crvpn1mgrv7bd2k683mpgs59785mkrjvmp1f14iyq4qrr0f9zzi";
+    sha256 = "0khrfxjas2ldh0kksq7l811srqy16ahjxchvz0hhykx5hykymxlb";
   };
 
   nativeBuildInputs = [ cmake pkgconfig wrapGAppsHook makeWrapper ];
@@ -64,9 +64,10 @@ stdenv.mkDerivation rec {
   patches = [ ./no-dl-googletest.patch ];
 
   postPatch = ''
-    for x in debian/CMakeLists.txt include/radiotray-ng/common.hpp data/*.desktop; do
+    for x in package/CMakeLists.txt include/radiotray-ng/common.hpp data/*.desktop; do
       substituteInPlace $x --replace /usr $out
     done
+    substituteInPlace package/CMakeLists.txt --replace /etc/xdg/autostart $out/etc/xdg/autostart
 
     # We don't find the radiotray-ng-notification icon otherwise
     substituteInPlace data/radiotray-ng.desktop \

--- a/pkgs/applications/audio/radiotray-ng/no-dl-googletest.patch
+++ b/pkgs/applications/audio/radiotray-ng/no-dl-googletest.patch
@@ -1,4 +1,4 @@
-From 2ce91cd2244e61d54e0c0a3b26851912240b0667 Mon Sep 17 00:00:00 2001
+From b6f7a9e2e0194c6baed63a33b7beff359080b8d9 Mon Sep 17 00:00:00 2001
 From: Will Dietz <w@wdtz.org>
 Date: Sat, 16 Mar 2019 11:40:00 -0500
 Subject: [PATCH] don't download googletest
@@ -9,7 +9,7 @@ Subject: [PATCH] don't download googletest
  2 files changed, 19 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index fc1b9de..301c266 100644
+index ddba1be..3396705 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -70,25 +70,7 @@ endif()
@@ -51,5 +51,5 @@ index 859c048..58ab5c2 100644
      target_include_directories(${target} PRIVATE ${JSONCPP_INCLUDE_DIRS})
      gtest_discover_tests(${target})
 -- 
-2.21.GIT
+2.22.0
 


### PR DESCRIPTION
###### Motivation for this change

https://github.com/ebruck/radiotray-ng/releases/tag/v0.2.6

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---