### PR TITLE
blobmoji: Init at 2019-06-14-Emoji-12

### DIFF
--- a/pkgs/data/fonts/blobmoji/default.nix
+++ b/pkgs/data/fonts/blobmoji/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, cairo, pngquant, zopfli
+, which, pythonPackages, pkgconfig, imagemagick }: stdenv.mkDerivation rec {
+  pname = "blobmoji";
+  version = "2019-06-14-Emoji-12";
+
+  src = fetchFromGitHub {
+    owner = "C1710";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "19xwjarpn40jyibp7d2g0ss2c9hifrskkig234wdng08gc1p4z84";
+  };
+
+  buildInputs = [ cairo ];
+  nativeBuildInputs = [ cairo pngquant zopfli which pkgconfig imagemagick ]
+                      ++ (with pythonPackages; [ python fonttools nototools ]);
+  enableParallelBuilding = true;
+
+  postPatch = ''
+    sed -i 's,^PNGQUANT :=.*,PNGQUANT := ${pngquant}/bin/pngquant,' Makefile
+    patchShebangs flag_glyph_name.py
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/noto
+    cp NotoColorEmoji.ttf fonts/Blobmoji.ttf $out/share/fonts/noto
+  '';
+
+  meta = with stdenv.lib; {
+    inherit version;
+    description = "Noto Emoji with extended Blob support";
+    homepage = "https://github.com/C1710/blobmoji";
+    license = with licenses; [ ofl asl20 ];
+    platforms = platforms.all;
+    maintainers = with maintainers; [ das_j ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16303,6 +16303,8 @@ in
 
   bibata-cursors = callPackage ../data/icons/bibata-cursors { };
 
+  blobmoji = callPackage ../data/fonts/blobmoji { };
+
   brise = callPackage ../data/misc/brise { };
 
   inherit (kdeFrameworks) breeze-icons;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Real emoji have curves! 😤

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
