### PR TITLE
mongodb: fix build on aarch64

### DIFF
--- a/pkgs/servers/nosql/mongodb/default.nix
+++ b/pkgs/servers/nosql/mongodb/default.nix
@@ -81,6 +81,8 @@ in stdenv.mkDerivation rec {
   preBuild = ''
     sconsFlags+=" CC=$CC"
     sconsFlags+=" CXX=$CXX"
+  '' + optionalString stdenv.isAarch64 ''
+    sconsFlags+=" CCFLAGS='-march=armv8-a+crc'"
   '';
 
   preInstall = ''


### PR DESCRIPTION
###### Motivation for this change
MongoDB currently [fails to build](https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.mongodb.aarch64-linux/all) on aarch64 because WiredTiger fails to compile without crc extensions on aarch64.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS (aarch64)
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---