### PR TITLE
Add x2goserver module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -158,6 +158,7 @@
   ./programs/way-cooler.nix
   ./programs/waybar.nix
   ./programs/wireshark.nix
+  ./programs/x2goserver.nix
   ./programs/xfs_quota.nix
   ./programs/xonsh.nix
   ./programs/xss-lock.nix

--- a/nixos/modules/programs/x2goserver.nix
+++ b/nixos/modules/programs/x2goserver.nix
@@ -1,0 +1,148 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.x2goserver;
+
+  defaults = {
+    superenicer = { "enable" = cfg.superenicer.enable; };
+  };
+  confText = generators.toINI {} (recursiveUpdate defaults cfg.settings);
+  x2goServerConf = pkgs.writeText "x2goserver.conf" confText;
+
+  x2goAgentOptions = pkgs.writeText "x2goagent.options" ''
+    X2GO_NXOPTIONS=""
+    X2GO_NXAGENT_DEFAULT_OPTIONS="${concatStringsSep " " cfg.nxagentDefaultOptions}"
+  '';
+
+in {
+  options.programs.x2goserver = {
+    enable = mkEnableOption "x2goserver" // {
+      description = ''
+        Enables the x2goserver module.
+        NOTE: This will create a good amount of symlinks in `/usr/local/bin`
+      '';
+    };
+
+    superenicer = {
+      enable = mkEnableOption "superenicer" // {
+        description = ''
+          Enables the SupeReNicer code in x2gocleansessions, this will renice
+          suspended sessions to nice level 19 and renice them to level 0 if the
+          session becomes marked as running again
+        '';
+      };
+    };
+
+    nxagentDefaultOptions = mkOption {
+      type = types.listOf types.str;
+      default = [ "-extension GLX" "-nolisten tcp" ];
+      example = [ "-extension GLX" "-nolisten tcp" ];
+      description = ''
+        List of default nx agent options.
+      '';
+    };
+
+    settings = mkOption {
+      type = types.attrsOf types.attrs;
+      default = {};
+      description = ''
+        x2goserver.conf ini configuration as nix attributes. See
+        `x2goserver.conf(5)` for details
+      '';
+      example = literalExample ''
+        superenicer = {
+          "enable" = "yes";
+          "idle-nice-level" = 19;
+        };
+        telekinesis = { "enable" = "no"; };
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    environment.systemPackages = [ pkgs.x2goserver ];
+
+    users.groups.x2go = {};
+    users.users.x2go = {
+      home = "/var/lib/x2go/db";
+      group = "x2go";
+    };
+
+    security.wrappers.x2gosqliteWrapper = {
+      source = "${pkgs.x2goserver}/lib/x2go/libx2go-server-db-sqlite3-wrapper.pl";
+      owner = "x2go";
+      group = "x2go";
+      setgid = true;
+    };
+    security.wrappers.x2goprintWrapper = {
+      source = "${pkgs.x2goserver}/bin/x2goprint";
+      owner = "x2go";
+      group = "x2go";
+      setgid = true;
+    };
+
+    systemd.tmpfiles.rules = with pkgs; [
+      "d /var/lib/x2go/ - x2go x2go - -"
+      "d /var/lib/x2go/db - x2go x2go - -"
+      "d /var/lib/x2go/conf - x2go x2go - -"
+      "d /run/x2go 0755 x2go x2go - -"
+    ] ++
+    # x2goclient sends SSH commands with preset PATH set to
+    # "/usr/local/bin;/usr/bin;/bin". Since we cannot filter arbitrary ssh
+    # commands, we have to make the following executables available.
+    map (f: "L+ /usr/local/bin/${f} - - - - ${x2goserver}/bin/${f}") [
+      "x2goagent" "x2gobasepath" "x2gocleansessions" "x2gocmdexitmessage"
+      "x2godbadmin" "x2gofeature" "x2gofeaturelist" "x2gofm" "x2gogetapps"
+      "x2gogetservers" "x2golistdesktops" "x2golistmounts" "x2golistsessions"
+      "x2golistsessions_root" "x2golistshadowsessions" "x2gomountdirs"
+      "x2gopath" "x2goprint" "x2goresume-desktopsharing" "x2goresume-session"
+      "x2goruncommand" "x2goserver-run-extensions" "x2gosessionlimit"
+      "x2gosetkeyboard" "x2goshowblocks" "x2gostartagent"
+      "x2gosuspend-desktopsharing" "x2gosuspend-session"
+      "x2goterminate-desktopsharing" "x2goterminate-session"
+      "x2goumount-session" "x2goversion"
+    ] ++ [
+      "L+ /usr/local/bin/awk - - - - ${gawk}/bin/awk"
+      "L+ /usr/local/bin/chmod - - - - ${coreutils}/bin/chmod"
+      "L+ /usr/local/bin/cp - - - - ${coreutils}/bin/cp"
+      "L+ /usr/local/bin/sed - - - - ${gnused}/bin/sed"
+      "L+ /usr/local/bin/setsid - - - - ${utillinux}/bin/setsid"
+      "L+ /usr/local/bin/xrandr - - - - ${xorg.xrandr}/bin/xrandr"
+      "L+ /usr/local/bin/xmodmap - - - - ${xorg.xmodmap}/bin/xmodmap"
+    ];
+
+    systemd.services.x2goserver = {
+      description = "X2Go Server Daemon";
+      wantedBy = [ "multi-user.target" ];
+      unitConfig.Documentation = "man:x2goserver.conf(5)";
+      serviceConfig = {
+        Type = "forking";
+        ExecStart = "${pkgs.x2goserver}/bin/x2gocleansessions";
+        PIDFile = "/run/x2go/x2goserver.pid";
+        User = "x2go";
+        Group = "x2go";
+        RuntimeDirectory = "x2go";
+        StateDirectory = "x2go";
+      };
+      preStart = ''
+        if [ ! -e /var/lib/x2go/setup_ran ]
+        then
+          mkdir -p /var/lib/x2go/conf
+          cp -r ${pkgs.x2goserver}/etc/x2go/* /var/lib/x2go/conf/
+          ln -sf ${x2goServerConf} /var/lib/x2go/conf/x2goserver.conf
+          ln -sf ${x2goAgentOptions} /var/lib/x2go/conf/x2goagent.options
+          ${pkgs.x2goserver}/bin/x2godbadmin --createdb
+          touch /var/lib/x2go/setup_ran
+        fi
+      '';
+    };
+
+    # https://bugs.x2go.org/cgi-bin/bugreport.cgi?bug=276
+    security.sudo.extraConfig = ''
+      Defaults  env_keep+=QT_GRAPHICSSYSTEM
+    '';
+  };
+}

--- a/pkgs/applications/networking/remote/x2goserver/default.nix
+++ b/pkgs/applications/networking/remote/x2goserver/default.nix
@@ -1,0 +1,93 @@
+{ stdenv, lib, fetchurl, perlPackages, makeWrapper, perl, which, nx-libs
+, utillinux, coreutils, glibc, gawk, gnused, gnugrep, findutils, xorg
+, nettools, iproute, bc, procps, psmisc, lsof, pwgen, openssh, sshfs, bash
+}:
+
+let
+  pname = "x2goserver";
+  version = "4.1.0.3";
+
+  src = fetchurl {
+    url = "http://code.x2go.org/releases/source/x2goserver/${pname}-${version}.tar.gz";
+    sha256 = "1l6wd708kbipib4ldprfiihqmj4895nifg0bkws4x97majislxk7";
+  };
+
+  x2go-perl = perlPackages.buildPerlPackage rec {
+    pname = "X2Go";
+    inherit version src;
+    makeFlags = [ "-f" "Makefile.perl" ];
+    patchPhase = ''
+      substituteInPlace X2Go/Config.pm --replace '/etc/x2go' '/var/lib/x2go/conf'
+      substituteInPlace X2Go/Server/DB.pm \
+        --replace '$x2go_lib_path/libx2go-server-db-sqlite3-wrapper' \
+                  '/run/wrappers/bin/x2gosqliteWrapper'
+      substituteInPlace X2Go/Server/DB/SQLite3.pm --replace "user='x2gouser'" "user='x2go'"
+    '';
+  };
+
+  perlEnv = perl.withPackages (p: with p; [
+    x2go-perl DBI DBDSQLite FileBaseDir TryTiny CaptureTiny ConfigSimple Switch
+  ]);
+
+  binaryDeps = [
+    perlEnv which nx-libs utillinux coreutils glibc.bin gawk gnused gnugrep
+    findutils nettools iproute bc procps psmisc lsof pwgen openssh sshfs
+    xorg.xauth xorg.xinit xorg.xrandr xorg.xmodmap xorg.xwininfo xorg.fontutil
+    xorg.xkbcomp xorg.setxkbmap
+  ];
+in
+stdenv.mkDerivation rec {
+  inherit pname version src;
+
+  buildInputs = [ perlEnv bash ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  prePatch = ''
+    patchShebangs .
+    sed -i '/Makefile.PL\|Makefile.perl/d' Makefile
+    for i in */Makefile; do
+      substituteInPlace "$i" --replace "-o root -g root " ""
+    done
+    substituteInPlace libx2go-server-db-perl/Makefile --replace "chmod 2755" "chmod 755"
+    for i in x2goserver/sbin/x2godbadmin x2goserver/bin/x2go*
+    do
+      substituteInPlace $i --replace '/etc/x2go' '/var/lib/x2go/conf'
+    done
+    substituteInPlace x2goserver/sbin/x2gocleansessions \
+      --replace '/var/run/x2goserver.pid' '/var/run/x2go/x2goserver.pid'
+    substituteInPlace x2goserver/sbin/x2godbadmin --replace 'user="x2gouser"' 'user="x2go"'
+    substituteInPlace x2goserver-xsession/etc/Xsession \
+      --replace "SSH_AGENT /bin/bash -c" "SSH_AGENT ${bash}/bin/bash -c" \
+      --replace "[ -f /etc/redhat-release ]" "[ -d /etc/nix ] || [ -f /etc/redhat-release ]"
+  '';
+
+  makeFlags = [ "PREFIX=/" "NXLIBDIR=${nx-libs}/lib/nx" ];
+
+  installFlags = [ "DESTDIR=$(out)" ];
+
+  postInstall = ''
+    mv $out/etc/x2go/x2goserver.conf{,.example}
+    mv $out/etc/x2go/x2goagent.options{,.example}
+    ln -sf ${nx-libs}/bin/nxagent $out/bin/x2goagent
+    for i in $out/sbin/x2go* $(find $out/bin -type f) \
+      $(ls $out/lib/x2go/x2go* | grep -v x2gocheckport)
+    do
+      wrapProgram $i --prefix PATH : ${lib.makeBinPath binaryDeps}:$out
+    done
+    # We're patching @INC of the setgid wrapper, because we can't mix
+    # the perl wrapper (for PERL5LIB) with security.wrappers (for setgid)
+    sed -ie "s,.\+bin/perl,#!${perl}/bin/perl -I ${perlEnv}/lib/perl5/site_perl," \
+      $out/lib/x2go/libx2go-server-db-sqlite3-wrapper.pl
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Remote desktop application, server component";
+    homepage = "http://x2go.org/";
+    platforms = stdenv.lib.platforms.linux;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.averelld ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21331,6 +21331,8 @@ in
 
   x2goclient = libsForQt5.callPackage ../applications/networking/remote/x2goclient { };
 
+  x2goserver = callPackage ../applications/networking/remote/x2goserver { };
+
   x2vnc = callPackage ../tools/X11/x2vnc { };
 
   x32edit = callPackage ../applications/audio/midas/x32edit.nix {};

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -2879,6 +2879,18 @@ let
     };
   };
 
+  ConfigSimple = buildPerlPackage {
+    pname = "Config-Simple";
+    version = "4.59";
+    src = fetchurl {
+      url = mirror://cpan/authors/id/S/SH/SHERZODR/Config-Simple-4.59.tar.gz;
+      sha256 = "0m0hg29baarw5ds768q9r4rxb27im8kj4fazyf9gjqw4mmssjy6b";
+    };
+    meta = {
+      description = "Simple configuration file class";
+    };
+  };
+
   ConfigStd = buildPerlModule {
     pname = "Config-Std";
     version = "0.903";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Packages x2goserver, the server side of x2goclient, a remote desktop solution based on some ancient X-server proxy and a lot of aging Perl scripts. Unfortunately no modern open source alternative exists with similar performance. Based mainly on the already existing nxagent from nx-libs.

Lots of hardcoded paths make this a little tricky, see the module component for some uglyness. I have been using this (mostly based on top of 19.03) locally for a while, and it's stable. But there are tons of moving parts, such as printing and sound, or various desktop environments (for example I use only xfce4) that have not been tested.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
