### PR TITLE
klavaro: 3.08 -> 3.09, patch format-string, espeak support

### DIFF
--- a/pkgs/games/klavaro/default.nix
+++ b/pkgs/games/klavaro/default.nix
@@ -1,16 +1,37 @@
-{ stdenv, fetchurl, makeWrapper, pkgconfig, intltool, curl, gtk3 }:
+{ stdenv, fetchurl, makeWrapper, pkgconfig, intltool, curl, gtk3, espeak }:
 
 stdenv.mkDerivation rec {
   name = "klavaro-${version}";
-  version = "3.08";
+  version = "3.09";
 
   src = fetchurl {
     url = "mirror://sourceforge/klavaro/${name}.tar.bz2";
-    sha256 = "0qmvr6d8wshwp0xvk5wbig4vlzxzcxrakhyhd32v8v3s18nhqsrc";
+    sha256 = "12gml7h45b1w9s318h0d5wxw92h7pgajn2kh57j0ak9saq0yb0wr";
   };
 
   nativeBuildInputs = [ intltool makeWrapper pkgconfig ];
   buildInputs = [ curl gtk3 ];
+
+  patches = [ (builtins.toFile "format-string" ''
+    Index: src/top10.c
+    ===================================================================
+    diff --git a/src/top10.c b/src/top10.c
+    --- a/src/top10.c	(revision 105)
+    +++ b/src/top10.c	(working copy)
+    @@ -845,7 +845,7 @@
+     		curl_easy_setopt (curl, CURLOPT_WRITEDATA, fh);
+     		curl_easy_setopt (curl, CURLOPT_SSL_VERIFYPEER, 0L);
+     		fail = curl_easy_perform (curl);
+    -		if (fail) g_message (curl_easy_strerror (fail));
+    +		if (fail) g_message ("error in download: %s", curl_easy_strerror (fail));
+     		fclose (fh);
+     	}
+     	curl_easy_cleanup (curl);
+  '') ];
+
+  postPatch = ''
+    substituteInPlace src/tutor.c --replace '"espeak ' '"${espeak}/bin/espeak '
+  '';
 
   postInstall = ''
     wrapProgram $out/bin/klavaro \


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---