### PR TITLE
protontricks: init at 1.2.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3248,6 +3248,11 @@
     email = "softs@metabarcoding.org";
     name = "Celine Mercier";
   };
+  metadark = {
+    email = "kira.bruneau@gmail.com";
+    name = "Kira Bruneau";
+    github = "metadark";
+  };
   mfossen = {
     email = "msfossen@gmail.com";
     github = "mfossen";

--- a/pkgs/development/python-modules/vdf/default.nix
+++ b/pkgs/development/python-modules/vdf/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub
+, pytest, pytestcov, mock }:
+
+buildPythonPackage rec {
+  pname = "vdf";
+  version = "3.1";
+
+  src = fetchFromGitHub {
+    owner = "ValvePython";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "19xqjq2159w2l9vaxlkickvy3zksp9ssdkvbfcfggxz31miwp1zr";
+  };
+
+  checkInputs = [ pytest pytestcov mock ];
+  checkPhase = "make test";
+
+  meta = with stdenv.lib; {
+    description = "Library for working with Valve's VDF text format";
+    homepage = https://github.com/ValvePython/vdf;
+    license = licenses.mit;
+    maintainers = with maintainers; [ metadark ];
+  };
+}

--- a/pkgs/tools/package-management/protontricks/default.nix
+++ b/pkgs/tools/package-management/protontricks/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, lib, buildPythonApplication, fetchFromGitHub
+, vdf, wine, winetricks, zenity
+}:
+
+buildPythonApplication rec {
+  pname = "protontricks";
+  version = "1.2.3";
+
+  src = fetchFromGitHub {
+    owner = "Matoking";
+    repo = pname;
+    rev = version;
+    sha256 = "1v7bgr1rkm8j99s5bv45cslw01qcx8i8zb6ysfrb53qz86zgkgsn";
+  };
+
+  propagatedBuildInputs = [ vdf ];
+
+  # The wine install shipped with Proton must run under steam's
+  # chrootenv, but winetricks and zenity break when running under
+  # it. See https://github.com/NixOS/nix/issues/902.
+  #
+  # The current workaround is to use wine from nixpkgs
+  makeWrapperArgs = [
+    "--set STEAM_RUNTIME 0"
+    "--set-default WINE ${wine}/bin/wine"
+    "--set-default WINESERVER ${wine}/bin/wineserver"
+    "--prefix PATH : ${lib.makeBinPath [
+      (winetricks.override { inherit wine; })
+      zenity
+    ]}"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A simple wrapper for running Winetricks commands for Proton-enabled games";
+    homepage = https://github.com/Matoking/protontricks;
+    license = licenses.gpl3;
+    platforms = with platforms; linux;
+    maintainers = with maintainers; [ metadark ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22014,6 +22014,12 @@ in
     gtk = pkgs.gtk3;
   };
 
+  protontricks = callPackage ../tools/package-management/protontricks {
+    inherit (python3Packages) buildPythonApplication vdf;
+    inherit (gnome3) zenity;
+    wine = wineWowPackages.minimal;
+  };
+
   stepmania = callPackage ../games/stepmania {
     ffmpeg = ffmpeg_2;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1010,6 +1010,8 @@ in {
 
   pyunifi = callPackage ../development/python-modules/pyunifi { };
 
+  vdf = callPackage ../development/python-modules/vdf { };
+
   vidstab = callPackage ../development/python-modules/vidstab { };
 
   webapp2 = callPackage ../development/python-modules/webapp2 { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
This adds the protontricks package with required dependencies: #61193.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS (with gstreamerSupport = false in pkgs/top-level/wine-packages.nix, see #63829)
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
