### PR TITLE
colm: fix cross-compilation

### DIFF
--- a/pkgs/development/compilers/colm/cross-compile.patch
+++ b/pkgs/development/compilers/colm/cross-compile.patch
@@ -1,0 +1,13 @@
+--- a/configure.ac	2019-07-09 22:41:03.166948024 -0700
++++ b/configure.ac	2019-07-09 22:41:16.699948056 -0700
+@@ -40,9 +40,7 @@
+ 
+ dnl Choose a default for the build_manual var. If the dist file is present in
+ dnl the root then default to no, otherwise go for it.
+-AC_CHECK_FILES( [$srcdir/DIST], 
+-	[. $srcdir/DIST;], 
+-	[build_manual=yes; ] )
++build_manual=yes;
+ 
+ dnl Set to true if the manual should be built.
+ AM_CONDITIONAL(BUILD_MANUAL, [test "x$build_manual" = "xyes"])

--- a/pkgs/development/compilers/colm/default.nix
+++ b/pkgs/development/compilers/colm/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, gcc, asciidoc }:
+{ stdenv, fetchurl, makeWrapper, gcc, asciidoc, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   name = "colm-${version}";
@@ -9,7 +9,9 @@ stdenv.mkDerivation rec {
     sha256 = "0f76iri173l2wja2v7qrwmf958cqwh5g9x4bhj2z8wknmlla6gz4";
   };
 
-  nativeBuildInputs = [ makeWrapper asciidoc ];
+  patches = [ ./cross-compile.patch ];
+
+  nativeBuildInputs = [ makeWrapper asciidoc autoreconfHook ];
 
   doCheck = true;
 


### PR DESCRIPTION

###### Motivation for this change

Colm inappropriately uses AC_CHECK_FILES, which is meant to check if a file is available on a host system, rather than in the source tree. It seems to use this for a custom distribution system, which nixpkgs doesn't need. We can eschew all this by just manually evaluating the else case.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
