### PR TITLE
cargo-flamegraph: init at 0.1.13

### DIFF
--- a/pkgs/development/tools/cargo-flamegraph/default.nix
+++ b/pkgs/development/tools/cargo-flamegraph/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, rustPlatform
+, Security
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cargo-flamegraph";
+  version = "0.1.13";
+
+  src = fetchFromGitHub {
+    owner = "ferrous-systems";
+    repo = "flamegraph";
+    rev = version;
+    sha256 = "1s0jnj78fqz5hlgq656rr2s9ykmia51b89iffadiw6c2aw4fhv1a";
+  };
+
+  cargoSha256 = "0kmw2n4j5bisac0bv3npbwfz2z00ncd6w8ichwaz5hac5mi1a72f";
+
+  buildInputs = stdenv.lib.optionals stdenv.isDarwin [
+    Security
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Easy flamegraphs for Rust projects and everything else, without Perl or pipes <3";
+    homepage = https://github.com/ferrous-systems/flamegraph;
+    license = with licenses; [ asl20 /* or */ mit ];
+    maintainers = with maintainers; [ killercup ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8054,6 +8054,10 @@ in
     inherit (darwin) cf-private;
   };
 
+  cargo-flamegraph = callPackage ../development/tools/cargo-flamegraph {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   carnix = (callPackage ../build-support/rust/carnix.nix { }).carnix { };
 
   defaultCrateOverrides = callPackage ../build-support/rust/default-crate-overrides.nix { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
