### PR TITLE
add modprobe.d config options for stage 1 (initrd)

### DIFF
--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -311,6 +311,15 @@ let
             '';
           symlink = "/etc/modprobe.d/ubuntu.conf";
         }
+
+        { object = pkgs.writeText "nixos.conf"
+	  ''
+            ${flip concatMapStrings config.boot.initrd.blacklistedKernelModules (name: '' blacklist ${name} '')}
+            ${config.boot.initrd.extraModprobeConfig}
+          '';
+          symlink = "/etc/modprobe.d/nixos.conf";
+        }
+
         { object = pkgs.kmod-debian-aliases;
           symlink = "/etc/modprobe.d/debian.conf";
         }
@@ -387,6 +396,32 @@ in
       description = ''
         Other initrd files to prepend to the final initrd we are building.
       '';
+    };
+
+    boot.initrd.blacklistedKernelModules = mkOption {
+      type = types.listOf types.str;
+      default = [];
+      example = [ "cirrusfb" "i2c_piix4" ];
+      description = ''
+        List of names of kernel modules that should not be loaded
+        automatically by the hardware probing code in stage 1.
+      '';
+    };
+
+    boot.initrd.extraModprobeConfig = mkOption {
+      default = "";
+      example =
+        ''
+          options parport_pc io=0x378 irq=7 dma=1
+        '';
+      description = ''
+        Any additional configuration to be appended to the generated
+        <filename>modprobe.conf</filename> in stage 1.  This is
+        typically used to specify module options.  See
+        <citerefentry><refentrytitle>modprobe.conf</refentrytitle>
+        <manvolnum>5</manvolnum></citerefentry> for details.
+      '';
+      type = types.lines;
     };
 
     boot.initrd.checkJournalingFS = mkOption {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
I am using Nixos as a Qemu/KVM hypervisor and in order to do PCI-passthrough, I need fine grained control over /etc/modprobe.d/nixos.conf in both the main system and during the stage 1 boot (initrd). A common pattern is to put a line like the following in /etc/modprobe.d/nixos.conf (in both stage 1 and stage 2):
`options vfio-pci ids=1000:0072`

Without this line in stage 1, the normal driver for the device gets attached in stage 1 and persists into stage 2. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
