### PR TITLE
gh-ost: update platforms

### DIFF
--- a/pkgs/tools/misc/gh-ost/default.nix
+++ b/pkgs/tools/misc/gh-ost/default.nix
@@ -21,7 +21,6 @@ buildGoPackage ({
       description = "Triggerless online schema migration solution for MySQL";
       homepage = https://github.com/github/gh-ost;
       license = licenses.mit;
-      platforms = platforms.linux;
     };
 })
 


### PR DESCRIPTION

###### Motivation for this change

It's a typical go app, it shouldn't need to be restricted to just linux. Verified that it compiles and successfully runs on os x.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
