### PR TITLE
nodePackages.gtop: init at 1.0.0

### DIFF
--- a/pkgs/development/node-packages/node-packages-v10.json
+++ b/pkgs/development/node-packages/node-packages-v10.json
@@ -45,6 +45,7 @@
 , "git-standup"
 , "graphql-cli"
 , "grunt-cli"
+, "gtop"
 , "gulp"
 , "gulp-cli"
 , "html-minifier"

--- a/pkgs/development/node-packages/node-packages-v10.nix
+++ b/pkgs/development/node-packages/node-packages-v10.nix
@@ -2281,13 +2281,13 @@ let
         sha512 = "hb+6E7kMzWlcwfe//ILDoktBPKL2a3+RnJT/CXnzRXaiLQpsdkf5li4q2v0fmvd+4v7L3tTN8KM+//lJyviEkg==";
       };
     };
-    "@snyk/dep-graph-1.10.0" = {
+    "@snyk/dep-graph-1.12.0" = {
       name = "_at_snyk_slash_dep-graph";
       packageName = "@snyk/dep-graph";
-      version = "1.10.0";
+      version = "1.12.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@snyk/dep-graph/-/dep-graph-1.10.0.tgz";
-        sha512 = "QwQTmmnVb1mjAffGsjKKrwit8ahLWyhlKWQcTVZo9UXFgWAwiuCjTXKAXhijZjGvrXQzNf5KbIBu+SZ1Dq2toQ==";
+        url = "https://registry.npmjs.org/@snyk/dep-graph/-/dep-graph-1.12.0.tgz";
+        sha512 = "n7+PlHn3SqznHgsCpeBRfEvU1oiQydoGkXQlnSB2+tfImiKXvY7YZbrg4wlbvYgylYiTbpCi5CpPNkJG14S+UQ==";
       };
     };
     "@snyk/gemfile-1.2.0" = {
@@ -2839,13 +2839,13 @@ let
         sha512 = "mlGER3Aqmq7bqR1tTTIVHq8KSAFFRyGbrxuM8C/H82g6k7r2fS+IMEkIu3D7JHzG10NvPdR8DNx0jr0pwpp4dA==";
       };
     };
-    "@types/ws-6.0.1" = {
+    "@types/ws-6.0.2" = {
       name = "_at_types_slash_ws";
       packageName = "@types/ws";
-      version = "6.0.1";
+      version = "6.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/ws/-/ws-6.0.1.tgz";
-        sha512 = "EzH8k1gyZ4xih/MaZTXwT2xOkPiIMSrhQ9b8wrlX88L0T02eYsddatQlwVFlEPyEqV0ChpdpNnE51QPH6NVT4Q==";
+        url = "https://registry.npmjs.org/@types/ws/-/ws-6.0.2.tgz";
+        sha512 = "22XiR1ox9LftTaAtn/c5JCninwc7moaqbkJfaDUb7PkaUitcf5vbTZHdq9dxSMviCm9C3W85rzB8e6yNR70apQ==";
       };
     };
     "@types/zen-observable-0.8.0" = {
@@ -2857,40 +2857,40 @@ let
         sha512 = "te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg==";
       };
     };
-    "@vue/cli-shared-utils-3.9.0" = {
+    "@vue/cli-shared-utils-3.10.0" = {
       name = "_at_vue_slash_cli-shared-utils";
       packageName = "@vue/cli-shared-utils";
-      version = "3.9.0";
+      version = "3.10.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@vue/cli-shared-utils/-/cli-shared-utils-3.9.0.tgz";
-        sha512 = "wumeMZTz5aQ+1Y6uxTKegIsgOXEWT3hT8f9sW2mj5SwNDVyQ+AHZTgSynYExTUJg3dH81uKgFDUpPdAvGxzh8g==";
+        url = "https://registry.npmjs.org/@vue/cli-shared-utils/-/cli-shared-utils-3.10.0.tgz";
+        sha512 = "i96XBUtLdWeKFCC/ot12ngqnVikN/dXpelGdyxvNZczCkX7Je0FUdrZkiw0+uTYTu1RmuYWpLs+vb/YQerjiWg==";
       };
     };
-    "@vue/cli-ui-3.9.3" = {
+    "@vue/cli-ui-3.10.0" = {
       name = "_at_vue_slash_cli-ui";
       packageName = "@vue/cli-ui";
-      version = "3.9.3";
+      version = "3.10.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@vue/cli-ui/-/cli-ui-3.9.3.tgz";
-        sha512 = "CDMQn1An4OlaLoB0paZfXBSvuUUkR3BPU/EWTLszP1lHqTecAkj7ESIdelXfpPwRhxchE/7c9s9XXEhpHublrQ==";
+        url = "https://registry.npmjs.org/@vue/cli-ui/-/cli-ui-3.10.0.tgz";
+        sha512 = "Tekgh54ClA+x3ey3H1td/RVhGt9MG02/z/OtG+q2Dcy9j47bscDDiTv3OJgw64WrH5tqz1aKEA/SibxL9ehS+Q==";
       };
     };
-    "@vue/cli-ui-addon-webpack-3.9.3" = {
+    "@vue/cli-ui-addon-webpack-3.10.0" = {
       name = "_at_vue_slash_cli-ui-addon-webpack";
       packageName = "@vue/cli-ui-addon-webpack";
-      version = "3.9.3";
+      version = "3.10.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@vue/cli-ui-addon-webpack/-/cli-ui-addon-webpack-3.9.3.tgz";
-        sha512 = "BQro2UwHx7w1DcM2MJoF7qfa/Pp48mZWLwqJjCJVqg1utFkAqwjlIM9VweYWEWO7/jJ5B4JfuKCzRrGTtGDbdw==";
+        url = "https://registry.npmjs.org/@vue/cli-ui-addon-webpack/-/cli-ui-addon-webpack-3.10.0.tgz";
+        sha512 = "c930BWpeFu1H+mbUZT4VSLngD95yaOAg9qr21Kq1KMZ3CW7gakbttwpgXjn8edwdkvUl65IpSkdh/n/XyYyXxg==";
       };
     };
-    "@vue/cli-ui-addon-widgets-3.9.3" = {
+    "@vue/cli-ui-addon-widgets-3.10.0" = {
       name = "_at_vue_slash_cli-ui-addon-widgets";
       packageName = "@vue/cli-ui-addon-widgets";
-      version = "3.9.3";
+      version = "3.10.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@vue/cli-ui-addon-widgets/-/cli-ui-addon-widgets-3.9.3.tgz";
-        sha512 = "DnIvWNbhilouNyaevH2aBKSzdUK1zhveQvGp3z9ddVNgD6MadY9qf0YIrGrtzK4gn2Jc42BpOh64Slzwq9KhcQ==";
+        url = "https://registry.npmjs.org/@vue/cli-ui-addon-widgets/-/cli-ui-addon-widgets-3.10.0.tgz";
+        sha512 = "FvPB05n8Gp0TbvWPXnlwcQPSLZIwEY+Mzwh0pMDTN9yoxnf+/xhIt2PwRmFtecIBqyBZAIyYI50wmCxs9c2Hbw==";
       };
     };
     "@webassemblyjs/ast-1.8.1" = {
@@ -3550,13 +3550,13 @@ let
         sha1 = "fd8270f71fbb4996b004fa880ee5d46573a731bf";
       };
     };
-    "acorn-globals-4.3.2" = {
+    "acorn-globals-4.3.3" = {
       name = "acorn-globals";
       packageName = "acorn-globals";
-      version = "4.3.2";
+      version = "4.3.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.2.tgz";
-        sha512 = "BbzvZhVtZP+Bs1J1HcwrQe8ycfO0wStkSGxuul3He3GkHOIZ6eTqOkPuw9IP1X3+IkOo4wiJmwkobzXYz4wewQ==";
+        url = "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.3.tgz";
+        sha512 = "vkR40VwS2SYO98AIeFvzWWh+xyc2qi9s7OoXSFEGIP/rOJKzjnhykaZJNnHdoq4BL2gGxI5EZOU16z896EYnOQ==";
       };
     };
     "acorn-jsx-3.0.1" = {
@@ -4189,6 +4189,15 @@ let
         sha512 = "8zjUtFJ3db/QoPXuuEMloS2AUf79/yeyttJ7Abr3hteopJu9HK8vsgGviGUMq+zyA6cZZO6gAyZoMTF6TgaEjA==";
       };
     };
+    "ansi-term-0.0.2" = {
+      name = "ansi-term";
+      packageName = "ansi-term";
+      version = "0.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ansi-term/-/ansi-term-0.0.2.tgz";
+        sha1 = "fd753efa4beada0eac99981bc52a3f6ff019deb7";
+      };
+    };
     "ansi-to-html-0.6.11" = {
       name = "ansi-to-html";
       packageName = "ansi-to-html";
@@ -4205,6 +4214,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz";
         sha1 = "a82250ddb0015e9a27ca82e82ea603bbfa45efaf";
+      };
+    };
+    "ansicolors-0.2.1" = {
+      name = "ansicolors";
+      packageName = "ansicolors";
+      version = "0.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz";
+        sha1 = "be089599097b74a5c9c4a84a0cdbcdb62bd87aef";
       };
     };
     "ansicolors-0.3.2" = {
@@ -4702,13 +4720,13 @@ let
         sha1 = "ff662b4a78201494a3ee544d3a33fe7496509ebc";
       };
     };
-    "archiver-3.0.3" = {
+    "archiver-3.1.1" = {
       name = "archiver";
       packageName = "archiver";
-      version = "3.0.3";
+      version = "3.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/archiver/-/archiver-3.0.3.tgz";
-        sha512 = "d0W7NUyXoLklozHHfvWnHoHS3dvQk8eB22pv5tBwcu1jEO5eZY8W+gHytkAaJ0R8fU2TnNThrWYxjvFlKvRxpw==";
+        url = "https://registry.npmjs.org/archiver/-/archiver-3.1.1.tgz";
+        sha512 = "5Hxxcig7gw5Jod/8Gq0OneVgLYET+oNHcxgWItq4TbhOzRLKNAFUb9edAftiMKXvXfCB0vbGrJdZDNq0dWMsxg==";
       };
     };
     "archiver-utils-1.3.0" = {
@@ -5539,13 +5557,13 @@ let
         sha512 = "z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==";
       };
     };
-    "async-limiter-1.0.0" = {
+    "async-limiter-1.0.1" = {
       name = "async-limiter";
       packageName = "async-limiter";
-      version = "1.0.0";
+      version = "1.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz";
-        sha512 = "jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==";
+        url = "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz";
+        sha512 = "csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==";
       };
     };
     "async-lock-1.2.2" = {
@@ -5701,13 +5719,13 @@ let
         sha1 = "00f35b2d27ac91b1f0d3ef2084c98cf1d1f0adc3";
       };
     };
-    "aws-sdk-2.503.0" = {
+    "aws-sdk-2.504.0" = {
       name = "aws-sdk";
       packageName = "aws-sdk";
-      version = "2.503.0";
+      version = "2.504.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.503.0.tgz";
-        sha512 = "DPwRxhPYCGNvKL9rUhpAoOVpMRyISbVMlXykLQknYo7wyOI+jYcyA7t8H7IFPAqj4ZG+R+Au9tO/KT4im+2gbg==";
+        url = "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.504.0.tgz";
+        sha512 = "azOX54oovJv0zWzO23fBgIprwsvx8KUuMR+cAUAOx23D8LJ5S+sl3UYS9Q1X4qF/blBTa4+ZNawZDV0N1HiQmw==";
       };
     };
     "aws-sign2-0.6.0" = {
@@ -6763,13 +6781,13 @@ let
         sha1 = "1101e9544f4a76b1bc3b26d452ca96d7a35e7978";
       };
     };
-    "base64-js-1.3.0" = {
+    "base64-js-1.3.1" = {
       name = "base64-js";
       packageName = "base64-js";
-      version = "1.3.0";
+      version = "1.3.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz";
-        sha512 = "ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==";
+        url = "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz";
+        sha512 = "mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==";
       };
     };
     "base64-url-1.2.1" = {
@@ -7078,13 +7096,13 @@ let
         sha512 = "Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==";
       };
     };
-    "binary-search-1.3.5" = {
+    "binary-search-1.3.6" = {
       name = "binary-search";
       packageName = "binary-search";
-      version = "1.3.5";
+      version = "1.3.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/binary-search/-/binary-search-1.3.5.tgz";
-        sha512 = "RHFP0AdU6KAB0CCZsRMU2CJTk2EpL8GLURT+4gilpjr1f/7M91FgUMnXuQLmf3OKLet34gjuNFwO7e4agdX5pw==";
+        url = "https://registry.npmjs.org/binary-search/-/binary-search-1.3.6.tgz";
+        sha512 = "nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA==";
       };
     };
     "binaryheap-0.0.3" = {
@@ -7121,15 +7139,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/bitfield/-/bitfield-0.1.0.tgz";
         sha1 = "b05d8b5f0d09f2df35a9db3b3a62d3808c46c457";
-      };
-    };
-    "bitfield-2.0.0" = {
-      name = "bitfield";
-      packageName = "bitfield";
-      version = "2.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/bitfield/-/bitfield-2.0.0.tgz";
-        sha512 = "4xM4DYejOHQ/qWBfeqBXNA4mJ12PwcOibFYnH1kYh5U9BHciCqEJBqGNVnMJXUhm8mflujNRLSv7IiVQxovgjw==";
       };
     };
     "bitfield-3.0.0" = {
@@ -7204,13 +7213,13 @@ let
         sha1 = "ffd2eabc141d36ed5c1817df7e992f91fd7fc65c";
       };
     };
-    "bittorrent-tracker-9.11.0" = {
+    "bittorrent-tracker-9.12.1" = {
       name = "bittorrent-tracker";
       packageName = "bittorrent-tracker";
-      version = "9.11.0";
+      version = "9.12.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/bittorrent-tracker/-/bittorrent-tracker-9.11.0.tgz";
-        sha512 = "T1zvW/kSeEnWT4I3JE+6c7aZbO5jtleZyQe911SyzIxFF9DvtUNWXud3p5ZUkXaoI2xXwfpvlks5VFj5SKEB+A==";
+        url = "https://registry.npmjs.org/bittorrent-tracker/-/bittorrent-tracker-9.12.1.tgz";
+        sha512 = "5gjqHG3xV3eEy3UOOn4kkB09sl66t+fYzBGFMI83lRC/+33xmgpDYnu2lOnjYdRPAKWv0nBJT5XR/l9JkQ341A==";
       };
     };
     "bl-0.8.2" = {
@@ -7285,6 +7294,24 @@ let
         sha1 = "825a8fc536a5dc43193467f3124f7e9b78b21cef";
       };
     };
+    "blessed-0.1.81" = {
+      name = "blessed";
+      packageName = "blessed";
+      version = "0.1.81";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/blessed/-/blessed-0.1.81.tgz";
+        sha1 = "f962d687ec2c369570ae71af843256e6d0ca1129";
+      };
+    };
+    "blessed-contrib-4.8.16" = {
+      name = "blessed-contrib";
+      packageName = "blessed-contrib";
+      version = "4.8.16";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/blessed-contrib/-/blessed-contrib-4.8.16.tgz";
+        sha512 = "B1fEJTR+8IsimEvYQbvXCvnV0L674rFxy9yMwqibiRO2nxa5fzwnoKhJjRJFCBYH27ztW+b6jKvnOvetnj30WA==";
+      };
+    };
     "blob-0.0.2" = {
       name = "blob";
       packageName = "blob";
@@ -7330,13 +7357,13 @@ let
         sha1 = "13ebfe778a03205cfe03751481ebb4b3300c126a";
       };
     };
-    "block-stream2-1.1.0" = {
+    "block-stream2-2.0.0" = {
       name = "block-stream2";
       packageName = "block-stream2";
-      version = "1.1.0";
+      version = "2.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/block-stream2/-/block-stream2-1.1.0.tgz";
-        sha1 = "c738e3a91ba977ebb5e1fef431e13ca11d8639e2";
+        url = "https://registry.npmjs.org/block-stream2/-/block-stream2-2.0.0.tgz";
+        sha512 = "1oI+RHHUEo64xomy1ozLgVJetFlHkIfQfJzTBQrj6xWnEMEPooeo2fZoqFjp0yzfHMBrgxwgh70tKp6T17+i3g==";
       };
     };
     "bluebird-1.1.1" = {
@@ -7409,6 +7436,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz";
         sha512 = "ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==";
+      };
+    };
+    "bn.js-5.0.0" = {
+      name = "bn.js";
+      packageName = "bn.js";
+      version = "5.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bn.js/-/bn.js-5.0.0.tgz";
+        sha512 = "bVwDX8AF+72fIUNuARelKAlQUNtPOfG2fRxorbVvFk4zpHbqLrPdOGfVg5vrKwVzLLePqPBiATaOZNELQzmS0A==";
       };
     };
     "bncode-0.2.3" = {
@@ -7652,6 +7688,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz";
         sha512 = "b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==";
+      };
+    };
+    "bresenham-0.0.3" = {
+      name = "bresenham";
+      packageName = "bresenham";
+      version = "0.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bresenham/-/bresenham-0.0.3.tgz";
+        sha1 = "abdab9e5b194e27c757cd314d8444314f299877a";
       };
     };
     "brfs-1.6.1" = {
@@ -8509,13 +8554,13 @@ let
         sha512 = "bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==";
       };
     };
-    "caniuse-lite-1.0.30000988" = {
+    "caniuse-lite-1.0.30000989" = {
       name = "caniuse-lite";
       packageName = "caniuse-lite";
-      version = "1.0.30000988";
+      version = "1.0.30000989";
       src = fetchurl {
-        url = "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000988.tgz";
-        sha512 = "lPj3T8poYrRc/bniW5SQPND3GRtSrQdUM/R4mCYTbZxyi3jQiggLvZH4+BYUuX0t4TXjU+vMM7KFDQg+rSzZUQ==";
+        url = "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000989.tgz";
+        sha512 = "vrMcvSuMz16YY6GSVZ0dWDTJP8jqk3iFQ/Aq5iqblPwxSVVZI+zxDyTX0VPqtQsDnfdrBDcsmhgTEOh5R8Lbpw==";
       };
     };
     "capture-stack-trace-1.0.1" = {
@@ -8525,6 +8570,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz";
         sha512 = "mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==";
+      };
+    };
+    "cardinal-1.0.0" = {
+      name = "cardinal";
+      packageName = "cardinal";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/cardinal/-/cardinal-1.0.0.tgz";
+        sha1 = "50e21c1b0aa37729f9377def196b5a9cec932ee9";
       };
     };
     "caseless-0.11.0" = {
@@ -8779,6 +8833,15 @@ let
         sha1 = "c0a1d2f3a7092e03774bfa83f14c0fc5790a8667";
       };
     };
