### PR TITLE
dragonfly-reverb: 1.1.4 -> 2.0.0

### DIFF
--- a/pkgs/applications/audio/dragonfly-reverb/default.nix
+++ b/pkgs/applications/audio/dragonfly-reverb/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "dragonfly-reverb";
-  version = "1.1.4";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "michaelwillis";
     repo = "dragonfly-reverb";
     rev = version;
-    sha256 = "060g4ddh1z222n39wqj8jxj0zgmpjrgraw76qgyg6xkn15cn9q9y";
+    sha256 = "1qrbv4kk5v6ynx424h1i54qj0w8v6vpw81b759jawxvzzprpgq72";
     fetchSubmodules = true;
   };
 
@@ -26,9 +26,11 @@ stdenv.mkDerivation rec {
     mkdir -p $out/lib/lv2/
     mkdir -p $out/lib/vst/
     cd bin
-    cp -a DragonflyReverb        $out/bin/
-    cp -a DragonflyReverb-vst.so $out/lib/vst/
-    cp -a DragonflyReverb.lv2/   $out/lib/lv2/
+    for bin in DragonflyHallReverb DragonflyRoomReverb; do
+      cp -a $bin        $out/bin/
+      cp -a $bin-vst.so $out/lib/vst/
+      cp -a $bin.lv2/   $out/lib/lv2/ ;
+    done
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
