### PR TITLE
[r19.03] dosbox: add patches for CVE-2019-7165 & CVE-2019-12594

### DIFF
--- a/pkgs/misc/emulators/dosbox/default.nix
+++ b/pkgs/misc/emulators/dosbox/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, makeDesktopItem, SDL, SDL_net, SDL_sound, libGLU_combined, libpng }:
+{ stdenv, lib, fetchurl, makeDesktopItem, SDL, SDL_net, SDL_sound, libGLU_combined, libpng, fetchpatch }:
 
 stdenv.mkDerivation rec {
   name = "dosbox-0.74-2";
@@ -7,6 +7,20 @@ stdenv.mkDerivation rec {
     url = "mirror://sourceforge/dosbox/${name}.tar.gz";
     sha256 = "1ksp1b5szi0vy4x55rm3j1y9wq5mlslpy8llpg87rpdyjlsk0xvh";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "cve-2019-7165.patch";
+      url = "https://salsa.debian.org/debian/dosbox/raw/30989a35ee478f8f4bc8e167fccbf92fc77e1519/debian/patches/cve-2019-7165.patch?inline=false";
+      sha256 = "12c2wq6l62x9iggg1hvs82xbdm5g5hirixvbzjpnjmkm8c4h4k38";
+    })
+    (fetchpatch {
+      name = "cve-2019-12594.patch";
+      url = "https://salsa.debian.org/debian/dosbox/raw/30989a35ee478f8f4bc8e167fccbf92fc77e1519/debian/patches/cve-2019-12594.patch?inline=false";
+      excludes = ["configure.in"];
+      sha256 = "1zrv2vnb86gdq9z4irqflzf7lz3r6rc6m46k1hdb8ldl1c88w8jj";
+    })
+  ];
 
   hardeningDisable = [ "format" ];
 


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2019-7165
https://nvd.nist.gov/vuln/detail/CVE-2019-12594

https://sourceforge.net/p/dosbox/bugs/508/

Raw patches aren't easily extractable from sourceforge's repos, so am using debian's package SCM.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
