### PR TITLE
wrapQtAppsHook: wrap binaries in libexec

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/kconfigwidgets/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kconfigwidgets/default.nix
@@ -11,10 +11,5 @@ mkDerivation {
   propagatedBuildInputs = [ kauth kcodecs kconfig kwidgetsaddons ];
   patches = [ ./0001-qdiriterator-follow-symlinks.patch ];
   outputs = [ "out" "dev" ];
-  preConfigure = ''
-    outputBin=dev
-  '';
-  postInstall = ''
-    moveToOutput share/man $dev
-  '';
+  outputBin = "dev";
 }

--- a/pkgs/development/libraries/qt-5/hooks/wrap-qt-apps-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/wrap-qt-apps-hook.sh
@@ -82,6 +82,8 @@ wrapQtAppsHook() {
 
         find "$targetDir" -executable -print0 | while IFS= read -r -d '' file
         do
+            isELF "$file" || continue
+
             if [ -f "$file" ]
             then
                 echo "wrapping $file"

--- a/pkgs/development/libraries/qt-5/hooks/wrap-qt-apps-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/wrap-qt-apps-hook.sh
@@ -77,7 +77,7 @@ wrapQtAppsHook() {
     [ -z "$wrapQtAppsHookHasRun" ] || return 0
     wrapQtAppsHookHasRun=1
 
-    local targetDirs=( "$prefix/bin" )
+    local targetDirs=( "$prefix/bin" "$prefix/libexec"  )
     echo "wrapping Qt applications in ${targetDirs[@]}"
 
     for targetDir in "${targetDirs[@]}"

--- a/pkgs/development/libraries/qt-5/hooks/wrap-qt-apps-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/wrap-qt-apps-hook.sh
@@ -64,10 +64,6 @@ qtOwnPathsHook() {
 
 preFixupPhases+=" qtOwnPathsHook"
 
-isQtApp () {
-    readelf -d "$1" 2>/dev/null | grep -q -F 'libQt5Core'
-}
-
 # Note: $qtWrapperArgs still gets defined even if $dontWrapQtApps is set.
 wrapQtAppsHook() {
     # skip this hook when requested
@@ -86,8 +82,6 @@ wrapQtAppsHook() {
 
         find "$targetDir" -executable -print0 | while IFS= read -r -d '' file
         do
-            isQtApp "$file" || continue
-
             if [ -f "$file" ]
             then
                 echo "wrapping $file"


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
See feedback at https://github.com/NixOS/nixpkgs/pull/54525#issuecomment-511164934.
This should be fine to do, it's already done in `wrapGAppsHook`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
