### PR TITLE
sensu-go: 5.10.0 -> 5.11.0

### DIFF
--- a/pkgs/servers/monitoring/sensu-go/default.nix
+++ b/pkgs/servers/monitoring/sensu-go/default.nix
@@ -4,8 +4,8 @@ let
   generic = { subPackages, pname, postInstall ? "" }:
     buildGoPackage rec {
       inherit pname;
-      version = "5.10.0";
-      shortRev = "c7551ba"; # for internal version info
+      version = "5.11.0";
+      shortRev = "dd8f160"; # for internal version info
 
       goPackagePath = "github.com/sensu/sensu-go";
 
@@ -13,7 +13,7 @@ let
         owner = "sensu";
         repo = "sensu-go";
         rev = version;
-        sha256 = "1hma54mdh150d51rwz5csqbn0h24qk6hydjmib68j7zd7kp92yb5";
+        sha256 = "05dx0nxcjl6fy68br2a37j52iz71kvqnqp29swcif2nwvq7w8mxx";
       };
 
       inherit subPackages postInstall;
@@ -44,7 +44,14 @@ in
         "''${!outputBin}/share/zsh/site-functions"
 
       ''${!outputBin}/bin/sensuctl completion bash > ''${!outputBin}/share/bash-completion/completions/sensuctl
-      ''${!outputBin}/bin/sensuctl completion zsh > ''${!outputBin}/share/zsh/site-functions/_sensuctl
+
+      # https://github.com/sensu/sensu-go/issues/3132
+      (
+        echo "#compdef sensuctl"
+        ''${!outputBin}/bin/sensuctl completion zsh
+        echo '_complete sensuctl 2>/dev/null'
+      ) > ''${!outputBin}/share/zsh/site-functions/_sensuctl
+
     '';
   };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Package update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
