### PR TITLE
pythonPackages.fastapi: init at 0.33.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5846,4 +5846,9 @@
     github = "mattmelling";
     name = "Matt Melling";
   };
+  wd15 = {
+    email = "daniel.wheeler2@gmail.com";
+    github = "wd15";
+    name = "Daniel Wheeler";
+  };
 }

--- a/pkgs/development/python-modules/fastapi/default.nix
+++ b/pkgs/development/python-modules/fastapi/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, uvicorn
+, starlette
+, pydantic
+, python
+, isPy3k
+, which
+}:
+
+buildPythonPackage rec {
+  pname = "fastapi";
+  version = "0.33.0";
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1mc8ljfk6xyn2cq725s8hgapp62z5mylzw9akvkhwwz3bh8m5a7f";
+  };
+
+  propagatedBuildInputs = [
+    uvicorn
+    starlette
+    pydantic
+  ];
+
+  patches = [ ./setup.py.patch ];
+
+  checkPhase = ''
+    ${python.interpreter} -c "from fastapi import FastAPI; app = FastAPI()"
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/tiangolo/fastapi";
+    description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production";
+    license = licenses.mit;
+    maintainers = with maintainers; [ wd15 ];
+  };
+}

--- a/pkgs/development/python-modules/fastapi/setup.py.patch
+++ b/pkgs/development/python-modules/fastapi/setup.py.patch
@@ -1,0 +1,13 @@
+diff --git a/setup.py b/setup.py
+index ccc3d2b..77ce446 100644
+--- a/setup.py
++++ b/setup.py
+@@ -10,7 +10,7 @@ package_data = \
+ {'': ['*']}
+ 
+ install_requires = \
+-['starlette >=0.11.1,<=0.12.0', 'pydantic >=0.30,<=0.30.0']
++['starlette >=0.11.1', 'pydantic >=0.30']
+ 
+ extras_require = \
+ {'all': ['requests',

--- a/pkgs/development/python-modules/pydantic/default.nix
+++ b/pkgs/development/python-modules/pydantic/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, ujson
+, email_validator
+, typing-extensions
+, python
+, isPy3k
+}:
+
+buildPythonPackage rec {
+  pname = "pydantic";
+  version = "0.31";
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0x9xc5hpyrlf05dc4bx9f7v51fahxcahkvh0ij8ibay15nwli53d";
+  };
+
+  propagatedBuildInputs = [
+    ujson
+    email_validator
+    typing-extensions
+  ];
+
+  checkPhase = ''
+    ${python.interpreter} -c """
+from datetime import datetime
+from typing import List
+from pydantic import BaseModel
+
+class User(BaseModel):
+    id: int
+    name = 'John Doe'
+    signup_ts: datetime = None
+    friends: List[int] = []
+
+external_data = {'id': '123', 'signup_ts': '2017-06-01 12:22', 'friends': [1, '2', b'3']}
+user = User(**external_data)
+assert user.id is "123"
+"""
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/samuelcolvin/pydantic";
+    description = "Data validation and settings management using Python type hinting";
+    license = licenses.mit;
+    maintainers = with maintainers; [ wd15 ];
+  };
+}

--- a/pkgs/development/python-modules/starlette/default.nix
+++ b/pkgs/development/python-modules/starlette/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, aiofiles
+, graphene
+, itsdangerous
+, jinja2
+, pyyaml
+, requests
+, ujson
+, pytest
+, python
+, uvicorn
+, isPy27
+}:
+
+buildPythonPackage rec {
+  pname = "starlette";
+  version = "0.12.4";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1m7qf4g5dn7n36406zbqsag71nmwp2dz91yxpplm7h7wiw2xxw93";
+  };
+
+  propagatedBuildInputs = [
+    aiofiles
+    graphene
+    itsdangerous
+    jinja2
+    pyyaml
+    requests
+    ujson
+    uvicorn
+  ];
+
+  checkPhase = ''
+    ${python.interpreter} -c """
+from starlette.applications import Starlette
+app = Starlette(debug=True)
+"""
+  '';
+
+  meta = with lib; {
+    homepage = https://www.starlette.io/;
+    description = "The little ASGI framework that shines";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ wd15 ];
+  };
+}

--- a/pkgs/development/python-modules/uvicorn/default.nix
+++ b/pkgs/development/python-modules/uvicorn/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, click
+, h11
+, httptools
+, uvloop
+, websockets
+, wsproto
+, isPy27
+}:
+
+buildPythonPackage rec {
+  pname = "uvicorn";
+  version = "0.8.4";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1l8rfm30inx9pma893i7sby9h7y910k58841zqaajksn563b882k";
+  };
+
+  propagatedBuildInputs = [
+    click
+    h11
+    httptools
+    uvloop
+    websockets
+    wsproto
+  ];
+
+  checkPhase = ''
+    $out/bin/uvicorn --help
+  '';
+
+  patches = [ ./setup.patch ];
+
+  meta = with lib; {
+    homepage = https://www.uvicorn.org/;
+    description = "The lightning-fast ASGI server";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ wd15 ];
+  };
+}

--- a/pkgs/development/python-modules/uvicorn/setup.patch
+++ b/pkgs/development/python-modules/uvicorn/setup.patch
@@ -1,0 +1,13 @@
+diff --git a/setup.py b/setup.py
+index 802cda4..561abf4 100755
+--- a/setup.py
++++ b/setup.py
+@@ -42,7 +42,7 @@ env_marker = (
+ 
+ requirements = [
+     "click==7.*",
+-    "h11==0.8.*",
++    "h11",
+     "websockets==7.*",
+     "httptools==0.0.13 ;" + env_marker,
+     "uvloop==0.12.* ;" + env_marker,

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5986,6 +5986,8 @@ in {
 
   uvicorn = callPackage ../development/python-modules/uvicorn { };
 
+  pydantic = callPackage ../development/python-modules/pydantic { };
+
 });
 
 in fix' (extends overrides packages)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5981,6 +5981,8 @@ in {
   aioesphomeapi = callPackage ../development/python-modules/aioesphomeapi { };
 
   mwparserfromhell = callPackage ../development/python-modules/mwparserfromhell { };
+  uvicorn = callPackage ../development/python-modules/uvicorn { };
+
 });
 
 in fix' (extends overrides packages)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5981,6 +5981,9 @@ in {
   aioesphomeapi = callPackage ../development/python-modules/aioesphomeapi { };
 
   mwparserfromhell = callPackage ../development/python-modules/mwparserfromhell { };
+
+  starlette = callPackage ../development/python-modules/starlette { };
+
   uvicorn = callPackage ../development/python-modules/uvicorn { };
 
 });

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5988,6 +5988,7 @@ in {
 
   pydantic = callPackage ../development/python-modules/pydantic { };
 
+  fastapi = callPackage ../development/python-modules/fastapi { };
 });
 
 in fix' (extends overrides packages)


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add [Starlette](https://www.starlette.io/) and [FastAPI](https://fastapi.tiangolo.com/) [ASGI](https://asgi.readthedocs.io/en/latest/) based Python web frameworks.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
