### PR TITLE
gopro: init at 1.0

### DIFF
--- a/pkgs/tools/video/gopro/default.nix
+++ b/pkgs/tools/video/gopro/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub
+, ffmpeg
+, imagemagick
+, makeWrapper
+, mplayer
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gopro";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "KonradIT";
+    repo = "gopro-linux";
+    rev = version;
+    sha256 = "0sb9vpiadrq8g4ag828h8mvq01fg0306j0wjwkxdmwfqync1128l";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 gopro -t $out/bin
+    wrapProgram $out/bin/gopro \
+      --prefix PATH ":" "${stdenv.lib.makeBinPath [ ffmpeg imagemagick mplayer ]}"
+
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Command line interface for processing media filmed on GoPro HERO 3, 4, 5, 6, and 7 cameras";
+    homepage = "https://github.com/KonradIT/gopro-linux";
+    platforms = platforms.linux;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3415,6 +3415,8 @@ in
 
   google-music-scripts = callPackage ../tools/audio/google-music-scripts { };
 
+  gopro = callPackage ../tools/video/gopro { };
+
   gource = callPackage ../applications/version-management/gource { };
 
   govc = callPackage ../tools/virtualization/govc { };


### PR DESCRIPTION
###### Motivation for this change
Resolves #65603

CLI QoL script for interacting with GoPro's

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @CMCDragonkai 

-----

it's big (mplayer is a 500MB closure), kind of feel like doing multiple outputs for some of the dependencies (mplayer and imagemagick), so I don't have to include the whole closure.
```
$ nix path-info -Sh ./result
/nix/store/b9dbwqyzqvd1jcyab0cbr7760nlq4rql-gopro-1.0    543.9M
```