### PR TITLE
screamingfrogseospider: init at 11.0

### DIFF
--- a/pkgs/tools/misc/screamingfrogseospider/default.nix
+++ b/pkgs/tools/misc/screamingfrogseospider/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, lib, fetchurl, dpkg, oraclejre }:
+with lib;
+let
+  version = "11.3";
+  url = "https://download.screamingfrog.co.uk/products/seo-spider/screamingfrogseospider_${version}_all.deb";
+  sha256 = "a6a7b9434dadcd0ca5d486df16386ce317ed7d4d2f7acc2730156e13859368f9";
+in stdenv.mkDerivation rec {
+  inherit version;
+  name = "screamingfrogseospider-${version}";
+  src = fetchurl {
+    inherit sha256 url;
+  };
+  buildInputs = [ dpkg ];
+  unpackPhase = "dpkg -X $src .";
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -R . $out/
+    sed -i 's|/usr/share/screamingfrogseospider/jre/|${oraclejre}/|' $out/usr/bin/screamingfrogseospider
+    sed -i "s|-jar /usr/share/screamingfrogseospider/ScreamingFrogSEOSpider.jar|-jar $out/usr/share/screamingfrogseospider/ScreamingFrogSEOSpider.jar|" $out/usr/bin/screamingfrogseospider
+    sed -i 's/-Djava.ext.dirs=/-classpath /' $out/usr/bin/screamingfrogseospider
+    ln -s $out/usr/bin/screamingfrogseospider $out/bin/screamingfrogseospider
+    rm -rf $out/usr/share/screamingfrogseospider/tmp
+  '';
+    meta = with lib; {
+      description = "Screaming Frog SEO Spider Tool";
+      homepage = https://www.screamingfrog.co.uk/;
+      license = licenses.unfree;
+      platforms = [ "x86_64-linux" "i686-linux"];
+      maintainers = with maintainers; [ melling ];
+    };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24495,4 +24495,6 @@ in
   dapper = callPackage ../development/tools/dapper { };
 
   kube3d =  callPackage ../applications/networking/cluster/kube3d {};
+
+  screamingfrogseospider = callPackage ../tools/misc/screamingfrogseospider {};
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Adding [Screaming Frog SEO Spider](https://www.screamingfrog.co.uk/seo-spider/).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
