### PR TITLE
pythonPackages.zarr: init at 2.3.2

### DIFF
--- a/pkgs/development/python-modules/numcodecs/default.nix
+++ b/pkgs/development/python-modules/numcodecs/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, setuptools_scm
+, cython
+, numpy
+, msgpack
+, pytest
+, python
+}:
+
+buildPythonPackage rec {
+  pname = "numcodecs";
+  version = "0.6.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "086qwlyi01rpgyyyy8bmhh9i7hpksyz33ldci3wdwmhiblyl362y";
+  };
+
+  nativeBuildInputs = [
+    setuptools_scm
+    cython
+  ];
+
+  propagatedBuildInputs = [
+    numpy
+    msgpack
+  ];
+
+  checkInputs = [
+    pytest
+  ];
+
+  checkPhase = ''
+    pytest $out/${python.sitePackages}/numcodecs -k "not test_backwards_compatibility"
+  '';
+
+  meta = with lib;{
+    homepage = https://github.com/alimanfoo/numcodecs;
+    license = licenses.mit;
+    description = "Buffer compression and transformation codecs for use in data storage and communication applications";
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/zarr/default.nix
+++ b/pkgs/development/python-modules/zarr/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, setuptools_scm
+, asciitree
+, numpy
+, fasteners
+, numcodecs
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "zarr";
+  version = "2.3.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "c62d0158fb287151c978904935a177b3d2d318dea3057cfbeac8541915dfa105";
+  };
+
+  nativeBuildInputs = [
+    setuptools_scm
+  ];
+
+  propagatedBuildInputs = [
+    asciitree
+    numpy
+    fasteners
+    numcodecs
+  ];
+
+  checkInputs = [
+    pytest
+  ];
+
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with lib; {
+    description = "An implementation of chunked, compressed, N-dimensional arrays for Python";
+    homepage = https://github.com/zarr-developers/zarr;
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3804,6 +3804,8 @@ in {
 
   numba = callPackage ../development/python-modules/numba { };
 
+  numcodecs = callPackage ../development/python-modules/numcodecs { };
+
   numexpr = callPackage ../development/python-modules/numexpr { };
 
   Nuitka = callPackage ../development/python-modules/nuitka { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3889,6 +3889,8 @@ in {
 
   zake = callPackage ../development/python-modules/zake { };
 
+  zarr = callPackage ../development/python-modules/zarr { };
+
   kazoo = callPackage ../development/python-modules/kazoo { };
 
   FormEncode = callPackage ../development/python-modules/FormEncode { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Awesome Scipy talk on zarr.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
