### PR TITLE
quickjs: init at 2019-07-09

### DIFF
--- a/pkgs/development/interpreters/quickjs/default.nix
+++ b/pkgs/development/interpreters/quickjs/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  pname = "quickjs";
+  version = "2019-07-09";
+
+  src = fetchurl {
+    url = "https://bellard.org/${pname}/${pname}-${version}.tar.xz";
+    sha256 = "0r6mgh0m85c11y8ah5iphzpw518br0hi36f92mgdg2iivpciq31m";
+  };
+
+  postPatch = ''
+    sed -e "s/^CONFIG_M32=y/#&/" -i Makefile
+  '';
+
+  makeFlags = [ "prefix=${placeholder ''out''}" ];
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "A small and embeddable Javascript engine";
+    homepage = https://bellard.org/quickjs/;
+    maintainers = [ maintainers.stesie ];
+    platforms = platforms.linux;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5536,6 +5536,8 @@ in
 
   qtikz = libsForQt5.callPackage ../applications/graphics/ktikz { };
 
+  quickjs = callPackage ../development/interpreters/quickjs { };
+
   quickserve = callPackage ../tools/networking/quickserve { };
 
   quicktun = callPackage ../tools/networking/quicktun { };


### PR DESCRIPTION
###### Motivation for this change

QuickJS is a new Javascript engine recently published by Fabrice Bellard

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
