### PR TITLE
pkgsStatic: improve usability

### DIFF
--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -62,6 +62,7 @@ rec {
         ];
         mesonFlags = (args.mesonFlags or []) ++ [ "-Ddefault_library=static" ];
       });
+      static = true;
     };
 
   /* Modify a stdenv so that the specified attributes are added to

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -65,6 +65,18 @@ rec {
       static = true;
     };
 
+
+  /* Modify a stdenv so that all buildInputs are implicitly propagated to
+     consuming derivations
+  */
+  propagateBuildInputs = stdenv: stdenv //
+    { mkDerivation = args: stdenv.mkDerivation (args // {
+        propagatedBuildInputs = (args.propagatedBuildInputs or []) ++ (args.buildInputs or []);
+        buildInputs = [];
+      });
+    };
+
+
   /* Modify a stdenv so that the specified attributes are added to
      every derivation returned by its mkDerivation function.
 

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -53,6 +53,14 @@ self: super: let
 
 in {
   stdenv = foldl (flip id) super.stdenv staticAdapters;
+  gcc49Stdenv = foldl (flip id) super.gcc49Stdenv staticAdapters;
+  gcc5Stdenv = foldl (flip id) super.gcc5Stdenv staticAdapters;
+  gcc6Stdenv = foldl (flip id) super.gcc6Stdenv staticAdapters;
+  gcc7Stdenv = foldl (flip id) super.gcc7Stdenv staticAdapters;
+  gcc8Stdenv = foldl (flip id) super.gcc8Stdenv staticAdapters;
+  gcc9Stdenv = foldl (flip id) super.gcc9Stdenv staticAdapters;
+  clangStdenv = foldl (flip id) super.clangStdenv staticAdapters;
+  libcxxStdenv = foldl (flip id) super.libcxxStdenv staticAdapters;
 
   haskell = super.haskell // {
     packageOverrides = composeExtensions

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -12,7 +12,8 @@
 
 self: super: let
   inherit (super.stdenvAdapters) makeStaticBinaries
-                                 makeStaticLibraries;
+                                 makeStaticLibraries
+                                 propagateBuildInputs;
   inherit (super.lib) foldl optional flip id composeExtensions;
   inherit (super) makeSetupHook;
 
@@ -30,7 +31,7 @@ self: super: let
     });
   };
 
-  staticAdapters = [ makeStaticLibraries ]
+  staticAdapters = [ makeStaticLibraries propagateBuildInputs ]
 
     # Apple does not provide a static version of libSystem or crt0.o
     # So we can’t build static binaries without extensive hacks.


### PR DESCRIPTION
###### Motivation for this change
Defining packages that require an extra `static` parameter to work with `pkgsStatic` in overlays is rather awkward right now. Passing `static` within stdenv removes the need to explicitly add most packages to the `pkgsStatic` attrset. The flag can be queried by `attrByPath ["static"] false stdenv`.

`stdenv`s with alternative compilers are now overridden in `pkgsStatic`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
