### PR TITLE
atlassian-jira: 8.1.0 -> 8.1.2

### DIFF
--- a/pkgs/servers/atlassian/jira.nix
+++ b/pkgs/servers/atlassian/jira.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   name = "atlassian-jira-${version}";
-  version = "8.1.0";
+  version = "8.1.2";
 
   src = fetchurl {
     url = "https://product-downloads.atlassian.com/software/jira/downloads/atlassian-jira-software-${version}.tar.gz";
-    sha256 = "0mi1xknly44haf7gls3k212fx1dsl8k35rq82a1b3zj27kynwqr3";
+    sha256 = "040x4fh8qqhpzgqk25phfkq86vwph9diy871k0dflkmb5ccq5nx6";
   };
 
   phases = [ "unpackPhase" "buildPhase" "installPhase" "fixupPhase" ];


### PR DESCRIPTION

###### Motivation for this change

Same motivation as #64596 : CVE-2019-11581
https://confluence.atlassian.com/jira/jira-security-advisory-2019-07-10-973486595.html

ping @ciil @globin 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
