### PR TITLE
klystrack: init at 1.7.6

### DIFF
--- a/pkgs/applications/audio/klystrack/default.nix
+++ b/pkgs/applications/audio/klystrack/default.nix
@@ -1,0 +1,52 @@
+{ stdenv, fetchFromGitHub, fetchpatch
+, SDL2, SDL2_image
+, pkgconfig
+}:
+
+stdenv.mkDerivation rec {
+  pname = "klystrack";
+  version = "1.7.6";
+
+  src = fetchFromGitHub {
+    owner = "kometbomb";
+    repo = pname;
+    rev = version;
+    fetchSubmodules = true;
+    sha256 = "1h99sm2ddaq483hhk2s3z4bjbgn0d2h7qna7l7qq98wvhqix8iyz";
+  };
+
+  buildInputs = [
+    SDL2 SDL2_image
+  ];
+  nativeBuildInputs = [ pkgconfig ];
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/kometbomb/klystrack/commit/bb537595d02140176831c4a1b8e9121978b32d22.patch";
+      sha256 = "06gl9q0jwg039kpxb13lg9x0k59s11968qn4lybgkadvzmhxkgmi";
+    })
+  ];
+
+  buildFlags = [ "PREFIX=${placeholder "out"}" "CFG=release" ];
+
+  installPhase = ''
+    install -Dm755 bin.release/klystrack $out/bin/klystrack
+
+    mkdir -p $out/lib/klystrack
+    cp -R res $out/lib/klystrack
+    cp -R key $out/lib/klystrack
+
+    install -DT icon/256x256.png $out/share/icons/hicolor/256x256/apps/klystrack.png
+    mkdir -p $out/share/applications
+    substitute linux/klystrack.desktop $out/share/applications/klystrack.desktop \
+      --replace "klystrack %f" "$out/bin/klystrack %f"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A chiptune tracker";
+    homepage = "https://kometbomb.github.io/klystrack";
+    license = licenses.mit;
+    maintainers = with maintainers; [ suhr ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4042,6 +4042,8 @@ in
 
   klick = callPackage ../applications/audio/klick { };
 
+  klystrack = callPackage ../applications/audio/klystrack { };
+
   knockknock = callPackage ../tools/security/knockknock { };
 
   kore = callPackage ../development/web/kore { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
