### PR TITLE
scalyr: init at git-20190628

### DIFF
--- a/pkgs/development/python-modules/scalyr/default.nix
+++ b/pkgs/development/python-modules/scalyr/default.nix
@@ -1,0 +1,30 @@
+{ lib, stdenv, fetchFromGitHub, python }:
+
+stdenv.mkDerivation rec {
+  pname = "scalyr";
+  version = "git-20190628";
+
+  src = fetchFromGitHub {
+    owner = "scalyr";
+    repo = "scalyr-tool";
+    rev = "9f6e6e7ddb6db3c19614e315f46d042852722a08"; # not tagged in repository
+    sha256 = "1a90wwkisrpaqwd0pl88czgqdpjxig8j1m9yscyz9cx2n324zhbp";
+  };
+
+  dontBuild = true;
+  
+  buildInputs = [ python ];
+
+  installPhase = ''
+    mkdir -p "$out/bin/"
+    cp scalyr $out/bin/
+    chmod +x $out/bin/scalyr
+  '';
+
+  meta = with lib; {
+    description = "CLI tool for scalyr service";
+    homepage = "https://github.com/scalyr/scalyr-tool";
+    license = licenses.asl20;
+    maintainers = [ maintainers.mog ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2487,6 +2487,8 @@ in {
 
   samplerate = callPackage ../development/python-modules/samplerate { };
 
+  scalyr = callPackage ../development/python-modules/scalyr { };
+
   ssdeep = callPackage ../development/python-modules/ssdeep { };
 
   ssdp = callPackage ../development/python-modules/ssdp { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
tool for using scalyr on cli

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
