### PR TITLE
git-crypt: include man pages in output

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-crypt/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-crypt/default.nix
@@ -3,15 +3,14 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "git-crypt-${version}";
+  pname = "git-crypt";
   version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "AGWA";
-    repo = "git-crypt";
-    rev = "${version}";
+    repo = pname;
+    rev = version;
     sha256 = "13m9y0m6gc3mlw3pqv9x4i0him2ycbysizigdvdanhh514kga602";
-    inherit name;
   };
 
   nativeBuildInputs = [ libxslt ];

--- a/pkgs/applications/version-management/git-and-tools/git-crypt/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-crypt/default.nix
@@ -1,4 +1,6 @@
-{ fetchFromGitHub, git, gnupg, makeWrapper, openssl, stdenv }:
+{ fetchFromGitHub, git, gnupg, makeWrapper, openssl, stdenv
+, libxslt, docbook_xsl
+}:
 
 stdenv.mkDerivation rec {
   name = "git-crypt-${version}";
@@ -12,6 +14,8 @@ stdenv.mkDerivation rec {
     inherit name;
   };
 
+  nativeBuildInputs = [ libxslt ];
+
   buildInputs = [ openssl makeWrapper ];
 
   patchPhase = ''
@@ -19,9 +23,14 @@ stdenv.mkDerivation rec {
       --replace '(escape_shell_arg(our_exe_path()))' '= "git-crypt"'
   '';
 
-  installPhase = ''
-    make install PREFIX=$out
-    wrapProgram $out/bin/* --prefix PATH : $out/bin:${git}/bin:${gnupg}/bin
+  makeFlags = [
+    "PREFIX=${placeholder ''out''}"
+    "ENABLE_MAN=yes"
+    "DOCBOOK_XSL=${docbook_xsl}/share/xml/docbook-xsl-nons/manpages/docbook.xsl"
+  ];
+
+  postFixup = ''
+    wrapProgram $out/bin/git-crypt --prefix PATH : $out/bin:${git}/bin:${gnupg}/bin
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Seems like they belong.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- ~[ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- ~[ ] Tested execution of all binary files (usually in `./result/bin/`)~
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after) (265632824 -> 265637088)
- ~[ ] Ensured that relevant documentation is up to date~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---