### PR TITLE
lazydocker: 0.5 -> 0.5.5

### DIFF
--- a/pkgs/tools/misc/lazydocker/default.nix
+++ b/pkgs/tools/misc/lazydocker/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "lazydocker";
-  version = "0.5";
+  version = "0.5.5";
 
   src = fetchFromGitHub {
     owner = "jesseduffield";
     repo = "lazydocker";
     rev = "v${version}";
-    sha256 = "0f062xn58dbci22pg6y4ifcdfs8whzlv2jjprxxk2ygzixrrjwnc";
+    sha256 = "0h2c1f9r67i6a8ppspsg1ln9rkm272092aaaw55sd15xxr51s4hb";
   };
 
-  modSha256 = "02n0lg28icy11a2j2rrlmp70blby0kmjas5j48jwh9h9a0yplqic";
+  modSha256 = "1lrrwcr95fxk4dlinyg74vqyxwwzagymncfps9bgig5v5d8gdd8j";
 
   subPackages = [ "." ];
 


### PR DESCRIPTION
###### Motivation for this change

https://github.com/jesseduffield/lazydocker/releases/tag/v0.5.5

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---