### PR TITLE
gn: 20181031 -> 20190726

### DIFF
--- a/pkgs/development/tools/build-managers/gn/default.nix
+++ b/pkgs/development/tools/build-managers/gn/default.nix
@@ -2,8 +2,8 @@
 , git, ninja, python2 }:
 
 let
-  rev = "96ff462cddf35f98e25fd5d098fc27bc81eab94a";
-  sha256 = "1ny23sprl7ygb2lpdnqxv60m8kaf4h2dmpqjp61l5vc2s7f32g97";
+  rev = "0bc16a82ea001ad9c94b870f097034be5c8e40b4";
+  sha256 = "01as6q5xr0smiihm9m1x74pykd2jcqi4rhv8irmv43v2f0pxwzi5";
 
   shortRev = builtins.substring 0 7 rev;
   lastCommitPosition = writeText "last_commit_position.h" ''
@@ -18,18 +18,12 @@ let
 in
 stdenv.mkDerivation rec {
   name = "gn-${version}";
-  version = "20181031";
+  version = "20190726";
 
   src = fetchgit {
     url = "https://gn.googlesource.com/gn";
     inherit rev sha256;
   };
-
-  postPatch = ''
-    # FIXME Needed with old Apple SDKs
-    substituteInPlace base/mac/foundation_util.mm \
-      --replace "NSArray<NSString*>*" "NSArray*"
-  '';
 
   nativeBuildInputs = [ ninja python2 git ];
   buildInputs = lib.optionals stdenv.isDarwin (with darwin; with apple_sdk.frameworks; [
@@ -43,7 +37,7 @@ stdenv.mkDerivation rec {
   ]);
 
   buildPhase = ''
-    python build/gen.py --no-sysroot --no-last-commit-position
+    python build/gen.py --no-last-commit-position
     ln -s ${lastCommitPosition} out/last_commit_position.h
     ninja -j $NIX_BUILD_CORES -C out gn
   '';


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Updates `gn` to the latest commit. This includes a commit that fixes the build on 32-bit ARM: https://gn.googlesource.com/gn.git/+/01237e9cd0f7e4e1bd4f09a7971b4eb9b8a3c390

cc @stesie @matthewbauer 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
