### PR TITLE
pwgen-secure: init at 0.9.1

### DIFF
--- a/pkgs/tools/security/pwgen-secure/default.nix
+++ b/pkgs/tools/security/pwgen-secure/default.nix
@@ -1,0 +1,36 @@
+{ lib, python3Packages, fetchFromGitHub }:
+
+with python3Packages;
+
+buildPythonApplication rec {
+  pname = "pwgen-secure";
+  version = "0.9.1";
+
+  # it needs `secrets` which was introduced in 3.6
+  disabled = pythonOlder "3.6";
+
+  # GH is newer than Pypi and contains both library *and* the actual program
+  # whereas Pypi only has the library
+  src = fetchFromGitHub {
+    owner = "mjmunger";
+    repo = "pwgen_secure";
+    rev = "v${version}";
+    sha256 = "15md5606hzy1xfhj2lxmc0nvynyrcs4vxa5jdi34kfm31rdklj28";
+  };
+
+  propagatedBuildInputs = [ docopt ];
+
+  postInstall = ''
+    install -Dm755 spwgen.py $out/bin/spwgen
+  '';
+
+  # there are no checks
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Secure password generation library to replace pwgen";
+    homepage = "https://github.com/mjmunger/pwgen_secure/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ peterhoeg ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5164,6 +5164,8 @@ in
 
   pwgen = callPackage ../tools/security/pwgen { };
 
+  pwgen-secure = callPackage ../tools/security/pwgen-secure { };
+
   pwnat = callPackage ../tools/networking/pwnat { };
 
   pwndbg = python3Packages.callPackage ../development/tools/misc/pwndbg { };


### PR DESCRIPTION
###### Motivation for this change

I'm upstreaming local changes in preparation for 19.09.

Cc: star reviewer @worldofpeace 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

