### PR TITLE
fcitx-qt5: 1.2.1 -> 1.2.3

### DIFF
--- a/pkgs/tools/inputmethods/fcitx/fcitx-qt5.nix
+++ b/pkgs/tools/inputmethods/fcitx/fcitx-qt5.nix
@@ -1,24 +1,15 @@
-{ stdenv, fetchurl, cmake, fcitx, pkgconfig, qtbase, extra-cmake-modules
-, fetchpatch
-}:
+{ stdenv, fetchFromGitLab, cmake, fcitx, pkgconfig, qtbase, extra-cmake-modules }:
 
 stdenv.mkDerivation rec {
-  name = "fcitx-qt5-${version}";
-  version = "1.2.1";
+  pname = "fcitx-qt5";
+  version = "1.2.3";
 
-  src = fetchurl {
-    url = "http://download.fcitx-im.org/fcitx-qt5/${name}.tar.xz";
-    sha256 = "0z8ax0dxk88byic41mfaiahjdv1k8ciwn97xfjkkgr4ijgscdr8c";
+  src = fetchFromGitLab {
+    owner = "fcitx";
+    repo = pname;
+    rev = version;
+    sha256 = "0860v3rxsh054wkkbawvyin5mk0flp4cwfcpmcpq147lvdm5lq2i";
   };
-
-  patches = [
-    # Fix build with Qt 5.11
-    # https://github.com/fcitx/fcitx-qt5/issues/34
-    (fetchpatch {
-      url = https://github.com/fcitx/fcitx-qt5/commit/af033e3d5305108eecc568adff7f8b2da5831ed6.diff;
-      sha256 = "14vfz1fw2k362wnqpglw766fg3d3mc8cmfgic2p96yyipjh9xx3b";
-    })
-  ];
 
   nativeBuildInputs = [ cmake extra-cmake-modules pkgconfig ];
 
@@ -32,11 +23,10 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage    = https://github.com/fcitx/fcitx-qt5;
+    homepage    = https://gitlab.com/fcitx/fcitx-qt5;
     description = "Qt5 IM Module for Fcitx";
     license     = licenses.gpl2;
     platforms   = platforms.linux;
     maintainers = with maintainers; [ ericsagnes ];
   };
-
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update `fcitx-qt5` to the latest release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
