### PR TITLE
qt-box-editor: init at unstable-2019-07-12

### DIFF
--- a/pkgs/applications/misc/qt-box-editor/default.nix
+++ b/pkgs/applications/misc/qt-box-editor/default.nix
@@ -1,0 +1,38 @@
+{ stdenv
+, fetchFromGitHub
+, qtbase
+, qtsvg
+, qmake
+, leptonica
+, tesseract
+}:
+
+stdenv.mkDerivation rec {
+  pname = "qt-box-editor";
+  version = "unstable-2019-07-12";
+
+  src = fetchFromGitHub {
+    owner = "zdenop";
+    repo = "qt-box-editor";
+    rev = "75a68b466868ba41ba2886caa796057403fe1901";
+    sha256 = "0zwsyy7cnbhy5aazwlkhd9y8bnzlgy1gffqa46abajn4809b95k3";
+  };
+
+  buildInputs = [ qtbase qtsvg leptonica tesseract ];
+
+  nativeBuildInputs = [ qmake ];
+
+  # remove with next release
+  # https://github.com/zdenop/qt-box-editor/pull/78
+  postPatch = ''
+    printf "INSTALLS += target\ntarget.path = $out/bin" >>  qt-box-editor.pro
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Editor of tesseract-ocr box files";
+    homepage = https://github.com/zdenop/qt-box-editor;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5617,6 +5617,8 @@ in
     jack2 = jack2Full;
   };
 
+  qt-box-editor = libsForQt5.callPackage ../applications/misc/qt-box-editor { };
+
   recutils = callPackage ../tools/misc/recutils { };
 
   recoll = callPackage ../applications/search/recoll { };


### PR DESCRIPTION
latest unstable version is only one to build with tesseract4 and qt5

###### Motivation for this change

LGTM I have tested that the binary works for my OCR training

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
