### PR TITLE
pyopenssl: Disable flaky test_wantWriteError test.

### DIFF
--- a/pkgs/development/python-modules/pyopenssl/default.nix
+++ b/pkgs/development/python-modules/pyopenssl/default.nix
@@ -46,6 +46,8 @@ let
     # These tests, we disable always.
     "test_set_default_verify_paths"
     "test_fallback_default_verify_paths"
+    # https://github.com/pyca/pyopenssl/issues/768
+    "test_wantWriteError"
   ] ++ (
     optionals (hasPrefix "libressl" openssl.meta.name) failingLibresslTests
   ) ++ (


### PR DESCRIPTION
Reopen of #50294, as the `Reopen and comment` button had no effect (I suspect a Github bug).