### PR TITLE
tome2: init at 2.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1109,10 +1109,6 @@
     githubId = 977929;
     name = "Cody Allen";
   };
-  cf6b88f = {
-    email = "elmo.todurov@eesti.ee";
-    name = "Elmo Todurov";
-  };
   cfouche = {
     email = "chaddai.fouche@gmail.com";
     github = "Chaddai";
@@ -1218,6 +1214,12 @@
     github = "ciil";
     githubId = 3956062;
     name = "Simon Lackerbauer";
+  };
+  cizra = {
+    email = "todurov+nix@gmail.com";
+    github = "cizra";
+    githubId = 2131991;
+    name = "Elmo Todurov";
   };
   ck3d = {
     email = "ck3d@gmx.de";

--- a/pkgs/games/tdm/default.nix
+++ b/pkgs/games/tdm/default.nix
@@ -96,7 +96,7 @@ EOF
     description = "The Dark Mod - stealth FPS inspired by the Thief series";
     homepage = "http://www.thedarkmod.com";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ cf6b88f ];
+    maintainers = with maintainers; [ cizra ];
     platforms = with platforms; [ "x86_64-linux" ];  # tdm also supports x86, but I don't have a x86 install at hand to test.
   };
 }

--- a/pkgs/games/tome2/default.nix
+++ b/pkgs/games/tome2/default.nix
@@ -1,0 +1,50 @@
+{ stdenv, fetchFromGitHub, makeDesktopItem, ncurses, libX11, boost, cmake }:
+
+let
+  pname = "tome2";
+  description = "A dungeon crawler similar to Angband, based on the works of Tolkien";
+
+  desktopItem = makeDesktopItem {
+    desktopName = pname;
+    name = pname;
+    exec = "${pname}-x11";
+    icon = pname;
+    terminal = "False";
+    comment = description;
+    type = "Application";
+    categories = "Game;RolePlaying;";
+    genericName = pname;
+  };
+
+in stdenv.mkDerivation {
+  inherit pname;
+  version = "2.4";
+
+  src = fetchFromGitHub {
+    owner = "tome2";
+    repo = "tome2";
+    rev = "4e6a906c80ff07b75a6acf4ff585b47303805e46";
+    sha256 = "06bddj55y673d7bnzblk8n01z32l6k2rad3bpzr8dmw464hx4wwf";
+  };
+
+  buildInputs = [ ncurses libX11 boost ];
+
+  nativeBuildInputs = [ cmake ];
+
+  cmakeFlags = [
+    "-DSYSTEM_INSTALL=ON"
+  ];
+
+  postInstall = ''
+    mkdir -p $out/share/applications
+    cp ${desktopItem}/share/applications/*.desktop $out/share/applications
+  '';
+
+  meta = with stdenv.lib; {
+    inherit description;
+    license = licenses.unfree;
+    maintainers = with maintainers; [ cizra ];
+    platforms = platforms.all;
+    homepage = "https://github.com/tome2/tome2";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22401,6 +22401,8 @@ in
 
   tinyfugue = callPackage ../games/tinyfugue { };
 
+  tome2 = callPackage ../games/tome2 { };
+
   tome4 = callPackage ../games/tome4 { };
 
   toppler = callPackage ../games/toppler { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
