### PR TITLE
syncthingtray: init at 0.9.1

### DIFF
--- a/pkgs/applications/misc/syncthingtray/default.nix
+++ b/pkgs/applications/misc/syncthingtray/default.nix
@@ -1,11 +1,21 @@
-{ mkDerivation, stdenv, lib, fetchFromGitHub
-, qtbase, extra-cmake-modules, cpp-utilities, qtutilities
-, cmake, kio, plasma-framework, qttools
+{ mkDerivation
+, stdenv
+, lib
+, fetchFromGitHub
+, qtbase
+, extra-cmake-modules
+, cpp-utilities
+, qtutilities
+, cmake
+, kio
+, plasma-framework
+, qttools
 , webviewProvider ? null
 , jsProvider ? null
 , enableKioPluginSupport ? false
 , enablePlasmoidSupport  ? false
-, systemdSupport ? true }:
+, systemdSupport ? true
+}:
 
 mkDerivation rec {
   version = "0.9.1";

--- a/pkgs/applications/misc/syncthingtray/default.nix
+++ b/pkgs/applications/misc/syncthingtray/default.nix
@@ -13,7 +13,7 @@ mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "Martchus";
-    repo = pname;
+    repo = "syncthingtray";
     rev = "v${version}";
     sha256 = "0ijwpwlwwbfh9fdfbwz6dgi6hpmaav2jm56mzxm6as50iwnb59fx";
   };

--- a/pkgs/applications/misc/syncthingtray/default.nix
+++ b/pkgs/applications/misc/syncthingtray/default.nix
@@ -12,10 +12,10 @@
 , kio
 , plasma-framework
 , qttools
-, webviewSupport ? false
-, jsSupport ? false
-, kioPluginSupport ? false
-, plasmoidSupport  ? false
+, webviewSupport ? true
+, jsSupport ? true
+, kioPluginSupport ? true
+, plasmoidSupport  ? true
 , systemdSupport ? true
 }:
 

--- a/pkgs/applications/misc/syncthingtray/default.nix
+++ b/pkgs/applications/misc/syncthingtray/default.nix
@@ -33,6 +33,7 @@ mkDerivation rec {
   # This is kind of ugly, but it works and it'll probably be quicker than to
   # bother the author of this program as he's using arch Linux and he'll probably be surprised that we
   # modify the prefix of our packages and not using `make DESTDIR= install`.
+  # See https://github.com/Martchus/syncthingtray/issues/42
   preInstall = ''
     echo grepping for ${qtbase.out} as \$qtbase in install files inside the build directory
     grep -l -R ${qtbase.out}/lib/qt- | while read f; do

--- a/pkgs/applications/misc/syncthingtray/default.nix
+++ b/pkgs/applications/misc/syncthingtray/default.nix
@@ -19,8 +19,8 @@ mkDerivation rec {
   };
 
   buildInputs = [ qtbase cpp-utilities qtutilities webviewProvider jsProvider ] 
-    ++ lib.optional enableKioPluginSupport kio
-    ++ lib.optional enablePlasmoidSupport [ extra-cmake-modules plasma-framework ]
+    ++ lib.optionals enableKioPluginSupport [ kio ]
+    ++ lib.optionals enablePlasmoidSupport [ extra-cmake-modules plasma-framework ]
   ;
 
   nativeBuildInputs = [ cmake qttools ];

--- a/pkgs/applications/misc/syncthingtray/default.nix
+++ b/pkgs/applications/misc/syncthingtray/default.nix
@@ -14,8 +14,8 @@
 , qttools
 , webviewSupport ? false
 , jsSupport ? false
-, enableKioPluginSupport ? false
-, enablePlasmoidSupport  ? false
+, kioPluginSupport ? false
+, plasmoidSupport  ? false
 , systemdSupport ? true
 }:
 
