### PR TITLE
[19.03] glib: fix CVE-2019-13012

### DIFF
--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -91,6 +91,12 @@ stdenv.mkDerivation rec {
         name = "CVE-2019-12450.patch";
         sha256 = "03ris8lllbb7i18qvbpqaf7xdwfz1dkskx8mb533dmwlp2ll69hg";
       })
+      # https://gitlab.gnome.org/GNOME/glib/issues/1658
+      (fetchpatch {
+        name = "CVE-2019-13012.patch";
+        url = "https://gitlab.gnome.org/GNOME/glib/commit/5e4da714f00f6bfb2ccd6d73d61329c6f3a08429.patch";
+        sha256 = "0ykfx9i1ipz06n7hvz27qw0l9hy9jslg5gqqxyfiivy81q4p7lnl";
+      })
     ];
 
   outputs = [ "bin" "out" "dev" "devdoc" ];


### PR DESCRIPTION
### CVE-2019-13012 Description:

The keyfile settings backend in GLib before 2.59.1 creates directories
using g_file_make_directory_with_parents (kfsb->dir, NULL, NULL) and
files using g_file_replace_contents (kfsb->file, contents, length, NULL, FALSE,
G_FILE_CREATE_REPLACE_DESTINATION, NULL, NULL, NULL).
Consequently, it does not properly restrict directory (and file) permissions.
Instead, for directories, 0777 permissions are used; for files, default file
permissions are used.

### Patch Summary:

Changes the permissions when a directory is created,
using 700 instead 777 in gio/gkeyfilesettingsbackend.c
and changes test to run in a temp directory in gio/tests/gsettings.c.

---

Upstream Issue: https://gitlab.gnome.org/GNOME/glib/issues/1658
Upstream MR: https://gitlab.gnome.org/GNOME/glib/merge_requests/604

Fixes #64657

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
To fix #64657

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
