### PR TITLE
Use upstream units for mdadm

### DIFF
--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -221,6 +221,7 @@ with lib;
     (mkRemovedOptionModule [ "services" "mysql" "pidDir" ] "Don't wait for pidfiles, describe dependencies through systemd")
     (mkRemovedOptionModule [ "services" "mysql" "rootPassword" ] "Use socket authentication or set the password outside of the nix store.")
     (mkRemovedOptionModule [ "services" "zabbixServer" "dbPassword" ] "Use services.zabbixServer.database.passwordFile instead.")
+    (mkRemovedOptionModule [ "systemd" "generator-packages" ] "Use systemd.packages instead.")
 
     # ZSH
     (mkRenamedOptionModule [ "programs" "zsh" "enableSyntaxHighlighting" ] [ "programs" "zsh" "syntaxHighlighting" "enable" ])
@@ -256,9 +257,6 @@ with lib;
     (mkRenamedOptionModule [ "networking" "dnsExtensionMechanism" ] [ "networking" "resolvconf" "dnsExtensionMechanism" ])
     (mkRenamedOptionModule [ "networking" "extraResolvconfConf" ] [ "networking" "resolvconf" "extraConfig" ])
     (mkRenamedOptionModule [ "networking" "resolvconfOptions" ] [ "networking" "resolvconf" "extraOptions" ])
