### PR TITLE
boot tests: fix globbing in qemu configuration

### DIFF
--- a/nixos/tests/boot.nix
+++ b/nixos/tests/boot.nix
@@ -78,21 +78,21 @@ let
 in {
 
     biosCdrom = makeBootTest "bios-cdrom" {
-      cdrom = ''glob("${iso}/iso/*.iso")'';
+      cdrom = "$(echo ${iso}/iso/*.iso)";
     };
 
     biosUsb = makeBootTest "bios-usb" {
-      usb = ''glob("${iso}/iso/*.iso")'';
+      usb = "$(echo ${iso}/iso/*.iso)";
     };
 
     uefiCdrom = makeBootTest "uefi-cdrom" {
-      cdrom = ''glob("${iso}/iso/*.iso"'';
-      bios = ''"${pkgs.OVMF.fd}/FV/OVMF.fd"'';
+      cdrom = "$(echo ${iso}/iso/*.iso)";
+      bios = "${pkgs.OVMF.fd}/FV/OVMF.fd";
     };
 
     uefiUsb = makeBootTest "uefi-usb" {
-      usb = ''glob("${iso}/iso/*.iso")'';
-      bios = ''"${pkgs.OVMF.fd}/FV/OVMF.fd"'';
+      usb = "$(echo ${iso}/iso/*.iso)";
+      bios = "${pkgs.OVMF.fd}/FV/OVMF.fd";
     };
 
     biosNetboot = makeNetbootTest "bios" {};


### PR DESCRIPTION
Before the refactoring for IPXE the configuration was literal perl
code and included a call to `glob`. After refactoring it became a map
of strings, where those strings contained the old perl
code. Ultimately this was passing perl fragements to the shell
interpreting the qemu command line. To restore the globbing behaviour,
we can inject the equivalent shell glob.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fix boot tests. Note that these tests won't pass without #65212.

For the record, I think injecting shell into the qemu command line through perl is a _terrible idea_, but it seems like the smallest change to restore the tests.

Tested:
 - [x] tests.boot.biosCdrom.x86_64-linux 
 - [x] tests.boot.biosUsb.x86_64-linux
 - [x] tests.boot.uefiCdrom.x86_64-linux 
 - [x] tests.boot.uefiUsb.x86_64-linux 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
