### PR TITLE
all-packages: add static exe alias for haskell 'shake' package

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9688,6 +9688,8 @@ in
 
   scss-lint = callPackage ../development/tools/scss-lint { };
 
+  shake = haskell.lib.justStaticExecutables haskellPackages.shake;
+
   shallot = callPackage ../tools/misc/shallot { };
 
   shards = callPackage ../development/tools/build-managers/shards { };


### PR DESCRIPTION
This executable exposes a `ninja`-compatible build system named `shake`, which is useful in its own right for people who use tools like CMake, etc.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS