### PR TITLE
postgis: allow on Darwin

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/postgis.nix
+++ b/pkgs/servers/sql/postgresql/ext/postgis.nix
@@ -70,6 +70,6 @@ stdenv.mkDerivation rec {
     homepage = https://postgis.net/;
     license = licenses.gpl2;
     maintainers = [ maintainers.marcweber ];
-    platforms = platforms.all;
+    inherit (postgresql.meta) platforms;
   };
 }

--- a/pkgs/servers/sql/postgresql/ext/postgis.nix
+++ b/pkgs/servers/sql/postgresql/ext/postgis.nix
@@ -10,6 +10,7 @@
 , pkgconfig
 , file
 , protobufc
+, libiconv
 }:
 stdenv.mkDerivation rec {
   name = "postgis-${version}";
@@ -22,7 +23,7 @@ stdenv.mkDerivation rec {
     sha256 = "0pnva72f2w4jcgnl1y7nw5rdly4ipx3hji4c9yc9s0hna1n2ijxn";
   };
 
-  buildInputs = [ libxml2 postgresql geos proj gdal json_c protobufc ];
+  buildInputs = [ libxml2 postgresql geos proj gdal json_c protobufc libiconv ];
   nativeBuildInputs = [ perl pkgconfig ];
   dontDisableStatic = true;
 
@@ -43,14 +44,13 @@ stdenv.mkDerivation rec {
     sed -i "s|\$(DESTDIR)\$(PGSQL_BINDIR)|$prefix/bin|g
             " \
         "raster/scripts/python/Makefile";
-  '';
-
-  preInstall = ''
     mkdir -p $out/bin
+    ln -s ${postgresql}/bin/postgres $out/bin/postgres
   '';
 
   # create aliases for all commands adding version information
   postInstall = ''
+    rm $out/bin/postgres
     for prog in $out/bin/*; do # */
       ln -s $prog $prog-${version}
     done
@@ -64,6 +64,6 @@ stdenv.mkDerivation rec {
     homepage = https://postgis.net/;
     license = licenses.gpl2;
     maintainers = [ maintainers.marcweber ];
-    platforms = platforms.linux;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/servers/sql/postgresql/ext/postgis.nix
+++ b/pkgs/servers/sql/postgresql/ext/postgis.nix
@@ -46,12 +46,17 @@ stdenv.mkDerivation rec {
             " \
         "raster/scripts/python/Makefile";
     mkdir -p $out/bin
+
+    # postgis' build system assumes it is being installed to the same place as postgresql, and looks
+    # for the postgres binary relative to $PREFIX. We gently support this system using an illusion.
     ln -s ${postgresql}/bin/postgres $out/bin/postgres
   '';
 
   # create aliases for all commands adding version information
   postInstall = ''
+    # Teardown the illusory postgres used for building; see postConfigure.
     rm $out/bin/postgres
+
     for prog in $out/bin/*; do # */
       ln -s $prog $prog-${version}
     done

--- a/pkgs/servers/sql/postgresql/ext/postgis.nix
+++ b/pkgs/servers/sql/postgresql/ext/postgis.nix
@@ -23,7 +23,8 @@ stdenv.mkDerivation rec {
     sha256 = "0pnva72f2w4jcgnl1y7nw5rdly4ipx3hji4c9yc9s0hna1n2ijxn";
   };
 
-  buildInputs = [ libxml2 postgresql geos proj gdal json_c protobufc libiconv ];
+  buildInputs = [ libxml2 postgresql geos proj gdal json_c protobufc ]
+                ++ stdenv.lib.optional stdenv.isDarwin libiconv;
   nativeBuildInputs = [ perl pkgconfig ];
   dontDisableStatic = true;
 


### PR DESCRIPTION
Resolves #65452.

To get PostGIS going on Darwin:
1. Add libiconv, as is often required.
2. Expand platforms to `platforms.all`.
3. Deal with PostGIS' quirky build system.

PostGIS' configure.ac has the following gem:

```
  AC_MSG_RESULT([------------------------------------------------------------------------])
  AC_MSG_RESULT([  WARNING: You have set the --prefix to '$prefix'. But we mostly    ])
  AC_MSG_RESULT([  ignore the --prefix. For your info, using the values determined from ])
  AC_MSG_RESULT([  $PG_CONFIG we will be installing:   ])
  AC_MSG_RESULT([    * postgis shared library in $PGSQL_LIBDIR ])
  AC_MSG_RESULT([    * postgis SQL files in $PGSQL_SHAREDIR/contrib/postgis-$POSTGIS_MAJOR_VERSION.$POSTGIS_MINOR_VERSION ])
  AC_MSG_RESULT([    * postgis executables in $PGSQL_BINDIR ])
  AC_MSG_RESULT([------------------------------------------------------------------------])
```

This is suggestive of some assumptions in the build system which are
revealed when building in Nix on Darwin: the build fails because the
postgres binary cannot be found in the install prefix specified for
postgis; viz.

```
  cc x -bundle_loader $POSTGIS_PREFIX/bin/postgres
```

The bundle_loader parameter is only available on Darwin `ld`, and this
problem doesn't appear to affect Linux systems.

The solution presented here is to symlink the postgres binary where
PostGIS expects it to be, and then remove it after the build completes.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
