### PR TITLE
mariadb: update packages

### DIFF
--- a/pkgs/applications/gis/grass/default.nix
+++ b/pkgs/applications/gis/grass/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, flex, bison, pkgconfig, zlib, libtiff, libpng, fftw
 , cairo, readline, ffmpeg, makeWrapper, wxGTK30, netcdf, blas
-, proj, gdal, geos, sqlite, postgresql, mysql, python2Packages, libLAS, proj-datumgrid
+, proj, gdal, geos, sqlite, postgresql, libmysqlclient, python2Packages, libLAS, proj-datumgrid
 }:
 
 stdenv.mkDerivation rec {
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ flex bison zlib proj gdal libtiff libpng fftw sqlite cairo proj
-  readline ffmpeg makeWrapper wxGTK30 netcdf geos postgresql mysql.connector-c blas
+  readline ffmpeg makeWrapper wxGTK30 netcdf geos postgresql libmysqlclient blas
   libLAS proj-datumgrid ]
     ++ (with python2Packages; [ python dateutil wxPython30 numpy ]);
 
@@ -37,8 +37,8 @@ stdenv.mkDerivation rec {
     "--with-postgres-libs=${postgresql.lib}/lib/"
     # it complains about missing libmysqld but doesn't really seem to need it
     "--with-mysql"
-    "--with-mysql-includes=${mysql.connector-c}/include/mysql"
-    "--with-mysql-libs=${mysql.connector-c}/lib/mysql"
+    "--with-mysql-includes=${libmysqlclient}/include/mysql"
+    "--with-mysql-libs=${libmysqlclient}/lib/mysql"
     "--with-blas"
     "--with-liblas=${libLAS}/bin/liblas-config"
   ];

--- a/pkgs/applications/office/kexi/default.nix
+++ b/pkgs/applications/office/kexi/default.nix
@@ -4,7 +4,7 @@
   breeze-icons, karchive, kcodecs, kcompletion, kconfig, kconfigwidgets, kcoreaddons,
   kcrash, kguiaddons, ki18n, kiconthemes, kitemviews, kio, ktexteditor, ktextwidgets,
   kwidgetsaddons, kxmlgui,
