### PR TITLE
foliate: init at 1.5.3

### DIFF
--- a/pkgs/applications/office/foliate/default.nix
+++ b/pkgs/applications/office/foliate/default.nix
@@ -26,14 +26,14 @@
 
 stdenv.mkDerivation rec {
   pname = "foliate";
-  version = "1.5.2";
+  version = "1.5.3";
 
   # Fetch this from gnome mirror if/when available there instead!
   src = fetchFromGitHub {
     owner = "johnfactotum";
     repo = pname;
     rev = version;
-    sha256 = "0jf4vgrrpg0s2nkj8rfmnkqpbdhsdipgmwgyxhhh5yvg4i78frl5";
+    sha256 = "1bjlk9n1j34yx3bvzl95mpb56m2fjc5xcd6yks96pwfyfvjnbp93";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/office/foliate/default.nix
+++ b/pkgs/applications/office/foliate/default.nix
@@ -11,14 +11,9 @@
 , gtk3
 , gsettings-desktop-schemas
 , webkitgtk
-, gdk_pixbuf
 , glib
 , desktop-file-utils
 , hicolor-icon-theme /* setup hook */
-, cairo
-, libgee
-, pantheon /* granite */
-, libxml2
 , libarchive
 /*, hyphen */
 , dict
@@ -47,17 +42,12 @@ stdenv.mkDerivation rec {
     hicolor-icon-theme
   ];
   buildInputs = [
-    gdk_pixbuf
     glib
     gtk3
     gjs
     webkitgtk
     gsettings-desktop-schemas
     gobject-introspection
-    cairo
-    libgee
-    pantheon.granite
-    libxml2
     libarchive
     # TODO: Add once packaged, unclear how language packages best handled
     # hyphen

--- a/pkgs/applications/office/foliate/default.nix
+++ b/pkgs/applications/office/foliate/default.nix
@@ -1,0 +1,91 @@
+{ stdenv
+, fetchFromGitHub
+, meson
+, ninja
+, gettext
+, pkgconfig
+, python3
+, wrapGAppsHook
+, gobject-introspection
+, gjs
+, gtk3
+, gsettings-desktop-schemas
+, webkitgtk
+, gdk_pixbuf
+, glib
+, desktop-file-utils
+, hicolor-icon-theme /* setup hook */
+, cairo
+, libgee
+, pantheon /* granite */
+, libxml2
+, libarchive
+/*, hyphen */
+, dict
+}:
+
+stdenv.mkDerivation rec {
+  pname = "foliate";
+  version = "1.5.2";
+
+  # Fetch this from gnome mirror if/when available there instead!
+  src = fetchFromGitHub {
+    owner = "johnfactotum";
+    repo = pname;
+    rev = version;
+    sha256 = "0jf4vgrrpg0s2nkj8rfmnkqpbdhsdipgmwgyxhhh5yvg4i78frl5";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkgconfig
+    gettext
+    python3
+    desktop-file-utils
+    wrapGAppsHook
+    hicolor-icon-theme
+  ];
+  buildInputs = [
+    gdk_pixbuf
+    glib
+    gtk3
+    gjs
+    webkitgtk
+    gsettings-desktop-schemas
+    gobject-introspection
+    cairo
+    libgee
+    pantheon.granite
+    libxml2
+    libarchive
+    # TODO: Add once packaged, unclear how language packages best handled
+    # hyphen
+    dict # dictd for offline dictionary support
+  ];
+
+  doCheck = true;
+
+  postPatch = ''
+    chmod +x build-aux/meson/postinstall.py
+    patchShebangs build-aux/meson/postinstall.py
+  '';
+
+  # Kludge so gjs can find resources by using the unwrapped name
+  # Improvements/alternatives welcome, but this seems to work for now :/.
+  # See: https://github.com/NixOS/nixpkgs/issues/31168#issuecomment-341793501
+  postInstall = ''
+    sed -e $'2iimports.package._findEffectiveEntryPointName = () => \'com.github.johnfactotum.Foliate\' ' \
+      -i $out/bin/com.github.johnfactotum.Foliate
+
+    # Also, create alias for sane usage from commandline, sheesh:
+    ln -s $out/bin/com.github.johnfactotum.Foliate $out/bin/foliate
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Simple and modern GTK eBook reader";
+    homepage = "https://johnfactotum.github.io/foliate/";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/applications/office/foliate/default.nix
+++ b/pkgs/applications/office/foliate/default.nix
@@ -41,6 +41,7 @@ stdenv.mkDerivation rec {
     wrapGAppsHook
     hicolor-icon-theme
   ];
+
   buildInputs = [
     glib
     gtk3
@@ -67,15 +68,12 @@ stdenv.mkDerivation rec {
   postInstall = ''
     sed -e $'2iimports.package._findEffectiveEntryPointName = () => \'com.github.johnfactotum.Foliate\' ' \
       -i $out/bin/com.github.johnfactotum.Foliate
-
-    # Also, create alias for sane usage from commandline, sheesh:
-    ln -s $out/bin/com.github.johnfactotum.Foliate $out/bin/foliate
   '';
 
   meta = with stdenv.lib; {
     description = "Simple and modern GTK eBook reader";
     homepage = "https://johnfactotum.github.io/foliate/";
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     maintainers = with maintainers; [ dtzWill ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2997,6 +2997,8 @@ in
 
   flvstreamer = callPackage ../tools/networking/flvstreamer { };
 
+  foliate = callPackage ../applications/office/foliate { inherit (gnome3) gjs; };
+
   hmetis = pkgsi686Linux.callPackage ../applications/science/math/hmetis { };
 
   libbsd = callPackage ../development/libraries/libbsd { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

"A simple and modern GTK eBook reader".

Took some wrangling to get gjs to run without having problems finding
'main' or some resource, see linked issues from code for some details of
similar.  Does seem to work nicely now, though! ^_^

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x]  Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---