### PR TITLE
evtest-qt: init at 0.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -250,6 +250,11 @@
     github = "akru";
     name = "Alexander Krupenkin ";
   };
+  alexarice = {
+    email = "alexrice999@hotmail.co.uk";
+    github = "alexarice";
+    name = "Alex Rice";
+  };
   alexchapman = {
     email = "alex@farfromthere.net";
     github = "AJChapman";

--- a/pkgs/applications/misc/evtest-qt/default.nix
+++ b/pkgs/applications/misc/evtest-qt/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, qtbase, cmake, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "evtest-qt";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "Grumbel";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1wfzkgq81764qzxgk0y5vvpxcrb3icvrr4dd4mj8njrqgbwmn0mw";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ qtbase ];
+
+  meta = with stdenv.lib; {
+    description = "Simple input device tester for linux with Qt GUI";
+    homepage = "https://github.com/Grumbel/evtest-qt";
+    maintainers = with maintainers; [ alexarice ];
+    platforms = platforms.linux;
+    license = licenses.gpl3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2838,6 +2838,8 @@ in
 
   evtest = callPackage ../applications/misc/evtest { };
 
+  evtest-qt = libsForQt5.callPackage ../applications/misc/evtest-qt { };
+
   exa = callPackage ../tools/misc/exa { };
 
   exempi = callPackage ../development/libraries/exempi {


### PR DESCRIPTION
###### Motivation for this change
Appears to be no existing package for this

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

For me this does not work when ran with sudo giving the error:
```
No protocol specified
qt.qpa.xcb: could not connect to display :0
```
though I expect this may have to do with me running wayland. Everything works fine for me when not running with sudo.
Further I am no expert with qt or cmake so if I have missed some dependency/ something important please let me know.
