### PR TITLE
coqPackages.equations: 1.2beta2 -> 1.2

### DIFF
--- a/pkgs/development/coq-modules/category-theory/default.nix
+++ b/pkgs/development/coq-modules/category-theory/default.nix
@@ -8,15 +8,16 @@ let
       rev = "3b9ba7b26a64d49a55e8b6ccea570a7f32c11ead";
       sha256 = "0f2nr8dgn1ab7hr7jrdmr1zla9g9h8216q4yf4wnff9qkln8sbbs";
     };
-    v20181016 = {
-      version = "20181016";
-      rev = "8049479c5aee00ed0b92e5edc7c8996aebf48208";
-      sha256 = "14f9rlwh8vgmcl6njykvsiwxx0jn623375afixk26mzpy12zdcph";
+    v20190414 = {
+      version = "20190414";
+      rev = "706fdb4065cc2302d92ac2bce62cb59713253119";
+      sha256 = "16lg4xs2wzbdbsn148xiacgl4wq4xwfqjnjkdhfr3w0qh1s81hay";
     };
   in {
     "8.6" = v20180709;
     "8.7" = v20180709;
-    "8.8" = v20181016;
+    "8.8" = v20190414;
+    "8.9" = v20190414;
   };
   param = params."${coq.coq-version}";
 in

--- a/pkgs/development/coq-modules/equations/default.nix
+++ b/pkgs/development/coq-modules/equations/default.nix
@@ -15,15 +15,21 @@ let
     };
 
     "8.8" = {
-      version = "1.2beta2";
-      rev = "v1.2-beta2-8.8";
-      sha256 = "1v9asdlhhks25ngnjn4dafx7nrcc5p0lhriqckh3y79nxbgpq4lx";
+      version = "1.2";
+      rev = "v1.2-8.8";
+      sha256 = "06452fyzalz7zcjjp73qb7d6xvmqb6skljkivf8pfm55fsc8s7kx";
     };
 
     "8.9" = {
-      version = "1.2beta2";
-      rev = "v1.2-beta2-8.9";
-      sha256 = "0y2zwv7jxs1crprj5qvg46h0v9wyfn99ln40yskq91y9h1lj5h3j";
+      version = "1.2";
+      rev = "v1.2-8.9";
+      sha256 = "1q3wvicr43bgy7xn1diwh4j43mnrhprrc2xd22qlbz9cl6bhf8bj";
+    };
+
+    "8.10" = {
+      version = "1.2";
+      rev = "v1.2-8.10";
+      sha256 = "1v5kx0xzxzsbs5r4w08rm1lrmjjggnd3ap0sd1my88ds17jzyasd";
     };
   };
   param = params."${coq.coq-version}";


### PR DESCRIPTION
###### Motivation for this change

Final version, including bug fixes: https://mattam82.github.io/Coq-Equations/equations/2019/05/17/1.2.html

Also update `category-theory` that has been broken for a while. cc @jwiegley 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
