### PR TITLE
kak-lsp: init at 6.2.1

### DIFF
--- a/pkgs/tools/misc/kak-lsp/default.nix
+++ b/pkgs/tools/misc/kak-lsp/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, lib, darwin, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "kak-lsp";
+  version = "6.2.1";
+
+  src = fetchFromGitHub {
+    owner = "ul";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0bazbz1g5iqxlwybn5whidvavglvgdl9yp9qswgsk1jrjmcr5klx";
+  };
+
+  cargoSha256 = "0w0mnh8fnl8zi9n0fxzqaqbvmfagf3ay5v2na3laxb72jm76hrwa";
+
+  buildInputs = lib.optional stdenv.isDarwin [ darwin.apple_sdk.frameworks.Security ];
+
+  meta = with lib; {
+    description = "Kakoune Language Server Protocol Client";
+    homepage = https://github.com/ul/kak-lsp;
+    license = with licenses; [ unlicense /* or */ mit ];
+    maintainers = [ maintainers.spacekookie ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3949,6 +3949,8 @@ in
 
   kakoune = callPackage ../applications/editors/kakoune { };
 
+  kak-lsp = callPackage ../tools/misc/kak-lsp { };
+
   kbdd = callPackage ../applications/window-managers/kbdd { };
 
   kdbplus = pkgsi686Linux.callPackage ../applications/misc/kdbplus { };


### PR DESCRIPTION
###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
