### PR TITLE
pythonPackages.rotate-backups: init at 6.0

### DIFF
--- a/pkgs/development/python-modules/capturer/default.nix
+++ b/pkgs/development/python-modules/capturer/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildPythonPackage, fetchFromGitHub, humanfriendly, pytest, pytestcov }:
+
+buildPythonPackage rec {
+  pname = "capturer";
+  version = "2.4";
+
+  src = fetchFromGitHub {
+    owner = "xolox";
+    repo = "python-capturer";
+    rev = version;
+    sha256 = "07zy264xd0g7pz9sxjqcpwmrck334xcbb7wfss26lmvgdr5nhcb9";
+  };
+
+  propagatedBuildInputs = [ humanfriendly ];
+
+  checkPhase = ''
+    PATH=$PATH:$out/bin pytest .
+  '';
+  checkInputs = [ pytest ];
+
+  meta = with lib; {
+    description = "Easily capture stdout/stderr of the current process and subprocesses";
+    homepage = https://github.com/xolox/python-capturer;
+    license = licenses.mit;
+    maintainers = with maintainers; [ eyjhb ];
+  };
+}

--- a/pkgs/development/python-modules/coloredlogs/default.nix
+++ b/pkgs/development/python-modules/coloredlogs/default.nix
@@ -1,0 +1,34 @@
+{ lib, buildPythonPackage, fetchFromGitHub, stdenv, isPy3k, fetchpatch, humanfriendly, verboselogs, capturer, pytest, mock, utillinux }:
+
+buildPythonPackage rec {
+  pname = "coloredlogs";
+  version = "10.0";
+
+  src = fetchFromGitHub {
+    owner = "xolox";
+    repo = "python-coloredlogs";
+    rev = version;
+    sha256 = "0rdvp4dfvzhx7z7s2jdl3fv7x1hazgpy5gc7bcf05bnbv2iia54a";
+  };
+
+  # patch by risicle
+  patches = lib.optional (stdenv.isDarwin && isPy3k) (fetchpatch {
+    name = "darwin-py3-capture-fix.patch";
+    url = "https://github.com/xolox/python-coloredlogs/pull/74.patch";
+    sha256 = "0pk7k94iz0gdripw623vzdl4hd83vwhsfzshl8pbvh1n6swi0xx9";
+  });
+
+  checkPhase = ''
+    PATH=$PATH:$out/bin pytest . -k "not test_plain_text_output_format"
+  '';
+  checkInputs = [ pytest mock utillinux ];
+
+  propagatedBuildInputs = [ humanfriendly verboselogs capturer ];
+
+  meta = with lib; {
+    description = "Colored stream handler for Python's logging module";
+    homepage = https://github.com/xolox/python-coloredlogs;
+    license = licenses.mit;
+    maintainers = with maintainers; [ eyjhb ];
+  };
+}

--- a/pkgs/development/python-modules/executor/default.nix
+++ b/pkgs/development/python-modules/executor/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonPackage, fetchFromGitHub, coloredlogs, property-manager, fasteners, pytest, mock, virtualenv }:
+
+buildPythonPackage rec {
+  pname = "executor";
+  version = "21.3";
+
+  src = fetchFromGitHub {
+    owner = "xolox";
+    repo = "python-executor";
+    rev = version;
+    sha256 = "0rc14vjx3d6irfaw0pczzw1pn0xjl7xikv32hc1fvxv2ibnldv5d";
+  };
+
+  propagatedBuildInputs = [ coloredlogs property-manager fasteners ];
+
+  checkInputs = [ pytest mock virtualenv ];
+
+  # ignore impure tests
+  checkPhase = ''
+    pytest . -k "not option and not retry \
+                 and not remote and not ssh \
+                 and not foreach and not local_context"
+  '';
+
+  meta = with lib; {
+    description = "Programmer friendly subprocess wrapper";
+    homepage = https://github.com/xolox/python-executor;
+    license = licenses.mit;
+    maintainers = with maintainers; [ eyjhb ];
+  };
+}

--- a/pkgs/development/python-modules/naturalsort/default.nix
+++ b/pkgs/development/python-modules/naturalsort/default.nix
@@ -1,0 +1,20 @@
+{ lib, buildPythonPackage, fetchFromGitHub }:
+
+buildPythonPackage rec {
+  pname = "naturalsort";
+  version = "1.5.1";
+
+  src = fetchFromGitHub {
+    owner = "xolox";
+    repo = "python-naturalsort";
+    rev = version;
+    sha256 = "0w43vlddzh97hffnvxp2zkrns9qyirx5g8ijxnxkbx1c4b4gq5ih";
+  };
+
+  meta = with lib; {
+    description = "Simple natural order sorting API for Python that just works";
+    homepage = https://github.com/xolox/python-naturalsort;
+    license = licenses.mit;
+    maintainers = with maintainers; [ eyjhb ];
+  };
+}

