### PR TITLE
pulseview,pavucontrol-qt: use qt5.mkDerivation

### DIFF
--- a/pkgs/applications/science/electronics/pulseview/default.nix
+++ b/pkgs/applications/science/electronics/pulseview/default.nix
@@ -1,9 +1,9 @@
 { stdenv, fetchurl, pkgconfig, cmake, glib, boost, libsigrok
 , libsigrokdecode, libserialport, libzip, udev, libusb1, libftdi1, glibmm
-, pcre, librevisa, python3, qtbase, qtsvg
+, pcre, librevisa, python3, qt5, qtbase, qtsvg
 }:
 
-stdenv.mkDerivation rec {
+qt5.mkDerivation rec {
   name = "pulseview-0.4.1";
 
   src = fetchurl {

--- a/pkgs/desktops/lxqt/pavucontrol-qt/default.nix
+++ b/pkgs/desktops/lxqt/pavucontrol-qt/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, cmake, pkgconfig, lxqt, libpulseaudio,
-  pcre, qtbase, qttools, qtx11extras }:
+  pcre, qt5, qtbase, qttools, qtx11extras }:
 
-stdenv.mkDerivation rec {
+qt5.mkDerivation rec {
   pname = "pavucontrol-qt";
   version = "0.14.1";
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
I've noticed both of these apps don't start anymore due to missing Qt plugin path.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
