### PR TITLE
feat(nixos/maintainers): add myself under maintainers

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5151,6 +5151,11 @@
     github = "uri-canva";
     name = "Uri Baghin";
   };
+  uroshercog = {
+    email = "uros.hercog@gmail.com";
+    github = "uroshercog";
+    name = "Uroš Hercog";
+  };
   uskudnik = {
     email = "urban.skudnik@gmail.com";
     github = "uskudnik";


### PR DESCRIPTION
This PR lists myself under maintainers so that I can reference myself when building new packages.