### PR TITLE
libosinfo: CVE-2019-13313

### DIFF
--- a/pkgs/development/libraries/libosinfo/default.nix
+++ b/pkgs/development/libraries/libosinfo/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, gobject-introspection, gtk-doc, docbook_xsl
+{ stdenv, fetchurl, fetchpatch, pkgconfig, intltool, gobject-introspection, gtk-doc, docbook_xsl
 , glib, libsoup, libxml2, libxslt, check, curl, perl, hwdata, osinfo-db, vala ? null
 }:
 
@@ -21,6 +21,17 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./osinfo-db-data-dir.patch
+    # https://nvd.nist.gov/vuln/detail/CVE-2019-13313
+    (fetchpatch {
+      url = "https://gitlab.com/libosinfo/libosinfo/commit/3654abee6ead9f11f8bb9ba8fc71efd6fa4dabbc.patch";
+      name = "CVE-2019-13313-1.patch";
+      sha256 = "1lybywfj6b41zfjk33ap90bab5l84lf5y3kif7vd2b6wq5r91rcn";
+    })
+    (fetchpatch {
+      url = "https://gitlab.com/libosinfo/libosinfo/commit/08fb8316b4ac42fe74c1fa5ca0ac593222cdf81a.patch";
+      name = "CVE-2019-13313-2.patch";
+      sha256 = "1f6rhkrgy3j8nmidk97wnz6p35zs1dsd63d3np76q7qs7ra74w9z";
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change

Fixes #64660.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
