### PR TITLE
prometheus-wireguard-exporter: 2.0.1 -> 3.0.0

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters/wireguard.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/wireguard.nix
@@ -23,12 +23,24 @@ in {
         to set the peers up.
       '';
     };
+
+    singleSubnetPerField = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        By default, all allowed IPs and subnets are comma-separated in the
+        <literal>allowed_ips</literal> field. With this option enabled,
+        a single IP and subnet will be listed in fields like <literal>allowed_ip_0</literal>,
+        <literal>allowed_ip_1</literal> and so on.
+      '';
+    };
   };
   serviceOpts = {
     script = ''
       ${pkgs.prometheus-wireguard-exporter}/bin/prometheus_wireguard_exporter \
         -p ${toString cfg.port} \
         ${optionalString cfg.verbose "-v"} \
+        ${optionalString cfg.singleSubnetPerField "-s"} \
         ${optionalString (cfg.wireguardConfig != null) "-n ${cfg.wireguardConfig}"}
     '';
 

--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -331,11 +331,12 @@ let
             inherit (snakeoil.peer1) publicKey;
           };
         };
+        systemd.services.prometheus-wireguard-exporter.after = [ "wireguard-wg0.service" ];
       };
       exporterTest = ''
         waitForUnit("prometheus-wireguard-exporter.service");
         waitForOpenPort(9586);
-        succeed("curl -sSf http://localhost:9586/metrics | grep '${snakeoil.peer1.publicKey}'");
+        waitUntilSucceeds("curl -sSf http://localhost:9586/metrics | grep '${snakeoil.peer1.publicKey}'");
       '';
     };
   };

--- a/pkgs/servers/monitoring/prometheus/wireguard-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/wireguard-exporter.nix
@@ -2,20 +2,18 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "wireguard-exporter";
-  version = "2.0.1";
+  version = "3.0.0";
 
   src = fetchFromGitHub {
     owner = "MindFlavor";
     repo = "prometheus_wireguard_exporter";
     rev = version;
-    sha256 = "11yrry8fzalcigqsx1wx371w543gdcsx48fd7dacbrsfl2dk2azp";
+    sha256 = "1vgwsg81xcxh7pcdc667mfviwwpzsm4lpllykf78vfahi9qmwffn";
   };
 
-  cargoSha256 = "1wnk39p144zjsdhnyjk6y41xs448bxnbbxkqk53r6i2f2wzrsk2m";
+  cargoSha256 = "06s9194lvwd7lynxnsrjfbjfj87ngvjbqjhx3idf7d1w9mgi4ysw";
 
   buildInputs = lib.optional stdenv.isDarwin Security;
-
-  doCheck = false;
 
   meta = with lib; {
     description = "A Prometheus exporter for WireGuard, written in Rust.";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Updates the `prometheus-wireguard-exporter` package to the latest version `3.0.0`. Please note that this version is incompatible with `2.0.1` as the `local_ip` and `local_port` field were replaced by a `allowed_ips` field with comma-separated peers.

With `-s` (or `services.prometheus.exporters.wireguard.singleSubnetPerField`) each peer has its own field `allowed_{ip,subnet}_<index>`.

cc @WilliButz you might be interested in this as well :) 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
