### PR TITLE
pythonPackages.monkeyhex: init at 1.7.1

### DIFF
--- a/pkgs/development/python-modules/monkeyhex/default.nix
+++ b/pkgs/development/python-modules/monkeyhex/default.nix
@@ -1,0 +1,30 @@
+{ buildPythonPackage
+, fetchPypi
+, future
+, lib
+}:
+
+buildPythonPackage rec {
+  pname = "monkeyhex";
+  version = "1.7.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "5ba913df664c34f3ce53916c83872fddf750adc78a0b0ecdd316ac3e728bb019";
+  };
+
+  propagatedBuildInputs = [ future ];
+
+  # No tests in repo.
+  doCheck = false;
+
+  # Verify import still works.
+  pythonImportsCheck = [ "monkeyhex" ];
+
+  meta = with lib; {
+    description = "A small library to assist users of the python shell who work in contexts where printed numbers are more usefully viewed in hexadecimal";
+    homepage = "https://github.com/rhelmot/monkeyhex";
+    license = licenses.mit;
+    maintainers = [ maintainers.pamplemousse ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -766,6 +766,8 @@ in {
 
   mkl-service = callPackage ../development/python-modules/mkl-service { };
 
+  monkeyhex = callPackage ../development/python-modules/monkeyhex { };
+
   monty = callPackage ../development/python-modules/monty { };
 
   mpi4py = callPackage ../development/python-modules/mpi4py {


### PR DESCRIPTION
##### Motivation for this change

Make the [monkeyhex](https://pypi.org/project/monkeyhex/) package available on NixOS.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).