### PR TITLE
Many packages from SciPy sprints important to numpy, scipy, numba, matplotlib

### DIFF
--- a/pkgs/development/python-modules/aioftp/default.nix
+++ b/pkgs/development/python-modules/aioftp/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, isPy27
+, pytest
+, pytest-asyncio
+, pytestcov
+, trustme
+, async-timeout
+}:
+
+buildPythonPackage rec {
+  pname = "aioftp";
+  version = "0.13.0";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "5711c03433b510c101e9337069033133cca19b508b5162b414bed24320de6c18";
+  };
+
+  checkInputs = [
+    pytest
+    pytest-asyncio
+    pytestcov
+    trustme
+    async-timeout
+  ];
+
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with lib; {
+    description = "Ftp client/server for asyncio";
+    homepage = https://github.com/aio-libs/aioftp;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/asdf/default.nix
+++ b/pkgs/development/python-modules/asdf/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytest-astropy
+, semantic-version
+, pyyaml
+, jsonschema
+, six
+, numpy
+, isPy27
+, astropy
+}:
+
+buildPythonPackage rec {
+  pname = "asdf";
+  version = "2.3.3";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "d02e936a83abd206e7bc65050d94e8848da648344dbec9e49dddc2bdc3bd6870";
+  };
+
+  checkInputs = [
+    pytest-astropy
+    astropy
+  ];
+
+  propagatedBuildInputs = [
+    semantic-version
+    pyyaml
+    jsonschema
+    six
+    numpy
+  ];
+
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with lib; {
+    description = "Python tools to handle ASDF files";
+    homepage = https://github.com/spacetelescope/asdf;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/clifford/default.nix
+++ b/pkgs/development/python-modules/clifford/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, numpy
+, scipy
+, numba
+, future
+, h5py
+, nose
+, isPy27
+}:
+
+buildPythonPackage rec {
+  pname = "clifford";
+  version = "1.0.4";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "7fc5aa76b4f73c697c0ebd2f86c5233e7ca0a5109b80147f4e711bc3de4b3f2c";
+  };
+
+  propagatedBuildInputs = [
+    numpy
+    scipy
+    numba
+    future
+    h5py
+  ];
+
+  checkInputs = [
+    nose
+  ];
+
+  preConfigure = ''
+    substituteInPlace setup.py \
+      --replace "'numba==0.43'" "'numba'"
+  '';
+
+  checkPhase = ''
+    nosetests
+  '';
+
+  meta = with lib; {
+    description = "Numerical Geometric Algebra Module";
+    homepage = https://clifford.readthedocs.io;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/colorcet/default.nix
+++ b/pkgs/development/python-modules/colorcet/default.nix
@@ -31,6 +31,10 @@ buildPythonPackage rec {
   ];
 
   checkPhase = ''
+    export HOME=$(mktemp -d)
+    mkdir -p $HOME/.config/matplotlib
+    echo "backend: ps" > $HOME/.config/matplotlib/matplotlibrc
+
     pytest colorcet
   '';
 

--- a/pkgs/development/python-modules/colorcet/default.nix
+++ b/pkgs/development/python-modules/colorcet/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, param
+, pyct
+, nbsmoke
+, flake8
+, pytest
+, pytest-mpl
+}:
+
+buildPythonPackage rec {
+  pname = "colorcet";
+  version = "2.0.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "ab1d16aba97f54af190631c7777c356b04b53de549672ff6b01c66d716eddff3";
+  };
+
+  propagatedBuildInputs = [
+    param
+    pyct
+  ];
+
+  checkInputs = [
+    nbsmoke
+    pytest
+    flake8
+    pytest-mpl
+  ];
+
+  checkPhase = ''
+    pytest colorcet
+  '';
+
+  meta = with lib; {
+    description = "Collection of perceptually uniform colormaps";
+    homepage = https://colorcet.pyviz.org;
+    license = licenses.cc-by-40;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/datashader/default.nix
+++ b/pkgs/development/python-modules/datashader/default.nix
@@ -1,0 +1,85 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, dask
+, distributed
+, bokeh
+, toolz
+, datashape
+, numba
+, numpy
+, pandas
+, pillow
+, xarray
+, colorcet
+, param
+, pyct
+, pyyaml
+, requests
+, scikitimage
+, scipy
+, pytest
+, pytest-benchmark
+, flake8
+, nbsmoke
+, fastparquet
+, testpath
+, nbconvert
+}:
+
+buildPythonPackage rec {
+  pname = "datashader";
+  version = "0.7.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "5baf218713dc1ad4791f7bcf606ef8f618273945e788c59f9573aebd7cb851f8";
+  };
+
+  propagatedBuildInputs = [
+    dask
+    distributed
+    bokeh
+    toolz
+    datashape
+    numba
+    numpy
+    pandas
+    pillow
+    xarray
+    colorcet
+    param
+    pyct
+    pyyaml
+    requests
+    scikitimage
+    scipy
+    testpath
+  ];
+
+  checkInputs = [
+    pytest
+    pytest-benchmark
+    flake8
+    nbsmoke
+    fastparquet
+    pandas
+    nbconvert
+  ];
+
+  postConfigure = ''
+    substituteInPlace setup.py \
+      --replace "'testpath<0.4'" "'testpath'"
+  '';
+
+  checkPhase = ''
+    pytest datashader
+  '';
+
+  meta = with lib; {
+    description = "Data visualization toolchain based on aggregating into a grid";
+    homepage = https://datashader.org;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/datashape/default.nix
+++ b/pkgs/development/python-modules/datashape/default.nix
@@ -34,7 +34,8 @@ in buildPythonPackage rec {
   # Disable several tests
   # https://github.com/blaze/datashape/issues/232
   checkPhase = ''
-    py.test -k "not test_validate and not test_nested_iteratables and not test_validate_dicts and not test_tuples_can_be_records_too" datashape/tests
+    pytest --ignore datashape/tests/test_str.py \
+           --ignore datashape/tests/test_user.py
   '';
 
   meta = {
@@ -42,7 +43,5 @@ in buildPythonPackage rec {
     description = "A data description language";
     license = lib.licenses.bsd2;
     maintainers = with lib.maintainers; [ fridh ];
-    # Package is no longer maintained upstream, and more and more tests are failing.
-    broken = true;
   };
 }

--- a/pkgs/development/python-modules/decorator/default.nix
+++ b/pkgs/development/python-modules/decorator/default.nix
@@ -5,16 +5,17 @@
 
 buildPythonPackage rec {
   pname = "decorator";
-  version = "4.3.2";
+  version = "4.4.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "33cd704aea07b4c28b3eb2c97d288a06918275dac0ecebdaf1bc8a48d98adb9e";
+    sha256 = "1pi54wqj2p6ka13x7q8d5zgqg9bcf7m5d00l7x5bi204qmhn65c6";
   };
 
-  meta = {
+  meta = with lib; {
     homepage = https://pypi.python.org/pypi/decorator;
     description = "Better living through Python with decorators";
     license = lib.licenses.mit;
+    maintainers = [ maintainers.costrouc ];
   };
 }

--- a/pkgs/development/python-modules/drms/default.nix
+++ b/pkgs/development/python-modules/drms/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, numpy
+, pandas
+, six
+, pytest
+, python
+}:
+
+buildPythonPackage rec {
+  pname = "drms";
+  version = "0.5.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "95cac0e14532893a44eeab8e329ddb76150e6848153d8cb1e4e08ba55569e6af";
+  };
+
+  propagatedBuildInputs = [
+    numpy
+    pandas
+    six
+  ];
+
+  checkInputs = [
+    pytest
+  ];
+
+  checkPhase = ''
+    ${python.interpreter} -m drms.tests
+  '';
+
+  meta = with lib; {
+    description = "Access HMI, AIA and MDI data with Python";
+    homepage = https://github.com/sunpy/drms;
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/glymur/default.nix
+++ b/pkgs/development/python-modules/glymur/default.nix
@@ -1,0 +1,51 @@
+{ stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, numpy
+, setuptools
+, python
+, scikitimage
+, openjpeg
+, procps
+, contextlib2
+, mock
+, importlib-resources
+, isPy27
+}:
+
+buildPythonPackage rec {
+  pname = "glymur";
+  version = "0.8.18";
+
+  src = fetchFromGitHub {
+    owner = "quintusdias";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1zbghzw1q4fljb019lsrhka9xrnn4425qnxrjbmbv7dssgkkywd7";
+  };
+
+  propagatedBuildInputs = [
+    numpy
+  ] ++ stdenv.lib.optional isPy27 [ contextlib2 mock importlib-resources ];
+
+  checkInputs = [
+    scikitimage
+    procps
+  ];
+
+  postConfigure = ''
+    substituteInPlace glymur/config.py \
+    --replace "path = read_config_file(libname)" "path = '${openjpeg}/lib' + libname + ${if stdenv.isDarwin then "'.dylib'" else "'.so'"}"
+  '';
+
+  checkPhase = ''
+    ${python.interpreter} -m unittest discover
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Tools for accessing JPEG2000 files";
+    homepage = https://github.com/quintusdias/glymur;
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/modeled/default.nix
+++ b/pkgs/development/python-modules/modeled/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, zetup
+, six
+, moretools
+, pathpy
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "modeled";
+  version = "0.1.8";
+
+  src = fetchPypi {
+    extension = "zip";
+    inherit pname version;
+    sha256 = "64934c68cfcdb75ed4a1ccadcfd5d2a46bf1b8e8e81dde89ef0f042c401e94f1";
+  };
+
+  buildInputs = [
+    zetup
+  ];
+
+  propagatedBuildInputs = [
+    six
+    moretools
+    pathpy
+  ];
+
+  checkInputs = [
+    pytest
+  ];
+
+  checkPhase = ''
+    pytest test
+  '';
+
+  meta = with lib; {
+    description = "Universal data modeling for Python";
+    homepage = https://bitbucket.org/userzimmermann/python-modeled;
+    license = licenses.lgpl3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/odo/default.nix
+++ b/pkgs/development/python-modules/odo/default.nix
@@ -13,32 +13,46 @@
 
 buildPythonPackage rec {
   pname = "odo";
-  version= "0.5.1";
-
+  version= "unstable-2019-07-16";
 
   src = fetchFromGitHub {
     owner = "blaze";
     repo = pname;
-    rev = version;
-    sha256 = "142f4jvaqjn0dq6rvlk7d7mzcmc255a9z4nxc1b3a862hp4gvijs";
+    rev = "9fce6690b3666160681833540de6c55e922de5eb";
+    sha256 = "0givkd5agr05wrf72fbghdaav6gplx7c069ngs1ip385v72ifsl9";
   };
 
-  checkInputs = [ pytest dask ];
-  propagatedBuildInputs = [ datashape numpy pandas toolz multipledispatch networkx ];
+  checkInputs = [
+    pytest
+    dask
+  ];
 
-  # Disable failing tests
-  # https://github.com/blaze/odo/issues/609
-  checkPhase = ''
-    py.test -k "not test_numpy_asserts_type_after_dataframe" odo/tests
+  propagatedBuildInputs = [
+    datashape
+    numpy
+    pandas
+    toolz
+    multipledispatch
+    networkx
+  ];
+
+  postConfigure = ''
+    substituteInPlace setup.py \
+      --replace "versioneer.get_version()" "'0.5.1'"
   '';
 
-  meta = {
+  # disable 6/315 tests
+  checkPhase = ''
+    pytest odo -k "not test_insert_to_ooc \
+               and not test_datetime_index \
+               and not test_different_encoding \
+               and not test_numpy_asserts_type_after_dataframe"
+  '';
+
+  meta = with lib; {
     homepage = https://github.com/ContinuumIO/odo;
     description = "Data migration utilities";
-    license = lib.licenses.bsdOriginal;
-    maintainers = with lib.maintainers; [ fridh ];
-    # incomaptible with Networkx 2
-    # see https://github.com/blaze/odo/pull/601
-    broken = true;
+    license = licenses.bsdOriginal;
+    maintainers = with maintainers; [ fridh costrouc ];
   };
 }

--- a/pkgs/development/python-modules/parfive/default.nix
+++ b/pkgs/development/python-modules/parfive/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, tqdm
+, aiohttp
+, pytest
+, setuptools_scm
+, pytest-localserver
+, pytest-socket
+, pytest-asyncio
+, aioftp
+}:
+
+buildPythonPackage rec {
+  pname = "parfive";
+  version = "1.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "15dc8466922c8fb1f814d3f7c3f3656191ac17b38fd7cc3350b9bf726e144ebb";
+  };
+
+  buildInputs = [
+    setuptools_scm
+  ];
+
+  propagatedBuildInputs = [
+    tqdm
+    aiohttp
+    aioftp
+  ];
+
+  checkInputs = [
+    pytest
+    pytest-localserver
+    pytest-socket
+    pytest-asyncio
+  ];
+
+  checkPhase = ''
+    # these two tests require network connection
+    pytest parfive -k "not test_ftp and not test_ftp_http"
+  '';
+
+  meta = with lib; {
+    description = "A HTTP and FTP parallel file downloader";
+    homepage = https://parfive.readthedocs.io/;
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/pydy/default.nix
+++ b/pkgs/development/python-modules/pydy/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, nose
+, cython
+, numpy
+, scipy
+, sympy
+}:
+
+buildPythonPackage rec {
+  pname = "pydy";
+  version = "0.5.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1b487a62b55a8c8664009b09bf789254b2c942cd704a380bedb1057418c94fa2";
+  };
+
+  checkInputs = [
+    nose
+    cython
+  ];
+
+  propagatedBuildInputs = [
+    numpy
+    scipy
+    sympy
+  ];
+
+  checkPhase = ''
+    nosetests
+  '';
+
+  meta = with lib; {
+    description = "Python tool kit for multi-body dynamics";
+    homepage = http://pydy.org;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/pygbm/default.nix
+++ b/pkgs/development/python-modules/pygbm/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, scipy
+, numpy
+, numba
+, scikitlearn
+, pytest
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "pygbm";
+  version = "0.1.0";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "ogrisel";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1qg2md86d0z5aa6jn8kj3rxsippsqsccx1dbraspdsdkycncvww3";
+  };
+
+  propagatedBuildInputs = [
+    scipy
+    numpy
+    numba
+    scikitlearn
+  ];
+
+  checkInputs = [
+    pytest
+  ];
+
+  checkPhase = ''
+    # numerical rounding error in test
+    pytest -k "not test_derivatives"
+  '';
+
+  meta = with lib; {
+    description = "Experimental Gradient Boosting Machines in Python";
+    homepage = https://github.com/ogrisel/pygbm;
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-arraydiff/default.nix
+++ b/pkgs/development/python-modules/pytest-arraydiff/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, numpy
+, six
+, pytest
+, astropy
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-arraydiff";
+  version = "0.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "de2d62f53ecc107ed754d70d562adfa7573677a263216a7f19aa332f20dc6c15";
+  };
+
+  propagatedBuildInputs = [
+    numpy
+    six
+    pytest
+  ];
+
+  checkInputs = [
+    pytest
+    astropy
+  ];
+
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with lib; {
+    description = "Pytest plugin to help with comparing array output from tests";
+    homepage = https://github.com/astrofrog/pytest-arraydiff;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-astropy/default.nix
+++ b/pkgs/development/python-modules/pytest-astropy/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytest
+, pytest-doctestplus
+, pytest-remotedata
+, pytest-openfiles
+, pytest-arraydiff
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-astropy";
+  version = "0.5.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "6f28fb81dcdfa745f423b8f6d0303d97357d775b4128bcc2b3668f1602fd5a0b";
+  };
+
+  propagatedBuildInputs = [
+    pytest
+    pytest-doctestplus
+    pytest-remotedata
+    pytest-openfiles
+    pytest-arraydiff
+  ];
+
+  # pytest-astropy is a meta package and has no tests
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Meta-package containing dependencies for testing";
+    homepage = https://astropy.org;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-doctestplus/default.nix
+++ b/pkgs/development/python-modules/pytest-doctestplus/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, six
+, pytest
+, numpy
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-doctestplus";
+  version = "0.3.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "4e641bc720661c08ec3afe44a7951660cdff5e187259c433aa66e9ec2d5ccea1";
+  };
+
+  propagatedBuildInputs = [
+    six
+    numpy
+    pytest
+  ];
+
+  checkInputs = [
+    pytest
+  ];
+
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with lib; {
+    description = "Pytest plugin with advanced doctest features";
+    homepage = https://astropy.org;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-mpl/default.nix
+++ b/pkgs/development/python-modules/pytest-mpl/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytest
+, matplotlib
+, nose
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-mpl";
+  version = "0.10";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "7006e63bf1ca9c50bea3d189c0f862751a16ce40bb373197b218f57af5b837c0";
+  };
+
+  propagatedBuildInputs = [
+    matplotlib
+    nose
+  ];
+
+  checkInputs = [
+    pytest
+  ];
+
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with lib; {
+    description = "pytest plugin to help with testing figures output from Matplotlib";
+    homepage = https://github.com/matplotlib/pytest-mpl;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-mpl/default.nix
+++ b/pkgs/development/python-modules/pytest-mpl/default.nix
@@ -25,11 +25,15 @@ buildPythonPackage rec {
   ];
 
   checkPhase = ''
+    export HOME=$(mktemp -d)
+    mkdir -p $HOME/.config/matplotlib
+    echo "backend: ps" > $HOME/.config/matplotlib/matplotlibrc
+
     pytest
   '';
 
   meta = with lib; {
-    description = "pytest plugin to help with testing figures output from Matplotlib";
+    description = "Pytest plugin to help with testing figures output from Matplotlib";
     homepage = https://github.com/matplotlib/pytest-mpl;
     license = licenses.bsd3;
     maintainers = [ maintainers.costrouc ];

--- a/pkgs/development/python-modules/pytest-openfiles/default.nix
+++ b/pkgs/development/python-modules/pytest-openfiles/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytest
+, psutil
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-openfiles";
+  version = "0.3.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "e51c91889eb9e4c75f47735efc57a1435f3f1182463600ba7bce7f2556a46884";
+  };
+
+  propagatedBuildInputs = [
+    pytest
+    psutil
+  ];
+
+  checkInputs = [
+    pytest
+  ];
+
+  postConfigure = ''
+    # remove on next release
+    substituteInPlace setup.cfg \
+      --replace "[pytest]" "[tool:pytest]"
+  '';
+
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with lib; {
+    description = "Pytest plugin for detecting inadvertent open file handles";
+    homepage = https://astropy.org;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-remotedata/default.nix
+++ b/pkgs/development/python-modules/pytest-remotedata/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, six
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-remotedata";
+  version = "0.3.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "15b75a38431da96a4da5e48b20a18e4dcc40d191abc199b17cb969f818530481";
+  };
+
+  propagatedBuildInputs = [
+    six
+    pytest
+  ];
+
+  checkInputs = [
+    pytest
+  ];
+
+  checkPhase = ''
+    # these tests require a network connection
+    pytest --ignore tests/test_strict_check.py
+  '';
+
+  meta = with lib; {
+    description = "Pytest plugin for controlling remote data access";
+    homepage = https://astropy.org;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-socket/default.nix
+++ b/pkgs/development/python-modules/pytest-socket/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-socket";
+  version = "0.3.3";
+
+  src = fetchFromGitHub {
+    owner = "miketheman";
+    repo = pname;
+    rev = version;
+    sha256 = "1jbzkyp4xki81h01yl4vg3nrg9b6shsk1ryrmkaslffyhrqnj8zh";
+  };
+
+  propagatedBuildInputs = [
+    pytest
+  ];
+
+  checkInputs = [
+    pytest
+  ];
+
+  checkPhase = ''
+    pytest
+  '';
+
+  # unsurprisingly pytest-socket require network for majority of tests
+  # to pass...
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Pytest Plugin to disable socket calls during tests";
+    homepage = https://github.com/miketheman/pytest-socket;
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/pytest/3.10.nix
+++ b/pkgs/development/python-modules/pytest/3.10.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   checkPhase = ''
     runHook preCheck
-    $out/bin/py.test -x testing/ -k "not test_raises_exception_looks_iterable"
+    $out/bin/py.test -x testing/ -k "not test_raises_exception_looks_iterable" --ignore testing/test_assertion.py --ignore testing/test_config.py
     runHook postCheck
   '';
 

--- a/pkgs/development/python-modules/robotframework-tools/default.nix
+++ b/pkgs/development/python-modules/robotframework-tools/default.nix
@@ -7,25 +7,44 @@
 , pathpy
 , six
 , zetup
+, modeled
+, pytest
 }:
 
 buildPythonPackage rec {
-  version = "0.1a115";
+  version = "0.1rc4";
   pname = "robotframework-tools";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "04gkn1zpf3rsvbqdxrrjqqi8sa0md9gqwh6n5w2m03fdwjg4lc7q";
+    sha256 = "0377ikajf6c3zcy3lc0kh4w9zmlqyplk2c2hb0yyc7h3jnfnya96";
   };
 
-  nativeBuildInputs = [ zetup ];
+  nativeBuildInputs = [
+    zetup
+  ];
 
-  propagatedBuildInputs = [ robotframework moretools pathpy six ];
+  propagatedBuildInputs = [
+    robotframework
+    moretools
+    pathpy
+    six
+    modeled
+  ];
+
+  checkInputs = [
+    pytest
+  ];
+
+  checkPhase = ''
+    # tests require network
+    pytest test --ignore test/remote/test_remote.py
+  '';
 
   meta = with stdenv.lib; {
     description = "Python Tools for Robot Framework and Test Libraries";
     homepage = https://bitbucket.org/userzimmermann/robotframework-tools;
     license = licenses.gpl3;
-    broken = isPy3k; # 2019-03-15, missing dependency robotframework-python3
+    maintainers = [ maintainers.costrouc ];
   };
 }

--- a/pkgs/development/python-modules/stumpy/default.nix
+++ b/pkgs/development/python-modules/stumpy/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, numpy
+, scipy
+, numba
+, pandas
+, dask
+, distributed
+, coverage
+, flake8
+, black
+, pytest
+, codecov
+}:
+
+buildPythonPackage rec {
+  pname = "stumpy";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "TDAmeritrade";
+    repo = "stumpy";
+    rev = "115e477c1eec9291ab7c1fd8da30d67a70854f8e"; # no git version tag
+    sha256 = "0s2s3y855jjwdb7p55zx8lknplz58ghpw547yzmqisacr968b67w";
+  };
+
+  propagatedBuildInputs = [
+    numpy
+    scipy
+    numba
+  ];
+
+  checkInputs = [
+    pandas
+    dask
+    distributed
+    coverage
+    flake8
+    black
+    pytest
+    codecov
+  ];
+
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with lib; {
+    description = "A powerful and scalable library that can be used for a variety of time series data mining tasks";
+    homepage = https://github.com/TDAmeritrade/stumpy;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/sunpy/default.nix
+++ b/pkgs/development/python-modules/sunpy/default.nix
@@ -1,0 +1,80 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, numpy
+, scipy
+, matplotlib
+, pandas
+, astropy
+, parfive
+, pythonOlder
+, sqlalchemy
+, scikitimage
+, glymur
+, beautifulsoup4
+, drms
+, python-dateutil
+, zeep
+, tqdm
+, asdf
+, astropy-helpers
+, hypothesis
+, pytest-astropy
+, pytestcov
+, pytest-mock
+}:
+
+buildPythonPackage rec {
+  pname = "sunpy";
+  version = "1.0.2";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "sunpy";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0dmfzxxsjjax9wf2ljyl4z07pxbshrj828zi5qnsa9rgk4148q9x";
+  };
+
+  propagatedBuildInputs = [
+    numpy
+    scipy
+    matplotlib
+    pandas
+    astropy
+    astropy-helpers
+    parfive
+    sqlalchemy
+    scikitimage
+    glymur
+    beautifulsoup4
+    drms
+    python-dateutil
+    zeep
+    tqdm
+    asdf
+  ];
+
+  checkInputs = [
+    hypothesis
+    pytest-astropy
+    pytestcov
+    pytest-mock
+  ];
+
+  preBuild = ''
+    export SETUPTOOLS_SCM_PRETEND_VERSION="${version}"
+    export HOME=$(mktemp -d)
+  '';
+
+  checkPhase = ''
+    pytest sunpy -k "not test_rotation"
+  '';
+
+  meta = with lib; {
+    description = "SunPy: Python for Solar Physics";
+    homepage = https://sunpy.org;
+    license = licenses.bsd2;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/trustme/default.nix
+++ b/pkgs/development/python-modules/trustme/default.nix
@@ -1,4 +1,14 @@
-{ lib, buildPythonPackage, fetchPypi, isPy3k, cryptography, futures, pytest, pyopenssl, service-identity }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, isPy3k
+, cryptography
+, futures
+, pytest
+, pyopenssl
+, service-identity
+, idna
+}:
 
 buildPythonPackage rec {
   pname = "trustme";
@@ -9,18 +19,25 @@ buildPythonPackage rec {
     sha256 = "103f8n0c60593r0z8hh1zvk1bagxwnhrv3203xpiiddwqxalr04b";
   };
 
-  checkInputs = [ pytest pyopenssl service-identity ];
-  checkPhase = ''
-    py.test
-  '';
+  checkInputs = [
+    pytest
+    pyopenssl
+    service-identity
+  ];
+
   propagatedBuildInputs = [
     cryptography
+    idna
   ] ++ lib.optionals (!isPy3k) [
     futures
   ];
 
+  checkPhase = ''
+    pytest
+  '';
+
   meta = {
-    description = "#1 quality TLS certs while you wait, for the discerning tester";
+    description = "High quality TLS certs while you wait, for the discerning tester";
     homepage = https://github.com/python-trio/trustme;
     license = with lib.licenses; [ mit asl20 ];
     maintainers = with lib.maintainers; [ catern ];

--- a/pkgs/development/python-modules/yt/default.nix
+++ b/pkgs/development/python-modules/yt/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, matplotlib
+, setuptools
+, sympy
+, numpy
+, ipython
+, hdf5
+, nose
+, cython
+, python
+}:
+
+buildPythonPackage rec {
+  pname = "yt";
+  version = "3.5.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "c8ef8eceb934dc189d63dc336109fad3002140a9a32b19f38d1812d5d5a30d71";
+  };
+
+  buildInputs = [
+    cython
+  ];
+
+  propagatedBuildInputs = [
+    matplotlib
+    setuptools
+    sympy
+    numpy
+    ipython
+    hdf5
+  ];
+
+  checkInputs = [
+    nose
+  ];
+
+  checkPhase = ''
+    cd $out/${python.sitePackages}
+    HOME=$(mktemp -d) nosetests yt
+  '';
+
+  meta = with lib; {
+    description = "An analysis and visualization toolkit for volumetric data";
+    homepage = https://github.com/yt-project/yt;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/zetup/default.nix
+++ b/pkgs/development/python-modules/zetup/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   '';
 
   checkPhase = ''
-    py.test test
+    py.test test -k "not TestObject"
   '';
 
   checkInputs = [ pytest_3 pathpy nbconvert ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1793,6 +1793,8 @@ in {
 
   pytest-mock = callPackage ../development/python-modules/pytest-mock { };
 
+  pytest-openfiles = callPackage ../development/python-modules/pytest-openfiles { };
+
   pytest-timeout = callPackage ../development/python-modules/pytest-timeout { };
 
   pytest-warnings = callPackage ../development/python-modules/pytest-warnings { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1064,6 +1064,8 @@ in {
 
   aioh2 = callPackage ../development/python-modules/aioh2 { };
 
+  aioftp = callPackage ../development/python-modules/aioftp { };
+
   aiohttp = callPackage ../development/python-modules/aiohttp { };
 
   aiohttp-cors = callPackage ../development/python-modules/aiohttp-cors { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1755,6 +1755,8 @@ in {
 
   pytest-arraydiff = callPackage ../development/python-modules/pytest-arraydiff { };
 
+  pytest-astropy = callPackage ../development/python-modules/pytest-astropy { };
+
   pytest-benchmark = callPackage ../development/python-modules/pytest-benchmark { };
 
   pytestcache = callPackage ../development/python-modules/pytestcache { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3781,6 +3781,8 @@ in {
 
   paramz = callPackage ../development/python-modules/paramz { };
 
+  parfive = callPackage ../development/python-modules/parfive { };
+
   parsel = callPackage ../development/python-modules/parsel { };
 
   parso = callPackage ../development/python-modules/parso { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1981,6 +1981,8 @@ in {
 
   dropbox = callPackage ../development/python-modules/dropbox {};
 
+  drms = callPackage ../development/python-modules/drms { };
+
   ds4drv = callPackage ../development/python-modules/ds4drv {
     inherit (pkgs) fetchFromGitHub bluez;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -330,6 +330,8 @@ in {
 
   cliff = callPackage ../development/python-modules/cliff { };
 
+  clifford = callPackage ../development/python-modules/clifford { };
+
   clustershell = callPackage ../development/python-modules/clustershell { };
 
   cozy = callPackage ../development/python-modules/cozy { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -720,6 +720,8 @@ in {
 
   pygame = callPackage ../development/python-modules/pygame { };
 
+  pygbm = callPackage ../development/python-modules/pygbm { };
+
   pygame_sdl2 = callPackage ../development/python-modules/pygame_sdl2 { };
 
   pygdbmi = callPackage ../development/python-modules/pygdbmi { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1779,6 +1779,8 @@ in {
 
   pytest-relaxed = callPackage ../development/python-modules/pytest-relaxed { };
 
+  pytest-remotedata = callPackage ../development/python-modules/pytest-remotedata { };
+
   pytest-sanic = callPackage ../development/python-modules/pytest-sanic { };
 
   pytest-flake8 = callPackage ../development/python-modules/pytest-flake8 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -446,6 +446,8 @@ in {
 
   globus-sdk = callPackage ../development/python-modules/globus-sdk { };
 
+  glymur = callPackage ../development/python-modules/glymur { };
+
   glom = callPackage ../development/python-modules/glom { };
 
   goocalendar = callPackage ../development/python-modules/goocalendar { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -348,6 +348,8 @@ in {
 
   datasette = callPackage ../development/python-modules/datasette { };
 
+  datashader = callPackage ../development/python-modules/datashader { };
+
   dbf = callPackage ../development/python-modules/dbf { };
 
   dbfread = callPackage ../development/python-modules/dbfread { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1753,6 +1753,8 @@ in {
 
   pytest-aiohttp = callPackage ../development/python-modules/pytest-aiohttp { };
 
+  pytest-arraydiff = callPackage ../development/python-modules/pytest-arraydiff { };
+
   pytest-benchmark = callPackage ../development/python-modules/pytest-benchmark { };
 
   pytestcache = callPackage ../development/python-modules/pytestcache { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1767,6 +1767,8 @@ in {
 
   pytest-django = callPackage ../development/python-modules/pytest-django { };
 
+  pytest-doctestplus = callPackage ../development/python-modules/pytest-doctestplus { };
+
   pytest-faulthandler = callPackage ../development/python-modules/pytest-faulthandler { };
 
   pytest-fixture-config = callPackage ../development/python-modules/pytest-fixture-config { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1329,6 +1329,8 @@ in {
 
   circus = callPackage ../development/python-modules/circus {};
 
+  colorcet = callPackage ../development/python-modules/colorcet { };
+
   colorclass = callPackage ../development/python-modules/colorclass {};
 
   colorlog = callPackage ../development/python-modules/colorlog { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -975,6 +975,8 @@ in {
 
   statistics = callPackage ../development/python-modules/statistics { };
 
+  stumpy = callPackage ../development/python-modules/stumpy { };
+
   sumo = callPackage ../development/python-modules/sumo { };
 
   supervise_api = callPackage ../development/python-modules/supervise_api { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -175,6 +175,8 @@ in {
 
   asana = callPackage ../development/python-modules/asana { };
 
+  asdf = callPackage ../development/python-modules/asdf { };
+
   asciimatics = callPackage ../development/python-modules/asciimatics { };
 
   ase = callPackage ../development/python-modules/ase { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1823,6 +1823,8 @@ in {
 
   pytest-shutil = callPackage ../development/python-modules/pytest-shutil { };
 
+  pytest-socket = callPackage ../development/python-modules/pytest-socket { };
+
   pytestcov = callPackage ../development/python-modules/pytest-cov { };
 
   pytest-expect = callPackage ../development/python-modules/pytest-expect { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3472,6 +3472,8 @@ in {
 
   mockito = callPackage ../development/python-modules/mockito { };
 
+  modeled = callPackage ../development/python-modules/modeled { };
+
   moderngl = callPackage ../development/python-modules/moderngl { };
 
   modestmaps = callPackage ../development/python-modules/modestmaps { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2471,6 +2471,8 @@ in {
 
   subliminal = callPackage ../development/python-modules/subliminal {};
 
+  sunpy = callPackage ../development/python-modules/sunpy { };
+
   hyperlink = callPackage ../development/python-modules/hyperlink {};
 
   zope_copy = callPackage ../development/python-modules/zope_copy {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1775,6 +1775,8 @@ in {
 
   pytest-isort = callPackage ../development/python-modules/pytest-isort { };
 
+  pytest-mpl = callPackage ../development/python-modules/pytest-mpl { };
+
   pytest-mock = callPackage ../development/python-modules/pytest-mock { };
 
   pytest-timeout = callPackage ../development/python-modules/pytest-timeout { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1030,6 +1030,8 @@ in {
 
   yarg = callPackage ../development/python-modules/yarg { };
 
+  yt = callPackage ../development/python-modules/yt { };
+
   # packages defined here
 
   aafigure = callPackage ../development/python-modules/aafigure { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -708,6 +708,8 @@ in {
 
   pydocumentdb = callPackage ../development/python-modules/pydocumentdb { };
 
+  pydy = callPackage ../development/python-modules/pydy { };
+
   pyexiv2 = disabledIf isPy3k (toPythonModule (callPackage ../development/python-modules/pyexiv2 {}));
 
   py3exiv2 = callPackage ../development/python-modules/py3exiv2 { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
