### PR TITLE
pythonPackages.fetchPypi: support SRI hashes

### DIFF
--- a/pkgs/development/interpreters/python/fetchpypi.nix
+++ b/pkgs/development/interpreters/python/fetchpypi.nix
@@ -1,0 +1,22 @@
+# `fetchPypi` function for fetching artifacts from PyPI.
+{ fetchurl
+, makeOverridable
+}:
+
+makeOverridable( {format ? "setuptools", ... } @attrs:
+  let
+    fetchWheel = {pname, version, sha256, python ? "py2.py3", abi ? "none", platform ? "any"}:
+    # Fetch a wheel. By default we fetch an universal wheel.
+    # See https://www.python.org/dev/peps/pep-0427/#file-name-convention for details regarding the optional arguments.
+      let
+        url = "https://files.pythonhosted.org/packages/${python}/${builtins.substring 0 1 pname}/${pname}/${pname}-${version}-${python}-${abi}-${platform}.whl";
+      in fetchurl {inherit url sha256;};
+    fetchSource = {pname, version, sha256, extension ? "tar.gz"}:
+    # Fetch a source tarball.
+      let
+        url = "mirror://pypi/${builtins.substring 0 1 pname}/${pname}/${pname}-${version}.${extension}";
+      in fetchurl {inherit url sha256;};
+    fetcher = (if format == "wheel" then fetchWheel
+      else if format == "setuptools" then fetchSource
+      else throw "Unsupported format ${format}");
+  in fetcher (builtins.removeAttrs attrs ["format"]) )

--- a/pkgs/development/interpreters/python/fetchpypi.nix
+++ b/pkgs/development/interpreters/python/fetchpypi.nix
@@ -20,9 +20,9 @@ let
 
   in compute (builtins.removeAttrs attrs ["format"]);
 
-in makeOverridable( {format ? "setuptools", sha256, ... } @attrs:
+in makeOverridable( {format ? "setuptools", sha256 ? "", hash ? "", ... } @attrs:
   let
-    url = computeUrl (builtins.removeAttrs attrs ["sha256"]) ;
+    url = computeUrl (builtins.removeAttrs attrs ["sha256" "hash"]) ;
   in fetchurl {
-    inherit url sha256;
+    inherit url sha256 hash;
   })

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -58,23 +58,7 @@ let
   # See build-setupcfg/default.nix for documentation.
   buildSetupcfg = import ../build-support/build-setupcfg self;
 
-  fetchPypi = makeOverridable( {format ? "setuptools", ... } @attrs:
-    let
-      fetchWheel = {pname, version, sha256, python ? "py2.py3", abi ? "none", platform ? "any"}:
-      # Fetch a wheel. By default we fetch an universal wheel.
-      # See https://www.python.org/dev/peps/pep-0427/#file-name-convention for details regarding the optional arguments.
-        let
-          url = "https://files.pythonhosted.org/packages/${python}/${builtins.substring 0 1 pname}/${pname}/${pname}-${version}-${python}-${abi}-${platform}.whl";
-        in pkgs.fetchurl {inherit url sha256;};
-      fetchSource = {pname, version, sha256, extension ? "tar.gz"}:
-      # Fetch a source tarball.
-        let
-          url = "mirror://pypi/${builtins.substring 0 1 pname}/${pname}/${pname}-${version}.${extension}";
-        in pkgs.fetchurl {inherit url sha256;};
-      fetcher = (if format == "wheel" then fetchWheel
-        else if format == "setuptools" then fetchSource
-        else throw "Unsupported kind ${kind}");
-    in fetcher (builtins.removeAttrs attrs ["format"]) );
+  fetchPypi = callPackage ../development/interpreters/python/fetchpypi.nix {};
 
   # Check whether a derivation provides a Python module.
   hasPythonModule = drv: drv?pythonModule && drv.pythonModule == python;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Commit https://github.com/NixOS/nixpkgs/commit/267c8d6b2fea05bc811c8e2c2f4529b1436eeb9a introduced support for SRI hashes to `pkgs.fetchurl`. This PR adds it to `fetchPypi`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
