### PR TITLE
 tgt: Install systemd tgtd.service 

### DIFF
--- a/pkgs/tools/networking/tgt/default.nix
+++ b/pkgs/tools/networking/tgt/default.nix
@@ -13,9 +13,9 @@ stdenv.mkDerivation rec {
     sha256 = "18bp7fcpv7879q3ppdxlqj7ayqmlh5zwrkz8gch6rq9lkmmrklrf";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ libxslt docbook_xsl makeWrapper ];
 
-  buildInputs = [ libxslt systemd libaio docbook_xsl ];
+  buildInputs = [ systemd libaio ];
 
   makeFlags = [
     "PREFIX=${placeholder "out"}"

--- a/pkgs/tools/networking/tgt/default.nix
+++ b/pkgs/tools/networking/tgt/default.nix
@@ -54,5 +54,6 @@ stdenv.mkDerivation rec {
     homepage = "http://stgt.sourceforge.net/";
     license = licenses.gpl2;
     platforms = platforms.linux;
+    maintainers = with maintainers; [ johnazoidberg ];
   };
 }

--- a/pkgs/tools/networking/tgt/default.nix
+++ b/pkgs/tools/networking/tgt/default.nix
@@ -36,9 +36,10 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  meta = {
-    description = "iSCSI Target daemon with rdma support";
-    license = stdenv.lib.licenses.gpl2;
-    platforms = stdenv.lib.platforms.linux;
+  meta = with stdenv.lib; {
+    description = "iSCSI Target daemon with RDMA support";
+    homepage = "http://stgt.sourceforge.net/";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/networking/tgt/default.nix
+++ b/pkgs/tools/networking/tgt/default.nix
@@ -38,6 +38,13 @@ stdenv.mkDerivation rec {
       --replace "#!/usr/bin/perl" "#! ${perl}/bin/perl -I${perlPackages.ConfigGeneral}/${perl.libPrefix}"
     wrapProgram $out/sbin/tgt-admin --prefix PATH : \
       ${lib.makeBinPath [ lsof sg3_utils (placeholder "out") ]}
+
+    install -D scripts/tgtd.service $out/etc/systemd/system/tgtd.service
+    substituteInPlace $out/etc/systemd/system/tgtd.service \
+      --replace "/usr/sbin/tgt" "$out/bin/tgt"
+
+    # See https://bugzilla.redhat.com/show_bug.cgi?id=848942
+    sed -i '/ExecStart=/a ExecStartPost=${coreutils}/bin/sleep 5' $out/etc/systemd/system/tgtd.service
   '';
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change
I wanted to try out iSCSI and saw, like @nyanloutre in #38012, that we're missing a service for tgt.

Like suggested, we can just use the upstream unit file with a bit of fixup.

I'm also working on a proper NixOS service (and maybe a test), but this is good enough for now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