--- a/pkgs/development/python-modules/property-manager/default.nix
+++ b/pkgs/development/python-modules/property-manager/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, fetchFromGitHub, humanfriendly, verboselogs, coloredlogs, pytest, pytestcov }:
+
+buildPythonPackage rec {
+  pname = "property-manager";
+  version = "2.3.1";
+
+  src = fetchFromGitHub {
+    owner = "xolox";
+    repo = "python-property-manager";
+    rev = version;
+    sha256 = "0s4nwipxd8c2vp4rd8mxrj8wbycniz5ki5n177d0dbrnll5amcz0";
+  };
+
+  propagatedBuildInputs = [ coloredlogs humanfriendly verboselogs ];
+  checkInputs = [ pytest pytestcov ];
+
+  meta = with lib; {
+    description = "Useful property variants for Python programming";
+    homepage = https://github.com/xolox/python-property-manager;
+    license = licenses.mit;
+    maintainers = with maintainers; [ eyjhb ];
+  };
+}

--- a/pkgs/development/python-modules/update-dotdee/default.nix
+++ b/pkgs/development/python-modules/update-dotdee/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildPythonPackage, fetchFromGitHub, executor, naturalsort }:
+
+buildPythonPackage rec {
+  pname = "update-dotdee";
+  version = "5.0";
+
+  src = fetchFromGitHub {
+    owner = "xolox";
+    repo = "python-update-dotdee";
+    rev = version;
+    sha256 = "1h3m593nwzx6vwa24k0wizb7la49yhqxwn73ipclxgxxi4dfdj01";
+  };
+
+  propagatedBuildInputs = [ executor naturalsort ];
+
+  meta = with lib; {
+    description = "Generic modularized configuration file manager";
+    homepage = https://github.com/xolox/python-update-dotdee;
+    license = licenses.mit;
+    maintainers = with maintainers; [ eyjhb ];
+  };
+}

--- a/pkgs/development/python-modules/verboselogs/default.nix
+++ b/pkgs/development/python-modules/verboselogs/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildPythonPackage, fetchFromGitHub, pytest, mock }:
+
+buildPythonPackage rec {
+  pname = "verboselogs";
+  version = "1.7";
+
+  src = fetchFromGitHub {
+    owner = "xolox";
+    repo = "python-verboselogs";
+    rev = version;
+    sha256 = "10jzm8pkl49as4y2zyiidmfqqj5zmqg3p73jvx4lfxi0gmp1vhl5";
+  };
+
+  # do not run pylint plugin test, as astroid is a old unsupported version
+  checkPhase = ''
+    PATH=$PATH:$out/bin pytest . -k "not test_pylint_plugin"
+  '';
+  checkInputs = [ pytest mock ];
+
+  meta = with lib; {
+    description = "Verbose logging for Python's logging module";
+    homepage = https://github.com/xolox/python-verboselogs;
+    license = licenses.mit;
+    maintainers = with maintainers; [ eyjhb ];
+  };
+}

