### PR TITLE
ccextractor: init at 0.88

### DIFF
--- a/pkgs/applications/video/ccextractor/default.nix
+++ b/pkgs/applications/video/ccextractor/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, pkgconfig, cmake
+, glew, glfw3, leptonica, libiconv, tesseract3, zlib }:
+
+with stdenv.lib;
+stdenv.mkDerivation rec {
+  pname = "ccextractor";
+  version = "0.88";
+
+  src = fetchFromGitHub {
+    owner = "CCExtractor";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1sya45hvv4d46bk7541yimmafgvgyhkpsvwfz9kv6pm4yi1lz6nb";
+  };
+
+  sourceRoot = "source/src";
+
+  nativeBuildInputs = [ pkgconfig cmake ];
+
+  buildInputs = [ glew glfw3 leptonica tesseract3 zlib ] ++ stdenv.lib.optional (!stdenv.isLinux) libiconv;
+
+  meta = {
+    homepage = "https://www.ccextractor.org";
+    description = "Tool that produces subtitles from closed caption data in videos";
+    longDescription = ''
+      A tool that analyzes video files and produces independent subtitle files from
+      closed captions data. CCExtractor is portable, small, and very fast.
+      It works on Linux, Windows, and OSX.
+    '';
+    platforms = platforms.unix;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ titanous ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -736,6 +736,8 @@ in
 
   container-linux-config-transpiler = callPackage ../development/tools/container-linux-config-transpiler { };
 
+  ccextractor = callPackage ../applications/video/ccextractor { };
+
   cconv = callPackage ../tools/text/cconv { };
 
   go-check = callPackage ../development/tools/check { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

ccextractor is used by MakeMKV to extract closed captions from DVDs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
