### PR TITLE
 deepin: use qt5.mkDerivation where needed, cleanup wrappers

### DIFF
--- a/pkgs/desktops/deepin/dde-calendar/default.nix
+++ b/pkgs/desktops/deepin/dde-calendar/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchFromGitHub, pkgconfig, cmake, qttools,
+{ stdenv, mkDerivation, fetchFromGitHub, pkgconfig, cmake, qttools,
   deepin-gettext-tools, dtkcore, dtkwidget, deepin
 }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   name = "${pname}-${version}";
   pname = "dde-calendar";
   version = "1.2.10";

--- a/pkgs/desktops/deepin/dde-control-center/default.nix
+++ b/pkgs/desktops/deepin/dde-control-center/default.nix
@@ -1,12 +1,12 @@
-{ stdenv, fetchFromGitHub, pkgconfig, cmake, deepin, qttools, qtdeclarative,
+{ stdenv, mkDerivation, fetchFromGitHub, pkgconfig, cmake, deepin, qttools, qtdeclarative,
  networkmanager, qtsvg, qtx11extras,  dtkcore, dtkwidget, geoip, gsettings-qt,
  dde-network-utils, networkmanager-qt, xorg, mtdev, fontconfig, freetype, dde-api,
  dde-daemon, qt5integration, deepin-desktop-base, deepin-desktop-schemas, dbus,
  systemd, dde-qt-dbus-factory, qtmultimedia, qtbase, glib, gnome3, which,
- substituteAll, wrapGAppsHook, tzdata
+ substituteAll, tzdata, wrapGAppsHook
 }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   name = "${pname}-${version}";
   pname = "dde-control-center";
   version = "4.10.11";

--- a/pkgs/desktops/deepin/dde-dock/default.nix
+++ b/pkgs/desktops/deepin/dde-dock/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, qttools, qtx11extras,
-  qtsvg, libsForQt5, polkit, gsettings-qt, dtkcore, dtkwidget,
+{ stdenv, mkDerivation, fetchFromGitHub, cmake, pkgconfig, qttools, qtx11extras,
+  qtsvg, polkit, gsettings-qt, dtkcore, dtkwidget,
   dde-qt-dbus-factory, dde-network-utils, dde-daemon,
   deepin-desktop-schemas, xorg, glib, wrapGAppsHook, deepin,
-  plugins ? [], symlinkJoin, makeWrapper }:
+  plugins ? [], symlinkJoin, makeWrapper, libdbusmenu }:
 
 let