+    "charm-0.1.2" = {
+      name = "charm";
+      packageName = "charm";
+      version = "0.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz";
+        sha1 = "06c21eed1a1b06aeb67553cdc53e23274bac2296";
+      };
+    };
     "charset-1.0.1" = {
       name = "charset";
       packageName = "charset";
@@ -9013,13 +9076,13 @@ let
         sha1 = "04a106672c18b085ab774d983dfa3ea138f22205";
       };
     };
-    "chunk-store-stream-4.0.0" = {
+    "chunk-store-stream-4.1.0" = {
       name = "chunk-store-stream";
       packageName = "chunk-store-stream";
-      version = "4.0.0";
+      version = "4.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/chunk-store-stream/-/chunk-store-stream-4.0.0.tgz";
-        sha512 = "hmtlqMozj1LbZlEpTBXL3YrBsLz4nJEXVihrSbe6ugfxH/Yae5JvUCXQwpWI7VELjXX0GyZK3ajQDBX/r30zBw==";
+        url = "https://registry.npmjs.org/chunk-store-stream/-/chunk-store-stream-4.1.0.tgz";
+        sha512 = "GjkZ16bFKMFnb8LrGZXAPeRoLXZTLu9ges6LCErJe28bMp6zKLxjWuJ7TYzR0jWq9nwo58hXG3BXZYy66Vze0Q==";
       };
     };
     "ci-info-1.6.0" = {
@@ -10165,13 +10228,13 @@ let
         sha1 = "524a9f10903f3a813389b0225d27c48bb751890f";
       };
     };
-    "compress-commons-2.0.0" = {
+    "compress-commons-2.1.1" = {
       name = "compress-commons";
       packageName = "compress-commons";
-      version = "2.0.0";
+      version = "2.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/compress-commons/-/compress-commons-2.0.0.tgz";
-        sha512 = "gnETNngrfsAoLBENM8M0DoiCDJkHwz3OfIg4mBtqKDcRgE4oXNwHxHxgHvwKKlrcD7eZ7BVTy4l8t9xVF7q3FQ==";
+        url = "https://registry.npmjs.org/compress-commons/-/compress-commons-2.1.1.tgz";
+        sha512 = "eVw6n7CnEMFzc3duyFVrQEuY1BlHR3rYsSztyG32ibGMW722i3C6IizEGMFmfMU+A+fALvBIwxN3czffTcdA+Q==";
       };
     };
     "compressible-2.0.17" = {
@@ -11065,6 +11128,15 @@ let
         sha1 = "e3cdd3b4df3168dd74e3de3fbbcb7b297fe908f4";
       };
     };
+    "crc32-stream-3.0.1" = {
+      name = "crc32-stream";
+      packageName = "crc32-stream";
+      version = "3.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/crc32-stream/-/crc32-stream-3.0.1.tgz";
+        sha512 = "mctvpXlbzsvK+6z8kJwSJ5crm7yBwrQMTybJzMw1O4lLGJqjlDCXY2Zw7KheiA6XBEcBmfLx1D88mjRGVJtY9w==";
+      };
+    };
     "create-ecdh-4.0.3" = {
       name = "create-ecdh";
       packageName = "create-ecdh";
@@ -11101,13 +11173,13 @@ let
         sha512 = "MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==";
       };
     };
-    "create-torrent-4.0.0" = {
+    "create-torrent-4.2.1" = {
       name = "create-torrent";
       packageName = "create-torrent";
-      version = "4.0.0";
+      version = "4.2.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/create-torrent/-/create-torrent-4.0.0.tgz";
-        sha512 = "16JQRuPJWAntC4p+k6EFMxKatqzQOKv037aAun6Comomizlg9fOoBiIhxC/QCQfJFmGIfnT6HMOEa6da5xUmsg==";
+        url = "https://registry.npmjs.org/create-torrent/-/create-torrent-4.2.1.tgz";
+        sha512 = "IlKF2B3vrAGVzcgYVVgfsekp4p2N9BqkGeVqckTljajs+qIQ5oAwAzELJtb6sZ14UQBT7ZQNOOyvxgIL98VpZg==";
       };
     };
     "creato-1.0.5" = {
@@ -13162,6 +13234,15 @@ let
         sha512 = "l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==";
       };
     };
+    "dom-serializer-0.2.1" = {
+      name = "dom-serializer";
+      packageName = "dom-serializer";
+      version = "0.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.1.tgz";
+        sha512 = "sK3ujri04WyjwQXVoK4PU3y8ula1stq10GJZpqHIUgoGZdsGzAGu65BnU3d08aTVSvO7mGPZUc0wTEDL+qGE0Q==";
+      };
+    };
     "dom-walk-0.1.1" = {
       name = "dom-walk";
       packageName = "dom-walk";
@@ -13205,6 +13286,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz";
         sha512 = "BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==";
+      };
+    };
+    "domelementtype-2.0.1" = {
+      name = "domelementtype";
+      packageName = "domelementtype";
+      version = "2.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz";
+        sha512 = "5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==";
       };
     };
     "domexception-1.0.1" = {
@@ -13385,6 +13475,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/drange/-/drange-1.1.1.tgz";
         sha512 = "pYxfDYpued//QpnLIm4Avk7rsNtAtQkUES2cwAYSvD/wd2pKD71gN2Ebj3e7klzXwjocvE8c5vx/1fxwpqmSxA==";
+      };
+    };
+    "drawille-blessed-contrib-1.0.0" = {
+      name = "drawille-blessed-contrib";
+      packageName = "drawille-blessed-contrib";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/drawille-blessed-contrib/-/drawille-blessed-contrib-1.0.0.tgz";
+        sha1 = "15c27934f57a0056ad13596e1561637bc941f0b7";
+      };
+    };
+    "drawille-canvas-blessed-contrib-0.1.3" = {
+      name = "drawille-canvas-blessed-contrib";
+      packageName = "drawille-canvas-blessed-contrib";
+      version = "0.1.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/drawille-canvas-blessed-contrib/-/drawille-canvas-blessed-contrib-0.1.3.tgz";
+        sha1 = "212f078a722bfd2ecc267ea86ab6dddc1081fd48";
       };
     };
     "dreamopt-0.6.0" = {
@@ -13648,13 +13756,13 @@ let
         sha512 = "PcW2a0tyTuPHz3tWyYqtK6r1fZ3gp+3Sop8Ph+ZYN81Ob5rwmbHEzaqs10N3BEsaGTkh/ooniXK+WwszGlc2+Q==";
       };
     };
-    "electron-to-chromium-1.3.210" = {
+    "electron-to-chromium-1.3.215" = {
       name = "electron-to-chromium";
       packageName = "electron-to-chromium";
-      version = "1.3.210";
+      version = "1.3.215";
       src = fetchurl {
-        url = "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.210.tgz";
-        sha512 = "m1i/F+gw9jkauxDx0mOr7Sj6vp6se1mfkQNYqZb1yL5VGTp0AC1NZH5CGI6YMSO7WaScILmkKDZFG9/hlR9axQ==";
+        url = "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.215.tgz";
+        sha512 = "ZV3OnwF0FlIygwxAG2H92yt7WGjWBpawyFAFu8e9k7xJatY+BPowID0D0Bs3PMACYAJATEejw/I9cawO27ZvTg==";
       };
     };
     "elegant-spinner-1.0.1" = {
@@ -14052,6 +14160,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz";
         sha512 = "f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==";
+      };
+    };
+    "entities-2.0.0" = {
+      name = "entities";
+      packageName = "entities";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz";
+        sha512 = "D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==";
       };
     };
     "env-paths-1.0.0" = {
@@ -14594,6 +14711,15 @@ let
         sha1 = "609ac5c2667eae5433b41eb9ecece2331b41498f";
       };
     };
+    "esprima-3.0.0" = {
+      name = "esprima";
+      packageName = "esprima";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/esprima/-/esprima-3.0.0.tgz";
+        sha1 = "53cf247acda77313e551c3aa2e73342d3fb4f7d9";
+      };
+    };
     "esprima-3.1.3" = {
       name = "esprima";
       packageName = "esprima";
@@ -14745,6 +14871,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/event-stream/-/event-stream-0.5.3.tgz";
         sha1 = "b77b9309f7107addfeab63f0c0eafd8db0bd8c1c";
+      };
+    };
+    "event-stream-0.9.8" = {
+      name = "event-stream";
+      packageName = "event-stream";
+      version = "0.9.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/event-stream/-/event-stream-0.9.8.tgz";
+        sha1 = "5da9cf3c7900975989db5a68c28e5b3c98ebe03a";
       };
     };
     "event-stream-3.1.5" = {
@@ -15845,13 +15980,13 @@ let
         sha512 = "7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==";
       };
     };
-    "filestream-4.1.3" = {
+    "filestream-5.0.0" = {
       name = "filestream";
       packageName = "filestream";
-      version = "4.1.3";
+      version = "5.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/filestream/-/filestream-4.1.3.tgz";
-        sha1 = "948fcaade8221f715f5ecaddc54862faaacc9325";
+        url = "https://registry.npmjs.org/filestream/-/filestream-5.0.0.tgz";
+        sha512 = "5H3RqSaJp12THfZiNWodYM7TiKfQvrpX+EIOrB1XvCceTys4yvfEIl8wDp+/yI8qj6Bxym8m0NYWwVXDAet/+A==";
       };
     };
     "fill-range-2.2.4" = {
@@ -16185,15 +16320,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/flatten/-/flatten-0.0.1.tgz";
         sha1 = "554440766da0a0d603999f433453f6c2fc6a75c1";
-      };
-    };
-    "flatten-1.0.2" = {
-      name = "flatten";
-      packageName = "flatten";
-      version = "1.0.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz";
-        sha1 = "dae46a9d78fbe25292258cc1e780a41d95c03782";
       };
     };
     "flow-bin-0.85.0" = {
@@ -17375,6 +17501,15 @@ let
         sha512 = "SsZUjg/P03KPzQBt7OxJPasGw6NRO5uOgiZ5RGXVud5iSIZ0eNZeNp5rTwCxtavrRUa/A77j8mePVc5lEvk0KQ==";
       };
     };
+    "gl-matrix-2.8.1" = {
+      name = "gl-matrix";
+      packageName = "gl-matrix";
+      version = "2.8.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/gl-matrix/-/gl-matrix-2.8.1.tgz";
+        sha512 = "0YCjVpE3pS5XWlN3J4X7AiAx65+nqAI54LndtVFnQZB6G/FVLkZH8y8V6R3cIoOQR4pUdfwQGd1iwyoXHJ4Qfw==";
+      };
+    };
     "glob-3.1.21" = {
       name = "glob";
       packageName = "glob";
@@ -17871,13 +18006,13 @@ let
         sha1 = "0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658";
       };
     };
-    "graceful-fs-4.2.0" = {
+    "graceful-fs-4.2.1" = {
       name = "graceful-fs";
       packageName = "graceful-fs";
-      version = "4.2.0";
+      version = "4.2.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz";
-        sha512 = "jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==";
+        url = "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.1.tgz";
+        sha512 = "b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw==";
       };
     };
     "graceful-readlink-1.0.1" = {
@@ -18762,6 +18897,15 @@ let
         sha1 = "8f2d508d0600b4a456da2f086556e7e5c056a3c6";
       };
     };
+    "here-0.0.2" = {
+      name = "here";
+      packageName = "here";
+      version = "0.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/here/-/here-0.0.2.tgz";
+        sha1 = "69c1af3f02121f3d8788e02e84dc8b3905d71195";
+      };
+    };
     "hex-color-regex-1.1.0" = {
       name = "hex-color-regex";
       packageName = "hex-color-regex";
@@ -18870,13 +19014,13 @@ let
         sha1 = "08a74d9272a9cc83ae8e6bbe0303f0ee76432094";
       };
     };
-    "hosted-git-info-2.7.1" = {
+    "hosted-git-info-2.8.2" = {
       name = "hosted-git-info";
       packageName = "hosted-git-info";
-      version = "2.7.1";
+      version = "2.8.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz";
-        sha512 = "7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==";
+        url = "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.2.tgz";
+        sha512 = "CyjlXII6LMsPMyUzxpTt8fzh5QwzGqPmQXgY/Jyf4Zfp27t/FvfhwoE/8laaMUcMy816CkWF20I7NeQhwwY88w==";
       };
     };
     "hsl-regex-1.0.0" = {
@@ -21226,6 +21370,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz";
         sha1 = "1f16e4aa22b04d1336b66188a66af3c600c3a66d";
+      };
+    };
+    "is-wsl-2.1.0" = {
+      name = "is-wsl";
+      packageName = "is-wsl";
+      version = "2.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-wsl/-/is-wsl-2.1.0.tgz";
+        sha512 = "pFTjpv/x5HRj8kbZ/Msxi9VrvtOMRBqaDi3OIcbwPI3OuH+r3lLxVWukLITBaOGJIbA/w2+M1eVmVa4XNQlAmQ==";
       };
     };
     "is-yarn-global-0.3.0" = {
@@ -24820,6 +24973,15 @@ let
         sha1 = "c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf";
       };
     };
+    "map-canvas-0.1.5" = {
+      name = "map-canvas";
+      packageName = "map-canvas";
+      version = "0.1.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/map-canvas/-/map-canvas-0.1.5.tgz";
+        sha1 = "8be6bade0bf3e9f9a8b56e8836a1d1d133cab186";
+      };
+    };
     "map-filter-reduce-2.2.1" = {
       name = "map-filter-reduce";
       packageName = "map-filter-reduce";
@@ -25016,6 +25178,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz";
         sha512 = "c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==";
+      };
+    };
+    "marked-terminal-1.7.0" = {
+      name = "marked-terminal";
+      packageName = "marked-terminal";
+      version = "1.7.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/marked-terminal/-/marked-terminal-1.7.0.tgz";
+        sha1 = "c8c460881c772c7604b64367007ee5f77f125904";
       };
     };
     "marky-1.2.1" = {
@@ -25324,6 +25495,15 @@ let
         sha512 = "ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==";
       };
     };
+    "memory-streams-0.1.3" = {
+      name = "memory-streams";
+      packageName = "memory-streams";
+      version = "0.1.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/memory-streams/-/memory-streams-0.1.3.tgz";
+        sha512 = "qVQ/CjkMyMInPaaRMrwWNDvf6boRZXaT/DbQeMYcCWuXPEBf1v8qChOc9OlEVQp2uOvRXa1Qu30fLmKhY6NipA==";
+      };
+    };
     "memorystore-1.6.1" = {
       name = "memorystore";
       packageName = "memorystore";
@@ -25331,6 +25511,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/memorystore/-/memorystore-1.6.1.tgz";
         sha512 = "rYRjVukgBR9sptGI3IfpAjZc4SkupddhAenUhPTGprnqM8Qh863PxfXxXWlfvHpMIAkJCok28Bm7ZlOKB4U+MA==";
+      };
+    };
+    "memorystream-0.3.1" = {
+      name = "memorystream";
+      packageName = "memorystream";
+      version = "0.3.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz";
+        sha1 = "86d7090b30ce455d63fbae12dda51a47ddcaf9b2";
       };
     };
     "menu-string-1.3.0" = {
@@ -26458,13 +26647,13 @@ let
         sha512 = "xasv76hl6nr1dEy3lPvy7Ej7K/Lx3O/FCvwge8PeVJpciPPoNCbaANcNiBug3IpdvTveZUcAV0DJzdnUDMesNQ==";
       };
     };
-    "multistream-3.0.0" = {
+    "multistream-3.1.0" = {
       name = "multistream";
       packageName = "multistream";
-      version = "3.0.0";
+      version = "3.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/multistream/-/multistream-3.0.0.tgz";
-        sha512 = "v1Fx9uhHEpTB725/Kj8YpRCvrLhb20LeABFLw+0dkBkKUUAbDCY6CUUNzGQsJ94ji/p50wBPsRjIQXN1iOwZYA==";
+        url = "https://registry.npmjs.org/multistream/-/multistream-3.1.0.tgz";
+        sha512 = "zBgD3kn8izQAN/TaL1PCMv15vYpf+Vcrsfub06njuYVYlzUldzpopTlrEZ53pZVEbfn3Shtv7vRFoOv6LOV87Q==";
       };
     };
     "mustache-2.3.2" = {
@@ -26584,13 +26773,13 @@ let
         sha512 = "iWo/23xFnl+IGeX+LlfwoVKtyY4volPSodf3nwPScPgxjws4k2ZUozPG98OouMA0yn0JamqApjRw7eqLrzyV2A==";
       };
     };
-    "muxrpcli-3.1.1" = {
+    "muxrpcli-3.1.2" = {
       name = "muxrpcli";
       packageName = "muxrpcli";
-      version = "3.1.1";
+      version = "3.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/muxrpcli/-/muxrpcli-3.1.1.tgz";
-        sha512 = "DSBXkmbfZgUrM9Y54Saeb2RySmuDMo5jAnMnBo0JHempIlHIXmnrIASdC0co0TQATq8kECF6SYcTFbJLKZUfJw==";
+        url = "https://registry.npmjs.org/muxrpcli/-/muxrpcli-3.1.2.tgz";
+        sha512 = "3nDL3dYXKxAN+spKSQBolxFoOl4HJCcm5UKlxjdjQxcjvLGLFLvwuNf1vCRpSveCHiFCxPLltWq2hT+vlDLPtQ==";
       };
     };
     "mv-2.1.1" = {
@@ -27480,6 +27669,15 @@ let
         sha512 = "SUDEb+o71XR5lXSTyivXd9J7fCloE3SyP4lSgt3lU2oSANiox+SxlNRGPjDKrwU1YN3ix2KN/VGGCg0t01rttQ==";
       };
     };
