### PR TITLE
zerotierone: 1.2.12 -> 1.4.0

### DIFF
--- a/pkgs/tools/networking/zerotierone/default.nix
+++ b/pkgs/tools/networking/zerotierone/default.nix
@@ -1,12 +1,14 @@
-{ stdenv, fetchurl, openssl, lzo, zlib, iproute, which, ronn }:
+{ stdenv, fetchFromGitHub, openssl, lzo, zlib, iproute, which, ronn }:
 
 stdenv.mkDerivation rec {
-  version = "1.2.12";
-  name = "zerotierone-${version}";
+  pname = "zerotierone";
+  version = "1.4.0";
 
-  src = fetchurl {
-    url = "https://github.com/zerotier/ZeroTierOne/archive/${version}.tar.gz";
-    sha256 = "1m7ynrgzpg2sp37hcmjkx6w173icfhakzn1c1zrdzrxmmszrj9r1";
+  src = fetchFromGitHub {
+    owner = "zerotier";
+    repo = "ZeroTierOne";
+    rev = version;
+    sha256 = "14iwhlxmxsnvnm9rrp6rysiz461w0v5nsmnz5p91rfi351103a63";
   };
 
   preConfigure = ''
@@ -15,9 +17,6 @@ stdenv.mkDerivation rec {
 
       substituteInPlace ./osdep/ManagedRoute.cpp \
         --replace '/sbin/ip' '${iproute}/bin/ip'
-
-      substituteInPlace ./osdep/LinuxEthernetTap.cpp \
-        --replace 'execlp("ip",' 'execlp("${iproute}/bin/ip",'
 
       patchShebangs ./doc/build.sh
       substituteInPlace ./doc/build.sh \


### PR DESCRIPTION
### Motivation for this change
https://github.com/zerotier/ZeroTierOne/releases/tag/1.4.0
for release notes.

Removed the substitution in `osdep/LinuxEthernetTap.cpp` since it appears they now set the IP address programmatically instead of using `ip` to do it. The substitution in `osdep/ManagedRoute.cpp` still looks correct, though.

Tested and working fine on my ZT network.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @sjmackenzie @zimbatm @ehmry @obadz
