### PR TITLE
tt-rss-plugin-fever-api: Init at 2.2.0

### DIFF
--- a/pkgs/servers/tt-rss/plugin-fever-api/default.nix
+++ b/pkgs/servers/tt-rss/plugin-fever-api/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, fetchpatch, ... }: stdenv.mkDerivation rec {
+  pname = "tt-rss-plugin-fever-api";
+  version = "2.2.0";
+
+  src = fetchFromGitHub {
+    owner = "DigitalDJ";
+    repo = "tinytinyrss-fever-plugin";
+    rev = version;
+    sha256 = "000ys6r6a90x1v6fjyb86b0aab6j7g2d29w8d5sccyv895m4x8r1";
+  };
+
+  installPhase = ''
+    mkdir -p $out/fever
+    cp *.php $out/fever
+  '';
+
+  meta = with stdenv.lib; {
+    description = "TT-RSS Fever API Plugin";
+    license = licenses.gpl3;
+    homepage = "https://github.com/DigitalDJ/tinytinyrss-fever-plugin";
+    platforms = platforms.all;
+    maintainers = with maintainers; [ ajs124 das_j ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14979,9 +14979,10 @@ in
   torque = callPackage ../servers/computing/torque { };
 
   tt-rss = callPackage ../servers/tt-rss { };
+  tt-rss-plugin-auth-ldap = callPackage ../servers/tt-rss/plugin-auth-ldap { };
+  tt-rss-plugin-fever-api = callPackage ../servers/tt-rss/plugin-fever-api { };
   tt-rss-plugin-ff-instagram = callPackage ../servers/tt-rss/plugin-ff-instagram { };
   tt-rss-plugin-tumblr-gdpr = callPackage ../servers/tt-rss/plugin-tumblr-gdpr { };
-  tt-rss-plugin-auth-ldap = callPackage ../servers/tt-rss/plugin-auth-ldap { };
   tt-rss-theme-feedly = callPackage ../servers/tt-rss/theme-feedly { };
 
   searx = callPackage ../servers/web-apps/searx { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

cc @ajs124 @Mic92 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
