### PR TITLE
idrisPackages.sdl2: 2018-01-19 -> 0.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5001,6 +5001,15 @@
     github = "sternenseemann";
     name = "Lukas Epple";
   };
+  steshaw = {
+    name = "Steven Shaw";
+    email = "steven@steshaw.org";
+    github = "steshaw";
+    keys = [{
+      longkeyid = "rsa4096/0x1D9A17DFD23DCB91";
+      fingerprint = "0AFE 77F7 474D 1596 EE55  7A29 1D9A 17DF D23D CB91";
+    }];
+  };
   stesie = {
     email = "stesie@brokenpipe.de";
     github = "stesie";

--- a/pkgs/development/idris-modules/sdl2.nix
+++ b/pkgs/development/idris-modules/sdl2.nix
@@ -6,26 +6,33 @@
 , SDL2
 , SDL2_gfx
 }:
-build-idris-package  {
+build-idris-package rec {
   name = "sdl2";
-  version = "2018-01-19";
+  version = "0.1.1";
 
   idrisDeps = [ effects ];
 
-  extraBuildInputs = [ pkgconfig SDL2 SDL2_gfx ];
+  extraBuildInputs = [
+    pkgconfig
+    SDL2
+    SDL2_gfx
+  ];
+
+  prePatch = "patchShebangs .";
 
   src = fetchFromGitHub {
     owner = "steshaw";
     repo = "idris-sdl2";
-    rev = "ebc36a0efb3e8086f2999120e7a8a8ac4952c6f6";
-    sha256 = "060k0i1pjilrc4pcz7v70hbipaw2crz14yxjlyjlhn6qm03131q0";
+    rev = version;
+    sha256 = sha256:1jslnlzyw04dcvcd7xsdjqa7waxzkm5znddv76sv291jc94xhl4a;
   };
 
   meta = {
     description = "SDL2 binding for Idris";
     homepage = https://github.com/steshaw/idris-sdl2;
-    maintainers = [ lib.maintainers.brainrape ];
-    # Can't find file sdl2.o
-    broken = true;
+    maintainers = with lib.maintainers; [
+      brainrape
+      steshaw
+    ];
   };
 }


### PR DESCRIPTION
Update to the latest release which unbreaks the package.

I'm happy to help maintain this package as I wrote the upstream package.

The previous version was broken but the current closure size is:

```sh-session
$ nix path-info -S -f . idrisPackages.sdl2
/nix/store/qwb0d8qh5mxfgrspjp0knlahfpkpy0kd-idris-sdl2-0.1.1        7096224
```

###### Motivation for this change

The package was set to `broken = true`. This change unbreaks it.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @brainrape 