### PR TITLE
ls4: init at 1.0

### DIFF
--- a/pkgs/applications/science/logic/ls4/default.nix
+++ b/pkgs/applications/science/logic/ls4/default.nix
@@ -15,8 +15,7 @@ gccStdenv.mkDerivation rec {
     # These object files were committed into the git repo, perhaps accidentally
     # They are also not built by the included Makefile, so we're manually 
     # regenerating them here.
-    rm -f aiger.o
-    rm -f aiger.o_32
+    rm aiger.o aiger.o_32
     gcc -g -O3 -c aiger.c
   '';
 
@@ -31,7 +30,7 @@ gccStdenv.mkDerivation rec {
     sha256 = "11j34qia9pb9jqfqggzpypi7y6bq7pdhx9pvl845n9cysc8zsdfj";
   };
 
-  meta = with gccStdenv.lib; {
+  meta = with lib; {
     description = "A solver for temporal logic, in particular a PLTL-prover based on labelled superposition with partial model guidance. Based off of minisat";
     homepage = "https://github.com/quickbeam123/ls4";
     license = licenses.mit;

--- a/pkgs/applications/science/logic/ls4/default.nix
+++ b/pkgs/applications/science/logic/ls4/default.nix
@@ -10,6 +10,8 @@
   preBuild = ''
     cd core
     # These object files were committed into the git repo, perhaps accidentally
+    # They are also not built by the included Makefile, so we're manually 
+    # regenerating them here.
     rm -f aiger.o
     rm -f aiger.o_32
     gcc -g -O3 -c aiger.c

--- a/pkgs/applications/science/logic/ls4/default.nix
+++ b/pkgs/applications/science/logic/ls4/default.nix
@@ -1,11 +1,11 @@
-{ zlib, stdenv, fetchFromGitHub }:
+{ zlib, gcc, stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
   pname = "ls4";
 
   version = "unstable-2019-07-31";
 
-  buildInputs = [ zlib ];
+  buildInputs = [ zlib gcc ];
 
   preBuild = ''
   cd core

--- a/pkgs/applications/science/logic/ls4/default.nix
+++ b/pkgs/applications/science/logic/ls4/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     description = "A solver for temporal logic, in particular a PLTL-prover based on labelled superposition with partial model guidance. Based off of minisat";
     homepage = "https://github.com/quickbeam123/ls4";
     license = licenses.mit;
-    platforms = platforms.unix;
+    platforms = platforms.x86;
     maintainers = with maintainers; [changlinli];
   };
 }

--- a/pkgs/applications/science/logic/ls4/default.nix
+++ b/pkgs/applications/science/logic/ls4/default.nix
@@ -1,24 +1,27 @@
 { zlib, stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  name = "ls4-${version}";
+  pname = "ls4";
 
-  version = "1.0";
+  version = "unstable-2019-07-31";
 
   buildInputs = [ zlib ];
 
-  buildPhase = ''
+  preBuild = ''
   cd core
   # These object files were committed into the git repo, perhaps accidentally
   rm -f aiger.o
   rm -f aiger.o_32
   gcc -g -O3 -c aiger.c
+  '';
+
+  buildPhase = ''
+  runHook preBuild
   make
   '';
 
   installPhase = ''
-  mkdir -p $out/bin
-  cp ls4 $out/bin
+  install -D ls4 $out/bin/ls4
   '';
 
   src = fetchFromGitHub {
@@ -29,7 +32,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with stdenv.lib; {
-    description = "A solver for temporal logic, in particular a PLTL-prover based on labelled superposition with partial model guidance. Based off of minisat.";
+    description = "A solver for temporal logic, in particular a PLTL-prover based on labelled superposition with partial model guidance. Based off of minisat";
     homepage = "https://github.com/quickbeam123/ls4";
     license = licenses.mit;
     platforms = platforms.unix;

--- a/pkgs/applications/science/logic/ls4/default.nix
+++ b/pkgs/applications/science/logic/ls4/default.nix
@@ -1,0 +1,38 @@
+{ zlib, stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "ls4-${version}";
+
+  version = "1.0";
+
+  buildInputs = [ zlib ];
+
+  buildPhase = ''
+  cd core
+  # These object files were committed into the git repo, perhaps accidentally
+  rm -f aiger.o
+  rm -f aiger.o_32
+  gcc -g -O3 -c aiger.c
+  make
+  '';
+
+  installPhase = ''
+  mkdir -p $out/bin
+  cp ls4 $out/bin
+  '';
+
+  src = fetchFromGitHub {
+    owner = "quickbeam123";
+    repo = "ls4";
+    rev = "0293895817ede193277b321a38226abdfdf75bef";
+    sha256 = "11j34qia9pb9jqfqggzpypi7y6bq7pdhx9pvl845n9cysc8zsdfj";
+  };
+
+  meta = with stdenv.lib; {
+    description = "A solver for temporal logic, in particular a PLTL-prover based on labelled superposition with partial model guidance. Based off of minisat.";
+    homepage = "https://github.com/quickbeam123/ls4";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [changlinli];
+  };
+}

--- a/pkgs/applications/science/logic/ls4/default.nix
+++ b/pkgs/applications/science/logic/ls4/default.nix
@@ -8,15 +8,15 @@
   buildInputs = [ zlib gcc ];
 
   preBuild = ''
-  cd core
-  # These object files were committed into the git repo, perhaps accidentally
-  rm -f aiger.o
-  rm -f aiger.o_32
-  gcc -g -O3 -c aiger.c
+    cd core
+    # These object files were committed into the git repo, perhaps accidentally
+    rm -f aiger.o
+    rm -f aiger.o_32
+    gcc -g -O3 -c aiger.c
   '';
 
   installPhase = ''
-  install -D ls4 $out/bin/ls4
+    install -D ls4 $out/bin/ls4
   '';
 
   src = fetchFromGitHub {

--- a/pkgs/applications/science/logic/ls4/default.nix
+++ b/pkgs/applications/science/logic/ls4/default.nix
@@ -1,6 +1,9 @@
-{ zlib, gcc, stdenv, fetchFromGitHub, overrideCC }:
+{ zlib, gcc, fetchFromGitHub, gccStdenv }:
 
-(overrideCC stdenv gcc).mkDerivation rec {
+# We require GCC because the source code uses GCC specific features that e.g.
+# clang lacks, which causes a build failure on darwin (where clang is the C
+# compiler provided by stdenv).
+gccStdenv.mkDerivation rec {
   pname = "ls4";
 
   version = "unstable-2019-07-31";
@@ -28,7 +31,7 @@
     sha256 = "11j34qia9pb9jqfqggzpypi7y6bq7pdhx9pvl845n9cysc8zsdfj";
   };
 
-  meta = with stdenv.lib; {
+  meta = with gccStdenv.lib; {
     description = "A solver for temporal logic, in particular a PLTL-prover based on labelled superposition with partial model guidance. Based off of minisat";
     homepage = "https://github.com/quickbeam123/ls4";
     license = licenses.mit;

--- a/pkgs/applications/science/logic/ls4/default.nix
+++ b/pkgs/applications/science/logic/ls4/default.nix
@@ -15,11 +15,6 @@ stdenv.mkDerivation rec {
   gcc -g -O3 -c aiger.c
   '';
 
-  buildPhase = ''
-  runHook preBuild
-  make
-  '';
-
   installPhase = ''
   install -D ls4 $out/bin/ls4
   '';

--- a/pkgs/applications/science/logic/ls4/default.nix
+++ b/pkgs/applications/science/logic/ls4/default.nix
@@ -1,6 +1,6 @@
-{ zlib, gcc, stdenv, fetchFromGitHub }:
+{ zlib, gcc, stdenv, fetchFromGitHub, overrideCC }:
 
-stdenv.mkDerivation rec {
+(overrideCC stdenv gcc).mkDerivation rec {
   pname = "ls4";
 
   version = "unstable-2019-07-31";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23238,7 +23238,7 @@ in
 
   logisim = callPackage ../applications/science/logic/logisim {};
 
-  ls4 = callPackage ../applications/science/logic/ls4 {};
+  ls4 = callPackage ../applications/science/logic/ls4 { };
 
   ltl2ba = callPackage ../applications/science/logic/ltl2ba {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23238,6 +23238,8 @@ in
 
   logisim = callPackage ../applications/science/logic/logisim {};
 
+  ls4 = callPackage ../applications/science/logic/ls4 {};
+
   ltl2ba = callPackage ../applications/science/logic/ltl2ba {};
 
   metis-prover = callPackage ../applications/science/logic/metis-prover { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Adds the ls4 solver.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

