### PR TITLE
cbindgen: Disable tests rather than abusing RUSTC_BOOTSTRAP

### DIFF
--- a/pkgs/development/tools/rust/cbindgen/default.nix
+++ b/pkgs/development/tools/rust/cbindgen/default.nix
@@ -16,7 +16,7 @@ rustPlatform.buildRustPackage rec {
   buildInputs = stdenv.lib.optional stdenv.isDarwin Security;
 
   # https://github.com/eqrion/cbindgen/issues/338
-  RUSTC_BOOTSTRAP = 1;
+  doCheck = false;
 
   meta = with stdenv.lib; {
     description = "A project for generating C bindings from Rust code";


### PR DESCRIPTION
###### Motivation for this change

Since https://github.com/NixOS/nixpkgs/pull/64733, the packaging of `cbindgen` uses the `RUSTC_BOOTSTRAP` environment variable.

https://github.com/NixOS/nixpkgs/blob/681d3c260d2947e21ccb4122e27b4404d3722b58/pkgs/development/tools/rust/cbindgen/default.nix#L19

# Background on Rust

The Rust programming language has a concept of “unstable features”. They are APIs, language features, or tool parameters whose designed is not completed yet. They may still change in incompatible way, potentially breaking users relying on them.

Having them at all in the implementation allows experimenting and iterating, rather than freezing a design while it’s still only theoretical. It is important for the long-term health of the language that it can keep experimenting this way.

To avoid unstable features becoming de-facto stable (if enough users start depending on them that there is pressure not to change them and keep an unfinished design), these features are not available in normal releases of the compiler, only on Nightly versions. And they require explicit opt-in.

rustc is a bootstrapping compiler: it is written in Rust and relies on some unstable features. In order to make it possible to build each release with the previous one, rustc’s build system uses the `RUSTC_BOOTSTRAP` environment variable to unlock unstable features despite using a bootstrap version of rustc that normally does not allow them. There is non-trivial work involved to keep all this working when breaking changes are made to unstable features.

Using `RUSTC_BOOTSTRAP` in another project technically allows using unstable features with a compiler that normally doesn’t, but this environment variable was never intended for anything other than building rustc itself.

# Abusing `RUSTC_BOOTSTRAP` is harmful

By relying on it anyway, NixOS contributes to normalize other projects relying on it and counting on unfinished features not changing. If enough projects adopt this strategy, this puts pressure on the Rust team to declare unfinished features to be de-facto stable, and robs them of their opportunity for experimentation.

Please don’t contribute to spoiling it for everybody.

# Background on cbindgen

An optional feature of cbindgen (expanding macros) involve shelling out to `rustc` with some unstable options. Therefore this requires Rust Nightly. Building Firefox requires cbindgen, but not macro-expansion feature. It is a goal of Firefox that it can be built with stable rustc. I expect that Firefox is the motivation to package cbindgen in NixOS.

Some of cbindgen’s own test suite exercise the macro-expansion feature, and therefore fails when run on stable rustc: https://github.com/eqrion/cbindgen/issues/338. But it’s only some tests.

# This PR

I have reproduced https://github.com/eqrion/cbindgen/issues/338 by running `cargo test ` in cbindgen, and verified that `cargo build` works correctly. I am told that `doCheck = false` is the way to make the nix packaging disable `cargo test` for a Rust package, but I have not tried it.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
