### PR TITLE
pythonPackages.mkl-service: init at 2.1.0

### DIFF
--- a/pkgs/development/python-modules/mkl-service/default.nix
+++ b/pkgs/development/python-modules/mkl-service/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildPythonPackage, fetchFromGitHub, cython, mkl, nose, six }:
+
+buildPythonPackage rec {
+  pname = "mkl-service";
+  version = "2.1.0";
+
+  src = fetchFromGitHub {
+    owner = "IntelPython";
+    repo = "mkl-service";
+    rev = "v${version}";
+    sha256 = "1bnpgx629rxqf0yhn0jn68ypj3dqv6njc3981j1g8j8rsm5lycrn";
+  };
+
+  MKLROOT = mkl;
+
+  checkInputs = [ nose ];
+  nativeBuildInputs = [ cython ];
+  propagatedBuildInputs = [ mkl six ];
+
+  meta = with lib; {
+    description = "Python hooks for Intel(R) Math Kernel Library runtime control settings";
+    homepage = "https://github.com/IntelPython/mkl-service";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ bhipple ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -536,9 +536,11 @@ in {
 
   maxminddb = callPackage ../development/python-modules/maxminddb { };
 
-  monty = callPackage ../development/python-modules/monty { };
-
   mininet-python = (toPythonModule (pkgs.mininet.override{ inherit python; })).py;
+
+  mkl-service = callPackage ../development/python-modules/mkl-service { };
+
+  monty = callPackage ../development/python-modules/monty { };
 
   mpi4py = callPackage ../development/python-modules/mpi4py {
     mpi = pkgs.openmpi;


### PR DESCRIPTION
###### Motivation for this change
This provides a python interface for controlling `mkl` runtime behavior.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
