### PR TITLE
ocamlPackages.toml: init at 5.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/toml/default.nix
+++ b/pkgs/development/ocaml-modules/toml/default.nix
@@ -1,0 +1,24 @@
+{ lib, fetchFromGitHub, buildDunePackage
+, iso8601, menhir
+}:
+
+buildDunePackage rec {
+  pname = "toml";
+  version = "5.0.0";
+  src = fetchFromGitHub {
+    owner = "ocaml-toml";
+    repo = "to.ml";
+    rev = "v${version}";
+    sha256 = "1505kwcwklcfaxw8wckajm8kc6yrlikmxyhi8f8cpvhlw9ys90nj";
+  };
+
+  buildInputs = [ menhir ];
+  propagatedBuildInputs = [ iso8601 ];
+
+  meta = {
+    description = "Implementation in OCaml of the Toml minimal langage";
+    homepage = "http://ocaml-toml.github.io/To.ml";
+    license = lib.licenses.lgpl3;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/development/tools/ocaml/dune/default.nix
+++ b/pkgs/development/tools/ocaml/dune/default.nix
@@ -1,5 +1,9 @@
 { stdenv, fetchurl, ocaml, findlib, opaline }:
 
+if !stdenv.lib.versionAtLeast ocaml.version "4.02"
+then throw "dune is not available for OCaml ${ocaml.version}"
+else
+
 stdenv.mkDerivation rec {
   pname = "dune";
   version = "1.10.0";

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -719,6 +719,8 @@ let
 
     stringext = callPackage ../development/ocaml-modules/stringext { };
 
+    toml = callPackage ../development/ocaml-modules/toml { };
+
     topkg = callPackage ../development/ocaml-modules/topkg { };
 
     tsdl = callPackage ../development/ocaml-modules/tsdl { };


### PR DESCRIPTION
###### Motivation for this change

This is an implementation in OCaml of the Toml minimal langage.

Homepage: http://ocaml-toml.github.io/To.ml/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
