### PR TITLE
libarchive: 3.3.3 -> 3.4.0

### DIFF
--- a/pkgs/development/libraries/libarchive/default.nix
+++ b/pkgs/development/libraries/libarchive/default.nix
@@ -1,5 +1,5 @@
 {
-  fetchurl, fetchpatch, stdenv, pkgconfig,
+  fetchFromGitHub, stdenv, pkgconfig, autoreconfHook,
   acl, attr, bzip2, e2fsprogs, libxml2, lzo, openssl, sharutils, xz, zlib,
 
   # Optional but increases closure only negligibly.
@@ -10,31 +10,18 @@ assert xarSupport -> libxml2 != null;
 
 stdenv.mkDerivation rec {
   name = "libarchive-${version}";
-  version = "3.3.3";
+  version = "3.4.0";
 
-  src = fetchurl {
-    url = "${meta.homepage}/downloads/${name}.tar.gz";
-    sha256 = "0bhfncid058p7n1n8v29l6wxm3mhdqfassscihbsxfwz3iwb2zms";
+  src = fetchFromGitHub {
+    owner = "libarchive";
+    repo = "libarchive";
+    rev = "v${version}";
+    sha256 = "063f5bw9qmksj3iy6094qxwawx174cx00q1fg6l698wqw7xn8ihq";
   };
-
-  patches = [
-    (fetchpatch {
-      # details: https://github.com/libarchive/libarchive/pull/1105
-      name = "cve-2018-1000877.diff"; # CVE-2018-1000877..80
-      url = "https://github.com/libarchive/libarchive/pull/1105.diff";
-      sha256 = "0mxcawfdy9m40mykzwhkl39a6vnh4ypgy0ipcz74qm4bi72x0gyf";
-    })
-    (fetchpatch {
-      # details: https://github.com/libarchive/libarchive/pull/1120
-      name = "cve-2019-1000019_cve-2019-1000020.diff";
-      url = "https://github.com/libarchive/libarchive/pull/1120.diff";
-      sha256 = "1mgx92v8hm7hw9j34nbfriqfkxshh3cy25rhavr7kl7lz4x5a6g4";
-    })
-  ];
 
   outputs = [ "out" "lib" "dev" ];
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig autoreconfHook ];
   buildInputs = [ sharutils zlib bzip2 openssl xz lzo ]
     ++ stdenv.lib.optionals stdenv.isLinux [ e2fsprogs attr acl ]
     ++ stdenv.lib.optional xarSupport libxml2;


### PR DESCRIPTION
###### Motivation for this change

Release notes: https://github.com/libarchive/libarchive/releases/tag/v3.4.0

cc maintainer @jcumming

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
