### PR TITLE
pythonPackages.fipy: init at 3.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5846,4 +5846,9 @@
     github = "mattmelling";
     name = "Matt Melling";
   };
+  wd15 = {
+    email = "daniel.wheeler2@gmail.com";
+    github = "wd15";
+    name = "Daniel Wheeler";
+  };
 }

--- a/pkgs/development/python-modules/fipy/default.nix
+++ b/pkgs/development/python-modules/fipy/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, numpy
+, scipy
+, pyamg
+, pysparse
+, future
+, matplotlib
+, tkinter
+, mpi4py
+, scikit-fmm
+, isPy27
+, gmsh
+, python
+, stdenv
+}:
+
+let
+  not_darwin_inputs = lib.optionals (! stdenv.isDarwin) [ gmsh ];
+in
+  buildPythonPackage rec {
+    pname = "fipy";
+    version = "3.3";
+
+    src = fetchPypi {
+      pname = "FiPy";
+      inherit version;
+      sha256 = "11agpg3d6yrns8igkpml1mxy3mkqkjq2yrw1mw12y07dkk12ii19";
+    };
+
+    propagatedBuildInputs = [
+      numpy
+      scipy
+      pyamg
+      matplotlib
+      tkinter
+      mpi4py
+      future
+      scikit-fmm
+    ] ++ lib.optionals isPy27 [ pysparse ] ++ not_darwin_inputs;
+
+    checkInputs = not_darwin_inputs;
+
+    checkPhase = ''
+      ${python.interpreter} setup.py test --modules
+    '';
+
+    meta = with lib; {
+      homepage = https://www.ctcms.nist.gov/fipy/;
+      description = "A Finite Volume PDE Solver Using Python";
+      license = licenses.free;
+      maintainers = with maintainers; [ costrouc wd15 ];
+    };
+  }

