### PR TITLE
citrix_workspace: add 1906 (`citrix_workspace_19_6_0`)

### DIFF
--- a/doc/package-specific-user-notes.xml
+++ b/doc/package-specific-user-notes.xml
@@ -409,11 +409,19 @@ overrides = self: super: rec {
  </section>
 
  <section xml:id="sec-citrix">
-  <title>Citrix Receiver</title>
+  <title>Citrix Receiver &amp; Citrix Workspace App</title>
 
   <para>
-   The <link xlink:href="https://www.citrix.com/products/receiver/">Citrix
-   Receiver</link> is a remote desktop viewer which provides access to
+   <note>
+    <para>
+     Please note that the <literal>citrix_receiver</literal> package has been deprecated since its
+     development was <link xlink:href="https://docs.citrix.com/en-us/citrix-workspace-app.html">discontinued by upstream</link>
+     and will be replaced by <link xlink:href="https://www.citrix.com/products/workspace-app/">the citrix workspace app</link>.
+    </para>
+   </note>
+   <link xlink:href="https://www.citrix.com/products/receiver/">Citrix Receiver</link> and
+   <link xlink:href="https://www.citrix.com/products/workspace-app/">Citrix Workspace App</link>
+   are a remote desktop viewers which provide access to
    <link xlink:href="https://www.citrix.com/products/xenapp-xendesktop/">XenDesktop</link>
    installations.
   </para>
@@ -423,30 +431,35 @@ overrides = self: super: rec {
 
    <para>
     The tarball archive needs to be downloaded manually as the license
-    agreements of the vendor need to be accepted first. This is available at
-    the
-    <link xlink:href="https://www.citrix.com/downloads/citrix-receiver/">download
-    page at citrix.com</link>. Then run <literal>nix-prefetch-url
-    file://$PWD/linuxx64-$version.tar.gz</literal>. With the archive available
+    agreements of the vendor for
+    <link xlink:href="https://www.citrix.com/downloads/citrix-receiver/">Citrix Receiver</link>
+    or <link xlink:href="https://www.citrix.de/downloads/workspace-app/linux/workspace-app-for-linux-latest.html">Citrix Workspace</link>
+    need to be accepted first.
+    Then run <command>nix-prefetch-url file://$PWD/linuxx64-$version.tar.gz</command>.
+    With the archive available
     in the store the package can be built and installed with Nix.
    </para>
 
-   <para>
-    <emphasis>Note: it's recommended to install <literal>Citrix
-    Receiver</literal> using <literal>nix-env -i</literal> or globally to
-    ensure that the <literal>.desktop</literal> files are installed properly
-    into <literal>$XDG_CONFIG_DIRS</literal>. Otherwise it won't be possible to
-    open <literal>.ica</literal> files automatically from the browser to start
-    a Citrix connection.</emphasis>
-   </para>
+   <warning>
+    <title>Caution with <command>nix-shell</command> installs</title>
+    <para>
+     It's recommended to install <literal>Citrix Receiver</literal>
+     and/or <literal>Citrix Workspace</literal> using
+     <literal>nix-env -i</literal> or globally to
+     ensure that the <literal>.desktop</literal> files are installed properly
+     into <literal>$XDG_CONFIG_DIRS</literal>. Otherwise it won't be possible to
+     open <literal>.ica</literal> files automatically from the browser to start
+     a Citrix connection.
+    </para>
+   </warning>
   </section>
 
   <section xml:id="sec-citrix-custom-certs">
    <title>Custom certificates</title>
 
    <para>
-    The <literal>Citrix Receiver</literal> in <literal>nixpkgs</literal> trusts
-    several certificates
+    The <literal>Citrix Receiver</literal> and <literal>Citrix Workspace App</literal>
+    in <literal>nixpkgs</literal> trust several certificates
     <link xlink:href="https://curl.haxx.se/docs/caextract.html">from the
     Mozilla database</link> by default. However several companies using Citrix
     might require their own corporate certificate. On distros with imperative
@@ -459,7 +472,7 @@ overrides = self: super: rec {
 <programlisting>
 <![CDATA[with import <nixpkgs> { config.allowUnfree = true; };
 let extraCerts = [ ./custom-cert-1.pem ./custom-cert-2.pem /* ... */ ]; in
-citrix_receiver.override {
+citrix_workspace.override { # the same applies for `citrix_receiver` if used.
   inherit extraCerts;
 }]]>
 </programlisting>

--- a/pkgs/applications/networking/remote/citrix-workspace/default.nix
+++ b/pkgs/applications/networking/remote/citrix-workspace/default.nix
@@ -22,22 +22,11 @@
 , fontconfig
 , gtk_engines
 , alsaLib
-, libidn
 , zlib
-, version ? "19.3.0"
+, version ? "19.6.0"
 }:
 
 let
-  # In 56e1bdc7f9c (libidn: 1.34 -> 1.35), libidn.so.11 became libidn.so.12.
-  # Citrix looks for the former so we build version 1.34 to please the binary
-  libidn_134 = libidn.overrideDerivation (_: rec {
-    name = "libidn-1.34";
-    src = fetchurl {
-      url = "mirror://gnu/libidn/${name}.tar.gz";
-      sha256 = "0g3fzypp0xjcgr90c5cyj57apx1cmy0c6y9lvw2qdcigbyby469p";
-    };
-  });
-
   versionInfo = let
     supportedVersions = {
       "19.3.0" = {
@@ -48,13 +37,27 @@ let
         x86hash   = "1hxgj5lk5ghbpssbqjd404qr84gls967vwrh8ww5hg3pn86kyf8w";
         x64suffix = "5";
         x86suffix = "5";
+        homepage  = https://www.citrix.com/downloads/workspace-app/legacy-workspace-app-for-linux/workspace-app-for-linux-1903.html;
+      };
+
+      "19.6.0" = {
+        major     = "19";
+        minor     = "6";
+        patch     = "0";
+        x64hash   = "0szqlfmigzgf0309i6ikxkizxaf4ri7qmhys75m0zi3bpwx6hzhs";
+        x86hash   = "16v3kgavrh62z6vxcbw6mn7h0bfishpl7m92k7g1p2882r1f8vaf";
+        x64suffix = "60";
+        x86suffix = "60";
         homepage  = https://www.citrix.com/downloads/workspace-app/linux/workspace-app-for-linux-latest.html;
       };
     };
 
     # Copied this file largely from the citrix-receiver package
     # Leaving this here even though there are no deprecations yet
-    # for ease of future maintenance
+    # for ease of future maintenance.
+    #
+    # The lifespans of Citrix products can be found here:
+    # https://www.citrix.com/support/product-lifecycle/milestones/receiver.html
     deprecatedVersions = let
       versions = [ ];
     in
@@ -117,7 +120,6 @@ let
         xorg.libXinerama
         xorg.libXfixes
         libpng12
-        libidn_134
         zlib
         gtk_engines
         freetype
@@ -208,6 +210,7 @@ let
         inherit homepage;
         description = "Citrix Workspace";
         platforms   = platforms.linux;
+        maintainers = with maintainers; [ ma27 ];
       };
     };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2132,10 +2132,14 @@ in
   };
 
   citrix_workspace_unwrapped = callPackage ../applications/networking/remote/citrix-workspace { };
