### PR TITLE
FUNDING: introduce open collective page

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,3 @@
 # These are supported funding model platforms
 
-custom: https://nixos.org/nixos/foundation.html
+open_collective: nixos

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [<img src="https://nixos.org/logo/nixos-hires.png" width="500px" alt="logo" />](https://nixos.org/nixos)
 
 [![Code Triagers Badge](https://www.codetriage.com/nixos/nixpkgs/badges/users.svg)](https://www.codetriage.com/nixos/nixpkgs)
+[![Open Collective supporters](https://opencollective.com/nixos/tiers/supporter/badge.svg?label=Supporter&color=brightgreen)](https://opencollective.com/nixos)
 
 Nixpkgs is a collection of packages for the [Nix](https://nixos.org/nix/) package
 manager. It is periodically built and tested by the [Hydra](https://hydra.nixos.org/)


### PR DESCRIPTION
We now have open collective page, which should bring more transparency into the foundation and provide easier means to donate.

- [x] https://github.com/NixOS/nixos-homepage/pull/289