--- a/pkgs/development/python-modules/pyamg/default.nix
+++ b/pkgs/development/python-modules/pyamg/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, numpy
+, scipy
+, pytest
+, pybind11
+}:
+
+buildPythonPackage rec {
+  pname = "pyamg";
+  version = "4.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "3ceb38ffd86e29774e759486f2961599c8ed847459c68727493cadeaf115a38a";
+  };
+
+  propagatedBuildInputs = [
+    numpy
+    scipy
+    pytest
+    pybind11
+  ];
+
+  preBuild = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  meta = with lib; {
+    description = "Algebraic Multigrid Solvers in Python";
+    homepage = https://github.com/pyamg/pyamg;
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/pysparse/default.nix
+++ b/pkgs/development/python-modules/pysparse/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, numpy
+, setuptools
+, liblapack
+, isPy27
+, python
+}:
+
+buildPythonPackage rec {
+  pname = "pysparse";
+  version = "1.3-dev";
+  disabled = !isPy27;
+
+  src = fetchFromGitHub {
+    owner = "PythonOptimizers";
+    repo = "pysparse";
+    rev = "f8430bd99ac2a6209c462657c5792d10033888cc";
+    sha256 = "19xcq8214yndra1xjhna3qjm32wprsqck97dlnw3xcww7rfy6hqh";
+  };
+
+  hardeningDisable = [ "all" ];
+
+  propagatedBuildInputs = [
+    numpy
+    numpy.blas
+    liblapack
+  ];
+
+  # Include patches from working version of PySparse 1.3-dev in
+  # Conda-Forge,
+  # https://github.com/conda-forge/pysparse-feedstock/tree/b69266911a2/recipe
+  # Thanks to https://github.com/guyer
+  patches = [ ./dropPackageLoader.patch ];
+
+  checkPhase = ''
+    cd test
+    ${python.interpreter} -c "import pysparse"
+    ${python.interpreter} test_sparray.py
+  '';
+
+  meta = with lib; {
+    homepage = https://github.com/PythonOptimizers/pysparse;
+    description = "A Sparse Matrix Library for Python";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/pysparse/dropPackageLoader.patch
+++ b/pkgs/development/python-modules/pysparse/dropPackageLoader.patch
@@ -1,0 +1,88 @@
+diff --git a/pysparse/__init__.py b/pysparse/__init__.py
+index 6d09b00..ff39084 100644
+--- a/pysparse/__init__.py
++++ b/pysparse/__init__.py
+@@ -1,9 +1,42 @@
+-"PySparse: A Fast Sparse Matrix Library for Python"
++"""
++PySparse: A Fast Sparse Matrix Library for Python
++=================================================
++
++Documentation is available in the docstrings and
++online at http://pysparse.sourceforge.net/.
++
++Contents
++--------
++Pysparse imports
++::
++ spmatrix                     --- sparse matrix types
++
++and, in addition, provides:
++    
++Subpackages
++-----------
++Using any of these subpackages requires an explicit import.  For example,
++``import pysparse.itsolvers``.
++
++::
++
++ itsolvers                    --- Iterative linear algebra solvers
++ precon                       --- Preconditioners
++ direct                       --- Direct solvers
++ direct.superlu               --- Wrappers to SuperLU library
++ direct.umfpack               --- Wrappers to UMFPACK library
++ eigen.jdsym                  --- Jacobi davidson eigenvalue solver for symmetric matrices
++ 
++Utility tools
++-------------
++::
++
++ __version__       --- pysparse version string
++"""
++
+ 
+ __docformat__ = 'restructuredtext'
+ 
+-# Imports
+-from numpy._import_tools import PackageLoader
+ try:
+     from version import version as __version__
+ except ImportError:
+@@ -11,31 +44,6 @@ except ImportError:
+     __version__ = 'undefined'
+     
+ from sparse import spmatrix
+-#from sparse import *
+-from misc import get_include
+-
+-pkgload = PackageLoader()
+-pkgload(verbose=False,postpone=True)
+-
+-if __doc__:
+-    __doc__ += """
+-
+-Available subpackages
+----------------------
+-"""
+-if __doc__:
+-    __doc__ += pkgload.get_pkgdocs()
+-
+-__all__ = filter(lambda s: not s.startswith('_'), dir())
+-__all__ += '__version__'
+-
+-__doc__ += """
+-
+-Miscellaneous
+--------------
+-
+-    __version__  :  pysparse version string
+-"""
+ 
+ from pysparse.misc import Deprecated
+ 
+@@ -47,3 +55,5 @@ class _superlu:
+         return self.factorizeFnc(*args, **kwargs)
+     
+ superlu = _superlu()
++
++__all__ = ['spmatrix', 'superlu', '__version__']

--- a/pkgs/development/python-modules/scikit-fmm/default.nix
+++ b/pkgs/development/python-modules/scikit-fmm/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, numpy
+, python
+}:
+
+buildPythonPackage rec {
+  pname = "scikit-fmm";
+  version = "2019.1.30";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "eb64b6d8e30b8df8f8636d5fc4fd7ca6a9b05938ccd62518c80c1d9e823069dd";
+  };
+
+  propagatedBuildInputs = [
+    numpy
+  ];
+
+  checkPhase = ''
+    mkdir testdir; cd testdir
+    ${python.interpreter} -c "import skfmm, sys; sys.exit(skfmm.test())"
+  '';
+
+  meta = with lib; {
+    description = "A Python extension module which implements the fast marching method";
+    homepage = https://github.com/scikit-fmm/scikit-fmm;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4420,6 +4420,8 @@ in {
 
   pyxattr = callPackage ../development/python-modules/pyxattr { };
 
+  pyamg = callPackage ../development/python-modules/pyamg { };
+
   pyaml = callPackage ../development/python-modules/pyaml { };
 
   pyyaml = callPackage ../development/python-modules/pyyaml { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4242,6 +4242,8 @@ in {
 
   pyspread = callPackage ../development/python-modules/pyspread { };
 
+  pysparse = callPackage ../development/python-modules/pysparse { };
+
   pyupdate = callPackage ../development/python-modules/pyupdate {};
 
   pyx = callPackage ../development/python-modules/pyx { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3979,6 +3979,8 @@ in {
 
   fixtures = callPackage ../development/python-modules/fixtures { };
 
+  fipy = callPackage ../development/python-modules/fipy { };
+
   pelican = callPackage ../development/python-modules/pelican {
     inherit (pkgs) glibcLocales git;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4633,6 +4633,8 @@ in {
 
   scikit-tda = callPackage ../development/python-modules/scikit-tda { };
 
+  scikit-fmm = callPackage ../development/python-modules/scikit-fmm { };
+
   scp = callPackage ../development/python-modules/scp {};
 
   seaborn = callPackage ../development/python-modules/seaborn { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add the FiPy PDE solver, see https://www.ctcms.nist.gov/fipy/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
