### PR TITLE
vscod{e,ium}: 1.36.0 -> 1.36.1

### DIFF
--- a/pkgs/applications/editors/vscode/vscode.nix
+++ b/pkgs/applications/editors/vscode/vscode.nix
@@ -11,13 +11,13 @@ let
   archive_fmt = if system == "x86_64-darwin" then "zip" else "tar.gz";
 
   sha256 = {
-    "x86_64-linux" = "02h71b9m9w4nc8g9iy2kafg041brli4zwv7pv6i1qg6p5cf2jdfx";
-    "x86_64-darwin" = "1awq0rwiizwbjqf7crv59qr7m7rmgpfba0b4qx2bpx1mn25fmq56";
+    "x86_64-linux" = "1ck13xpnfklfc81jd8d5md09fcp0gjypacdqj276mzhr5mig29cd";
+    "x86_64-darwin" = "0xpzm372swv0by22saxib16fvvvfjr7d68aj3l5dsl5c9a8v23qj";
   }.${system};
 in
   callPackage ./generic.nix rec {
 
-    version = "1.36.0";
+    version = "1.36.1";
     pname = "vscode";
 
     executableName = "code" + lib.optionalString isInsiders "-insiders";

--- a/pkgs/applications/editors/vscode/vscodium.nix
+++ b/pkgs/applications/editors/vscode/vscodium.nix
@@ -11,13 +11,13 @@ let
   archive_fmt = if system == "x86_64-darwin" then "zip" else "tar.gz";
 
   sha256 = {
-    "x86_64-linux" = "09vmq87az0f91xwyfby85pnn4mg0rlf7pyvs5bkrxv0r8jxxfpq7";
-    "x86_64-darwin" = "16yzzmlf3v9aj7dyglqjxdksabv0cc98w6kdv5rbfw865hj4bbck";
+    "x86_64-linux" = "1ay4zvkbln2wf2j1d71mn13b6p2fqvzgz45mzrgaqwsszhbg4xzp";
+    "x86_64-darwin" = "17r9krb1qd92ybx078hkw9zlyym6kbnmbl91vjdilsq77bkf9jmw";
   }.${system};
 in
   callPackage ./generic.nix rec {
 
-    version = "1.36.0";
+    version = "1.36.1";
     pname = "vscodium";
 
     executableName = "codium";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
