### PR TITLE
Revert "qtbase: Fix paths returned by qmake -query"

### DIFF
--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -171,7 +171,7 @@ stdenv.mkDerivation {
     NIX_OUTPUT_BIN = $bin
     NIX_OUTPUT_DEV = $dev
     NIX_OUTPUT_OUT = $out
-    NIX_OUTPUT_DOC = $out/$qtDocPrefix
+    NIX_OUTPUT_DOC = $dev/$qtDocPrefix
     NIX_OUTPUT_QML = $bin/$qtQmlPrefix
     NIX_OUTPUT_PLUGIN = $bin/$qtPluginPrefix
     EOF
@@ -385,18 +385,6 @@ stdenv.mkDerivation {
     + ''
       moveQtDevTools
       moveToOutput bin "$dev"
-    ''
-
-    # Fix paths returned by qmake -query
-    + ''
-      cat > $dev/bin/qt.conf <<EOF
-        [Paths]
-        Prefix = $out
-        Headers = $dev/include
-        Plugins = $bin/$qtPluginPrefix
-        Documentation = $out/$qtDocPrefix
-        HostBinaries = $dev/bin
-      EOF
     ''
 
     + (


### PR DESCRIPTION
Reverts NixOS/nixpkgs#57097 to fix the `qt-full` build.

`qmake` is not expected to work correctly outside of the Nix builder or a `qt5.env`.