### PR TITLE
Lookup hunspell dictionaries in XDG_DATA_DIRS

### DIFF
--- a/pkgs/development/libraries/hunspell/0001-Make-hunspell-look-in-XDG_DATA_DIRS-for-dictionaries.patch
+++ b/pkgs/development/libraries/hunspell/0001-Make-hunspell-look-in-XDG_DATA_DIRS-for-dictionaries.patch
@@ -1,0 +1,37 @@
+From 8c67f314de2684d77315eecd99ef091d441f17dd Mon Sep 17 00:00:00 2001
+From: Matthew Bauer <mjbauer95@gmail.com>
+Date: Wed, 24 Jul 2019 15:35:18 -0400
+Subject: [PATCH] Make hunspell look in XDG_DATA_DIRS for dictionaries
+
+Some dictionaries may exist but only show up under XDG_DATA_DIRS. For
+instance, $HOME/.local/share/hunspell could contain some dictionaries.
+
+This patch adds each directory in the hunspell subdir of each
+XDG_DATA_DIRS to the lookup path.
+
+Upstream pr is available at: https://github.com/hunspell/hunspell/pull/637
+---
+ src/tools/hunspell.cxx | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/src/tools/hunspell.cxx b/src/tools/hunspell.cxx
+index 690e34a..6cd127e 100644
+--- a/src/tools/hunspell.cxx
++++ b/src/tools/hunspell.cxx
+@@ -2044,6 +2044,13 @@ int main(int argc, char** argv) {
+     if (getenv("DICPATH")) {
+       path_std_str.append(getenv("DICPATH")).append(PATHSEP);
+     }
++    if (getenv("XDG_DATA_DIRS")) {
++      char* dir = strtok(getenv("XDG_DATA_DIRS"), ":");
++      while (dir != NULL) {
++        path_std_str.append(dir).append("/hunspell:");
++        dir = strtok(NULL, ":");
++      }
++    }
+     path_std_str.append(LIBDIR).append(PATHSEP);
+     if (HOME) {
+       const char * userooodir[] = USEROOODIR;
+-- 
+2.22.0
+

--- a/pkgs/development/libraries/hunspell/default.nix
+++ b/pkgs/development/libraries/hunspell/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ ncurses readline ];
   nativeBuildInputs = [ autoreconfHook ];
 
+  patches = [ ./0001-Make-hunspell-look-in-XDG_DATA_DIRS-for-dictionaries.patch ];
+
   postPatch = ''
     patchShebangs tests
   '';

--- a/pkgs/development/libraries/hunspell/dictionaries.nix
+++ b/pkgs/development/libraries/hunspell/dictionaries.nix
@@ -286,10 +286,11 @@ let
       };
     };
 
