### PR TITLE
sendxmpp-rs: Init at unstable-2019-03-02

### DIFF
--- a/pkgs/tools/networking/sendxmpp-rs/default.nix
+++ b/pkgs/tools/networking/sendxmpp-rs/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, rustPlatform, pkgconfig, openssl, fetchFromGitHub }:
+
+rustPlatform.buildRustPackage {
+  pname = "sendxmpp-rs";
+  version = "unstable-2019-03-02";
+
+  src = fetchFromGitHub {
+    owner = "moparisthebest";
+    repo = "sendxmpp-rs";
+    rev = "37b5efd4b62c416e6f47f44ab57a42b61ee3dbcb";
+    sha256 = "0x847xla6655z587jinbk9msp1l3w4pnq2kxpmm1al7g128j9n1y";
+  };
+
+  nativeBuildInputs = [ pkgconfig openssl ];
+  cargoSha256 = "0qiwrq44f388vx3gww65b1im2xfv6q8sph9608bq5xghp9qfjn69";
+
+  meta = with stdenv.lib; {
+    description = "sendxmpp in rust";
+    homepage = "https://github.com/moparisthebest/sendxmpp-rs";
+    license = licenses.gpl3;
+    maintainers = [ ajs124 das_j ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5897,6 +5897,8 @@ in
 
   seexpr = callPackage ../development/compilers/seexpr { };
 
+  sendxmpp-rs = callPackage ../tools/networking/sendxmpp-rs { };
+
   setroot = callPackage  ../tools/X11/setroot { };
 
   setserial = callPackage ../tools/system/setserial { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

cc @ajs124

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
