### PR TITLE
dhcpcd: 7.2.3 -> 8.0.2

### DIFF
--- a/pkgs/tools/networking/dhcpcd/default.nix
+++ b/pkgs/tools/networking/dhcpcd/default.nix
@@ -4,11 +4,11 @@ stdenv.mkDerivation rec {
   # when updating this to >=7, check, see previous reverts:
   # nix-build -A nixos.tests.networking.scripted.macvlan.x86_64-linux nixos/release-combined.nix
   pname = "dhcpcd";
-  version = "8.0.1";
+  version = "8.0.2";
 
   src = fetchurl {
     url = "mirror://roy/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "0cd9vcyc9bisxzb56z2yrpiy7678bgzl7hzy2i3v8hddynz4y7q3";
+    sha256 = "0p3sc9yfb40fn1z8rvvxqd0jpxsxm1967pp6w77x4v2lc7anm8ik";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/tools/networking/dhcpcd/default.nix
+++ b/pkgs/tools/networking/dhcpcd/default.nix
@@ -3,11 +3,12 @@
 stdenv.mkDerivation rec {
   # when updating this to >=7, check, see previous reverts:
   # nix-build -A nixos.tests.networking.scripted.macvlan.x86_64-linux nixos/release-combined.nix
-  name = "dhcpcd-7.2.3";
+  pname = "dhcpcd";
+  version = "8.0.1";
 
   src = fetchurl {
-    url = "mirror://roy/dhcpcd/${name}.tar.xz";
-    sha256 = "0vjnd27y6jm5q2v7fkyxmsn77dcpvpzyzb5bq9lfkas8flbkiavl";
+    url = "mirror://roy/${pname}/${pname}-${version}.tar.xz";
+    sha256 = "0cd9vcyc9bisxzb56z2yrpiy7678bgzl7hzy2i3v8hddynz4y7q3";
   };
 
   nativeBuildInputs = [ pkgconfig ];
@@ -27,14 +28,14 @@ stdenv.mkDerivation rec {
     "--localstatedir=/var"
   ];
 
-  makeFlags = "PREFIX=\${out}";
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
 
   # Hack to make installation succeed.  dhcpcd will still use /var/db
   # at runtime.
-  installFlags = "DBDIR=\${TMPDIR}/db SYSCONFDIR=$(out)/etc";
+  installFlags = [ "DBDIR=$(TMPDIR)/db" "SYSCONFDIR=${placeholder "out"}/etc" ];
 
   # Check that the udev plugin got built.
-  postInstall = stdenv.lib.optional (udev != null) "[ -e $out/lib/dhcpcd/dev/udev.so ]";
+  postInstall = stdenv.lib.optional (udev != null) "[ -e ${placeholder "out"}/lib/dhcpcd/dev/udev.so ]";
 
   meta = with stdenv.lib; {
     description = "A client for the Dynamic Host Configuration Protocol (DHCP)";


### PR DESCRIPTION

###### Motivation for this change

https://roy.marples.name/blog/dhcpcd-8-0-0-released
https://roy.marples.name/blog/dhcpcd-8-0-1-released
https://roy.marples.name/blog/dhcpcd-8-0-2-released

Haven't checked the tests yet, should definitely check before proceeding
:).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---