### PR TITLE
django: Init at 2.0.2

### DIFF
--- a/pkgs/development/python-modules/django/2_0_2.nix
+++ b/pkgs/development/python-modules/django/2_0_2.nix
@@ -1,0 +1,38 @@
+{ stdenv, buildPythonPackage, fetchPypi, substituteAll,
+  isPy3k,
+  geos, gdal, pytz, sqlparse,
+  withGdal ? false
+}:
+
+buildPythonPackage rec {
+  pname = "Django";
+  version = "2.0.2";
+
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1w257da9lcvck7jhix59mq1m6r8g91fh4qlcc9jfvg7iak862fyw";
+  };
+
+  patches = stdenv.lib.optional withGdal
+    (substituteAll {
+      src = ./1.10-gis-libs.template.patch;
+      geos = geos;
+      gdal = gdal;
+      extension = stdenv.hostPlatform.extensions.sharedLibrary;
+    })
+  ;
+
+  propagatedBuildInputs = [ pytz sqlparse ];
+
+  # too complicated to setup
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "A high-level Python Web framework";
+    homepage = https://www.djangoproject.com/;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ mrmebelman georgewhewell lsix ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2541,6 +2541,8 @@ in {
     gdal = self.gdal;
   };
 
+  django_2_0_2 = callPackage ../development/python-modules/django/2_0_2.nix { };
+
   django_2_2 = callPackage ../development/python-modules/django/2_2.nix { };
 
   django_1_8 = callPackage ../development/python-modules/django/1_8.nix { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Adding an older version of Django that is still being used in some projects.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
