### PR TITLE
raul: 2017-07-23 -> 2019-12-09

### DIFF
--- a/pkgs/development/libraries/audio/raul/default.nix
+++ b/pkgs/development/libraries/audio/raul/default.nix
@@ -1,13 +1,15 @@
 { stdenv, fetchgit, boost, gtk2, pkgconfig, python, wafHook }:
 
 stdenv.mkDerivation rec {
-  name = "raul-unstable-${rev}";
-  rev = "2017-07-23";
+  pname = "raul";
+  version = "unstable-2019-12-09";
+  name = "${pname}-${version}";
 
   src = fetchgit {
-    url = "http://git.drobilla.net/cgit.cgi/raul.git";
-    rev = "4db870b2b20b0a608ec0283139056b836c5b1624";
-    sha256 = "04fajrass3ymr72flx5js5vxc601ccrmx8ny8scp0rw7j0igyjdr";
+    url = "https://gitlab.com/drobilla/raul.git";
+    fetchSubmodules = true;
+    rev = "e87bb398f025912fb989a09f1450b838b251aea1";
+    sha256 = "1z37jb6ghc13b8nv8a8hcg669gl8vh4ni9djvfgga9vcz8rmcg8l";
   };
 
   nativeBuildInputs = [ pkgconfig wafHook ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
