### PR TITLE
_3llo: init at 0.3.0

### DIFF
--- a/pkgs/development/ruby-modules/bundler-app/default.nix
+++ b/pkgs/development/ruby-modules/bundler-app/default.nix
@@ -36,7 +36,7 @@
 let
   basicEnv = (callPackage ../bundled-common {}) args;
 
-  cmdArgs = removeAttrs args [ "pname" "postBuild" "gemConfig" "passthru" ] // {
+  cmdArgs = removeAttrs args [ "pname" "postBuild" "gemConfig" "passthru" "gemset" ] // {
     inherit preferLocalBuild allowSubstitutes; # pass the defaults
 
     buildInputs = buildInputs ++ lib.optional (scripts != []) makeWrapper;

--- a/pkgs/tools/misc/3llo/Gemfile
+++ b/pkgs/tools/misc/3llo/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem '3llo', '0.3.0'

--- a/pkgs/tools/misc/3llo/Gemfile.lock
+++ b/pkgs/tools/misc/3llo/Gemfile.lock
@@ -1,0 +1,27 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    3llo (0.3.0)
+      tty-prompt (~> 0.12.0)
+    equatable (0.6.1)
+    necromancer (0.4.0)
+    pastel (0.7.3)
+      equatable (~> 0.6)
+      tty-color (~> 0.5)
+    tty-color (0.5.0)
+    tty-cursor (0.4.0)
+    tty-prompt (0.12.0)
+      necromancer (~> 0.4.0)
+      pastel (~> 0.7.0)
+      tty-cursor (~> 0.4.0)
+      wisper (~> 1.6.1)
+    wisper (1.6.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  3llo (= 0.3.0)
+
+BUNDLED WITH
+   1.17.2

--- a/pkgs/tools/misc/3llo/default.nix
+++ b/pkgs/tools/misc/3llo/default.nix
@@ -1,0 +1,31 @@
+{ lib, ruby, bundlerApp, fetchpatch }:
+
+bundlerApp {
+  pname = "3llo";
+
+  gemfile = ./Gemfile;
+  lockfile = ./Gemfile.lock;
+
+  gemset = lib.recursiveUpdate (import ./gemset.nix) ({
+    "3llo" = {
+      dontBuild = false;
+      patches = [
+        (fetchpatch {
+          url = https://github.com/qcam/3llo/commit/7667c67fdc975bac315da027a3c69f49e7c06a2e.patch;
+          sha256 = "0ahp19igj77x23b2j9zk3znlmm7q7nija7mjgsmgqkgfbz2r1y7v";
+        })
+      ];
+    };
+  });
+
+  inherit ruby;
+
+  exes = [ "3llo" ];
+
+  meta = with lib; {
+    description = "Trello interactive CLI on terminal";
+    license = licenses.mit;
+    homepage = https://github.com/qcam/3llo;
+    maintainers = with maintainers; [ ma27 ];
+  };
+}

--- a/pkgs/tools/misc/3llo/gemset.nix
+++ b/pkgs/tools/misc/3llo/gemset.nix
@@ -1,0 +1,85 @@
+{
+  "3llo" = {
+    dependencies = ["tty-prompt"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "082g42lkkynnb2piz37ih696zm2ms63mz2q9rnfzjsd149ig39yy";
+      type = "gem";
+    };
+    version = "0.3.0";
+  };
+  equatable = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0fzx2ishipnp6c124ka6fiw5wk42s7c7gxid2c4c1mb55b30dglf";
+      type = "gem";
+    };
+    version = "0.6.1";
+  };
+  necromancer = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0v9nhdkv6zrp7cn48xv7n2vjhsbslpvs0ha36mfkcd56cp27pavz";
+      type = "gem";
+    };
+    version = "0.4.0";
+  };
+  pastel = {
+    dependencies = ["equatable" "tty-color"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0m43wk7gswwkl6lfxwlliqc9v1qp8arfygihyz91jc9icf270xzm";
+      type = "gem";
+    };
+    version = "0.7.3";
+  };
+  tty-color = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1zpp6zixkkchrc2lqnabrsy24pxikz2px87ggz5ph6355fs803da";
+      type = "gem";
+    };
+    version = "0.5.0";
+  };
+  tty-cursor = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "07whfm8mnp7l49s2cm2qy1snhsqq3a90sqwb71gvym4hm2kx822a";
+      type = "gem";
+    };
+    version = "0.4.0";
+  };
+  tty-prompt = {
+    dependencies = ["necromancer" "pastel" "tty-cursor" "wisper"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1026nyqhgmgxi2nmk8xk3hca07gy5rpisjs8y6w00wnw4f01kpv0";
+      type = "gem";
+    };
+    version = "0.12.0";
+  };
+  wisper = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "19bw0z1qw1dhv7gn9lad25hgbgpb1bkw8d599744xdfam158ms2s";
+      type = "gem";
+    };
+    version = "1.6.1";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -435,6 +435,8 @@ in
 
   _0x0 = callPackage ../tools/misc/0x0 { };
 
+  _3llo = callPackage ../tools/misc/3llo { };
+
   _1password = callPackage ../applications/misc/1password { };
 
   _9pfs = callPackage ../tools/filesystems/9pfs { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Simple CLI client for `trello.com`. It can be used like this:

```
$ export TRELLO_USER=your_username
$ export TRELLO_KEY=your_key
$ export TRELLO_TOKEN=your_token
$ ./result/bin/3llo
```

I didn't create a module for this as I don't think that those secrets
should live in the Nix store. Ideally `3llo` can be used from a script
which retrieves secrets from some kind of password store like this:

```
export TRELLO_KEY=$(pass show trello/key)
export TRELLO_TOKEN=$(pass show trello/token)
3llo $@
```



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
