### PR TITLE
maven: Wrap mvnDebug for convenience

### DIFF
--- a/pkgs/development/tools/build-managers/apache-maven/builder.sh
+++ b/pkgs/development/tools/build-managers/apache-maven/builder.sh
@@ -6,6 +6,7 @@ mkdir -p $out/maven
 cp -r $name/* $out/maven
 
 makeWrapper $out/maven/bin/mvn $out/bin/mvn --set JAVA_HOME "$jdk"
+makeWrapper $out/maven/bin/mvnDebug $out/bin/mvnDebug --set JAVA_HOME "$jdk"
 
 # Add the maven-axis and JIRA plugin by default when using maven 1.x
 if [ -e $out/maven/bin/maven ]


### PR DESCRIPTION
Since maven 2.0.8, it is shipped with a debugger, mvnDebug, which is sometimes useful.
Wrapping it is more convenient for use, instead of looking for it in the nix store.

###### Things done

- Built on :
   - [x] NixOS
   - [ ] macOS

- Tested : 
- [x] Tested using **nix-env -f ~/sources/nixpkgs/ -iA maven**, then calling mvnDebug.


- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
