### PR TITLE
libxkbcommon: fix build on darwin with upstream patch

### DIFF
--- a/pkgs/development/libraries/libxkbcommon/default.nix
+++ b/pkgs/development/libraries/libxkbcommon/default.nix
@@ -20,11 +20,13 @@ stdenv.mkDerivation rec {
     "-Dx-locale-root=${libX11.out}/share/X11/locale"
   ];
 
-  # Remove example program which fail on Darwin
-  postPatch = if stdenv.isDarwin then ''
-    substituteInPlace meson.build \
-      --replace "executable('rmlvo-to-keymap', 'test/rmlvo-to-keymap.c', dependencies: test_dep)" ""
-  '' else null;
+  patches = stdenv.lib.optionals stdenv.isDarwin [
+    # Fix build on darwin
+    (fetchpatch {
+      url = "https://github.com/xkbcommon/libxkbcommon/commit/32d178b50fe0da05e51e4fe8903c84371d133331.patch";
+      sha256 = "1wqdjla8hmgdqr8xc2manw363sxrqqsn3s8bd397h3cd7fj3hh1v";
+    })
+  ];
 
   doCheck = false; # fails, needs unicode locale
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
https://github.com/xkbcommon/libxkbcommon/pull/101 got accepted upstream.
Made more sense to just fix the portability issue in the test program.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
