### PR TITLE
purple-matrix: pname, fix cflags, restore hardening

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-matrix/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-matrix/default.nix
@@ -1,25 +1,25 @@
-{ stdenv, fetchgit, pkgconfig, pidgin, json-glib, glib, http-parser, sqlite, olm, libgcrypt } :
+{ stdenv, fetchFromGitHub, pkgconfig, pidgin, json-glib, glib, http-parser, sqlite, olm, libgcrypt } :
 
-let
-  version = "2018-08-03";
-in
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "purple-matrix-unstable";
-  inherit version;
+  version = "2019-06-06";
 
-  src = fetchgit {
-    url = "https://github.com/matrix-org/purple-matrix";
-    rev = "5a7166a3f54f85793c6b60662f8d12196aeaaeb0";
-    sha256 = "0ph0s24b37d1c50p8zbzgf4q2xns43a8v6vk85iz633wdd72zsa0";
+  src = fetchFromGitHub {
+    owner = "matrix-org";
+    repo = "purple-matrix";
+    rev = "4494ba22b479917f0b1f96a3019792d3d75bcff1";
+    sha256 = "1gjm0z4wa5vi9x1xk43rany5pffrwg958n180ahdj9a7sa8a4hpm";
   };
 
-  # glib-2.62 deprecations
-  NIX_CFLAGS_COMPILE = [ "-DGLIB_DISABLE_DEPRECATION_WARNINGS" ];
+  NIX_CFLAGS_COMPILE = [
+    # glib-2.62 deprecations
+    "-DGLIB_DISABLE_DEPRECATION_WARNINGS"
+    # override "-O0 -Werror" set by build system
+    "-O3" "-Wno-error"
+  ];
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ pidgin json-glib glib http-parser sqlite olm libgcrypt ];
-
-  hardeningDisable = [ "fortify" ]; # upstream compiles with -O0
 
   makeFlags = [
     "PLUGIN_DIR_PURPLE=${placeholder "out"}/lib/purple-2"


### PR DESCRIPTION
###### Motivation for this change

Also bump to latest, although not sure the changes are significant
functionally.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - Using plugin presently, LGTM? :D
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---