### PR TITLE
edk2: 2017-12-05 -> 201905

### DIFF
--- a/pkgs/applications/virtualization/OVMF/default.nix
+++ b/pkgs/applications/virtualization/OVMF/default.nix
@@ -1,4 +1,9 @@
-{ stdenv, lib, edk2, nasm, iasl, seabios, openssl, secureBoot ? false }:
+{ stdenv, lib, edk2, utillinux, nasm, iasl
+, csmSupport ? false, seabios ? null
+, secureBoot ? false
+}:
+
+assert csmSupport -> seabios != null;
 
 let
 
@@ -12,59 +17,24 @@ let
     throw "Unsupported architecture";
 
   version = (builtins.parseDrvName edk2.name).version;
-
-  src = edk2.src;
 in
 
-stdenv.mkDerivation (edk2.setup projectDscPath {
+edk2.mkDerivation projectDscPath {
   name = "OVMF-${version}";
-
-  inherit src;
 
   outputs = [ "out" "fd" ];
 
-  # TODO: properly include openssl for secureBoot
-  buildInputs = [nasm iasl] ++ stdenv.lib.optionals (secureBoot == true) [ openssl ];
+  buildInputs = [ utillinux nasm iasl ];
 
-  hardeningDisable = [ "stackprotector" "pic" "fortify" ];
+  hardeningDisable = [ "format" "stackprotector" "pic" "fortify" ];
 
-  unpackPhase = ''
-    # $fd is overwritten during the build
-    export OUTPUT_FD=$fd
+  buildFlags =
+    lib.optional secureBoot "-DSECURE_BOOT_ENABLE=TRUE"
+    ++ lib.optionals csmSupport [ "-D CSM_ENABLE" "-D FD_SIZE_2MB" ];
 
-    for file in \
-      "${src}"/{UefiCpuPkg,MdeModulePkg,IntelFrameworkModulePkg,PcAtChipsetPkg,FatBinPkg,EdkShellBinPkg,MdePkg,ShellPkg,OptionRomPkg,IntelFrameworkPkg,FatPkg,CryptoPkg,SourceLevelDebugPkg};
-    do
-      ln -sv "$file" .
-    done
-
-    ${if stdenv.isAarch64 then ''
-      ln -sv ${src}/ArmPkg .
-      ln -sv ${src}/ArmPlatformPkg .
-      ln -sv ${src}/ArmVirtPkg .
-      ln -sv ${src}/EmbeddedPkg .
-      ln -sv ${src}/OvmfPkg .
-    '' else if seabios != null then ''
-        cp -r ${src}/OvmfPkg .
-        chmod +w OvmfPkg/Csm/Csm16
-        cp ${seabios}/Csm16.bin OvmfPkg/Csm/Csm16/Csm16.bin
-    '' else ''
-        ln -sv ${src}/OvmfPkg .
-    ''}
-
-    ${lib.optionalString secureBoot ''
-      ln -sv ${src}/SecurityPkg .
-      ln -sv ${src}/CryptoPkg .
-    ''}
+  postPatch = lib.optionalString csmSupport ''
+    cp ${seabios}/Csm16.bin OvmfPkg/Csm/Csm16/Csm16.bin
   '';
-
-  buildPhase = if stdenv.isAarch64 then ''
-      build -n $NIX_BUILD_CORES
-    '' else if seabios == null then ''
-      build -n $NIX_BUILD_CORES ${lib.optionalString secureBoot "-DSECURE_BOOT_ENABLE=TRUE"}
-    '' else ''
-      build -n $NIX_BUILD_CORES -D CSM_ENABLE -D FD_SIZE_2MB ${lib.optionalString secureBoot "-DSECURE_BOOT_ENABLE=TRUE"}
-    '';
 
   postFixup = if stdenv.isAarch64 then ''
     mkdir -vp $fd/FV
@@ -77,8 +47,8 @@ stdenv.mkDerivation (edk2.setup projectDscPath {
     dd of=$fd/AAVMF/QEMU_EFI-pflash.raw       if=$fd/FV/QEMU_EFI.fd conv=notrunc
     dd of=$fd/AAVMF/vars-template-pflash.raw if=/dev/zero bs=1M    count=64
   '' else ''
-    mkdir -vp $OUTPUT_FD/FV
-    mv -v $out/FV/OVMF{,_CODE,_VARS}.fd $OUTPUT_FD/FV
+    mkdir -vp $fd/FV
+    mv -v $out/FV/OVMF{,_CODE,_VARS}.fd $fd/FV
   '';
 
   dontPatchELF = true;
@@ -89,4 +59,4 @@ stdenv.mkDerivation (edk2.setup projectDscPath {
     license = stdenv.lib.licenses.bsd2;
     platforms = ["x86_64-linux" "i686-linux" "aarch64-linux"];
   };
-})
+}

--- a/pkgs/development/compilers/edk2/default.nix
+++ b/pkgs/development/compilers/edk2/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchFromGitHub, fetchpatch, libuuid, python2, iasl }:
+{ stdenv, fetchgit, fetchpatch, libuuid, python3, iasl, bc }:
 
 let
-  pythonEnv = python2.withPackages(ps: [ps.tkinter]);
+  pythonEnv = python3.withPackages (ps: [ps.tkinter]);
 
 targetArch = if stdenv.isi686 then
   "IA32"
@@ -13,80 +13,67 @@ else
   throw "Unsupported architecture";
 
 edk2 = stdenv.mkDerivation {
-  name = "edk2-2017-12-05";
+  pname = "edk2";
+  version = "201905";
 
-  src = fetchFromGitHub {
-    owner = "tianocore";
-    repo = "edk2";
-    rev = "f71a70e7a4c93a6143d7bad8ab0220a947679697";
-    sha256 = "0k48xfwxcgcim1bhkggc19hilvsxsf5axvvcpmld0ng1fcfg0cr6";
+  # submodules
+  src = fetchgit {
+    url = "https://github.com/tianocore/edk2";
+    rev = "edk2-stable${edk2.version}";
+    sha256 = "0fk40h4nj4qg8shg0yd1zj4iyspslms5fx95ysi04akv90k5sqkn";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "short-circuit-the-transfer-of-an-empty-S3_CONTEXT.patch";
-      url = "https://github.com/tianocore/edk2/commit/9e2a8e928995c3b1bb664b73fd59785055c6b5f6.diff";
-      sha256 = "0x24npijhgpjpsn3n74wayf8qcbaj97vi4z2iyf4almavqq8qaz4";
-    })
-  ];
 
   buildInputs = [ libuuid pythonEnv ];
 
-  makeFlags = "-C BaseTools";
+  makeFlags = [ "-C BaseTools" ];
 
   hardeningDisable = [ "format" "fortify" ];
 
   installPhase = ''
     mkdir -vp $out
     mv -v BaseTools $out
-    mv -v EdkCompatibilityPkg $out
     mv -v edksetup.sh $out
   '';
 
   enableParallelBuilding = true;
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Intel EFI development kit";
     homepage = https://sourceforge.net/projects/edk2/;
-    license = stdenv.lib.licenses.bsd2;
-    branch = "UDK2017";
-    platforms = ["x86_64-linux" "i686-linux" "aarch64-linux"];
+    license = licenses.bsd2;
+    platforms = [ "x86_64-linux" "i686-linux" "aarch64-linux" ];
   };
 
   passthru = {
-    setup = projectDscPath: attrs: {
-      buildInputs = [ pythonEnv ] ++
-        stdenv.lib.optionals (attrs ? buildInputs) attrs.buildInputs;
+    mkDerivation = projectDscPath: attrs: stdenv.mkDerivation ({
+      inherit (edk2) src;
 
-      configurePhase = ''
-        mkdir -v Conf
+      buildInputs = [ bc pythonEnv ] ++ attrs.buildInputs or [];
 
-        cp ${edk2}/BaseTools/Conf/target.template Conf/target.txt
-        sed -i Conf/target.txt \
-          -e 's|Nt32Pkg/Nt32Pkg.dsc|${projectDscPath}|' \
-          -e 's|MYTOOLS|GCC49|' \
-          -e 's|IA32|${targetArch}|' \
-          -e 's|DEBUG|RELEASE|'\
-
-        cp ${edk2}/BaseTools/Conf/tools_def.template Conf/tools_def.txt
-        sed -i Conf/tools_def.txt \
-          -e 's|DEFINE GCC48_IA32_PREFIX       = /usr/bin/|DEFINE GCC48_IA32_PREFIX       = ""|' \
-          -e 's|DEFINE GCC48_X64_PREFIX        = /usr/bin/|DEFINE GCC48_X64_PREFIX        = ""|' \
-          -e 's|DEFINE UNIX_IASL_BIN           = /usr/bin/iasl|DEFINE UNIX_IASL_BIN           = ${iasl}/bin/iasl|'
-
-        export WORKSPACE="$PWD"
-        export EFI_SOURCE="$PWD/EdkCompatibilityPkg"
+      prePatch = ''
+        rm -rf BaseTools
         ln -sv ${edk2}/BaseTools BaseTools
-        ln -sv ${edk2}/EdkCompatibilityPkg EdkCompatibilityPkg
-        . ${edk2}/edksetup.sh BaseTools
       '';
 
-      buildPhase = "
-        build
-      ";
+      configurePhase = ''
+        runHook preConfigure
+        export WORKSPACE="$PWD"
+        . ${edk2}/edksetup.sh BaseTools
+        runHook postConfigure
+      '';
 
-      installPhase = "mv -v Build/*/* $out";
-    } // (removeAttrs attrs [ "buildInputs" ] );
+      buildPhase = ''
+        runHook preBuild
+        build -a ${targetArch} -b RELEASE -t GCC5 -p ${projectDscPath} -n $NIX_BUILD_CORES $buildFlags
+        runHook postBuild
+      '';
+
+      installPhase = ''
+        runHook preInstall
+        mv -v Build/*/* $out
+        runHook postInstall
+      '';
+    } // removeAttrs attrs [ "buildInputs" ]);
   };
 };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14626,9 +14626,9 @@ in
 
   qboot = pkgsi686Linux.callPackage ../applications/virtualization/qboot { };
 
-  OVMF = callPackage ../applications/virtualization/OVMF { seabios = null; openssl = null; };
-  OVMF-CSM = OVMF.override { openssl = null; };
-  #WIP: OVMF-secureBoot = OVMF.override { seabios = null; secureBoot = true; };
+  OVMF = callPackage ../applications/virtualization/OVMF { };
+  OVMF-CSM = OVMF.override { csmSupport = true; };
+  OVMF-secureBoot = OVMF.override { secureBoot = true; };
 
   seabios = callPackage ../applications/virtualization/seabios { };
 


### PR DESCRIPTION
* Move to stable version;
* Refactor `setup` to `mkDerivation`;
* Use flags instead of `sed`.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Did this while investigating UEFI PXE netboot testing problems.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Ran `qemu` with this several times during debugging and testing unrelated PR.