### PR TITLE
grpcui: init at 0.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4080,6 +4080,16 @@
     github = "pradeepchhetri";
     name = "Pradeep Chhetri";
   };
+  pradyuman = {
+    email = "me@pradyuman.co";
+    github = "pradyuman";
+    name = "Pradyuman Vig";
+    keys = [
+      { longkeyid = "rsa4096/4F74D5361C4CA31E";
+        fingerprint = "240B 57DE 4271 2480 7CE3  EAC8 4F74 D536 1C4C A31E";
+      }
+    ];
+  };
   prikhi = {
     email = "pavan.rikhi@gmail.com";
     github = "prikhi";

--- a/pkgs/tools/networking/grpcui/default.nix
+++ b/pkgs/tools/networking/grpcui/default.nix
@@ -1,0 +1,23 @@
+{ buildGoModule, fetchFromGitHub, lib }:
+
+buildGoModule rec {
+  pname = "grpcui";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "fullstorydev";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0h4xpyd6phj3svjzxh6nd98ym81x4a2v6jxcnqj4psjinwd4p3md";
+  };
+  
+  modSha256 = "1hsq2gfhscl4wvld346xrp018sb1g3xvga3d8chlbgw93rmhhszb";
+
+  meta = with lib; {
+    description = "An interactive web UI for gRPC, along the lines of postman";
+    homepage = "https://github.com/fullstorydev/grpcui";
+    license = licenses.mit;
+    maintainers = with maintainers; [ pradyuman ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3444,6 +3444,8 @@ in
 
   grpcurl = callPackage ../tools/networking/grpcurl { };
 
+  grpcui = callPackage ../tools/networking/grpcui { };
+
   grub = pkgsi686Linux.callPackage ../tools/misc/grub ({
     stdenv = overrideCC stdenv buildPackages.pkgsi686Linux.gcc6;
   } // (config.grub or {}));


### PR DESCRIPTION
###### Motivation for this change
I'd like to get this straight from nixpkgs so it's easier for other team members to use as well.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
