### PR TITLE
google-fonts: 2018-07-13 -> 2019-07-14

### DIFF
--- a/pkgs/data/fonts/google-fonts/default.nix
+++ b/pkgs/data/fonts/google-fonts/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "google-fonts-${version}";
-  version = "2018-07-13";
+  version = "2019-07-14";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "fonts";
-    rev = "3ca591dae7372a26e254ec6d22e7b453813b9530";
-    sha256 = "01ak3dzw2kihwa0dy27x8vvpiscd66mnkf61vj1xn29m4g48y0lr";
+    rev = "f113126dc4b9b1473d9354a86129c9d7b837aa1a";
+    sha256 = "0safw5prpa63mqcyfw3gr3a535w4c9hg5ayw5pkppiwil7n3pyxs";
   };
 
   outputHashAlgo = "sha256";
@@ -28,6 +28,13 @@ stdenv.mkDerivation rec {
       ofl/mrbedford \
       ofl/siamreap \
       ofl/terminaldosislight
+
+    # See comment above, the structure of these is a bit odd
+    # We keep the ofl/<font>/static/ variants
+    rm -rv ofl/comfortaa/*.ttf \
+      ofl/mavenpro/*.ttf \
+      ofl/muli/*.ttf \
+      ofl/oswald/*.ttf
 
     if find . -name "*.ttf" | sed 's|.*/||' | sort | uniq -c | sort -n | grep -v '^.*1 '; then
       echo "error: duplicate font names"

--- a/pkgs/data/fonts/google-fonts/default.nix
+++ b/pkgs/data/fonts/google-fonts/default.nix
@@ -11,10 +11,6 @@ stdenv.mkDerivation rec {
     sha256 = "0safw5prpa63mqcyfw3gr3a535w4c9hg5ayw5pkppiwil7n3pyxs";
   };
 
-  outputHashAlgo = "sha256";
-  outputHashMode = "recursive";
-  outputHash = "1pzm26794nwdbsvjnczpfchxiqa1n1zhp517g6g39wfm1nfszz83";
-
   phases = [ "unpackPhase" "patchPhase" "installPhase" ];
 
   patchPhase = ''


### PR DESCRIPTION
###### Motivation for this change

This PR updates the `google-fonts` package to a newer version.
There's some more post-processing to be done because of duplicate
fonts. The reasoning is documented and it generally seems to work.

I'm also removing the fixed output derivation hashes. Generally
they don't really add much in terms of reproducable builds. They
make updating the package more annoying and cumbersome. Plus, there's
the issue where if the build starts failing at some point, this will
be shadowed by the fact that people will just get hydra cached versions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---