### PR TITLE
docker.nix: Add options for named volumes and networks

### DIFF
--- a/nixos/modules/virtualisation/docker.nix
+++ b/nixos/modules/virtualisation/docker.nix
@@ -9,6 +9,67 @@ let
   cfg = config.virtualisation.docker;
   proxy_env = config.networking.proxy.envVars;
 
+  inherit (builtins) attrNames;
+
+  mkUncreateMaybe = networks: volumes: ''
+    set -euo pipefail
+
+    nexisting=$(${pkgs.coreutils}/bin/mktemp)
+    nwanted=$(${pkgs.coreutils}/bin/mktemp)
+    vexisting=$(${pkgs.coreutils}/bin/mktemp)
+    vwanted=$(${pkgs.coreutils}/bin/mktemp)
+
+    cleanup() {
+      rm -f "$nexisting" "$nwanted" "$vexisting" "$vwanted"
+    }
+    trap cleanup EXIT
+
+    ${pkgs.docker}/bin/docker network ls --format '{{.Name}}' > "$nexisting"
+    echo -e "bridge\nhost\nnone\n${concatStringsSep "\n" networks}" > "$nwanted"
+
+    ${pkgs.docker}/bin/docker volume ls --format '{{.Name}}' > "$vexisting"
+    echo -e "${concatStringsSep "\n" volumes}" > "$vwanted"
+
+    nsuperfluous="$(${pkgs.gnugrep}/bin/grep -vxF -f $nwanted $nexisting || true)"
+    vsuperfluous="$(${pkgs.gnugrep}/bin/grep -vxF -f $vwanted $vexisting || true)"
+
+    while read -r net; do
+      if [[ ! -z "$net" ]]; then
+        echo -n "Removed superfluous Docker network: "
+        ${pkgs.docker}/bin/docker network rm "$net" || true
+      fi
+    done <<< "$nsuperfluous"
+
+    while read -r vol; do
+      if [[ ! -z "$vol" ]]; then
+        echo -n "Removed superfluous Docker volume: "
+        ${pkgs.docker}/bin/docker volume rm "$vol" || true
+      fi
+    done <<< "$vsuperfluous"
+  '';
+
+  mkNetworkOpts = opts: concatStringsSep " "
+    ([ "--driver=${opts.driver}" ]
+    ++ optional (cfg ? subnet && cfg.subnet != null) "--subnet=${opts.subnet}"
+    ++ optional (cfg ? ip-range && cfg.ip-range != null) "--ip-range=${opts.ip-range}"
+    ++ optional (cfg ? gateway && cfg.gateway != null) "--gateway=${opts.gateway}"
+    ++ optional (cfg ? ipv6 && cfg.ipv6) "--ipv6"
+    ++ optional (cfg ? internal && cfg.internal) "--internal");
+
+
+  mkNetwork = name: opts: ''
+    if [[ $(${pkgs.docker}/bin/docker network ls --quiet --filter name=${name} | wc -c) -eq 0 ]]; then
+      echo "*** docker network create ${mkNetworkOpts opts} ${name}"
+      ${pkgs.docker}/bin/docker network create ${mkNetworkOpts opts} ${name}
+    fi
+  '';
+
+  mkVolume = name: ''
+    if [[ $(${pkgs.docker}/bin/docker volume ls --quiet --filter name=${name} | wc -c) -eq 0 ]]; then
+      echo "*** docker volume create ${name}"
+      ${pkgs.docker}/bin/docker volume create ${name}
+    fi
+  '';
 in
 
 {
@@ -93,6 +154,16 @@ in
           '';
       };
 
+    logLevel =
+      mkOption {
+        type = types.enum ["debug" "info" "warn" "error" "fatal"];
+        default = "info";
+        description =
+          ''
+            This option determines the log level for the Docker daemon.
+          '';
+      };
+
     extraOptions =
       mkOption {
         type = types.separatedString " ";
@@ -144,6 +215,90 @@ in
         Docker package to be used in the module.
       '';
     };