+    "node-notifier-5.4.2" = {
+      name = "node-notifier";
+      packageName = "node-notifier";
+      version = "5.4.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.2.tgz";
+        sha512 = "85nkTziazE2dR4pyoLxMwz0b9MmxFQPVXYs/WlWI7CPtBkARJOV+89khdNjpbclXIJDECQYnTvh1xuZV3WHkCA==";
+      };
+    };
     "node-persist-2.1.0" = {
       name = "node-persist";
       packageName = "node-persist";
@@ -27757,6 +27955,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/nopt/-/nopt-2.0.0.tgz";
         sha1 = "ca7416f20a5e3f9c3b86180f96295fa3d0b52e0d";
+      };
+    };
+    "nopt-2.1.2" = {
+      name = "nopt";
+      packageName = "nopt";
+      version = "2.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz";
+        sha1 = "6cccd977b80132a07731d6e8ce58c2c8303cf9af";
       };
     };
     "nopt-2.2.1" = {
@@ -28766,6 +28973,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/optimist/-/optimist-0.2.8.tgz";
         sha1 = "e981ab7e268b457948593b55674c099a815cac31";
+      };
+    };
+    "optimist-0.3.7" = {
+      name = "optimist";
+      packageName = "optimist";
+      version = "0.3.7";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz";
+        sha1 = "c90941ad59e4273328923074d2cf2e7cbc6ec0d9";
       };
     };
     "optimist-0.6.0" = {
@@ -30163,6 +30379,15 @@ let
         sha512 = "oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==";
       };
     };
+    "picture-tuber-1.0.2" = {
+      name = "picture-tuber";
+      packageName = "picture-tuber";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/picture-tuber/-/picture-tuber-1.0.2.tgz";
+        sha512 = "49/xq+wzbwDeI32aPvwQJldM8pr7dKDRuR76IjztrkmiCkAQDaWFJzkmfVqCHmt/iFoPFhHmI9L0oKhthrTOQw==";
+      };
+    };
     "pid-from-port-1.1.3" = {
       name = "pid-from-port";
       packageName = "pid-from-port";
@@ -30458,6 +30683,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz";
         sha512 = "2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==";
+      };
+    };
+    "png-js-0.1.1" = {
+      name = "png-js";
+      packageName = "png-js";
+      version = "0.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/png-js/-/png-js-0.1.1.tgz";
+        sha1 = "1cc7c212303acabe74263ec3ac78009580242d93";
       };
     };
     "pngjs-2.3.1" = {
@@ -31253,13 +31487,13 @@ let
         sha1 = "8e57123c396ab988897fb327fd3aedc3e735e4fe";
       };
     };
-    "prompts-2.1.0" = {
+    "prompts-2.2.1" = {
       name = "prompts";
       packageName = "prompts";
-      version = "2.1.0";
+      version = "2.2.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/prompts/-/prompts-2.1.0.tgz";
-        sha512 = "+x5TozgqYdOwWsQFZizE/Tra3fKvAoy037kOyU6cgz84n8f6zxngLOV4O32kTwt9FcLCxAqw0P/c8rOr9y+Gfg==";
+        url = "https://registry.npmjs.org/prompts/-/prompts-2.2.1.tgz";
+        sha512 = "VObPvJiWPhpZI6C5m60XOzTfnYg/xc/an+r9VYymj9WJW3B/DIH+REzjpAACPf8brwPeP+7vz3bIim3S+AaMjw==";
       };
     };
     "promzard-0.3.0" = {
@@ -33071,6 +33305,15 @@ let
         sha1 = "c1b2007b42d57eb1389079b3c8333639d5e1ccaa";
       };
     };
+    "redeyed-1.0.1" = {
+      name = "redeyed";
+      packageName = "redeyed";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/redeyed/-/redeyed-1.0.1.tgz";
+        sha1 = "e96c193b40c0816b00aec842698e61185e55498a";
+      };
+    };
     "redis-0.12.1" = {
       name = "redis";
       packageName = "redis";
@@ -34727,13 +34970,13 @@ let
         sha512 = "sDtmZDpibGH2ixj3FOmsC3Z/b08eaB2/KAvy2oSp4qvcGdhatBSfb1RdVpwjQl5c3J83WbBo1HSZ7DBtMu43lA==";
       };
     };
-    "secret-stack-6.2.1" = {
+    "secret-stack-6.3.0" = {
       name = "secret-stack";
       packageName = "secret-stack";
-      version = "6.2.1";
+      version = "6.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/secret-stack/-/secret-stack-6.2.1.tgz";
-        sha512 = "7hw13S77Et4yC23uVXOFDRyullxAvFuoN3XW6PvHlAVkYMirLkyeglPOwPTk5JhYwIKPdpIz6vQ7DM0zSlOUHA==";
+        url = "https://registry.npmjs.org/secret-stack/-/secret-stack-6.3.0.tgz";
+        sha512 = "abIfcP1tlJ3gbfgAkp6mgqEc7M70GvXVTyE//iHDXMQz21zQxOD5WcWAiMg1Lgw5FgLfHM1WF+c8PqFNNE3WOg==";
       };
     };
     "secure-keys-1.0.0" = {
@@ -35591,13 +35834,13 @@ let
         sha1 = "5d3d5751bb39aeba2f710d8eec78768df821f38d";
       };
     };
-    "simple-websocket-7.2.0" = {
+    "simple-websocket-8.0.0" = {
       name = "simple-websocket";
       packageName = "simple-websocket";
-      version = "7.2.0";
+      version = "8.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/simple-websocket/-/simple-websocket-7.2.0.tgz";
-        sha512 = "wdxFg1fHw1yqFKWDcw+yNb4VIYqtl+vknZMlpLhvZSlR6l7/iVuwozqo+Qtl73mB1IH5QnXzonD1S+hAaLNTvQ==";
+        url = "https://registry.npmjs.org/simple-websocket/-/simple-websocket-8.0.0.tgz";
+        sha512 = "DwBEoqOq8gvnblarMPkhZD6AWituWbVfTil/UflowYm/Bu5SK23BDKGxrVwgQXGKydzxlSiYva7LC3/hXSRLIw==";
       };
     };
     "single-line-log-0.4.1" = {
@@ -35627,13 +35870,13 @@ let
         sha512 = "dKKwjIoTOa587TARYLlBRXq2lkbu5Iz35XrEVWpelhBP1m8r2BGOy1QlaZe84GTFHG/BTucEUd2btnNc8QzIVA==";
       };
     };
-    "sisteransi-1.0.2" = {
+    "sisteransi-1.0.3" = {
       name = "sisteransi";
       packageName = "sisteransi";
-      version = "1.0.2";
+      version = "1.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.2.tgz";
-        sha512 = "ZcYcZcT69nSLAR2oLN2JwNmLkJEKGooFMCdvOkFrToUt/WfcRWqhIg4P4KwY4dmLbuyXIx4o4YmPsvMRJYJd/w==";
+        url = "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.3.tgz";
+        sha512 = "SbEG75TzH8G7eVXFSN5f9EExILKfly7SUvVY5DhhYLvfhKqhDFY0OzevWa/zwak0RLRfWS5AvfMWpd9gJvr5Yg==";
       };
     };
     "skin-tone-1.0.0" = {
@@ -35843,22 +36086,22 @@ let
         sha1 = "6541184cc90aeea6c6e7b35e2659082443c66198";
       };
     };
-    "snyk-1.208.0" = {
+    "snyk-1.210.0" = {
       name = "snyk";
       packageName = "snyk";
-      version = "1.208.0";
+      version = "1.210.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk/-/snyk-1.208.0.tgz";
-        sha512 = "MMOQazfz+5fvoCDEBBJiuYNdcrtE3anemGvL7VJFlWu4uc8YgVZ8gvetEO7OmLmn4FfTmJ/hAthEQgcXYjDjFw==";
+        url = "https://registry.npmjs.org/snyk/-/snyk-1.210.0.tgz";
+        sha512 = "k6/EIX1Dc4Qk8omcKQDm13RRywkKqXoQ0IMz5Nyk1y8sdmg1S78QSWnfTaEPe+OQE1olrtjInrDX3Yu20CnMzg==";
       };
     };
-    "snyk-config-2.2.2" = {
+    "snyk-config-2.2.3" = {
       name = "snyk-config";
       packageName = "snyk-config";
-      version = "2.2.2";
+      version = "2.2.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-config/-/snyk-config-2.2.2.tgz";
-        sha512 = "ud1UJhU5b3z2achCVbXin6m3eeESvJTn9hBDYjp5BafI+1ajOJt0LnUB9+SAZ3CnQIK90PUb/3nSx0xjtda7sA==";
+        url = "https://registry.npmjs.org/snyk-config/-/snyk-config-2.2.3.tgz";
+        sha512 = "9NjxHVMd1U1LFw66Lya4LXgrsFUiuRiL4opxfTFo0LmMNzUoU5Bk/p0zDdg3FE5Wg61r4fP2D8w+QTl6M8CGiw==";
       };
     };
     "snyk-docker-plugin-1.25.1" = {
@@ -35906,13 +36149,13 @@ let
         sha512 = "A+CCyBSa4IKok5uEhqT+hV/35RO6APFNLqk9DRRHg7xW2/j//nPX8wTSZUPF8QeRNEk/sX+6df7M1y6PBHGSHA==";
       };
     };
-    "snyk-mvn-plugin-2.3.1" = {
+    "snyk-mvn-plugin-2.3.3" = {
       name = "snyk-mvn-plugin";
       packageName = "snyk-mvn-plugin";
-      version = "2.3.1";
+      version = "2.3.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-2.3.1.tgz";
-        sha512 = "2RgBnYe3Upc7SL+sL7MmnoCoJV/TZZ7q2L0J1BAbjoD/4cca4q0TCR6QVLzytHf4fSqc6QjSMjTUfmAo0kgsBg==";
+        url = "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-2.3.3.tgz";
+        sha512 = "NYFL+jtHfAJk+Jdyme4I8pTvg/wfoHgkOs1g1nFUEPTcpBb5mfqy7Q9hDJWvnfXY8M6P9aEqvO+bmCVgTQvySg==";
       };
     };
     "snyk-nodejs-lockfile-parser-1.16.0" = {
@@ -35924,13 +36167,13 @@ let
         sha512 = "cf3uozRXEG88nsjOQlo+SfOJPpcLs45qpnuk2vhBBZ577IMnV+fTOJQsP2YRiikLUbdgkVlduviwUO6OVn1PhA==";
       };
     };
-    "snyk-nuget-plugin-1.11.2" = {
+    "snyk-nuget-plugin-1.11.3" = {
       name = "snyk-nuget-plugin";
       packageName = "snyk-nuget-plugin";
-      version = "1.11.2";
+      version = "1.11.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-1.11.2.tgz";
-        sha512 = "dNAwwFzrxI0gJh+3Eta7EFlz+jzXeTqXUwThaEASxCNNugV8gKsK/v+k0pQBsRPKvTLFlswB2D2Bt1E7YSOixA==";
+        url = "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-1.11.3.tgz";
+        sha512 = "UgLTMr7Vz0qZoL15SkFAUfMb4Vw/qFxf6lBoL2v8xA+Mqdvn2Yu9x/yW659ElFVSUjniqKTFyloKq9/XSv+c+A==";
       };
     };
     "snyk-paket-parser-1.5.0" = {
@@ -36248,13 +36491,13 @@ let
         sha512 = "UMmCHovws/sxIBZsIRhIl8uRPou/RFDD0vVop81T1hG106NLLgqajKKuHAOtAP6hflnZ0UrVA2VFwddTd/NQyA==";
       };
     };
-    "sodium-native-2.4.3" = {
+    "sodium-native-2.4.5" = {
       name = "sodium-native";
       packageName = "sodium-native";
-      version = "2.4.3";
+      version = "2.4.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/sodium-native/-/sodium-native-2.4.3.tgz";
-        sha512 = "UCj3G++buo7HFADLMXyG+K7trEl6h17lde/2Sd3Al9ozcfPIQyKohmVqDncHY7ZggWkhzdwHKyDnlFWFQHZ5pg==";
+        url = "https://registry.npmjs.org/sodium-native/-/sodium-native-2.4.5.tgz";
+        sha512 = "G1uhd4l1OexzUC/6eHIbAvoivCs9T7ncDlEWodZglPZVUOXi6jtSe7tCi25aYB06zRoOjVfE4SL+hZ4EfkyZgw==";
       };
     };
     "sodium-universal-2.0.0" = {
@@ -36507,6 +36750,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz";
         sha512 = "dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw==";
+      };
+    };
+    "sparkline-0.1.2" = {
+      name = "sparkline";
+      packageName = "sparkline";
+      version = "0.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/sparkline/-/sparkline-0.1.2.tgz";
+        sha1 = "c3bde46252b1354e710c4b200d54816bd9f07a32";
       };
     };
     "sparse-bitfield-3.0.3" = {
@@ -37499,6 +37751,15 @@ let
         sha512 = "ryeEu3DGMt/095uTShIYGzLbbhZ+tHQtgp5HWEhXALSoc4U1iLSvpReZUdysahnJ3tki80wBBgryqqBzFZ0KaA==";
       };
     };
+    "stream-to-blob-2.0.0" = {
+      name = "stream-to-blob";
+      packageName = "stream-to-blob";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/stream-to-blob/-/stream-to-blob-2.0.0.tgz";
+        sha512 = "E+YitTtIHo7RQ4Cmgl+EzlMpqvLroTynRgt4t0pI4y5oz/piqlBQB8NFXLIWcjGOsKw+THnImrdpWcOCVxK25Q==";
+      };
+    };
     "stream-to-blob-url-2.1.2" = {
       name = "stream-to-blob-url";
       packageName = "stream-to-blob-url";
@@ -38480,6 +38741,15 @@ let
         sha512 = "YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==";
       };
     };
+    "systeminformation-4.14.4" = {
+      name = "systeminformation";
+      packageName = "systeminformation";
+      version = "4.14.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/systeminformation/-/systeminformation-4.14.4.tgz";
+        sha512 = "ib2dodksiiaGOW4rcKvFr5naHkODI9GwQPugLb6FLKppkIsE7rj2dfY2UdMBr7oX0/iZP981hoxmbk2e6zl99Q==";
+      };
+    };
     "syswide-cas-5.3.0" = {
       name = "syswide-cas";
       packageName = "syswide-cas";
@@ -38796,6 +39066,15 @@ let
         sha512 = "LB83o9bfZGrntdqPuRdanIVCPReam9SOZKW0fOy5I9X3A854GGWi0tjCqoXEk84XIEYBc/x9Hq3EFop/H5wJaw==";
       };
     };
+    "term-canvas-0.0.5" = {
+      name = "term-canvas";
+      packageName = "term-canvas";
+      version = "0.0.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/term-canvas/-/term-canvas-0.0.5.tgz";
+        sha1 = "597afac2fa6369a6f17860bce9c5f66d6ea0ca96";
+      };
+    };
     "term-size-1.2.0" = {
       name = "term-size";
       packageName = "term-size";
@@ -38805,13 +39084,13 @@ let
         sha1 = "458b83887f288fc56d6fffbfad262e26638efa69";
       };
     };
-    "terminal-kit-1.29.2" = {
+    "terminal-kit-1.29.3" = {
       name = "terminal-kit";
       packageName = "terminal-kit";
-      version = "1.29.2";
+      version = "1.29.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/terminal-kit/-/terminal-kit-1.29.2.tgz";
-        sha512 = "Ky4kxKivTqdH7OXZEOh1oaUx9OZSf707nW3OHN97UpLAfU/U75lzUlQhDxoKsG0T9qejC7b8qCbX3Ps+kX14SQ==";
+        url = "https://registry.npmjs.org/terminal-kit/-/terminal-kit-1.29.3.tgz";
+        sha512 = "RngmihiCinQ0CT3Q7l2R4aiV50czaB0gmGZ2rOZXhX5vWAkUAsnRVcv4JG068KQP1FbQNhm88CU/nBCZQmMPUQ==";
       };
     };
     "terser-3.17.0" = {
@@ -38823,13 +39102,13 @@ let
         sha512 = "/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==";
       };
     };
-    "terser-4.1.2" = {
+    "terser-4.1.3" = {
       name = "terser";
       packageName = "terser";
-      version = "4.1.2";
+      version = "4.1.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/terser/-/terser-4.1.2.tgz";
-        sha512 = "jvNoEQSPXJdssFwqPSgWjsOrb+ELoE+ILpHPKXC83tIxOlh2U75F1KuB2luLD/3a6/7K3Vw5pDn+hvu0C4AzSw==";
+        url = "https://registry.npmjs.org/terser/-/terser-4.1.3.tgz";
+        sha512 = "on13d+cnpn5bMouZu+J8tPYQecsdRJCJuxFJ+FVoPBoLJgk5bCBkp+Uen2hWyi0KIUm6eDarnlAlH+KgIx/PuQ==";
       };
     };
     "terser-webpack-plugin-1.4.1" = {
@@ -40092,13 +40371,13 @@ let
         sha512 = "/XrQjW0e5Z915m1A0qeXD9tSLDmz8zGjR6imhGDme6rMtXYudFpXXhaToKnM52nPPCNdCh6YQsLLkwbbkFvzVA==";
       };
     };
-    "type-1.0.1" = {
+    "type-1.0.3" = {
       name = "type";
       packageName = "type";
-      version = "1.0.1";
+      version = "1.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/type/-/type-1.0.1.tgz";
-        sha512 = "MAM5dBMJCJNKs9E7JXo4CXRAansRfG0nlJxW7Wf6GZzSOvH31zClSaHdIMWLehe/EGMBkqeC55rrkaOr5Oo7Nw==";
+        url = "https://registry.npmjs.org/type/-/type-1.0.3.tgz";
+        sha512 = "51IMtNfVcee8+9GJvj0spSuFcZHe9vSib6Xtgsny1Km9ugyz2mbS08I3rsUIRYgJohFRFU1160sgRodYz378Hg==";
       };
     };
     "type-check-0.3.2" = {
@@ -41586,6 +41865,15 @@ let
         sha512 = "CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==";
       };
     };
