### PR TITLE
[lxc] fix bash completions

### DIFF
--- a/pkgs/os-specific/linux/lxc/default.nix
+++ b/pkgs/os-specific/linux/lxc/default.nix
@@ -67,6 +67,22 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     wrapPythonPrograms
+
+    pushd $out/share/bash-completion/completions/
+    mv lxc lxc-start
+    ln -sfn lxc-start lxc-attach
+    ln -sfn lxc-start lxc-cgroup
+    ln -sfn lxc-start lxc-console
+    ln -sfn lxc-start lxc-destroy
+    ln -sfn lxc-start lxc-device
+    ln -sfn lxc-start lxc-execute
+    ln -sfn lxc-start lxc-freeze
+    ln -sfn lxc-start lxc-info
+    ln -sfn lxc-start lxc-monitor
+    ln -sfn lxc-start lxc-snapshot
+    ln -sfn lxc-start lxc-stop
+    ln -sfn lxc-start lxc-unfreeze
+    popd
   '';
 
   meta = {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Moves the `lxc` bash completion file to `lxc-start` and than symlinks all lxc commands that have completions to `lxc-start`. This allows bash completions to work correctly for all `lxc-*` commands.
 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
