### PR TITLE
mathematica: 11.3.0 -> 12.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2100,6 +2100,11 @@
     github = "henrytill";
     name = "Henry Till";
   };
+  herberteuler = {
+    email = "herberteuler@gmail.com";
+    github = "herberteuler";
+    name = "Guanpeng Xu";
+  };
   hhm = {
     email = "heehooman+nixpkgs@gmail.com";
     github = "hhm0";

--- a/pkgs/applications/science/math/mathematica/11.nix
+++ b/pkgs/applications/science/math/mathematica/11.nix
@@ -1,6 +1,7 @@
 { stdenv
 , coreutils
 , patchelf
+, requireFile
 , callPackage
 , alsaLib
 , dbus
@@ -24,10 +25,11 @@
 
 let
   l10n =
-    with stdenv.lib;
-    with callPackage ./l10ns.nix {};
-    flip (findFirst (l: l.lang == lang)) l10ns
-      (throw "Language '${lang}' not supported");
+    import ./l10ns.nix {
+      lib = stdenv.lib;
+      inherit requireFile lang;
+      majorVersion = "11";
+    };
 in
 stdenv.mkDerivation rec {
   inherit (l10n) version name src;

--- a/pkgs/applications/science/math/mathematica/default.nix
+++ b/pkgs/applications/science/math/mathematica/default.nix
@@ -1,0 +1,150 @@
+{ stdenv
+, coreutils
+, patchelf
+, requireFile
+, callPackage
+, alsaLib
+, dbus
+, fontconfig
+, freetype
+, gcc
+, glib
+, ncurses
+, opencv
+, openssl
+, unixODBC
+, xkeyboard_config
+, xorg
+, zlib
+, libxml2
+, libuuid
+, lang ? "en"
+, libGL
+, libGLU
+}:
+
+let
+  l10n =
+    import ./l10ns.nix {
+      lib = stdenv.lib;
+      inherit requireFile lang;
+    };
+in
+stdenv.mkDerivation rec {
+  inherit (l10n) version name src;
+
+  buildInputs = [
+    coreutils
+    patchelf
+    alsaLib
+    coreutils
+    dbus
+    fontconfig
+    freetype
+    gcc.cc
+    gcc.libc
+    glib
+    ncurses
+    opencv
+    openssl
+    unixODBC
+    xkeyboard_config
+    libxml2
+    libuuid
+    zlib
+    libGL
+    libGLU
+  ] ++ (with xorg; [
+    libX11
+    libXext
+    libXtst
+    libXi
+    libXmu
+    libXrender
+    libxcb
+    libXcursor
+    libXfixes
+    libXrandr
+    libICE
+    libSM
+  ]);
+
+  ldpath = stdenv.lib.makeLibraryPath buildInputs
+    + stdenv.lib.optionalString (stdenv.hostPlatform.system == "x86_64-linux")
+      (":" + stdenv.lib.makeSearchPathOutput "lib" "lib64" buildInputs);
+
+  unpackPhase = ''
+    echo "=== Extracting makeself archive ==="
+    # find offset from file
+    offset=$(${stdenv.shell} -c "$(grep -axm1 -e 'offset=.*' $src); echo \$offset" $src)
+    dd if="$src" ibs=$offset skip=1 | tar -xf -
+    cd Unix
+  '';
+
+  installPhase = ''
+    cd Installer
+    # don't restrict PATH, that has already been done
+    sed -i -e 's/^PATH=/# PATH=/' MathInstaller
+    sed -i -e 's/\/bin\/bash/\/bin\/sh/' MathInstaller
+
+    echo "=== Running MathInstaller ==="
+    ./MathInstaller -auto -createdir=y -execdir=$out/bin -targetdir=$out/libexec/Mathematica -silent
+
+    # Fix library paths
+    cd $out/libexec/Mathematica/Executables
+    for path in mathematica MathKernel Mathematica WolframKernel wolfram math; do
+      sed -i -e 's#export LD_LIBRARY_PATH$#export LD_LIBRARY_PATH=${zlib}/lib:\''${LD_LIBRARY_PATH}#' $path
+    done
+
+    # Fix xkeyboard config path for Qt
+    for path in mathematica Mathematica; do
+      sed -i -e "2iexport QT_XKB_CONFIG_ROOT=\"${xkeyboard_config}/share/X11/xkb\"\n" $path
+    done
+  '';
+
+  preFixup = ''
+    echo "=== PatchElfing away ==="
+    # This code should be a bit forgiving of errors, unfortunately
+    set +e
+    find $out/libexec/Mathematica/SystemFiles -type f -perm -0100 | while read f; do
+      type=$(readelf -h "$f" 2>/dev/null | grep 'Type:' | sed -e 's/ *Type: *\([A-Z]*\) (.*/\1/')
+      if [ -z "$type" ]; then
+        :
+      elif [ "$type" == "EXEC" ]; then
+        echo "patching $f executable <<"
+        patchelf --shrink-rpath "$f"
+        patchelf \
+	  --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+          --set-rpath "$(patchelf --print-rpath "$f"):${ldpath}" \
+          "$f" \
+          && patchelf --shrink-rpath "$f" \
+          || echo unable to patch ... ignoring 1>&2
+      elif [ "$type" == "DYN" ]; then
+        echo "patching $f library <<"
+        patchelf \
+          --set-rpath "$(patchelf --print-rpath "$f"):${ldpath}" \
+          "$f" \
+          && patchelf --shrink-rpath "$f" \
+          || echo unable to patch ... ignoring 1>&2
+      else
+        echo "not patching $f <<: unknown elf type"
+      fi
+    done
+  '';
+
+  dontBuild = true;
+
+  # all binaries are already stripped
+  dontStrip = true;
+
+  # we did this in prefixup already
+  dontPatchELF = true;
+
+  meta = with stdenv.lib; {
+    description = "Wolfram Mathematica computational software system";
+    homepage = http://www.wolfram.com/mathematica/;
+    license = licenses.unfree;
+    maintainers = with maintainers; [ herberteuler ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/applications/science/math/mathematica/l10ns.nix
+++ b/pkgs/applications/science/math/mathematica/l10ns.nix
@@ -8,6 +8,12 @@ let allVersions = with lib; flip map
   # N.B. Versions in this list should be ordered from newest to oldest.
   [
     {
+      version = "12.0.0";
+      lang = "en";
+      language = "English";
+      sha256 = "b9fb71e1afcc1d72c200196ffa434512d208fa2920e207878433f504e58ae9d7";
+    }
+    {
       version = "11.3.0";
       lang = "en";
       language = "English";

--- a/pkgs/applications/science/math/mathematica/l10ns.nix
+++ b/pkgs/applications/science/math/mathematica/l10ns.nix
@@ -1,8 +1,11 @@
-{ lib, requireFile }:
+{ lib
+, requireFile
+, lang
+, majorVersion ? null
+}:
 
-with lib;
-{
-  l10ns = flip map
+let allVersions = with lib; flip map
+  # N.B. Versions in this list should be ordered from newest to oldest.
   [
     {
       version = "11.3.0";
@@ -30,4 +33,16 @@ with lib;
       inherit sha256;
     };
   });
-}
+minVersion =
+  with lib;
+  if majorVersion == null
+  then elemAt (builtins.splitVersion (elemAt allVersions 0).version) 0
+  else majorVersion;
+maxVersion = toString (1 + builtins.fromJSON minVersion);
+in
+with lib;
+findFirst (l: (l.lang == lang
+               && l.version >= minVersion
+               && l.version < maxVersion))
+          (throw "Version ${minVersion} in language ${lang} not supported")
+          allVersions

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22663,9 +22663,9 @@ in
 
   magma = callPackage ../development/libraries/science/math/magma { };
 
-  mathematica = callPackage ../applications/science/math/mathematica { };
   mathematica9 = callPackage ../applications/science/math/mathematica/9.nix { };
   mathematica10 = callPackage ../applications/science/math/mathematica/10.nix { };
+  mathematica11 = callPackage ../applications/science/math/mathematica/11.nix { };
 
   metis = callPackage ../development/libraries/science/math/metis {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22663,6 +22663,7 @@ in
 
   magma = callPackage ../development/libraries/science/math/magma { };
 
+  mathematica = callPackage ../applications/science/math/mathematica { };
   mathematica9 = callPackage ../applications/science/math/mathematica/9.nix { };
   mathematica10 = callPackage ../applications/science/math/mathematica/10.nix { };
   mathematica11 = callPackage ../applications/science/math/mathematica/11.nix { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This pull request incorporates ideas from #63843 and #63620. It intends to upgrade Mathematica to 12.0.0.

I tried many many ways to adopt `autoPatchelfHook`, and all of them failed. Some definitions require old packages that are missing/already obsolete in Nixpkgs and hence cannot be built. Some definitions can be built, but the resulting executable either fails to run by relocation error, or crashes by segmentation fault. Also, manually debugging definitions is a rather painful process: every change typically requires 10-20 minutes of building, and it is not guaranteed to be successful.

Thus IMHO keeping the current `preFixup` definition is an acceptable way of providing 12.0 by now. An ideal way would be to write a program to analyze the (complex) dependencies of Mathematica and auto-generate definitions for every version, but this cannot be done easily and quickly for 12.0.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
