### PR TITLE
lipx: init at 1.2

### DIFF
--- a/pkgs/tools/misc/lipx/default.nix
+++ b/pkgs/tools/misc/lipx/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, lib, fetchFromGitHub, python }:
+
+with lib;
+
+stdenv.mkDerivation rec {
+  name = "lipx-${version}";
+  version = "1.2";
+
+  src = fetchFromGitHub {
+    owner = "kylon";
+    repo = "Lipx";
+    rev = "1c01fcff06f1015750ad5461d5c898cba692326d";
+    sha256 = "0mgjpbzx9anap513wc4pn313k424hm93rvbxgdij54zps89k8qf9";
+  };
+
+  nativeBuildInputs = [ python ];
+
+  buildCommand = ''
+    install -vD $src/lipx.py $out/bin/lipx
+    chmod u+x $out/bin/lipx
+    patchShebangs $out/bin/lipx
+  '';
+
+  meta = {
+    description = "IPS patcher";
+    homepage = https://github.com/kylon/Lipx;
+    maintainers = [ maintainers.coconnor ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2672,6 +2672,10 @@ in
 
   epubcheck = callPackage ../tools/text/epubcheck { };
 
+  lipx = callPackage ../tools/misc/lipx {
+    python = python3;
+  };
+
   mcrcon = callPackage ../tools/networking/mcrcon {};
 
   s-tar = callPackage ../tools/archivers/s-tar {};


### PR DESCRIPTION
###### Motivation for this change

add IPS patching tool

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ x] Tested execution of all binary files (usually in `./result/bin/`)
- [ x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
