### PR TITLE
[darwin] Fix fetchzip call by using https not http 

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/adv_cmds/boot.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/adv_cmds/boot.nix
@@ -11,7 +11,7 @@
 # the more recent adv_cmds release is used for everything else in this package
 
 let recentAdvCmds = fetchzip {
-  url = "http://opensource.apple.com/tarballs/adv_cmds/adv_cmds-158.tar.gz";
+  url = "https://opensource.apple.com/tarballs/adv_cmds/adv_cmds-158.tar.gz";
   sha256 = "0z081kcprzg5jcvqivfnwvvv6wfxzkjg2jc2lagsf8c7j7vgm8nn";
 };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
The installation of `adv_cmds` on OSX 10.14.4 failed because the hardcoded URL failed to work with fetchzip/fetchurl. This may be due to changes in how AWS hosts S3 files over HTTP/HTTPS.

This PR updates the hardcoded URL scheme from HTTP to HTTPS. On this OSX machine, the build passes as a result.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
