### PR TITLE
[security] [19.03-backport] matrix-synapse: 0.99.5.2 -> 1.2.1

### DIFF
--- a/pkgs/development/python-modules/service_identity/default.nix
+++ b/pkgs/development/python-modules/service_identity/default.nix
@@ -10,6 +10,8 @@
 , pytest
 }:
 
+# Note to maintainers: package duplicated in nixpkgs/pkgs/servers/matrix-synapse/default.nix
+
 buildPythonPackage rec {
   pname = "service_identity";
   version = "17.0.0";

--- a/pkgs/servers/matrix-synapse/default.nix
+++ b/pkgs/servers/matrix-synapse/default.nix
@@ -1,8 +1,20 @@
-{ lib, stdenv, python3
+{ lib, stdenv, fetchFromGitHub, python3, openssl
 , enableSystemd ? stdenv.isLinux
 }:
 
-with python3.pkgs;
+with python3.pkgs.override {
+  overrides = self: super: {
+    service-identity = super.service-identity.overrideAttrs (oldAttrs: rec {
+      version = "18.1.0";
+      src = fetchFromGitHub {
+        owner = "pyca";
+        repo = "service_identity";
+        rev = version;
+        sha256 = "1aw475ksmd4vpl8cwfdcsw2v063nbhnnxpy633sb75iqp9aazhlx";
+      };
+    });
+  };
+};
 
 let
   matrix-synapse-ldap3 = buildPythonPackage rec {
@@ -23,11 +35,11 @@ let
 
 in buildPythonApplication rec {
   pname = "matrix-synapse";
-  version = "0.99.5.2";
+  version = "1.2.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0c1kf9zq7cg9scwnvph4vwk449gypbprmdjzrzrg0wp1rcc8h3gn";
+    sha256 = "0pr17n52vdq490q6c282nqnn51j5k0lf7mzaazpxjy4q86pxdfy5";
   };
 
   patches = [
@@ -72,7 +84,7 @@ in buildPythonApplication rec {
     unpaddedbase64
   ] ++ lib.optional enableSystemd systemd;
 
-  checkInputs = [ mock parameterized ];
+  checkInputs = [ mock parameterized openssl ];
 
   checkPhase = ''
     PYTHONPATH=".:$PYTHONPATH" ${python3.interpreter} -m twisted.trial tests

--- a/pkgs/servers/matrix-synapse/homeserver-script.patch
+++ b/pkgs/servers/matrix-synapse/homeserver-script.patch
@@ -1,21 +1,23 @@
 diff --git a/homeserver b/homeserver
 new file mode 120000
-index 0000000..2f1d413
+index 000000000..2f1d41351
 --- /dev/null
 +++ b/homeserver
-@@ -0,0 +1,1 @@
+@@ -0,0 +1 @@
 +synapse/app/homeserver.py
 \ No newline at end of file
 diff --git a/setup.py b/setup.py
-index b00c2af..c7f6e0a 100755
+index 5ce06c898..f1ccd95bc 100755
 --- a/setup.py
 +++ b/setup.py
-@@ -92,6 +92,6 @@ setup(
-     include_package_data=True,
-     zip_safe=False,
-     long_description=long_description,
+@@ -115,6 +115,6 @@ setup(
+         "Programming Language :: Python :: 3.6",
+         "Programming Language :: Python :: 3.7",
+     ],
 -    scripts=["synctl"] + glob.glob("scripts/*"),
 +    scripts=["synctl", "homeserver"] + glob.glob("scripts/*"),
-     cmdclass={'test': TestCommand},
+     cmdclass={"test": TestCommand},
  )
+-- 
+2.22.0
 


### PR DESCRIPTION
###### Motivation for this change

__Security update__: see https://github.com/matrix-org/synapse/releases/tag/v1.2.1

Package builds, unit tests and NixOS test are passing.

Backport of https://github.com/NixOS/nixpkgs/pull/65463.


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC package maintainers: @ralith @roblabla @ekleog