### PR TITLE
pythonPackages.lightgbm: fix build on darwin

### DIFF
--- a/pkgs/development/python-modules/lightgbm/default.nix
+++ b/pkgs/development/python-modules/lightgbm/default.nix
@@ -1,10 +1,11 @@
-{ lib
+{ stdenv
 , buildPythonPackage
 , fetchPypi
 , cmake
 , numpy
 , scipy
 , scikitlearn
+, llvmPackages ? null
 }:
 
 buildPythonPackage rec {
@@ -20,6 +21,19 @@ buildPythonPackage rec {
     cmake
   ];
 
+  # we never actually explicitly call the install command so this is the only way
+  # to inject these options to it - however, openmp-library doesn't appear to have
+  # any effect, so we have to inject it into NIX_LDFLAGS manually below
+  postPatch = stdenv.lib.optionalString stdenv.cc.isClang ''
+    cat >> setup.cfg <<EOF
+
+    [install]
+    openmp-include-dir=${llvmPackages.openmp}/include
+    openmp-library=${llvmPackages.openmp}/lib/libomp.dylib
+
+    EOF
+  '';
+
   propagatedBuildInputs = [
     numpy
     scipy
@@ -28,6 +42,8 @@ buildPythonPackage rec {
 
   postConfigure = ''
     export HOME=$(mktemp -d)
+  '' + stdenv.lib.optionalString stdenv.cc.isClang ''
+    export NIX_LDFLAGS="$NIX_LDFLAGS -L${llvmPackages.openmp}/lib -lomp"
   '';
 
   # The pypi package doesn't distribute the tests from the GitHub
@@ -35,10 +51,10 @@ buildPythonPackage rec {
   # `make check`.
   doCheck = false;
 
-  meta = with lib; {
+  meta = with stdenv.lib; {
     description = "A fast, distributed, high performance gradient boosting (GBDT, GBRT, GBM or MART) framework";
     homepage = https://github.com/Microsoft/LightGBM;
     license = licenses.mit;
-    maintainers = with lib.maintainers; [ teh costrouc ];
+    maintainers = with maintainers; [ teh costrouc ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Fix build on darwin. This was a pretty hard one to debug what with `cmake` being the most debugging-hostile tool on the planet, and build flags that don't do what they're supposed to, but in the end I forced clang to link against `libomp.dylib` by using `NIX_LDFLAGS`.

Tested on macos 10.13.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
