### PR TITLE
cnijfilter: add 3.80

### DIFF
--- a/pkgs/misc/cups/drivers/cnijfilter_3_80/default.nix
+++ b/pkgs/misc/cups/drivers/cnijfilter_3_80/default.nix
@@ -1,0 +1,157 @@
+{ stdenv, lib, fetchpatch, fetchzip,
+  autoconf, automake, libtool, gtk2,
+  cups, popt, libtiff, libpng, pkg-config,
+  ghostscript, glib, libusb, libxml2 }:
+
+/* this derivation is basically just a transcription of the rpm .spec
+   file included in the tarball */
+
+let arch =
+      if stdenv.hostPlatform.system == "x86_64-linux" then "64"
+      else if stdenv.hostPlatform.system == "i686-linux" then "32"
+      else throw "Unsupported system ${stdenv.hostPlatform.system}";
+
+in stdenv.mkDerivation rec {
+  name = "cnijfilter-${version}";
+
+  /* important note about versions: cnijfilter packages seem to use
+     versions in a non-standard way.  the version indicates which
+     printers are supported in the package.  so this package should
+     not be "upgraded" in the usual way.
+
+     instead, if you want to include another version supporting your
+     printer, you should try to abstract out the common things (which
+     should be pretty much everything except the version and the 'pr'
+     and 'pr_id' values to loop over). */
+  version = "3.80";
+
+  src = fetchzip {
+    url = "http://gdlp01.c-wss.com/gds/3/0100004693/01/cnijfilter-source-3.80-1.tar.gz";
+    sha256 = "03v4yn346xn4hk498lzz8ykdbhd4l8qna909fmr0qrkypyhd4627";
+  };
+
+  nativeBuildInputs = [ autoconf automake libtool pkg-config ];
+  buildInputs = [ cups popt libtiff libpng gtk2
+                  ghostscript glib libusb libxml2 ];
+
+  # patches from https://github.com/tokiclover/bar-overlay/tree/master/net-print/cnijfilter
+  patches = [
+    (fetchpatch {
+      url = "https://gitlab.com/tokiclover/bar-overlay/-/raw/6ef05309c0890fd7620092d3ec7ffa1d068b13f9/net-print/cnijfilter/files/cnijfilter-3.80-1-cups-1.6.patch";
+      name = "cnijfilter-3.80-1-cups-1.6.patch";
+      sha256 = "0sv5ixxa72dhm86shfbaidiyxx3cm6a5wsi6nklpmjf5fz621gwy";
+    })
+    (fetchpatch {
+      url = "https://gitlab.com/tokiclover/bar-overlay/-/raw/6ef05309c0890fd7620092d3ec7ffa1d068b13f9/net-print/cnijfilter/files/cnijfilter-3.80-6-cups-1.6.patch";
+      name = "cnijfilter-3.80-6-cups-1.6.patch";
+      sha256 = "09l9zq6l0xnb2nbf9yrnkhhl218ja0kid8bqfjjqvqj5d9lb7pd4";
+    })
+    (fetchpatch {
+      url = "https://gitlab.com/tokiclover/bar-overlay/-/raw/6ef05309c0890fd7620092d3ec7ffa1d068b13f9/net-print/cnijfilter/files/cnijfilter-3.80-6-headers.patch";
+      name = "cnijfilter-3.80-6-headers.patch";
+      sha256 = "136f2gm44xz47cln8s4laks4dy5ql2dwqvv20mybl6jpcxflkkj5";
+    })
+    ./patches/abi_x86_32.patch
+    ./patches/ppd.patch
+    ./patches/libpng15.patch
+    ./patches/missing_paren.patch
+  ];
+
+  postPatch = ''
+    sed -i "s|/usr/lib/cups/backend|$out/lib/cups/backend|" backend/src/Makefile.am;
+    sed -i "s|/usr/lib/cups/backend|$out/lib/cups/backend|" backendnet/backend/Makefile.am;
+    sed -i "s|/usr|$out|" backend/src/cnij_backend_common.c;
+    sed -i "s|/usr/bin|${ghostscript}/bin|" pstocanonij/filter/pstocanonij.c;
+  '';
+
+  configurePhase = ''
+    cd libs
+    ./autogen.sh --prefix=$out
+
+    cd ../cngpij
+    ./autogen.sh --prefix=$out --enable-progpath=$out/bin
+
+    cd ../cngpijmnt
+    ./autogen.sh --prefix=$out --enable-progpath=$out/bin
+
+    cd ../pstocanonij
+    ./autogen.sh --prefix=$out --enable-progpath=$out/bin
+
+    cd ../backend
+    ./autogen.sh --prefix=$out --enable-progpath=$out/bin
+
+    cd ../backendnet
+    ./autogen.sh --prefix=$out --enable-libpath=$out/lib/bjlib --enable-progpath=$out/bin
+
+    cd ../lgmon
+    # no --prefix=$out because it builds a static library that the build system looks for in lgmon/src
+    ./autogen.sh
+
+    cd ../cngpijmon/cnijnpr
+    ./autogen.sh --prefix=$out --enable-libpath=$out/lib/bjlib
+
+    cd ../..;
+  '';
+
+  preBuild = ''
+    pushd lgmon
+    make
+    popd
+  '';
+
+  preInstall = ''
+    mkdir -p $out/bin $out/lib/cups/filter $out/share/cups/model;
+  '';
+
+  postInstall = ''
+    set -o xtrace
+    for pr in e510  ip7200  mg2200  mg3200  mg4200  mg5400  mg6300  mp230; do
+      cd ppd;
+      ./autogen.sh --prefix=$out --program-suffix=$pr
+      make clean;
+      make;
+      make install;
+
+      cd ../cnijfilter;
+      ./autogen.sh --prefix=$out --program-suffix=$pr --enable-libpath=$out/lib/cups/path/lib/bjlib --enable-binpath=$out/bin;
+      make clean;
+      make;
+      make install;
+
+      cd ..;
+    done;
+
+    install -c -s -m 755 com/libs_bin${arch}/libcnnet.so.* $out/lib;
+
+    mkdir -p $out/lib/bjlib;
+    for pr_id in 401 402 403 405 406 407 408; do
+      install -c -m 755 $pr_id/database/* $out/lib/bjlib;
+      install -c -s -m 755 $pr_id/libs_bin${arch}/*.so.* $out/lib;
+    done;
+
+    pushd $out/lib;
+    for so_file in *.so.*; do
+      ln -s $so_file ''${so_file/.so.*/}.so;
+      patchelf --set-rpath $out/lib $so_file;
+    done;
+    popd;
+  '';
+
+  /* the tarball includes some pre-built shared libraries.  we run
+     'patchelf --set-rpath' on them just a few lines above, so that
+     they can find each other.  but that's not quite enough.  some of
+     those libraries load each other in non-standard ways -- they
+     don't list each other in the DT_NEEDED section.  so, if the
+     standard 'patchelf --shrink-rpath' (from
+     pkgs/development/tools/misc/patchelf/setup-hook.sh) is run on
+     them, it undoes the --set-rpath.  this prevents that. */
+  dontPatchELF = true;
+
+  meta = with lib; {
+    description = "Canon InkJet printer drivers for the MP430 MG2200 E510 MG3200 MG4200 MG5400 MG6300 and IP7200 series.";
+    homepage = "https://www.canon-europe.com/support/consumer_products/products/printers/inkjet/pixma_ip_series/pixma_ip7250.html?type=drivers&driverdetailid=tcm:13-994531";
+    license = licenses.unfree;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ terlar ];
+  };
+}

