### PR TITLE
Python: add sitecustomize.py, listen to NIX_PYTHONPATH

### DIFF
--- a/pkgs/development/interpreters/python/cpython/2.7/default.nix
+++ b/pkgs/development/interpreters/python/cpython/2.7/default.nix
@@ -256,6 +256,11 @@ in with passthru; stdenv.mkDerivation ({
 
     inherit passthru;
 
+    postFixup = ''
+      # Include a sitecustomize.py file. Note it causes an error when it's in postInstall with 2.7.
+      cp ${../../sitecustomize.py} $out/${sitePackages}/sitecustomize.py
+    '';
+
     enableParallelBuilding = true;
 
     doCheck = false; # expensive, and fails

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -221,6 +221,9 @@ in with passthru; stdenv.mkDerivation {
     find $out/lib/python*/config-* -type f -print -exec nuke-refs -e $out '{}' +
     find $out/lib -name '_sysconfigdata*.py*' -print -exec nuke-refs -e $out '{}' +
 
+    # Include a sitecustomize.py file
+    cp ${../sitecustomize.py} $out/${sitePackages}/sitecustomize.py
+
     # Determinism: rebuild all bytecode
     # We exclude lib2to3 because that's Python 2 code which fails
     # We rebuild three times, once for each optimization level

--- a/pkgs/development/interpreters/python/pypy/default.nix
+++ b/pkgs/development/interpreters/python/pypy/default.nix
@@ -137,6 +137,9 @@ in with passthru; stdenv.mkDerivation rec {
 
     # Python on Nix is not manylinux1 compatible. https://github.com/NixOS/nixpkgs/issues/18484
     echo "manylinux1_compatible=False" >> $out/lib/${libPrefix}/_manylinux.py
+
+    # Include a sitecustomize.py file
+    cp ${../sitecustomize.py} $out/${sitePackages}/sitecustomize.py
   '';
 
   inherit passthru;

--- a/pkgs/development/interpreters/python/pypy/prebuilt.nix
+++ b/pkgs/development/interpreters/python/pypy/prebuilt.nix
@@ -84,6 +84,10 @@ in with passthru; stdenv.mkDerivation {
     echo "Removing bytecode"
     find . -name "__pycache__" -type d -depth -exec rm -rf {} \;
     popd
+
+    # Include a sitecustomize.py file
+    cp ${../sitecustomize.py} $out/${sitePackages}/sitecustomize.py
+
   '';
 
   doInstallCheck = true;

--- a/pkgs/development/interpreters/python/sitecustomize.py
+++ b/pkgs/development/interpreters/python/sitecustomize.py
@@ -1,0 +1,18 @@
+"""
+This is a Nix-specific module for discovering modules built with Nix.
+
+The module recursively adds paths that are on `NIX_PYTHONPATH` to `sys.path`. In
+order to process possible `.pth` files `site.addsitedir` is used.
+
+The paths listed in `PYTHONPATH` are added to `sys.path` afterwards, but they
+will be added before the entries we add here and thus take precedence.
+
+Note the `NIX_PYTHONPATH` environment variable is unset in order to prevent leakage.
+"""
+import site
+import os
+import functools
+
+paths = os.environ.pop('NIX_PYTHONPATH', None)
+if paths:
+    functools.reduce(lambda k, p: site.addsitedir(p, k), paths.split(':'), site._init_pathinfo())

--- a/pkgs/development/interpreters/python/wrapper.nix
+++ b/pkgs/development/interpreters/python/wrapper.nix
@@ -13,6 +13,7 @@
 let
   env = let
     paths = requiredPythonModules (extraLibs ++ [ python ] ) ;
+    pythonPath = "${placeholder "out"}/${python.sitePackages}";
   in buildEnv {
     name = "${python.name}-env";
 
@@ -35,7 +36,7 @@ let
             if [ -f "$prg" ]; then
               rm -f "$out/bin/$prg"
               if [ -x "$prg" ]; then
-                makeWrapper "$path/bin/$prg" "$out/bin/$prg" --set PYTHONHOME "$out" ${if permitUserSite then "" else ''--set PYTHONNOUSERSITE "true"''} ${stdenv.lib.concatStringsSep " " makeWrapperArgs}
+                makeWrapper "$path/bin/$prg" "$out/bin/$prg" --set NIX_PYTHONPATH ${pythonPath} ${if permitUserSite then "" else ''--set PYTHONNOUSERSITE "true"''} ${stdenv.lib.concatStringsSep " " makeWrapperArgs}
               fi
             fi
           done


### PR DESCRIPTION
##### Motivation for this change

Split from https://github.com/NixOS/nixpkgs/pull/25985.

Add a `sitecustomize.py` file that listens to `NIX_PYTHONPATH` and unsets it afterwards. This gives the same feature as both `PYTHONHOME` and `PYTHONPATH`, however, without preventing the user from using those environment variables, and without leaking the variable.

This variable is now used in `python.buildEnv`, thereby solving issues with a leaking `PYTHONHOME` which could break nested Python programs/environments.

In the future we may choose to use this as well in `buildPythonPackage`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
