### PR TITLE
firejail: allow wrapping .desktop applications

### DIFF
--- a/nixos/modules/programs/firejail.nix
+++ b/nixos/modules/programs/firejail.nix
@@ -5,6 +5,13 @@ with lib;
 let
   cfg = config.programs.firejail;
 
+  applicationBinaries =
+    let
+      withBinary = _: application: application.binary != null;
+      toBinary = _: application: "${application.jailOptions} ${application.binary}";
+    in
+      mapAttrs toBinary (filterAttrs withBinary cfg.wrappedApplications);
+
   wrappedBins = pkgs.stdenv.mkDerivation rec {
     name = "firejail-wrapped-binaries";
     nativeBuildInputs = with pkgs; [ makeWrapper ];
@@ -16,7 +23,21 @@ let
       /run/wrappers/bin/firejail ${binary} "\$@"
       _EOF
       chmod 0755 $out/bin/${command}
-      '') cfg.wrappedBinaries)}
+      '') (cfg.wrappedBinaries // applicationBinaries))}
+    '';
+  };
+
+  wrappedApps = pkgs.stdenv.mkDerivation rec {
+    name = "firejail-wrapped-applications";
+    nativeBuildInputs = with pkgs; [ makeWrapper ];
+    buildCommand = ''
+      mkdir -p $out/share/applications
+      ${lib.concatStringsSep "\n" (lib.mapAttrsToList (name: app: ''
+      cat ${app.desktopFile} \
+          | sed -e 's:^Exec\s*=:Exec=/run/wrappers/bin/firejail ${app.jailOptions}:' \
+          > $out/share/applications/${name}.desktop
+      chmod 0555 $out/share/applications/${name}.desktop
+      '') cfg.wrappedApplications)}
     '';
   };
 
@@ -36,12 +57,38 @@ in {
         not wrapped if they specify the absolute path to the binary.
       '';
     };
+
+    wrappedApplications = mkOption {
+      type = types.attrsOf (types.submodule {
+        options = {
+          binary = mkOption {
+            type = types.nullOr types.string;
+            description = ''
+              If set, wrap the binary in firejail and place it in the global path.
+            '';
+          };
+          desktopFile = mkOption {
+            type = types.string;
+            description = ''
+              Wrap the desktop file 'Exec' in firejail.
+            '';
+          };
+          jailOptions = mkOption {
+            type = types.str;
+            default = "";
+            description = ''
+              Options to pass on to firejail.
+            '';
+          };
+        };
+      });
+    };
   };
 
   config = mkIf cfg.enable {
     security.wrappers.firejail.source = "${lib.getBin pkgs.firejail}/bin/firejail";
 
-    environment.systemPackages = [ wrappedBins ];
+    environment.systemPackages = [ wrappedBins wrappedApps ];
   };
 
   meta.maintainers = with maintainers; [ peterhoeg ];


### PR DESCRIPTION
###### Motivation for this change

In addition to wrapping binaries it's convenient to wrap the 'Exec' attribute in
.desktop files with firejail. For example, wrapping the firefox binary with firejail
removes the firefox.desktop file so you cannot start firefox using an
application launches like in Gnome.

This patch allows to specify an attribute set of applications whose desktop file
to wrap. For convenience it allows wrapping their binary through the same config
element. Since firejail options cannot be part of the desktop file attribute, a
separate option is provided for those.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
