### PR TITLE
libglvnd, ocl-icd, vulkan-loader: Remove addOpenGLRunpath where not needed.

### DIFF
--- a/pkgs/development/libraries/libglvnd/default.nix
+++ b/pkgs/development/libraries/libglvnd/default.nix
@@ -43,10 +43,11 @@ stdenv.mkDerivation rec {
     });
   outputs = [ "out" "dev" ];
 
-  # Set RUNPATH so that driver libraries in /run/opengl-driver(-32)/lib can be found.
-  # See the explanation in addOpenGLRunpath.
+  # Set RUNPATH so that libGLX can find driver libraries in /run/opengl-driver(-32)/lib.
+  # Note that libEGL does not need it because it uses driver config files which should
+  # contain absolute paths to libraries.
   postFixup = ''
-    addOpenGLRunpath $out/lib/libGLX.so $out/lib/libEGL.so
+    addOpenGLRunpath $out/lib/libGLX.so
   '';
 
   passthru = { inherit (addOpenGLRunpath) driverLink; };

--- a/pkgs/development/libraries/ocl-icd/default.nix
+++ b/pkgs/development/libraries/ocl-icd/default.nix
@@ -9,18 +9,12 @@ stdenv.mkDerivation rec {
     sha256 = "0f14gpa13sdm0kzqv5yycp4pschbmi6n5fj7wl4ilspzsrqcgqr2";
   };
 
-  nativeBuildInputs = [ ruby addOpenGLRunpath ];
+  nativeBuildInputs = [ ruby ];
 
   buildInputs = [ opencl-headers ];
 
   postPatch = ''
     sed -i 's,"/etc/OpenCL/vendors","${addOpenGLRunpath.driverLink}/etc/OpenCL/vendors",g' ocl_icd_loader.c
-  '';
-
-  # Set RUNPATH so that driver libraries in /run/opengl-driver(-32)/lib can be found.
-  # See the explanation in addOpenGLRunpath.
-  postFixup = ''
-    addOpenGLRunpath $out/lib/libOpenCL.so
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/vulkan-loader/default.nix
+++ b/pkgs/development/libraries/vulkan-loader/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     sha256 = "0zhrwj1gi90x2w8gaaaw5h4b969a8gfy244kn0drrplhhb1nqz3b";
   };
 
-  nativeBuildInputs = [ pkgconfig addOpenGLRunpath ];
+  nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ cmake python3 xlibsWrapper libxcb libXrandr libXext wayland ];
   enableParallelBuilding = true;
 
@@ -29,12 +29,6 @@ stdenv.mkDerivation rec {
   ];
 
   outputs = [ "out" "dev" ];
-
-  # Set RUNPATH so that driver libraries in /run/opengl-driver(-32)/lib can be found.
-  # See the explanation in addOpenGLRunpath.
-  postFixup = ''
-    addOpenGLRunpath $out/lib/libvulkan.so
-  '';
 
   meta = with stdenv.lib; {
     description = "LunarG Vulkan loader";


### PR DESCRIPTION
For APIs that use driver config files, the config files should point to libraries using absolute paths, so `RUNPATH` should be unnecessary. It is still needed for `libGLX` because that does not use config files but the dispatch library receives just a vendor name from the X server.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Remove unneeded `RUNPATH` from library. See the discussion https://github.com/NixOS/nixpkgs/pull/60985#discussion_r290238476. This is is possible for NVidia after #62870 and #62859 were merged; open-source drivers already use absolute paths.

###### Things done

Tested with drivers:
- `nvidia`, `nvidiaLegacy390`: `glxinfo`, `es2_info`, `vulkaninfo` and `opencl-info` still work, including 32-bit programs on 64-bit system.
- `amdgpu`: `glxinfo`, `es2_info` and `vulkaninfo` still work, including 32-bit programs on 64-bit system (OpenCL does not work anyway).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
