### PR TITLE
avro-tools: init at 1.9.0

### DIFF
--- a/pkgs/development/tools/avro-tools/default.nix
+++ b/pkgs/development/tools/avro-tools/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchurl, makeWrapper, jre, lib }:
+
+stdenv.mkDerivation rec {
+  version = "1.9.0";
+  name = "avro-tools-${version}";
+
+  src = fetchurl {
+    url =
+    "https://repo1.maven.org/maven2/org/apache/avro/avro-tools/${version}/${name}.jar";
+    sha256 = "164mcz7ljd2ikwsq9ba98galcjar4g4n6ag7kkh466nwrpbmd2zi";
+  };
+
+  dontUnpack = true;
+
+  buildInputs = [ jre ];
+  nativeBuildInputs = [ makeWrapper ];
+  sourceRoot = ".";
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/libexec/avro-tools
+    mv $src ${name}.jar
+    cp ${name}.jar $out/libexec/avro-tools
+
+    makeWrapper ${jre}/bin/java $out/bin/avro-tools \
+    --add-flags "-jar $out/libexec/avro-tools/${name}.jar"
+  '';
+
+  meta = with stdenv.lib; {
+    homepage    = https://avro.apache.org/;
+    description = "Avro command-line tools and utilities";
+    license     = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.nequissimus ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -128,6 +128,8 @@ in
 
   addOpenGLRunpath = callPackage ../build-support/add-opengl-runpath { };
 
+  avro-tools = callPackage ../development/tools/avro-tools { };
+
   # Zip file format only allows times after year 1980, which makes e.g. Python wheel building fail with:
   # ValueError: ZIP does not support timestamps before 1980
   ensureNewerSourcesForZipFilesHook = ensureNewerSourcesHook { year = "1980"; };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Access the avro-tools cli.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
