### PR TITLE
dablin: init at 1.11.0

### DIFF
--- a/pkgs/applications/radio/dablin/default.nix
+++ b/pkgs/applications/radio/dablin/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig
+, mpg123, SDL2, gnome3, faad2, pcre
+} :
+
+stdenv.mkDerivation rec {
+  pname = "dablin";
+  version = "1.11.0";
+
+  src = fetchFromGitHub {
+    owner = "Opendigitalradio";
+    repo = "dablin";
+    rev = "${version}";
+    sha256 = "04ir7yg7psnnb48s1qfppvvx6lak4s8f6fqdg721y2kd9129jm82";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+
+  buildInputs = [ faad2 mpg123 SDL2 gnome3.gtkmm pcre ];
+
+  meta = with stdenv.lib; {
+    description = "Play DAB/DAB+ from ETI-NI aligned stream";
+    homepage = https://github.com/Opendigitalradio/dablin;
+    license = with licenses; [ gpl3 lgpl21 ];
+    platforms = platforms.linux;
+    maintainers = [ maintainers.markuskowa ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17418,6 +17418,8 @@ in
 
   cyclone = callPackage ../applications/audio/pd-plugins/cyclone  { };
 
+  dablin = callPackage ../applications/radio/dablin { };
+
   darcs = haskell.lib.overrideCabal (haskell.lib.justStaticExecutables haskellPackages.darcs) (drv: {
     configureFlags = (stdenv.lib.remove "-flibrary" drv.configureFlags or []) ++ ["-f-library"];
   });


### PR DESCRIPTION
###### Motivation for this change
DAB/DAB+ radio app that reads ETI streams.

###### Things done
* tested along with RTL-SDR receiver and dab2eti from dabtools

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
