### PR TITLE
disk_indicator: 2014-05-19 -> 2018-12-18

### DIFF
--- a/pkgs/os-specific/linux/disk-indicator/default.nix
+++ b/pkgs/os-specific/linux/disk-indicator/default.nix
@@ -1,22 +1,24 @@
 { stdenv, fetchgit, libX11 }:
 
 stdenv.mkDerivation {
-  name = "disk-indicator-2014-05-19";
+  name = "disk-indicator-2018-12-18";
 
   src = fetchgit {
     url = git://github.com/MeanEYE/Disk-Indicator.git;
-    rev = "51ef4afd8141b8d0659cbc7dc62189c56ae9c2da";
-    sha256 = "10jx6mx9qarn21p2l2jayxkn1gmqhvck1wymgsr4jmbwxl8ra5kd";
+    rev = "ec2d2f6833f038f07a72d15e2d52625c23e10b12";
+    sha256 = "08q9cnjgxscx5rcn1nxdzsb81mam2yh8aqff4sr5a7vs24is06ki";
   };
 
   buildInputs = [ libX11 ];
 
   patchPhase = ''
-    substituteInPlace ./makefile --replace "COMPILER=c99" "COMPILER=gcc -std=c99"
-    substituteInPlace ./makefile --replace "COMPILE_FLAGS=" "COMPILE_FLAGS=-O2 "
+    substituteInPlace ./Makefile --replace "COMPILER=c99" "COMPILER=gcc -std=c99"
+    substituteInPlace ./Makefile --replace "COMPILE_FLAGS=" "COMPILE_FLAGS=-O2 "
+    patchShebangs ./configure.sh
   '';
 
-  buildPhase = "make -f makefile";
+  configurePhase = "./configure.sh --all";
+  buildPhase = "make -f Makefile";
 
   NIX_CFLAGS_COMPILE = "-Wno-error=cpp";
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Hi ! I needed the newer `disk_indicator`, so I've updated the one available.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
