### PR TITLE
bukubrow: 2.4.0 -> 5.0.0

### DIFF
--- a/pkgs/tools/networking/bukubrow/default.nix
+++ b/pkgs/tools/networking/bukubrow/default.nix
@@ -1,34 +1,46 @@
-{ stdenv, rustPlatform, fetchFromGitHub, sqlite }:
+{ stdenv, rustPlatform, fetchFromGitHub, sqlite }: let
 
-rustPlatform.buildRustPackage rec {
-  pname = "bukubrow";
-  version = "2.4.0";
+manifest = {
+  description = "Bukubrow extension host application";
+  name = "com.samhh.bukubrow";
+  path = "@out@/bin/bukubrow";
+  type = "stdio";
+};
+
+in rustPlatform.buildRustPackage rec {
+  pname = "bukubrow-host";
+  version = "5.0.0";
 
   src = fetchFromGitHub {
     owner = "SamHH";
-    repo = "bukubrow";
-    rev = version;
-    sha256 = "1wrwav7am73bmgbpwh1pi0b8k7vhydqvw91hmmhnvbjhrhbns7s5";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1a3gqxj6d1shv3w0v9m8x2xr0bvcynchy778yqalxkc3x4vr0nbn";
   };
-  sourceRoot = "source/binary";
 
-  cargoSha256 = "0553awiba24a3a8xwjhlwf8yzbs44lnirjvcxnvsgah7dc44r0gj";
+  cargoSha256 = "06nh99cvg3y4f98fs0j5bkidzq6fg46wk47z5jfzz5lf72ha54lk";
 
   buildInputs = [ sqlite ];
 
+  passAsFile = [ "firefoxManifest" "chromeManifest" ];
+  firefoxManifest = builtins.toJSON (manifest // {
+    allowed_extensions = [ "bukubrow@samhh.com" ];
+  });
+  chromeManifest = builtins.toJSON (manifest // {
+    allowed_origins = [ "chrome-extension://ghniladkapjacfajiooekgkfopkjblpn/" ];
+  });
+  postBuild = ''
+    substituteAll $firefoxManifestPath firefox.json
+    substituteAll $chromeManifestPath chrome.json
+  '';
   postInstall = ''
-    mkdir -p $out/etc $out/lib/mozilla/native-messaging-hosts
-
-    host_file="$out/bin/bukubrow"
-    sed -e "s!%%replace%%!$host_file!" browser-hosts/firefox.json > "$out/etc/firefox-host.json"
-    sed -e "s!%%replace%%!$host_file!" browser-hosts/chrome.json > "$out/etc/chrome-host.json"
-
-    ln -s $out/etc/firefox-host.json $out/lib/mozilla/native-messaging-hosts/com.samhh.bukubrow.json
+    install -Dm0644 firefox.json $out/lib/mozilla/native-messaging-hosts/com.samhh.bukubrow.json
+    install -Dm0644 chrome.json $out/etc/chromium/native-messaging-hosts/com.samhh.bukubrow.json
   '';
 
   meta = with stdenv.lib; {
     description = "Bukubrow is a WebExtension for Buku, a command-line bookmark manager";
-    homepage = https://github.com/SamHH/bukubrow;
+    homepage = https://github.com/SamHH/bukubrow-host;
     license = licenses.gpl3;
     platforms = platforms.all;
     maintainers = with maintainers; [ infinisil ];


### PR DESCRIPTION
##### Motivation for this change

Seems like this hasn't been touched in a while? Unfortunately it [tries to be smart](https://github.com/SamHH/bukubrow-host/blob/v5.0.0/src/hosts/installer.rs) and generates the [json](https://github.com/SamHH/bukubrow-host/blob/v5.0.0/src/hosts/targets/firefox.rs) on-demand and [guesses where it should go](https://github.com/SamHH/bukubrow-host/blob/v5.0.0/src/hosts/paths.rs) and I'm not even going to begin to try using that in the build so I've just included the files themselves. Could use `toJSON` instead if anyone wants it to be fancy I guess?

Not entirely sure about the chromium path, chrome docs say to use /etc/chromium but I've only tested with firefox.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
