### PR TITLE
bitlbee-mastodon: init at 1.4.2

### DIFF
--- a/pkgs/applications/networking/instant-messengers/bitlbee-mastodon/default.nix
+++ b/pkgs/applications/networking/instant-messengers/bitlbee-mastodon/default.nix
@@ -1,0 +1,30 @@
+{ fetchgit, stdenv, bitlbee, autoreconfHook, pkgconfig, glib }:
+
+with stdenv.lib;
+stdenv.mkDerivation rec {
+  pname = "bitlbee-mastodon";
+  version = "1.4.2";
+
+  src = fetchgit {
+    url = "https://alexschroeder.ch/cgit/bitlbee-mastodon";
+    rev = "v${version}";
+    sha256 = "04rakgr1pfsg1vhfwlfbggbzw249j7dmk88xrsnf3n84c5ccdyas";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  buildInputs = [ bitlbee glib ];
+
+  preConfigure = ''
+    export BITLBEE_PLUGINDIR=$out/lib/bitlbee
+    export BITLBEE_DATADIR=$out/share/bitlbee
+    ./autogen.sh
+  '';
+
+  meta = {
+    description = "Bitlbee plugin for Mastodon";
+    homepage = "https://alexschroeder.ch/cgit/bitlbee-mastodon/about";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ jpotier ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17072,6 +17072,8 @@ in
 
   bitlbee-steam = callPackage ../applications/networking/instant-messengers/bitlbee-steam { };
 
+  bitlbee-mastodon = callPackage ../applications/networking/instant-messengers/bitlbee-mastodon { };
+
   bitmeter = callPackage ../applications/audio/bitmeter { };
 
   bitscope = recurseIntoAttrs


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] (NA) Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] (NA) Tested execution of all binary files (usually in `./result/bin/`)
- [ ] (NA) Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