-in {
+in rec {
 
   /* ENGLISH */
 
+  en_US = en-us;
   en-us = mkDictFromWordlist {
     shortName = "en-us";
     shortDescription = "English (United States)";
@@ -300,6 +301,7 @@ in {
     };
   };
 
+  en_CA = en-ca;
   en-ca = mkDictFromWordlist {
     shortName = "en-ca";
     shortDescription = "English (Canada)";
@@ -310,6 +312,7 @@ in {
     };
   };
 
+  en_GB-ise = en-gb-ise;
   en-gb-ise = mkDictFromWordlist {
     shortName = "en-gb-ise";
     shortDescription = "English (United Kingdom, 'ise' ending)";
@@ -320,6 +323,7 @@ in {
     };
   };
 
+  en_GB-ize = en-gb-ize;
   en-gb-ize = mkDictFromWordlist {
     shortName = "en-gb-ize";
     shortDescription = "English (United Kingdom, 'ize' ending)";
@@ -332,126 +336,147 @@ in {
 
   /* SPANISH */
 
+  es_ANY = es-any;
   es-any = mkDictFromRla {
     shortName = "es-any";
     shortDescription = "Spanish (any variant)";
     dictFileName = "es_ANY";
   };
 
+  es_AR = es-ar;
   es-ar = mkDictFromRla {
     shortName = "es-ar";
     shortDescription = "Spanish (Argentina)";
     dictFileName = "es_AR";
   };
 
+  es_BO = es-bo;
   es-bo = mkDictFromRla {
     shortName = "es-bo";
     shortDescription = "Spanish (Bolivia)";
     dictFileName = "es_BO";
   };
 
+  es_CL = es-cl;
   es-cl = mkDictFromRla {
     shortName = "es-cl";
     shortDescription = "Spanish (Chile)";
     dictFileName = "es_CL";
   };
 
+  es_CO = es-co;
   es-co = mkDictFromRla {
     shortName = "es-co";
     shortDescription = "Spanish (Colombia)";
     dictFileName = "es_CO";
   };
 
+  es_CR = es-cr;
   es-cr = mkDictFromRla {
     shortName = "es-cr";
     shortDescription = "Spanish (Costra Rica)";
     dictFileName = "es_CR";
   };
 
+  es_CU = es-cu;
   es-cu = mkDictFromRla {
     shortName = "es-cu";
     shortDescription = "Spanish (Cuba)";
     dictFileName = "es_CU";
   };
 
+  es_DO = es-do;
   es-do = mkDictFromRla {
     shortName = "es-do";
     shortDescription = "Spanish (Dominican Republic)";
     dictFileName = "es_DO";
   };
 
+  es_EC = es-ec;
   es-ec = mkDictFromRla {
     shortName = "es-ec";
     shortDescription = "Spanish (Ecuador)";
     dictFileName = "es_EC";
   };
 
+  es_ES = es-es;
   es-es = mkDictFromRla {
     shortName = "es-es";
     shortDescription = "Spanish (Spain)";
     dictFileName = "es_ES";
   };
 
+  es_GT = es-gt;
   es-gt = mkDictFromRla {
     shortName = "es-gt";
     shortDescription = "Spanish (Guatemala)";
     dictFileName = "es_GT";
   };
 
+  es_HN = es-hn;
   es-hn = mkDictFromRla {
     shortName = "es-hn";
     shortDescription = "Spanish (Honduras)";
     dictFileName = "es_HN";
   };
 
+  es_MX = es-mx;
   es-mx = mkDictFromRla {
     shortName = "es-mx";
     shortDescription = "Spanish (Mexico)";
     dictFileName = "es_MX";
   };
 
+  es_NI = es-ni;
   es-ni = mkDictFromRla {
     shortName = "es-ni";
     shortDescription = "Spanish (Nicaragua)";
     dictFileName = "es_NI";
   };
 
+  es_PA = es-pa;
   es-pa = mkDictFromRla {
     shortName = "es-pa";
     shortDescription = "Spanish (Panama)";
     dictFileName = "es_PA";
   };
 
+  es_PE = es-pe;
   es-pe = mkDictFromRla {
     shortName = "es-pe";
     shortDescription = "Spanish (Peru)";
     dictFileName = "es_PE";
   };
 
+  es_PR = es-pr;
   es-pr = mkDictFromRla {
     shortName = "es-pr";
     shortDescription = "Spanish (Puerto Rico)";
     dictFileName = "es_PR";
   };
 
+  es_PY = es-py;
   es-py = mkDictFromRla {
     shortName = "es-py";
     shortDescription = "Spanish (Paraguay)";
     dictFileName = "es_PY";
   };
 
+  es_SV = es-sv;
   es-sv = mkDictFromRla {
     shortName = "es-sv";
     shortDescription = "Spanish (El Salvador)";
     dictFileName = "es_SV";
   };
 
+  es_UY = es-uy;
   es-uy = mkDictFromRla {
     shortName = "es-uy";
     shortDescription = "Spanish (Uruguay)";
     dictFileName = "es_UY";
   };
 
+  es_VE = es-ve;
   es-ve = mkDictFromRla {
     shortName = "es-ve";
     shortDescription = "Spanish (Venezuela)";
@@ -505,6 +530,7 @@ in {
 
   /* ITALIAN */
 
+  it_IT = it-it;
   it-it =  mkDictFromLinguistico rec {
     shortName = "it-it";
     dictFileName = "it_IT";
@@ -517,6 +543,7 @@ in {
 
   /* BASQUE */
 
+  eu_ES = eu-es;
   eu-es = mkDictFromXuxen {
     shortName = "eu-es";
     dictFileName = "eu_ES";
@@ -549,6 +576,7 @@ in {
 
   /* HUNGARIAN */
 
+  hu_HU = hu-hu;
   hu-hu = mkDictFromLibreOffice {
     shortName = "hu-hu";
     dictFileName = "hu_HU";
@@ -557,7 +585,8 @@ in {
   };
 
   /* SWEDISH */
-  
+
+  sv_SE = sv-se;
   sv-se = mkDictFromDSSO rec {
     shortName = "sv-se";
     dictFileName = "sv_SE";
@@ -565,26 +594,30 @@ in {
   };
 
   # Finlandian Swedish (hello Linus Torvalds)
+  sv_FI = sv-fi;
   sv-fi = mkDictFromDSSO rec {
     shortName = "sv-fi";
     dictFileName = "sv_FI";
     shortDescription = "Swedish (Finland)";
   };
-  
+
   /* GERMAN */
 
+  de_DE = de-de;
   de-de = mkDictFromJ3e {
     shortName = "de-de";
     shortDescription = "German (Germany)";
     dictFileName = "de_DE";
   };
 
+  de_AT = de-at;
   de-at = mkDictFromJ3e {
     shortName = "de-at";
     shortDescription = "German (Austria)";
     dictFileName = "de_AT";
   };
 
+  de_CH = de-ch;
   de-ch = mkDictFromJ3e {
     shortName = "de-ch";
     shortDescription = "German (Switzerland)";
@@ -593,6 +626,7 @@ in {
 
   /* UKRAINIAN */
 
+  uk_UA = uk-ua;
   uk-ua = mkDict rec {
     name = "hunspell-dict-uk-ua-${version}";
     version = "4.2.5";


### PR DESCRIPTION
Adds a patch to support XDG_DATA_DIRS in hunspell.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
