### PR TITLE
pythonPackages.simple-salesforce: init at 0.74.3

### DIFF
--- a/pkgs/development/python-modules/simple-salesforce/default.nix
+++ b/pkgs/development/python-modules/simple-salesforce/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, buildPythonPackage,
+  mock, requests, nose, pytz, responses, pylint }:
+
+buildPythonPackage rec {
+  pname = "simple-salesforce";
+  version = "0.74.3";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1n960xgrnmv20l31nm0im7pb4nfa83bmx4x4clqrh2jkpzq3ric0";
+  };
+
+  checkInputs = [ mock nose pytz responses pylint ];
+
+  postPatch = ''
+    substituteInPlace setup.py --replace "mock==1.0.1" "mock"
+  '';
+
+  propagatedBuildInputs = [ requests ];
+
+  meta = with stdenv.lib; {
+    description = "A basic Salesforce.com REST API client";
+    homepage = "https://github.com/simple-salesforce/simple-salesforce";
+    maintainers = with maintainers; [ mrmebelman ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2453,6 +2453,8 @@ in {
 
   schema = callPackage ../development/python-modules/schema {};
 
+  simple-salesforce = callPackage ../development/python-modules/simple-salesforce {};
+
   simple-websocket-server = callPackage ../development/python-modules/simple-websocket-server {};
 
   stem = callPackage ../development/python-modules/stem { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Adding a missing package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