--- a/pkgs/tools/backup/rotate-backups/default.nix
+++ b/pkgs/tools/backup/rotate-backups/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, fetchFromGitHub, update-dotdee, simpleeval, dateutil }:
+
+buildPythonPackage rec {
+  pname = "rotate-backups";
+  version = "6.0";
+
+  src = fetchFromGitHub {
+    owner = "xolox";
+    repo = "python-rotate-backups";
+    rev = version;
+    sha256 = "0i59qfv1cfm0ss63ab2nrkn5wr4rxpqqmvfd7pf9c3pl9dbfq20c";
+  };
+
+  propagatedBuildInputs = [ update-dotdee simpleeval dateutil ];
+
+  meta = with lib; {
+    description = "Simple command line interface for backup rotation";
+    homepage = https://github.com/xolox/python-rotate-backups;
+    license = licenses.mit;
+    maintainers = with maintainers; [ eyjhb ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2845,6 +2845,8 @@ in
 
   execline = skawarePackages.execline;
 
+  executor = with python3Packages; toPythonApplication executor;
+
   exif = callPackage ../tools/graphics/exif { };
 
   exiftags = callPackage ../tools/graphics/exiftags { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5090,6 +5090,8 @@ in
 
   oppai-ng = callPackage ../tools/misc/oppai-ng { };
 
+  update-dotdee = with python3Packages; toPythonApplication update-dotdee;
+
   update-resolv-conf = callPackage ../tools/networking/openvpn/update-resolv-conf.nix { };
 
   opae = callPackage ../development/libraries/opae { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13097,6 +13097,8 @@ in
 
   rocksdb_lite = rocksdb.override { enableLite = true; };
 
+  rotate-backups = with python3Packages; toPythonApplication rotate-backups;
+
   rote = callPackage ../development/libraries/rote { };
 
   ronn = callPackage ../development/tools/ronn { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3711,6 +3711,8 @@ in
 
   hubicfuse = callPackage ../tools/filesystems/hubicfuse { };
 
+  humanfriendly = with python3Packages; toPythonApplication humanfriendly;
+
   hwinfo = callPackage ../tools/system/hwinfo { };
 
   hybridreverb2 = callPackage ../applications/audio/hybridreverb2 { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1302,6 +1302,8 @@ in
 
   clprover = callPackage ../applications/science/logic/clprover/clprover.nix { };
 
+  coloredlogs = with python3Packages; toPythonApplication coloredlogs;
+
   colord-kde = libsForQt5.callPackage ../tools/misc/colord-kde {};
 
   colpack = callPackage ../applications/science/math/colpack { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2176,6 +2176,8 @@ in {
 
   execnet = callPackage ../development/python-modules/execnet { };
 
+  executor = callPackage ../development/python-modules/executor { };
+
   ezdxf = callPackage ../development/python-modules/ezdxf {};
 
   facebook-sdk = callPackage ../development/python-modules/facebook-sdk { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4807,6 +4807,8 @@ in {
 
   update-copyright = callPackage ../development/python-modules/update-copyright {};
 
+  update-dotdee = callPackage ../development/python-modules/update-dotdee { };
+
   uritemplate = callPackage ../development/python-modules/uritemplate { };
 
   uproot = callPackage ../development/python-modules/uproot {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4819,6 +4819,8 @@ in {
 
   user-agents = callPackage ../development/python-modules/user-agents { };
 
+  verboselogs = callPackage ../development/python-modules/verboselogs { };
+
   vega_datasets = callPackage ../development/python-modules/vega_datasets { };
 
   virtkey = callPackage ../development/python-modules/virtkey {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1489,6 +1489,8 @@ in {
 
   colorcet = callPackage ../development/python-modules/colorcet { };
 
+  coloredlogs = callPackage ../development/python-modules/coloredlogs { };
+
   colorclass = callPackage ../development/python-modules/colorclass {};
 
   colorlog = callPackage ../development/python-modules/colorlog { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4085,6 +4085,8 @@ in {
 
   prettytable = callPackage ../development/python-modules/prettytable { };
 
+  property-manager = callPackage ../development/python-modules/property-manager { };
+
   prompt_toolkit = let
     filename = if isPy3k then ../development/python-modules/prompt_toolkit else ../development/python-modules/prompt_toolkit/1.nix;
   in callPackage filename { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2665,6 +2665,8 @@ in {
 
   roman = callPackage ../development/python-modules/roman { };
 
+  rotate-backups = callPackage ../tools/backup/rotate-backups { };
+
   librosa = callPackage ../development/python-modules/librosa { };
 
   samplerate = callPackage ../development/python-modules/samplerate { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2448,6 +2448,8 @@ in {
 
   natsort = callPackage ../development/python-modules/natsort { };
 
+  naturalsort = callPackage ../development/python-modules/naturalsort { };
+
   ncclient = callPackage ../development/python-modules/ncclient {};
 
   logfury = callPackage ../development/python-modules/logfury { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1465,6 +1465,8 @@ in {
 
   capstone = callPackage ../development/python-modules/capstone { };
 
+  capturer = callPackage ../development/python-modules/capturer { };
+
   cement = callPackage ../development/python-modules/cement {};
 
   cgen = callPackage ../development/python-modules/cgen { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Wanting roate-backups, but keep in mind it has A LOT of dependencies which depend on each other.
I have done my best to keep it clean, and make as many tests as possible work.

I couldn't find a good way to put them into the python-packages.nix file, as the alphabetic order is.. Non existing. So I have grouped them together.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
