### PR TITLE
yaml-cpp: init at 0.6.2

### DIFF
--- a/pkgs/development/libraries/yaml-cpp/default.nix
+++ b/pkgs/development/libraries/yaml-cpp/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, cmake }:
+
+stdenv.mkDerivation rec {
+  pname = "yaml-cpp";
+  version = "0.6.2";
+
+  src = fetchFromGitHub {
+    owner = "jbeder";
+    repo = pname;
+    rev = "${pname}-${version}";
+    sha256 = "16lclpa487yghf9019wymj419wkyx4795wv9q7539hhimajw9kpb";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "A YAML parser and emitter in C++ ";
+    homepage = "https://github.com/jbeder/yaml-cpp";
+    maintainers = with maintainers; [ spacekookie ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13838,6 +13838,8 @@ in
 
   yajl = callPackage ../development/libraries/yajl { };
 
+  yaml-cpp = callPackage ../development/libraries/yaml-cpp { };
+
   yder = callPackage ../development/libraries/yder { };
 
   yojimbo = callPackage ../development/libraries/yojimbo { };


### PR DESCRIPTION
###### Things done

I did test using this library in a project, which will be packaged at a later time.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---