### PR TITLE
dragon-drop: git-2014-08-14 -> 1.1.0

### DIFF
--- a/pkgs/tools/X11/dragon-drop/default.nix
+++ b/pkgs/tools/X11/dragon-drop/default.nix
@@ -1,15 +1,14 @@
-
 { stdenv, gtk, pkgconfig, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
   name = "dragon-drop-${version}";
-  version = "git-2014-08-14";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "mwh";
     repo = "dragon";
-    rev = "a49d775dd9d43bd22cee4c1fd3e32ede0dc2e9c2";
-    sha256 = "03vdbmqlbmk3j2ay1wy6snrm2y27faxz7qv81vyzjzngj345095a";
+    rev = "v${version}";
+    sha256 = "0iwlrcqvbjshpwvg0gsqdqcjv48q1ary59pm74zzjnr8v9470smr";
   };
 
   nativeBuildInputs = [ pkgconfig ];
@@ -23,7 +22,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Simple drag-and-drop source/sink for X";
     homepage = https://github.com/mwh/dragon;
-    maintainers = with maintainers; [ jb55 ];
+    maintainers = with maintainers; [ jb55 markus1189 ];
     license = licenses.gpl3;
     platforms = with platforms; unix;
   };


### PR DESCRIPTION
###### Motivation for this change
Update `dragon-drop` to `1.1.0`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
