### PR TITLE
blockbook: increase ulimit -n on darwin for packr execution

### DIFF
--- a/pkgs/servers/blockbook/default.nix
+++ b/pkgs/servers/blockbook/default.nix
@@ -1,4 +1,5 @@
-{ buildGoPackage
+{ stdenv
+, buildGoPackage
 , lib
 , fetchFromGitHub
 , rocksdb
@@ -30,7 +31,9 @@ buildGoPackage rec {
 
   nativeBuildInputs = [ pkg-config packr ];
 
-  preBuild = ''
+  preBuild = lib.optionalString stdenv.isDarwin ''
+    ulimit -n 8192
+  '' + ''
     export CGO_CFLAGS="-I${rocksdb}/include"
     export CGO_LDFLAGS="-L${rocksdb}/lib -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy -llz4"
     packr clean && packr


### PR DESCRIPTION
###### Motivation for this change
When testing #64987, `blockbook`'s build would fail for me on macos 10.13 due to too many open files during the `packr` process. Bumping the `ulimit -n` fixes that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
