### PR TITLE
netsurf: 3.5 → 3.9

### DIFF
--- a/pkgs/applications/misc/netsurf/browser/default.nix
+++ b/pkgs/applications/misc/netsurf/browser/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, libpng, openssl, curl, gtk2, check, SDL
-, libxml2, libidn, perl, nettools, perlPackages
+, libxml2, libidn, perl, nettools, perlPackages, xxd
 , libXcursor, libXrandr, makeWrapper
 , uilib ? "framebuffer"
 , buildsystem
@@ -14,21 +14,28 @@
 , libnsgif
 , libnsutils
 , libutf8proc
+, wrapGAppsHook
 }:
 
 stdenv.mkDerivation rec {
 
   name = "netsurf-${version}";
-  version = "3.5";
+  version = "3.9";
 
   # UI libs incldue Framebuffer, and gtk
 
   src = fetchurl {
     url = "http://download.netsurf-browser.org/netsurf/releases/source/netsurf-${version}-src.tar.gz";
-    sha256 = "1k0x8mzgavfy7q9kywl6kzsc084g1xlymcnsxi5v6jp279nsdwwq";
+    sha256 = "1hzcm2s2wh5sapgr000lg63hcdbj6hyajxl43xa1x80kc5piqbyp";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [
+    pkgconfig
+    xxd
+  ] ++ stdenv.lib.optionals (uilib == "gtk") [
+    wrapGAppsHook
+  ];
+
   buildInputs = [ libpng openssl curl gtk2 check libxml2 libidn perl
     nettools perlPackages.HTMLParser libXcursor libXrandr makeWrapper SDL
     buildsystem
@@ -63,7 +70,7 @@ stdenv.mkDerivation rec {
     cmd=$(case "${uilib}" in framebuffer) echo nsfb;; gtk) echo nsgtk;; esac)
     cp $cmd $out/bin/netsurf
     wrapProgram $out/bin/netsurf --set NETSURFRES $out/share/Netsurf/${uilib}/res
-    tar -hcf - ${uilib}/res | (cd $out/share/Netsurf/ && tar -xvpf -)
+    tar -hcf - frontends/${uilib}/res | (cd $out/share/Netsurf/ && tar -xvpf -)
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/misc/netsurf/browser/default.nix
+++ b/pkgs/applications/misc/netsurf/browser/default.nix
@@ -1,18 +1,22 @@
 { stdenv, fetchurl, pkgconfig, libpng, openssl, curl, gtk2, check, SDL
 , libxml2, libidn, perl, nettools, perlPackages, xxd
 , libXcursor, libXrandr, makeWrapper
+, libwebp
 , uilib ? "framebuffer"
 , buildsystem
 , nsgenbind
 , libnsfb
 , libwapcaplet
 , libparserutils
+, libnslog
 , libcss
 , libhubbub
 , libdom
 , libnsbmp
 , libnsgif
+, libsvgtiny
 , libnsutils
+, libnspsl
 , libutf8proc
 , wrapGAppsHook
 }:
@@ -38,17 +42,21 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libpng openssl curl gtk2 check libxml2 libidn perl
     nettools perlPackages.HTMLParser libXcursor libXrandr makeWrapper SDL
+    libwebp
     buildsystem
     nsgenbind
     libnsfb
     libwapcaplet
     libparserutils
+    libnslog
     libcss
     libhubbub
     libdom
     libnsbmp
     libnsgif
+    libsvgtiny
     libnsutils
+    libnspsl
     libutf8proc
  ];
 

--- a/pkgs/applications/misc/netsurf/browser/default.nix
+++ b/pkgs/applications/misc/netsurf/browser/default.nix
@@ -86,8 +86,15 @@ stdenv.mkDerivation rec {
     mkdir -p $out/bin $out/share/Netsurf/${uilib}
     cmd=$(case "${uilib}" in framebuffer) echo nsfb;; gtk) echo nsgtk;; esac)
     cp $cmd $out/bin/netsurf
