### PR TITLE
imv: 3.0.0 -> 3.1.2

### DIFF
--- a/pkgs/applications/graphics/imv/default.nix
+++ b/pkgs/applications/graphics/imv/default.nix
@@ -1,32 +1,34 @@
 { stdenv, fetchFromGitHub, SDL2, SDL2_ttf
 , freeimage, fontconfig, pkgconfig
 , asciidoc, docbook_xsl, libxslt, cmocka
+, librsvg
 }:
 
 stdenv.mkDerivation rec {
   name = "imv-${version}";
-  version = "3.0.0";
+  version = "3.1.2";
 
   src = fetchFromGitHub {
     owner  = "eXeC64";
     repo   = "imv";
     rev    = "v${version}";
-    sha256 = "0j5aykdkm1g518ism5y5flhwxvjvl92ksq989fhl2wpnv0la82jp";
+    sha256 = "0gg362x2f7hli6cr6s7dmlanh4cqk7fd2pmk4zs9438jvqklf4cl";
   };
 
   buildInputs = [
     SDL2 SDL2_ttf freeimage fontconfig pkgconfig
-    asciidoc docbook_xsl libxslt cmocka
+    asciidoc docbook_xsl libxslt cmocka librsvg
   ];
 
   installFlags = [ "PREFIX=$(out)" "CONFIGPREFIX=$(out)/etc" ];
 
+  doCheck = true;
+
   meta = with stdenv.lib; {
     description = "A command line image viewer for tiling window managers";
-    homepage    = https://github.com/eXeC64/imv; 
+    homepage    = https://github.com/eXeC64/imv;
     license     = licenses.gpl2;
-    maintainers = with maintainers; [ rnhmjoj ];
+    maintainers = with maintainers; [ rnhmjoj markus1189 ];
     platforms   = [ "i686-linux" "x86_64-linux" ];
   };
 }
-


### PR DESCRIPTION
###### Motivation for this change
Update imv from `3.0.0` to `3.1.2`
Also, activate the tests

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
