### PR TITLE
ghc: always use ld.gold

### DIFF
--- a/pkgs/development/compilers/ghc/8.2.2.nix
+++ b/pkgs/development/compilers/ghc/8.2.2.nix
@@ -166,7 +166,7 @@ stdenv.mkDerivation (rec {
     export CC="${targetCC}/bin/${targetCC.targetPrefix}cc"
     export CXX="${targetCC}/bin/${targetCC.targetPrefix}cxx"
     # Use gold to work around https://sourceware.org/bugzilla/show_bug.cgi?id=16177
-    export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld${stdenv.lib.optionalString targetPlatform.isAarch32 ".gold"}"
+    export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld.gold"
     export AS="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}as"
     export AR="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ar"
     export NM="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}nm"

--- a/pkgs/development/compilers/ghc/8.4.4.nix
+++ b/pkgs/development/compilers/ghc/8.4.4.nix
@@ -126,7 +126,7 @@ stdenv.mkDerivation (rec {
     export CC="${targetCC}/bin/${targetCC.targetPrefix}cc"
     export CXX="${targetCC}/bin/${targetCC.targetPrefix}cxx"
     # Use gold to work around https://sourceware.org/bugzilla/show_bug.cgi?id=16177
-    export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld${stdenv.lib.optionalString targetPlatform.isAarch32 ".gold"}"
+    export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld.gold"
     export AS="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}as"
     export AR="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ar"
     export NM="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}nm"

--- a/pkgs/development/compilers/ghc/8.6.4.nix
+++ b/pkgs/development/compilers/ghc/8.6.4.nix
@@ -125,7 +125,7 @@ stdenv.mkDerivation (rec {
     export CC="${targetCC}/bin/${targetCC.targetPrefix}cc"
     export CXX="${targetCC}/bin/${targetCC.targetPrefix}cxx"
     # Use gold to work around https://sourceware.org/bugzilla/show_bug.cgi?id=16177
-    export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld${stdenv.lib.optionalString targetPlatform.isAarch32 ".gold"}"
+    export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld.gold"
     export AS="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}as"
     export AR="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ar"
     export NM="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}nm"

--- a/pkgs/development/compilers/ghc/8.6.5.nix
+++ b/pkgs/development/compilers/ghc/8.6.5.nix
@@ -125,7 +125,7 @@ stdenv.mkDerivation (rec {
     export CC="${targetCC}/bin/${targetCC.targetPrefix}cc"
     export CXX="${targetCC}/bin/${targetCC.targetPrefix}cxx"
     # Use gold to work around https://sourceware.org/bugzilla/show_bug.cgi?id=16177
-    export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld${stdenv.lib.optionalString targetPlatform.isAarch32 ".gold"}"
+    export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld.gold"
     export AS="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}as"
     export AR="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ar"
     export NM="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}nm"

--- a/pkgs/development/compilers/ghc/8.8.1.nix
+++ b/pkgs/development/compilers/ghc/8.8.1.nix
@@ -110,7 +110,7 @@ stdenv.mkDerivation (rec {
     export CC="${targetCC}/bin/${targetCC.targetPrefix}cc"
     export CXX="${targetCC}/bin/${targetCC.targetPrefix}cxx"
     # Use gold to work around https://sourceware.org/bugzilla/show_bug.cgi?id=16177
-    export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld${stdenv.lib.optionalString targetPlatform.isAarch32 ".gold"}"
+    export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld.gold"
     export AS="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}as"
     export AR="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ar"
     export NM="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}nm"

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -119,7 +119,8 @@ stdenv.mkDerivation (rec {
     export CC="${targetCC}/bin/${targetCC.targetPrefix}cc"
     export CXX="${targetCC}/bin/${targetCC.targetPrefix}cxx"
     # Use gold to work around https://sourceware.org/bugzilla/show_bug.cgi?id=16177
-    export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld${stdenv.lib.optionalString targetPlatform.isAarch32 ".gold"}"
+    # and more generally have a faster linker.
+    export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld.gold"
     export AS="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}as"
     export AR="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ar"
     export NM="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}nm"


### PR DESCRIPTION
###### Motivation for this change

`ld.gold` has been known to speed up GHC compilations for some time, and is often recommended whenever linking time becomes unreasonably big. @bgamari and I thought it might be a good idea to use it by default for all GHCs that are built in nixpkgs. Both have bugs but `ld.gold` tends to be reliable and consistently faster.

I also have concrete numbers to back this up, at the end of this comment.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

First, a tiny script that measures the time that it takes just to link aeson's `Setup.hs`, producing a `Setup` executable, with ld.gold and ld.bfd,10 times over, recording the timings (all in seconds). 

Here's a table with just the system times reported. The two files with system and user times are available at the end.

| Linker | Run 1 | Run 2 | Run 3 | Run 4 | Run 5 | Run 6 | Run 7 | Run 8 | Run 9 | Run 10 |
|:---       |       ---:|       ---:|       ---:|       ---:|       ---:|       ---:|       ---:|       ---:|       ---:|         ---:|
| bfd     | 15.51 | 15.32 | 15.82 | 17.90 | 17.77 | 16.49 | 16.57 | 15.54 | 15.68 | 15.43 |
| gold    | 8.26 | 6.76 | 6.77 | 7.28 | 7.83 | 7.38 | 7.10 | 7.26 | 6.91 | 6.85 |

Second, a script that measures the time it takes to compile `ghc-events-analyze` (alone, without its deps) with `ld.bfd` and `ld.gold`. Like before, script & raw data available at the end.

| Linker | Run 1 | Run 2 | Run 3 | Run 4 | Run 5 | Run 6 | Run 7 | Run 8 | Run 9 | Run 10 |
|:---       |       ---:|       ---:|       ---:|       ---:|       ---:|       ---:|       ---:|       ---:|       ---:|         ---:|
| bfd     | 80.27 | 80.81 | 80.88 | 80.67 | 80.79 | 80.64 | 80.77 | 80.70 | 89.40 | 87.91 |
| gold    | 74.41 | 74.52 | 73.07 | 75.05 | 74.45 | 74.22 | 73.61 | 74.14 | 75.00 | 85.80 |

Those numbers follow a clear trend that we have been seeing during our work on/around GHC, but I could definitely collect more data points if this is not convincing enough.

---
aeson Setup.hs data:

``` sh
#!/run/current-system/sw/bin/env nix-shell
#!nix-shell -i bash -p cabal-install -p haskell.compiler.ghc844 -p binutils

# Using Cabal/Cabal's Setup.hs as an example
cabal get aeson; cd aeson-*
rm -rf Setup Setup.hi Setup.o
ghc -O Setup.lhs

for i in `seq 10`; do
  rm Setup
  command time -o ../gold -a -f '%S %U' ghc -O -optl-fuse-ld=gold Setup.lhs
  rm Setup
  command time -o ../bfd -a -f '%S %U' ghc -O -optl-fuse-ld=bfd Setup.lhs
done

cd ..
```

[bfd.txt](https://github.com/NixOS/nixpkgs/files/3438194/bfd.txt)
[gold.txt](https://github.com/NixOS/nixpkgs/files/3438195/gold.txt)

---

ghc-events-analyze compilation data:

``` nix
{ nixpkgs ? import <nixpkgs> {} }:
with nixpkgs;

let deps =
  [ cabal-install haskell.compiler.ghc844
    binutils zlib.dev zlib.out
  ];

in

mkShell {
  name = "ghc-gold-bench";
  buildInputs = deps;

  shellHook = ''
    export LD_LIBRARY_PATH=${zlib.out}/lib:$LD_LIBRARY_PATH
  '';
}
```

``` sh
#!/usr/bin/env sh

# Building a whole (executable) package
cabal new-update
cabal get ghc-events-analyze
cd ghc-events-analyze*
cabal new-build --ghc-options="-optl-fuse-ld=gold"
cabal new-build --ghc-options="-optl-fuse-ld=bfd"

for i in `seq 10`; do
    rm -r dist-newstyle
    command time -o ../gold-gea -a -f '%S %U' cabal new-build --ghc-options="-optl-fuse-ld=gold"
    rm -r dist-newstyle
    command time -o ../bfd-gea -a -f '%S %U' cabal new-build --ghc-options="-optl-fuse-ld=bfd"
done
cd ..
```

[bfd-gea.txt](https://github.com/NixOS/nixpkgs/files/3438947/bfd-gea.txt)
[gold-gea.txt](https://github.com/NixOS/nixpkgs/files/3438948/gold-gea.txt)
