### PR TITLE
checksec: 1.5 -> 2.0.1

### DIFF
--- a/pkgs/os-specific/linux/checksec/0001-attempt-to-modprobe-config-before-checking-kernel.patch
+++ b/pkgs/os-specific/linux/checksec/0001-attempt-to-modprobe-config-before-checking-kernel.patch
@@ -8,20 +8,21 @@ Signed-off-by: Austin Seipp <aseipp@pobox.com>
  checksec.sh | 3 ++-
  1 file changed, 2 insertions(+), 1 deletion(-)
 
-diff --git a/checksec.sh b/checksec.sh
+diff --git a/checksec b/checksec
 index dd1f72e..63acc29 100644
---- a/checksec.sh
-+++ b/checksec.sh
-@@ -337,7 +337,8 @@ kernelcheck() {
-   printf "  userspace processes, this option lists the status of kernel configuration\n"
-   printf "  options that harden the kernel itself against attack.\n\n"
-   printf "  Kernel config: "
-- 
+--- a/checksec
++++ b/checksec
+@@ -676,7 +676,8 @@ kernelcheck() {
+   echo_message "  userspace processes, this option lists the status of kernel configuration\n" '' '' ''
+   echo_message "  options that harden the kernel itself against attack.\n\n" '' '' ''
+   echo_message "  Kernel config:\n" '' '' '{ "kernel": '
+-
 +
 +  modprobe configs 2> /dev/null
-   if [ -f /proc/config.gz ] ; then
-     kconfig="zcat /proc/config.gz"
-     printf "\033[32m/proc/config.gz\033[m\n\n"
+   if [[ ! "${1}" == "" ]] ; then
+     kconfig="cat ${1}"
+     echo_message "  Warning: The config ${1} on disk may not represent running kernel config!\n\n" "${1}" "<kernel config=\"${1}\"" "{ \"KernelConfig\":\"${1}\","
+     # update the architecture based on the config rather than the system
 -- 
 1.8.3.2
 

--- a/pkgs/os-specific/linux/checksec/default.nix
+++ b/pkgs/os-specific/linux/checksec/default.nix
@@ -1,43 +1,39 @@
-{ stdenv, fetchurl, file, findutils, binutils-unwrapped, glibc, coreutils, sysctl }:
+{ stdenv, fetchFromGitHub, makeWrapper, file, findutils
+, binutils-unwrapped, glibc, coreutils, sysctl, openssl
+}:
 
 stdenv.mkDerivation rec {
-  name = "checksec-${version}";
-  version = "1.5";
+  pname = "checksec";
+  version = "2.0.1";
 
-  src = fetchurl {
-    url    = "https://www.trapkit.de/tools/checksec.sh";
-    sha256 = "0iq9v568mk7g7ksa1939g5f5sx7ffq8s8n2ncvphvlckjgysgf3p";
+  src = fetchFromGitHub {
+    owner = "slimm609";
+    repo = "checksec.sh";
+    rev = version;
+    sha256 = "04lzwm24d576h425rgvgjj2wim29i3961jrj35r43wrswmrsc3r2";
   };
 
   patches = [ ./0001-attempt-to-modprobe-config-before-checking-kernel.patch ];
+  nativeBuildInputs = [ makeWrapper ];
 
-  unpackPhase = ''
-    mkdir ${name}
-    cp $src ${name}/checksec.sh
-    cd ${name}
-  '';
-
-  installPhase = ''
+  installPhase = let
+    path = stdenv.lib.makeBinPath [
+      findutils file binutils-unwrapped sysctl openssl
+    ];
+  in ''
     mkdir -p $out/bin
-    cp checksec.sh $out/bin/checksec
-    chmod +x $out/bin/checksec
-    substituteInPlace $out/bin/checksec --replace /bin/bash ${stdenv.shell}
+    install checksec $out/bin
     substituteInPlace $out/bin/checksec --replace /lib/libc.so.6 ${glibc.out}/lib/libc.so.6
-    substituteInPlace $out/bin/checksec --replace find ${findutils}/bin/find
-    substituteInPlace $out/bin/checksec --replace "file $" "${file}/bin/file $"
-    substituteInPlace $out/bin/checksec --replace "xargs file" "xargs ${file}/bin/file"
-    substituteInPlace $out/bin/checksec --replace " readelf -" " ${binutils-unwrapped}/bin/readelf -"
-    substituteInPlace $out/bin/checksec --replace "(readelf -" "(${binutils-unwrapped}/bin/readelf -"
-    substituteInPlace $out/bin/checksec --replace "command_exists readelf" "command_exists ${binutils-unwrapped}/bin/readelf"
-    substituteInPlace $out/bin/checksec --replace "/sbin/sysctl -" "${sysctl}/bin/sysctl -"
     substituteInPlace $out/bin/checksec --replace "/usr/bin/id -" "${coreutils}/bin/id -"
+    wrapProgram $out/bin/checksec \
+      --prefix PATH : ${path}
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "A tool for checking security bits on executables";
     homepage    = "http://www.trapkit.de/tools/checksec.html";
-    license     = stdenv.lib.licenses.bsd3;
-    platforms   = stdenv.lib.platforms.linux;
-    maintainers = [ stdenv.lib.maintainers.thoughtpolice ];
+    license     = licenses.bsd3;
+    platforms   = platforms.linux;
+    maintainers = with maintainers; [ thoughtpolice globin ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
New release

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - N/A macOS
   - [ ] other Linux distributions
- N/A Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
