### PR TITLE
openjdk: enable bootstrapping on ARM

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -150,21 +150,11 @@ let
     ] ++ optionals (useVaapi) [
       # source: https://aur.archlinux.org/cgit/aur.git/plain/chromium-vaapi.patch?h=chromium-vaapi
       ./patches/chromium-vaapi.patch
-    ] ++ optionals (!stdenv.cc.isClang && (versionRange "71" "72")) [
-      ( githubPatch "65be571f6ac2f7942b4df9e50b24da517f829eec" "1sqv0aba0mpdi4x4f21zdkxz2cf8ji55ffgbfcr88c5gcg0qn2jh" )
-    ] ++ optional stdenv.isAarch64
-           (if (versionOlder version "71") then
-              fetchpatch {
-                url       = https://raw.githubusercontent.com/OSSystems/meta-browser/e4a667deaaf9a26a3a1aeb355770d1f29da549ad/recipes-browser/chromium/files/aarch64-skia-build-fix.patch;
-                sha256    = "0dkchqair8cy2f5a5p5vi24r9b4d28pgn2bfvm1568lypbjw6iab";
-              }
-            else
-              fetchpatch {
-                url       = https://raw.githubusercontent.com/OSSystems/meta-browser/e4a667deaaf9a26a3a1aeb355770d1f29da549ad/recipes-browser/chromium/files/aarch64-skia-build-fix.patch;
-                postFetch = "substituteInPlace $out --replace __aarch64__ SK_CPU_ARM64";
-                sha256    = "018fbdzyw9rvia8m0qkk5gv8q8gl7x34rrjbn7mi1fgxdsayn22s";
-              }
-            );
+    ] ++ optional stdenv.isAarch64 (fetchpatch {
+      url       = https://raw.githubusercontent.com/OSSystems/meta-browser/e4a667deaaf9a26a3a1aeb355770d1f29da549ad/recipes-browser/chromium/files/aarch64-skia-build-fix.patch;
+      postFetch = "substituteInPlace $out --replace __aarch64__ SK_CPU_ARM64";
+      sha256    = "018fbdzyw9rvia8m0qkk5gv8q8gl7x34rrjbn7mi1fgxdsayn22s";
+    });
 
     postPatch = ''
       # We want to be able to specify where the sandbox is via CHROME_DEVEL_SANDBOX

--- a/pkgs/development/compilers/adoptopenjdk-bin/generate-sources.py
+++ b/pkgs/development/compilers/adoptopenjdk-bin/generate-sources.py
@@ -12,8 +12,9 @@ types = ["jre", "jdk"]
 impls = ["hotspot", "openj9"]
 
 arch_to_nixos = {
-    "x64": "x86_64",
-    "aarch64": "aarch64",
+    "x64": ("x86_64",),
+    "aarch64": ("aarch64",),
+    "arm": ("armv6l", "armv7l"),
 }
 
 def get_sha256(url):
@@ -42,12 +43,13 @@ def generate_sources(release, assets):
             "vmType": asset["openjdk_impl"],
         })
 
-        arch_map[arch_to_nixos[asset["architecture"]]] = {
-            "url": asset["binary_link"],
-            "sha256": get_sha256(asset["checksum_link"]),
-            "version": version,
-            "build": build,
-        }
+        for nixos_arch in arch_to_nixos[asset["architecture"]]:
+            arch_map[nixos_arch] = {
+                "url": asset["binary_link"],
+                "sha256": get_sha256(asset["checksum_link"]),
+                "version": version,
+                "build": build,
+            }
 
     return out
 

--- a/pkgs/development/compilers/adoptopenjdk-bin/generate-sources.py
+++ b/pkgs/development/compilers/adoptopenjdk-bin/generate-sources.py
@@ -6,10 +6,10 @@ import re
 import requests
 import sys
 
