### PR TITLE
vdr: fix shebang of svdrpsend

### DIFF
--- a/pkgs/applications/video/vdr/default.nix
+++ b/pkgs/applications/video/vdr/default.nix
@@ -16,7 +16,7 @@
 
   postPatch = "substituteInPlace Makefile --replace libsystemd-daemon libsystemd";
 
-  buildInputs = [ fontconfig libjpeg libcap freetype ]
+  buildInputs = [ fontconfig libjpeg libcap freetype perl ]
   ++ lib.optional enableSystemd systemd
   ++ lib.optional enableBidi fribidi;
 


### PR DESCRIPTION
###### Motivation for this change
svdrpsend shebang was wrong

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
