### PR TITLE
mongodb-compass: 1.13.1 -> 1.17.0

### DIFF
--- a/pkgs/tools/misc/mongodb-compass/default.nix
+++ b/pkgs/tools/misc/mongodb-compass/default.nix
@@ -1,10 +1,10 @@
 { stdenv, fetchurl, dpkg
 , alsaLib, atk, cairo, cups, curl, dbus, expat, fontconfig, freetype, glib
-, gnome2, libnotify, libxcb, nspr, nss, systemd, xorg }:
+, gnome2, gnome3, libnotify, libxcb, nspr, nss, systemd, xorg }:
 
 let
 
-  version = "1.13.1";
+  version = "1.17.0";
 
   rpath = stdenv.lib.makeLibraryPath [
     alsaLib
@@ -19,7 +19,7 @@ let
     glib
     gnome2.GConf
     gnome2.gdk_pixbuf
-    gnome2.gtk
+    gnome3.gtk
     gnome2.pango
     libnotify
     libxcb
@@ -46,7 +46,7 @@ let
     if stdenv.hostPlatform.system == "x86_64-linux" then
       fetchurl {
         url = "https://downloads.mongodb.com/compass/mongodb-compass_${version}_amd64.deb";
-        sha256 = "0x23jshnr0rafm5sn2vhq2y2gryg8mksahzyv5fszblgaxay234p";
+        sha256 = "085xq1ik8kyza1kq9kn0pf98zk6g2qa21clxhn48rgnqk20aninv";
       }
     else
       throw "MongoDB compass is not supported on ${stdenv.hostPlatform.system}";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Updating MongoDB Compass application.

Please note, while the latest stable version is 1.18.0, this update brings in 1.17.0. I was unable to make 1.18.0 work on NixOS, it ends stuck in an endless loading loop. Compass 1.17.0 seems to work just fine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
