### PR TITLE
mpd-mpris: init at 0.2.3

### DIFF
--- a/pkgs/tools/audio/mpd-mpris/default.nix
+++ b/pkgs/tools/audio/mpd-mpris/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "mpd-mpris";
+  version = "0.2.3";
+
+  src = fetchFromGitHub {
+    owner = "natsukagami";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "19sz1ykdzradhpdwdvvxh9scp5sv2i072qircs0q4374cdgccfbb";
+  };
+
+  modSha256 = "1a95kfy8w952269x4llbl0afyxr5fjkg30mxsn81zdh5wr8gabwh";
+
+  subPackages = [ "cmd/${pname}" ];
+
+  postInstall = ''
+    substituteInPlace mpd-mpris.service \
+      --replace /usr/bin $out/bin
+    mkdir -p $out/lib/systemd/user
+    cp mpd-mpris.service $out/lib/systemd/user
+  '';
+
+  meta = with stdenv.lib; {
+    description = "An implementation of the MPRIS protocol for MPD";
+    homepage = "https://github.com/natsukagami/mpd-mpris";
+    license = licenses.mit;
+    maintainers = with maintainers; [ doronbehar ];
+    platforms = platforms.linux;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1756,6 +1756,8 @@ in
 
   mpdris2 = callPackage ../tools/audio/mpdris2 { };
 
+  mpd-mpris = callPackage ../tools/audio/mpd-mpris { };
+
   mq-cli = callPackage ../tools/system/mq-cli { };
 
   nfdump = callPackage ../tools/networking/nfdump { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

#### One thing I'm not sure of:

I've add a `postInstall` script that copies the upstream provided user systemd service to the appropriate location in `$out`. I've installed the package and the service file appears in `~/.nix-profile/lib/systemd/user` along with all other user installed packages' user systemd services. However, `systemctl --user enable mpd-mpris.service` fails with:

```
Failed to enable unit: Unit file mpd-mpris.service does not exist.
```

Maybe that's not such a big deal as one can manually link `~/.nix-profile/lib/systemd/user/mpd-mpris.service` to ` ~/.config/systemd/user/default.target.wants/` but I'm pretty sure that's something other packages have handled somehow.

I couldn't find any mention of something to be done in such a case in the manual..