### PR TITLE
mirrors.nix: add alsa-project.org for alsa

### DIFF
--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -409,9 +409,10 @@ rec {
 
   # Alsa Project
   alsa = [
-     ftp://ftp.alsa-project.org/pub/
-     http://alsa.cybermirror.org/
-     http://www.mirrorservice.org/sites/ftp.alsa-project.org/pub/
-     http://alsa.mirror.fr/
+    https://www.alsa-project.org/files/pub/
+    ftp://ftp.alsa-project.org/pub/
+    http://alsa.cybermirror.org/
+    http://www.mirrorservice.org/sites/ftp.alsa-project.org/pub/
+    http://alsa.mirror.fr/
   ];
 }


### PR DESCRIPTION
###### Motivation for this change
Aside from being an HTTPS endpoint, this is the canonical mirror for alsa
project downloads.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
