### PR TITLE
llvm8 bare metal fixes

### DIFF
--- a/pkgs/development/compilers/llvm/8/clang/compiler-rt-baremetal.patch
+++ b/pkgs/development/compilers/llvm/8/clang/compiler-rt-baremetal.patch
@@ -1,0 +1,53 @@
+Index: lib/Driver/ToolChains/BareMetal.cpp
+===================================================================
+--- a/lib/Driver/ToolChains/BareMetal.cpp
++++ b/lib/Driver/ToolChains/BareMetal.cpp
+@@ -157,7 +157,7 @@
+ void BareMetal::AddLinkRuntimeLib(const ArgList &Args,
+                                   ArgStringList &CmdArgs) const {
+   CmdArgs.push_back(Args.MakeArgString("-lclang_rt.builtins-" +
+-                                       getTriple().getArchName() + ".a"));
++                                       getTriple().getArchName()));
+ }
+ 
+ void baremetal::Linker::ConstructJob(Compilation &C, const JobAction &JA,
+Index: test/Driver/baremetal.cpp
+===================================================================
+--- a/test/Driver/baremetal.cpp
++++ b/test/Driver/baremetal.cpp
+@@ -13,7 +13,7 @@
+ // CHECK-V6M-C-NEXT: "{{[^"]*}}ld{{(\.(lld|bfd|gold))?}}{{(\.exe)?}}" "{{.*}}.o" "-Bstatic"
+ // CHECK-V6M-C-SAME: "-L[[RESOURCE_DIR:[^"]+]]{{[/\\]+}}lib{{[/\\]+}}baremetal"
+ // CHECK-V6M-C-SAME: "-T" "semihosted.lds" "-Lsome{{[/\\]+}}directory{{[/\\]+}}user{{[/\\]+}}asked{{[/\\]+}}for"
+-// CHECK-V6M-C-SAME: "-lc" "-lm" "-lclang_rt.builtins-armv6m.a"
++// CHECK-V6M-C-SAME: "-lc" "-lm" "-lclang_rt.builtins-armv6m"
+ // CHECK-V6M-C-SAME: "-o" "{{.*}}.o"
+ 
+ // RUN: %clang -no-canonical-prefixes %s -### -o %t.o 2>&1 \
+@@ -35,7 +35,7 @@
+ // CHECK-V6M-DEFAULTCXX: "{{[^"]*}}ld{{(\.(lld|bfd|gold))?}}{{(\.exe)?}}" "{{.*}}.o" "-Bstatic"
+ // CHECK-V6M-DEFAULTCXX-SAME: "-L{{[^"]*}}{{[/\\]+}}lib{{(64)?}}{{[/\\]+}}clang{{[/\\]+}}{{.*}}{{[/\\]+}}lib{{[/\\]+}}baremetal"
+ // CHECK-V6M-DEFAULTCXX-SAME: "-lc++" "-lc++abi" "-lunwind"
+-// CHECK-V6M-DEFAULTCXX-SAME: "-lc" "-lm" "-lclang_rt.builtins-armv6m.a"
++// CHECK-V6M-DEFAULTCXX-SAME: "-lc" "-lm" "-lclang_rt.builtins-armv6m"
+ // CHECK-V6M-DEFAULTCXX-SAME: "-o" "{{.*}}.o"
+ 
+ // RUN: %clangxx -no-canonical-prefixes %s -### -o %t.o 2>&1 \
+@@ -48,7 +48,7 @@
+ // CHECK-V6M-LIBCXX: "{{[^"]*}}ld{{(\.(lld|bfd|gold))?}}{{(\.exe)?}}" "{{.*}}.o" "-Bstatic"
+ // CHECK-V6M-LIBCXX-SAME: "-L{{[^"]*}}{{[/\\]+}}lib{{(64)?}}{{[/\\]+}}clang{{[/\\]+}}{{.*}}{{[/\\]+}}lib{{[/\\]+}}baremetal"
+ // CHECK-V6M-LIBCXX-SAME: "-lc++" "-lc++abi" "-lunwind"
+-// CHECK-V6M-LIBCXX-SAME: "-lc" "-lm" "-lclang_rt.builtins-armv6m.a"
++// CHECK-V6M-LIBCXX-SAME: "-lc" "-lm" "-lclang_rt.builtins-armv6m"
+ // CHECK-V6M-LIBCXX-SAME: "-o" "{{.*}}.o"
+ 
+ // RUN: %clangxx -no-canonical-prefixes %s -### -o %t.o 2>&1 \
+@@ -61,7 +61,7 @@
+ // CHECK-V6M-LIBSTDCXX: "{{[^"]*}}ld{{(\.(lld|bfd|gold))?}}{{(\.exe)?}}" "{{.*}}.o" "-Bstatic"
+ // CHECK-V6M-LIBSTDCXX-SAME: "-L{{[^"]*}}{{[/\\]+}}lib{{(64)?}}{{[/\\]+}}clang{{[/\\]+}}{{.*}}{{[/\\]+}}lib{{[/\\]+}}baremetal"
+ // CHECK-V6M-LIBSTDCXX-SAME: "-lstdc++" "-lsupc++" "-lunwind"
+-// CHECK-V6M-LIBSTDCXX-SAME: "-lc" "-lm" "-lclang_rt.builtins-armv6m.a"
++// CHECK-V6M-LIBSTDCXX-SAME: "-lc" "-lm" "-lclang_rt.builtins-armv6m"
+ // CHECK-V6M-LIBSTDCXX-SAME: "-o" "{{.*}}.o"
+ 
+ // RUN: %clangxx -no-canonical-prefixes %s -### -o %t.o 2>&1 \

--- a/pkgs/development/compilers/llvm/8/clang/default.nix
+++ b/pkgs/development/compilers/llvm/8/clang/default.nix
@@ -47,6 +47,8 @@ let
       # Backport for the `--unwindlib=[libgcc|compiler-rt]` flag, which is
       # needed for our bootstrapping to not interfere with C.
       ./unwindlib.patch
+      # https://reviews.llvm.org/D51899
+      ./compiler-rt-baremetal.patch
     ];
 
     postPatch = ''

--- a/pkgs/development/compilers/llvm/8/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/8/compiler-rt.nix
@@ -27,6 +27,9 @@ stdenv.mkDerivation rec {
     "-DCOMPILER_RT_BUILD_XRAY=OFF"
     "-DCOMPILER_RT_BUILD_LIBFUZZER=OFF"
     "-DCOMPILER_RT_BUILD_PROFILE=OFF"
+  ] ++ stdenv.lib.optionals (stdenv.hostPlatform.parsed.kernel.name == "none") [
+    "-DCOMPILER_RT_BAREMETAL_BUILD=ON"
+    "-DCOMPILER_RT_OS_DIR=baremetal"
   ];
 
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
###### Motivation for this change

The compiler-rt flags are [as described in llvm docs](https://llvm.org/docs/HowToCrossCompileBuiltinsOnArm.html#building-compiler-rt-builtins-for-arm), and the clang patch is required to allow linking with it to succeed (it [otherwise tries to pass `-lclang_rt.builtins-ARCH.a` to the linker](https://reviews.llvm.org/D51899) which is just, wrong).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
