### PR TITLE
nudoku: init at 1.0.0

### DIFF
--- a/pkgs/games/nudoku/default.nix
+++ b/pkgs/games/nudoku/default.nix
@@ -1,0 +1,32 @@
+{stdenv, fetchurl, ncurses}:
+let
+  s = 
+  rec {
+    baseName = "nudoku";
+    version = "1.0.0";
+    name = "${baseName}-${version}";
+    url = "https://github.com/jubalh/nudoku/releases/download/${version}/${baseName}-${version}.tar.xz";
+    sha256 = "0nr2j2z07nxk70s8xnmmpzccxicf7kn5mbwby2kg6aq8paarjm8k";
+  };
+  buildInputs = [
+    ncurses
+  ];
+in
+stdenv.mkDerivation {
+  inherit (s) name version;
+  inherit buildInputs;
+  src = fetchurl {
+    inherit (s) url sha256;
+  };
+  preInstall = ''
+    mkdir -p {share/man,bin}
+  '';
+  meta = {
+    inherit (s) version;
+    description = ''A ncurses based sudoku game'';
+    license = stdenv.lib.licenses.gpl3;
+    maintainers = [ "Manuel Reinhardt <manuel.reinhardt@neon-cathedral.net>" ];
+    platforms = stdenv.lib.platforms.linux;
+    homepage = https://github.com/jubalh/nudoku;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21832,6 +21832,8 @@ in
 
   newtonwars = callPackage ../games/newtonwars { };
 
+  nudoku = callPackage ../games/nudoku { };
+
   nxengine-evo = callPackage ../games/nxengine-evo { };
 
   odamex = callPackage ../games/odamex { };


### PR DESCRIPTION
###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
