### PR TITLE
wine: disable zbar in gst-plugins-bad

### DIFF
--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -2,6 +2,7 @@
 , config
 , pkgconfig, python3, gst-plugins-base, orc
 , gobject-introspection
+, enableZbar ? true
 , faacSupport ? false, faac ? null
 , faad2, libass, libkate, libmms, librdf, ladspaH
 , libnice, webrtc-audio-processing, lilv, lv2, serd, sord, sratom
@@ -136,13 +137,13 @@ stdenv.mkDerivation rec {
     soundtouch
     spandsp
     srtp
-    zbar
     fluidsynth libvdpau
     libwebp xvidcore gnutls libGLU_combined
     libgme openssl x265 libxml2
     libintl
     srt
   ]
+    ++ optional enableZbar zbar
     ++ optional faacSupport faac
     ++ optional stdenv.isLinux wayland
     # wildmidi requires apple's OpenAL
@@ -158,6 +159,7 @@ stdenv.mkDerivation rec {
     "-Dexamples=disabled" # requires many dependencies and probably not useful for our users
 
     "-Ddts=disabled" # required `libdca` library not packaged in nixpkgs as of writing, and marked as "BIG FAT WARNING: libdca is still in early development"
+    "-Dzbar=${if enableZbar then "enabled" else "disabled"}"
     "-Dfaac=${if faacSupport then "enabled" else "disabled"}"
     "-Diqa=disabled" # required `dssim` library not packaging in nixpkgs as of writing
     "-Dmsdk=disabled" # not packaged in nixpkgs as of writing / no Windows support

--- a/pkgs/misc/emulators/wine/base.nix
+++ b/pkgs/misc/emulators/wine/base.nix
@@ -46,7 +46,9 @@ stdenv.mkDerivation ((lib.optionalAttrs (buildScript != null) {
   ++ lib.optional udevSupport            pkgs.udev
   ++ lib.optional vulkanSupport          pkgs.vulkan-loader
   ++ lib.optional sdlSupport             pkgs.SDL2
-  ++ lib.optionals gstreamerSupport      (with pkgs.gst_all_1; [ gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-libav ])
+  ++ lib.optionals gstreamerSupport      (with pkgs.gst_all_1;
+    [ gstreamer gst-plugins-base gst-plugins-good gst-plugins-ugly gst-libav 
+    (gst-plugins-bad.override { enableZbar = false; }) ])
   ++ lib.optionals gtkSupport    [ pkgs.gtk3 pkgs.glib ]
   ++ lib.optionals openclSupport [ pkgs.opencl-headers pkgs.ocl-icd ]
   ++ lib.optionals xmlSupport    [ pkgs.libxml2 pkgs.libxslt ]


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Wine doesn't build currently. This together with #63677 is a workaround. 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
