### PR TITLE
beam-packages: default erlangR20 -> erlangR22

### DIFF
--- a/pkgs/development/tools/erlang/hex2nix/default.nix
+++ b/pkgs/development/tools/erlang/hex2nix/default.nix
@@ -2,20 +2,20 @@
 
 rebar3Relx rec {
     name = "hex2nix";
-    version = "0.0.6-a31eadd7";
+    version = "0.0.6-42d7b2ec";
 
     releaseType = "escript";
 
     checkouts = fetchRebar3Deps {
       inherit name version;
       src = "${src}/rebar.config";
-      sha256 = "1b59vk6ynakdiwqd1s6axaj9bvkaaq7ll28b48nv613z892h7nm5";
+      sha256 = "0z6v1f6hagl3qyj97frqr2ww3adrwgfwdyb2zshaai0d3xchg3ly";
     };
 
     src = fetchFromGitHub {
       owner  = "erlang-nix";
       repo   = "hex2nix";
-      rev    = "a31eadd7af2cbdac1b87991b378e98ea4fb40ae0";
-      sha256 = "1hnkrksyrbpq2gq25rfsrnm86n0g3biab88gswm3zj88ddrz6dyk";
+      rev    = "42d7b2ec64f61f21061066b192003cf7f460bf43";
+      sha256 = "0ac1fmckvid5077djg3ajycxn7gwbf7pdk1knhfp8yva3c5qq58r";
     };
 }

--- a/pkgs/development/tools/erlang/relx-exe/default.nix
+++ b/pkgs/development/tools/erlang/relx-exe/default.nix
@@ -2,18 +2,18 @@
 
 rebar3Relx rec {
   name = "relx-exe";
-  version = "3.23.1";
+  version = "3.32.1";
   releaseType = "escript";
 
   src = fetchHex {
     pkg = "relx";
-    sha256 = "13j7wds2d7b8v3r9pwy3zhwhzywgwhn6l9gm3slqzyrs1jld0a9d";
-    version = "3.23.1";
+    sha256 = "0693k8ac7hvpm9jd3ysbdn8bk97d68ini22p1fsqdsi9qv9f7nq7";
+    inherit version;
   };
 
   checkouts = fetchRebar3Deps {
     inherit name version;
     src = "${src}/rebar.lock";
-    sha256 = "046b1lb9rymndlvzmin3ppa3vkssjqspyfp98869k11s5avg76hd";
+    sha256 = "0l7r3x7zwcz49013zv8z5v2i06p7wqkgzdyzrl8jk0hglscvhpf6";
   };
 }

--- a/pkgs/servers/http/couchdb/2.0.0.nix
+++ b/pkgs/servers/http/couchdb/2.0.0.nix
@@ -5,6 +5,8 @@ stdenv.mkDerivation rec {
   name = "couchdb-${version}";
   version = "2.3.0";
 
+  # when updating this, please consider bumping the OTP version
+  # in all-packages.nix
   src = fetchurl {
     url = "mirror://apache/couchdb/source/${version}/apache-${name}.tar.gz";
     sha256 = "0lpk64n6fip85j1jz59kq20jdliwv6mh8j2h5zyxjn5i8b86hf0b";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14235,6 +14235,7 @@ in
 
   couchdb2 = callPackage ../servers/http/couchdb/2.0.0.nix {
     spidermonkey = spidermonkey_1_8_5;
+    erlang = erlangR21;
   };
 
   couchpotato = callPackage ../servers/couchpotato {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8310,9 +8310,8 @@ in
   inherit (beam.packages.erlang)
     rebar rebar3-open rebar3
     hexRegistrySnapshot fetchHex beamPackages
-    hex2nix;
+    hex2nix relxExe;
 
-  inherit (beam.packages.erlangR18) relxExe;
   inherit (beam.packages.erlangR19) cuter;
 
   groovy = callPackage ../development/interpreters/groovy { };

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -6,12 +6,12 @@ rec {
   # Each
   interpreters = rec {
 
-    # R20 is the default version.
-    erlang = erlangR20; # The main switch to change default Erlang version.
-    erlang_odbc = erlangR20_odbc;
-    erlang_javac = erlangR20_javac;
-    erlang_odbc_javac = erlangR20_odbc_javac;
-    erlang_nox = erlangR20_nox;
+    # R22 is the default version.
+    erlang = erlangR22; # The main switch to change default Erlang version.
+    erlang_odbc = erlangR22_odbc;
+    erlang_javac = erlangR22_javac;
+    erlang_odbc_javac = erlangR22_odbc_javac;
+    erlang_nox = erlangR22_nox;
 
     # These are standard Erlang versions, using the generic builder.
     erlangR18 = lib.callErlang ../development/interpreters/erlang/R18.nix {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Last time: https://github.com/NixOS/nixpkgs/pull/44640
This has worked for us since february, it's time to upstream it. R22 was released in the meantime.

cc: @LnL7 @ankhers 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
