### PR TITLE
castget: init at 1_2_4

### DIFF
--- a/pkgs/applications/networking/feedreaders/castget/default.nix
+++ b/pkgs/applications/networking/feedreaders/castget/default.nix
@@ -37,6 +37,7 @@ stdenv.mkDerivation rec {
       primarily intended for automatic, unattended downloading of podcasts.
     '';
     homepage = "http://castget.johndal.com/";
+    maintainers = with maintainers; [ doronbehar ];
     license = licenses.gpl2;
     platforms = platforms.linux;
   };

--- a/pkgs/applications/networking/feedreaders/castget/default.nix
+++ b/pkgs/applications/networking/feedreaders/castget/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     sha256 = "1pfrjmsikv35cc0praxgim26zq4r7dfp1pkn6n9fz3fm73gxylyv";
   };
   # Otherwise, the autoreconfHook fails since Makefile.am requires it
-  prePatch = ''
+  preAutoreconf = ''
     touch NEWS
     touch README
     touch ChangeLog

--- a/pkgs/applications/networking/feedreaders/castget/default.nix
+++ b/pkgs/applications/networking/feedreaders/castget/default.nix
@@ -10,12 +10,14 @@
 
 stdenv.mkDerivation rec {
   pname = "castget";
-  version = "1_2_4";
+  version = "1.2.4";
 
   src = fetchFromGitHub {
     owner = "mlj";
     repo = pname;
-    rev = "rel_${version}";
+    # Upstream uses `_` instead of `.` for the version, let's hope it will
+    # change in the next release
+    rev = "rel_${lib.replaceStrings ["."] ["_"] version}";
     sha256 = "1pfrjmsikv35cc0praxgim26zq4r7dfp1pkn6n9fz3fm73gxylyv";
   };
   prePatch = ''

--- a/pkgs/applications/networking/feedreaders/castget/default.nix
+++ b/pkgs/applications/networking/feedreaders/castget/default.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation rec {
     rev = "rel_${lib.replaceStrings ["."] ["_"] version}";
     sha256 = "1pfrjmsikv35cc0praxgim26zq4r7dfp1pkn6n9fz3fm73gxylyv";
   };
+  # Otherwise, the autoreconfHook fails since Makefile.am requires it
   prePatch = ''
     touch NEWS
     touch README

--- a/pkgs/applications/networking/feedreaders/castget/default.nix
+++ b/pkgs/applications/networking/feedreaders/castget/default.nix
@@ -1,5 +1,12 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig
-, glib, ronn, curl, id3lib, libxml2 }:
+{ lib, stdenv, fetchFromGitHub
+, autoreconfHook
+, pkgconfig
+, glib
+, ronn
+, curl
+, id3lib
+, libxml2
+}:
 
 stdenv.mkDerivation rec {
   pname = "castget";

--- a/pkgs/applications/networking/feedreaders/castget/default.nix
+++ b/pkgs/applications/networking/feedreaders/castget/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig
+, glib, ronn, curl, id3lib, libxml2 }:
+
+stdenv.mkDerivation rec {
+  pname = "castget";
+  version = "1_2_4";
+
+  src = fetchFromGitHub {
+    owner = "mlj";
+    repo = pname;
+    rev = "rel_${version}";
+    sha256 = "1pfrjmsikv35cc0praxgim26zq4r7dfp1pkn6n9fz3fm73gxylyv";
+  };
+  prePatch = ''
+    touch NEWS
+    touch README
+    touch ChangeLog
+  '';
+
+  buildInputs = [ glib curl id3lib libxml2 ];
+  nativeBuildInputs = [ ronn autoreconfHook pkgconfig ];
+
+  meta = with stdenv.lib; {
+    description = "A simple, command-line based RSS enclosure downloader";
+    longDescription = ''
+      castget is a simple, command-line based RSS enclosure downloader. It is
+      primarily intended for automatic, unattended downloading of podcasts.
+    '';
+    homepage = "http://castget.johndal.com/";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -149,6 +149,8 @@ in
 
   buildMaven = callPackage ../build-support/build-maven.nix {};
 
+  castget = callPackage ../applications/networking/feedreaders/castget { };
+
   castxml = callPackage ../development/tools/castxml { };
 
   cmark = callPackage ../development/libraries/cmark { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
