### PR TITLE
ranger: Add myself to CODEOWNERS for ranger

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -139,3 +139,6 @@
 
 # Bazel
 /pkgs/development/tools/build-managers/bazel @mboes @Profpatsch
+
+# Ranger
+/pkgs/applications/misc/ranger @toonn


### PR DESCRIPTION
I'm one of the maintainers of the ranger package but I'm not a NixOS
maintainer so I don't get notified when PRs affect the package. This
makes it hard to "maintain" anything. I always figured this would be a
misuse of CODEOWNERS but multiple NixOS maintainers have told me, "Well,
that's what CODEOWNERS is for." So this is my way of committing to
maintaining the nixpkgs expression for ranger.