### PR TITLE
gl2ps: init at 1.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5362,6 +5362,15 @@
     github = "twey";
     name = "James ‘Twey’ Kay";
   };
+  twhitehead = {
+    name = "Tyson Whitehead";
+    email = "twhitehead@gmail.com";
+    github = "twhitehead";
+    keys = [{
+      longkeyid = "rsa2048/0x594258F0389D2802";
+      fingerprint = "E631 8869 586F 99B4 F6E6  D785 5942 58F0 389D 2802";
+    }];
+  };
   typetetris = {
     email = "ericwolf42@mail.com";
     github = "typetetris";

--- a/pkgs/development/libraries/gl2ps/default.nix
+++ b/pkgs/development/libraries/gl2ps/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, cmake
+, zlib, libGL, libGLU, libpng, freeglut }:
+
+stdenv.mkDerivation rec {
+  version = "1.4.0";
+  name = "gl2ps-${version}";
+
+  src = fetchurl {
+    url = "http://geuz.org/gl2ps/src/${name}.tgz";
+    sha256 = "1qpidkz8x3bxqf69hlhyz1m0jmfi9kq24fxsp7rq6wfqzinmxjq3";
+  };
+
+  buildInputs = [
+    cmake
+    zlib
+    libGL
+    libGLU
+    libpng
+    freeglut
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = http://geuz.org/gl2ps;
+    description = "An OpenGL to PostScript printing library";
+    platforms = platforms.all;
+    license = licenses.lgpl2;
+    maintainers = with maintainers; [raskin twhitehead];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3280,6 +3280,8 @@ in
 
   gitea = callPackage ../applications/version-management/gitea { };
 
+  gl2ps = callPackage ../development/libraries/gl2ps { };
+
   glusterfs = callPackage ../tools/filesystems/glusterfs { };
 
   glmark2 = callPackage ../tools/graphics/glmark2 { };


### PR DESCRIPTION
<!-- Nixpkgs  of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions:has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Library required by octave to close #38459. Picked @7c6f434c as maintainer as is the maintainer of octave. Hope this was okay.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
