### PR TITLE
riot-web: fallback to example config

### DIFF
--- a/pkgs/applications/networking/instant-messengers/riot/riot-web.nix
+++ b/pkgs/applications/networking/instant-messengers/riot/riot-web.nix
@@ -3,7 +3,6 @@
 # Note for maintainers:
 # Versions of `riot-web` and `riot-desktop` should be kept in sync.
 
-let configFile = writeText "riot-config.json" conf; in
 stdenv.mkDerivation rec {
   name= "riot-web-${version}";
   version = "1.2.2";
@@ -13,10 +12,14 @@ stdenv.mkDerivation rec {
     sha256 = "19nb6gyjaijah068ika6hvk18hraivm71830i9cd4ssl6g5j4k8x";
   };
 
-  installPhase = ''
+  installPhase = let
+    configFile = if (conf != null)
+      then writeText "riot-config.json" conf
+      else "$out/config.sample.json";
+  in ''
     mkdir -p $out/
     cp -R . $out/
-    ${lib.optionalString (conf != null) "ln -s ${configFile} $out/config.json"}
+    ln -s ${configFile} $out/config.json
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Since 1.2.2, specifying defaults seems to be required for the app to start.
This fixes issue #64543 (riot-desktop starts and just displays "Riot is misconfigured").
The problem isn't apparent when the user is already logged in.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC: @bachp @nyanloutre 