### PR TITLE
kjv: init at unstable-2018-12-25

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2601,6 +2601,11 @@
     github = "jraygauthier";
     name = "Raymond Gauthier";
   };
+  jtobin = {
+    email = "jared@jtobin.io";
+    github = "jtobin";
+    name = "Jared Tobin";
+  };
   jtojnar = {
     email = "jtojnar@gmail.com";
     github = "jtojnar";

--- a/pkgs/applications/misc/kjv/default.nix
+++ b/pkgs/applications/misc/kjv/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchFromGitHub, fetchpatch }:
+
+let
+
+patch-base = https://github.com/LukeSmithxyz/kjv/commit/;
+
+add-apocrypha = fetchpatch {
+  url = patch-base + "b92b7622285d10464f9274f11e740bef90705bbc.patch";
+  sha256 = "0n4sj8p9m10fcair4msc129jxkkx5whqzhjbr5k4lfgp6nb1zk8k";
+};
+
+add-install-target = fetchpatch {
+  url = patch-base + "f4ad73539eb73f1890f4b791d8d38dd95900a4a4.patch";
+  sha256 = "1yzj72i5fkzn2i4wl09q6jx7nwn2h4jwm49fc23nxfwchzar9m1q";
+};
+
+in
+
+stdenv.mkDerivation rec {
+  pname = "kjv";
+  version = "unstable-2018-12-25";
+
+  src = fetchFromGitHub {
+    owner = "bontibon";
+    repo = pname;
+    rev = "fda81a610e4be0e7c5cf242de655868762dda1d4";
+    sha256 = "1favfcjvd3pzz1ywwv3pbbxdg7v37s8vplgsz8ag016xqf5ykqqf";
+  };
+
+  patches = [ add-apocrypha add-install-target ];
+
+  makeFlags = [
+    "PREFIX=${placeholder ''out''}"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "The Bible, King James Version";
+    homepage = "https://github.com/bontibon/kjv";
+    license = licenses.publicDomain;
+    maintainers = [ maintainers.jtobin ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -858,6 +858,8 @@ in
     inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
   };
 
+  kjv = callPackage ../applications/misc/kjv { };
+
   luigi = callPackage ../applications/networking/cluster/luigi { };
 
   m-cli = callPackage ../os-specific/darwin/m-cli { };


### PR DESCRIPTION
###### Motivation for this change

Simply adds bonibon's `kjv` to nixpkgs.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
