### PR TITLE
smlnj: 110.85 -> 110.91

### DIFF
--- a/pkgs/development/compilers/smlnj/default.nix
+++ b/pkgs/development/compilers/smlnj/default.nix
@@ -1,32 +1,32 @@
 { stdenv, fetchurl, darwin }:
 let
-  version = "110.85";
+  version = "110.91";
   baseurl = "http://smlnj.cs.uchicago.edu/dist/working/${version}";
 
   sources = map fetchurl [
-    { url = "${baseurl}/config.tgz";              sha256 = "1qlir3q0vi7f1wyz2jyaiqy3z72d0xngsa122ks5g0b7b0hcdgm1"; }
-    { url = "${baseurl}/cm.tgz";                  sha256 = "0330jkmaxgy085hsgajqikm242gms650rks24mfxhgk11r4ks105"; }
-    { url = "${baseurl}/compiler.tgz";            sha256 = "1zrqqvi9332g3clrh01z19sl06g3zlnp6zzz5z8rvsfwbiqp929m"; }
-    { url = "${baseurl}/runtime.tgz";             sha256 = "1n9hd99s2i834yihx4n59gl1cnh7hiiz8im735bmifmv50vzfdf4"; }
-    { url = "${baseurl}/system.tgz";              sha256 = "17samia4lzcz3mk73i330bspap2ks937arx35n9dr7bws0appfm8"; }
-    { url = "${baseurl}/MLRISC.tgz";              sha256 = "039g6dwxy96bkvw1z19vwn8q150h7s8jlcmsg851bgz3j3h6vs18"; }
-    { url = "${baseurl}/smlnj-lib.tgz";           sha256 = "1wk4w1npipm6qqgwis2xrbdjamwmiwv6ci4y40nzryhb37yxfj6d"; }
-    { url = "${baseurl}/old-basis.tgz";           sha256 = "0lkhbkkglz7lk1c93hc1y1di5dx20fgfhybvsqjp1bcwz8jsd70y"; }
-    { url = "${baseurl}/ckit.tgz";                sha256 = "14qxgw2vhq4dfiv5zl2gdhvjp75s10dqw97mqxffmh3vayyad1fi"; }
-    { url = "${baseurl}/nlffi.tgz";               sha256 = "16l8iszkyh34dqdbplsxycipvbw61yjamgxllcq8axiq4h7spy7w"; }
-    { url = "${baseurl}/cml.tgz";                 sha256 = "05dlqz4r3qa3rpqgjlx91fsfx7j6gk3dkw28zcgg5g32irmd1la3"; }
-    { url = "${baseurl}/eXene.tgz";               sha256 = "07mahzxns26hkfax9gc8cq4s8sfzj531wwnm47b8qkhd72d3ncn2"; }
-    { url = "${baseurl}/ml-lpt.tgz";              sha256 = "0073hfn98l61ryshhqw9855fb49vs9qcz9nplbg2pa2f7manqbk0"; }
-    { url = "${baseurl}/ml-lex.tgz";              sha256 = "106km17f4wyvhzkx62cfq2gp4ihya8l234550laqb50zf8vxyklq"; }
-    { url = "${baseurl}/ml-yacc.tgz";             sha256 = "1r0k7lz8xnir271pykbs4agadysbs35kkmg1p816kzfyz5bsrrq9"; }
-    { url = "${baseurl}/ml-burg.tgz";             sha256 = "10jqasplbxp50ryq74aazbnyaz8l492rhdij5mr1kzyfj79fysh9"; }
-    { url = "${baseurl}/pgraph.tgz";              sha256 = "1pxqddbrb7y9kp89gz8v8vfjmw4wajfy6757gb8c6x499jarxa60"; }
-    { url = "${baseurl}/trace-debug-profile.tgz"; sha256 = "0fkalpdzdrm1gmafn33ck4dw8s92p9iwm4fav4m9jcqyha9az3g7"; }
-    { url = "${baseurl}/heap2asm.tgz";            sha256 = "056gkmrylyrf0q0r3cpx76zx8mc62033jkn1bnjn0f8r31yhbipc"; }
-    { url = "${baseurl}/smlnj-c.tgz";             sha256 = "04c4jnylj5dnd4sjywzwnqlv9g7dkrilq6d4cy543dw03yhjdykw"; }
-    { url = "${baseurl}/doc.tgz";                 sha256 = "1rpk9g1nhjpc2b4pmzmj8v80knrhljn17ghiwznnljv53hka7jzx"; }
-    { url = "${baseurl}/boot.x86-unix.tgz";       sha256 = "05rh1y74jvp6zs96mb7nkwbgwwbss0zy2iw4gicdkyf6in0nk4la"; }
-    { url = "${baseurl}/asdl.tgz";                sha256 = "1d465bncgy92ni6430dbq6isvnysfhvykjrxm98dz82iih7a6vqb"; }
+    { url = "${baseurl}/config.tgz";              sha256 = "00vbg2kpwgkf272m697p5hd35pawficbrifchn7dnd519wpdx436"; }
+    { url = "${baseurl}/cm.tgz";                  sha256 = "0wxb0s2fwh7lbb3z2pfvmvhk5v0gm75kchkv7gg9f895ahyvm6yd"; }
+    { url = "${baseurl}/compiler.tgz";            sha256 = "0iq06ycivy562i59vvbma9zi575zw1djhdfkcy0bn7m9kfzzbgkh"; }
+    { url = "${baseurl}/runtime.tgz";             sha256 = "0km8p4vmy3m38xv0rl8d3mh2nlk2mvx010npm34gs374bmmzc7z9"; }
+    { url = "${baseurl}/system.tgz";              sha256 = "16d5vs1rn7ly6jxjm08222cj0sry73pr57xpc9d6k286b1v0910b"; }
+    { url = "${baseurl}/MLRISC.tgz";              sha256 = "1c9sw8zm90ykas5nwbhk2wic7sxkjrylb610x37v46m5ips1wlma"; }
+    { url = "${baseurl}/smlnj-lib.tgz";           sha256 = "09ka20ym7ahrpj4r6vc5phflc8y57dj09qvwk8ambfwb2p2274sw"; }
+    { url = "${baseurl}/old-basis.tgz";           sha256 = "1bhq9fv6p8diz489h9571g0xrsi8yx7h6gh9410255klxjrw964h"; }
+    { url = "${baseurl}/ckit.tgz";                sha256 = "1lq9ljai0shc6hszx5v6bqmkz16a3f295mfg7q622apzgzark3vd"; }
+    { url = "${baseurl}/nlffi.tgz";               sha256 = "1xjmlwiclgckj73z5hz3hnqlavp3ax9sfvgc0rvj3xpy3i3n6axj"; }
+    { url = "${baseurl}/cml.tgz";                 sha256 = "1sjzipxnvr9dgcg16bllfk3b46ac9f8h353nh1ccykwwq4whi9bf"; }
+    { url = "${baseurl}/eXene.tgz";               sha256 = "04clbchrlqx5v35gkbydbfnpl720i4nqijkshiwn0v592n4xfdf4"; }
+    { url = "${baseurl}/ml-lpt.tgz";              sha256 = "0max073nzwv7vx13caj7zmlhslvxlgg8rj52278g7f6fqcrwp5cf"; }
+    { url = "${baseurl}/ml-lex.tgz";              sha256 = "0x2mbg45l71049sgvvkl6bnqc5svz70vh1m1rbf3xk41z5bapcgr"; }
+    { url = "${baseurl}/ml-yacc.tgz";             sha256 = "0a1pbwpw1y6d1xn9yjarqpmybrxqwp5snp28by36745h1jvb1p1b"; }
+    { url = "${baseurl}/ml-burg.tgz";             sha256 = "119mq5jrbkn9vf9fgb0wyz483hf26al9hwb91xpmlmfx5qqnfzik"; }
+    { url = "${baseurl}/pgraph.tgz";              sha256 = "1s7jmh3q88rz29bk02y3gzdqrgvk484j5ji8bn7s6fc78m50nqp8"; }
+    { url = "${baseurl}/trace-debug-profile.tgz"; sha256 = "1gzf1pbmw2cn5w6f5qfdm3d6n6069n1nnzz6z4v7mr07x54c6mdv"; }
+    { url = "${baseurl}/heap2asm.tgz";            sha256 = "09cgj568a9x017awysjdx35mlp5zkdmc2fs67fvnm5ifl7ivfs8j"; }
+    { url = "${baseurl}/smlnj-c.tgz";             sha256 = "1g4xhcxychs9q25x7a5lvqfamq52c5ljlx84bc5cazvpkhixyg04"; }
+    { url = "${baseurl}/doc.tgz";                 sha256 = "1l0x91dscizk2pyj1lw595r84h1h0shxh0x5hva891717a1hfa51"; }
+    { url = "${baseurl}/boot.x86-unix.tgz";       sha256 = "0f6x4nfhrgm1z4dx862df2yaffdh1sd6zx2lyb2vph5mhp7x9n58"; }
+    { url = "${baseurl}/asdl.tgz";                sha256 = "1pi3m21jllyd2h0zpz4bajskfv58g6pjhpprqiwgmikn6w1pryp8"; }
   ];
 in stdenv.mkDerivation {
   name = "smlnj-${version}";

--- a/pkgs/development/compilers/smlnj/default.nix
+++ b/pkgs/development/compilers/smlnj/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, darwin }:
+{ stdenv, fetchurl }:
 let
   version = "110.91";
   baseurl = "http://smlnj.cs.uchicago.edu/dist/working/${version}";
