### PR TITLE
coqPackages.flocq: 3.1.0 -> 3.2.0

### DIFF
--- a/pkgs/development/coq-modules/flocq/default.nix
+++ b/pkgs/development/coq-modules/flocq/default.nix
@@ -1,14 +1,12 @@
-{ stdenv, bash, which, autoconf, automake, fetchurl, coq }:
+{ stdenv, bash, which, autoconf, automake, fetchzip, coq }:
 
 let params =
   if stdenv.lib.versionAtLeast coq.coq-version "8.7" then {
     version = "3.2.0";
-    uid = "38103";
-    sha256 = "1snvzyyj6l1fv7nb70x5w8rjnhk483g9x8gszl9ls8qn2gd35fs0";
+    sha256 = "15bi36x7zj0glsb3s2gwqd4wswhfzh36rbp7imbyff53a7nna95l";
   } else {
     version = "2.6.1";
-    uid = "37454";
-    sha256 = "06msp1fwpqv6p98a3i1nnkj7ch9rcq3rm916yxq8dxf51lkghrin";
+    sha256 = "1y4czkfrd8p37vwv198nns4hz1brfv71na17pxsidwpxy7qnyfw1";
   }
 ; in
 
@@ -17,8 +15,8 @@ stdenv.mkDerivation rec {
   name = "coq${coq.coq-version}-flocq-${version}";
   inherit (params) version;
 
-  src = fetchurl {
-    url = "https://gforge.inria.fr/frs/download.php/file/${params.uid}/flocq-${version}.tar.gz";
+  src = fetchzip {
+    url = "https://gitlab.inria.fr/flocq/flocq/-/archive/flocq-${version}.tar.gz";
     inherit (params) sha256;
   };
 

--- a/pkgs/development/coq-modules/flocq/default.nix
+++ b/pkgs/development/coq-modules/flocq/default.nix
@@ -2,9 +2,9 @@
 
 let params =
   if stdenv.lib.versionAtLeast coq.coq-version "8.7" then {
-    version = "3.1.0";
-    uid = "37901";
-    sha256 = "02szrgz9m0ac51la1lqpiv6i2g0zbgx9gz5rp0q1g00ajldyna5c";
+    version = "3.2.0";
+    uid = "38103";
+    sha256 = "1snvzyyj6l1fv7nb70x5w8rjnhk483g9x8gszl9ls8qn2gd35fs0";
   } else {
     version = "2.6.1";
     uid = "37454";
@@ -46,6 +46,6 @@ stdenv.mkDerivation rec {
   };
 
   passthru = {
-    compatibleCoqVersions = v: builtins.elem v [ "8.5" "8.6" "8.7" "8.8" "8.9" ];
+    compatibleCoqVersions = v: builtins.elem v [ "8.5" "8.6" "8.7" "8.8" "8.9" "8.10" ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Ensures compatibility with Coq 8.10

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
