### PR TITLE
libblockdev: 2.20 -> 2.22

### DIFF
--- a/pkgs/development/libraries/libblockdev/default.nix
+++ b/pkgs/development/libraries/libblockdev/default.nix
@@ -1,18 +1,18 @@
-{ stdenv, fetchFromGitHub, substituteAll, autoreconfHook, pkgconfig, gtk-doc, libxslt, docbook_xsl
-, docbook_xml_dtd_43, python3, gobject-introspection, glib, udev, kmod, parted, gptfdisk, libyaml
+{ stdenv, fetchFromGitHub, substituteAll, autoreconfHook, pkgconfig, gtk-doc
+, docbook_xml_dtd_43, python3, gobject-introspection, glib, udev, kmod, parted
 , cryptsetup, lvm2, dmraid, utillinux, libbytesize, libndctl, nss, volume_key
+, libxslt, docbook_xsl, gptfdisk, libyaml, autoconf-archive
+, thin-provisioning-tools, makeWrapper
 }:
-
-let
-  version = "2.20";
-in stdenv.mkDerivation rec {
-  name = "libblockdev-${version}";
+stdenv.mkDerivation rec {
+  pname = "libblockdev";
+  version = "2.22";
 
   src = fetchFromGitHub {
     owner = "storaged-project";
     repo = "libblockdev";
     rev = "${version}-1";
-    sha256 = "13xy8vx2dnnxczpnwapchc5ncigcxb2fhpmrmglbpkjqmhn2zbdj";
+    sha256 = "03y4ps37wbi9p1136q0xzgshfnrjg4lgy8pgm1a3ihfcjnbwrbnq";
   };
 
   outputs = [ "out" "dev" "devdoc" ];
@@ -29,18 +29,25 @@ in stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [
-    autoreconfHook pkgconfig gtk-doc libxslt docbook_xsl docbook_xml_dtd_43 python3 gobject-introspection
+    autoreconfHook pkgconfig gtk-doc libxslt docbook_xsl docbook_xml_dtd_43
+    python3 gobject-introspection autoconf-archive makeWrapper
   ];
 
   buildInputs = [
-    glib udev kmod parted gptfdisk cryptsetup lvm2 dmraid utillinux libbytesize libndctl nss volume_key libyaml
+    glib udev kmod parted gptfdisk cryptsetup lvm2 dmraid utillinux libbytesize
+    libndctl nss volume_key libyaml
   ];
+
+  postInstall = ''
+    wrapProgram $out/bin/lvm-cache-stats --prefix PATH : \
+      ${stdenv.lib.makeBinPath [ thin-provisioning-tools ]}
+  '';
 
   meta = with stdenv.lib; {
     description = "A library for manipulating block devices";
-    homepage = http://storaged.org/libblockdev/;
-    license = licenses.lgpl2Plus; # lgpl2Plus for the library, gpl2Plus for the utils
-    maintainers = with maintainers; [];
+    homepage = "http://storaged.org/libblockdev/";
+    license = with licenses; [ lgpl2Plus gpl2Plus ]; # lgpl2Plus for the library, gpl2Plus for the utils
+    maintainers = with maintainers; [ johnazoidberg ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
https://github.com/storaged-project/libblockdev/releases/tag/2.22-1
https://github.com/storaged-project/libblockdev/releases/tag/2.21-1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
