### PR TITLE
django-simple-captcha: init at 0.5.6

### DIFF
--- a/pkgs/development/python-modules/django-ranged-response/default.nix
+++ b/pkgs/development/python-modules/django-ranged-response/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl, fetchPypi, buildPythonPackage, django }:
+
+buildPythonPackage rec {
+  pname = "django-ranged-response";
+  version = "0.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "11gr3jpmb5rvg3scv026kjwwkmnxwivgq5ypxadnnc9p58szy7zp";
+  };
+
+  # tests not included in PyPi package, github source is not up to date with 0.2.0
+  doCheck = false;
+
+  propagatedBuildInputs = [ django ];
+
+  meta = with stdenv.lib; {
+    description = "A modified FileResponse that returns `Content-Range` headers with the HTTP response, so browsers (read Safari 9+) that request the file, can stream the response properly";
+    homepage = "https://github.com/wearespindle/django-ranged-fileresponse";
+    license = licenses.mit;
+    maintainers = with maintainers; [ mrmebelman ];
+  };
+}

--- a/pkgs/development/python-modules/django-simple-captcha/default.nix
+++ b/pkgs/development/python-modules/django-simple-captcha/default.nix
@@ -1,13 +1,15 @@
-{ stdenv, fetchurl, python, buildPythonPackage, six, testfixtures,
+{ stdenv, buildPythonPackage, fetchFromGitHub, python, six, testfixtures,
 django, django-ranged-response, pillow }:
 
 buildPythonPackage rec {
   pname = "django-simple-captcha";
   version = "0.5.11";
 
-  src = fetchurl {
-    url = "https://files.pythonhosted.org/packages/86/d4/5baf10bfc9eb7844872c256898a405e81f22f7213e008ec90875689f913d/django-simple-captcha-0.5.11.zip";
-    sha256 = "0zws9my33ayrxpprxw4k68mimpj8ganff28343xxzqvv415mqkp1";
+  src = fetchFromGitHub {
+    owner = "mbi";
+    repo = "django-simple-captcha";
+    rev = "v${version}";
+    sha256 = "0wdfhag3ybvsmxyklly0fi0p5zbi6bf46z9si64glgk3nq3ipg7z";
   };
 
   checkInputs = [ testfixtures ];

--- a/pkgs/development/python-modules/django-simple-captcha/default.nix
+++ b/pkgs/development/python-modules/django-simple-captcha/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, python, buildPythonPackage, six, testfixtures,
+django, django-ranged-response, pillow }:
+
+buildPythonPackage rec {
+  pname = "django-simple-captcha";
+  version = "0.5.11";
+
+  src = fetchurl {
+    url = "https://files.pythonhosted.org/packages/86/d4/5baf10bfc9eb7844872c256898a405e81f22f7213e008ec90875689f913d/django-simple-captcha-0.5.11.zip";
+    sha256 = "0zws9my33ayrxpprxw4k68mimpj8ganff28343xxzqvv415mqkp1";
+  };
+
+  checkInputs = [ testfixtures ];
+  checkPhase = ''
+    cd testproject
+    ${python.interpreter} manage.py test captcha
+  '';
+
+  propagatedBuildInputs = [ django django-ranged-response six pillow ];
+
+  meta = with stdenv.lib; {
+    description = "An extremely simple, yet highly customizable Django application to add captcha images to any Django form";
+    homepage = "https://github.com/mbi/django-simple-captcha";
+    license = licenses.mit;
+    maintainers = with maintainers; [ mrmebelman ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2589,6 +2589,8 @@ in {
 
   django-sampledatahelper = callPackage ../development/python-modules/django-sampledatahelper { };
 
+  django-simple-captcha = callPackage ../development/python-modules/django-simple-captcha { };
+
   django-sites = callPackage ../development/python-modules/django-sites { };
 
   django-sr = callPackage ../development/python-modules/django-sr { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2585,6 +2585,8 @@ in {
 
   django_polymorphic = callPackage ../development/python-modules/django-polymorphic { };
 
+  django-ranged-response = callPackage ../development/python-modules/django-ranged-response { };
+
   django-rest-auth = callPackage ../development/python-modules/django-rest-auth { };
 
   django-sampledatahelper = callPackage ../development/python-modules/django-sampledatahelper { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Adding a missing Django package. It depends on [django-ranged-response](https://github.com/NixOS/nixpkgs/pull/64521).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
