### PR TITLE
Prebuild /etc/passwd and /etc/group if possible

### DIFF
--- a/nixos/modules/config/update-users-groups.pl
+++ b/nixos/modules/config/update-users-groups.pl
@@ -185,7 +185,7 @@ foreach my $u (@{$spec->{users}}) {
     my $name = $u->{name};
 
     # Resolve the gid of the user.
-    if ($u->{group} =~ /^[0-9]$/) {
+    if ($u->{group} =~ /^[0-9]+$/) {
         $u->{gid} = $u->{group};
     } elsif (defined $groupsOut{$u->{group}}) {
         $u->{gid} = $groupsOut{$u->{group}}->{gid} // die;

--- a/nixos/modules/config/update-users-groups.pl
+++ b/nixos/modules/config/update-users-groups.pl
@@ -211,12 +211,6 @@ foreach my $u (@{$spec->{users}}) {
         }
     }
 
-    # Create a home directory.
-    if ($u->{createHome}) {
-        make_path($u->{home}, { mode => 0700 }) if ! -e $u->{home};
-        chown $u->{uid}, $u->{gid}, $u->{home};
-    }
-
     if (defined $u->{passwordFile}) {
         if (-e $u->{passwordFile}) {
             $u->{hashedPassword} = read_file($u->{passwordFile});

--- a/nixos/modules/config/update-users-groups.pl
+++ b/nixos/modules/config/update-users-groups.pl
@@ -177,7 +177,6 @@ my @lines = map { join(":", $_->{name}, $_->{password}, $_->{gid}, $_->{members}
     (sort { $a->{gid} <=> $b->{gid} } values(%groupsOut));
 updateFile($gidMapFile, encode_json($gidMap));
 updateFile("/etc/group", \@lines);
-system("nscd --invalidate group");
 
 # Generate a new /etc/passwd containing the declared users.
 my %usersOut;
@@ -247,7 +246,6 @@ foreach my $name (keys %usersCur) {
     (sort { $a->{uid} <=> $b->{uid} } (values %usersOut));
 updateFile($uidMapFile, encode_json($uidMap));
 updateFile("/etc/passwd", \@lines);
-system("nscd --invalidate passwd");
 
 
 # Rewrite /etc/shadow to add new accounts or remove dead ones.

--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -519,7 +519,7 @@ in {
       render.gid = ids.gids.render;
     };
 
-    system.activationScripts.users = stringAfter [ "stdio" ]
+    system.activationScripts.users-before-etc =
       ''
         install -m 0700 -d /root
         install -m 0755 -d /home
@@ -529,6 +529,10 @@ in {
           -I${pkgs.perlPackages.JSON}/${pkgs.perl.libPrefix} \
           ${./update-users-groups.pl} ${spec}
       '';
+
+    # allow either "users-before-etc" or "etc" to create passwd/group; either
+    # way, "users" just exists to be a target for later snippets to depend on.
+    system.activationScripts.users = stringAfter [ "etc" ] "";
 
     # for backwards compatibility
     system.activationScripts.groups = stringAfter [ "users" ] "";

--- a/nixos/modules/system/activation/activation-script.nix
+++ b/nixos/modules/system/activation/activation-script.nix
@@ -8,7 +8,7 @@ let
   sortSnippets = set: let withHeadlines = mapAttrs (a: v:
     let entry = if isString v then noDepEntry v else v;
     in entry // {
-    text = ''
+    text = optionalString (entry.text != "") ''
       #### Activation script snippet ${a}:
       _localstatus=0
       ${entry.text}
@@ -16,8 +16,9 @@ let
       if (( _localstatus > 0 )); then
         printf "Activation script snippet '%s' failed (%s)\n" "${a}" "$_localstatus"
       fi
+
     '';
-  }) set; in textClosureMap id (withHeadlines) (attrNames withHeadlines);
+  }) set; in concatStrings (textClosureList withHeadlines (attrNames withHeadlines));
 
   path = with pkgs; map getBin
     [ coreutils

--- a/nixos/modules/system/activation/activation-script.nix
+++ b/nixos/modules/system/activation/activation-script.nix
@@ -25,7 +25,6 @@ let
       gnugrep
       findutils
       getent
-      stdenv.cc.libc # nscd in update-users-groups.pl
       shadow
       nettools # needed for hostname
       utillinux # needed for mount and mountpoint

--- a/nixos/modules/system/etc/etc.nix
+++ b/nixos/modules/system/etc/etc.nix
@@ -150,7 +150,7 @@ in
 
     system.build.etc = etc;
 
-    system.activationScripts.etc = stringAfter [ "users" "groups" ]
+    system.activationScripts.etc = stringAfter [ "users-before-etc" ]
       ''
         # Set up the statically computed bits of /etc.
         echo "setting up /etc..."

--- a/nixos/modules/system/etc/setup-etc.pl
+++ b/nixos/modules/system/etc/setup-etc.pl
@@ -75,15 +75,28 @@ find(\&cleanup, "/etc");
 
 
 # Use /etc/.clean to keep track of copied files.
-my @oldCopied = read_file("/etc/.clean", chomp => 1, err_mode => 'quiet');
+my @oldClean = read_file("/etc/.clean", chomp => 1, err_mode => 'quiet');
 open CLEAN, ">>/etc/.clean";
 
+
+# Leave all copied files owned by root and with their Nix store permissions
+# until all files are in place, in case /etc/passwd or /etc/group are being
+# updated this way. Since we're deferring ownership changes, we have to also
+# defer permissions changes; otherwise an unprivileged service could lose
+# access to its config files during this window. Leaving files readable by
+# everyone for a bit isn't a security problem because the source of these files
+# is already world-readable in the Nix store.
+my %copied;
+sub set_ownership {
+    my $target = shift;
+    $copied{$target} = \@_;
+}
 
 # For every file in the etc tree, create a corresponding symlink in
 # /etc to /etc/static.  The indirection through /etc/static is to make
 # switching to a new configuration somewhat more atomic.
 my %created;
-my @copied;
+my @clean;
 
 sub link {
     my $fn = substr $File::Find::name, length($etc) + 1 or next;
@@ -108,13 +121,10 @@ sub link {
             my $uid = read_file("$_.uid"); chomp $uid;
             my $gid = read_file("$_.gid"); chomp $gid;
             copy "$static/$fn", "$target.tmp" or warn;
-            $uid = getpwnam $uid unless $uid =~ /^\+/;
-            $gid = getgrnam $gid unless $gid =~ /^\+/;
-            chown int($uid), int($gid), "$target.tmp" or warn;
-            chmod oct($mode), "$target.tmp" or warn;
             rename "$target.tmp", $target or warn;
+            set_ownership $target, oct($mode), $uid, $gid;
         }
-        push @copied, $fn;
+        push @clean, $fn;
         print CLEAN "$fn\n";
     } elsif (-l "$_") {
         atomicSymlink "$static/$fn", $target or warn;
@@ -124,9 +134,20 @@ sub link {
 find(\&link, $etc);
 
 
+# Now that all files are in place, it should be safe to call getpwnam and
+# getgrnam.
+foreach my $target (keys %copied) {
+    my ($mode, $uid, $gid) = @{$copied{$target}};
+    $uid = getpwnam $uid unless $uid =~ /^\+/;
+    $gid = getgrnam $gid unless $gid =~ /^\+/;
+    chown int($uid), int($gid), "$target" or warn;
+    chmod $mode, "$target" or warn;
+}
+
+
 # Delete files that were copied in a previous version but not in the
 # current.
-foreach my $fn (@oldCopied) {
+foreach my $fn (@oldClean) {
     if (!defined $created{$fn}) {
         $fn = "/etc/$fn";
         print STDERR "removing obsolete file ‘$fn’...\n";
@@ -137,4 +158,4 @@ foreach my $fn (@oldCopied) {
 
 # Rewrite /etc/.clean.
 close CLEAN;
-write_file("/etc/.clean", map { "$_\n" } @copied);
+write_file("/etc/.clean", map { "$_\n" } @clean);


### PR DESCRIPTION
###### Motivation for this change

When `mutableUsers = false` and all users and groups have assigned UID/GIDs, we can precompute exactly what `update-users-groups.pl` would output for `/etc/passwd` and `/etc/group`. In those cases we don't need to run it at activation time; we can generate the right files at build time and just symlink them into place.

These patches make that happen automatically when it's safe to do so. Until #64268 gets merged most NixOS configurations won't see any benefit because `nscd` doesn't have an assigned UID, but you can always manually assign UIDs and GIDs as needed to make these changes trigger. In my testing I just disabled nscd instead.

The first few commits are just cleanups that I think are worth applying regardless. In particular, "no output for empty snippets" just makes the generated activation script easier to read. Since the snippets I introduce in later commits are empty under various circumstances, it's nice to have that cleanup in place first.

I didn't do this because of closure size, but it does reduce the closure size for my test configurations by more than I expected: 187kB savings if no users have `password` or `passwordFile` set. If any users do have one of those options, that adds 32kB to pull in `mkpasswd`, which is still a 155kB savings. Of course, that's all rounding errors in these 539MB closures...

Hey @peterhoeg and @arianvp, you seemed interested in this work, so here's the pull request I promised.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
