### PR TITLE
font-awesome_4: Readd, font-awesome_5: 5.9.0 -> 5.10.0

### DIFF
--- a/pkgs/data/fonts/font-awesome-5/default.nix
+++ b/pkgs/data/fonts/font-awesome-5/default.nix
@@ -1,30 +1,45 @@
 { lib, fetchFromGitHub }:
-
 let
-  version = "5.9.0";
-in fetchFromGitHub rec {
-  name = "font-awesome-${version}";
+  font-awesome = { version, sha256, rev ? version}: fetchFromGitHub rec {
+    name = "font-awesome-${version}";
 
-  owner = "FortAwesome";
-  repo = "Font-Awesome";
-  rev = version;
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
-    install -m444 -Dt $out/share/fonts/opentype otfs/*.otf
-  '';
+    owner = "FortAwesome";
+    repo = "Font-Awesome";
+    inherit rev;
 
-  sha256 = "0sz7mn7g968vp5hszs05grpphd7zr3073az8lyy1lj0096zvjjii";
-
-  meta = with lib; {
-    description = "Font Awesome - OTF font";
-    longDescription = ''
-      Font Awesome gives you scalable vector icons that can instantly be customized.
-      This package includes only the OTF font. For full CSS etc. see the project website.
+    postFetch = ''
+      tar xf $downloadedFile --strip=1
+      install -m444 -Dt $out/share/fonts/opentype {fonts,otfs}/*.otf
     '';
-    homepage = http://fortawesome.github.io/Font-Awesome/;
-    license = licenses.ofl;
-    platforms = platforms.all;
-    maintainers = with maintainers; [ abaldeau ];
+
+    inherit sha256;
+
+    meta = with lib; {
+      description = "Font Awesome - OTF font";
+      longDescription = ''
+        Font Awesome gives you scalable vector icons that can instantly be customized.
+        This package includes only the OTF font. For full CSS etc. see the project website.
+      '';
+      homepage = "http://fortawesome.github.io/Font-Awesome/";
+      license = licenses.ofl;
+      platforms = platforms.all;
+      maintainers = with maintainers; [ abaldeau johnazoidberg ];
+    };
+  };
+in {
+  # Keeping version 4 because version 5 is incompatible for some icons. That
+  # means that projects which depend on it need to actively convert the
+  # symbols. See:
+  # https://github.com/greshake/i3status-rust/issues/130
+  # https://fontawesome.com/how-to-use/on-the-web/setup/upgrading-from-version-4
+  v4 = font-awesome {
+    version = "4.7.0";
+    rev = "v4.7.0";
+    sha256 = "1j8i32dq6rrlv3kf2hnq81iqks06kczaxjks7nw3zyq1231winm9";
+  };
+  v5 = font-awesome {
+    version = "5.9.0";
+    sha256 = "0sz7mn7g968vp5hszs05grpphd7zr3073az8lyy1lj0096zvjjii";
   };
 }

--- a/pkgs/data/fonts/font-awesome-5/default.nix
+++ b/pkgs/data/fonts/font-awesome-5/default.nix
@@ -39,7 +39,7 @@ in {
     sha256 = "1j8i32dq6rrlv3kf2hnq81iqks06kczaxjks7nw3zyq1231winm9";
   };
   v5 = font-awesome {
-    version = "5.9.0";
-    sha256 = "0sz7mn7g968vp5hszs05grpphd7zr3073az8lyy1lj0096zvjjii";
+    version = "5.10.0";
+    sha256 = "11nga1drlpkrmw307ga6plbj5z1b70cnckr465z8z6vkbcd6jkv3";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16393,7 +16393,8 @@ in
 
   fira-mono = callPackage ../data/fonts/fira-mono { };
 
-  font-awesome_5 = callPackage ../data/fonts/font-awesome-5 { };
+  font-awesome_4 = (callPackage ../data/fonts/font-awesome-5 { }).v4;
+  font-awesome_5 = (callPackage ../data/fonts/font-awesome-5 { }).v5;
   font-awesome = font-awesome_5;
 
   freefont_ttf = callPackage ../data/fonts/freefont-ttf { };


### PR DESCRIPTION
###### Motivation for this change
Version 5 is incompatible for some icons, so projects that depend on it
need to actively convert the symbols, see:
https://github.com/greshake/i3status-rust/issues/130
    
Reintroducing the old version lets us use those programs that haven't
been updated.
    
Was removed in 0a393f53a9702cea04a6afea506c3a91a1a2bf60

cc @Mic92 and @baldo 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
