### PR TITLE
 python3Packages.PyGithub: 1.36 -> 1.43.8 

### DIFF
--- a/pkgs/development/python-modules/deprecated/default.nix
+++ b/pkgs/development/python-modules/deprecated/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchPypi, buildPythonPackage,
+	wrapt, pytest, tox }:
+
+buildPythonPackage rec {
+  pname = "Deprecated";
+  version = "1.2.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1hcw9y7dvhwg5flk6wy8aa4kkgpvcqq3q4jd53h54586fp7w85d5";
+  };
+
+  postPatch = ''
+    # odd broken tests, don't appear in GitHub repo
+    rm tests/demo_classic_usage*.py
+  '';
+
+  propagatedBuildInputs = [ wrapt ];
+  checkInputs = [ pytest ];
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/tantale/deprecated";
+    description = "Python @deprecated decorator to deprecate old python classes, functions or methods";
+    platforms = platforms.all;
+    license = licenses.mit;
+    maintainers = with maintainers; [ tilpner ];
+  };
+}

--- a/pkgs/development/python-modules/pyGithub/default.nix
+++ b/pkgs/development/python-modules/pyGithub/default.nix
@@ -1,23 +1,20 @@
 { stdenv, fetchFromGitHub
-, buildPythonPackage, python-jose, pyjwt }:
+, buildPythonPackage, python-jose, pyjwt, requests, deprecated, httpretty }:
 
 buildPythonPackage rec {
   pname = "PyGithub";
-  version = "1.36";
-  name = pname + "-" + version;
+  version = "1.43.8";
 
   src = fetchFromGitHub {
     owner = "PyGithub";
     repo = "PyGithub";
     rev = "v${version}";
-    sha256 = "0yb74f9hg2vdsy766m850hfb1ss17lbgcdvvklm4qf72w12nxc5w";
+    sha256 = "1625v558xga5mwhl9jqmibywy5qafmg1vqrirqz6zfq1la1d22mw";
   };
 
-  postPatch = ''
-    # requires network
-    echo "" > github/tests/Issue142.py
-  '';
-  propagatedBuildInputs = [ python-jose pyjwt ];
+  propagatedBuildInputs = [ python-jose pyjwt requests deprecated httpretty ];
+  doCheck = false;
+
   meta = with stdenv.lib; {
     homepage = https://github.com/PyGithub/PyGithub;
     description = "A Python (2 and 3) library to access the GitHub API v3";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1890,6 +1890,8 @@ in {
 
   demjson = callPackage ../development/python-modules/demjson { };
 
+  deprecated = callPackage ../development/python-modules/deprecated { };
+
   deprecation = callPackage ../development/python-modules/deprecation { };
 
   derpconf = callPackage ../development/python-modules/derpconf { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

cc @jhhuh

Didn't manage to keep the tests on, something must have changed about import paths, but I don't know enough about Python packaging to tell what.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
