### PR TITLE
egalaxtouch: init at 2.5.9321

### DIFF
--- a/pkgs/os-specific/linux/egalaxtouch/default.nix
+++ b/pkgs/os-specific/linux/egalaxtouch/default.nix
@@ -1,0 +1,85 @@
+{ stdenv
+, lib
+, fetchurl
+, autoPatchelfHook
+, libX11
+, libXext
+, libXi
+, libXrandr
+, libXrender
+, libSM
+, libICE
+, libXfixes
+, libXinerama
+, alsa-lib
+, fontconfig
+, freetype
+, libXcursor
+}:
+
+stdenv.mkDerivation rec {
+  pname = "egalaxtouch";
+  version = "2.5.9321";
+
+  src = fetchurl {
+    url = "https://www.eeti.com/touch_driver/Linux/20201110/eGTouch_v${version}.L-x.tar.gz";
+    sha256 = "sha256:0i2is8ad0y4jx7clh4wyabz4is1k6bx76w90i7ivrqbqhx3iyb67";
+  };
+
+  buildInputs = [
+    stdenv.cc.cc.lib
+    libSM
+    libICE
+    libXi
+    libXrender
+    libXrandr
+    libXfixes
+    libXcursor
+    libXinerama
+    freetype
+    fontconfig
+    libXext
+    libX11
+    alsa-lib
+  ];
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+  ];
+
+  sourceRoot = ".";
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  system = "x86_64-linux";
+
+  installPhase = ''
+    mkdir -p $out/bin
+    rm -rf ./eGTouch_v${version}.L-x/eGTouch32
+    cp -R ./eGTouch_v${version}.L-x/ $out/opt
+    # fix the path in the desktop file
+    substituteInPlace \
+      $out/opt/Rule/eGTouchD.service \
+      --replace /usr/bin/ $out/bin/
+    # symlink the binary to bin/
+    ln -s $out/opt/eGTouch64/eGTouch64withX/eGTouchD $out/bin/eGTouchD
+    ln -s $out/opt/eGTouch64/eGTouch64withX/eGTouchU $out/bin/eGTouchU
+    ln -s $out/opt/eGTouch64/eGTouch64withX/eCalib $out/bin/eCalib
+  '';
+
+  preFixup = ''
+    chmod +x $out/opt/eGTouch64/eGTouch64withX/eGTouchD
+    chmod +x $out/opt/eGTouch64/eGTouch64withX/eGTouchU
+    chmod +x $out/opt/eGTouch64/eGTouch64nonX/eGTouchD
+    chmod +x $out/opt/eGTouch64/eGTouch64withX/eCalib
+  '';
+
+  meta = with lib; {
+    maintainers = with maintainers; [ _0x4A6F ];
+    description = "eGalaxTouch driver for X11";
+    homepage = https://www.eeti.com/drivers_Linux.html;
+    license = licenses.free;
+    platforms = platforms.linux; # Probably, works with other unices as well
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32467,6 +32467,8 @@ in
 
   tomb = callPackage ../os-specific/linux/tomb {};
 
+  egalaxtouch = callPackage ../os-specific/linux/egalaxtouch {};
+
   tomboy = callPackage ../applications/misc/tomboy { };
 
   imatix_gsl = callPackage ../development/tools/imatix_gsl {};


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Supporting [eGalaxTouch](http://www.eeti.com.tw/drivers.html) touchscreens.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
