### PR TITLE
 python3Packages.imbalanced-learn: 0.4.3 -> 0.5.0

### DIFF
--- a/pkgs/development/python-modules/imbalanced-learn/0.4.nix
+++ b/pkgs/development/python-modules/imbalanced-learn/0.4.nix
@@ -1,0 +1,29 @@
+{ stdenv, buildPythonPackage, fetchPypi, scikitlearn, pandas, nose, pytest }:
+
+buildPythonPackage rec {
+  pname = "imbalanced-learn";
+  version = "0.4.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "5bd9e86e40ce4001a57426541d7c79b18143cbd181e3330c1a3e5c5c43287083";
+  };
+
+  propagatedBuildInputs = [ scikitlearn ];
+  checkInputs = [ nose pytest pandas ];
+  checkPhase = ''
+    export HOME=$PWD
+    # skip some tests that fail because of minimal rounding errors
+    # or large dependencies
+    py.test imblearn -k 'not classification \
+                         and not _generator \
+                         and not _forest \
+                         and not wrong_memory'
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Library offering a number of re-sampling techniques commonly used in datasets showing strong between-class imbalance";
+    homepage = https://github.com/scikit-learn-contrib/imbalanced-learn;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/imbalanced-learn/default.nix
+++ b/pkgs/development/python-modules/imbalanced-learn/default.nix
@@ -1,25 +1,30 @@
-{ stdenv, buildPythonPackage, fetchPypi, scikitlearn, pandas, nose, pytest }:
+{ stdenv, buildPythonPackage, fetchPypi, isPy27
+, nose
+, pandas
+, pytest
+, scikitlearn
+, tensorflow
+}:
 
 buildPythonPackage rec {
   pname = "imbalanced-learn";
-  version = "0.4.3";
+  version = "0.5.0";
+  disabled = isPy27; # scikit-learn>=0.21 doesn't work on python2
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "5bd9e86e40ce4001a57426541d7c79b18143cbd181e3330c1a3e5c5c43287083";
+    sha256 = "1m8r055mvkws0s449s1dyrkgricls6basnszwbwqwrw6g19n1xsx";
   };
 
   propagatedBuildInputs = [ scikitlearn ];
   checkInputs = [ nose pytest pandas ];
   checkPhase = ''
-    export HOME=$PWD
+    export HOME=$TMPDIR
     # skip some tests that fail because of minimal rounding errors
-    # or large dependencies
-    py.test imblearn -k 'not classification \
-                         and not _generator \
-                         and not _forest \
-                         and not wrong_memory'
-    py.test doc/*.rst
+    # or very large dependencies (keras + tensorflow)
+    py.test imblearn -k 'not estimator \
+                         and not classification \
+                         and not _generator'
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/python-modules/imbalanced-learn/default.nix
+++ b/pkgs/development/python-modules/imbalanced-learn/default.nix
@@ -14,7 +14,11 @@ buildPythonPackage rec {
   checkPhase = ''
     export HOME=$PWD
     # skip some tests that fail because of minimal rounding errors
-    py.test imblearn --ignore=imblearn/metrics/classification.py
+    # or large dependencies
+    py.test imblearn -k 'not classification \
+                         and not _generator \
+                         and not _forest \
+                         and not wrong_memory'
     py.test doc/*.rst
   '';
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2353,7 +2353,11 @@ in {
 
   image-match = callPackage ../development/python-modules/image-match { };
 
-  imbalanced-learn = callPackage ../development/python-modules/imbalanced-learn { };
+  imbalanced-learn =
+    if isPy27 then
+      callPackage ../development/python-modules/imbalanced-learn/0.4.nix { }
+    else
+      callPackage ../development/python-modules/imbalanced-learn { };
 
   immutables = callPackage ../development/python-modules/immutables {};
 


### PR DESCRIPTION
###### Motivation for this change
Noticed it was out of date while fixing the build.

Had to freeze it for python2 because scikit-learn>=0.21 is no longer compatible.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
