### PR TITLE
librecad-git: add -git version that supports qt5

### DIFF
--- a/pkgs/applications/misc/librecad/git.nix
+++ b/pkgs/applications/misc/librecad/git.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchgit, qt5, muparser, which, boost, pkgconfig }:
+
+let
+  # master as of 2019-07-28
+  rev = "10d502db66527ea64a2a012add2e57059e2409f0";
+in
+stdenv.mkDerivation rec {
+  name = "librecad-git-${rev}";
+
+  src = fetchgit {
+    url = https://github.com/LibreCAD/LibreCAD;
+    inherit rev;
+    sha256 = "0172xgrnr7q3xlnjvq6rxyby9bjbc3vp9g2bgdvw3dsq3fqxyii3";
+  };
+
+  patchPhase = ''
+    sed -i -e s,/bin/bash,`type -P bash`, scripts/postprocess-unix.sh
+    sed -i -e s,/usr/share,$out/share, librecad/src/lib/engine/rs_system.cpp
+  '';
+
+  qmakeFlags = [ "MUPARSER_DIR=${muparser}" "BOOST_DIR=${boost.dev}" ];
+
+  installPhase = ''
+    install -m 555 -D unix/librecad $out/bin/librecad
+    install -m 444 -D desktop/librecad.desktop $out/share/applications/librecad.desktop
+    install -m 444 -D desktop/librecad.sharedmimeinfo $out/share/mime/packages/librecad.xml
+    install -m 444 -D desktop/graphics_icons_and_splash/Icon\ LibreCAD/Icon_Librecad.svg \
+      $out/share/icons/hicolor/scalable/apps/librecad.svg
+    cp -R unix/resources $out/share/librecad
+  '';
+
+  buildInputs = [ qt5.qtbase qt5.qtsvg muparser which boost ];
+  nativeBuildInputs = [ pkgconfig qt5.qmake ];
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "A 2D CAD package based upon Qt";
+    homepage = https://librecad.org;
+    repositories.git = git://github.com/LibreCAD/LibreCAD.git;
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = with stdenv.lib.maintainers; [ ];
+    platforms = with stdenv.lib.platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18976,6 +18976,7 @@ in
   libowfat = callPackage ../development/libraries/libowfat { };
 
   librecad = callPackage ../applications/misc/librecad { };
+  librecad-git = callPackage ../applications/misc/librecad/git.nix { };
 
   libreoffice = hiPrio libreoffice-still;
   libreoffice-unwrapped = libreoffice.libreoffice;


### PR DESCRIPTION
###### Motivation for this change
Provide a git-version that is qt5 compatible while there is no released version supporting qt5.

###### Things done

- [x] Tested using sandboxing (nixos variant) ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
