### PR TITLE
Add checkPhase to pythonPackages.astropy and several other related packages 

### DIFF
--- a/pkgs/development/python-modules/aplpy/default.nix
+++ b/pkgs/development/python-modules/aplpy/default.nix
@@ -11,13 +11,13 @@
 , pillow
 , scikitimage
 , shapely
+, pytest
+, pytest-astropy
 }:
 
 buildPythonPackage rec {
   pname = "aplpy";
   version = "2.0.3";
-
-  doCheck = false; # tests require pytest-astropy
 
   src = fetchPypi {
     pname = "APLpy";
@@ -28,7 +28,6 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     numpy
     astropy
-    astropy-helpers
     matplotlib
     reproject
     pyavm
@@ -38,9 +37,19 @@ buildPythonPackage rec {
     shapely
   ];
 
+  nativeBuildInputs = [ astropy-helpers ];
+
+  checkInputs = [ pytest pytest-astropy ];
+
   # Disable automatic update of the astropy-helper module
   postPatch = ''
     substituteInPlace setup.cfg --replace "auto_use = True" "auto_use = False"
+  '';
+
+  # Tests must be run in the build directory
+  checkPhase = ''
+    cd build/lib
+    pytest
   '';
 
   meta = with lib; {

--- a/pkgs/development/python-modules/astropy/default.nix
+++ b/pkgs/development/python-modules/astropy/default.nix
@@ -3,7 +3,10 @@
 , buildPythonPackage
 , isPy3k
 , numpy
-, pytest }:
+, pytest
+, pytest-astropy
+, astropy-helpers
+}:
 
 buildPythonPackage rec {
   pname = "astropy";
@@ -11,14 +14,30 @@ buildPythonPackage rec {
 
   disabled = !isPy3k; # according to setup.py
 
-  doCheck = false; #Some tests are failing. More importantly setup.py hangs on completion. Needs fixing with a proper shellhook.
-
   src = fetchPypi {
     inherit pname version;
     sha256 = "706c0457789c78285e5464a5a336f5f0b058d646d60f4e5f5ba1f7d5bf424b28";
   };
 
-  propagatedBuildInputs = [ pytest numpy ]; # yes it really has pytest in install_requires
+  nativeBuildInputs = [ astropy-helpers ];
+
+  propagatedBuildInputs = [ numpy pytest ]; # yes it really has pytest in install_requires
+
+  checkInputs = [ pytest pytest-astropy ];
+
+  # Disable automatic update of the astropy-helper module
+  postPatch = ''
+    substituteInPlace setup.cfg --replace "auto_use = True" "auto_use = False"
+  '';
+
+  # Tests must be run from the build directory.  astropy/samp tests
+  # require a network connection, so we ignore them. For some reason
+  # pytest --ignore does not work, so we delete the tests instead.
+  checkPhase = ''
+    cd build/lib.*
+    rm -f astropy/samp/tests/*
+    pytest
+  '';
 
   meta = {
     description = "Astronomy/Astrophysics library for Python";

--- a/pkgs/development/python-modules/astroquery/conftest-astropy-3-fix.patch
+++ b/pkgs/development/python-modules/astroquery/conftest-astropy-3-fix.patch
@@ -1,0 +1,54 @@
+diff -ruN astroquery-0.3.9.orig/astroquery/conftest.py astroquery-0.3.9/astroquery/conftest.py
+--- astroquery-0.3.9.orig/astroquery/conftest.py	2018-11-27 14:51:16.000000000 +0100
++++ astroquery-0.3.9/astroquery/conftest.py	2019-07-23 18:19:17.000000000 +0200
+@@ -5,15 +5,20 @@
+ # by importing them here in conftest.py they are discoverable by py.test
+ # no matter how it is invoked within the source tree.
+ 
+-from astropy.tests.pytest_plugins import (PYTEST_HEADER_MODULES,
+-                                          enable_deprecations_as_exceptions,
+-                                          TESTED_VERSIONS)
++from astropy.version import version as astropy_version
+ 
+-try:
+-    packagename = os.path.basename(os.path.dirname(__file__))
+-    TESTED_VERSIONS[packagename] = version.version
+-except NameError:
+-    pass
++if astropy_version < '3.0':
++    # With older versions of Astropy, we actually need to import the pytest
++    # plugins themselves in order to make them discoverable by pytest.
++    from astropy.tests.pytest_plugins import *
++else:
++    # As of Astropy 3.0, the pytest plugins provided by Astropy are
++    # automatically made available when Astropy is installed. This means it's
++    # not necessary to import them here, but we still need to import global
++    # variables that are used for configuration.
++    from astropy.tests.plugins.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
++
++from astropy.tests.helper import enable_deprecations_as_exceptions
+ 
+ # Add astropy to test header information and remove unused packages.
+ # Pytest header customisation was introduced in astropy 1.0.
+@@ -36,12 +41,17 @@
+     # The warnings_to_ignore_by_pyver parameter was added in astropy 2.0
+     enable_deprecations_as_exceptions(modules_to_ignore_on_import=['requests'])
+ 
++# add '_testrun' to the version name so that the user-agent indicates that
++# it's being run in a test
++from . import version
++version.version += '_testrun'
++
++
+ # This is to figure out the affiliated package version, rather than
+ # using Astropy's
+-try:
+-    from .version import version
+-except ImportError:
+-    version = 'dev'
++from .version import version, astropy_helpers_version
++
+ 
+ packagename = os.path.basename(os.path.dirname(__file__))
+ TESTED_VERSIONS[packagename] = version
++TESTED_VERSIONS['astropy_helpers'] = astropy_helpers_version

--- a/pkgs/development/python-modules/astroquery/default.nix
+++ b/pkgs/development/python-modules/astroquery/default.nix
@@ -6,20 +6,41 @@
 , keyring
 , beautifulsoup4
 , html5lib
+, pytest
+, pytest-astropy
+, astropy-helpers
 }:
 
 buildPythonPackage rec {
   pname = "astroquery";
   version = "0.3.9";
 
-  doCheck = false; # Tests require the pytest-astropy package
-
   src = fetchPypi {
     inherit pname version;
     sha256 = "0zw3xp2rfc6h2v569iqsyvzhfnzp7bfjb7jrj61is1hrqw1cqjrb";
   };
 
+  # Fix tests using conftest.py from HEAD in the upstream GitHub
+  # repository.
+  patches = [ ./conftest-astropy-3-fix.patch ];
+
   propagatedBuildInputs = [ astropy requests keyring beautifulsoup4 html5lib ];
+
+  nativeBuildInputs = [ astropy-helpers ];
+
+  checkInputs = [ pytest pytest-astropy ];
+
+  # Disable automatic update of the astropy-helper module
+  postPatch = ''
+    substituteInPlace setup.cfg --replace "auto_use = True" "auto_use = False"
+  '';
+
+  # Tests must be run in the build directory. The tests create files
+  # in $HOME/.astropy so we need to set HOME to $TMPDIR.
+  checkPhase = ''
+    cd build/lib
+    HOME=$TMPDIR pytest
+  '';
 
   meta = with pkgs.lib; {
     description = "Functions and classes to access online data resources";

--- a/pkgs/development/python-modules/pytest-arraydiff/default.nix
+++ b/pkgs/development/python-modules/pytest-arraydiff/default.nix
@@ -22,14 +22,10 @@ buildPythonPackage rec {
     pytest
   ];
 
-  checkInputs = [
-    pytest
-    astropy
-  ];
-
-  checkPhase = ''
-    pytest
-  '';
+  # The tests requires astropy, which itself requires
+  # pytest-arraydiff. This causes an infinite recursion if the tests
+  # are enabled.
+  doCheck = false;
 
   meta = with lib; {
     description = "Pytest plugin to help with comparing array output from tests";

--- a/pkgs/development/python-modules/radio_beam/default.nix
+++ b/pkgs/development/python-modules/radio_beam/default.nix
@@ -1,13 +1,16 @@
 { lib
 , fetchPypi
 , buildPythonPackage
-, astropy }:
+, astropy
+, pytest
+, pytest-astropy
+, astropy-helpers
+, scipy
+}:
 
 buildPythonPackage rec {
   pname = "radio_beam";
   version = "0.3.1";
-
-  doCheck = false; # the tests requires several pytest plugins that are not in nixpkgs
 
   src = fetchPypi {
     inherit pname version;
@@ -15,6 +18,21 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [ astropy ];
+
+  nativeBuildInputs = [ astropy-helpers ];
+
+  # Disable automatic update of the astropy-helper module
+  postPatch = ''
+    substituteInPlace setup.cfg --replace "auto_use = True" "auto_use = False"
+  '';
+
+  checkInputs = [ pytest pytest-astropy scipy ];
+
+  # Tests must be run in the build directory
+  checkPhase = ''
+    cd build/lib
+    pytest
+  '';
 
   meta = {
     description = "Tools for Beam IO and Manipulation";

--- a/pkgs/development/python-modules/spectral-cube/default.nix
+++ b/pkgs/development/python-modules/spectral-cube/default.nix
@@ -3,20 +3,36 @@
 , buildPythonPackage
 , astropy
 , radio_beam
-, pytest }:
+, pytest
+, pytest-astropy
+, astropy-helpers
+}:
 
 buildPythonPackage rec {
   pname = "spectral-cube";
   version = "0.4.4";
-
-  doCheck = false; # the tests requires several pytest plugins that are not in nixpkgs
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "9051ede204b1e25b6358b5e0e573b624ec0e208c24eb03a7ed4925b745c93b5e";
   };
 
-  propagatedBuildInputs = [ astropy radio_beam pytest ];
+  propagatedBuildInputs = [ astropy radio_beam ];
+
+  nativeBuildInputs = [ astropy-helpers ];
+
+  checkInputs = [ pytest pytest-astropy ];
+
+  # Disable automatic update of the astropy-helper module
+  postPatch = ''
+    substituteInPlace setup.cfg --replace "auto_use = True" "auto_use = False"
+  '';
+
+  # Tests must be run in the build directory
+  checkPhase = ''
+    cd build/lib
+    pytest
+  '';
 
   meta = {
     description = "Library for reading and analyzing astrophysical spectral data cubes";


### PR DESCRIPTION
###### Motivation for this change

Add a `checkPhase` in `pythonPackages.astropy` and several other related packages.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
