### PR TITLE
Python: introduce NIX_PYTHONEXECUTABLE in order to set sys.executable

### DIFF
--- a/pkgs/development/interpreters/python/sitecustomize.py
+++ b/pkgs/development/interpreters/python/sitecustomize.py
@@ -8,11 +8,19 @@ The paths listed in `PYTHONPATH` are added to `sys.path` afterwards, but they
 will be added before the entries we add here and thus take precedence.
 
 Note the `NIX_PYTHONPATH` environment variable is unset in order to prevent leakage.
+
+Similarly, this module listens to the environment variable `NIX_PYTHONEXECUTABLE`
+and sets `sys.executable` to its value.
 """
 import site
+import sys
 import os
 import functools
 
 paths = os.environ.pop('NIX_PYTHONPATH', None)
 if paths:
     functools.reduce(lambda k, p: site.addsitedir(p, k), paths.split(':'), site._init_pathinfo())
+
+executable = os.environ.pop('NIX_PYTHONEXECUTABLE', None)
+if 'PYTHONEXECUTABLE' not in os.environ and executable:
+    sys.executable = executable

--- a/pkgs/development/interpreters/python/wrapper.nix
+++ b/pkgs/development/interpreters/python/wrapper.nix
@@ -14,6 +14,7 @@ let
   env = let
     paths = requiredPythonModules (extraLibs ++ [ python ] ) ;
     pythonPath = "${placeholder "out"}/${python.sitePackages}";
+    pythonExecutable = "${placeholder "out"}/bin/${python.executable}";
   in buildEnv {
     name = "${python.name}-env";
 
@@ -36,7 +37,7 @@ let
             if [ -f "$prg" ]; then
               rm -f "$out/bin/$prg"
               if [ -x "$prg" ]; then
-                makeWrapper "$path/bin/$prg" "$out/bin/$prg" --set NIX_PYTHONPATH ${pythonPath} ${if permitUserSite then "" else ''--set PYTHONNOUSERSITE "true"''} ${stdenv.lib.concatStringsSep " " makeWrapperArgs}
+                makeWrapper "$path/bin/$prg" "$out/bin/$prg" --set NIX_PYTHONEXECUTABLE ${pythonExecutable} --set NIX_PYTHONPATH ${pythonPath} ${if permitUserSite then "" else ''--set PYTHONNOUSERSITE "true"''} ${stdenv.lib.concatStringsSep " " makeWrapperArgs}
               fi
             fi
           done


### PR DESCRIPTION
This is needed in case of `python.buildEnv` to make sure sys.executable
does not point to the unwrapped executable.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fixes issues mentioned in https://github.com/NixOS/nixpkgs/commit/ec7f569211091282410050e89e68832d4fe60528

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
