### PR TITLE
clair: 2.0.7 -> 2.0.8

### DIFF
--- a/pkgs/tools/admin/clair/default.nix
+++ b/pkgs/tools/admin/clair/default.nix
@@ -2,15 +2,15 @@
 
 buildGoPackage rec {
   pname = "clair";
-  version = "2.0.7";
+  version = "2.0.8";
 
   goPackagePath = "github.com/coreos/clair";
 
   src = fetchFromGitHub {
     owner = "coreos";
-    repo = "clair";
+    repo = pname;
     rev = "v${version}";
-    sha256 = "0n4pxdw71hd1rxzgf422fvycpjkrxxnvcidys0hpjy7gs88zjz5x";
+    sha256 = "1gwn533fdz8daz1db7w7g7mhls7d5a4vndn47blkpbx2yxdwdh62";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -22,8 +22,8 @@ buildGoPackage rec {
 
   meta = with lib; {
     description = "Vulnerability Static Analysis for Containers";
-    homepage = https://github.com/coreos/clair;
+    homepage = "https://github.com/coreos/clair";
     license = licenses.asl20;
-    maintainers = [ maintainers.marsam ];
+    maintainers = with maintainers; [ marsam ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update `clair` to the latest release.
 - https://github.com/coreos/clair/releases/tag/v2.0.8
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
