### PR TITLE
 libsForQt5.fcitx-qt5: fix build 

### DIFF
--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-libpinyin/default.nix
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-libpinyin/default.nix
@@ -25,8 +25,6 @@ stdenv.mkDerivation rec {
   preInstall = ''
     substituteInPlace src/cmake_install.cmake \
       --replace ${fcitx} $out
-    substituteInPlace po/cmake_install.cmake \
-      --replace ${fcitx} $out
     substituteInPlace data/cmake_install.cmake \
       --replace ${fcitx} $out
     substituteInPlace dictmanager/cmake_install.cmake \

--- a/pkgs/tools/inputmethods/fcitx/fcitx-qt5.nix
+++ b/pkgs/tools/inputmethods/fcitx/fcitx-qt5.nix
@@ -1,6 +1,12 @@
-{ stdenv, fetchFromGitLab, cmake, fcitx, pkgconfig, qtbase, extra-cmake-modules }:
+{ lib, mkDerivation, fetchFromGitLab
+, cmake
+, extra-cmake-modules
+, fcitx
+, pkgconfig
+, qtbase
+}:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "fcitx-qt5";
   version = "1.2.3";
 
@@ -17,12 +23,12 @@ stdenv.mkDerivation rec {
 
   preInstall = ''
     substituteInPlace platforminputcontext/cmake_install.cmake \
-      --replace ${qtbase.out} $out
+      --replace ${qtbase.bin} $out
     substituteInPlace quickphrase-editor/cmake_install.cmake \
       --replace ${fcitx} $out
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage    = https://gitlab.com/fcitx/fcitx-qt5;
     description = "Qt5 IM Module for Fcitx";
     license     = licenses.gpl2;


### PR DESCRIPTION
###### Motivation for this change

While reviewing another PR, found this was broken due to output path error.

libpinyin was the original derivation that was failing due to the fcitx-qt5 error, I cleaned up an "unused substitutation". Verified the cmake file wasn't making any reference to a fcitx storepath.

EDIT:
Resolves  #65547

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
