### PR TITLE
lxqt: use qt5's mkDerivation

### DIFF
--- a/pkgs/desktops/lxqt/compton-conf/default.nix
+++ b/pkgs/desktops/lxqt/compton-conf/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, qtbase, qttools, lxqt,
+{ lib, mkDerivation, fetchFromGitHub, cmake, pkgconfig, qtbase, qttools, lxqt,
   libconfig }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "compton-conf";
   version = "0.14.1";
 
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
       --replace "DESTINATION \"\''${LXQT_ETC_XDG_DIR}" "DESTINATION \"etc/xdg" \
     '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "GUI configuration tool for compton X composite manager";
     homepage = https://github.com/lxqt/compton-conf;
     license = licenses.lgpl21;

--- a/pkgs/desktops/lxqt/libfm-qt/default.nix
+++ b/pkgs/desktops/lxqt/libfm-qt/default.nix
@@ -1,10 +1,10 @@
 {
-  stdenv, fetchFromGitHub, cmake, pkgconfig, lxqt-build-tools,
+  lib, mkDerivation, fetchFromGitHub, cmake, pkgconfig, lxqt-build-tools,
   pcre, libexif, xorg, libfm, menu-cache,
   qtx11extras, qttools
 }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "libfm-qt";
   version = "0.14.1";
 
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     menu-cache
   ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Core library of PCManFM-Qt (Qt binding for libfm)";
     homepage = https://github.com/lxqt/libfm-qt;
     license = licenses.lgpl21;

--- a/pkgs/desktops/lxqt/liblxqt/default.nix
+++ b/pkgs/desktops/lxqt/liblxqt/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchFromGitHub, cmake, lxqt-build-tools, qtx11extras,
+{ lib, mkDerivation, fetchFromGitHub, cmake, lxqt-build-tools, qtx11extras,
   qttools, qtsvg, libqtxdg, polkit-qt, kwindowsystem, xorg }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "liblxqt";
   version = "0.14.1";
 
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
       --replace "\''${LXQT_TRANSLATIONS_DIR}" "''${out}/share/lxqt/translations"
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Core utility library for all LXQt components";
     homepage = https://github.com/lxqt/liblxqt;
     license = licenses.lgpl21Plus;

--- a/pkgs/desktops/lxqt/liblxqt/default.nix
+++ b/pkgs/desktops/lxqt/liblxqt/default.nix
@@ -27,15 +27,8 @@ mkDerivation rec {
     xorg.libXScrnSaver
   ];
 
-  cmakeFlags = [
-    "-DLXQT_ETC_XDG_DIR=/run/current-system/sw/etc/xdg"
-  ];
-
   postPatch = ''
-    sed -i 's|set(LXQT_SHARE_DIR .*)|set(LXQT_SHARE_DIR "/run/current-system/sw/share/lxqt")|' CMakeLists.txt
     sed -i "s|\''${POLKITQT-1_POLICY_FILES_INSTALL_DIR}|''${out}/share/polkit-1/actions|" CMakeLists.txt
-    substituteInPlace CMakeLists.txt \
-      --replace "\''${LXQT_TRANSLATIONS_DIR}" "''${out}/share/lxqt/translations"
   '';
 
   meta = with lib; {

--- a/pkgs/desktops/lxqt/libqtxdg/default.nix
+++ b/pkgs/desktops/lxqt/libqtxdg/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, cmake, qtbase, qtsvg, lxqt-build-tools }:
+{ lib, mkDerivation, fetchFromGitHub, cmake, qtbase, qtsvg, lxqt-build-tools }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "libqtxdg";
   version = "3.3.1";
 
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     )
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Qt implementation of freedesktop.org xdg specs";
     homepage = https://github.com/lxqt/libqtxdg;
     license = licenses.lgpl21;

--- a/pkgs/desktops/lxqt/libsysstat/default.nix
+++ b/pkgs/desktops/lxqt/libsysstat/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, cmake, qtbase, lxqt-build-tools }:
+{ lib, mkDerivation, fetchFromGitHub, cmake, qtbase, lxqt-build-tools }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "libsysstat";
   version = "0.4.2";
 
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ qtbase ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Library used to query system info and statistics";
     homepage = https://github.com/lxqt/libsysstat;
     license = licenses.lgpl21Plus;

--- a/pkgs/desktops/lxqt/lximage-qt/default.nix
+++ b/pkgs/desktops/lxqt/lximage-qt/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, qtbase, qttools,
+{ lib, mkDerivation, fetchFromGitHub, cmake, pkgconfig, qtbase, qttools,
   qtx11extras, qtsvg, xorg, lxqt-build-tools, libfm-qt, libexif }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "lximage-qt";
   version = "0.14.1";
 
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     libexif
   ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "The image viewer and screenshot tool for lxqt";
     homepage = https://github.com/lxqt/lximage-qt;
     license = licenses.gpl2;

