### PR TITLE
kdevelop, kdev-php, kdev-python: 5.3.2 -> 5.3.3

### DIFF
--- a/pkgs/applications/editors/kdevelop5/kdev-php.nix
+++ b/pkgs/applications/editors/kdevelop5/kdev-php.nix
@@ -1,15 +1,12 @@
 { stdenv, lib, fetchurl, cmake, extra-cmake-modules, threadweaver, ktexteditor, kdevelop-unwrapped, kdevelop-pg-qt }:
 
-let
-  pname = "kdev-php";
-  version = "5.3.2";
-in
 stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
+  pname = "kdev-php";
+  version = "5.3.3";
 
   src = fetchurl {
     url = "https://github.com/KDE/${pname}/archive/v${version}.tar.gz";
-    sha256 = "0yjn7y7al2xs8g0mrjvcym8gbjy4wmiv7lsljcrasjd7ymag1wgs";
+    sha256 = "0nn3yfbi60h7p7p1w2pvgg098qplbds79rk2iadyvhvl3sjd77wf";
   };
 
   nativeBuildInputs = [ cmake extra-cmake-modules ];
@@ -19,7 +16,7 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.aanderse ];
     platforms = platforms.linux;
     description = "PHP support for KDevelop";
-    homepage = https://www.kdevelop.org;
+    homepage = "https://www.kdevelop.org";
     license = [ licenses.gpl2 ];
   };
 }

--- a/pkgs/applications/editors/kdevelop5/kdev-python.nix
+++ b/pkgs/applications/editors/kdevelop5/kdev-python.nix
@@ -1,15 +1,12 @@
 { stdenv, lib, fetchurl, cmake, extra-cmake-modules, threadweaver, ktexteditor, kdevelop-unwrapped, python }:
 
-let
-  pname = "kdev-python";
-  version = "5.3.2";
-in
 stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
+  pname = "kdev-python";
+  version = "5.3.3";
 
   src = fetchurl {
     url = "https://github.com/KDE/${pname}/archive/v${version}.tar.gz";
-    sha256 = "0gqv1abzfpxkrf538rb62d2291lmlra8rghm9q9r3x8a46wh96zm";
+    sha256 = "0bqsny2jgi6wi1cz65i2j9r1hiwna2x10mzy7vdk8bz7b4z766yg";
   };
 
   cmakeFlags = [
@@ -23,7 +20,7 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.aanderse ];
     platforms = platforms.linux;
     description = "Python support for KDevelop";
-    homepage = https://www.kdevelop.org;
+    homepage = "https://www.kdevelop.org";
     license = [ licenses.gpl2 ];
   };
 }

--- a/pkgs/applications/editors/kdevelop5/kdevelop.nix
+++ b/pkgs/applications/editors/kdevelop5/kdevelop.nix
@@ -8,16 +8,15 @@
 }:
 
 let
-  pname = "kdevelop";
-  version = "5.3.2";
   qtVersion = "5.${lib.versions.minor qtbase.version}";
 in
 mkDerivation rec {
-  name = "${pname}-${version}";
+  pname = "kdevelop";
+  version = "5.3.3";
 
   src = fetchurl {
-    url = "mirror://kde/stable/${pname}/${version}/src/${name}.tar.xz";
-    sha256 = "0akgdnvrab6mbwnmvgzsplk0qh83k1hnm5xc06yxr1s1a5sxbk08";
+    url = "mirror://kde/stable/${pname}/${version}/src/${pname}-${version}.tar.xz";
+    sha256 = "0778587qvi268ab2fgggfl40cv2swgr8q891q1paflp3m1xirpff";
   };
 
   nativeBuildInputs = [
@@ -76,7 +75,7 @@ mkDerivation rec {
         programing languages. It is based on KDevPlatform, KDE and Qt
         libraries and is under development since 1998.
       '';
-    homepage = https://www.kdevelop.org;
+    homepage = "https://www.kdevelop.org";
     license = with licenses; [ gpl2Plus lgpl2Plus ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
version bump

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
