### PR TITLE
WIP buildPythonPackage: rename options to buildFlags, installFlags an…

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -595,7 +595,6 @@ All parameters from `stdenv.mkDerivation` function are still supported. The foll
 * `disabled` ? false: If `true`, package is not build for the particular Python interpreter version.
 * `dontWrapPythonPrograms ? false`: Skip wrapping of python programs.
 * `permitUserSite ? false`: Skip setting the `PYTHONNOUSERSITE` environment variable in wrapped programs.
-* `installFlags ? []`: A list of strings. Arguments to be passed to `pip install`. To pass options to `python setup.py install`, use `--install-option`. E.g., `installFlags=["--install-option='--cpp_implementation'"]`.
 * `format ? "setuptools"`: Format of the source. Valid options are `"setuptools"`, `"pyproject"`, `"flit"`, `"wheel"`, and `"other"`. `"setuptools"` is for when the source has a `setup.py` and `setuptools` is used to build a wheel, `flit`, in case `flit` should be used to build a wheel, and `wheel` in case a wheel is provided. Use `other` when a custom `buildPhase` and/or `installPhase` is needed.
 * `makeWrapperArgs ? []`: A list of strings. Arguments to be passed to `makeWrapper`, which wraps generated binaries. By default, the arguments to `makeWrapper` set `PATH` and `PYTHONPATH` environment variables before calling the binary. Additional arguments here can allow a developer to set environment variables which will be available when the binary is run. For example, `makeWrapperArgs = ["--set FOO BAR" "--set BAZ QUX"]`.
 * `namePrefix`: Prepends text to `${name}` parameter. In case of libraries, this defaults to `"python3.5-"` for Python 3.5, etc., and in case of applications to `""`.
@@ -603,8 +602,9 @@ All parameters from `stdenv.mkDerivation` function are still supported. The foll
 * `preShellHook`: Hook to execute commands before `shellHook`.
 * `postShellHook`: Hook to execute commands after `shellHook`.
 * `removeBinByteCode ? true`: Remove bytecode from `/bin`. Bytecode is only created when the filenames end with `.py`.
-* `setupPyGlobalFlags ? []`: List of flags passed to `setup.py` command.
-* `setupPyBuildFlags ? []`: List of flags passed to `setup.py build_ext` command.
+* `globalFlags ? []`: List of flags passed to `python setup.py` command.
+* `installFlags ? []`: List of flags passed to `pip install`. To pass options to `python setup.py install`, use `--install-option`. E.g., `installFlags=["--install-option='--cpp_implementation'"]`.
+* `buildFlags ? []`: List of flags passed to `setup.py build_ext` command.
 
 The `stdenv.mkDerivation` function accepts various parameters for describing build inputs (see "Specifying dependencies"). The following are of special
 interest for Python packages, either because these are primarily used, or because their behaviour is different:

--- a/pkgs/development/interpreters/python/build-python-package-common.nix
+++ b/pkgs/development/interpreters/python/build-python-package-common.nix
@@ -4,9 +4,12 @@
 }:
 
 { buildInputs ? []
-# Additional flags to pass to "pip install".
+# `install-options` to pass to `pip install`.
 , installFlags ? []
 , ... } @ attrs:
+
+let
+  installFlagsString = lib.concatMapStringsSep " " (option: "--install-option ${option}") installFlags;
 
 attrs // {
   buildInputs = buildInputs ++ [ python.pythonForBuild.pkgs.bootstrapped-pip ];
@@ -23,7 +26,7 @@ attrs // {
     export PYTHONPATH="$out/${python.sitePackages}:$PYTHONPATH"
 
     pushd dist
-    ${python.pythonForBuild.pkgs.bootstrapped-pip}/bin/pip install *.whl --no-index --prefix=$out --no-cache ${toString installFlags} --build tmpbuild
+    ${python.pythonForBuild.pkgs.bootstrapped-pip}/bin/pip install *.whl --no-index --prefix=$out --no-cache ${installFlagsString} --build tmpbuild
     popd
 
     runHook postInstall

