### PR TITLE
lib: allow sourceByRegex to be composed after cleanSourceWith

### DIFF
--- a/lib/sources.nix
+++ b/lib/sources.nix
@@ -53,12 +53,16 @@ rec {
   # Filter sources by a list of regular expressions.
   #
   # E.g. `src = sourceByRegex ./my-subproject [".*\.py$" "^database.sql$"]`
-  sourceByRegex = src: regexes: cleanSourceWith {
-    filter = (path: type:
-      let relPath = lib.removePrefix (toString src + "/") (toString path);
-      in lib.any (re: builtins.match re relPath != null) regexes);
-    inherit src;
-  };
+  sourceByRegex = src: regexes:
+    let
+      isFiltered = src ? _isLibCleanSourceWith;
+      origSrc = if isFiltered then src.origSrc else src;
+    in lib.cleanSourceWith {
+      filter = (path: type:
+        let relPath = lib.removePrefix (toString origSrc + "/") (toString path);
+        in lib.any (re: builtins.match re relPath != null) regexes);
+      inherit src;
+    };
 
   # Get all files ending with the specified suffices from the given
   # directory or its descendants.  E.g. `sourceFilesBySuffices ./dir


### PR DESCRIPTION
`sourceByRegex src regexes` should include a source file if one of the regular expressions `regexes` matches the path of that file relative to `src`.

However to compute this relative path `sourceByRegex` uses:

```
relPath = lib.removePrefix (toString src + "/") (toString path);
```

Note that `toString path` evaluates to an absolute file somewhere under `src` and not under `/nix/store`.

The problem is that this doesn't work if `src` is a `cleanSourceWith` invocation as well because `toString src` will then evaluate to `src.outPath` which will evaluate to `builtins.filterSource ...` which evaluates to a path in `/nix/store` which is not a prefix of `path`.

The solution is to replace `src` with `origSrc` where

```
origSrc = if isFiltered then src.origSrc else src;
isFiltered = src ? _isLibCleanSourceWith;
```

Test this by executing the following from the nixpkgs repo:

```
(cat << 'EOI'
let
  pkgs = import ./. {};
in pkgs.runCommand "test-sourceByRegex" {
  test_sourceByRegex =
    let
      src1 = pkgs.lib.sourceByRegex ./.  [ "^test-sourceByRegex.nix$" ];
      src2 = pkgs.lib.sourceByRegex src1 [ "^test-sourceByRegex.nix$" ];
    in src2 + "/test-sourceByRegex.nix";
} ''
 cp $test_sourceByRegex $out
''
EOI
) > test-sourceByRegex.nix
nix-build test-sourceByRegex.nix
```

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
