### PR TITLE
matomo: 3.9.1 -> 3.10.0

### DIFF
--- a/pkgs/servers/web-apps/matomo/default.nix
+++ b/pkgs/servers/web-apps/matomo/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "matomo-${version}";
-  version = "3.9.1";
+  version = "3.10.0";
 
   src = fetchurl {
     url = "https://builds.matomo.org/matomo-${version}.tar.gz";
-    sha256 = "1y406dnwn4jyrjr2d5qfsg3b4v7nfbh09v74dm1vlcy3mkbhv2bp";
+    sha256 = "1mzqn2wh63ffzv6436cr8shl40nlj8sazsj2j37lx9pkz89n2wjz";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -39,8 +39,8 @@ stdenv.mkDerivation rec {
     cp -ra * $out/share/
     # tmp/ is created by matomo in PIWIK_USER_PATH
     rmdir $out/share/tmp
-    # config/ needs to be copied to PIWIK_USER_PATH anyway
-    mv $out/share/config $out/
+    # config/ needs to be accessed by PIWIK_USER_PATH anyway
+    ln -s $out/share/config $out/
 
     makeWrapper ${php}/bin/php $out/bin/matomo-console \
       --add-flags "$out/share/console"

--- a/pkgs/servers/web-apps/matomo/default.nix
+++ b/pkgs/servers/web-apps/matomo/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, makeWrapper, php }:
 
 stdenv.mkDerivation rec {
-  name = "matomo-${version}";
+  pname = "matomo";
   version = "3.10.0";
 
   src = fetchurl {


### PR DESCRIPTION
###### Motivation for this change
Was doing a review of #64839 and noticed the binary would just throw a runtime error, this is to fix it not being able to find a config file.

<details> <summary> before </summary>

```
$ ./result/bin/matomo-console

Warning: require(/nix/store/rppa93chjkiikyx75hbb53b67vhsc9vb-matomo-3.9.1/share/config/global.php): failed to open stream: No such file or directory in /nix/store/rppa93chjkiikyx75hbb53b67vhsc9vb-matomo-3.9.1/share/vendor/php-di/php-di/src/DI/Definition/Source/DefinitionFile.php on line 56

Fatal error: require(): Failed opening required '/nix/store/rppa93chjkiikyx75hbb53b67vhsc9vb-matomo-3.9.1/share/config/global.php' (include_path='/nix/store/rppa93chjkiikyx75hbb53b67vhsc9vb-matomo-3.9.1/share/vendor/pear/pear_exception:/nix/store/rppa93chjkiikyx75hbb53b67vhsc9vb-matomo-3.9.1/share/vendor/pear/console_getopt:/nix/store/rppa93chjkiikyx75hbb53b67vhsc9vb-matomo-3.9.1/share/vendor/pear/pear-core-minimal/src:/nix/store/rppa93chjkiikyx75hbb53b67vhsc9vb-matomo-3.9.1/share/vendor/pear/archive_tar:.:/nix/store/hvh94cgh6ppcyf244gf4f9pm9fli8zk0-php-7.3.7/lib/php') in /nix/store/rppa93chjkiikyx75hbb53b67vhsc9vb-matomo-3.9.1/share/vendor/php-di/php-di/src/DI/Definition/Source/DefinitionFile.php on line 56
```

</details>


<details> <summary> after </summary>

```
$ ./result/bin/matomo-console

The configuration file {/nix/store/kjb2s0fr0m8fm8ic169zg0gqcrchfip3-matomo-3.10.0/share/config/config.ini.php} has not been found or could not be read.
 » Please check that /nix/store/kjb2s0fr0m8fm8ic169zg0gqcrchfip3-matomo-3.10.0/share/config/config.ini.php is readable by the user 'jon'.


Matomo version 3.10.0

Usage:
 command [options] [arguments]

Options:
 --help (-h)           Display this help message
 --quiet (-q)          Do not output any message
 --verbose (-v|vv|vvv) Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 --version (-V)        Display this application version
 --ansi                Force ANSI output
 --no-ansi             Disable ANSI output
 --no-interaction (-n) Do not ask any interactive question
 --matomo-domain       Matomo URL (protocol and domain) eg. "http://matomo.example.org"
 --piwik-domain        [DEPRECATED] Matomo URL (protocol and domain) eg. "http://matomo.example.org"
 --xhprof              Enable profiling with XHProf
```

</details>


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @florianjacob as you seem to be the original maintainer
