### PR TITLE
squashfuse - fix sha for 0.1.103

### DIFF
--- a/pkgs/tools/filesystems/squashfuse/default.nix
+++ b/pkgs/tools/filesystems/squashfuse/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     owner = "vasi";
     repo  = "${pname}";
     rev = "540204955134eee44201d50132a5f66a246bcfaf";
-    sha256 = "07jv4qjjz9ky3mw3p5prgs19g1bna9dcd7jjdz8083s1wyipdgcq";
+    sha256 = "062s77y32p80vc24a79z31g90b9wxzvws1xvicgx5fn1pd0xa0q6";
   };
 
   nativeBuildInputs = [ autoreconfHook libtool pkgconfig ];


### PR DESCRIPTION
This sha was from 0.1.101

Before:
```
$ grep -B 1 sha default.nix
    rev = "540204955134eee44201d50132a5f66a246bcfaf";
    sha256 = "07jv4qjjz9ky3mw3p5prgs19g1bna9dcd7jjdz8083s1wyipdgcq";

$ nix-build -E 'with import <nixpkgs> {}; callPackage ./default.nix {}'
these paths will be fetched (2.21 MiB download, 12.08 MiB unpacked):
  /nix/store/847cqb062fl6j0vxp2mk3kx392711kyw-pcre-8.43
  /nix/store/cb9f9d1a1gg9kyjb5bzaxwg7zjfb1wrs-fuse-2.9.9
  /nix/store/gnkgv4i8kkn6zf1d6v7bzmsf8ksv3yys-lzo-2.10
  /nix/store/hl4hc5i5x8dv8p5l09mb4i7p8d8kfy9n-zstd-1.4.0
  /nix/store/hzjx5kj1s5a5aj28wsk22vpggs1jcqnw-util-linux-2.33.1-bin
  /nix/store/mki5p8408jklwf0znj9160r4msjzglk3-lz4-1.8.3
  /nix/store/mzvffy1yvzq8mhygga1r7q0npc7qcdnb-gnugrep-3.3
  /nix/store/rqmcbh8hxms5pc92z4namrqx8hanfjyl-util-linux-2.33.1
  /nix/store/x16x3l0xjad9mbyvn6405y340l28iwcq-squashfuse-0.1.103
copying path '/nix/store/mki5p8408jklwf0znj9160r4msjzglk3-lz4-1.8.3' from 'https://cache.nixos.org'...
copying path '/nix/store/gnkgv4i8kkn6zf1d6v7bzmsf8ksv3yys-lzo-2.10' from 'https://cache.nixos.org'...
copying path '/nix/store/847cqb062fl6j0vxp2mk3kx392711kyw-pcre-8.43' from 'https://cache.nixos.org'...
copying path '/nix/store/rqmcbh8hxms5pc92z4namrqx8hanfjyl-util-linux-2.33.1' from 'https://cache.nixos.org'...
copying path '/nix/store/mzvffy1yvzq8mhygga1r7q0npc7qcdnb-gnugrep-3.3' from 'https://cache.nixos.org'...
copying path '/nix/store/hzjx5kj1s5a5aj28wsk22vpggs1jcqnw-util-linux-2.33.1-bin' from 'https://cache.nixos.org'...
copying path '/nix/store/hl4hc5i5x8dv8p5l09mb4i7p8d8kfy9n-zstd-1.4.0' from 'https://cache.nixos.org'...
copying path '/nix/store/cb9f9d1a1gg9kyjb5bzaxwg7zjfb1wrs-fuse-2.9.9' from 'https://cache.nixos.org'...
copying path '/nix/store/x16x3l0xjad9mbyvn6405y340l28iwcq-squashfuse-0.1.103' from 'https://cache.nixos.org'...
/nix/store/x16x3l0xjad9mbyvn6405y340l28iwcq-squashfuse-0.1.103

$ ./result/bin/squashfuse_ll -h
squashfuse 0.1.101 (c) 2012 Dave Vasilevsky
```

