### PR TITLE
termdown: 1.15.0 -> 1.16.0

### DIFF
--- a/pkgs/applications/misc/termdown/default.nix
+++ b/pkgs/applications/misc/termdown/default.nix
@@ -6,11 +6,11 @@ with stdenv.lib;
 buildPythonApplication rec {
 
   name    = "termdown-${version}";
-  version = "1.15.0";
+  version = "1.16.0";
 
   src = fetchFromGitHub {
     rev    = version;
-    sha256 = "08l03yk5jc1g0gps789q1s2knnaqzlidy4s5q5nhwg9g25la19nr";
+    sha256 = "0k429ss1xifm9vbgyzpp71r79byn9jclvr0rm77bai2r8nz3s2vf";
     repo   = "termdown";
     owner  = "trehn";
   };


### PR DESCRIPTION
###### Motivation for this change

Minor update:
https://github.com/trehn/termdown/blob/1.16.0/CHANGELOG.md

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---