### PR TITLE
cool-retro-term: Wrap with wrapQtApps

### DIFF
--- a/pkgs/applications/misc/cool-retro-term/default.nix
+++ b/pkgs/applications/misc/cool-retro-term/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchFromGitHub, qtbase, qtquick1, qmltermwidget
+{ stdenv, fetchFromGitHub, mkDerivation, qtbase, qtquick1, qmltermwidget
 , qtquickcontrols, qtgraphicaleffects, qmake }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   version = "1.1.1";
   name = "cool-retro-term-${version}";
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

On my 19.03 machine, a fresh build from nixos-unstable wouldn't start, with this wrapped, it starts.

 #65399