--- a/pkgs/development/interpreters/python/build-python-package-pyproject.nix
+++ b/pkgs/development/interpreters/python/build-python-package-pyproject.nix
@@ -6,11 +6,11 @@
 
 {
 # Global options passed to "python setup.py"
-  setupPyGlobalFlags ? []
+  globalFlags ? []
 # Build options passed to "build_ext"
 # https://github.com/pypa/pip/issues/881
 # Rename to `buildOptions` because it is not setuptools specific?
-, setupPyBuildFlags ? []
+, buildFlags ? []
 # Execute before shell hook
 , preShellHook ? ""
 # Execute after shell hook
@@ -18,14 +18,14 @@
 , ... } @ attrs:
 
 let
-  pipGlobalFlagsString = lib.concatMapStringsSep " " (option: "--global-option ${option}") setupPyGlobalFlags;
-  pipBuildFlagsString = lib.concatMapStringsSep " " (option: "--build-option ${option}") setupPyBuildFlags;
+  globalFlagsString = lib.concatMapStringsSep " " (option: "--global-option ${option}") globalFlags;
+  buildFlagsString = lib.concatMapStringsSep " " (option: "--build-option ${option}") buildFlags;
 in attrs // {
   buildPhase = attrs.buildPhase or ''
     runHook preBuild
     mkdir -p dist
     echo "Creating a wheel..."
-    ${python.pythonForBuild.interpreter} -m pip wheel --no-index --no-deps --no-clean --no-build-isolation --wheel-dir dist ${pipGlobalFlagsString} ${pipBuildFlagsString} .
+    ${python.pythonForBuild.interpreter} -m pip wheel --no-index --no-deps --no-clean --no-build-isolation --wheel-dir dist ${globalFlagsString} ${buildFlagsString} .
     echo "Finished creating a wheel..."
     runHook postBuild
   '';

--- a/pkgs/development/interpreters/python/build-python-package-setuptools.nix
+++ b/pkgs/development/interpreters/python/build-python-package-setuptools.nix
@@ -6,10 +6,10 @@
 
 {
 # Global options passed to "python setup.py"
-  setupPyGlobalFlags ? []
+  globalFlags ? []
 # Build options passed to "python setup.py build_ext"
 # https://github.com/pypa/pip/issues/881
-, setupPyBuildFlags ? []
+, buildFlags ? []
 # Execute before shell hook
 , preShellHook ? ""
 # Execute after shell hook
@@ -21,8 +21,8 @@ let
   # pip does the same thing: https://github.com/pypa/pip/pull/3265
   setuppy = ./run_setup.py;
 
-  setupPyGlobalFlagsString = lib.concatStringsSep " " setupPyGlobalFlags;
-  setupPyBuildExtString = lib.optionalString (setupPyBuildFlags != []) ("build_ext " + (lib.concatStringsSep " " setupPyBuildFlags));
+  globalFlagsString = lib.concatStringsSep " " globalFlags;
+  buildFlagsString = lib.optionalString (buildFlags != []) ("build_ext " + (lib.concatStringsSep " " buildFlags));
 
 in attrs // {
   # we copy nix_run_setup over so it's executed relative to the root of the source
@@ -30,7 +30,7 @@ in attrs // {
   buildPhase = attrs.buildPhase or ''
     runHook preBuild
     cp ${setuppy} nix_run_setup
-    ${python.pythonForBuild.interpreter} nix_run_setup ${setupPyGlobalFlagsString} ${setupPyBuildExtString} bdist_wheel
+    ${python.pythonForBuild.interpreter} nix_run_setup ${globalFlagsString} ${buildFlagsString} bdist_wheel
     runHook postBuild
   '';
 


### PR DESCRIPTION
…d globalFlags

Should actually be buildOptions installOptions globalOptions

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
