### PR TITLE
tacacs+: init 4.0.4.28

### DIFF
--- a/pkgs/servers/tacacs+/default.nix
+++ b/pkgs/servers/tacacs+/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchurl, tcp_wrappers, flex, bison, perl }:
+
+stdenv.mkDerivation rec {
+  pname = "tacacs+";
+  version = "4.0.4.28";
+
+  src = fetchurl {
+    url = "ftp://ftp.shrubbery.net/pub/tac_plus/tacacs-F${version}.tar.gz";
+    sha256 = "17i18z3s58c8yy8jxp01q3hzz5nirs4cjxms18zzkli6ip4jszql";
+  };
+
+  nativeBuildInputs = [ flex bison ];
+  buildInputs = [ tcp_wrappers perl ];
+
+  meta = with stdenv.lib; {
+    description = "A protocol for authentication, authorization and accounting (AAA) services for routers and network devices";
+    homepage = "http://www.shrubbery.net/tac_plus/";
+    license = licenses.free;
+    maintainers = [ maintainers."0x4A6F" ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7823,6 +7823,8 @@ in
   psc-package = haskell.lib.justStaticExecutables
     (haskellPackages.callPackage ../development/compilers/purescript/psc-package { });
 
+  "tacacs+" = callPackage ../servers/tacacs+ { };
+
   tamarin-prover =
     (haskellPackages.callPackage ../applications/science/logic/tamarin-prover {
       # NOTE: do not use the haskell packages 'graphviz' and 'maude'


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Adding package for a [TACACS+](http://www.shrubbery.net/tac_plus/) implementation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
