### PR TITLE
 dovecot: 2.3.7 > 2.3.7.1

### DIFF
--- a/pkgs/servers/mail/dovecot/2.2.x-module_dir.patch
+++ b/pkgs/servers/mail/dovecot/2.2.x-module_dir.patch
@@ -1,8 +1,8 @@
 diff --git a/src/auth/main.c b/src/auth/main.c
-index 5a87c57..74bff52 100644
+index 2dbf9e1..b1e778a 100644
 --- a/src/auth/main.c
 +++ b/src/auth/main.c
-@@ -194,7 +194,7 @@ static void main_preinit(void)
+@@ -192,7 +192,7 @@ static void main_preinit(void)
  	mod_set.debug = global_auth_settings->debug;
  	mod_set.filter_callback = auth_module_filter;
  
@@ -11,7 +11,7 @@ index 5a87c57..74bff52 100644
  	module_dir_init(modules);
  
  	if (!worker)
-@@ -225,7 +225,7 @@ void auth_module_load(const char *names)
+@@ -223,7 +223,7 @@ void auth_module_load(const char *names)
  	mod_set.debug = global_auth_settings->debug;
  	mod_set.ignore_missing = TRUE;
  
@@ -21,19 +21,19 @@ index 5a87c57..74bff52 100644
  	module_dir_init(modules);
  }
 diff --git a/src/config/all-settings.c b/src/config/all-settings.c
-index de223a5..2df2d21 100644
+index 4a2ab53..5057d63 100644
 --- a/src/config/all-settings.c
 +++ b/src/config/all-settings.c
