### PR TITLE
palemoon: 27.9.4 -> 28.6.0.1, refactor

### DIFF
--- a/pkgs/applications/networking/browsers/palemoon/default.nix
+++ b/pkgs/applications/networking/browsers/palemoon/default.nix
@@ -130,6 +130,6 @@ in stdenv.mkDerivation rec {
     homepage    = "https://www.palemoon.org/";
     license     = licenses.mpl20;
     maintainers = with maintainers; [ rnhmjoj AndersonTorres OPNA2608 ];
-    platforms   = platforms.linux;
+    platforms   = [ "i686-linux" "x86_64-linux" ];
   };
 }

--- a/pkgs/applications/networking/browsers/palemoon/default.nix
+++ b/pkgs/applications/networking/browsers/palemoon/default.nix
@@ -1,14 +1,17 @@
 { stdenv, fetchFromGitHub, makeDesktopItem
 , pkgconfig, autoconf213, alsaLib, bzip2, cairo
-, dbus, dbus-glib, file, fontconfig, freetype
-, gnome2, gnum4, gstreamer, gst-plugins-base, gst_all_1
-, gtk2, hunspell, icu, libevent, libjpeg, libnotify
-, libstartup_notification, libvpx, makeWrapper, libGLU_combined
-, nspr, nss, pango, perl, python, libpulseaudio, sqlite
+, dbus, dbus-glib, ffmpeg, file, fontconfig, freetype
+, gnome2, gnum4, gtk2, hunspell, libevent, libjpeg
+, libnotify, libstartup_notification, makeWrapper
+, libGLU_combined, perl, python, libpulseaudio
 , unzip, xorg, wget, which, yasm, zip, zlib
 }:
 
