### PR TITLE
zsh-powerlevel10k init at 2019-07-28

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5859,6 +5859,15 @@
     github = "zraexy";
     name = "David Mell";
   };
+  zyradyl = {
+    email = "zyra@zyradyl.moe";
+    github = "zyradyl";
+    keys = [{
+      longkeyid = "rsa4096/0x777457F87573F3ED";
+      fingerprint = "DDCE 7874 4833 D540 5E08 5E7A 7774 57F8 7573 F3ED";
+    }];
+    name = "Zephyr Spencer";
+  };
   zx2c4 = {
     email = "Jason@zx2c4.com";
     github = "zx2c4";

--- a/pkgs/shells/zsh/zsh-powerlevel10k/default.nix
+++ b/pkgs/shells/zsh/zsh-powerlevel10k/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchFromGitHub }:
+
+# To make use of this derivation, use
+# `programs.zsh.promptInit = "source ${pkgs.zsh-powerlevel10k}/share/zsh-powerlevel10k/powerlevel10k.zsh-theme";`
+
+let
+  version = "2019-07-28";
+in
+
+stdenv.mkDerivation rec {
+  name = "powerlevel10k-${version}";
+
+  src = fetchFromGitHub {
+    owner = "romkatv";
+    repo = "powerlevel10k";
+    rev = "e3f5a1c3438b361d75080c3f06b95b4c98a66fee";
+    sha256 = "0nv3651xysngx8q2h795z7y16vrqajy3ybhnawc8kfzid06hs8zh";
+  };
+
+  installPhase= ''
+    install -D powerlevel10k.zsh-theme --target-directory=$out/share/zsh-powerlevel10k
+    install -D powerlevel9k.zsh-theme --target-directory=$out/share/zsh-powerlevel10k
+    install -D prompt_powerlevel10k_setup --target-directory=$out/share/zsh-powerlevel10k
+    install -D prompt_powerlevel9k_setup --target-directory=$out/share/zsh-powerlevel10k
+    install -D config/* --target-directory=$out/share/zsh-powerlevel10k/config
+    install -D functions/* --target-directory=$out/share/zsh-powerlevel10k/functions
+    install -D gitstatus/*.zsh --target-directory=$out/share/zsh-powerlevel10k/gitstatus
+    install -D gitstatus/bin/* --target-directory=$out/share/zsh-powerlevel10k/gitstatus/bin
+    install -D internal/* --target-directory=$out/share/zsh-powerlevel10k/internal
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A fast reimplementation of Powerlevel9k ZSH theme";
+    homepage = https://github.com/romkatv/powerlevel10k;
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = [
+      maintainers.zyradyl
+    ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7026,6 +7026,8 @@ in
 
   zsh-powerlevel9k = callPackage ../shells/zsh/zsh-powerlevel9k { };
 
+  zsh-powerlevel10k = callPackage ../shells/zsh/zsh-powerlevel10k { };
+
   zsh-command-time = callPackage ../shells/zsh/zsh-command-time { };
 
   zsh-you-should-use = callPackage ../shells/zsh/zsh-you-should-use { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
zsh-powerlevel9k can increase latency with large git repositories. Powerlevel10k is a drop in replacement that decreases that latency.

Additionally, I have added myself to the maintainers file. I am planning on (fingers crossed) submitting more than just this pull, so I hope this is appropriate. :sweat_smile: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
