### PR TITLE
Add spotifyd package and service

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -333,6 +333,11 @@
     github = "andersk";
     name = "Anders Kaseorg";
   };
+  anderslundstedt = {
+    email = "git@anderslundstedt.se";
+    github = "anderslundstedt";
+    name = "Anders Lundstedt";
+  };
   AndersonTorres = {
     email = "torres.anderson.85@protonmail.com";
     github = "AndersonTorres";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -198,6 +198,7 @@
   ./services/audio/slimserver.nix
   ./services/audio/snapserver.nix
   ./services/audio/squeezelite.nix
+  ./services/audio/spotifyd.nix
   ./services/audio/ympd.nix
   ./services/backup/automysqlbackup.nix
   ./services/backup/bacula.nix

--- a/nixos/modules/services/audio/spotifyd.nix
+++ b/nixos/modules/services/audio/spotifyd.nix
@@ -1,0 +1,42 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.spotifyd;
+  spotifydConf = pkgs.writeText "spotifyd.conf" cfg.config;
+in
+{
+  options = {
+    services.spotifyd = {
+      enable = mkEnableOption "spotifyd, a Spotify playing daemon";
+
+      config = mkOption {
+        default = "";
+        type = types.lines;
+        description = ''
+          Configuration for Spotifyd. For syntax and directives, see
+          https://github.com/Spotifyd/spotifyd#Configuration.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.spotifyd = {
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network-online.target" "sound.target" ];
+      description = "spotifyd, a Spotify playing daemon";
+      serviceConfig = {
+        ExecStart = "${pkgs.spotifyd}/bin/spotifyd --no-daemon --cache_path /var/cache/spotifyd --config ${spotifydConf}";
+        Restart = "always";
+        RestartSec = 12;
+        DynamicUser = true;
+        CacheDirectory = "spotifyd";
+        SupplementaryGroups = ["audio"];
+      };
+    };
+  };
+
+  meta.maintainers = [ maintainers.anderslundstedt ];
+}

--- a/pkgs/applications/audio/spotifyd/default.nix
+++ b/pkgs/applications/audio/spotifyd/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchFromGitHub, rustPlatform, pkgconfig, openssl
+, withALSA ? true, alsaLib ? null
+, withPulseAudio ? false, libpulseaudio ? null
+, withPortAudio ? false, portaudio ? null
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "spotifyd";
+  version = "0.2.11";
+
+  src = fetchFromGitHub {
+    owner = "Spotifyd";
+    repo = "spotifyd";
+    rev = "${version}";
+    sha256 = "1iybk9xrrvhrcl2xl5r2xhyn1ydhrgwnnb8ldhsw5c16b32z03q1";
+  };
+
+  cargoSha256 = "0879p1h32259schmy8j3xnwpw3sw80f8mrj8s6b5aihi3yyzz521";
+
+  cargoBuildFlags = [
+    "--no-default-features"
+    "--features"
+    "${stdenv.lib.optionalString withALSA "alsa_backend,"}${stdenv.lib.optionalString withPulseAudio "pulseaudio_backend,"}${stdenv.lib.optionalString withPortAudio "portaudio_backend,"}"
+  ];
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [ openssl ]
+    ++ stdenv.lib.optional withALSA alsaLib
+    ++ stdenv.lib.optional withPulseAudio libpulseaudio
+    ++ stdenv.lib.optional withPortAudio portaudio;
+
+  meta = with stdenv.lib; {
+    description = "An open source Spotify client running as a UNIX daemon";
+    homepage = "https://github.com/Spotifyd/spotifyd";
+    license = with licenses; [ gpl3 ];
+    maintainers = [ maintainers.anderslundstedt ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18496,6 +18496,12 @@ in
 
   spectral = qt5.callPackage ../applications/networking/instant-messengers/spectral { };
 
+  spotifyd = callPackage ../applications/audio/spotifyd {
+    withALSA = stdenv.isLinux;
+    withPulseAudio = config.pulseaudio or true;
+    withPortAudio = stdenv.isDarwin;
+  };
+
   super-productivity = callPackage ../applications/networking/super-productivity { };
 
   wlc = callPackage ../development/libraries/wlc { };


### PR DESCRIPTION
###### Motivation for this change

Spotifyd is a nice spotify connect server. This adds a spotifyd package and a spotifyd service.

I took over the abandoned #55923, addressing the comments to the best of my ability. I am not very experienced with adding packages or services to NixOS, so likely there are still things to address.

###### Additional comments

Here are the differences between this pull request and #55923:

- In the package:

  - Version bumped to 0.2.11, which also eliminates the need for the `noavxcrypto.patch` patch.

  - `platforms.unix` instead of `platforms.all`.

- In the service module:

  - As suggested by a comment, removed the `dataDir` option. As far as I can see, this option does indeed seem unnecessary.

  - As suggested by a comment, use command line option `--cache_path /var/lib/spotifyd` instead of setting `Environment = "HOME=/var/lib/spotifyd"`.

  - Added `spotifyd` user belonging to the `audio` group. (Did not work for me without this.)

Unresolved #55923 comments not addressed by the above changes:

- Using `lib.generators.toINI` to generate the config line from the `config` service option. I did not feel I had the competence to make such a change (and it is not clear to me why such a change would be preferable).

- Dropping the `--no-daemon` from the service start. I tried this which resulted in the service crashing.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---