-releases = ["openjdk11"]
-oses = ["mac", "linux"]
-types = ["jre", "jdk"]
-impls = ["hotspot", "openj9"]
+releases = ("openjdk8", "openjdk11")
+oses = ("mac", "linux")
+types = ("jre", "jdk")
+impls = ("hotspot", "openj9")
 
 arch_to_nixos = {
     "x64": ("x86_64",),
@@ -24,7 +24,6 @@ def get_sha256(url):
         sys.exit(1)
     return resp.text.strip().split(" ")[0]
 
-RE_RELEASE_NAME = re.compile(r'[^-]+-([0-9.]+)\+([0-9]+)') # example release name: jdk-11.0.1+13
 def generate_sources(release, assets):
     out = {}
     for asset in assets:
@@ -34,7 +33,8 @@ def generate_sources(release, assets):
         if asset["heap_size"] != "normal": continue
         if asset["architecture"] not in arch_to_nixos: continue
 
-        version, build = RE_RELEASE_NAME.match(asset["release_name"]).groups()
+        # examples: 11.0.1+13, 8.0.222+10
+        version, build = asset["version_data"]["semver"].split("+")
 
         type_map = out.setdefault(asset["os"], {})
         impl_map = type_map.setdefault(asset["binary_type"], {})

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk-darwin-base.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk-darwin-base.nix
@@ -46,9 +46,6 @@ let cpuName = stdenv.hostPlatform.parsed.cpu.name;
 
   passthru.home = result;
 
-  # for backward compatibility
-  passthru.architecture = "";
-
   meta = with stdenv.lib; {
     license = licenses.gpl2Classpath;
     description = "AdoptOpenJDK, prebuilt OpenJDK binary";

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk-linux-base.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk-linux-base.nix
@@ -1,48 +1,16 @@
 sourcePerArch:
 
-{ swingSupport ? true
-, stdenv
+{ stdenv
+, lib
 , fetchurl
-, file
-, xorg ? null
-, glib
-, libxml2
-, ffmpeg_2
-, libxslt
-, libGL
-, freetype
-, fontconfig
-, gtk2
-, pango
-, cairo
+, autoPatchelfHook
 , alsaLib
-, atk
-, gdk-pixbuf
+, freetype
 , zlib
-, elfutils
+, xorg
 }:
 
-assert swingSupport -> xorg != null;
-
 let
-  rSubPaths = [
-    "lib/jli"
-    "lib/server"
-    "lib/compressedrefs" # OpenJ9
-    "lib/j9vm" # OpenJ9
-    "lib"
-  ];
-
-  libraries = [
-    stdenv.cc.libc glib libxml2 ffmpeg_2 libxslt libGL
-    xorg.libXxf86vm alsaLib fontconfig freetype pango gtk2 cairo gdk-pixbuf
-    atk zlib elfutils
-  ] ++ (stdenv.lib.optionals swingSupport [
-    xorg.libX11 xorg.libXext xorg.libXtst xorg.libXi xorg.libXp xorg.libXt
-    xorg.libXrender
-    stdenv.cc.cc
-  ]);
-
   cpuName = stdenv.hostPlatform.parsed.cpu.name;
 in
 
@@ -57,7 +25,12 @@ let result = stdenv.mkDerivation rec {
     inherit (sourcePerArch.${cpuName}) url sha256;
   };
 
-  nativeBuildInputs = [ file ];
+  buildInputs = [
+    alsaLib freetype zlib xorg.libX11 xorg.libXext xorg.libXtst xorg.libXi
+    xorg.libXrender
+  ];
+
+  nativeBuildInputs = [ autoPatchelfHook ];
 
   # See: https://github.com/NixOS/patchelf/issues/10
   dontStrip = 1;
@@ -74,10 +47,7 @@ let result = stdenv.mkDerivation rec {
 
     # Remove embedded freetype to avoid problems like
     # https://github.com/NixOS/nixpkgs/issues/57733
-    rm $out/lib/libfreetype.so
-
-    # for backward compatibility
-    ln -s $out $out/jre
+    find "$out" -name 'libfreetype.so*' -delete
 
     mkdir -p $out/nix-support
 
@@ -87,32 +57,16 @@ let result = stdenv.mkDerivation rec {
     EOF
   '';
 
-  postFixup = ''
-    rpath+="''${rpath:+:}${stdenv.lib.concatStringsSep ":" (map (a: "$out/${a}") rSubPaths)}"
-
-    # set all the dynamic linkers
-    find $out -type f -perm -0100 \
-        -exec patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-        --set-rpath "$rpath" {} \;
-
-    find $out -name "*.so" -exec patchelf --set-rpath "$rpath" {} \;
-  '';
-
-  rpath = stdenv.lib.strings.makeLibraryPath libraries;
-
   # FIXME: use multiple outputs or return actual JRE package
   passthru.jre = result;
 
   passthru.home = result;
 
-  # for backward compatibility
-  passthru.architecture = "";
-
   meta = with stdenv.lib; {
     license = licenses.gpl2Classpath;
     description = "AdoptOpenJDK, prebuilt OpenJDK binary";
-    platforms = stdenv.lib.mapAttrsToList (arch: _: arch + "-linux") sourcePerArch; # some inherit jre.meta.platforms
-    maintainers = with stdenv.lib.maintainers; [ taku0 ];
+    platforms = lib.mapAttrsToList (arch: _: arch + "-linux") sourcePerArch; # some inherit jre.meta.platforms
+    maintainers = with lib.maintainers; [ taku0 ];
   };
 
 }; in result

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk-linux-base.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk-linux-base.nix
@@ -6,6 +6,7 @@ sourcePerArch:
 , autoPatchelfHook
 , alsaLib
 , freetype
+, fontconfig
 , zlib
 , xorg
 }:
@@ -26,8 +27,8 @@ let result = stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    alsaLib freetype zlib xorg.libX11 xorg.libXext xorg.libXtst xorg.libXi
-    xorg.libXrender
+    alsaLib freetype fontconfig zlib xorg.libX11 xorg.libXext xorg.libXtst
+    xorg.libXi xorg.libXrender
   ];
 
   nativeBuildInputs = [ autoPatchelfHook ];
@@ -52,9 +53,14 @@ let result = stdenv.mkDerivation rec {
     mkdir -p $out/nix-support
 
     # Set JAVA_HOME automatically.
-    cat <<EOF >> $out/nix-support/setup-hook
+    cat <<EOF >> "$out/nix-support/setup-hook"
     if [ -z "\$JAVA_HOME" ]; then export JAVA_HOME=$out; fi
     EOF
+  '';
+
+  preFixup = ''
+    find "$out" -name libfontmanager.so -exec \
+      patchelf --add-needed libfontconfig.so {} \;
   '';
 
   # FIXME: use multiple outputs or return actual JRE package

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk8-darwin.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk8-darwin.nix
@@ -1,0 +1,9 @@
+let
+  sources = builtins.fromJSON (builtins.readFile ./sources.json);
+in
+{
+  jdk-hotspot = import ./jdk-darwin-base.nix sources.openjdk8.mac.jdk.hotspot;
+  jre-hotspot = import ./jdk-darwin-base.nix sources.openjdk8.mac.jre.hotspot;
+  jdk-openj9 = import ./jdk-darwin-base.nix sources.openjdk8.mac.jdk.openj9;
+  jre-openj9 = import ./jdk-darwin-base.nix sources.openjdk8.mac.jre.openj9;
+}

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk8-linux.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk8-linux.nix
@@ -1,0 +1,9 @@
+let
+  sources = builtins.fromJSON (builtins.readFile ./sources.json);
+in
+{
+  jdk-hotspot = import ./jdk-linux-base.nix sources.openjdk8.linux.jdk.hotspot;
+  jre-hotspot = import ./jdk-linux-base.nix sources.openjdk8.linux.jre.hotspot;
+  jdk-openj9 = import ./jdk-linux-base.nix sources.openjdk8.linux.jdk.openj9;
+  jre-openj9 = import ./jdk-linux-base.nix sources.openjdk8.linux.jre.openj9;
+}

--- a/pkgs/development/compilers/adoptopenjdk-bin/sources.json
+++ b/pkgs/development/compilers/adoptopenjdk-bin/sources.json
@@ -4,10 +4,10 @@
       "jdk": {
         "hotspot": {
           "aarch64": {
-            "build": "7",
-            "sha256": "894a846600ddb0df474350037a2fb43e3343dc3606809a20c65e750580d8f2b9",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.3_7.tar.gz",
-            "version": "11.0.3"
+            "build": "11",
+            "sha256": "10e33e1862638e11a9158947b3d7b461727d8e396e378b171be1eb4dfe12f1ed",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.4%2B11/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.4_11.tar.gz",
+            "version": "11.0.4"
           },
           "armv6l": {
             "build": "7",
@@ -24,48 +24,48 @@
           "packageType": "jdk",
           "vmType": "hotspot",
           "x86_64": {
-            "build": "7",
-            "sha256": "23cded2b43261016f0f246c85c8948d4a9b7f2d44988f75dad69723a7a526094",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7/OpenJDK11U-jdk_x64_linux_hotspot_11.0.3_7.tar.gz",
-            "version": "11.0.3"
+            "build": "11",
+            "sha256": "90c33cf3f2ed0bd773f648815de7347e69cfbb3416ef3bf41616ab1c4aa0f5a8",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.4%2B11/OpenJDK11U-jdk_x64_linux_hotspot_11.0.4_11.tar.gz",
+            "version": "11.0.4"
           }
         },
         "openj9": {
           "packageType": "jdk",
           "vmType": "openj9",
           "x86_64": {
-            "build": "7",
-            "sha256": "bb8396b3fbaa160bf2173eadbc83cce50bcd5a0879dc24b4122efb7411370d12",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7_openj9-0.14.3/OpenJDK11U-jdk_x64_linux_openj9_11.0.3_7_openj9-0.14.3.tar.gz",
-            "version": "11.0.3"
+            "build": "11",
+            "sha256": "b1099cccc80a3f434728c9bc3b8a90395793b625f4680ca05267cf635143d64d",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.4%2B11_openj9-0.15.1/OpenJDK11U-jdk_x64_linux_openj9_11.0.4_11_openj9-0.15.1.tar.gz",
+            "version": "11.0.4"
           }
         }
       },
       "jre": {
         "hotspot": {
           "aarch64": {
-            "build": "7",
-            "sha256": "de31fab70640c6d5099de5fc8fa8b4d6b484a7352fa48a9fafbdc088ca708564",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7/OpenJDK11U-jre_aarch64_linux_hotspot_11.0.3_7.tar.gz",
-            "version": "11.0.3"
+            "build": "11",
+            "sha256": "5f7b5c110fc0f344a549cb11784a6d76838061a2b6f654f7841f60e0cd286c6a",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.4%2B11/OpenJDK11U-jre_aarch64_linux_hotspot_11.0.4_11.tar.gz",
+            "version": "11.0.4"
           },
           "packageType": "jre",
           "vmType": "hotspot",
           "x86_64": {
-            "build": "7",
-            "sha256": "d2df8bc799b09c8375f79bf646747afac3d933bb1f65de71d6c78e7466ff8fe4",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7/OpenJDK11U-jre_x64_linux_hotspot_11.0.3_7.tar.gz",
-            "version": "11.0.3"
+            "build": "11",
+            "sha256": "70d2cc675155476f1d8516a7ae6729d44681e4fad5a6fc8dfa65cab36a67b7e0",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.4%2B11/OpenJDK11U-jre_x64_linux_hotspot_11.0.4_11.tar.gz",
+            "version": "11.0.4"
           }
         },
         "openj9": {
           "packageType": "jre",
           "vmType": "openj9",
           "x86_64": {
-            "build": "7",
-            "sha256": "493a90023447f9f422db011560732cb018795023ed1166dfc04ffa18a4c1fb83",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7_openj9-0.14.3/OpenJDK11U-jre_x64_linux_openj9_11.0.3_7_openj9-0.14.3.tar.gz",
-            "version": "11.0.3"
+            "build": "11",
+            "sha256": "c2601e7cb22af7a910e03883280cee805074656104d6d3dcaaf30e3bbb832690",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.4%2B11_openj9-0.15.1/OpenJDK11U-jre_x64_linux_openj9_11.0.4_11_openj9-0.15.1.tar.gz",
+            "version": "11.0.4"
           }
         }
       }
@@ -76,20 +76,20 @@
           "packageType": "jdk",
           "vmType": "hotspot",
           "x86_64": {
-            "build": "7",
-            "sha256": "5ca2a24f1827bd7c110db99854693bf418f51ee3093c31332db5cd605278faad",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7/OpenJDK11U-jdk_x64_mac_hotspot_11.0.3_7.tar.gz",
-            "version": "11.0.3"
+            "build": "11",
+            "sha256": "a50b211f475b9497311c9b65594764d7b852b1653f249582bb20fc3c302846a5",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.4%2B11/OpenJDK11U-jdk_x64_mac_hotspot_11.0.4_11.tar.gz",
+            "version": "11.0.4"
           }
         },
         "openj9": {
           "packageType": "jdk",
           "vmType": "openj9",
           "x86_64": {
-            "build": "7",
-            "sha256": "9217cab0b5dc6301b386ea837d6df38f93adcb5139e5f67a93bb42c3e36df624",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7_openj9-0.14.3/OpenJDK11U-jdk_x64_mac_openj9_11.0.3_7_openj9-0.14.3.tar.gz",
-            "version": "11.0.3"
+            "build": "11",
+            "sha256": "7c09678d9c2d9dd0366693c6ab27bed39c76a23e7ac69b8a25c794e99dcf3ba7",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.4%2B11_openj9-0.15.1/OpenJDK11U-jdk_x64_mac_openj9_11.0.4_11_openj9-0.15.1.tar.gz",
+            "version": "11.0.4"
           }
         }
       },
@@ -98,20 +98,126 @@
           "packageType": "jre",
           "vmType": "hotspot",
           "x86_64": {
-            "build": "7",
-            "sha256": "9523b97288ff5d50e404565d346ed8ea8f19dd155092951af88d4be6b8414776",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7/OpenJDK11U-jre_x64_mac_hotspot_11.0.3_7.tar.gz",
-            "version": "11.0.3"
+            "build": "11",
+            "sha256": "1647fded28d25e562811f7bce2092eb9c21d30608843b04250c023b40604ff26",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.4%2B11/OpenJDK11U-jre_x64_mac_hotspot_11.0.4_11.tar.gz",
+            "version": "11.0.4"
           }
         },
         "openj9": {
           "packageType": "jre",
           "vmType": "openj9",
           "x86_64": {
-            "build": "7",
-            "sha256": "eb448ffa9dc1178e0b3c198b87a3f7f2f9fc8a2c036dc066bec1212a9d819971",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7_openj9-0.14.3/OpenJDK11U-jre_x64_mac_openj9_11.0.3_7_openj9-0.14.3.tar.gz",
-            "version": "11.0.3"
+            "build": "11",
+            "sha256": "1a8e84bae517a848aa5f25c7b04f26ab3a3bfffaa7fdf9be24e1f83325e46766",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.4%2B11_openj9-0.15.1/OpenJDK11U-jre_x64_mac_openj9_11.0.4_11_openj9-0.15.1.tar.gz",
+            "version": "11.0.4"
+          }
+        }
+      }
+    }
+  },
+  "openjdk8": {
+    "linux": {
+      "jdk": {
+        "hotspot": {
+          "aarch64": {
+            "build": "10",
+            "sha256": "652776586ede124189dc218174b5922cc97feac81021ad81905900b349a352d2",
+            "url": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u222-b10/OpenJDK8U-jdk_aarch64_linux_hotspot_8u222b10.tar.gz",
+            "version": "8.0.222"
+          },
+          "packageType": "jdk",
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "10",
+            "sha256": "37356281345b93feb4212e6267109b4409b55b06f107619dde4960e402bafa77",
+            "url": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u222-b10/OpenJDK8U-jdk_x64_linux_hotspot_8u222b10.tar.gz",
+            "version": "8.0.222"
+          }
+        },
+        "openj9": {
+          "packageType": "jdk",
+          "vmType": "openj9",
+          "x86_64": {
+            "build": "10",
+            "sha256": "20cff719c6de43f8bb58c7f59e251da7c1fa2207897c9a4768c8c669716dc819",
+            "url": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u222-b10_openj9-0.15.1/OpenJDK8U-jdk_x64_linux_openj9_8u222b10_openj9-0.15.1.tar.gz",
+            "version": "8.0.222"
+          }
+        }
+      },
+      "jre": {
+        "hotspot": {
+          "aarch64": {
+            "build": "10",
+            "sha256": "dfaf5a121f7606c54bd6232793677a4267eddf65d29cde352b84d84edbccbb51",
+            "url": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u222-b10/OpenJDK8U-jre_aarch64_linux_hotspot_8u222b10.tar.gz",
+            "version": "8.0.222"
+          },
+          "packageType": "jre",
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "10",
+            "sha256": "a418ce895c8bf3ca2e7b2f423f038b8b093941684c9430f2e40da0982e12b52d",
+            "url": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u222-b10/OpenJDK8U-jre_x64_linux_hotspot_8u222b10.tar.gz",
+            "version": "8.0.222"
+          }
+        },
+        "openj9": {
+          "packageType": "jre",
+          "vmType": "openj9",
+          "x86_64": {
+            "build": "10",
+            "sha256": "ae56994a7c8e8c19939c0c2ff8fe5a850eb2f23845c499aa5ede26deb3d5ad28",
+            "url": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u222-b10_openj9-0.15.1/OpenJDK8U-jre_x64_linux_openj9_8u222b10_openj9-0.15.1.tar.gz",
+            "version": "8.0.222"
+          }
+        }
+      }
+    },
+    "mac": {
+      "jdk": {
+        "hotspot": {
+          "packageType": "jdk",
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "10",
+            "sha256": "9605fd00d2960934422437f601c7a9a1c5537309b9199d5bc75f84f20cd29a76",
+            "url": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u222-b10/OpenJDK8U-jdk_x64_mac_hotspot_8u222b10.tar.gz",
+            "version": "8.0.222"
+          }
+        },
+        "openj9": {
+          "packageType": "jdk",
+          "vmType": "openj9",
+          "x86_64": {
+            "build": "10",
+            "sha256": "df185e167756332163633a826b329db067f8a721f7d5d27f0b353a35fc415de0",
+            "url": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u222-b10_openj9-0.15.1/OpenJDK8U-jdk_x64_mac_openj9_8u222b10_openj9-0.15.1.tar.gz",
+            "version": "8.0.222"
+          }
+        }
+      },
+      "jre": {
+        "hotspot": {
+          "packageType": "jre",
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "10",
+            "sha256": "b3ac2436534cea932ccf665b317dbf5ffc0ee065efca808b22b6c2d795ca1b90",
+            "url": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u222-b10/OpenJDK8U-jre_x64_mac_hotspot_8u222b10.tar.gz",
+            "version": "8.0.222"
+          }
+        },
+        "openj9": {
+          "packageType": "jre",
+          "vmType": "openj9",
+          "x86_64": {
+            "build": "10",
+            "sha256": "d5754413d7bc3a3233aaa7f8465451fbdabaf2a0c2a91743155bf135a3047ec8",
+            "url": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u222-b10_openj9-0.15.1/OpenJDK8U-jre_x64_mac_openj9_8u222b10_openj9-0.15.1.tar.gz",
+            "version": "8.0.222"
           }
         }
       }

--- a/pkgs/development/compilers/adoptopenjdk-bin/sources.json
+++ b/pkgs/development/compilers/adoptopenjdk-bin/sources.json
@@ -9,6 +9,18 @@
             "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.3_7.tar.gz",
             "version": "11.0.3"
           },
