### PR TITLE
nixos/tests: extend grafana test, nixos/grafana: use group grafana instead of nogroup

### DIFF
--- a/nixos/modules/services/monitoring/grafana.nix
+++ b/nixos/modules/services/monitoring/grafana.nix
@@ -552,6 +552,8 @@ in {
       description = "Grafana user";
       home = cfg.dataDir;
       createHome = true;
+      group = "grafana";
     };
+    users.groups.grafana = {};
   };
 }

--- a/nixos/tests/grafana.nix
+++ b/nixos/tests/grafana.nix
@@ -1,25 +1,91 @@
-import ./make-test.nix ({ lib, ... }:
-{
-  name = "grafana";
+import ./make-test.nix ({ lib, pkgs, ... }:
 
-  meta = with lib.maintainers; {
-    maintainers = [ willibutz ];
-  };
+let
+  inherit (lib) mkMerge nameValuePair maintainers;
 
-  machine = { ... }: {
+  baseGrafanaConf = {
     services.grafana = {
       enable = true;
       addr = "localhost";
       analytics.reporting.enable = false;
       domain = "localhost";
-      security.adminUser = "testusername";
+      security = {
+        adminUser = "testadmin";
+        adminPassword = "snakeoilpwd";
+      };
     };
   };
 
+  extraNodeConfs = {
+    postgresql = {
+      services.grafana.database = {
+        host = "127.0.0.1:5432";
+        user = "grafana";
+      };
+      services.postgresql = {
+        enable = true;
+        ensureDatabases = [ "grafana" ];
+        ensureUsers = [{
+          name = "grafana";
+          ensurePermissions."DATABASE grafana" = "ALL PRIVILEGES";
+        }];
+      };
+      systemd.services.grafana.after = [ "postgresql.service" ];
+    };
+
+    mysql = {
+      services.grafana.database.user = "grafana";
+      services.mysql = {
+        enable = true;
+        ensureDatabases = [ "grafana" ];
+        ensureUsers = [{
+          name = "grafana";
+          ensurePermissions."grafana.*" = "ALL PRIVILEGES";
+        }];
+        package = pkgs.mariadb;
+      };
+      systemd.services.grafana.after = [ "mysql.service" ];
+    };
+  };
+
+  nodes = builtins.listToAttrs (map (dbName:
+    nameValuePair dbName (mkMerge [
+    baseGrafanaConf
+    (extraNodeConfs.${dbName} or {})
+  ])) [ "sqlite" "postgresql" "mysql" ]);
+
+in {
+  name = "grafana";
+
+  meta = with maintainers; {
+    maintainers = [ willibutz ];
+  };
+
+  inherit nodes;
+
   testScript = ''
-    $machine->start;
-    $machine->waitForUnit("grafana.service");
-    $machine->waitForOpenPort(3000);
-    $machine->succeed("curl -sSfL http://127.0.0.1:3000/");
+    startAll();
+
+    subtest "Grafana sqlite", sub {
+      $sqlite->waitForUnit("grafana.service");
+      $sqlite->waitForOpenPort(3000);
+      $sqlite->succeed("curl -sSfN -u testadmin:snakeoilpwd http://127.0.0.1:3000/api/org/users | grep -q testadmin\@localhost");
+    };
+
+    subtest "Grafana postgresql", sub {
+      $postgresql->waitForUnit("grafana.service");
+      $postgresql->waitForUnit("postgresql.service");
+      $postgresql->waitForOpenPort(3000);
+      $postgresql->waitForOpenPort(5432);
+      $postgresql->succeed("curl -sSfN -u testadmin:snakeoilpwd http://127.0.0.1:3000/api/org/users | grep -q testadmin\@localhost");
+    };
+
+    subtest "Grafana mysql", sub {
+      $mysql->waitForUnit("grafana.service");
+      $mysql->waitForUnit("mysql.service");
+      $mysql->waitForOpenPort(3000);
+      $mysql->waitForOpenPort(3306);
+      $mysql->succeed("curl -sSfN -u testadmin:snakeoilpwd http://127.0.0.1:3000/api/org/users | grep -q testadmin\@localhost");
+    };
   '';
 })


### PR DESCRIPTION
###### Motivation for this change
#64281

###### Things done
This extends the grafana test with configurations for postgresql and mariadb.
Also the user `grafana` is now in the group `grafana`, because `nogroup` was used before.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS (x86_64-linux & aarch64-linux)
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
/cc @aanderse