### PR TITLE
firefoxPackages.tor-browser: 8.5.2 -> 8.5.3

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -245,16 +245,16 @@ in rec {
   };
 
   tor-browser-8-5 = tbcommon rec {
-    ffversion = "60.7.0esr";
-    tbversion = "8.5.2";
+    ffversion = "60.8.0esr";
+    tbversion = "8.5.4";
 
     # FIXME: fetchFromGitHub is not ideal, unpacked source is >900Mb
     src = fetchFromGitHub {
       owner = "SLNOS";
       repo  = "tor-browser";
-      # branch "tor-browser-60.7.0esr-8.5-2-slnos"
-      rev   = "b8216328bf6bf1996fcd794d4531689a7c373a2f";
-      sha256 = "0zmqam3c91iww33jpfyl6q6wacj20nqkfzyqryalfvnvx3zi0i1q";
+      # branch "tor-browser-60.8.0esr-8.5-1-slnos"
+      rev   = "9ec7e4832a68ba3a77f5e8e21dc930a25757f55d";
+      sha256 = "10x9h2nm1p8cs0qnd8yjp7ly5raxagqyfjn4sj2y3i86ya5zygb9";
     };
 
     patches = [


### PR DESCRIPTION
# `git log`

- firefoxPackages.tor-browser: 8.5.2 -> 8.5.3

# `nix-instantiate` environment

- Host OS: Linux 4.9, SLNOS 19.09
- Nix: nix-env (Nix) 2.2.2
- Multi-user: yes
- Sandbox: yes
- NIXPKGS_CONFIG:

```nix
{
  checkMeta = true;
  doCheckByDefault = true;
}
```

# `nix-env -qaP` diffs

- On x86_64-linux:
  - Updated (2):
    - firefoxPackages.tor-browser
    - tor-browser-bundle
- On aarch64-linux: ditto
- On x86_64-darwin:
  - Updated (1):
    - firefoxPackages.tor-browser

/cc @joachifm