### PR TITLE
gocryptfs: 1.6.1 -> 1.7

### DIFF
--- a/pkgs/tools/filesystems/gocryptfs/default.nix
+++ b/pkgs/tools/filesystems/gocryptfs/default.nix
@@ -2,13 +2,13 @@
 { stdenv, buildGoPackage, fetchFromGitHub, openssl, pandoc, pkgconfig }:
 
 let
-  version = "v1.6.1";
   goFuseVersion = with stdenv.lib; substring 0 7 (head (filter (
     d: d.goPackagePath == "github.com/hanwen/go-fuse"
   ) (import ./deps.nix))).fetch.rev;
 in
 buildGoPackage rec {
-  name = "gocryptfs-${version}";
+  pname = "gocryptfs";
+  version = "1.7"; # TODO: Drop `patches` with next release. Remove `fix-unix2syscall_darwin.go-build-failure.patch`.
 
   goPackagePath = "github.com/rfjakob/gocryptfs";
 
@@ -17,10 +17,14 @@ buildGoPackage rec {
 
   src = fetchFromGitHub {
     owner = "rfjakob";
-    repo = "gocryptfs";
-    rev = version;
-    sha256 = "0aqbl25g48b4jp6l09k6kic6w3p0q7d9ip2wvrcvh8lhnrbdkhzd";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1sr3i73haw07faqpw785cdda2kna8q3a0zhwab1p3i935rvp4qaa";
   };
+
+  # Fixes build on darwin
+  # Source: https://github.com/rfjakob/gocryptfs/commit/b1468a732fa26550f2a6f8a21cc7bd47b65a8c96
+  patches = [ ./fix-unix2syscall_darwin.go-build-failure.patch ];
 
   postPatch = "rm -r tests";
 

--- a/pkgs/tools/filesystems/gocryptfs/deps.nix
+++ b/pkgs/tools/filesystems/gocryptfs/deps.nix
@@ -1,39 +1,12 @@
 # file generated from Gopkg.lock using dep2nix (https://github.com/nixcloud/dep2nix)
 [
   {
-    goPackagePath  = "github.com/conejoninja/hid";
-    fetch = {
-      type = "git";
-      url = "https://github.com/conejoninja/hid";
-      rev =  "3a959b87ebefc18767a31fa567eea402eb37239e";
-      sha256 = "1i1x7fhs3g9a48h2wxjczshx7gzmj9p6pd71l22ky998zgjadlim";
-    };
-  }
-  {
-    goPackagePath  = "github.com/conejoninja/tesoro";
-    fetch = {
-      type = "git";
-      url = "https://github.com/conejoninja/tesoro";
-      rev =  "e0e839b6a6f14bce56d1bfac9a86311a1646a6a3";
-      sha256 = "19q1ibj6l6pk2a3iwcyrj60sscvkqw450psd9zdflvb293cjsx8v";
-    };
-  }
-  {
-    goPackagePath  = "github.com/golang/protobuf";
-    fetch = {
-      type = "git";
-      url = "https://github.com/golang/protobuf";
-      rev =  "b4deda0973fb4c70b50d226b1af49f3da59f5265";
-      sha256 = "0ya4ha7m20bw048m1159ppqzlvda4x0vdprlbk5sdgmy74h3xcdq";
-    };
-  }
-  {
     goPackagePath  = "github.com/hanwen/go-fuse";
     fetch = {
       type = "git";
       url = "https://github.com/hanwen/go-fuse";
-      rev =  "95c6370914ac7822973d1893680e878e156f8d70";
-      sha256 = "1h701c1hxrw7ljh7kc0rjx18bfw2mzdbpmqqilb5wb0ngpdjpqxp";
+      rev =  "a533f0a5a633cccc0928c81985b13fa24407a211";
+      sha256 = "0kc2jjjyhnrd934jn7hzfx8kd4z2yq5yblwrxr6xcjjql1vb1n9k";
     };
   }
   {
@@ -41,8 +14,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/jacobsa/crypto";
-      rev =  "c73681c634de898c869684602cf0c0d2ce938c4d";
-      sha256 = "02jbiy6szshbzcmp4j3gpc577hrhikxqvm4kzxixp27k9f2cx5si";
+      rev =  "d95898ceee0769dac9bf74c46f8f68d3d3d79100";
+      sha256 = "0dgcvms7if672f09y0cj49n711i9r0609p5f1s27i53yah4qlm19";
     };
   }
   {
@@ -50,8 +23,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/pkg/xattr";
-      rev =  "f5b647e257e19d63831e7c7adb95dfb79d9ff4d9";
-      sha256 = "0cqxibbfllhs6ffxq65gn08088g7g7aw752p9g3vbnj35jk2p8i9";
+      rev =  "7782c2d6871d6e659e1563dc19c86b845264a6fc";
+      sha256 = "1j3z5b9nwgkxia925rkiq8n5avhf4zhmsdbpn2s3xb16a2w66prd";
     };
   }
   {
@@ -64,39 +37,12 @@
     };
   }
   {
-    goPackagePath  = "github.com/trezor/trezord-go";
-    fetch = {
-      type = "git";
-      url = "https://github.com/trezor/trezord-go";
-      rev =  "bae9c40e5d71c459bde056d42d4b19ab318c90c2";
-      sha256 = "12j7b4vjs8n68214zrh5ivpqm3fcifk27bj6rszd9x2839nk3hy8";
-    };
-  }
-  {
-    goPackagePath  = "github.com/xaionaro-go/cryptoWallet";
-    fetch = {
-      type = "git";
-      url = "https://github.com/xaionaro-go/cryptoWallet";
-      rev =  "47f9f6877e4324a8bc47fc5661c32d2fe6d29586";
-      sha256 = "14h2vnl2jm2wj10znizdf2f0mxsk27rsjskjw5qffy8nf5a0i3i6";
-    };
-  }
-  {
-    goPackagePath  = "github.com/zserge/hid";
-    fetch = {
-      type = "git";
-      url = "https://github.com/zserge/hid";
-      rev =  "c86e7adeabafd6fcb3371ad64d6ed366b04d55db";
-      sha256 = "1y2zqndq6mafgsdai5gnkw4g8dzl9vmjcxq0i8xspaj4dmck19c4";
-    };
-  }
-  {
     goPackagePath  = "golang.org/x/crypto";
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/crypto";
-      rev =  "de0752318171da717af4ce24d0a2e8626afaeb11";
-      sha256 = "1ps1dl2a5lwr3vbwcy8n4i1v73m567y024sk961fk281phrzp13i";
+      rev =  "8dd112bcdc25174059e45e07517d9fc663123347";
+      sha256 = "0gbcz7gxmgg88s28vb90dsp1vdq0har7zvg2adsqbp8bm05x9q6b";
     };
   }
   {
@@ -104,8 +50,8 @@
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/sync";
-      rev =  "1d60e4601c6fd243af51cc01ddf169918a5407ca";
-      sha256 = "046jlanz2lkxq1r57x9bl6s4cvfqaic6p2xybsj8mq1120jv4rs6";
+      rev =  "e225da77a7e68af35c70ccbf71af2b83e6acac3c";
+      sha256 = "0bh3583smcfw6jw3w6lp0za93rz7hpxfdz8vhxng75b7a6vdlw4p";
     };
   }
   {
@@ -113,17 +59,8 @@
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/sys";
-      rev =  "14742f9018cd6651ec7364dc6ee08af0baaa1031";
-      sha256 = "17k06vwhnlb18n9rb1cdcdqyjcn353znfrr4c90xb3carz1sqfq5";
-    };
-  }
-  {
-    goPackagePath  = "golang.org/x/text";
-    fetch = {
-      type = "git";
-      url = "https://go.googlesource.com/text";
-      rev =  "f21a4dfb5e38f5895301dc265a8def02365cc3d0";
-      sha256 = "0r6x6zjzhr8ksqlpiwm5gdd7s209kwk5p4lw54xjvz10cs3qlq19";
+      rev =  "61b9204099cb1bebc803c9ffb9b2d3acd9d457d9";
+      sha256 = "110carnw1rxk9awbcdbg5is0zl28vynm649y7rza36pg1vlv8rrh";
     };
   }
 ]

