### PR TITLE
pythonPackages.knack: 0.6.2 -> 0.6.3

### DIFF
--- a/pkgs/development/python-modules/knack/default.nix
+++ b/pkgs/development/python-modules/knack/default.nix
@@ -17,11 +17,11 @@
 
 buildPythonPackage rec {
   pname = "knack";
-  version = "0.6.2";
+  version = "0.6.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1kxxj9m2mvva9rz11m6pgdg0mi712d28faj4633rl23qa53sh7i8";
+    sha256 = "08g15kwfppdr7vhbsg6qclpqbf11d9k3hwgrmvhh5fa1jrk95b5i";
   };
 
   propagatedBuildInputs = [
@@ -40,9 +40,8 @@ buildPythonPackage rec {
     pytest
   ];
 
-  # tries to make a '/homeless-shelter' dir
   checkPhase = ''
-    pytest -k 'not test_cli_exapp1'
+    HOME=$TMPDIR pytest .
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
Finally figured out why /home-shelter was coming up in tests after more time rummaging around the builders. Decided to fix the tests after i saw #64882

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

```
nix-review wip
...
[5 built, 0.0 MiB DL]
4 package were build:
python27Packages.azure-cli-core python27Packages.knack python37Packages.azure-cli-core python37Packages.knack
```


```
nix path-info -Sh ./result
/nix/store/z9jczg3mn1j8c8sqvn0mqsm232qg2633-python3.7-knack-0.6.2	 129.4M
nix path-info -Sh ./results/python37Packages.knack
/nix/store/93p7bxdh25zm8jddqi36l27l313i4i21-python3.7-knack-0.6.3	 129.5M
```