### PR TITLE
Improve ergonomics of clwrapper

### DIFF
--- a/pkgs/development/lisp-modules/clwrapper/cl-wrapper.sh
+++ b/pkgs/development/lisp-modules/clwrapper/cl-wrapper.sh
@@ -8,7 +8,12 @@ eval "$NIX_LISP_PREHOOK"
 NIX_LISP_COMMAND="$1"
 shift
 
-[ -z "$NIX_LISP" ] && NIX_LISP="${NIX_LISP_COMMAND##*/}"
+if [ -z "$NIX_LISP" ]; then
+    while [ -h "${NIX_LISP_COMMAND}" ]; do
+        NIX_LISP_COMMAND="$(readlink -n "${NIX_LISP_COMMAND}")"
+    done
+    NIX_LISP="${NIX_LISP_COMMAND##*/}"
+fi
 
 export NIX_LISP NIX_LISP_LOAD_FILE NIX_LISP_EXEC_CODE NIX_LISP_COMMAND NIX_LISP_FINAL_PARAMETERS
 

--- a/pkgs/development/lisp-modules/clwrapper/cl-wrapper.sh
+++ b/pkgs/development/lisp-modules/clwrapper/cl-wrapper.sh
@@ -121,8 +121,10 @@ nix_lisp_build_system(){
 
 eval "$NIX_LISP_PRELAUNCH_HOOK"
 
-[ -z "$NIX_LISP_SKIP_CODE" ] && "$NIX_LISP_COMMAND" $NIX_LISP_EARLY_OPTIONS \
-	$NIX_LISP_EXEC_CODE "${NIX_LISP_ASDF_LOAD:-"(load \"$NIX_LISP_ASDF/lib/common-lisp/asdf/build/asdf.$NIX_LISP_FASL_TYPE\")"}" \
-	$NIX_LISP_EXEC_CODE "$NIX_LISP_ASDF_REGISTRY_CODE" \
-	${NIX_LISP_FINAL_PARAMETERS[*]:+"${NIX_LISP_FINAL_PARAMETERS[@]}"} \
-	"$@"
+if [ -z "$NIX_LISP_SKIP_CODE" ]; then
+    "$NIX_LISP_COMMAND" $NIX_LISP_EARLY_OPTIONS \
+	                $NIX_LISP_EXEC_CODE "${NIX_LISP_ASDF_LOAD:-"(load \"$NIX_LISP_ASDF/lib/common-lisp/asdf/build/asdf.$NIX_LISP_FASL_TYPE\")"}" \
+	                $NIX_LISP_EXEC_CODE "$NIX_LISP_ASDF_REGISTRY_CODE" \
+	                ${NIX_LISP_FINAL_PARAMETERS[*]:+"${NIX_LISP_FINAL_PARAMETERS[@]}"} \
+	                "$@"
+fi


### PR DESCRIPTION
###### Motivation for this change

`lispPackages.clwrapper` is a useful package for creating nix derivations that support a variety of lisp compilers.  Instead of running the compiler directly (and thus depending on a specific one), you use the `common-lisp.sh` script to actually invoke the compiler.  Neat!  Unfortunately, not all functionality is exposed conveniently.  For example, if you want to get your compiler to load a file, you need to jump through some hoops.  Right now, the easiest way to do that is to source `cl-wrapper.sh` and use the variables it sets.

Over in https://github.com/bradleyjensen/ql2nix, I to source `cl-wrapper.sh` during a `buildPhase`.  Unfortunately, `cl-wrapper.sh` always returns a non-zero exit code when `NIX_LISP_SKIP_CODE` is the empty string.  So, I had to hack around it by tossing a `|| true` into my `buildPhase`.  This PR corrects that.

This PR also makes clwrapper work with CCL.  The `common-lisp.sh` script passes in the path to the `ccl` symlink rather than the path to the actual executable binary.  That causes `cl-wrapper.sh` to fail to recognize the implementation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
