### PR TITLE
[WIP] Revert "bazel: drop absolute Python path"

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -139,6 +139,8 @@ stdenv.mkDerivation rec {
     # This is breaking the build of any C target. This patch removes the last
     # argument if it's found to be an empty string.
     ./trim-last-argument-to-gcc-if-empty.patch
+
+    ./python-stub-path-fix.patch
   ] ++ lib.optional enableNixHacks ./nix-hacks.patch;
 
 
@@ -221,7 +223,7 @@ stdenv.mkDerivation rec {
       cpp = callPackage ./cpp-test.nix { inherit runLocal bazelTest bazel-examples; };
       java = callPackage ./java-test.nix { inherit runLocal bazelTest bazel-examples; };
       protobuf = callPackage ./protobuf-test.nix { inherit runLocal bazelTest; };
-      pythonBinPath = callPackage ./python-bin-path-test.nix { inherit runLocal bazelTest; };
+      pythonBinPath = callPackage ./python-bin-path-test.nix{ inherit runLocal bazelTest; };
 
       bashToolsWithNixHacks = callPackage ./bash-tools-test.nix { inherit runLocal bazelTest; bazel = bazelWithNixHacks; };
 
@@ -323,8 +325,9 @@ stdenv.mkDerivation rec {
     genericPatches = ''
       # Substitute python's stub shebang to plain python path. (see TODO add pr URL)
       # See also `postFixup` where python is added to $out/nix-support
-      patchShebangs src/main/java/com/google/devtools/build/lib/bazel/rules/python/python_stub_template.txt \
-          --replace "#!/usr/bin/env python" "#!${python3}/bin/python"
+      substituteInPlace src/main/java/com/google/devtools/build/lib/bazel/rules/python/python_stub_template.txt\
+          --replace "/usr/bin/env python" "${python3}/bin/python" \
+          --replace "NIX_STORE_PYTHON_PATH" "${python3}/bin/python" \
 
       # md5sum is part of coreutils
       sed -i 's|/sbin/md5|md5sum|' \

--- a/pkgs/development/tools/build-managers/bazel/python-stub-path-fix.patch
+++ b/pkgs/development/tools/build-managers/bazel/python-stub-path-fix.patch
@@ -1,0 +1,13 @@
+diff --git a/src/main/java/com/google/devtools/build/lib/bazel/rules/python/python_stub_template.txt b/src/main/java/com/google/devtools/build/lib/bazel/rules/python/python_stub_template.txt
+index dac21c9a83..69b11c283f 100644
+--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/python/python_stub_template.txt
++++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/python/python_stub_template.txt
+@@ -67,7 +67,7 @@ def FindPythonBinary(module_space):
+     return os.path.join(module_space, PYTHON_BINARY)
+   else:
+     # Case 4: Path has to be looked up in the search path.
+-    return SearchPath(PYTHON_BINARY)
++    return "NIX_STORE_PYTHON_PATH"
+
+ def CreatePythonPathEntries(python_imports, module_space):
+   parts = python_imports.split(':');


### PR DESCRIPTION
This reverts commit bd98f3521c13ec5520b46d306bc64d1cb87a9fc0.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I'm currently using `rules_docker`, and #64903 has broken it. It cannot find the Python binary anymore. I'm going to attempt to add a failing test for the regression on Bazel, until then please consider this a draft.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
