### PR TITLE
croc: init at 6.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2156,6 +2156,11 @@
     github = "hlolli";
     name = "Hlodver Sigurdsson";
   };
+  hugoreeves = {
+    email = "hugolreeves@gmail.com";
+    github = "hugoreeves";
+    name = "Hugo Reeves";
+  };
   hodapp = {
     email = "hodapp87@gmail.com";
     github = "Hodapp87";

--- a/pkgs/tools/networking/croc/default.nix
+++ b/pkgs/tools/networking/croc/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "croc";
+  version = "6.1.1";
+
+  goPackagePath = "github.com/schollz/croc";
+
+  src = fetchFromGitHub {
+    owner = "schollz";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "08gkwllk3m5hpkr1iwabvs739rvl6rzdnra2v040dzdj6zgyd12r";
+  };
+
+  modSha256 = "026m3hc2imna7bf4jpqm7yq6mr4l5is2crsx1vxdpr4h0n6z0v3i";
+  subPackages = [ "." ];
+
+  meta = with stdenv.lib; {
+    description = "Easily and securely send things from one computer to another";
+    homepage = https://github.com/schollz/croc;
+    license = licenses.mit;
+    maintainers = with maintainers; [ hugoreeves ];
+
+    longDescription = ''
+      Croc is a command line tool written in Go that allows any two computers to
+      simply and securely transfer files and folders.
+
+      Croc does all of the following:
+      - Allows any two computers to transfer data (using a relay)
+      - Provides end-to-end encryption (using PAKE)
+      - Enables easy cross-platform transfers (Windows, Linux, Mac)
+      - Allows multiple file transfers
+      - Allows resuming transfers that are interrupted
+      - Does not require a server or port-forwarding
+    '';
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1276,6 +1276,8 @@ in
 
   ccnet = callPackage ../tools/networking/ccnet { };
 
+  croc = callPackage ../tools/networking/croc { };
+
   cddl = callPackage ../development/tools/cddl { };
 
   cedille = callPackage ../applications/science/logic/cedille


### PR DESCRIPTION
###### Motivation for this change

This is my first PR to anything Nix. Croc is a golang cli tool that I use frequently when setting up new devices and it is not currently present within nixpkgs. Croc sends files securely use PAKE between two devices. I have added the derivation for croc v6.1.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers
N/A
