### PR TITLE
victor-mono: improvements from previous PR

### DIFF
--- a/pkgs/data/fonts/victor-mono/default.nix
+++ b/pkgs/data/fonts/victor-mono/default.nix
@@ -3,27 +3,37 @@
 let
   pname = "victor-mono";
   version = "1.2.1";
-in fetchFromGitHub {
+in fetchFromGitHub rec {
   name = "${pname}-${version}";
 
   owner = "rubjo";
   repo = pname;
   rev = "v${version}";
 
+  # Upstream prefers we download from the website,
+  # but we really insist on a more versioned resource.
+  # Happily, tagged releases on github contain the same
+  # file `VictorMonoAll.zip` as from the website,
+  # so we extract it from the tagged release.
+  # Both methods produce the same file, but this way
+  # we can safely reason about what version it is.
   postFetch = ''
-    tar xf $downloadedFile --strip=1
-    unzip public/VictorMonoAll.zip TTF/\*
-    mkdir -p $out/share/fonts/truetype/${pname}
-    cp TTF/*.ttf $out/share/fonts/truetype/${pname}
+    tar xvf $downloadedFile --strip-components=2 ${name}/public/VictorMonoAll.zip
+
+    mkdir -p $out/share/fonts/{true,open}type/${pname}
+
+    unzip -j VictorMonoAll.zip \*.ttf -d $out/share/fonts/truetype/${pname}
+    unzip -j VictorMonoAll.zip \*.otf -d $out/share/fonts/opentype/${pname}
   '';
 
-  sha256 = "0gisjcywmn3kjgwfmzcv8ibxqd126s93id2w0zjly0c7m3ckamh8";
+  sha256 = "0347n3kdyrbg42rxcgnyghi21qz5iz6w30v7ms2vjal7pfm6h2vn";
 
   meta = with lib; {
-    homepage = https://rubjo.github.io/victor-mono;
-    description = "A free programming font with cursive italics and ligatures";
+    description = "Free programming font with cursive italics and ligatures";
+    homepage = "https://rubjo.github.io/victor-mono";
     license = with licenses; [ mit ];
-    maintainers = with maintainers; [ jpotier ];
+    maintainers = with maintainers; [ jpotier dtzWill ];
     platforms = platforms.all;
   };
 }
+


### PR DESCRIPTION
Fixes #64465.

Resolves conflicts with earlier merged PR,
notable differences in the result
(by our powers combined!):

* provide both ttf and otf versions
* quote URL, since folks seem to like those
* don't put fonts in ${pname} subdirs
  fontconfig's hashing/cache is mostly geared
  for the many-fonts-in-one-place situation,
  although this may be fixed in more recent versions.
  Anyway minor change and mostly went with not modifying
  what I had ;) so happy to adjust back if that
  better matches your senses/style/use.
* Drop leading 'A' from description,
  I think this is per policy written.. somewhere O:).
* alpha-sort the meta attributes, which is easy to rem
  and generally matches what most expressions do anyway :)

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->


------------


See #64544 for previous incarnation, apparently can't reopen that one since I force-pushed? :cry: