### PR TITLE
qt5*: Enforce strict compatible version paths 

### DIFF
--- a/pkgs/development/libraries/qt-5/5.11/default.nix
+++ b/pkgs/development/libraries/qt-5/5.11/default.nix
@@ -9,9 +9,8 @@ top-level attribute to `top-level/all-packages.nix`.
 1. Update the URL in `pkgs/development/libraries/qt-5/$VERSION/fetch.sh`.
 2. From the top of the Nixpkgs tree, run
    `./maintainers/scripts/fetch-kde-qt.sh > pkgs/development/libraries/qt-5/$VERSION/srcs.nix`.
-3. Update `qtCompatVersion` below if the minor version number changes.
-4. Check that the new packages build correctly.
-5. Commit the changes and open a pull request.
+3. Check that the new packages build correctly.
+4. Commit the changes and open a pull request.
 
 */
 
@@ -32,7 +31,7 @@ with stdenv.lib;
 
 let
 
-  qtCompatVersion = "5.11";
+  qtCompatVersion = srcs.qtbase.version;
 
   stdenvActual = if stdenv.cc.isClang then llvmPackages_5.stdenv else stdenv;
 

--- a/pkgs/development/libraries/qt-5/5.12/default.nix
+++ b/pkgs/development/libraries/qt-5/5.12/default.nix
@@ -9,9 +9,8 @@ top-level attribute to `top-level/all-packages.nix`.
 1. Update the URL in `pkgs/development/libraries/qt-5/$VERSION/fetch.sh`.
 2. From the top of the Nixpkgs tree, run
    `./maintainers/scripts/fetch-kde-qt.sh > pkgs/development/libraries/qt-5/$VERSION/srcs.nix`.
-3. Update `qtCompatVersion` below if the minor version number changes.
-4. Check that the new packages build correctly.
-5. Commit the changes and open a pull request.
+3. Check that the new packages build correctly.
+4. Commit the changes and open a pull request.
 
 */
 
@@ -32,7 +31,7 @@ with stdenv.lib;
 
 let
 
-  qtCompatVersion = "5.12";
+  qtCompatVersion = srcs.qtbase.version;
 
   stdenvActual = if stdenv.cc.isClang then llvmPackages_5.stdenv else stdenv;
 

--- a/pkgs/development/libraries/qt-5/5.6/default.nix
+++ b/pkgs/development/libraries/qt-5/5.6/default.nix
@@ -18,9 +18,8 @@ existing packages here and modify it as necessary.
 1. Update the URL in `./fetch.sh`.
 2. Run `./maintainers/scripts/fetch-kde-qt.sh pkgs/development/libraries/qt-5/$VERSION/`
    from the top of the Nixpkgs tree.
-3. Update `qtCompatVersion` below if the minor version number changes.
-4. Check that the new packages build correctly.
-5. Commit the changes and open a pull request.
+3. Check that the new packages build correctly.
+4. Commit the changes and open a pull request.
 
 */
 
@@ -40,7 +39,7 @@ with stdenv.lib;
 
 let
 
-  qtCompatVersion = "5.6";
+  qtCompatVersion = srcs.qtbase.version;
 
   mirror = "http://download.qt.io";
   srcs = import ./srcs.nix { inherit fetchurl; inherit mirror; };

--- a/pkgs/development/libraries/qt-5/5.9/default.nix
+++ b/pkgs/development/libraries/qt-5/5.9/default.nix
@@ -9,9 +9,8 @@ top-level attribute to `top-level/all-packages.nix`.
 1. Update the URL in `pkgs/development/libraries/qt-5/$VERSION/fetch.sh`.
 2. From the top of the Nixpkgs tree, run
    `./maintainers/scripts/fetch-kde-qt.sh > pkgs/development/libraries/qt-5/$VERSION/srcs.nix`.
-3. Update `qtCompatVersion` below if the minor version number changes.
-4. Check that the new packages build correctly.
-5. Commit the changes and open a pull request.
+3. Check that the new packages build correctly.
+4. Commit the changes and open a pull request.
 
 */
 
@@ -31,7 +30,7 @@ with stdenv.lib;
 
 let
 
-  qtCompatVersion = "5.9";
+  qtCompatVersion = srcs.qtbase.version;
 
   mirror = "http://download.qt.io";
   srcs = import ./srcs.nix { inherit fetchurl; inherit mirror; };


### PR DESCRIPTION
###### Motivation for this change

Ensure we don't see the following error anymore:

```
Cannot mix incompatible Qt library (version 0x50c00) with this library (version 0x50c03)
```

This PR forces the path to use the minor version (5.major.minor) in the plugin paths, ensuring that it's improbable for Qt to look into an incompatible minor version's path for plugins. This builds upon discoveries made in #44047, see the end of the initial PR body.

This was tested on top of eb4e067686d1121d2d4a3d7ac2ed080339125eeb, which has Qt 5.12.3. This was tested running on a 19.03 system which has 5.12.0-reliant software installed in the system.

This was verified using `multimc` (EDIT) With #65486 applied!

This was verified by using `strace` and comparing what it tries to load, and **validating it loads** the equivalent right library for 5.12.3.

(EDIT) Additionally, missing wrapQtAppsHook now fails more decisively at runtime, rather than using whatever traces could be found in the environment. This is both an advantage and a drawback. On one hand, it will force `wrapQtAppsHook` to happen to every Qt packages, ensuring they stay functional with mismatched versions. On the other hand, it will break a bunch of Qt apps at runtime, until every one of them is fixed. I think the advantage far outweighs the drawback.

* * *

> > So, there is at least an input method impurity...
>
> This is intentional: we don't want for users to rebuild the world to change input methods. :slightly_frowning_face: 

Good news, Qt is able to load the right 5.12.3 input method by name, as I thought while experimenting.

```
 5008 19814 openat(AT_FDCWD, "/nix/store/gk8injsql81blxkxvxc0wf7qzz7b7p0b-qtbase-5.12.3-bin/lib/qt-5.12.3/plugins/platforminputcontexts/libibusplatforminputcontextplugin.so", O_RDONLY|O_CLOEXEC) = 7
 5009 19814 read(7, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0\0\0\0\0\0\0\0\0"..., 832) = 832
```

* * *

And since Qt now looks for `5.12.3`, instead of `5.12`, in plugin paths, we don't have to care that much for the impure environment caused by PATH, as even if it's shock full of incompatible minor versions, Qt will not look for them.

* * *

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
   - 🔲 macOS
   - 🔲 other Linux distributions
- 🔲 Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- 🔲 Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- 🔲 Tested execution of all binary files (usually in `./result/bin/`)
- 🔲 Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ✔️ Ensured that relevant documentation is up to date
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


ref #65399 
cc @FRidh who reverted the 5.12.3 bump
cc @ttuegel 
