### PR TITLE
rocksdb: Remove gflags dependency 

### DIFF
--- a/pkgs/development/libraries/rocksdb/default.nix
+++ b/pkgs/development/libraries/rocksdb/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, lib, bzip2, cmake, gflags, lz4, snappy, zlib, zstd, enableLite ? false }:
+{ stdenv, fetchFromGitHub, lib, bzip2, cmake, lz4, snappy, zlib, zstd, enableLite ? false }:
 
 stdenv.mkDerivation rec {
   pname = "rocksdb";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ bzip2 gflags lz4 snappy zlib zstd ];
+  buildInputs = [ bzip2 lz4 snappy zlib zstd ];
 
   patches = [ ./0001-findzlib.patch ];
 
@@ -27,6 +27,7 @@ stdenv.mkDerivation rec {
     "-DWITH_SNAPPY=1"
     "-DWITH_ZLIB=1"
     "-DWITH_ZSTD=1"
+    "-DWITH_GFLAGS=0"
     (lib.optional
         (stdenv.hostPlatform.system == "i686-linux"
          || stdenv.hostPlatform.system == "x86_64-linux")


### PR DESCRIPTION
###### Motivation for this change

GFlags are only used for the tools, which are not installed in any case.

According to the rocksdb docs 
 https://github.com/facebook/rocksdb/blob/master/INSTALL.md :

> gflags - a library that handles command line flags processing. You can compile rocksdb library even if you don't have gflags installed.


Additionally, on master, the file `/nix/store/nrxnwbsk869v48h868h858mx0b5sk87g-rocksdb-6.1.2/lib/cmake/rocksdb/RocksDBTargets.cmake` refers to a library `gflags_shared` (without specifying a full path), which causes errors when trying to use `rocksdb` through cmake

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
Not applicable: no binaries
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
