### PR TITLE
devilutionx: init at unstable-2019-07-28

### DIFF
--- a/pkgs/games/devilutionx/default.nix
+++ b/pkgs/games/devilutionx/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub, cmake, SDL2, SDL2_mixer, SDL2_ttf, libsodium, pkg-config }:
+stdenv.mkDerivation rec {
+  version = "unstable-2019-07-28";
+  pname = "devilutionx";
+
+  src = fetchFromGitHub {
+    owner = "diasurgical";
+    repo = "devilutionX";
+    rev = "b2f358874705598ec139f290b21e340c73d250f6";
+    sha256 = "0s812km118qq5pzlzvzfndvag0mp6yzvm69ykc97frdiq608zw4f";
+  };
+
+  NIX_CFLAGS_COMPILE = "-I${SDL2_ttf}/include/SDL2";
+
+  # compilation will fail due to -Werror=format-security
+  hardeningDisable = [ "format" ];
+
+  nativeBuildInputs = [ pkg-config cmake ];
+  buildInputs = [ libsodium SDL2 SDL2_mixer SDL2_ttf ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp devilutionx $out/bin
+
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/diasurgical/devilutionX";
+    description = "Diablo build for modern operating systems";
+    license = licenses.unlicense;
+    maintainers = [ maintainers.karolchmist ];
+    platforms = platforms.linux ++ platforms.darwin ++ platforms.windows;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21690,6 +21690,8 @@ in
 
   cuyo = callPackage ../games/cuyo { };
 
+  devilutionx = callPackage ../games/devilutionx {};
+
   dhewm3 = callPackage ../games/dhewm3 {};
 
   digikam = libsForQt5.callPackage ../applications/graphics/digikam {


### PR DESCRIPTION
###### Motivation for this change

This PR adds [DevilutionX](https://github.com/diasurgical/devilutionX), a build of Diablo game from 1996 for modern operating systems.

To make it run, a file with original data from the game (`diabdat.mpq`) must be placed in `~/.local/share/diasurgical/devilution`. In future releases of DevilutionX, this is planned to be configurable. We could make it a parameter as well when possible. 

This PR builds a recent master commit, because since the last release (0.4.0) there have been a lot of improvements for 64 bit build. I've managed to build and run the game on a 64 bit NixOs and play it quite well. 

As soon a next version is released, I plan to keep DevilutionX track the official releases.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
