### PR TITLE
hubstaff: 1.4.6 -> 1.4.9

### DIFF
--- a/pkgs/applications/misc/hubstaff/revision.json
+++ b/pkgs/applications/misc/hubstaff/revision.json
@@ -1,5 +1,5 @@
 {
-  "url": "https://hubstaff-production.s3.amazonaws.com/downloads/HubstaffClient/Builds/Release/1.4.6-4aba8ab5/Hubstaff-1.4.6-4aba8ab5.sh",
-  "version": "1.4.6-4aba8ab5",
-  "sha256": "14js4d7wazn5r5p9n3iic9kwqrinm079jj1k7r00v684jrgq62fc"
+  "url": "https://hubstaff-production.s3.amazonaws.com/downloads/HubstaffClient/Builds/Release/1.4.9-86828309/Hubstaff-1.4.9-86828309.sh",
+  "version": "1.4.9-86828309",
+  "sha256": "0p9b7s2damzxmbrm8m97bj06g0faslbjw51dmxq8icz6ldbqsspx"
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
