### PR TITLE
RFC: Emacs 27 derivation

### DIFF
--- a/pkgs/applications/editors/emacs/clean-env-head.patch
+++ b/pkgs/applications/editors/emacs/clean-env-head.patch
@@ -1,0 +1,16 @@
+Dump temacs in an empty environment to prevent -dev paths from ending
+up in the dumped image.
+
+diff --git a/src/Makefile.in b/src/Makefile.in
+index fd05a45df5..13f529c253 100644
+--- a/src/Makefile.in
++++ b/src/Makefile.in
+@@ -570,7 +570,7 @@ emacs$(EXEEXT): temacs$(EXEEXT) \
+                 lisp.mk $(etc)/DOC $(lisp) \
+                 $(lispsource)/international/charprop.el ${charsets}
+ ifeq ($(DUMPING),unexec)
+-	LC_ALL=C $(RUN_TEMACS) -batch $(BUILD_DETAILS) -l loadup --temacs=dump
++	env -i LC_ALL=C $(RUN_TEMACS) -batch $(BUILD_DETAILS) -l loadup --temacs=dump
+   ifneq ($(PAXCTL_dumped),)
+ 	      $(PAXCTL_dumped) emacs$(EXEEXT)
+   endif

--- a/pkgs/applications/editors/emacs/head.nix
+++ b/pkgs/applications/editors/emacs/head.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchurl, ncurses, xlibsWrapper, libXaw, libXpm
 , Xaw3d, libXcursor,  pkgconfig, gettext, libXft, dbus, libpng, libjpeg, libungif
 , libtiff, librsvg, gconf, libxml2, imagemagick, gnutls, libselinux
-, alsaLib, cairo, acl, gpm, AppKit, GSS, ImageIO, m17n_lib, libotf
+, alsaLib, cairo, acl, gpm, AppKit, GSS, ImageIO, m17n_lib, libotf, jansson
 , fetchFromGitHub
 , systemd ? null
 , withX ? !stdenv.isDarwin
@@ -38,8 +38,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "emacs-mirror";
     repo = "emacs";
-    rev = "dfb0ba79b5f41ca6fed25a03d2a5cd6996ec4753";
-    sha256 = "0cr8mlcxyib4rd8xj65hb1wxwlmppgg4823z7h3dbbxi273gz5b0";
+    rev = "dd162a3f2264940e3e329d0bfb195f56d00ed08f";
+    sha256 = "17gc4cfyazag2p601l3pkxad5153rwf5503y07x2l48ndc784mx9";
   };
 
   enableParallelBuilding = true;
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
     ++ lib.optional (withX && (withGTK3 || withXwidgets)) wrapGAppsHook;
 
   buildInputs =
