### PR TITLE
ocamlPackages.secp256k1: init at 0.4.0

### DIFF
--- a/pkgs/development/ocaml-modules/secp256k1/default.nix
+++ b/pkgs/development/ocaml-modules/secp256k1/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchFromGitHub, buildDunePackage, base, stdio, configurator, secp256k1 }:
+
+buildDunePackage rec {
+  pname = "secp256k1";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "dakk";
+    repo = "secp256k1-ml";
+    rev = "42c04c93e2ed9596f6378676e944c8cfabfa69d7";
+    sha256 = "1zw2kgg181a9lj1m8z0ybijs8gw9w1kk990avh1bp9x8kc1asffg";
+  };
+
+  buildInputs = [ base stdio configurator secp256k1 ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/dakk/secp256k1-ml;
+    description = "Elliptic curve library secp256k1 wrapper for Ocaml";
+    license = licenses.mit;
+    maintainers = [ maintainers.vyorkin ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -591,6 +591,10 @@ let
 
     result = callPackage ../development/ocaml-modules/ocaml-result { };
 
+    secp256k1 = callPackage ../development/ocaml-modules/secp256k1 {
+      inherit (pkgs) secp256k1;
+    };
+
     seq = callPackage ../development/ocaml-modules/seq { };
 
     sequence = callPackage ../development/ocaml-modules/sequence { };


### PR DESCRIPTION
###### Motivation for this change

Add [secp256k1](https://github.com/dakk/secp256k1-ml): Elliptic curve library secp256k1 wrapper for Ocaml.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).