+    "v8-compile-cache-2.1.0" = {
+      name = "v8-compile-cache";
+      packageName = "v8-compile-cache";
+      version = "2.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz";
+        sha512 = "usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==";
+      };
+    };
     "v8-debug-1.0.1" = {
       name = "v8-debug";
       packageName = "v8-debug";
@@ -42018,13 +42306,13 @@ let
         sha1 = "2fb1decd4c466aa88b0f9341af33dc1aff2478d5";
       };
     };
-    "videostream-3.2.0" = {
+    "videostream-3.2.1" = {
       name = "videostream";
       packageName = "videostream";
-      version = "3.2.0";
+      version = "3.2.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/videostream/-/videostream-3.2.0.tgz";
-        sha512 = "8+EY2dBxpJti9OBWUHtTn8wZEzyUwX7ldm/rwz8LKsgK+ccGVbTug9F6nyBOehLhifXALCs6Ca+CeYPVGBwobg==";
+        url = "https://registry.npmjs.org/videostream/-/videostream-3.2.1.tgz";
+        sha512 = "Z4EcsX9aYNJZD1M+0jCeQ0t+5ETlHE88B2SF1fCuVxfn+XxHGJVec6tbHGqpULk4esOOLJEipAScOCDGHk+teQ==";
       };
     };
     "vinyl-0.4.6" = {
@@ -42567,13 +42855,13 @@ let
         sha512 = "YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==";
       };
     };
-    "webpack-4.39.0" = {
+    "webpack-4.39.1" = {
       name = "webpack";
       packageName = "webpack";
-      version = "4.39.0";
+      version = "4.39.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/webpack/-/webpack-4.39.0.tgz";
-        sha512 = "nrxFNSEKm4T1C/EsgOgN50skt//Pl4X7kgJC1MrlE47M292LSCVmMOC47iTGL0CGxbdwhKGgeThrJcw0bstEfA==";
+        url = "https://registry.npmjs.org/webpack/-/webpack-4.39.1.tgz";
+        sha512 = "/LAb2TJ2z+eVwisldp3dqTEoNhzp/TLCZlmZm3GGGAlnfIWDgOEE758j/9atklNLfRyhKbZTCOIoPqLJXeBLbQ==";
       };
     };
     "webpack-cli-3.3.6" = {
@@ -42594,13 +42882,13 @@ let
         sha1 = "fc571588c8558da77be9efb6debdc5a3b172bdc2";
       };
     };
-    "webpack-sources-1.4.1" = {
+    "webpack-sources-1.4.3" = {
       name = "webpack-sources";
       packageName = "webpack-sources";
-      version = "1.4.1";
+      version = "1.4.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.1.tgz";
-        sha512 = "XSz38193PTo/1csJabKaV4b53uRVotlMgqJXm3s3eje0Bu6gQTxYDqpD38CmQfDBA+gN+QqaGjasuC8I/7eW3Q==";
+        url = "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz";
+        sha512 = "lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==";
       };
     };
     "websocket-driver-0.7.3" = {
@@ -42630,13 +42918,13 @@ let
         sha512 = "EXy/zXb9kNHI07TIMz1oIUIrPZxQRA8aeJ5XYg5ihV8K4kD1DuA+FY6R96HfdIHzlSzS8HiISAfrm+vVQkZBug==";
       };
     };
-    "webtorrent-0.105.3" = {
+    "webtorrent-0.106.0" = {
       name = "webtorrent";
       packageName = "webtorrent";
-      version = "0.105.3";
+      version = "0.106.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/webtorrent/-/webtorrent-0.105.3.tgz";
-        sha512 = "Jm2Y4NIwRdAOTnFCueE9t1bcFjFK9W75pEfvx9WNidLo20eUvdLuERLu75Gnl7eI44mue1nAtk7MgaYk2CaeRw==";
+        url = "https://registry.npmjs.org/webtorrent/-/webtorrent-0.106.0.tgz";
+        sha512 = "CTj4J6yj6TuNTfrjRL84tunlCwIM+4hBu/6BfZslgi+iHdiJklUmFra/1WXBsx1madUB6/Ujx1eh4w+FO0on7g==";
       };
     };
     "whatwg-encoding-1.0.5" = {
@@ -43276,6 +43564,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz";
         sha1 = "474b50865af3a49a9c4657f05acd145458f77d82";
+      };
+    };
+    "x256-0.0.2" = {
+      name = "x256";
+      packageName = "x256";
+      version = "0.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/x256/-/x256-0.0.2.tgz";
+        sha1 = "c9af18876f7a175801d564fe70ad9e8317784934";
       };
     };
     "xdg-basedir-3.0.0" = {
@@ -44062,13 +44359,13 @@ let
         sha1 = "a8bc45f4c1b49699c6b90198baacaacdbcd4ba04";
       };
     };
-    "zip-stream-2.1.0" = {
+    "zip-stream-2.1.2" = {
       name = "zip-stream";
       packageName = "zip-stream";
-      version = "2.1.0";
+      version = "2.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/zip-stream/-/zip-stream-2.1.0.tgz";
-        sha512 = "F/xoLqlQShgvn1BzHQCNiYIoo2R93GQIMH+tA6JC3ckMDkme4bnhEEXSferZcG5ea/6bZNx3GqSUHqT8TUO6uQ==";
+        url = "https://registry.npmjs.org/zip-stream/-/zip-stream-2.1.2.tgz";
+        sha512 = "ykebHGa2+uzth/R4HZLkZh3XFJzivhVsjJt8bN3GvBzLaqqrUdRacu+c4QtnUgjkkQfsOuNE1JgLKMCPNmkKgg==";
       };
     };
     "zmq-2.15.3" = {
@@ -44169,13 +44466,13 @@ in
       sources."get-stream-4.1.0"
       sources."getpass-0.1.7"
       sources."glob-7.1.4"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-1.0.3"
       sources."has-flag-3.0.0"
       sources."has-symbols-1.0.0"
-      sources."hosted-git-info-2.7.1"
+      sources."hosted-git-info-2.8.2"
       sources."http-cache-semantics-3.8.1"
       (sources."http-proxy-agent-2.1.0" // {
         dependencies = [
@@ -44561,7 +44858,7 @@ in
       sources."globalyzer-0.1.4"
       sources."globrex-0.1.2"
       sources."got-9.6.0"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       (sources."gulp-vinyl-zip-2.1.2" // {
         dependencies = [
           sources."readable-stream-2.3.6"
@@ -44736,10 +45033,10 @@ in
   "@vue/cli" = nodeEnv.buildNodePackage {
     name = "_at_vue_slash_cli";
     packageName = "@vue/cli";
-    version = "3.9.3";
+    version = "3.10.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/@vue/cli/-/cli-3.9.3.tgz";
-      sha512 = "+l/N5sNSwvDe6UsVrqcz8GIWp8QO5Q72OUW7P0X3xdcVo0XPnzwJ/jzKaYGnp7/syOFTIfL6KyW4gVezPE2oPA==";
+      url = "https://registry.npmjs.org/@vue/cli/-/cli-3.10.0.tgz";
+      sha512 = "0A2wsUPAoiiqr4B/EAlz1SPUNbq0pbyt4I8V6fiwie5oJXaxfJ8Vl8rpSUsZ2PzwpowgdiutjFkOxvFmhHAkQQ==";
     };
     dependencies = [
       sources."@akryum/winattr-3.0.0"
@@ -44875,16 +45172,16 @@ in
       sources."@types/node-12.6.9"
       sources."@types/range-parser-1.2.3"
       sources."@types/serve-static-1.13.2"
-      sources."@types/ws-6.0.1"
+      sources."@types/ws-6.0.2"
       sources."@types/zen-observable-0.8.0"
-      sources."@vue/cli-shared-utils-3.9.0"
-      (sources."@vue/cli-ui-3.9.3" // {
+      sources."@vue/cli-shared-utils-3.10.0"
+      (sources."@vue/cli-ui-3.10.0" // {
         dependencies = [
           sources."clone-2.1.2"
         ];
       })
-      sources."@vue/cli-ui-addon-webpack-3.9.3"
-      sources."@vue/cli-ui-addon-widgets-3.9.3"
+      sources."@vue/cli-ui-addon-webpack-3.10.0"
+      sources."@vue/cli-ui-addon-widgets-3.10.0"
       sources."@wry/context-0.4.4"
       sources."@wry/equality-0.1.9"
       sources."abbrev-1.1.1"
@@ -44952,7 +45249,7 @@ in
       sources."ast-types-0.11.7"
       sources."async-1.5.2"
       sources."async-each-1.0.3"
-      sources."async-limiter-1.0.0"
+      sources."async-limiter-1.0.1"
       sources."async-retry-1.2.3"
       sources."asynckit-0.4.0"
       sources."atob-2.1.2"
@@ -44967,7 +45264,7 @@ in
           sources."define-property-1.0.0"
         ];
       })
-      sources."base64-js-1.3.0"
+      sources."base64-js-1.3.1"
       sources."bcrypt-pbkdf-1.0.2"
       sources."binary-extensions-1.13.1"
       sources."bl-1.2.2"
@@ -44995,7 +45292,7 @@ in
       sources."cache-base-1.0.1"
       sources."call-me-maybe-1.0.1"
       sources."camelcase-4.1.0"
-      sources."caniuse-lite-1.0.30000988"
+      sources."caniuse-lite-1.0.30000989"
       sources."capture-stack-trace-1.0.1"
       sources."caseless-0.12.0"
       sources."caw-2.0.1"
@@ -45120,7 +45417,7 @@ in
       sources."ecc-jsbn-0.1.2"
       sources."ee-first-1.1.1"
       sources."ejs-2.6.2"
-      sources."electron-to-chromium-1.3.210"
+      sources."electron-to-chromium-1.3.215"
       sources."encodeurl-1.0.2"
       sources."end-of-stream-1.4.1"
       sources."entities-1.1.2"
@@ -45241,7 +45538,7 @@ in
       })
       sources."good-listener-1.2.2"
       sources."got-6.7.1"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."graceful-readlink-1.0.1"
       sources."graphql-14.4.2"
       (sources."graphql-anywhere-4.2.4" // {
@@ -45425,9 +45722,9 @@ in
       sources."node-fetch-2.6.0"
       sources."node-ipc-9.1.1"
       sources."node-modules-regexp-1.0.0"
-      (sources."node-notifier-5.4.0" // {
+      (sources."node-notifier-5.4.2" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."is-wsl-2.1.0"
         ];
       })
       (sources."node-releases-1.1.26" // {
@@ -46099,7 +46396,7 @@ in
         ];
       })
       sources."globals-11.12.0"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."has-color-0.1.7"
       sources."has-flag-3.0.0"
       sources."homedir-polyfill-1.0.3"
@@ -46605,10 +46902,10 @@ in
   azure-functions-core-tools = nodeEnv.buildNodePackage {
     name = "azure-functions-core-tools";
     packageName = "azure-functions-core-tools";
-    version = "2.7.1480";
+    version = "2.7.1505";
     src = fetchurl {
-      url = "https://registry.npmjs.org/azure-functions-core-tools/-/azure-functions-core-tools-2.7.1480.tgz";
-      sha512 = "Yr0YtXQ6JHB8ep68X9E5FQvbNb0Hs05t8o8exl+LJ8c/0VpIg2Ff7slzRHseTuQF4RysYk2VbRNPaN6ZPS1kWw==";
+      url = "https://registry.npmjs.org/azure-functions-core-tools/-/azure-functions-core-tools-2.7.1505.tgz";
+      sha512 = "3v1lDv6zwhGi2Qb8rNFA3tR+8h/vlufuanRgbw2ofPCPBCC29yiyQs2+IiCTBHVAxcBPN0h5rsELstoZ3S2Odw==";
     };
     dependencies = [
       sources."agent-base-4.3.0"
@@ -46635,7 +46932,7 @@ in
       sources."fs.realpath-1.0.0"
       sources."fstream-1.0.12"
       sources."glob-7.1.3"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."has-flag-3.0.0"
       sources."https-proxy-agent-2.2.1"
       sources."inflight-1.0.6"
@@ -46683,7 +46980,7 @@ in
     dependencies = [
       sources."abab-2.0.0"
       sources."acorn-5.7.3"
-      (sources."acorn-globals-4.3.2" // {
+      (sources."acorn-globals-4.3.3" // {
         dependencies = [
           sources."acorn-6.2.1"
         ];
@@ -46696,7 +46993,7 @@ in
       sources."array-equal-1.0.0"
       sources."asn1-0.2.4"
       sources."assert-plus-1.0.0"
-      sources."async-limiter-1.0.0"
+      sources."async-limiter-1.0.1"
       sources."asynckit-0.4.0"
       sources."aws-sign2-0.7.0"
       sources."aws4-1.8.0"
@@ -46934,14 +47231,14 @@ in
       sources."find-up-1.1.2"
       (sources."fs-extra-0.26.7" // {
         dependencies = [
-          sources."graceful-fs-4.2.0"
+          sources."graceful-fs-4.2.1"
         ];
       })
       sources."fs.realpath-1.0.0"
       sources."get-stdin-4.0.1"
       sources."glob-6.0.4"
       sources."graceful-fs-3.0.11"
-      sources."hosted-git-info-2.7.1"
+      sources."hosted-git-info-2.8.2"
       sources."indent-string-2.1.0"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
@@ -46952,21 +47249,22 @@ in
       sources."is-utf8-0.2.1"
       (sources."jsonfile-2.4.0" // {
         dependencies = [
-          sources."graceful-fs-4.2.0"
+          sources."graceful-fs-4.2.1"
         ];
       })
       (sources."klaw-1.3.1" // {
         dependencies = [
-          sources."graceful-fs-4.2.0"
+          sources."graceful-fs-4.2.1"
         ];
       })
       (sources."load-json-file-1.1.0" // {
         dependencies = [
-          sources."graceful-fs-4.2.0"
+          sources."graceful-fs-4.2.1"
         ];
       })
       sources."lodash-4.2.1"
       sources."loud-rejection-1.6.0"
+      sources."lru-cache-5.1.1"
       sources."map-obj-1.0.1"
       sources."meow-3.7.0"
       sources."mime-db-1.40.0"
@@ -46990,7 +47288,7 @@ in
       sources."path-parse-1.0.6"
       (sources."path-type-1.1.0" // {
         dependencies = [
-          sources."graceful-fs-4.2.0"
+          sources."graceful-fs-4.2.1"
         ];
       })
       sources."pify-2.3.0"
@@ -47027,6 +47325,7 @@ in
       sources."trim-newlines-1.0.0"
       sources."validate-npm-package-license-3.0.4"
       sources."wrappy-1.0.2"
+      sources."yallist-3.0.3"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -47062,7 +47361,7 @@ in
         ];
       })
       sources."balanced-match-1.0.0"
-      sources."base64-js-1.3.0"
+      sources."base64-js-1.3.1"
       sources."bn.js-4.11.8"
       sources."brace-expansion-1.1.11"
       sources."brorand-1.1.0"
@@ -47248,7 +47547,7 @@ in
       sources."aws-sign2-0.7.0"
       sources."aws4-1.8.0"
       sources."balanced-match-1.0.0"
-      sources."base64-js-1.3.0"
+      sources."base64-js-1.3.1"
       sources."bcrypt-pbkdf-1.0.2"
       sources."bencode-2.0.1"
       sources."bitfield-0.1.0"
@@ -47346,12 +47645,12 @@ in
       sources."getpass-0.1.7"
       sources."glob-7.1.4"
       sources."got-1.2.2"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-ansi-1.0.3"
       sources."hat-0.0.3"
-      sources."hosted-git-info-2.7.1"
+      sources."hosted-git-info-2.8.2"
       sources."http-signature-1.2.0"
       sources."immediate-chunk-store-1.0.8"
       sources."indent-string-2.1.0"
@@ -47387,6 +47686,7 @@ in
       sources."long-2.4.0"
       sources."loud-rejection-1.6.0"
       sources."lru-2.0.1"
+      sources."lru-cache-5.1.1"
       sources."magnet-uri-5.2.4"
       sources."map-obj-1.0.1"
       (sources."mdns-js-1.0.3" // {
@@ -47613,6 +47913,7 @@ in
       sources."xmldom-0.1.27"
       sources."xspfr-0.3.1"
       sources."xtend-4.0.2"
+      sources."yallist-3.0.3"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -47823,7 +48124,7 @@ in
           sources."define-property-1.0.0"
         ];
       })
-      sources."base64-js-1.3.0"
+      sources."base64-js-1.3.1"
       sources."bcrypt-pbkdf-1.0.2"
       sources."big-integer-1.6.44"
       (sources."body-parser-1.19.0" // {
@@ -48020,7 +48321,7 @@ in
           sources."get-stream-3.0.0"
         ];
       })
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-1.0.3"
@@ -48032,7 +48333,7 @@ in
           sources."kind-of-4.0.0"
         ];
       })
-      sources."hosted-git-info-2.7.1"
+      sources."hosted-git-info-2.8.2"
       (sources."http-errors-1.7.2" // {
         dependencies = [
           sources."inherits-2.0.3"
@@ -48106,7 +48407,7 @@ in
       sources."lodash.debounce-4.0.8"
       sources."loud-rejection-2.1.0"
       sources."lowercase-keys-1.0.1"
-      sources."lru-cache-4.1.5"
+      sources."lru-cache-5.1.1"
       sources."macos-release-2.3.0"
       sources."make-dir-1.3.0"
       sources."map-cache-0.2.2"
@@ -48335,6 +48636,8 @@ in
           sources."cross-spawn-5.1.0"
           sources."execa-0.7.0"
           sources."get-stream-3.0.0"
+          sources."lru-cache-4.1.5"
+          sources."yallist-2.1.2"
         ];
       })
       sources."through-2.3.8"
@@ -48398,7 +48701,7 @@ in
       sources."xdg-basedir-3.0.0"
       sources."xmlbuilder-9.0.7"
       sources."xmldom-0.1.27"
-      sources."yallist-2.1.2"
+      sources."yallist-3.0.3"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -48533,14 +48836,14 @@ in
       })
       sources."glob-to-regexp-0.3.0"
       sources."globby-9.2.0"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."has-value-1.0.0"
       (sources."has-values-1.0.0" // {
         dependencies = [
           sources."kind-of-4.0.0"
         ];
       })
-      sources."hosted-git-info-2.7.1"
+      sources."hosted-git-info-2.8.2"
       sources."ignore-4.0.6"
       sources."indent-string-3.2.0"
       sources."inflight-1.0.6"
