### PR TITLE
squid, squid4: bump/add patch fixing CVE-2019-13345

### DIFF
--- a/pkgs/servers/squid/4.nix
+++ b/pkgs/servers/squid/4.nix
@@ -2,11 +2,11 @@
 , expat, libxml2, openssl }:
 
 stdenv.mkDerivation rec {
-  name = "squid-4.7";
+  name = "squid-4.8";
 
   src = fetchurl {
     url = "http://www.squid-cache.org/Versions/v4/${name}.tar.xz";
-    sha256 = "0kimbvp2mzask9k58va4s829vv3m54fzxrj7ryqshw5bfxgzd752";
+    sha256 = "0432m0ix046rkja7r7qpydgsm2kf1w393xym15nx6h9kv4jb7kbq";
   };
 
   buildInputs = [

--- a/pkgs/servers/squid/default.nix
+++ b/pkgs/servers/squid/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, perl, openldap, pam, db, cyrus_sasl, libcap
-, expat, libxml2, openssl }:
+, expat, libxml2, openssl, fetchpatch }:
 
 stdenv.mkDerivation rec {
   name = "squid-3.5.28";
@@ -8,6 +8,14 @@ stdenv.mkDerivation rec {
     url = "http://www.squid-cache.org/Versions/v3/3.5/${name}.tar.xz";
     sha256 = "1n4f55g56b11qz4fazrnvgzx5wp6b6637c4qkbd1lrjwwqibchgx";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "3.5-CVE-2019-13345.patch";
+      url = "https://github.com/squid-cache/squid/commit/5730c2b5cb56e7639dc423dd62651c8736a54e35.patch";
+      sha256 = "0955432g9a00vwxzcrwpjzx6vywspx1cxhr7bknr7jzbzam5sxi3";
+    })
+  ];
 
   buildInputs = [
     perl openldap db cyrus_sasl expat libxml2 openssl


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2019-13345

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
