### PR TITLE
syncthing: create default group if not overridden

### DIFF
--- a/nixos/modules/services/networking/syncthing.nix
+++ b/nixos/modules/services/networking/syncthing.nix
@@ -372,16 +372,18 @@ in {
 
     systemd.packages = [ pkgs.syncthing ];
 
-    users = mkIf (cfg.systemService && cfg.user == defaultUser) {
-      users."${defaultUser}" =
+    users.users = mkIf (cfg.systemService && cfg.user == defaultUser) {
+      "${defaultUser}" =
         { group = cfg.group;
           home  = cfg.dataDir;
           createHome = true;
           uid = config.ids.uids.syncthing;
           description = "Syncthing daemon user";
         };
+    };
 
-      groups."${defaultUser}".gid =
+    users.groups = mkIf (cfg.systemService && cfg.group == defaultUser) {
+      "${defaultUser}".gid =
         config.ids.gids.syncthing;
     };
 


### PR DESCRIPTION
###### Motivation for this change

The following configuration generates a systemd unit that doesn't start.
```nix
{
  services.syncthing = {
    enable = true;
    user = "my-user";
  };
}
```

It fails with
```
systemd[1]: Started Syncthing service.
systemd[6745]: syncthing.service: Failed to determine group credentials: No such process
systemd[6745]: syncthing.service: Failed at step GROUP spawning /nix/store/n1ydz3i08nqp1ajc50ycy1zribmphqc9-syncthing-1.1.4-bin/bin/syncthing: No such process
systemd[1]: syncthing.service: Main process exited, code=exited, status=216/GROUP
systemd[1]: syncthing.service: Failed with result 'exit-code'.
```

This is due to the fact that `syncthing` group (default) is not created if the user is overridden.

Add a separate check for setting up the default group, so that user/group are created independently.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This became an issue after https://github.com/NixOS/nixpkgs/pull/65078
/cc @peterhoeg @aanderse 