### PR TITLE
firefox: 67.0.4 -> 68.0, firefox-esr: 60.7.2esr -> 68.0esr, rust-cbindgen: 0.8.3 -> 0.8.7

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/fix-virtualenv-symlinks.patch
+++ b/pkgs/applications/networking/browsers/firefox/fix-virtualenv-symlinks.patch
@@ -1,0 +1,256 @@
+diff --git a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/bin/activate_this.py b/obj-x86_64-pc-linux-gnu/_virtualenvs/init/bin/activate_this.py
+deleted file mode 100644
+index f18193b..0000000
+--- a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/bin/activate_this.py
++++ /dev/null
+@@ -1,34 +0,0 @@
+-"""By using execfile(this_file, dict(__file__=this_file)) you will
+-activate this virtualenv environment.
+-
+-This can be used when you must use an existing Python interpreter, not
+-the virtualenv bin/python
+-"""
+-
+-try:
+-    __file__
+-except NameError:
+-    raise AssertionError(
+-        "You must run this like execfile('path/to/activate_this.py', dict(__file__='path/to/activate_this.py'))")
+-import sys
+-import os
+-
+-old_os_path = os.environ.get('PATH', '')
+-os.environ['PATH'] = os.path.dirname(os.path.abspath(__file__)) + os.pathsep + old_os_path
+-base = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+-if sys.platform == 'win32':
+-    site_packages = os.path.join(base, 'Lib', 'site-packages')
+-else:
+-    site_packages = os.path.join(base, 'lib', 'python%s' % sys.version[:3], 'site-packages')
+-prev_sys_path = list(sys.path)
+-import site
+-site.addsitedir(site_packages)
+-sys.real_prefix = sys.prefix
+-sys.prefix = base
+-# Move the added items to the front of the path:
+-new_sys_path = []
+-for item in list(sys.path):
+-    if item not in prev_sys_path:
+-        new_sys_path.append(item)
+-        sys.path.remove(item)
+-sys.path[:0] = new_sys_path
+diff --git a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/bin/python b/obj-x86_64-pc-linux-gnu/_virtualenvs/init/bin/python
+deleted file mode 120000
+index 8f7a3c1..0000000
+--- a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/bin/python
++++ /dev/null
+@@ -1 +0,0 @@
+-python2.7
+\ No newline at end of file
+diff --git a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/bin/python2 b/obj-x86_64-pc-linux-gnu/_virtualenvs/init/bin/python2
+deleted file mode 120000
+index 8f7a3c1..0000000
+--- a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/bin/python2
++++ /dev/null
+@@ -1 +0,0 @@
+-python2.7
+\ No newline at end of file
+diff --git a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/UserDict.py b/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/UserDict.py
+deleted file mode 120000
+index 1dcde33..0000000
+--- a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/UserDict.py
++++ /dev/null
+@@ -1 +0,0 @@
+-/usr/lib/python2.7/UserDict.py
+\ No newline at end of file
+diff --git a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/_abcoll.py b/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/_abcoll.py
+deleted file mode 120000
+index e39c38d..0000000
+--- a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/_abcoll.py
++++ /dev/null
+@@ -1 +0,0 @@
+-/usr/lib/python2.7/_abcoll.py
+\ No newline at end of file
+diff --git a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/_weakrefset.py b/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/_weakrefset.py
+deleted file mode 120000
+index a3c1cd4..0000000
+--- a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/_weakrefset.py
++++ /dev/null
+@@ -1 +0,0 @@
+-/usr/lib/python2.7/_weakrefset.py
+\ No newline at end of file
+diff --git a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/abc.py b/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/abc.py
+deleted file mode 120000
+index cb3e5d1..0000000
+--- a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/abc.py
++++ /dev/null
+@@ -1 +0,0 @@
+-/usr/lib/python2.7/abc.py
+\ No newline at end of file
+diff --git a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/codecs.py b/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/codecs.py
+deleted file mode 120000
+index 50169dc..0000000
+--- a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/codecs.py
++++ /dev/null
+@@ -1 +0,0 @@
+-/usr/lib/python2.7/codecs.py
+\ No newline at end of file
+diff --git a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/copy_reg.py b/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/copy_reg.py
+deleted file mode 120000
+index 5dc0af3..0000000
+--- a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/copy_reg.py
++++ /dev/null
+@@ -1 +0,0 @@
+-/usr/lib/python2.7/copy_reg.py
+\ No newline at end of file
+diff --git a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/encodings b/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/encodings
+deleted file mode 120000
+index 1250ad8..0000000
+--- a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/encodings
++++ /dev/null
+@@ -1 +0,0 @@
+-/usr/lib/python2.7/encodings
+\ No newline at end of file
+diff --git a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/fnmatch.py b/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/fnmatch.py
+deleted file mode 120000
+index ec3e10c..0000000
+--- a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/fnmatch.py
++++ /dev/null
+@@ -1 +0,0 @@
+-/usr/lib/python2.7/fnmatch.py
+\ No newline at end of file
+diff --git a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/genericpath.py b/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/genericpath.py
+deleted file mode 120000
+index cb8897c..0000000
+--- a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/genericpath.py
++++ /dev/null
+@@ -1 +0,0 @@
+-/usr/lib/python2.7/genericpath.py
+\ No newline at end of file
+diff --git a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/lib-dynload b/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/lib-dynload
+deleted file mode 120000
+index c706a1e..0000000
+--- a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/lib-dynload
++++ /dev/null
+@@ -1 +0,0 @@
+-/usr/lib/python2.7/lib-dynload
+\ No newline at end of file
+diff --git a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/linecache.py b/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/linecache.py
+deleted file mode 120000
+index 943c429..0000000
+--- a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/linecache.py
++++ /dev/null
+@@ -1 +0,0 @@
+-/usr/lib/python2.7/linecache.py
+\ No newline at end of file
+diff --git a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/locale.py b/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/locale.py
+deleted file mode 120000
+index 92c243c..0000000
+--- a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/locale.py
++++ /dev/null
+@@ -1 +0,0 @@
+-/usr/lib/python2.7/locale.py
+\ No newline at end of file
+diff --git a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/ntpath.py b/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/ntpath.py
+deleted file mode 120000
+index 5659ae1..0000000
+--- a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/ntpath.py
++++ /dev/null
+@@ -1 +0,0 @@
+-/usr/lib/python2.7/ntpath.py
+\ No newline at end of file
+diff --git a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/os.py b/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/os.py
+deleted file mode 120000
+index 950fc8d..0000000
+--- a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/os.py
++++ /dev/null
+@@ -1 +0,0 @@
+-/usr/lib/python2.7/os.py
+\ No newline at end of file
+diff --git a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/posixpath.py b/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/posixpath.py
+deleted file mode 120000
+index 30cb8ca..0000000
+--- a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/posixpath.py
++++ /dev/null
+@@ -1 +0,0 @@
+-/usr/lib/python2.7/posixpath.py
+\ No newline at end of file
+diff --git a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/re.py b/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/re.py
+deleted file mode 120000
+index 56a0731..0000000
+--- a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/re.py
++++ /dev/null
+@@ -1 +0,0 @@
+-/usr/lib/python2.7/re.py
+\ No newline at end of file
+diff --git a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/sre.py b/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/sre.py
+deleted file mode 120000
+index 27f81b9..0000000
+--- a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/sre.py
++++ /dev/null
+@@ -1 +0,0 @@
+-/usr/lib/python2.7/sre.py
+\ No newline at end of file
+diff --git a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/sre_compile.py b/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/sre_compile.py
+deleted file mode 120000
+index dce5da4..0000000
+--- a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/sre_compile.py
++++ /dev/null
+@@ -1 +0,0 @@
+-/usr/lib/python2.7/sre_compile.py
+\ No newline at end of file
+diff --git a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/sre_constants.py b/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/sre_constants.py
+deleted file mode 120000
+index b9c9797..0000000
+--- a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/sre_constants.py
++++ /dev/null
+@@ -1 +0,0 @@
+-/usr/lib/python2.7/sre_constants.py
+\ No newline at end of file
+diff --git a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/sre_parse.py b/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/sre_parse.py
+deleted file mode 120000
+index f33a572..0000000
+--- a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/sre_parse.py
++++ /dev/null
+@@ -1 +0,0 @@
+-/usr/lib/python2.7/sre_parse.py
+\ No newline at end of file
+diff --git a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/stat.py b/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/stat.py
+deleted file mode 120000
+index c1d654c..0000000
+--- a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/stat.py
++++ /dev/null
+@@ -1 +0,0 @@
+-/usr/lib/python2.7/stat.py
+\ No newline at end of file
+diff --git a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/types.py b/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/types.py
+deleted file mode 120000
+index 5546478..0000000
+--- a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/types.py
++++ /dev/null
+@@ -1 +0,0 @@
+-/usr/lib/python2.7/types.py
+\ No newline at end of file
+diff --git a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/warnings.py b/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/warnings.py
+deleted file mode 120000
+index a9c4730..0000000
+--- a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/warnings.py
++++ /dev/null
+@@ -1 +0,0 @@
+-/usr/lib/python2.7/warnings.py
+\ No newline at end of file
+diff --git a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/local/bin b/obj-x86_64-pc-linux-gnu/_virtualenvs/init/local/bin
+deleted file mode 120000
+index dd1e4ca..0000000
+--- a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/local/bin
++++ /dev/null
+@@ -1 +0,0 @@
+-/builds/worker/workspace/build/src/obj-x86_64-pc-linux-gnu/_virtualenvs/init/bin
+\ No newline at end of file
+diff --git a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/local/lib b/obj-x86_64-pc-linux-gnu/_virtualenvs/init/local/lib
+deleted file mode 120000
+index b835bc3..0000000
+--- a/obj-x86_64-pc-linux-gnu/_virtualenvs/init/local/lib
++++ /dev/null
+@@ -1 +0,0 @@
+-/builds/worker/workspace/build/src/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib
+\ No newline at end of file

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -17,14 +17,16 @@ rec {
 
   firefox = common rec {
     pname = "firefox";
-    ffversion = "67.0.4";
+    ffversion = "68.0";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${ffversion}/source/firefox-${ffversion}.source.tar.xz";
-      sha512 = "3krwkc90m320a74vjyzlrxs4jc63cykbmpgisac9kv8m9n0bis5i1yf0dl9n14d9p4p541wvzhqygx7byj6mnvkhbk5b2l0nlvwias2";
+      sha512 = "0pg8ww2ldlvdlri0zrzv20x69x00gxshr4afq62pnz7rgrnppkdd0pw5snflisgvpxq1syxcrg5750wz1k4bfjwnyq47jk9h3fzddpw";
     };
 
     patches = [
       ./no-buildconfig-ffx65.patch
+      # https://github.com/NixOS/nixpkgs/pull/64577#issuecomment-510131246
+      ./fix-virtualenv-symlinks.patch
     ];
 
     extraNativeBuildInputs = [ python3 ];

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -72,29 +72,27 @@ rec {
     gtk3Support = false;
   };
 
-  firefox-esr-60 = common rec {
+  firefox-esr-68 = common rec {
     pname = "firefox-esr";
-    ffversion = "60.7.2esr";
+    ffversion = "68.0esr";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${ffversion}/source/firefox-${ffversion}.source.tar.xz";
-      sha512 = "0mw5dgrxd5vj6cngd9v3dy6hzdsg82s0cs9fabhrzrl1dy3pqdkccqqnj9r0hxwmcrdgca3s35i5lwwmlljagq6nyb5q6qv4fzv0n0j";
+      sha512 = "29iqxxwkz2zgk2ppgq05w0bhs8c0938gina5s8brmwn6zn15nv379pa82a9djpzjryl6c5ff0hk0z7gx6n3xvf7w7ky9010h9il0kbg";
     };
 
     patches = [
       ./no-buildconfig-ffx65.patch
-
-      # this one is actually an omnipresent bug
-      # https://bugzilla.mozilla.org/show_bug.cgi?id=1444519
-      ./fix-pa-context-connect-retval.patch
-
-      missing-documentation-patch
+      # https://github.com/NixOS/nixpkgs/pull/64577#issuecomment-510131246
+      ./fix-virtualenv-symlinks.patch
     ];
+
+    extraNativeBuildInputs = [ python3 ];
 
     meta = firefox.meta // {
       description = "A web browser built from Firefox Extended Support Release source tree";
     };
     updateScript = callPackage ./update.nix {
-      attrPath = "firefox-esr-60-unwrapped";
+      attrPath = "firefox-esr-68-unwrapped";
       versionSuffix = "esr";
       versionKey = "ffversion";
     };

--- a/pkgs/development/libraries/nss/default.nix
+++ b/pkgs/development/libraries/nss/default.nix
@@ -5,7 +5,7 @@ let
     url = http://dev.gentoo.org/~polynomial-c/mozilla/nss-3.15.4-pem-support-20140109.patch.xz;
     sha256 = "10ibz6y0hknac15zr6dw4gv9nb5r5z9ym6gq18j3xqx7v7n3vpdw";
   };
