### PR TITLE
debianutils: 4.8.6.1 -> 4.8.6.2

### DIFF
--- a/pkgs/tools/misc/debianutils/default.nix
+++ b/pkgs/tools/misc/debianutils/default.nix
@@ -1,15 +1,15 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  version = "4.8.6.1";
-  name = "debianutils-${version}";
+  pname = "debianutils";
+  version = "4.8.6.2";
 
   src = fetchurl {
-    url = "mirror://debian/pool/main/d/debianutils/debianutils_${version}.tar.xz";
-    sha256 = "1vamrgzsfdb2183xgj1qmfzh710iqj2dlbdsl92n3ckqfa51x7q9";
+    url = "mirror://debian/pool/main/d/${pname}/${pname}_${version}.tar.xz";
+    sha256 = "1fhbn62v85ydcap4pjx6jb37bly42lf3l64ig4ppr7yiaax8i8xc";
   };
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Miscellaneous utilities specific to Debian";
     longDescription = ''
        This package provides a number of small utilities which are used primarily by the installation scripts of Debian packages, although you may use them directly.
@@ -17,8 +17,8 @@ stdenv.mkDerivation rec {
        The specific utilities included are: add-shell installkernel ischroot remove-shell run-parts savelog tempfile which
     '';
     downloadPage = https://packages.debian.org/sid/debianutils;
-    license = with stdenv.lib.licenses; [ gpl2Plus publicDomain smail ];
+    license = with licenses; [ gpl2Plus publicDomain smail ];
     maintainers = [];
-    platforms = stdenv.lib.platforms.all;
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update `debianutils` to the latest release.
- https://packages.debian.org/sid/debianutils
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
