### PR TITLE
telega-server: init at 0.4.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/telegram/telega-server/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/telega-server/default.nix
@@ -1,0 +1,32 @@
+{ fetchFromGitHub, stdenv, tdlib }:
+
+stdenv.mkDerivation rec {
+  version = "0.4.0";
+  pname = "telega-server";
+
+  src = fetchFromGitHub {
+    owner = "zevlg";
+    repo = "telega.el";
+    rev = version;
+    sha256 = "1a5fxix2zvs461vn6zn36qgpg65bl38gfb3ivr24wmxq1avja5s1";
+  };
+
+  buildInputs = [ tdlib ];
+
+  preBuild = ''
+    cd server
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp telega-server $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Server for GNU Emacs telegram client (unofficial)";
+    homepage = "https://github.com/zevlg/telega.el";
+    license = [ licenses.gpl3 ];
+    platforms = platforms.linux;
+    maintainers = [ maintainers.vyorkin ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20478,6 +20478,8 @@ in
 
   telegram-cli = callPackage ../applications/networking/instant-messengers/telegram/telegram-cli { };
 
+  telega-server = callPackage ../applications/networking/instant-messengers/telegram/telega-server { };
+
   telepathy-gabble = callPackage ../applications/networking/instant-messengers/telepathy/gabble { };
 
   telepathy-haze = callPackage ../applications/networking/instant-messengers/telepathy/haze {};


### PR DESCRIPTION
###### Motivation for this change

Adds the [telega-server](https://github.com/zevlg/telega.el/tree/master/server).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).