### PR TITLE
mako: 1.3 -> 1.4

### DIFF
--- a/pkgs/applications/misc/mako/default.nix
+++ b/pkgs/applications/misc/mako/default.nix
@@ -1,33 +1,22 @@
 { stdenv, fetchFromGitHub, meson, ninja, pkgconfig, scdoc
 , systemd, pango, cairo, gdk_pixbuf
-, wayland, wayland-protocols
-, fetchpatch }:
+, wayland, wayland-protocols }:
 
 stdenv.mkDerivation rec {
   pname = "mako";
-  version = "1.3";
+  version = "1.4";
 
   src = fetchFromGitHub {
     owner = "emersion";
     repo = pname;
     rev = "v${version}";
-    sha256 = "17azdc37xsbmx13fkfp23vg9lznrv9fh6nhagn64wdq3nhsxm3b6";
+    sha256 = "11ymiq6cr2ma0iva1mqybn3j6k73bsc6lv6pcbdq7hkhd4f9b7j9";
   };
-
-  # to be removed with next release
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/emersion/mako/commit/ca8e763f06756136c534b1bbd2e5b536be6b1995.patch";
-      sha256 = "09mi7nn2vwc69igxxc6y2m36n3snhsz0ady99yabhrzl17k4ryds";
-    })
-  ];
 
   nativeBuildInputs = [ meson ninja pkgconfig scdoc wayland-protocols ];
   buildInputs = [ systemd pango cairo gdk_pixbuf wayland ];
 
-  mesonFlags = [
-    "-Dicons=enabled" "-Dman-pages=enabled" "-Dzsh-completions=true"
-  ];
+  mesonFlags = [ "-Dzsh-completions=true" ];
 
   meta = with stdenv.lib; {
     description = "A lightweight Wayland notification daemon";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

https://github.com/emersion/mako/releases/tag/v1.4

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
