### PR TITLE
Fix build for gimp-with-plugins against exiv2 0.27.1

### DIFF
--- a/pkgs/applications/graphics/gimp/plugins/default.nix
+++ b/pkgs/applications/graphics/gimp/plugins/default.nix
@@ -157,17 +157,17 @@ stdenv.lib.makeScope pkgs.newScope (self: with self; {
   ufraw = pkgs.ufraw.gimpPlugin;
 
   gimplensfun = pluginDerivation rec {
-    version = "0.2.4";
+    version = "unstable-2018-10-21";
     name = "gimplensfun-${version}";
 
     src = fetchFromGitHub {
       owner = "seebk";
       repo = "GIMP-Lensfun";
-      rev = version;
-      sha256 = "0zlmp9v732qmzj083mnk5z421s57mnckmpjhiw890wmmwzj2lhxz";
+      rev = "1c5a5c1534b5faf098b7441f8840d22835592f17";
+      sha256 = "1jj3n7spkjc63aipwdqsvq9gi07w13bb1v8iqzvxwzld2kxa3c8w";
     };
 
-    buildInputs = with pkgs; [ lensfun exiv2 ];
+    buildInputs = with pkgs; [ lensfun gexiv2 ];
 
     installPhase = "
       installPlugins gimp-lensfun

--- a/pkgs/applications/graphics/ufraw/default.nix
+++ b/pkgs/applications/graphics/ufraw/default.nix
@@ -1,38 +1,71 @@
-{ fetchurl, stdenv, pkgconfig, gtk2, gettext, bzip2, zlib
-, withGimpPlugin ? true, gimp ? null
-, libjpeg, libtiff, cfitsio, exiv2, lcms2, gtkimageview, lensfun }:
+{ stdenv
+, fetchFromGitHub
+
+, autoconf
+, automake
+, autoreconfHook
+, bzip2
+, cfitsio
+, exiv2
+, gettext
+, gimp ? null
+, gtk2
+, gtkimageview
+, lcms2
+, lensfun
+, libjpeg
+, libtiff
+, perl
+, pkgconfig
+, zlib
+
+, withGimpPlugin ? true
+}:
 
 assert withGimpPlugin -> gimp != null;
 
 stdenv.mkDerivation rec {
-  name = "ufraw-0.22";
+  pname = "ufraw";
+  version = "unstable-2019-06-12";
 
-  src = fetchurl {
-    # XXX: These guys appear to mutate uploaded tarballs!
-    url = "mirror://sourceforge/ufraw/${name}.tar.gz";
-    sha256 = "0pm216pg0vr44gwz9vcvq3fsf8r5iayljhf5nis2mnw7wn6d5azp";
+  # The original ufraw repo is unmaintained and broken;
+  # this is a fork that collects patches
+  src = fetchFromGitHub {
+    owner = "sergiomb2";
+    repo = "ufraw";
+    rev = "c65b4237dcb430fb274e4778afaf5df9a18e04e6";
+    sha256 = "02icn67bsinvgliy62qa6v7gmwgp2sh15jvm8iiz3c7g1h74f0b7";
   };
 
   outputs = [ "out" ] ++ stdenv.lib.optional withGimpPlugin "gimpPlugin";
 
-  nativeBuildInputs = [ pkgconfig gettext ];
+  nativeBuildInputs = [ autoconf automake autoreconfHook gettext perl pkgconfig ];
+
   buildInputs = [
-    gtk2 gtkimageview bzip2 zlib
-    libjpeg libtiff cfitsio exiv2 lcms2 lensfun
+    bzip2
+    cfitsio
+    exiv2
+    gtk2
+    gtkimageview
+    lcms2
+    lensfun
+    libjpeg
+    libtiff
+    zlib
   ] ++ stdenv.lib.optional withGimpPlugin gimp;
 
   configureFlags = [
-    "--enable-extras"
-    "--enable-dst-correction"
     "--enable-contrast"
+    "--enable-dst-correction"
+    "--enable-extras"
   ] ++ stdenv.lib.optional withGimpPlugin "--with-gimp";
 
   postInstall = stdenv.lib.optionalString withGimpPlugin ''
     moveToOutput "lib/gimp" "$gimpPlugin"
   '';
 
-  meta = {
-    homepage = http://ufraw.sourceforge.net/;
+  meta = with stdenv.lib; {
+    homepage = https://github.com/sergiomb2/ufraw;
 
     description = "Utility to read and manipulate raw images from digital cameras";
 
@@ -46,9 +79,9 @@ stdenv.mkDerivation rec {
          the camera's tone curves.
       '';
 
-    license = stdenv.lib.licenses.gpl2Plus;
+    license = licenses.gpl2Plus;
 
-    maintainers = [ ];
-    platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;  # needs GTK+
+    maintainers = with maintainers; [ gloaming ];
+    platforms   = with platforms; all;
   };
 }

--- a/pkgs/applications/graphics/ufraw/default.nix
+++ b/pkgs/applications/graphics/ufraw/default.nix
@@ -57,7 +57,6 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--enable-contrast"
     "--enable-dst-correction"
-    "--enable-extras"
   ] ++ stdenv.lib.optional withGimpPlugin "--with-gimp";
 
   postInstall = stdenv.lib.optionalString withGimpPlugin ''


### PR DESCRIPTION
###### Motivation for this change

Fixes #64586

###### Things done

Path size `1803392632` vs `1798388408` when building against `exiv2 0.26.2018.12.30`

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