@@ -48572,6 +48875,7 @@ in
       })
       sources."locate-path-2.0.0"
       sources."loud-rejection-1.6.0"
+      sources."lru-cache-5.1.1"
       sources."make-dir-2.1.0"
       sources."map-cache-0.2.2"
       sources."map-obj-2.0.0"
@@ -48720,6 +49024,7 @@ in
       sources."use-3.1.1"
       sources."validate-npm-package-license-3.0.4"
       sources."wrappy-1.0.2"
+      sources."yallist-3.0.3"
       sources."yargs-parser-10.1.0"
     ];
     buildInputs = globalBuildInputs;
@@ -48859,7 +49164,7 @@ in
       sources."symbol-observable-1.2.0"
       sources."through-2.3.8"
       sources."tmp-0.0.33"
-      sources."type-1.0.1"
+      sources."type-1.0.3"
       sources."util-deprecate-1.0.2"
       (sources."variable-diff-1.1.0" // {
         dependencies = [
@@ -48921,7 +49226,7 @@ in
       sources."fstream-1.0.12"
       sources."fstream-ignore-1.0.5"
       sources."glob-7.1.4"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."has-flag-3.0.0"
       sources."hyperquest-2.1.3"
       sources."iconv-lite-0.4.24"
@@ -49021,7 +49326,7 @@ in
       sources."cross-spawn-5.1.0"
       sources."escape-string-regexp-1.0.5"
       sources."fs-extra-4.0.3"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."has-flag-3.0.0"
       sources."isexe-2.0.0"
       sources."jsonfile-4.0.0"
@@ -49311,7 +49616,7 @@ in
       sources."global-4.3.2"
       sources."global-dirs-0.1.1"
       sources."got-6.7.1"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-1.0.3"
@@ -49586,7 +49891,11 @@ in
         ];
       })
       sources."sodium-javascript-0.5.5"
-      sources."sodium-native-2.4.3"
+      (sources."sodium-native-2.4.5" // {
+        dependencies = [
+          sources."node-gyp-build-4.1.0"
+        ];
+      })
       sources."sodium-universal-2.0.0"
       sources."sorted-array-functions-1.2.0"
       sources."sorted-indexof-1.0.0"
@@ -49909,10 +50218,10 @@ in
       sources."assert-plus-1.0.0"
       sources."async-2.6.3"
       sources."asynckit-0.4.0"
-      sources."aws-sdk-2.503.0"
+      sources."aws-sdk-2.504.0"
       sources."aws-sign2-0.7.0"
       sources."aws4-1.8.0"
-      sources."base64-js-1.3.0"
+      sources."base64-js-1.3.1"
       sources."bcrypt-pbkdf-1.0.2"
       sources."buffer-4.9.1"
       sources."buffer-queue-1.0.0"
@@ -50037,7 +50346,7 @@ in
       sources."ansi-styles-2.2.1"
       sources."anymatch-3.0.3"
       sources."async-each-1.0.3"
-      sources."async-limiter-1.0.0"
+      sources."async-limiter-1.0.1"
       sources."binary-extensions-2.0.0"
       sources."braces-3.0.2"
       sources."chalk-1.1.3"
@@ -50142,7 +50451,7 @@ in
       sources."supports-color-2.0.0"
       sources."timers-ext-0.1.7"
       sources."to-regex-range-5.0.1"
-      sources."type-1.0.1"
+      sources."type-1.0.3"
       sources."unpipe-1.0.0"
       sources."url-parse-1.4.3"
       sources."which-1.3.1"
@@ -50251,13 +50560,18 @@ in
       sources."get-stream-3.0.0"
       sources."globals-9.18.0"
       sources."got-7.1.0"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."has-ansi-3.0.0"
       sources."has-flag-3.0.0"
       sources."has-symbol-support-x-1.4.2"
       sources."has-to-string-tag-x-1.4.1"
       sources."home-or-tmp-2.0.0"
-      sources."hosted-git-info-2.7.1"
+      (sources."hosted-git-info-2.8.2" // {
+        dependencies = [
+          sources."lru-cache-5.1.1"
+          sources."yallist-3.0.3"
+        ];
+      })
       sources."import-jsx-1.3.2"
       sources."imurmurhash-0.1.4"
       sources."indent-string-3.2.0"
@@ -50566,7 +50880,7 @@ in
       sources."tslib-1.10.0"
       sources."type-check-0.3.2"
       sources."uri-js-4.2.2"
-      sources."v8-compile-cache-2.0.3"
+      sources."v8-compile-cache-2.1.0"
       sources."which-1.3.1"
       sources."wordwrap-1.0.0"
       sources."wrappy-1.0.2"
@@ -50720,7 +51034,7 @@ in
       sources."tslib-1.10.0"
       sources."type-check-0.3.2"
       sources."uri-js-4.2.2"
-      sources."v8-compile-cache-2.0.3"
+      sources."v8-compile-cache-2.1.0"
       sources."which-1.3.1"
       sources."wordwrap-1.0.0"
       sources."wrappy-1.0.2"
@@ -50790,13 +51104,13 @@ in
       sources."fs-extra-1.0.0"
       sources."get-stdin-4.0.1"
       sources."getpass-0.1.7"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-ansi-2.0.0"
       sources."has-flag-3.0.0"
       sources."hasha-2.2.0"
-      sources."hosted-git-info-2.7.1"
+      sources."hosted-git-info-2.8.2"
       sources."http-signature-1.2.0"
       sources."indent-string-2.1.0"
       sources."inherits-2.0.4"
@@ -50826,6 +51140,7 @@ in
       })
       sources."log-update-1.0.2"
       sources."loud-rejection-1.6.0"
+      sources."lru-cache-5.1.1"
       sources."map-obj-1.0.1"
       sources."meow-3.7.0"
       sources."mime-db-1.40.0"
@@ -50912,6 +51227,7 @@ in
       sources."validate-npm-package-license-3.0.4"
       sources."verror-1.10.0"
       sources."which-1.3.1"
+      sources."yallist-3.0.3"
       sources."yauzl-2.4.1"
       sources."zen-observable-0.5.2"
     ];
@@ -50976,9 +51292,14 @@ in
       sources."generate-function-1.1.0"
       sources."generate-object-property-1.2.0"
       sources."get-stream-3.0.0"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."has-flag-3.0.0"
-      sources."hosted-git-info-2.7.1"
+      (sources."hosted-git-info-2.8.2" // {
+        dependencies = [
+          sources."lru-cache-5.1.1"
+          sources."yallist-3.0.3"
+        ];
+      })
       sources."iconv-lite-0.4.24"
       sources."indent-string-3.2.0"
       sources."inherits-2.0.4"
@@ -51230,7 +51551,7 @@ in
       sources."glob-7.1.4"
       sources."glob-base-0.3.0"
       sources."glob-parent-2.0.0"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       (sources."has-value-1.0.0" // {
         dependencies = [
           sources."isobject-3.0.1"
@@ -51633,7 +51954,7 @@ in
       sources."muxrpc-6.4.2"
       sources."nan-2.14.0"
       sources."nearley-2.18.0"
-      sources."node-gyp-build-3.9.0"
+      sources."node-gyp-build-4.1.0"
       sources."node-polyglot-1.0.0"
       sources."non-private-ip-1.4.4"
       sources."options-0.0.6"
@@ -51708,7 +52029,7 @@ in
         ];
       })
       sources."sodium-chloride-1.1.2"
-      sources."sodium-native-2.4.3"
+      sources."sodium-native-2.4.5"
       sources."split-buffer-1.0.0"
       sources."ssb-avatar-0.2.0"
       sources."ssb-caps-1.1.0"
@@ -51982,7 +52303,7 @@ in
       sources."global-modules-1.0.0"
       sources."global-prefix-1.0.2"
       sources."got-6.7.1"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."graphcool-json-schema-1.2.1"
       (sources."graphcool-yml-0.4.15" // {
         dependencies = [
@@ -52020,7 +52341,12 @@ in
       sources."has-flag-3.0.0"
       sources."header-case-1.0.1"
       sources."homedir-polyfill-1.0.3"
-      sources."hosted-git-info-2.7.1"
+      (sources."hosted-git-info-2.8.2" // {
+        dependencies = [
+          sources."lru-cache-5.1.1"
+          sources."yallist-3.0.3"
+        ];
+      })
       (sources."http-errors-1.7.2" // {
         dependencies = [
           sources."inherits-2.0.3"
@@ -52670,6 +52996,80 @@ in
     production = true;
     bypassCache = true;
   };
+  gtop = nodeEnv.buildNodePackage {
+    name = "gtop";
+    packageName = "gtop";
+    version = "1.0.1";
+    src = fetchurl {
+      url = "https://registry.npmjs.org/gtop/-/gtop-1.0.1.tgz";
+      sha512 = "rDONVL6bOSKi9H2PuZ+nItRvFML39EeLgV65JRkGPdLri5saUAMVISZV/4jW8LylZBRHysVmaI1nCu5S/0Iilg==";
+    };
+    dependencies = [
+      sources."abbrev-1.1.1"
+      sources."ansi-regex-2.1.1"
+      sources."ansi-styles-2.2.1"
+      sources."ansi-term-0.0.2"
+      sources."ansicolors-0.2.1"
+      sources."blessed-0.1.81"
+      sources."blessed-contrib-4.8.16"
+      sources."bresenham-0.0.3"
+      sources."buffers-0.1.1"
+      sources."cardinal-1.0.0"
+      sources."chalk-1.1.3"
+      sources."charm-0.1.2"
+      sources."cli-table-0.3.1"
+      sources."colors-1.0.3"
+      sources."core-util-is-1.0.2"
+      sources."drawille-blessed-contrib-1.0.0"
+      sources."drawille-canvas-blessed-contrib-0.1.3"
+      sources."escape-string-regexp-1.0.5"
+      sources."esprima-3.0.0"
+      (sources."event-stream-0.9.8" // {
+        dependencies = [
+          sources."optimist-0.2.8"
+        ];
+      })
+      sources."gl-matrix-2.8.1"
+      sources."has-ansi-2.0.0"
+      sources."here-0.0.2"
+      sources."inherits-2.0.4"
+      sources."isarray-0.0.1"
+      sources."lodash-4.17.15"
+      sources."lodash.assign-4.2.0"
+      sources."lodash.toarray-4.4.0"
+      sources."map-canvas-0.1.5"
+      sources."marked-0.6.3"
+      sources."marked-terminal-1.7.0"
+      sources."memory-streams-0.1.3"
+      sources."memorystream-0.3.1"
+      sources."node-emoji-1.10.0"
+      sources."nopt-2.1.2"
+      sources."optimist-0.3.7"
+      sources."picture-tuber-1.0.2"
+      sources."png-js-0.1.1"
+      sources."readable-stream-1.0.34"
+      sources."redeyed-1.0.1"
+      sources."sax-1.2.4"
+      sources."sparkline-0.1.2"
+      sources."string_decoder-0.10.31"
+      sources."strip-ansi-3.0.1"
+      sources."supports-color-2.0.0"
+      sources."systeminformation-4.14.4"
+      sources."term-canvas-0.0.5"
+      sources."wordwrap-0.0.3"
+      sources."x256-0.0.2"
+      sources."xml2js-0.4.19"
+      sources."xmlbuilder-9.0.7"
+    ];
+    buildInputs = globalBuildInputs;
+    meta = {
+      description = "graphic top";
+      homepage = "https://github.com/aksakalli/gtop#readme";
+      license = "MIT";
+    };
+    production = true;
+    bypassCache = true;
+  };
   gulp = nodeEnv.buildNodePackage {
     name = "gulp";
     packageName = "gulp";
@@ -52853,7 +53253,7 @@ in
       sources."global-modules-1.0.0"
       sources."global-prefix-1.0.2"
       sources."glogg-1.0.2"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."gulp-cli-2.2.0"
       sources."gulplog-1.0.0"
       sources."has-symbols-1.0.0"
@@ -52864,7 +53264,7 @@ in
         ];
       })
       sources."homedir-polyfill-1.0.3"
-      sources."hosted-git-info-2.7.1"
+      sources."hosted-git-info-2.8.2"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
       sources."ini-1.3.5"
@@ -52905,6 +53305,7 @@ in
       sources."lead-1.0.0"
       sources."liftoff-3.1.0"
       sources."load-json-file-1.1.0"
+      sources."lru-cache-5.1.1"
       sources."make-iterator-1.0.1"
       sources."map-cache-0.2.2"
       sources."map-visit-1.0.0"
@@ -53077,7 +53478,7 @@ in
       sources."to-regex-3.0.2"
       sources."to-regex-range-2.1.1"
       sources."to-through-2.0.0"
-      sources."type-1.0.1"
+      sources."type-1.0.3"
       sources."typedarray-0.0.6"
       sources."unc-path-regex-0.1.2"
       sources."undertaker-1.2.1"
@@ -53110,6 +53511,7 @@ in
       sources."wrappy-1.0.2"
       sources."xtend-4.0.2"
       sources."y18n-3.2.1"
+      sources."yallist-3.0.3"
       sources."yargs-7.1.0"
       sources."yargs-parser-5.0.0"
     ];
@@ -53229,7 +53631,7 @@ in
       sources."global-modules-1.0.0"
       sources."global-prefix-1.0.2"
       sources."glogg-1.0.2"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."gulplog-1.0.0"
       sources."has-value-1.0.0"
       (sources."has-values-1.0.0" // {
@@ -53238,7 +53640,7 @@ in
         ];
       })
       sources."homedir-polyfill-1.0.3"
-      sources."hosted-git-info-2.7.1"
+      sources."hosted-git-info-2.8.2"
       sources."inherits-2.0.4"
       sources."ini-1.3.5"
       sources."interpret-1.2.0"
@@ -53282,6 +53684,7 @@ in
       sources."lcid-1.0.0"
       sources."liftoff-3.1.0"
       sources."load-json-file-1.1.0"
+      sources."lru-cache-5.1.1"
       (sources."make-iterator-1.0.1" // {
         dependencies = [
           sources."kind-of-6.0.2"
@@ -53426,7 +53829,7 @@ in
       })
       sources."to-regex-3.0.2"
       sources."to-regex-range-2.1.1"
-      sources."type-1.0.1"
+      sources."type-1.0.3"
       sources."typedarray-0.0.6"
       sources."unc-path-regex-0.1.2"
       sources."union-value-1.0.1"
@@ -53449,6 +53852,7 @@ in
       sources."which-module-1.0.0"
       sources."wrap-ansi-2.1.0"
       sources."y18n-3.2.1"
+      sources."yallist-3.0.3"
       sources."yargs-7.1.0"
       sources."yargs-parser-5.0.0"
     ];
@@ -53523,9 +53927,10 @@ in
       sources."dashdash-1.14.1"
       sources."date-now-0.1.4"
       sources."delayed-stream-1.0.0"
-      (sources."dom-serializer-0.1.1" // {
+      (sources."dom-serializer-0.2.1" // {
         dependencies = [
-          sources."entities-1.1.2"
+          sources."domelementtype-2.0.1"
+          sources."entities-2.0.0"
         ];
       })
       sources."domelementtype-1.3.1"
@@ -53790,7 +54195,7 @@ in
       sha512 = "RJ8nHsE4diosqkSpKot3unMn05ExCisUDy/URw/3M9t8MetvthBBQpcfaRPGftXRGebaMF1HnH6dLG994TpNVQ==";
     };
     dependencies = [
-      sources."async-limiter-1.0.0"
+      sources."async-limiter-1.0.1"
       sources."chrome-remote-interface-0.26.1"
       sources."commander-2.11.0"
       sources."node-fetch-2.6.0"
@@ -53835,7 +54240,7 @@ in
       sources."ansi-styles-3.2.1"
       sources."ast-types-0.13.2"
       sources."astral-regex-1.0.0"
-      sources."async-limiter-1.0.0"
+      sources."async-limiter-1.0.1"
       sources."asynckit-0.4.0"
       sources."balanced-match-1.0.0"
       sources."brace-expansion-1.1.11"
@@ -53902,7 +54307,7 @@ in
       sources."get-stream-4.1.0"
       sources."get-uri-2.0.3"
       sources."glob-7.1.4"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."has-flag-3.0.0"
       sources."http-errors-1.7.3"
       (sources."http-proxy-agent-2.1.0" // {
@@ -54257,7 +54662,7 @@ in
       sources."abab-2.0.0"
       sources."abbrev-1.1.1"
       sources."acorn-5.7.3"
-      (sources."acorn-globals-4.3.2" // {
+      (sources."acorn-globals-4.3.3" // {
         dependencies = [
           sources."acorn-6.2.1"
         ];
@@ -54284,7 +54689,7 @@ in
       sources."asap-2.0.6"
       sources."asn1-0.2.4"
       sources."assert-plus-1.0.0"
-      sources."async-limiter-1.0.0"
+      sources."async-limiter-1.0.1"
       sources."async-mutex-0.1.3"
       sources."asynckit-0.4.0"
       sources."atob-2.1.2"
@@ -54392,7 +54797,7 @@ in
       sources."getpass-0.1.7"
       sources."github-from-package-0.0.0"
       sources."glob-7.1.4"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-ansi-2.0.0"
@@ -54666,7 +55071,7 @@ in
           sources."q-0.9.7"
         ];
       })
-      sources."terminal-kit-1.29.2"
+      sources."terminal-kit-1.29.3"
       (sources."tkwidgets-0.5.26" // {
         dependencies = [
           sources."is-fullwidth-code-point-2.0.0"
@@ -54822,7 +55227,7 @@ in
       sources."catharsis-0.8.11"
       sources."entities-1.1.2"
       sources."escape-string-regexp-2.0.0"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."js2xmlparser-4.0.0"
       sources."klaw-3.0.0"
       sources."linkify-it-2.2.0"
@@ -54866,9 +55271,10 @@ in
       sources."console-browserify-1.1.0"
       sources."core-util-is-1.0.2"
       sources."date-now-0.1.4"
-      (sources."dom-serializer-0.1.1" // {
+      (sources."dom-serializer-0.2.1" // {
         dependencies = [
-          sources."entities-1.1.2"
+          sources."domelementtype-2.0.1"
+          sources."entities-2.0.0"
         ];
       })
       sources."domelementtype-1.3.1"
@@ -55101,7 +55507,7 @@ in
           sources."get-stream-4.1.0"
         ];
       })
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-flag-3.0.0"
@@ -55320,7 +55726,7 @@ in
       sources."anymatch-3.0.3"
       sources."arraybuffer.slice-0.0.7"
       sources."async-2.6.3"
