### PR TITLE
zam-plugins: 3.10 -> 3.11

### DIFF
--- a/pkgs/applications/audio/zam-plugins/default.nix
+++ b/pkgs/applications/audio/zam-plugins/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "zam-plugins-${version}";
-  version = "3.10";
+  version = "3.11";
 
   src = fetchgit {
     url = "https://github.com/zamaudio/zam-plugins.git";
     deepClone = true;
-    rev = "a3321af1892a6994d64fb705e48ae8adf8d7df20";
-    sha256 = "0yqrs21ph2lx00p0jlc70qkmzfrnf9ihg1r3i9j5n2r903ljdg5p";
+    rev = "af338057e42dd5d07cba1889bfc74eda517c6147";
+    sha256 = "1qbskhcvy2k2xv0f32lw13smz5g72v0yy47zv6vnhnaiaqf3f2d5";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION

###### Motivation for this change


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
