### PR TITLE
deluge:  1.1.11 -> 2.0.3

### DIFF
--- a/pkgs/applications/networking/p2p/deluge/default.nix
+++ b/pkgs/applications/networking/p2p/deluge/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchpatch, intltool, libtorrentRasterbar, pythonPackages
-, gtk3, gobjectIntrospection, librsvg, wrapGAppsHook }:
+, gtk3, gobject-introspection, librsvg, wrapGAppsHook }:
 
 pythonPackages.buildPythonPackage rec {
   pname = "deluge";
@@ -15,7 +15,7 @@ pythonPackages.buildPythonPackage rec {
     libtorrentRasterbar.dev libtorrentRasterbar.python
     setproctitle pillow rencode six zope_interface
     dbus-python pygobject3 pycairo
-    gtk3 gobjectIntrospection librsvg
+    gtk3 gobject-introspection librsvg
   ];
 
   nativeBuildInputs = [ intltool wrapGAppsHook ];

--- a/pkgs/applications/networking/p2p/deluge/default.nix
+++ b/pkgs/applications/networking/p2p/deluge/default.nix
@@ -1,34 +1,37 @@
-{ stdenv, fetchurl, fetchpatch, intltool, libtorrentRasterbar, pythonPackages }:
+{ stdenv, fetchurl, fetchpatch, intltool, libtorrentRasterbar, pythonPackages
+, gtk3, gobjectIntrospection, librsvg, wrapGAppsHook }:
 
 pythonPackages.buildPythonPackage rec {
-  name = "deluge-${version}";
-  version = "1.3.15";
+  pname = "deluge";
+  version = "2.0.3";
 
   src = fetchurl {
-    url = "http://download.deluge-torrent.org/source/${name}.tar.bz2";
-    sha256 = "1467b9hmgw59gf398mhbf40ggaka948yz3afh6022v753c9j7y6w";
+    url = "http://download.deluge-torrent.org/source/2.0/${pname}-${version}.tar.xz";
+    sha256 = "14d8kn2pvr1qv8mwqrxmj85jycr73vwfqz12hzag0ararbkfhyky";
   };
 
-  patches = [
-    # Fix preferences when built against libtorrent >=0.16
-    (fetchpatch {
-      url = "https://git.deluge-torrent.org/deluge/patch/?id=38d7b7cdfde3c50d6263602ffb03af92fcbfa52e";
-      sha256 = "0la3i0lkj6yv4725h4kbd07mhfwcb34w7prjl9gxg12q7px6c31d";
-    })
-  ];
-
   propagatedBuildInputs = with pythonPackages; [
-    pyGtkGlade twisted Mako chardet pyxdg pyopenssl service-identity
+    twisted Mako chardet pyxdg pyopenssl service-identity
     libtorrentRasterbar.dev libtorrentRasterbar.python
+    setproctitle pillow rencode six zope_interface
+    dbus-python pygobject3 pycairo
+    gtk3 gobjectIntrospection librsvg
   ];
 
-  nativeBuildInputs = [ intltool ];
+  nativeBuildInputs = [ intltool wrapGAppsHook ];
+
+  checkInputs = with pythonPackages; [
+    pytest /* pytest-twisted */ pytestcov mock
+    mccabe pylint
+  ];
+
+  doCheck = false; # until pytest-twisted is packaged
 
   postInstall = ''
      mkdir -p $out/share/applications
-     cp -R deluge/data/pixmaps $out/share/
-     cp -R deluge/data/icons $out/share/
-     cp deluge/data/share/applications/deluge.desktop $out/share/applications
+     cp -R deluge/ui/data/pixmaps $out/share/
+     cp -R deluge/ui/data/icons $out/share/
+     cp deluge/ui/data/share/applications/deluge.desktop $out/share/applications
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/libtorrent-rasterbar/default.nix
+++ b/pkgs/development/libraries/libtorrent-rasterbar/default.nix
@@ -3,7 +3,7 @@
 }:
 
 let
-  version = "1.1.11";
+  version = "1.2.1";
   formattedVersion = lib.replaceChars ["."] ["_"] version;
 
   # Make sure we override python, so the correct version is chosen
@@ -16,8 +16,8 @@ in stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "arvidn";
     repo = "libtorrent";
-    rev = "libtorrent_${formattedVersion}";
-    sha256 = "0nwdsv6d2gkdsh7l5a46g6cqx27xwh3msify5paf02l1qzjy4s5l";
+    rev = "libtorrent-${formattedVersion}";
+    sha256 = "0sl7gq6a98w4ksq92w3ywkqachrpbwlbmhazgvlcncik7bq1gkjj";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2464,7 +2464,8 @@ in
   ddrutility = callPackage ../tools/system/ddrutility { };
 
   deluge = callPackage ../applications/networking/p2p/deluge {
-    pythonPackages = python2Packages;
+    pythonPackages = python3Packages;
+    libtorrentRasterbar = libtorrentRasterbar.override { python = python3; };
   };
 
   desktop-file-utils = callPackage ../tools/misc/desktop-file-utils { };


### PR DESCRIPTION
###### Motivation for this change

Requires libtorrentrasterbar update, will link relevant PR's shortly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---