### PR TITLE
[WIP] Enable testing in core scientific python libraries and move to github as src

### DIFF
--- a/pkgs/development/python-modules/numpy/default.nix
+++ b/pkgs/development/python-modules/numpy/default.nix
@@ -1,4 +1,14 @@
-{ lib, fetchPypi, python, buildPythonPackage, gfortran, pytest, blas, writeTextFile, isPyPy }:
+{ lib
+, fetchFromGitHub
+, python
+, buildPythonPackage
+, gfortran
+, pytest
+, cython
+, blas
+, writeTextFile
+, isPyPy
+}:
 
 let
   blasImplementation = lib.nameFromURL blas.name "-";
@@ -18,14 +28,22 @@ in buildPythonPackage rec {
   pname = "numpy";
   version = "1.16.4";
 
-  src = fetchPypi {
-    inherit pname version;
-    extension = "zip";
-    sha256 = "7242be12a58fec245ee9734e625964b97cf7e3f2f7d016603f9e56660ce479c7";
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "15gnn4pz653qfm24c2wd3lcgix2xk6lwiqxa8f73jbrhzmfl70jd";
   };
 
-  nativeBuildInputs = [ gfortran pytest ];
-  buildInputs = [ blas ];
+  nativeBuildInputs = [
+    gfortran
+    pytest
+    cython
+  ];
+
+  buildInputs = [
+    blas
+  ];
 
   patches = lib.optionals python.hasDistutilsCxxPatch [
     # We patch cpython/distutils to fix https://bugs.python.org/issue1222585
@@ -68,6 +86,6 @@ in buildPythonPackage rec {
   meta = {
     description = "Scientific tools for Python";
     homepage = http://numpy.scipy.org/;
-    maintainers = with lib.maintainers; [ fridh ];
+    maintainers = with lib.maintainers; [ fridh costrouc ];
   };
 }

--- a/pkgs/development/python-modules/scipy/default.nix
+++ b/pkgs/development/python-modules/scipy/default.nix
@@ -1,27 +1,42 @@
-{lib, fetchPypi, python, buildPythonPackage, gfortran, nose, pytest, numpy}:
+{ lib
+, fetchFromGitHub
+, python
+, buildPythonPackage
+, gfortran
+, nose
+, pytest
+, numpy
+, cython
+}:
 
 buildPythonPackage rec {
   pname = "scipy";
   version = "1.3.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "c3bb4bd2aca82fb498247deeac12265921fe231502a6bc6edea3ee7fe6c40a7a";
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "17xfnn7r21z7ncclmlgi6r9d5rxihnybzgdfby557i14zqklvk1c";
   };
 
-  checkInputs = [ nose pytest ];
-  nativeBuildInputs = [ gfortran ];
-  buildInputs = [ numpy.blas ];
-  propagatedBuildInputs = [ numpy ];
+  nativeBuildInputs = [
+    gfortran
+    cython
+  ];
 
-  # Remove tests because of broken wrapper
-  prePatch = ''
-    rm scipy/linalg/tests/test_lapack.py
-  '';
+  buildInputs = [
+    numpy.blas
+  ];
 
-  # INTERNALERROR, solved with https://github.com/scipy/scipy/pull/8871
-  # however, it does not apply cleanly.
-  doCheck = false;
+  checkInputs = [
+    nose
+    pytest
+  ];
+
+  propagatedBuildInputs = [
+    numpy
+  ];
 
   preConfigure = ''
     sed -i '0,/from numpy.distutils.core/s//import setuptools;from numpy.distutils.core/' setup.py
@@ -51,6 +66,6 @@ buildPythonPackage rec {
   meta = {
     description = "SciPy (pronounced 'Sigh Pie') is open-source software for mathematics, science, and engineering. ";
     homepage = https://www.scipy.org/;
-    maintainers = with lib.maintainers; [ fridh ];
+    maintainers = with lib.maintainers; [ fridh costrouc ];
   };
 }

--- a/pkgs/development/python-modules/sympy/default.nix
+++ b/pkgs/development/python-modules/sympy/default.nix
@@ -1,6 +1,6 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , fetchpatch
 , glibcLocales
 , mpmath
@@ -10,17 +10,16 @@ buildPythonPackage rec {
   pname = "sympy";
   version = "1.4"; # Upgrades may break sage. Please test or ping @timokau.
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "1q937csy8rd18pk2fz1ssj7jyj7l3rjx4nzbiz5vcymfhrb1x8bi";
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "sympy-${version}";
+    sha256 = "0rpp82alvli7w3cab7h4dyydkk00nkc6nf3ph35kjywxpdnp3fsm";
   };
 
-  checkInputs = [ glibcLocales ];
-
-  propagatedBuildInputs = [ mpmath ];
-
-  # tests take ~1h
-  doCheck = false;
+  propagatedBuildInputs = [
+    mpmath
+  ];
 
   patches = [
     # to be fixed by https://github.com/sympy/sympy/pull/13476
@@ -30,14 +29,10 @@ buildPythonPackage rec {
     })
   ];
 
-  preCheck = ''
-    export LANG="en_US.UTF-8"
-  '';
-
   meta = {
     description = "A Python library for symbolic mathematics";
     homepage    = http://www.sympy.org/;
     license     = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ lovek323 timokau ];
+    maintainers = with lib.maintainers; [ lovek323 timokau costrouc ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

There are several motivations for this PR.

Packages I am focusing on: numpy, scipy, numba, dask, sympy, matplotlib, and a few others.

1. I've noticed that many of the core python scientific libraries in nix are not being currently tested and the derivations could be cleaned up
2. (Selfish intention) Right now I am running downstream testing for the major python scientific libraries with hydra. https://hydra.aves.io/jobset/python-downstream-testing/master. I am testing to see if any commits on master from these major packages affect packages that depend on them. This is hard to do if the nixpkgs derivation is not based on the repository instead of sdist.

Questions/Opinions

1. After doing some of this work. I am under the impression that if it is a well maintained project we should almost always prefer to use the git repository instead of the sdist. This guarentees tests being available and allows the user to override a package to a git commit that does not have a git tag.
2. Is there a prefered amount of time that tests should run in? For example numba and sympy both take around an hour for the full test suite.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
