### PR TITLE
duc: optional x11/cairo

### DIFF
--- a/pkgs/tools/misc/duc/default.nix
+++ b/pkgs/tools/misc/duc/default.nix
@@ -1,4 +1,10 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, tokyocabinet, cairo, pango, ncurses }:
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig
+, tokyocabinet, ncurses
+, cairo ? null, pango ? null
+, enableCairo ? stdenv.isLinux
+}:
+
+assert enableCairo -> cairo != null && pango != null;
 
 stdenv.mkDerivation rec {
   name = "duc-${version}";
@@ -12,14 +18,18 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
-  buildInputs = [ tokyocabinet cairo pango ncurses ];
+  buildInputs = [ tokyocabinet ncurses ] ++
+    stdenv.lib.optionals enableCairo [ cairo pango ];
+
+  configureFlags =
+    stdenv.lib.optionals (!enableCairo) [ "--disable-x11" "--disable-cairo" ];
 
   meta = with stdenv.lib; {
     homepage = http://duc.zevv.nl/;
     description = "Collection of tools for inspecting and visualizing disk usage";
     license = licenses.gpl2;
 
-    platforms = platforms.linux;
+    platforms = platforms.all;
     maintainers = [ maintainers.lethalman ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Allow configuring it to only use the ncurses interface and also enable darwin hydra builds.

```
:; nix path-info -Sh '(with import ./. { }; [ duc (duc.override { enableCairo = false; }) ])'
/nix/store/b8nhd2y7fl2k95670lqsl72ybb410d5b-duc-1.4.4     69.8M
/nix/store/dmrc5kmcp675qfwqy29l9lc60qqhqjkm-duc-1.4.4     34.8M
```

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---