### PR TITLE
victor-mono: init at 1.2.1

### DIFF
--- a/pkgs/data/fonts/victor-mono/default.nix
+++ b/pkgs/data/fonts/victor-mono/default.nix
@@ -1,0 +1,31 @@
+{ lib, fetchzip }:
+
+let
+  version = "1.2.1";
+in fetchzip rec {
+  name = "victor-mono-${version}";
+
+  url = "https://github.com/rubjo/victor-mono/archive/v1.2.1.zip";
+
+  # Grab VictorMonoAll.zip via versioned zip from github,
+  # instead of unversioned URL on main website.
+  # (they currently hash the same, happily)
+  postFetch = ''
+  unzip -j $downloadedFile \*/public/VictorMonoAll.zip
+
+  mkdir -p $out/share/fonts
+
+  unzip -j VictorMonoAll.zip \*.ttf -d $out/share/fonts/truetype
+  unzip -j VictorMonoAll.zip \*.otf -d $out/share/fonts/opentype
+  '';
+  sha256 = "0gnnymvgc2qm8wl1dyha1ilpwr1c5bz8xy8jxg1kz0m61kr16xac";
+
+  meta = with lib; {
+    description = "Free programming font with cursive italics and ligatures";
+    homepage = https://rubjo.github.io/victor-mono/;
+    maintainers = with maintainers; [ dtzWill ];
+    license = licenses.mit; # see LICENSE.txt in unpacked zip
+    platforms = platforms.all;
+  };
+}
+

--- a/pkgs/data/fonts/victor-mono/default.nix
+++ b/pkgs/data/fonts/victor-mono/default.nix
@@ -5,7 +5,7 @@ let
 in fetchzip rec {
   name = "victor-mono-${version}";
 
-  url = "https://github.com/rubjo/victor-mono/archive/v1.2.1.zip";
+  url = "https://github.com/rubjo/victor-mono/archive/v${version}.zip";
 
   # Grab VictorMonoAll.zip via versioned zip from github,
   # instead of unversioned URL on main website.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16776,6 +16776,8 @@ in
 
   vegur = callPackage ../data/fonts/vegur { };
 
+  victor-mono = callPackage ../data/fonts/victor-mono { };
+
   vistafonts = callPackage ../data/fonts/vista-fonts { };
 
   vistafonts-chs = callPackage ../data/fonts/vista-fonts-chs { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fixes #64465.

Haven't tested installation but inspecting output LGTM-- requester want
to confirm this works for you? :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---