### PR TITLE
proot: 20190510 -> 5.1.0

### DIFF
--- a/pkgs/tools/system/proot/default.nix
+++ b/pkgs/tools/system/proot/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   pname = "proot";
-  version = "20190510";
+  version = "5.1.0";
 
   src = fetchFromGitHub {
     repo = "proot";
     owner = "proot-me";
-    rev = "803e54d8a1b3d513108d3fc413ba6f7c80220b74";
-    sha256 = "0gwzqm5wpscj3fchlv3qggf3zzn0v00s4crb5ciwljan1zrqadhy";
+    rev = "v${version}";
+    sha256 = "0azsqis99gxldmbcg43girch85ysg4hwzf0h1b44bmapnsm89fbz";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change
[Fix repology entry](https://repology.org/project/proot/versions#nix_unstable). and update the package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

$ nix path-info -Sh ./result
/nix/store/1gz638vyk1k8cmypj8zrflaj3yfg9jdy-proot-20190510        94.4M
$ nix path-info -Sh ./result
/nix/store/qzwdwjsqn9px5dfs8g5rrppqqjcnpppx-proot-5.1.0   94.1M

```
$ nix-review wip
...
[2 built, 14 copied (21.6 MiB), 4.4 MiB DL]
2 package were build:
proot udocker
```
