### PR TITLE
 pythonPackages.mwparserfromhell: init at 0.5.4 

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5817,4 +5817,9 @@
     github = "turboMaCk";
     name = "Marek Fajkus";
   };
+  melling = {
+    email = "mattmelling@fastmail.com";
+    github = "mattmelling";
+    name = "Matt Melling";
+  };
 }

--- a/pkgs/development/python-modules/mwparserfromhell/default.nix
+++ b/pkgs/development/python-modules/mwparserfromhell/default.nix
@@ -1,0 +1,21 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "mwparserfromhell";
+  version = "0.5.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "aaf5416ab9b75e99e286f8a4216f77a2f7d834afd4c8f81731e701e59bf99305";
+  };
+
+  meta = with stdenv.lib; {
+    description = "MWParserFromHell is a parser for MediaWiki wikicode";
+    homepage = "https://mwparserfromhell.readthedocs.io/en/latest/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ melling ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5753,6 +5753,8 @@ in {
   flickrapi = callPackage ../development/python-modules/flickrapi { };
 
   aioesphomeapi = callPackage ../development/python-modules/aioesphomeapi { };
+
+  mwparserfromhell = callPackage ../development/python-modules/mwparserfromhell { };
 });
 
 in fix' (extends overrides packages)


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
A Python parser for MediaWiki wikicode. `mwparserfromhell` is listed as a pip dependency for the existing `textacy` package.

###### Things done
- Created new package for `mwparserfromhell`
- Added self as maintainer
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---