### PR TITLE
games/crawl: add support for MacOS/Darwin builds for Dungeon Crawl

### DIFF
--- a/pkgs/games/crawl/crawl_purify.patch
+++ b/pkgs/games/crawl/crawl_purify.patch
@@ -1,6 +1,19 @@
 diff -ru3 crawl-ref-0.23.2-src-old/crawl-ref/source/Makefile crawl-ref-0.23.2-src-new/crawl-ref/source/Makefile
 --- crawl-ref-0.23.2-src-old/crawl-ref/source/Makefile	1970-01-01 03:00:01.000000000 +0300
 +++ crawl-ref-0.23.2-src-new/crawl-ref/source/Makefile	2017-07-27 14:45:34.611221571 +0300
+@@ -224,9 +224,9 @@
+	STRIP := strip -x
+	NEED_APPKIT = YesPlease
+	LIBNCURSES_IS_UNICODE = Yes
+-	NO_PKGCONFIG = Yes
+-	BUILD_SQLITE = YesPlease
+-	BUILD_ZLIB = YesPlease
++	#NO_PKGCONFIG = Yes
++	#BUILD_SQLITE = YesPlease
++	#BUILD_ZLIB = YesPlease
+	ifdef TILES
+		EXTRA_LIBS += -framework AppKit -framework AudioUnit -framework CoreAudio -framework ForceFeedback -framework Carbon -framework IOKit -framework OpenGL -framework AudioToolbox -framework CoreVideo contrib/install/$(ARCH)/lib/libSDL2main.a
+		BUILD_FREETYPE = YesPlease
 @@ -286,13 +286,7 @@
  LIBZ := contrib/install/$(ARCH)/lib/libz.a
  

--- a/pkgs/games/crawl/default.nix
+++ b/pkgs/games/crawl/default.nix
@@ -1,6 +1,9 @@
 { stdenv, lib, fetchFromGitHub, fetchpatch, which, sqlite, lua5_1, perl, python3, zlib, pkgconfig, ncurses
 , dejavu_fonts, libpng, SDL2, SDL2_image, SDL2_mixer, libGLU_combined, freetype, pngcrush, advancecomp
 , tileMode ? false, enableSound ? tileMode
+
+# MacOS / Darwin builds
+, darwin ? null
 }:
 
 stdenv.mkDerivation rec {
@@ -15,7 +18,7 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
-    ./crawl_purify.patch  # Patch hard-coded paths
+    ./crawl_purify.patch  # Patch hard-coded paths and remove force library builds
     (fetchpatch {         # Use a nice high-res app icon
       url = "https://github.com/crawl/crawl/commit/2aa1166087e44e6585b26cedf1fe81b3f3ba547f.patch";
       sha256 = "1jqrdv4wy18shg1fdabdb421232hg5micphkixcyzxd1lrmvadg0";
@@ -28,7 +31,13 @@ stdenv.mkDerivation rec {
   buildInputs = [ lua5_1 zlib sqlite ncurses ]
                 ++ (with python3.pkgs; [ pyyaml ])
                 ++ lib.optionals tileMode [ libpng SDL2 SDL2_image freetype libGLU_combined ]
-                ++ lib.optional enableSound SDL2_mixer;
+                ++ lib.optional enableSound SDL2_mixer
+                ++ (lib.optionals stdenv.isDarwin (
+                  assert (lib.assertMsg (darwin != null) "Must have darwin frameworks available for darwin builds");
+                  with darwin.apple_sdk.frameworks; [
+                    AppKit AudioUnit CoreAudio ForceFeedback Carbon IOKit OpenGL
+                   ]
+                ));
 
   preBuild = ''
     cd crawl-ref/source
@@ -64,7 +73,7 @@ stdenv.mkDerivation rec {
       with dangerous and unfriendly monsters in a quest to rescue the
       mystifyingly fabulous Orb of Zot.
     '';
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     license = with licenses; [ gpl2Plus bsd2 bsd3 mit licenses.zlib cc0 ];
     maintainers = [ maintainers.abbradar ];
   };

--- a/pkgs/tools/compression/advancecomp/default.nix
+++ b/pkgs/tools/compression/advancecomp/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     description = ''A set of tools to optimize deflate-compressed files'';
     license = licenses.gpl3 ;
     maintainers = [ maintainers.raskin ];
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     homepage = https://github.com/amadvance/advancecomp;
 
   };


### PR DESCRIPTION
games/crawl: Add support for darwin builds.  Also,
compression/advancecomp: Add support for darwin builds in meta (which already worked).

advancecomp already compiles out-of-box on darwin.
crawl mostly did, but required that the osx frameworks be made available and
disable the makefile's attempt to force-build the contrib libraries.

I've tested non-tiles build on mac, and it seems fine.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
