### PR TITLE
spectral: v2019-03-03 -> v2019-08-15

### DIFF
--- a/pkgs/applications/networking/instant-messengers/spectral/default.nix
+++ b/pkgs/applications/networking/instant-messengers/spectral/default.nix
@@ -1,49 +1,40 @@
 { stdenv, fetchgit
-, pkgconfig, makeWrapper
-, qmake, qtbase, qtquickcontrols2, qtmultimedia
+, pkgconfig, wrapQtAppsHook
+, cmake
+, qtbase, qttools, qtquickcontrols2, qtmultimedia, qtkeychain
 , libpulseaudio
 # Not mentioned but seems needed
 , qtgraphicaleffects
 , qtdeclarative
 , qtmacextras
+, olm, cmark
 }:
 
-let
-  # Following "borrowed" from yubikey-manager-qt
-  qmlPath = qmlLib: "${qmlLib}/${qtbase.qtQmlPrefix}";
-
-  inherit (stdenv) lib;
-
-  qml2ImportPath = lib.concatMapStringsSep ":" qmlPath [
-    qtbase.bin qtdeclarative.bin qtquickcontrols2.bin qtgraphicaleffects qtmultimedia
-  ];
-
+let qtkeychain-qt5 = qtkeychain.override {
+  inherit qtbase qttools;
+  withQt5 = true;
+};
 in stdenv.mkDerivation {
   pname = "spectral";
-  version = "2019-03-03";
+  version = "unstable-2019-08-30";
 
   src = fetchgit {
     url = "https://gitlab.com/b0/spectral.git";
-    rev = "0473f25d38a064ee4e18203ec16eeae84fea4866";
-    sha256 = "1n09ginw6g0p42xj3zgxm52dvyyvj5psllv70vx21i50lvkbh9rw";
+    rev = "ee86c948aec5fe72979fc6df97f4a6ef711bdf94";
+    sha256 = "1mqabdkvzq48wki92wm2r79kj8g8m7ganpl47sh60qfsk4bxa8b2";
     fetchSubmodules = true;
   };
 
-  qmakeFlags = [ "CONFIG+=qtquickcompiler" "BUNDLE_FONT=true" ];
+  #qmakeFlags = [ "CONFIG+=qtquickcompiler" "BUNDLE_FONT=true" ];
 
-  postInstall = ''
-    wrapProgram $out/bin/spectral \
-      --set QML2_IMPORT_PATH "${qml2ImportPath}"
-  '';
-
-  nativeBuildInputs = [ pkgconfig qmake makeWrapper ];
-  buildInputs = [ qtbase qtquickcontrols2 qtmultimedia qtgraphicaleffects qtdeclarative ]
+  nativeBuildInputs = [ pkgconfig cmake wrapQtAppsHook ];
+  buildInputs = [ qtbase qtkeychain-qt5 qtquickcontrols2 qtmultimedia qtgraphicaleffects qtdeclarative olm cmark ]
     ++ stdenv.lib.optional stdenv.hostPlatform.isLinux libpulseaudio
     ++ stdenv.lib.optional stdenv.hostPlatform.isDarwin qtmacextras;
 
   meta = with stdenv.lib; {
-    description = "A glossy client for Matrix, written in QtQuick Controls 2 and C++";
-    homepage = https://gitlab.com/b0/spectral;
+    description = "A glossy cross-platform Matrix client.";
+    homepage = "https://gitlab.com/b0/spectral";
     license = licenses.gpl3;
     platforms = with platforms; linux ++ darwin;
     maintainers = with maintainers; [ dtzWill ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update `spectral`.

Works for me!

cc: @dtzWill

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
