### PR TITLE
spago: init at 0.8.5.0

### DIFF
--- a/pkgs/development/web/spago/default.nix
+++ b/pkgs/development/web/spago/default.nix
@@ -1,0 +1,55 @@
+{ stdenv, gmp, zlib, ncurses5 }:
+
+let
+  patchelf = libPath: if stdenv.isDarwin
+    then ""
+    else ''
+          chmod u+w $SPAGO
+          patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" --set-rpath ${libPath} $SPAGO
+          chmod u-w $SPAGO
+        '';
+
+in stdenv.mkDerivation rec {
+  pname = "spago";
+
+  version = "0.8.5.0";
+
+  src = if stdenv.isDarwin
+    then builtins.fetchurl {
+      url = "https://github.com/spacchetti/spago/releases/download/0.8.5.0/osx.tar.gz";
+      sha256 = "0a6s4xpzdvbyh16ffcn0qsc3f9q15chg0qfaxhrgc8a7qg84ym5n";
+    }
+    else builtins.fetchurl {
+      url = "https://github.com/spacchetti/spago/releases/download/0.8.5.0/linux.tar.gz";
+      sha256 = "0r66pmjfwv89c1h71s95nkq9hgbk7b8h9sk05bfmhsx2gprnd3bq";
+    };
+
+  buildInputs = [ gmp zlib ncurses5 ];
+  nativeBuildInputs = [ stdenv.cc.cc.lib ];
+
+  libPath = stdenv.lib.makeLibraryPath (buildInputs ++ nativeBuildInputs);
+
+  dontStrip = true;
+
+  unpackPhase = ''
+      mkdir -p $out/bin
+      tar xf $src -C $out/bin
+
+      SPAGO=$out/bin/spago
+      ${patchelf libPath}
+
+
+      mkdir -p $out/etc/bash_completion.d/
+      $SPAGO --bash-completion-script $SPAGO > $out/etc/bash_completion.d/spago-completion.bash
+    '';
+
+  dontInstall = true;
+
+  meta = with stdenv.lib; {
+    description = "PureScript package manager and build tool powered by Dhall and package-sets";
+    homepage = https://github.com/spacchetti/spago;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ shou ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7588,6 +7588,8 @@ in
   psc-package = haskell.lib.justStaticExecutables
     (haskellPackages.callPackage ../development/compilers/purescript/psc-package { });
 
+  spago = callPackage ../development/web/spago { };
+
   tamarin-prover =
     (haskellPackages.callPackage ../applications/science/logic/tamarin-prover {
       # NOTE: do not use the haskell packages 'graphviz' and 'maude'


### PR DESCRIPTION
Credit to [justinwoo/easy-purescript-nix][1].

[1]: https://github.com/justinwoo/easy-purescript-nix

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
