### PR TITLE
mage: 1.7.1 -> 1.8.0

### DIFF
--- a/pkgs/development/tools/build-managers/mage/default.nix
+++ b/pkgs/development/tools/build-managers/mage/default.nix
@@ -1,32 +1,30 @@
-{ buildGoPackage, fetchFromGitHub, lib }:
+{ buildGoModule, fetchFromGitHub, lib }:
 
-with lib;
-
-buildGoPackage rec {
-  name = "mage-${version}";
-  version = "1.7.1";
-
-  goPackagePath = "github.com/magefile/mage";
-  subPackages = [ "." ];
+buildGoModule rec {
+  pname = "mage";
+  version = "1.8.0";
 
   src = fetchFromGitHub {
     owner = "magefile";
-    repo = "mage";
+    repo = pname;
     rev = "v${version}";
-    sha256 = "0n4k5dy338rxwzj654smxzlanmd0zws6mdzv0wc4byqjhr7mqhg2";
+    sha256 = "0vkzm2k2v3np30kdgz9kpwkhnshbjcn8j1y321djz2h3w23k5h7r";
   };
 
-  buildFlagsArray = [ 
+  modSha256 = "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5";
+
+  buildFlagsArray = [
     "-ldflags="
     "-X github.com/magefile/mage/mage.commitHash=v${version}"
     "-X github.com/magefile/mage/mage.gitTag=v${version}"
+    "-X github.com/magefile/mage/mage.timestamp=1970-01-01T00:00:00Z"
   ];
 
-  meta = {
+  meta = with lib; {
     description = "A Make/Rake-like Build Tool Using Go";
+    homepage = "https://magefile.org/";
     license = licenses.asl20;
-    maintainers = [ maintainers.swdunlop ];
-    homepage = https://magefile.org/;
+    maintainers = with maintainers; [ swdunlop ];
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update `mage` to the latest release.
- https://github.com/magefile/mage/releases/tag/v1.8.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
