### PR TITLE
module zabbixProxy: server is a mandatory parameter

### DIFF
--- a/nixos/modules/services/monitoring/zabbix-proxy.nix
+++ b/nixos/modules/services/monitoring/zabbix-proxy.nix
@@ -23,6 +23,7 @@ let
     LogType = console
     ListenIP = ${cfg.listen.ip}
     ListenPort = ${toString cfg.listen.port}
+    Server = ${cfg.server}
     # TODO: set to cfg.database.socket if database type is pgsql?
     DBHost = ${optionalString (cfg.database.createLocally != true) cfg.database.host}
     ${optionalString (cfg.database.createLocally != true) "DBPort = ${cfg.database.port}"}
@@ -49,6 +50,13 @@ in
 
     services.zabbixProxy = {
       enable = mkEnableOption "the Zabbix Proxy";
+
+      server = mkOption {
+        type = types.str;
+        description = ''
+          The IP address or hostname of the Zabbix server to connect to.
+          '';
+        };
 
       package = mkOption {
         type = types.package;


### PR DESCRIPTION
###### Motivation for this change

The ``Server`` is a mandatory parameter when configuring the Zabbix proxy.

I'm not sure when or where this got dropped during the Zabbix module update.

```
Jul 26 13:53:12  zabbix_proxy[2489]: zabbix_proxy [2489]: missing mandatory parameter "Server" in config file "/nix/store/kms45lmh1x7bvi4vy8569k2q3zmd0fb6-zabbix_proxy.conf"
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