-    [ ncurses gconf libxml2 gnutls alsaLib acl gpm gettext ]
+    [ ncurses gconf libxml2 gnutls alsaLib acl gpm gettext jansson ]
     ++ lib.optionals stdenv.isLinux [ dbus libselinux systemd ]
     ++ lib.optionals withX
       [ xlibsWrapper libXaw Xaw3d libXpm libpng libjpeg libungif libtiff librsvg libXft

--- a/pkgs/applications/editors/emacs/head.nix
+++ b/pkgs/applications/editors/emacs/head.nix
@@ -1,0 +1,160 @@
+{ stdenv, lib, fetchurl, ncurses, xlibsWrapper, libXaw, libXpm
+, Xaw3d, libXcursor,  pkgconfig, gettext, libXft, dbus, libpng, libjpeg, libungif
+, libtiff, librsvg, gconf, libxml2, imagemagick, gnutls, libselinux
+, alsaLib, cairo, acl, gpm, AppKit, GSS, ImageIO, m17n_lib, libotf
+, fetchFromGitHub
+, systemd ? null
+, withX ? !stdenv.isDarwin
+, withNS ? stdenv.isDarwin
+, withGTK2 ? false, gtk2-x11 ? null
+, withGTK3 ? true, gtk3-x11 ? null, gsettings-desktop-schemas ? null
+, withXwidgets ? false, webkitgtk ? null, wrapGAppsHook ? null
+, withCsrc ? true
+, srcRepo ? true, autoconf ? null, automake ? null, texinfo ? null
+, siteStart ? ./site-start.el
+}:
+
+assert (libXft != null) -> libpng != null;      # probably a bug
+assert stdenv.isDarwin -> libXaw != null;       # fails to link otherwise
+assert withNS -> !withX;
+assert withNS -> stdenv.isDarwin;
+assert (withGTK2 && !withNS) -> withX;
+assert (withGTK3 && !withNS) -> withX;
+assert withGTK2 -> !withGTK3 && gtk2-x11 != null;
+assert withGTK3 -> !withGTK2 && gtk3-x11 != null;
+assert withXwidgets -> withGTK3 && webkitgtk != null;
+
+let
+  toolkit =
+    if withGTK2 then "gtk2"
+    else if withGTK3 then "gtk3"
+    else "lucid";
+in
+stdenv.mkDerivation rec {
+  name = "emacs-${version}${versionModifier}";
+  version = "27";
+  versionModifier = "";
+
+  src = fetchFromGitHub {
+    owner = "emacs-mirror";
+    repo = "emacs";
+    rev = "dfb0ba79b5f41ca6fed25a03d2a5cd6996ec4753";
+    sha256 = "0cr8mlcxyib4rd8xj65hb1wxwlmppgg4823z7h3dbbxi273gz5b0";
+  };
+
+  enableParallelBuilding = true;
+
+  patches = [
+    # ./clean-env.patch
+    ./tramp-detect-wrapped-gvfsd.patch
+  ];
+
+  postPatch = lib.optionalString srcRepo ''
+    rm -fr .git
+  '';
+
+  CFLAGS = "-DMAC_OS_X_VERSION_MAX_ALLOWED=101200";
+
+  nativeBuildInputs = [ pkgconfig ]
+    ++ lib.optionals srcRepo [ autoconf automake texinfo ]
+    ++ lib.optional (withX && (withGTK3 || withXwidgets)) wrapGAppsHook;
+
+  buildInputs =
+    [ ncurses gconf libxml2 gnutls alsaLib acl gpm gettext ]
+    ++ lib.optionals stdenv.isLinux [ dbus libselinux systemd ]
+    ++ lib.optionals withX
+      [ xlibsWrapper libXaw Xaw3d libXpm libpng libjpeg libungif libtiff librsvg libXft
+        gconf ]
+    ++ lib.optionals (withX || withNS) [ imagemagick ]
+    ++ lib.optionals (stdenv.isLinux && withX) [ m17n_lib libotf ]
+    ++ lib.optional (withX && withGTK2) gtk2-x11
+    ++ lib.optionals (withX && withGTK3) [ gtk3-x11 gsettings-desktop-schemas ]
+    ++ lib.optional (stdenv.isDarwin && withX) cairo
+    ++ lib.optionals (withX && withXwidgets) [ webkitgtk ]
+    ++ lib.optionals withNS [ AppKit GSS ImageIO ];
+
+  hardeningDisable = [ "format" ];
+
+  configureFlags = [
+    "--disable-build-details" # for a (more) reproducible build
+    "--with-modules"
+  ] ++
+    (lib.optional stdenv.isDarwin
+      (lib.withFeature withNS "ns")) ++
+    (if withNS
+      then [ "--disable-ns-self-contained" ]
+    else if withX
+      then [ "--with-x-toolkit=${toolkit}" "--with-xft" ]
+      else [ "--with-x=no" "--with-xpm=no" "--with-jpeg=no" "--with-png=no"
+             "--with-gif=no" "--with-tiff=no" ])
+    ++ lib.optional withXwidgets "--with-xwidgets";
+
+  preConfigure = lib.optionalString srcRepo ''
+    ./autogen.sh
+  '' + ''
+    substituteInPlace lisp/international/mule-cmds.el \
+      --replace /usr/share/locale ${gettext}/share/locale
+
+    for makefile_in in $(find . -name Makefile.in -print); do
+        substituteInPlace $makefile_in --replace /bin/pwd pwd
+    done
+  '';
+
+  installTargets = "tags install";
+
+  postInstall = ''
+    mkdir -p $out/share/emacs/site-lisp
+    cp ${siteStart} $out/share/emacs/site-lisp/site-start.el
+    $out/bin/emacs --batch -f batch-byte-compile $out/share/emacs/site-lisp/site-start.el
+
+    rm -rf $out/var
+    rm -rf $out/share/emacs/${version}/site-lisp
+  '' + lib.optionalString withCsrc ''
+    for srcdir in src lisp lwlib ; do
+      dstdir=$out/share/emacs/${version}/$srcdir
+      mkdir -p $dstdir
+      find $srcdir -name "*.[chm]" -exec cp {} $dstdir \;
+      cp $srcdir/TAGS $dstdir
+      echo '((nil . ((tags-file-name . "TAGS"))))' > $dstdir/.dir-locals.el
+    done
+  '' + lib.optionalString withNS ''
+    mkdir -p $out/Applications
+    mv nextstep/Emacs.app $out/Applications
+  '';
+
+  postFixup =
+    let libPath = lib.makeLibraryPath [
+      libXcursor
+    ];
+    in lib.optionalString (stdenv.isLinux && withX && toolkit == "lucid") ''
+      patchelf --set-rpath \
+        "$(patchelf --print-rpath "$out/bin/emacs"):${libPath}" \
+        "$out/bin/emacs"
+      patchelf --add-needed "libXcursor.so.1" "$out/bin/emacs"
+    '';
+
+  meta = with stdenv.lib; {
+    description = "The extensible, customizable GNU text editor";
+    homepage    = https://www.gnu.org/software/emacs/;
+    license     = licenses.gpl3Plus;
+    maintainers = with maintainers; [ lovek323 peti the-kenny jwiegley ];
+    platforms   = platforms.all;
+
+    longDescription = ''
+      GNU Emacs is an extensible, customizable text editor—and more.  At its
+      core is an interpreter for Emacs Lisp, a dialect of the Lisp
+      programming language with extensions to support text editing.
+
+      The features of GNU Emacs include: content-sensitive editing modes,
+      including syntax coloring, for a wide variety of file types including
+      plain text, source code, and HTML; complete built-in documentation,
+      including a tutorial for new users; full Unicode support for nearly all
+      human languages and their scripts; highly customizable, using Emacs
+      Lisp code or a graphical interface; a large number of extensions that
+      add other functionality, including a project planner, mail and news
+      reader, debugger interface, calendar, and more.  Many of these
+      extensions are distributed with GNU Emacs; others are available
+      separately.
+    '';
+  };
+}

--- a/pkgs/applications/editors/emacs/head.nix
+++ b/pkgs/applications/editors/emacs/head.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   patches = [
-    # ./clean-env.patch
+    ./clean-env-head.patch
     ./tramp-detect-wrapped-gvfsd.patch
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17585,6 +17585,18 @@ in
   emacsPackages = emacs26Packages;
   emacsPackagesNg = emacs26PackagesNg;
 
+  emacsHead = callPackage ../applications/editors/emacs/head.nix {
+    # use override to enable additional features
+    libXaw = xorg.libXaw;
+    Xaw3d = null;
+    gconf = null;
+    alsaLib = null;
+    imagemagick = null;
+    acl = null;
+    gpm = null;
+    inherit (darwin.apple_sdk.frameworks) AppKit GSS ImageIO;
+  };
+
   emacs26 = callPackage ../applications/editors/emacs {
     # use override to enable additional features
     libXaw = xorg.libXaw;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Emacs 27 has a few desirable changes, like early-init.el and a native json parser (50x speed up). Unfortunately, it won't be released for a few months minimum, probably a year. I need help testing emacs, as it is so big. I also haven't checked if there any new compile options, etc, etc. This is all pretty overwhelming, so if you spot anything please let me know.

I am also wondering how we should version the release, because at a guess we can't ask for `master` revision because the sha256 will fail. Right now my plan was to just periodically update the rev and sha, but there's *gotta be a better waaaaaaaaaaay*.

You can build it with `nix-build -A emacsHead`

Changelog: https://github.com/emacs-mirror/emacs/blob/master/etc/NEWS

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
