### PR TITLE
kube-router: 0.2.5 -> 0.3.1

### DIFF
--- a/pkgs/applications/networking/cluster/kube-router/default.nix
+++ b/pkgs/applications/networking/cluster/kube-router/default.nix
@@ -1,17 +1,16 @@
-{ stdenv, buildGoPackage, fetchFromGitHub }:
+{ lib, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage rec {
-  name = "kube-router-${version}";
-  version = "0.2.5";
-  rev = "v${version}";
+  pname = "kube-router";
+  version = "0.3.1";
 
   goPackagePath = "github.com/cloudnativelabs/kube-router";
 
   src = fetchFromGitHub {
-    inherit rev;
     owner = "cloudnativelabs";
-    repo = "kube-router";
-    sha256 = "1j6q6kg4qj75v2mdy9ivvwq8mx9fpdf0w08959l8imrp5byd56wv";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "06azrghcxp6n4bvrqxpwhmg60qk4jqcrkl1lh1rardlzhl71lk1h";
   };
 
   buildFlagsArray = ''
@@ -22,7 +21,7 @@ buildGoPackage rec {
     ${goPackagePath}/pkg/cmd.buildDate=Nix
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "https://www.kube-router.io/";
     description = "All-in-one router, firewall and service proxy for Kubernetes";
     license = licenses.asl20;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update `kube-router` to the latest release.
 - https://github.com/cloudnativelabs/kube-router/releases/tag/v0.3.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
