### PR TITLE
pax-utils: 1.2.2 -> 1.2.4

### DIFF
--- a/pkgs/os-specific/linux/pax-utils/default.nix
+++ b/pkgs/os-specific/linux/pax-utils/default.nix
@@ -1,17 +1,17 @@
-{ stdenv, fetchurl }:
+{ stdenv, lib, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "pax-utils-${version}";
-  version = "1.2.2";
+  pname = "pax-utils";
+  version = "1.2.4";
 
   src = fetchurl {
-    url = "https://dev.gentoo.org/~vapier/dist/${name}.tar.xz";
-    sha512 = "26f7lqr1s2iywj8qfbf24sm18bl6f7cwsf77nxwwvgij1z88gvh6yx3gp65zap92l0xjdp8kwq9y96xld39p86zd9dmkm447czykbvb";
+    url = "http://distfiles.gentoo.org/distfiles/${pname}-${version}.tar.xz";
+    sha256 = "01kr6l2c3bhbgdrmwgzh6jk0jjkw3pi9xrzzl9cpn0ibyf68p1aj";
   };
 
   makeFlags = [ "PREFIX=$(out)" ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "ELF utils that can check files for security relevant properties";
     longDescription = ''
       A suite of ELF tools to aid auditing systems. Contains
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
       for displaying PaX and security info on a large groups of
       binary files.
     '';
-    homepage = https://wiki.gentoo.org/wiki/Hardened/PaX_Utilities;
+    homepage = "https://wiki.gentoo.org/wiki/Hardened/PaX_Utilities";
     license = licenses.gpl2;
     platforms = platforms.unix;
     maintainers = with maintainers; [ thoughtpolice joachifm ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update `pax-utils` to the latest release.
* https://gitweb.gentoo.org/proj/pax-utils.git

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
