### PR TITLE
ocamlPackages.lambdasoup: init at 0.6.3

### DIFF
--- a/pkgs/development/ocaml-modules/lambdasoup/default.nix
+++ b/pkgs/development/ocaml-modules/lambdasoup/default.nix
@@ -1,0 +1,23 @@
+{ lib, fetchFromGitHub, buildDunePackage, markup }:
+
+buildDunePackage rec {
+  pname = "lambdasoup";
+  version = "0.6.3"; # NB: double-check the license when updating
+
+  src = fetchFromGitHub {
+    owner = "aantron";
+    repo = pname;
+    rev = version;
+    sha256 = "1w4zp3vswijzvrx0c3fv269ncqwnvvrzc46629nnwm9shwv07vmv";
+  };
+
+  propagatedBuildInputs = [ markup ];
+
+  meta = {
+    description = "Functional HTML scraping and rewriting with CSS in OCaml";
+    homepage = "https://aantron.github.io/lambdasoup/";
+    license = lib.licenses.bsd2;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -376,6 +376,8 @@ let
 
     lacaml = callPackage ../development/ocaml-modules/lacaml { };
 
+    lambdasoup = callPackage ../development/ocaml-modules/lambdasoup { };
+
     lambdaTerm-1_6 = callPackage ../development/ocaml-modules/lambda-term/1.6.nix { lwt = lwt2; };
     lambdaTerm =
       if lib.versionOlder "4.02" ocaml.version


### PR DESCRIPTION
###### Motivation for this change

Lambda Soup is a functional HTML scraping and manipulation library for OCaml aimed at being easy to use.

Homepage: https://aantron.github.io/lambdasoup/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
