### PR TITLE
Remove no commits maintainers

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -745,11 +745,6 @@
     github = "boj";
     name = "Brian Jones";
   };
-  boothead = {
-    email = "ben@perurbis.com";
-    github = "boothead";
-    name = "Ben Ford";
-  };
   borisbabic = {
     email = "boris.ivan.babic@gmail.com";
     github = "borisbabic";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5572,11 +5572,6 @@
     github = "xeji";
     name = "Uli Baum";
   };
-  xnaveira = {
-    email = "xnaveira@gmail.com";
-    github = "xnaveira";
-    name = "Xavier Naveira";
-  };
   xnwdd = {
     email = "nwdd+nixos@no.team";
     github = "xnwdd";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3133,11 +3133,6 @@
     github = "matthiasbeyer";
     name = "Matthias Beyer";
   };
-  matti-kariluoma = {
-    email = "matti@kariluo.ma";
-    github = "matti-kariluoma";
-    name = "Matti Kariluoma";
-  };
   maurer = {
     email = "matthew.r.maurer+nix@gmail.com";
     github = "maurer";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1797,11 +1797,6 @@
     github = "freezeboy";
     name = "freezeboy";
   };
-  Fresheyeball = {
-    email = "fresheyeball@gmail.com";
-    github = "fresheyeball";
-    name = "Isaac Shapira";
-  };
   fridh = {
     email = "fridh@fridh.nl";
     github = "fridh";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2822,11 +2822,6 @@
     github = "leo60228";
     name = "leo60228";
   };
-  leonardoce = {
-    email = "leonardo.cecchi@gmail.com";
-    github = "leonardoce";
-    name = "Leonardo Cecchi";
-  };
   lethalman = {
     email = "lucabru@src.gnome.org";
     github = "lethalman";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3494,11 +3494,6 @@
     github = "mt-caret";
     name = "Masayuki Takeda";
   };
-  MtP = {
-    email = "marko.nixos@poikonen.de";
-    github = "MtP76";
-    name = "Marko Poikonen";
-  };
   mtreskin = {
     email = "zerthurd@gmail.com";
     github = "Zert";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2325,11 +2325,6 @@
     github = "jerith666";
     name = "Matt McHenry";
   };
-  jeschli = {
-    email = "jeschli@gmail.com";
-    github = "jeschli";
-    name = "Markus Hihn";
-  };
   jethro = {
     email = "jethrokuan95@gmail.com";
     github = "jethrokuan";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2330,11 +2330,6 @@
     github = "jethrokuan";
     name = "Jethro Kuan";
   };
-  jfb = {
-    email = "james@yamtime.com";
-    github = "tftio";
-    name = "James Felix Black";
-  };
   jflanglois = {
     email = "yourstruly@julienlanglois.me";
     github = "jflanglois";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1875,11 +1875,6 @@
     github = "garrison";
     name = "Jim Garrison";
   };
-  gavin = {
-    email = "gavin.rogers@holo.host";
-    github = "gavinrogers";
-    name = "Gavin Rogers";
-  };
   gebner = {
     email = "gebner@gebner.org";
     github = "gebner";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3875,11 +3875,6 @@
     github = "pbogdan";
     name = "Piotr Bogdan";
   };
-  pcarrier = {
-    email = "pc@rrier.ca";
-    github = "pcarrier";
-    name = "Pierre Carrier";
-  };
   periklis = {
     email = "theopompos@gmail.com";
     github = "periklis";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4438,11 +4438,6 @@
     github = "ryanartecona";
     name = "Ryan Artecona";
   };
-  ryansydnor = {
-    email = "ryan.t.sydnor@gmail.com";
-    github = "ryansydnor";
-    name = "Ryan Sydnor";
-  };
   ryantm = {
     email = "ryan@ryantm.com";
     github = "ryantm";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3208,11 +3208,6 @@
     github = "melchips";
     name = "Francois Truphemus";
   };
-  melsigl = {
-    email = "melanie.bianca.sigl@gmail.com";
-    github = "melsigl";
-    name = "Melanie B. Sigl";
-  };
   melkor333 = {
     email = "samuel@ton-kunst.ch";
     github = "melkor333";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5602,11 +5602,6 @@
     github = "xzfc";
     name = "Albert Safin";
   };
-  y0no = {
-    email = "y0no@y0no.fr";
-    github = "y0no";
-    name = "Yoann Ono";
-  };
   yarny = {
     email = "41838844+Yarny0@users.noreply.github.com";
     github = "Yarny0";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3446,11 +3446,6 @@
     github = "fstamour";
     name = "Francis St-Amour";
   };
-  mredaelli = {
-    email = "massimo@typish.io";
-    github = "mredaelli";
-    name = "Massimo Redaelli";
-  };
   mrkkrp = {
     email = "markkarpov92@gmail.com";
     github = "mrkkrp";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -313,11 +313,6 @@
     github = "amiloradovsky";
     name = "Andrew Miloradovsky";
   };
-  aminb = {
-    email = "amin@aminb.org";
-    github = "aminb";
-    name = "Amin Bandali";
-  };
   aminechikhaoui = {
     email = "amine.chikhaoui91@gmail.com";
     github = "AmineChikhaoui";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1258,11 +1258,6 @@
     github = "DerTim1";
     name = "Tim Digel";
   };
-  desiderius = {
-    email = "didier@devroye.name";
-    github = "desiderius";
-    name = "Didier J. Devroye";
-  };
   devhell = {
     email = "\"^\"@regexmail.net";
     github = "devhell";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4650,11 +4650,6 @@
     github = "shlevy";
     name = "Shea Levy";
   };
-  shmish111 = {
-    email = "shmish111@gmail.com";
-    github = "shmish111";
-    name = "David Smith";
-  };
   shou = {
     email = "x+g@shou.io";
     github = "Shou";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -517,11 +517,6 @@
     github = "atnnn";
     name = "Etienne Laurin";
   };
-  auntie = {
-    email = "auntieNeo@gmail.com";
-    github = "auntie";
-    name = "Jonathan Glines";
-  };
   avaq = {
     email = "avaq+nixos@xs4all.nl";
     github = "avaq";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4974,11 +4974,6 @@
     github = "Radvendii";
     name = "Taeer Bar-Yam";
   };
-  taha = {
-    email = "xrcrod@gmail.com";
-    github = "tgharib";
-    name = "Taha Gharib";
-  };
   tailhook = {
     email = "paul@colomiets.name";
     github = "tailhook";


### PR DESCRIPTION
#### Motivation for this change

Removing the maintainers that have no commits, checked by running

```bash
./maintainers/scripts/check-maintainer-github-handles.sh | grep -i "no commits"
```

It has to be decided whether we actually want this, though.