-
-    # systemd
-    (mkRenamedOptionModule [ "systemd" "generator-packages" ] [ "systemd" "generatorPackages" ])
 
   ] ++ (flip map [ "blackboxExporter" "collectdExporter" "fritzboxExporter"
                    "jsonExporter" "minioExporter" "nginxExporter" "nodeExporter"

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -257,6 +257,9 @@ with lib;
     (mkRenamedOptionModule [ "networking" "extraResolvconfConf" ] [ "networking" "resolvconf" "extraConfig" ])
     (mkRenamedOptionModule [ "networking" "resolvconfOptions" ] [ "networking" "resolvconf" "extraOptions" ])
 
+    # systemd
+    (mkRenamedOptionModule [ "systemd" "generator-packages" ] [ "systemd" "generatorPackages" ])
+
   ] ++ (flip map [ "blackboxExporter" "collectdExporter" "fritzboxExporter"
                    "jsonExporter" "minioExporter" "nginxExporter" "nodeExporter"
                    "snmpExporter" "unifiExporter" "varnishExporter" ]

--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -217,13 +217,11 @@ let
             --replace ata_id ${extraUtils}/bin/ata_id \
             --replace scsi_id ${extraUtils}/bin/scsi_id \
             --replace cdrom_id ${extraUtils}/bin/cdrom_id \
-            --replace ${pkgs.utillinux}/sbin/blkid ${extraUtils}/bin/blkid \
-            --replace /sbin/blkid ${extraUtils}/bin/blkid \
+            --replace ${pkgs.coreutils}/bin/basename ${extraUtils}/bin/basename \
+            --replace ${pkgs.utillinux}/bin/blkid ${extraUtils}/bin/blkid \
             --replace ${pkgs.lvm2}/sbin ${extraUtils}/bin \
-            --replace /sbin/mdadm ${extraUtils}/bin/mdadm \
+            --replace ${pkgs.mdadm}/sbin ${extraUtils}/sbin \
             --replace ${pkgs.bash}/bin/sh ${extraUtils}/bin/sh \
-            --replace /usr/bin/readlink ${extraUtils}/bin/readlink \
-            --replace /usr/bin/basename ${extraUtils}/bin/basename \
             --replace ${udev}/bin/udevadm ${extraUtils}/bin/udevadm
       done
 

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -497,7 +497,7 @@ in
       '';
     };
 
-    systemd.generator-packages = mkOption {
+    systemd.generatorPackages = mkOption {
       default = [];
       type = types.listOf types.package;
       example = literalExample "[ pkgs.systemd-cryptsetup-generator ]";
@@ -762,10 +762,10 @@ in
 
     environment.etc = let
       # generate contents for /etc/systemd/system-generators from
-      # systemd.generators and systemd.generator-packages
+      # systemd.generators and systemd.generatorPackages
       generators = pkgs.runCommand "system-generators" {
           preferLocalBuild = true;
-          packages = cfg.generator-packages;
+          packages = cfg.generatorPackages;
         } ''
         mkdir -p $out
         for package in $packages

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -427,7 +427,8 @@ in
     systemd.packages = mkOption {
       default = [];
       type = types.listOf types.package;
-      description = "Packages providing systemd units.";
+      example = literalExample "[ pkgs.systemd-cryptsetup-generator ]";
+      description = "Packages providing systemd units and hooks.";
     };
 
     systemd.targets = mkOption {
@@ -497,13 +498,6 @@ in
       '';
     };
 
-    systemd.generatorPackages = mkOption {
-      default = [];
-      type = types.listOf types.package;
-      example = literalExample "[ pkgs.systemd-cryptsetup-generator ]";
-      description = "Packages providing systemd generators.";
-    };
-
     systemd.shutdown = mkOption {
       type = types.attrsOf types.path;
       default = {};
@@ -512,13 +506,6 @@ in
         For each <literal>NAME = VALUE</literal> pair of the attrSet, a link is generated from
         <literal>/etc/systemd/system-shutdown/NAME</literal> to <literal>VALUE</literal>.
       '';
-    };
-
-    systemd.shutdownPackages = mkOption {
-      default = [];
-      type = types.listOf types.package;
-      example = literalExample "[ pkgs.mdadm ]";
-      description = "Packages providing systemd shutdown executables.";
     };
 
     systemd.defaultUnit = mkOption {
@@ -779,9 +766,9 @@ in
 
     environment.etc = let
       # generate contents for /etc/systemd/system-${type} from attrset of links and packages
-      hooks = type: links: packages: pkgs.runCommand "system-${type}" {
+      hooks = type: links: pkgs.runCommand "system-${type}" {
           preferLocalBuild = true;
-          packages = packages;
+          packages = cfg.packages;
       } ''
         set -e
         mkdir -p $out
@@ -854,8 +841,8 @@ in
         ${concatStringsSep "\n" cfg.tmpfiles.rules}
       '';
 
-      "systemd/system-generators" = { source = hooks "generators" cfg.generators cfg.generatorPackages; };
-      "systemd/system-shutdown" = { source = hooks "shutdown" cfg.shutdown cfg.shutdownPackages; };
+      "systemd/system-generators" = { source = hooks "generators" cfg.generators; };
+      "systemd/system-shutdown" = { source = hooks "shutdown" cfg.shutdown; };
     });
 
     services.dbus.enable = true;

--- a/nixos/modules/tasks/filesystems/nfs.nix
+++ b/nixos/modules/tasks/filesystems/nfs.nix
@@ -56,7 +56,7 @@ in
     boot.initrd.kernelModules = mkIf inInitrd [ "nfs" ];
 
     systemd.packages = [ pkgs.nfs-utils ];
-    systemd.generator-packages = [ pkgs.nfs-utils ];
+    systemd.generatorPackages = [ pkgs.nfs-utils ];
 
     environment.etc = {
       "idmapd.conf".source = idmapdConfFile;

--- a/nixos/modules/tasks/filesystems/nfs.nix
+++ b/nixos/modules/tasks/filesystems/nfs.nix
@@ -56,7 +56,6 @@ in
     boot.initrd.kernelModules = mkIf inInitrd [ "nfs" ];
 
     systemd.packages = [ pkgs.nfs-utils ];
-    systemd.generatorPackages = [ pkgs.nfs-utils ];
 
     environment.etc = {
       "idmapd.conf".source = idmapdConfFile;

--- a/nixos/modules/tasks/swraid.nix
+++ b/nixos/modules/tasks/swraid.nix
@@ -7,7 +7,6 @@
   services.udev.packages = [ pkgs.mdadm ];
 
   systemd.packages = [ pkgs.mdadm ];
-  systemd.shutdownPackages = [ pkgs.mdadm ];
 
   boot.initrd.availableKernelModules = [ "md_mod" "raid0" "raid1" "raid10" "raid456" ];
 

--- a/nixos/modules/tasks/swraid.nix
+++ b/nixos/modules/tasks/swraid.nix
@@ -6,51 +6,13 @@
 
   services.udev.packages = [ pkgs.mdadm ];
 
+  systemd.packages = [ pkgs.mdadm ];
+  systemd.shutdownPackages = [ pkgs.mdadm ];
+
   boot.initrd.availableKernelModules = [ "md_mod" "raid0" "raid1" "raid10" "raid456" ];
 
   boot.initrd.extraUdevRulesCommands = ''
     cp -v ${pkgs.mdadm}/lib/udev/rules.d/*.rules $out/
   '';
 
-  systemd.services.mdadm-shutdown = {
-    wantedBy = [ "final.target"];
-    after = [ "umount.target" ];
-
-    unitConfig = {
-      DefaultDependencies = false;
-    };
-
-    serviceConfig = {
-      Type = "oneshot";
-      ExecStart = ''${pkgs.mdadm}/bin/mdadm --wait-clean --scan'';
-    };
-  };
-
-  systemd.services."mdmon@" = {
-    description = "MD Metadata Monitor on /dev/%I";
-
-    unitConfig.DefaultDependencies = false;
-
-    serviceConfig = {
-      Type = "forking";
-      Environment = "IMSM_NO_PLATFORM=1";
-      ExecStart = ''${pkgs.mdadm}/bin/mdmon --offroot --takeover %I'';
-      KillMode = "none";
-    };
-  };
-
-  systemd.services."mdadm-grow-continue@" = {
-    description = "Manage MD Reshape on /dev/%I";
-
-    unitConfig.DefaultDependencies = false;
-
-    serviceConfig = {
-      ExecStart = ''${pkgs.mdadm}/bin/mdadm --grow --continue /dev/%I'';
-      StandardInput = "null";
-      StandardOutput = "null";
-      StandardError = "null";
-      KillMode = "none";
-    };
-  };
- 
 }

--- a/nixos/tests/systemd.nix
+++ b/nixos/tests/systemd.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix {
+import ./make-test.nix ({ pkgs, ... }: {
   name = "systemd";
 
   machine = { lib, ... }: {
@@ -20,6 +20,14 @@ import ./make-test.nix {
     systemd.user.extraConfig = "DefaultEnvironment=\"XXX_USER=bar\"";
     services.journald.extraConfig = "Storage=volatile";
     services.xserver.displayManager.auto.user = "alice";
+
+    systemd.shutdown.test = pkgs.writeScript "test.shutdown" ''
+      #!${pkgs.stdenv.shell}
+      PATH=${lib.makeBinPath (with pkgs; [ utillinux coreutils ])}
+      mount -t 9p shared -o trans=virtio,version=9p2000.L /tmp/shared
+      touch /tmp/shared/shutdown-test
+      umount /tmp/shared
+    '';
 
     systemd.services.testservice1 = {
       description = "Test Service 1";
@@ -69,5 +77,20 @@ import ./make-test.nix {
       # has a last mount time, because the file system wasn't checked.
       $machine->fail('dumpe2fs /dev/vdb | grep -q "^Last mount time: *n/a"');
     };
+
+    # Regression test for https://github.com/NixOS/nixpkgs/issues/35268
+    subtest "file system with x-initrd.mount is not unmounted", sub {
+      $machine->shutdown;
+      $machine->waitForUnit('multi-user.target');
+      # If the file system was unmounted during the shutdown the file system
+      # has a last mount time, because the file system wasn't checked.
+      $machine->fail('dumpe2fs /dev/vdb | grep -q "^Last mount time: *n/a"');
+    };
+
+    subtest "systemd-shutdown works", sub {
+      $machine->shutdown;
+      $machine->waitForUnit('multi-user.target');
+      $machine->succeed('test -e /tmp/shared/shutdown-test');
+    };
   '';
-}
+})

--- a/pkgs/os-specific/linux/mdadm/default.nix
+++ b/pkgs/os-specific/linux/mdadm/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, groff, system-sendmail }:
+{ stdenv, utillinux, coreutils, fetchurl, groff, system-sendmail }:
 
 stdenv.mkDerivation rec {
   name = "mdadm-4.1";
@@ -8,26 +8,34 @@ stdenv.mkDerivation rec {
     sha256 = "0jjgjgqijpdp7ijh8slzzjjw690kydb1jjadf0x5ilq85628hxmb";
   };
 
-  # This is to avoid self-references, which causes the initrd to explode
-  # in size and in turn prevents mdraid systems from booting.
-  allowedReferences = [ stdenv.cc.libc.out system-sendmail ];
-
   patches = [ ./no-self-references.patch ];
 
   makeFlags = [
-    "NIXOS=1" "INSTALL=install" "INSTALL_BINDIR=$(out)/sbin"
+    "NIXOS=1" "INSTALL=install" "BINDIR=$(out)/sbin"
     "MANDIR=$(out)/share/man" "RUN_DIR=/dev/.mdadm"
     "STRIP="
   ] ++ stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
   ];
 
+  enableParallelBuilding = true;
+
   nativeBuildInputs = [ groff ];
 
-  preConfigure = ''
+  postPatch = ''
     sed -e 's@/lib/udev@''${out}/lib/udev@' \
         -e 's@ -Werror @ @' \
         -e 's@/usr/sbin/sendmail@${system-sendmail}@' -i Makefile
+    sed -i \
+        -e 's@/usr/bin/basename@${coreutils}/bin/basename@g' \
+        -e 's@BINDIR/blkid@${utillinux}/bin/blkid@g' \
+        *.rules
+  '';
+
+  # This is to avoid self-references, which causes the initrd to explode
+  # in size and in turn prevents mdraid systems from booting.
+  postFixup = ''
+    grep -r $out $out/bin && false || true
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/os-specific/linux/mdadm/default.nix
+++ b/pkgs/os-specific/linux/mdadm/default.nix
@@ -12,11 +12,14 @@ stdenv.mkDerivation rec {
 
   makeFlags = [
     "NIXOS=1" "INSTALL=install" "BINDIR=$(out)/sbin"
+    "SYSTEMD_DIR=$(out)/lib/systemd/system"
     "MANDIR=$(out)/share/man" "RUN_DIR=/dev/.mdadm"
     "STRIP="
   ] ++ stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
   ];
+
+  installFlags = [ "install-systemd" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -24,8 +24,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "NixOS";
     repo = "systemd";
-    rev = "aa4c4d39d75ce52664cb28d569b1ceafda7b4c06";
-    sha256 = "1ax94gzbdwdcf3wgj7f9cabdkvn2zynnnli7gkbz4isidlpis86g";
+    rev = "5fb35fbc783516e2014115c3488134a2afb8494c";
+    sha256 = "0pyjvzzh8nnxv4z58n82lz1mjnzv44sylcjgkvw8sp35vx1ryxfh";
   };
 
   outputs = [ "out" "lib" "man" "dev" ];


### PR DESCRIPTION
###### Motivation for this change

Fix RAID1 rebuild on each reboot.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

[WIP] because I still need to test it better. I don't have good ideas for automated testing for now.