### PR TITLE
 pythonPackages.diofant: init at 0.10.0

### DIFF
--- a/pkgs/development/python-modules/diofant/default.nix
+++ b/pkgs/development/python-modules/diofant/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, isPy3k
+, buildPythonPackage
+, fetchPypi
+, pytestrunner
+, setuptools_scm
+, isort
+, mpmath
+, strategies
+}:
+
+buildPythonPackage rec {
+  pname = "diofant";
+  version = "0.10.0";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "Diofant";
+    sha256 = "0qjg0mmz2cqxryr610mppx3virf1gslzrsk24304502588z53v8w";
+  };
+
+  nativeBuildInputs = [
+    isort
+    pytestrunner
+    setuptools_scm
+  ];
+
+  propagatedBuildInputs = [
+    mpmath
+    strategies
+  ];
+
+  # tests take ~1h
+  doCheck = false;
+
+  disabled = !isPy3k;
+
+  meta = with lib; {
+    description = "A Python CAS library";
+    homepage = "https://diofant.readthedocs.io/";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ suhr ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -502,6 +502,8 @@ in {
 
   diff_cover = callPackage ../development/python-modules/diff_cover { };
 
+  diofant = callPackage ../development/python-modules/diofant { };
+
   docrep = callPackage ../development/python-modules/docrep { };
 
   dominate = callPackage ../development/python-modules/dominate { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
