### PR TITLE
dex-oidc: 2.16.0 -> 2.17.0

### DIFF
--- a/pkgs/servers/dex/default.nix
+++ b/pkgs/servers/dex/default.nix
@@ -1,36 +1,36 @@
-{ lib, buildGoPackage, fetchFromGitHub }:
+{ lib, buildGoModule, fetchFromGitHub }:
 
-buildGoPackage rec {
+buildGoModule rec {
   pname = "dex";
-  version = "2.16.0";
-
-  goPackagePath = "github.com/dexidp/dex";
+  version = "2.17.0";
 
   src = fetchFromGitHub {
-    rev = "v${version}";
     owner = "dexidp";
     repo = pname;
-    sha256 = "0w8nl7inqp4grbaq320dgynmznbrln8vihd799dwb2cx86laxsi1";
+    rev = "v${version}";
+    sha256 = "1z94svpiwrs64m83gpfnniv0ac1fnmvywvl05f20ind1wlf8bvwn";
   };
+
+  modSha256 = "043sjq547nwg5v8708nhij0g7d2j28pyn676fgbnpps35ymnywfi";
 
   subPackages = [
     "cmd/dex"
   ];
 
   buildFlagsArray = [
-    "-ldflags=-w -X ${goPackagePath}/version.Version=${src.rev}"
+    "-ldflags=-w -X github.com/dexidp/dex/version.Version=${src.rev}"
   ];
 
   postInstall = ''
     mkdir -p $out/share
-    cp -r go/src/${goPackagePath}/web $out/share/web
+    cp -r $src/web $out/share/web
   '';
 
-  meta = {
+  meta = with lib; {
     description = "OpenID Connect and OAuth2 identity provider with pluggable connectors";
-    license = lib.licenses.asl20;
-    homepage = https://github.com/dexidp/dex;
-    maintainers = with lib.maintainers; [benley];
-    platforms = lib.platforms.unix;
+    homepage = "https://github.com/dexidp/dex";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ benley ];
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update `dex-oidc` to the latest release.
 - https://github.com/dexidp/dex/releases/tag/v2.17.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