@@ -36,15 +36,7 @@ in stdenv.mkDerivation {
   patchPhase = ''
     sed -i '/PATH=/d' config/_arch-n-opsys base/runtime/config/gen-posix-names.sh
     echo SRCARCHIVEURL="file:/$TMP" > config/srcarchiveurl
-  '' + stdenv.lib.optionalString stdenv.isDarwin (with darwin; ''
-    sed -i '/^[[:space:]]*\*x86-darwin\*)$/,/^[[:space:]]*\*) ;;/ c\
-\  \*x86-darwin\*)\
-\    INCLFILE=${stdenv.lib.getDev apple_sdk.sdk}/include/unistd.h\
-\    ;;\
-\  \*) ;;
-' base/runtime/config/gen-posix-names.sh
-    sed -i 's|^AS =\([[:space:]]*\)/usr/bin/as|AS =\1as|' base/runtime/objs/mk.x86-darwin
-  '');
+  '';
 
   unpackPhase = ''
     for s in $sources; do
@@ -74,7 +66,7 @@ in stdenv.mkDerivation {
     description = "Standard ML of New Jersey, a compiler";
     homepage    = http://smlnj.org;
     license     = licenses.bsd3;
-    platforms   = [ "i686-linux" ] ++ platforms.darwin;
+    platforms   = [ "i686-linux" ];
     maintainers = with maintainers; [ thoughtpolice ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