+          "armv6l": {
+            "build": "7",
+            "sha256": "3fbe418368e6d5888d0f15c4751139eb60d9785b864158a001386537fa46f67e",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7/OpenJDK11U-jdk_arm_linux_hotspot_11.0.3_7.tar.gz",
+            "version": "11.0.3"
+          },
+          "armv7l": {
+            "build": "7",
+            "sha256": "3fbe418368e6d5888d0f15c4751139eb60d9785b864158a001386537fa46f67e",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7/OpenJDK11U-jdk_arm_linux_hotspot_11.0.3_7.tar.gz",
+            "version": "11.0.3"
+          },
           "packageType": "jdk",
           "vmType": "hotspot",
           "x86_64": {
@@ -23,8 +35,8 @@
           "vmType": "openj9",
           "x86_64": {
             "build": "7",
-            "sha256": "7012edd56fc958070bc4747073de14ea08eb43081eb6ea19bdbf4763186e2d17",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7_openj9-0.14.0/OpenJDK11U-jdk_x64_linux_openj9_11.0.3_7_openj9-0.14.0.tar.gz",
+            "sha256": "bb8396b3fbaa160bf2173eadbc83cce50bcd5a0879dc24b4122efb7411370d12",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7_openj9-0.14.3/OpenJDK11U-jdk_x64_linux_openj9_11.0.3_7_openj9-0.14.3.tar.gz",
             "version": "11.0.3"
           }
         }
@@ -51,8 +63,8 @@
           "vmType": "openj9",
           "x86_64": {
             "build": "7",
-            "sha256": "14c660294832c7b2deb2845d96dce83df677e204b4f0f1fee0052764c4a56720",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7_openj9-0.14.0/OpenJDK11U-jre_x64_linux_openj9_11.0.3_7_openj9-0.14.0.tar.gz",
+            "sha256": "493a90023447f9f422db011560732cb018795023ed1166dfc04ffa18a4c1fb83",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7_openj9-0.14.3/OpenJDK11U-jre_x64_linux_openj9_11.0.3_7_openj9-0.14.3.tar.gz",
             "version": "11.0.3"
           }
         }
@@ -75,8 +87,8 @@
           "vmType": "openj9",
           "x86_64": {
             "build": "7",
-            "sha256": "01045a99ff23bda354f82c0fd3fa6e8222e4a5acce7494e82495f47b30bc5e18",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7_openj9-0.14.0/OpenJDK11U-jdk_x64_mac_openj9_11.0.3_7_openj9-0.14.0.tar.gz",
+            "sha256": "9217cab0b5dc6301b386ea837d6df38f93adcb5139e5f67a93bb42c3e36df624",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7_openj9-0.14.3/OpenJDK11U-jdk_x64_mac_openj9_11.0.3_7_openj9-0.14.3.tar.gz",
             "version": "11.0.3"
           }
         }
@@ -97,8 +109,8 @@
           "vmType": "openj9",
           "x86_64": {
             "build": "7",
-            "sha256": "150c4065a57ec368b692276e8e3320b183ee17b402b7db07e676dff5837f0c52",
-            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7_openj9-0.14.0/OpenJDK11U-jre_x64_mac_openj9_11.0.3_7_openj9-0.14.0.tar.gz",
+            "sha256": "eb448ffa9dc1178e0b3c198b87a3f7f2f9fc8a2c036dc066bec1212a9d819971",
+            "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7_openj9-0.14.3/OpenJDK11U-jre_x64_mac_openj9_11.0.3_7_openj9-0.14.3.tar.gz",
             "version": "11.0.3"
           }
         }

--- a/pkgs/development/compilers/openjdk/005_enable-infinality.patch
+++ b/pkgs/development/compilers/openjdk/005_enable-infinality.patch
@@ -6,7 +6,7 @@ diff -ur a/jdk/src/share/native/sun/font/freetypeScaler.c b/jdk/src/share/native
 @@ -23,6 +23,9 @@
   * questions.
   */
- 
+
 +/* Use Infinality patches as default */
 +#define INFINALITY
 +
@@ -21,13 +21,13 @@ diff -ur a/jdk/src/share/native/sun/font/freetypeScaler.c b/jdk/src/share/native
 +#include FT_LCD_FILTER_H
 +#include <fontconfig/fontconfig.h>
 +#endif
- 
+
  #include "fontscaler.h"
- 
+
 @@ -676,6 +683,147 @@ static void CopyFTSubpixelVToSubpixel(co
      }
  }
- 
+
 +#ifdef INFINALITY
 +typedef struct {
 +    FT_Render_Mode ftRenderMode;
@@ -169,7 +169,7 @@ diff -ur a/jdk/src/share/native/sun/font/freetypeScaler.c b/jdk/src/share/native
 +    rp->ftLcdFilter = ftLcdFilter;
 +}
 +#endif
- 
+
  /*
   * Class:     sun_font_FreetypeFontScaler
 @@ -691,7 +839,9 @@ Java_sun_font_FreetypeFontScaler_getGlyp
@@ -180,28 +180,27 @@ diff -ur a/jdk/src/share/native/sun/font/freetypeScaler.c b/jdk/src/share/native
      int renderFlags = FT_LOAD_RENDER, target;
 +#endif
      FT_GlyphSlot ftglyph;
- 
+
      FTScalerContext* context =
-@@ -709,6 +859,11 @@ Java_sun_font_FreetypeFontScaler_getGlyp
+@@ -709,5 +859,10 @@ Java_sun_font_FreetypeFontScaler_getGlyp
          return ptr_to_jlong(getNullGlyphImage());
      }
- 
+
 +#ifdef INFINALITY
 +    RenderingProperties renderingProperties;
 +    readFontconfig((const FcChar8 *) scalerInfo->face->family_name,
 +                   context->ptsz, context->aaType, &renderingProperties);
 +#else
-     /* if algorithmic styling is required then we do not request bitmap */
-     if (context->doBold || context->doItalize) {
-         renderFlags =  FT_LOAD_DEFAULT;
+     if (!context->useSbits) {
+          renderFlags |= FT_LOAD_NO_BITMAP;
 @@ -731,10 +886,17 @@ Java_sun_font_FreetypeFontScaler_getGlyp
          target = FT_LOAD_TARGET_LCD_V;
      }
      renderFlags |= target;
 +#endif
- 
+
      glyph_index = FT_Get_Char_Index(scalerInfo->face, glyphCode);
- 
+
 +#ifdef INFINALITY
 +    FT_Library_SetLcdFilter(scalerInfo->library, renderingProperties.ftLcdFilter);
 +    error = FT_Load_Glyph(scalerInfo->face, glyphCode, renderingProperties.ftLoadFlags);
@@ -213,7 +212,7 @@ diff -ur a/jdk/src/share/native/sun/font/freetypeScaler.c b/jdk/src/share/native
          //do not destroy scaler yet.
          //this can be problem of particular context (e.g. with bad transform)
 @@ -753,9 +915,13 @@ Java_sun_font_FreetypeFontScaler_getGlyp
- 
+
      /* generate bitmap if it is not done yet
       e.g. if algorithmic styling is performed and style was added to outline */
 +#ifdef INFINALITY
@@ -223,7 +222,7 @@ diff -ur a/jdk/src/share/native/sun/font/freetypeScaler.c b/jdk/src/share/native
          FT_Render_Glyph(ftglyph, FT_LOAD_TARGET_MODE(target));
      }
 +#endif
- 
+
      width  = (UInt16) ftglyph->bitmap.width;
      height = (UInt16) ftglyph->bitmap.rows;
 @@ -969,7 +1135,9 @@ Java_sun_font_FreetypeFontScaler_getGlyp
@@ -239,7 +238,7 @@ diff -ur a/jdk/src/share/native/sun/font/freetypeScaler.c b/jdk/src/share/native
 @@ -984,11 +1152,22 @@ static FT_Outline* getFTOutline(JNIEnv*
          return NULL;
      }