-  version = "3.44";
+  version = "3.44.1";
   underscoreVersion = builtins.replaceStrings ["."] ["_"] version;
 
 in stdenv.mkDerivation rec {
@@ -14,7 +14,7 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://mozilla/security/nss/releases/NSS_${underscoreVersion}_RTM/src/${name}.tar.gz";
-    sha256 = "1zvabgxlyvz3fnv4w89y4a5qkscjmm88naf929dgvvgfnrchwqm5";
+    sha256 = "1y0jvva4s3j7cjz22kqw2lsml0an1295bgpc2raf7kc9r60cpr7w";
   };
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];

--- a/pkgs/development/tools/rust/cbindgen/default.nix
+++ b/pkgs/development/tools/rust/cbindgen/default.nix
@@ -2,18 +2,21 @@
 
 rustPlatform.buildRustPackage rec {
   name = "rust-cbindgen-${version}";
-  version = "0.8.3";
+  version = "0.8.7";
 
   src = fetchFromGitHub {
     owner = "eqrion";
     repo = "cbindgen";
     rev = "v${version}";
-    sha256 = "08zlnk1k1nddjciccfdcplxqngsnz6ml3zxm57mijabzybry8zz1";
+    sha256 = "040rivayr0dgmrhlly5827c850xbr0j5ngiy6rvwyba5j9iv2x0y";
   };
 
   cargoSha256 = "1nig4891p7ii4z4f4j4d4pxx39f501g7yrsygqbpkr1nrgjip547";
 
   buildInputs = stdenv.lib.optional stdenv.isDarwin Security;
+
+  # https://github.com/eqrion/cbindgen/issues/338
+  RUSTC_BOOTSTRAP = 1;
 
   meta = with stdenv.lib; {
     description = "A project for generating C bindings from Rust code";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18079,15 +18079,15 @@ in
 
   firefox-unwrapped = firefoxPackages.firefox;
   firefox-esr-52-unwrapped = firefoxPackages.firefox-esr-52;
-  firefox-esr-60-unwrapped = firefoxPackages.firefox-esr-60;
+  firefox-esr-68-unwrapped = firefoxPackages.firefox-esr-68;
   tor-browser-unwrapped = firefoxPackages.tor-browser;
   icecat-unwrapped = firefoxPackages.icecat;
 
   firefox = wrapFirefox firefox-unwrapped { };
   firefox-wayland = wrapFirefox firefox-unwrapped { gdkWayland = true; };
   firefox-esr-52 = wrapFirefox firefox-esr-52-unwrapped { };
-  firefox-esr-60 = wrapFirefox firefox-esr-60-unwrapped { };
-  firefox-esr = firefox-esr-60;
+  firefox-esr-68 = wrapFirefox firefox-esr-68-unwrapped { };
+  firefox-esr = firefox-esr-68;
   icecat = wrapFirefox icecat-unwrapped { };
 
   firefox-bin-unwrapped = callPackage ../applications/networking/browsers/firefox-bin {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

- Critical security fixes
- Other improvements
- ESR is now based on version 68.

https://www.mozilla.org/en-US/firefox/68.0/releasenotes/
https://www.mozilla.org/en-US/security/advisories/mfsa2019-21/

Related: #64577

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
`fix-virtualenv-symlinks.patch` deletes all symlinks and `activate_this.py` in virtualenv to force recreate it. Otherwise it results in `OSError: [Errno 17] File exists: '/build/firefox-68.0/obj-x86_64-pc-linux-gnu/_virtualenvs/init/lib/python2.7/lib-dynload'`. See also https://github.com/NixOS/nixpkgs/pull/64577#issuecomment-510131246.

`rust-cbindgen` and `nss` are required to be up-to-date. `rust-cbindgen` needs nightly compiler for now, so I have added `RUSTC_BOOTSTRAP = 1;`. See https://github.com/eqrion/cbindgen/issues/338 for details.

This PR may results in mass rebuild. Should I PR against the staging branch rather than the master?