### PR TITLE
moto: fix colliding dependencies

### DIFF
--- a/pkgs/development/python-modules/jsondiff/default.nix
+++ b/pkgs/development/python-modules/jsondiff/default.nix
@@ -5,11 +5,11 @@
 
 buildPythonPackage rec {
   pname = "jsondiff";
-  version = "1.1.2";
+  version = "1.2.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "7e18138aecaa4a8f3b7ac7525b8466234e6378dd6cae702b982c9ed851d2ae21";
+    sha256 = "00v3689175aqzdscrxpffm712ylp8jvcpqdg51ca22ni6721p51l";
   };
 
   # No tests
@@ -20,5 +20,4 @@ buildPythonPackage rec {
     homepage = https://github.com/ZoomerAnalytics/jsondiff;
     license = lib.licenses.mit;
   };
-
 }

--- a/pkgs/development/python-modules/jsondiff/default.nix
+++ b/pkgs/development/python-modules/jsondiff/default.nix
@@ -12,6 +12,10 @@ buildPythonPackage rec {
     sha256 = "00v3689175aqzdscrxpffm712ylp8jvcpqdg51ca22ni6721p51l";
   };
 
+  postPatch = ''
+    sed -e "/'jsondiff=jsondiff.cli:main_deprecated',/d" -i setup.py
+  '';
+
   # No tests
   doCheck = false;
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update jsondiff, and remove the jsondiff binary to prevent collision with jsonpatch effectively breaking the moto package.

closes #65287 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

TODO:
- [ ] Fix the `__pycache__/__init__.cpython-37.pyc` collision between `python3.7-backports.weakref-1.0.post1` and `python3.7-backports.tempfile-1.0`.

```
collision between `/nix/store/ns2w9qjcac97iw3j8sn1ygnmcxlhjgw8-python3.7-backports.weakref-1.0.post1/lib/python3.7/site-packages/backports/__pycache__/__init__.cpython-37.pyc' and `/nix/store/0v89qm932fmifhib68nlimwzlzr6bnyq-python3.7-backports.tempfile-1.0/lib/python3.7/site-packages/backports/__pycache__/__init__.cpython-37.pyc'
```