- 
+
 +#ifdef INFINALITY
 +    RenderingProperties renderingProperties;
 +    readFontconfig((const FcChar8 *) scalerInfo->face->family_name,
@@ -247,9 +246,9 @@ diff -ur a/jdk/src/share/native/sun/font/freetypeScaler.c b/jdk/src/share/native
 +#else
      renderFlags = FT_LOAD_NO_HINTING | FT_LOAD_NO_BITMAP;
 +#endif
- 
+
      glyph_index = FT_Get_Char_Index(scalerInfo->face, glyphCode);
- 
+
 +#ifdef INFINALITY
 +    error = FT_Load_Glyph(scalerInfo->face, glyphCode, renderingProperties.ftLoadFlags);
 +#else

--- a/pkgs/development/compilers/openjdk/11.nix
+++ b/pkgs/development/compilers/openjdk/11.nix
@@ -10,7 +10,7 @@
 
 let
   major = "11";
-  update = ".0.3";
+  update = ".0.4";
   build = "ga";
 
   openjdk = stdenv.mkDerivation rec {

--- a/pkgs/development/compilers/openjdk/11.nix
+++ b/pkgs/development/compilers/openjdk/11.nix
@@ -1,42 +1,33 @@
-{ stdenv, lib, fetchurl, bash, cpio, autoconf, pkgconfig, file, which, unzip, zip, cups, freetype
-, alsaLib, bootjdk, perl, fontconfig, zlib, lndir
-, libX11, libICE, libXrender, libXext, libXt, libXtst, libXi, libXinerama, libXcursor, libXrandr
-, libjpeg, giflib
+{ stdenv, lib, fetchurl, bash, pkgconfig, autoconf, cpio, file, which, unzip
+, zip, perl, cups, freetype, alsaLib, libjpeg, giflib, libpng, zlib, lcms2
+, libX11, libICE, libXrender, libXext, libXt, libXtst, libXi, libXinerama
+, libXcursor, libXrandr, fontconfig, openjdk11-bootstrap
 , setJavaClassPath
-, minimal ? false
-, enableJavaFX ? true, openjfx
+, headless ? false
+, enableJavaFX ? openjfx.meta.available, openjfx
 , enableGnome2 ? true, gtk3, gnome_vfs, glib, GConf
 }:
 
 let
-
-  /**
-   * The JDK libraries are in directories that depend on the CPU.
-   */
-  architecture =
-    if stdenv.hostPlatform.system == "i686-linux" then
-      "i386"
-    else "amd64";
-
   major = "11";
   update = ".0.3";
   build = "ga";
-  repover = "jdk-${major}${update}-${build}";
 
-  openjdk = stdenv.mkDerivation {
-    name = "openjdk-${major}${update}-${build}";
+  openjdk = stdenv.mkDerivation rec {
+    pname = "openjdk" + lib.optionalString headless "-headless";
+    version = "${major}${update}-${build}";
 
     src = fetchurl {
-      url = "http://hg.openjdk.java.net/jdk-updates/jdk${major}u/archive/${repover}.tar.gz";
+      url = "http://hg.openjdk.java.net/jdk-updates/jdk${major}u/archive/jdk-${version}.tar.gz";
       sha256 = "1v6pam38iidlhz46046h17hf5kki6n3kl302awjcyxzk7bmkvb8x";
     };
 
-    nativeBuildInputs = [ pkgconfig ];
+    nativeBuildInputs = [ pkgconfig autoconf ];
     buildInputs = [
-      autoconf cpio file which unzip zip perl bootjdk zlib cups freetype alsaLib
-      libjpeg giflib libX11 libICE libXext libXrender libXtst libXt libXtst
-      libXi libXinerama libXcursor libXrandr lndir fontconfig
-    ] ++ lib.optionals (!minimal && enableGnome2) [
+      cpio file which unzip zip perl zlib cups freetype alsaLib libjpeg giflib
+      libpng zlib lcms2 libX11 libICE libXrender libXext libXtst libXt libXtst
+      libXi libXinerama libXcursor libXrandr fontconfig openjdk11-bootstrap
+    ] ++ lib.optionals (!headless && enableGnome2) [
       gtk3 gnome_vfs GConf glib
     ];
 
@@ -45,66 +36,60 @@ let
       ./read-truststore-from-env-jdk10.patch
       ./currency-date-range-jdk10.patch
       ./increase-javadoc-heap.patch
-    ] ++ lib.optionals (!minimal && enableGnome2) [
+    ] ++ lib.optionals (!headless && enableGnome2) [
       ./swing-use-gtk-jdk10.patch
     ];
 
     preConfigure = ''
       chmod +x configure
       substituteInPlace configure --replace /bin/bash "${bash}/bin/bash"
-
-      configureFlagsArray=(
-        "--with-boot-jdk=${bootjdk.home}"
-        "--with-update-version=${major}${update}"
-        "--with-build-number=${build}"
-        "--with-milestone=fcs"
-        "--enable-unlimited-crypto"
-        "--disable-debug-symbols"
-        "--with-zlib=system"
-        "--with-giflib=system"
-        "--with-stdc++lib=dynamic"
-
-        # glibc 2.24 deprecated readdir_r so we need this
-        # See https://www.mail-archive.com/openembedded-devel@lists.openembedded.org/msg49006.html
-        "--with-extra-cflags=-Wno-error=deprecated-declarations -Wno-error=format-contains-nul -Wno-error=unused-result"
-    ''
-    + lib.optionalString (architecture == "amd64") " \"--with-jvm-features=zgc\""
-    + lib.optionalString minimal " \"--enable-headless-only\""
-    + lib.optionalString (!minimal && enableJavaFX) " \"--with-import-modules=${openjfx}\""
-    + ");"
-    # https://bugzilla.redhat.com/show_bug.cgi?id=1306558
-    # https://github.com/JetBrains/jdk8u/commit/eaa5e0711a43d64874111254d74893fa299d5716
-    + stdenv.lib.optionalString stdenv.cc.isGNU ''
-      NIX_CFLAGS_COMPILE+=" -fno-lifetime-dse -fno-delete-null-pointer-checks -std=gnu++98 -Wno-error"
     '';
 
-    NIX_LDFLAGS= lib.optionals (!minimal) [
+    configureFlags = [
+      "--with-boot-jdk=${openjdk11-bootstrap.home}"
+      "--enable-unlimited-crypto"
+      "--with-native-debug-symbols=internal"
+      "--with-libjpeg=system"
+      "--with-giflib=system"
+      "--with-libpng=system"
+      "--with-zlib=system"
+      "--with-lcms=system"
+      "--with-stdc++lib=dynamic"
+    ] ++ lib.optional stdenv.isx86_64 "--with-jvm-features=zgc"
+      ++ lib.optional headless "--enable-headless-only"
+      ++ lib.optional (!headless && enableJavaFX) "--with-import-modules=${openjfx}";
+
+    separateDebugInfo = true;
+
+    NIX_CFLAGS_COMPILE = [ "-Wno-error" ];
+
+    NIX_LDFLAGS = lib.optionals (!headless) [
       "-lfontconfig" "-lcups" "-lXinerama" "-lXrandr" "-lmagic"
-    ] ++ lib.optionals (!minimal && enableGnome2) [
+    ] ++ lib.optionals (!headless && enableGnome2) [
       "-lgtk-3" "-lgio-2.0" "-lgnomevfs-2" "-lgconf-2"
     ];
 
     buildFlags = [ "all" ];
 
     installPhase = ''
-      mkdir -p $out/lib/openjdk $out/share
+      mkdir -p $out/lib
 
-      cp -av build/*/images/jdk/* $out/lib/openjdk
+      mv build/*/images/jdk $out/lib/openjdk
 
       # Remove some broken manpages.
       rm -rf $out/lib/openjdk/man/ja*
 
       # Mirror some stuff in top-level.
-      mkdir $out/include $out/share/man
-      ln -s $out/lib/openjdk/include/* $out/include/
-      ln -s $out/lib/openjdk/man/* $out/share/man/
+      mkdir -p $out/share
+      ln -s $out/lib/openjdk/include $out/include
+      ln -s $out/lib/openjdk/man $out/share/man
 
       # jni.h expects jni_md.h to be in the header search path.
       ln -s $out/include/linux/*_md.h $out/include/
 
       # Remove crap from the installation.
       rm -rf $out/lib/openjdk/demo
-      ${lib.optionalString minimal ''
+      ${lib.optionalString headless ''
         rm $out/lib/openjdk/lib/{libjsound,libfontmanager}.so
       ''}
 
@@ -129,11 +114,12 @@ let
       # Build the set of output library directories to rpath against
       LIBDIRS=""
       for output in $outputs; do
+        if [ "$output" = debug ]; then continue; fi
         LIBDIRS="$(find $(eval echo \$$output) -name \*.so\* -exec dirname {} \+ | sort | uniq | tr '\n' ':'):$LIBDIRS"
       done
-
       # Add the local library paths to remove dependencies on the bootstrap
       for output in $outputs; do
+        if [ "$output" = debug ]; then continue; fi
         OUTPUTDIR=$(eval echo \$$output)
         BINLIBS=$(find $OUTPUTDIR/bin/ -type f; find $OUTPUTDIR -name \*.so\*)
         echo "$BINLIBS" | while read i; do
@@ -141,26 +127,20 @@ let
           patchelf --shrink-rpath "$i" || true
         done
       done
-
-      # Test to make sure that we don't depend on the bootstrap
-      for output in $outputs; do
-        if grep -q -r '${bootjdk}' $(eval echo \$$output); then
-          echo "Extraneous references to ${bootjdk} detected"
-          exit 1
-        fi
-      done
     '';
+
+    disallowedReferences = [ openjdk11-bootstrap ];
 
     meta = with stdenv.lib; {
       homepage = http://openjdk.java.net/;
       license = licenses.gpl2;
       description = "The open-source Java Development Kit";
       maintainers = with maintainers; [ edwtjo ];
-      platforms = ["i686-linux" "x86_64-linux"];
+      platforms = [ "i686-linux" "x86_64-linux" "aarch64-linux" "armv7l-linux" "armv6l-linux" ];
     };
 
     passthru = {
-      inherit architecture;
+      architecture = "";
       home = "${openjdk}/lib/openjdk";
     };
   };

--- a/pkgs/development/compilers/openjdk/8.nix
+++ b/pkgs/development/compilers/openjdk/8.nix
@@ -1,9 +1,10 @@
 { stdenv, lib, fetchurl, bash, cpio, pkgconfig, file, which, unzip, zip, cups, freetype
-, alsaLib, bootjdk, cacert, perl, liberation_ttf, fontconfig, zlib, lndir
+, alsaLib, cacert, perl, liberation_ttf, fontconfig, zlib
 , libX11, libICE, libXrender, libXext, libXt, libXtst, libXi, libXinerama, libXcursor, libXrandr
 , libjpeg, giflib
+, openjdk8-bootstrap
 , setJavaClassPath
-, minimal ? false
+, headless ? false
 , enableInfinality ? true # font rendering patch
 , enableGnome2 ? true, gtk2, gnome_vfs, glib, GConf
 }:
@@ -13,52 +14,71 @@ let
   /**
    * The JRE libraries are in directories that depend on the CPU.
    */
-  architecture =
-    if stdenv.hostPlatform.system == "i686-linux" then
-      "i386"
-    else if stdenv.hostPlatform.system == "x86_64-linux" then
-      "amd64"
-    else
-      throw "openjdk requires i686-linux or x86_64 linux";
+  architecture = {
+    "i686-linux" = "i386";
+    "x86_64-linux" = "amd64";
+    "aarch64-linux" = "aarch64";
+  }.${stdenv.system} or (throw "Unsupported platform");
 
   update = "212";
-  build = "ga";
-  baseurl = "http://hg.openjdk.java.net/jdk8u/jdk8u";
-  repover = "jdk8u${update}-${build}";
+  build = if stdenv.isAarch64 then "b04"
+          else "ga";
+  baseurl = if stdenv.isAarch64 then "https://hg.openjdk.java.net/aarch64-port/jdk8u-shenandoah"
+            else "https://hg.openjdk.java.net/jdk8u/jdk8u";
+  repover = lib.optionalString stdenv.isAarch64 "aarch64-shenandoah-"
+            + "jdk8u${update}-${build}";
+
   jdk8 = fetchurl {
+             name = "jdk8-${repover}.tar.gz";
              url = "${baseurl}/archive/${repover}.tar.gz";
-             sha256 = "00rl33h4cl4b4p3hcid765h38x2jdkb14ylh8k1zhnd0ka76crgg";
+             sha256 = if stdenv.isAarch64 then "0z2n2b5f1jmdzycb7ppqz3dx5sf1rwwd3fvk15zq4cm7908wapjw"
+                      else "00rl33h4cl4b4p3hcid765h38x2jdkb14ylh8k1zhnd0ka76crgg";
           };
   langtools = fetchurl {
+             name = "langtools-${repover}.tar.gz";
              url = "${baseurl}/langtools/archive/${repover}.tar.gz";
-             sha256 = "0va6g2dccf1ph6mpwxswbks5axp7zz258cl89qq9r8jn4ni04agw";
+             sha256 = if stdenv.isAarch64 then "0j0fbxj7fkl8bn8lq3s3sssa26hskaf8c9rmsay8r91m4vnxisv1"
+                      else "0va6g2dccf1ph6mpwxswbks5axp7zz258cl89qq9r8jn4ni04agw";
           };
   hotspot = fetchurl {
+             name = "hotspot-${repover}.tar.gz";
              url = "${baseurl}/hotspot/archive/${repover}.tar.gz";
-             sha256 = "0sgr9df10hs49pjld6c6kr374v4zwd9s52pc3drz68zrlk71ja4s";
+             sha256 = if stdenv.isAarch64 then "1ld76jx0v1z6755a61k5da0cks7dqwvwc5l8rvyw9r9py1n7421w"
+                      else "0sgr9df10hs49pjld6c6kr374v4zwd9s52pc3drz68zrlk71ja4s";
           };
   corba = fetchurl {
+             name = "corba-${repover}.tar.gz";
              url = "${baseurl}/corba/archive/${repover}.tar.gz";
-             sha256 = "1hq0sr4k4k4iv815kg72i9lvd7n7mn5pmw96ckk9p1rnyagn9z03";
+             sha256 = if stdenv.isAarch64 then "1jcw90y3d8rnvqpiyyvsx976f5i8d60p0d6652v4mz41pyjjhyw5"
+                      else "1hq0sr4k4k4iv815kg72i9lvd7n7mn5pmw96ckk9p1rnyagn9z03";
           };
   jdk = fetchurl {
+             name = "jdk-${repover}.tar.gz";
              url = "${baseurl}/jdk/archive/${repover}.tar.gz";
-             sha256 = "1fc59jrbfq8l067mggzy5dnrvni7lwaqd7hahs4nqv87kyrfg545";
+             sha256 = if stdenv.isAarch64 then "19mnlw7igxblxx8qp6l9rn2w0xw1akdx2v1rw6pq14d03dgwby22"
+                      else "1fc59jrbfq8l067mggzy5dnrvni7lwaqd7hahs4nqv87kyrfg545";
           };
   jaxws = fetchurl {
+             name = "jaxws-${repover}.tar.gz";
              url = "${baseurl}/jaxws/archive/${repover}.tar.gz";
-             sha256 = "1ka2fvyxdmpfhk814s314gx53yvdr19vpsqygx283v9nbq90l1yg";
+             sha256 = if stdenv.isAarch64 then "1dvlcj5jrwia08im1is9ms6r619jvzkhyg3ls0czh2yycabg6p51"
+                      else "1ka2fvyxdmpfhk814s314gx53yvdr19vpsqygx283v9nbq90l1yg";
           };
   jaxp = fetchurl {
+             name = "jaxp-${repover}.tar.gz";
              url = "${baseurl}/jaxp/archive/${repover}.tar.gz";
-             sha256 = "15vlgs5v2ax8sqwh7bg50fnlrwlpnkp0myzrvpqs1mcza8pyasp8";
+             sha256 = if stdenv.isAarch64 then "1imz7bsiqhhh5qx8hjpm46y7a4j282vmdd6xljz8n148vml2p936"
+                      else "15vlgs5v2ax8sqwh7bg50fnlrwlpnkp0myzrvpqs1mcza8pyasp8";
           };
   nashorn = fetchurl {
+             name = "nashorn-${repover}.tar.gz";
              url = "${baseurl}/nashorn/archive/${repover}.tar.gz";
-             sha256 = "1jzn0yi0v6lda5y8ib07g1p6zymnbcx9yy6iz8niggpm7205y93h";
+             sha256 = if stdenv.isAarch64 then "0rnrzz42f3ismhwj05sim7d05wccp5bcr5rhxgnvs3hjqaqvq51n"
+                      else "1jzn0yi0v6lda5y8ib07g1p6zymnbcx9yy6iz8niggpm7205y93h";
           };
   openjdk8 = stdenv.mkDerivation {
-    name = "openjdk-8u${update}-${build}";
+    pname = "openjdk" + lib.optionalString headless "-headless";
+    version = "8u${update}-${build}";
 
     srcs = [ jdk8 langtools hotspot corba jdk jaxws jaxp nashorn ];
     sourceRoot = ".";
@@ -67,15 +87,15 @@ let
 
     nativeBuildInputs = [ pkgconfig ];
     buildInputs = [
-      cpio file which unzip zip perl bootjdk zlib cups freetype alsaLib
+      cpio file which unzip zip perl openjdk8-bootstrap zlib cups freetype alsaLib
       libjpeg giflib libX11 libICE libXext libXrender libXtst libXt libXtst
-      libXi libXinerama libXcursor libXrandr lndir fontconfig
-    ] ++ lib.optionals (!minimal && enableGnome2) [
+      libXi libXinerama libXcursor libXrandr fontconfig
+    ] ++ lib.optionals (!headless && enableGnome2) [
       gtk2 gnome_vfs GConf glib
     ];
 
-    #move the seven other source dirs under the main jdk8u directory,
-    #with version suffixes removed, as the remainder of the build will expect
+    # move the seven other source dirs under the main jdk8u directory,
+    # with version suffixes removed, as the remainder of the build will expect
     prePatch = ''
       mainDir=$(find . -maxdepth 1 -name jdk8u\*);
       find . -maxdepth 1 -name \*jdk\* -not -name jdk8u\* | awk -F- '{print $1}' | while read p; do
@@ -88,10 +108,10 @@ let
       ./fix-java-home-jdk8.patch
       ./read-truststore-from-env-jdk8.patch
       ./currency-date-range-jdk8.patch
-    ] ++ lib.optionals (!minimal && enableInfinality) [
+    ] ++ lib.optionals (!headless && enableInfinality) [
       ./004_add-fontconfig.patch
       ./005_enable-infinality.patch
-    ] ++ lib.optionals (!minimal && enableGnome2) [
+    ] ++ lib.optionals (!headless && enableGnome2) [
       ./swing-use-gtk-jdk8.patch
     ];
 
@@ -103,33 +123,39 @@ let
       substituteInPlace configure --replace /bin/bash "${bash}/bin/bash"
       substituteInPlace hotspot/make/linux/adlc_updater --replace /bin/sh "${stdenv.shell}"
       substituteInPlace hotspot/make/linux/makefiles/dtrace.make --replace /usr/include/sys/sdt.h "/no-such-path"
-    ''
-    # https://bugzilla.redhat.com/show_bug.cgi?id=1306558
-    # https://github.com/JetBrains/jdk8u/commit/eaa5e0711a43d64874111254d74893fa299d5716
-    + stdenv.lib.optionalString stdenv.cc.isGNU ''
-      NIX_CFLAGS_COMPILE+=" -fno-lifetime-dse -fno-delete-null-pointer-checks -std=gnu++98 -Wno-error"
     '';
 
     configureFlags = [
-      "--with-boot-jdk=${bootjdk.home}"
+      "--with-boot-jdk=${openjdk8-bootstrap.home}"
       "--with-update-version=${update}"
       "--with-build-number=${build}"
       "--with-milestone=fcs"
       "--enable-unlimited-crypto"
-      "--disable-debug-symbols"
+      "--with-native-debug-symbols=internal"
       "--disable-freetype-bundling"
       "--with-zlib=system"
       "--with-giflib=system"
       "--with-stdc++lib=dynamic"
+    ] ++ lib.optional headless "--disable-headful";
 
+    separateDebugInfo = true;
+
+    NIX_CFLAGS_COMPILE = [
       # glibc 2.24 deprecated readdir_r so we need this
       # See https://www.mail-archive.com/openembedded-devel@lists.openembedded.org/msg49006.html
-      "--with-extra-cflags=\"-Wno-error=deprecated-declarations\""
-    ] ++ lib.optional minimal "--disable-headful";
+      "-Wno-error=deprecated-declarations"
+    ] ++ lib.optionals stdenv.cc.isGNU [
+      # https://bugzilla.redhat.com/show_bug.cgi?id=1306558
+      # https://github.com/JetBrains/jdk8u/commit/eaa5e0711a43d64874111254d74893fa299d5716
+      "-fno-lifetime-dse"
+      "-fno-delete-null-pointer-checks"
+      "-std=gnu++98"
+      "-Wno-error"
+    ];
 
-    NIX_LDFLAGS= lib.optionals (!minimal) [
+    NIX_LDFLAGS= lib.optionals (!headless) [
       "-lfontconfig" "-lcups" "-lXinerama" "-lXrandr" "-lmagic"
-    ] ++ lib.optionals (!minimal && enableGnome2) [
+    ] ++ lib.optionals (!headless && enableGnome2) [
       "-lgtk-x11-2.0" "-lgio-2.0" "-lgnomevfs-2" "-lgconf-2"
     ];
 
@@ -138,45 +164,39 @@ let
     doCheck = false; # fails with "No rule to make target 'y'."
 
     installPhase = ''
-      mkdir -p $out/lib/openjdk $out/share $jre/lib/openjdk
+      mkdir -p $out/lib
 
-      cp -av build/*/images/j2sdk-image/* $out/lib/openjdk
+      mv build/*/images/j2sdk-image $out/lib/openjdk
 
       # Remove some broken manpages.
       rm -rf $out/lib/openjdk/man/ja*
 
       # Mirror some stuff in top-level.
-      mkdir $out/include $out/share/man
-      ln -s $out/lib/openjdk/include/* $out/include/
-      ln -s $out/lib/openjdk/man/* $out/share/man/
+      mkdir -p $out/share
+      ln -s $out/lib/openjdk/include $out/include
+      ln -s $out/lib/openjdk/man $out/share/man
 
       # jni.h expects jni_md.h to be in the header search path.
       ln -s $out/include/linux/*_md.h $out/include/
 
       # Remove crap from the installation.
       rm -rf $out/lib/openjdk/demo $out/lib/openjdk/sample
-      ${lib.optionalString minimal ''
+      ${lib.optionalString headless ''
         rm $out/lib/openjdk/jre/lib/${architecture}/{libjsound,libjsoundalsa,libsplashscreen,libawt*,libfontmanager}.so
         rm $out/lib/openjdk/jre/bin/policytool
         rm $out/lib/openjdk/bin/{policytool,appletviewer}
       ''}
 
-      # Move the JRE to a separate output and setup fallback fonts
-      mv $out/lib/openjdk/jre $jre/lib/openjdk/
-      mkdir $out/lib/openjdk/jre
-      ${lib.optionalString (!minimal) ''
-        mkdir -p $jre/lib/openjdk/jre/lib/fonts/fallback
-        lndir ${liberation_ttf}/share/fonts/truetype $jre/lib/openjdk/jre/lib/fonts/fallback
+      # Move the JRE to a separate output
+      mkdir -p $jre/lib/openjdk
+      mv $out/lib/openjdk/jre $jre/lib/openjdk/jre
+      ln -s $jre/lib/openjdk/jre $out/lib/openjdk/jre
+
+      # Setup fallback fonts
+      ${lib.optionalString (!headless) ''
+        mkdir -p $jre/lib/openjdk/jre/lib/fonts
+        ln -s ${liberation_ttf}/share/fonts/truetype $jre/lib/openjdk/jre/lib/fonts/fallback
       ''}
-      lndir $jre/lib/openjdk/jre $out/lib/openjdk/jre
-
-      rm -rf $out/lib/openjdk/jre/bina
-      ln -s $out/lib/openjdk/bin $out/lib/openjdk/jre/bin
-
-      # Make sure cmm/*.pf are not symlinks:
-      # https://youtrack.jetbrains.com/issue/IDEA-147272
-      rm -rf $out/lib/openjdk/jre/lib/cmm
-      ln -s {$jre,$out}/lib/openjdk/jre/lib/cmm
 
       # Remove duplicate binaries.
       for i in $(cd $out/lib/openjdk/bin && echo *); do
@@ -198,12 +218,7 @@ let
       ln -s $jre/lib/openjdk/jre $out/jre
     '';
 
-    # FIXME: this is unnecessary once the multiple-outputs branch is merged.
     preFixup = ''
-      prefix=$jre stripDirs "$STRIP" "$stripDebugList" "''${stripDebugFlags:--S}"
-      patchELF $jre
-      propagatedBuildInputs+=" $jre"
-
       # Propagate the setJavaClassPath setup hook from the JRE so that
       # any package that depends on the JRE has $CLASSPATH set up
       # properly.
@@ -221,11 +236,12 @@ let
       # Build the set of output library directories to rpath against
       LIBDIRS=""
       for output in $outputs; do
+        if [ "$output" = debug ]; then continue; fi
         LIBDIRS="$(find $(eval echo \$$output) -name \*.so\* -exec dirname {} \+ | sort | uniq | tr '\n' ':'):$LIBDIRS"
       done
-
       # Add the local library paths to remove dependencies on the bootstrap
       for output in $outputs; do
+        if [ "$output" = debug ]; then continue; fi
         OUTPUTDIR=$(eval echo \$$output)
         BINLIBS=$(find $OUTPUTDIR/bin/ -type f; find $OUTPUTDIR -name \*.so\*)
         echo "$BINLIBS" | while read i; do
@@ -233,22 +249,16 @@ let
           patchelf --shrink-rpath "$i" || true
         done
       done
-
-      # Test to make sure that we don't depend on the bootstrap
-      for output in $outputs; do
-        if grep -q -r '${bootjdk}' $(eval echo \$$output); then
-          echo "Extraneous references to ${bootjdk} detected"
-          exit 1
-        fi
-      done
     '';
 
-    meta = with stdenv.lib; {
+    disallowedReferences = [ openjdk8-bootstrap ];
+
+    meta = with lib; {
       homepage = http://openjdk.java.net/;
       license = licenses.gpl2;
       description = "The open-source Java Development Kit";
       maintainers = with maintainers; [ edwtjo nequissimus ];
-      platforms = platforms.linux;
+      platforms = [ "i686-linux" "x86_64-linux" "aarch64-linux" ];
     };
 
     passthru = {

--- a/pkgs/development/compilers/openjdk/8.nix
+++ b/pkgs/development/compilers/openjdk/8.nix
@@ -20,8 +20,8 @@ let
     "aarch64-linux" = "aarch64";
   }.${stdenv.system} or (throw "Unsupported platform");
 
-  update = "212";
-  build = if stdenv.isAarch64 then "b04"
+  update = "222";
+  build = if stdenv.isAarch64 then "b10"
           else "ga";
   baseurl = if stdenv.isAarch64 then "https://hg.openjdk.java.net/aarch64-port/jdk8u-shenandoah"
             else "https://hg.openjdk.java.net/jdk8u/jdk8u";
@@ -31,50 +31,50 @@ let
   jdk8 = fetchurl {
              name = "jdk8-${repover}.tar.gz";
              url = "${baseurl}/archive/${repover}.tar.gz";
-             sha256 = if stdenv.isAarch64 then "0z2n2b5f1jmdzycb7ppqz3dx5sf1rwwd3fvk15zq4cm7908wapjw"
-                      else "00rl33h4cl4b4p3hcid765h38x2jdkb14ylh8k1zhnd0ka76crgg";
+             sha256 = if stdenv.isAarch64 then "1h19zpmc76f8v4s0mfvqxmxvv8imdwq92z5dmgi19y4xnl978qq8"
+                      else "19dyqayn8n2y08p08g34xxnf0dkm6bfjxkp7633m7dx50mjcpxnj";
           };
   langtools = fetchurl {
              name = "langtools-${repover}.tar.gz";
              url = "${baseurl}/langtools/archive/${repover}.tar.gz";
-             sha256 = if stdenv.isAarch64 then "0j0fbxj7fkl8bn8lq3s3sssa26hskaf8c9rmsay8r91m4vnxisv1"
-                      else "0va6g2dccf1ph6mpwxswbks5axp7zz258cl89qq9r8jn4ni04agw";
+             sha256 = if stdenv.isAarch64 then "09phy2izw2yyp3hnw7jmb7lp559dgnp2a0rymx1k3q97anfz3bzj"
+                      else "11nibmqnf7nap10sydk57gimgwpxqk5mn12dyg6fzg4s2fxf0y1q";
           };
   hotspot = fetchurl {
              name = "hotspot-${repover}.tar.gz";
              url = "${baseurl}/hotspot/archive/${repover}.tar.gz";
-             sha256 = if stdenv.isAarch64 then "1ld76jx0v1z6755a61k5da0cks7dqwvwc5l8rvyw9r9py1n7421w"
-                      else "0sgr9df10hs49pjld6c6kr374v4zwd9s52pc3drz68zrlk71ja4s";
+             sha256 = if stdenv.isAarch64 then "1dqrzg2af94pjam6jg9nq8ydaibn4bsjv7ai6m7m3r2ph2fml80s"
+                      else "1g512xrrxvnrk5szg7wqqz00x4gv53dx3yffk5im2zfcalyka2q7";
           };
   corba = fetchurl {
              name = "corba-${repover}.tar.gz";
              url = "${baseurl}/corba/archive/${repover}.tar.gz";
-             sha256 = if stdenv.isAarch64 then "1jcw90y3d8rnvqpiyyvsx976f5i8d60p0d6652v4mz41pyjjhyw5"
-                      else "1hq0sr4k4k4iv815kg72i9lvd7n7mn5pmw96ckk9p1rnyagn9z03";
+             sha256 = if stdenv.isAarch64 then "15l1ccvk2slx8wf5gilzjvhc428hl57gg1knbma1jqgs3ymnqwpr"
+                      else "0h8nprfzpy21mfl39fxxzfa420skwmaaji4r31j7lj3g8c1wp62r";
           };
   jdk = fetchurl {
              name = "jdk-${repover}.tar.gz";
              url = "${baseurl}/jdk/archive/${repover}.tar.gz";
-             sha256 = if stdenv.isAarch64 then "19mnlw7igxblxx8qp6l9rn2w0xw1akdx2v1rw6pq14d03dgwby22"
-                      else "1fc59jrbfq8l067mggzy5dnrvni7lwaqd7hahs4nqv87kyrfg545";
+             sha256 = if stdenv.isAarch64 then "179ij3rs1ahl6dh3n64k4xp2prv413ckqk7sj1g5lw48rj7bjh83"
+                      else "1sb38h0rckgkr2y0kfzav6mb74nv5whb9l8m842mv1jpavxrdv6k";
           };
   jaxws = fetchurl {
              name = "jaxws-${repover}.tar.gz";
              url = "${baseurl}/jaxws/archive/${repover}.tar.gz";
-             sha256 = if stdenv.isAarch64 then "1dvlcj5jrwia08im1is9ms6r619jvzkhyg3ls0czh2yycabg6p51"
-                      else "1ka2fvyxdmpfhk814s314gx53yvdr19vpsqygx283v9nbq90l1yg";
+             sha256 = if stdenv.isAarch64 then "16bayw7c4vzm9s0ixhw2dv6pan6wywyiddh9a8dss35660dnhrm0"
+                      else "0akn5zapff5m32ibgm3f4lhgq96bsqx74g4xl38xmivvxddsd6kz";
           };
   jaxp = fetchurl {
              name = "jaxp-${repover}.tar.gz";
              url = "${baseurl}/jaxp/archive/${repover}.tar.gz";
-             sha256 = if stdenv.isAarch64 then "1imz7bsiqhhh5qx8hjpm46y7a4j282vmdd6xljz8n148vml2p936"
-                      else "15vlgs5v2ax8sqwh7bg50fnlrwlpnkp0myzrvpqs1mcza8pyasp8";
+             sha256 = if stdenv.isAarch64 then "176db7pi2irc7q87c273cjm5nrlj5g973fjmh24m6a1jxanrrm9x"
+                      else "0bw4q8yhmrl8hqlimy1ijnarav4r91dj73lpr7axba77rqlr41c8";
           };
   nashorn = fetchurl {
              name = "nashorn-${repover}.tar.gz";
              url = "${baseurl}/nashorn/archive/${repover}.tar.gz";
-             sha256 = if stdenv.isAarch64 then "0rnrzz42f3ismhwj05sim7d05wccp5bcr5rhxgnvs3hjqaqvq51n"
-                      else "1jzn0yi0v6lda5y8ib07g1p6zymnbcx9yy6iz8niggpm7205y93h";
+             sha256 = if stdenv.isAarch64 then "0vi3kbsqfpdjxc08ayxk2c87zycd7z0qbqw9xka1vc59iyv97n62"
+                      else "0bfcf3iv2lr0xlp6sclxq7zz7b9ahajl008hz5rasjnrnr993qja";
           };
   openjdk8 = stdenv.mkDerivation {
     pname = "openjdk" + lib.optionalString headless "-headless";

--- a/pkgs/development/compilers/openjdk/default.nix
+++ b/pkgs/development/compilers/openjdk/default.nix
@@ -1,42 +1,33 @@
-{ stdenv, lib, fetchurl, bash, cpio, autoconf, pkgconfig, file, which, unzip, zip, cups, freetype
-, alsaLib, bootjdk, perl, liberation_ttf, fontconfig, zlib, lndir
-, libX11, libICE, libXrender, libXext, libXt, libXtst, libXi, libXinerama, libXcursor, libXrandr
-, libjpeg, giflib
+{ stdenv, lib, fetchurl, bash, pkgconfig, autoconf, cpio, file, which, unzip
+, zip, perl, cups, freetype, alsaLib, libjpeg, giflib, libpng, zlib, lcms2
+, libX11, libICE, libXrender, libXext, libXt, libXtst, libXi, libXinerama
+, libXcursor, libXrandr, fontconfig, openjdk11
 , setJavaClassPath
-, minimal ? false
-, enableJavaFX ? true, openjfx
+, headless ? false
+, enableJavaFX ? openjfx.meta.available, openjfx
 , enableGnome2 ? true, gtk3, gnome_vfs, glib, GConf
 }:
 
 let
-
-  /**
-   * The JDK libraries are in directories that depend on the CPU.
-   */
-  architecture =
-    if stdenv.hostPlatform.system == "i686-linux" then
-      "i386"
-    else "amd64";
-
   major = "12";
   update = ".0.2";
   build = "ga";
-  repover = "jdk-${major}${update}-${build}";
 
-  openjdk = stdenv.mkDerivation {
-    name = "openjdk-${major}${update}-${build}";
+  openjdk = stdenv.mkDerivation rec {
+    pname = "openjdk" + lib.optionalString headless "-headless";
+    version = "${major}${update}-${build}";
 
     src = fetchurl {
-      url = "http://hg.openjdk.java.net/jdk-updates/jdk${major}u/archive/${repover}.tar.gz";
+      url = "http://hg.openjdk.java.net/jdk-updates/jdk${major}u/archive/jdk-${version}.tar.gz";
       sha256 = "1ndlxmikyy298z7lqpr1bd0zxq7yx6xidj8y3c8mw9m9fy64h9c7";
     };
 
-    nativeBuildInputs = [ pkgconfig ];
+    nativeBuildInputs = [ pkgconfig autoconf ];
     buildInputs = [
-      autoconf cpio file which unzip zip perl bootjdk zlib cups freetype alsaLib
-      libjpeg giflib libX11 libICE libXext libXrender libXtst libXt libXtst
-      libXi libXinerama libXcursor libXrandr lndir fontconfig
-    ] ++ lib.optionals (!minimal && enableGnome2) [
+      cpio file which unzip zip perl zlib cups freetype alsaLib libjpeg giflib
+      libpng zlib lcms2 libX11 libICE libXrender libXext libXtst libXt libXtst
+      libXi libXinerama libXcursor libXrandr fontconfig openjdk11
+    ] ++ lib.optionals (!headless && enableGnome2) [
       gtk3 gnome_vfs GConf glib
     ];
 
@@ -53,62 +44,60 @@ let
         url = https://src.fedoraproject.org/rpms/java-openjdk/raw/06c001c7d87f2e9fe4fedeef2d993bcd5d7afa2a/f/rh1673833-remove_removal_of_wformat_during_test_compilation.patch;
         sha256 = "082lmc30x64x583vqq00c8y0wqih3y4r0mp1c4bqq36l22qv6b6r";
       })
-    ] ++ lib.optionals (!minimal && enableGnome2) [
+    ] ++ lib.optionals (!headless && enableGnome2) [
       ./swing-use-gtk-jdk10.patch
     ];
 
-    preConfigure = ''
+    prePatch = ''
       chmod +x configure
-      substituteInPlace configure --replace /bin/bash "${bash}/bin/bash"
-
-      configureFlagsArray=(
-        "--with-boot-jdk=${bootjdk.home}"
-        "--enable-unlimited-crypto"
-        "--with-zlib=system"
-        "--with-giflib=system"
-        "--with-stdc++lib=dynamic"
-
-        # glibc 2.24 deprecated readdir_r so we need this
-        # See https://www.mail-archive.com/openembedded-devel@lists.openembedded.org/msg49006.html
-        "--with-extra-cflags=-Wno-error=deprecated-declarations -Wno-error=unused-result"
-    ''
-    + lib.optionalString (architecture == "amd64") " \"--with-jvm-features=zgc\""
-    + lib.optionalString minimal " \"--enable-headless-only\""
-    + lib.optionalString (!minimal && enableJavaFX) " \"--with-import-modules=${openjfx}\""
-    + ");"
-    # https://bugzilla.redhat.com/show_bug.cgi?id=1306558
-    # https://github.com/JetBrains/jdk8u/commit/eaa5e0711a43d64874111254d74893fa299d5716
-    + stdenv.lib.optionalString stdenv.cc.isGNU ''
-      NIX_CFLAGS_COMPILE+=" -fno-lifetime-dse -fno-delete-null-pointer-checks -std=gnu++98 -Wno-error"
+      patchShebangs --build configure
     '';
 
-    NIX_LDFLAGS= lib.optionals (!minimal) [
+    configureFlags = [
+      "--with-boot-jdk=${openjdk11.home}"
+      "--enable-unlimited-crypto"
+      "--with-native-debug-symbols=internal"
+      "--with-libjpeg=system"
+      "--with-giflib=system"
+      "--with-libpng=system"
+      "--with-zlib=system"
+      "--with-lcms=system"
+      "--with-stdc++lib=dynamic"
+    ] ++ lib.optional stdenv.isx86_64 "--with-jvm-features=zgc"
+      ++ lib.optional headless "--enable-headless-only"
+      ++ lib.optional (!headless && enableJavaFX) "--with-import-modules=${openjfx}";
+
+    separateDebugInfo = true;
+
+    NIX_CFLAGS_COMPILE = [ "-Wno-error" ];
+
+    NIX_LDFLAGS = lib.optionals (!headless) [
       "-lfontconfig" "-lcups" "-lXinerama" "-lXrandr" "-lmagic"
-    ] ++ lib.optionals (!minimal && enableGnome2) [
+    ] ++ lib.optionals (!headless && enableGnome2) [
       "-lgtk-3" "-lgio-2.0" "-lgnomevfs-2" "-lgconf-2"
     ];
 
     buildFlags = [ "all" ];
 
     installPhase = ''
-      mkdir -p $out/lib/openjdk $out/share
+      mkdir -p $out/lib
 
-      cp -av build/*/images/jdk/* $out/lib/openjdk
+      mv build/*/images/jdk $out/lib/openjdk
 
       # Remove some broken manpages.
       rm -rf $out/lib/openjdk/man/ja*
 
       # Mirror some stuff in top-level.
-      mkdir $out/include $out/share/man
-      ln -s $out/lib/openjdk/include/* $out/include/
-      ln -s $out/lib/openjdk/man/* $out/share/man/
+      mkdir -p $out/share
+      ln -s $out/lib/openjdk/include $out/include
+      ln -s $out/lib/openjdk/man $out/share/man
 
       # jni.h expects jni_md.h to be in the header search path.
       ln -s $out/include/linux/*_md.h $out/include/
 
       # Remove crap from the installation.
       rm -rf $out/lib/openjdk/demo
-      ${lib.optionalString minimal ''
+      ${lib.optionalString headless ''
         rm $out/lib/openjdk/lib/{libjsound,libfontmanager}.so
       ''}
 
@@ -133,11 +122,12 @@ let
       # Build the set of output library directories to rpath against
       LIBDIRS=""
       for output in $outputs; do
+        if [ "$output" = debug ]; then continue; fi
         LIBDIRS="$(find $(eval echo \$$output) -name \*.so\* -exec dirname {} \+ | sort | uniq | tr '\n' ':'):$LIBDIRS"
       done
-
       # Add the local library paths to remove dependencies on the bootstrap
       for output in $outputs; do
+        if [ "$output" = debug ]; then continue; fi
         OUTPUTDIR=$(eval echo \$$output)
         BINLIBS=$(find $OUTPUTDIR/bin/ -type f; find $OUTPUTDIR -name \*.so\*)
         echo "$BINLIBS" | while read i; do
@@ -145,26 +135,20 @@ let
           patchelf --shrink-rpath "$i" || true
         done
       done
-
-      # Test to make sure that we don't depend on the bootstrap
-      for output in $outputs; do
-        if grep -q -r '${bootjdk}' $(eval echo \$$output); then
-          echo "Extraneous references to ${bootjdk} detected"
-          exit 1
-        fi
-      done
     '';
+
+    disallowedReferences = [ openjdk11 ];
 
     meta = with stdenv.lib; {
       homepage = http://openjdk.java.net/;
       license = licenses.gpl2;
       description = "The open-source Java Development Kit";
       maintainers = with maintainers; [ edwtjo ];
-      platforms = ["i686-linux" "x86_64-linux"];
+      platforms = [ "i686-linux" "x86_64-linux" "aarch64-linux" "armv7l-linux" "armv6l-linux" ];
     };
 
     passthru = {
-      inherit architecture;
+      architecture = "";
       home = "${openjdk}/lib/openjdk";
     };
   };

--- a/pkgs/development/compilers/openjdk/openjfx/11.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/11.nix
@@ -1,5 +1,6 @@
-{ stdenv, fetchurl, writeText, openjdk, bootjdk, gradleGen, pkgconfig, perl, cmake, gperf
-, gtk2, gtk3, libXtst, libXxf86vm, glib, alsaLib, ffmpeg, python, ruby }:
+{ stdenv, lib, fetchurl, writeText, openjdk11, gradleGen, pkgconfig, perl, cmake
+, gperf, gtk2, gtk3, libXtst, libXxf86vm, glib, alsaLib, ffmpeg, python, ruby
+, openjdk11-bootstrap }:
 
 let
   major = "11";
@@ -7,7 +8,7 @@ let
   build = "1";
   repover = "${major}${update}+${build}";
   gradle_ = (gradleGen.override {
-    java = bootjdk;
+    java = openjdk11-bootstrap;
   }).gradle_4_10;
 
   makePackage = args: stdenv.mkDerivation ({
@@ -25,7 +26,7 @@ let
 
     config = writeText "gradle.properties" (''
       CONF = Release
-      JDK_HOME = ${bootjdk}/lib/openjdk
+      JDK_HOME = ${openjdk11-bootstrap.home}
     '' + args.gradleProperties or "");
 
     buildPhase = ''
@@ -56,11 +57,11 @@ let
 
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
-    outputHash =
-      # Downloaded AWT jars differ by platform.
-      if stdenv.system == "x86_64-linux" then "0d4msxswdav1xsfkpr0qd3xgqkcbxzf47v1zdy5jmg5w4bs6a78a"
-      else if stdenv.system == "i686-linux" then "0mjlyf6jvbis7nrm5d394sjv4hjw6k3753hr1nwdxk8skwc3ry08"
-      else throw "Unsupported platform";
+    # Downloaded AWT jars differ by platform.
+    outputHash = {
+      "i686-linux" = "0mjlyf6jvbis7nrm5d394sjv4hjw6k3753hr1nwdxk8skwc3ry08";
+      "x86_64-linux" = "0d4msxswdav1xsfkpr0qd3xgqkcbxzf47v1zdy5jmg5w4bs6a78a";
+    }.${stdenv.system} or (throw "Unsupported platform");
   };
 
 in makePackage {
@@ -87,24 +88,20 @@ in makePackage {
   postFixup = ''
     # Remove references to bootstrap.
     find "$out" -name \*.so | while read lib; do
-      new_refs="$(patchelf --print-rpath "$lib" | sed -E 's,:?${bootjdk}[^:]*,,')"
+      new_refs="$(patchelf --print-rpath "$lib" | sed -E 's,:?${openjdk11-bootstrap}[^:]*,,')"
       patchelf --set-rpath "$new_refs" "$lib"
     done
-
-    # Test to make sure that we don't depend on the bootstrap
-    if grep -q -r '${bootjdk}' "$out"; then
-      echo "Extraneous references to ${bootjdk} detected" >&2
-      exit 1
-    fi
   '';
+
+  disallowedReferences = [ openjdk11-bootstrap ];
 
   passthru.deps = deps;
 
   meta = with stdenv.lib; {
     homepage = http://openjdk.java.net/projects/openjfx/;
-    license = openjdk.meta.license;
+    license = openjdk11.meta.license;
     description = "The next-generation Java client toolkit.";
     maintainers = with maintainers; [ abbradar ];
-    platforms = openjdk.meta.platforms;
+    platforms = [ "i686-linux" "x86_64-linux" ];
   };
 }

--- a/pkgs/development/compilers/openjdk/openjfx/11.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/11.nix
@@ -12,10 +12,10 @@ let
   }).gradle_4_10;
 
   makePackage = args: stdenv.mkDerivation ({
-    version = "${major}${update}-${repover}";
+    version = "${major}${update}-${build}";
 
     src = fetchurl {
-      url = "http://hg.openjdk.java.net/openjfx/${major}/rt/archive/${repover}.tar.gz";
+      url = "https://hg.openjdk.java.net/openjfx/${major}/rt/archive/${repover}.tar.gz";
       sha256 = "1h7qsylr7rnwnbimqjyn3whszp9kv4h3gpicsrb3mradxc9yv194";
     };
 

--- a/pkgs/development/compilers/openjdk/openjfx/12.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/12.nix
@@ -1,5 +1,6 @@
-{ stdenv, fetchurl, writeText, openjdk, bootjdk, gradleGen, pkgconfig, perl, cmake, gperf
-, gtk2, gtk3, libXtst, libXxf86vm, glib, alsaLib, ffmpeg, python, ruby }:
+{ stdenv, lib, fetchurl, writeText, openjdk11_headless, openjdk12, gradleGen
+, pkgconfig, perl, cmake, gperf, gtk2, gtk3, libXtst, libXxf86vm, glib, alsaLib
+, ffmpeg, python, ruby }:
 
 let
   major = "12";
@@ -7,14 +8,14 @@ let
   build = "14";
   repover = "${major}${update}+${build}";
   gradle_ = (gradleGen.override {
-    java = bootjdk;
+    java = openjdk11_headless;
   }).gradle_4_10;
 
   makePackage = args: stdenv.mkDerivation ({
-    version = "${major}${update}-${repover}";
+    version = "${major}${update}-${build}";
 
     src = fetchurl {
-      url = "http://hg.openjdk.java.net/openjfx/${major}-dev/rt/archive/${repover}.tar.gz";
+      url = "https://hg.openjdk.java.net/openjfx/${major}/rt/archive/${repover}.tar.gz";
       sha256 = "16jjfjkrg57wsj9mmm52i2kl3byz3ba1f9f8wwc8zwqm4cpjzliz";
     };
 
@@ -25,7 +26,7 @@ let
 
     config = writeText "gradle.properties" (''
       CONF = Release
-      JDK_HOME = ${bootjdk}/lib/openjdk
+      JDK_HOME = ${openjdk11_headless.home}
     '' + args.gradleProperties or "");
 
     buildPhase = ''
@@ -56,11 +57,11 @@ let
 
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
-    outputHash =
-      # Downloaded AWT jars differ by platform.
-      if stdenv.system == "x86_64-linux" then "1z5qar5l28ja4pkf5l5m48xbv3x1yrnilsv9lpf2j3vkdk9h1nci"
-      else if stdenv.system == "i686-linux" then "0rbygvjc7w197fi5nxldqdrm6mpiyd3n45042g3gd4s5qk08spjd"
-      else throw "Unsupported platform";
+    # Downloaded AWT jars differ by platform.
+    outputHash = {
+      "x86_64-linux" = "1z5qar5l28ja4pkf5l5m48xbv3x1yrnilsv9lpf2j3vkdk9h1nci";
+      "i686-linux" = "0rbygvjc7w197fi5nxldqdrm6mpiyd3n45042g3gd4s5qk08spjd";
+    }.${stdenv.system} or (throw "Unsupported platform");
   };
 
 in makePackage {
@@ -87,24 +88,20 @@ in makePackage {
   postFixup = ''
     # Remove references to bootstrap.
     find "$out" -name \*.so | while read lib; do
-      new_refs="$(patchelf --print-rpath "$lib" | sed -E 's,:?${bootjdk}[^:]*,,')"
+      new_refs="$(patchelf --print-rpath "$lib" | sed -E 's,:?${openjdk11_headless}[^:]*,,')"
       patchelf --set-rpath "$new_refs" "$lib"
     done
-
-    # Test to make sure that we don't depend on the bootstrap
-    if grep -q -r '${bootjdk}' "$out"; then
-      echo "Extraneous references to ${bootjdk} detected" >&2
-      exit 1
-    fi
   '';
+
+  disallowedReferences = [ openjdk11_headless ];
 
   passthru.deps = deps;
 
   meta = with stdenv.lib; {
     homepage = http://openjdk.java.net/projects/openjfx/;
-    license = openjdk.meta.license;
+    license = openjdk12.meta.license;
     description = "The next-generation Java client toolkit.";
     maintainers = with maintainers; [ abbradar ];
-    platforms = openjdk.meta.platforms;
+    platforms = [ "i686-linux" "x86_64-linux" ];
   };
 }

--- a/pkgs/development/compilers/openjdk/read-truststore-from-env-jdk8.patch
+++ b/pkgs/development/compilers/openjdk/read-truststore-from-env-jdk8.patch
@@ -1,21 +1,30 @@
-diff -ur openjdk-7u65-b32/jdk/src/share/classes/sun/security/ssl/TrustManagerFactoryImpl.java openjdk-7u65-b32.new/jdk/src/share/classes/sun/security/ssl/TrustManagerFactoryImpl.java
---- openjdk-7u65-b32/jdk/src/share/classes/sun/security/ssl/TrustManagerFactoryImpl.java	2014-07-17 12:12:14.000000000 +0200
-+++ openjdk-7u65-b32.new/jdk/src/share/classes/sun/security/ssl/TrustManagerFactoryImpl.java	2014-12-09 13:31:27.821960372 +0100
-@@ -161,6 +161,7 @@
-         /*
-          * Try:
-          *      javax.net.ssl.trustStore  (if this variable exists, stop)
-+         *      system environment variable JAVAX_NET_SSL_TRUSTSTORE
-          *      jssecacerts
-          *      cacerts
-          *
-@@ -169,6 +169,9 @@
- 
-         try {
-             storeFileName = props.get("trustStore");
-+            if (storeFileName == null) {
-+                storeFileName = System.getenv("JAVAX_NET_SSL_TRUSTSTORE");
-+            }
-             if (!"NONE".equals(storeFileName)) {
-                 if (storeFileName != null) {
-                     storeFile = new File(storeFileName);
+--- a/jdk/src/share/classes/sun/security/ssl/TrustStoreManager.java	2017-06-26 21:48:25.000000000 -0400
++++ b/jdk/src/share/classes/sun/security/ssl/TrustStoreManager.java	2017-07-05 20:45:57.491295030 -0400
+@@ -71,6 +71,7 @@
+      *
+      * The preference of the default trusted KeyStore is:
+      *    javax.net.ssl.trustStore
++     *    system environment variable JAVAX_NET_SSL_TRUSTSTORE
+      *    jssecacerts
+      *    cacerts
+      */
+@@ -132,7 +133,8 @@
+                 public TrustStoreDescriptor run() {
+                     // Get the system properties for trust store.
+                     String storePropName = System.getProperty(
+-                            "javax.net.ssl.trustStore", jsseDefaultStore);
++                            "javax.net.ssl.trustStore",
++                            System.getenv("JAVAX_NET_SSL_TRUSTSTORE"));
+                     String storePropType = System.getProperty(
+                             "javax.net.ssl.trustStoreType",
+                             KeyStore.getDefaultType());
+@@ -144,6 +146,9 @@
+                     String temporaryName = "";
+                     File temporaryFile = null;
+                     long temporaryTime = 0L;
++                    if (storePropName == null) {
++                        storePropName = jsseDefaultStore;
++                    }
+                     if (!"NONE".equals(storePropName)) {
+                         String[] fileNames =
+                                 new String[] {storePropName, defaultStore};

--- a/pkgs/development/libraries/libdrm/default.nix
+++ b/pkgs/development/libraries/libdrm/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchurl, pkgconfig, meson, ninja, libpthreadstubs, libpciaccess, valgrind-light }:
+{ stdenv, lib, fetchurl, pkgconfig, meson, ninja, libpthreadstubs, libpciaccess
+, withValgrind ? valgrind-light.meta.available, valgrind-light
+}:
 
 stdenv.mkDerivation rec {
   pname = "libdrm";
@@ -12,7 +14,8 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" "bin" ];
 
   nativeBuildInputs = [ pkgconfig meson ninja ];
-  buildInputs = [ libpthreadstubs libpciaccess valgrind-light ];
+  buildInputs = [ libpthreadstubs libpciaccess ]
+    ++ lib.optional withValgrind valgrind-light;
 
   patches = [ ./cross-build-nm-path.patch ];
 
@@ -22,14 +25,13 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  mesonFlags =
-    [
-      "-Dnm-path=${stdenv.cc.targetPrefix}nm"
-      "-Dinstall-test-programs=true" ]
-    ++ stdenv.lib.optionals (stdenv.isAarch32 || stdenv.isAarch64)
-      [ "-Dtegra=true" "-Detnaviv=true" ]
-    ++ stdenv.lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "-Dintel=false"
-    ;
+  mesonFlags = [
+    "-Dnm-path=${stdenv.cc.targetPrefix}nm"
+    "-Dinstall-test-programs=true"
+  ] ++ lib.optionals (stdenv.isAarch32 || stdenv.isAarch64) [
+    "-Dtegra=true"
+    "-Detnaviv=true"
+  ] ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "-Dintel=false";
 
   enableParallelBuilding = true;
 
@@ -37,6 +39,6 @@ stdenv.mkDerivation rec {
     homepage = https://dri.freedesktop.org/libdrm/;
     description = "Library for accessing the kernel's Direct Rendering Manager";
     license = "bsd";
-    platforms = stdenv.lib.platforms.unix;
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7862,15 +7862,15 @@ in
 
   hugs = callPackage ../development/interpreters/hugs { };
 
-  bootjdk = callPackage ../development/compilers/openjdk/bootstrap.nix { version = "10"; };
+  openjfx11 = callPackage ../development/compilers/openjdk/openjfx/11.nix { };
 
-  openjfx11 =
-    if stdenv.isDarwin then
-      null
+  openjfx12 = callPackage ../development/compilers/openjdk/openjfx/12.nix { };
+
+  openjdk8-bootstrap =
+    if adoptopenjdk-hotspot-bin-8.meta.available then
+      adoptopenjdk-hotspot-bin-8
     else
-      callPackage ../development/compilers/openjdk/openjfx/11.nix {
-        openjdk = openjdk11;
-      };
+      callPackage ../development/compilers/openjdk/bootstrap.nix { version = "8"; };
 
   /* legacy jdk for use as needed by older apps */
   openjdk8 =
@@ -7878,9 +7878,20 @@ in
       callPackage ../development/compilers/openjdk/darwin/8.nix { }
     else
       callPackage ../development/compilers/openjdk/8.nix {
-        bootjdk = bootjdk.override { version = "8"; };
         inherit (gnome2) GConf gnome_vfs;
       };
+
+  openjdk8_headless =
+    if stdenv.isDarwin || stdenv.isAarch64 then
+      openjdk8
+    else
+      openjdk8.override { headless = true; };
+
+  openjdk11-bootstrap =
+    if adoptopenjdk-hotspot-bin-11.meta.available then
+      adoptopenjdk-hotspot-bin-11
+    else
+      callPackage ../development/compilers/openjdk/bootstrap.nix { version = "10"; };
 
   /* currently maintained LTS JDK */
   openjdk11 =
@@ -7892,62 +7903,43 @@ in
         inherit (gnome2) GConf gnome_vfs;
       };
 
-  openjfx12 =
+  openjdk11_headless =
     if stdenv.isDarwin then
-      null
+      openjdk11
     else
-      callPackage ../development/compilers/openjdk/openjfx/12.nix {
-        openjdk = openjdk12;
-        bootjdk = openjdk11;
-      };
+      openjdk11.override { headless = true; };
 
   /* current JDK */
   openjdk12 =
     if stdenv.isDarwin then
-      callPackage ../development/compilers/openjdk/darwin/default.nix { }
+      callPackage ../development/compilers/openjdk/darwin { }
     else
-      callPackage ../development/compilers/openjdk/default.nix {
+      callPackage ../development/compilers/openjdk {
         openjfx = openjfx12;
         inherit (gnome2) GConf gnome_vfs;
-        bootjdk = openjdk11;
       };
 
+  openjdk12_headless =
+    if stdenv.isDarwin then
+      openjdk12
+    else
+      openjdk12.override { headless = true; };
+
   openjdk = openjdk8;
+  openjdk_headless = openjdk8_headless;
 
-  jdk8 = if stdenv.isAarch32 || stdenv.isAarch64 then oraclejdk8 else openjdk8 // { outputs = [ "out" ]; };
-  jre8 = if stdenv.isAarch32 || stdenv.isAarch64 then oraclejre8 else lib.setName "openjre-${lib.getVersion pkgs.openjdk8.jre}"
-    (lib.addMetaAttrs { outputsToInstall = [ "jre" ]; }
-      (openjdk8.jre // { outputs = [ "jre" ]; }));
-  jre8_headless =
-    if stdenv.isAarch32 || stdenv.isAarch64 then
-      oraclejre8
-    else if stdenv.isDarwin then
-      jre8
-    else
-      lib.setName "openjre-${lib.getVersion pkgs.openjdk8.jre}-headless"
-        (lib.addMetaAttrs { outputsToInstall = [ "jre" ]; }
-          ((openjdk8.override { minimal = true; }).jre // { outputs = [ "jre" ]; }));
+  jdk8 = openjdk8;
+  jre8 = openjdk8.jre;
+  jre8_headless = openjdk8_headless.jre;
 
-  jdk11 = openjdk11 // { outputs = [ "out" ]; };
-  jdk11_headless =
-    if stdenv.isDarwin then
-      jdk11
-    else
-      lib.setName "openjdk-${lib.getVersion pkgs.openjdk11}-headless"
-        (lib.addMetaAttrs {}
-          ((openjdk11.override { minimal = true; }) // {}));
+  jdk11 = openjdk11;
+  jdk11_headless = openjdk11_headless;
 
-  jdk12 = openjdk12 // { outputs = [ "out" ]; };
-  jdk12_headless =
-    if stdenv.isDarwin then
-      jdk12
-    else
-      lib.setName "openjdk-${lib.getVersion pkgs.openjdk12}-headless"
-        (lib.addMetaAttrs {}
-          ((openjdk12.override { minimal = true; }) // {}));
+  jdk12 = openjdk12;
+  jdk12_headless = openjdk12_headless;
 
   jdk = jdk8;
-  jre = if stdenv.isAarch32 || stdenv.isAarch64 then adoptopenjdk-jre-bin else jre8;
+  jre = jre8;
   jre_headless = jre8_headless;
 
   inherit (callPackages ../development/compilers/graalvm { }) mx jvmci8 graalvm8;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7262,6 +7262,24 @@ in
     then callPackage adoptopenjdk-bin-11-packages-linux.jre-openj9 {}
     else callPackage adoptopenjdk-bin-11-packages-darwin.jre-openj9 {};
 
+  adoptopenjdk-bin-8-packages-linux = import ../development/compilers/adoptopenjdk-bin/jdk8-linux.nix;
+  adoptopenjdk-bin-8-packages-darwin = import ../development/compilers/adoptopenjdk-bin/jdk8-darwin.nix;
+
+  adoptopenjdk-hotspot-bin-8 = if stdenv.isLinux
+    then callPackage adoptopenjdk-bin-8-packages-linux.jdk-hotspot {}
+    else callPackage adoptopenjdk-bin-8-packages-darwin.jdk-hotspot {};
+  adoptopenjdk-jre-hotspot-bin-8 = if stdenv.isLinux
+    then callPackage adoptopenjdk-bin-8-packages-linux.jre-hotspot {}
+    else callPackage adoptopenjdk-bin-8-packages-darwin.jre-hotspot {};
+
+  adoptopenjdk-openj9-bin-8 = if stdenv.isLinux
+    then callPackage adoptopenjdk-bin-8-packages-linux.jdk-openj9 {}
+    else callPackage adoptopenjdk-bin-8-packages-darwin.jdk-openj9 {};
+
+  adoptopenjdk-jre-openj9-bin-8 = if stdenv.isLinux
+    then callPackage adoptopenjdk-bin-8-packages-linux.jre-openj9 {}
+    else callPackage adoptopenjdk-bin-8-packages-darwin.jre-openj9 {};
+
   adoptopenjdk-bin = adoptopenjdk-hotspot-bin-11;
   adoptopenjdk-jre-bin = adoptopenjdk-jre-hotspot-bin-11;
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I started out with the goal of adding support for 32-bit ARM to `adoptopenjdk-bin`, but then quickly realized that this binary package could be used to bootstrap the OpenJDK build on these platforms. This led to me also making a lot of changes to clean up the OpenJDK packages.

###### Things done

This PR makes `openjdk8` and `openjdk11` use `adoptopenjdk-bin` for bootstrapping. [AdoptOpenJDK](https://adoptopenjdk.net/) is a well-known organization that provides prebuilt OpenJDK binaries for many architectures. Their build scripts are open source and their infrastructure is publicly visible, which I believe makes Nix's OpenJDK bootstrapping process more transparent and trustworthy than the status quo, which uses a bootstrapping tarball of undocumented origin. From a technical standpoint, AdoptOpenJDK binaries make it easier to bootstrap OpenJDK on more platforms.

While I was working on this, I tried to clean up parts of the packages that I believe are no longer necessary or could be done better, but in doing so I there is the possibility that I broke something. Are there any particularly problematic packages I should test?

###### Testing

|  | `x86_64-linux` | `i686-linux` | `aarch64-linux` | `armv6l-linux` | `armv7l-linux` |
|----------------------|----------------|--------------|-----------------|----------------|----------------|
| `openjdk8` | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :no_entry_sign: | :no_entry_sign: |
| `openjdk8_headless` | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :no_entry_sign: | :no_entry_sign: |
| `openjdk11` | :heavy_check_mark: | :x:<sup>1</sup> | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
| `openjdk11_headless` | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
| `bazel` | :heavy_check_mark: | | :heavy_check_mark: | | | 
| `jmeter` | :heavy_check_mark: | | | | |
| `jetbrains.idea-community`<sup>2</sup> | :heavy_check_mark: | | | |
| `javaPackages` | :heavy_check_mark: |

:heavy_check_mark: = builds and runs
:x: = fails to build
:no_entry_sign: = not supported
blank = not tested

<sup>1</sup>`openjfx11` (and therefore `openjdk11`) fails to build on `i686-linux` for non-obvious reasons, even without this PR, and I did not try to fix it.

<sup>2</sup>Overridden to use OpenJDK 11 built from source

I do not have the ability to test on macOS, but I did not really touch anything Darwin related.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of binary files (usually in `./result/bin/`) (I didn't test every single binary)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
