### PR TITLE
xcape: 1.2 -> 20180301

### DIFF
--- a/pkgs/tools/X11/xcape/default.nix
+++ b/pkgs/tools/X11/xcape/default.nix
@@ -1,30 +1,29 @@
 { stdenv, fetchFromGitHub, pkgconfig, libX11, libXtst, xorgproto,
 libXi }:
 
-let
-  baseName = "xcape";
-  version = "1.2";
-in
-
 stdenv.mkDerivation rec {
-  name = "${baseName}-${version}";
+  pname = "xcape";
+  version = "unstable-20180301";
 
   src = fetchFromGitHub {
     owner = "alols";
-    repo = baseName;
-    rev = "v${version}";
-    sha256 = "09a05cxgrip6nqy1qmwblamp2bhknqnqmxn7i2a1rgxa0nba95dm";
+    repo = pname;
+    rev = "a34d6bae27bbd55506852f5ed3c27045a3c0bd9e";
+    sha256 = "04grs4w9kpfzz25mqw82zdiy51g0w355gpn5b170p7ha5972ykc8";
   };
 
   nativeBuildInputs = [ pkgconfig ];
 
   buildInputs = [ libX11 libXtst xorgproto libXi ];
 
-  makeFlags = [ "PREFIX=$(out)" "MANDIR=/share/man/man1" ];
+  makeFlags = [
+    "PREFIX=$(out)"
+    "MANDIR=/share/man/man1"
+  ];
 
-  postInstall = "install -D --target-directory $out/share/doc README.md";
+  postInstall = "install -Dm444 --target-directory $out/share/doc README.md";
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Utility to configure modifier keys to act as other keys";
     longDescription = ''
       xcape allows you to use a modifier key as another key when
@@ -35,8 +34,8 @@ stdenv.mkDerivation rec {
       released on its own.
     '';
     homepage = https://github.com/alols/xcape;
-    license = stdenv.lib.licenses.gpl3 ;
-    platforms = stdenv.lib.platforms.linux;
-    maintainers = [ stdenv.lib.maintainers.raskin ];
+    license = licenses.gpl3 ;
+    maintainers = with maintainers; [ raskin ];
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

1.2 only allows running in the foreground if debug mode is enabled which generates lots of noise for journald.

The changes from the most recent release is only a few minor fixes plus support for running in the foreground with the `-f` flag.

Using it here as a daily driver - all good.

Cc: @7c6f434c 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
