### PR TITLE
[WIP] pythonPackages.cq-editor: init at 0.1RC1

### DIFF
--- a/pkgs/development/python-modules/cadquery/default.nix
+++ b/pkgs/development/python-modules/cadquery/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pyparsing
+, opencascade_oce
+, pythonocc-core
+}:
+
+buildPythonPackage rec {
+  pname = "cadquery";
+  version = "2.0RC0";
+
+  src = fetchFromGitHub {
+    owner = "CadQuery";
+    repo = pname;
+    rev = version;
+    sha256 = "1s5arr8w1mn60isaf44diqf72vyscy5ihns3072h16ysbl0b509s";
+  };
+
+  buildInputs = [
+    opencascade_oce
+  ];
+
+  propagatedBuildInputs = [
+    pyparsing
+    pythonocc-core
+  ];
+
+  meta = with lib; {
+    description = "Parametric scripting language for creating and traversing CAD models";
+    homepage = https://github.com/CadQuery/cadquery;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/cq-editor/default.nix
+++ b/pkgs/development/python-modules/cq-editor/default.nix
@@ -1,0 +1,68 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, cadquery
+, Logbook
+, qt5
+, pyqt5
+, pyparsing
+, pyqtgraph
+, spyder
+, pathpy
+, qtconsole
+, requests
+, pytest
+, pytest-xvfb
+, pytest-mock
+, pytestcov
+, pytest-repeat
+, pytest-qt
+}:
+
+buildPythonPackage rec {
+  pname = "cq-editor";
+  version = "0.1RC1";
+
+  src = fetchFromGitHub {
+    owner = "CadQuery";
+    repo = "CQ-editor";
+    rev = version;
+    sha256 = "0iwcpnj15s64k16948sakvkn1lb4mqwrhmbxk3r03bczs0z33zax";
+  };
+
+  propagatedBuildInputs = [
+    cadquery
+    Logbook
+    pyqt5
+    pyparsing
+    pyqtgraph
+    spyder
+    pathpy
+    qtconsole
+    requests
+  ];
+
+  checkInputs = [
+    pytest
+    pytest-xvfb
+    pytest-mock
+    pytestcov
+    pytest-repeat
+    pytest-qt
+  ];
+
+  checkPhase = ''
+    pytest --no-xvfb
+  '';
+
+  # requires X server
+  doCheck = false;
+
+  meta = with lib; {
+    description = "CadQuery GUI editor based on PyQT";
+    homepage = https://github.com/CadQuery/CQ-editor;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+
+}

--- a/pkgs/development/python-modules/pyscreenshot/default.nix
+++ b/pkgs/development/python-modules/pyscreenshot/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, EasyProcess
+}:
+
+buildPythonPackage rec {
+  pname = "pyscreenshot";
+  version = "0.5.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "19ec6d17a61c0cd4e7fcf3ab2685598a54b53dc781755393cc5f76dcb7bf359c";
+  };
+
+  propagatedBuildInputs = [
+    EasyProcess
+  ];
+
+  # recursive dependency on pyvirtualdisplay
+  doCheck = false;
+
+  meta = with lib; {
+    description = "python screenshot";
+    homepage = https://github.com/ponty/pyscreenshot;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-qt/default.nix
+++ b/pkgs/development/python-modules/pytest-qt/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, setuptools_scm
+, pytest
+, pyqt5
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-qt";
+  version = "3.2.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "f6ecf4b38088ae1092cbd5beeaf714516d1f81f8938626a2eac546206cdfe7fa";
+  };
+
+  buildInputs = [
+    setuptools_scm
+  ];
+
+  propagatedBuildInputs = [
+    pytest
+  ];
+
+  checkInputs = [
+    pytest
+    pyqt5
+  ];
+
+  # tests require X server
+  doCheck = false;
+
+  meta = with lib; {
+    description = "pytest support for PyQt and PySide applications";
+    homepage = http://github.com/pytest-dev/pytest-qt;
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-repeat/default.nix
+++ b/pkgs/development/python-modules/pytest-repeat/default.nix
@@ -8,32 +8,29 @@
 
 buildPythonPackage rec {
   pname = "pytest-repeat";
-  version = "0.7.0";
+  version = "0.8.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0axbrpqal3cqw9zq6dakdbg49pnf5gvyvq6yn93hp1ayc7fnhzk3";
+    sha256 = "1nbdmklpi0ra1jnfm032wz96y9nxdlcr4m9sjlnffwm7n4x43g2j";
   };
 
-  # fixes support for pytest >3.6. Should be droppable during the
-  # next bump.
-  patches = [
-    (fetchpatch {
-      url = https://github.com/pytest-dev/pytest-repeat/commit/f94b6940e3651b7593aca5a7a987eb56abe04cb1.patch;
-      sha256 = "00da1gmpq9pslcmm8pw93jcbp8j2zymzqdsm6jq3xinkvjpsbmny";
-    })
+  buildInputs = [
+    setuptools_scm
   ];
 
-  buildInputs = [ setuptools_scm pytest ];
+  checkInputs = [
+    pytest
+  ];
 
   checkPhase = ''
-    py.test
+    pytest
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Pytest plugin for repeating tests";
     homepage = https://github.com/pytest-dev/pytest-repeat;
-    maintainers = with lib.maintainers; [ costrouc ];
-    license = lib.licenses.mpl20;
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ costrouc ];
   };
 }

