### PR TITLE
monoid: 2016-07-21 -> 0.61

### DIFF
--- a/pkgs/data/fonts/monoid/default.nix
+++ b/pkgs/data/fonts/monoid/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "monoid-${version}";
-  version = "2016-07-21";
+  version = "0.61";
 
   src = fetchFromGitHub {
     owner = "larsenwork";
     repo = "monoid";
-    rev = "e9d77ec18c337dc78ceae787a673328615f0b120";
-    sha256 = "07h5q6cn6jjpmxp9vyag1bxx481waz344sr2kfs7d37bba8yjydj";
+    rev = "0.61";
+    sha256 = "1h18r93klpsc0h744cnlx6ca7p790k427j0lq0y4gnhcbw14zr4f";
   };
 
   nativeBuildInputs = [ python fontforge ];
@@ -29,8 +29,8 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://larsenwork.com/monoid;
     description = "Customisable coding font with alternates, ligatures and contextual positioning";
+    homepage = "http://larsenwork.com/monoid";
     license = [ licenses.ofl licenses.mit ];
     platforms = platforms.all;
     maintainers = [ maintainers.romildo ];


### PR DESCRIPTION
###### Motivation for this change
Fixing another "problematic" repology package.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

it's big
$ nix path-info -Sh ./result
/nix/store/s8xn788iwlmsiibcjrja5kx16s71gp09-monoid-2016-07-21    430.7M
$ nix path-info -Sh ./result
/nix/store/y7xgxx35vzawaszjnx2alvcmvrj510qn-monoid-0.61  429.9M