-      sources."async-limiter-1.0.0"
+      sources."async-limiter-1.0.1"
       sources."backo2-1.0.2"
       sources."balanced-match-1.0.0"
       sources."base64-arraybuffer-0.1.5"
@@ -55384,7 +55790,7 @@ in
       sources."fsevents-2.0.7"
       sources."glob-7.1.4"
       sources."glob-parent-5.0.0"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."has-binary2-1.0.3"
       sources."has-cors-1.1.0"
       sources."http-errors-1.7.2"
@@ -55525,7 +55931,7 @@ in
       sources."glob-7.1.4"
       sources."glob-parent-3.1.0"
       sources."glob-stream-6.1.0"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."has-symbols-1.0.0"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
@@ -56272,7 +56678,7 @@ in
           sources."pify-4.0.1"
         ];
       })
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       (sources."handlebars-4.1.2" // {
         dependencies = [
           sources."source-map-0.6.1"
@@ -56290,7 +56696,7 @@ in
           sources."kind-of-4.0.0"
         ];
       })
-      sources."hosted-git-info-2.7.1"
+      sources."hosted-git-info-2.8.2"
       sources."http-cache-semantics-3.8.1"
       sources."http-proxy-agent-2.1.0"
       sources."http-signature-1.2.0"
@@ -56832,7 +57238,7 @@ in
       sources."forever-agent-0.6.1"
       sources."form-data-2.3.3"
       sources."getpass-0.1.7"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."http-signature-1.2.0"
@@ -57026,7 +57432,7 @@ in
           sources."is-glob-3.1.0"
         ];
       })
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."has-value-1.0.0"
       (sources."has-values-1.0.0" // {
         dependencies = [
@@ -57250,7 +57656,7 @@ in
       sources."assert-plus-1.0.0"
       sources."assign-symbols-1.0.0"
       sources."async-each-1.0.3"
-      sources."async-limiter-1.0.0"
+      sources."async-limiter-1.0.1"
       sources."asynckit-0.4.0"
       sources."atob-2.1.2"
       sources."aws-sign2-0.7.0"
@@ -57368,7 +57774,7 @@ in
       sources."github-slugger-1.2.1"
       sources."glob-base-0.3.0"
       sources."glob-parent-2.0.0"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       (sources."has-binary2-1.0.3" // {
@@ -57997,7 +58403,7 @@ in
           sources."isobject-3.0.1"
         ];
       })
-      sources."base64-js-1.3.0"
+      sources."base64-js-1.3.1"
       sources."big.js-5.2.2"
       sources."binary-extensions-1.13.1"
       sources."bl-1.2.2"
@@ -58035,7 +58441,7 @@ in
       })
       sources."call-me-maybe-1.0.1"
       sources."camelcase-5.3.1"
-      sources."caniuse-lite-1.0.30000988"
+      sources."caniuse-lite-1.0.30000989"
       sources."caw-2.0.1"
       (sources."chalk-2.4.2" // {
         dependencies = [
@@ -58194,7 +58600,7 @@ in
       })
       sources."duplexer3-0.1.4"
       sources."duplexify-3.7.1"
-      sources."electron-to-chromium-1.3.210"
+      sources."electron-to-chromium-1.3.215"
       sources."elliptic-6.5.0"
       sources."emoji-regex-7.0.3"
       sources."emojis-list-2.1.0"
@@ -58389,7 +58795,7 @@ in
           sources."p-cancelable-1.1.0"
         ];
       })
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."graceful-readlink-1.0.1"
       sources."has-ansi-2.0.0"
       sources."has-flag-3.0.0"
@@ -58415,7 +58821,7 @@ in
       sources."hash.js-1.1.7"
       sources."hmac-drbg-1.0.1"
       sources."homedir-polyfill-1.0.3"
-      sources."hosted-git-info-2.7.1"
+      sources."hosted-git-info-2.8.2"
       sources."http-cache-semantics-3.8.1"
       sources."https-browserify-1.0.0"
       sources."ieee754-1.1.13"
@@ -58907,7 +59313,7 @@ in
       sources."supports-color-2.0.0"
       sources."tapable-1.1.3"
       sources."tar-stream-1.6.2"
-      (sources."terser-4.1.2" // {
+      (sources."terser-4.1.3" // {
         dependencies = [
           sources."commander-2.20.0"
           sources."source-map-0.6.1"
@@ -58982,7 +59388,7 @@ in
       sources."vm-browserify-1.1.0"
       sources."watchpack-1.6.0"
       sources."wcwidth-1.0.1"
-      (sources."webpack-4.39.0" // {
+      (sources."webpack-4.39.1" // {
         dependencies = [
           sources."arr-diff-4.0.0"
           sources."array-unique-0.3.2"
@@ -59034,7 +59440,7 @@ in
           sources."source-map-0.4.4"
         ];
       })
-      (sources."webpack-sources-1.4.1" // {
+      (sources."webpack-sources-1.4.3" // {
         dependencies = [
           sources."source-list-map-2.0.1"
           sources."source-map-0.6.1"
@@ -59480,7 +59886,7 @@ in
       sources."fragment-cache-0.2.1"
       (sources."fs-mkdirp-stream-1.0.0" // {
         dependencies = [
-          sources."graceful-fs-4.2.0"
+          sources."graceful-fs-4.2.1"
           sources."readable-stream-2.3.6"
           sources."string_decoder-1.1.1"
           sources."through2-2.0.5"
@@ -59535,7 +59941,7 @@ in
       })
       (sources."gulp-sourcemaps-2.6.4" // {
         dependencies = [
-          sources."graceful-fs-4.2.0"
+          sources."graceful-fs-4.2.1"
           sources."readable-stream-2.3.6"
           sources."source-map-0.6.1"
           sources."string_decoder-1.1.1"
@@ -59552,7 +59958,7 @@ in
           sources."extend-shallow-1.1.4"
           sources."glob-7.1.4"
           sources."glob-stream-6.1.0"
-          sources."graceful-fs-4.2.0"
+          sources."graceful-fs-4.2.1"
           sources."kind-of-1.1.0"
           sources."minimatch-3.0.4"
           sources."ordered-read-streams-1.0.1"
@@ -59654,7 +60060,7 @@ in
       sources."lead-1.0.0"
       (sources."less-2.7.3" // {
         dependencies = [
-          sources."graceful-fs-4.2.0"
+          sources."graceful-fs-4.2.1"
         ];
       })
       sources."liftoff-2.5.0"
@@ -59897,7 +60303,7 @@ in
       sources."tough-cookie-2.3.4"
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
-      sources."type-1.0.1"
+      sources."type-1.0.3"
       sources."typescript-3.5.3"
       (sources."uglify-js-3.4.9" // {
         dependencies = [
@@ -59940,7 +60346,7 @@ in
         dependencies = [
           sources."clone-2.1.2"
           sources."clone-stats-1.0.0"
-          sources."graceful-fs-4.2.0"
+          sources."graceful-fs-4.2.1"
           sources."vinyl-2.2.0"
         ];
       })
@@ -60268,7 +60674,7 @@ in
       sources."gauge-2.7.4"
       sources."getpass-0.1.7"
       sources."glob-7.1.4"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-unicode-2.0.1"
@@ -60451,14 +60857,14 @@ in
         ];
       })
       sources."glob-5.0.15"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."har-schema-1.0.5"
       sources."har-validator-4.2.1"
       sources."has-unicode-2.0.1"
       sources."hawk-3.1.3"
       sources."headless-0.1.7"
       sources."hoek-2.16.3"
-      sources."hosted-git-info-2.7.1"
+      sources."hosted-git-info-2.8.2"
       sources."http-errors-1.7.2"
       sources."http-signature-1.1.1"
       sources."iconv-lite-0.4.24"
@@ -60490,6 +60896,7 @@ in
       sources."load-json-file-1.1.0"
       sources."lodash-2.4.2"
       sources."loud-rejection-1.6.0"
+      sources."lru-cache-5.1.1"
       sources."map-obj-1.0.1"
       sources."media-typer-0.3.0"
       sources."meow-3.7.0"
@@ -60647,6 +61054,7 @@ in
       sources."xmldom-0.1.27"
       sources."xtend-4.0.2"
       sources."y18n-3.2.1"
+      sources."yallist-3.0.3"
       sources."yargs-3.32.0"
     ];
     buildInputs = globalBuildInputs;
@@ -60793,7 +61201,7 @@ in
       sources."asn1-0.2.4"
       sources."assert-plus-1.0.0"
       sources."async-0.1.22"
-      sources."async-limiter-1.0.0"
+      sources."async-limiter-1.0.1"
       sources."asynckit-0.4.0"
       sources."aws-sign2-0.7.0"
       sources."aws4-1.8.0"
@@ -60934,7 +61342,7 @@ in
           sources."string_decoder-1.1.1"
         ];
       })
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-unicode-2.0.1"
@@ -61188,7 +61596,7 @@ in
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       sources."twitter-ng-0.6.2"
-      sources."type-1.0.1"
+      sources."type-1.0.3"
       sources."type-is-1.6.18"
       sources."typedarray-0.0.6"
       sources."uc.micro-1.0.6"
@@ -61257,7 +61665,7 @@ in
       sources."aws-sign2-0.7.0"
       sources."aws4-1.8.0"
       sources."balanced-match-1.0.0"
-      sources."base64-js-1.3.0"
+      sources."base64-js-1.3.1"
       sources."bcrypt-pbkdf-1.0.2"
       sources."brace-expansion-1.1.11"
       sources."buffer-from-1.1.1"
@@ -61299,11 +61707,11 @@ in
       sources."gauge-2.7.4"
       sources."getpass-0.1.7"
       sources."glob-7.1.4"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-unicode-2.0.1"
-      sources."hosted-git-info-2.7.1"
+      sources."hosted-git-info-2.8.2"
       sources."http-signature-1.2.0"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
@@ -61318,6 +61726,7 @@ in
       sources."json-stringify-safe-5.0.1"
       sources."jsonfile-1.0.1"
       sources."jsprim-1.4.1"
+      sources."lru-cache-5.1.1"
       sources."mime-db-1.40.0"
       sources."mime-types-2.1.24"
       sources."minimatch-3.0.4"
@@ -61559,7 +61968,7 @@ in
       })
       sources."global-dirs-0.1.1"
       sources."got-6.7.1"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."has-flag-3.0.0"
       sources."has-value-1.0.0"
       (sources."has-values-1.0.0" // {
@@ -61891,11 +62300,11 @@ in
       sources."glob-7.1.4"
       sources."global-dirs-0.1.1"
       sources."got-9.6.0"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."has-ansi-2.0.0"
       sources."has-flag-3.0.0"
       sources."has-yarn-2.1.0"
-      sources."hosted-git-info-2.7.1"
+      sources."hosted-git-info-2.8.2"
       sources."http-cache-semantics-3.8.1"
       sources."http-proxy-agent-2.1.0"
       sources."https-proxy-agent-2.2.2"
@@ -62015,7 +62424,7 @@ in
       sources."progress-2.0.3"
       sources."promise-inflight-1.0.1"
       sources."promise-retry-1.1.1"
-      sources."prompts-2.1.0"
+      sources."prompts-2.2.1"
       sources."protoduck-5.0.1"
       sources."pseudomap-1.0.2"
       sources."pump-3.0.0"
@@ -62065,7 +62474,7 @@ in
       sources."shebang-command-1.2.0"
       sources."shebang-regex-1.0.0"
       sources."signal-exit-3.0.2"
-      sources."sisteransi-1.0.2"
+      sources."sisteransi-1.0.3"
       sources."smart-buffer-4.0.2"
       sources."socks-2.3.2"
       (sources."socks-proxy-agent-4.0.2" // {
@@ -62505,7 +62914,7 @@ in
       sources."abab-2.0.0"
       sources."abbrev-1.1.1"
       sources."acorn-5.7.3"
-      (sources."acorn-globals-4.3.2" // {
+      (sources."acorn-globals-4.3.3" // {
         dependencies = [
           sources."acorn-6.2.1"
         ];
@@ -62538,7 +62947,7 @@ in
       sources."assert-plus-1.0.0"
       sources."assign-symbols-1.0.0"
       sources."async-each-1.0.3"
-      sources."async-limiter-1.0.0"
+      sources."async-limiter-1.0.1"
       sources."asynckit-0.4.0"
       sources."atob-2.1.2"
       sources."aws-sign2-0.7.0"
@@ -62561,7 +62970,7 @@ in
           sources."define-property-1.0.0"
         ];
       })
-      sources."base64-js-1.3.0"
+      sources."base64-js-1.3.1"
       sources."bcrypt-pbkdf-1.0.2"
       sources."binary-extensions-1.13.1"
       sources."bindings-1.2.1"
@@ -62598,7 +63007,7 @@ in
       sources."caller-path-2.0.0"
       sources."callsites-2.0.0"
       sources."caniuse-api-3.0.0"
-      sources."caniuse-lite-1.0.30000988"
+      sources."caniuse-lite-1.0.30000989"
       sources."caseless-0.12.0"
       sources."chalk-2.4.2"
       sources."chokidar-2.1.6"
@@ -62718,7 +63127,12 @@ in
       sources."des.js-1.0.0"
       sources."destroy-1.0.4"
       sources."diffie-hellman-5.0.3"
-      sources."dom-serializer-0.1.1"
+      (sources."dom-serializer-0.2.1" // {
+        dependencies = [
+          sources."domelementtype-2.0.1"
+          sources."entities-2.0.0"
+        ];
+      })
       sources."domain-browser-1.2.0"
       sources."domelementtype-1.3.1"
       sources."domexception-1.0.1"
@@ -62731,7 +63145,7 @@ in
       sources."ecc-jsbn-0.1.2"
       sources."editorconfig-0.15.3"
       sources."ee-first-1.1.1"
-      sources."electron-to-chromium-1.3.210"
+      sources."electron-to-chromium-1.3.215"
       sources."elliptic-6.5.0"
       sources."encodeurl-1.0.2"
       sources."entities-1.1.2"
@@ -62789,7 +63203,7 @@ in
       })
       sources."glob-to-regexp-0.3.0"
       sources."globals-11.12.0"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."grapheme-breaker-0.3.2"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