+  citrix_workspace_unwrapped_19_6_0 = citrix_workspace_unwrapped.override { version = "19.6.0"; };
   citrix_workspace_unwrapped_19_3_0 = citrix_workspace_unwrapped.override { version = "19.3.0"; };
 
   citrix_workspace = callPackage ../applications/networking/remote/citrix-workspace/wrapper.nix {
     citrix_workspace = citrix_workspace_unwrapped;
+  };
+  citrix_workspace_19_6_0 = callPackage ../applications/networking/remote/citrix-workspace/wrapper.nix {
+    citrix_workspace = citrix_workspace_unwrapped_19_6_0;
   };
   citrix_workspace_19_3_0 = callPackage ../applications/networking/remote/citrix-workspace/wrapper.nix {
     citrix_workspace = citrix_workspace_unwrapped_19_3_0;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

New release available:
https://www.citrix.com/downloads/workspace-app/linux/workspace-app-for-linux-latest.html

Apart from the new version the following things changed:

* Updated the docs as all notes about `citrix_receiver` also apply for
  `citrix_workspace`. Also added a deprecation warning about the
  upcoming removal.

* Removed the `libidn_134` override as neither `citrix_workspace_19_3_0`
  nor `citrix_workspace_19_6_0` require this library anymore according
  to `readelf -d ./result/opt/citrix-icaclient/wfica` (in contrast to
  `citrix_receiver_13_10_0`).

* Added myself as maintainer as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
