### PR TITLE
poezio: 0.12 -> 0.12.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/poezio/default.nix
+++ b/pkgs/applications/networking/instant-messengers/poezio/default.nix
@@ -1,22 +1,24 @@
-{ lib, buildPythonApplication, fetchurl, pythonOlder
+{ lib, buildPythonApplication, fetchFromGitHub, pythonOlder
 , pytest, aiodns, slixmpp, pyinotify, potr, mpd2, cffi, pkgconfig }:
 buildPythonApplication rec {
-    name = "poezio-${version}";
-    version = "0.12";
+    pname = "poezio";
+    version = "0.12.1";
 
     disabled = pythonOlder "3.4";
 
-    buildInputs = [ pytest ];
+    checkInputs = [ pytest ];
     propagatedBuildInputs = [ aiodns slixmpp pyinotify potr mpd2 cffi ];
     nativeBuildInputs = [ pkgconfig ];
 
-    src = fetchurl {
-      url = "http://dev.louiz.org/attachments/download/129/${name}.tar.gz";
-      sha256 = "11n9x82xyjwbqk28lsfnvqwn8qc9flv6w2c64camh6j3148ykpvz";
+    src = fetchFromGitHub {
+      owner = pname;
+      repo = pname;
+      rev = "v${version}";
+      sha256 = "04qnsr0l12i55k6xl4q4akx317gai9wv5f1wpkfkq01wp181i5ll";
     };
 
     checkPhase = ''
-      py.test
+      pytest
     '';
 
     meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

Upgrade to latest upstream version, 0.12 -> 0.12.1.

Fixing the failed build due to pytest not being in ```checkInput```.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
