### PR TITLE
pythonPackages.configshell: Add urwid to deps

### DIFF
--- a/pkgs/development/python-modules/configshell/default.nix
+++ b/pkgs/development/python-modules/configshell/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, buildPythonPackage, pyparsing, six }:
+{ stdenv, fetchFromGitHub, buildPythonPackage, pyparsing, six, urwid }:
 
 buildPythonPackage rec {
   pname = "configshell";
@@ -11,7 +11,7 @@ buildPythonPackage rec {
     sha256 = "0zpr2n4105qqsklyfyr9lzl1rhxjcv0mnsl57hgk0m763w6na90h";
   };
 
-  propagatedBuildInputs = [ pyparsing six ];
+  propagatedBuildInputs = [ pyparsing six urwid ];
 
   meta = with stdenv.lib; {
     description = "A Python library for building configuration shells";


### PR DESCRIPTION
##### Motivation for this change
It's required in
https://github.com/open-iscsi/configshell-fb/blob/master/configshell/node.py#L1062
and crashes when reaching the function with that import.

Reproduce with:
1. Open targetcli
2. Execute a plain cd without a path.

```
> nix-shell -p targetcli --run targetcli
targetcli shell version 2.1.fb49
Copyright 2011-2013 by Datera, Inc and others.
For help on commands, type 'help'.

You are not root, disabling privileged commands.

/> cd
Traceback (most recent call last):
  File "/nix/store/v8jymljdrangfpj03rs50a48ymmpmmqm-targetcli-2.1.fb49/bin/.targetcli-wrapped", line 123, in <module>
    main()
  File "/nix/store/v8jymljdrangfpj03rs50a48ymmpmmqm-targetcli-2.1.fb49/bin/.targetcli-wrapped", line 113, in main
    shell.run_interactive()
  File "/nix/store/h2306py2z6xs9gpfplm1vd25p1xirbvk-python2.7-configshell-1.1.fb25/lib/python2.7/site-packages/configshell_fb/shell.py", line 905, in run_interactive
    self._cli_loop()
  File "/nix/store/h2306py2z6xs9gpfplm1vd25p1xirbvk-python2.7-configshell-1.1.fb25/lib/python2.7/site-packages/configshell_fb/shell.py", line 734, in _cli_loop
    self.run_cmdline(cmdline)
  File "/nix/store/h2306py2z6xs9gpfplm1vd25p1xirbvk-python2.7-configshell-1.1.fb25/lib/python2.7/site-packages/configshell_fb/shell.py", line 848, in run_cmdline
    self._execute_command(path, command, pparams, kparams)
  File "/nix/store/h2306py2z6xs9gpfplm1vd25p1xirbvk-python2.7-configshell-1.1.fb25/lib/python2.7/site-packages/configshell_fb/shell.py", line 823, in _execute_command
    result = target.execute_command(command, pparams, kparams)
  File "/nix/store/h2306py2z6xs9gpfplm1vd25p1xirbvk-python2.7-configshell-1.1.fb25/lib/python2.7/site-packages/configshell_fb/node.py", line 1406, in execute_command
    return method(*pparams, **kparams)
  File "/nix/store/h2306py2z6xs9gpfplm1vd25p1xirbvk-python2.7-configshell-1.1.fb25/lib/python2.7/site-packages/configshell_fb/node.py", line 1028, in ui_command_cd
    selected = self._lines_walker(lines, start_pos=start_pos)
  File "/nix/store/h2306py2z6xs9gpfplm1vd25p1xirbvk-python2.7-configshell-1.1.fb25/lib/python2.7/site-packages/configshell_fb/node.py", line 1062, in _lines_walker
    import urwid
ImportError: No module named urwid
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
