### PR TITLE
zsh-fast-syntax-highlighting:init at 1.54

### DIFF
--- a/pkgs/shells/zsh/zsh-fast-syntax-highlighting/default.nix
+++ b/pkgs/shells/zsh/zsh-fast-syntax-highlighting/default.nix
@@ -1,0 +1,32 @@
+{ stdenvNoCC, lib, fetchFromGitHub }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "zsh-fast-syntax-highlighting";
+  version = "1.54";
+
+  src = fetchFromGitHub {
+    owner = "zdharma";
+    repo = "fast-syntax-highlighting";
+    rev = "v${version}";
+    sha256 = "019hda2pj8lf7px4h1z07b9l6icxx4b2a072jw36lz9bh6jahp32";
+  };
+
+  #adapted from https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=zsh-fast-syntax-highlighting-git
+  installPhase = ''
+    _plugindir="$out/share/zsh/site-functions"
+
+    cd "$src"
+    install -dm0755 "$_plugindir"
+    install -m0644 -- {,_,-}fast-* "$_plugindir"
+
+    cp -r {.,$_plugindir}/chroma
+    cp -r {.,$_plugindir}/themes
+  '';
+
+  meta = with lib; {
+    description = "Syntax-highlighting for Zshell";
+    homepage = "https://github.com/zdharma/fast-syntax-highlighting";
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/shells/zsh/zsh-fast-syntax-highlighting/default.nix
+++ b/pkgs/shells/zsh/zsh-fast-syntax-highlighting/default.nix
@@ -11,16 +11,14 @@ stdenvNoCC.mkDerivation rec {
     sha256 = "019hda2pj8lf7px4h1z07b9l6icxx4b2a072jw36lz9bh6jahp32";
   };
 
-  #adapted from https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=zsh-fast-syntax-highlighting-git
+  dontConfigure = true;
+  dontBuild = true;
+
   installPhase = ''
-    _plugindir="$out/share/zsh/site-functions"
+    plugindir="$out/share/zsh/site-functions"
 
-    cd "$src"
-    install -dm0755 "$_plugindir"
-    install -m0644 -- {,_,-}fast-* "$_plugindir"
-
-    cp -r {.,$_plugindir}/chroma
-    cp -r {.,$_plugindir}/themes
+    mkdir -p "$plugindir"
+    cp -r -- {,_,-}fast-* chroma themes "$plugindir"/
   '';
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7035,6 +7035,8 @@ in
   zsh-navigation-tools = callPackage ../tools/misc/zsh-navigation-tools { };
 
   zsh-syntax-highlighting = callPackage ../shells/zsh/zsh-syntax-highlighting { };
+  
+  zsh-fast-syntax-highlighting = callPackage ../shells/zsh/zsh-fast-syntax-highlighting { };
 
   zsh-autosuggestions = callPackage ../shells/zsh/zsh-autosuggestions { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
