### PR TITLE
nixos/tests/cassandra: Test jmxPort

### DIFF
--- a/nixos/tests/cassandra.nix
+++ b/nixos/tests/cassandra.nix
@@ -8,11 +8,12 @@ let
   jmxRoles = [{ username = "me"; password = "password"; }];
   jmxRolesFile = ./cassandra-jmx-roles;
   jmxAuthArgs = "-u ${(builtins.elemAt jmxRoles 0).username} -pw ${(builtins.elemAt jmxRoles 0).password}";
+  jmxPort = 7200;  # Non-standard port so it doesn't accidentally work
 
   # Would usually be assigned to 512M
   numMaxHeapSize = "400";
   getHeapLimitCommand = ''
-    nodetool info | grep "^Heap Memory" | awk \'{print $NF}\'
+    nodetool info -p ${toString jmxPort} | grep "^Heap Memory" | awk \'{print $NF}\'
   '';
   checkHeapLimitCommand = ''
     [ 1 -eq "$(echo "$(${getHeapLimitCommand}) < ${numMaxHeapSize}" | ${pkgs.bc}/bin/bc)" ]
@@ -27,19 +28,20 @@ let
       package = testPackage;
       maxHeapSize = "${numMaxHeapSize}M";
       heapNewSize = "100M";
+      inherit jmxPort;
     };
