### PR TITLE
python3Packages.ibis-framework: init at 1.2.0

### DIFF
--- a/pkgs/development/python-modules/ibis-framework/default.nix
+++ b/pkgs/development/python-modules/ibis-framework/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, multipledispatch
+, numpy
+, pandas
+, pytz
+, regex
+, toolz
+, isPy27
+, pytest
+, sqlalchemy
+, requests
+, tables
+, pyarrow
+, graphviz
+}:
+
+buildPythonPackage rec {
+  pname = "ibis-framework";
+  version = "1.2.0";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "3a0b79dae6924be0a79669c881a9a1d4817997ad2f81a0f3b1cd03d70aebb071";
+  };
+
+  propagatedBuildInputs = [
+    multipledispatch
+    numpy
+    pandas
+    pytz
+    regex
+    toolz
+    sqlalchemy
+    requests
+    graphviz
+    tables
+    pyarrow
+  ];
+
+  checkInputs = [
+    pytest
+  ];
+
+  checkPhase = ''
+    pytest ibis
+  '';
+
+  meta = with lib; {
+    description = "Productivity-centric Python Big Data Framework";
+    homepage = https://github.com/ibis-project/ibis;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/ibis/default.nix
+++ b/pkgs/development/python-modules/ibis/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, python
+, isPy27
+}:
+
+buildPythonPackage rec {
+  pname = "ibis";
+  version = "1.6.0";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "dmulholl";
+    repo = pname;
+    rev = version;
+    sha256 = "0xqhk397gzanvj2znwcgy4n5l1lc9r310smxkhjbm1xwvawpixx0";
+  };
+
+  checkPhase = ''
+    ${python.interpreter} test_ibis.py
+  '';
+
+  meta = with lib; {
+    description = "A lightweight template engine";
+    homepage = https://github.com/dmulholland/ibis;
+    license = licenses.publicDomain;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5913,6 +5913,8 @@ in {
 
   IBMQuantumExperience = callPackage ../development/python-modules/ibmquantumexperience { };
 
+  ibis = callPackage ../development/python-modules/ibis { };
+
   qiskit = callPackage ../development/python-modules/qiskit { };
 
   qasm2image = callPackage ../development/python-modules/qasm2image { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5915,6 +5915,8 @@ in {
 
   ibis = callPackage ../development/python-modules/ibis { };
 
+  ibis-framework = callPackage ../development/python-modules/ibis-framework { };
+
   qiskit = callPackage ../development/python-modules/qiskit { };
 
   qasm2image = callPackage ../development/python-modules/qasm2image { };


### PR DESCRIPTION

###### Motivation for this change

Adding ibis-framework for a project currently working on

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
