### PR TITLE
jormungandr: init at 0.3.1

### DIFF
--- a/pkgs/applications/altcoins/jormungandr/default.nix
+++ b/pkgs/applications/altcoins/jormungandr/default.nix
@@ -1,0 +1,38 @@
+{ stdenv
+, fetchgit
+, rustPlatform
+, openssl
+, pkgconfig
+, protobuf
+, rustup
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "jormungandr";
+  version = "0.3.1";
+
+  src = fetchgit {
+    url = "https://github.com/input-output-hk/${pname}";
+    rev = "v${version}";
+    sha256 = "0ys8sw73c7binxnl79dqi7sxva62bgifbhgyzvvjvmjjdxgq4kfp";
+    fetchSubmodules = true;
+  };
+
+  cargoSha256 = "0fphjzz78ym15qbka01idnq6vkyf4asrnhrhvxngwc3bifmnj937";
+
+  nativeBuildInputs = [ pkgconfig protobuf rustup ];
+  buildInputs = [ openssl ];
+
+  PROTOC = "${protobuf}/bin/protoc";
+
+  # Disabling integration tests
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "An aspiring blockchain node";
+    homepage = "https://input-output-hk.github.io/jormungandr/";
+    license = licenses.mit;
+    maintainers = [ maintainers.mmahut ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18799,6 +18799,8 @@ in
 
   josm = callPackage ../applications/misc/josm { };
 
+  jormungandr = callPackage ../applications/altcoins/jormungandr { };
+
   jbrout = callPackage ../applications/graphics/jbrout { };
 
   jwm = callPackage ../applications/window-managers/jwm { };


### PR DESCRIPTION
###### Motivation for this change

init at 0.3.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
