### PR TITLE
haskellPackages.glpk-hs: fix for ghc-8.6

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1369,4 +1369,9 @@ self: super: {
     })];
   });
 
+  # https://github.com/jyp/glpk-hs/pull/11
+  # patch is the above PR with conflicts resolved
+  glpk-hs = assert super.glpk-hs.version == "0.7"; 
+    appendPatch super.glpk-hs ./patches/glpk-hs-ghc86.patch;
+
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -5098,7 +5098,6 @@ broken-packages:
   - gloss-export
   - gloss-game
   - gloss-sodium
-  - glpk-hs
   - glue
   - gmap
   - gmndl

--- a/pkgs/development/haskell-modules/patches/glpk-hs-ghc86.patch
+++ b/pkgs/development/haskell-modules/patches/glpk-hs-ghc86.patch
@@ -1,0 +1,83 @@
+--- a/glpk-hs.cabal
++++ b/glpk-hs.cabal
+@@ -28,7 +28,7 @@
+   main-is:          examples/example1.hs
+   build-depends:    base >= 4 && < 5, array, containers, mtl, deepseq, gasp, glpk-hs
+-  ghc-options:      -O2 -Wall
++  ghc-options:      -O2 -Wall -threaded
+   default-language: Haskell2010
+ 
+ library
+   Build-Depends:    base >= 4 && < 5, array, containers, mtl, deepseq, gasp
+--- a/src/Data/LinearProgram/Common.hs
++++ b/src/Data/LinearProgram/Common.hs
+@@ -5,15 +5,15 @@
+ 	module Algebra.Classes,
+ 	module Data.LinearProgram.Types) where
+ 
+-import Data.LinearProgram.Spec
+-import Algebra.Classes
+-import Data.LinearProgram.Types
++import           Algebra.Classes
++import           Data.LinearProgram.Spec
++import           Data.LinearProgram.Types
+ 
+-import Data.Map
+-import GHC.Exts (build)
++import           Data.Map
++import           GHC.Exts                 (build)
+ 
+ {-# RULES
+-	"assocs" assocs = \ m -> build (\ c n -> foldWithKey (curry c) n m);
+-	"elems" elems = \ m -> build (\ c n -> foldWithKey (const c) n m);
+-	"keys" keys = \ m -> build (\ c n -> foldWithKey (\ k _ -> c k) n m);
++	"assocs" assocs = \ m -> build (\ c n -> foldrWithKey (curry c) n m);
++	"elems" elems = \ m -> build (\ c n -> foldrWithKey (const c) n m);
++	"keys" keys = \ m -> build (\ c n -> foldrWithKey (\ k _ -> c k) n m);
+ 	#-}
+--- a/src/Data/LinearProgram/GLPK/Types.hs
++++ b/src/Data/LinearProgram/GLPK/Types.hs
+@@ -1,22 +1,24 @@
+-{-# LANGUAGE EmptyDataDecls, ForeignFunctionInterface #-}
++{-# LANGUAGE EmptyDataDecls           #-}
++{-# LANGUAGE ForeignFunctionInterface #-}
+ 
+ module Data.LinearProgram.GLPK.Types where
+ 
+-import Control.Concurrent (runInBoundThread)
+-import Control.Exception (bracket)
+-import Control.Monad.Trans (MonadIO (..))
+-import Control.Monad (ap)
++import           Control.Concurrent  (runInBoundThread)
++import           Control.Exception   (bracket)
++import           Control.Monad       (ap)
++import           Control.Monad.Fail
++import           Control.Monad.Trans (MonadIO (..))
+ 
+-import Foreign.Ptr
+-import Foreign.ForeignPtr
++import           Foreign.ForeignPtr
++import           Foreign.Ptr
+ 
+ foreign import ccall unsafe "c_glp_create_prob" glpCreateProb :: IO (Ptr GlpProb)
+ foreign import ccall unsafe "c_glp_delete_prob" glpDelProb :: Ptr GlpProb -> IO ()
+ 
+ data GlpProb
+ 
+-data ReturnCode = Success | InvalidBasis | SingularMatrix | IllConditionedMatrix | 
+-        InvalidBounds | SolverFailed | ObjLowerLimReached | ObjUpperLimReached | 
++data ReturnCode = Success | InvalidBasis | SingularMatrix | IllConditionedMatrix |
++        InvalidBounds | SolverFailed | ObjLowerLimReached | ObjUpperLimReached |
+         IterLimReached | TimeLimReached | NoPrimalFeasible | NoDualFeasible | RootLPOptMissing |
+         SearchTerminated | MipGapTolReached | NoPrimDualFeasSolution | NoConvergence |
+         NumericalInstability | InvalidData | ResultOutOfRange deriving (Eq, Show, Enum)
+@@ -29,6 +31,9 @@
+ runGLPK :: GLPK a -> IO a
+ runGLPK m = runInBoundThread $ bracket glpCreateProb glpDelProb (execGLPK m)
+ 
++instance MonadFail GLPK where
++  fail = error
++
+ instance Monad GLPK where
+         {-# INLINE return #-}
+         {-# INLINE (>>=) #-}


### PR DESCRIPTION
###### Motivation for this change
From what I was able to understand, the hackage version of __glpk-hs__ does not work with the new __gasp__. Moreover, due to deprecated calls __glpk-hs__ doesn't compile with __ghc-8.6__, which is fixed by the patch.

The last [upstream](https://github.com/jyp/glpk-hs) change was 8 months ago.

###### Things done

Compiles fine with __ghc-8.4.4__, __ghc-8.6.5__, __ghc-8.8.1__.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
