### PR TITLE
cypress: init at 3.4.0

### DIFF
--- a/pkgs/development/web/cypress/default.nix
+++ b/pkgs/development/web/cypress/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchzip, autoPatchelfHook, xorg, gtk2, gnome2, gtk3, nss, alsaLib, udev, unzip }:
+
+stdenv.mkDerivation rec{
+  pname = "cypress";
+  version = "3.4.0";
+
+  src = fetchzip {
+    url = "https://cdn.cypress.io/desktop/${version}/linux-x64/cypress.zip";
+    sha256 = "1j59az9j37a61ryvh975bc7bj43qi3dq0871fyambh1j2mby00qn";
+  };
+
+  # don't remove runtime deps
+  dontPatchELF = true;
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  buildInputs = with xorg; [
+    libXScrnSaver libXdamage libXtst
+  ] ++ [
+    nss gtk2 alsaLib gnome2.GConf gtk3 unzip
+  ];
+
+  runtimeDependencies = [ udev.lib ];
+
+  installPhase = ''
+    mkdir -p $out/bin $out/opt/cypress
+    cp -vr * $out/opt/cypress/
+    # Let's create the file binary_state ourselves to make the npm package happy on initial verification.
+    echo '{"verified": true}' > $out/opt/cypress/binary_state.json
+    ln -s $out/opt/cypress/Cypress $out/bin/Cypress
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Fast, easy and reliable testing for anything that runs in a browser";
+    homepage = "https://www.cypress.io";
+    license = licenses.mit;
+    platforms = ["x86_64-linux"];
+    maintainers = with maintainers; [ tweber mmahut ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10237,6 +10237,8 @@ in
 
   cxxtest = callPackage ../development/libraries/cxxtest { };
 
+  cypress = callPackage ../development/web/cypress { };
+
   cyrus_sasl = callPackage ../development/libraries/cyrus-sasl {
     kerberos = if stdenv.isFreeBSD then libheimdal else kerberos;
   };


### PR DESCRIPTION
###### Motivation for this change

cypress: init at 3.4.0

This is based on previous pull request #58423. It works fine with Electrum but not with Chromium (this is reported to upstream at https://github.com/cypress-io/cypress/issues/3852) and I do not consider it a blocker to merge this package given Electrum is the main browser used in most CI.

@acyuta108 please open a pull request if you want to be added as a maintainer to this package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
