### PR TITLE
pdfcpu: 0.1.25 -> 0.2.1

### DIFF
--- a/pkgs/applications/graphics/pdfcpu/default.nix
+++ b/pkgs/applications/graphics/pdfcpu/default.nix
@@ -2,13 +2,13 @@
 
 buildGoModule rec {
   pname = "pdfcpu";
-  version = "0.1.25";
+  version = "0.2.1";
 
   src = fetchFromGitHub {
     owner = "hhrutter";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0vmmc7nnvpvsf92yi69rvqif1irkpya2shqyz49sa3s42jh1446b";
+    sha256 = "0cg17nph3qv1ca86j3wcd33vqs6clkzi6y2nrajmk7dq5vbzr6nn";
   };
 
   modSha256 = "0cz4gs88s9z2yv1gc9ap92vv2j93ab6kr25zjgl2r7z6clbl5fzp";


### PR DESCRIPTION
~I switched to buildGoPackage from buildGoModule. There's some problem with using Go modules with this version, upstream was reported: https://github.com/hhrutter/pdfcpu/issues/92 . I used [vgo2nix](https://github.com/adisbladis/vgo2nix) to generate `deps.nix`.~ Upstream fix from 0.2 -> 0.2.1 removed the need for that.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
