### PR TITLE
bazel-remote, bazel-deps: mark as broken

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/bazel-deps/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel-deps/default.nix
@@ -2,7 +2,7 @@
 
 buildBazelPackage rec {
   name = "bazel-deps-${version}";
-  version = "2019-02-01";
+  version = "2019-07-11";
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/johnynek/bazel-deps";
@@ -10,13 +10,14 @@ buildBazelPackage rec {
     license = licenses.mit;
     maintainers = [ maintainers.uri-canva ];
     platforms = platforms.all;
+    broken = true; # global variable '_common_attrs_for_plugin_bootstrapping' is referenced before assignment.
   };
 
   src = fetchFromGitHub {
     owner = "johnynek";
     repo = "bazel-deps";
-    rev = "6585033409e09028852403ec15ec0c77851234be";
-    sha256 = "0hypf7mcbpx2djqm92k82vn1k6pbnv564xbnazx8nw60f6ns0x87";
+    rev = "48fdf7f8bcf3aadfa07f9f7e6f0c9f4247cb0f58";
+    sha256 = "0wpn5anfgq5wfljfhpn8gbgdmgcp0claffjgqcnv5dh70ch7i0gi";
   };
 
   bazelTarget = "//src/scala/com/github/johnynek/bazel_deps:parseproject_deploy.jar";
@@ -24,49 +25,7 @@ buildBazelPackage rec {
   buildInputs = [ git makeWrapper ];
 
   fetchAttrs = {
-    preInstall = ''
-      # Remove all built in external workspaces, Bazel will recreate them when building
-      rm -rf $bazelOut/external/{bazel_tools,\@bazel_tools.marker,embedded_jdk,\@embedded_jdk.marker,local_*,\@local_*}
-      # For each external workspace, remove all files that aren't referenced by Bazel
-      # Many of these files are non-hermetic (for example .git/refs/remotes/origin/HEAD)
-      files_to_delete=()
-      for workspace in $(find $bazelOut/external -maxdepth 2 -name "WORKSPACE" -print0 | xargs -0L1 dirname); do
-        workspaceOut="$NIX_BUILD_TOP/workspaces/$(basename workspace)/output"
-        workspaceUserRoot="$NIX_BUILD_TOP/workspaces/$(basename workspace)/tmp"
-        rm -rf $workspace/.git
-        if ! targets_and_files=$(cd "$workspace" && bazel --output_base="$workspaceOut" --output_user_root="$workspaceUserRoot" query '//...:*' 2> /dev/null | sort -u); then
-          continue
-        fi
-        if ! targets=$(cd "$workspace" && bazel --output_base="$workspaceOut" --output_user_root="$workspaceUserRoot" query '//...:all' 2> /dev/null | sort -u); then
-          continue
-        fi
-        mapfile -t referenced_files < <(comm -23 <(printf '%s' "$targets_and_files") <(printf '%s' "$targets") | sed -e 's,^//:,,g' | sed -e 's,^//,,g' | sed -e 's,:,/,g')
-        referenced_files+=( "WORKSPACE" )
-        for referenced_file in "''${referenced_files[@]}"; do
-          # Some of the referenced files are symlinks to non-referenced files.
-          # The symlink targets have deterministic contents, but non-deterministic
-          # paths. Copy them to the referenced path, which is deterministic.
-          if target=$(readlink "$workspace/$referenced_file"); then
-            rm "$workspace/$referenced_file"
-            cp -a "$target" "$workspace/$referenced_file"
-          fi
-        done
-        mapfile -t workspace_files_to_delete < <(find "$workspace" -type f -or -type l | sort -u | comm -23 - <(printf "$workspace/%s\n" "''${referenced_files[@]}" | sort -u))
-        for workspace_file_to_delete in "''${workspace_files_to_delete[@]}"; do
-          files_to_delete+=("$workspace_file_to_delete")
-        done
-        # We're running bazel in many different workspaces in a loop. Letting the
-        # daemon shut down on its own would leave several daemons alive at the
-        # same time, using up a lot of memory. Shut them down explicitly instead.
-        bazel --output_base="$workspaceOut" --output_user_root="$workspaceUserRoot" shutdown 2> /dev/null
-      done
-      for file_to_delete in "''${files_to_delete[@]}"; do
-        rm "$file_to_delete"
-      done
-      find . -type d -empty -delete
-    '';
-
-    sha256 = "1yirrzhhrsmbgd27fg709plhrhyi8pzwqv84yg72sd3799kswh9m";
+    sha256 = "1r5qxsbw2cgww7vcg5psh7404l3jcxpvc0ndgl3k8vj1x8y93nkf";
   };
 
   buildAttrs = {

--- a/pkgs/development/tools/build-managers/bazel/bazel-remote/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel-remote/default.nix
@@ -76,5 +76,6 @@ buildBazelPackage rec {
     license = licenses.asl20;
     maintainers = [ maintainers.uri-canva ];
     platforms = platforms.darwin;
+    broken = true; # global variable '_layer' is referenced before assignment.
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

These don't build successfully for a long time.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @uri-canva 