### PR TITLE
bluedevil: make bluez-qt a propagatedBuildInputs

### DIFF
--- a/pkgs/desktops/plasma-5/bluedevil.nix
+++ b/pkgs/desktops/plasma-5/bluedevil.nix
@@ -11,4 +11,5 @@ mkDerivation {
     bluez-qt ki18n kio kwindowsystem plasma-framework qtdeclarative kcoreaddons
     kdbusaddons kded kiconthemes knotifications kwidgetsaddons
   ];
+  propagatedBuildInputs = [ bluez-qt ];
 }


### PR DESCRIPTION
###### Motivation for this change

The plasma bluetooth applet fails to show with the following error:

> Error loading QML file: file:///nix/store/90rl8rq4dkgvj66w4b4ihs80x62cjf23-bluedevil-5.15.5/share/plasma/plasmoids/org.kde.plasma.bluetooth/contents/ui/BluetoothApplet.qml:24:1: module "org.kde.bluezqt" is not installed

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
