### PR TITLE
libtorrent-rasterbar: 1.1.11 -> 1.2.1

### DIFF
--- a/pkgs/development/libraries/libtorrent-rasterbar/default.nix
+++ b/pkgs/development/libraries/libtorrent-rasterbar/default.nix
@@ -3,7 +3,7 @@
 }:
 
 let
-  version = "1.1.11";
+  version = "1.2.1";
   formattedVersion = lib.replaceChars ["."] ["_"] version;
 
   # Make sure we override python, so the correct version is chosen
@@ -16,8 +16,8 @@ in stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "arvidn";
     repo = "libtorrent";
-    rev = "libtorrent_${formattedVersion}";
-    sha256 = "0nwdsv6d2gkdsh7l5a46g6cqx27xwh3msify5paf02l1qzjy4s5l";
+    rev = "libtorrent-${formattedVersion}";
+    sha256 = "0sl7gq6a98w4ksq92w3ywkqachrpbwlbmhazgvlcncik7bq1gkjj";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change

https://github.com/arvidn/libtorrent/releases/tag/libtorrent-1_2_1
https://github.com/arvidn/libtorrent/releases/tag/libtorrent_1_2_0
https://github.com/arvidn/libtorrent/releases/tag/libtorrent-1_1_13
https://github.com/arvidn/libtorrent/releases/tag/libtorrent_1_1_12

Needed for deluge update following shortly, as I recall...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---