### PR TITLE
fxlinuxprint: init at 1.1.2-1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1237,6 +1237,11 @@
     github = "deepfire";
     name = "Kosyrev Serge";
   };
+  delan = {
+    name = "Delan Azabani";
+    email = "delan@azabani.com";
+    github = "delan";
+  };
   delroth = {
     email = "delroth@gmail.com";
     github = "delroth";

--- a/pkgs/misc/cups/drivers/fxlinuxprint/default.nix
+++ b/pkgs/misc/cups/drivers/fxlinuxprint/default.nix
@@ -1,0 +1,51 @@
+{ stdenv, lib, fetchzip, dpkg, autoPatchelfHook, cups }:
+let
+  debPlatform =
+    if stdenv.hostPlatform.system == "x86_64-linux" then "amd64"
+    else if stdenv.hostPlatform.system == "i686-linux" then "i386"
+         else throw "Unsupported system: ${stdenv.hostPlatform.system}";
+in
+stdenv.mkDerivation rec {
+  name = "fxlinuxprint-${version}";
+  version = "1.1.2-1";
+
+  src = fetchzip {
+    url = "https://onlinesupport.fujixerox.com/driver_downloads/fxlinuxpdf112119031.zip";
+    sha256 = "1mv07ch6ysk9bknfmjqsgxb803sj6vfin29s9knaqv17jvgyh0n3";
+    curlOpts = "--user-agent Mozilla/5.0";  # HTTP 410 otherwise
+  };
+
+  nativeBuildInputs = [ dpkg autoPatchelfHook ];
+  buildInputs = [ cups ];
+
+  sourceRoot = ".";
+  unpackCmd = "dpkg-deb -x $curSrc/fxlinuxprint_${version}_${debPlatform}.deb .";
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out
+    mv etc $out
+    mv usr/lib $out
+
+    mkdir -p $out/share/cups/model
+    mv usr/share/ppd/FujiXerox/* $out/share/cups/model
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Fuji Xerox Linux Printer Driver";
+    longDescription = ''
+      DocuPrint P365/368 d
+      DocuPrint CM315/318 z
+      DocuPrint CP315/318 dw
+      ApeosPort-VI C2271/C3370/C3371/C4471/C5571/C6671/C7771
+      DocuCentre-VI C2271/C3370/C3371/C4471/C5571/C6671/C7771
+      DocuPrint 3205 d/3208 d/3505 d/3508 d/4405 d/4408 d
+    '';
+    homepage = https://onlinesupport.fujixerox.com;
+    license = licenses.unfree;
+    maintainers = with maintainers; [ delan ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23899,6 +23899,8 @@ in
 
   brlaser = callPackage ../misc/cups/drivers/brlaser { };
 
+  fxlinuxprint = callPackage ../misc/cups/drivers/fxlinuxprint { };
+
   brscan4 = callPackage ../applications/graphics/sane/backends/brscan4 { };
 
   dsseries = callPackage ../applications/graphics/sane/backends/dsseries { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] ~~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~~
- [ ] ~~Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`~~
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] ~~Ensured that relevant documentation is up to date~~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
