### PR TITLE
libgdata: add gnome-online-accounts to propagatedBuildInputs

### DIFF
--- a/pkgs/development/libraries/libgdata/default.nix
+++ b/pkgs/development/libraries/libgdata/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , fetchurl
+, fetchpatch
 , pkgconfig
 , meson
 , ninja
@@ -31,6 +32,21 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./installed-tests-path.patch
+    (fetchpatch {
+      # Meson fixes
+      url = "https://gitlab.gnome.org/GNOME/libgdata/commit/f6d0e3f3b6fa8e8ee9569372c5709c1fb84af2c1.diff";
+      sha256 = "00yrppn0s21i41r9mwzvrrv7j5dida09kh7i44kv8hrbrlfag7bm";
+    })
+    (fetchpatch {
+      # Meson minor fixes
+      url = "https://gitlab.gnome.org/GNOME/libgdata/commit/b653f602b3c2b518101c5d909e1651534c22757a.diff";
+      sha256 = "1bn0rffsvkzjl59aw8dmq1wil58x1fshz0m6xabpn79ffvbjld8j";
+    })
+    (fetchpatch {
+      # Meson: Fix G_LOG_DOMAIN
+      url = "https://gitlab.gnome.org/GNOME/libgdata/commit/5d318e0bf905d0f1a8b3fe1e47ee7847739082e3.diff";
+      sha256 = "11i2blq811d53433kdq4hhsscgkrq5f50d9ih4ixgs3j47hg7b1w";
+    })
   ];
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/libgdata/default.nix
+++ b/pkgs/development/libraries/libgdata/default.nix
@@ -45,7 +45,6 @@ stdenv.mkDerivation rec {
   buildInputs = [
     gcr
     glib
-    gnome3.gnome-online-accounts
     liboauth
     libsoup
     libxml2
@@ -55,6 +54,7 @@ stdenv.mkDerivation rec {
   ];
 
   propagatedBuildInputs = [
+    gnome3.gnome-online-accounts
     json-glib
   ];
 


### PR DESCRIPTION
###### Motivation for this change

`libgdata`'s new Meson config lists `gnome-online-accounts` as a dependency. Downstream apps which use Meson (like `shotwell`) refuse to build without `gnome-online-accounts` in the build env.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
