### PR TITLE
cordless: init at 2019-06-13

### DIFF
--- a/pkgs/applications/networking/instant-messengers/cordless/default.nix
+++ b/pkgs/applications/networking/instant-messengers/cordless/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, buildGoModule, fetchurl }:
+
+buildGoModule rec {
+  name = "cordless-${version}";
+  version = "2019-06-13";
+
+  src = fetchurl {
+    url = "https://github.com/Bios-Marcel/cordless/archive/${version}.tar.gz";
+    sha256 = "ef9c4db21b7c75a5263281ed783c905b47e752f8b596575e0a41cd6e7d450566";
+  };
+
+  doCheck = true;
+
+  modSha256 = "08a1dg4d7fjdy8w3sbri3ik8k7c1snpa0rzwinal6inzmdyancys";
+
+  subPackages = [ "." ];
+
+  meta = with stdenv.lib; {
+    description = "A third party Discord client";
+    longDescription = ''
+      Cordless is a third party Discord client that runs on the
+      commandline and aims to have a low memory footprint and
+      bandwidth consumption.
+    '';
+    homepage = https://www.github.com/Bios-Marcel/cordless;
+    license = licenses.bsd3;
+    maintainers = [ "Marcel Schramm <marceloschr@googlemail.com>" ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -740,6 +740,8 @@ in
 
   cozy = callPackage ../applications/audio/cozy-audiobooks { };
 
+  cordless = callPackage ../applications/networking/instant-messengers/cordless { };
+
   ctrtool = callPackage ../tools/archivers/ctrtool { };
 
   crumbs = callPackage ../applications/misc/crumbs { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