+
+    volumes = mkOption {
+      default = [];
+      type = types.listOf types.str;
+      example = [ "volume_1" "volume_2" ];
+      description = ''
+        A list of named volumes that should be created.
+      '';
+    };
+
+
+    networks = mkOption {
+      default = {};
+      type = types.attrsOf (types.submodule {
+        options = {
+          driver = mkOption {
+            default = "bridge";
+            type = types.str;
+            example = "overlay";
+            description = ''
+              Driver to manage the network. One of bridge, or overlay.
+            '';
+          };
+
+          subnet = mkOption {
+            default = null;
+            type = types.nullOr types.str;
+            example = "172.28.0.0/16";
+            description = ''
+              Subnet in CIDR format that represents a network segment.
+            '';
+          };
+
+          ip-range = mkOption {
+            default = null;
+            type = types.nullOr types.str;
+            example = "172.28.5.0/24";
+            description = ''
+              Allocate container ip from a sub-range.
+            '';
+          };
+
+          gateway = mkOption {
+            default = null;
+            type = types.nullOr types.str;
+            example = "172.28.5.254";
+            description = ''
+              IPv4 or IPv6 Gateway for the master subnet.
+            '';
+          };
+
+          ipv6 = mkOption {
+            default = false;
+            type = types.bool;
+            example = true;
+            description = ''
+              Enable IPv6 networking.
+            '';
+          };
+
+          internal = mkOption {
+            default = false;
+            type = types.bool;
+            example = true;
+            description = ''
+              Restrict external access to the network.
+            '';
+          };
+        };
+      });
+
+      example = {
+        my-network = {
+          driver = "bridge";
+          subnet = "172.28.0.0/16";
+          ip-range = "172.28.5.0/24";
+          gateway = "172.28.5.254";
+        };
+      };
+
+      description = ''
+        A list of named networks to be created.
+      '';
+    };
   };
 
   ###### implementation
@@ -157,6 +312,11 @@ in
       systemd.services.docker = {
         wantedBy = optional cfg.enableOnBoot "multi-user.target";
         environment = proxy_env;
+
+        postStart = mkUncreateMaybe (attrNames cfg.networks) cfg.volumes
+                  + concatStrings (mapAttrsToList mkNetwork cfg.networks)
+                  + concatStrings (map mkVolume cfg.volumes);
+
         serviceConfig = {
           ExecStart = [
             ""
@@ -165,11 +325,13 @@ in
                 --group=docker \
                 --host=fd:// \
                 --log-driver=${cfg.logDriver} \
+                --log-level=${cfg.logLevel} \
                 ${optionalString (cfg.storageDriver != null) "--storage-driver=${cfg.storageDriver}"} \
                 ${optionalString cfg.liveRestore "--live-restore" } \
                 ${optionalString cfg.enableNvidia "--add-runtime nvidia=${pkgs.nvidia-docker}/bin/nvidia-container-runtime" } \
                 ${cfg.extraOptions}
             ''];
+
           ExecReload=[
             ""
             "${pkgs.procps}/bin/kill -s HUP $MAINPID"

--- a/nixos/tests/docker.nix
+++ b/nixos/tests/docker.nix
@@ -10,8 +10,19 @@ import ./make-test.nix ({ pkgs, ...} : {
     docker =
       { pkgs, ... }:
         {
-          virtualisation.docker.enable = true;
-          virtualisation.docker.package = pkgs.docker;
+          virtualisation.docker = {
+            enable = true;
+            package = pkgs.docker;
+            volumes = [ "thevolume" ];
+            networks.thenetwork = {
+              driver = "bridge";
+              subnet = "172.28.0.0/16";
+              ip-range = "172.28.5.0/24";
+              gateway = "172.28.5.254";
+            };
+
+            logLevel = "warn";
+          };
 
           users.users = {
             noprivs = {
@@ -40,6 +51,15 @@ import ./make-test.nix ({ pkgs, ...} : {
     $docker->succeed("sudo -u hasprivs docker ps");
     $docker->fail("sudo -u noprivs docker ps");
     $docker->succeed("docker stop sleeping");
+
+    $docker->succeed("docker volume ls | grep thevolume");
+    $docker->succeed("docker network ls | grep thenetwork");
+
+    $docker->succeed("docker volume create superfluousvolume");
+    $docker->succeed("docker network create superfluousnetwork");
+    $docker->systemctl("restart docker");
+    $docker->waitForUnit("docker.service");
+    $docker->fail("docker volume ls | grep superfluous");
 
     # Must match version twice to ensure client and server versions are correct
     $docker->succeed('[ $(docker version | grep ${pkgs.docker.version} | wc -l) = "2" ]');


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
I was porting some `docker-compose` stuff to `docker-containers.nix` and found the lack of declarative networks and volumes.

###### Things done
* Added options:
  * `services.docker.volumes = [ "one" "two" ];`
  * `services.docker.networks.foo = {};`
* Added tests

A few notes:

* Code runs in a `docker.service` `postStart`, since I didn't want to tie it to any particular way to run docker containers, plus these entities are "docker-global", and so I think they fit well in the `docker` module.
* This is probably incompatible with imperative creation of volumes and networks. The code removes any named volumes and networks other than the default ones and the ones declared in the module.
* The "remove unnecessary things" code is a little more complex than I had hoped for. At least, turns out you can just use `grep` to do a set complement, which is nice.
* I have never written any nixos tests before, I'm not sure if the way I test for entity removal is the way to go here; feedback is most welcome.
* `nix-build -A nixosTests.docker` passes on my computer.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
