### PR TITLE
Add riscv-gnu-toolchain

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2343,6 +2343,11 @@
     github = "javaguirre";
     name = "Javier Aguirre";
   };
+  jaykru = {
+    email = "j@dank.systems";
+    github = "jaykru";
+    name = "Jay Kruer";
+  };
   jb55 = {
     email = "jb55@jb55.com";
     github = "jb55";

--- a/pkgs/development/compilers/riscv-gnu-toolchain/default.nix
+++ b/pkgs/development/compilers/riscv-gnu-toolchain/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, gmp, mpfr, libmpc, wget, curl, texinfo, bison, flex, expat }:
+
+with import <nixpkgs> {};
+stdenv.mkDerivation rec {
+  name = "riscv-gnu-toolchain";
+  
+  buildInputs = [ gmp mpfr libmpc wget curl texinfo bison flex expat ];
+  configureFlags = [ "--enable-multilib" ];
+  hardeningDisable = [ "format" ];
+  src = fetchgit {
+    rev = "1321568527a6ac7d9ad464a425aa3baf11d0f300";
+    url = "git://github.com/riscv/riscv-gnu-toolchain.git";
+    sha256 = "131dgwlr60ilczixpqkdhb5hrjpasgh3yx78nvki7fbrxig5z47a";
+  };
+
+  meta = with stdenv.lib; {
+    description = "GNU toolchain for RISC-V, including GCC";
+    longDescription = "A GNU+Linux multilib (riscv64 and riscv32)
+                       Newlib (libc) cross-compilation toolchain
+                       oriented toward embedded systems
+                       applications";
+    homepage = https://github.com/riscv/riscv-gnu-toolchain;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.jaykru ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16012,7 +16012,9 @@ in
   rfkill = callPackage ../os-specific/linux/rfkill { };
 
   rfkill_udev = callPackage ../os-specific/linux/rfkill/udev.nix { };
-
+  
+  riscv-gnu-toolchain = callPackage ../development/compilers/riscv-gnu-toolchain {};
+  
   riscv-pk = callPackage ../misc/riscv-pk { };
 
   riscv-pk-with-kernel = riscv-pk.override {


### PR DESCRIPTION
###### Motivation for this change
Adds a derivation for riscv-gnu-toolchain (https://github.com/riscv/riscv-gnu-toolchain) which is a GNU toolchain for RISC-V, including GCC. The derivation currently builds a Linux multilib (riscv64 and riscv32) Newlib cross-compilation toolchain oriented toward embedded systems applications, though one could add options to the derivation to build Linux/glibc and single-arch toolchains.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [N/A] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [N/A] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
