### PR TITLE
unityhub: init at 2.2.2

### DIFF
--- a/pkgs/development/tools/unityhub/default.nix
+++ b/pkgs/development/tools/unityhub/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchurl, appimageTools, gsettings-desktop-schemas, gtk3 }:
+
+let
+  pname = "unityhub";
+  version = "2.2.2";
+in
+
+appimageTools.wrapType2 rec {
+
+  name = pname;
+
+  extraPkgs = (pkgs: with pkgs; with xorg; [ gtk2 gdk_pixbuf glib libGL libGLU nss nspr
+    alsaLib cups gnome2.GConf libcap fontconfig freetype pango
+    cairo dbus dbus-glib libdbusmenu libdbusmenu-gtk2 expat zlib libpng12 udev tbb
+    libpqxx gtk3 libsecret lsb-release openssl nodejs ncurses5
+
+    libX11 libXcursor libXdamage libXfixes libXrender libXi
+    libXcomposite libXext libXrandr libXtst libSM libICE libxcb ]);
+    
+
+  profile = ''
+    export XDG_DATA_DIRS=${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${gtk3}/share/gsettings-schemas/${gtk3.name}:$XDG_DATA_DIRS
+  '';
+  
+  src = fetchurl {
+    url = "https://public-cdn.cloud.unity3d.com/hub/prod/UnityHub.AppImage";
+    sha256 = "1rx7ih94ig3pd1yx1d3fpx7zpixq3j5birkpnzkh778qqsdrg0nf";
+  };
+  
+  meta = with stdenv.lib; {
+    homepage = https://unity3d.com/;
+    description = "Game development tool";
+    longDescription = ''
+      Popular development platform for creating 2D and 3D multiplatform games
+      and interactive experiences.
+    '';
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ tesq0 ];
+  };
+}

--- a/pkgs/development/tools/unityhub/default.nix
+++ b/pkgs/development/tools/unityhub/default.nix
@@ -6,7 +6,7 @@ let
 in
 
 appimageTools.wrapType2 rec {
-  name = "${pname}-${version}";;
+  name = "${pname}-${version}";
 
   extraPkgs = (pkgs: with pkgs; with xorg; [ gtk2 gdk_pixbuf glib libGL libGLU nss nspr
     alsaLib cups gnome2.GConf libcap fontconfig freetype pango

--- a/pkgs/development/tools/unityhub/default.nix
+++ b/pkgs/development/tools/unityhub/default.nix
@@ -6,7 +6,7 @@ let
 in
 
 appimageTools.wrapType2 rec {
-  name = pname;
+  name = "${pname}-${version}";;
 
   extraPkgs = (pkgs: with pkgs; with xorg; [ gtk2 gdk_pixbuf glib libGL libGLU nss nspr
     alsaLib cups gnome2.GConf libcap fontconfig freetype pango

--- a/pkgs/development/tools/unityhub/default.nix
+++ b/pkgs/development/tools/unityhub/default.nix
@@ -6,7 +6,6 @@ let
 in
 
 appimageTools.wrapType2 rec {
-
   name = pname;
 
   extraPkgs = (pkgs: with pkgs; with xorg; [ gtk2 gdk_pixbuf glib libGL libGLU nss nspr
@@ -16,17 +15,16 @@ appimageTools.wrapType2 rec {
 
     libX11 libXcursor libXdamage libXfixes libXrender libXi
     libXcomposite libXext libXrandr libXtst libSM libICE libxcb ]);
-    
 
   profile = ''
     export XDG_DATA_DIRS=${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${gtk3}/share/gsettings-schemas/${gtk3.name}:$XDG_DATA_DIRS
   '';
-  
+
   src = fetchurl {
     url = "https://public-cdn.cloud.unity3d.com/hub/prod/UnityHub.AppImage";
     sha256 = "1rx7ih94ig3pd1yx1d3fpx7zpixq3j5birkpnzkh778qqsdrg0nf";
   };
-  
+
   meta = with stdenv.lib; {
     homepage = https://unity3d.com/;
     description = "Game development tool";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25259,6 +25259,8 @@ in
     inherit (gnome2) GConf;
   };
 
+  unityhub = callPackage ../development/tools/unityhub { };
+
   urbit = callPackage ../misc/urbit { };
 
   utf8proc = callPackage ../development/libraries/utf8proc { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
 #65229 

Let's switch to unity hub so people can manage different versions of unity. 
Seems like we don't need the old package anymore.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