-stdenv.mkDerivation rec {
+let
+
+  libPath = stdenv.lib.makeLibraryPath [ ffmpeg ];
+
+in stdenv.mkDerivation rec {
   pname = "palemoon";
   version = "28.6.0.1";
 
@@ -39,11 +42,10 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    alsaLib bzip2 cairo dbus dbus-glib file fontconfig freetype
-    gnome2.GConf gnum4 gst-plugins-base gstreamer gst_all_1.gst-plugins-base gtk2
-    hunspell icu libevent libjpeg libnotify libstartup_notification
-    libvpx makeWrapper libGLU_combined nspr nss pango perl pkgconfig python
-    libpulseaudio sqlite unzip wget which yasm zip zlib
+    alsaLib bzip2 cairo dbus dbus-glib ffmpeg file fontconfig freetype
+    gnome2.GConf gnum4 gtk2 hunspell libevent libjpeg libnotify
+    libstartup_notification makeWrapper libGLU_combined perl
+    pkgconfig python libpulseaudio unzip wget which yasm zip zlib
   ] ++ (with xorg; [
     libX11 libXext libXft libXi libXrender libXScrnSaver
     libXt pixman xorgproto
@@ -107,6 +109,9 @@ stdenv.mkDerivation rec {
       cp $src/application/palemoon/branding/official/default$n.png \
          $out/share/icons/hicolor/$size/apps/palemoon.png
     done
+
+    wrapProgram $out/lib/palemoon-${version}/palemoon \
+      --prefix LD_LIBRARY_PATH : "${libPath}"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/networking/browsers/palemoon/default.nix
+++ b/pkgs/applications/networking/browsers/palemoon/default.nix
@@ -1,23 +1,23 @@
 { stdenv, fetchFromGitHub, makeDesktopItem
 , pkgconfig, autoconf213, alsaLib, bzip2, cairo
 , dbus, dbus-glib, file, fontconfig, freetype
-, gstreamer, gst-plugins-base, gst_all_1
+, gnome2, gnum4, gstreamer, gst-plugins-base, gst_all_1
 , gtk2, hunspell, icu, libevent, libjpeg, libnotify
 , libstartup_notification, libvpx, makeWrapper, libGLU_combined
 , nspr, nss, pango, perl, python, libpulseaudio, sqlite
-, unzip, xorg, which, yasm, zip, zlib
+, unzip, xorg, wget, which, yasm, zip, zlib
 }:
 
 stdenv.mkDerivation rec {
-  name = "palemoon-${version}";
-  version = "27.9.4";
+  pname = "palemoon";
+  version = "28.6.0.1";
 
   src = fetchFromGitHub {
-    name   = "palemoon-src";
+    name   = "${pname}-${version}";
     owner  = "MoonchildProductions";
-    repo   = "Pale-Moon";
-    rev    = version + "_Release";
-    sha256 = "0ir5gzhw98gfn15x58g1fwi11jd7gysvacqxg1v0jdjhgdl4m5sx";
+    repo   = "UXP";
+    rev    = "PM${version}_Release";
+    sha256 = "1adgajy5vsghvjlv2nqyrbp6mnv3k6slqxxi8r949xlb5h6d210b";
   };
 
   desktopItem = makeDesktopItem {
@@ -40,10 +40,10 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     alsaLib bzip2 cairo dbus dbus-glib file fontconfig freetype
-    gst-plugins-base gstreamer gst_all_1.gst-plugins-base gtk2
+    gnome2.GConf gnum4 gst-plugins-base gstreamer gst_all_1.gst-plugins-base gtk2
     hunspell icu libevent libjpeg libnotify libstartup_notification
     libvpx makeWrapper libGLU_combined nspr nss pango perl pkgconfig python
-    libpulseaudio sqlite unzip which yasm zip zlib
+    libpulseaudio sqlite unzip wget which yasm zip zlib
   ] ++ (with xorg; [
     libX11 libXext libXft libXi libXrender libXScrnSaver
     libXt pixman xorgproto
@@ -52,57 +52,65 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   configurePhase = ''
-    export AUTOCONF=${autoconf213}/bin/autoconf
-    export MOZBUILD_STATE_PATH=$(pwd)/.mozbuild
-    export MOZ_CONFIG=$(pwd)/.mozconfig
-    export builddir=$(pwd)/build
-    mkdir -p $MOZBUILD_STATE_PATH $builddir
-    echo > $MOZ_CONFIG "
-    . $src/build/mozconfig.common
-    ac_add_options --prefix=$out
-    ac_add_options --with-pthreads
-    ac_add_options --enable-application=browser
+    export MOZBUILD_STATE_PATH=$(pwd)/mozbuild
+    export MOZCONFIG=$(pwd)/mozconfig
+    export builddir=$(pwd)/pmbuild
+
+    echo > $MOZCONFIG "
+    mk_add_options AUTOCLOBBER=1
+    mk_add_options MOZ_OBJDIR=$builddir
+    ac_add_options --enable-application=palemoon
+
+    ac_add_options --enable-optimize='-O2'
+
+    # Please see https://www.palemoon.org/redist.shtml for restrictions when using the official branding.
     ac_add_options --enable-official-branding
-    ac_add_options --enable-optimize="-O2"
-    ac_add_options --enable-release
-    ac_add_options --enable-devtools
+    export MOZILLA_OFFICIAL=1
+
+    ac_add_options --enable-default-toolkit=cairo-gtk2
     ac_add_options --enable-jemalloc
-    ac_add_options --enable-shared-js
     ac_add_options --enable-strip
+    ac_add_options --with-pthreads
+
     ac_add_options --disable-tests
-    ac_add_options --disable-installer
-    ac_add_options --disable-updaters
+    ac_add_options --disable-eme
+    ac_add_options --disable-parental-controls
+    ac_add_options --disable-accessibility
+    ac_add_options --disable-webrtc
+    ac_add_options --disable-gamepad
+    ac_add_options --disable-necko-wifi
+    ac_add_options --disable-updater
+
+    ac_add_options --x-libraries=${xorg.libX11.out}/lib
+
+    ac_add_options --prefix=$out
+    mk_add_options MOZ_MAKE_FLAGS='-j$NIX_BUILD_CORES'
+    mk_add_options AUTOCONF=${autoconf213}/bin/autoconf
     "
   '';
 
-  patchPhase = ''
-    chmod u+w .
-  '';
-
   hardeningDisable = [ "format" ];
-  
+
   buildPhase = ''
-    cd $builddir
     $src/mach build
   '';
 
   installPhase = ''
+    $src/mach install
+
     mkdir -p $out/share/applications
     cp ${desktopItem}/share/applications/* $out/share/applications
 
     for n in 16 22 24 32 48 256; do
       size=$n"x"$n
       mkdir -p $out/share/icons/hicolor/$size/apps
-      cp $src/browser/branding/official/default$n.png \
+      cp $src/application/palemoon/branding/official/default$n.png \
          $out/share/icons/hicolor/$size/apps/palemoon.png
     done
-
-    cd $builddir
-    $src/mach install
   '';
 
   meta = with stdenv.lib; {
-    description = "A web browser";
+    description = "An Open Source, Goanna-based web browser focusing on efficiency and customization";
     longDescription = ''
       Pale Moon is an Open Source, Goanna-based web browser focusing on
       efficiency and customization.
@@ -114,9 +122,9 @@ stdenv.mkDerivation rec {
       experience, while offering full customization and a growing collection of
       extensions and themes to make the browser truly your own.
     '';
-    homepage    = https://www.palemoon.org/;
+    homepage    = "https://www.palemoon.org/";
     license     = licenses.mpl20;
-    maintainers = with maintainers; [ rnhmjoj AndersonTorres ];
+    maintainers = with maintainers; [ rnhmjoj AndersonTorres OPNA2608 ];
     platforms   = platforms.linux;
   };
 }


### PR DESCRIPTION
supersedes #51161
closes #51160

![Screenshot_NixOS_19 03_2019-07-09_08:36:04](https://user-images.githubusercontent.com/23431373/60887381-8b53fa80-a254-11e9-99c5-96892329948a.png)

---

GConf dependency added as discussed in #55161.

The NixOS build problem that was encountered there took some log digging to find:
There was an attempted invocation of `m4` that failed, but didn't causes an abortion of the build phase. Later on, that seemingly resulted in some files missing and an abortion of the install phase.

This seems to have not been an issue on non-NixOS systems, where the lack of sandboxing lead to `m4` being found inside the user's PATH?

The configure script also checks for the presence of `wget`, but I don't know what for. Just to be safe, I added it to `buildInputs` as well.

I think `gstreamer` was deprecated afew versions ago and can be removed from `buildInputs`, I will do some testing in general to figure out what else might not be required anymore though.

(Also, it looks like Pale Moon can be built for GTK3 so having a `withGtk3` option could make sense, question would be how endorsed that is by upstream and if it may continue using the official branding in that case.)

---

~~A major *not-nice* aspect of this PR is a set of exceptions that get thrown during the install phase:~~
~~They don't abort the installation however, and the browser appears to work fine. I don't know how to fix those yet, but I'll look into it. If anyone wants to help me, be my guest ofc. :slightly_smiling_face:~~

See comment below.


###### Motivation for this change

see #51160

tl;dr, the currently packaged version is

1) out-of-date
2) frequently complaining about being out-of-date
3) lacking important security updates that have been added since its release

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