-unwrapped = stdenv.mkDerivation rec {
+unwrapped = mkDerivation rec {
   name = "${pname}-${version}";
   pname = "dde-dock";
   version = "4.10.3";
@@ -34,7 +34,7 @@ unwrapped = stdenv.mkDerivation rec {
     dtkwidget
     glib.bin
     gsettings-qt
-    libsForQt5.libdbusmenu
+    libdbusmenu
     polkit
     qtsvg
     qtx11extras

--- a/pkgs/desktops/deepin/dde-file-manager/default.nix
+++ b/pkgs/desktops/deepin/dde-file-manager/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pkgconfig, avfs, dde-daemon, dde-dock,
+{ stdenv, mkDerivation, fetchFromGitHub, pkgconfig, avfs, dde-daemon, dde-dock,
   dde-polkit-agent, dde-qt-dbus-factory, deepin, deepin-anything,
   deepin-desktop-schemas, deepin-gettext-tools, deepin-movie-reborn,
   deepin-shortcut-viewer, deepin-terminal, dtkcore, dtkwidget,
@@ -8,7 +8,7 @@
   qtx11extras, runtimeShell, samba, shadow, taglib, udisks2-qt5,
   xdg-user-dirs, xorg, zlib, wrapGAppsHook }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   name = "${pname}-${version}";
   pname = "dde-file-manager";
   version = "4.8.6.4";

--- a/pkgs/desktops/deepin/dde-launcher/default.nix
+++ b/pkgs/desktops/deepin/dde-launcher/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, fetchFromGitHub, pkgconfig, cmake, dde-qt-dbus-factory,
+{ stdenv, mkDerivation, fetchFromGitHub, pkgconfig, cmake, dde-qt-dbus-factory,
   dde-session-ui, deepin, deepin-desktop-schemas, deepin-wallpapers,
   dtkcore, dtkwidget, gsettings-qt, qtsvg, qttools, qtx11extras,
   which, xdg_utils, wrapGAppsHook }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   name = "${pname}-${version}";
   pname = "dde-launcher";
   version = "4.6.13";

--- a/pkgs/desktops/deepin/dde-network-utils/default.nix
+++ b/pkgs/desktops/deepin/dde-network-utils/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchFromGitHub, substituteAll, qmake, pkgconfig, qttools,
+{ stdenv, mkDerivation, fetchFromGitHub, substituteAll, qmake, pkgconfig, qttools,
   dde-qt-dbus-factory, proxychains, which, deepin }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   name = "${pname}-${version}";
   pname = "dde-network-utils";
   version = "0.1.4";

--- a/pkgs/desktops/deepin/dde-polkit-agent/default.nix
+++ b/pkgs/desktops/deepin/dde-polkit-agent/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchFromGitHub, pkgconfig, qmake, qttools, polkit-qt,
+{ stdenv, mkDerivation, fetchFromGitHub, pkgconfig, qmake, qttools, polkit-qt,
   dtkcore, dtkwidget, dde-qt-dbus-factory, deepin }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   name = "${pname}-${version}";
   pname = "dde-polkit-agent";
   version = "0.2.10";

--- a/pkgs/desktops/deepin/dde-session-ui/default.nix
+++ b/pkgs/desktops/deepin/dde-session-ui/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchFromGitHub, pkgconfig, qmake, dbus, dde-daemon,
+{ stdenv, mkDerivation, fetchFromGitHub, pkgconfig, qmake, dbus, dde-daemon,
   dde-qt-dbus-factory, deepin, deepin-desktop-schemas,
   deepin-gettext-tools, deepin-icon-theme, deepin-wallpapers, dtkcore,
   dtkwidget, gnugrep, gsettings-qt, hicolor-icon-theme, lightdm_qt,
   onboard, qtsvg, qttools, qtx11extras, setxkbmap, utillinux, which,
   xkeyboard_config, xorg, xrandr, wrapGAppsHook }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   name = "${pname}-${version}";
   pname = "dde-session-ui";
   version = "4.9.12";
@@ -109,7 +109,7 @@ stdenv.mkDerivation rec {
   postFixup = ''
     # wrapGAppsHook does not work with binaries outside of $out/bin or $out/libexec
     for binary in $out/lib/deepin-daemon/*; do
-      wrapProgram $binary "''${gappsWrapperArgs[@]}"
+      wrapProgram $binary "''${qtWrapperArgs[@]}"
     done
 
     searchHardCodedPaths $out  # debugging

--- a/pkgs/desktops/deepin/deepin-anything/default.nix
+++ b/pkgs/desktops/deepin/deepin-anything/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchFromGitHub, pkgconfig, qtbase, udisks2-qt5, utillinux,
+{ stdenv, mkDerivation, fetchFromGitHub, pkgconfig, qtbase, udisks2-qt5, utillinux,
   dtkcore, deepin }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   name = "${pname}-${version}";
   pname = "deepin-anything";
   version = "0.1.0";

--- a/pkgs/desktops/deepin/deepin-calculator/default.nix
+++ b/pkgs/desktops/deepin/deepin-calculator/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchFromGitHub, pkgconfig, qmake, qttools, qtsvg, dtkcore,
+{ stdenv, mkDerivation, fetchFromGitHub, pkgconfig, qmake, qttools, qtsvg, dtkcore,
   dtkwidget, deepin }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   name = "${pname}-${version}";
   pname = "deepin-calculator";
   version = "1.0.11";
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
   postFixup = ''
     searchHardCodedPaths $out  # debugging
   '';
-  
+
   passthru.updateScript = deepin.updateScript { inherit name; };
 
   meta = with stdenv.lib; {

--- a/pkgs/desktops/deepin/deepin-image-viewer/default.nix
+++ b/pkgs/desktops/deepin/deepin-image-viewer/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, fetchFromGitHub, pkgconfig, qmake, qttools, qtsvg,
+{ stdenv, mkDerivation, fetchFromGitHub, pkgconfig, qmake, qttools, qtsvg,
   qtx11extras, dtkcore, dtkwidget, qt5integration, freeimage, libraw,
   libexif, deepin
 }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   name = "${pname}-${version}";
   pname = "deepin-image-viewer";
   version = "1.3.17";

--- a/pkgs/desktops/deepin/deepin-menu/default.nix
+++ b/pkgs/desktops/deepin/deepin-menu/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchFromGitHub, pkgconfig, qmake, dtkcore, dtkwidget,
+{ stdenv, mkDerivation, fetchFromGitHub, pkgconfig, qmake, dtkcore, dtkwidget,
   qt5integration, deepin }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   name = "${pname}-${version}";
   pname = "deepin-menu";
   version = "3.4.8";

--- a/pkgs/desktops/deepin/deepin-metacity/default.nix
+++ b/pkgs/desktops/deepin/deepin-metacity/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, pkgconfig, intltool, libtool, gnome3, glib,
   gtk3, libgtop, bamf, json-glib, libcanberra-gtk3, libxkbcommon,
   libstartup_notification, deepin-wallpapers, deepin-desktop-schemas,
-  deepin }:
+  deepin, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
@@ -21,6 +21,7 @@ stdenv.mkDerivation rec {
     libtool
     glib.dev
     gnome3.gnome-common
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/desktops/deepin/deepin-movie-reborn/default.nix
+++ b/pkgs/desktops/deepin/deepin-movie-reborn/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, qttools, qtx11extras,
+{ stdenv, mkDerivation, fetchFromGitHub, cmake, pkgconfig, qttools, qtx11extras,
   dtkcore, dtkwidget, ffmpeg, ffmpegthumbnailer, mpv, pulseaudio,
   libdvdnav, libdvdread, xorg, deepin }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   name = "${pname}-${version}";
   pname = "deepin-movie-reborn";
   version = "3.2.24";

--- a/pkgs/desktops/deepin/deepin-screenshot/default.nix
+++ b/pkgs/desktops/deepin/deepin-screenshot/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchFromGitHub, fetchpatch, cmake, pkgconfig, xdg_utils, qttools, qtx11extras,
+{ stdenv, mkDerivation, fetchFromGitHub, fetchpatch, cmake, pkgconfig, xdg_utils, qttools, qtx11extras,
   dtkcore, dtkwidget, dtkwm, deepin-turbo, deepin-shortcut-viewer,
   deepin }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   name = "${pname}-${version}";
   pname = "deepin-screenshot";
   version = "4.2.1";

--- a/pkgs/desktops/deepin/deepin-shortcut-viewer/default.nix
+++ b/pkgs/desktops/deepin/deepin-shortcut-viewer/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchFromGitHub, pkgconfig, qmake, dtkcore, dtkwidget,
+{ stdenv, mkDerivation, fetchFromGitHub, pkgconfig, qmake, dtkcore, dtkwidget,
   qt5integration, deepin }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   name = "${pname}-${version}";
   pname = "deepin-shortcut-viewer";
   version = "1.3.5";

--- a/pkgs/desktops/deepin/deepin-terminal/default.nix
+++ b/pkgs/desktops/deepin/deepin-terminal/default.nix
@@ -2,7 +2,7 @@
   gettext, at-spi2-core, dbus, epoxy, expect, gtk3, json-glib,
   libXdmcp, libgee, libpthreadstubs, librsvg, libsecret, libtasn1,
   libxcb, libxkbcommon, p11-kit, pcre, vte, wnck, libselinux,
-  libsepol, utillinux, deepin-menu, deepin-shortcut-viewer, deepin }:
+  libsepol, utillinux, deepin-menu, deepin-shortcut-viewer, deepin, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
@@ -24,6 +24,7 @@ stdenv.mkDerivation rec {
     gettext
     libselinux libsepol utillinux # required by gio
     deepin.setupHook
+    wrapGAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/desktops/deepin/deepin-turbo/default.nix
+++ b/pkgs/desktops/deepin/deepin-turbo/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, qtbase, deepin }:
+{ stdenv, mkDerivation, fetchFromGitHub, cmake, pkgconfig, qtbase, deepin }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   name = "${pname}-${version}";
   pname = "deepin-turbo";
   version = "0.0.3";

--- a/pkgs/desktops/deepin/dtkcore/default.nix
+++ b/pkgs/desktops/deepin/dtkcore/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, pkgconfig, qmake, gsettings-qt, pythonPackages, deepin }:
+{ stdenv, mkDerivation, fetchFromGitHub, pkgconfig, qmake, gsettings-qt, pythonPackages, deepin }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   name = "${pname}-${version}";
   pname = "dtkcore";
   version = "2.0.14";

--- a/pkgs/desktops/deepin/dtkwidget/default.nix
+++ b/pkgs/desktops/deepin/dtkwidget/default.nix
@@ -31,12 +31,13 @@ mkDerivation rec {
     dtkcore
   ];
 
-  preConfigure = ''
-    qmakeFlags="$qmakeFlags \
-      INCLUDE_INSTALL_DIR=$out/include \
-      LIB_INSTALL_DIR=$out/lib \
-      QT_HOST_DATA=$out"
-  '';
+  outRef = placeholder "out";
+
+  qmakeFlags = [
+    "INCLUDE_INSTALL_DIR=${outRef}/include"
+    "LIB_INSTALL_DIR=${outRef}/lib"
+    "QT_HOST_DATA=${outRef}"
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/desktops/deepin/dtkwidget/default.nix
+++ b/pkgs/desktops/deepin/dtkwidget/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchFromGitHub, pkgconfig, qmake, qttools, qtmultimedia,
+{ stdenv, mkDerivation, fetchFromGitHub, pkgconfig, qmake, qttools, qtmultimedia,
   qtsvg, qtx11extras, librsvg, libstartup_notification, gsettings-qt,
   dde-qt-dbus-factory, dtkcore, deepin }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   name = "${pname}-${version}";
   pname = "dtkwidget";
   version = "2.0.14";

--- a/pkgs/desktops/deepin/dtkwm/default.nix
+++ b/pkgs/desktops/deepin/dtkwm/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchFromGitHub, pkgconfig, qmake, qtx11extras, dtkcore,
+{ stdenv, mkDerivation, fetchFromGitHub, pkgconfig, qmake, qtx11extras, dtkcore,
   deepin }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   name = "${pname}-${version}";
   pname = "dtkwm";
   version = "2.0.11";

--- a/pkgs/desktops/deepin/dtkwm/default.nix
+++ b/pkgs/desktops/deepin/dtkwm/default.nix
@@ -23,12 +23,13 @@ mkDerivation rec {
     qtx11extras
   ];
 
-  preConfigure = ''
-    qmakeFlags="$qmakeFlags \
-      QT_HOST_DATA=$out \
-      INCLUDE_INSTALL_DIR=$out/include \
-      LIB_INSTALL_DIR=$out/lib"
-  '';
+  outRef = placeholder "out";
+
+  qmakeFlags = [
+    "QT_HOST_DATA=${outRef}"
+    "INCLUDE_INSTALL_DIR=${outRef}/include"
+    "LIB_INSTALL_DIR=${outRef}/lib"
+  ];
 
   passthru.updateScript = deepin.updateScript { inherit name; };
 

--- a/pkgs/desktops/deepin/qcef/default.nix
+++ b/pkgs/desktops/deepin/qcef/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pkgconfig, cmake, qtbase, qttools,
+{ stdenv, mkDerivation, fetchFromGitHub, pkgconfig, cmake, qtbase, qttools,
   qtwebchannel, qtx11extras,
   gnome2, nss, nspr, alsaLib, atk, cairo, cups, dbus,
   expat, fontconfig, gdk_pixbuf, glib, gtk2,
@@ -38,7 +38,7 @@ let
   libPath = stdenv.lib.makeLibraryPath rpahtLibraries;
 in
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   name = "${pname}-${version}";
   pname = "qcef";
   version = "1.1.6";

--- a/pkgs/desktops/deepin/qt5dxcb-plugin/default.nix
+++ b/pkgs/desktops/deepin/qt5dxcb-plugin/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchFromGitHub, pkgconfig, qmake, qtx11extras, libSM,
+{ stdenv, mkDerivation, fetchFromGitHub, pkgconfig, qmake, qtx11extras, libSM,
   mtdev, cairo, deepin }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   name = "${pname}-${version}";
   pname = "qt5dxcb-plugin";
   version = "1.2.2";

--- a/pkgs/desktops/deepin/qt5dxcb-plugin/default.nix
+++ b/pkgs/desktops/deepin/qt5dxcb-plugin/default.nix
@@ -1,5 +1,5 @@
 { stdenv, mkDerivation, fetchFromGitHub, pkgconfig, qmake, qtx11extras, libSM,
-  mtdev, cairo, deepin }:
+  mtdev, cairo, deepin, qtbase }:
 
 mkDerivation rec {
   name = "${pname}-${version}";
@@ -25,9 +25,9 @@ mkDerivation rec {
     cairo
   ];
 
-  preConfigure = ''
-    qmakeFlags="$qmakeFlags INSTALL_PATH=$out/$qtPluginPrefix/platforms"
-  '';
+  qmakeFlags = [
+    "INSTALL_PATH=${placeholder ''out''}/${qtbase.qtPluginPrefix}/platforms"
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/desktops/deepin/qt5integration/default.nix
+++ b/pkgs/desktops/deepin/qt5integration/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchFromGitHub, pkgconfig, qmake, mtdev ,
-  lxqt, qtx11extras, qtmultimedia, qtsvg ,
+{ stdenv, mkDerivation, fetchFromGitHub, pkgconfig, qmake, mtdev,
+  lxqt, qtx11extras, qtmultimedia, qtsvg,
   qt5dxcb-plugin, qtstyleplugins, dtkcore, dtkwidget, deepin }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   name = "${pname}-${version}";
   pname = "qt5integration";
   version = "0.3.12";

--- a/pkgs/desktops/deepin/udisks2-qt5/default.nix
+++ b/pkgs/desktops/deepin/udisks2-qt5/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, qmake, qtbase, deepin }:
+{ stdenv, mkDerivation, fetchFromGitHub, qmake, qtbase, deepin }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   name = "${pname}-${version}";
   pname = "udisks2-qt5";
   version = "0.0.1";


### PR DESCRIPTION
###### Commit Message

This switches a majority of the applications to using `qt5.mkDerivation`
which automatically adds `wrapQtAppsHook`.

In certain places, where GLib and gtk intersect with Qt, we
also needed to use `wrapGAppsHook` . In these cases there will be
multiple wrappers.

###### Motivation for this change
Something we should be doing.

It would be best to test this with #63813, and I also believe it will make
the `lightdm-deepin-greeter` module function as expected.

**Edit**: `lightdm-deepin-greeter` appears to work as expected with this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
