### PR TITLE
make-tarball / lib-tests: reduce duplication

### DIFF
--- a/lib/tests/release.nix
+++ b/lib/tests/release.nix
@@ -1,11 +1,9 @@
 { pkgs ? import ((import ../.).cleanSource ../..) {} }:
 
-pkgs.stdenv.mkDerivation {
-  name = "nixpkgs-lib-tests";
-  buildInputs = [ pkgs.nix ];
+pkgs.runCommandNoCC "nixpkgs-lib-tests" {
+  buildInputs = [ pkgs.nix (import ./check-eval.nix) ];
   NIX_PATH="nixpkgs=${pkgs.path}";
-
-  buildCommand = ''
+} ''
     datadir="${pkgs.nix}/share"
     export TEST_ROOT=$(pwd)/test-tmp
     export NIX_BUILD_HOOK=
@@ -22,10 +20,5 @@ pkgs.stdenv.mkDerivation {
     cd ${pkgs.path}/lib/tests
     bash ./modules.sh
 
-    [[ "$(nix-instantiate --eval --strict misc.nix)" == "[ ]" ]]
-
-    [[ "$(nix-instantiate --eval --strict systems.nix)" == "[ ]" ]]
-
     touch $out
-  '';
-}
+''


### PR DESCRIPTION
The misc.nix and systems.nix tests were invoked at three different
places. Let's not that.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
