### PR TITLE
Add dropPrivileges options for vault module

### DIFF
--- a/nixos/modules/services/security/vault.nix
+++ b/nixos/modules/services/security/vault.nix
@@ -47,6 +47,14 @@ in
         description = "The name of the ip interface to listen to";
       };
 
+      dropPrivileges = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether the vault service should be run as a non-root vault user.
+        '';
+      };
+
       tlsCertFile = mkOption {
         type = types.nullOr types.str;
         default = null;
@@ -133,8 +141,8 @@ in
       restartIfChanged = false; # do not restart on "nixos-rebuild switch". It would seal the storage and disrupt the clients.
 
       serviceConfig = {
-        User = "vault";
-        Group = "vault";
+        User = if cfg.dropPrivileges then "vault" else null;
+        Group = if cfg.dropPrivileges then "vault" else null;
         ExecStart = "${cfg.package}/bin/vault server -config ${configFile}";
         PrivateDevices = true;
         PrivateTmp = true;


### PR DESCRIPTION
###### Motivation for this change

This would enable running vaul systemd unit as root if the option dropPrivileges is set to false.
running as vault would cause a lot of issue when deploying certificate using `nixops`.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
