### PR TITLE
pyscard: fix darwin build, remove pcsc library mixing

### DIFF
--- a/pkgs/development/python-modules/pyscard/default.nix
+++ b/pkgs/development/python-modules/pyscard/default.nix
@@ -1,5 +1,13 @@
 { stdenv, fetchPypi, fetchpatch, buildPythonPackage, swig, pcsclite, PCSC }:
 
+let
+  # Package does not support configuring the pcsc library.
+  withApplePCSC = stdenv.isDarwin;
+
+  inherit (stdenv.lib) getLib getDev optionalString optionals;
+  inherit (stdenv.hostPlatform.extensions) sharedLibrary;
+in
+
 buildPythonPackage rec {
   version = "1.9.8";
   pname = "pyscard";
@@ -9,24 +17,28 @@ buildPythonPackage rec {
     sha256 = "15fh00z1an6r5j7hrz3jlq0rb3jygwf3x4jcwsa008bv8vpcg7gm";
   };
 
-  postPatch = ''
-    sed -e 's!"libpcsclite\.so\.1"!"${stdenv.lib.getLib pcsclite}/lib/libpcsclite.so.1"!' \
-        -i smartcard/scard/winscarddll.c
+  postPatch = if withApplePCSC then ''
+    substituteInPlace smartcard/scard/winscarddll.c \
+      --replace "/System/Library/Frameworks/PCSC.framework/PCSC" \
+                "${PCSC}/Library/Frameworks/PCSC.framework/PCSC"
+  '' else ''
+    substituteInPlace smartcard/scard/winscarddll.c \
+      --replace "libpcsclite.so.1" \
+                "${getLib pcsclite}/lib/libpcsclite${sharedLibrary}"
   '';
 
-  NIX_CFLAGS_COMPILE = "-isystem ${stdenv.lib.getDev pcsclite}/include/PCSC/";
+  NIX_CFLAGS_COMPILE = optionalString (! withApplePCSC)
+    "-I ${getDev pcsclite}/include/PCSC";
 
-  patches = [
-    # Fixes darwin tests
-    # See: https://github.com/LudovicRousseau/pyscard/issues/77
-    (fetchpatch {
-      url = "https://github.com/LudovicRousseau/pyscard/commit/62e675028086c75656444cc21d563d9f08ebf8e7.patch";
-      sha256 = "1lr55npcpc8j750vf7vaisqyk18d5f00l7nii2lvawg4sssjaaf7";
-    })
-  ];
+  # The error message differs depending on the macOS host version.
+  # Since Nix reports a constant host version, but proxies to the
+  # underlying library, it's not possible to determine the correct
+  # expected error message.  This patch allows both errors to be
+  # accepted.
+  # See: https://github.com/LudovicRousseau/pyscard/issues/77
+  patches = optionals withApplePCSC [ ./ignore-macos-bug.patch ];
 
-  propagatedBuildInputs = [ pcsclite ];
-  buildInputs = stdenv.lib.optional stdenv.isDarwin PCSC;
+  propagatedBuildInputs = if withApplePCSC then [ PCSC ] else [ pcsclite ];
   nativeBuildInputs = [ swig ];
 
   meta = {

--- a/pkgs/development/python-modules/pyscard/ignore-macos-bug.patch
+++ b/pkgs/development/python-modules/pyscard/ignore-macos-bug.patch
@@ -1,0 +1,22 @@
+diff --git a/test/test_SCardGetErrorMessage.py b/test/test_SCardGetErrorMessage.py
+old mode 100644
+new mode 100755
+index c6fe755..c1217f5
+--- a/test/test_SCardGetErrorMessage.py
++++ b/test/test_SCardGetErrorMessage.py
+@@ -29,12 +29,10 @@ class TestError(unittest.TestCase):
+         self.assertEqual(res, expected)
+ 
+         res = SCardGetErrorMessage(1)
++        expected = "Unknown error: 0x00000001"
+         # macOS bug not yet fixed
+-        if get_platform().startswith('macosx-') and get_platform() < 'macosx-10.13':
+-            expected = "Unkown error: 0x00000001"
+-        else:
+-            expected = "Unknown error: 0x00000001"
+-        self.assertEqual(res, expected)
++        macos_bug_expected = "Unkown error: 0x00000001"
++        self.assertIn(res, [expected, macos_bug_expected])
+ 
+ 
+ if __name__ == '__main__':


### PR DESCRIPTION
This should be built against a single version of PCSC: either the one
from pcsclite, or the one from Apple's PCSC framework.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fix [failing Darwin build][]. I didn't find the exact cause, but eliminating the library mixing seems sufficient.

Tested with python2 and python3 on macOS and Linux with an "OMNIKEY CardMan 1021" talking to Aventra myEIDs.

[failing Darwin build]: https://hydra.nixos.org/job/nixpkgs/trunk/python37Packages.pyscard.x86_64-darwin

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
