### PR TITLE
django-maintenance-mode: init at 0.13.1

### DIFF
--- a/pkgs/development/python-modules/django-maintenance-mode/default.nix
+++ b/pkgs/development/python-modules/django-maintenance-mode/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, buildPythonPackage, pytest, django }:
+
+buildPythonPackage rec {
+  pname = "django-maintenance-mode";
+  version = "0.14.0";
+
+  src = fetchFromGitHub {
+    owner = "fabiocaccamo";
+    repo = pname;
+    rev = version;
+    sha256 = "1k06fhqd8wyrkp795x5j2r328l2phqgg1m1qm7fh4l2qrha43aw6";
+  };
+
+  checkInputs = [ pytest ];
+
+  propagatedBuildInputs = [ django ];
+
+  meta = with stdenv.lib; {
+    description = "Shows a 503 error page when maintenance-mode is on";
+    homepage = "https://github.com/fabiocaccamo/django-maintenance-mode";
+    maintainers = with maintainers; [ mrmebelman ];
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1610,6 +1610,8 @@ in {
 
   django-multiselectfield = callPackage ../development/python-modules/django-multiselectfield { };
 
+  django-maintenance-mode = callPackage ../development/python-modules/django-maintenance-mode { };
+
   django_nose = callPackage ../development/python-modules/django_nose { };
 
   django-oauth-toolkit = callPackage ../development/python-modules/django-oauth-toolkit { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Adding a missing Django package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
