### PR TITLE
highlight: 3.43 -> 3.52, use GitLab source

### DIFF
--- a/pkgs/tools/text/highlight/default.nix
+++ b/pkgs/tools/text/highlight/default.nix
@@ -1,17 +1,19 @@
-{ stdenv, fetchFromGitHub, getopt, lua, boost, pkgconfig, gcc }:
+{ stdenv, fetchFromGitLab, getopt, lua, boost, pkgconfig, gcc }:
 
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "highlight-${version}";
-  version = "3.43";
+  version = "3.52";
 
-  src = fetchFromGitHub {
-    owner = "andre-simon";
+  src = fetchFromGitLab {
+    owner = "saalen";
     repo = "highlight";
     rev = "v${version}";
-    sha256 = "126nsf4cjxflg2kiv72qf1xl5fsilk0jqcncs6qqgm72cpjfmlsy";
+    sha256 = "0zhn1k70ck82ks7ckzsy1yiz686ym2ps7c28wjmkgxfpyjanilrq";
   };
+
+  enableParallelBuilding = true;
 
   nativeBuildInputs = [ pkgconfig ] ++ optional stdenv.isDarwin  gcc ;
 


### PR DESCRIPTION
###### Motivation for this change
The GitHub repo was archived: https://github.com/andre-simon/highlight
The [source](https://gitlab.com/saalen/highlight) is now hosted on GitLab as mentioned here: https://github.com/andre-simon/highlight/blob/master/README#L2-L3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS x86_64-linux & aarch64-linux
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---