### PR TITLE
pythonPackages.optuna: init at 0.13.0

### DIFF
--- a/pkgs/development/python-modules/cliff/default.nix
+++ b/pkgs/development/python-modules/cliff/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pbr
+, prettytable
+, pyparsing
+, six
+, stevedore
+, pyyaml
+, unicodecsv
+, cmd2
+}:
+
+buildPythonPackage rec {
+  pname = "cliff";
+  version = "2.15.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "fe044273539250a99a5b9915843902e40e4e9b32ac5698c1fae89e31200d649f";
+  };
+
+  propagatedBuildInputs = [
+    pbr
+    prettytable
+    pyparsing
+    six
+    stevedore
+    pyyaml
+    cmd2
+    unicodecsv
+  ];
+
+  # test dependencies are complex
+  # and would require about 20 packages
+  # to be added
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Command Line Interface Formulation Framework";
+    homepage = https://docs.openstack.org/cliff/latest/;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/lightgbm/default.nix
+++ b/pkgs/development/python-modules/lightgbm/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, cmake
+, numpy
+, scipy
+, scikitlearn
+}:
+
+buildPythonPackage rec {
+  pname = "lightgbm";
+  version = "2.2.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "40354d21da6bfa73c7ada4d01b2e0b22eaae00f93e90bdaf3fc423020c273890";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  propagatedBuildInputs = [
+    numpy
+    scipy
+    scikitlearn
+  ];
+
+  postConfigure = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  # The pypi package doesn't distribute the tests from the GitHub
+  # repository. It contains c++ tests which don't seem to wired up to
+  # `make check`.
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A fast, distributed, high performance gradient boosting (GBDT, GBRT, GBM or MART) framework";
+    homepage = https://github.com/Microsoft/LightGBM;
+    license = licenses.mit;
+    maintainers = with lib.maintainers; [ teh costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/optuna/default.nix
+++ b/pkgs/development/python-modules/optuna/default.nix
@@ -1,0 +1,81 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytest
+, mock
+, bokeh
+, plotly
+, chainer
+, xgboost
+, mpi4py
+, lightgbm
+, Keras
+, mxnet
+, scikit-optimize
+, tensorflow
+, sqlalchemy
+, numpy
+, scipy
+, six
+, cliff
+, colorlog
+, pandas
+, alembic
+, typing
+, pythonOlder
+, isPy27
+}:
+
+buildPythonPackage rec {
+  pname = "optuna";
+  version = "0.13.0";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "915b9d7b28f7f7cdf015d8617c689ca90eda7a5bbd59c5fc232c9eccc9a91585";
+  };
+
+  checkInputs = [
+    pytest
+    mock
+    bokeh
+    plotly
+    chainer
+    xgboost
+    mpi4py
+    lightgbm
+    Keras
+    mxnet
+    scikit-optimize
+    tensorflow
+  ];
+
+  propagatedBuildInputs = [
+    sqlalchemy
+    numpy
+    scipy
+    six
+    cliff
+    colorlog
+    pandas
+    alembic
+  ] ++ lib.optionals (pythonOlder "3.5") [ typing ];
+
+  configurePhase = if !(pythonOlder "3.5") then ''
+    substituteInPlace setup.py \
+      --replace "'typing'" ""
+  '' else "";
+
+  checkPhase = ''
+    pytest --ignore tests/test_cli.py \
+           --ignore tests/integration_tests/test_chainermn.py
+  '';
+
+  meta = with lib; {
+    description = "A hyperparameter optimization framework";
+    homepage = https://optuna.org/;
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/scikit-optimize/default.nix
+++ b/pkgs/development/python-modules/scikit-optimize/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, numpy
+, scipy
+, scikitlearn
+, pyaml
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "scikit-optimize";
+  version = "0.6";
+
+  src = fetchFromGitHub {
+    owner = "scikit-optimize";
+    repo = "scikit-optimize";
+    rev = "v${version}";
+    sha256 = "1srbb20k8ddhpcfxwdflapfh6xfyrd3dnclcg3bsfq1byrcmv0d4";
+  };
+
+  propagatedBuildInputs = [
+    numpy
+    scipy
+    scikitlearn
+    pyaml
+  ];
+
+  checkInputs = [
+    pytest
+  ];
+
+  # remove --ignore at next release > 0.6
+  checkPhase = ''
+    pytest skopt --ignore skopt/tests/test_searchcv.py
+  '';
+
+  meta = with lib; {
+    description = "Sequential model-based optimization toolbox";
+    homepage = https://scikit-optimize.github.io/;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4312,6 +4312,8 @@ in {
 
   scikit-build = callPackage ../development/python-modules/scikit-build { };
 
+  scikit-optimize = callPackage ../development/python-modules/scikit-optimize { };
+
   scp = callPackage ../development/python-modules/scp {};
 
   seaborn = callPackage ../development/python-modules/seaborn { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -331,6 +331,8 @@ in {
 
   clikit = callPackage ../development/python-modules/clikit { };
 
+  cliff = callPackage ../development/python-modules/cliff { };
+
   clustershell = callPackage ../development/python-modules/clustershell { };
 
   cozy = callPackage ../development/python-modules/cozy { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1593,6 +1593,8 @@ in {
 
   openidc-client = callPackage ../development/python-modules/openidc-client {};
 
+  optuna = callPackage ../development/python-modules/optuna { };
+
   idna = callPackage ../development/python-modules/idna { };
 
   mahotas = callPackage ../development/python-modules/mahotas { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2148,6 +2148,8 @@ in {
 
   lightblue = callPackage ../development/python-modules/lightblue { };
 
+  lightgbm = callPackage ../development/python-modules/lightgbm { };
+
   lightning = callPackage ../development/python-modules/lightning { };
 
   jupyter = callPackage ../development/python-modules/jupyter { };


### PR DESCRIPTION
###### Motivation for this change

Listened to an awesome optuna talk at SciPy! So I wanted to contribute the package to nixpkgs

This closes PR #31954

###### Things done

 - pythonPackages.scikit-optimize: init at 0.6 
 - pythonPackages.optuna: init at 0.13.0 
 - pythonPackages.lightgbm: init at 2.2.3 
 - pythonPackages.cliff: init at 2.15.0 

cc: @wd15 @g-votte thanks to the awesome nix and optuna talks :smile: 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
