### PR TITLE
 zsh-powerlevel10k:init at 2019-07-23 

### DIFF
--- a/pkgs/shells/zsh/zsh-powerlevel10lk/default.nix
+++ b/pkgs/shells/zsh/zsh-powerlevel10lk/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub }:
+
+# To make use of this derivation, use
+# `programs.zsh.promptInit = "source ${pkgs.zsh-powerlevel10k}/share/zsh-powerlevel9k/powerlevel9k.zsh-theme";`
+
+stdenv.mkDerivation rec {
+  pname = "powerlevel10k";
+  version = "2019-07-23";
+  src = fetchFromGitHub {
+    owner = "romkatv";
+    repo = "powerlevel10k";
+    rev = "5ef0ec415eefbc8b4431a6e4b8e2a5e0d299176a";
+    sha256 = "14fdvqgqswxkdam18c2pyvkf9889p5505a59mqdq3i9qcmv72ah0";
+  };
+
+  installPhase= ''
+    install -D powerlevel9k.zsh-theme --target-directory=$out/share/zsh-powerlevel9k
+    install -D functions/* --target-directory=$out/share/zsh-powerlevel9k/functions
+    install -D internal/* --target-directory=$out/share/zsh-powerlevel9k/internal
+  '';
+
+  meta = {
+    description = "A fast reimplementation of Powerlevel9k ZSH theme";
+    homepage = https://github.com/romkatv/powerlevel10k;
+    license = stdenv.lib.licenses.mit;
+
+    platforms = stdenv.lib.platforms.unix;
+    # maintainers = [ stdenv.lib.maintainers.pierrechevalier83 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7040,6 +7040,8 @@ in
 
   zsh-powerlevel9k = callPackage ../shells/zsh/zsh-powerlevel9k { };
 
+  zsh-powerlevel10k = callPackage ../shells/zsh/zsh-powerlevel10zsh-powerlevel9k = callPackage ../shells/zsh/zsh-powerlevel9k { };zsh-powerlevel9k = callPackage ../shells/zsh/zsh-powerlevel9k { };zsh-powerlevel9k = callPackage ../shells/zsh/zsh-powerlevel9k { };k { };
+
   zsh-command-time = callPackage ../shells/zsh/zsh-command-time { };
 
   zsh-you-should-use = callPackage ../shells/zsh/zsh-you-should-use { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7040,7 +7040,7 @@ in
 
   zsh-powerlevel9k = callPackage ../shells/zsh/zsh-powerlevel9k { };
 
-  zsh-powerlevel10k = callPackage ../shells/zsh/zsh-powerlevel10zsh-powerlevel9k = callPackage ../shells/zsh/zsh-powerlevel9k { };zsh-powerlevel9k = callPackage ../shells/zsh/zsh-powerlevel9k { };zsh-powerlevel9k = callPackage ../shells/zsh/zsh-powerlevel9k { };k { };
+  zsh-powerlevel10k = callPackage ../shells/zsh/zsh-powerlevel10lk { };
 
   zsh-command-time = callPackage ../shells/zsh/zsh-command-time { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
