### PR TITLE
pythonPackages.capstone: 3.0.4 -> 3.0.5

### DIFF
--- a/pkgs/development/python-modules/capstone/default.nix
+++ b/pkgs/development/python-modules/capstone/default.nix
@@ -6,11 +6,15 @@
 
 buildPythonPackage rec {
   pname = "capstone";
-  version = "3.0.4";
+  version = "3.0.5.post1";
+
+  setupPyBuildFlags = [
+    "--plat-name x86_64-linux"
+  ];
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "945d3b8c3646a1c3914824c416439e2cf2df8969dd722c8979cdcc23b40ad225";
+    sha256 = "3c0f73db9f8392f7048c8a244809f154d7c39f354e2167f6c477630aa517ed04";
   };
 
   patches = [


### PR DESCRIPTION
  * Added `setupPyBuildFlags` to avoid the error
  `ERROR: capstone-3.0.5.post1-py3-none-manylinux1_x86_64.whl is not a
  supported wheel on this platform.`

---

###### Motivation for this change

There is an updated version of Capstone available: https://github.com/aquynh/capstone/releases/tag/3.0.5 .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS.
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
**There does not seem to be any for this package**
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
**I think... not sure how to interpret the output (see bottom of this comment)**
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
**Ha, I do not have a `./result/bin`... :/**
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
**This command returns the following: `error: Please be informed that this pseudo-package is not the only part of
Nixpkgs that fails to evaluate. [...]`**
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

<details>
<summary>the log of `nix-shell -p nix-review --run "nix-review wip"`</summary>

```
nix-shell -p nix-review --run "nix-review wip"                            
these paths will be fetched (0.03 MiB download, 0.10 MiB unpacked):
  /nix/store/syhnxfx4i3rl2bfxj3hlmhsrkd8vv36a-nix-review-2.0.1                                                                             
copying path '/nix/store/syhnxfx4i3rl2bfxj3hlmhsrkd8vv36a-nix-review-2.0.1' from 'https://cache.nixos.org'...                              
$ git fetch --force https://github.com/NixOS/nixpkgs master:refs/nix-review/0                                                              
remote: Enumerating objects: 1350, done. 
remote: Counting objects: 100% (1350/1350), done.
remote: Compressing objects: 100% (27/27), done.
remote: Total 2267 (delta 1326), reused 1334 (delta 1320), pack-reused 917                                                                 
Receiving objects: 100% (2267/2267), 998.49 KiB | 19.97 MiB/s, done.
Resolving deltas: 100% (1642/1642), completed with 566 local objects.
From https://github.com/NixOS/nixpkgs     
 * [new branch]              master     -> refs/nix-review/0
$ git worktree add /home/pamplemousse/.cache/nix-review/rev-ac58f318bc3ec864fe060dc1462f55526e69c262-dirty/nixpkgs 5bf68e1354d2a6ad3663c8296
75ddf90b6996e24                                                                                                                            
Preparing worktree (detached HEAD 5bf68e1354d)                                                                                             
Checking out files: 100% (19281/19281), done.                                                                                              
HEAD is now at 5bf68e1354d Merge #64742: firefox 67 -> 68, and related updates                                                             
$ nix-env -f /home/pamplemousse/.cache/nix-review/rev-ac58f318bc3ec864fe060dc1462f55526e69c262-dirty/nixpkgs -qaP --xml --out-path --show-tr
ace                                           
No diff detected, stopping review...   
$ git worktree prune 
```
</details>