### PR TITLE
graphene-hardened-malloc: 190405.003.2019.04.01.19 -> 1

### DIFF
--- a/pkgs/development/libraries/graphene-hardened-malloc/default.nix
+++ b/pkgs/development/libraries/graphene-hardened-malloc/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "graphene-hardened-malloc-${version}";
-  version = "190405.003.2019.04.01.19";
+  version = "1";
 
   src = fetchurl {
-    url = "https://github.com/GrapheneOS/hardened_malloc/archive/PQ2A.${version}.tar.gz";
-    sha256 = "1qczmajy3q07jd236dmal4iq5xxcsrkyw26gc9r4vs4wj4m42d11";
+    url = "https://github.com/GrapheneOS/hardened_malloc/archive/${version}.tar.gz";
+    sha256 = "1z3kb9fr6w9fcdc42bh8k5b4r10sn5hrwwk4m691qjdgk5hlj3aa";
   };
 
   installPhase = ''
@@ -16,6 +16,8 @@ stdenv.mkDerivation rec {
     substitute preload.sh $out/bin/preload-hardened-malloc --replace "\$dir" $out/lib
     chmod 0555 $out/bin/preload-hardened-malloc
   '';
+
+  separateDebugInfo = true;
 
   doInstallCheck = true;
   installCheckPhase = ''
@@ -27,7 +29,7 @@ stdenv.mkDerivation rec {
     make
 
     # these tests don't actually appear to generate overflows currently
-    rm read_after_free_small string_overflow
+    rm read_after_free_small string_overflow eight_byte_overflow_large
 
     for t in `find . -regex ".*/[a-z_]+"` ; do
       echo "Running $t..."


### PR DESCRIPTION
The initial stable standalone release.

The integer numbered tags are the standalone releases, while the
PQ3B.190705.003.2019.07.01.21 style tags are part of GrapheneOS releases.

For us it probably makes the most sense to track the standalone releases.

Note that the install check phase currently fails, so this is WIP. It's a little unclear to me that the install check phase is all that useful, does it really uncover problems in the packaging or upstream bugs? It seems to me primarily the latter. @risicle thoughts on this?