--- a/pkgs/development/python-modules/pytest-xvfb/default.nix
+++ b/pkgs/development/python-modules/pytest-xvfb/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytest
+, virtual-display
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-xvfb";
+  version = "1.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "a7544ca8d0c7c40db4b40d7a417a7b071c68d6ef6bdf9700872d7a167302f979";
+  };
+
+  propagatedBuildInputs = [
+    pytest
+    virtual-display
+  ];
+
+  meta = with lib; {
+    description = "A pytest plugin to run Xvfb for tests";
+    homepage = https://github.com/The-Compiler/pytest-xvfb;
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -456,6 +456,8 @@ in {
 
   cachy = callPackage ../development/python-modules/cachy { };
 
+  cadquery = callPackage ../development/python-modules/cadquery { };
+
   cdecimal = callPackage ../development/python-modules/cdecimal { };
 
   cfn-flip = callPackage ../development/python-modules/cfn-flip { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -947,6 +947,8 @@ in {
 
   pyschedule = callPackage ../development/python-modules/pyschedule { };
 
+  pyscreenshot = callPackage ../development/python-modules/pyscreenshot { };
+
   pyside = callPackage ../development/python-modules/pyside { };
 
   pysideShiboken = callPackage ../development/python-modules/pyside/shiboken.nix {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1001,6 +1001,8 @@ in {
 
   pytest-xprocess = callPackage ../development/python-modules/pytest-xprocess { };
 
+  pytest-xvfb = callPackage ../development/python-modules/pytest-xvfb { };
+
   python-binance = callPackage ../development/python-modules/python-binance { };
 
   python-dbusmock = callPackage ../development/python-modules/python-dbusmock { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -995,6 +995,8 @@ in {
 
   pytest-pylint = callPackage ../development/python-modules/pytest-pylint { };
 
+  pytest-qt = callPackage ../development/python-modules/pytest-qt { };
+
   pytest-testmon = callPackage ../development/python-modules/pytest-testmon { };
 
   pytest-tornado = callPackage ../development/python-modules/pytest-tornado { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -476,6 +476,8 @@ in {
 
   cozy = callPackage ../development/python-modules/cozy { };
 
+  cq-editor = callPackage ../development/python-modules/cq-editor { };
+
   curio = callPackage ../development/python-modules/curio { };
 
   dendropy = callPackage ../development/python-modules/dendropy { };


### PR DESCRIPTION

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


---
