### PR TITLE
postgresql: running `initdb` from command line now works

### DIFF
--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -251,6 +251,10 @@ in
 
     environment.systemPackages = [ postgresql ];
 
+    environment.pathsToLink = [
+     "/share/postgresql"
+    ];
+
     systemd.services.postgresql =
       { description = "PostgreSQL Server";
 

--- a/nixos/tests/initdb.nix
+++ b/nixos/tests/initdb.nix
@@ -1,0 +1,26 @@
+let
+  pkgs = import <nixpkgs> { };
+in
+with import <nixpkgs/nixos/lib/testing.nix> { inherit pkgs; system = builtins.currentSystem; };
+with pkgs.lib;
+
+makeTest {
+    name = "pg-initdb";
+
+    machine = {...}:
+      {
+        documentation.enable = false;
+        services.postgresql.enable = true;
+        services.postgresql.package = pkgs.postgresql_9_6;
+        environment.pathsToLink = [
+          "/share/postgresql"
+        ];
+      };
+
+    testScript = ''
+      $machine->start;
+      $machine->succeed("sudo -u postgres initdb -D /tmp/testpostgres2");
+      $machine->shutdown;
+    '';
+
+  }


### PR DESCRIPTION
The issue was only with NixOS service, `postgresql` installed through
`nix-env` was not affected.

Fixes https://github.com/NixOS/nixpkgs/issues/23655, see test in https://github.com/NixOS/nixpkgs/issues/23655#issuecomment-514323824