### PR TITLE
packr: 2.5.1 -> 2.5.2

### DIFF
--- a/pkgs/development/libraries/packr/default.nix
+++ b/pkgs/development/libraries/packr/default.nix
@@ -5,16 +5,16 @@
 
 buildGoModule rec {
   pname = "packr";
-  version = "2.5.1";
+  version = "2.5.2";
 
   src = fetchFromGitHub {
     owner = "gobuffalo";
     repo = pname;
     rev = "v${version}";
-    sha256 = "070hpnsr5w1r1cg9wl80cafmhkx4z3s29wq04fa7rk49hmwml4jy";
+    sha256 = "1ciffa5xbd93fylwz93wr4m4fj83dcla55dmdshaqz28rbsapnc1";
   };
 
-  modSha256 = "0xvpk9jjcqac44s4fp0jwpljxvs0ypjwc5qfg0w90s2r7jn50fxn";
+  modSha256 = "086gydrl3i35hawb5m7rsb4a0llcpdpgid1xfw2z9n6jkwkclw4n";
 
   meta = with lib; {
     description = "The simple and easy way to embed static files into Go binaries";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update `packr` to the latest release.
- https://github.com/gobuffalo/packr/releases/tag/v2.5.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
@GrahamcOfBorg build packr