### PR TITLE
sortmerna: init at 3.0.3

### DIFF
--- a/pkgs/applications/science/biology/sortmerna/default.nix
+++ b/pkgs/applications/science/biology/sortmerna/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, cmake, rocksdb, rapidjson, pkgconfig, fetchFromGitHub, fetchpatch, zlib }:
+
+stdenv.mkDerivation rec {
+  pname = "sortmerna";
+  version = "3.0.3";
+
+  src = fetchFromGitHub {
+    repo = pname;
+    owner = "biocore";
+    rev = "v${version}";
+    sha256 = "0zx5fbzyr8wdr0zwphp8hhcn1xz43s5lg2ag4py5sv0pv5l1jh76";
+  };
+
+  patches = [
+    (fetchpatch {
+      name = "CMakeInstallPrefix.patch";
+      url = "https://github.com/biocore/sortmerna/commit/4d36d620a3207e26cf3f588d4ec39889ea21eb79.patch";
+      sha256 = "0hc3jwdr6ylbyigg52q8islqc0mb1k8rrjadvjfqaxnili099apd";
+    })
+  ];
+
+  nativeBuildInputs = [ cmake rapidjson pkgconfig ];
+  buildInputs = [ zlib rocksdb rapidjson ];
+
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DROCKSDB_HOME=${rocksdb}"
+    "-DRAPIDJSON_HOME=${rapidjson}"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Tools for filtering, mapping, and OTU-picking from shotgun genomics data";
+    license = licenses.lgpl3;
+    platforms = platforms.x86_64;
+    homepage = https://bioinfo.lifl.fr/RNA/sortmerna/;
+    maintainers = with maintainers; [ luispedro ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22853,6 +22853,8 @@ in
 
   somatic-sniper = callPackage ../applications/science/biology/somatic-sniper { };
 
+  sortmerna = callPackage ../applications/science/biology/sortmerna { };
+
   stacks = callPackage ../applications/science/biology/stacks { };
 
   star = callPackage ../applications/science/biology/star { };


### PR DESCRIPTION
This is a useful package in bioinformatics, the corresponding bioconda package has [> 50,000 downloads](https://anaconda.org/bioconda/sortmerna)


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)

