### PR TITLE
vault-bin: init at 1.1.3

### DIFF
--- a/pkgs/tools/security/vault/vault-bin.nix
+++ b/pkgs/tools/security/vault/vault-bin.nix
@@ -1,0 +1,57 @@
+{ stdenv, fetchurl, unzip }:
+
+let
+
+  version = "1.1.3";
+  sources = let
+
+    base = "https://releases.hashicorp.com/vault/${version}";
+
+  in {
+    "x86_64-linux" = fetchurl {
+      url = "${base}/vault_${version}_linux_amd64.zip";
+      sha256 = "293b88f4d31f6bcdcc8b508eccb7b856a0423270adebfa0f52f04144c5a22ae0";
+    };
+    "i686-linux" = fetchurl {
+      url = "${base}/vault_${version}_linux_386.zip";
+      sha256 = "9f2fb99e08fa3d25af1497516d08b5d2d8a73bcacd5354ddec024e9628795867";
+    };
+    "x86_64-darwin" = fetchurl {
+      url = "${base}/vault_${version}_darwin_amd64.zip";
+      sha256 = "a0a7a242f8299ac4a00af8aa10ccedaf63013c8a068f56eadfb9d730b87155ea";
+    };
+    "i686-darwin" = fetchurl {
+      url = "${base}/vault_${version}_darwin_386.zip";
+      sha256 = "50542cfb37abb06e8bb6b8ba41f5ca7d72a4d6a4396d4e3f4a8391bed14f63be";
+    };
+    "aarch64-linux" = fetchurl {
+      url = "${base}/vault_${version}_linux_arm64.zip";
+      sha256 = "c243dce14b2e48e3667c2aa5b7fb37009dd7043b56032d6ebe50dd456715fd3f";
+    };
+  };
+
+in
+  stdenv.mkDerivation {
+
+    src = sources."${stdenv.hostPlatform.system}" or (throw "unsupported system: ${stdenv.hostPlatform.system}");
+
+    name = "vault-bin-${version}";
+
+    nativeBuildInputs = [ unzip ];
+
+    unpackPhase = "unzip $src -d vault";
+
+    installPhase = ''
+      mkdir -p $out/bin $out/share/bash-completion/completions
+      mv vault/vault $out/bin
+      echo "complete -C $out/bin/vault vault" > $out/share/bash-completion/completions/vault
+    '';
+
+    meta = with stdenv.lib; {
+      homepage = https://www.vaultproject.io;
+      description = "A tool for managing secrets, this binary includes the UI";
+      platforms = [ "x86_64-linux" "i686-linux" "x86_64-darwin" "aarch64-linux" "i686-darwin" ];
+      license = licenses.mpl20;
+      maintainers = with maintainers; [ offline psyanticy ];
+    };
+  }

--- a/pkgs/tools/security/vault/vault-bin.nix
+++ b/pkgs/tools/security/vault/vault-bin.nix
@@ -1,12 +1,10 @@
 { stdenv, fetchurl, unzip }:
 
 let
-
   version = "1.1.3";
+
   sources = let
-
     base = "https://releases.hashicorp.com/vault/${version}";
-
   in {
     "x86_64-linux" = fetchurl {
       url = "${base}/vault_${version}_linux_amd64.zip";
@@ -30,28 +28,26 @@ let
     };
   };
 
-in
-  stdenv.mkDerivation {
+in stdenv.mkDerivation {
+  name = "vault-bin-${version}";
 
-    src = sources."${stdenv.hostPlatform.system}" or (throw "unsupported system: ${stdenv.hostPlatform.system}");
+  src = sources."${stdenv.hostPlatform.system}" or (throw "unsupported system: ${stdenv.hostPlatform.system}");
 
-    name = "vault-bin-${version}";
+  nativeBuildInputs = [ unzip ];
 
-    nativeBuildInputs = [ unzip ];
+  sourceRoot = ".";
 
-    unpackPhase = "unzip $src -d vault";
+  installPhase = ''
+    mkdir -p $out/bin $out/share/bash-completion/completions
+    mv vault $out/bin
+    echo "complete -C $out/bin/vault vault" > $out/share/bash-completion/completions/vault
+  '';
 
-    installPhase = ''
-      mkdir -p $out/bin $out/share/bash-completion/completions
-      mv vault/vault $out/bin
-      echo "complete -C $out/bin/vault vault" > $out/share/bash-completion/completions/vault
-    '';
-
-    meta = with stdenv.lib; {
-      homepage = https://www.vaultproject.io;
-      description = "A tool for managing secrets, this binary includes the UI";
-      platforms = [ "x86_64-linux" "i686-linux" "x86_64-darwin" "aarch64-linux" "i686-darwin" ];
-      license = licenses.mpl20;
-      maintainers = with maintainers; [ offline psyanticy ];
-    };
-  }
+  meta = with stdenv.lib; {
+    homepage = https://www.vaultproject.io;
+    description = "A tool for managing secrets, this binary includes the UI";
+    platforms = [ "x86_64-linux" "i686-linux" "x86_64-darwin" "aarch64-linux" "i686-darwin" ];
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ offline psyanticy ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24077,6 +24077,8 @@ in
 
   vault = callPackage ../tools/security/vault { };
 
+  vault-bin = callPackage ../tools/security/vault/vault-bin.nix { };
+
   vaultenv = haskellPackages.vaultenv;
 
   vazir-fonts = callPackage ../data/fonts/vazir-fonts { };


### PR DESCRIPTION
Currently the vault module do not include the ui part of it due to some complications (check this pr: #49082) I think instead of doing the packaging from source we can use the binary Hashicorp is providing that includes the UI.
This is still just a draft and some more work will be made (how to handle darwin and udpate the module with a UI option) if we agree on proceeding using this method. 
 cc @LnL7  @rushmorem  @offline @pradeepchhetri
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
