### PR TITLE
zpaq: fix version and pull from github

### DIFF
--- a/pkgs/tools/archivers/zpaq/default.nix
+++ b/pkgs/tools/archivers/zpaq/default.nix
@@ -1,16 +1,15 @@
-{ stdenv, fetchurl, perl, unzip }:
+{ stdenv, fetchFromGitHub, perl, unzip }:
+
 stdenv.mkDerivation rec {
   name = "zpaq-${version}";
-  version = "715";
+  version = "7.15";
 
-  src = let
-    mungedVersion = with stdenv.lib; concatStrings (splitString "." version);
-  in fetchurl {
-    sha256 = "066l94yyladlfzri877nh2dhkvspagjn3m5bmv725fmhkr9c4pp8";
-    url = "http://mattmahoney.net/dc/zpaq${mungedVersion}.zip";
+  src = fetchFromGitHub {
+    owner = "zpaq";
+    repo = "zpaq";
+    rev = version;
+    sha256 = "0v44rlg9gvwc4ggr2lhcqll8ppal3dk7zsg5bqwcc5lg3ynk2pz4";
   };
-
-  sourceRoot = ".";
 
   nativeBuildInputs = [ perl /* for pod2man */ ];
   buildInputs = [ unzip ];


### PR DESCRIPTION
###### Motivation for this change
[Repology didn't like we were missing the "." between major and minor.](https://repology.org/project/zpaq/versions#nix_unstable)

The repo was also migrated to git and is using it for releases, so transfered to pulling from github.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

```
$ nix path-info -Sh ./result
/nix/store/i5b30y5plwgblzl8mfgcnnnb4ql57f35-zpaq-715      32.7M
$ nix path-info -Sh ./result
/nix/store/v0i0wf7w6aqq3m8v5zqxc55xyapkck3x-zpaq-7.15     32.7M
```

```
$ nix-review wip
...
[1 built, 0.0 MiB DL]
1 package were build:
zpaq
```

```
$ ./result/bin/zpaq
zpaq v7.15 journaling archiver, compiled Jan  1 1970
Usage: zpaq command archive[.zpaq] files... -options...
```