After:
```
$ grep -B 1 sha default.nix
    rev = "540204955134eee44201d50132a5f66a246bcfaf";
    sha256 = "062s77y32p80vc24a79z31g90b9wxzvws1xvicgx5fn1pd0xa0q6";

$ nix-build -E 'with import <nixpkgs> {}; callPackage ./default.nix {}'
these derivations will be built:
  /nix/store/kqa03vhiazr4x5bsmn8k7q2ld2hmx44z-source.drv
  /nix/store/gcl771ydc882l7vnw5vadpnr4xni3hdh-squashfuse-0.1.103.drv
these paths will be fetched (55.13 MiB download, 252.08 MiB unpacked):
  /nix/store/0bjp89ji70xl81j55wg2ixkf9xmaijcv-bison-3.3.2
  /nix/store/0dsk1x8j94pzd65fnysjc6wa1zad1s3d-nghttp2-1.38.0
  /nix/store/2czn8xhnpx82802v4lww80r4q6s3xhyk-patch-2.7.6
  /nix/store/31raqw28q43v4spkfzsiiihqx2jm5a8i-unzip-6.0
  /nix/store/3h8wyghnjzk8hn4f5zhwvvlwq9xrpry8-expand-response-params
  /nix/store/3k6hy33b1dkdfldii7s5f4vy9lll74x5-mirrors-list
  /nix/store/5c5yyihla8kzzy82sa1bf34m61isfzm1-linux-headers-4.19.16
  /nix/store/6a1djj4dvsd8bdvs544krj64zlq2d1xf-gcc-7.4.0
  /nix/store/6yg0jj8x9agnzqh94nxxlfwjjxjn2z35-gnumake-4.2.1
  /nix/store/6yjpyqkx6d9k5f2s2g8h9kz40q6rz1yx-binutils-2.31.1
  /nix/store/7vhy5372gjpfj9day5wrvch54mwj4l8d-stdenv-linux
  /nix/store/96sxibafi2h67xljsgkh9ix2j616iqrd-nghttp2-1.38.0-dev
  /nix/store/b2fy54j80bizmnfaqxy3rl0vk2006jm4-gawk-4.2.1
  /nix/store/bz73l5rgz7wffmfxwqnsdz48vzh7il95-c-ares-1.15.0
  /nix/store/c8ifvpkrr7lgr3j475gabqzs5bm8sk4z-binutils-wrapper-2.31.1
  /nix/store/dd6g1cvqk791l7zqznfhfqi1pgy56qdx-curl-7.64.1-dev
  /nix/store/dmjc6zqbr5h36rw3jy9qzcnl3mgnl1n8-hook
  /nix/store/dsjpr08xs2bcr9bphcmd53m8if31z2kk-diffutils-3.7
  /nix/store/fzdm7x4j4nf8d4a8lrcabbf4zi7s0ys6-libtool-2.4.6
  /nix/store/g6rhmp2xcdzgibhx1i4b32gvsxbcqj09-gnum4-1.4.18
  /nix/store/gk7whjwi6zg4a94v3pk5fk108m2x4d6z-pkg-config-0.29.2
  /nix/store/gx3xv0vnfrxf7zfb8h2hnw9pzzkygixy-libssh2-1.8.2-dev
  /nix/store/h9n269c03cky1q0h30y88px26fxmbwv7-nghttp2-1.38.0-bin
  /nix/store/i12myp4crs9blcjxbs598di17cp018h9-openssl-1.0.2r-bin
  /nix/store/i546smf3my4rvn2ymxarzzgivcvwksly-openssl-1.0.2r-dev
  /nix/store/j2mb6w72ycxpmabhhprbz3biczfnr27r-findutils-4.6.0
  /nix/store/jg5rlm10r0yvdmx0g8nl5z2rqjndfdzd-curl-7.64.1-bin
  /nix/store/jh11qj0kjsv5bslrdvn7qdcacah54d1j-xz-5.2.4-dev
  /nix/store/jyqagsh6yhfbx5w0xspwi91lfr3nyvda-stdenv-linux
  /nix/store/n0pjpb8gq2bd7nadav6ziz3xz7rvxx6z-libkrb5-1.17-dev
  /nix/store/nsnwjpp0yihpjhh9036hljzihjkawrip-ed-1.15
  /nix/store/prnm6wrsgfqcs684ymprnjvn1w6g10jg-lz4-1.8.3-dev
  /nix/store/ra3441ikg993p85kw3p1cnnm1g73h6hk-gcc-wrapper-7.4.0
  /nix/store/riaglhp3igiyi5r9ahg9yw9p6nb7iwi3-curl-7.64.1-man
  /nix/store/ry56l2m6y8ajx7613vvq17rqgffzga6f-gettext-0.19.8.1
  /nix/store/sahaj6vg42sfvdpmv43l4h4hxqaj4h1g-autoconf-2.69
  /nix/store/skc18xbf3sb6ik2q201qw42hjg8fq9r1-libev-4.25
  /nix/store/wzn5g91zj8ajqzdwwlyxcwaw4y1bj04h-perl-5.28.2
  /nix/store/xvq0kcfh5z66j6ir1fskn0cx3n3qbc44-automake-1.16.1
  /nix/store/yhm526ifvk6cb217r28h8m8vv2n3qzp8-libtool-2.4.6-lib
  /nix/store/yjdnj9pcjgb09xif4ngmf13vb8npklys-glibc-2.27-dev
  /nix/store/yya1b8cb81jv4i348f4kpaspafs1xqhi-zlib-1.2.11-dev
  /nix/store/zw60vbl6khdzcx8vwivm7gwz4bvam3xy-patchelf-0.9
copying path '/nix/store/b2fy54j80bizmnfaqxy3rl0vk2006jm4-gawk-4.2.1' from 'https://cache.nixos.org'...
copying path '/nix/store/6yjpyqkx6d9k5f2s2g8h9kz40q6rz1yx-binutils-2.31.1' from 'https://cache.nixos.org'...
copying path '/nix/store/bz73l5rgz7wffmfxwqnsdz48vzh7il95-c-ares-1.15.0' from 'https://cache.nixos.org'...
copying path '/nix/store/jg5rlm10r0yvdmx0g8nl5z2rqjndfdzd-curl-7.64.1-bin' from 'https://cache.nixos.org'...
copying path '/nix/store/riaglhp3igiyi5r9ahg9yw9p6nb7iwi3-curl-7.64.1-man' from 'https://cache.nixos.org'...
copying path '/nix/store/dsjpr08xs2bcr9bphcmd53m8if31z2kk-diffutils-3.7' from 'https://cache.nixos.org'...
copying path '/nix/store/nsnwjpp0yihpjhh9036hljzihjkawrip-ed-1.15' from 'https://cache.nixos.org'...
copying path '/nix/store/3h8wyghnjzk8hn4f5zhwvvlwq9xrpry8-expand-response-params' from 'https://cache.nixos.org'...
copying path '/nix/store/j2mb6w72ycxpmabhhprbz3biczfnr27r-findutils-4.6.0' from 'https://cache.nixos.org'...
copying path '/nix/store/g6rhmp2xcdzgibhx1i4b32gvsxbcqj09-gnum4-1.4.18' from 'https://cache.nixos.org'...
copying path '/nix/store/6yg0jj8x9agnzqh94nxxlfwjjxjn2z35-gnumake-4.2.1' from 'https://cache.nixos.org'...
copying path '/nix/store/0bjp89ji70xl81j55wg2ixkf9xmaijcv-bison-3.3.2' from 'https://cache.nixos.org'...
copying path '/nix/store/skc18xbf3sb6ik2q201qw42hjg8fq9r1-libev-4.25' from 'https://cache.nixos.org'...
copying path '/nix/store/ry56l2m6y8ajx7613vvq17rqgffzga6f-gettext-0.19.8.1' from 'https://cache.nixos.org'...
copying path '/nix/store/n0pjpb8gq2bd7nadav6ziz3xz7rvxx6z-libkrb5-1.17-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/gx3xv0vnfrxf7zfb8h2hnw9pzzkygixy-libssh2-1.8.2-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/yhm526ifvk6cb217r28h8m8vv2n3qzp8-libtool-2.4.6-lib' from 'https://cache.nixos.org'...
copying path '/nix/store/5c5yyihla8kzzy82sa1bf34m61isfzm1-linux-headers-4.19.16' from 'https://cache.nixos.org'...
copying path '/nix/store/prnm6wrsgfqcs684ymprnjvn1w6g10jg-lz4-1.8.3-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/yjdnj9pcjgb09xif4ngmf13vb8npklys-glibc-2.27-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/3k6hy33b1dkdfldii7s5f4vy9lll74x5-mirrors-list' from 'https://cache.nixos.org'...
copying path '/nix/store/c8ifvpkrr7lgr3j475gabqzs5bm8sk4z-binutils-wrapper-2.31.1' from 'https://cache.nixos.org'...
copying path '/nix/store/6a1djj4dvsd8bdvs544krj64zlq2d1xf-gcc-7.4.0' from 'https://cache.nixos.org'...
copying path '/nix/store/0dsk1x8j94pzd65fnysjc6wa1zad1s3d-nghttp2-1.38.0' from 'https://cache.nixos.org'...
copying path '/nix/store/ra3441ikg993p85kw3p1cnnm1g73h6hk-gcc-wrapper-7.4.0' from 'https://cache.nixos.org'...
copying path '/nix/store/h9n269c03cky1q0h30y88px26fxmbwv7-nghttp2-1.38.0-bin' from 'https://cache.nixos.org'...
copying path '/nix/store/fzdm7x4j4nf8d4a8lrcabbf4zi7s0ys6-libtool-2.4.6' from 'https://cache.nixos.org'...
copying path '/nix/store/96sxibafi2h67xljsgkh9ix2j616iqrd-nghttp2-1.38.0-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/2czn8xhnpx82802v4lww80r4q6s3xhyk-patch-2.7.6' from 'https://cache.nixos.org'...
copying path '/nix/store/zw60vbl6khdzcx8vwivm7gwz4bvam3xy-patchelf-0.9' from 'https://cache.nixos.org'...
copying path '/nix/store/wzn5g91zj8ajqzdwwlyxcwaw4y1bj04h-perl-5.28.2' from 'https://cache.nixos.org'...
copying path '/nix/store/gk7whjwi6zg4a94v3pk5fk108m2x4d6z-pkg-config-0.29.2' from 'https://cache.nixos.org'...
copying path '/nix/store/sahaj6vg42sfvdpmv43l4h4hxqaj4h1g-autoconf-2.69' from 'https://cache.nixos.org'...
copying path '/nix/store/xvq0kcfh5z66j6ir1fskn0cx3n3qbc44-automake-1.16.1' from 'https://cache.nixos.org'...
copying path '/nix/store/i12myp4crs9blcjxbs598di17cp018h9-openssl-1.0.2r-bin' from 'https://cache.nixos.org'...
copying path '/nix/store/dmjc6zqbr5h36rw3jy9qzcnl3mgnl1n8-hook' from 'https://cache.nixos.org'...
copying path '/nix/store/i546smf3my4rvn2ymxarzzgivcvwksly-openssl-1.0.2r-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/7vhy5372gjpfj9day5wrvch54mwj4l8d-stdenv-linux' from 'https://cache.nixos.org'...
copying path '/nix/store/jyqagsh6yhfbx5w0xspwi91lfr3nyvda-stdenv-linux' from 'https://cache.nixos.org'...
copying path '/nix/store/31raqw28q43v4spkfzsiiihqx2jm5a8i-unzip-6.0' from 'https://cache.nixos.org'...
copying path '/nix/store/jh11qj0kjsv5bslrdvn7qdcacah54d1j-xz-5.2.4-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/yya1b8cb81jv4i348f4kpaspafs1xqhi-zlib-1.2.11-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/dd6g1cvqk791l7zqznfhfqi1pgy56qdx-curl-7.64.1-dev' from 'https://cache.nixos.org'...
building '/nix/store/kqa03vhiazr4x5bsmn8k7q2ld2hmx44z-source.drv'...

trying https://github.com/vasi/squashfuse/archive/540204955134eee44201d50132a5f66a246bcfaf.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   157    0   157    0     0    501      0 --:--:-- --:--:-- --:--:--   501
100 58730    0 58730    0     0  56362      0 --:--:--  0:00:01 --:--:--  284k
unpacking source archive /tmp/nix-build-source.drv-0/540204955134eee44201d50132a5f66a246bcfaf.tar.gz
building '/nix/store/gcl771ydc882l7vnw5vadpnr4xni3hdh-squashfuse-0.1.103.drv'...
unpacking sources
unpacking source archive /nix/store/3634l5iajqgh2q1nj5w4xkk8kb9rb9mh-source
source root is source
patching sources
autoreconfPhase
autoreconf: Entering directory `.'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal --force -I m4 --install
aclocal: installing 'm4/pkg.m4' from '/nix/store/gk7whjwi6zg4a94v3pk5fk108m2x4d6z-pkg-config-0.29.2/share/aclocal/pkg.m4'
aclocal: installing 'm4/libtool.m4' from '/nix/store/fzdm7x4j4nf8d4a8lrcabbf4zi7s0ys6-libtool-2.4.6/share/aclocal/libtool.m4'
aclocal: installing 'm4/ltoptions.m4' from '/nix/store/fzdm7x4j4nf8d4a8lrcabbf4zi7s0ys6-libtool-2.4.6/share/aclocal/ltoptions.m4'
aclocal: installing 'm4/ltsugar.m4' from '/nix/store/fzdm7x4j4nf8d4a8lrcabbf4zi7s0ys6-libtool-2.4.6/share/aclocal/ltsugar.m4'
aclocal: installing 'm4/ltversion.m4' from '/nix/store/fzdm7x4j4nf8d4a8lrcabbf4zi7s0ys6-libtool-2.4.6/share/aclocal/ltversion.m4'
aclocal: installing 'm4/lt~obsolete.m4' from '/nix/store/fzdm7x4j4nf8d4a8lrcabbf4zi7s0ys6-libtool-2.4.6/share/aclocal/lt~obsolete.m4'
autoreconf: configure.ac: tracing
autoreconf: configure.ac: creating directory build-aux
autoreconf: running: libtoolize --copy --force
libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
libtoolize: copying file 'build-aux/ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
libtoolize: copying file 'm4/libtool.m4'
libtoolize: copying file 'm4/ltoptions.m4'
libtoolize: copying file 'm4/ltsugar.m4'
libtoolize: copying file 'm4/ltversion.m4'
libtoolize: copying file 'm4/lt~obsolete.m4'
autoreconf: running: /nix/store/sahaj6vg42sfvdpmv43l4h4hxqaj4h1g-autoconf-2.69/bin/autoconf --force
autoreconf: running: /nix/store/sahaj6vg42sfvdpmv43l4h4hxqaj4h1g-autoconf-2.69/bin/autoheader --force
autoreconf: running: automake --add-missing --copy --force-missing
configure.ac:8: installing 'build-aux/ar-lib'
configure.ac:8: installing 'build-aux/compile'
configure.ac:5: installing 'build-aux/config.guess'
configure.ac:5: installing 'build-aux/config.sub'
configure.ac:6: installing 'build-aux/install-sh'
configure.ac:6: installing 'build-aux/missing'
Makefile.am: installing 'build-aux/depcomp'
autoreconf: Leaving directory `.'
configuring
fixing libtool script ./build-aux/ltmain.sh
configure flags: --disable-static --disable-dependency-tracking --prefix=/nix/store/2f121bjbx0pkybs962q45878rhv66z5p-squashfuse-0.1.103
checking build system type... x86_64-pc-linux-gnu
checking host system type... x86_64-pc-linux-gnu
checking target system type... x86_64-pc-linux-gnu
checking for a BSD-compatible install... /nix/store/dfsviv3myzcwzc9l416xv92w1j33av25-coreutils-8.31/bin/install -c
checking whether build environment is sane... yes
checking for a thread-safe mkdir -p... /nix/store/dfsviv3myzcwzc9l416xv92w1j33av25-coreutils-8.31/bin/mkdir -p
checking for gawk... gawk
checking whether make sets $(MAKE)... yes
checking whether make supports nested variables... yes
checking whether make supports nested variables... (cached) yes
checking whether make supports the include directive... yes (GNU style)
checking for gcc... gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables...
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether gcc accepts -g... yes
checking for gcc option to accept ISO C89... none needed
checking whether gcc understands -c and -o together... yes
checking dependency style of gcc... none
checking the archiver (ar) interface... ar
checking how to print strings... printf
checking for a sed that does not truncate output... /nix/store/cch4zpdfh5acdx913dfvwjlvjy0a0ajz-gnused-4.7/bin/sed
checking for grep that handles long lines and -e... /nix/store/mzvffy1yvzq8mhygga1r7q0npc7qcdnb-gnugrep-3.3/bin/grep
checking for egrep... /nix/store/mzvffy1yvzq8mhygga1r7q0npc7qcdnb-gnugrep-3.3/bin/grep -E
checking for fgrep... /nix/store/mzvffy1yvzq8mhygga1r7q0npc7qcdnb-gnugrep-3.3/bin/grep -F
checking for ld used by gcc... ld
checking if the linker (ld) is GNU ld... yes
checking for BSD- or MS-compatible name lister (nm)... nm
checking the name lister (nm) interface... BSD nm
checking whether ln -s works... yes
checking the maximum length of command line arguments... 1572864
checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
checking for ld option to reload object files... -r
checking for objdump... objdump
checking how to recognize dependent libraries... pass_all
checking for dlltool... no
checking how to associate runtime and link libraries... printf %s\n
checking for archiver @FILE support... @
checking for strip... strip
checking for ranlib... ranlib
checking command to parse nm output from gcc object... ok
checking for sysroot... no
checking for a working dd... /nix/store/dfsviv3myzcwzc9l416xv92w1j33av25-coreutils-8.31/bin/dd
checking how to truncate binary pipes... /nix/store/dfsviv3myzcwzc9l416xv92w1j33av25-coreutils-8.31/bin/dd bs=4096 count=1
./configure: line 6862: /usr/bin/file: No such file or directory
checking for mt... no
checking if : is a manifest tool... no
checking how to run the C preprocessor... gcc -E
checking for ANSI C header files... yes
checking for sys/types.h... yes
checking for sys/stat.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for memory.h... yes
checking for strings.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for unistd.h... yes
checking for dlfcn.h... yes
checking for objdir... .libs
checking if gcc supports -fno-rtti -fno-exceptions... no
checking for gcc option to produce PIC... -fPIC -DPIC
checking if gcc PIC flag -fPIC -DPIC works... yes
checking if gcc static flag -static works... no
checking if gcc supports -c -o file.o... yes
checking if gcc supports -c -o file.o... (cached) yes
checking whether the gcc linker (ld) supports shared libraries... yes
checking whether -lc should be explicitly linked in... no
checking dynamic linker characteristics... GNU/Linux ld.so
checking how to hardcode library paths into programs... immediate
checking whether stripping libraries is possible... yes
checking if libtool supports shared libraries... yes
checking whether to build shared libraries... yes
checking whether to build static libraries... no
checking for pkg-config... /nix/store/gk7whjwi6zg4a94v3pk5fk108m2x4d6z-pkg-config-0.29.2/bin/pkg-config
checking pkg-config is at least version 0.9.0... yes
checking for gawk... (cached) gawk
checking for a sed that does not truncate output... (cached) /nix/store/cch4zpdfh5acdx913dfvwjlvjy0a0ajz-gnused-4.7/bin/sed
checking how to run the C preprocessor... gcc -E
checking for special C compiler options needed for large files... no
checking for _FILE_OFFSET_BITS value needed for large files... no
checking for option for POSIX-2001 preprocessor... none
checking how to enable all compiler warnings... -Wall
checking for QNX makedev... no
checking for sys/mkdev.h... no
checking for sys/sysmacros.h... yes
configure: checking for definition needed by makedev
checking if makedev works without changes... yes
configure: checking for definition needed by pread
checking if pread works without changes... no
checking if pread requires changing _DARWIN_C_SOURCE... no
checking if pread requires changing _NETBSD_SOURCE... no
checking if pread requires changing _XOPEN_SOURCE... yes
configure: checking for definition needed by S_IFSOCK
checking if S_IFSOCK works without changes... no
checking if S_IFSOCK requires changing _DARWIN_C_SOURCE... no
checking if S_IFSOCK requires changing _NETBSD_SOURCE... no
checking if S_IFSOCK requires changing _XOPEN_SOURCE... yes
checking for attr/xattr.h... no
configure: checking for definition needed by ENOATTR
checking if ENOATTR works without changes... no
checking if ENOATTR requires changing _DARWIN_C_SOURCE... no
checking if ENOATTR requires changing _NETBSD_SOURCE... no
checking if ENOATTR requires changing _XOPEN_SOURCE... no
checking if ENOATTR requires changing _BSD_SOURCE... no
checking if ENOATTR requires changing _GNU_SOURCE... no
checking if ENOATTR requires changing _POSIX_C_SOURCE... no
checking for library containing uncompress... -lz
checking zlib.h usability... yes
checking zlib.h presence... yes
checking for zlib.h... yes
checking for liblzma... yes
checking for library containing lzma_stream_buffer_decode... none required
checking lzma.h usability... yes
checking lzma.h presence... yes
checking for lzma.h... yes
checking for library containing lzo1x_decompress_safe... -llzo2
checking lzo/lzo1x.h usability... yes
checking lzo/lzo1x.h presence... yes
checking for lzo/lzo1x.h... yes
checking for library containing LZ4_decompress_safe... -llz4
checking lz4.h usability... yes
checking lz4.h presence... yes
checking for lz4.h... yes
checking for library containing ZSTD_decompress... -lzstd
checking zstd.h usability... yes
checking zstd.h presence... yes
checking for zstd.h... yes
checking for fuse >= 2.5... yes
checking for FUSE library... already present
checking for FUSE header... yes
checking whether fuse_lowlevel_new is declared... yes
checking for fuse_lowlevel_new... yes
checking whether fuse_add_direntry is declared... yes
checking whether fuse_add_dirent is declared... no
checking whether fuse_daemonize is declared... yes
checking whether fuse_session_remove_chan is declared... yes
checking for two-argument fuse_unmount... yes
checking for position argument to FUSE xattr operations... no
checking if make supports export... yes
checking for __le16... yes
checking that generated files are newer than configure... done
configure: creating ./config.status
config.status: creating Makefile
config.status: creating squashfuse.pc
config.status: creating config.h
config.status: executing depfiles commands
config.status: executing libtool commands

Compression support ....... : ZLIB XZ LZO LZ4 ZSTD
High-level FUSE driver .... : yes
Low-level FUSE driver ..... : yes
Demo program .............. : yes

building
build flags: SHELL=/nix/store/2ch3pwfv40ls6qhdmzwsz9wky9pq6cyl-bash-4.4-p23/bin/bash
make  all-am
make[1]: Entering directory '/tmp/nix-build-squashfuse-0.1.103.drv-0/source'
  CC       squashfuse-hl.o
SED="/nix/store/cch4zpdfh5acdx913dfvwjlvjy0a0ajz-gnused-4.7/bin/sed" ./gen_swap.sh ./squashfs_fs.h
  CC       libsquashfuse_la-swap.lo
  CC       libsquashfuse_la-cache.lo
  CC       libsquashfuse_la-table.lo
  CC       libsquashfuse_la-dir.lo
  CC       libsquashfuse_la-file.lo
  CC       libsquashfuse_la-fs.lo
  CC       libsquashfuse_la-decompress.lo
  CC       libsquashfuse_la-xattr.lo
  CC       libsquashfuse_la-hash.lo
  CC       libsquashfuse_la-stack.lo
  CC       libsquashfuse_la-traverse.lo
  CC       libsquashfuse_la-util.lo
  CC       libsquashfuse_la-nonstd-pread.lo
  CC       libsquashfuse_la-nonstd-stat.lo
  CCLD     libsquashfuse.la
  CC       libfuseprivate_la-fuseprivate.lo
  CC       libfuseprivate_la-nonstd-makedev.lo
  CC       libfuseprivate_la-nonstd-enoattr.lo
  CCLD     libfuseprivate.la
  CCLD     squashfuse
  CC       squashfuse_ll-ll.o
  CC       squashfuse_ll-ll_inode.o
  CC       squashfuse_ll-nonstd-daemon.o
  CCLD     squashfuse_ll
  CC       ls.o
  CCLD     squashfuse_ls
  CC       squashfuse_extract-extract.o
extract.c: In function 'sqfs_stat':
extract.c:51:17: warning: implicit declaration of function 'sqfs_makedev'; did you mean 'sqfs_mode'? [-Wimplicit-function-declaration]
   st->st_rdev = sqfs_makedev(inode->xtra.dev.major,
                 ^~~~~~~~~~~~
                 sqfs_mode
  CCLD     squashfuse_extract
make[1]: Leaving directory '/tmp/nix-build-squashfuse-0.1.103.drv-0/source'
installing
install flags: SHELL=/nix/store/2ch3pwfv40ls6qhdmzwsz9wky9pq6cyl-bash-4.4-p23/bin/bash install
make[1]: Entering directory '/tmp/nix-build-squashfuse-0.1.103.drv-0/source'
 /nix/store/dfsviv3myzcwzc9l416xv92w1j33av25-coreutils-8.31/bin/mkdir -p '/nix/store/2f121bjbx0pkybs962q45878rhv66z5p-squashfuse-0.1.103/lib'
 /nix/store/2ch3pwfv40ls6qhdmzwsz9wky9pq6cyl-bash-4.4-p23/bin/bash ./libtool   --mode=install /nix/store/dfsviv3myzcwzc9l416xv92w1j33av25-coreutils-8.31/bin/install -c   libsquashfuse.la libfuseprivate.la '/nix/store/2f121bjbx0pkybs962q45878rhv66z5p-squashfuse-0.1.103/lib'
libtool: install: /nix/store/dfsviv3myzcwzc9l416xv92w1j33av25-coreutils-8.31/bin/install -c .libs/libsquashfuse.so.0.0.0 /nix/store/2f121bjbx0pkybs962q45878rhv66z5p-squashfuse-0.1.103/lib/libsquashfuse.so.0.0.0
libtool: install: (cd /nix/store/2f121bjbx0pkybs962q45878rhv66z5p-squashfuse-0.1.103/lib && { ln -s -f libsquashfuse.so.0.0.0 libsquashfuse.so.0 || { rm -f libsquashfuse.so.0 && ln -s libsquashfuse.so.0.0.0 libsquashfuse.so.0; }; })
libtool: install: (cd /nix/store/2f121bjbx0pkybs962q45878rhv66z5p-squashfuse-0.1.103/lib && { ln -s -f libsquashfuse.so.0.0.0 libsquashfuse.so || { rm -f libsquashfuse.so && ln -s libsquashfuse.so.0.0.0 libsquashfuse.so; }; })
libtool: install: /nix/store/dfsviv3myzcwzc9l416xv92w1j33av25-coreutils-8.31/bin/install -c .libs/libsquashfuse.lai /nix/store/2f121bjbx0pkybs962q45878rhv66z5p-squashfuse-0.1.103/lib/libsquashfuse.la
libtool: install: /nix/store/dfsviv3myzcwzc9l416xv92w1j33av25-coreutils-8.31/bin/install -c .libs/libfuseprivate.so.0.0.0 /nix/store/2f121bjbx0pkybs962q45878rhv66z5p-squashfuse-0.1.103/lib/libfuseprivate.so.0.0.0
libtool: install: (cd /nix/store/2f121bjbx0pkybs962q45878rhv66z5p-squashfuse-0.1.103/lib && { ln -s -f libfuseprivate.so.0.0.0 libfuseprivate.so.0 || { rm -f libfuseprivate.so.0 && ln -s libfuseprivate.so.0.0.0 libfuseprivate.so.0; }; })
libtool: install: (cd /nix/store/2f121bjbx0pkybs962q45878rhv66z5p-squashfuse-0.1.103/lib && { ln -s -f libfuseprivate.so.0.0.0 libfuseprivate.so || { rm -f libfuseprivate.so && ln -s libfuseprivate.so.0.0.0 libfuseprivate.so; }; })
libtool: install: /nix/store/dfsviv3myzcwzc9l416xv92w1j33av25-coreutils-8.31/bin/install -c .libs/libfuseprivate.lai /nix/store/2f121bjbx0pkybs962q45878rhv66z5p-squashfuse-0.1.103/lib/libfuseprivate.la
libtool: finish: PATH="/nix/store/sahaj6vg42sfvdpmv43l4h4hxqaj4h1g-autoconf-2.69/bin:/nix/store/xvq0kcfh5z66j6ir1fskn0cx3n3qbc44-automake-1.16.1/bin:/nix/store/ry56l2m6y8ajx7613vvq17rqgffzga6f-gettext-0.19.8.1/bin:/nix/store/fzdm7x4j4nf8d4a8lrcabbf4zi7s0ys6-libtool-2.4.6/bin:/nix/store/g6rhmp2xcdzgibhx1i4b32gvsxbcqj09-gnum4-1.4.18/bin:/nix/store/gk7whjwi6zg4a94v3pk5fk108m2x4d6z-pkg-config-0.29.2/bin:/nix/store/zw60vbl6khdzcx8vwivm7gwz4bvam3xy-patchelf-0.9/bin:/nix/store/ra3441ikg993p85kw3p1cnnm1g73h6hk-gcc-wrapper-7.4.0/bin:/nix/store/6a1djj4dvsd8bdvs544krj64zlq2d1xf-gcc-7.4.0/bin:/nix/store/ngf4xva3wvw1m0pb84v9h4jgl784lxkh-glibc-2.27-bin/bin:/nix/store/dfsviv3myzcwzc9l416xv92w1j33av25-coreutils-8.31/bin:/nix/store/c8ifvpkrr7lgr3j475gabqzs5bm8sk4z-binutils-wrapper-2.31.1/bin:/nix/store/6yjpyqkx6d9k5f2s2g8h9kz40q6rz1yx-binutils-2.31.1/bin:/nix/store/ngf4xva3wvw1m0pb84v9h4jgl784lxkh-glibc-2.27-bin/bin:/nix/store/dfsviv3myzcwzc9l416xv92w1j33av25-coreutils-8.31/bin:/nix/store/mki5p8408jklwf0znj9160r4msjzglk3-lz4-1.8.3/bin:/nix/store/hx8iii059gcfp2530kj453cbbx55rqlw-xz-5.2.4-bin/bin:/nix/store/hl4hc5i5x8dv8p5l09mb4i7p8d8kfy9n-zstd-1.4.0/bin:/nix/store/cb9f9d1a1gg9kyjb5bzaxwg7zjfb1wrs-fuse-2.9.9/bin:/nix/store/dfsviv3myzcwzc9l416xv92w1j33av25-coreutils-8.31/bin:/nix/store/j2mb6w72ycxpmabhhprbz3biczfnr27r-findutils-4.6.0/bin:/nix/store/dsjpr08xs2bcr9bphcmd53m8if31z2kk-diffutils-3.7/bin:/nix/store/cch4zpdfh5acdx913dfvwjlvjy0a0ajz-gnused-4.7/bin:/nix/store/mzvffy1yvzq8mhygga1r7q0npc7qcdnb-gnugrep-3.3/bin:/nix/store/b2fy54j80bizmnfaqxy3rl0vk2006jm4-gawk-4.2.1/bin:/nix/store/qxpnd7kdz119phdvhfica39pzbyi05sl-gnutar-1.32/bin:/nix/store/iyjjp49s7w3lm2w9n2p26vxzg0qyhbpk-gzip-1.10/bin:/nix/store/11hv812f14jzb3xjgb3g48z8b5rr71z9-bzip2-1.0.6.0.1-bin/bin:/nix/store/6yg0jj8x9agnzqh94nxxlfwjjxjn2z35-gnumake-4.2.1/bin:/nix/store/2ch3pwfv40ls6qhdmzwsz9wky9pq6cyl-bash-4.4-p23/bin:/nix/store/2czn8xhnpx82802v4lww80r4q6s3xhyk-patch-2.7.6/bin:/nix/store/hx8iii059gcfp2530kj453cbbx55rqlw-xz-5.2.4-bin/bin:/sbin" ldconfig -n /nix/store/2f121bjbx0pkybs962q45878rhv66z5p-squashfuse-0.1.103/lib
----------------------------------------------------------------------
Libraries have been installed in:
   /nix/store/2f121bjbx0pkybs962q45878rhv66z5p-squashfuse-0.1.103/lib

If you ever happen to want to link against installed libraries
in a given directory, LIBDIR, you must either use libtool, and
specify the full pathname of the library, or use the '-LLIBDIR'
flag during linking and do at least one of the following:
   - add LIBDIR to the 'LD_LIBRARY_PATH' environment variable
     during execution
   - add LIBDIR to the 'LD_RUN_PATH' environment variable
     during linking
   - use the '-Wl,-rpath -Wl,LIBDIR' linker flag

See any operating system documentation about shared libraries for
more information, such as the ld(1) and ld.so(8) manual pages.
----------------------------------------------------------------------
 /nix/store/dfsviv3myzcwzc9l416xv92w1j33av25-coreutils-8.31/bin/mkdir -p '/nix/store/2f121bjbx0pkybs962q45878rhv66z5p-squashfuse-0.1.103/bin'
  /nix/store/2ch3pwfv40ls6qhdmzwsz9wky9pq6cyl-bash-4.4-p23/bin/bash ./libtool   --mode=install /nix/store/dfsviv3myzcwzc9l416xv92w1j33av25-coreutils-8.31/bin/install -c squashfuse squashfuse_ll '/nix/store/2f121bjbx0pkybs962q45878rhv66z5p-squashfuse-0.1.103/bin'
libtool: install: /nix/store/dfsviv3myzcwzc9l416xv92w1j33av25-coreutils-8.31/bin/install -c .libs/squashfuse /nix/store/2f121bjbx0pkybs962q45878rhv66z5p-squashfuse-0.1.103/bin/squashfuse
libtool: install: /nix/store/dfsviv3myzcwzc9l416xv92w1j33av25-coreutils-8.31/bin/install -c .libs/squashfuse_ll /nix/store/2f121bjbx0pkybs962q45878rhv66z5p-squashfuse-0.1.103/bin/squashfuse_ll
 /nix/store/dfsviv3myzcwzc9l416xv92w1j33av25-coreutils-8.31/bin/mkdir -p '/nix/store/2f121bjbx0pkybs962q45878rhv66z5p-squashfuse-0.1.103/include'
 /nix/store/dfsviv3myzcwzc9l416xv92w1j33av25-coreutils-8.31/bin/install -c -m 644 squashfuse.h squashfs_fs.h '/nix/store/2f121bjbx0pkybs962q45878rhv66z5p-squashfuse-0.1.103/include'
 /nix/store/dfsviv3myzcwzc9l416xv92w1j33av25-coreutils-8.31/bin/mkdir -p '/nix/store/2f121bjbx0pkybs962q45878rhv66z5p-squashfuse-0.1.103/share/man/man1'
 /nix/store/dfsviv3myzcwzc9l416xv92w1j33av25-coreutils-8.31/bin/install -c -m 644 squashfuse.1 '/nix/store/2f121bjbx0pkybs962q45878rhv66z5p-squashfuse-0.1.103/share/man/man1'
 /nix/store/dfsviv3myzcwzc9l416xv92w1j33av25-coreutils-8.31/bin/mkdir -p '/nix/store/2f121bjbx0pkybs962q45878rhv66z5p-squashfuse-0.1.103/lib/pkgconfig'
 /nix/store/dfsviv3myzcwzc9l416xv92w1j33av25-coreutils-8.31/bin/install -c -m 644 squashfuse.pc '/nix/store/2f121bjbx0pkybs962q45878rhv66z5p-squashfuse-0.1.103/lib/pkgconfig'
make[1]: Leaving directory '/tmp/nix-build-squashfuse-0.1.103.drv-0/source'
post-installation fixup
shrinking RPATHs of ELF executables and libraries in /nix/store/2f121bjbx0pkybs962q45878rhv66z5p-squashfuse-0.1.103
shrinking /nix/store/2f121bjbx0pkybs962q45878rhv66z5p-squashfuse-0.1.103/lib/libsquashfuse.so.0.0.0
shrinking /nix/store/2f121bjbx0pkybs962q45878rhv66z5p-squashfuse-0.1.103/lib/libfuseprivate.so.0.0.0
shrinking /nix/store/2f121bjbx0pkybs962q45878rhv66z5p-squashfuse-0.1.103/bin/squashfuse_ll
shrinking /nix/store/2f121bjbx0pkybs962q45878rhv66z5p-squashfuse-0.1.103/bin/squashfuse
gzipping man pages under /nix/store/2f121bjbx0pkybs962q45878rhv66z5p-squashfuse-0.1.103/share/man/
strip is /nix/store/6yjpyqkx6d9k5f2s2g8h9kz40q6rz1yx-binutils-2.31.1/bin/strip
stripping (with command strip and flags -S) in /nix/store/2f121bjbx0pkybs962q45878rhv66z5p-squashfuse-0.1.103/lib  /nix/store/2f121bjbx0pkybs962q45878rhv66z5p-squashfuse-0.1.103/bin
patching script interpreter paths in /nix/store/2f121bjbx0pkybs962q45878rhv66z5p-squashfuse-0.1.103
checking for references to /tmp/nix-build-squashfuse-0.1.103.drv-0/ in /nix/store/2f121bjbx0pkybs962q45878rhv66z5p-squashfuse-0.1.103...
/nix/store/2f121bjbx0pkybs962q45878rhv66z5p-squashfuse-0.1.103

$ ./result/bin/squashfuse_ll -h
squashfuse 0.1.103 (c) 2012 Dave Vasilevsky
```

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Installing squashfuse  0.1.103 from nix installs an old version (0.1.101)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
