### PR TITLE
dj-static: init at 0.0.6

### DIFF
--- a/pkgs/development/python-modules/dj-static/default.nix
+++ b/pkgs/development/python-modules/dj-static/default.nix
@@ -1,0 +1,23 @@
+{ lib, fetchPypi, buildPythonPackage, django, static3 }:
+
+buildPythonPackage rec {
+  pname = "dj-static";
+  version = "0.0.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1vz8ij123nhg5mhr8z0wzkjcq6pvlq2damp9wgk24yb16b2w2bh3";
+  };
+
+  doCheck = true;
+
+  propagatedBuildInputs = [ django static3 ];
+
+  meta = with lib; {
+    description = "A simple Django middleware utility that allows you to properly serve static assets from production with a WSGI server like Gunicorn";
+    homepage = "https://github.com/heroku-python/dj-static";
+    maintainers = with maintainers; [ mrmebelman ];
+    license = licenses.bsd2;
+  };
+}
+

--- a/pkgs/development/python-modules/static3/default.nix
+++ b/pkgs/development/python-modules/static3/default.nix
@@ -1,0 +1,25 @@
+{ lib, fetchFromGitHub, buildPythonPackage, genshi, pytestCheckHook, pytest-cov, webtest }:
+
+buildPythonPackage rec {
+  pname = "static3";
+  version = "0.7.0";
+
+  src = fetchFromGitHub {
+    owner = "rmohr";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-uFgv+57/UZs4KoOdkFxbvTEDQrJbb0iYJ5JoWWN4yFY=";
+  };
+
+  propagatedBuildInputs = [ genshi ];
+
+  checkInputs = [ pytestCheckHook pytest-cov webtest ];
+
+  meta = with lib; {
+    description = "A really simple WSGI way to serve static (or mixed) content";
+    homepage = "https://github.com/rmohr/static3";
+    maintainers = with maintainers; [ mrmebelman ];
+    license = licenses.lgpl21Plus;
+  };
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2676,6 +2676,8 @@ in {
 
   dj-search-url = callPackage ../development/python-modules/dj-search-url { };
 
+  dj-static = callPackage ../development/python-modules/dj-static { };
+
   dkimpy = callPackage ../development/python-modules/dkimpy { };
 
   dlib = callPackage ../development/python-modules/dlib {
@@ -10611,6 +10613,8 @@ in {
   starline = callPackage ../development/python-modules/starline { };
 
   stashy = callPackage ../development/python-modules/stashy { };
+
+  static3 = callPackage ../development/python-modules/static3 { };
 
   staticjinja = callPackage ../development/python-modules/staticjinja { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Adding a missing Django package, including dependency static3 v0.7.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
