### PR TITLE
home-assistant: 0.93.2 -> 0.96.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2085,7 +2085,7 @@
     githubId = 2817965;
     name = "f--t";
   };
-  f-breidenstein = {
+  fleaz = {
     email = "mail@felixbreidenstein.de";
     github = "fleaz";
     githubId = 2489598;

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,11 +2,12 @@
 # Do not edit!
 
 {
-  version = "0.93.2";
+  version = "0.96.2";
   components = {
     "abode" = ps: with ps; [  ];
     "acer_projector" = ps: with ps; [ pyserial ];
     "actiontec" = ps: with ps; [  ];
+    "adguard" = ps: with ps; [  ];
     "ads" = ps: with ps; [  ];
     "aftership" = ps: with ps; [  ];
     "air_quality" = ps: with ps; [  ];
@@ -31,8 +32,10 @@
     "api" = ps: with ps; [ aiohttp-cors ];
     "apns" = ps: with ps; [  ];
     "apple_tv" = ps: with ps; [ pyatv ];
+    "aprs" = ps: with ps; [  ];
     "aqualogic" = ps: with ps; [  ];
     "aquostv" = ps: with ps; [  ];
+    "arcam_fmj" = ps: with ps; [  ];
     "arduino" = ps: with ps; [  ];
     "arest" = ps: with ps; [  ];
     "arlo" = ps: with ps; [ ha-ffmpeg ];
@@ -43,6 +46,7 @@
     "asuswrt" = ps: with ps; [  ];
     "august" = ps: with ps; [  ];
     "aurora" = ps: with ps; [  ];
+    "aurora_abb_powerone" = ps: with ps; [  ];
     "auth" = ps: with ps; [ aiohttp-cors ];
     "automatic" = ps: with ps; [ aiohttp-cors ];
     "automation" = ps: with ps; [ aiohttp-cors ];
@@ -50,6 +54,7 @@
     "awair" = ps: with ps; [  ];
     "aws" = ps: with ps; [  ];
     "axis" = ps: with ps; [  ];
+    "azure_event_hub" = ps: with ps; [  ];
     "baidu" = ps: with ps; [  ];
     "bayesian" = ps: with ps; [  ];
     "bbb_gpio" = ps: with ps; [  ];
@@ -125,12 +130,13 @@
     "deconz" = ps: with ps; [  ];
     "decora" = ps: with ps; [  ];
     "decora_wifi" = ps: with ps; [  ];
-    "default_config" = ps: with ps; [ pynacl aiohttp-cors distro sqlalchemy zeroconf ];
+    "default_config" = ps: with ps; [ pynacl aiohttp-cors distro netdisco sqlalchemy zeroconf ];
     "deluge" = ps: with ps; [ deluge-client ];
     "demo" = ps: with ps; [ aiohttp-cors ];
     "denon" = ps: with ps; [  ];
     "denonavr" = ps: with ps; [  ];
     "deutsche_bahn" = ps: with ps; [  ];
+    "device_automation" = ps: with ps; [ aiohttp-cors ];
     "device_sun_light_trigger" = ps: with ps; [  ];
     "device_tracker" = ps: with ps; [  ];
     "dht" = ps: with ps; [  ];
@@ -174,6 +180,7 @@
     "eight_sleep" = ps: with ps; [  ];
     "eliqonline" = ps: with ps; [  ];
     "elkm1" = ps: with ps; [  ];
+    "elv" = ps: with ps; [  ];
     "emby" = ps: with ps; [  ];
     "emoncms" = ps: with ps; [  ];
     "emoncms_history" = ps: with ps; [  ];
@@ -183,6 +190,7 @@
     "enocean" = ps: with ps; [  ];
     "enphase_envoy" = ps: with ps; [  ];
     "entur_public_transport" = ps: with ps; [  ];
+    "environment_canada" = ps: with ps; [  ];
     "envirophat" = ps: with ps; [  ];
     "envisalink" = ps: with ps; [  ];
     "ephember" = ps: with ps; [  ];
@@ -233,6 +241,7 @@
     "fritzbox_callmonitor" = ps: with ps; [ fritzconnection ];
     "fritzbox_netmonitor" = ps: with ps; [ fritzconnection ];
     "fritzdect" = ps: with ps; [  ];
+    "fronius" = ps: with ps; [  ];
     "frontend" = ps: with ps; [ aiohttp-cors ];
     "frontier_silicon" = ps: with ps; [  ];
     "futurenow" = ps: with ps; [  ];
@@ -256,6 +265,7 @@
     "gogogate2" = ps: with ps; [  ];
     "google" = ps: with ps; [ google_api_python_client httplib2 oauth2client ];
     "google_assistant" = ps: with ps; [ aiohttp-cors ];
+    "google_cloud" = ps: with ps; [ google_cloud_texttospeech ];
     "google_domains" = ps: with ps; [  ];
     "google_maps" = ps: with ps; [  ];
     "google_pubsub" = ps: with ps; [ google_cloud_pubsub ];
@@ -364,6 +374,7 @@
     "lcn" = ps: with ps; [  ];
     "lg_netcast" = ps: with ps; [  ];
     "lg_soundbar" = ps: with ps; [  ];
+    "life360" = ps: with ps; [  ];
     "lifx" = ps: with ps; [ aiolifx aiolifx-effects ];
     "lifx_cloud" = ps: with ps; [  ];
     "lifx_legacy" = ps: with ps; [  ];
@@ -408,6 +419,7 @@
     "mastodon" = ps: with ps; [  ];
     "matrix" = ps: with ps; [ matrix-client ];
     "maxcube" = ps: with ps; [  ];
+    "mcp23017" = ps: with ps; [  ];
     "media_extractor" = ps: with ps; [ aiohttp-cors youtube-dl-light ];
     "media_player" = ps: with ps; [ aiohttp-cors ];
     "mediaroom" = ps: with ps; [  ];
@@ -478,6 +490,7 @@
     "noaa_tides" = ps: with ps; [  ];
     "norway_air" = ps: with ps; [  ];
     "notify" = ps: with ps; [  ];
+    "notion" = ps: with ps; [  ];
     "nsw_fuel_station" = ps: with ps; [  ];
     "nsw_rural_fire_service_feed" = ps: with ps; [  ];
     "nuheat" = ps: with ps; [  ];
@@ -530,6 +543,7 @@
     "ping" = ps: with ps; [  ];
     "pioneer" = ps: with ps; [  ];
     "pjlink" = ps: with ps; [  ];
+    "plaato" = ps: with ps; [ aiohttp-cors ];
     "plant" = ps: with ps; [  ];
     "plex" = ps: with ps; [  ];
     "plum_lightpad" = ps: with ps; [  ];
@@ -554,6 +568,7 @@
     "pyload" = ps: with ps; [  ];
     "python_script" = ps: with ps; [  ];
     "qbittorrent" = ps: with ps; [  ];
+    "qld_bushfire" = ps: with ps; [  ];
     "qnap" = ps: with ps; [  ];
     "qrcode" = ps: with ps; [ pillow ];
     "quantum_gateway" = ps: with ps; [  ];
@@ -574,6 +589,8 @@
     "rejseplanen" = ps: with ps; [  ];
     "remember_the_milk" = ps: with ps; [ httplib2 ];
     "remote" = ps: with ps; [  ];
+    "remote_rpi_gpio" = ps: with ps; [  ];
+    "repetier" = ps: with ps; [  ];
     "rest" = ps: with ps; [  ];
     "rest_command" = ps: with ps; [  ];
     "rflink" = ps: with ps; [  ];
@@ -632,7 +649,9 @@
     "sleepiq" = ps: with ps; [  ];
     "sma" = ps: with ps; [  ];
     "smappee" = ps: with ps; [  ];
+    "smarthab" = ps: with ps; [  ];
     "smartthings" = ps: with ps; [ aiohttp-cors ];
+    "smarty" = ps: with ps; [  ];
     "smhi" = ps: with ps; [  ];
     "smtp" = ps: with ps; [  ];
     "snapcast" = ps: with ps; [ snapcast ];
@@ -640,7 +659,10 @@
     "snmp" = ps: with ps; [ pysnmp ];
     "sochain" = ps: with ps; [  ];
     "socialblade" = ps: with ps; [  ];
-    "solaredge" = ps: with ps; [  ];
+    "solaredge" = ps: with ps; [ stringcase ];
+    "solaredge_local" = ps: with ps; [  ];
+    "solax" = ps: with ps; [  ];
+    "somfy" = ps: with ps; [  ];
     "somfy_mylink" = ps: with ps; [  ];
     "sonarr" = ps: with ps; [  ];
     "songpal" = ps: with ps; [  ];
@@ -657,6 +679,7 @@
     "sql" = ps: with ps; [ sqlalchemy ];
     "squeezebox" = ps: with ps; [  ];
     "srp_energy" = ps: with ps; [  ];
+    "ssdp" = ps: with ps; [ netdisco ];
     "starlingbank" = ps: with ps; [  ];
     "startca" = ps: with ps; [ xmltodict ];
     "statistics" = ps: with ps; [  ];
@@ -664,6 +687,7 @@
     "steam_online" = ps: with ps; [  ];
     "stiebel_eltron" = ps: with ps; [  ];
     "stream" = ps: with ps; [ aiohttp-cors av ];
+    "streamlabswater" = ps: with ps; [  ];
     "stride" = ps: with ps; [  ];
     "sun" = ps: with ps; [  ];
     "supervisord" = ps: with ps; [  ];
@@ -703,7 +727,7 @@
     "tensorflow" = ps: with ps; [ numpy pillow protobuf ];
     "tesla" = ps: with ps; [  ];
     "tfiac" = ps: with ps; [  ];
-    "thermoworks_smoke" = ps: with ps; [  ];
+    "thermoworks_smoke" = ps: with ps; [ stringcase ];
     "thethingsnetwork" = ps: with ps; [  ];
     "thingspeak" = ps: with ps; [  ];
     "thinkingcleaner" = ps: with ps; [  ];
@@ -724,9 +748,10 @@
     "touchline" = ps: with ps; [  ];
     "tplink" = ps: with ps; [  ];
     "tplink_lte" = ps: with ps; [  ];
-    "traccar" = ps: with ps; [  ];
+    "traccar" = ps: with ps; [ stringcase ];
     "trackr" = ps: with ps; [  ];
     "tradfri" = ps: with ps; [  ];
+    "trafikverket_train" = ps: with ps; [  ];
     "trafikverket_weatherstation" = ps: with ps; [  ];
     "transmission" = ps: with ps; [ transmissionrpc ];
     "transport_nsw" = ps: with ps; [  ];
@@ -740,11 +765,10 @@
     "twitch" = ps: with ps; [  ];
     "twitter" = ps: with ps; [  ];
     "ubee" = ps: with ps; [  ];
-    "uber" = ps: with ps; [  ];
     "ubus" = ps: with ps; [  ];
     "ue_smart_radio" = ps: with ps; [  ];
     "uk_transport" = ps: with ps; [  ];
-    "unifi" = ps: with ps; [ aiounifi pyunifi ];
+    "unifi" = ps: with ps; [ aiounifi ];
     "unifi_direct" = ps: with ps; [ pexpect ];
     "universal" = ps: with ps; [  ];
     "upc_connect" = ps: with ps; [ defusedxml ];
@@ -760,6 +784,7 @@
     "utility_meter" = ps: with ps; [  ];
     "uvc" = ps: with ps; [  ];
     "vacuum" = ps: with ps; [  ];
+    "vallox" = ps: with ps; [  ];
     "vasttrafik" = ps: with ps; [  ];
     "velbus" = ps: with ps; [  ];
     "velux" = ps: with ps; [  ];
@@ -771,6 +796,7 @@
     "viaggiatreno" = ps: with ps; [  ];
     "vizio" = ps: with ps; [  ];
     "vlc" = ps: with ps; [  ];
+    "vlc_telnet" = ps: with ps; [  ];
     "voicerss" = ps: with ps; [  ];
     "volkszaehler" = ps: with ps; [  ];
     "volumio" = ps: with ps; [  ];
@@ -782,6 +808,7 @@
     "water_heater" = ps: with ps; [  ];
     "waterfurnace" = ps: with ps; [  ];
     "watson_iot" = ps: with ps; [  ];
+    "watson_tts" = ps: with ps; [  ];
     "waze_travel_time" = ps: with ps; [ WazeRouteCalculator ];
     "weather" = ps: with ps; [  ];
     "webhook" = ps: with ps; [ aiohttp-cors ];
@@ -799,6 +826,7 @@
     "wsdot" = ps: with ps; [  ];
     "wunderground" = ps: with ps; [  ];
     "wunderlist" = ps: with ps; [  ];
+    "wwlln" = ps: with ps; [  ];
     "x10" = ps: with ps; [  ];
     "xbox_live" = ps: with ps; [  ];
     "xeoma" = ps: with ps; [  ];
@@ -816,7 +844,7 @@
     "yeelight" = ps: with ps; [  ];
     "yeelightsunflower" = ps: with ps; [  ];
     "yessssms" = ps: with ps; [  ];
-    "yi" = ps: with ps; [ ha-ffmpeg ];
+    "yi" = ps: with ps; [ aioftp ha-ffmpeg ];
     "yr" = ps: with ps; [ xmltodict ];
     "yweather" = ps: with ps; [ yahooweather ];
     "zabbix" = ps: with ps; [  ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, python3, protobuf3_6
+{ lib, fetchurl, fetchFromGitHub, python3, protobuf3_6
 
 # Look up dependencies of specified components in component-packages.nix
 , extraComponents ? []
@@ -26,20 +26,24 @@ let
       "0c3c816a028d47f659d6ff5c745cb2acf1f966da1fe5c19c77a70282b25f4c5f")
     (mkOverride "attrs" "19.1.0"
       "f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399")
-    (mkOverride "bcrypt" "3.1.6"
-      "44636759d222baa62806bbceb20e96f75a015a6381690d1bc2eda91c01ec02ea")
+    (mkOverride "bcrypt" "3.1.7"
+      "0b0069c752ec14172c5f78208f1863d7ad6755a6fae6fe76ec2c80d13be41e42")
     (mkOverride "pyjwt" "1.7.1"
       "8d59a976fb773f3e6a39c85636357c4f0e242707394cadadd9814f5cbaa20e96")
-    (mkOverride "cryptography" "2.6.1"
-      "26c821cbeb683facb966045e2064303029d572a87ee69ca5a1bf54bf55f93ca6")
-    (mkOverride "cryptography_vectors" "2.6.1" # required by cryptography==2.6.1
-      "03f38115dccb266dd96538f94067442a877932c2322661bdc5bf2502c76658af")
+    (mkOverride "cryptography" "2.7"
+      "e6347742ac8f35ded4a46ff835c60e68c22a536a8ae5c4422966d06946b6d4c6")
+    (mkOverride "cryptography_vectors" "2.7" # required by cryptography==2.7
+      "f12dfb9bd669a68004074cb5b26df6e93ed1a95ebd1a999dff0a840212ff68bc")
+    (mkOverride "importlib-metadata" "0.18"
+      "cb6ee23b46173539939964df59d3d72c3e0c1b5d54b84f1d8a7e912fe43612db")
     (mkOverride "python-slugify" "3.0.2"
       "57163ffb345c7e26063435a27add1feae67fa821f1ef4b2f292c25847575d758")
-    (mkOverride "requests" "2.21.0"
-      "502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e")
-    (mkOverride "ruamel_yaml" "0.15.94"
-      "0939bcb399ad037ef903d74ccf2f8a074f06683bc89133ad19305067d34487c8")
+    (mkOverride "pyyaml" "5.1.1"
+      "b4bb4d3f5e232425e25dda21c070ce05168a786ac9eda43768ab7f3ac2770955")
+    (mkOverride "requests" "2.22.0"
+      "11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4")
+    (mkOverride "ruamel_yaml" "0.15.97"
+      "17dbf6b7362e7aee8494f7a0f5cffd44902a6331fe89ef0853b855a7930ab845")
     (mkOverride "voluptuous" "0.11.5"
       "567a56286ef82a9d7ae0628c5842f65f516abcb496e74f3f59f1d7b28df314ef")
     (mkOverride "voluptuous-serialize" "2.1.0"
@@ -98,7 +102,7 @@ let
   extraBuildInputs = extraPackages py.pkgs;
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "0.93.2";
+  hassVersion = "0.96.2";
 
 in with py.pkgs; buildPythonApplication rec {
   pname = "homeassistant";
@@ -113,13 +117,14 @@ in with py.pkgs; buildPythonApplication rec {
     owner = "home-assistant";
     repo = "home-assistant";
     rev = version;
-    sha256 = "01zdg6yfj6qal8jpr9bskmq25crrvz7w3vifrfxmlqws6hv35gc8";
+    sha256 = "0qxdsr7zh2yqzignbhi8gcp67ba6gcp2yiyr1rww33a42r4fi0g5";
   };
 
   propagatedBuildInputs = [
     # From setup.py
-    aiohttp astral async-timeout attrs bcrypt certifi jinja2 pyjwt cryptography pip
-    python-slugify pytz pyyaml requests ruamel_yaml voluptuous voluptuous-serialize
+    aiohttp astral async-timeout attrs bcrypt certifi importlib-metadata jinja2
+    pyjwt cryptography pip python-slugify pytz pyyaml requests ruamel_yaml
+    voluptuous voluptuous-serialize
     # From http, frontend and recorder components and auth.mfa_modules.totp
     sqlalchemy aiohttp-cors hass-frontend pyotp pyqrcode
   ] ++ componentBuildInputs ++ extraBuildInputs;

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -149,6 +149,6 @@ in with py.pkgs; buildPythonApplication rec {
     homepage = https://home-assistant.io/;
     description = "Open-source home automation platform running on Python 3";
     license = licenses.asl20;
-    maintainers = with maintainers; [ f-breidenstein dotlambda globin ];
+    maintainers = with maintainers; [ fleaz dotlambda globin ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
0.93.2 is currently broken on master because it uses an old version of pyyaml that seems to have incompatibilities with recent Python interpreters. 0.96.2 has a fix for this, so bumping seems valuable.

This also bumps a few Python dependencies of home-assistant. While not technically necessary since the home-assistant derivation has version overrides anyway, I would feel bad having newer versions pinned in home-assistant that aren't available in nixpkgs natively.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
