### PR TITLE
writefreely: init at 0.10.0

### DIFF
--- a/pkgs/applications/networking/writefreely/default.nix
+++ b/pkgs/applications/networking/writefreely/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, lib, fetchFromGitHub, buildGoModule }:
+
+buildGoModule rec {
+  name = "writefreely-${version}";
+  version = "0.10.0";
+
+  src = fetchFromGitHub {
+    owner = "writeas";
+    repo = "writefreely";
+    rev = "v${version}";
+    sha256 = "1nnxba549nqcv9pmldkf42yggipxrwbx914anrh4wx5c128yjgbs";
+  };
+
+  modSha256 = "0n95awrf2a63z3qf3y2y7snmw0pfgzn6aliqdp6y03r7ipdqs9ij";
+
+  meta = with lib; {
+    description = "A simple, federated blogging platform";
+    homepage = https://writefreely.org;
+    license = licenses.agpl3;
+    maintainers = with maintainers; [ matthiasbeyer ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24046,6 +24046,8 @@ in
 
   wraith = callPackage ../applications/networking/irc/wraith { };
 
+  writefreely = callPackage ../applications/networking/writefreely { };
+
   wxmupen64plus = callPackage ../misc/emulators/wxmupen64plus { };
 
   wxsqlite3 = callPackage ../development/libraries/wxsqlite3 {


### PR DESCRIPTION
###### Motivation for this change

My attempt with https://github.com/NixOS/nixpkgs/issues/63335

Does not work yet though. If someone has experience with go packaging, please give it a try!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixphttps://github.com/NixOS/nixpkgs/issues/63335kgs/blob/master/.github/CONTRIBUTING.md).

---
