### PR TITLE
WIP python37Packages.textacy: fixing broken package

### DIFF
--- a/pkgs/development/python-modules/textacy/default.nix
+++ b/pkgs/development/python-modules/textacy/default.nix
@@ -19,6 +19,7 @@
 , spacy
 , tqdm
 , unidecode
+, mwparserfromhell
 }:
 
 buildPythonPackage rec {
@@ -50,6 +51,7 @@ buildPythonPackage rec {
     spacy
     tqdm
     unidecode
+    mwparserfromhell
   ];
 
   postPatch = ''

--- a/pkgs/development/python-modules/textacy/default.nix
+++ b/pkgs/development/python-modules/textacy/default.nix
@@ -54,7 +54,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "'ftfy>=4.2.0,<5.0.0'," "'ftfy>=5.0.0',"
+      --replace 'ftfy>=4.2.0,<5.0.0' 'ftfy>=5.0.0'
   '';
 
   doCheck = false;  # tests want to download data files


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Added missing dependency and fixed a broken package version restriction.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
