### PR TITLE
pmacct: init at 1.7.3

### DIFF
--- a/pkgs/tools/networking/pmacct/default.nix
+++ b/pkgs/tools/networking/pmacct/default.nix
@@ -1,0 +1,62 @@
+{ stdenv
+, fetchFromGitHub
+, pkgconfig
+, autoreconfHook
+, libtool
+, libpcap
+
+# Optional Dependencies
+, zlib ? null
+, withJansson ? true, jansson ? null
+, withNflog ? true, libnetfilter_log ? null
+, withSQLite ? true, sqlite ? null
+, withPgSQL ? true, postgresql ? null
+, withMysql ? true, libmysqlclient ? null }:
+
+assert withJansson -> jansson != null;
+assert withNflog -> libnetfilter_log != null;
+assert withSQLite -> sqlite != null;
+assert withPgSQL -> postgresql != null;
+assert withMysql -> libmysqlclient != null;
+
+let inherit (stdenv.lib) optional; in
+
+stdenv.mkDerivation rec {
+  version = "1.7.3";
+  pname = "pmacct";
+
+  src = fetchFromGitHub {
+    owner = "pmacct";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0j5qmkya67q7jvaddcj00blmaac37bkir1zb3m1xmm95gm5lf2p5";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig libtool ];
+  buildInputs = [ libpcap ]
+    ++ optional withJansson jansson
+    ++ optional withNflog libnetfilter_log
+    ++ optional withSQLite sqlite
+    ++ optional withPgSQL postgresql
+    ++ optional withMysql [ libmysqlclient zlib ];
+
+  configureFlags = [
+    "--with-pcap-includes=${libpcap}/include"
+  ] ++ optional withJansson "--enable-jansson"
+    ++ optional withNflog "--enable-nflog"
+    ++ optional withSQLite "--enable-sqlite3"
+    ++ optional withPgSQL "--enable-pgsql"
+    ++ optional withMysql "--enable-mysql";
+
+  meta = with stdenv.lib; {
+    description = "pmacct is a small set of multi-purpose passive network monitoring tools";
+    longDescription = ''
+      pmacct is a small set of multi-purpose passive network monitoring tools
+      [NetFlow IPFIX sFlow libpcap BGP BMP RPKI IGP Streaming Telemetry]
+    '';
+    homepage = "http://www.pmacct.net/";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ "0x4A6F" ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5743,6 +5743,8 @@ in
 
   pastebinit = callPackage ../tools/misc/pastebinit { };
 
+  pmacct = callPackage ../tools/networking/pmacct { };
+
   polygraph = callPackage ../tools/networking/polygraph { };
 
   progress = callPackage ../tools/misc/progress { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Adding package for [pmacct](http://www.pmacct.net/).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
