### PR TITLE
Fix x2goclient startup

### DIFF
--- a/pkgs/applications/networking/remote/x2goclient/default.nix
+++ b/pkgs/applications/networking/remote/x2goclient/default.nix
@@ -3,12 +3,12 @@
 
 stdenv.mkDerivation rec {
   pname = "x2goclient";
-  version = "unstable-2018-11-30";
+  version = "unstable-2019-07-24";
 
   src = fetchgit {
    url = "git://code.x2go.org/x2goclient.git";
-   rev = "659655675f11ffd361ab9fb48fa77a01a1536fe8";
-   sha256 = "05gfs11m259bchy3k0ihqpwg9wf8lp94rbca5dzla9fjzrb7pyy4";
+   rev = "704c4ab92d20070dd160824c9b66a6d1c56dcc49";
+   sha256 = "1pndp3lfzwifyxqq0gps3p1bwakw06clbk6n8viv020l4bsfmq5f";
   };
 
   buildInputs = [ cups libssh libXpm nx-libs openldap openssh

--- a/pkgs/applications/networking/remote/x2goclient/default.nix
+++ b/pkgs/applications/networking/remote/x2goclient/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchgit, cups, libssh, libXpm, nx-libs, openldap, openssh
-, makeWrapper, qtbase, qtsvg, qtx11extras, qttools, phonon, pkgconfig }:
+, mkDerivation, qtbase, qtsvg, qtx11extras, qttools, phonon, pkgconfig }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "x2goclient";
   version = "unstable-2019-07-24";
 
@@ -13,7 +13,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ cups libssh libXpm nx-libs openldap openssh
                   qtbase qtsvg qtx11extras qttools phonon pkgconfig ];
-  nativeBuildInputs = [ makeWrapper ];
 
   postPatch = ''
      substituteInPlace Makefile \
@@ -28,9 +27,8 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   installTargets = [ "install_client" "install_man" ];
-  postInstall = ''
-    wrapProgram "$out/bin/x2goclient" --suffix PATH : "${nx-libs}/bin:${openssh}/libexec";
-  '';
+
+  qtWrapperArgs = [ ''--suffix PATH : ${nx-libs}/bin:${openssh}/libexec'' ];
 
   meta = with stdenv.lib; {
     description = "Graphical NoMachine NX3 remote desktop client";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fixes the following error:
```
qt.qpa.plugin: Could not find the Qt platform plugin "xcb" in ""
This application failed to start because no Qt platform plugin could be initialized.
Reinstalling the application may fix this problem.
```
    
See also #54484 and others.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
