### PR TITLE
axel: 2.17.1 -> 2.17.3

### DIFF
--- a/pkgs/tools/networking/axel/default.nix
+++ b/pkgs/tools/networking/axel/default.nix
@@ -1,15 +1,18 @@
-{ stdenv, fetchurl, autoreconfHook, pkgconfig, gettext, libssl }:
+{ stdenv, fetchFromGitHub, autoreconfHook, autoconf-archive
+, pkgconfig, gettext, libssl }:
 
 stdenv.mkDerivation rec {
-  name = "axel-${version}";
-  version = "2.17.1";
+  pname = "axel";
+  version = "2.17.3";
 
-  src = fetchurl {
-  url = "https://github.com/axel-download-accelerator/axel/releases/download/v${version}/${name}.tar.xz";
-    sha256 = "1mwyps6yvrjxp7mpzc0a2hwr2pw050c63fc9aqjzdzjjw123dfrn";
+  src = fetchFromGitHub {
+    owner = "axel-download-accelerator";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0kdd2y92plv240ba2j3xrm0f8xygvm1ijghnric4whsnxvmgym7h";
   };
 
-  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig autoconf-archive ];
 
   buildInputs = [ gettext libssl ];
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update `axel` to the latest release.
- https://github.com/axel-download-accelerator/axel/releases/tag/v2.17.3
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
