### PR TITLE
docs: update docs for postgresql plugins

### DIFF
--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -181,7 +181,7 @@ in
         default = [];
         example = literalExample "with pkgs.postgresql_11.pkgs; [ postgis pg_repack ]";
         description = ''
-          List of Postgresql plugins. Postgresql version for each plugin should
+          List of PostgreSQL plugins. PostgreSQL version for each plugin should
           match version for <literal>services.postgresql.package</literal> value.
         '';
       };

--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -6,26 +6,10 @@ let
 
   cfg = config.services.postgresql;
 
-  # see description of extraPlugins
-  postgresqlAndPlugins = pg:
-    if cfg.extraPlugins == [] then pg
-    else pkgs.buildEnv {
-      name = "postgresql-and-plugins-${(builtins.parseDrvName pg.name).version}";
-      paths = [ pg pg.lib ] ++ cfg.extraPlugins;
-      # We include /bin to ensure the $out/bin directory is created which is
-      # needed because we'll be removing files from that directory in postBuild
-      # below. See #22653
-      pathsToLink = [ "/" "/bin" ];
-      buildInputs = [ pkgs.makeWrapper ];
-      postBuild =
-        ''
-          rm $out/bin/{pg_config,postgres,pg_ctl}
-          cp --target-directory=$out/bin ${pg}/bin/{postgres,pg_config,pg_ctl}
-          wrapProgram $out/bin/postgres --set NIX_PGLIBDIR $out/lib
-        '';
-    };
-
-  postgresql = postgresqlAndPlugins cfg.package;
+  postgresql =
+    if cfg.extraPlugins == []
+      then cfg.package
+      else cfg.package.withPackages (_: cfg.extraPlugins);
 
   # The main PostgreSQL configuration file.
   configFile = pkgs.writeText "postgresql.conf"