@@ -33,8 +33,8 @@ mkDerivation rec {
   buildInputs = [ qtbase cpp-utilities qtutilities ]
     ++ lib.optionals webviewSupport [ qtwebengine ]
     ++ lib.optionals jsSupport [ qtdeclarative ]
-    ++ lib.optionals enableKioPluginSupport [ kio ]
-    ++ lib.optionals enablePlasmoidSupport [ extra-cmake-modules plasma-framework ]
+    ++ lib.optionals kioPluginSupport [ kio ]
+    ++ lib.optionals plasmoidSupport [ extra-cmake-modules plasma-framework ]
   ;
 
   nativeBuildInputs = [ cmake qttools ];
@@ -42,8 +42,8 @@ mkDerivation rec {
   cmakeFlags = [
     # See https://github.com/Martchus/syncthingtray/issues/42
     "-DQT_PLUGIN_DIR:STRING=${placeholder "out"}/lib/qt-5"
-  ] ++ lib.optionals (!enablePlasmoidSupport) ["-DNO_PLASMOID=ON"]
-    ++ lib.optionals (!enableKioPluginSupport) ["-DNO_FILE_ITEM_ACTION_PLUGIN=ON"]
+  ] ++ lib.optionals (!plasmoidSupport) ["-DNO_PLASMOID=ON"]
+    ++ lib.optionals (!kioPluginSupport) ["-DNO_FILE_ITEM_ACTION_PLUGIN=ON"]
     ++ lib.optionals systemdSupport ["-DSYSTEMD_SUPPORT=ON"]
   ;
 

--- a/pkgs/applications/misc/syncthingtray/default.nix
+++ b/pkgs/applications/misc/syncthingtray/default.nix
@@ -39,11 +39,12 @@ mkDerivation rec {
 
   nativeBuildInputs = [ cmake qttools ];
 
-  cmakeFlags = lib.optionals (!enablePlasmoidSupport) ["-DNO_PLASMOID=ON"]
+  cmakeFlags = [
+    # See https://github.com/Martchus/syncthingtray/issues/42
+    "-DQT_PLUGIN_DIR:STRING=${placeholder "out"}/lib/qt-5"
+  ] ++ lib.optionals (!enablePlasmoidSupport) ["-DNO_PLASMOID=ON"]
     ++ lib.optionals (!enableKioPluginSupport) ["-DNO_FILE_ITEM_ACTION_PLUGIN=ON"]
     ++ lib.optionals systemdSupport ["-DSYSTEMD_SUPPORT=ON"]
-    # See https://github.com/Martchus/syncthingtray/issues/42
-    ++ lib.optionals enablePlasmoidSupport ["-DQT_PLUGIN_DIR:STRING=${placeholder "out"}/lib/qt-5"]
   ;
 
   meta = with lib; {

--- a/pkgs/applications/misc/syncthingtray/default.nix
+++ b/pkgs/applications/misc/syncthingtray/default.nix
@@ -3,6 +3,8 @@
 , lib
 , fetchFromGitHub
 , qtbase
+, qtwebengine
+, qtdeclarative
 , extra-cmake-modules
 , cpp-utilities
 , qtutilities
@@ -10,8 +12,8 @@
 , kio
 , plasma-framework
 , qttools
-, webviewProvider ? null
-, jsProvider ? null
+, webviewSupport ? false
+, jsSupport ? false
 , enableKioPluginSupport ? false
 , enablePlasmoidSupport  ? false
 , systemdSupport ? true
@@ -28,7 +30,9 @@ mkDerivation rec {
     sha256 = "0ijwpwlwwbfh9fdfbwz6dgi6hpmaav2jm56mzxm6as50iwnb59fx";
   };
 
-  buildInputs = [ qtbase cpp-utilities qtutilities webviewProvider jsProvider ] 
+  buildInputs = [ qtbase cpp-utilities qtutilities ]
+    ++ lib.optionals webviewSupport [ qtwebengine ]
+    ++ lib.optionals jsSupport [ qtdeclarative ]
     ++ lib.optionals enableKioPluginSupport [ kio ]
     ++ lib.optionals enablePlasmoidSupport [ extra-cmake-modules plasma-framework ]
   ;

--- a/pkgs/applications/misc/syncthingtray/default.nix
+++ b/pkgs/applications/misc/syncthingtray/default.nix
@@ -42,18 +42,9 @@ mkDerivation rec {
   cmakeFlags = lib.optionals (!enablePlasmoidSupport) ["-DNO_PLASMOID=ON"]
     ++ lib.optionals (!enableKioPluginSupport) ["-DNO_FILE_ITEM_ACTION_PLUGIN=ON"]
     ++ lib.optionals systemdSupport ["-DSYSTEMD_SUPPORT=ON"]
+    # See https://github.com/Martchus/syncthingtray/issues/42
+    ++ lib.optionals enablePlasmoidSupport ["-DQT_PLUGIN_DIR:STRING=${placeholder "out"}/lib/qt-5"]
   ;
-  # Without this hook, `make install` fails since it tries to write to ${qtbase.out}/lib/qt-<version>/...
-  # This is kind of ugly, but it works and it'll probably be quicker than to
-  # bother the author of this program as he's using arch Linux and he'll probably be surprised that we
-  # modify the prefix of our packages and not using `make DESTDIR= install`.
-  # See https://github.com/Martchus/syncthingtray/issues/42
-  preInstall = ''
-    echo grepping for ${qtbase.out} as \$qtbase in install files inside the build directory
-    grep -l -R ${qtbase.out}/lib/qt- | while read f; do
-      substituteInPlace "$f" --replace ${qtbase.out} ${placeholder "out"}
-    done
-  '';
 
   meta = with lib; {
     homepage = "https://github.com/Martchus/syncthingtray";

--- a/pkgs/applications/misc/syncthingtray/default.nix
+++ b/pkgs/applications/misc/syncthingtray/default.nix
@@ -1,0 +1,50 @@
+{ mkDerivation, stdenv, lib, fetchFromGitHub
+, qtbase, extra-cmake-modules, cpp-utilities, qtutilities
+, cmake, kio, plasma-framework, qttools
+, webviewProvider ? null
+, jsProvider ? null
+, enableKioPluginSupport ? false
+, enablePlasmoidSupport  ? false
+, systemdSupport ? true }:
+
+mkDerivation rec {
+  version = "0.9.1";
+  pname = "syncthingtray";
+
+  src = fetchFromGitHub {
+    owner  = "Martchus";
+    repo   = pname;
+    rev    = "v${version}";
+    sha256 = "0ijwpwlwwbfh9fdfbwz6dgi6hpmaav2jm56mzxm6as50iwnb59fx";
+  };
+
+  buildInputs = [ qtbase cpp-utilities qtutilities webviewProvider jsProvider ] 
+    ++ lib.optional enableKioPluginSupport kio
+    ++ lib.optional enablePlasmoidSupport [ extra-cmake-modules plasma-framework ]
+  ;
+
+  nativeBuildInputs = [ cmake qttools ];
+
+  cmakeFlags = lib.optionals (enablePlasmoidSupport == false) ["-DNO_PLASMOID=ON"]
+    ++ lib.optionals (enableKioPluginSupport == false) ["-DNO_FILE_ITEM_ACTION_PLUGIN=ON"]
+    ++ lib.optionals systemdSupport ["-DSYSTEMD_SUPPORT=ON"]
+  ;
+  # Without this hook, `make install` fails since it tries to write to ${qtbase.out}/lib/qt-<version>/...
+  # This is kind of ugly, but it works and it'll probably be quicker than to
+  # bother the author of this program as he's using arch Linux and he'll probably be surprised that we
+  # modify the prefix of our packages and not using `make DESTDIR= install`.
+  preInstall = ''
+    echo grepping for ${qtbase.out} as \$qtbase in install files inside the build directory
+    grep -l -R ${qtbase.out}/lib/qt- | while read f; do
+      substituteInPlace $f --replace ${qtbase.out} $out
+    done || :
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/Martchus/syncthingtray";
+    description = "Tray application and Dolphin/Plasma integration for Syncthing";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ doronbehar ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/syncthingtray/default.nix
+++ b/pkgs/applications/misc/syncthingtray/default.nix
@@ -37,7 +37,7 @@ mkDerivation rec {
     echo grepping for ${qtbase.out} as \$qtbase in install files inside the build directory
     grep -l -R ${qtbase.out}/lib/qt- | while read f; do
       substituteInPlace "$f" --replace ${qtbase.out} ${placeholder "out"}
-    done || :
+    done
   '';
 
   meta = with lib; {

--- a/pkgs/applications/misc/syncthingtray/default.nix
+++ b/pkgs/applications/misc/syncthingtray/default.nix
@@ -12,9 +12,9 @@ mkDerivation rec {
   pname = "syncthingtray";
 
   src = fetchFromGitHub {
-    owner  = "Martchus";
-    repo   = pname;
-    rev    = "v${version}";
+    owner = "Martchus";
+    repo = pname;
+    rev = "v${version}";
     sha256 = "0ijwpwlwwbfh9fdfbwz6dgi6hpmaav2jm56mzxm6as50iwnb59fx";
   };
 

--- a/pkgs/applications/misc/syncthingtray/default.nix
+++ b/pkgs/applications/misc/syncthingtray/default.nix
@@ -25,8 +25,8 @@ mkDerivation rec {
 
   nativeBuildInputs = [ cmake qttools ];
 
-  cmakeFlags = lib.optionals (enablePlasmoidSupport == false) ["-DNO_PLASMOID=ON"]
-    ++ lib.optionals (enableKioPluginSupport == false) ["-DNO_FILE_ITEM_ACTION_PLUGIN=ON"]
+  cmakeFlags = lib.optionals (!enablePlasmoidSupport) ["-DNO_PLASMOID=ON"]
+    ++ lib.optionals (!enableKioPluginSupport) ["-DNO_FILE_ITEM_ACTION_PLUGIN=ON"]
     ++ lib.optionals systemdSupport ["-DSYSTEMD_SUPPORT=ON"]
   ;
   # Without this hook, `make install` fails since it tries to write to ${qtbase.out}/lib/qt-<version>/...

--- a/pkgs/applications/misc/syncthingtray/default.nix
+++ b/pkgs/applications/misc/syncthingtray/default.nix
@@ -36,7 +36,7 @@ mkDerivation rec {
   preInstall = ''
     echo grepping for ${qtbase.out} as \$qtbase in install files inside the build directory
     grep -l -R ${qtbase.out}/lib/qt- | while read f; do
-      substituteInPlace $f --replace ${qtbase.out} $out
+      substituteInPlace "$f" --replace ${qtbase.out} ${placeholder "out"}
     done || :
   '';
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20751,10 +20751,8 @@ in
 
   syncthingtray-minimal = libsForQt5.callPackage ../applications/misc/syncthingtray { };
   syncthingtray = libsForQt5.callPackage ../applications/misc/syncthingtray {
-    # Could be qt5.qtwebengine as well
-    webviewProvider = qt5.qtwebkit;
-    # Could be qt5.qtdeclarative as well
-    jsProvider = qt5.qtscript;
+    webviewSupport = true;
+    jsSupport = true;
     enableKioPluginSupport = true;
     enablePlasmoidSupport = true;
     systemdSupport = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20749,12 +20749,12 @@ in
 
   syncthing-tray = callPackage ../applications/misc/syncthing-tray { };
 
-  syncthingtray-minimal = libsForQt5.callPackage ../applications/misc/syncthingtray { };
-  syncthingtray = libsForQt5.callPackage ../applications/misc/syncthingtray {
-    webviewSupport = true;
-    jsSupport = true;
-    kioPluginSupport = true;
-    plasmoidSupport = true;
+  syncthingtray = libsForQt5.callPackage ../applications/misc/syncthingtray { };
+  syncthingtray-minumal = libsForQt5.callPackage ../applications/misc/syncthingtray {
+    webviewSupport = false;
+    jsSupport = false;
+    kioPluginSupport = false;
+    plasmoidSupport = false;
     systemdSupport = true;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20753,8 +20753,8 @@ in
   syncthingtray = libsForQt5.callPackage ../applications/misc/syncthingtray {
     webviewSupport = true;
     jsSupport = true;
-    enableKioPluginSupport = true;
-    enablePlasmoidSupport = true;
+    kioPluginSupport = true;
+    plasmoidSupport = true;
     systemdSupport = true;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20749,6 +20749,17 @@ in
 
   syncthing-tray = callPackage ../applications/misc/syncthing-tray { };
 
+  syncthingtray-minimal = libsForQt5.callPackage ../applications/misc/syncthingtray { };
+  syncthingtray = libsForQt5.callPackage ../applications/misc/syncthingtray {
+    # Could be qt5.qtwebengine as well
+    webviewProvider = qt5.qtwebkit;
+    # Could be qt5.qtdeclarative as well
+    jsProvider = qt5.qtscript;
+    enableKioPluginSupport = true;
+    enablePlasmoidSupport = true;
+    systemdSupport = true;
+  };
+
   synergy = callPackage ../applications/misc/synergy {
     stdenv = if stdenv.cc.isClang then llvmPackages_5.stdenv else stdenv;
     inherit (darwin.apple_sdk.frameworks) ApplicationServices Carbon Cocoa CoreServices ScreenSaver;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
