### PR TITLE
purple-libnotify-plus: init at 2018-05-30, as well as dependency

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-events/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-events/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, pidgin, glib, autoreconfHook, pkgconfig, intltool }:
+
+stdenv.mkDerivation rec {
+  pname = "purple-events";
+  version = "2017-08-25";
+
+  src = fetchFromGitHub {
+    owner = "sardemff7";
+    repo = pname;
+    rev = "7b01b0a2724f675dadf41a8d8e9bee203ef1ccc2";
+    sha256 = "1mhg40swa12inkdhhxf6x9c45h2dijzvdlx1325zgvs2k1vv0a3k";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig intltool ];
+  autoreconfPhase = "${stdenv.shell} ./autogen.sh";
+  buildInputs = [ pidgin glib ];
+
+  configureFlags = [ "--with-purple-plugindir=${placeholder "out"}/lib/purple-2" ];
+
+  meta = with stdenv.lib; {
+    homepage = http://purple-events.sardemff7.net/;
+    description = "libpurple events handling plugin and library";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-libnotify-plus/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-libnotify-plus/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, pidgin, glib, libnotify, purple-events, autoreconfHook, pkgconfig, intltool }:
+
+stdenv.mkDerivation rec {
+  pname = "purple-libnotify-plus";
+  version = "2018-05-30";
+
+  src = fetchFromGitHub {
+    owner = "sardemff7";
+    repo = pname;
+    rev = "67987f8427b722a2edce75678254ad27ae56297d";
+    sha256 = "0gh86dknzd064y2d8nck4p8r6ci23vwrlhgy1q75mmc0px94gz34";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig intltool ];
+  autoreconfPhase = "${stdenv.shell} ./autogen.sh";
+  buildInputs = [ pidgin glib libnotify purple-events ];
+
+  configureFlags = [ "--with-purple-plugindir=${placeholder "out"}/lib/purple-2" ];
+
+  meta = with stdenv.lib; {
+    homepage = http://purple-libnotify-plus.sardemff7.net/;
+    description = "Plugin to provide libnotify interface to Pidgin and Finch";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19830,6 +19830,8 @@ in
 
   purple-hangouts = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-hangouts { };
 
+  purple-libnotify-plus = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-libnotify-plus { };
+
   purple-lurch = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-lurch { };
 
   purple-matrix = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-matrix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19824,6 +19824,8 @@ in
 
   pidgin-window-merge = callPackage ../applications/networking/instant-messengers/pidgin-plugins/window-merge { };
 
+  purple-events = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-events { };
+
   purple-discord = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-discord { };
 
   purple-hangouts = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-hangouts { };


### PR DESCRIPTION
###### Motivation for this change

Message notifications!

Needs `purple-events` as well, which maybe should be added to plugin list
alongside `purple-libnotify-plus` in order to use this.

Doing so works, haven't tried only adding `purple-libnotify-plus`
(which might maybe possibly find or otherwise 'pull in'
`purple-events`).

In retrospect I probably could have just used notify-send{,.sh} and the
command-execute plugin or something :P but this seems to work without
the fiddling :).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---