### PR TITLE
dazel: init at 0.0.36

### DIFF
--- a/pkgs/development/tools/dazel/default.nix
+++ b/pkgs/development/tools/dazel/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, buildPythonApplication, fetchPypi }:
+buildPythonApplication rec {
+  version = "0.0.36";
+  pname = "dazel";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "10likhnbz5bg4bmlk8rzra9a2gyh0s7afj3gy7kgyvnlqkrvp5kv";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/nadirizr/dazel;
+    description = "Run Google's bazel inside a docker container via a seamless proxy.";
+    license = licenses.mit;
+    maintainers = with maintainers; [
+      q3k
+    ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -750,6 +750,8 @@ in
 
   cue = callPackage ../development/tools/cue { };
 
+  dazel = python36Packages.callPackage ../development/tools/dazel { };
+
   deskew = callPackage ../applications/graphics/deskew { };
 
   detect-secrets = python3Packages.callPackage ../development/tools/detect-secrets { };


### PR DESCRIPTION
###### Motivation for this change

Introduce [dazel](https://github.com/nadirizr/dazel).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
