### PR TITLE
pythonPackages.filebytes: 0.9.20 -> 0.9.21

### DIFF
--- a/pkgs/development/python-modules/filebytes/default.nix
+++ b/pkgs/development/python-modules/filebytes/default.nix
@@ -5,11 +5,11 @@
 
 buildPythonPackage rec {
   pname = "filebytes";
-  version = "0.9.20";
+  version = "0.9.21";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "6c33986ca048e49cf1a5e2f167af9f02c7f866576b3b91a8a9124d32e57f935d";
+    sha256 = "09e306feafd435e240b6ca22e6319ce51862dbe99e3481368fc9a2d15d2263d5";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
##### Motivation for this change

Relates to #64930 : solves the failing `nix-build -A python27Packages.ropper`, as `filebytes` is one of its dependencies.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review pr 64931"`
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
