### PR TITLE
hyperkit: init at 0.20190201

### DIFF
--- a/pkgs/applications/virtualization/hyperkit/default.nix
+++ b/pkgs/applications/virtualization/hyperkit/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, lib, fetchFromGitHub
+, Hypervisor, vmnet, SystemConfiguration
+, xpc, libobjc, dtrace
+}:
+
+stdenv.mkDerivation rec {
+  pname   = "hyperkit";
+  version = "0.20190201"; # keep in sync with src.rev
+
+  src = fetchFromGitHub {
+    owner = "moby";
+    repo = "hyperkit";
+    rev = "64bbfbec66900334d91bb2ac32de60b5187cf6c9";
+    sha256 = "0ql581m5s65l5a7v61bxhl8x1213dl9f0h82lwjsaii4h240bvkf";
+  };
+
+  buildInputs = [ Hypervisor vmnet SystemConfiguration xpc libobjc dtrace ];
+
+  # 1. Don't use git to determine version
+  # 2. Include dtrace probes
+  prePatch = ''
+    substituteInPlace Makefile \
+      --replace 'shell git describe --abbrev=6 --dirty --always --tags' "v${version}" \
+      --replace 'shell git rev-parse HEAD' "${src.rev}" \
+      --replace 'PHONY: clean' 'PHONY:'
+    make src/include/xhyve/dtrace.h
+  '';
+
+  makeFlags = [
+    "CFLAGS+=-Wno-shift-sign-overflow"
+    ''CFLAGS+=-DVERSION=\"v${version}\"''
+    ''CFLAGS+=-DVERSION_SHA1=\"${src.rev}\"'' # required for vmnet
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp build/hyperkit $out/bin
+  '';
+
+  meta = with lib; {
+    description = "A toolkit for embedding hypervisor capabilities in your application";
+    homepage = https://github.com/moby/hyperkit;
+    maintainers = with maintainers; [ nicknovitski ];
+    platforms = platforms.darwin;
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1662,6 +1662,12 @@ in
 
   hr = callPackage ../applications/misc/hr { };
 
+  hyperkit = callPackage ../applications/virtualization/hyperkit {
+    inherit (darwin.apple_sdk.frameworks) Hypervisor vmnet SystemConfiguration;
+    inherit (darwin.apple_sdk.libs) xpc;
+    inherit (darwin) libobjc dtrace;
+  };
+
   hyx = callPackage ../tools/text/hyx { };
 
   icdiff = callPackage ../tools/text/icdiff {};


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- ~[ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~
- ~[ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`~
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- ~[ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)~
- ~[ ] Ensured that relevant documentation is up to date~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---