### PR TITLE
ngrok: fix build on darwin

### DIFF
--- a/pkgs/tools/networking/ngrok-2/default.nix
+++ b/pkgs/tools/networking/ngrok-2/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
 
   sourceRoot = ".";
 
-  nativeBuildInputs = [ patchelfUnstable ];
+  nativeBuildInputs = optionals stdenv.isLinux [ patchelfUnstable ];
 
   unpackPhase = "cp $src ngrok";
 
@@ -32,10 +32,10 @@ stdenv.mkDerivation {
 
   installPhase = ''
     install -D ngrok $out/bin/ngrok
-
+  '' + optionalString stdenv.isLinux ''
     patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
               $out/bin/ngrok
-    '';
+  '';
 
   passthru.updateScript = ./update.sh;
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

On darwin the build does not produce an ELF binary, so `patchelf` fails.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- ~[ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)~
- ~[ ] Ensured that relevant documentation is up to date~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---