### PR TITLE
pythonPackages.sphinxcontrib_plantuml: use top-level plantuml

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -644,8 +644,6 @@ in {
 
   pims = callPackage ../development/python-modules/pims { };
 
-  plantuml = callPackage ../tools/misc/plantuml { };
-
   poetry = callPackage ../development/python-modules/poetry { };
 
   pplpy = callPackage ../development/python-modules/pplpy { };
@@ -4876,7 +4874,9 @@ in {
 
   sphinxcontrib_newsfeed = callPackage ../development/python-modules/sphinxcontrib_newsfeed { };
 
-  sphinxcontrib_plantuml = callPackage ../development/python-modules/sphinxcontrib_plantuml { };
+  sphinxcontrib_plantuml = callPackage ../development/python-modules/sphinxcontrib_plantuml {
+    inherit (pkgs) plantuml;
+  };
 
   sphinxcontrib-spelling = callPackage ../development/python-modules/sphinxcontrib-spelling { };
 


### PR DESCRIPTION
###### Motivation for this change

`plantuml` declared in python packages implicitly captures graphviz python library instead of the top-level package and thus doesn't work property after installation, trying to access
`/nix/store/<hash>-python2.7-graphviz-0.10.1/bin/dot` and failing to find it.