### PR TITLE
pythonPackages.scrapy: 1.7.1 -> 1.7.2

### DIFF
--- a/pkgs/development/python-modules/scrapy/default.nix
+++ b/pkgs/development/python-modules/scrapy/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, buildPythonPackage, fetchPypi, fetchpatch, glibcLocales, mock, pytest, botocore,
+{ stdenv, buildPythonPackage, fetchPypi, glibcLocales, mock, pytest, botocore,
   testfixtures, pillow, six, twisted, w3lib, lxml, queuelib, pyopenssl,
   service-identity, parsel, pydispatcher, cssselect, lib }:
 buildPythonPackage rec {
-  version = "1.7.1";
+  version = "1.7.2";
   pname = "Scrapy";
 
   checkInputs = [ glibcLocales mock pytest botocore testfixtures pillow ];
@@ -16,12 +16,6 @@ buildPythonPackage rec {
     # root and readonly. As a consequence scrapy can't edit the
     # project templates.
     ./permissions-fix.patch
-
-    # Fix configparser import for python2. See: https://github.com/scrapy/scrapy/pull/3887
-    (fetchpatch {
-      url = "https://github.com/scrapy/scrapy/commit/21345dc9ec60dcc1cd2e5c0eace5788aa502ce23.patch";
-      sha256 = "09834rcjyggvyj6zignvfga2xbqkknygly5p4a96k2mvz0xn3v6z";
-    })
   ];
 
   LC_ALL="en_US.UTF-8";
@@ -37,7 +31,7 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "da8987d199092c3bb33d4d1d021507cd933aa67f5177e2d36f31343e8a6bd7f1";
+    sha256 = "7a4ed68cfb44dc86e1895f0fb46257ee4adb1090754ac21faec205763f054464";
   };
 
   postInstall = ''


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
