### PR TITLE
bazel-buildtools: 0.22.0 -> unstable-2019-06-21

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/buildtools/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/buildtools/default.nix
@@ -1,16 +1,16 @@
-{ stdenv, buildGoPackage, fetchFromGitHub }:
+{ stdenv, buildGoPackage, fetchgit, fetchhg, fetchbzr, fetchsvn }:
 
 buildGoPackage rec {
-  name = "bazel-buildtools-${version}";
-  version = "0.22.0";
+  name = "bazel-buildtools-unstable-${version}";
+  version = "2019-06-21";
+  rev = "baa9c57c396019f0b7272b95d66f8e2681ed7d2a";
 
   goPackagePath = "github.com/bazelbuild/buildtools";
 
-  src = fetchFromGitHub {
-    owner = "bazelbuild";
-    repo = "buildtools";
-    rev = "55b64c3d2ddfb57f06477c1d94ef477419c96bd6";
-    sha256 = "0n6q8pkgy3vvmwyrxvkmjfbcxc31i31czg2bjdzq7awwrr4fdbwy";
+  src = fetchgit {
+    inherit rev;
+    url = "https://github.com/bazelbuild/buildtools";
+    sha256 = "0xwsm05y8xbxpyzzgcxhznvzxb6vpqw8qnsil1g6crmaa2jjfpw6";
   };
 
   goDeps = ./deps.nix;

--- a/pkgs/development/tools/build-managers/bazel/buildtools/deps.nix
+++ b/pkgs/development/tools/build-managers/bazel/buildtools/deps.nix
@@ -5,17 +5,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/golang/protobuf";
-      rev = "b5d812f8a3706043e23a9cd5babf2e5423744d30";
-      sha256 = "15am4s4646qy6iv0g3kkqq52rzykqjhm4bf08dk0fy2r58knpsyl";
-    };
-  }
-  {
-    goPackagePath = "github.com/google/skylark";
-    fetch = {
-      type = "git";
-      url = "https://github.com/google/skylark";
-      rev = "a5f7082aabed29c0e429c722292c66ec8ecf9591";
-      sha256 = "16vsa6ngsby27n6indj441r1glcdfgipjcwcb0rs6zl2dqlqr286";
+      rev = "6c65a5562fc06764971b7c5d05c76c75e84bdbf7";
+      sha256 = "1k1wb4zr0qbwgpvz9q5ws9zhlal8hq7dmq62pwxxriksayl6hzym";
     };
   }
 ]


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Continuation from https://github.com/NixOS/nixpkgs/pull/63856

Update to HEAD of master. There are a few nice features there, so it might make sense to go directly to HEAD.

I used [go2nix](https://github.com/kamilchm/go2nix) to produce the files, even though I patched `default.nix` to include the meta info.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
