### PR TITLE
ytcc: enable tests

### DIFF
--- a/pkgs/tools/networking/ytcc/default.nix
+++ b/pkgs/tools/networking/ytcc/default.nix
@@ -11,10 +11,20 @@ python3Packages.buildPythonApplication rec {
     sha256 = "080p145j5pg8db88kb0y3x1pfc3v4aj3w68pdihlmi68dhjdr7i7";
   };
 
-  doCheck = false; # try to access /homeless-shelter
+  nativeBuildInputs = [ gettext ];
+
   propagatedBuildInputs = with python3Packages; [ feedparser lxml sqlalchemy youtube-dl ];
 
-  nativeBuildInputs = [ gettext ];
+  checkInputs = with python3Packages; [ nose pytest ];
+
+  # Disable tests that touch network or shell out to commands
+  checkPhase = ''
+    pytest . -k 'not get_channels \
+                 and not play_video \
+                 and not download_videos \
+                 and not update_all \
+                 and not add_channel_duplicate'
+  '';
 
   meta = {
     description = "Command Line tool to keep track of your favourite YouTube channels without signing up for a Google account";


### PR DESCRIPTION
###### Motivation for this change
Was ripgrepping through nixpkgs and noticed it had tests disabled, enabled to verify it's not going to be broken by upstream dependencies.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

```
$ nix path-info -Sh ./result
/nix/store/hhjr5fk9zbwwpfzjdwzrvk2afps43sjj-ytcc-1.8.1   244.1M
```
```
$ nix-review wip
...
[1 built, 0.0 MiB DL]
1 package were build:
ytcc

```