### PR TITLE
redo-apenwarr: update to release 0.42 and added docs and checks

### DIFF
--- a/pkgs/development/tools/build-managers/redo-apenwarr/beautifulsoup.nix
+++ b/pkgs/development/tools/build-managers/redo-apenwarr/beautifulsoup.nix
@@ -1,0 +1,20 @@
+{ pythonPackages, isPy3k, pkgs }:
+
+pythonPackages.buildPythonPackage rec {
+  name = "beautifulsoup-3.2.1";
+  disabled = isPy3k;
+
+  src = pkgs.fetchurl {
+    url = "http://www.crummy.com/software/BeautifulSoup/download/3.x/BeautifulSoup-3.2.1.tar.gz";
+    sha256 = "1nshbcpdn0jpcj51x0spzjp519pkmqz0n0748j7dgpz70zlqbfpm";
+  };
+
+  # error: invalid command 'test'
+  doCheck = false;
+
+  meta = {
+    homepage = http://www.crummy.com/software/BeautifulSoup/;
+    license = "bsd";
+    description = "Undemanding HTML/XML parser";
+  };
+}

--- a/pkgs/development/tools/build-managers/redo-apenwarr/default.nix
+++ b/pkgs/development/tools/build-managers/redo-apenwarr/default.nix
@@ -1,30 +1,80 @@
-{stdenv, fetchFromGitHub, python2, which}:
-stdenv.mkDerivation {
-  pname = "redo-apenwarr";
+{ stdenv, lib, python27, fetchFromGitHub, mkdocs, which, findutils, coreutils
+, perl
+, doCheck ? true
+}: let
 
-  version = "unstable-2019-06-21";
+  # copy from 
+  # pkgs/applications/networking/pyload/beautifulsoup.nix
+  beautifulsoup = python27.pkgs.callPackage ./beautifulsoup.nix {
+    pythonPackages = python27.pkgs;
+  };
+
+  mkdocs-exclude = python27.pkgs.callPackage ./mkdocs-exclude.nix {
+    pythonPackages = python27.pkgs;
+  };
+in stdenv.mkDerivation rec {
+
+  pname = "redo-apenwarr";
+  version = "0.42";
 
   src = fetchFromGitHub {
     owner = "apenwarr";
-    repo = "redo";
-    rev = "8924fa35fa7363b531f8e6b48a1328d2407ad5cf";
-    sha256 = "1dj20w29najqjyvk0jh5kqbcd10k32rad986q5mzv4v49qcwdc1q";
+    repo = pname;
+    rev = "${pname}-${version}";
+    sha256 = "1060yb7hrxm8c7bfvb0y4j0acpxsj6hbykw1d9549zpkxxr9nsgm";
   };
 
-  DESTDIR="";
-  PREFIX = placeholder "out";
+  postPatch = ''
 
-  patchPhase = ''
-    patchShebangs .
+    patchShebangs minimal/do
+
+  '' + lib.optionalString doCheck ''
+    unset CC CXX
+
+    substituteInPlace minimal/do.test \
+      --replace "/bin/pwd" "${coreutils}/bin/pwd"
+
+    substituteInPlace t/105-sympath/all.do \
+      --replace "/bin/pwd" "${coreutils}/bin/pwd"
+
+    substituteInPlace t/all.do \
+      --replace "/bin/ls" "ls"
+
+    substituteInPlace t/110-compile/hello.o.do \
+      --replace "/usr/include" "${stdenv.cc.libc.dev}/include"
+
+    substituteInPlace t/200-shell/nonshelltest.do \
+      --replace "/usr/bin/env perl" "${perl}/bin/perl"
+
   '';
 
-  buildInputs = [ python2 which ];
+  inherit doCheck;
 
-  meta = with stdenv.lib; {
-    description = "Apenwarr version of the redo build tool.";
-    homepage = https://github.com/apenwarr/redo/;
-    license = stdenv.lib.licenses.asl20;
-    platforms = platforms.all;
-    maintainers = with stdenv.lib.maintainers; [ andrewchambers ];
+  checkTarget = "test";
+
+  outputs = [ "out" "man" ];
+
+  installFlags = [
+    "PREFIX=$(out)"
+    "DESTDIR=/"
+  ];
+
+  nativeBuildInputs = [
+    python27
+    beautifulsoup
+    mkdocs
+    mkdocs-exclude
+    which
+    findutils
+  ];
+
+  meta = with lib; {
+    description = "Smaller, easier, more powerful, and more reliable than make. An implementation of djb's redo.";
+    homepage = https://github.com/apenwarr/redo;
+    maintainers = with maintainers; [
+      andrewchambers
+      ck3d
+    ];
+    license = licenses.asl20;
   };
 }

--- a/pkgs/development/tools/build-managers/redo-apenwarr/mkdocs-exclude.nix
+++ b/pkgs/development/tools/build-managers/redo-apenwarr/mkdocs-exclude.nix
@@ -1,0 +1,20 @@
+{ pythonPackages, isPy3k, pkgs }:
+
+pythonPackages.buildPythonPackage rec {
+  name = "mkdocs-exclude";
+  disabled = isPy3k;
+
+  src = pkgs.fetchFromGitHub {
+    owner = "apenwarr";
+    repo = "mkdocs-exclude";
+    rev = "fdd67d2685ff706de126e99daeaaaf3f6f7cf3ae";
+    sha256 = "1phhl79xf4xq8w2sb2w5zm4bahcr33gsbxkz7dl1dws4qhcbxrfd";
+  };
+
+  buildInputs = with pkgs; [
+    mkdocs
+  ];
+
+  # error: invalid command 'test'
+  doCheck = false;
+}


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