--- a/pkgs/misc/cups/drivers/cnijfilter_3_80/patches/abi_x86_32.patch
+++ b/pkgs/misc/cups/drivers/cnijfilter_3_80/patches/abi_x86_32.patch
@@ -1,0 +1,75 @@
+--- a/backendnet/configure.in	2014-08-11 08:38:46.034984462 +0200
++++ b/backendnet/configure.in	2014-08-11 08:35:42.902985813 +0200
+@@ -19,7 +19,11 @@
+ AC_DEFINE_UNQUOTED(BJLIB_PATH, "$enable_libpath")
+ AC_SUBST(BJLIB_PATH)
+ 
+-ARC=`getconf LONG_BIT`
++case "$ABI" in
++    x86) ARC=32;;
++    amd64) ARC=64;;
++    *) ARC=`getconf LONG_BIT`;;
++esac
+ AC_SUBST(ARC)
+ 
+ # Checks for programs.
+--- a/cnijfilter/configure.in	2014-08-11 08:39:44.426984031 +0200
++++ b/cnijfilter/configure.in	2014-08-11 08:35:19.788985984 +0200
+@@ -43,7 +43,11 @@
+ esac
+ AC_SUBST(CNCL_LIB_ID)
+ 
+-ARC=`getconf LONG_BIT`
++case "$ABI" in
++    x86) ARC=32;;
++    amd64) ARC=64;;
++    *) ARC=`getconf LONG_BIT`;;
++esac
+ AC_SUBST(ARC)
+ 
+ AC_PROG_CC
+--- a/cngpijmon/cnijnpr/configure.in	2014-08-11 08:41:12.712983380 +0200
++++ b/cngpijmon/cnijnpr/configure.in	2014-08-11 08:40:44.354983589 +0200
+@@ -37,7 +37,11 @@
+ 
+ CFLAGS="-O2"
+ 
+-ARC=`getconf LONG_BIT`
++case "$ABI" in
++    x86) ARC=32;;
++    amd64) ARC=64;;
++    *) ARC=`getconf LONG_BIT`;;
++esac
+ AC_SUBST(ARC)
+ 
+ AC_OUTPUT(Makefile
+--- a/lgmon/configure.in	2014-08-11 08:41:56.070983060 +0200
++++ b/lgmon/configure.in	2014-08-11 08:34:47.338986223 +0200
+@@ -37,7 +37,11 @@
+ esac
+ AC_SUBST(CNCL_LIB_ID)
+ 
+-ARC=`getconf LONG_BIT`
++case "$ABI" in
++    x86) ARC=32;;
++    amd64) ARC=64;;
++    *) ARC=`getconf LONG_BIT`;;
++esac
+ AC_SUBST(ARC)
+ 
+ AC_PROG_CC
+--- a/maintenance/configure.in	2014-08-11 08:33:40.208986718 +0200
++++ b/maintenance/configure.in	2014-08-11 08:27:46.788989326 +0200
+@@ -97,7 +97,11 @@
+ XML2_CFLAGS=`xml2-config --cflags`
+ AC_SUBST(XML2_CFLAGS)
+ 
+-ARC=`getconf LONG_BIT`
++case "$ABI" in
++    x86) ARC=32;;
++    amd64) ARC=64;;
++    *) ARC=`getconf LONG_BIT`;;
++esac
+ AC_SUBST(ARC)
+ 
+ AC_OUTPUT([

--- a/pkgs/misc/cups/drivers/cnijfilter_3_80/patches/libpng15.patch
+++ b/pkgs/misc/cups/drivers/cnijfilter_3_80/patches/libpng15.patch
@@ -1,0 +1,31 @@
+--- a/cnijfilter/src/bjfimage.c
++++ b/cnijfilter/src/bjfimage.c
+@@ -1520,8 +1520,8 @@ static short png_image_init( LPBJF_IMAGEINFO lpbjfimage )
+ 	short			tmpformat;
+ 	short			retbyte = 0;
+ 	short			bpp = 3;
+-	long			width = 0;
+-	long			length = 0;
++	png_uint_32		width = 0;
++	png_uint_32		length = 0;
+ 	long			rstep = 0;
+ 	long			RasterLength = 0;
+ 	long			i;
+@@ -1574,7 +1574,7 @@ static short png_image_init( LPBJF_IMAGEINFO lpbjfimage )
+ 		goto onErr;
+ 	}
+ 
+-	if (setjmp (png_p->jmpbuf))
++	if (setjmp (png_jmpbuf(png_p))
+ 	{
+ 		png_destroy_read_struct(&png_p, &info_p, (png_infopp)NULL);
+ 		goto onErr;
+@@ -1585,7 +1585,7 @@ static short png_image_init( LPBJF_IMAGEINFO lpbjfimage )
+ 
+ 	png_read_info( png_p, info_p );
+ 
+-	png_get_IHDR( png_p, info_p, (unsigned long *)&width, (unsigned long *)&length, &bit_depth,
++	png_get_IHDR( png_p, info_p, &width, &length, &bit_depth,
+ 	              &color_type, &interlace_type, NULL, NULL);
+ 
+ 	/* not support Interlace */

--- a/pkgs/misc/cups/drivers/cnijfilter_3_80/patches/missing_paren.patch
+++ b/pkgs/misc/cups/drivers/cnijfilter_3_80/patches/missing_paren.patch
@@ -1,0 +1,20 @@
+--- a/cnijfilter/src/bjfimage.c	2019-07-27 21:25:05.901136465 +0200
++++ b/cnijfilter/src/bjfimage.c	2019-07-27 22:15:11.027228225 +0200
+@@ -38,6 +38,8 @@
+ */
+ 
+ #include <stdio.h>
++#include <string.h>
++#include <unistd.h>
+ #include <stdlib.h>
+ #include <png.h>
+ 
+@@ -1574,7 +1576,7 @@
+ 		goto onErr;
+ 	}
+ 
+-	if (setjmp (png_jmpbuf(png_p))
++	if (setjmp (png_jmpbuf(png_p)))
+ 	{
+ 		png_destroy_read_struct(&png_p, &info_p, (png_infopp)NULL);
+ 		goto onErr;

--- a/pkgs/misc/cups/drivers/cnijfilter_3_80/patches/ppd.patch
+++ b/pkgs/misc/cups/drivers/cnijfilter_3_80/patches/ppd.patch
@@ -1,0 +1,20 @@
+--- a/cngpijmon/src/bjcupsmon_cups.c	2012-06-01 14:45:32.054513422 +0200
++++ a/cngpijmon/src/bjcupsmon_cups.c	2012-06-01 14:46:28.921802482 +0200
+@@ -20,6 +20,7 @@
+ /*** Includes ***/
+ #include <cups/cups.h>
+ #include <cups/language.h>
++#include <cups/ppd.h>
+ #include <sys/types.h>
+ #include <unistd.h>
+ #include <pwd.h>
+--- a/backend/src/cnij_backend_common.c	2012-06-01 14:45:19.251673478 +0200
++++ a/backend/src/cnij_backend_common.c	2012-06-01 14:46:13.486995445 +0200
+@@ -38,6 +38,7 @@
+ // CUPS Header
+ #include <cups/cups.h>
+ #include <cups/ipp.h>
++#include <cups/ppd.h>
+ 
+ // Header file for CANON
+ #include "cnij_backend_common.h"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25197,6 +25197,10 @@ in
   # this driver ships with pre-compiled 32-bit binary libraries
   cnijfilter_2_80 = pkgsi686Linux.callPackage ../misc/cups/drivers/cnijfilter_2_80 { };
 
+  cnijfilter_3_80 = callPackage ../misc/cups/drivers/cnijfilter_3_80 {
+    libusb = libusb1;
+  };
+
   cnijfilter_4_00 = callPackage ../misc/cups/drivers/cnijfilter_4_00 {
     libusb = libusb1;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
I have a IP7200 printer and cannot get it working well with the gutenprint drivers (borderless and duplex printing). I would like to give the proprietary drivers a go. This adds support for the following printers: MP430 MG2200 E510 MG3200 MG4200 MG5400 MG6300 and IP7200 series

The versioning of the cnijfilter is not in the way where more and more support is added, so therefore I cannot use the later or earlier versions. As support for previous printers is removed.

###### Things done

This PR is not fully ready yet, as I got stuck during the build process. But I open this PR here early in hopes that someone might have an idea. It is based on the cnijfilter_4_00 but there seems to be no `bscc2sts` in the source, but it is part of the dependencies, so not sure how to get that working, currently this is where it complains.

[UPDATE]: Working and tried with the printer IP7250.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