-@@ -836,7 +836,7 @@ static const struct mail_user_settings mail_user_default_settings = {
+@@ -1079,7 +1079,7 @@ static const struct mail_user_settings mail_user_default_settings = {
  	.last_valid_gid = 0,
  
  	.mail_plugins = "",
 -	.mail_plugin_dir = MODULEDIR,
 +	.mail_plugin_dir = "/etc/dovecot/modules",
  
- 	.mail_log_prefix = "%s(%u): ",
+ 	.mail_log_prefix = "%s(%u)<%{pid}><%{session}>: ",
  
-@@ -3545,7 +3545,7 @@ const struct doveadm_settings doveadm_default_settings = {
+@@ -4723,7 +4723,7 @@ const struct doveadm_settings doveadm_default_settings = {
  	.base_dir = PKG_RUNDIR,
  	.libexec_dir = PKG_LIBEXECDIR,
  	.mail_plugins = "",
@@ -43,12 +43,12 @@ index de223a5..2df2d21 100644
  	.auth_socket_path = "auth-userdb",
  	.doveadm_socket_path = "doveadm-server",
 diff --git a/src/config/config-parser.c b/src/config/config-parser.c
-index 2a5009a..134f92b 100644
+index 6894123..07e9fec 100644
 --- a/src/config/config-parser.c
 +++ b/src/config/config-parser.c
-@@ -1047,7 +1047,7 @@ void config_parse_load_modules(void)
+@@ -1077,7 +1077,7 @@ void config_parse_load_modules(void)
  
- 	memset(&mod_set, 0, sizeof(mod_set));
+ 	i_zero(&mod_set);
  	mod_set.abi_version = DOVECOT_ABI_VERSION;
 -	modules = module_dir_load(CONFIG_MODULE_DIR, NULL, &mod_set);
 +	modules = module_dir_load("/etc/dovecot/modules/settings", NULL, &mod_set);
@@ -56,10 +56,10 @@ index 2a5009a..134f92b 100644
  
  	i_array_init(&new_roots, 64);
 diff --git a/src/dict/main.c b/src/dict/main.c
-index e6c945e..06ad6c5 100644
+index 722ed02..4ed12ae 100644
 --- a/src/dict/main.c
 +++ b/src/dict/main.c
-@@ -62,7 +62,7 @@ static void main_init(void)
+@@ -104,7 +104,7 @@ static void main_init(void)
  	mod_set.abi_version = DOVECOT_ABI_VERSION;
  	mod_set.require_init_funcs = TRUE;
  
@@ -69,10 +69,10 @@ index e6c945e..06ad6c5 100644
  
  	/* Register only after loading modules. They may contain SQL drivers,
 diff --git a/src/doveadm/doveadm-settings.c b/src/doveadm/doveadm-settings.c
-index df12284..19c18da 100644
+index 88da40c..141ed05 100644
 --- a/src/doveadm/doveadm-settings.c
 +++ b/src/doveadm/doveadm-settings.c
-@@ -81,7 +81,7 @@ const struct doveadm_settings doveadm_default_settings = {
+@@ -86,7 +86,7 @@ const struct doveadm_settings doveadm_default_settings = {
  	.base_dir = PKG_RUNDIR,
  	.libexec_dir = PKG_LIBEXECDIR,
  	.mail_plugins = "",
@@ -82,7 +82,7 @@ index df12284..19c18da 100644
  	.auth_socket_path = "auth-userdb",
  	.doveadm_socket_path = "doveadm-server",
 diff --git a/src/lib-fs/fs-api.c b/src/lib-fs/fs-api.c
-index b50fbe0..ace3aff 100644
+index a939f61..846cf86 100644
 --- a/src/lib-fs/fs-api.c
 +++ b/src/lib-fs/fs-api.c
 @@ -114,7 +114,7 @@ static void fs_class_try_load_plugin(const char *driver)
@@ -95,10 +95,10 @@ index b50fbe0..ace3aff 100644
  	module_dir_init(fs_modules);
  
 diff --git a/src/lib-ssl-iostream/iostream-ssl.c b/src/lib-ssl-iostream/iostream-ssl.c
-index a0659ab..dba3729 100644
+index f857ec9..0d1023b 100644
 --- a/src/lib-ssl-iostream/iostream-ssl.c
 +++ b/src/lib-ssl-iostream/iostream-ssl.c
-@@ -34,7 +34,7 @@ static int ssl_module_load(const char **error_r)
+@@ -53,7 +53,7 @@ int ssl_module_load(const char **error_r)
  	mod_set.abi_version = DOVECOT_ABI_VERSION;
  	mod_set.setting_name = "<built-in lib-ssl-iostream lookup>";
  	mod_set.require_init_funcs = TRUE;
@@ -108,15 +108,28 @@ index a0659ab..dba3729 100644
  					&mod_set, error_r) < 0)
  		return -1;
 diff --git a/src/lib-storage/mail-storage-settings.c b/src/lib-storage/mail-storage-settings.c
-index e2233bf..bbf981e 100644
+index b314b52..7055094 100644
 --- a/src/lib-storage/mail-storage-settings.c
 +++ b/src/lib-storage/mail-storage-settings.c
-@@ -274,7 +274,7 @@ static const struct mail_user_settings mail_user_default_settings = {
+@@ -337,7 +337,7 @@ static const struct mail_user_settings mail_user_default_settings = {
  	.last_valid_gid = 0,
  
  	.mail_plugins = "",
 -	.mail_plugin_dir = MODULEDIR,
 +	.mail_plugin_dir = "/etc/dovecot/modules",
  
- 	.mail_log_prefix = "%s(%u): ",
+ 	.mail_log_prefix = "%s(%u)<%{pid}><%{session}>: ",
  
+diff --git a/src/lmtp/lmtp-settings.c b/src/lmtp/lmtp-settings.c
+index 1666ec9..8a27200 100644
+--- a/src/lmtp/lmtp-settings.c
++++ b/src/lmtp/lmtp-settings.c
+@@ -89,7 +89,7 @@ static const struct lmtp_settings lmtp_default_settings = {
+ 	.login_trusted_networks = "",
+ 
+ 	.mail_plugins = "",
+-	.mail_plugin_dir = MODULEDIR,
++	.mail_plugin_dir = "/etc/dovecot/modules",
+ };
+ 
+ static const struct setting_parser_info *lmtp_setting_dependencies[] = {

--- a/pkgs/servers/mail/dovecot/default.nix
+++ b/pkgs/servers/mail/dovecot/default.nix
@@ -9,7 +9,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "dovecot-2.3.7";
+  name = "dovecot-2.3.7.1";
 
   nativeBuildInputs = [ perl pkgconfig ];
   buildInputs =
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://dovecot.org/releases/2.3/${name}.tar.gz";
-    sha256 = "1al382ykm94if5agasb9h2442a8s7wn43hlwh292ir1rhnp5dq8i";
+    sha256 = "1hq333vj4px4xa9djl8c1v3c8rac98v2mrb9vx1wisg6frpiv9f5";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/servers/mail/dovecot/plugins/pigeonhole/default.nix
+++ b/pkgs/servers/mail/dovecot/plugins/pigeonhole/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "dovecot-pigeonhole-${version}";
-  version = "0.5.6";
+  version = "0.5.7.1";
 
   src = fetchurl {
     url = "https://pigeonhole.dovecot.org/releases/2.3/dovecot-2.3-pigeonhole-${version}.tar.gz";
-    sha256 = "1f7m2213w4hvqr3lvr03bv4lh92k35gxl01c2x8q8akk7viffbvw";
+    sha256 = "0a10mam68pmdh3fw8fnv5jff6xj1k770hvadym2c39vm3x6b4w1j";
   };
 
   buildInputs = [ dovecot openssl ];


### PR DESCRIPTION
#### Motivation for this change
Update packages dovecto to 2.3.7.1 and dovecot-pigeonhole to 0.5.7.1

Fixed load plugin sieve.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
