### PR TITLE
libstrangle: init at 2017-02-22

### DIFF
--- a/pkgs/tools/X11/libstrangle/default.nix
+++ b/pkgs/tools/X11/libstrangle/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "libstrangle";
+  version = "2017-02-22";
+
+  src = fetchFromGitHub {
+    owner = "milaq";
+    repo = pname;
+    rev = "6020f9e375ba747c75eb7996b7d5f0214ac3221e";
+    sha256 = "04ikacbjcq9phdc8q5y1qjjpa1sxmzfm0idln9ys95prg289zp4h";
+  };
+
+  makeFlags = [ "prefix=" "DESTDIR=$(out)" ];
+
+  patches = [ ./nixos.patch ];
+
+  postPatch = ''
+    substituteAllInPlace src/strangle.sh
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/milaq/libstrangle";
+    description = "Frame rate limiter for Linux/OpenGL";
+    license = licenses.gpl3;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ aske ];
+  };
+}

--- a/pkgs/tools/X11/libstrangle/nixos.patch
+++ b/pkgs/tools/X11/libstrangle/nixos.patch
@@ -1,0 +1,29 @@
+diff --git a/makefile b/makefile
+index eb13054..a3a1125 100644
+--- a/makefile
++++ b/makefile
+@@ -27,12 +27,10 @@ $(BUILDDIR)libstrangle32.so: $(BUILDDIR)
+ 	$(CC) $(CFLAGS) $(LDFLAGS) -m32 -o $(BUILDDIR)libstrangle32.so $(SOURCES)
+ 
+ install: all
+-	install -m 0644 -D -T $(BUILDDIR)libstrangle.conf $(DESTDIR)/etc/ld.so.conf.d/libstrangle.conf
+ 	install -m 0755 -D -T $(BUILDDIR)libstrangle32.so $(DESTDIR)$(LIB32_PATH)/libstrangle.so
+ 	install -m 0755 -D -T $(BUILDDIR)libstrangle64.so $(DESTDIR)$(LIB64_PATH)/libstrangle.so
+ 	install -m 0755 -D -T $(SOURCEDIR)strangle.sh $(DESTDIR)$(bindir)/strangle
+ 	install -m 0644 -D -T COPYING $(DESTDIR)$(DOC_PATH)/LICENSE
+-	ldconfig
+ 
+ clean:
+ 	rm -f $(BUILDDIR)libstrangle64.so
+diff --git a/src/strangle.sh b/src/strangle.sh
+index e280e86..b2dd42b 100755
+--- a/src/strangle.sh
++++ b/src/strangle.sh
+@@ -31,6 +31,5 @@ if [ "$#" -eq 0 ]; then
+   exit 1
+ fi
+ 
+-# Execute the strangled program under a clean environment
+ # pass through the FPS and overriden LD_PRELOAD environment variables
+-exec env FPS="${FPS}" LD_PRELOAD="${LD_PRELOAD}:libstrangle.so" "$@"
++FPS="${FPS}" LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:@out@/lib/libstrangle/lib64:@out@/lib/libstrangle/lib32" LD_PRELOAD="${LD_PRELOAD}:libstrangle.so" exec "$@"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20211,6 +20211,10 @@ in
 
   insync = callPackage ../applications/networking/insync { };
 
+  libstrangle = callPackage ../tools/X11/libstrangle {
+    stdenv = stdenv_32bit;
+  };
+
   lightdm = libsForQt5.callPackage ../applications/display-managers/lightdm { };
 
   lightdm_qt = lightdm.override { withQt5 = true; };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

Frame rate limiter for Linux/OpenGL.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---