### PR TITLE
librtorrent: 0.13.7 -> 0.13.8,  rtorrent: 0.9.7 -> 0.9.8

### DIFF
--- a/pkgs/tools/networking/p2p/libtorrent/default.nix
+++ b/pkgs/tools/networking/p2p/libtorrent/default.nix
@@ -5,14 +5,14 @@
 , openssl, libsigcxx, zlib }:
 
 stdenv.mkDerivation rec {
-  name = "libtorrent-${version}";
-  version = "0.13.7";
+  pname = "libtorrent";
+  version = "0.13.8";
 
   src = fetchFromGitHub {
     owner = "rakshasa";
-    repo = "libtorrent";
+    repo = pname;
     rev = "v${version}";
-    sha256 = "027qanwcisxhx0bq8dn8cpg8563q0k2pm8ls278f04n7jqvvwkp0";
+    sha256 = "1h5y6ab3gs20yyprdfwcw8fh1c6czs4yrdj0kf54d2vp9qwz685r";
   };
 
   nativeBuildInputs = [ pkgconfig ];
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   preConfigure = "./autogen.sh";
 
   meta = with stdenv.lib; {
-    inherit (src.meta) homepage;
+    homepage = "https://github.com/rakshasa/libtorrent";
     description = "A BitTorrent library written in C++ for *nix, with focus on high performance and good code";
 
     platforms = platforms.unix;

--- a/pkgs/tools/networking/p2p/rtorrent/default.nix
+++ b/pkgs/tools/networking/p2p/rtorrent/default.nix
@@ -8,14 +8,14 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "rtorrent-${version}";
-  version = "0.9.7";
+  pname = "rtorrent";
+  version = "0.9.8";
 
   src = fetchFromGitHub {
     owner = "rakshasa";
-    repo = "rtorrent";
+    repo = pname;
     rev = "v${version}";
-    sha256 = "0a9dk3cz56f7gad8ghsma79iy900rwdvzngs6k6x08nlwaqid8ga";
+    sha256 = "0hcaf1brk402caa7hhlb2r1c93mjzxkm8gb19xfl33gkp3jpf372";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
