### PR TITLE
qt512.qtwebengine: darwin patch

### DIFF
--- a/pkgs/development/libraries/qt-5/5.12/qtwebengine-darwin-no-platform-check.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qtwebengine-darwin-no-platform-check.patch
@@ -19,3 +19,15 @@ diff --git a/mkspecs/features/platform.prf b/mkspecs/features/platform.prf
      }
    } else {
      skipBuild("Unknown platform. Qt WebEngine only supports Linux, Windows, and macOS.")
+diff --git a/src/core/config/mac_osx.pri b/src/core/config/mac_osx.pri
+--- a/src/core/config/mac_osx.pri
++++ b/src/core/config/mac_osx.pri
+@@ -5,8 +5,6 @@ load(functions)
+ # otherwise query for it.
+ QMAKE_MAC_SDK_VERSION = $$eval(QMAKE_MAC_SDK.$${QMAKE_MAC_SDK}.SDKVersion)
+ isEmpty(QMAKE_MAC_SDK_VERSION) {
+-     QMAKE_MAC_SDK_VERSION = $$system("/usr/bin/xcodebuild -sdk $${QMAKE_MAC_SDK} -version SDKVersion 2>/dev/null")
+-     isEmpty(QMAKE_MAC_SDK_VERSION): error("Could not resolve SDK version for \'$${QMAKE_MAC_SDK}\'")
+ }
+
+ QMAKE_CLANG_DIR = "/usr"


### PR DESCRIPTION
###### Motivation for this change

This same patch is currently applied to qtwebengine-5.11 (which is [broken](https://hydra.nixos.org/job/nixpkgs/trunk/qt511.qtwebengine.x86_64-darwin) regardless), it just seems to have been omitted from 5.12 in #56440. Doesn't actually fix the build but expands on @veprbl's changes to get past [failing to start the build](https://hydra.nixos.org/build/96030738/nixlog/1), and maybe someone will feel like investigating the actual failure related to macos sdk versions/headers.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
