### PR TITLE
buildRustPackage: avoid appending to source code's cargo config 

### DIFF
--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -80,7 +80,6 @@ in stdenv.mkDerivation (args // {
     "linker" = "${ccForHost}"
     ''}
     EOF
-    cat .cargo/config
 
     unset cargoDepsCopy
     export RUST_LOG=${logLevel}

--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -72,14 +72,6 @@ in stdenv.mkDerivation (args // {
     substitute $config .cargo/config \
       --subst-var-by vendor "$(pwd)/$cargoDepsCopy"
 
-    unset cargoDepsCopy
-
-    export RUST_LOG=${logLevel}
-  '' + (args.postUnpack or "");
-
-  configurePhase = args.configurePhase or ''
-    runHook preConfigure
-    mkdir -p .cargo
     cat >> .cargo/config <<'EOF'
     [target."${stdenv.buildPlatform.config}"]
     "linker" = "${ccForBuild}"
@@ -89,6 +81,13 @@ in stdenv.mkDerivation (args // {
     ''}
     EOF
     cat .cargo/config
+
+    unset cargoDepsCopy
+    export RUST_LOG=${logLevel}
+  '' + (args.postUnpack or "");
+
+  configurePhase = args.configurePhase or ''
+    runHook preConfigure
     runHook postConfigure
   '';
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Setting the linker at `${build_root}/.cargo/config` instead of append in `${source}/.cargo/config`
Appending to sources code's `.cargo/config` may cause malformed TOML format.



for example, origin config:
```toml
[target.x86_64-pc-windows-gnu]
rustflags = []
```
after appending:
```toml
[target.x86_64-pc-windows-gnu]
rustflags = []

[target.x86_64-unknown-linux-gnu]
linker = "/nix/store/7nvy9l5jcp1c6z6n96l1a5x1bwbvamqn-gcc-wrapper-7.4.0/bin/cc"
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
