### PR TITLE
wire-desktop: refactor to add Darwin support

### DIFF
--- a/pkgs/applications/networking/instant-messengers/wire-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/wire-desktop/default.nix
@@ -1,97 +1,29 @@
-{ stdenv, fetchurl, dpkg, makeDesktopItem, libuuid, gtk3, atk, cairo, pango
-, gdk_pixbuf, glib, freetype, fontconfig, dbus, libnotify, libX11, xorg, libXi
-, libXcursor, libXdamage, libXrandr, libXcomposite, libXext, libXfixes
-, libXrender, libXtst, libXScrnSaver, nss, nspr, alsaLib, cups, expat, udev
-, xdg_utils, hunspell, pulseaudio, pciutils, at-spi2-atk
+{ stdenv, fetchurl, makeDesktopItem
+
+, alsaLib, at-spi2-atk, atk, cairo, cups, dbus, dpkg, expat, fontconfig
+, freetype, gdk_pixbuf, glib, gtk3, hunspell, libX11, libXScrnSaver
+, libXcomposite, libXcursor, libXdamage, libXext, libXfixes, libXi, libXrandr
+, libXrender, libXtst, libnotify, libuuid, nspr, nss, pango, pciutils
+, pulseaudio, udev, xdg_utils, xorg
+
+, cpio, xar
 }:
 
 let
 
-  rpath = stdenv.lib.makeLibraryPath [
-    alsaLib
-    atk
-    cairo
-    cups
-    dbus
-    expat
-    fontconfig
-    freetype
-    gdk_pixbuf
-    glib
-    gtk3
-    at-spi2-atk
-    hunspell
-    libuuid
-    libnotify
-    libX11
-    libXcomposite
-    libXcursor
-    libXdamage
-    libXext
-    libXfixes
-    libXi
-    libXrandr
-    libXrender
-    libXScrnSaver
-    libXtst
-    nspr
-    nss
-    pango
-    pciutils
-    pulseaudio
-    stdenv.cc.cc
-    udev
-    xdg_utils
-    xorg.libxcb
-  ];
+  inherit (stdenv.hostPlatform) system;
 
-in
-
-stdenv.mkDerivation rec {
   pname = "wire-desktop";
-  version = "3.9.2895";
 
-  src = fetchurl {
-    url = "https://wire-app.wire.com/linux/debian/pool/main/Wire-${version}_amd64.deb";
-    sha256 = "0wrn95m64j4b7ym44h9zawq13kg4m12aixlyyzp56bfyczmjq4a5";
-  };
+  version = {
+    "x86_64-linux" = "3.9.2895";
+    "x86_64-darwin" = "3.9.2943";
+  }.${system};
 
-  desktopItem = makeDesktopItem {
-    name = "wire-desktop";
-    exec = "wire-desktop %U";
-    icon = "wire-desktop";
-    comment = "Secure messenger for everyone";
-    desktopName = "Wire Desktop";
-    genericName = "Secure messenger";
-    categories = "Network;InstantMessaging;Chat;VideoConference";
-  };
-
-  dontBuild = true;
-  dontPatchELF = true;
-  dontConfigure = true;
-
-  nativeBuildInputs = [ dpkg ];
-  unpackPhase = "dpkg-deb -x $src .";
-  installPhase = ''
-    mkdir -p "$out"
-    cp -R "opt" "$out"
-    cp -R "usr/share" "$out/share"
-
-    chmod -R g-w "$out"
-
-    # Patch wire-desktop
-    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-      --set-rpath "${rpath}:$out/opt/Wire" \
-      "$out/opt/Wire/wire-desktop"
-
-    # Symlink to bin
-    mkdir -p "$out/bin"
-    ln -s "$out/opt/Wire/wire-desktop" "$out/bin/wire-desktop"
-
-    # Desktop file
-    mkdir -p "$out/share/applications"
-    cp "${desktopItem}/share/applications/"* "$out/share/applications"
-  '';
+  sha256 = {
+    "x86_64-linux" = "0wrn95m64j4b7ym44h9zawq13kg4m12aixlyyzp56bfyczmjq4a5";
+    "x86_64-darwin" = "1y1bzsjmjrj518q29xfx6gg1nhdbaz7y5hzaqrp241az6plp090k";
+  }.${system};
 
   meta = with stdenv.lib; {
     description = "A modern, secure messenger for everyone";
@@ -107,9 +39,94 @@ stdenv.mkDerivation rec {
         * Synced across your phone, desktop and tablet
     '';
     homepage = https://wire.com/;
-    platforms = [ "x86_64-linux" ];
     downloadPage = https://wire.com/download/;
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ toonn worldofpeace ];
+    platforms = [ "x86_64-darwin" "x86_64-linux" ];
   };
-}
+
+  linux = stdenv.mkDerivation rec {
+    inherit pname version meta;
+
+    src = fetchurl {
+      url = "https://wire-app.wire.com/linux/debian/pool/main/"
+        + "Wire-${version}_amd64.deb";
+      inherit sha256;
+    };
+
+    desktopItem = makeDesktopItem {
+      name = "wire-desktop";
+      exec = "wire-desktop %U";
+      icon = "wire-desktop";
+      comment = "Secure messenger for everyone";
+      desktopName = "Wire Desktop";
+      genericName = "Secure messenger";
+      categories = "Network;InstantMessaging;Chat;VideoConference";
+    };
+
+    dontBuild = true;
+    dontPatchELF = true;
+    dontConfigure = true;
+
+    nativeBuildInputs = [ dpkg ];
+    rpath = stdenv.lib.makeLibraryPath [
+      alsaLib at-spi2-atk atk cairo cups dbus expat fontconfig freetype
+      gdk_pixbuf glib gtk3 hunspell libX11 libXScrnSaver libXcomposite
+      libXcursor libXdamage libXext libXfixes libXi libXrandr libXrender
+      libXtst libnotify libuuid nspr nss pango pciutils pulseaudio
+      stdenv.cc.cc udev xdg_utils xorg.libxcb
+    ];
+
+    unpackPhase = "dpkg-deb -x $src .";
+
+    installPhase = ''
+      mkdir -p "$out"
+      cp -R "opt" "$out"
+      cp -R "usr/share" "$out/share"
+      chmod -R g-w "$out"
+
+      # Patch wire-desktop
+      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+        --set-rpath "${rpath}:$out/opt/Wire" \
+        "$out/opt/Wire/wire-desktop"
+
+      # Symlink to bin
+      mkdir -p "$out/bin"
+      ln -s "$out/opt/Wire/wire-desktop" "$out/bin/wire-desktop"
+
+      # Desktop file
+      mkdir -p "$out/share/applications"
+      cp "${desktopItem}/share/applications/"* "$out/share/applications"
+    '';
+  };
+
+  darwin = stdenv.mkDerivation rec {
+    inherit pname version meta;
+
+    src = fetchurl {
+      url = "https://github.com/wireapp/wire-desktop/releases/download/"
+        + "macos%2F${version}/Wire.pkg";
+      inherit sha256;
+    };
+
+    buildInputs = [ cpio xar ];
+
+    unpackPhase = ''
+      xar -xf $src
+      cd com.wearezeta.zclient.mac.pkg
+    '';
+
+
+    buildPhase = ''
+      cat Payload | gunzip -dc | cpio -i
+    '';
+
+    installPhase = ''
+      mkdir -p $out/Applications
+      cp -r Wire.app $out/Applications
+    '';
+  };
+
+in if stdenv.isDarwin
+  then darwin
+  else linux

--- a/pkgs/applications/networking/instant-messengers/wire-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/wire-desktop/default.nix
@@ -94,10 +94,22 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "A modern, secure messenger";
+    description = "A modern, secure messenger for everyone";
+    longDescription = ''
+      Wire Personal is a secure, privacy-friendly messenger. It combines useful
+      and fun features, audited security, and a beautiful, distinct user
+      interface.  It does not require a phone number to register and chat.
+
+        * End-to-end encrypted chats, calls, and files
+        * Crystal clear voice and video calling
+        * File and screen sharing
+        * Timed messages and chats
+        * Synced across your phone, desktop and tablet
+    '';
     homepage = https://wire.com/;
-    license = licenses.gpl3;
-    maintainers = with maintainers; [ worldofpeace ];
     platforms = [ "x86_64-linux" ];
+    downloadPage = https://wire.com/download/;
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ toonn worldofpeace ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
The derivation didn't have Darwin support but the software does.
I refactored the package putting all the linux/darwin specific stuff in their own attrsets and then that's  merged into the common bits like `pname` and `meta`.

I updated the `meta` while I was at it. The license in the repo is actually GPLv3 *or later* but I'm not sure whether that's accurate because terms and conditions apply. 

You can find them in the [README for the project](https://github.com/wireapp/wire-desktop/blob/staging/README.md), reproduced here for convenience:

  > For licensing information, see the attached LICENSE file and the list of third-party licenses at wire.com/legal/licenses/.

  > If you compile the open source software that we make available from time to time to develop your own mobile, desktop or web application, and cause that application to connect to our servers for any purposes, we refer to that resulting application as an “Open Source App”. All Open Source Apps are subject to, and may only be used and/or commercialized in accordance with, the Terms of Use applicable to the Wire Application, which can be found at https://wire.com/legal/#terms. Additionally, if you choose to build an Open Source App, certain restrictions apply, as follows:

  > a. You agree not to change the way the Open Source App connects and interacts with our servers;
    b. You agree not to weaken any of the security features of the Open Source App;
    c. You agree not to use our servers to store data for purposes other than the intended and original functionality of the Open Source App;
    d. You acknowledge that you are solely responsible for any and all updates to your Open Source App.

  > For clarity, if you compile the open source software that we make available from time to time to develop your own mobile, desktop or web application, and do not cause that application to connect to our servers for any purposes, then that application will not be deemed an Open Source App and the foregoing will not apply to that application.

  > No license is granted to the Wire trademark and its associated logos, all of which will continue to be owned exclusively by Wire Swiss GmbH. Any use of the Wire trademark and/or its associated logos is expressly prohibited without the express prior written consent of Wire Swiss GmbH.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`) **Tested the executable inside the `.app`.**
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after) **Tried to but the original derivation wouldn't build on darwin. The result is about 150MB though.**
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
