### PR TITLE
brewtarget: init at 2.3.1

### DIFF
--- a/pkgs/applications/misc/brewtarget/default.nix
+++ b/pkgs/applications/misc/brewtarget/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, mkDerivation
+, fetchFromGitHub
+, bash
+, cmake
+, qtbase
+, qttools
+, qtmultimedia
+, qtwebkit
+, qtsvg
+}:
+
+mkDerivation rec {
+  pname = "brewtarget";
+  version = "2.3.1";
+
+  src = fetchFromGitHub {
+    owner = "Brewtarget";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "14xmm6f8xmvypagx4qdw8q9llzmyi9zzfhnzh4kbbflhjbcr7isz";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ qtbase qttools qtmultimedia qtwebkit qtsvg ];
+
+  preConfigure = ''
+    chmod +x configure
+    substituteInPlace configure --replace /bin/bash "${bash}/bin/bash"
+  '';
+
+  meta = with lib; {
+    description = "Open source beer recipe creation tool";
+    homepage = "http://www.brewtarget.org/";
+    license = licenses.gpl3;
+    maintainers = [ maintainers.mmahut ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -661,6 +661,8 @@ in
 
   brakeman = callPackage ../development/tools/analysis/brakeman { };
 
+  brewtarget = libsForQt5.callPackage ../applications/misc/brewtarget { } ;
+
   ec2_api_tools = callPackage ../tools/virtualization/ec2-api-tools { };
 
   ec2_ami_tools = callPackage ../tools/virtualization/ec2-ami-tools { };


### PR DESCRIPTION
###### Motivation for this change

init at 2.3.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
