### PR TITLE
conda: update default condaDeps

### DIFF
--- a/pkgs/tools/package-management/conda/default.nix
+++ b/pkgs/tools/package-management/conda/default.nix
@@ -6,11 +6,12 @@
 , buildFHSUserEnv
 , libselinux
 , libarchive
+, libGL
 , xorg
 # Conda installs its packages and environments under this directory
 , installationPath ? "~/.conda"
 # Conda manages most pkgs itself, but expects a few to be on the system.
-, condaDeps ? [ stdenv.cc xorg.libSM xorg.libICE xorg.libXrender libselinux ]
+, condaDeps ? [ stdenv.cc xorg.libSM xorg.libICE xorg.libX11 xorg.libXau xorg.libXi xorg.libXrender libselinux libGL ]
 # Any extra nixpkgs you'd like available in the FHS env for Conda to use
 , extraPkgs ? [ ]
 }:


### PR DESCRIPTION
###### Motivation for this change
Make conda Qt5 applications start instead of failing due to missing libs.

###### Things done
- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
