### PR TITLE
pantheon.cerbere: 0.2.4 -> 2.5.0

### DIFF
--- a/pkgs/desktops/pantheon/services/cerbere/default.nix
+++ b/pkgs/desktops/pantheon/services/cerbere/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cerbere";
-  version = "0.2.4";
+  version = "2.5.0";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "0f9jr6q5z6nir5b77f96wm9rx6r6s9i0sr1yrymg3n7jyjgrvdwp";
+    sha256 = "12y6gg4vyc1rhdm2c7pr7bgmdrah7ddphyh25fgh3way8l9gh7vw";
   };
 
   passthru = {


### PR DESCRIPTION
Fixes #60955

###### Motivation for this change
Upstream should have fixes for #60955 but it seemed like it was still timing out on my
system so I've opened this for feedback. If it's the case that it's not actually fixed I should
be able to re-open the issue upstream.

> https://github.com/elementary/cerbere/releases/tag/2.5.0
> * Handle SIGHUP and SIGTERM to prevent hang on system shutdown

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
