### PR TITLE
ansible: 2.8.1 -> 2.8.2

### DIFF
--- a/pkgs/development/python-modules/ansible/default.nix
+++ b/pkgs/development/python-modules/ansible/default.nix
@@ -18,11 +18,11 @@
 
 buildPythonPackage rec {
   pname = "ansible";
-  version = "2.8.1";
+  version = "2.8.2";
 
   src = fetchurl {
     url = "https://releases.ansible.com/ansible/${pname}-${version}.tar.gz";
-    sha256 = "0ia4x17ywym3r1m96ar4h0wc2xlylhbjp6x4wzwkh4p2i0x1vmg1";
+    sha256 = "1e5ba829ca0602c55b33da399b06f99b135a34014b661d1c36d8892a1e2d3730";
   };
 
   prePatch = ''


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

ansible: 2.8.1 -> 2.8.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

```sh
stanislas@nixpsla ~/nixpkgs> (ansible/update/2.8.2|✚1) ./result/bin/ansible --version
ansible 2.8.2
  config file = None
  configured module search path = ['/home/stanislas/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /nix/store/1ip77rqvv64ijkm67d3pmy6vzsd2fz4v-python3.7-ansible-2.8.2/lib/python3.7/site-packages/ansible
  executable location = /nix/store/1ip77rqvv64ijkm67d3pmy6vzsd2fz4v-python3.7-ansible-2.8.2/bin/ansible
  python version = 3.7.3 (default, Mar 25 2019, 20:59:09) [GCC 7.4.0]
```