### PR TITLE
dabtools: init at 20180405

### DIFF
--- a/pkgs/applications/radio/dabtools/default.nix
+++ b/pkgs/applications/radio/dabtools/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig
+, libusb1, rtl-sdr, fftw
+} :
+
+stdenv.mkDerivation rec {
+  pname = "dabtools";
+  version = "20180405";
+
+  src = fetchFromGitHub {
+    owner = "Opendigitalradio";
+    repo = "dabtools";
+    rev = "8b0b2258b02020d314efd4d0d33a56c8097de0d1";
+    sha256 = "18nkdybgg2w6zh56g6xwmg49sifalvraz4rynw8w5d8cqi3dm9sm";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = [ rtl-sdr fftw libusb1 ];
+
+  meta = with stdenv.lib; {
+    description = "Commandline tools for DAB and DAB+ digital radio broadcasts";
+    homepage = "https://github.com/Opendigitalradio/dabtools";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.markuskowa ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1377,6 +1377,8 @@ in
 
   cucumber = callPackage ../development/tools/cucumber {};
 
+  dabtools = callPackage ../applications/radio/dabtools { };
+
   daemontools = callPackage ../tools/admin/daemontools { };
 
   dale = callPackage ../development/compilers/dale { };


### PR DESCRIPTION
###### Motivation for this change
Tools for recording and playback of DAB and DAB+ radio. 

###### Things done
Tested with RTL-SDR receiver.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
