### PR TITLE
go-chromecast: init at 0.0.11

### DIFF
--- a/pkgs/applications/video/go-chromecast/default.nix
+++ b/pkgs/applications/video/go-chromecast/default.nix
@@ -1,0 +1,21 @@
+{ buildGoModule, fetchFromGitHub, lib }:
+
+buildGoModule rec {
+  pname = "go-chromecast";
+  version = "0.0.11";
+
+  src = fetchFromGitHub {
+    owner = "vishen";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    sha256 = "1p8yilg8iv66g2752ygvy0hzs46d6f92rn7jb7wxz9j216yz4gvj";
+  };
+  modSha256 = "01zmhrkgdfkf0ssd7mydf6lhqipwcqbm9bim5sayhms4bzbljaic";
+
+  meta = with lib; {
+    homepage = https://github.com/vishen/go-chromecast;
+    description = "cli for Google Chromecast, Home devices and Cast Groups";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18030,6 +18030,8 @@ in
 
   gr-osmosdr = callPackage ../applications/radio/gnuradio/osmosdr.nix { };
 
+  go-chromecast = callPackage ../applications/video/go-chromecast { };
+
   goldendict = libsForQt5.callPackage ../applications/misc/goldendict { };
 
   gomuks = callPackage ../applications/networking/instant-messengers/gomuks { };


### PR DESCRIPTION
###### Motivation for this change

Slightly finnicky re:formats and detecting my device,
but seems actively maintained and AFAIK aren't many
options otherwise.  Terminal UI is a nice touch ^_^.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---