### PR TITLE
pythonPackages.anonip: init at 1.0.0

### DIFF
--- a/pkgs/development/python-modules/anonip/default.nix
+++ b/pkgs/development/python-modules/anonip/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, lib, buildPythonPackage, fetchFromGitHub, ipaddress, isPy27 }:
+
+buildPythonPackage rec {
+  pname = "anonip";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "DigitaleGesellschaft";
+    repo = "Anonip";
+    rev = "v${version}";
+    sha256 = "0y5xqivcinp6pwx4whc8ca1n2wxrvff7a2lpbz2dhivilfanmljs";
+  };
+
+  propagatedBuildInputs = lib.optionals isPy27 [ ipaddress ];
+
+  checkPhase = "python tests.py";
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/DigitaleGesellschaft/Anonip";
+    description = "A tool to anonymize IP-addresses in log-files";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.mmahut ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1106,6 +1106,8 @@ in {
 
   aniso8601 = callPackage ../development/python-modules/aniso8601 {};
 
+  anonip = callPackage ../development/python-modules/anonip { };
+
   asgiref = callPackage ../development/python-modules/asgiref { };
 
   python-editor = callPackage ../development/python-modules/python-editor { };


### PR DESCRIPTION
###### Motivation for this change

init at 1.0.0, fixes #64573.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