--- a/pkgs/tools/filesystems/gocryptfs/fix-unix2syscall_darwin.go-build-failure.patch
+++ b/pkgs/tools/filesystems/gocryptfs/fix-unix2syscall_darwin.go-build-failure.patch
@@ -1,0 +1,14 @@
+--- a/internal/syscallcompat/unix2syscall_darwin.go
++++ b/internal/syscallcompat/unix2syscall_darwin.go
+@@ -19,8 +19,8 @@ func Unix2syscall(u unix.Stat_t) syscall.Stat_t {
+ 		Size:      u.Size,
+ 		Blksize:   u.Blksize,
+ 		Blocks:    u.Blocks,
+-		Atimespec: syscall.Timespec(u.Atimespec),
+-		Mtimespec: syscall.Timespec(u.Mtimespec),
+-		Ctimespec: syscall.Timespec(u.Ctimespec),
++		Atimespec: syscall.Timespec(u.Atim),
++		Mtimespec: syscall.Timespec(u.Mtim),
++		Ctimespec: syscall.Timespec(u.Ctim),
+ 	}
+ }


### PR DESCRIPTION
###### Notes for a future gocryptfs updates

- Delete `fix-unix2syscall_darwin.go-build-failure.patch`
- Delete `patches` within `default.nix`

---

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Just a minor package version update.
By the way, I haven't worked with go packages before.
This thing with `deps2nix` is for a noob as me a bit complicated to just update a package.

Not jet tested, as I still have not a practicable workflow for this here on my side.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
