### PR TITLE
emacs: add zmq package

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17716,7 +17716,7 @@ in
       inherit (pythonPackages) elpy;
       inherit
         autoconf automake git libffi libpng pkgconfig poppler rtags w3m zlib
-        substituteAll rustPlatform cmake llvmPackages;
+        substituteAll rustPlatform cmake llvmPackages libtool zeromq;
     };
   };
 

--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -417,6 +417,39 @@ let
 
   zeitgeist = callPackage ../applications/editors/emacs-modes/zeitgeist { };
 
+  zmq = melpaBuild rec {
+    pname = "zmq";
+    ename = "zmq";
+    version = "0.10.10";
+    src = fetchFromGitHub {
+      owner = "dzop";
+      repo = "emacs-zmq";
+      rev = "v0.10.10";
+      sha256 = "0ngxm5mm0kqgvn8977ryrngamx0khzlw86d8vz5s0jhm2kgwnqp8";
+    };
+    recipe = fetchurl {
+      url = "https://raw.githubusercontent.com/milkypostman/melpa/72f4dcc2723de826bf1af7235ac6d9119a243c63/recipes/zmq";
+      sha256 = "14bbh00a58xgxyxl8zjxl57rf6351fnwsnk4cvvy341fvf86dklc";
+      name = "recipe";
+    };
+    stripDebugList = [ "share" ];
+    packageRequires = [ emacs ];
+    nativeBuildInputs = [ external.autoconf external.automake external.pkgconfig external.libtool external.zeromq ];
+    preBuild = ''
+      make
+    '';
+    postInstall = ''
+      mv $out/share/emacs/site-lisp/elpa/zmq-*/src/.libs/emacs-zmq.so $out/share/emacs/site-lisp/elpa/zmq-*
+      rm -r $out/share/emacs/site-lisp/elpa/zmq-*/src
+      rm $out/share/emacs/site-lisp/elpa/zmq-*/Makefile
+    '';
+    meta = {
+      homepage = "https://melpa.org/#/zmq";
+      description = "Emacs bindings to ØMQ";
+      license = lib.licenses.gpl2;
+    };
+  };
+
   };
 
 in


### PR DESCRIPTION
This builds emacs-zmq.so automatically.

Fixes #59774

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
