### PR TITLE
wmc-mpris: init at 2019-04-12

### DIFF
--- a/pkgs/applications/misc/web-media-controller/default.nix
+++ b/pkgs/applications/misc/web-media-controller/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, glib, pcre, json-glib }:
+
+stdenv.mkDerivation rec {
+  pname = "wmc-mpris";
+  version = "unstable-2019-07-24";
+
+  src = fetchFromGitHub {
+    owner = "f1u77y";
+    repo = pname;
+    rev = "3b92847c576662732984ad791d6c7899a39f7787";
+    sha256 = "0q19z0zx53pd237x529rif21kliklwzjrdddx8jfr9hgghjv9giq";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = [ glib pcre json-glib ];
+  cmakeFlags = [
+    "-DCHROMIUM_MANIFEST_DESTINATION=${placeholder ''out''}/etc/chromium/native-messaging-hosts"
+    "-DCHROME_MANIFEST_DESTINATION=${placeholder ''out''}/etc/opt/chrome/native-messaging-hosts"
+    "-DFIREFOX_MANIFEST_DESTINATION=${placeholder ''out''}/lib/mozilla/native-messaging-hosts"
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/f1u77y/wmc-mpris";
+    description = "MPRIS proxy for usage with 'Web Media Controller' web extension";
+    license = licenses.unlicense;
+    maintainers = with maintainers; [ doronbehar ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6832,6 +6832,8 @@ in
 
   wml = callPackage ../development/web/wml { };
 
+  wmc-mpris = callPackage ../applications/misc/web-media-controller { };
+
   wol = callPackage ../tools/networking/wol { };
 
   wolf-shaper = callPackage ../applications/audio/wolf-shaper { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

See web extension: https://addons.mozilla.org/en-US/firefox/addon/web-media-controller/ .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
