### PR TITLE
powerstat: 0.02.18 -> 0.02.19

### DIFF
--- a/pkgs/os-specific/linux/powerstat/default.nix
+++ b/pkgs/os-specific/linux/powerstat/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "powerstat-${version}";
-  version = "0.02.18";
+  version = "0.02.19";
   src = fetchurl {
     url = "https://kernel.ubuntu.com/~cking/tarballs/powerstat/powerstat-${version}.tar.gz";
-    sha256 = "1glryfmq9h7h8hsasg5ffl9vrcbjkkq3xqdxmbdhxmn137w7vgm5";
+    sha256 = "0yh6l2mx5gfdgrfx406hxbi03c12cgi29pwlzgdfrpz6zs2icaw5";
   };
-  installFlags = [ "DESTDIR=$(out)" ];
+  installFlags = [ "DESTDIR=${placeholder "out"}" ];
   postInstall = ''
     mv $out/usr/* $out
     rm -r $out/usr

--- a/pkgs/os-specific/linux/powerstat/default.nix
+++ b/pkgs/os-specific/linux/powerstat/default.nix
@@ -1,17 +1,21 @@
 { stdenv, lib, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "powerstat-${version}";
+  pname = "powerstat";
   version = "0.02.19";
+  
   src = fetchurl {
-    url = "https://kernel.ubuntu.com/~cking/tarballs/powerstat/powerstat-${version}.tar.gz";
+    url = "https://kernel.ubuntu.com/~cking/tarballs/${pname}/${pname}-${version}.tar.gz";
     sha256 = "0yh6l2mx5gfdgrfx406hxbi03c12cgi29pwlzgdfrpz6zs2icaw5";
   };
+  
   installFlags = [ "DESTDIR=${placeholder "out"}" ];
+  
   postInstall = ''
     mv $out/usr/* $out
     rm -r $out/usr
   '';
+  
   meta = with lib; {
     description = "Laptop power measuring tool";
     homepage = https://kernel.ubuntu.com/~cking/powerstat/;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---