### PR TITLE
tmux-ctrlw: init at 0.1.0

### DIFF
--- a/pkgs/misc/tmux-plugins/default.nix
+++ b/pkgs/misc/tmux-plugins/default.nix
@@ -90,6 +90,15 @@ in rec {
     };
   };
 
+  ctrlw = mkDerivation {
+    pluginName = "ctrlw";
+    src = fetchgit {
+      url = "https://github.com/eraserhd/tmux-ctrlw";
+      rev = "2354b5d56828813d0f7a4b228ca74b6134c2695f";
+      sha256 = "00hy1axmki8h2285mivsj923z327xkq89wfl2x4dxc71xjhdl216";
+    };
+  };
+
   fpp = mkDerivation {
     pluginName = "fpp";
     src = fetchgit {


### PR DESCRIPTION
###### Motivation for this change

Allow installing of this package from Nix.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---