### PR TITLE
xygrib: init at 1.2.6.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2271,6 +2271,11 @@
     github = "j-keck";
     name = "Jürgen Keck";
   };
+  j03 = {
+    email = "github@johannesloetzsch.de";
+    github = "johannesloetzsch";
+    name = "Johannes Lötzsch";
+  };
   jagajaga = {
     email = "ars.seroka@gmail.com";
     github = "jagajaga";

--- a/pkgs/applications/misc/xygrib/default.nix
+++ b/pkgs/applications/misc/xygrib/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, cmake, bzip2, qtbase, qttools, libnova, proj, libpng, openjpeg } :
+
+stdenv.mkDerivation rec {
+  version = "1.2.6.1";
+  pname = "xygrib";
+
+  src = fetchFromGitHub {
+    owner = "opengribs";
+    repo = "XyGrib";
+    rev = "v${version}";
+    sha256 = "0xzsm8pr0zjk3f8j880fg5n82jyxn8xf1330qmmq1fqv7rsrg9ia";
+  };
+
+  nativeBuildInputs = [ cmake qttools ];
+  buildInputs = [ bzip2 qtbase libnova proj openjpeg libpng ];
+  cmakeFlags = [ "-DOPENJPEG_INCLUDE_DIR=${openjpeg.dev}/include/openjpeg-2.3" ];
+
+  postInstall = ''
+    mkdir $out/bin
+    ln -s $out/XyGrib/XyGrib $out/bin/XyGrib
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://opengribs.org";
+    description = "Weather Forecast Visualization";
+    longDescription = ''XyGrib is a leading opensource weather visualization package.
+                        It interacts with OpenGribs's Grib server providing a choice
+                        of global and large area atmospheric and wave models.'';
+    license = licenses.gpl3;
+    platforms = platforms.all;
+    maintainers = [ maintainers.j03 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21317,6 +21317,8 @@ in
     inherit (gnome2) scrollkeeper libglade;
   };
 
+  xygrib = libsForQt5.callPackage ../applications/misc/xygrib/default.nix {};
+
   xzgv = callPackage ../applications/graphics/xzgv { };
 
   yabar = callPackage ../applications/window-managers/yabar { };
@@ -24412,5 +24414,4 @@ in
   dapper = callPackage ../development/tools/dapper { };
 
   kube3d =  callPackage ../applications/networking/cluster/kube3d {};
-
 }


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).