### PR TITLE
boot tests: don't use globbing

### DIFF
--- a/nixos/tests/boot.nix
+++ b/nixos/tests/boot.nix
@@ -17,7 +17,7 @@ let
         ];
     }).config.system.build.isoImage;
 
-  perlAttrs = params: "{ ${concatStringsSep "," (mapAttrsToList (name: param: "${name} => '${toString param}'") params)} }";
+  perlAttrs = params: "{ ${concatStringsSep ", " (mapAttrsToList (name: param: "${name} => ${builtins.toJSON param}") params)} }";
 
   makeBootTest = name: extraConfig:
     let
@@ -79,28 +79,28 @@ let
 in {
 
     biosCdrom = makeBootTest "bios-cdrom" {
-      cdrom = ''glob("${iso}/iso/*.iso")'';
+      cdrom = "${iso}/iso/${iso.isoName}";
     };
 
     biosUsb = makeBootTest "bios-usb" {
-      usb = ''glob("${iso}/iso/*.iso")'';
+      usb = "${iso}/iso/${iso.isoName}";
     };
 
     uefiCdrom = makeBootTest "uefi-cdrom" {
-      cdrom = ''glob("${iso}/iso/*.iso"'';
-      bios = ''"${pkgs.OVMF.fd}/FV/OVMF.fd"'';
+      cdrom = "${iso}/iso/${iso.isoName}";
+      bios = "${pkgs.OVMF.fd}/FV/OVMF.fd";
     };
 
     uefiUsb = makeBootTest "uefi-usb" {
-      usb = ''glob("${iso}/iso/*.iso")'';
-      bios = ''"${pkgs.OVMF.fd}/FV/OVMF.fd"'';
+      usb = "${iso}/iso/${iso.isoName}";
+      bios = "${pkgs.OVMF.fd}/FV/OVMF.fd";
     };
 
     biosNetboot = makeNetbootTest "bios" {};
 
     uefiNetboot = makeNetbootTest "uefi" {
-      bios = ''"${pkgs.OVMF.fd}/FV/OVMF.fd"'';
+      bios = "${pkgs.OVMF.fd}/FV/OVMF.fd";
       # Custom ROM is needed for EFI PXE boot. I failed to understand exactly why, because QEMU should still use iPXE for EFI.
-      netFrontendArgs = ''romfile="${pkgs.ipxe}/ipxe.efirom"'';
+      netFrontendArgs = "romfile=${pkgs.ipxe}/ipxe.efirom";
     };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fix boot tests without resorting to shell-in-Perl injection. See also https://github.com/NixOS/nixpkgs/pull/65214.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
Ran the following tests:
* tests.boot.biosUsb.x86_64-linux
* tests.boot.uefiUsb.x86_64-linux
* tests.boot.uefiCdrom.x86_64-linux
* tests.boot.biosCdrom.x86_64-linux
* tests.boot.uefiNetboot.x86_64-linux
* tests.boot.biosNetboot.x86_64-linux

Combined testing with https://github.com/NixOS/nixpkgs/pull/65212:
* tests.installer.simple.x86_64-linux
* tests.bittorrent.x86_64-linux

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