-    wrapProgram $out/bin/netsurf --set NETSURFRES $out/share/Netsurf/${uilib}/res
     tar -hcf - frontends/${uilib}/res | (cd $out/share/Netsurf/ && tar -xvpf -)
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --set NETSURFRES $out/share/Netsurf/${uilib}/res
+    )
+  '' + stdenv.lib.optionalString (uilib != "gtk") ''
+    wrapProgram $out/bin/netsurf "''${gappsWrapperArgs[@]}"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/misc/netsurf/browser/default.nix
+++ b/pkgs/applications/misc/netsurf/browser/default.nix
@@ -1,9 +1,8 @@
 { stdenv, fetchurl, fetchpatch, pkgconfig, libpng, openssl, curl, gtk2, check, SDL
-, libxml2, libidn, perl, nettools, perlPackages, xxd
 , libXcursor, libXrandr, makeWrapper
 , libwebp
+, libxml2, libidn, perl, perlPackages, xxd
 , uilib ? "framebuffer"
-, buildsystem
 , nsgenbind
 , libnsfb
 , libwapcaplet
@@ -26,8 +25,6 @@ stdenv.mkDerivation rec {
   name = "netsurf-${version}";
   version = "3.9";
 
-  # UI libs incldue Framebuffer, and gtk
-
   src = fetchurl {
     url = "http://download.netsurf-browser.org/netsurf/releases/source/netsurf-${version}-src.tar.gz";
     sha256 = "1hzcm2s2wh5sapgr000lg63hcdbj6hyajxl43xa1x80kc5piqbyp";
@@ -43,16 +40,17 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [
+    perl
+    perlPackages.HTMLParser
     pkgconfig
     xxd
   ] ++ stdenv.lib.optionals (uilib == "gtk") [
     wrapGAppsHook
   ];
 
-  buildInputs = [ libpng openssl curl gtk2 check libxml2 libidn perl
-    nettools perlPackages.HTMLParser libXcursor libXrandr makeWrapper SDL
+  buildInputs = [ libpng openssl curl gtk2 check libxml2 libidn
+    libXcursor libXrandr makeWrapper SDL
     libwebp
-    buildsystem
     nsgenbind
     libnsfb
     libwapcaplet
@@ -78,7 +76,6 @@ stdenv.mkDerivation rec {
 
   makeFlags = [
     "PREFIX=$(out)"
-    "NSSHARED=${buildsystem}/share/netsurf-buildsystem"
     "TARGET=${uilib}"
   ];
 

--- a/pkgs/applications/misc/netsurf/browser/default.nix
+++ b/pkgs/applications/misc/netsurf/browser/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, libpng, openssl, curl, gtk2, check, SDL
+{ stdenv, fetchurl, fetchpatch, pkgconfig, libpng, openssl, curl, gtk2, check, SDL
 , libxml2, libidn, perl, nettools, perlPackages, xxd
 , libXcursor, libXrandr, makeWrapper
 , libwebp
@@ -32,6 +32,15 @@ stdenv.mkDerivation rec {
     url = "http://download.netsurf-browser.org/netsurf/releases/source/netsurf-${version}-src.tar.gz";
     sha256 = "1hzcm2s2wh5sapgr000lg63hcdbj6hyajxl43xa1x80kc5piqbyp";
   };
+
+  patches = [
+    # GTK: prefer using curl's intrinsic defaults for CURLOPT_CA*
+    (fetchpatch {
+	  name = "0001-GTK-prefer-using-curl-s-intrinsic-defaults-for-CURLO.patch";
+      url = "http://source.netsurf-browser.org/netsurf.git/patch/?id=87177d8aa109206d131e0d80a2080ce55dab01c7";
+      sha256 = "08bc60pc5k5qpckqv21zgmgszj3rpwskfc84shs8vg92vkimv2ai";
+    })
+  ];
 
   nativeBuildInputs = [
     pkgconfig

--- a/pkgs/applications/misc/netsurf/libcss/default.nix
+++ b/pkgs/applications/misc/netsurf/libcss/default.nix
@@ -8,11 +8,11 @@ stdenv.mkDerivation rec {
 
   name = "netsurf-${libname}-${version}";
   libname = "libcss";
-  version = "0.6.0";
+  version = "0.9.0";
 
   src = fetchurl {
     url = "http://download.netsurf-browser.org/libs/releases/${libname}-${version}-src.tar.gz";
-    sha256 = "0qp4p1q1dwgdra4pkrzd081zjzisxkgwx650ijx323j8bj725daf";
+    sha256 = "1vw9j3d2mr4wbvs8fyqmgslkbxknvac10456775hflxxcivbm3xr";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/applications/misc/netsurf/libdom/default.nix
+++ b/pkgs/applications/misc/netsurf/libdom/default.nix
@@ -9,11 +9,11 @@ stdenv.mkDerivation rec {
 
   name = "netsurf-${libname}-${version}";
   libname = "libdom";
-  version = "0.3.0";
+  version = "0.4.0";
 
   src = fetchurl {
     url = "http://download.netsurf-browser.org/libs/releases/${libname}-${version}-src.tar.gz";
-    sha256 = "1kk6qbqagx5ypiy9kf0059iqdzyz8fqaw336vzhb5gnrzjw3wv4a";
+    sha256 = "1ixkqsl3f7dl1kajksm0c231w1v5xy8z6hm3v67hgm9nh4qcvfcy";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/applications/misc/netsurf/libhubbub/default.nix
+++ b/pkgs/applications/misc/netsurf/libhubbub/default.nix
@@ -7,11 +7,11 @@ stdenv.mkDerivation rec {
 
   name = "netsurf-${libname}-${version}";
   libname = "libhubbub";
-  version = "0.3.3";
+  version = "0.3.6";
 
   src = fetchurl {
     url = "http://download.netsurf-browser.org/libs/releases/${libname}-${version}-src.tar.gz";
-    sha256 = "101781iw32p47386fxqr01nrkywi12w17ajh02k2vlga4z8zyv86";
+    sha256 = "1x3v7xvagx85v9h3pypzc86rcxs4mij87mmcqkp8pq50q6awfmnp";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/applications/misc/netsurf/libnsbmp/default.nix
+++ b/pkgs/applications/misc/netsurf/libnsbmp/default.nix
@@ -6,11 +6,11 @@ stdenv.mkDerivation rec {
 
   name = "netsurf-${libname}-${version}";
   libname = "libnsbmp";
-  version = "0.1.3";
+  version = "0.1.5";
 
   src = fetchurl {
     url = "http://download.netsurf-browser.org/libs/releases/${libname}-${version}-src.tar.gz";
-    sha256 = "0gmvzw1whh7553d6s98vr4ri2whjwrgggcq1z5b160gwjw20mzyy";
+    sha256 = "0lib2m07d1i0k80m4blkwnj0g7rha4jbm5vrgd0wwbkyfa0hvk35";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/applications/misc/netsurf/libnsfb/default.nix
+++ b/pkgs/applications/misc/netsurf/libnsfb/default.nix
@@ -6,11 +6,11 @@ stdenv.mkDerivation rec {
 
   name = "netsurf-${libname}-${version}";
   libname = "libnsfb";
-  version = "0.1.4";
+  version = "0.2.1";
 
   src = fetchurl {
     url = "http://download.netsurf-browser.org/libs/releases/${libname}-${version}-src.tar.gz";
-    sha256 = "176f8why9gzbaca9nnxjqasl02qzc6g507z5w3dzkcjifnkz4mzl";
+    sha256 = "09qag9lgn5ahanbcyf2rvfmsz15vazfwnl8xpn8f1iczd44b0bv0";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/applications/misc/netsurf/libnsgif/default.nix
+++ b/pkgs/applications/misc/netsurf/libnsgif/default.nix
@@ -6,11 +6,11 @@ stdenv.mkDerivation rec {
 
   name = "netsurf-${libname}-${version}";
   libname = "libnsgif";
-  version = "0.1.3";
+  version = "0.2.1";
 
   src = fetchurl {
     url = "http://download.netsurf-browser.org/libs/releases/${libname}-${version}-src.tar.gz";
-    sha256 = "1a4z45gh0fw4iybf34fig725av25h31ffk0azi0snzh4130cklnk";
+    sha256 = "0jwshypgmx16xlsbx3d8njk8a5khazlplca5mxd3rdbhrlsabbly";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/applications/misc/netsurf/libnslog/default.nix
+++ b/pkgs/applications/misc/netsurf/libnslog/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchurl, pkgconfig, bison, flex
+, buildsystem
+}:
+
+stdenv.mkDerivation rec {
+
+  name = "netsurf-${libname}-${version}";
+  libname = "libnslog";
+  version = "0.1.2";
+
+  src = fetchurl {
+    url = "http://download.netsurf-browser.org/libs/releases/${libname}-${version}-src.tar.gz";
+    sha256 = "1ggs6xvxp8fbg5w8pifalipm458ygr9ab6j2yvj8fnnmxwvdh4jd";
+  };
+
+  nativeBuildInputs = [ pkgconfig bison flex ];
+  buildInputs = [
+    buildsystem
+  ];
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    "NSSHARED=${buildsystem}/share/netsurf-buildsystem"
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = http://www.netsurf-browser.org/;
+    description = "NetSurf Parametric Logging Library";
+    license = licenses.mit;
+    maintainers = [ maintainers.samueldr ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/netsurf/libnspsl/default.nix
+++ b/pkgs/applications/misc/netsurf/libnspsl/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchurl, pkgconfig
+, buildsystem
+}:
+
+stdenv.mkDerivation rec {
+
+  name = "netsurf-${libname}-${version}";
+  libname = "libnspsl";
+  version = "0.1.5";
+
+  src = fetchurl {
+    url = "http://download.netsurf-browser.org/libs/releases/${libname}-${version}-src.tar.gz";
+    sha256 = "0siq8zjfxv75i9fw6q5hkaijpdm1w3zskd5qk6vsvz8cqan4vifd";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [
+    buildsystem
+  ];
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    "NSSHARED=${buildsystem}/share/netsurf-buildsystem"
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = http://www.netsurf-browser.org/;
+    description = "NetSurf Public Suffix List - Handling library";
+    license = licenses.mit;
+    maintainers = [ maintainers.samueldr ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/netsurf/libnsutils/default.nix
+++ b/pkgs/applications/misc/netsurf/libnsutils/default.nix
@@ -6,11 +6,11 @@ stdenv.mkDerivation rec {
 
   name = "netsurf-${libname}-${version}";
   libname = "libnsutils";
-  version = "0.0.2";
+  version = "0.0.5";
 
   src = fetchurl {
     url = "http://download.netsurf-browser.org/libs/releases/${libname}-${version}-src.tar.gz";
-    sha256 = "03p4xmd08yhj70nyj7acjccmmshs59lv4n4zsqpsn5lgkwa23lzy";
+    sha256 = "09w1rixps1iiq6wirjwxmd6h87llvjzvw565rahjb3rlyhcplfqf";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/applications/misc/netsurf/libparserutils/default.nix
+++ b/pkgs/applications/misc/netsurf/libparserutils/default.nix
@@ -6,11 +6,11 @@ stdenv.mkDerivation rec {
 
   name = "netsurf-${libname}-${version}";
   libname = "libparserutils";
-  version = "0.2.3";
+  version = "0.2.4";
 
   src = fetchurl {
     url = "http://download.netsurf-browser.org/libs/releases/${libname}-${version}-src.tar.gz";
-    sha256 = "01gzlsabgl6x0icd8758d9jqs8rrf9574bdkjainn04w3fs3znf5";
+    sha256 = "1n2794y2l0c8nv8z2pxwfnbn882987ifmxjv60zdxkhcndhswarj";
   };
 
   buildInputs = [ buildsystem perl ];

--- a/pkgs/applications/misc/netsurf/libsvgtiny/default.nix
+++ b/pkgs/applications/misc/netsurf/libsvgtiny/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchurl, pkgconfig, gperf
+, buildsystem
+, libdom
+, libhubbub
+, libparserutils
+, libwapcaplet
+}:
+
+stdenv.mkDerivation rec {
+
+  name = "netsurf-${libname}-${version}";
+  libname = "libsvgtiny";
+  version = "0.1.7";
+
+  src = fetchurl {
+    url = "http://download.netsurf-browser.org/libs/releases/${libname}-${version}-src.tar.gz";
+    sha256 = "10bpkmvfpydj74im3r6kqm9vnvgib6afy0alx71q5n0w5yawy39c";
+  };
+
+  nativeBuildInputs = [ pkgconfig gperf ];
+  buildInputs = [
+    buildsystem
+    libdom
+    libhubbub
+    libparserutils
+    libwapcaplet
+  ];
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    "NSSHARED=${buildsystem}/share/netsurf-buildsystem"
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = http://www.netsurf-browser.org/;
+    description = "NetSurf SVG decoder";
+    license = licenses.mit;
+    maintainers = [ maintainers.samueldr ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/netsurf/libutf8proc/default.nix
+++ b/pkgs/applications/misc/netsurf/libutf8proc/default.nix
@@ -6,11 +6,11 @@ stdenv.mkDerivation rec {
 
   name = "netsurf-${libname}-${version}";
   libname = "libutf8proc";
-  version = "1.3.1";
+  version = "2.4.0-1";
 
   src = fetchurl {
     url = "http://download.netsurf-browser.org/libs/releases/${libname}-${version}-src.tar.gz";
-    sha256 = "0xf659y3c6ikjnip47r30wv796a34d71p6qhc4xjs64iqszm1sbq";
+    sha256 = "0wn409laqaqlqnz2d77419b5rya99vvc696vj187biy1i5livaq1";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/applications/misc/netsurf/libwapcaplet/default.nix
+++ b/pkgs/applications/misc/netsurf/libwapcaplet/default.nix
@@ -6,11 +6,11 @@ stdenv.mkDerivation rec {
 
   name = "netsurf-${libname}-${version}";
   libname = "libwapcaplet";
-  version = "0.3.0";
+  version = "0.4.2";
 
   src = fetchurl {
     url = "http://download.netsurf-browser.org/libs/releases/${libname}-${version}-src.tar.gz";
-    sha256 = "0cs1dd2afjgc3wf5gqg434hv6jdabrp9qvlpl4dp53nhkyfywna3";
+    sha256 = "1fjwzbn7j8bi1b9bvwxsy3i2cr6byq2s2d29866801pjnf528g86";
   };
 
   buildInputs = [ buildsystem ];

--- a/pkgs/applications/misc/netsurf/nsgenbind/default.nix
+++ b/pkgs/applications/misc/netsurf/nsgenbind/default.nix
@@ -6,11 +6,11 @@
 stdenv.mkDerivation rec {
 
   name = "netsurf-nsgenbind-${version}";
-  version = "0.3";
+  version = "0.7";
 
   src = fetchurl {
     url = "http://download.netsurf-browser.org/libs/releases/nsgenbind-${version}-src.tar.gz";
-    sha256 = "16xsazly7gxwywmlkf2xix9b924sj3skhgdak7218l0nc62a08gg";
+    sha256 = "0rplmky4afsjwiwh7grkmcdmzg86zksa55j93dvq92f91yljwqqq";
   };
 
   buildInputs = [ buildsystem flex bison ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4283,6 +4283,8 @@ in
 
     libsvgtiny = callPackage ../applications/misc/netsurf/libsvgtiny { };
 
+    libnspsl = callPackage ../applications/misc/netsurf/libnspsl { };
+
     libutf8proc = callPackage ../applications/misc/netsurf/libutf8proc { };
 
     browser = callPackage ../applications/misc/netsurf/browser { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4265,6 +4265,8 @@ in
 
     libparserutils = callPackage ../applications/misc/netsurf/libparserutils { };
 
+    libnslog = callPackage ../applications/misc/netsurf/libnslog { };
+
     libcss = callPackage ../applications/misc/netsurf/libcss { };
 
     libhubbub = callPackage ../applications/misc/netsurf/libhubbub { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4281,6 +4281,8 @@ in
 
     libnsutils = callPackage ../applications/misc/netsurf/libnsutils { };
 
+    libsvgtiny = callPackage ../applications/misc/netsurf/libsvgtiny { };
+
     libutf8proc = callPackage ../applications/misc/netsurf/libutf8proc { };
 
     browser = callPackage ../applications/misc/netsurf/browser { };


### PR DESCRIPTION
###### Motivation for this change

Updates netsurf and related libraries.

The default config for netsurf (framebuffer) wasn't tested, I can't get it to work, in the previous iteration either. The gtk ui, though works fine.

tip:

```
nix-build -E '(import ./. {}).netsurf.browser.override{uilib = "gtk";}'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
   - 🔲 macOS
   - 🔲 other Linux distributions
- 🔲 Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ✔️ Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- ✔️ Tested execution of all binary files (usually in `./result/bin/`)
- 🔲 Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ✔️ Assured whether relevant documentation is up to date
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @fgaz @S-NA 