### PR TITLE
skaffold: 0.30.0 -> 0.33.0

### DIFF
--- a/pkgs/development/tools/skaffold/default.nix
+++ b/pkgs/development/tools/skaffold/default.nix
@@ -2,9 +2,9 @@
 
 buildGoPackage rec {
   name = "skaffold-${version}";
-  version = "0.30.0";
-  # rev is the 0.30.0 commit, mainly for skaffold version command output
-  rev = "fe31429012110e6fd70f97971288bd266ba95bed";
+  version = "0.33.0";
+  # rev is the 0.33.0 commit, mainly for skaffold version command output
+  rev = "68fe5670b38a19cc5f689040ad2088c5bdeea779";
 
   goPackagePath = "github.com/GoogleContainerTools/skaffold";
   subPackages = ["cmd/skaffold"];
@@ -20,7 +20,7 @@ buildGoPackage rec {
     owner = "GoogleContainerTools";
     repo = "skaffold";
     rev = "v${version}";
-    sha256 = "1vh7vlz14gfjpxf2wy1pybw5x55mw34j6isyy5zl0rsbs9mf6ci1";
+    sha256 = "1r7r0i7x2qbi94fqaxzvllvcrfh0sh9z6qm7h23gcmh9hsyniddn";
   };
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

https://github.com/GoogleContainerTools/skaffold/releases/tag/v0.33.0
https://github.com/GoogleContainerTools/skaffold/releases/tag/v0.32.0
https://github.com/GoogleContainerTools/skaffold/releases/tag/v0.31.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---