### PR TITLE
make nixos.stateVersion mandatory

### DIFF
--- a/nixos/lib/testing.nix
+++ b/nixos/lib/testing.nix
@@ -188,6 +188,7 @@ in rec {
             networking.hostName = "client";
             nix.readOnlyStore = false;
             virtualisation.writableStore = false;
+            system.stateVersion = "19.09"; # TODO: determine automatically
           }
         ];
 

--- a/nixos/modules/misc/version.nix
+++ b/nixos/modules/misc/version.nix
@@ -49,7 +49,9 @@ in
 
     stateVersion = mkOption {
       type = types.str;
-      default = cfg.release;
+      # Deliberately no default, as automatically upgrading the stateVersion can
+      # lead systems to stop working.
+      example = cfg.release;
       description = ''
         Every once in a while, a new NixOS release may change
         configuration defaults in a way incompatible with stateful

--- a/nixos/modules/misc/version.nix
+++ b/nixos/modules/misc/version.nix
@@ -53,15 +53,16 @@ in
       # lead systems to stop working.
       example = cfg.release;
       description = ''
-        Every once in a while, a new NixOS release may change
-        configuration defaults in a way incompatible with stateful
-        data. For instance, if the default version of PostgreSQL
-        changes, the new version will probably be unable to read your
-        existing databases. To prevent such breakage, you can set the
-        value of this option to the NixOS release with which you want
-        to be compatible. The effect is that NixOS will option
-        defaults corresponding to the specified release (such as using
-        an older version of PostgreSQL).
+        This option exists to prevent breakage for NixOS modules that depend on
+        state which can't be controlled by them. The value of this option
+        represents the <em>initial</em> NixOS version installed, and should
+        therefore <em>not</em> be ever changed unless you make sure to run all
+        necessary migrations yourself. By fixing this value, NixOS modules can
+        know what version your state is in, such that they can make incompatible
+        changes for new installations, without breaking the module for all
+        existing installations. For example this is used in the postgresql
+        module, where a new module version uses a newer postgresql version which
+        can't read the databases of older versions.
       '';
     };
 


### PR DESCRIPTION
###### Motivation for this change

In #61321 a necessary migration was only run if the stateVersion is older than 19.09. The default value of cfg.release (= 19.09) prevented it from being run on systems without explicit stateVersion.

In this particular case, maybe using stateVersion could have been avoided, but in general, it is not safe to have a system without explicitly set stateVersion.

All systems installed in the last few years should have it set automatically, but there are surely still a lot of configs out there with it not set.

(While stateVersion as it is currently designed has other problems, like mentioned in #50112, the goal here is to just do the minimal change to get systems safe.)

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [N/A] macOS
   - [N/A] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
