### PR TITLE
doc: put Java software's build-time dependencies into nativeBuildInputs instead of into buildInputs

### DIFF
--- a/doc/languages-frameworks/java.xml
+++ b/doc/languages-frameworks/java.xml
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
   name = "...";
   src = fetchurl { ... };
 
-  buildInputs = [ jdk ant ];
+  nativeBuildInputs = [ jdk ant ];
 
   buildPhase = "ant";
 }
@@ -30,7 +30,8 @@ stdenv.mkDerivation {
   <filename>foo.jar</filename> in its <filename>share/java</filename>
   directory, and another package declares the attribute
 <programlisting>
-buildInputs = [ jdk libfoo ];
+buildInputs = [ libfoo ];
+nativeBuildInputs = [ jdk ];
 </programlisting>
   then <envar>CLASSPATH</envar> will be set to
   <filename>/nix/store/...-libfoo/share/java/foo.jar</filename>.
@@ -46,7 +47,7 @@ buildInputs = [ jdk libfoo ];
   script to run it using the OpenJRE. You can use
   <literal>makeWrapper</literal> for this:
 <programlisting>
-buildInputs = [ makeWrapper ];
+nativeBuildInputs = [ makeWrapper ];
 
 installPhase =
   ''
@@ -76,7 +77,7 @@ installPhase =
   It is possible to use a different Java compiler than <command>javac</command>
   from the OpenJDK. For instance, to use the GNU Java Compiler:
 <programlisting>
-buildInputs = [ gcj ant ];
+nativeBuildInputs = [ gcj ant ];
 </programlisting>
   Here, Ant will automatically use <command>gij</command> (the GNU Java
   Runtime) instead of the OpenJRE.


### PR DESCRIPTION
Put Java software's build-time dependencies into `nativeBuildInputs` instead of into `buildInputs` in the examples of the NixPkgs manual.

###### Motivation for this change

`jdk`, `ant`, `gcj` and `makeWrapper` aren't needed at run-time by most Java software, even when they're being used for building the software.

See conversation at https://github.com/NixOS/nixpkgs/pull/56893#discussion_r303222522

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
