### PR TITLE
fly: init at 5.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2228,6 +2228,15 @@
     email = "tkatchev@gmail.com";
     name = "Ivan Tkatchev";
   };
+  ivanbrennan = {
+    email = "ivan.brennan@gmail.com";
+    github = "ivanbrennan";
+    name = "Ivan Brennan";
+    keys = [{
+      longkeyid = "rsa4096/0x79C3C47DC652EA54";
+      fingerprint = "7311 2700 AB4F 4CDF C68C  F6A5 79C3 C47D C652 EA54";
+    }];
+  };
   ivegotasthma = {
     email = "ivegotasthma@protonmail.com";
     github = "ivegotasthma";

--- a/pkgs/development/tools/continuous-integration/fly/default.nix
+++ b/pkgs/development/tools/continuous-integration/fly/default.nix
@@ -1,0 +1,37 @@
+{ buildGoModule, fetchFromGitHub, lib, writeText }:
+
+buildGoModule rec {
+  pname = "fly";
+  version = "5.3.0";
+
+  src = fetchFromGitHub {
+    owner = "concourse";
+    repo = "concourse";
+    rev = "v${version}";
+    sha256 = "06ns98k47nafhkkj7gkmxp7msn4ssypyss6ll0fm6380vq2cavnj";
+  };
+
+  modSha256 = "11rnlmn5hp9nsgkmd716dsjmkr273035j9gzfhjxjsfpiax60i0a";
+
+  subPackages = [ "fly" ];
+
+  buildFlagsArray = ''
+    -ldflags=
+      -X github.com/concourse/concourse.Version=${version}
+  '';
+
+  # The fly.bash file included with this derivation can be replaced by a
+  # call to `fly completion bash` once the `completion` subcommand has
+  # made it into a release. Similarly, `fly completion zsh` will provide
+  # zsh completions. https://github.com/concourse/concourse/pull/4012
+  postInstall = ''
+    install -D -m 444 ${./fly.bash} $out/share/bash-completion/completions/fly
+  '';
+
+  meta = with lib; {
+    description = "A command line interface to Concourse CI";
+    homepage = https://concourse-ci.org;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ivanbrennan ];
+  };
+}

--- a/pkgs/development/tools/continuous-integration/fly/fly.bash
+++ b/pkgs/development/tools/continuous-integration/fly/fly.bash
@@ -1,0 +1,10 @@
+# credits:
+# https://godoc.org/github.com/jessevdk/go-flags#hdr-Completion
+# https://github.com/concourse/concourse/issues/1309#issuecomment-452893900
+_fly_compl() {
+    args=("${COMP_WORDS[@]:1:$COMP_CWORD}")
+    local IFS=$'\n'
+    COMPREPLY=($(GO_FLAGS_COMPLETION=1 ${COMP_WORDS[0]} "${args[@]}"))
+    return 0
+}
+complete -F _fly_compl fly

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9244,6 +9244,8 @@ in
     inherit (darwin) cf-private;
   };
 
+  fly = callPackage ../development/tools/continuous-integration/fly { };
+
   foreman = callPackage ../tools/system/foreman { };
   goreman = callPackage ../tools/system/goreman { };
 


### PR DESCRIPTION
Add `fly` CLI for working with [Concourse](https://concourse-ci.org/).

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

There was no existing derivation for fly CLI.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
