### PR TITLE
nixos-test-driver: allow configuration of net frontend and backend

### DIFF
--- a/nixos/lib/test-driver/Machine.pm
+++ b/nixos/lib/test-driver/Machine.pm
@@ -31,12 +31,17 @@ sub new {
 
     if (!$startCommand) {
         # !!! merge with qemu-vm.nix.
-        my $netArgs = "";
-        $netArgs .= ",romfile=$args->{netRomFile}"
-            if defined $args->{netRomFile};
+        my $netBackend = "-netdev user,id=net0";
+        my $netFrontend = "-device virtio-net-pci,netdev=net0";
+
+        $netBackend .= "," . $args->{netBackendArgs}
+            if defined $args->{netBackendArgs};
+
+        $netFrontend .= "," . $args->{netFrontendArgs}
+            if defined $args->{netFrontendArgs};
+
         $startCommand =
-            "qemu-kvm -m 384 " .
-            "-device virtio-net-pci,netdev=net0${netArgs} \$QEMU_OPTS ";
+            "qemu-kvm -m 384 $netBackend $netFrontend \$QEMU_OPTS ";
 
         if (defined $args->{hda}) {
             if ($args->{hdaInterface} eq "scsi") {

--- a/nixos/tests/boot.nix
+++ b/nixos/tests/boot.nix
@@ -61,7 +61,8 @@ let
         ];
       };
       machineConfig = perlAttrs ({
-        qemuFlags = "-boot order=n -netdev user,id=net0,tftp=${ipxeBootDir}/,bootfile=netboot.ipxe -m 2000";
+        qemuFlags = "-boot order=n -m 2000";
+        netBackendArgs = "tftp=${ipxeBootDir},bootfile=netboot.ipxe";
       } // extraConfig);
     in
       makeTest {
@@ -100,6 +101,6 @@ in {
     uefiNetboot = makeNetbootTest "uefi" {
       bios = ''"${pkgs.OVMF.fd}/FV/OVMF.fd"'';
       # Custom ROM is needed for EFI PXE boot. I failed to understand exactly why, because QEMU should still use iPXE for EFI.
-      netRomFile = ''"${pkgs.ipxe}/ipxe.efirom"'';
+      netFrontendArgs = ''romfile="${pkgs.ipxe}/ipxe.efirom"'';
     };
 }


### PR DESCRIPTION
When IPXE tests were added, an option was added for configuring only
the frontend, and the backend configuration was dropped entirely. This
caused most installer tests to fail.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Restore installer tests. 

Tested:
 - [x] tests.installer.simple.x86_64-linux
 - [x] tests.boot.biosNetboot.x86_64-linux
 - [x] tests.boot.uefiNetboot.x86_64-linux

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
