### PR TITLE
mesa: build iris

### DIFF
--- a/pkgs/development/libraries/mesa/0001-meson-gallium_drivers-support-auto-with-additional-d.patch
+++ b/pkgs/development/libraries/mesa/0001-meson-gallium_drivers-support-auto-with-additional-d.patch
@@ -1,0 +1,31 @@
+From 1c3bd25af4e2a092e6cb57024fde2ea90971681e Mon Sep 17 00:00:00 2001
+From: Cole Mickens <cole.mickens@gmail.com>
+Date: Thu, 18 Jul 2019 08:42:27 +0000
+Subject: [PATCH] meson: gallium_drivers support auto with additional drivers
+ added
+
+---
+ meson.build | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index 13b561f99de..3d2172b4afa 100644
+--- a/meson.build
++++ b/meson.build
+@@ -143,11 +143,11 @@ if gallium_drivers.contains('auto')
+   if system_has_kms_drm
+     # TODO: PPC, Sparc
+     if ['x86', 'x86_64'].contains(host_machine.cpu_family())
+-      gallium_drivers = [
++      gallium_drivers += [
+         'r300', 'r600', 'radeonsi', 'nouveau', 'virgl', 'svga', 'swrast'
+       ]
+     elif ['arm', 'aarch64'].contains(host_machine.cpu_family())
+-      gallium_drivers = [
++      gallium_drivers += [
+         'kmsro', 'v3d', 'vc4', 'freedreno', 'etnaviv', 'nouveau',
+         'tegra', 'virgl', 'lima', 'swrast'
+       ]
+-- 
+2.19.2
+

--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -5,7 +5,7 @@
 , libelf, libvdpau, python3Packages
 , libglvnd
 , enableRadv ? true
-, galliumDrivers ? ["auto"]
+, galliumDrivers ? ["auto" "iris" ]
 , driDrivers ? ["auto"]
 , vulkanDrivers ? ["auto"]
 , eglPlatforms ? [ "x11" ] ++ lib.optionals stdenv.isLinux [ "wayland" "drm" ]
@@ -51,6 +51,7 @@ stdenv.mkDerivation rec {
   #  revive ./dricore-gallium.patch when it gets ported (from Ubuntu), as it saved
   #  ~35 MB in $drivers; watch https://launchpad.net/ubuntu/+source/mesa/+changelog
   patches = [
+    ./0001-meson-gallium_drivers-support-auto-with-additional-d.patch
     ./missing-includes.patch # dev_t needs sys/stat.h, time_t needs time.h, etc.-- fixes build w/musl
     ./opencl-install-dir.patch
     ./disk_cache-include-dri-driver-path-in-cache-key.patch


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fixes #65016.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