--- a/pkgs/desktops/lxqt/lxqt-about/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-about/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, cmake, lxqt-build-tools, qtx11extras, qttools, qtsvg, kwindowsystem, liblxqt, libqtxdg }:
+{ lib, mkDerivation, fetchFromGitHub, cmake, lxqt-build-tools, qtx11extras, qttools, qtsvg, kwindowsystem, liblxqt, libqtxdg }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "lxqt-about";
   version = "0.14.1";
 
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
       --replace "\''${LXQT_TRANSLATIONS_DIR}" "''${out}/share/lxqt/translations"
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Dialogue window providing information about LXQt and the system it's running on";
     homepage = https://github.com/lxqt/lxqt-about;
     license = licenses.lgpl21;

--- a/pkgs/desktops/lxqt/lxqt-about/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-about/default.nix
@@ -25,11 +25,6 @@ mkDerivation rec {
     libqtxdg
   ];
 
-  postPatch = ''
-    substituteInPlace CMakeLists.txt \
-      --replace "\''${LXQT_TRANSLATIONS_DIR}" "''${out}/share/lxqt/translations"
-  '';
-
   meta = with lib; {
     description = "Dialogue window providing information about LXQt and the system it's running on";
     homepage = https://github.com/lxqt/lxqt-about;

--- a/pkgs/desktops/lxqt/lxqt-admin/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-admin/default.nix
@@ -29,11 +29,6 @@ mkDerivation rec {
   postPatch = ''
     sed "s|\''${POLKITQT-1_POLICY_FILES_INSTALL_DIR}|''${out}/share/polkit-1/actions|" \
       -i lxqt-admin-user/CMakeLists.txt
-
-    for f in lxqt-admin-{user,time}/CMakeLists.txt; do
-      substituteInPlace $f \
-        --replace "\''${LXQT_TRANSLATIONS_DIR}" "''${out}/share/lxqt/translations"
-    done
   '';
 
   meta = with lib; {

--- a/pkgs/desktops/lxqt/lxqt-admin/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-admin/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, cmake, lxqt-build-tools, qtx11extras, qttools, qtsvg, kwindowsystem, liblxqt, libqtxdg, polkit-qt }:
+{ lib, mkDerivation, fetchFromGitHub, cmake, lxqt-build-tools, qtx11extras, qttools, qtsvg, kwindowsystem, liblxqt, libqtxdg, polkit-qt }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "lxqt-admin";
   version = "0.14.1";
 
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "LXQt system administration tool";
     homepage = https://github.com/lxqt/lxqt-admin;
     license = licenses.lgpl21;

--- a/pkgs/desktops/lxqt/lxqt-archiver/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-archiver/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, lxqt-build-tools, json-glib, libfm-qt, qtbase, qttools, qtx11extras }:
+{ lib, mkDerivation, fetchFromGitHub, cmake, pkgconfig, lxqt-build-tools, json-glib, libfm-qt, qtbase, qttools, qtx11extras }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   name = "${pname}-${version}";
   pname = "lxqt-archiver";
   version = "0.0.96";
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Archive tool for the LXQt desktop environment";
     homepage = https://github.com/lxqt/lxqt-archiver/;
     license = licenses.gpl2;

--- a/pkgs/desktops/lxqt/lxqt-archiver/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-archiver/default.nix
@@ -1,7 +1,6 @@
 { lib, mkDerivation, fetchFromGitHub, cmake, pkgconfig, lxqt-build-tools, json-glib, libfm-qt, qtbase, qttools, qtx11extras }:
 
 mkDerivation rec {
-  name = "${pname}-${version}";
   pname = "lxqt-archiver";
   version = "0.0.96";
 

--- a/pkgs/desktops/lxqt/lxqt-build-tools/LXQtConfigVars.cmake
+++ b/pkgs/desktops/lxqt/lxqt-build-tools/LXQtConfigVars.cmake
@@ -1,0 +1,7 @@
+add_definitions("-DLXQT_RELATIVE_SHARE_DIR=\"${LXQT_RELATIVE_SHARE_DIR}\"")
+add_definitions("-DLXQT_SHARE_DIR=\"${LXQT_SHARE_DIR}\"")
+add_definitions("-DLXQT_RELATIVE_SHARE_TRANSLATIONS_DIR=\"${LXQT_RELATIVE_TRANSLATIONS_DIR}\"")
+add_definitions("-DLXQT_SHARE_TRANSLATIONS_DIR=\"${LXQT_TRANSLATIONS_DIR}\"")
+add_definitions("-DLXQT_GRAPHICS_DIR=\"${LXQT_GRAPHICS_DIR}\"")
+add_definitions("-DLXQT_ETC_XDG_DIR=\"${LXQT_ETC_XDG_DIR}\"")
+add_definitions("-DLXQT_DATA_DIR=\"${LXQT_DATA_DIR}\"")

--- a/pkgs/desktops/lxqt/lxqt-build-tools/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-build-tools/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, pcre, qtbase, glib }:
+{ lib, mkDerivation, fetchFromGitHub, cmake, pkgconfig, pcre, qtbase, glib }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "lxqt-build-tools";
   version = "0.6.0";
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''cmakeFlags+=" -DLXQT_ETC_XDG_DIR=$out/etc/xdg"'';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Various packaging tools and scripts for LXQt applications";
     homepage = https://github.com/lxqt/lxqt-build-tools;
     license = licenses.lgpl21;

--- a/pkgs/desktops/lxqt/lxqt-build-tools/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-build-tools/default.nix
@@ -11,11 +11,18 @@ mkDerivation rec {
     sha256 = "0i7m9s4g5rsw28vclc9nh0zcapx85cqfwxkx7rrw7wa12svy7pm2";
   };
 
-  nativeBuildInputs = [ cmake pkgconfig ];
+  nativeBuildInputs = [ cmake pkgconfig setupHook ];
 
   buildInputs = [ qtbase glib pcre ];
 
-  preConfigure = ''cmakeFlags+=" -DLXQT_ETC_XDG_DIR=$out/etc/xdg"'';
+  setupHook = ./setup-hook.sh;
+
+  # We're dependent on this macro doing add_definitions in most places
+  # But we have the setup-hook to set the values.
+  postInstall = ''
+    rm $out/share/cmake/lxqt-build-tools/modules/LXQtConfigVars.cmake
+    cp ${./LXQtConfigVars.cmake} $out/share/cmake/lxqt-build-tools/modules/LXQtConfigVars.cmake
+  '';
 
   meta = with lib; {
     description = "Various packaging tools and scripts for LXQt applications";

--- a/pkgs/desktops/lxqt/lxqt-build-tools/setup-hook.sh
+++ b/pkgs/desktops/lxqt/lxqt-build-tools/setup-hook.sh
@@ -1,0 +1,15 @@
+LXQtCMakePostHook() {
+  cmakeFlagsArray+=(
+    -DLXQT_LIBRARY_NAME=lxqt
+    -DLXQT_SHARE_DIR=$out/share/lxqt
+    -DLXQT_TRANSLATIONS_DIR=$out/share/lxqt/translations
+    -DLXQT_GRAPHICS_DIR=$out/share/lxqt/graphics
+    -DLXQT_ETC_XDG_DIR=$out/etc/xdg
+    -DLXQT_DATA_DIR=$out/share
+    -DLXQT_RELATIVE_SHARE_DIR=lxqt
+    -DLXQT_RELATIVE_SHARE_TRANSLATIONS_DIR=lxqt/translations
+  )
+
+}
+
+postHooks+=(LXQtCMakePostHook)

--- a/pkgs/desktops/lxqt/lxqt-config/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-config/default.nix
@@ -38,23 +38,6 @@ mkDerivation rec {
   ];
 
   postPatch = ''
-    substituteInPlace src/CMakeLists.txt \
-      --replace "DESTINATION \"\''${LXQT_ETC_XDG_DIR}" "DESTINATION \"etc/xdg"
-
-    for f in \
-      lxqt-config-file-associations/CMakeLists.txt \
-      lxqt-config-brightness/CMakeLists.txt \
-      lxqt-config-appearance/CMakeLists.txt \
-      lxqt-config-locale/CMakeLists.txt \
-      lxqt-config-monitor/CMakeLists.txt \
-      lxqt-config-input/CMakeLists.txt \
-      liblxqt-config-cursor/CMakeLists.txt \
-      src/CMakeLists.txt
-    do
-      substituteInPlace $f \
-        --replace "\''${LXQT_TRANSLATIONS_DIR}" "''${out}/share/lxqt/translations"
-    done
-
     sed -i "/\''${XORG_LIBINPUT_INCLUDE_DIRS}/a ${xorg.xf86inputlibinput.dev}/include/xorg" lxqt-config-input/CMakeLists.txt
   '';
 

--- a/pkgs/desktops/lxqt/lxqt-config/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-config/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, lxqt-build-tools, qtbase,
+{ lib, mkDerivation, fetchFromGitHub, cmake, pkgconfig, lxqt-build-tools, qtbase,
   qtx11extras, qttools, qtsvg, kwindowsystem, libkscreen, liblxqt,
   libqtxdg, xorg }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "lxqt-config";
   version = "0.14.1";
 
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
     sed -i "/\''${XORG_LIBINPUT_INCLUDE_DIRS}/a ${xorg.xf86inputlibinput.dev}/include/xorg" lxqt-config-input/CMakeLists.txt
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Tools to configure LXQt and the underlying operating system";
     homepage = https://github.com/lxqt/lxqt-config;
     license = licenses.lgpl21;

--- a/pkgs/desktops/lxqt/lxqt-globalkeys/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-globalkeys/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, cmake, lxqt-build-tools, qtbase, qttools, qtx11extras, qtsvg, kwindowsystem, liblxqt, libqtxdg }:
+{ lib, mkDerivation, fetchFromGitHub, cmake, lxqt-build-tools, qtbase, qttools, qtx11extras, qtsvg, kwindowsystem, liblxqt, libqtxdg }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "lxqt-globalkeys";
   version = "0.14.1";
 
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
       --replace "\''${LXQT_TRANSLATIONS_DIR}" "''${out}/share/lxqt/translations"
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Daemon used to register global keyboard shortcuts";
     homepage = https://github.com/lxqt/lxqt-globalkeys;
     license = licenses.lgpl21;

--- a/pkgs/desktops/lxqt/lxqt-globalkeys/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-globalkeys/default.nix
@@ -26,16 +26,6 @@ mkDerivation rec {
     libqtxdg
   ];
 
-  postPatch = ''
-    for dir in autostart xdg; do
-      substituteInPlace $dir/CMakeLists.txt \
-        --replace "DESTINATION \"\''${LXQT_ETC_XDG_DIR}" "DESTINATION \"etc/xdg"
-    done
-
-    substituteInPlace config/CMakeLists.txt \
-      --replace "\''${LXQT_TRANSLATIONS_DIR}" "''${out}/share/lxqt/translations"
-  '';
-
   meta = with lib; {
     description = "Daemon used to register global keyboard shortcuts";
     homepage = https://github.com/lxqt/lxqt-globalkeys;

--- a/pkgs/desktops/lxqt/lxqt-notificationd/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-notificationd/default.nix
@@ -16,16 +16,6 @@ mkDerivation rec {
     lxqt-build-tools
   ];
 
-  postPatch = ''
-    substituteInPlace autostart/CMakeLists.txt \
-      --replace "DESTINATION \"\''${LXQT_ETC_XDG_DIR}" "DESTINATION \"etc/xdg"
-
-    for f in {config,src}/CMakeLists.txt; do
-      substituteInPlace $f \
-        --replace "\''${LXQT_TRANSLATIONS_DIR}" "''${out}/share/lxqt/translations"
-    done
-  '';
-
   buildInputs = [
     qtbase
     qttools

--- a/pkgs/desktops/lxqt/lxqt-notificationd/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-notificationd/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, cmake, lxqt-build-tools, qtbase, qttools, qtsvg, kwindowsystem, liblxqt, libqtxdg, qtx11extras }:
+{ lib, mkDerivation, fetchFromGitHub, cmake, lxqt-build-tools, qtbase, qttools, qtsvg, kwindowsystem, liblxqt, libqtxdg, qtx11extras }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "lxqt-notificationd";
   version = "0.14.1";
 
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     qtx11extras
   ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "The LXQt notification daemon";
     homepage = https://github.com/lxqt/lxqt-notificationd;
     license = licenses.lgpl21;

--- a/pkgs/desktops/lxqt/lxqt-openssh-askpass/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-openssh-askpass/default.nix
@@ -26,11 +26,6 @@ mkDerivation rec {
     libqtxdg
   ];
 
-  postPatch = ''
-    substituteInPlace CMakeLists.txt \
-      --replace "\''${LXQT_TRANSLATIONS_DIR}" "''${out}/share/lxqt/translations"
-  '';
-
   meta = with lib; {
     description = "GUI to query passwords on behalf of SSH agents";
     homepage = https://github.com/lxqt/lxqt-openssh-askpass;

--- a/pkgs/desktops/lxqt/lxqt-openssh-askpass/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-openssh-askpass/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, cmake, lxqt-build-tools, qtbase, qttools, qtsvg, qtx11extras, kwindowsystem, liblxqt, libqtxdg }:
+{ lib, mkDerivation, fetchFromGitHub, cmake, lxqt-build-tools, qtbase, qttools, qtsvg, qtx11extras, kwindowsystem, liblxqt, libqtxdg }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "lxqt-openssh-askpass";
   version = "0.14.1";
 
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
       --replace "\''${LXQT_TRANSLATIONS_DIR}" "''${out}/share/lxqt/translations"
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "GUI to query passwords on behalf of SSH agents";
     homepage = https://github.com/lxqt/lxqt-openssh-askpass;
     license = licenses.lgpl21;

--- a/pkgs/desktops/lxqt/lxqt-panel/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-panel/default.nix
@@ -1,5 +1,5 @@
 {
-  stdenv, fetchFromGitHub,
+  lib, mkDerivation, fetchFromGitHub,
   cmake, pkgconfig, lxqt-build-tools,
   qtbase, qttools, qtx11extras, qtsvg, libdbusmenu, kwindowsystem, solid,
   kguiaddons, liblxqt, libqtxdg, lxqt-globalkeys, libsysstat,
@@ -7,7 +7,7 @@
   lxmenu-data, pcre, libXdamage
 }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "lxqt-panel";
   version = "0.14.1";
 
@@ -63,7 +63,7 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "The LXQt desktop panel";
     homepage = https://github.com/lxqt/lxqt-panel;
     license = licenses.lgpl21;

--- a/pkgs/desktops/lxqt/lxqt-panel/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-panel/default.nix
@@ -49,20 +49,6 @@ mkDerivation rec {
     libXdamage
   ];
 
-  postPatch = ''
-    for dir in  autostart menu; do
-      substituteInPlace $dir/CMakeLists.txt \
-        --replace "DESTINATION \"\''${LXQT_ETC_XDG_DIR}" "DESTINATION \"etc/xdg"
-    done
-    substituteInPlace panel/CMakeLists.txt \
-      --replace "DESTINATION \''${LXQT_ETC_XDG_DIR}" "DESTINATION etc/xdg"
-
-    for f in cmake/BuildPlugin.cmake panel/CMakeLists.txt; do
-      substituteInPlace $f \
-        --replace "\''${LXQT_TRANSLATIONS_DIR}" "''${out}/share/lxqt/translations"
-    done
-  '';
-
   meta = with lib; {
     description = "The LXQt desktop panel";
     homepage = https://github.com/lxqt/lxqt-panel;

--- a/pkgs/desktops/lxqt/lxqt-policykit/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-policykit/default.nix
@@ -1,10 +1,10 @@
 {
-  stdenv, fetchFromGitHub, cmake, pkgconfig, lxqt-build-tools,
+  lib, mkDerivation, fetchFromGitHub, cmake, pkgconfig, lxqt-build-tools,
   qtbase, qttools, qtx11extras, qtsvg, polkit-qt, kwindowsystem, liblxqt,
   libqtxdg, pcre
 }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "lxqt-policykit";
   version = "0.14.1";
 
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
       --replace "\''${LXQT_TRANSLATIONS_DIR}" "''${out}/share/lxqt/translations"
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "The LXQt PolicyKit agent";
     homepage = https://github.com/lxqt/lxqt-policykit;
     license = licenses.lgpl21;

--- a/pkgs/desktops/lxqt/lxqt-policykit/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-policykit/default.nix
@@ -33,14 +33,6 @@ mkDerivation rec {
     pcre
   ];
 
-  postPatch = ''
-    substituteInPlace autostart/CMakeLists.txt \
-      --replace "DESTINATION \"\''${LXQT_ETC_XDG_DIR}" "DESTINATION \"etc/xdg"
-
-    substituteInPlace CMakeLists.txt \
-      --replace "\''${LXQT_TRANSLATIONS_DIR}" "''${out}/share/lxqt/translations"
-  '';
-
   meta = with lib; {
     description = "The LXQt PolicyKit agent";
     homepage = https://github.com/lxqt/lxqt-policykit;

--- a/pkgs/desktops/lxqt/lxqt-powermanagement/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-powermanagement/default.nix
@@ -28,16 +28,6 @@ mkDerivation rec {
     libqtxdg
   ];
 
-  postPatch = ''
-    substituteInPlace autostart/CMakeLists.txt \
-      --replace "DESTINATION \"\''${LXQT_ETC_XDG_DIR}" "DESTINATION \"etc/xdg"
-
-    for f in {config,src}/CMakeLists.txt; do
-      substituteInPlace $f \
-        --replace "\''${LXQT_TRANSLATIONS_DIR}" "''${out}/share/lxqt/translations"
-    done
-  '';
-
   meta = with lib; {
     description = "Power management module for LXQt";
     homepage = https://github.com/lxqt/lxqt-powermanagement;

--- a/pkgs/desktops/lxqt/lxqt-powermanagement/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-powermanagement/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, cmake, lxqt-build-tools, qtbase, qttools, qtx11extras, qtsvg, kwindowsystem, solid, kidletime, liblxqt, libqtxdg }:
+{ lib, mkDerivation, fetchFromGitHub, cmake, lxqt-build-tools, qtbase, qttools, qtx11extras, qtsvg, kwindowsystem, solid, kidletime, liblxqt, libqtxdg }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "lxqt-powermanagement";
   version = "0.14.1";
 
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Power management module for LXQt";
     homepage = https://github.com/lxqt/lxqt-powermanagement;
     license = licenses.lgpl21;

--- a/pkgs/desktops/lxqt/lxqt-qtplugin/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-qtplugin/default.nix
@@ -1,10 +1,10 @@
 {
-  stdenv, fetchFromGitHub,
+  lib, mkDerivation, fetchFromGitHub,
   cmake, lxqt-build-tools,
   qtbase, qtx11extras, qttools, qtsvg, libdbusmenu, libqtxdg, libfm-qt
 }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "lxqt-qtplugin";
   version = "0.14.0";
 
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
       --replace "DESTINATION \"\''${QT_PLUGINS_DIR}" "DESTINATION \"$qtPluginPrefix"
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "LXQt Qt platform integration plugin";
     homepage = https://github.com/lxqt/lxqt-qtplugin;
     license = licenses.lgpl21;

--- a/pkgs/desktops/lxqt/lxqt-runner/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-runner/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, lxqt-build-tools, qtbase, qttools, qtsvg, kwindowsystem, liblxqt, libqtxdg, lxqt-globalkeys, qtx11extras,
+{ lib, mkDerivation, fetchFromGitHub, cmake, pkgconfig, lxqt-build-tools, qtbase, qttools, qtsvg, kwindowsystem, liblxqt, libqtxdg, lxqt-globalkeys, qtx11extras,
 menu-cache, muparser, pcre }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "lxqt-runner";
   version = "0.14.1";
 
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
       --replace "\''${LXQT_TRANSLATIONS_DIR}" "''${out}/share/lxqt/translations"
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Tool used to launch programs quickly by typing their names";
     homepage = https://github.com/lxqt/lxqt-runner;
     license = licenses.lgpl21;

--- a/pkgs/desktops/lxqt/lxqt-runner/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-runner/default.nix
@@ -32,14 +32,6 @@ mkDerivation rec {
     pcre
   ];
 
-  postPatch = ''
-    substituteInPlace autostart/CMakeLists.txt \
-      --replace "DESTINATION \"\''${LXQT_ETC_XDG_DIR}" "DESTINATION \"etc/xdg"
-
-    substituteInPlace CMakeLists.txt \
-      --replace "\''${LXQT_TRANSLATIONS_DIR}" "''${out}/share/lxqt/translations"
-  '';
-
   meta = with lib; {
     description = "Tool used to launch programs quickly by typing their names";
     homepage = https://github.com/lxqt/lxqt-runner;

--- a/pkgs/desktops/lxqt/lxqt-session/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-session/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, lxqt-build-tools, qtbase, qttools, qtsvg, qtx11extras, kwindowsystem, liblxqt, libqtxdg, xorg, xdg-user-dirs }:
+{ lib, mkDerivation, fetchFromGitHub, cmake, pkgconfig, lxqt-build-tools, qtbase, qttools, qtsvg, qtx11extras, kwindowsystem, liblxqt, libqtxdg, xorg, xdg-user-dirs }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "lxqt-session";
   version = "0.14.1";
 
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "An alternative session manager ported from the original razor-session";
     homepage = https://github.com/lxqt/lxqt-session;
     license = licenses.lgpl21;

--- a/pkgs/desktops/lxqt/lxqt-session/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-session/default.nix
@@ -30,18 +30,6 @@ mkDerivation rec {
     xdg-user-dirs
   ];
 
-  postPatch = ''
-    for dir in autostart config; do
-      substituteInPlace $dir/CMakeLists.txt \
-        --replace "DESTINATION \"\''${LXQT_ETC_XDG_DIR}" "DESTINATION \"etc/xdg"
-    done
-
-    for f in lxqt-{config-session,leave,session}/CMakeLists.txt; do
-      substituteInPlace $f \
-        --replace "\''${LXQT_TRANSLATIONS_DIR}" "''${out}/share/lxqt/translations"
-    done
-  '';
-
   meta = with lib; {
     description = "An alternative session manager ported from the original razor-session";
     homepage = https://github.com/lxqt/lxqt-session;

--- a/pkgs/desktops/lxqt/lxqt-sudo/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-sudo/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, cmake, lxqt-build-tools, qtbase, qttools, qtx11extras, qtsvg, kwindowsystem, liblxqt, libqtxdg, sudo }:
+{ lib, mkDerivation, fetchFromGitHub, cmake, lxqt-build-tools, qtbase, qttools, qtx11extras, qtsvg, kwindowsystem, liblxqt, libqtxdg, sudo }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "lxqt-sudo";
   version = "0.14.1";
 
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
       --replace "\''${LXQT_TRANSLATIONS_DIR}" "''${out}/share/lxqt/translations"
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "GUI frontend for sudo/su";
     homepage = https://github.com/lxqt/lxqt-sudo;
     license = licenses.lgpl21;

--- a/pkgs/desktops/lxqt/lxqt-sudo/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-sudo/default.nix
@@ -27,11 +27,6 @@ mkDerivation rec {
     sudo
   ];
 
-  postPatch = ''
-    substituteInPlace CMakeLists.txt \
-      --replace "\''${LXQT_TRANSLATIONS_DIR}" "''${out}/share/lxqt/translations"
-  '';
-
   meta = with lib; {
     description = "GUI frontend for sudo/su";
     homepage = https://github.com/lxqt/lxqt-sudo;

--- a/pkgs/desktops/lxqt/lxqt-themes/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-themes/default.nix
@@ -16,13 +16,6 @@ mkDerivation rec {
     lxqt-build-tools
   ];
 
-  postPatch = ''
-    substituteInPlace CMakeLists.txt \
-      --replace "DESTINATION \"\''${LXQT_GRAPHICS_DIR}" "DESTINATION \"share/lxqt/graphics"
-    substituteInPlace themes/CMakeLists.txt \
-      --replace "DESTINATION \"\''${LXQT_SHARE_DIR}" "DESTINATION \"share/lxqt"
-  '';
-
   meta = with lib; {
     description = "Themes, graphics and icons for LXQt";
     homepage = https://github.com/lxqt/lxqt-themes;

--- a/pkgs/desktops/lxqt/lxqt-themes/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-themes/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, cmake, lxqt-build-tools }:
+{ lib, mkDerivation, fetchFromGitHub, cmake, lxqt-build-tools }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "lxqt-themes";
   version = "0.14.0";
 
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
       --replace "DESTINATION \"\''${LXQT_SHARE_DIR}" "DESTINATION \"share/lxqt"
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Themes, graphics and icons for LXQt";
     homepage = https://github.com/lxqt/lxqt-themes;
     license = licenses.lgpl21;

--- a/pkgs/desktops/lxqt/obconf-qt/default.nix
+++ b/pkgs/desktops/lxqt/obconf-qt/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, pcre, qtbase, qttools,
+{ lib, mkDerivation, fetchFromGitHub, cmake, pkgconfig, pcre, qtbase, qttools,
   qtx11extras, xorg, lxqt-build-tools, openbox, hicolor-icon-theme }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "obconf-qt";
   version = "0.14.1";
 
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     hicolor-icon-theme
   ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "The Qt port of obconf, the Openbox configuration tool";
     homepage = https://github.com/lxqt/obconf-qt;
     license = licenses.gpl2;

--- a/pkgs/desktops/lxqt/pavucontrol-qt/default.nix
+++ b/pkgs/desktops/lxqt/pavucontrol-qt/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, lxqt, libpulseaudio,
+{ lib, mkDerivation, fetchFromGitHub, cmake, pkgconfig, lxqt, libpulseaudio,
   pcre, qtbase, qttools, qtx11extras }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "pavucontrol-qt";
   version = "0.14.1";
 
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     pcre
   ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A Pulseaudio mixer in Qt (port of pavucontrol)";
     homepage = https://github.com/lxqt/pavucontrol-qt;
     license = licenses.gpl2;

--- a/pkgs/desktops/lxqt/pcmanfm-qt/default.nix
+++ b/pkgs/desktops/lxqt/pcmanfm-qt/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, lxqt, qtbase, qttools,
+{ lib, mkDerivation, fetchFromGitHub, cmake, pkgconfig, lxqt, qtbase, qttools,
   qtx11extras, libfm-qt, menu-cache, lxmenu-data }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "pcmanfm-qt";
   version = "0.14.1";
 
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "File manager and desktop icon manager (Qt port of PCManFM and libfm)";
     homepage = https://github.com/lxqt/pcmanfm-qt;
     license = licenses.gpl2;

--- a/pkgs/desktops/lxqt/pcmanfm-qt/default.nix
+++ b/pkgs/desktops/lxqt/pcmanfm-qt/default.nix
@@ -28,13 +28,6 @@ mkDerivation rec {
     lxmenu-data
   ];
 
-  postPatch = ''
-    for dir in autostart config; do
-      substituteInPlace $dir/CMakeLists.txt \
-        --replace "DESTINATION \"\''${LXQT_ETC_XDG_DIR}" "DESTINATION \"etc/xdg"
-    done
-  '';
-
   meta = with lib; {
     description = "File manager and desktop icon manager (Qt port of PCManFM and libfm)";
     homepage = https://github.com/lxqt/pcmanfm-qt;

--- a/pkgs/desktops/lxqt/qlipper/default.nix
+++ b/pkgs/desktops/lxqt/qlipper/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, cmake, qtbase, qttools }:
+{ lib, mkDerivation, fetchFromGitHub, cmake, qtbase, qttools }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   name = "${pname}-${version}";
   pname = "qlipper";
   version = "5.1.1";
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ qtbase qttools ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Cross-platform clipboard history applet";
     homepage = https://github.com/pvanek/qlipper;
     license = licenses.gpl2Plus;

--- a/pkgs/desktops/lxqt/qps/default.nix
+++ b/pkgs/desktops/lxqt/qps/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchFromGitHub, cmake, qtbase, qtx11extras, qttools,
+{ lib, mkDerivation, fetchFromGitHub, cmake, qtbase, qtx11extras, qttools,
   lxqt-build-tools }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "qps";
   version = "1.10.20";
 
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ qtbase qtx11extras qttools ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "The Qt process manager";
     homepage = https://github.com/lxqt/qps;
     license = licenses.gpl2;

--- a/pkgs/desktops/lxqt/qterminal/default.nix
+++ b/pkgs/desktops/lxqt/qterminal/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchFromGitHub, cmake, lxqt-build-tools, qtermwidget,
+{ lib, mkDerivation, fetchFromGitHub, cmake, lxqt-build-tools, qtermwidget,
   qtbase, qttools, qtx11extras }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "qterminal";
   version = "0.14.1";
 
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     qtermwidget
   ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A lightweight Qt-based terminal emulator";
     homepage = https://github.com/lxqt/qterminal;
     license = licenses.gpl2;

--- a/pkgs/desktops/lxqt/qtermwidget/default.nix
+++ b/pkgs/desktops/lxqt/qtermwidget/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, cmake, qtbase, qttools, lxqt-build-tools }:
+{ lib, mkDerivation, fetchFromGitHub, cmake, qtbase, qttools, lxqt-build-tools }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "qtermwidget";
   version = "0.14.1";
 
@@ -13,9 +13,9 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake lxqt-build-tools ];
 
-  buildInputs = [ qtbase qttools];
+  buildInputs = [ qtbase qttools ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A terminal emulator widget for Qt 5";
     homepage = https://github.com/lxqt/qtermwidget;
     license = licenses.gpl2;

--- a/pkgs/desktops/lxqt/screengrab/default.nix
+++ b/pkgs/desktops/lxqt/screengrab/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, qtbase, qttools, qtx11extras, qtsvg, kwindowsystem, libqtxdg, xorg, autoPatchelfHook }:
+{ lib, mkDerivation, fetchFromGitHub, cmake, pkgconfig, qtbase, qttools, qtx11extras, qtsvg, kwindowsystem, libqtxdg, xorg, autoPatchelfHook }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "screengrab";
   version = "1.101";
 
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     xorg.libXdmcp
   ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Crossplatform tool for fast making screenshots";
     homepage = https://github.com/lxqt/screengrab;
     license = licenses.gpl2;


### PR DESCRIPTION
#### Motivation for this change
Wrap lxqt applications https://github.com/NixOS/nixpkgs/issues/65399 https://github.com/NixOS/nixpkgs/issues/65399#issuecomment-515706258

LXQT now starts in a vm for me, however there seems to be something up with the
theme and or icons.

#### Appearance before wrapQtAppsHook
![Screenshot from 2019-07-27 17 30 32](https://user-images.githubusercontent.com/28888242/61999877-eed58900-b098-11e9-9290-2fbc0e1f4a68.png)

#### Appearance after wrapQtAppsHook
![Screenshot from 2019-07-27 17 32 12](https://user-images.githubusercontent.com/28888242/61999878-f301a680-b098-11e9-9d6f-9ee0648abd23.png)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
