### PR TITLE
zstd: 1.4.1 -> 1.4.2

### DIFF
--- a/pkgs/tools/compression/zstd/default.nix
+++ b/pkgs/tools/compression/zstd/default.nix
@@ -5,10 +5,10 @@
 
 stdenv.mkDerivation rec {
   pname = "zstd";
-  version = "1.4.1";
+  version = "1.4.2";
 
   src = fetchFromGitHub {
-    sha256 = "1f2nvhsx1fsd6zbnwvc6bbrm9ghkcvamqqg79fxgk5284rc6nynv";
+    sha256 = "0ihvkzp9v740sm43wan1f8ah8z29fhiwd4nxq11vp541sf66834g";
     rev = "v${version}";
     repo = "zstd";
     owner = "facebook";


### PR DESCRIPTION
###### Motivation for this change

https://github.com/facebook/zstd/releases/tag/v1.4.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---