-  nodeCfg = ipAddress: extra: {pkgs, config, ...}:
-    { environment.systemPackages = [ testPackage ];
-      networking = {
-        firewall.allowedTCPPorts = [ 7000 7199 9042 ];
-        useDHCP = false;
-        interfaces.eth1.ipv4.addresses = pkgs.lib.mkOverride 0 [
-          { address = ipAddress; prefixLength = 24; }
-        ];
-      };
-      services.cassandra = cassandraCfg ipAddress // extra;
-      virtualisation.memorySize = 1024;
+  nodeCfg = ipAddress: extra: {pkgs, config, ...}: rec {
+    environment.systemPackages = [ testPackage ];
+    networking = {
+      firewall.allowedTCPPorts = [ 7000 9042 services.cassandra.jmxPort ];
+      useDHCP = false;
+      interfaces.eth1.ipv4.addresses = pkgs.lib.mkOverride 0 [
+        { address = ipAddress; prefixLength = 24; }
+      ];
     };
+    services.cassandra = cassandraCfg ipAddress // extra;
+    virtualisation.memorySize = 1024;
+  };
 in
 {
   name = "cassandra-ci";
@@ -50,7 +52,9 @@ in
     cass2 = nodeCfg "192.168.1.3" { jvmOpts = [ "-Dcassandra.replace_address=cass1" ]; };
   };
 
-  testScript = ''
+  testScript = let
+    jmxPortS = toString jmxPort;
+  in ''
     # Check configuration
     subtest "Timers exist", sub {
       $cass0->succeed("systemctl list-timers | grep cassandra-full-repair.timer");
@@ -63,51 +67,51 @@ in
     };
     subtest "Nodetool is operational", sub {
       $cass0->waitForUnit("cassandra.service");
-      $cass0->waitUntilSucceeds("nc -z localhost 7199");
-      $cass0->succeed("nodetool status --resolve-ip | egrep '^UN[[:space:]]+cass0'");
+      $cass0->waitUntilSucceeds("nc -z localhost ${jmxPortS}");
+      $cass0->succeed("nodetool status -p ${jmxPortS} --resolve-ip | egrep '^UN[[:space:]]+cass0'");
     };
     subtest "Cluster name was set", sub {
       $cass0->waitForUnit("cassandra.service");
-      $cass0->waitUntilSucceeds("nc -z localhost 7199");
-      $cass0->waitUntilSucceeds("nodetool describecluster | grep 'Name: ${clusterName}'");
+      $cass0->waitUntilSucceeds("nc -z localhost ${jmxPortS}");
+      $cass0->waitUntilSucceeds("nodetool describecluster -p ${jmxPortS} | grep 'Name: ${clusterName}'");
     };
     subtest "Heap limit set correctly", sub {
       # Nodetool takes a while until it can display info
-      $cass0->waitUntilSucceeds('nodetool info');
+      $cass0->waitUntilSucceeds('nodetool info -p ${jmxPortS}');
       $cass0->succeed('${checkHeapLimitCommand}');
     };
 
     # Check cluster interaction
     subtest "Bring up cluster", sub {
       $cass1->waitForUnit("cassandra.service");
-      $cass1->waitUntilSucceeds("nodetool ${jmxAuthArgs} status | egrep -c '^UN' | grep 2");
-      $cass0->succeed("nodetool status --resolve-ip | egrep '^UN[[:space:]]+cass1'");
+      $cass1->waitUntilSucceeds("nodetool -p ${jmxPortS} ${jmxAuthArgs} status | egrep -c '^UN' | grep 2");
+      $cass0->succeed("nodetool status -p ${jmxPortS} --resolve-ip | egrep '^UN[[:space:]]+cass1'");
     };
   '' + lib.optionalString testRemoteAuth ''
     subtest "Remote authenticated jmx", sub {
       # Doesn't work if not enabled
-      $cass0->waitUntilSucceeds("nc -z localhost 7199");
-      $cass1->fail("nc -z 192.168.1.1 7199");
-      $cass1->fail("nodetool -h 192.168.1.1 status");
+      $cass0->waitUntilSucceeds("nc -z localhost ${jmxPortS}");
+      $cass1->fail("nc -z 192.168.1.1 ${toString jmxPort}");
+      $cass1->fail("nodetool -p ${jmxPortS} -h 192.168.1.1 status");
 
       # Works if enabled
-      $cass1->waitUntilSucceeds("nc -z localhost 7199");
-      $cass0->succeed("nodetool -h 192.168.1.2 ${jmxAuthArgs} status");
+      $cass1->waitUntilSucceeds("nc -z localhost ${toString jmxPort}");
+      $cass0->succeed("nodetool -p ${jmxPortS} -h 192.168.1.2 ${jmxAuthArgs} status");
     };
   '' + ''
     subtest "Break and fix node", sub {
       $cass1->block;
-      $cass0->waitUntilSucceeds("nodetool status --resolve-ip | egrep -c '^DN[[:space:]]+cass1'");
-      $cass0->succeed("nodetool status | egrep -c '^UN'  | grep 1");
+      $cass0->waitUntilSucceeds("nodetool status -p ${jmxPortS} --resolve-ip | egrep -c '^DN[[:space:]]+cass1'");
+      $cass0->succeed("nodetool status -p ${jmxPortS} | egrep -c '^UN'  | grep 1");
       $cass1->unblock;
-      $cass1->waitUntilSucceeds("nodetool ${jmxAuthArgs} status | egrep -c '^UN'  | grep 2");
-      $cass0->succeed("nodetool status | egrep -c '^UN'  | grep 2");
+      $cass1->waitUntilSucceeds("nodetool -p ${jmxPortS} ${jmxAuthArgs} status | egrep -c '^UN'  | grep 2");
+      $cass0->succeed("nodetool status -p ${jmxPortS} | egrep -c '^UN'  | grep 2");
     };
     subtest "Replace crashed node", sub {
       $cass1->crash;
       $cass2->waitForUnit("cassandra.service");
-      $cass0->waitUntilFails("nodetool status --resolve-ip | egrep '^UN[[:space:]]+cass1'");
-      $cass0->waitUntilSucceeds("nodetool status --resolve-ip | egrep '^UN[[:space:]]+cass2'");
+      $cass0->waitUntilFails("nodetool status -p ${jmxPortS} --resolve-ip | egrep '^UN[[:space:]]+cass1'");
+      $cass0->waitUntilSucceeds("nodetool status -p ${jmxPortS} --resolve-ip | egrep '^UN[[:space:]]+cass2'");
     };
   '';
 })


### PR DESCRIPTION
###### Motivation for this change
The test sets it to a non-standard port so it won't work accidentally
now and we'll be sure that our NixOS option works.

ofBorg won't run the test because it takes too long (cluster start up, repair, ...) but it works fine on my machine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @cransom 
