### PR TITLE
Update moto

### DIFF
--- a/pkgs/development/python-modules/moto/default.nix
+++ b/pkgs/development/python-modules/moto/default.nix
@@ -1,54 +1,78 @@
-{ buildPythonPackage, fetchPypi, jinja2, werkzeug, flask, cfn-lint
-, requests, pytz, backports_tempfile, cookies, jsondiff, botocore, aws-xray-sdk, docker, responses
-, six, boto, httpretty, xmltodict, nose, sure, boto3, freezegun, dateutil, mock, pyaml, python-jose }:
+{ lib, buildPythonPackage, fetchPypi, isPy27
+, aws-xray-sdk
+, backports_tempfile
+, boto
+, boto3
+, botocore
+, cfn-lint
+, docker
+, flask
+, freezegun
+, jinja2
+, jsondiff
+, mock
+, nose
+, pyaml
+, python-jose
+, pytz
+, requests
+, responses
+, six
+, sshpubkeys
+, sure
+, werkzeug
+, xmltodict
+}:
 
 buildPythonPackage rec {
   pname = "moto";
-  version = "1.3.8";
+  version = "1.3.10";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "9cb02134148fbe3ed81f11d6ab9bd71bbd6bc2db7e59a45de77fb1d0fedb744e";
+    sha256 = "0vlq015irqqwdknk1an7qqkg1zjk18c7jd89r7zbxxfwy3bgzwwj";
   };
 
   postPatch = ''
-    # regarding aws-xray-sdk: https://github.com/spulec/moto/commit/31eac49e1555c5345021a252cb0c95043197ea16
-    # regarding python-jose: https://github.com/spulec/moto/pull/1927
     substituteInPlace setup.py \
-      --replace "aws-xray-sdk<0.96," "aws-xray-sdk" \
-      --replace "jsondiff==1.1.1" "jsondiff>=1.1.1" \
-      --replace "python-jose<3.0.0" "python-jose<4.0.0"
+      --replace "jsondiff==1.1.2" "jsondiff~=1.1"
+    sed -i '/datetime/d' setup.py # should be taken care of by std library
   '';
 
   propagatedBuildInputs = [
     aws-xray-sdk
     boto
     boto3
+    botocore
     cfn-lint
-    dateutil
-    flask
-    httpretty
+    docker
+    flask # required for server
     jinja2
-    pytz
-    werkzeug
-    requests
-    six
-    xmltodict
+    jsondiff
     mock
     pyaml
-    backports_tempfile
-    cookies
-    jsondiff
-    botocore
-    docker
-    responses
     python-jose
-  ];
+    pytz
+    six
+    requests
+    responses
+    sshpubkeys
+    werkzeug
+    xmltodict
+  ] ++ lib.optionals isPy27 [ backports_tempfile ];
 
-  checkInputs = [ boto3 nose sure freezegun ];
+  checkInputs = [ boto3 freezegun nose sure ];
 
-  checkPhase = "nosetests";
+  checkPhase = ''nosetests -v ./tests/ \
+                  -e test_invoke_function_from_sns \
+                  -e test_invoke_requestresponse_function \
+                  -e test_context_manager \
+                  -e test_decorator_start_and_stop'';
 
-  # TODO: make this true; I think lots of the tests want network access but we can probably run the others
-  doCheck = false;
+  meta = with lib; {
+    description = "This project extends the Application Insights API surface to support Python";
+    homepage = https://github.com/spulec/moto;
+    license = licenses.asl20;
+    maintainers = [ ];
+  };
 }

--- a/pkgs/development/python-modules/sshpubkeys/default.nix
+++ b/pkgs/development/python-modules/sshpubkeys/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildPythonPackage, fetchFromGitHub
+, cryptography
+, ecdsa
+}:
+
+buildPythonPackage rec {
+  version = "3.1.0";
+  pname = "sshpubkeys";
+
+  src = fetchFromGitHub {
+    owner = "ojarva";
+    repo = "python-${pname}";
+    rev = "v${version}";
+    sha256 = "1h4gwmcfn84kkqh83km1vfz8sc5kr2g4gzgzmr8gz704jmqiv7nq";
+  };
+
+  propagatedBuildInputs = [ cryptography ecdsa ];
+
+  meta = with lib; {
+    description = "OpenSSH Public Key Parser for Python";
+    homepage = https://github.com/ojarva/python-sshpubkeys;
+    license = licenses.bsd3;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1121,6 +1121,8 @@ in {
 
   spglib = callPackage ../development/python-modules/spglib { };
 
+  sshpubkeys = callPackage ../development/python-modules/sshpubkeys { };
+
   sslib = callPackage ../development/python-modules/sslib { };
 
   statistics = callPackage ../development/python-modules/statistics { };


### PR DESCRIPTION
###### Motivation for this change
Partially help with #65287

backports isn't need by python3, while editing decided to:

-  update the package
-  add tests
- groom the dependencies.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

```
# nix path-info -Sh ....
/nix/store/jy0yqccn70mk7h1837rbdpvj74xfhw63-python2.7-moto-1.3.8         212.9M
/nix/store/f38r2ixcjnviq5vnc3ia4vk4mxzf3353-python2.7-moto-1.3.10        214.4M

/nix/store/9dyr50mfa43jbf5g84nq4svdpfl8i3fk-python3.7-moto-1.3.8         210.3M
/nix/store/pgnljjwla7a9iqkd04lzh1x5pbzag872-python3.7-moto-1.3.10        211.8M
```

```
$ ./result/bin/moto_server
 * Running on http://127.0.0.1:5000/ (Press CTRL+C to quit)
```