### PR TITLE
pythonPackages.sklearn-deap: 0.2.2 -> 0.2.3

### DIFF
--- a/pkgs/development/python-modules/sklearn-deap/default.nix
+++ b/pkgs/development/python-modules/sklearn-deap/default.nix
@@ -1,16 +1,24 @@
-{ stdenv, buildPythonPackage, fetchFromGitHub, numpy, scipy, deap, scikitlearn, python, isPy3k }:
+{ stdenv, buildPythonPackage, fetchFromGitHub, fetchpatch, numpy, scipy, deap, scikitlearn, python }:
 
 buildPythonPackage rec {
   pname = "sklearn-deap";
-  version = "0.2.2";
+  version = "0.2.3";
 
   # No tests in Pypi
   src = fetchFromGitHub {
     owner = "rsteca";
     repo = pname;
     rev = "${version}";
-    sha256 = "01ynmzxg181xhv2d7bs53zjvk9x2qpxix32sspq54mpigxh13ava";
+    sha256 = "1yqnmy8h08i2y6bb2s0a5nx9cwvyg45293whqh420c195gpzg1x3";
   };
+
+  patches = [
+    # Fix for newer versions of scikit-learn. See: https://github.com/rsteca/sklearn-deap/pull/62
+    (fetchpatch {
+      url = "https://github.com/rsteca/sklearn-deap/commit/3ae62990fc87f36b59382e7c4db3c74cf99ec3bf.patch";
+      sha256 = "1na6wf4v0dcmyz3pz8aiqkmv76d1iz3hi4iyfq9kfnycgzpv1kxk";
+    })
+  ];
 
   propagatedBuildInputs = [ numpy scipy deap scikitlearn ];
 
@@ -23,7 +31,6 @@ buildPythonPackage rec {
     homepage = https://github.com/rsteca/sklearn-deap;
     license = licenses.lgpl3;
     maintainers = with maintainers; [ psyanticy ];
-    broken = isPy3k; # https://github.com/rsteca/sklearn-deap/issues/65
   };
 }
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
