### PR TITLE
gn: 20190726 -> 20190403 (downgrade to fix Chromium)

### DIFF
--- a/pkgs/development/tools/build-managers/gn/default.nix
+++ b/pkgs/development/tools/build-managers/gn/default.nix
@@ -2,8 +2,8 @@
 , git, ninja, python2 }:
 
 let
-  rev = "0bc16a82ea001ad9c94b870f097034be5c8e40b4";
-  sha256 = "01as6q5xr0smiihm9m1x74pykd2jcqi4rhv8irmv43v2f0pxwzi5";
+  rev = "64b846c96daeb3eaf08e26d8a84d8451c6cb712b";
+  sha256 = "1v2kzsshhxn0ck6gd5w16gi2m3higwd9vkyylmsczxfxnw8skgpy";
 
   shortRev = builtins.substring 0 7 rev;
   lastCommitPosition = writeText "last_commit_position.h" ''
@@ -18,7 +18,7 @@ let
 in
 stdenv.mkDerivation rec {
   name = "gn-${version}";
-  version = "20190726";
+  version = "20190403";
 
   src = fetchgit {
     url = "https://gn.googlesource.com/gn";


### PR DESCRIPTION
Upstream knowingly broke compatibility with Chromium (https://gn-review.googlesource.com/c/gn/+/4980). Instead of the latest commit, we should use the version specified in the Chromium repository, as is done by Arch Linux: https://git.archlinux.org/svntogit/packages.git/tree/trunk/chromium-gn-version.sh?h=packages/gn

I am currently building Chromium.

cc @delroth 

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