-  kdb, kproperty, kreport, lcms2, mysql, marble, postgresql
+  kdb, kproperty, kreport, lcms2, libmysqlclient, marble, postgresql
 }:
 
 mkDerivation rec {
@@ -23,7 +23,7 @@ mkDerivation rec {
     breeze-icons karchive kcodecs kcompletion kconfig kconfigwidgets kcoreaddons
     kcrash kguiaddons ki18n kiconthemes kitemviews kio ktexteditor ktextwidgets
     kwidgetsaddons kxmlgui
-    kdb kproperty kreport lcms2 mysql.connector-c marble postgresql
+    kdb kproperty kreport lcms2 libmysqlclient marble postgresql
   ];
 
   propagatedUserEnvPkgs = [ kproperty ];

--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -4,7 +4,7 @@
 , bison, flex, zip, unzip, gtk3, gtk2, libmspack, getopt, file, cairo, which
 , icu, boost, jdk, ant, cups, xorg, libcmis, fontforge
 , openssl, gperf, cppunit, GConf, ORBit2, poppler, utillinux
-, librsvg, gnome_vfs, libGLU_combined, bsh, CoinMP, libwps, libabw, mysql
+, librsvg, gnome_vfs, libGLU_combined, bsh, CoinMP, libwps, libabw, libmysqlclient
 , autoconf, automake, openldap, bash, hunspell, librdf_redland, nss, nspr
 , libwpg, dbus-glib, qt4, clucene_core, libcdr, lcms, vigra
 , unixODBC, mdds, sane-backends, mythes, libexttextcat, libvisio
@@ -361,7 +361,7 @@ in stdenv.mkDerivation rec {
       libmspack librdf_redland librsvg libsndfile libvisio libwpd libwpg libX11
       libXaw libXext libXi libXinerama libxml2 libxslt libXtst
       libXdmcp libpthreadstubs libGLU_combined mythes gst_all_1.gstreamer
-      gst_all_1.gst-plugins-base glib mysql.connector-c
+      gst_all_1.gst-plugins-base glib libmysqlclient
       neon nspr nss openldap openssl ORBit2 pam perl pkgconfig poppler
       python3 sablotron sane-backends unzip vigra which zip zlib
       mdds bluez5 libcmis libwps libabw libzmf

--- a/pkgs/applications/office/libreoffice/still.nix
+++ b/pkgs/applications/office/libreoffice/still.nix
@@ -4,7 +4,7 @@
 , bison, flex, zip, unzip, gtk3, gtk2, libmspack, getopt, file, cairo, which
 , icu, boost, jdk, ant, cups, xorg, libcmis, fontforge
 , openssl, gperf, cppunit, GConf, ORBit2, poppler, utillinux
-, librsvg, gnome_vfs, libGLU_combined, bsh, CoinMP, libwps, libabw, mysql
+, librsvg, gnome_vfs, libGLU_combined, bsh, CoinMP, libwps, libabw, libmysqlclient
 , autoconf, automake, openldap, bash, hunspell, librdf_redland, nss, nspr
 , libwpg, dbus-glib, qt4, clucene_core, libcdr, lcms, vigra
 , unixODBC, mdds, sane-backends, mythes, libexttextcat, libvisio
@@ -358,7 +358,7 @@ in stdenv.mkDerivation rec {
       libmspack librdf_redland librsvg libsndfile libvisio libwpd libwpg libX11
       libXaw libXext libXi libXinerama libxml2 libxslt libXtst
       libXdmcp libpthreadstubs libGLU_combined mythes gst_all_1.gstreamer
-      gst_all_1.gst-plugins-base glib mysql.connector-c
+      gst_all_1.gst-plugins-base glib libmysqlclient
       neon nspr nss openldap openssl ORBit2 pam perl poppler
       python3 sablotron sane-backends unzip vigra which zip zlib
       mdds bluez5 libcmis libwps libabw libzmf

--- a/pkgs/applications/science/math/glsurf/default.nix
+++ b/pkgs/applications/science/math/glsurf/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, ocamlPackages, libGLU_combined, freeglut
-, mysql, mpfr, gmp, libtiff, libjpeg, libpng, giflib
+, libmysqlclient, mpfr, gmp, libtiff, libjpeg, libpng, giflib
 }:
 
 stdenv.mkDerivation {
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
     sha256 = "0w8xxfnw2snflz8wdr2ca9f5g91w5vbyp1hwlx1v7vg83d4bwqs7";
   };
 
-  buildInputs = [ freeglut libGLU_combined mysql.connector-c mpfr gmp
+  buildInputs = [ freeglut libGLU_combined libmysqlclient mpfr gmp
     libtiff libjpeg libpng giflib ]
   ++ (with ocamlPackages; [
     ocaml findlib ocaml_mysql lablgl camlimages_4_0 mlgmpidl

--- a/pkgs/applications/video/kodi/default.nix
+++ b/pkgs/applications/video/kodi/default.nix
@@ -13,7 +13,7 @@
 , libmpeg2, libsamplerate, libmad
 , libogg, libvorbis, flac, libxslt
 , lzo, libcdio, libmodplug, libass, libbluray
-, sqlite, mysql, nasm, gnutls, libva, libdrm
+, sqlite, libmysqlclient, nasm, gnutls, libva, libdrm
 , curl, bzip2, zip, unzip, glxinfo, xdpyinfo
 , libcec, libcec_platform, dcadec, libuuid
 , libcrossguid, libmicrohttpd
@@ -161,7 +161,7 @@ in stdenv.mkDerivation {
       libmpeg2 libsamplerate libmad
       libogg libvorbis flac libxslt systemd
       lzo libcdio libmodplug libass libbluray
-      sqlite mysql.connector-c avahi lame
+      sqlite libmysqlclient avahi lame
       curl bzip2 zip unzip glxinfo xdpyinfo
       libcec libcec_platform dcadec libuuid
       libgcrypt libgpgerror libunistring

--- a/pkgs/development/compilers/gerbil/build.nix
+++ b/pkgs/development/compilers/gerbil/build.nix
@@ -1,6 +1,6 @@
 { stdenv, makeStaticLibraries,
   coreutils, rsync, bash,
-  openssl, zlib, sqlite, libxml2, libyaml, mysql, lmdb, leveldb, postgresql,
+  openssl, zlib, sqlite, libxml2, libyaml, libmysqlclient, lmdb, leveldb, postgresql,
   version, git-version, gambit, src }:
 
 # TODO: distinct packages for gerbil-release and gerbil-devel
@@ -12,13 +12,13 @@ stdenv.mkDerivation rec {
   inherit src;
 
   # Use makeStaticLibraries to enable creation of statically linked binaries
-  buildInputs_libraries = [ openssl zlib sqlite libxml2 libyaml mysql.connector-c lmdb leveldb postgresql ];
+  buildInputs_libraries = [ openssl zlib sqlite libxml2 libyaml libmysqlclient lmdb leveldb postgresql ];
   buildInputs_staticLibraries = map makeStaticLibraries buildInputs_libraries;
 
   buildInputs = [ gambit rsync bash ]
     ++ buildInputs_libraries ++ buildInputs_staticLibraries;
 
-  NIX_CFLAGS_COMPILE = [ "-I${mysql.connector-c}/include/mysql" "-L${mysql.connector-c}/lib/mysql" ];
+  NIX_CFLAGS_COMPILE = [ "-I${libmysqlclient}/include/mysql" "-L${libmysqlclient}/lib/mysql" ];
 
   postPatch = ''
     echo '(define (gerbil-version-string) "v${git-version}")' > src/gerbil/runtime/gx-version.scm
@@ -40,7 +40,7 @@ ZLIB=${makeStaticLibraries zlib}/lib/libz.a
 # SQLITE=${makeStaticLibraries sqlite}/lib/sqlite.a # MISSING!
 # LIBXML2=${makeStaticLibraries libxml2}/lib/libxml2.a # MISSING!
 # YAML=${makeStaticLibraries libyaml}/lib/libyaml.a # MISSING!
-MYSQL=${makeStaticLibraries mysql.connector-c}/lib/mariadb/libmariadb.a
+MYSQL=${makeStaticLibraries libmysqlclient}/lib/mariadb/libmariadb.a
 # LMDB=${makeStaticLibraries lmdb}/lib/mysql/libmysqlclient_r.a # MISSING!
 LEVELDB=${makeStaticLibraries lmdb}/lib/libleveldb.a
 EOF

--- a/pkgs/development/compilers/hhvm/default.nix
+++ b/pkgs/development/compilers/hhvm/default.nix
@@ -2,7 +2,7 @@
 , pcre, libevent, gd, curl, libxml2, icu, flex, bison, openssl, zlib, php
 , expat, libcap, oniguruma, libdwarf, libmcrypt, tbb, gperftools, glog, libkrb5
 , bzip2, openldap, readline, libelf, uwimap, binutils, cyrus_sasl, pam, libpng
-, libxslt, freetype, gdb, git, perl, mysql, gmp, libyaml, libedit
+, libxslt, freetype, gdb, git, perl, libmysqlclient, gmp, libyaml, libedit
 , libvpx, imagemagick, fribidi, gperf, which, ocamlPackages
 }:
 
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs =
-    [ cmake pkgconfig boost libunwind mysql.connector-c libmemcached pcre gdb git perl
+    [ cmake pkgconfig boost libunwind libmysqlclient libmemcached pcre gdb git perl
       libevent gd curl libxml2 icu flex bison openssl zlib php expat libcap
       oniguruma libdwarf libmcrypt tbb gperftools bzip2 openldap readline
       libelf uwimap binutils cyrus_sasl pam glog libpng libxslt libkrb5

--- a/pkgs/development/compilers/neko/default.nix
+++ b/pkgs/development/compilers/neko/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, boehmgc, zlib, sqlite, pcre, cmake, pkgconfig
-, git, apacheHttpd, apr, aprutil, mysql, mbedtls, openssl, pkgs, gtk2, libpthreadstubs
+, git, apacheHttpd, apr, aprutil, libmysqlclient, mbedtls, openssl, pkgs, gtk2, libpthreadstubs
 }:
 
 stdenv.mkDerivation rec {
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkgconfig git ];
   buildInputs =
     [ boehmgc zlib sqlite pcre apacheHttpd apr aprutil
-      mysql.connector-c mbedtls openssl libpthreadstubs ]
+      libmysqlclient mbedtls openssl libpthreadstubs ]
       ++ stdenv.lib.optional stdenv.isLinux gtk2
       ++ stdenv.lib.optionals stdenv.isDarwin [ pkgs.darwin.apple_sdk.frameworks.Security
                                                 pkgs.darwin.apple_sdk.frameworks.Carbon];

--- a/pkgs/development/compilers/urweb/default.nix
+++ b/pkgs/development/compilers/urweb/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, file, openssl, mlton
-, mysql, postgresql, sqlite, gcc, icu
+, libmysqlclient, postgresql, sqlite, gcc, icu
 }:
 
 stdenv.mkDerivation rec {
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "1cl0x0sy7w1lazszc8q06q3wx0x0rczxh27vimrsw54s6s9y096s";
   };
 
-  buildInputs = [ openssl mlton mysql.connector-c postgresql sqlite icu ];
+  buildInputs = [ openssl mlton libmysqlclient postgresql sqlite icu ];
 
   prePatch = ''
     sed -e 's@/usr/bin/file@${file}/bin/file@g' -i configure
@@ -21,13 +21,13 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
     export PGHEADER="${postgresql}/include/libpq-fe.h";
-    export MSHEADER="${mysql.connector-c}/include/mysql/mysql.h";
+    export MSHEADER="${libmysqlclient}/include/mysql/mysql.h";
     export SQHEADER="${sqlite.dev}/include/sqlite3.h";
 
     export CC="${gcc}/bin/gcc";
     export CCARGS="-I$out/include \
                    -L${openssl.out}/lib \
-                   -L${mysql.connector-c}/lib \
+                   -L${libmysqlclient}/lib \
                    -L${postgresql.lib}/lib \
                    -L${sqlite.out}/lib";
   '';

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -53,7 +53,7 @@ self: super: builtins.intersectAttrs super {
 
   # Use the default version of mysql to build this package (which is actually mariadb).
   # test phase requires networking
-  mysql = dontCheck (super.mysql.override { mysql = pkgs.mysql.connector-c; });
+  mysql = dontCheck (super.mysql.override { mysql = pkgs.libmysqlclient; });
 
   # CUDA needs help finding the SDK headers and libraries.
   cuda = overrideCabal super.cuda (drv: {

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -1,6 +1,6 @@
 # pcre functionality is tested in nixos/tests/php-pcre.nix
 { lib, stdenv, fetchurl, autoconf, bison, libtool, pkgconfig, re2c
-, mysql, libxml2, readline, zlib, curl, postgresql, gettext
+, libmysqlclient, libxml2, readline, zlib, curl, postgresql, gettext
 , openssl, pcre, pcre2, sqlite, config, libjpeg, libpng, freetype
 , libxslt, libmcrypt, bzip2, icu, openldap, cyrus_sasl, libmhash, unixODBC
 , uwimap, pam, gmp, apacheHttpd, libiconv, systemd, libsodium, html-tidy, libargon2
@@ -64,7 +64,7 @@ let
   }:
 
     let
-      mysqlBuildInputs = optional (!mysqlndSupport) mysql.connector-c;
+      mysqlBuildInputs = optional (!mysqlndSupport) libmysqlclient;
       libmcrypt' = libmcrypt.override { disablePosixThreads = true; };
     in stdenv.mkDerivation {
 
@@ -149,9 +149,9 @@ let
       ++ optional postgresqlSupport "--with-pgsql=${postgresql}"
       ++ optional pdo_odbcSupport "--with-pdo-odbc=unixODBC,${unixODBC}"
       ++ optional pdo_pgsqlSupport "--with-pdo-pgsql=${postgresql}"
-      ++ optional pdo_mysqlSupport "--with-pdo-mysql=${if mysqlndSupport then "mysqlnd" else mysql.connector-c}"
+      ++ optional pdo_mysqlSupport "--with-pdo-mysql=${if mysqlndSupport then "mysqlnd" else libmysqlclient}"
       ++ optionals mysqliSupport [
-        "--with-mysqli=${if mysqlndSupport then "mysqlnd" else "${mysql.connector-c}/bin/mysql_config"}"
+        "--with-mysqli=${if mysqlndSupport then "mysqlnd" else "${libmysqlclient}/bin/mysql_config"}"
       ]
       ++ optional ( pdo_mysqlSupport || mysqliSupport ) "--with-mysql-sock=/run/mysqld/mysqld.sock"
       ++ optional bcmathSupport "--enable-bcmath"

--- a/pkgs/development/libraries/cppdb/default.nix
+++ b/pkgs/development/libraries/cppdb/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, sqlite, mysql, postgresql, unixODBC }:
+{ stdenv, fetchurl, cmake, sqlite, libmysqlclient, postgresql, unixODBC }:
 
 stdenv.mkDerivation rec {
   pname = "cppdb";
@@ -11,10 +11,10 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  buildInputs = [ cmake sqlite mysql.connector-c postgresql unixODBC ];
+  buildInputs = [ cmake sqlite libmysqlclient postgresql unixODBC ];
 
   cmakeFlags = [ "--no-warn-unused-cli" ];
-  NIX_CFLAGS_COMPILE = [ "-I${mysql.connector-c}/include/mysql" "-L${mysql.connector-c}/lib/mysql" ];
+  NIX_CFLAGS_COMPILE = [ "-I${libmysqlclient}/include/mysql" "-L${libmysqlclient}/lib/mysql" ];
 
   meta = with stdenv.lib; {
     homepage = http://cppcms.com/sql/cppdb/;

--- a/pkgs/development/libraries/gdal/2.4.0.nix
+++ b/pkgs/development/libraries/gdal/2.4.0.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchpatch, unzip, libjpeg, libtiff, zlib
-, postgresql, mysql, libgeotiff, pythonPackages, proj, geos, openssl
+, postgresql, libmysqlclient, libgeotiff, pythonPackages, proj, geos, openssl
 , libpng, sqlite, libspatialite, poppler, hdf4, qhull, giflib, expat
 , libiconv, libxml2
 , netcdfSupport ? true, netcdf, hdf5, curl
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     "--with-poppler=${poppler.dev}" # optional
     "--with-libz=${zlib.dev}"       # optional
     "--with-pg=${postgresql}/bin/pg_config"
-    "--with-mysql=${mysql.connector-c or mysql}/bin/mysql_config"
+    "--with-mysql=${libmysqlclient}/bin/mysql_config"
     "--with-geotiff=${libgeotiff.dev}"
     "--with-sqlite3=${sqlite.dev}"
     "--with-spatialite=${libspatialite}"

--- a/pkgs/development/libraries/gdal/default.nix
+++ b/pkgs/development/libraries/gdal/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, fetchpatch, unzip, libjpeg, libtiff, zlib
-, postgresql, mysql, libgeotiff, pythonPackages, proj, geos, openssl
+, postgresql, libmysqlclient, libgeotiff, pythonPackages, proj, geos, openssl
 , libpng, sqlite, libspatialite, poppler, hdf4, qhull, giflib, expat
 , libiconv, libxml2, autoreconfHook
 , netcdfSupport ? true, netcdf, hdf5, curl
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
     "--with-poppler=${poppler.dev}" # optional
     "--with-libz=${zlib.dev}"       # optional
     "--with-pg=${postgresql}/bin/pg_config"
-    "--with-mysql=${mysql.connector-c or mysql}/bin/mysql_config"
+    "--with-mysql=${libmysqlclient}/bin/mysql_config"
     "--with-geotiff=${libgeotiff}"
     "--with-sqlite3=${sqlite.dev}"
     "--with-spatialite=${libspatialite}"

--- a/pkgs/development/libraries/kdb/default.nix
+++ b/pkgs/development/libraries/kdb/default.nix
@@ -1,7 +1,7 @@
 {
   mkDerivation, lib, fetchurl,
   extra-cmake-modules,
-  qtbase, qttranslations, kcoreaddons, python2, sqlite, postgresql, mysql
+  qtbase, qttranslations, kcoreaddons, python2, sqlite, postgresql, libmysqlclient
 }:
 
 mkDerivation rec {
@@ -15,7 +15,7 @@ mkDerivation rec {
 
   nativeBuildInputs = [ extra-cmake-modules ];
 
-  buildInputs = [ qttranslations kcoreaddons python2 sqlite postgresql mysql.connector-c ];
+  buildInputs = [ qttranslations kcoreaddons python2 sqlite postgresql libmysqlclient ];
 
   propagatedBuildInputs = [ qtbase ];
 

--- a/pkgs/development/libraries/libagar/default.nix
+++ b/pkgs/development/libraries/libagar/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, libtool, perl, bsdbuild, gettext, mandoc
 , libpng, libjpeg, xlibsWrapper, libXinerama, freetype, SDL, libGLU_combined
-, libsndfile, portaudio, mysql, fontconfig
+, libsndfile, portaudio, libmysqlclient, fontconfig
 }:
 
 let srcs = import ./srcs.nix { inherit fetchurl; }; in
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
     "--with-gettext=${gettext}"
     "--with-jpeg=${libjpeg.dev}"
     "--with-gl=${libGLU_combined}"
-    "--with-mysql=${mysql.connector-c}"
+    "--with-mysql=${libmysqlclient}"
     "--with-manpages=yes"
   ];
 
@@ -29,7 +29,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ pkgconfig libtool gettext ];
 
   buildInputs = [
-    bsdbuild perl xlibsWrapper libXinerama SDL libGLU_combined mysql.connector-c mandoc
+    bsdbuild perl xlibsWrapper libXinerama SDL libGLU_combined libmysqlclient mandoc
     freetype.dev libpng libjpeg.dev fontconfig portaudio libsndfile
   ];
 

--- a/pkgs/development/libraries/libdbi-drivers/default.nix
+++ b/pkgs/development/libraries/libdbi-drivers/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, libdbi
-, mysql ? null
+, libmysqlclient ? null
 , sqlite ? null
 , postgresql ? null
 }:
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     sha256 = "0m680h8cc4428xin4p733azysamzgzcmv4psjvraykrsaz6ymlj3";
   };
 
-  buildInputs = [ libdbi sqlite postgresql ] ++ optional (mysql != null) mysql.connector-c;
+  buildInputs = [ libdbi sqlite postgresql ] ++ optional (libmysqlclient != null) libmysqlclient;
 
   postPatch = ''
     sed -i '/SQLITE3_LIBS/ s/-lsqlite/-lsqlite3/' configure;
@@ -26,10 +26,10 @@ stdenv.mkDerivation rec {
     "--enable-libdbi"
     "--with-dbi-incdir=${libdbi}/include"
     "--with-dbi-libdir=${libdbi}/lib"
-  ] ++ optionals (mysql != null) [
+  ] ++ optionals (libmysqlclient != null) [
     "--with-mysql"
-    "--with-mysql-incdir=${mysql.connector-c}/include/mysql"
-    "--with-mysql-libdir=${mysql.connector-c}/lib/mysql"
+    "--with-mysql-incdir=${libmysqlclient}/include/mysql"
+    "--with-mysql-libdir=${libmysqlclient}/lib/mysql"
   ] ++ optionals (sqlite != null) [
     "--with-sqlite3"
     "--with-sqlite3-incdir=${sqlite.dev}/include/sqlite"

--- a/pkgs/development/libraries/libgda/default.nix
+++ b/pkgs/development/libraries/libgda/default.nix
@@ -1,10 +1,10 @@
 { stdenv, fetchurl, pkgconfig, intltool, itstool, libxml2, gtk3, openssl, gnome3, gobject-introspection, vala, libgee
 , overrideCC, gcc6
-, mysqlSupport ? false, mysql ? null
+, mysqlSupport ? false, libmysqlclient ? null
 , postgresSupport ? false, postgresql ? null
 }:
 
-assert mysqlSupport -> mysql != null;
+assert mysqlSupport -> libmysqlclient != null;
 assert postgresSupport -> postgresql != null;
 
 (if stdenv.isAarch64 then overrideCC stdenv gcc6 else stdenv).mkDerivation rec {
@@ -25,7 +25,7 @@ assert postgresSupport -> postgresql != null;
 
   nativeBuildInputs = [ pkgconfig intltool itstool libxml2 gobject-introspection vala ];
   buildInputs = with stdenv.lib; [ gtk3 openssl libgee ]
-    ++ optional (mysqlSupport) mysql.connector-c
+    ++ optional (mysqlSupport) libmysqlclient
     ++ optional (postgresSupport) postgresql;
 
   passthru = {

--- a/pkgs/development/libraries/librdf/redland.nix
+++ b/pkgs/development/libraries/librdf/redland.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, openssl, libxslt, perl
 , curl, pcre, libxml2, librdf_rasqal, gmp
-, mysql, withMysql ? false
+, libmysqlclient, withMysql ? false
 , postgresql, withPostgresql ? false
 , sqlite, withSqlite ? true
 , db, withBdb ? false
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ perl pkgconfig ];
 
   buildInputs = [ openssl libxslt curl pcre libxml2 gmp ]
-    ++ stdenv.lib.optional withMysql mysql.connector-c
+    ++ stdenv.lib.optional withMysql libmysqlclient
     ++ stdenv.lib.optional withSqlite sqlite
     ++ stdenv.lib.optional withPostgresql postgresql
     ++ stdenv.lib.optional withBdb db;

--- a/pkgs/development/libraries/opendbx/default.nix
+++ b/pkgs/development/libraries/opendbx/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, readline, mysql, postgresql, sqlite }:
+{ stdenv, fetchurl, readline, libmysqlclient, postgresql, sqlite }:
 
 stdenv.mkDerivation rec {
   name = "opendbx-1.4.6";
@@ -9,12 +9,12 @@ stdenv.mkDerivation rec {
   };
 
   preConfigure = ''
-    export CPPFLAGS="-I${mysql.connector-c}/include/mysql"
-    export LDFLAGS="-L${mysql.connector-c}/lib/mysql -L${postgresql}/lib"
+    export CPPFLAGS="-I${libmysqlclient}/include/mysql"
+    export LDFLAGS="-L${libmysqlclient}/lib/mysql -L${postgresql}/lib"
     configureFlagsArray=(--with-backends="mysql pgsql sqlite3")
   '';
 
-  buildInputs = [ readline mysql.connector-c postgresql sqlite ];
+  buildInputs = [ readline libmysqlclient postgresql sqlite ];
 
   meta = with stdenv.lib; {
     description = "Extremely lightweight but extensible database access library written in C";

--- a/pkgs/development/libraries/poco/default.nix
+++ b/pkgs/development/libraries/poco/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, pkgconfig, zlib, pcre, expat, sqlite, openssl, unixODBC, mysql }:
+{ stdenv, fetchurl, cmake, pkgconfig, zlib, pcre, expat, sqlite, openssl, unixODBC, libmysqlclient }:
 
 stdenv.mkDerivation rec {
   pname = "poco";
@@ -12,9 +12,9 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake pkgconfig ];
 
-  buildInputs = [ zlib pcre expat sqlite openssl unixODBC mysql.connector-c ];
+  buildInputs = [ zlib pcre expat sqlite openssl unixODBC libmysqlclient ];
 
-  MYSQL_DIR = mysql.connector-c;
+  MYSQL_DIR = libmysqlclient;
   MYSQL_INCLUDE_DIR = "${MYSQL_DIR}/include/mysql";
 
   cmakeFlags = [

--- a/pkgs/development/libraries/qt-3/default.nix
+++ b/pkgs/development/libraries/qt-3/default.nix
@@ -5,7 +5,7 @@
 , xineramaSupport ? true, libXinerama ? null
 , cursorSupport ? true, libXcursor ? null
 , threadSupport ? true
-, mysqlSupport ? false, mysql ? null
+, mysqlSupport ? false, libmysqlclient ? null
 , libGLSupported ? stdenv.lib.elem stdenv.hostPlatform.system stdenv.lib.platforms.mesaPlatforms
 , openglSupport ? stdenv.lib.elem stdenv.hostPlatform.system stdenv.lib.platforms.mesaPlatforms
 , libGLU_combined ? null, libXmu ? null
@@ -16,7 +16,7 @@ assert xftSupport -> libXft != null;
 assert xrenderSupport -> xftSupport && libXrender != null;
 assert xrandrSupport -> libXrandr != null;
 assert cursorSupport -> libXcursor != null;
-assert mysqlSupport -> mysql != null;
+assert mysqlSupport -> libmysqlclient != null;
 assert openglSupport -> libGLU_combined != null && libXmu != null;
 
 stdenv.mkDerivation {
@@ -62,7 +62,7 @@ stdenv.mkDerivation {
   ] ++ stdenv.lib.optionals cursorSupport [
     "-L${libXcursor.out}/lib -I${libXcursor.dev}/include"
   ] ++ stdenv.lib.optionals mysqlSupport [
-    "-qt-sql-mysql" "-L${mysql.connector-c}/lib/mysql" "-I${mysql.connector-c}/include/mysql"
+    "-qt-sql-mysql" "-L${libmysqlclient}/lib/mysql" "-I${libmysqlclient}/include/mysql"
   ] ++ stdenv.lib.optionals xftSupport [
     "-L${libXft.out}/lib" "-I${libXft.dev}/include"
     "-L${libXft.freetype.out}/lib" "-I${libXft.freetype.dev}/include"

--- a/pkgs/development/libraries/qt-4.x/4.8/default.nix
+++ b/pkgs/development/libraries/qt-4.x/4.8/default.nix
@@ -2,7 +2,7 @@
 , libXrender, libXinerama, libXcursor, libXv, libXext
 , libXfixes, libXrandr, libSM, freetype, fontconfig, zlib, libjpeg, libpng
 , libmng, which, libGLU, openssl, dbus, cups, pkgconfig
-, libtiff, glib, icu, mysql, postgresql, sqlite, perl, coreutils, libXi
+, libtiff, glib, icu, libmysqlclient, postgresql, sqlite, perl, coreutils, libXi
 , buildMultimedia ? stdenv.isLinux, alsaLib, gstreamer, gst-plugins-base
 , buildWebkit ? (stdenv.isLinux || stdenv.isDarwin)
 , libGLSupported ? stdenv.lib.elem stdenv.hostPlatform.system stdenv.lib.platforms.mesaPlatforms
@@ -166,7 +166,7 @@ stdenv.mkDerivation rec {
     (mk (!stdenv.isFreeBSD) "opengl") "-xrender" "-xrandr" "-xinerama" "-xcursor" "-xinput" "-xfixes" "-fontconfig"
     "-qdbus" (mk (cups != null) "cups") "-glib" "-dbus-linked" "-openssl-linked"
 
-    "-${if mysql != null then "plugin" else "no"}-sql-mysql" "-system-sqlite"
+    "-${if libmysqlclient != null then "plugin" else "no"}-sql-mysql" "-system-sqlite"
 
     "-exceptions" "-xmlpatterns"
 
@@ -192,7 +192,7 @@ stdenv.mkDerivation rec {
   buildInputs =
     [ cups # Qt dlopen's libcups instead of linking to it
       postgresql sqlite libjpeg libmng libtiff icu ]
-    ++ lib.optionals (mysql != null) [ mysql.connector-c ]
+    ++ lib.optionals (libmysqlclient != null) [ libmysqlclient ]
     ++ lib.optionals gtkStyle [ gtk2 gdk-pixbuf ]
     ++ lib.optionals stdenv.isDarwin [ ApplicationServices OpenGL Cocoa AGL libcxx libobjc ];
 

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -14,7 +14,7 @@
   zlib,
 
   # optional dependencies
-  cups ? null, mysql ? null, postgresql ? null,
+  cups ? null, libmysqlclient ? null, postgresql ? null,
   withGtk3 ? false, dconf ? null, gtk3 ? null,
 
   # options
@@ -80,7 +80,7 @@ stdenv.mkDerivation {
     )
     ++ lib.optional developerBuild gdb
     ++ lib.optional (cups != null) cups
-    ++ lib.optional (mysql != null) mysql.connector-c
+    ++ lib.optional (libmysqlclient != null) libmysqlclient
     ++ lib.optional (postgresql != null) postgresql;
 
   nativeBuildInputs =
@@ -285,7 +285,7 @@ stdenv.mkDerivation {
       "-L" "${openssl.out}/lib"
       "-I" "${openssl.dev}/include"
       "-system-sqlite"
-      ''-${if mysql != null then "plugin" else "no"}-sql-mysql''
+      ''-${if libmysqlclient != null then "plugin" else "no"}-sql-mysql''
       ''-${if postgresql != null then "plugin" else "no"}-sql-psql''
 
       "-make libs"
@@ -349,9 +349,9 @@ stdenv.mkDerivation {
           "-L" "${cups.lib}/lib"
           "-I" "${cups.dev}/include"
         ]
-        ++ lib.optionals (mysql != null) [
-          "-L" "${mysql.out}/lib"
-          "-I" "${mysql.out}/include"
+        ++ lib.optionals (libmysqlclient != null) [
+          "-L" "${libmysqlclient}/lib"
+          "-I" "${libmysqlclient}/include"
         ]
     );
 

--- a/pkgs/development/libraries/tntdb/default.nix
+++ b/pkgs/development/libraries/tntdb/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cxxtools, postgresql, mysql, sqlite, zlib, openssl }:
+{ stdenv, fetchurl, cxxtools, postgresql, libmysqlclient, sqlite, zlib, openssl }:
 
 stdenv.mkDerivation rec {
   pname = "tntdb";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "0js79dbvkic30bzw1pf26m64vs2ssw2sbj55w1dc0sy69dlv4fh9";
   };
 
-  buildInputs = [ cxxtools postgresql mysql.connector-c sqlite zlib openssl ];
+  buildInputs = [ cxxtools postgresql libmysqlclient sqlite zlib openssl ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/unixODBCDrivers/default.nix
+++ b/pkgs/development/libraries/unixODBCDrivers/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, unixODBC, cmake, postgresql, mysql, libmysqlclient, sqlite, zlib, libxml2, dpkg, lib, kerberos, curl, libuuid, autoPatchelfHook }:
+{ fetchurl, stdenv, unixODBC, cmake, postgresql, mysql, libmysqlclient, sqlite, zlib, libxml2, dpkg, lib, openssl, kerberos, curl, libuuid, autoPatchelfHook }:
 
 # I haven't done any parameter tweaking.. So the defaults provided here might be bad
 
@@ -29,18 +29,23 @@
 
   mariadb = stdenv.mkDerivation rec {
     pname = "mariadb-connector-odbc";
-    version = "2.0.10";
+    version = "3.1.2";
 
     src = fetchurl {
-      url = "https://downloads.mariadb.org/interstitial/connector-odbc-${version}/src/${pname}-${version}-ga-src.tar.gz";
-      sha256 = "0b6ximy0dg0xhqbrm1l7pn8hjapgpmddi67kh54h6i9cq9hqfdvz";
+      url = "https://downloads.mariadb.org/interstitial/connector-odbc-${version}/${pname}-${version}-ga-src.tar.gz";
+      sha256 = "0iibly2mbqijqyq4pzpb6dh40clqhvqrhgnj8knm4bw3nlksd0d5";
     };
 
     nativeBuildInputs = [ cmake ];
-    buildInputs = [ unixODBC libmysqlclient ];
+    buildInputs = [ unixODBC libmysqlclient openssl ];
 
     cmakeFlags = [
-      "-DMARIADB_INCLUDE_DIR=${libmysqlclient}/include/mariadb"
+      "-DWITH_OPENSSL=ON"
+    ];
+
+   NIX_CFLAGS_COMPILE = [
+     "-I${libmysqlclient}/include/mysql"
+     "-L${libmysqlclient}/lib/mysql"
     ];
 
     passthru = {

--- a/pkgs/development/libraries/unixODBCDrivers/default.nix
+++ b/pkgs/development/libraries/unixODBCDrivers/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, unixODBC, cmake, postgresql, mysql, mariadb, sqlite, zlib, libxml2, dpkg, lib, kerberos, curl, libuuid, autoPatchelfHook }:
+{ fetchurl, stdenv, unixODBC, cmake, postgresql, mysql, libmysqlclient, sqlite, zlib, libxml2, dpkg, lib, kerberos, curl, libuuid, autoPatchelfHook }:
 
 # I haven't done any parameter tweaking.. So the defaults provided here might be bad
 
@@ -37,10 +37,10 @@
     };
 
     nativeBuildInputs = [ cmake ];
-    buildInputs = [ unixODBC mariadb.connector-c ];
+    buildInputs = [ unixODBC libmysqlclient ];
 
     cmakeFlags = [
-      "-DMARIADB_INCLUDE_DIR=${mariadb.connector-c}/include/mariadb"
+      "-DMARIADB_INCLUDE_DIR=${libmysqlclient}/include/mariadb"
     ];
 
     passthru = {

--- a/pkgs/development/libraries/wt/default.nix
+++ b/pkgs/development/libraries/wt/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, cmake, boost, pkgconfig, doxygen, qt48Full, libharu
-, pango, fcgi, firebird, mysql, postgresql, graphicsmagick, glew, openssl
+, pango, fcgi, firebird, libmysqlclient, postgresql, graphicsmagick, glew, openssl
 , pcre
 }:
 
@@ -22,7 +22,7 @@ let
       nativeBuildInputs = [ pkgconfig ];
       buildInputs = [
         cmake boost doxygen qt48Full libharu
-        pango fcgi firebird mysql.connector-c postgresql graphicsmagick glew
+        pango fcgi firebird libmysqlclient postgresql graphicsmagick glew
         openssl pcre
       ];
 
@@ -30,7 +30,7 @@ let
         "-DWT_WRASTERIMAGE_IMPLEMENTATION=GraphicsMagick"
         "-DWT_CPP_11_MODE=-std=c++11"
         "-DGM_PREFIX=${graphicsmagick}"
-        "-DMYSQL_PREFIX=${mysql.connector-c}"
+        "-DMYSQL_PREFIX=${libmysqlclient}"
         "--no-warn-unused-cli"
       ];
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-overrides.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-overrides.nix
@@ -53,11 +53,11 @@ in
   cl-async-ssl = addNativeLibs [pkgs.openssl (import ./openssl-lib-marked.nix)];
   cl-async-test = addNativeLibs [pkgs.openssl];
   clsql = x: {
-    propagatedBuildInputs = with pkgs; [mysql.connector-c postgresql sqlite zlib];
+    propagatedBuildInputs = with pkgs; [libmysqlclient postgresql sqlite zlib];
     overrides = y: (x.overrides y) // {
       preConfigure = ((x.overrides y).preConfigure or "") + ''
-        export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${pkgs.mysql.connector-c}/include/mysql"
-        export NIX_LDFLAGS="$NIX_LDFLAGS -L${pkgs.mysql.connector-c}/lib/mysql"
+        export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${pkgs.libmysqlclient}/include/mysql"
+        export NIX_LDFLAGS="$NIX_LDFLAGS -L${pkgs.libmysqlclient}/lib/mysql"
       '';
     };
   };
@@ -77,7 +77,7 @@ $out/lib/common-lisp/query-fs"
     };
   };
   cffi = addNativeLibs [pkgs.libffi];
-  cl-mysql = addNativeLibs [pkgs.mysql];
+  cl-mysql = addNativeLibs [pkgs.libmysqlclient];
   cl-ppcre-template = x: {
     overrides = y: (x.overrides y) // {
       postPatch = ''

--- a/pkgs/development/lisp-modules/shell.nix
+++ b/pkgs/development/lisp-modules/shell.nix
@@ -6,11 +6,11 @@ self = rec {
   env = buildEnv { name = name; paths = buildInputs; };
   buildInputs = [
     gcc stdenv
-    openssl fuse libuv mysql.connector-c libfixposix libev sqlite
+    openssl fuse libuv libmysqlclient libfixposix libev sqlite
     freetds
     lispPackages.quicklisp-to-nix lispPackages.quicklisp-to-nix-system-info
   ];
   CPATH = "${libfixposix}/include";
-  LD_LIBRARY_PATH = "${openssl.out}/lib:${fuse}/lib:${libuv}/lib:${libev}/lib:${mysql.connector-c}/lib:${mysql.connector-c}/lib/mysql:${postgresql.lib}/lib:${sqlite.out}/lib:${libfixposix}/lib:${freetds}/lib:${openssl_lib_marked}/lib";
+  LD_LIBRARY_PATH = "${openssl.out}/lib:${fuse}/lib:${libuv}/lib:${libev}/lib:${libmysqlclient}/lib:${libmysqlclient}/lib/mysql:${postgresql.lib}/lib:${sqlite.out}/lib:${libfixposix}/lib:${freetds}/lib:${openssl_lib_marked}/lib";
 };
 in stdenv.mkDerivation self

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -154,12 +154,12 @@ with super;
   luadbi-mysql = super.luadbi-mysql.override({
     extraVariables = ''
       -- Can't just be /include and /lib, unfortunately needs the trailing 'mysql'
-      MYSQL_INCDIR='${pkgs.mysql.connector-c}/include/mysql';
-      MYSQL_LIBDIR='${pkgs.mysql.connector-c}/lib/mysql';
+      MYSQL_INCDIR='${pkgs.libmysqlclient}/include/mysql';
+      MYSQL_LIBDIR='${pkgs.libmysqlclient}/lib/mysql';
     '';
     buildInputs = [
       pkgs.mysql.client
-      pkgs.mysql.connector-c
+      pkgs.libmysqlclient
     ];
   });
 

--- a/pkgs/development/ocaml-modules/mysql/default.nix
+++ b/pkgs/development/ocaml-modules/mysql/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, ocaml, findlib, mysql }:
+{ stdenv, fetchurl, fetchpatch, ocaml, findlib, libmysqlclient }:
 
 # TODO: la versione stabile da' un errore di compilazione dovuto a
 # qualche cambiamento negli header .h
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   createFindlibDestdir = true;
 
-  propagatedBuildInputs = [ mysql.connector-c ];
+  propagatedBuildInputs = [ libmysqlclient ];
 
   patches = [
     (fetchpatch {

--- a/pkgs/development/perl-modules/DBD-mysql/default.nix
+++ b/pkgs/development/perl-modules/DBD-mysql/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, buildPerlPackage, DBI, DevelChecklib, mysql }:
+{ fetchurl, buildPerlPackage, DBI, DevelChecklib, libmysqlclient }:
 
 buildPerlPackage {
   pname = "DBD-mysql";
@@ -9,7 +9,7 @@ buildPerlPackage {
     sha256 = "0y4djb048i09dk19av7mzfb3khr72vw11p3ayw2p82jsy4gm8j2g";
   };
 
-  buildInputs = [ mysql.connector-c DevelChecklib ] ;
+  buildInputs = [ libmysqlclient DevelChecklib ] ;
   propagatedBuildInputs = [ DBI ];
 
   doCheck = false;

--- a/pkgs/development/pure-modules/glpk/default.nix
+++ b/pkgs/development/pure-modules/glpk/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl,
-  pkgconfig, pure, glpk, gmp, libtool, mysql, libiodbc }:
+  pkgconfig, pure, glpk, gmp, libtool, libmysqlclient, libiodbc }:
 
 stdenv.mkDerivation rec {
   baseName = "glpk";
@@ -12,13 +12,13 @@ stdenv.mkDerivation rec {
   };
 
   glpkWithExtras = lib.overrideDerivation glpk (attrs: {
-    propagatedBuildInputs = [ gmp libtool mysql.connector-c libiodbc ];
+    propagatedBuildInputs = [ gmp libtool libmysqlclient libiodbc ];
 
     CPPFLAGS = "-I${gmp.dev}/include";
 
     preConfigure = ''
       substituteInPlace configure \
-        --replace /usr/include/mysql ${mysql.connector-c}/include/mysql
+        --replace /usr/include/mysql ${libmysqlclient}/include/mysql
     '';
     configureFlags = [ "--enable-dl"
                        "--enable-odbc"

--- a/pkgs/development/python-modules/mysqlclient/default.nix
+++ b/pkgs/development/python-modules/mysqlclient/default.nix
@@ -1,15 +1,15 @@
-{ stdenv, buildPythonPackage, fetchPypi, mysql }:
+{ stdenv, buildPythonPackage, fetchPypi, libmysqlclient }:
 
 buildPythonPackage rec {
   pname = "mysqlclient";
   version = "1.4.4";
 
   nativeBuildInputs = [
-    mysql.connector-c
+    libmysqlclient
   ];
 
   buildInputs = [
-    mysql.connector-c
+    libmysqlclient
   ];
 
   # Tests need a MySQL database

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -325,7 +325,7 @@ let
     rmatio = [ pkgs.zlib.dev ];
     Rmpfr = [ pkgs.gmp pkgs.mpfr.dev ];
     Rmpi = [ pkgs.openmpi ];
-    RMySQL = [ pkgs.zlib pkgs.mysql.connector-c pkgs.openssl.dev ];
+    RMySQL = [ pkgs.zlib pkgs.libmysqlclient pkgs.openssl.dev ];
     RNetCDF = [ pkgs.netcdf pkgs.udunits ];
     RODBCext = [ pkgs.libiodbc ];
     RODBC = [ pkgs.libiodbc ];
@@ -810,7 +810,7 @@ let
     });
 
     RMySQL = old.RMySQL.overrideDerivation (attrs: {
-      MYSQL_DIR=pkgs.mysql.connector-c;
+      MYSQL_DIR="${pkgs.libmysqlclient}";
       preConfigure = ''
         patchShebangs configure
       '';

--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -20,7 +20,7 @@
 { lib, fetchurl, writeScript, ruby, kerberos, libxml2, libxslt, python, stdenv, which
 , libiconv, postgresql, v8_3_16_14, clang, sqlite, zlib, imagemagick
 , pkgconfig , ncurses, xapian, gpgme, utillinux, fetchpatch, tzdata, icu, libffi
-, cmake, libssh2, openssl, mysql, darwin, git, perl, pcre, gecode_3, curl
+, cmake, libssh2, openssl, libmysqlclient, darwin, git, perl, pcre, gecode_3, curl
 , msgpack, qt59, libsodium, snappy, libossp_uuid, lxc, libpcap, xorg, gtk2, buildRubyGem
 , cairo, re2, rake, gobject-introspection, gdk-pixbuf, zeromq, czmq, graphicsmagick, libcxx
 , file, libvirt, glib, vips, taglib, libopus, linux-pam, libidn, protobuf, fribidi, harfbuzz
@@ -348,11 +348,11 @@ in
   };
 
   mysql = attrs: {
-    buildInputs = [ mysql.connector-c zlib openssl ];
+    buildInputs = [ libmysqlclient zlib openssl ];
   };
 
   mysql2 = attrs: {
-    buildInputs = [ mysql.connector-c zlib openssl ];
+    buildInputs = [ libmysqlclient zlib openssl ];
   };
 
   ncursesw = attrs: {

--- a/pkgs/development/tools/misc/sysbench/default.nix
+++ b/pkgs/development/tools/misc/sysbench/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, vim, mysql
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, vim, libmysqlclient
 , libaio }:
 
 stdenv.mkDerivation {
   name = "sysbench-1.0.17";
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
-  buildInputs = [ vim mysql.connector-c libaio ];
+  buildInputs = [ vim libmysqlclient libaio ];
 
   src = fetchFromGitHub {
     owner = "akopytov";

--- a/pkgs/development/tools/tora/default.nix
+++ b/pkgs/development/tools/tora/default.nix
@@ -1,5 +1,5 @@
 { mkDerivation, lib, fetchFromGitHub, cmake, extra-cmake-modules, makeWrapper
-, boost, doxygen, openssl, mysql, postgresql, graphviz, loki
+, boost, doxygen, openssl, libmysqlclient, postgresql, graphviz, loki
 , qscintilla, qtbase, qttools }:
 
 mkDerivation {
@@ -16,7 +16,7 @@ mkDerivation {
   nativeBuildInputs = [ cmake extra-cmake-modules makeWrapper qttools ];
 
   buildInputs = [
-    boost doxygen graphviz loki mysql.connector-c openssl postgresql qscintilla qtbase
+    boost doxygen graphviz loki libmysqlclient openssl postgresql qscintilla qtbase
   ];
 
   preConfigure = ''
@@ -47,7 +47,7 @@ mkDerivation {
     "-lssl"
   ];
 
-  NIX_CFLAGS_COMPILE = [ "-L${mysql.connector-c}/lib/mysql" "-I${mysql.connector-c}/include/mysql" ];
+  NIX_CFLAGS_COMPILE = [ "-L${libmysqlclient}/lib/mysql" "-I${libmysqlclient}/include/mysql" ];
 
   qtWrapperArgs = [
     ''--prefix PATH : ${lib.getBin graphviz}/bin''

--- a/pkgs/games/zod/default.nix
+++ b/pkgs/games/zod/default.nix
@@ -1,5 +1,5 @@
 { fetchurl, stdenv, unrar, unzip, SDL, SDL_image, SDL_ttf, SDL_mixer
-, mysql, makeWrapper }:
+, libmysqlclient, makeWrapper }:
 
 stdenv.mkDerivation {
   name = "zod-engine-2011-03-18";
@@ -24,9 +24,9 @@ stdenv.mkDerivation {
     sourceRoot=`pwd`/src
   '';
 
-  buildInputs = [ unrar unzip SDL SDL_image SDL_ttf SDL_mixer mysql.connector-c makeWrapper ];
+  buildInputs = [ unrar unzip SDL SDL_image SDL_ttf SDL_mixer libmysqlclient makeWrapper ];
 
-  NIX_LDFLAGS = "-L${mysql.connector-c}/lib/mysql";
+  NIX_LDFLAGS = "-L${libmysqlclient}/lib/mysql";
 
   installPhase = ''
     mkdir -p $out/bin $out/share/zod

--- a/pkgs/servers/clickhouse/default.nix
+++ b/pkgs/servers/clickhouse/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, cmake, libtool
 , boost, capnproto, cctz, clang-unwrapped, double-conversion, gperftools, icu
-, libcpuid, libxml2, lld, llvm, lz4 , mysql, openssl, poco, re2, rdkafka
+, libcpuid, libxml2, lld, llvm, lz4 , libmysqlclient, openssl, poco, re2, rdkafka
 , readline, sparsehash, unixODBC, zstd, ninja, jemalloc, brotli, protobuf, xxHash
 }:
 
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake libtool ninja ];
   buildInputs = [
     boost capnproto cctz clang-unwrapped double-conversion gperftools icu
-    libcpuid libxml2 lld llvm lz4 mysql.connector-c openssl poco re2 rdkafka
+    libcpuid libxml2 lld llvm lz4 libmysqlclient openssl poco re2 rdkafka
     readline sparsehash unixODBC zstd jemalloc brotli protobuf xxHash
   ];
 

--- a/pkgs/servers/computing/slurm/default.nix
+++ b/pkgs/servers/computing/slurm/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, pkgconfig, libtool, curl
 , python, munge, perl, pam, openssl, zlib
-, ncurses, mysql, gtk2, lua, hwloc, numactl
+, ncurses, libmysqlclient, gtk2, lua, hwloc, numactl
 , readline, freeipmi, libssh2, xorg, lz4
 # enable internal X11 support via libssh2
 , enableX11 ? true
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig libtool ];
   buildInputs = [
     curl python munge perl pam openssl zlib
-      mysql.connector-c ncurses gtk2 lz4
+      libmysqlclient ncurses gtk2 lz4
       lua hwloc numactl readline freeipmi
   ] ++ stdenv.lib.optionals enableX11 [ libssh2 xorg.xauth ];
 

--- a/pkgs/servers/freeradius/default.nix
+++ b/pkgs/servers/freeradius/default.nix
@@ -13,7 +13,7 @@
 , withMemcached ? false
 , hiredis
 , withRedis ? false
-, mysql
+, libmysqlclient
 , withMysql ? false
 , json_c
 , withJson ? false
@@ -31,7 +31,7 @@ assert withPcap -> libpcap != null;
 assert withCap -> libcap != null;
 assert withMemcached -> libmemcached != null;
 assert withRedis -> hiredis != null;
-assert withMysql -> mysql != null;
+assert withMysql -> libmysqlclient != null;
 assert withYubikey -> libyubikey != null;
 assert withCollectd -> collectd != null;
 assert withRest -> curl != null && withJson;
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
     ++ optional withCap libcap
     ++ optional withMemcached libmemcached
     ++ optional withRedis hiredis
-    ++ optional withMysql mysql.connector-c
+    ++ optional withMysql libmysqlclient
     ++ optional withJson json_c
     ++ optional withYubikey libyubikey
     ++ optional withCollectd collectd

--- a/pkgs/servers/http/lighttpd/default.nix
+++ b/pkgs/servers/http/lighttpd/default.nix
@@ -1,6 +1,6 @@
 { stdenv, buildPackages, fetchurl, pkgconfig, pcre, libxml2, zlib, bzip2, which, file
 , openssl, enableMagnet ? false, lua5_1 ? null
-, enableMysql ? false, mysql ? null
+, enableMysql ? false, libmysqlclient ? null
 , enableLdap ? false, openldap ? null
 , enableWebDAV ? false, sqlite ? null, libuuid ? null
 , enableExtendedAttrs ? false, attr ? null
@@ -8,7 +8,7 @@
 }:
 
 assert enableMagnet -> lua5_1 != null;
-assert enableMysql -> mysql != null;
+assert enableMysql -> libmysqlclient != null;
 assert enableLdap -> openldap != null;
 assert enableWebDAV -> sqlite != null;
 assert enableWebDAV -> libuuid != null;
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ pcre pcre.dev libxml2 zlib bzip2 which file openssl ]
              ++ stdenv.lib.optional enableMagnet lua5_1
-             ++ stdenv.lib.optional enableMysql mysql.connector-c
+             ++ stdenv.lib.optional enableMysql libmysqlclient
              ++ stdenv.lib.optional enableLdap openldap
              ++ stdenv.lib.optional enableWebDAV sqlite
              ++ stdenv.lib.optional enableWebDAV libuuid;

--- a/pkgs/servers/mail/dovecot/default.nix
+++ b/pkgs/servers/mail/dovecot/default.nix
@@ -3,7 +3,7 @@
 , clucene_core_2, icu, openldap, libsodium, libstemmer, cyrus_sasl
 , nixosTests
 # Auth modules
-, withMySQL ? false, mysql
+, withMySQL ? false, libmysqlclient
 , withPgSQL ? false, postgresql
 , withSQLite ? true, sqlite
 }:
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   buildInputs =
     [ openssl bzip2 zlib lz4 clucene_core_2 icu openldap libsodium libstemmer cyrus_sasl.dev ]
     ++ lib.optionals (stdenv.isLinux) [ systemd pam libcap inotify-tools ]
-    ++ lib.optional withMySQL mysql.connector-c
+    ++ lib.optional withMySQL libmysqlclient
     ++ lib.optional withPgSQL postgresql
     ++ lib.optional withSQLite sqlite;
 

--- a/pkgs/servers/mail/exim/default.nix
+++ b/pkgs/servers/mail/exim/default.nix
@@ -1,6 +1,6 @@
 { coreutils, db, fetchurl, openssl, pcre, perl, pkgconfig, stdenv
 , enableLDAP ? false, openldap
-, enableMySQL ? false, mysql, zlib
+, enableMySQL ? false, libmysqlclient, zlib
 , enableAuthDovecot ? false, dovecot
 , enablePAM ? false, pam
 , enableSPF ? true, libspf2
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ coreutils db openssl perl pcre ]
     ++ stdenv.lib.optional enableLDAP openldap
-    ++ stdenv.lib.optionals enableMySQL [ mysql.connector-c zlib ]
+    ++ stdenv.lib.optionals enableMySQL [ libmysqlclient zlib ]
     ++ stdenv.lib.optional enableAuthDovecot dovecot
     ++ stdenv.lib.optional enablePAM pam
     ++ stdenv.lib.optional enableSPF libspf2;
@@ -53,10 +53,10 @@ stdenv.mkDerivation rec {
       ''}
       ${stdenv.lib.optionalString enableMySQL ''
         s:^# \(LOOKUP_MYSQL=yes\)$:\1:
-        s:^# \(LOOKUP_MYSQL_PC=mysql.connector-c\)$:\1:
-        s:^\(LOOKUP_LIBS\)=\(.*\):\1=\2 -lmysqlclient -L${mysql.connector-c}/lib/mysql -lssl -ldl -lm -lpthread -lz:
-        s:^# \(LOOKUP_LIBS\)=.*:\1=-lmysqlclient -L${mysql.connector-c}/lib/mysql -lssl -ldl -lm -lpthread -lz:
-        s:^# \(LOOKUP_INCLUDE\)=.*:\1=-I${mysql.connector-c}/include/mysql/:
+        s:^# \(LOOKUP_MYSQL_PC=libmysqlclient\)$:\1:
+        s:^\(LOOKUP_LIBS\)=\(.*\):\1=\2 -lmysqlclient -L${libmysqlclient}/lib/mysql -lssl -ldl -lm -lpthread -lz:
+        s:^# \(LOOKUP_LIBS\)=.*:\1=-lmysqlclient -L${libmysqlclient}/lib/mysql -lssl -ldl -lm -lpthread -lz:
+        s:^# \(LOOKUP_INCLUDE\)=.*:\1=-I${libmysqlclient}/include/mysql/:
       ''}
       ${stdenv.lib.optionalString enableAuthDovecot ''
         s:^# \(AUTH_DOVECOT\)=.*:\1=yes:

--- a/pkgs/servers/mail/opensmtpd/extras.nix
+++ b/pkgs/servers/mail/opensmtpd/extras.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, openssl, libevent, libasr,
-  python2, pkgconfig, lua5, perl, mysql, postgresql, sqlite, hiredis,
+  python2, pkgconfig, lua5, perl, libmysqlclient, postgresql, sqlite, hiredis,
   enablePython ? true,
   enableLua ? true,
   enablePerl ? true,
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ openssl libevent
-    libasr python2 lua5 perl mysql.connector-c postgresql sqlite hiredis ];
+    libasr python2 lua5 perl libmysqlclient postgresql sqlite hiredis ];
 
   configureFlags = [
     "--sysconfdir=/etc"
@@ -80,7 +80,7 @@ stdenv.mkDerivation rec {
     stdenv.lib.optional enableRedis
       "-I${hiredis}/include/hiredis -lhiredis"
     ++ stdenv.lib.optional enableMysql
-      "-L${mysql.connector-c}/lib/mysql";
+      "-L${libmysqlclient}/lib/mysql";
 
   meta = with stdenv.lib; {
     homepage = https://www.opensmtpd.org/;

--- a/pkgs/servers/mail/postfix/default.nix
+++ b/pkgs/servers/mail/postfix/default.nix
@@ -3,7 +3,7 @@
 , buildPackages
 , withLDAP ? true, openldap
 , withPgSQL ? false, postgresql
-, withMySQL ? false, mysql
+, withMySQL ? false, libmysqlclient
 , withSQLite ? false, sqlite
 }:
 
@@ -12,7 +12,7 @@ let
     "-DUSE_TLS" "-DUSE_SASL_AUTH" "-DUSE_CYRUS_SASL" "-I${cyrus_sasl.dev}/include/sasl"
     "-DHAS_DB_BYPASS_MAKEDEFS_CHECK"
    ] ++ lib.optional withPgSQL "-DHAS_PGSQL"
-     ++ lib.optionals withMySQL [ "-DHAS_MYSQL" "-I${mysql.connector-c}/include/mysql" "-L${mysql.connector-c}/lib/mysql" ]
+     ++ lib.optionals withMySQL [ "-DHAS_MYSQL" "-I${libmysqlclient}/include/mysql" "-L${libmysqlclient}/lib/mysql" ]
      ++ lib.optional withSQLite "-DHAS_SQLITE"
      ++ lib.optionals withLDAP ["-DHAS_LDAP" "-DUSE_LDAP_SASL"]);
    auxlibs = lib.concatStringsSep " " ([
@@ -36,7 +36,7 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [ makeWrapper m4 ];
   buildInputs = [ db openssl cyrus_sasl icu libnsl pcre ]
                 ++ lib.optional withPgSQL postgresql
-                ++ lib.optional withMySQL mysql.connector-c
+                ++ lib.optional withMySQL libmysqlclient
                 ++ lib.optional withSQLite sqlite
                 ++ lib.optional withLDAP openldap;
 

--- a/pkgs/servers/monitoring/plugins/default.nix
+++ b/pkgs/servers/monitoring/plugins/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, fetchpatch, autoreconfHook
 , coreutils, gnugrep, gnused, lm_sensors, net_snmp, openssh, openssl, perl
-, dnsutils, libdbi, mysql, zlib, openldap, procps
+, dnsutils, libdbi, libmysqlclient, zlib, openldap, procps
 , runtimeShell }:
 
 with stdenv.lib;
@@ -48,7 +48,7 @@ in stdenv.mkDerivation {
   '';
 
   # !!! make openssh a runtime dependency only
-  buildInputs = [ dnsutils libdbi mysql net_snmp openldap openssh openssl perl procps zlib ];
+  buildInputs = [ dnsutils libdbi libmysqlclient net_snmp openldap openssh openssl perl procps zlib ];
 
   nativeBuildInputs = [ autoreconfHook ];
 

--- a/pkgs/servers/monitoring/zabbix/proxy.nix
+++ b/pkgs/servers/monitoring/zabbix/proxy.nix
@@ -3,7 +3,7 @@
 , snmpSupport ? true, net_snmp
 , sshSupport ? true, libssh2
 , sqliteSupport ? false, sqlite
-, mysqlSupport ? false, mysql
+, mysqlSupport ? false, libmysqlclient
 , postgresqlSupport ? false, postgresql
 }:
 
@@ -37,7 +37,7 @@ in
       ++ optional snmpSupport net_snmp
       ++ optional sqliteSupport sqlite
       ++ optional sshSupport libssh2
-      ++ optional mysqlSupport mysql.connector-c
+      ++ optional mysqlSupport libmysqlclient
       ++ optional postgresqlSupport postgresql;
 
       configureFlags = [

--- a/pkgs/servers/monitoring/zabbix/server.nix
+++ b/pkgs/servers/monitoring/zabbix/server.nix
@@ -4,7 +4,7 @@
 , odbcSupport ? true, unixODBC
 , snmpSupport ? true, net_snmp
 , sshSupport ? true, libssh2
-, mysqlSupport ? false, mysql
+, mysqlSupport ? false, libmysqlclient
 , postgresqlSupport ? false, postgresql
 }:
 
@@ -40,7 +40,7 @@ in
       ++ optional ldapSupport openldap
       ++ optional snmpSupport net_snmp
       ++ optional sshSupport libssh2
-      ++ optional mysqlSupport mysql.connector-c
+      ++ optional mysqlSupport libmysqlclient
       ++ optional postgresqlSupport postgresql;
 
       configureFlags = [

--- a/pkgs/servers/sql/mariadb/connector-c/2_3.nix
+++ b/pkgs/servers/sql/mariadb/connector-c/2_3.nix
@@ -1,6 +1,0 @@
-{ callPackage, ... } @ args:
-
-callPackage ./. (args // {
-  version = "2.3.7";
-  sha256 = "13izi35vvxhiwl2dsnqrz75ciisy2s2k30giv7hrm01qlwnmiycl";
-})

--- a/pkgs/servers/sql/mariadb/connector-c/2_3.nix
+++ b/pkgs/servers/sql/mariadb/connector-c/2_3.nix
@@ -1,0 +1,6 @@
+{ callPackage, ... } @ args:
+
+callPackage ./. (args // {
+  version = "2.3.7";
+  sha256 = "13izi35vvxhiwl2dsnqrz75ciisy2s2k30giv7hrm01qlwnmiycl";
+})

--- a/pkgs/servers/sql/mariadb/connector-c/3_1.nix
+++ b/pkgs/servers/sql/mariadb/connector-c/3_1.nix
@@ -1,0 +1,6 @@
+{ callPackage, ... } @ args:
+
+callPackage ./. (args // {
+  version = "3.1.2";
+  sha256 = "0pgz8m8d39mvj9wnjll6c83xvdl2h24273b3dkx0g5pxj7ga4shm";
+})

--- a/pkgs/servers/sql/mariadb/connector-c/default.nix
+++ b/pkgs/servers/sql/mariadb/connector-c/default.nix
@@ -6,10 +6,7 @@
 
 with stdenv.lib;
 
-let
-  isVer3 = versionAtLeast version "3.0";
-
-in stdenv.mkDerivation {
+stdenv.mkDerivation {
   pname = "mariadb-connector-c";
   inherit version;
 
@@ -24,7 +21,8 @@ in stdenv.mkDerivation {
   cmakeFlags = [
     "-DWITH_EXTERNAL_ZLIB=ON"
     "-DMYSQL_UNIX_ADDR=/run/mysqld/mysqld.sock"
-  ] ++ optional isVer3 "-DWITH_CURL=ON";
+    "-DWITH_CURL=ON"
+  ];
 
   # The cmake setup-hook uses $out/lib by default, this is not the case here.
   preConfigure = optionalString stdenv.isDarwin ''
@@ -32,7 +30,7 @@ in stdenv.mkDerivation {
   '';
 
   nativeBuildInputs = [ cmake ];
-  propagatedBuildInputs = [ openssl zlib ] ++ optional isVer3 curl;
+  propagatedBuildInputs = [ curl openssl zlib ];
   buildInputs = [ libiconv ];
 
   enableParallelBuilding = true;
@@ -41,12 +39,10 @@ in stdenv.mkDerivation {
     ln -sv mariadb_config $out/bin/mysql_config
     ln -sv mariadb $out/lib/mysql
     ln -sv mariadb $out/include/mysql
-    ${optionalString isVer3 ''
-      ln -sv libmariadbclient.a $out/lib/mariadb/libmysqlclient.a
-      ln -sv libmariadbclient.a $out/lib/mariadb/libmysqlclient_r.a
-      ln -sv libmariadb.so $out/lib/mariadb/libmysqlclient.so
-      ln -sv libmariadb.so $out/lib/mariadb/libmysqlclient_r.so
-    ''}
+    ln -sv libmariadbclient.a $out/lib/mariadb/libmysqlclient.a
+    ln -sv libmariadbclient.a $out/lib/mariadb/libmysqlclient_r.a
+    ln -sv libmariadb.so $out/lib/mariadb/libmysqlclient.so
+    ln -sv libmariadb.so $out/lib/mariadb/libmysqlclient_r.so
   '';
 
   meta = {

--- a/pkgs/servers/sql/mariadb/connector-c/default.nix
+++ b/pkgs/servers/sql/mariadb/connector-c/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, fetchurl, cmake
+, openssl, zlib
+, libiconv
+, version, sha256, ...
+}:
+
+with stdenv.lib;
+
+stdenv.mkDerivation {
+  pname = "mariadb-connector-c";
+  inherit version;
+
+  src = fetchurl {
+    urls = [
+      "https://downloads.mariadb.org/f/connector-c-${version}/mariadb-connector-c-${version}-src.tar.gz"
+      "https://downloads.mariadb.com/Connectors/c/connector-c-${version}/mariadb-connector-c-${version}-src.tar.gz"
+    ];
+    inherit sha256;
+  };
+
+  cmakeFlags = [
+    "-DWITH_EXTERNAL_ZLIB=ON"
+    "-DMYSQL_UNIX_ADDR=/run/mysqld/mysqld.sock"
+  ];
+
+  # The cmake setup-hook uses $out/lib by default, this is not the case here.
+  preConfigure = optionalString stdenv.isDarwin ''
+    cmakeFlagsArray+=("-DCMAKE_INSTALL_NAME_DIR=$out/lib/mariadb")
+  '';
+
+  nativeBuildInputs = [ cmake ];
+  propagatedBuildInputs = [ openssl zlib ];
+  buildInputs = [ libiconv ];
+
+  enableParallelBuilding = true;
+
+  postFixup = ''
+    ln -sv mariadb_config $out/bin/mysql_config
+    ln -sv mariadb $out/lib/mysql
+    ln -sv mariadb $out/include/mysql
+  '';
+
+  meta = {
+    description = "Client library that can be used to connect to MySQL or MariaDB";
+    license = licenses.lgpl21;
+    maintainers = with maintainers; [ globin ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/servers/sql/mariadb/default.nix
+++ b/pkgs/servers/sql/mariadb/default.nix
@@ -18,12 +18,6 @@ mytopEnv = perl.withPackages (p: with p; [ DataDumper DBDmysql DBI TermReadKey ]
 mariadb = server // {
   inherit client; # MariaDB Client
   server = server; # MariaDB Server
-  inherit galera;
-};
-
-galeraLibs = buildEnv {
-  name = "galera-lib-inputs-united";
-  paths = [ openssl.out boost check ];
 };
 
 common = rec { # attributes common to both builds
@@ -215,54 +209,4 @@ server = stdenv.mkDerivation (common // {
 
   CXXFLAGS = optionalString stdenv.isi686 "-fpermissive";
 });
-
-galera = stdenv.mkDerivation rec {
-  pname = "mariadb-galera";
-  version = "25.3.26";
-
-  src = fetchFromGitHub {
-    owner = "codership";
-    repo = "galera";
-    rev = "release_${version}";
-    sha256 = "0fs0c1px9lknf1a5wwb12z1hj7j7b6hsfjddggikvkdkrnr2xs1f";
-    fetchSubmodules = true;
-  };
-
-  buildInputs = [ asio boost check openssl scons ];
-
-  postPatch = ''
-    substituteInPlace SConstruct \
-      --replace "boost_library_path = '''" "boost_library_path = '${boost}/lib'"
-  '';
-
-  preConfigure = ''
-    export CPPFLAGS="-I${asio}/include -I${boost.dev}/include -I${check}/include -I${openssl.dev}/include"
-    export LIBPATH="${galeraLibs}/lib"
-  '';
-
-  sconsFlags = "ssl=1 system_asio=0 strict_build_flags=0";
-
-  installPhase = ''
-    # copied with modifications from scripts/packages/freebsd.sh
-    GALERA_LICENSE_DIR="$share/licenses/${pname}-${version}"
-    install -d $out/{bin,lib/galera,share/doc/galera,$GALERA_LICENSE_DIR}
-    install -m 555 "garb/garbd"                       "$out/bin/garbd"
-    install -m 444 "libgalera_smm.so"                 "$out/lib/galera/libgalera_smm.so"
-    install -m 444 "scripts/packages/README"          "$out/share/doc/galera/"
-    install -m 444 "scripts/packages/README-MySQL"    "$out/share/doc/galera/"
-    install -m 444 "scripts/packages/freebsd/LICENSE" "$out/$GALERA_LICENSE_DIR"
-    install -m 444 "LICENSE"                          "$out/$GALERA_LICENSE_DIR/GPLv2"
-    install -m 444 "asio/LICENSE_1_0.txt"             "$out/$GALERA_LICENSE_DIR/LICENSE.asio"
-    install -m 444 "www.evanjones.ca/LICENSE"         "$out/$GALERA_LICENSE_DIR/LICENSE.crc32c"
-    install -m 444 "chromium/LICENSE"                 "$out/$GALERA_LICENSE_DIR/LICENSE.chromium"
-  '';
-
-  meta = {
-    description = "Galera 3 wsrep provider library";
-    homepage = http://galeracluster.com/;
-    license = licenses.lgpl2;
-    maintainers = with maintainers; [ izorkin ];
-    platforms = platforms.all;
-  };
-};
 in mariadb

--- a/pkgs/servers/sql/mariadb/galera/25.nix
+++ b/pkgs/servers/sql/mariadb/galera/25.nix
@@ -1,6 +1,6 @@
 { callPackage, ... } @ args:
 
 callPackage ./. (args // {
-  version = "25.3.26";
-  sha256 = "0fs0c1px9lknf1a5wwb12z1hj7j7b6hsfjddggikvkdkrnr2xs1f";
+  version = "25.3.27";
+  sha256 = "143kzj0fmak1gdww4qkqmmliw8klxm6mwk5531748swlwm6gqr5q";
 })

--- a/pkgs/servers/sql/mariadb/galera/25.nix
+++ b/pkgs/servers/sql/mariadb/galera/25.nix
@@ -1,0 +1,6 @@
+{ callPackage, ... } @ args:
+
+callPackage ./. (args // {
+  version = "25.3.26";
+  sha256 = "0fs0c1px9lknf1a5wwb12z1hj7j7b6hsfjddggikvkdkrnr2xs1f";
+})

--- a/pkgs/servers/sql/mariadb/galera/default.nix
+++ b/pkgs/servers/sql/mariadb/galera/default.nix
@@ -1,0 +1,63 @@
+{ stdenv, fetchFromGitHub, buildEnv
+, asio, boost, check, openssl, scons
+, version, sha256, ...
+}:
+
+let
+  pname = "mariadb-galera";
+  galeraLibs = buildEnv {
+    name = "galera-lib-inputs-united";
+    paths = [ openssl.out boost check ];
+  };
+
+in stdenv.mkDerivation {
+  inherit pname;
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "codership";
+    repo = "galera";
+    rev = "release_${version}";
+    inherit sha256;
+    fetchSubmodules = true;
+  };
+
+  buildInputs = [ asio boost check openssl scons ];
+
+  postPatch = ''
+    substituteInPlace SConstruct \
+      --replace "boost_library_path = '''" "boost_library_path = '${boost}/lib'"
+  '';
+
+  preConfigure = ''
+    export CPPFLAGS="-I${asio}/include -I${boost.dev}/include -I${check}/include -I${openssl.dev}/include"
+    export LIBPATH="${galeraLibs}/lib"
+  '';
+
+  sconsFlags = "ssl=1 system_asio=1 strict_build_flags=0";
+
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    # copied with modifications from scripts/packages/freebsd.sh
+    GALERA_LICENSE_DIR="$share/licenses/${pname}"
+    install -d $out/{bin,lib/galera,share/doc/galera,$GALERA_LICENSE_DIR}
+    install -m 555 "garb/garbd"                       "$out/bin/garbd"
+    install -m 444 "libgalera_smm.so"                 "$out/lib/galera/libgalera_smm.so"
+    install -m 444 "scripts/packages/README"          "$out/share/doc/galera/"
+    install -m 444 "scripts/packages/README-MySQL"    "$out/share/doc/galera/"
+    install -m 444 "scripts/packages/freebsd/LICENSE" "$out/$GALERA_LICENSE_DIR"
+    install -m 444 "LICENSE"                          "$out/$GALERA_LICENSE_DIR/GPLv2"
+    install -m 444 "asio/LICENSE_1_0.txt"             "$out/$GALERA_LICENSE_DIR/LICENSE.asio"
+    install -m 444 "www.evanjones.ca/LICENSE"         "$out/$GALERA_LICENSE_DIR/LICENSE.crc32c"
+    install -m 444 "chromium/LICENSE"                 "$out/$GALERA_LICENSE_DIR/LICENSE.chromium"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Galera 3 wsrep provider library";
+    homepage = http://galeracluster.com/;
+    license = licenses.lgpl2;
+    maintainers = with maintainers; [ izorkin ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/servers/uwsgi/default.nix
+++ b/pkgs/servers/uwsgi/default.nix
@@ -4,7 +4,7 @@
 , pam, withPAM ? stdenv.isLinux
 , systemd, withSystemd ? stdenv.isLinux
 , python2, python3, ncurses
-, ruby, php-embed, mysql
+, ruby, php-embed, libmysqlclient
 }:
 
 let pythonPlugin = pkg : lib.nameValuePair "python${if pkg.isPy2 then "2" else "3"}" {
@@ -34,7 +34,7 @@ let pythonPlugin = pkg : lib.nameValuePair "python${if pkg.isPy2 then "2" else "
                     # usage: https://uwsgi-docs.readthedocs.io/en/latest/PHP.html#running-php-apps-with-nginx
                     path = "plugins/php";
                     inputs = [ php-embed ] ++ php-embed.buildInputs;
-                    NIX_CFLAGS_LINK = [ "-L${mysql.connector-c}/lib/mysql" ];
+                    NIX_CFLAGS_LINK = [ "-L${libmysqlclient}/lib/mysql" ];
                   })
                 ];
 

--- a/pkgs/tools/backup/bareos/default.nix
+++ b/pkgs/tools/backup/bareos/default.nix
@@ -1,10 +1,10 @@
 { stdenv, fetchFromGitHub, pkgconfig, nettools, gettext, flex
 , readline ? null, openssl ? null, python2 ? null, ncurses ? null, rocksdb
-, sqlite ? null, postgresql ? null, mysql ? null, zlib ? null, lzo ? null
+, sqlite ? null, postgresql ? null, libmysqlclient ? null, zlib ? null, lzo ? null
 , jansson ? null, acl ? null, glusterfs ? null, libceph ? null, libcap ? null
 }:
 
-assert sqlite != null || postgresql != null || mysql != null;
+assert sqlite != null || postgresql != null || libmysqlclient != null;
 
 with stdenv.lib;
 let
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
     nettools gettext readline openssl python2 flex ncurses sqlite postgresql
-    mysql.connector-c zlib lzo jansson acl glusterfs libceph libcap rocksdb
+    libmysqlclient zlib lzo jansson acl glusterfs libceph libcap rocksdb
   ];
 
   postPatch = ''
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
     ++ optional (openssl != null) "--with-openssl=${openssl.dev}"
     ++ optional (sqlite != null) "--with-sqlite3=${sqlite.dev}"
     ++ optional (postgresql != null) "--with-postgresql=${postgresql}"
-    ++ optional (mysql != null) "--with-mysql=${mysql.connector-c}"
+    ++ optional (libmysqlclient != null) "--with-mysql=${libmysqlclient}"
     ++ optional (zlib != null) "--with-zlib=${zlib.dev}"
     ++ optional (lzo != null) "--with-lzo=${lzo}"
     ++ optional (jansson != null) "--with-jansson=${jansson}"

--- a/pkgs/tools/backup/mydumper/default.nix
+++ b/pkgs/tools/backup/mydumper/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, cmake, pkgconfig
-, glib, zlib, pcre, mysql, libressl }:
+, glib, zlib, pcre, libmysqlclient, libressl }:
 
 stdenv.mkDerivation rec {
   version = "0.9.5";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake pkgconfig ];
 
-  buildInputs = [ glib zlib pcre mysql.connector-c libressl ];
+  buildInputs = [ glib zlib pcre libmysqlclient libressl ];
 
   meta = with stdenv.lib; {
     description = ''High-perfomance MySQL backup tool'';

--- a/pkgs/tools/networking/kea/default.nix
+++ b/pkgs/tools/networking/kea/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, autoreconfHook, pkgconfig, openssl, botan2, log4cplus
-, boost, python3, postgresql, mysql, gmp, bzip2 }:
+, boost, python3, postgresql, libmysqlclient, gmp, bzip2 }:
 
 stdenv.mkDerivation rec {
   pname = "kea";
@@ -20,12 +20,12 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--localstatedir=/var"
     "--with-pgsql=${postgresql}/bin/pg_config"
-    "--with-mysql=${mysql.connector-c}/bin/mysql_config"
+    "--with-mysql=${libmysqlclient}/bin/mysql_config"
   ];
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
   buildInputs = [
-    openssl log4cplus boost python3 mysql.connector-c
+    openssl log4cplus boost python3 libmysqlclient
     botan2 gmp bzip2
   ];
 

--- a/pkgs/tools/networking/mailutils/default.nix
+++ b/pkgs/tools/networking/mailutils/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, fetchpatch, autoreconfHook, dejagnu, gettext, pkgconfig
 , gdbm, pam, readline, ncurses, gnutls, guile, texinfo, gnum4, sasl, fribidi, nettools
-, python, gss, mysql, system-sendmail }:
+, python, gss, libmysqlclient, system-sendmail }:
 
 stdenv.mkDerivation rec {
   name = "${project}-${version}";
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     sed -i -e '/chown root:mail/d' \
            -e 's/chmod [24]755/chmod 0755/' \
       */Makefile{.in,.am}
-    sed -i 's:/usr/lib/mysql:${mysql.connector-c}/lib/mysql:' configure.ac
+    sed -i 's:/usr/lib/mysql:${libmysqlclient}/lib/mysql:' configure.ac
     sed -i 's/0\.18/0.19/' configure.ac
     sed -i -e 's:mysql/mysql.h:mysql.h:' \
            -e 's:mysql/errmsg.h:errmsg.h:' \
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     gdbm pam readline ncurses gnutls guile texinfo gnum4 sasl fribidi nettools
-    gss mysql.connector-c python
+    gss libmysqlclient python
   ];
 
   patches = [
@@ -62,7 +62,7 @@ stdenv.mkDerivation rec {
     (fetchurl { url = "${p}/weed.at"; sha256 = "1101xakhc99f5gb9cs3mmydn43ayli7b270pzbvh7f9rbvh0d0nh"; })
   ];
 
-  NIX_CFLAGS_COMPILE = "-L${mysql.connector-c}/lib/mysql -I${mysql.connector-c}/include/mysql";
+  NIX_CFLAGS_COMPILE = "-L${libmysqlclient}/lib/mysql -I${libmysqlclient}/include/mysql";
 
   checkInputs = [ dejagnu ];
   doCheck = false; # fails 1 out of a bunch of tests, looks like a bug

--- a/pkgs/tools/networking/maxscale/default.nix
+++ b/pkgs/tools/networking/maxscale/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, cmake, pkgconfig, glibc
-, bison2, curl, flex, gperftools, jansson, jemalloc, kerberos, lua, mariadb
+, bison2, curl, flex, gperftools, jansson, jemalloc, kerberos, lua, libmysqlclient
 , ncurses, openssl, pcre, pcre2, perl, rabbitmq-c, sqlite, tcl
 , libaio, libedit, libtool, libui, libuuid, zlib
 }:
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkgconfig ];
 
   buildInputs = [
-    bison2 curl flex gperftools jansson jemalloc kerberos lua mariadb.connector-c
+    bison2 curl flex gperftools jansson jemalloc kerberos lua libmysqlclient
     ncurses openssl pcre pcre2 perl rabbitmq-c sqlite tcl
     libaio libedit libtool libui libuuid zlib
   ];
@@ -63,7 +63,7 @@ stdenv.mkDerivation rec {
   postInstall = ''
     find $out/bin -type f -perm -0100 | while read f1; do
       patchelf \
-        --set-rpath "$(patchelf --print-rpath $f1):${mariadb.connector-c}/lib/mariadb:$out/lib/maxscale" \
+        --set-rpath "$(patchelf --print-rpath $f1):${libmysqlclient}/lib/mariadb:$out/lib/maxscale" \
         --set-interpreter "$(cat ${stdenv.cc}/nix-support/dynamic-linker)" $f1 \
         && patchelf --shrink-rpath $f1
     done

--- a/pkgs/tools/security/thc-hydra/default.nix
+++ b/pkgs/tools/security/thc-hydra/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, zlib, openssl, ncurses, libidn, pcre, libssh, mysql, postgresql
+{ stdenv, lib, fetchurl, zlib, openssl, ncurses, libidn, pcre, libssh, libmysqlclient, postgresql
 , withGUI ? false, makeWrapper, pkgconfig, gtk2 }:
 
 let
@@ -23,7 +23,7 @@ in stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = lib.optionals withGUI [ pkgconfig makeWrapper ];
-  buildInputs = [ zlib openssl ncurses libidn pcre libssh mysql.connector-c postgresql ]
+  buildInputs = [ zlib openssl ncurses libidn pcre libssh libmysqlclient postgresql ]
                 ++ lib.optional withGUI gtk2;
 
   postInstall = lib.optionalString withGUI ''

--- a/pkgs/tools/system/collectd/default.nix
+++ b/pkgs/tools/system/collectd/default.nix
@@ -22,7 +22,7 @@
 , libtool
 , lm_sensors
 , lvm2
-, mysql
+, libmysqlclient
 , numactl
 , postgresql
 , protobufc
@@ -63,7 +63,7 @@ stdenv.mkDerivation rec {
     libxml2 postgresql protobufc rrdtool
     varnish yajl jdk libtool python hiredis libmicrohttpd
     riemann_c_client mosquitto rdkafka mongoc
-  ] ++ stdenv.lib.optionals (mysql != null) [ mysql.connector-c
+  ] ++ stdenv.lib.optionals (libmysqlclient != null) [ libmysqlclient
   ] ++ stdenv.lib.optionals stdenv.isLinux [
     iptables libatasmart libcredis libmodbus libsigrok
     lm_sensors lvm2 rabbitmq-c udev net_snmp libmnl

--- a/pkgs/tools/system/rsyslog/default.nix
+++ b/pkgs/tools/system/rsyslog/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, autoreconfHook, libestr, json_c, zlib, pythonPackages, fastJson
-, libkrb5 ? null, systemd ? null, jemalloc ? null, mysql ? null, postgresql ? null
+, libkrb5 ? null, systemd ? null, jemalloc ? null, libmysqlclient ? null, postgresql ? null
 , libdbi ? null, net_snmp ? null, libuuid ? null, curl ? null, gnutls ? null
 , libgcrypt ? null, liblognorm ? null, openssl ? null, librelp ? null, libksi ? null
 , libgt ? null, liblogging ? null, libnet ? null, hadoop ? null, rdkafka ? null
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     postgresql libdbi net_snmp libuuid curl gnutls libgcrypt liblognorm openssl
     librelp libgt libksi liblogging libnet hadoop rdkafka libmongo-client czmq
     rabbitmq-c hiredis mongoc
-  ] ++ stdenv.lib.optional (mysql != null) mysql.connector-c
+  ] ++ stdenv.lib.optional (libmysqlclient != null) libmysqlclient
     ++ stdenv.lib.optional stdenv.isLinux systemd;
 
   hardeningDisable = [ "format" ];
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
     (mkFlag false                     "valgrind")
     (mkFlag false                     "diagtools")
     (mkFlag true                      "usertools")
-    (mkFlag (mysql != null)           "mysql")
+    (mkFlag (libmysqlclient != null)  "mysql")
     (mkFlag (postgresql != null)      "pgsql")
     (mkFlag (libdbi != null)          "libdbi")
     (mkFlag (net_snmp != null)        "snmp")

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -187,7 +187,6 @@ mapAliases ({
   libintlOrEmpty = stdenv.lib.optional (!stdenv.isLinux || stdenv.hostPlatform.libc != "glibc") gettext; # added 2018-03-14
   libjson_rpc_cpp = libjson-rpc-cpp; # added 2017-02-28
   liblapackWithoutAtlas = liblapack; # added 2018-11-05
-  libmysql = mariadb-connector-c; # added # 2017-12-28, this was a misnomer refering to libmysqlclient
   libqrencode = qrencode;  # added 2019-01-01
   librecad2 = librecad;  # backwards compatibility alias, added 2015-10
   libsysfs = sysfsutils; # added 2018-04-25

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -187,7 +187,7 @@ mapAliases ({
   libintlOrEmpty = stdenv.lib.optional (!stdenv.isLinux || stdenv.hostPlatform.libc != "glibc") gettext; # added 2018-03-14
   libjson_rpc_cpp = libjson-rpc-cpp; # added 2017-02-28
   liblapackWithoutAtlas = liblapack; # added 2018-11-05
-  libmysql = mysql.connector-c; # added # 2017-12-28, this was a misnomer refering to libmysqlclient
+  libmysql = mariadb-connector-c; # added # 2017-12-28, this was a misnomer refering to libmysqlclient
   libqrencode = qrencode;  # added 2019-01-01
   librecad2 = librecad;  # backwards compatibility alias, added 2015-10
   libsysfs = sysfsutils; # added 2018-04-25

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14889,6 +14889,7 @@ in
   libmysqlclient = mariadb-connector-c;
   mariadb-connector-c = mariadb-connector-c_2_3;
   mariadb-connector-c_2_3 = callPackage ../servers/sql/mariadb/connector-c/2_3.nix { };
+  mariadb-connector-c_3_1 = callPackage ../servers/sql/mariadb/connector-c/3_1.nix { };
 
   mariadb = callPackage ../servers/sql/mariadb {
     asio = asio_1_10;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13893,7 +13893,9 @@ in
 
   unixODBC = callPackage ../development/libraries/unixODBC { };
 
-  unixODBCDrivers = recurseIntoAttrs (callPackages ../development/libraries/unixODBCDrivers {});
+  unixODBCDrivers = recurseIntoAttrs (callPackages ../development/libraries/unixODBCDrivers {
+    libmysqlclient = libmysqlclient_2_3;
+  });
 
   ustr = callPackage ../development/libraries/ustr { };
 
@@ -14886,8 +14888,10 @@ in
 
   rpcbind = callPackage ../servers/rpcbind { };
 
-  libmysqlclient = mariadb-connector-c;
-  mariadb-connector-c = mariadb-connector-c_2_3;
+  libmysqlclient = libmysqlclient_3_1;
+  libmysqlclient_2_3 = mariadb-connector-c_2_3;
+  libmysqlclient_3_1 = mariadb-connector-c_3_1;
+  mariadb-connector-c = mariadb-connector-c_3_1;
   mariadb-connector-c_2_3 = callPackage ../servers/sql/mariadb/connector-c/2_3.nix { };
   mariadb-connector-c_3_1 = callPackage ../servers/sql/mariadb/connector-c/3_1.nix { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13893,9 +13893,7 @@ in
 
   unixODBC = callPackage ../development/libraries/unixODBC { };
 
-  unixODBCDrivers = recurseIntoAttrs (callPackages ../development/libraries/unixODBCDrivers {
-    libmysqlclient = libmysqlclient_2_3;
-  });
+  unixODBCDrivers = recurseIntoAttrs (callPackages ../development/libraries/unixODBCDrivers { });
 
   ustr = callPackage ../development/libraries/ustr { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14887,10 +14887,8 @@ in
   rpcbind = callPackage ../servers/rpcbind { };
 
   libmysqlclient = libmysqlclient_3_1;
-  libmysqlclient_2_3 = mariadb-connector-c_2_3;
   libmysqlclient_3_1 = mariadb-connector-c_3_1;
   mariadb-connector-c = mariadb-connector-c_3_1;
-  mariadb-connector-c_2_3 = callPackage ../servers/sql/mariadb/connector-c/2_3.nix { };
   mariadb-connector-c_3_1 = callPackage ../servers/sql/mariadb/connector-c/3_1.nix { };
 
   mariadb-galera = mariadb-galera_25;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1961,7 +1961,7 @@ in
     libkrb5 = null;
     systemd = null;
     jemalloc = null;
-    mysql = null;
+    libmysqlclient = null;
     postgresql = null;
     libdbi = null;
     net_snmp = null;
@@ -11703,7 +11703,7 @@ in
   libdbi = callPackage ../development/libraries/libdbi { };
 
   libdbiDriversBase = libdbiDrivers.override {
-    mysql = null;
+    libmysqlclient = null;
     sqlite = null;
   };
 
@@ -13128,7 +13128,7 @@ in
     cups = if stdenv.isLinux then cups else null;
 
     # XXX: mariadb doesn't built on fbsd as of nov 2015
-    mysql = if (!stdenv.isFreeBSD) then mysql else null;
+    libmysqlclient = if (!stdenv.isFreeBSD) then libmysqlclient else null;
 
     inherit (pkgs.darwin) libobjc;
     inherit (pkgs.darwin.apple_sdk.frameworks) ApplicationServices OpenGL Cocoa AGL;
@@ -14886,6 +14886,7 @@ in
 
   rpcbind = callPackage ../servers/rpcbind { };
 
+  libmysqlclient = mariadb-connector-c;
   mariadb-connector-c = mariadb-connector-c_2_3;
   mariadb-connector-c_2_3 = callPackage ../servers/sql/mariadb/connector-c/2_3.nix { };
 
@@ -24129,7 +24130,7 @@ in
   mnemonicode = callPackage ../misc/mnemonicode { };
 
   mysql-workbench = callPackage ../applications/misc/mysql-workbench (let mysql = mysql57; in {
-    gdal = gdal.override {mysql = mysql // {lib = {dev = mysql;};};};
+    gdal = gdal.override {libmysqlclient = mysql // {lib = {dev = mysql;};};};
     mysql = mysql;
     pcre = pcre-cpp;
   });

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14891,8 +14891,12 @@ in
   mariadb-connector-c_2_3 = callPackage ../servers/sql/mariadb/connector-c/2_3.nix { };
   mariadb-connector-c_3_1 = callPackage ../servers/sql/mariadb/connector-c/3_1.nix { };
 
-  mariadb = callPackage ../servers/sql/mariadb {
+  mariadb-galera = mariadb-galera_25;
+  mariadb-galera_25 = callPackage ../servers/sql/mariadb/galera/25.nix {
     asio = asio_1_10;
+  };
+
+  mariadb = callPackage ../servers/sql/mariadb {
     # As per mariadb's cmake, "static jemalloc_pic.a can only be used up to jemalloc 4".
     # https://jira.mariadb.org/browse/MDEV-15034
     jemalloc = jemalloc450.override ({ disableInitExecTls = true; });

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14886,6 +14886,9 @@ in
 
   rpcbind = callPackage ../servers/rpcbind { };
 
+  mariadb-connector-c = mariadb-connector-c_2_3;
+  mariadb-connector-c_2_3 = callPackage ../servers/sql/mariadb/connector-c/2_3.nix { };
+
   mariadb = callPackage ../servers/sql/mariadb {
     asio = asio_1_10;
     # As per mariadb's cmake, "static jemalloc_pic.a can only be used up to jemalloc 4".


### PR DESCRIPTION
###### Motivation for this change
Move packages connector-c and galera to external. Need to will the package appear on https://nixos.org/nixos/packages.html
Update package galera to v25.3.27
Add packages:
- connector-c v3.1.2
- galera v26.4.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
