### PR TITLE
screamingfrogseospider: init at 12.4

### DIFF
--- a/pkgs/tools/misc/screamingfrogseospider/default.nix
+++ b/pkgs/tools/misc/screamingfrogseospider/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, lib, fetchurl, dpkg, oraclejre  }:
+with stdenv.lib;
+stdenv.mkDerivation rec {
+  version = "12.4";
+  name = "screamingfrogseospider-${version}";
+  src = fetchurl {
+    url = "https://download.screamingfrog.co.uk/products/seo-spider/screamingfrogseospider_${version}_all.deb";
+    sha256 = "587167924f8d4914adbf0c122c190aafdafcd388353d6fca3449dcae8c148814";
+  };
+  buildInputs = [ dpkg ];
+  unpackPhase = "dpkg -X $src .";
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -R . $out/
+    substituteInPlace $out/usr/bin/screamingfrogseospider \
+        --replace '/usr/share/screamingfrogseospider/jre/' "${oraclejre}/" \
+        --replace '-jar /usr/share/' "-jar $out/usr/share/" \
+        --replace '-Djava.ext.dirs=' '-classpath '
+    ln -s $out/usr/bin/screamingfrogseospider $out/bin/screamingfrogseospider
+    rm -rf $out/usr/share/screamingfrogseospider/tmp
+  '';
+    meta = {
+      description = "Screaming Frog SEO Spider Tool";
+      homepage = https://www.screamingfrog.co.uk/;
+      license = licenses.unfree;
+      platforms = [ "x86_64-linux" "i686-linux"];
+      maintainers = with maintainers; [ melling ];
+    };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25798,4 +25798,6 @@ in
 
   kcli = callPackage ../development/tools/kcli {};
 
+  screamingfrogseospider = callPackage ../tools/misc/screamingfrogseospider {};
+
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Adding package for Screaming Frog SEO Spider

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
