### PR TITLE
lutris: Make steam optional

### DIFF
--- a/pkgs/applications/misc/lutris/default.nix
+++ b/pkgs/applications/misc/lutris/default.nix
@@ -1,5 +1,7 @@
 { stdenv, pkgs, buildFHSUserEnv, makeDesktopItem, fetchFromGitHub
-, wrapGAppsHook, python3Packages }:
+, wrapGAppsHook, python3Packages
+, steam ? pkgs.steam
+}:
 
 let
   qt5Deps = with pkgs; with qt5; [ qtbase qtmultimedia ];
@@ -93,9 +95,6 @@ let
     # Snes9x
     epoxy minizip
 
-    # Steam
-    steam
-
     # Vice
     bison flex
 
@@ -107,7 +106,8 @@ let
 
     # ZDOOM
     soundfont-fluid bzip2 game-music-emu
-  ] ++ qt5Deps
+  ] ++ (if isNull steam then [] else [steam])
+    ++ qt5Deps
     ++ gnome3Deps
     ++ python3Deps
     ++ xorgDeps


### PR DESCRIPTION
###### Motivation for this change

I want to play MTG Arena, but not with unfree shit on my devices.

Thus this is an ongoing effort to make lutris free of any unfree stuff, bit by bit.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


Help welcome!