### PR TITLE
mtm: init at 1.0.1

### DIFF
--- a/pkgs/tools/misc/mtm/default.nix
+++ b/pkgs/tools/misc/mtm/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, ncurses }:
+
+stdenv.mkDerivation rec {
+  pname = "mtm";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "deadpixi";
+    repo = pname;
+    rev = version;
+    sha256 = "0q23z1dfjz3qkmxqm0d8sg81gn6w1j2n2j6c9hk1kk7iv21v1zb0";
+  };
+
+  buildInputs = [ ncurses ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 -t $out/bin mtm
+    install -Dm644 -t $out/share/man/man1 mtm.1
+
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Perhaps the smallest useful terminal multiplexer in the world";
+    homepage = "https://github.com/deadpixi/mtm";
+    license = licenses.gpl3Plus;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.marsam ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4927,6 +4927,8 @@ in
 
   mpack = callPackage ../tools/networking/mpack { };
 
+  mtm = callPackage ../tools/misc/mtm { };
+
   pa_applet = callPackage ../tools/audio/pa-applet { };
 
   pandoc-imagine = python3Packages.callPackage ../tools/misc/pandoc-imagine { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add https://github.com/deadpixi/mtm

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
