### PR TITLE
pkgsStatic: override libunwind

### DIFF
--- a/pkgs/development/compilers/llvm/8/libunwind.nix
+++ b/pkgs/development/compilers/llvm/8/libunwind.nix
@@ -1,4 +1,4 @@
-{ stdenv, version, fetch, cmake, fetchpatch }:
+{ stdenv, version, fetch, cmake, fetchpatch, enableShared ? true }:
 
 stdenv.mkDerivation {
   name = "libunwind-${version}";
@@ -19,4 +19,6 @@ stdenv.mkDerivation {
   ];
 
   enableParallelBuilding = true;
+
+  cmakeFlags = stdenv.lib.optional (!enableShared) "-DLIBUNWIND_ENABLE_SHARED=OFF";
 }

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -154,9 +154,11 @@ in {
         enableShared = false;
         inherit libcxxabi;
       };
+      libunwind = super.llvmPackages_8.libraries.libunwind.override {
+        enableShared = false;
+      };
     };
   };
 
   python27 = super.python27.override { static = true; };
-
 }


### PR DESCRIPTION
###### Motivation for this change

Adds static override to LLVM `libunwind`. Try:
```
nix build nixpkgs.pkgsStatic.llvmPackages_8.libraries.libunwind
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
