### PR TITLE
libxslt: CVE-2019-13118 CVE-2019-13117

### DIFF
--- a/pkgs/development/libraries/libxslt/default.nix
+++ b/pkgs/development/libraries/libxslt/default.nix
@@ -24,6 +24,11 @@ stdenv.mkDerivation rec {
       url = "https://gitlab.gnome.org/GNOME/libxslt/commit/e03553605b45c88f0b4b2980adfbbb8f6fca2fd6.patch";
       sha256 = "0pkpb4837km15zgg6h57bncp66d5lwrlvkr73h0lanywq7zrwhj8";
     })
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/libxslt/commit/c5eb6cf3aba0af048596106ed839b4ae17ecbcb1.patch";
+      name = "CVE-2019-13117.patch";
+      sha256 = "0ynfq8y5h623cypj1426iiz7796n3mqbjqa24ndvh2am6rl5lw15";
+    })
   ];
 
   outputs = [ "bin" "dev" "out" "man" "doc" ] ++ stdenv.lib.optional pythonSupport "py";

--- a/pkgs/development/libraries/libxslt/default.nix
+++ b/pkgs/development/libraries/libxslt/default.nix
@@ -29,6 +29,11 @@ stdenv.mkDerivation rec {
       name = "CVE-2019-13117.patch";
       sha256 = "0ynfq8y5h623cypj1426iiz7796n3mqbjqa24ndvh2am6rl5lw15";
     })
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/libxslt/commit/6ce8de69330783977dd14f6569419489875fb71b.patch";
+      name = "CVE-2019-13118.patch";
+      sha256 = "0bglz9m9sh2vi50qxcm06iqrazw3h45ycgxnp15iankq95z283iq";
+    })
   ];
 
   outputs = [ "bin" "dev" "out" "man" "doc" ] ++ stdenv.lib.optional pythonSupport "py";


### PR DESCRIPTION
###### Motivation for this change

Fixes #64661.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
