### PR TITLE
esy: init at 0.5.8 (aborted attempt)

### DIFF
--- a/pkgs/development/ocaml-modules/cudf/default.nix
+++ b/pkgs/development/ocaml-modules/cudf/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchurl, ocaml, ocamlbuild, findlib, ocaml_extlib, perl }:
+
+stdenv.mkDerivation rec {
+  pname = "cudf";
+  version = "0.9";
+
+  src = fetchurl {
+    url = "https://gforge.inria.fr/frs/download.php/36602/cudf-0.9.tar.gz";
+    sha256 = "0771lwljqwwn3cryl0plny5a5dyyrj4z6bw66ha5n8yfbpcy8clr";
+  };
+
+  buildInputs = [
+    ocaml
+    ocamlbuild
+    findlib
+    ocaml_extlib
+    perl
+  ];
+
+  makeFlags = [
+    "OCAMLLIBDIR=$(out)/lib"
+    "BINDIR=$(out)/bin"
+    "LIBDIR=$(out)/lib"
+    "INCDIR=$(out)/include"
+  ];
+
+  createFindlibDestdir = true;
+
+  meta = {
+    description = "CUDF (for Common Upgradeability Description Format) is a format for describing upgrade scenarios in package-based Free and Open Source Software distribution.";
+    license = stdenv.lib.licenses.lgpl3;
+    homepage = "http://www.mancoosi.org/cudf/";
+  };
+}

--- a/pkgs/development/ocaml-modules/dose3/default.nix
+++ b/pkgs/development/ocaml-modules/dose3/default.nix
@@ -1,0 +1,60 @@
+{ stdenv, fetchurl, ocaml, ocamlbuild, findlib
+, cppo, cudf, ocamlgraph, ocaml_extlib, re, perl }:
+
+let base_patch_url = "https://raw.githubusercontent.com/ocaml/opam-repository/master/packages/dose3/dose3.5.0.1/files";
+in
+
+stdenv.mkDerivation rec {
+  pname = "dose3";
+  version = "5.0.1";
+
+  src = fetchurl {
+    url = "https://gforge.inria.fr/frs/download.php/file/36063/dose3-5.0.1.tar.gz";
+    sha256 = "00yvyfm4j423zqndvgc1ycnmiffaa2l9ab40cyg23pf51qmzk2jm";
+  };
+
+  patches = [
+    (fetchurl {
+      url = "${base_patch_url}/0001-Install-mli-cmx-etc.patch";
+      sha256 = "1cp2sjkv5psl7lpy6bziv6vihig1z09pp4xq1fdj7yz6lgz1z7xi";
+    })
+    (fetchurl {
+      url = "${base_patch_url}/0002-dont-make-printconf.patch";
+      sha256 = "0gzqm4p9p2gnn1cgl2r8m4lvzp5ap2lcdzsvi77i4p8pyzrybjnl";
+    })
+    (fetchurl {
+      url = "${base_patch_url}/0003-Fix-for-ocaml-4.06.patch";
+      sha256 = "02zxwn2hh861inc0r5707dymwh2aj9z3maqcan1cnhwfwshp59bv";
+    })
+    (fetchurl {
+      url = "${base_patch_url}/0004-Add-unix-as-dependency-to-dose3.common-in-META.in.patch";
+      sha256 = "0zdfh47bcx66b5lch5mn6lwdc67pvlwsnhvfwjrg7kiqssvgn0l1";
+    })
+  ];
+
+  buildInputs = [
+    ocaml
+    ocamlbuild
+    findlib
+    cppo
+    cudf
+    ocamlgraph
+    ocaml_extlib
+    re
+    perl
+  ];
+
+  makeFlags = [
+    "BINDIR=$(out)/bin"
+    "LIBDIR=$(out)/lib"
+    "INCDIR=$(out)/include"
+  ];
+
+  createFindlibDestdir = true;
+
+  meta = {
+    description = "Dose library (part of Mancoosi tools).";
+    license = stdenv.lib.licenses.lgpl3;
+    homepage = "http://www.mancoosi.org/software/";
+  };
+}

