### PR TITLE
openscad: not using qt5 and libsForQt5 directly

### DIFF
--- a/pkgs/applications/graphics/openscad/default.nix
+++ b/pkgs/applications/graphics/openscad/default.nix
@@ -1,7 +1,30 @@
-{ stdenv, fetchFromGitHub, qt5, libsForQt5
-, bison, flex, eigen, boost, libGLU_combined, glew, opencsg, cgal
-, mpfr, gmp, glib, pkgconfig, harfbuzz, gettext, freetype, fontconfig
-, double-conversion, lib3mf, libzip, mkDerivation
+{ stdenv
+, fetchFromGitHub
+, qtbase
+, qtmultimedia
+, qscintilla
+, bison
+, flex
+, eigen
+, boost
+, libGLU_combined
+, glew
+, opencsg
+, cgal
+, mpfr
+, gmp
+, glib
+, pkgconfig
+, harfbuzz
+, gettext
+, freetype
+, fontconfig
+, double-conversion
+, lib3mf
+, libzip
+, mkDerivation
+, qtmacextras
+, qmake
 }:
 
 mkDerivation rec {
@@ -15,14 +38,14 @@ mkDerivation rec {
     sha256 = "1qz384jqgk75zxk7sqd22ma9pyd94kh4h6a207ldx7p9rny6vc5l";
   };
 
-  nativeBuildInputs = [ bison flex pkgconfig gettext qt5.qmake ];
+  nativeBuildInputs = [ bison flex pkgconfig gettext qmake ];
 
   buildInputs = [
     eigen boost glew opencsg cgal mpfr gmp glib
     harfbuzz lib3mf libzip double-conversion freetype fontconfig
+    qtbase qtmultimedia qscintilla
   ] ++ stdenv.lib.optional stdenv.isLinux libGLU_combined
-    ++ (with qt5; [qtbase qtmultimedia] ++ stdenv.lib.optional stdenv.isDarwin qtmacextras)
-    ++ (with libsForQt5; [qscintilla])
+    ++ stdenv.lib.optional stdenv.isDarwin qtmacextras
   ;
 
   qmakeFlags = [ "VERSION=${version}" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19672,7 +19672,7 @@ in
 
   openorienteering-mapper = libsForQt5.callPackage ../applications/gis/openorienteering-mapper { };
 
-  openscad = qt5.callPackage ../applications/graphics/openscad {};
+  openscad = libsForQt5.callPackage ../applications/graphics/openscad {};
 
   opentimestamps-client = python3Packages.callPackage ../tools/misc/opentimestamps-client {};
 


### PR DESCRIPTION
###### Motivation for this change

Additional fix for #65522.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
