### PR TITLE
victor-mono: init at 1.2.1

### DIFF
--- a/pkgs/data/fonts/victor-mono/default.nix
+++ b/pkgs/data/fonts/victor-mono/default.nix
@@ -1,0 +1,29 @@
+{ lib, fetchFromGitHub }:
+
+let
+  pname = "victor-mono";
+  version = "1.2.1";
+in fetchFromGitHub {
+  name = "${pname}-${version}";
+
+  owner = "rubjo";
+  repo = pname;
+  rev = "v${version}";
+
+  postFetch = ''
+    tar xf $downloadedFile --strip=1
+    unzip public/VictorMonoAll.zip TTF/\*
+    mkdir -p $out/share/fonts/truetype/${pname}
+    cp TTF/*.ttf $out/share/fonts/truetype/${pname}
+  '';
+
+  sha256 = "0gisjcywmn3kjgwfmzcv8ibxqd126s93id2w0zjly0c7m3ckamh8";
+
+  meta = with lib; {
+    homepage = https://rubjo.github.io/victor-mono;
+    description = "A free programming font with cursive italics and ligatures";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ jpotier ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16811,6 +16811,8 @@ in
 
   vegur = callPackage ../data/fonts/vegur { };
 
+  victor-mono = callPackage ../data/fonts/victor-mono { };
+
   vistafonts = callPackage ../data/fonts/vista-fonts { };
 
   vistafonts-chs = callPackage ../data/fonts/vista-fonts-chs { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
