### PR TITLE
hplip: update version to 3.19.6, fix `hpcups` segfault, enable udev rule file

### DIFF
--- a/pkgs/misc/drivers/hplip/3.16.11.nix
+++ b/pkgs/misc/drivers/hplip/3.16.11.nix
@@ -142,8 +142,6 @@ pythonPackages.buildPythonApplication {
 
     mkdir -p $out/etc/sane.d/dll.d
     mv $out/etc/sane.d/dll.conf $out/etc/sane.d/dll.d/hpaio.conf
-
-    rm $out/etc/udev/rules.d/56-hpmud.rules
   '';
 
   # The installed executables are just symlinks into $out/share/hplip,
@@ -171,9 +169,9 @@ pythonPackages.buildPythonApplication {
 
   postFixup = ''
     substituteInPlace $out/etc/hp/hplip.conf --replace /usr $out
-  '' + stdenv.lib.optionalString (!withPlugin) ''
-    # A udev rule to notify users that they need the binary plugin.
-    # Needs a lot of patching but might save someone a bit of confusion:
+    # Patch udev rules:
+    # with plugin, they upload firmware to printers,
+    # without plugin, they complain about the missing plugin.
     substituteInPlace $out/etc/udev/rules.d/56-hpmud.rules \
       --replace {,${bash}}/bin/sh \
       --replace /usr/bin/nohup "" \

--- a/pkgs/misc/drivers/hplip/3.16.11.nix
+++ b/pkgs/misc/drivers/hplip/3.16.11.nix
@@ -176,7 +176,7 @@ pythonPackages.buildPythonApplication {
     # Needs a lot of patching but might save someone a bit of confusion:
     substituteInPlace $out/etc/udev/rules.d/56-hpmud.rules \
       --replace {,${bash}}/bin/sh \
-      --replace {/usr,${coreutils}}/bin/nohup \
+      --replace /usr/bin/nohup "" \
       --replace {,${utillinux}/bin/}logger \
       --replace {/usr,$out}/bin
   '';

--- a/pkgs/misc/drivers/hplip/3.16.11.nix
+++ b/pkgs/misc/drivers/hplip/3.16.11.nix
@@ -184,6 +184,7 @@ pythonPackages.buildPythonApplication {
   meta = with stdenv.lib; {
     description = "Print, scan and fax HP drivers for Linux";
     homepage = http://hplipopensource.com/;
+    downloadPage = https://sourceforge.net/projects/hplip/files/hplip/;
     license = if withPlugin
       then licenses.unfree
       else with licenses; [ mit bsd2 gpl2Plus ];

--- a/pkgs/misc/drivers/hplip/3.18.5.nix
+++ b/pkgs/misc/drivers/hplip/3.18.5.nix
@@ -216,6 +216,7 @@ pythonPackages.buildPythonApplication {
   meta = with stdenv.lib; {
     description = "Print, scan and fax HP drivers for Linux";
     homepage = https://developers.hp.com/hp-linux-imaging-and-printing;
+    downloadPage = https://sourceforge.net/projects/hplip/files/hplip/;
     license = if withPlugin
       then licenses.unfree
       else with licenses; [ mit bsd2 gpl2Plus ];

--- a/pkgs/misc/drivers/hplip/3.18.5.nix
+++ b/pkgs/misc/drivers/hplip/3.18.5.nix
@@ -208,7 +208,7 @@ pythonPackages.buildPythonApplication {
     # Needs a lot of patching but might save someone a bit of confusion:
     substituteInPlace $out/etc/udev/rules.d/56-hpmud.rules \
       --replace {,${bash}}/bin/sh \
-      --replace {/usr,${coreutils}}/bin/nohup \
+      --replace /usr/bin/nohup "" \
       --replace {,${utillinux}/bin/}logger \
       --replace {/usr,$out}/bin
   '';

--- a/pkgs/misc/drivers/hplip/3.18.5.nix
+++ b/pkgs/misc/drivers/hplip/3.18.5.nix
@@ -174,8 +174,6 @@ pythonPackages.buildPythonApplication {
 
     mkdir -p $out/var/lib/hp
     cp ${hplipState} $out/var/lib/hp/hplip.state
-
-    rm $out/etc/udev/rules.d/56-hpmud.rules
   '';
 
   # The installed executables are just symlinks into $out/share/hplip,
@@ -203,9 +201,9 @@ pythonPackages.buildPythonApplication {
 
   postFixup = ''
     substituteInPlace $out/etc/hp/hplip.conf --replace /usr $out
-  '' + stdenv.lib.optionalString (!withPlugin) ''
-    # A udev rule to notify users that they need the binary plugin.
-    # Needs a lot of patching but might save someone a bit of confusion:
+    # Patch udev rules:
+    # with plugin, they upload firmware to printers,
+    # without plugin, they complain about the missing plugin.
     substituteInPlace $out/etc/udev/rules.d/56-hpmud.rules \
       --replace {,${bash}}/bin/sh \
       --replace /usr/bin/nohup "" \

--- a/pkgs/misc/drivers/hplip/default.nix
+++ b/pkgs/misc/drivers/hplip/default.nix
@@ -12,16 +12,16 @@
 let
 
   name = "hplip-${version}";
-  version = "3.19.1";
+  version = "3.19.6";
 
   src = fetchurl {
     url = "mirror://sourceforge/hplip/${name}.tar.gz";
-    sha256 = "1kl1q4753xx1w76dhp92wgrhn5k1yx1ib35pyi0vi3mw0njbhrzm";
+    sha256 = "0vfnc6pg7wzs68qn5mlk3cyl969d8n55bydgydq2wzfikvpfvnpw";
   };
 
   plugin = fetchurl {
     url = "https://www.openprinting.org/download/printdriver/auxfiles/HP/plugins/${name}-plugin.run";
-    sha256 = "1fwjypy1ycyi7rr1vk1yxhbdhx51n7fxhvjb36mzw8qz71dif2i3";
+    sha256 = "1b5gys04kh41gg7r7rzlpdbc2f4jirl2ik22cd935mm85k7abfwq";
   };
 
   hplipState = substituteAll {

--- a/pkgs/misc/drivers/hplip/default.nix
+++ b/pkgs/misc/drivers/hplip/default.nix
@@ -181,8 +181,6 @@ pythonPackages.buildPythonApplication {
 
     mkdir -p $out/var/lib/hp
     cp ${hplipState} $out/var/lib/hp/hplip.state
-
-    rm $out/etc/udev/rules.d/56-hpmud.rules
   '';
 
   # The installed executables are just symlinks into $out/share/hplip,
@@ -210,9 +208,9 @@ pythonPackages.buildPythonApplication {
 
   postFixup = ''
     substituteInPlace $out/etc/hp/hplip.conf --replace /usr $out
-  '' + stdenv.lib.optionalString (!withPlugin) ''
-    # A udev rule to notify users that they need the binary plugin.
-    # Needs a lot of patching but might save someone a bit of confusion:
+    # Patch udev rules:
+    # with plugin, they upload firmware to printers,
+    # without plugin, they complain about the missing plugin.
     substituteInPlace $out/etc/udev/rules.d/56-hpmud.rules \
       --replace {,${bash}}/bin/sh \
       --replace /usr/bin/nohup "" \

--- a/pkgs/misc/drivers/hplip/default.nix
+++ b/pkgs/misc/drivers/hplip/default.nix
@@ -215,7 +215,7 @@ pythonPackages.buildPythonApplication {
     # Needs a lot of patching but might save someone a bit of confusion:
     substituteInPlace $out/etc/udev/rules.d/56-hpmud.rules \
       --replace {,${bash}}/bin/sh \
-      --replace {/usr,${coreutils}}/bin/nohup \
+      --replace /usr/bin/nohup "" \
       --replace {,${utillinux}/bin/}logger \
       --replace {/usr,$out}/bin
   '';

--- a/pkgs/misc/drivers/hplip/default.nix
+++ b/pkgs/misc/drivers/hplip/default.nix
@@ -216,6 +216,7 @@ pythonPackages.buildPythonApplication {
   meta = with stdenv.lib; {
     description = "Print, scan and fax HP drivers for Linux";
     homepage = https://developers.hp.com/hp-linux-imaging-and-printing;
+    downloadPage = https://sourceforge.net/projects/hplip/files/hplip/;
     license = if withPlugin
       then licenses.unfree
       else with licenses; [ mit bsd2 gpl2Plus ];

--- a/pkgs/misc/drivers/hplip/default.nix
+++ b/pkgs/misc/drivers/hplip/default.nix
@@ -82,6 +82,13 @@ pythonPackages.buildPythonApplication {
 
   makeWrapperArgs = [ "--prefix" "PATH" ":" "${nettools}/bin" ];
 
+  patches = [
+    # remove ImageProcessor usage, it causes segfaults, see
+    # https://bugs.launchpad.net/hplip/+bug/1788706
+    # https://bugs.launchpad.net/hplip/+bug/1787289
+    ./image-processor.patch
+  ];
+
   prePatch = ''
     # HPLIP hardcodes absolute paths everywhere. Nuke from orbit.
     find . -type f -exec sed -i \

--- a/pkgs/misc/drivers/hplip/image-processor.patch
+++ b/pkgs/misc/drivers/hplip/image-processor.patch
@@ -1,0 +1,62 @@
+diff --git i/prnt/hpcups/HPCupsFilter.cpp w/prnt/hpcups/HPCupsFilter.cpp
+index 5b282d8..153ee3a 100644
+--- i/prnt/hpcups/HPCupsFilter.cpp
++++ w/prnt/hpcups/HPCupsFilter.cpp
+@@ -31,7 +31,6 @@
+ \*****************************************************************************/
+ 
+ #include "HPCupsFilter.h"
+-#include "ImageProcessor.h"
+ 
+ #include <signal.h>
+ #include <sys/wait.h>
+@@ -637,16 +636,10 @@ int HPCupsFilter::processRasterData(cups_raster_t *cups_raster)
+ 
+ 
+     sprintf(hpPreProcessedRasterFile, "%s/hp_%s_cups_SwapedPagesXXXXXX",CUPS_TMP_DIR, m_JA.user_name);
+-    image_processor_t* imageProcessor = imageProcessorCreate();
+ 
+     while (cupsRasterReadHeader2(cups_raster, &cups_header))
+     {
+ 
+-        IMAGE_PROCESSOR_ERROR result = imageProcessorStartPage(imageProcessor, &cups_header);
+-        if (result != IPE_SUCCESS){
+-            dbglog("DEBUG: imageProcessorStartPage failed result = %d\n", result);
+-        }
+-
+         current_page_number++;
+ 
+         if (current_page_number == 1) {
+@@ -745,11 +738,6 @@ int HPCupsFilter::processRasterData(cups_raster_t *cups_raster)
+             color_raster = rgbRaster;
+             black_raster = kRaster;
+ 
+-            result = imageProcessorProcessLine(imageProcessor, m_pPrinterBuffer, cups_header.cupsBytesPerLine);
+-            if (result != IPE_SUCCESS){
+-                dbglog("DEBUG: imageProcessorProcessLine failed result = %d\n", result);
+-            }
+-
+ 
+             if ((y == 0) && !is_ljmono) {
+                 //For ljmono, make sure that first line is not a blankRaster line.Otherwise printer
+@@ -780,11 +768,6 @@ int HPCupsFilter::processRasterData(cups_raster_t *cups_raster)
+             }
+         }  // for() loop end
+ 
+-        result = imageProcessorEndPage(imageProcessor);
+-        if (result != IPE_SUCCESS){
+-                dbglog("DEBUG: imageProcessorEndPage failed result = %d\n", result);
+-        }
+-
+ 
+         m_Job.NewPage();
+         if (err != NO_ERROR) {
+@@ -800,8 +783,6 @@ int HPCupsFilter::processRasterData(cups_raster_t *cups_raster)
+         rgbRaster = NULL;
+     }
+ 
+-    imageProcessorDestroy(imageProcessor);
+-
+     unlink(hpPreProcessedRasterFile);
+     return ret_status;
+ }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

* Regular update 3.19.1 -> 3.19.6 .
* Segfaults hound `hpcups` since 3.18.7. Add a patch to cure those.
* Uploading firmware to certain printers requires a udev rule file that was previously deleted in the WithPlugin version of the package. The pull request reinstates that rule file and improves the script that patches paths in the file.
* Expand package metadata with download URL.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)): *no tests available*
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`: *no depending packages*
- [x] Tested execution of all binary files (usually in `./result/bin/`): *see note below*
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after): *new version adds 770KiB to package size*
- [x] Ensured that relevant documentation is up to date: *none*
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

* Most binaries are just python script wrappers. Most scripts fail due to missing GUI support or other reasons. This, however, is not due to this pull request.
* The pull request was tested with HP LaserJet 1000, connected via USB. Uploading firmware works, triggered by udev. Printing works, with `hpcups` in the filter chain. Tests have been performed with `hplipWithPlugin_3_16_11`, `hplipWithPlugin_3_18_5`, and with `hplipWithPlugin`.
* CC maintainer @ttuegel, and @jgeerds for 3.18.5
* @ttuegel: You removed the udev rule file from the WithPlugin version with commit 8ffd6af27e6dfae0a3b4d77db03409f62c5b8d98 ("don't use udev rules to change device owner").  Is this (still) an issue?  If it is, I can try to patch away the offending lines in the rule file.