### PR TITLE
urbit: 0.7.4 -> 0.8.0

### DIFF
--- a/pkgs/misc/urbit/default.nix
+++ b/pkgs/misc/urbit/default.nix
@@ -1,31 +1,31 @@
-{ stdenv, fetchFromGitHub, curl, git, gmp, libsigsegv, meson, ncurses, ninja
-, openssl, pkgconfig, re2c, zlib
-}:
+{ stdenv, fetchFromGitHub }:
 
-stdenv.mkDerivation rec {
-  name = "urbit-${version}";
-  version = "0.7.3";
+let
 
-  src = fetchFromGitHub {
-    owner = "urbit";
-    repo = "urbit";
+  pname = "urbit";
+
+  version = "0.8.0";
+
+  urbit-derivs = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
     rev = "v${version}";
-    sha256 = "192843pjzh8z55fd0x70m3l1vncmixljia3nphgn7j7x4976xkp2";
-    fetchSubmodules = true;
+    sha256 = "047x05mm23kljy9yr8fi3hg6ygiikq4ll8fy7s3k8w3z6b43y7i6";
   };
 
-  nativeBuildInputs = [ pkgconfig ninja meson ];
-  buildInputs = [ curl git gmp libsigsegv ncurses openssl re2c zlib ];
+in
 
-  postPatch = ''
-    patchShebangs .
-  '';
+  with import urbit-derivs;
 
-  meta = with stdenv.lib; {
-    description = "An operating function";
-    homepage = https://urbit.org;
-    license = licenses.mit;
-    maintainers = with maintainers; [ mudri ];
-    platforms = with platforms; linux;
-  };
-}
+  urbit.overrideAttrs (_: {
+    inherit pname version;
+
+    meta = with stdenv.lib; {
+      description = "A personal server operating function";
+      homepage = https://urbit.org;
+      license = licenses.mit;
+      maintainers = with maintainers; [ jtobin ];
+      platforms = with platforms; linux ++ darwin;
+    };
+  })
+


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
