### PR TITLE
desktop-file-utils: 0.23 -> 0.24

### DIFF
--- a/pkgs/tools/misc/desktop-file-utils/default.nix
+++ b/pkgs/tools/misc/desktop-file-utils/default.nix
@@ -1,22 +1,15 @@
-{ stdenv, fetchurl, fetchpatch, pkgconfig, glib, libintl }:
+{ stdenv, fetchurl, pkgconfig, glib, libintl }:
 
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  name = "desktop-file-utils-0.23";
+  pname = "desktop-file-utils";
+  version = "0.24";
 
   src = fetchurl {
-    url = "https://www.freedesktop.org/software/desktop-file-utils/releases/${name}.tar.xz";
-    sha256 = "119kj2w0rrxkhg4f9cf5waa55jz1hj8933vh47vcjipcplql02bc";
+    url = "https://www.freedesktop.org/software/${pname}/releases/${pname}-${version}.tar.xz";
+    sha256 = "1nc3bwjdrpcrkbdmzvhckq0yngbcxspwj2n1r7jr3gmx1jk5vpm1";
   };
-
-  patches = [
-    # Makes font a recognized media type. Committed upstream, but no release has been made.
-    (fetchpatch {
-      url = "https://gitlab.freedesktop.org/xdg/desktop-file-utils/commit/92af4108750ceaf4191fd54e255885c7d8a78b70.patch";
-      sha256 = "14sqy10p5skp6hv4hgiwnj9hpr460250x42k5z0390l6nr6gahsq";
-    })
-  ];
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ glib libintl ];


### PR DESCRIPTION
###### Motivation for this change

https://hpjansson.org/blag/2019/07/26/desktop-file-utils-0-24-released/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---