### PR TITLE
rls: 1.34 -> 1.35

### DIFF
--- a/pkgs/development/tools/rust/rls/default.nix
+++ b/pkgs/development/tools/rust/rls/default.nix
@@ -1,46 +1,38 @@
 { stdenv, fetchFromGitHub, rustPlatform
-, openssh, openssl, pkgconfig, cmake, zlib, curl, libiconv }:
+, openssh, openssl, pkgconfig, cmake, zlib, curl, libiconv
+, CoreFoundation, Security }:
 
 rustPlatform.buildRustPackage rec {
-  name = "rls-${version}";
+  pname = "rls";
   # with rust 1.x you can only build rls version 1.x.y
-  version = "1.34.0";
+  version = "1.35.0";
 
   src = fetchFromGitHub {
     owner = "rust-lang";
-    repo = "rls";
-    rev = "0d6f53e1a4adbaf7d83cdc0cb54720203fcb522e";
-    sha256 = "1aabs0kr87sp68n9893im5wz21dicip9ixir9a9l56nis4qxpm7i";
+    repo = pname;
+    rev = version;
+    sha256 = "1l3fvlgfzri8954nbwqxqghjy5wa8p1aiml12r1lqs92dh0g192f";
   };
 
-  cargoSha256 = "16r9rmjhb0dbdgx9qf740nsckjazz4z663vaajw5z9i4qh0jsy18";
+  cargoSha256 = "0v96ndys6bv5dfjg01chrqrqjc57qqfjw40n6vppi9bpw0f6wkf5";
 
   # a nightly compiler is required unless we use this cheat code.
   RUSTC_BOOTSTRAP=1;
 
-  # clippy is hard to build with stable rust so we disable clippy lints
-  cargoBuildFlags = [ "--no-default-features" ];
-
   nativeBuildInputs = [ pkgconfig cmake ];
-  buildInputs = [ openssh openssl curl zlib libiconv ];
+  buildInputs = [ openssh openssl curl zlib libiconv ]
+    ++ (stdenv.lib.optionals stdenv.isDarwin [ CoreFoundation Security ]);
 
   doCheck = true;
-  # the default checkPhase has no way to pass --no-default-features
-  checkPhase = ''
-    runHook preCheck
-
+  preCheck = ''
     # client tests are flaky
     rm tests/client.rs
-
-    echo "Running cargo test"
-    cargo test --no-default-features
-    runHook postCheck
   '';
 
   meta = with stdenv.lib; {
     description = "Rust Language Server - provides information about Rust programs to IDEs and other tools";
     homepage = https://github.com/rust-lang/rls/;
-    license = licenses.mit;
+    license = with licenses; [ asl20 /* or */ mit ];
     maintainers = with maintainers; [ symphorien ];
     platforms = platforms.all;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8120,7 +8120,9 @@ in
 
   pyo3-pack = callPackage ../development/tools/rust/pyo3-pack { };
   rainicorn = callPackage ../development/tools/rust/rainicorn { };
-  rls = callPackage ../development/tools/rust/rls { };
+  rls = callPackage ../development/tools/rust/rls {
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
+  };
   rustfmt = callPackage ../development/tools/rust/rustfmt { };
   rustracer = callPackage ../development/tools/rust/racer { };
   rustracerd = callPackage ../development/tools/rust/racerd { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
 
fix rls after rustc version bump

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
