### PR TITLE
pythonPackages.openapi-spec-validator: init at 0.2.7

### DIFF
--- a/pkgs/development/python-modules/openapi-spec-validator/default.nix
+++ b/pkgs/development/python-modules/openapi-spec-validator/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildPythonPackage, isPy27, fetchPypi
+, jsonschema, pyyaml, six, pathlib
+, mock, pytest, pytestcov, pytest-flake8, tox }:
+
+buildPythonPackage rec {
+  pname = "openapi-spec-validator";
+  version = "0.2.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1sz9ls6a7h056nc5q76w4xl43sr1h9in2f23qwkxazcazr3zpi3p";
+  };
+
+  propagatedBuildInputs = [ jsonschema pyyaml six ]
+    ++ (lib.optionals (isPy27) [ pathlib ]);
+
+  checkInputs = [ mock pytest pytestcov pytest-flake8 tox ];
+
+  meta = with lib; {
+    homepage = https://github.com/p1c2u/openapi-spec-validator;
+    description = "Validates OpenAPI Specs against the OpenAPI 2.0 (aka Swagger) and OpenAPI 3.0.0 specification";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ rvl ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4888,6 +4888,8 @@ in {
 
   swagger-spec-validator = callPackage ../development/python-modules/swagger-spec-validator { };
 
+  openapi-spec-validator = callPackage ../development/python-modules/openapi-spec-validator { };
+
   freezegun = callPackage ../development/python-modules/freezegun { };
 
   taskw = callPackage ../development/python-modules/taskw { };


### PR DESCRIPTION
###### Motivation for this change

Adds a useful OpenAPI spec validator tool.

###### Things done

Tested the program built against `pythonPackages` and `python3Packages`.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc: @vanschelven (swagger_spec_validator) and @Shou (openapi-generator-cli)