@@ -62818,7 +63232,7 @@ in
       sources."html-tags-1.2.0"
       (sources."htmlnano-0.2.4" // {
         dependencies = [
-          sources."terser-4.1.2"
+          sources."terser-4.1.3"
         ];
       })
       (sources."htmlparser2-3.10.1" // {
@@ -63292,7 +63706,7 @@ in
       sources."util-deprecate-1.0.2"
       sources."util.promisify-1.0.0"
       sources."uuid-3.3.2"
-      sources."v8-compile-cache-2.0.3"
+      sources."v8-compile-cache-2.1.0"
       sources."vendors-1.0.3"
       sources."verror-1.10.0"
       sources."vlq-0.2.3"
@@ -63417,11 +63831,11 @@ in
       sources."get-browser-rtc-1.0.2"
       sources."get-stdin-4.0.1"
       sources."glob-7.1.4"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."has-ansi-2.0.0"
       sources."has-flag-3.0.0"
       sources."hat-0.0.3"
-      sources."hosted-git-info-2.7.1"
+      sources."hosted-git-info-2.8.2"
       sources."http-headers-3.0.2"
       sources."iconv-lite-0.4.24"
       sources."immediate-chunk-store-1.0.8"
@@ -63463,6 +63877,7 @@ in
       sources."lodash-3.10.1"
       sources."loud-rejection-1.6.0"
       sources."lru-2.0.1"
+      sources."lru-cache-5.1.1"
       sources."magnet-uri-5.2.4"
       sources."map-obj-1.0.1"
       sources."meow-3.7.0"
@@ -63612,6 +64027,7 @@ in
       sources."xmlbuilder-4.0.0"
       sources."xmldom-0.1.27"
       sources."xtend-4.0.2"
+      sources."yallist-3.0.3"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -63635,7 +64051,7 @@ in
       sources."addr-to-ip-port-1.5.1"
       sources."after-0.8.2"
       sources."ajv-6.10.2"
-      sources."archiver-3.0.3"
+      sources."archiver-3.1.1"
       (sources."archiver-utils-2.1.0" // {
         dependencies = [
           sources."readable-stream-2.3.6"
@@ -63651,7 +64067,7 @@ in
       sources."backo2-1.0.2"
       sources."balanced-match-1.0.0"
       sources."base64-arraybuffer-0.1.5"
-      sources."base64-js-1.3.0"
+      sources."base64-js-1.3.1"
       sources."base64-url-1.2.1"
       sources."base64id-1.0.0"
       sources."basic-auth-1.0.4"
@@ -63697,7 +64113,7 @@ in
       sources."component-bind-1.0.0"
       sources."component-emitter-1.2.1"
       sources."component-inherit-0.0.3"
-      (sources."compress-commons-2.0.0" // {
+      (sources."compress-commons-2.1.1" // {
         dependencies = [
           sources."readable-stream-2.3.6"
         ];
@@ -63729,11 +64145,7 @@ in
       sources."cookie-signature-1.0.6"
       sources."core-util-is-1.0.2"
       sources."crc-3.8.0"
-      (sources."crc32-stream-2.0.0" // {
-        dependencies = [
-          sources."readable-stream-2.3.6"
-        ];
-      })
+      sources."crc32-stream-3.0.1"
       (sources."csrf-3.0.6" // {
         dependencies = [
           sources."uid-safe-2.1.4"
@@ -63811,7 +64223,7 @@ in
       sources."get-browser-rtc-1.0.2"
       sources."getpass-0.1.7"
       sources."glob-7.1.4"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       (sources."has-binary-0.1.7" // {
@@ -64076,7 +64488,7 @@ in
       sources."xmlhttprequest-ssl-1.5.3"
       sources."xtend-4.0.2"
       sources."yeast-0.1.2"
-      sources."zip-stream-2.1.0"
+      sources."zip-stream-2.1.2"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -64090,10 +64502,10 @@ in
   pnpm = nodeEnv.buildNodePackage {
     name = "pnpm";
     packageName = "pnpm";
-    version = "3.6.2";
+    version = "3.6.3";
     src = fetchurl {
-      url = "https://registry.npmjs.org/pnpm/-/pnpm-3.6.2.tgz";
-      sha512 = "/UW87zxOU3p60deTeo94GX/ZR6ph1tGDDZmCnIFvo2gMsAaWAM/nePuAdT/RZ3cbSJfG3+/HXxsYOxetAjC/Sg==";
+      url = "https://registry.npmjs.org/pnpm/-/pnpm-3.6.3.tgz";
+      sha512 = "Hxk8VouMZRh870u0hJHCcumylGO8VV6Id+Fm7S+MyZVGGgtaZlEFFV2HIndVd9nXTksS+RuhINX6jGIVmqTmDg==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -64147,7 +64559,7 @@ in
       })
       sources."async-1.5.2"
       sources."balanced-match-1.0.0"
-      sources."base64-js-1.3.0"
+      sources."base64-js-1.3.1"
       sources."bn.js-4.11.8"
       sources."brace-expansion-1.1.11"
       sources."brorand-1.1.0"
@@ -64221,7 +64633,7 @@ in
       sources."get-assigned-identifiers-1.2.0"
       sources."glob-7.1.4"
       sources."globule-1.2.1"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."has-1.0.3"
       sources."hash-base-3.0.4"
       sources."hash.js-1.1.7"
@@ -64453,7 +64865,7 @@ in
       sources."esprima-3.1.3"
       sources."esprima-fb-13001.1001.0-dev-harmony-fb"
       sources."glob-5.0.15"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."iconv-lite-0.4.24"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
@@ -65083,7 +65495,7 @@ in
       sources."for-in-1.0.2"
       sources."fragment-cache-0.2.1"
       sources."get-value-2.0.6"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."graceful-readlink-1.0.1"
       sources."has-value-1.0.0"
       (sources."has-values-1.0.0" // {
@@ -65376,14 +65788,14 @@ in
   snyk = nodeEnv.buildNodePackage {
     name = "snyk";
     packageName = "snyk";
-    version = "1.208.0";
+    version = "1.210.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/snyk/-/snyk-1.208.0.tgz";
-      sha512 = "MMOQazfz+5fvoCDEBBJiuYNdcrtE3anemGvL7VJFlWu4uc8YgVZ8gvetEO7OmLmn4FfTmJ/hAthEQgcXYjDjFw==";
+      url = "https://registry.npmjs.org/snyk/-/snyk-1.210.0.tgz";
+      sha512 = "k6/EIX1Dc4Qk8omcKQDm13RRywkKqXoQ0IMz5Nyk1y8sdmg1S78QSWnfTaEPe+OQE1olrtjInrDX3Yu20CnMzg==";
     };
     dependencies = [
       sources."@snyk/composer-lockfile-parser-1.0.3"
-      sources."@snyk/dep-graph-1.10.0"
+      sources."@snyk/dep-graph-1.12.0"
       sources."@snyk/gemfile-1.2.0"
       sources."@types/agent-base-4.2.0"
       sources."@types/debug-4.1.4"
@@ -65495,10 +65907,15 @@ in
           sources."get-stream-3.0.0"
         ];
       })
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."graphlib-2.1.7"
       sources."has-flag-3.0.0"
-      sources."hosted-git-info-2.7.1"
+      (sources."hosted-git-info-2.8.2" // {
+        dependencies = [
+          sources."lru-cache-5.1.1"
+          sources."yallist-3.0.3"
+        ];
+      })
       sources."http-errors-1.7.3"
       (sources."http-proxy-agent-2.1.0" // {
         dependencies = [
@@ -65652,7 +66069,7 @@ in
       sources."shebang-regex-1.0.0"
       sources."signal-exit-3.0.2"
       sources."smart-buffer-4.0.2"
-      sources."snyk-config-2.2.2"
+      sources."snyk-config-2.2.3"
       (sources."snyk-docker-plugin-1.25.1" // {
         dependencies = [
           sources."debug-4.1.1"
@@ -65670,13 +66087,13 @@ in
         ];
       })
       sources."snyk-module-1.9.1"
-      (sources."snyk-mvn-plugin-2.3.1" // {
+      (sources."snyk-mvn-plugin-2.3.3" // {
         dependencies = [
           sources."tslib-1.9.3"
         ];
       })
       sources."snyk-nodejs-lockfile-parser-1.16.0"
-      sources."snyk-nuget-plugin-1.11.2"
+      sources."snyk-nuget-plugin-1.11.3"
       sources."snyk-paket-parser-1.5.0"
       (sources."snyk-php-plugin-1.6.4" // {
         dependencies = [
@@ -65801,7 +66218,7 @@ in
       sources."accepts-1.3.7"
       sources."after-0.8.2"
       sources."arraybuffer.slice-0.0.7"
-      sources."async-limiter-1.0.0"
+      sources."async-limiter-1.0.1"
       sources."backo2-1.0.2"
       sources."base64-arraybuffer-0.1.5"
       sources."base64id-1.0.0"
@@ -65894,7 +66311,12 @@ in
       sources."color-name-1.1.3"
       sources."configstore-3.1.2"
       sources."create-error-class-3.0.2"
-      sources."cross-spawn-5.1.0"
+      (sources."cross-spawn-5.1.0" // {
+        dependencies = [
+          sources."lru-cache-4.1.5"
+          sources."yallist-2.1.2"
+        ];
+      })
       sources."crypto-random-string-1.0.0"
       sources."currently-unhandled-0.4.1"
       sources."debug-3.1.0"
@@ -65918,9 +66340,9 @@ in
       sources."get-stream-3.0.0"
       sources."global-dirs-0.1.1"
       sources."got-6.7.1"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."has-flag-3.0.0"
-      sources."hosted-git-info-2.7.1"
+      sources."hosted-git-info-2.8.2"
       sources."http-proxy-agent-2.1.0"
       sources."https-proxy-agent-2.2.2"
       sources."import-lazy-2.1.0"
@@ -65947,7 +66369,7 @@ in
       sources."log-update-2.3.0"
       sources."loud-rejection-1.6.0"
       sources."lowercase-keys-1.0.1"
-      sources."lru-cache-4.1.5"
+      sources."lru-cache-5.1.1"
       sources."make-dir-1.3.0"
       sources."map-obj-2.0.0"
       sources."meow-5.0.0"
@@ -66023,7 +66445,7 @@ in
       sources."xdg-basedir-3.0.0"
       sources."xml2js-0.4.19"
       sources."xmlbuilder-9.0.7"
-      sources."yallist-2.1.2"
+      sources."yallist-3.0.3"
       sources."yargs-parser-10.1.0"
     ];
     buildInputs = globalBuildInputs;
@@ -66076,7 +66498,7 @@ in
       sources."base64-url-2.3.2"
       sources."bash-color-0.0.4"
       sources."binary-extensions-1.13.1"
-      sources."binary-search-1.3.5"
+      sources."binary-search-1.3.6"
       (sources."bl-0.8.2" // {
         dependencies = [
           sources."isarray-0.0.1"
@@ -66228,7 +66650,7 @@ in
       sources."glob-parent-2.0.0"
       sources."globby-4.1.0"
       sources."gossip-query-2.0.2"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."has-1.0.3"
       sources."has-ansi-2.0.0"
       sources."has-network-0.0.1"
@@ -66344,11 +66766,7 @@ in
           sources."string_decoder-0.10.31"
         ];
       })
-      (sources."leveldown-5.1.1" // {
-        dependencies = [
-          sources."node-gyp-build-4.1.0"
-        ];
-      })
+      sources."leveldown-5.1.1"
       sources."levelup-4.1.0"
       sources."libnested-1.4.1"
       sources."libsodium-0.7.5"
@@ -66392,7 +66810,7 @@ in
       sources."muxrpc-6.4.2"
       sources."muxrpc-usage-2.1.0"
       sources."muxrpc-validation-3.0.2"
-      sources."muxrpcli-3.1.1"
+      sources."muxrpcli-3.1.2"
       (sources."mv-2.1.1" // {
         dependencies = [
           sources."rimraf-2.4.5"
@@ -66410,7 +66828,7 @@ in
       sources."ncp-2.0.0"
       sources."nearley-2.18.0"
       sources."nice-try-1.0.5"
-      sources."node-gyp-build-3.9.0"
+      sources."node-gyp-build-4.1.0"
       sources."non-private-ip-1.4.4"
       sources."normalize-path-2.1.1"
       sources."normalize-uri-1.1.2"
@@ -66620,7 +67038,7 @@ in
       sources."safe-buffer-5.1.2"
       sources."safe-regex-1.1.0"
       sources."secret-handshake-1.1.20"
-      sources."secret-stack-6.2.1"
+      sources."secret-stack-6.3.0"
       sources."semver-5.7.0"
       sources."separator-escape-0.0.0"
       (sources."set-value-2.0.1" // {
@@ -66669,7 +67087,7 @@ in
         ];
       })
       sources."sodium-chloride-1.1.2"
-      sources."sodium-native-2.4.3"
+      sources."sodium-native-2.4.5"
       sources."source-map-0.5.7"
       sources."source-map-resolve-0.5.2"
       sources."source-map-url-0.4.0"
@@ -66899,9 +67317,9 @@ in
       sources."asn1-0.2.4"
       sources."assert-plus-0.2.0"
       sources."async-1.5.2"
-      sources."async-limiter-1.0.0"
+      sources."async-limiter-1.0.1"
       sources."asynckit-0.4.0"
-      sources."aws-sdk-2.503.0"
+      sources."aws-sdk-2.504.0"
       sources."aws-sign2-0.6.0"
       sources."aws4-1.8.0"
       sources."babel-runtime-6.26.0"
@@ -66916,7 +67334,7 @@ in
       })
       sources."balanced-match-1.0.0"
       sources."base64-arraybuffer-0.1.5"
-      sources."base64-js-1.3.0"
+      sources."base64-js-1.3.1"
       sources."base64id-1.0.0"
       sources."base64url-3.0.1"
       sources."basic-auth-1.1.0"
@@ -67097,7 +67515,7 @@ in
           sources."ms-2.1.2"
         ];
       })
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."graphlib-2.1.7"
       sources."har-schema-2.0.0"
       sources."har-validator-2.0.6"
@@ -67117,7 +67535,12 @@ in
         ];
       })
       sources."hoek-2.16.3"
-      sources."hosted-git-info-2.7.1"
+      (sources."hosted-git-info-2.8.2" // {
+        dependencies = [
+          sources."lru-cache-5.1.1"
+          sources."yallist-3.0.3"
+        ];
+      })
       (sources."http-errors-1.7.2" // {
         dependencies = [
           sources."inherits-2.0.3"
@@ -67681,10 +68104,14 @@ in
         ];
       })
       sources."define-properties-1.1.3"
-      sources."dom-serializer-0.1.1"
+      (sources."dom-serializer-0.2.1" // {
+        dependencies = [
+          sources."domelementtype-2.0.1"
+        ];
+      })
       sources."domelementtype-1.3.1"
       sources."domutils-1.7.0"
-      sources."entities-1.1.2"
+      sources."entities-2.0.0"
       sources."es-abstract-1.13.0"
       sources."es-to-primitive-1.2.0"
       sources."escape-string-regexp-1.0.5"
@@ -67926,7 +68353,7 @@ in
       })
       sources."global-dirs-0.1.1"
       sources."got-6.7.1"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       (sources."graphlib-2.1.7" // {
         dependencies = [
           sources."lodash-4.17.15"
@@ -68366,7 +68793,7 @@ in
       sources."argparse-1.0.10"
       sources."asn1-0.2.4"
       sources."assert-plus-1.0.0"
-      sources."async-limiter-1.0.0"
+      sources."async-limiter-1.0.1"
       sources."asynckit-0.4.0"
       sources."aws-sign2-0.7.0"
       sources."aws4-1.8.0"
@@ -68494,7 +68921,7 @@ in
       sources."errno-0.1.7"
       sources."fs.realpath-1.0.0"
       sources."glob-7.1.4"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
       sources."isarray-1.0.0"
@@ -68592,11 +69019,11 @@ in
       sources."function-bind-1.1.1"
       sources."get-stdin-5.0.1"
       sources."glob-7.1.4"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."has-1.0.3"
       sources."has-ansi-2.0.0"
       sources."has-symbols-1.0.0"
-      sources."hosted-git-info-2.7.1"
+      sources."hosted-git-info-2.8.2"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
       sources."is-alphabetical-1.0.3"
@@ -68630,6 +69057,7 @@ in
       sources."locate-path-2.0.0"
       sources."lodash-4.17.15"
       sources."log-symbols-1.0.2"
+      sources."lru-cache-5.1.1"
       sources."map-like-2.0.0"
       sources."markdown-escapes-1.0.3"
       sources."md5-2.2.1"
@@ -68730,6 +69158,7 @@ in
       sources."x-is-string-0.1.0"
       sources."xml-escape-1.1.0"
       sources."xtend-4.0.2"
+      sources."yallist-3.0.3"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -68837,7 +69266,12 @@ in
       sources."configstore-3.1.2"
       sources."core-util-is-1.0.2"
       sources."create-error-class-3.0.2"
-      sources."cross-spawn-5.1.0"
+      (sources."cross-spawn-5.1.0" // {
+        dependencies = [
+          sources."lru-cache-4.1.5"
+          sources."yallist-2.1.2"
+        ];
+      })
       sources."crypto-random-string-1.0.0"
       sources."currently-unhandled-0.4.1"
       sources."cuss-1.16.0"
@@ -68867,9 +69301,9 @@ in
       sources."glob-7.1.4"
       sources."global-dirs-0.1.1"
       sources."got-6.7.1"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."has-flag-3.0.0"
-      sources."hosted-git-info-2.7.1"
+      sources."hosted-git-info-2.8.2"
       sources."ignore-3.3.10"
       sources."import-lazy-2.1.0"
       sources."imurmurhash-0.1.4"
@@ -68911,7 +69345,7 @@ in
       sources."lodash.intersection-4.4.0"
       sources."loud-rejection-1.6.0"
       sources."lowercase-keys-1.0.1"
-      sources."lru-cache-4.1.5"
+      sources."lru-cache-5.1.1"
       (sources."make-dir-1.3.0" // {
         dependencies = [
           sources."pify-3.0.0"
@@ -69085,7 +69519,7 @@ in
       sources."x-is-string-0.1.0"
       sources."xdg-basedir-3.0.0"
       sources."xtend-4.0.2"
-      sources."yallist-2.1.2"
+      sources."yallist-3.0.3"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -69460,7 +69894,7 @@ in
       sources."asn1-0.2.3"
       sources."asn1.js-5.2.0"
       sources."assert-plus-1.0.0"
-      sources."async-limiter-1.0.0"
+      sources."async-limiter-1.0.1"
       sources."asynckit-0.4.0"
       sources."aws-sign2-0.7.0"
       sources."aws4-1.8.0"
@@ -69572,7 +70006,7 @@ in
       sources."getpass-0.1.7"
       sources."glob-7.1.4"
       sources."got-9.6.0"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."grapheme-splitter-1.0.4"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
@@ -69904,7 +70338,7 @@ in
       sources."fs.realpath-1.0.0"
       sources."getpass-0.1.7"
       sources."glob-7.1.4"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."http-signature-1.2.0"
@@ -70270,7 +70704,7 @@ in
       sources."commander-2.20.0"
       sources."crypto-random-string-1.0.0"
       sources."fs-extra-7.0.1"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."jsonfile-4.0.0"
       sources."p-debounce-1.0.0"
       sources."temp-dir-1.0.0"
@@ -70334,7 +70768,7 @@ in
       sources."asn1-0.2.4"
       sources."assert-plus-1.0.0"
       sources."async-1.0.0"
-      sources."async-limiter-1.0.0"
+      sources."async-limiter-1.0.1"
       sources."asynckit-0.4.0"
       sources."aws-sign2-0.7.0"
       sources."aws4-1.8.0"
@@ -70480,7 +70914,7 @@ in
       sources."getmac-1.4.6"
       sources."getpass-0.1.7"
       sources."glob-7.1.4"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       (sources."has-binary2-1.0.3" // {
@@ -70496,7 +70930,12 @@ in
           sources."mkdirp-0.3.0"
         ];
       })
-      sources."hosted-git-info-2.7.1"
+      (sources."hosted-git-info-2.8.2" // {
+        dependencies = [
+          sources."lru-cache-5.1.1"
+          sources."yallist-3.0.3"
+        ];
+      })
       sources."http-errors-1.7.2"
       sources."http-signature-1.2.0"
       sources."iconv-lite-0.4.24"
@@ -70845,7 +71284,7 @@ in
       sources."aws-sign2-0.7.0"
       sources."aws4-1.8.0"
       sources."balanced-match-1.0.0"
-      sources."base64-js-1.3.0"
+      sources."base64-js-1.3.1"
       sources."bcrypt-pbkdf-1.0.2"
       sources."bl-1.2.2"
       sources."bluebird-3.5.5"
@@ -70925,7 +71364,7 @@ in
       sources."git-clone-0.1.0"
       sources."glob-7.1.4"
       sources."got-6.7.1"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."graceful-readlink-1.0.1"
       sources."gray-matter-2.1.1"
       sources."handlebars-4.1.2"
@@ -71267,7 +71706,12 @@ in
       sources."core-js-2.6.9"
       sources."core-util-is-1.0.2"
       sources."create-error-class-3.0.2"
-      sources."cross-spawn-5.1.0"
+      (sources."cross-spawn-5.1.0" // {
+        dependencies = [
+          sources."lru-cache-4.1.5"
+          sources."yallist-2.1.2"
+        ];
+      })
       sources."crypto-random-string-1.0.0"
       sources."css-parse-1.7.0"
       sources."currently-unhandled-0.4.1"
@@ -71291,7 +71735,12 @@ in
       sources."doctrine-3.0.0"
       sources."dot-prop-4.2.0"
       sources."duplexer3-0.1.4"