@@ -58,7 +42,7 @@ in
 
       package = mkOption {
         type = types.package;
-        example = literalExample "pkgs.postgresql_9_6";
+        example = literalExample "pkgs.postgresql_11";
         description = ''
           PostgreSQL package to use.
         '';
@@ -74,7 +58,7 @@ in
 
       dataDir = mkOption {
         type = types.path;
-        example = "/var/lib/postgresql/9.6";
+        example = "/var/lib/postgresql/11";
         description = ''
           Data directory for PostgreSQL.
         '';
@@ -195,17 +179,11 @@ in
       extraPlugins = mkOption {
         type = types.listOf types.path;
         default = [];
-        example = literalExample "[ (pkgs.postgis.override { postgresql = pkgs.postgresql_9_4; }) ]";
+        example = literalExample "with pkgs.postgresql_11.pkgs; [ postgis pg_repack ]";
         description = ''
-          When this list contains elements a new store path is created.
-          PostgreSQL and the elements are symlinked into it. Then pg_config,
-          postgres and pg_ctl are copied to make them use the new
-          $out/lib directory as pkglibdir. This makes it possible to use postgis
-          without patching the .sql files which reference $libdir/postgis-1.5.
+          List of Postgresql plugins. Postgresql version for each plugin should
+          match version for <literal>services.postgresql.package</literal> value.
         '';
-        # Note: the duplication of executables is about 4MB size.
-        # So a nicer solution was patching postgresql to allow setting the
-        # libdir explicitely.
       };
 
       extraConfig = mkOption {

--- a/nixos/modules/services/databases/postgresql.xml
+++ b/nixos/modules/services/databases/postgresql.xml
@@ -122,7 +122,7 @@ self: super: {
 </programlisting>
   </para>
   <para>
-    Here's a receipt on how to override a particular plugin through overlay:
+    Here's a recipe on how to override a particular plugin through an overlay:
 <programlisting>
 self: super: {
   postgresql_11 = super.postgresql_11.override { this = self.postgresql_11; } // {

--- a/nixos/modules/services/databases/postgresql.xml
+++ b/nixos/modules/services/databases/postgresql.xml
@@ -78,7 +78,7 @@ Type "help" for help.
   <title>Plugins</title>
 
   <para>
-   Plugins collection for each Postgresql version can be accessed with
+   Plugins collection for each PostgreSQL version can be accessed with
    <literal>.pkgs</literal>. For example, for
    <literal>pkgs.postgresql_11</literal> package it's plugin collection is
    accessed by <literal>pkgs.postgresql_11.pkgs</literal>:

--- a/nixos/modules/services/databases/postgresql.xml
+++ b/nixos/modules/services/databases/postgresql.xml
@@ -80,7 +80,7 @@ Type "help" for help.
   <para>
    Plugins collection for each PostgreSQL version can be accessed with
    <literal>.pkgs</literal>. For example, for
-   <literal>pkgs.postgresql_11</literal> package it's plugin collection is
+   <literal>pkgs.postgresql_11</literal> package, its plugin collection is
    accessed by <literal>pkgs.postgresql_11.pkgs</literal>:
 <screen>
 <prompt>$ </prompt>nix repl '&lt;nixpkgs&gt;'

--- a/nixos/modules/services/databases/postgresql.xml
+++ b/nixos/modules/services/databases/postgresql.xml
@@ -111,7 +111,7 @@ postgresql_11.pkgs.pg_partman        postgresql_11.pkgs.pgroonga
   <para>
    You can build custom Postgresql-with-plugins (to be used outside of NixOS) using
    function <literal>.withPackages</literal>. For example, creating a custom
-   Postgresql package in an overlay can look like:
+   PostgreSQL package in an overlay can look like:
 <programlisting>
 self: super: {
   postgresql_custom = self.postgresql_11.withPackages (ps: [

--- a/nixos/modules/services/databases/postgresql.xml
+++ b/nixos/modules/services/databases/postgresql.xml
@@ -27,10 +27,10 @@
    <filename>configuration.nix</filename>:
 <programlisting>
 <xref linkend="opt-services.postgresql.enable"/> = true;
-<xref linkend="opt-services.postgresql.package"/> = pkgs.postgresql_9_4;
+<xref linkend="opt-services.postgresql.package"/> = pkgs.postgresql_11;
 </programlisting>
    Note that you are required to specify the desired version of PostgreSQL
-   (e.g. <literal>pkgs.postgresql_9_4</literal>). Since upgrading your
+   (e.g. <literal>pkgs.postgresql_11</literal>). Since upgrading your
    PostgreSQL version requires a database dump and reload (see below), NixOS
    cannot provide a default value for
    <xref linkend="opt-services.postgresql.package"/> such as the most recent
@@ -72,6 +72,72 @@ Type "help" for help.
   <para>
    A complete list of options for the PostgreSQL module may be found
    <link linkend="opt-services.postgresql.enable">here</link>.
+  </para>
+ </section>
+ <section xml:id="module-services-postgres-plugins">
+  <title>Plugins</title>
+
+  <para>
+   Plugins collection for each Postgresql version can be accessed with
+   <literal>.pkgs</literal>. For example, for
+   <literal>pkgs.postgresql_11</literal> package it's plugin collection is
+   accessed by <literal>pkgs.postgresql_11.pkgs</literal>:
+<screen>
+<prompt>$ </prompt>nix repl '&lt;nixpkgs&gt;'
+
+Loading '&lt;nixpkgs&gt;'...
+Added 10574 variables.
+
+<prompt>nix-repl&gt; </prompt>postgresql_11.pkgs.&lt;TAB&gt;&lt;TAB&gt;
+postgresql_11.pkgs.cstore_fdw        postgresql_11.pkgs.pg_repack
+postgresql_11.pkgs.pg_auto_failover  postgresql_11.pkgs.pg_safeupdate
+postgresql_11.pkgs.pg_bigm           postgresql_11.pkgs.pg_similarity
+postgresql_11.pkgs.pg_cron           postgresql_11.pkgs.pg_topn
+postgresql_11.pkgs.pg_hll            postgresql_11.pkgs.pgjwt
+postgresql_11.pkgs.pg_partman        postgresql_11.pkgs.pgroonga
+...
+</screen>
+  </para>
+  <para>
+    To add plugins via NixOS configuration, set <literal>services.postgresql.extraPlugins</literal>:
+<programlisting>
+<xref linkend="opt-services.postgresql.package"/> = pkgs.postgresql_11;
+<xref linkend="opt-services.postgresql.extraPlugins"/> = with pkgs.postgresql_11.pkgs; [
+  pg_repack
+  postgis
+];
+</programlisting>
+  </para>
+  <para>
+   You can build custom Postgresql-with-plugins (to be used outside of NixOS) using
+   function <literal>.withPackages</literal>. For example, creating a custom
+   Postgresql package in an overlay can look like:
+<programlisting>
+self: super: {
+  postgresql_custom = self.postgresql_11.withPackages (ps: [
+    ps.pg_repack
+    ps.postgis
+  ]);
+}
+</programlisting>
+  </para>
+  <para>
+    Here's a receipt on how to override a particular plugin through overlay:
+<programlisting>
+self: super: {
+  postgresql_11 = super.postgresql_11.override { this = self.postgresql_11; } // {
+    pkgs = super.postgresql_11.pkgs // {
+      pg_repack = super.postgresql_11.pkgs.pg_repack.overrideAttrs (_: {
+        name = "pg_repack-v20181024";
+        src = self.fetchzip {
+          url = "https://github.com/reorg/pg_repack/archive/923fa2f3c709a506e111cc963034bf2fd127aa00.tar.gz";
+          sha256 = "17k6hq9xaax87yz79j773qyigm4fwk8z4zh5cyp6z0sxnwfqxxw5";
+        };
+      });
+    };
+  };
+}
+</programlisting>
   </para>
  </section>
 </chapter>

--- a/nixos/modules/services/databases/postgresql.xml
+++ b/nixos/modules/services/databases/postgresql.xml
@@ -109,7 +109,7 @@ postgresql_11.pkgs.pg_partman        postgresql_11.pkgs.pgroonga
 </programlisting>
   </para>
   <para>
-   You can build custom Postgresql-with-plugins (to be used outside of NixOS) using
+   You can build custom PostgreSQL-with-plugins (to be used outside of NixOS) using
    function <literal>.withPackages</literal>. For example, creating a custom
    PostgreSQL package in an overlay can look like:
 <programlisting>

--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -151,6 +151,9 @@ let
     # below. See #22653
     pathsToLink = ["/" "/bin"];
 
+    # Note: the duplication of executables is about 4MB size.
+    # So a nicer solution was patching postgresql to allow setting the
+    # libdir explicitely.
     postBuild = ''
       mkdir -p $out/bin
       rm $out/bin/{pg_config,postgres,pg_ctl}


### PR DESCRIPTION
Rendered
![Screenshot from 2019-07-16 14-56-19](https://user-images.githubusercontent.com/743057/61292478-f617af80-a7d9-11e9-896e-9cc6ff369513.png)

Related: https://github.com/NixOS/nixpkgs/pull/58251 (alternative fix for that issue), https://github.com/NixOS/nixpkgs/pull/38698 (documentation part), https://github.com/NixOS/nixpkgs/issues/38616 (finally missing docs are added), https://github.com/NixOS/nixpkgs/issues/21042 (fixes issue), https://github.com/NixOS/nixpkgs/pull/54319 (the PR which introduced the need for this doc)