### PR TITLE
protonmail-bridge: 1.1.5 -> 1.1.6

### DIFF
--- a/pkgs/applications/networking/protonmail-bridge/default.nix
+++ b/pkgs/applications/networking/protonmail-bridge/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchurl, lib, qtbase, qtmultimedia, qtsvg, qtdeclarative, qttools, full
-, libsecret, libGL, libpulseaudio, glib, wrapQtAppsHook, makeDesktopItem }:
+{ stdenv, fetchurl, lib, qtbase, qtmultimedia, qtsvg, qtdeclarative, qttools, qtgraphicaleffects, qtquickcontrols2, full
+, libsecret, libGL, libpulseaudio, glib, wrapQtAppsHook, makeDesktopItem, mkDerivation }:
 
 let
-  version = "1.1.5-1";
+  version = "1.1.6-1";
 
   description = ''
     An application that runs on your computer in the background and seamlessly encrypts
@@ -20,15 +20,14 @@ let
     genericName = "ProtonMail Bridge for Linux";
     categories = "Utility;Security;Network;Email";
   };
-in stdenv.mkDerivation rec {
+
+in mkDerivation rec {
   name = "protonmail-bridge-${version}";
 
   src = fetchurl {
     url = "https://protonmail.com/download/protonmail-bridge_${version}_amd64.deb";
-    sha256 = "1y5mphrs60zd6km9z64vskk70q9zzw4g6js7qvgl572wv81w2l75";
+    sha256 = "108dql9q5znsqjkrs41pc6psjbg5bz09rdmjl036xxbvsdvq4a8r";
   };
-
-  nativeBuildInputs = [ wrapQtAppsHook ];
 
   sourceRoot = ".";
 
@@ -51,6 +50,8 @@ in stdenv.mkDerivation rec {
     rpath = lib.makeLibraryPath [
       stdenv.cc.cc.lib
       qtbase
+      qtquickcontrols2
+      qtgraphicaleffects
       qtmultimedia
       qtsvg
       qtdeclarative
@@ -66,6 +67,8 @@ in stdenv.mkDerivation rec {
       --set-rpath "${rpath}" \
       $out/lib/protonmail-bridge
   '';
+
+  buildInputs = [ qtbase qtquickcontrols2 qtmultimedia qtgraphicaleffects qtdeclarative ];
 
   meta = with stdenv.lib; {
     homepage = "https://www.protonmail.com/bridge";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19869,7 +19869,7 @@ in
 
   properties-cpp = callPackage ../development/libraries/properties-cpp { };
 
-  protonmail-bridge = libsForQt511.callPackage ../applications/networking/protonmail-bridge { };
+  protonmail-bridge = libsForQt512.callPackage ../applications/networking/protonmail-bridge { };
 
   protonvpn-cli = callPackage ../applications/networking/protonvpn-cli { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update: 1.1.5 -> 1.1.6

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
