### PR TITLE
most: 5.0.0a -> 5.1.0

### DIFF
--- a/pkgs/tools/misc/most/default.nix
+++ b/pkgs/tools/misc/most/default.nix
@@ -1,12 +1,19 @@
 { stdenv, fetchurl, slang, ncurses }:
 
-stdenv.mkDerivation {
-  name = "most-5.0.0a";
+stdenv.mkDerivation rec {
+  pname = "most";
+  version = "5.1.0";
 
   src = fetchurl {
-    url = ftp://space.mit.edu/pub/davis/most/most-5.0.0a.tar.bz2;
-    sha256 = "1aas904g8x48vsfh3wcr2k6mjzkm5808lfgl2qqhdfdnf4p5mjwl";
+    url = "https://www.jedsoft.org/releases/${pname}/${pname}-${version}.tar.gz";
+    sha256 = "008537ns659pw2aag15imwjrxj73j26aqq90h285is6kz8gmv06v";
   };
+
+  outputs = [ "out" "doc" ];
+
+  makeFlags = [
+    "DOC_DIR=${placeholder ''doc''}/share/doc/most"
+  ];
 
   preConfigure = ''
     sed -i -e "s|-ltermcap|-lncurses|" configure
@@ -19,15 +26,15 @@ stdenv.mkDerivation {
 
   buildInputs = [ slang ncurses ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "A terminal pager similar to 'more' and 'less'";
     longDescription = ''
       MOST is a powerful paging program for Unix, VMS, MSDOS, and win32
       systems. Unlike other well-known paging programs most supports multiple
       windows and can scroll left and right. Why settle for less?
     '';
-    homepage = http://www.jedsoft.org/most/index.html;
-    license = stdenv.lib.licenses.gpl2;
-    platforms = stdenv.lib.platforms.unix;
+    homepage = "https://www.jedsoft.org/most/index.html";
+    license = licenses.gpl2;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update `most` to the latest release.
- https://www.jedsoft.org/releases/most/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
@GrahamcOfBorg build most