-      sources."editorconfig-0.15.3"
+      (sources."editorconfig-0.15.3" // {
+        dependencies = [
+          sources."lru-cache-4.1.5"
+          sources."yallist-2.1.2"
+        ];
+      })
       sources."element-helper-json-2.0.5"
       sources."emoji-regex-7.0.3"
       sources."error-ex-1.3.2"
@@ -71358,7 +71807,7 @@ in
       sources."global-dirs-0.1.1"
       sources."globals-11.12.0"
       sources."got-6.7.1"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."gridsome-helper-json-1.0.3"
       sources."has-1.0.3"
       (sources."has-ansi-2.0.0" // {
@@ -71390,7 +71839,7 @@ in
       sources."hast-util-parse-selector-2.2.2"
       sources."hast-util-to-string-1.0.2"
       sources."hast-util-whitespace-1.0.3"
-      sources."hosted-git-info-2.7.1"
+      sources."hosted-git-info-2.8.2"
       sources."html-void-elements-1.0.4"
       sources."html-whitespace-sensitive-tag-names-1.0.1"
       sources."iconv-lite-0.4.24"
@@ -71508,7 +71957,7 @@ in
       sources."longest-streak-1.0.0"
       sources."loud-rejection-1.6.0"
       sources."lowercase-keys-1.0.1"
-      sources."lru-cache-4.1.5"
+      sources."lru-cache-5.1.1"
       sources."make-dir-1.3.0"
       sources."map-cache-0.2.2"
       sources."map-obj-2.0.0"
@@ -72014,7 +72463,7 @@ in
       sources."xdg-basedir-3.0.0"
       sources."xtend-4.0.2"
       sources."y18n-3.2.1"
-      sources."yallist-2.1.2"
+      sources."yallist-3.0.3"
       (sources."yargs-4.7.1" // {
         dependencies = [
           sources."ansi-regex-2.1.1"
@@ -72063,7 +72512,7 @@ in
       sources."@cliqz-oss/node-firefox-connect-1.2.1"
       sources."@sindresorhus/is-0.14.0"
       sources."@snyk/composer-lockfile-parser-1.0.3"
-      sources."@snyk/dep-graph-1.10.0"
+      sources."@snyk/dep-graph-1.12.0"
       sources."@snyk/gemfile-1.2.0"
       sources."@szmarczak/http-timer-1.1.2"
       sources."@types/agent-base-4.2.0"
@@ -72169,7 +72618,7 @@ in
           sources."define-property-1.0.0"
         ];
       })
-      sources."base64-js-1.3.0"
+      sources."base64-js-1.3.1"
       sources."bcrypt-pbkdf-1.0.2"
       sources."binary-extensions-1.13.1"
       (sources."bl-1.2.2" // {
@@ -72561,7 +73010,7 @@ in
           sources."get-stream-3.0.0"
         ];
       })
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."graceful-readlink-1.0.1"
       sources."graphlib-2.1.7"
       sources."growly-1.3.0"
@@ -72577,7 +73026,12 @@ in
         ];
       })
       sources."has-yarn-2.1.0"
-      sources."hosted-git-info-2.7.1"
+      (sources."hosted-git-info-2.8.2" // {
+        dependencies = [
+          sources."lru-cache-5.1.1"
+          sources."yallist-3.0.3"
+        ];
+      })
       sources."htmlparser2-3.10.1"
       sources."http-cache-semantics-4.0.3"
       sources."http-errors-1.7.3"
@@ -73049,7 +73503,7 @@ in
         ];
       })
       sources."snapdragon-util-3.0.1"
-      (sources."snyk-1.208.0" // {
+      (sources."snyk-1.210.0" // {
         dependencies = [
           sources."ansi-regex-4.1.0"
           sources."debug-3.2.6"
@@ -73058,7 +73512,7 @@ in
           sources."update-notifier-2.5.0"
         ];
       })
-      (sources."snyk-config-2.2.2" // {
+      (sources."snyk-config-2.2.3" // {
         dependencies = [
           sources."debug-3.2.6"
           sources."ms-2.1.2"
@@ -73091,13 +73545,13 @@ in
           sources."ms-2.1.2"
         ];
       })
-      (sources."snyk-mvn-plugin-2.3.1" // {
+      (sources."snyk-mvn-plugin-2.3.3" // {
         dependencies = [
           sources."tslib-1.9.3"
         ];
       })
       sources."snyk-nodejs-lockfile-parser-1.16.0"
-      (sources."snyk-nuget-plugin-1.11.2" // {
+      (sources."snyk-nuget-plugin-1.11.3" // {
         dependencies = [
           sources."debug-3.2.6"
           sources."ms-2.1.2"
@@ -73254,7 +73708,7 @@ in
       sources."tslib-1.10.0"
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
-      sources."type-1.0.1"
+      sources."type-1.0.3"
       sources."type-check-0.3.2"
       sources."type-fest-0.5.2"
       sources."typedarray-0.0.6"
@@ -73378,10 +73832,10 @@ in
   webpack = nodeEnv.buildNodePackage {
     name = "webpack";
     packageName = "webpack";
-    version = "4.39.0";
+    version = "4.39.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/webpack/-/webpack-4.39.0.tgz";
-      sha512 = "nrxFNSEKm4T1C/EsgOgN50skt//Pl4X7kgJC1MrlE47M292LSCVmMOC47iTGL0CGxbdwhKGgeThrJcw0bstEfA==";
+      url = "https://registry.npmjs.org/webpack/-/webpack-4.39.1.tgz";
+      sha512 = "/LAb2TJ2z+eVwisldp3dqTEoNhzp/TLCZlmZm3GGGAlnfIWDgOEE758j/9atklNLfRyhKbZTCOIoPqLJXeBLbQ==";
     };
     dependencies = [
       sources."@webassemblyjs/ast-1.8.5"
@@ -73434,7 +73888,7 @@ in
           sources."define-property-1.0.0"
         ];
       })
-      sources."base64-js-1.3.0"
+      sources."base64-js-1.3.1"
       sources."big.js-5.2.2"
       sources."binary-extensions-1.13.1"
       sources."bluebird-3.5.5"
@@ -73566,7 +74020,7 @@ in
           sources."is-glob-3.1.0"
         ];
       })
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."has-value-1.0.0"
       (sources."has-values-1.0.0" // {
         dependencies = [
@@ -73777,7 +74231,7 @@ in
       sources."stream-shift-1.0.0"
       sources."string_decoder-1.1.1"
       sources."tapable-1.1.3"
-      (sources."terser-4.1.2" // {
+      (sources."terser-4.1.3" // {
         dependencies = [
           sources."source-map-0.6.1"
         ];
@@ -73830,7 +74284,7 @@ in
       sources."util-deprecate-1.0.2"
       sources."vm-browserify-1.1.0"
       sources."watchpack-1.6.0"
-      (sources."webpack-sources-1.4.1" // {
+      (sources."webpack-sources-1.4.3" // {
         dependencies = [
           sources."source-map-0.6.1"
         ];
@@ -73970,7 +74424,7 @@ in
         ];
       })
       sources."global-prefix-1.0.2"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."has-flag-3.0.0"
       sources."has-value-1.0.0"
       (sources."has-values-1.0.0" // {
@@ -74181,20 +74635,20 @@ in
   webtorrent-cli = nodeEnv.buildNodePackage {
     name = "webtorrent-cli";
     packageName = "webtorrent-cli";
-    version = "2.0.2";
+    version = "3.0.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/webtorrent-cli/-/webtorrent-cli-2.0.2.tgz";
-      sha512 = "thdHJQpoOLDXZMJQ708JhAQvqceds3R79LIDmzAALLRV5h1O/Ezmj7en3L3b/s1ek0TLkYW9TJxs1ohDcjaU9Q==";
+      url = "https://registry.npmjs.org/webtorrent-cli/-/webtorrent-cli-3.0.0.tgz";
+      sha512 = "ktehmMXkJbM1gnlPxiiVbTYq0rQHLs+U/A/3pXNt0vIYjHgzsydooejwHZlmL7vxdfZAaSHilbkBDRgWW071rA==";
     };
     dependencies = [
       sources."addr-to-ip-port-1.5.1"
       sources."airplay-js-0.3.0"
       sources."ascli-0.3.0"
-      sources."async-limiter-1.0.0"
+      sources."async-limiter-1.0.1"
       sources."balanced-match-1.0.0"
       sources."bencode-2.0.1"
-      sources."binary-search-1.3.5"
-      sources."bitfield-2.0.0"
+      sources."binary-search-1.3.6"
+      sources."bitfield-3.0.0"
       (sources."bittorrent-dht-9.0.1" // {
         dependencies = [
           sources."debug-4.1.1"
@@ -74204,12 +74658,11 @@ in
       sources."bittorrent-peerid-1.3.0"
       (sources."bittorrent-protocol-3.1.0" // {
         dependencies = [
-          sources."bitfield-3.0.0"
           sources."debug-4.1.1"
           sources."ms-2.1.2"
         ];
       })
-      (sources."bittorrent-tracker-9.11.0" // {
+      (sources."bittorrent-tracker-9.12.1" // {
         dependencies = [
           sources."debug-4.1.1"
           sources."ms-2.1.2"
@@ -74217,13 +74670,8 @@ in
         ];
       })
       sources."blob-to-buffer-1.2.8"
-      (sources."block-stream2-1.1.0" // {
-        dependencies = [
-          sources."readable-stream-2.3.6"
-          sources."safe-buffer-5.1.2"
-        ];
-      })
-      sources."bn.js-4.11.8"
+      sources."block-stream2-2.0.0"
+      sources."bn.js-5.0.0"
       sources."brace-expansion-1.1.11"
       sources."browserify-package-json-1.0.1"
       sources."buffer-alloc-1.2.0"
@@ -74243,7 +74691,7 @@ in
           sources."mime-1.6.0"
         ];
       })
-      sources."chunk-store-stream-4.0.0"
+      sources."chunk-store-stream-4.1.0"
       sources."clivas-0.2.0"
       sources."closest-to-2.0.0"
       sources."colour-0.7.1"
@@ -74254,13 +74702,13 @@ in
         dependencies = [
           sources."readable-stream-2.3.6"
           sources."safe-buffer-5.1.2"
+          sources."string_decoder-1.1.1"
         ];
       })
       sources."core-util-is-1.0.2"
-      sources."create-torrent-4.0.0"
+      sources."create-torrent-4.2.1"
       sources."debug-2.6.9"
       sources."decompress-response-3.3.0"
-      sources."defined-1.0.0"
       (sources."dlnacasts-0.1.0" // {
         dependencies = [
           sources."mime-1.6.0"
@@ -74273,13 +74721,7 @@ in
       sources."elementtree-0.1.7"
       sources."end-of-stream-1.4.1"
       sources."executable-4.1.1"
-      (sources."filestream-4.1.3" // {
-        dependencies = [
-          sources."readable-stream-2.3.6"
-          sources."safe-buffer-5.1.2"
-        ];
-      })
-      sources."flatten-1.0.2"
+      sources."filestream-5.0.0"
       (sources."fs-chunk-store-1.7.0" // {
         dependencies = [
           sources."thunky-1.0.3"
@@ -74340,7 +74782,7 @@ in
           sources."thunky-1.0.3"
         ];
       })
-      sources."multistream-3.0.0"
+      sources."multistream-3.1.0"
       sources."netmask-1.0.6"
       sources."network-address-1.1.2"
       sources."next-event-1.0.0"
@@ -74349,7 +74791,7 @@ in
       sources."nodebmc-0.0.7"
       sources."on-finished-2.3.0"
       sources."once-1.4.0"
-      sources."opn-6.0.0"
+      sources."open-6.4.0"
       sources."optjs-3.2.2"
       sources."package-json-versionify-1.0.4"
       sources."parse-numeric-range-0.0.2"
@@ -74402,21 +74844,23 @@ in
         ];
       })
       sources."simple-sha1-2.1.2"
-      (sources."simple-websocket-7.2.0" // {
+      (sources."simple-websocket-8.0.0" // {
         dependencies = [
-          sources."debug-3.2.6"
+          sources."debug-4.1.1"
           sources."ms-2.1.2"
-          sources."readable-stream-2.3.6"
-          sources."safe-buffer-5.1.2"
         ];
       })
       sources."speedometer-1.1.0"
       sources."split-1.0.1"
-      sources."stream-to-blob-1.0.2"
-      sources."stream-to-blob-url-2.1.2"
+      sources."stream-to-blob-2.0.0"
+      (sources."stream-to-blob-url-2.1.2" // {
+        dependencies = [
+          sources."stream-to-blob-1.0.2"
+        ];
+      })
       sources."stream-with-known-length-to-buffer-1.0.3"
       sources."string2compact-1.3.0"
-      (sources."string_decoder-1.1.1" // {
+      (sources."string_decoder-1.2.0" // {
         dependencies = [
           sources."safe-buffer-5.1.2"
         ];
@@ -74442,7 +74886,6 @@ in
       sources."url-join-4.0.1"
       (sources."ut_metadata-3.4.0" // {
         dependencies = [
-          sources."bitfield-3.0.0"
           sources."debug-4.1.1"
           sources."ms-2.1.2"
         ];
@@ -74450,9 +74893,9 @@ in
       sources."ut_pex-1.2.1"
       sources."utf-8-validate-5.0.2"
       sources."util-deprecate-1.0.2"
-      sources."videostream-3.2.0"
+      sources."videostream-3.2.1"
       sources."vlc-command-1.1.2"
-      (sources."webtorrent-0.105.3" // {
+      (sources."webtorrent-0.106.0" // {
         dependencies = [
           sources."debug-4.1.1"
           sources."ms-2.1.2"
@@ -74461,11 +74904,10 @@ in
       })
       sources."winreg-1.2.4"
       sources."wrappy-1.0.2"
-      sources."ws-6.2.1"
+      sources."ws-7.1.1"
       sources."xml2js-0.4.19"
       sources."xmlbuilder-9.0.7"
       sources."xmldom-0.1.27"
-      sources."xtend-4.0.2"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -74766,7 +75208,7 @@ in
       sources."global-tunnel-ng-2.7.1"
       sources."globby-8.0.2"
       sources."got-8.3.2"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."grouped-queue-0.3.3"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
@@ -74785,7 +75227,12 @@ in
           sources."kind-of-4.0.0"
         ];
       })
-      sources."hosted-git-info-2.7.1"
+      (sources."hosted-git-info-2.8.2" // {
+        dependencies = [
+          sources."lru-cache-5.1.1"
+          sources."yallist-3.0.3"
+        ];
+      })
       sources."http-cache-semantics-3.8.1"
       sources."http-signature-1.2.0"
       sources."humanize-string-1.0.2"

--- a/pkgs/development/node-packages/node-packages-v12.nix
+++ b/pkgs/development/node-packages/node-packages-v12.nix
@@ -184,13 +184,13 @@ let
         sha512 = "5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==";
       };
     };
-    "base64-js-1.3.0" = {
+    "base64-js-1.3.1" = {
       name = "base64-js";
       packageName = "base64-js";
-      version = "1.3.0";
+      version = "1.3.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz";
-        sha512 = "ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==";
+        url = "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz";
+        sha512 = "mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==";
       };
     };
     "bcrypt-pbkdf-1.0.2" = {
@@ -724,13 +724,13 @@ let
         sha1 = "dbf743c6c14992593c655568cb66ed32c0122ebe";
       };
     };
-    "graceful-fs-4.2.0" = {
+    "graceful-fs-4.2.1" = {
       name = "graceful-fs";
       packageName = "graceful-fs";
-      version = "4.2.0";
+      version = "4.2.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz";
-        sha512 = "jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==";
+        url = "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.1.tgz";
+        sha512 = "b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw==";
       };
     };
     "grunt-known-options-1.1.1" = {
@@ -814,13 +814,13 @@ let
         sha512 = "eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==";
       };
     };
-    "hosted-git-info-2.7.1" = {
+    "hosted-git-info-2.8.2" = {
       name = "hosted-git-info";
       packageName = "hosted-git-info";
-      version = "2.7.1";
+      version = "2.8.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz";
-        sha512 = "7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==";
+        url = "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.2.tgz";
+        sha512 = "CyjlXII6LMsPMyUzxpTt8fzh5QwzGqPmQXgY/Jyf4Zfp27t/FvfhwoE/8laaMUcMy816CkWF20I7NeQhwwY88w==";
       };
     };
     "http-signature-1.2.0" = {
@@ -1181,6 +1181,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/liftoff/-/liftoff-2.5.0.tgz";
         sha1 = "2009291bb31cea861bbf10a7c15a28caf75c31ec";
+      };
+    };
+    "lru-cache-5.1.1" = {
+      name = "lru-cache";
+      packageName = "lru-cache";
+      version = "5.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz";
+        sha512 = "KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==";
       };
     };
     "make-iterator-1.0.1" = {
@@ -2607,7 +2616,7 @@ in
       sources."aws-sign2-0.7.0"
       sources."aws4-1.8.0"
       sources."balanced-match-1.0.0"
-      sources."base64-js-1.3.0"
+      sources."base64-js-1.3.1"
       sources."bcrypt-pbkdf-1.0.2"
       sources."brace-expansion-1.1.11"
       sources."buffer-from-1.1.1"
@@ -2649,11 +2658,11 @@ in
       sources."gauge-2.7.4"
       sources."getpass-0.1.7"
       sources."glob-7.1.4"
-      sources."graceful-fs-4.2.0"
+      sources."graceful-fs-4.2.1"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-unicode-2.0.1"
-      sources."hosted-git-info-2.7.1"
+      sources."hosted-git-info-2.8.2"
       sources."http-signature-1.2.0"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
@@ -2668,6 +2677,7 @@ in
       sources."json-stringify-safe-5.0.1"
       sources."jsonfile-1.0.1"
       sources."jsprim-1.4.1"
+      sources."lru-cache-5.1.1"
       sources."mime-db-1.40.0"
       sources."mime-types-2.1.24"
       sources."minimatch-3.0.4"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15476,6 +15476,8 @@ in
 
   gradm = callPackage ../os-specific/linux/gradm { };
 
+  inherit (nodePackages) gtop;
+
   hd-idle = callPackage ../os-specific/linux/hd-idle { };
 
   hdparm = callPackage ../os-specific/linux/hdparm { };


### PR DESCRIPTION
##### Motivation for this change

This PR adds `gtop` to the nodePackages list. It is a system monitoring dashboard for the terminal.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
