### PR TITLE
nixos/ldap: unify secrets handling

### DIFF
--- a/nixos/modules/config/ldap.nix
+++ b/nixos/modules/config/ldap.nix
@@ -224,6 +224,14 @@ in
 
   config = mkIf cfg.enable {
 
+    assertions = [{
+      assertion = config.services.nscd.enable;
+      message = ''
+        `users.ldap.enable = true` requires `services.nscd.enable = true`
+        (otherwise most programs won't be able to find the LDAP NSS module)
+      '';
+    }];
+
     environment.etc = optional (!cfg.daemon.enable) ldapConfig;
 
     system.activationScripts = mkIf (!cfg.daemon.enable) {

--- a/nixos/modules/config/ldap.nix
+++ b/nixos/modules/config/ldap.nix
@@ -7,48 +7,95 @@ let
 
   cfg = config.users.ldap;
 
+  # Generate a list of shell commands which emit config directives for the
+  # given secret. If `key` is set, then there should be a corresponding secret
+  # in `file`, which should be included in the config file as the value of the
+  # `option` setting. Otherwise this secret is not necessary, so this function
+  # returns an empty list.
+  secretFileFor = key: option: file: optional (key != "") ''
+    test -s ${escapeShellArg file} && echo "${option} $(cat ${escapeShellArg file})"
+  '';
+
   commonConfig = ''
     uri ${cfg.server}
     base ${cfg.base}
     timelimit ${toString cfg.timeLimit}
     bind_timelimit ${toString cfg.bind.timeLimit}
-    ${optionalString (cfg.bind.distinguishedName != "") ''
-      binddn ${cfg.bind.distinguishedName}
-    ''}
+    ${optionalString (cfg.bind.distinguishedName != "")
+      "binddn ${cfg.bind.distinguishedName}"}
   '';
+
+  commonSecrets = secretFileFor cfg.bind.distinguishedName "bindpw" cfg.bind.passwordFile;
 
   # Careful: OpenLDAP seems to be very picky about the indentation of
   # this file.  Directives HAVE to start in the first column!
   ldapConfig = {
     target = "ldap.conf";
-    source = writeText "ldap.conf" ''
+    text = ''
       bind_policy ${cfg.bind.policy}
-      ${optionalString cfg.useTLS ''
-        ssl start_tls
-      ''}
+      ${optionalString cfg.useTLS "ssl start_tls"}
       ${commonConfig}
       ${cfg.extraConfig}
     '';
+    secrets = commonSecrets;
+    secretPath = "/run/nscd/ldap.conf";
+    secretOwner = "nscd";
   };
 
-  nslcdConfig = writeText "nslcd.conf" ''
-    uid nslcd
-    gid nslcd
-    ${optionalString (cfg.daemon.rootpwmoddn != "")
-      "rootpwmoddn ${cfg.daemon.rootpwmoddn}" }
-    ${commonConfig}
-    ${cfg.daemon.extraConfig}
-  '';
+  nslcdConfig = {
+    target = "nslcd.conf";
+    text = ''
+      uid nslcd
+      gid nslcd
+      ${optionalString (cfg.daemon.rootpwmoddn != "")
+        "rootpwmoddn ${cfg.daemon.rootpwmoddn}"}
+      ${commonConfig}
+      ${cfg.daemon.extraConfig}
+    '';
+    secrets = commonSecrets ++
+      secretFileFor cfg.daemon.rootpwmoddn "rootpwmodpw" cfg.daemon.rootpwmodpwFile;
+    secretPath = "/run/nslcd/nslcd.conf";
+    secretOwner = "nslcd";
+  };
 
-  # nslcd normally reads configuration from /etc/nslcd.conf.
-  # this file might contain secrets. We append those at runtime,
-  # so redirect its location to something more temporary.
-  nslcdWrapped = runCommandNoCC "nslcd-wrapped" { nativeBuildInputs = [ makeWrapper ]; } ''
-    mkdir -p $out/bin
-    makeWrapper ${nss_pam_ldapd}/sbin/nslcd $out/bin/nslcd \
-      --set LD_PRELOAD    "${pkgs.libredirect}/lib/libredirect.so" \
-      --set NIX_REDIRECTS "/etc/nslcd.conf=/run/nslcd/nslcd.conf"
-  '';
+  # Set up a symlink in /etc to the right configuration file. If the config has
+  # no use for secrets, then it will be a symlink to a file in the Nix store;
+  # otherwise it's a symlink to a file which mkConfigScript is responsible for
+  # creating.
+  mkEtc = thisConfig: { ${thisConfig.target} =
+    if thisConfig.secrets == []
+    then { inherit (thisConfig) text; }
+    else {
+      source = thisConfig.secretPath;
+      mode = "direct-symlink";
+    };
+  };
+
+  # Construct a list of commands, suitable for serviceConfig.ExecStartPre,
+  # which will arrange that thisConfig.target includes any secrets it needs. If
+  # the config has no use for secrets, this will be an empty list. Otherwise
+  # the returned command will start with "!", which tells systemd to run this
+  # command as root even if the service is configured to run as a different
+  # user.
+  mkConfigScript = thisConfig: optional (thisConfig.secrets != []) "!${
+    let baseconf = writeText (baseNameOf thisConfig.target) thisConfig.text;
+    in writeScript "${baseNameOf thisConfig.target}-append-secrets" ''
+      #!${pkgs.runtimeShell} -e
+      umask 0377
+      secrets=$(mktemp ${escapeShellArg thisConfig.secretPath}.XXXXXXXXXX)
+      {
+        ${concatStringsSep "  " thisConfig.secrets}
+      } > "$secrets"
+      if test -s "$secrets"; then
+        cat ${baseconf} >> "$secrets"
+        mv -fT "$secrets" ${escapeShellArg thisConfig.secretPath}
+        chown ${thisConfig.secretOwner} ${escapeShellArg thisConfig.secretPath}
+      else
+        rm -f "$secrets"
+        ln -sfn ${baseconf} ${escapeShellArg thisConfig.secretPath}
+      fi
+    ''
+  }";
 
 in
 
@@ -234,20 +281,8 @@ in
 
   (mkIf (!cfg.daemon.enable) {
     system.nssModules = [ nss_ldap ];
-
-    environment.etc = ldapConfig;
-
-    system.activationScripts = {
-      ldap = stringAfter [ "etc" "groups" "users" ] ''
-        if test -f "${cfg.bind.passwordFile}" ; then
-          umask 0077
-          conf="$(mktemp)"
-          printf 'bindpw %s\n' "$(cat ${cfg.bind.passwordFile})" |
-          cat ${ldapConfig.source} - >"$conf"
-          mv -fT "$conf" /etc/ldap.conf
-        fi
-      '';
-    };
+    environment.etc = mkEtc ldapConfig;
+    systemd.services.nscd.serviceConfig.ExecStartPre = mkConfigScript ldapConfig;
   })
 
   (mkIf cfg.daemon.enable {
@@ -265,26 +300,14 @@ in
       };
     };
 
+    environment.etc = mkEtc nslcdConfig;
     systemd.services = {
       nslcd = {
         wantedBy = [ "multi-user.target" ];
 
-        preStart = ''
-          umask 0077
-          conf="$(mktemp)"
-          {
-            cat ${nslcdConfig}
-            test -z '${cfg.bind.distinguishedName}' -o ! -f '${cfg.bind.passwordFile}' ||
-            printf 'bindpw %s\n' "$(cat '${cfg.bind.passwordFile}')"
-            test -z '${cfg.daemon.rootpwmoddn}' -o ! -f '${cfg.daemon.rootpwmodpwFile}' ||
-            printf 'rootpwmodpw %s\n' "$(cat '${cfg.daemon.rootpwmodpwFile}')"
-          } >"$conf"
-          mv -fT "$conf" /run/nslcd/nslcd.conf
-        '';
-        restartTriggers = [ "/run/nslcd/nslcd.conf" ];
-
         serviceConfig = {
-          ExecStart = "${nslcdWrapped}/bin/nslcd";
+          ExecStartPre = mkConfigScript nslcdConfig;
+          ExecStart = "${nss_pam_ldapd}/sbin/nslcd";
           Type = "forking";
           Restart = "always";
           User = "nslcd";

--- a/nixos/modules/config/ldap.nix
+++ b/nixos/modules/config/ldap.nix
@@ -12,16 +12,16 @@ let
   ldapConfig = {
     target = "ldap.conf";
     source = writeText "ldap.conf" ''
-      uri ${config.users.ldap.server}
-      base ${config.users.ldap.base}
-      timelimit ${toString config.users.ldap.timeLimit}
-      bind_timelimit ${toString config.users.ldap.bind.timeLimit}
-      bind_policy ${config.users.ldap.bind.policy}
-      ${optionalString config.users.ldap.useTLS ''
+      uri ${cfg.server}
+      base ${cfg.base}
+      timelimit ${toString cfg.timeLimit}
+      bind_timelimit ${toString cfg.bind.timeLimit}
+      bind_policy ${cfg.bind.policy}
+      ${optionalString cfg.useTLS ''
         ssl start_tls
       ''}
-      ${optionalString (config.users.ldap.bind.distinguishedName != "") ''
-        binddn ${config.users.ldap.bind.distinguishedName}
+      ${optionalString (cfg.bind.distinguishedName != "") ''
+        binddn ${cfg.bind.distinguishedName}
       ''}
       ${optionalString (cfg.extraConfig != "") cfg.extraConfig }
     '';

--- a/nixos/modules/config/ldap.nix
+++ b/nixos/modules/config/ldap.nix
@@ -7,38 +7,37 @@ let
 
   cfg = config.users.ldap;
 
+  commonConfig = ''
+    uri ${cfg.server}
+    base ${cfg.base}
+    timelimit ${toString cfg.timeLimit}
+    bind_timelimit ${toString cfg.bind.timeLimit}
+    ${optionalString (cfg.bind.distinguishedName != "") ''
+      binddn ${cfg.bind.distinguishedName}
+    ''}
+  '';
+
   # Careful: OpenLDAP seems to be very picky about the indentation of
   # this file.  Directives HAVE to start in the first column!
   ldapConfig = {
     target = "ldap.conf";
     source = writeText "ldap.conf" ''
-      uri ${cfg.server}
-      base ${cfg.base}
-      timelimit ${toString cfg.timeLimit}
-      bind_timelimit ${toString cfg.bind.timeLimit}
       bind_policy ${cfg.bind.policy}
       ${optionalString cfg.useTLS ''
         ssl start_tls
       ''}
-      ${optionalString (cfg.bind.distinguishedName != "") ''
-        binddn ${cfg.bind.distinguishedName}
-      ''}
-      ${optionalString (cfg.extraConfig != "") cfg.extraConfig }
+      ${commonConfig}
+      ${cfg.extraConfig}
     '';
   };
 
   nslcdConfig = writeText "nslcd.conf" ''
     uid nslcd
     gid nslcd
-    uri ${cfg.server}
-    base ${cfg.base}
-    timelimit ${toString cfg.timeLimit}
-    bind_timelimit ${toString cfg.bind.timeLimit}
-    ${optionalString (cfg.bind.distinguishedName != "")
-      "binddn ${cfg.bind.distinguishedName}" }
     ${optionalString (cfg.daemon.rootpwmoddn != "")
       "rootpwmoddn ${cfg.daemon.rootpwmoddn}" }
-    ${optionalString (cfg.daemon.extraConfig != "") cfg.daemon.extraConfig }
+    ${commonConfig}
+    ${cfg.daemon.extraConfig}
   '';
 
   # nslcd normally reads configuration from /etc/nslcd.conf.


### PR DESCRIPTION
**NOTE:** _This pull request only works if both #64268 and #64387 are merged first_, which it's looking like they will be. I'm opening this PR even though those haven't landed yet so that these changes can get some review ahead of time.

###### Motivation for this change

I just wanted to get rid of some activation scripts, but this module demanded a bit more attention.

These patches all affect only `nixos/modules/config/ldap.nix`, which implements the `users.ldap` configuration options for systems which connect to an LDAP server for authentication.

Each patch cleans up some aspect of the module implementation, and the last patch additionally fixes several corner-case bugs around switching configurations while `users.ldap.enable` is true, or changing secrets. Details are in the commit messages.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).