### PR TITLE
coqPackages.coquelicot: 3.0.2 -> 3.0.3

### DIFF
--- a/pkgs/development/coq-modules/coquelicot/default.nix
+++ b/pkgs/development/coq-modules/coquelicot/default.nix
@@ -1,10 +1,23 @@
 { stdenv, fetchurl, which, coq, ssreflect }:
 
-stdenv.mkDerivation {
-  name = "coq${coq.coq-version}-coquelicot-3.0.2";
-  src = fetchurl {
-    url = "https://gforge.inria.fr/frs/download.php/file/37523/coquelicot-3.0.2.tar.gz";
+let param =
+  if stdenv.lib.versionAtLeast coq.coq-version "8.8"
+  then {
+    version = "3.0.3";
+    uid = "38105";
+    sha256 = "0y52lqx1jphv6fwf0d702vzprxmfmxggnh1hy3fznxyl4isfpg4j";
+  } else {
+    version = "3.0.2";
+    uid = "37523";
     sha256 = "1biia7nfqf7vaqq5gmykl4rwjyvrcwss6r2jdf0in5pvp2rnrj2w";
+  }
+; in
+
+stdenv.mkDerivation {
+  name = "coq${coq.coq-version}-coquelicot-${param.version}";
+  src = fetchurl {
+    url = "https://gforge.inria.fr/frs/download.php/file/${param.uid}/coquelicot-${param.version}.tar.gz";
+    inherit (param) sha256;
   };
 
   nativeBuildInputs = [ which ];
@@ -24,7 +37,7 @@ stdenv.mkDerivation {
   };
 
   passthru = {
-    compatibleCoqVersions = v: builtins.elem v [ "8.5" "8.6" "8.7" "8.8" "8.9" ];
+    compatibleCoqVersions = v: builtins.elem v [ "8.5" "8.6" "8.7" "8.8" "8.9" "8.10" ];
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change

Ensures compatibility with Coq 8.10

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
