### PR TITLE
gtk3: fix pkgconfig paths

### DIFF
--- a/pkgs/development/libraries/gtk+/01-build-Fix-path-handling-in-pkgconfig.patch
+++ b/pkgs/development/libraries/gtk+/01-build-Fix-path-handling-in-pkgconfig.patch
@@ -1,0 +1,30 @@
+From 7b692e618c4183a51af3d3b0037f106c4fec2355 Mon Sep 17 00:00:00 2001
+From: worldofpeace <worldofpeace@protonmail.ch>
+Date: Fri, 19 Jul 2019 13:32:57 -0400
+Subject: [PATCH] build: Fix path handling in pkgconfig
+
+---
+ meson.build | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index 36913b3f04..161b378ba5 100644
+--- a/meson.build
++++ b/meson.build
+@@ -834,10 +834,10 @@ configure_file(input: 'config.h.meson',
+ # pkg-config files - bit of a mess all of this
+ pkgconf = configuration_data()
+ 
+-pkgconf.set('prefix', get_option('prefix'))
++pkgconf.set('prefix', gtk_prefix)
+ pkgconf.set('exec_prefix', '${prefix}')
+-pkgconf.set('libdir', '${prefix}/@0@'.format(get_option('libdir')))
+-pkgconf.set('includedir', '${prefix}/@0@'.format(get_option('includedir')))
++pkgconf.set('libdir', gtk_libdir)
++pkgconf.set('includedir', join_paths('${prefix}', gtk_includedir))
+ pkgconf.set('GTK_API_VERSION', gtk_api_version)
+ pkgconf.set('VERSION', meson.project_version())
+ pkgconf.set('GTK_BINARY_VERSION', gtk_binary_version)
+-- 
+2.22.0
+

--- a/pkgs/development/libraries/gtk+/3.x.nix
+++ b/pkgs/development/libraries/gtk+/3.x.nix
@@ -64,6 +64,8 @@ stdenv.mkDerivation rec {
       url = "https://bug757142.bugzilla-attachments.gnome.org/attachment.cgi?id=344123";
       sha256 = "0g6fhqcv8spfy3mfmxpyji93k8d4p4q4fz1v9a1c1cgcwkz41d7p";
     })
+    # https://gitlab.gnome.org/GNOME/gtk/merge_requests/1002
+    ./01-build-Fix-path-handling-in-pkgconfig.patch
   ] ++ optionals stdenv.isDarwin [
     # X11 module requires <gio/gdesktopappinfo.h> which is not installed on Darwin
     # let’s drop that dependency in similar way to how other parts of the library do it


### PR DESCRIPTION
MR Upstream: https://gitlab.gnome.org/GNOME/gtk/merge_requests/1002

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
See https://github.com/NixOS/nixpkgs/pull/63874#issuecomment-513300516

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
