### PR TITLE
treesheets: 2018-8-18 -> 1.0.1

### DIFF
--- a/pkgs/applications/office/treesheets/default.nix
+++ b/pkgs/applications/office/treesheets/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name    = "treesheets-${version}";
-  version = "2018-08-18";
+  version = "1.0.1";
 
   src = fetchFromGitHub {
     owner  = "aardappel";
     repo   = "treesheets";
-    rev    = "3af41d99c8f9f32603a36ab64af3560b6d61dd73";
-    sha256 = "147y8ggh3clwjgsi15z8i4jnzlkh8p17mmlg532jym53zzbcva65";
+    rev    = "v${version}";
+    sha256 = "0krsj7i5yr76imf83krz2lmlmpbsvpwqg2d4r0jwxiydjfyj4qr4";
   };
 
   buildInputs = [ wxGTK makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change
Fixing "troubled" packages on repology

tested application, seems to work fine, but im not a user of it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

$ nix path-info -Sh ./result
/nix/store/wcpz3zkm63fzkgzvdpjmbg80j1zv3zcw-treesheets-2018-08-18        304.9M
$ nix path-info -Sh ./result
/nix/store/iv9jkcygk5g2knp0r5pdr878bld6vrql-treesheets-1.0.1     304.9M