### PR TITLE
pythonPackages.picos: init at 1.2.0

### DIFF
--- a/pkgs/development/python-modules/picos/default.nix
+++ b/pkgs/development/python-modules/picos/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitLab
+, numpy
+, cvxopt
+, python
+}:
+
+buildPythonPackage rec {
+  pname = "picos";
+  version = "1.2.0";
+
+  src = fetchFromGitLab {
+    owner = "picos-api";
+    repo = "picos";
+    rev = "v${version}";
+    sha256 = "018xhc7cb2crkk27lhl63c7h77w5wa37fg41i7nqr4xclr43cs9z";
+  };
+
+  propagatedBuildInputs = [
+    numpy
+    cvxopt
+  ];
+
+  checkPhase = ''
+    ${python.interpreter} test.py
+  '';
+  
+  meta = with lib; {
+    description = "A Python interface to conic optimization solvers";
+    homepage = https://gitlab.com/picos-api/picos;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ tobiasBora ];
+  };
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4201,6 +4201,8 @@ in {
 
   pickleshare = callPackage ../development/python-modules/pickleshare { };
 
+  picos = callPackage ../development/python-modules/picos { };
+
   piep = callPackage ../development/python-modules/piep { };
 
   piexif = callPackage ../development/python-modules/piexif { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Introduce the picos library, a "user friendly Python API to several conic and integer programming solvers, very much like YALMIP or CVX under MATLAB."

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