--- a/pkgs/development/ocaml-modules/lwt/ppx.nix
+++ b/pkgs/development/ocaml-modules/lwt/ppx.nix
@@ -5,8 +5,7 @@ buildDunePackage {
 
   inherit (lwt) src version;
 
-  buildInputs = [ ppx_tools_versioned ];
-  propagatedBuildInputs = [ lwt ];
+  propagatedBuildInputs = [ lwt ppx_tools_versioned ];
 
   meta = {
     description = "Ppx syntax extension for Lwt";

--- a/pkgs/development/ocaml-modules/opam-core/default.nix
+++ b/pkgs/development/ocaml-modules/opam-core/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, buildDunePackage
+, cppo, ocamlgraph, opam-file-format, re }:
+
+buildDunePackage rec {
+  pname = "opam-core";
+  version = "2.0.5";
+
+  src = fetchFromGitHub {
+    owner = "ocaml";
+    repo = "opam";
+    rev = version;
+    sha256 = "0pf2smq2sdcxryq5i87hz3dv05pb3zasb1is3kxq1pi1s4cn55mx";
+  };
+
+  buildInputs = [
+    cppo
+  ];
+
+  propagatedBuildInputs = [
+    ocamlgraph
+    opam-file-format
+    re
+  ];
+
+  enable_checks = "no";
+
+  meta = {
+    description = "Small standard library extensions, and generic system interaction modules used by opam.";
+    license = stdenv.lib.licenses.lgpl2;
+  };
+}

--- a/pkgs/development/ocaml-modules/opam-format/default.nix
+++ b/pkgs/development/ocaml-modules/opam-format/default.nix
@@ -1,0 +1,15 @@
+{ stdenv, fetchFromGitHub, buildDunePackage, opam-core }:
+
+buildDunePackage rec {
+  pname = "opam-format";
+  inherit (opam-core) version src enable_checks;
+
+  propagatedBuildInputs = [
+    opam-core
+  ];
+
+  meta = {
+    description = "Definition of opam datastructures and its file interface.";
+    license = stdenv.lib.licenses.lgpl2;
+  };
+}

--- a/pkgs/development/ocaml-modules/opam-repository/default.nix
+++ b/pkgs/development/ocaml-modules/opam-repository/default.nix
@@ -1,0 +1,15 @@
+{ stdenv, fetchFromGitHub, buildDunePackage, opam-format }:
+
+buildDunePackage rec {
+  pname = "opam-repository";
+  inherit (opam-format) version src enable_checks;
+
+  propagatedBuildInputs = [
+    opam-format
+  ];
+
+  meta = {
+    description = "This library includes repository and remote sources handling, including curl/wget, rsync, git, mercurial, darcs backends.";
+    license = stdenv.lib.licenses.lgpl2;
+  };
+}

--- a/pkgs/development/ocaml-modules/opam-state/default.nix
+++ b/pkgs/development/ocaml-modules/opam-state/default.nix
@@ -1,0 +1,15 @@
+{ stdenv, fetchFromGitHub, buildDunePackage, opam-repository }:
+
+buildDunePackage rec {
+  pname = "opam-state";
+  inherit (opam-repository) version src enable_checks;
+
+  buildInputs = [
+    opam-repository
+  ];
+
+  meta = {
+    description = "Handling of the ~/.opam hierarchy, repository and switch states.";
+    license = stdenv.lib.licenses.lgpl2;
+  };
+}

--- a/pkgs/development/tools/ocaml/esy/default.nix
+++ b/pkgs/development/tools/ocaml/esy/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, fetchFromGitHub, ocamlPackages, reason }:
+
+with ocamlPackages;
+
+buildDunePackage rec {
+  pname = "esy";
+  version = "0.5.8";
+
+  src = fetchFromGitHub {
+    owner = "esy";
+    repo = "esy";
+    rev = "v${version}";
+    sha256 = "0n2606ci86vqs7sm8icf6077h5k6638909rxyj43lh55ah33l382";
+  };
+
+  buildInputs = [
+    angstrom
+    astring
+    bos
+    cmdliner
+    cudf
+    dose3
+    fmt
+    logs
+    lwt_ppx
+    opam-file-format
+    opam-format
+    opam-state
+    ppx_deriving
+    ppx_deriving_yojson
+    ppx_expect
+    ppx_here
+    ppx_inline_test
+    ppx_let
+    ppx_sexp_conv
+    ppxlib
+    re
+    reason
+    rresult
+    yojson
+  ];
+
+  meta = {
+    description = "package.json workflow for native development with Reason/OCaml";
+    license = stdenv.lib.licenses.bsd2;
+    maintainers = [ stdenv.lib.maintainers.Zimmi48 ];
+    homepage = "https://esy.sh";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -221,6 +221,8 @@ in
 
   etBook = callPackage ../data/fonts/et-book { };
 
+  esy = callPackage ../development/tools/ocaml/esy { };
+
   fetchbower = callPackage ../build-support/fetchbower {
     inherit (nodePackages) bower2nix;
   };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -199,6 +199,8 @@ let
 
     csv-lwt = callPackage ../development/ocaml-modules/csv/lwt.nix { };
 
+    cudf = callPackage ../development/ocaml-modules/cudf/default.nix { };
+
     curses = callPackage ../development/ocaml-modules/curses { };
 
     custom_printf = callPackage ../development/ocaml-modules/custom_printf { };
@@ -220,6 +222,8 @@ let
     dolog = callPackage ../development/ocaml-modules/dolog { };
 
     domain-name = callPackage ../development/ocaml-modules/domain-name { };
+
+    dose3 = callPackage ../development/ocaml-modules/dose3 { };
 
     dtoa = callPackage ../development/ocaml-modules/dtoa { };
 
@@ -571,7 +575,15 @@ let
 
     omd = callPackage ../development/ocaml-modules/omd { };
 
+    opam-core = callPackage ../development/ocaml-modules/opam-core { };
+
     opam-file-format = callPackage ../development/ocaml-modules/opam-file-format { };
+
+    opam-format = callPackage ../development/ocaml-modules/opam-format { };
+
+    opam-repository = callPackage ../development/ocaml-modules/opam-repository { };
+
+    opam-state = callPackage ../development/ocaml-modules/opam-state { };
 
     opium = callPackage ../development/ocaml-modules/opium { };
 


### PR DESCRIPTION
Aborted attempt to add the esy package manager to nixpkgs.  I think I was almost there to get its dependencies, but I have no idea if building it like a dune package would have been enough to make it work.  The last hurdle has been with cudf and dose3.  The first problem when building dose3 was a string-byte problem, fixed by pinning the ocaml version of esy to 4.05.  I don't know how to fix the next one: dose3 attempts to find a cudf.cmxa in a folder that contains a cudf.cma but no cmxa.

This submission is in the hope that this PR can be partially salvaged and my work was not totally useless.