### PR TITLE
sequoia: init at 0.9.0

### DIFF
--- a/pkgs/tools/security/sequoia/default.nix
+++ b/pkgs/tools/security/sequoia/default.nix
@@ -1,0 +1,67 @@
+{ stdenv, fetchFromGitLab, lib
+, git, nettle, llvmPackages_8, cargo, rustc
+, rustPlatform, pkgconfig, glib
+, openssl, sqlite, capnproto
+, pythonSupport ? true, python37Packages ? null
+}:
+
+assert pythonSupport -> python37Packages != null;
+
+rustPlatform.buildRustPackage rec {
+  version = "0.9.0";
+  pname = "sequoia";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.com";
+    owner = "sequoia-pgp";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "13dzwdzz33dy2lgnznsv8wqnw2501f2ggrkfwpqy5x6d1kgms8rj";
+  };
+  cargoSha256 = "1zcnkpzcar3a2fk2rn3i3nb70b59ds9fpfa44f15r3aaxajsdhdi";
+
+  nativeBuildInputs = [
+    pkgconfig
+    cargo
+    rustc
+    git
+    llvmPackages_8.libclang
+    llvmPackages_8.clang
+  ]
+    ++ lib.optional pythonSupport python37Packages.cffi
+    ++ lib.optional pythonSupport python37Packages.pytest
+    ++ lib.optional pythonSupport python37Packages.pytestrunner
+    ++ lib.optional pythonSupport python37Packages.setuptools
+  ;
+  buildInputs = [
+    openssl
+    sqlite
+    nettle
+    capnproto
+  ]
+    ++ lib.optional pythonSupport python37Packages.python
+    ++ lib.optional pythonSupport python37Packages.cffi
+  ;
+  LIBCLANG_PATH = "${llvmPackages_8.libclang}/lib";
+
+  # Set the Epoch to 1980; otherwise the Python wheel/zip code 
+  # gets very angry SOURCE_DATE_EPOCH=315532800;
+  preConfigure = ''
+    find . -type f | while read file; do
+      touch -d @315532800 $file
+    done
+  '';
+  # Python bindings are enabled by default in the source distribution
+  installPhase = if pythonSupport then ''
+    make PREFIX=$out PYTHONPATH=$out/lib/python3.7/site-packages:$PYTHONPATH install
+  '' else ''
+    make PREFIX=$out PYTHON=disable install
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A Cool OpenPGP Library";
+    homepage = "https://sequoia-pgp.org/";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24356,6 +24356,8 @@ in
 
   sequelpro = callPackage ../applications/misc/sequelpro {};
 
+  sequoia = callPackage ../tools/security/sequoia { };
+
   sidequest = callPackage ../applications/misc/sidequest {};
 
   maphosts = callPackage ../tools/networking/maphosts {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4610,6 +4610,10 @@ in {
 
   seqdiag = callPackage ../development/python-modules/seqdiag { };
 
+  sequoia = toPythonModule (callPackage ../tools/security/sequoia {
+    pythonSupport = true;
+  });
+
   safe = callPackage ../development/python-modules/safe { };
 
   sampledata = callPackage ../development/python-modules/sampledata { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---