### PR TITLE
parity: 2.4.9 -> 2.5.5,  parity-beta: 2.5.4 -> 2.6.0

### DIFF
--- a/pkgs/applications/altcoins/parity/beta.nix
+++ b/pkgs/applications/altcoins/parity/beta.nix
@@ -1,6 +1,6 @@
 let
-  version     = "2.5.4";
-  sha256      = "103kg0lrijf6d0mc1nk4pdgwgkmp9ga51rwfqrkkm133lylrr0lf";
-  cargoSha256 = "1w9p43v76igb62mbjk2rl7fynk13l4hpz25jd4f4hk5b2y2wf3r7";
+  version     = "2.6.0";
+  sha256      = "1v0wc6l09nr42ljlq5lq1dgignm53hq3pmrgp2sld9zfxy3vdy0x";
+  cargoSha256 = "1bkcvziz0diy76nbcgykajpnp6akva0m7ka7q6w3s9k7awxjxkx3";
 in
   import ./parity.nix { inherit version sha256 cargoSha256; }

--- a/pkgs/applications/altcoins/parity/default.nix
+++ b/pkgs/applications/altcoins/parity/default.nix
@@ -1,6 +1,6 @@
 let
-  version     = "2.4.9";
-  sha256      = "0pj3yyjzc3fq0r7g8j22anzqxvm377pbcy27np1g7ygkzapzb2v6";
-  cargoSha256 = "1dxn00zxivmgk4a61nxwhjlv7fjsy2ngadyw0br1ssrkgz9k7af2";
+  version     = "2.5.5";
+  sha256      = "193fnrf1pr67wblyxd5gbrg1rgflphnfaxgm3kb4iawjh18br6c6";
+  cargoSha256 = "1w9p43v76igb62mbjk2rl7fynk13l4hpz25jd4f4hk5b2y2wf3r7";
 in
   import ./parity.nix { inherit version sha256 cargoSha256; }

--- a/pkgs/applications/altcoins/parity/parity.nix
+++ b/pkgs/applications/altcoins/parity/parity.nix
@@ -3,9 +3,10 @@
 , cargoSha256
 }:
 
-{ stdenv
+{ lib
 , fetchFromGitHub
 , rustPlatform
+
 , pkgconfig
 , openssl
 , systemd
@@ -14,7 +15,8 @@
 }:
 
 rustPlatform.buildRustPackage rec {
-  name = "parity-${version}";
+  pname = "parity";
+  inherit version;
   inherit cargoSha256;
 
   src = fetchFromGitHub {
@@ -34,11 +36,11 @@ rustPlatform.buildRustPackage rec {
   # test result: FAILED. 80 passed; 12 failed; 0 ignored; 0 measured; 0 filtered out
   doCheck = false;
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Fast, light, robust Ethereum implementation";
     homepage = "http://parity.io";
     license = licenses.gpl3;
-    maintainers = [ maintainers.akru ];
+    maintainers = with maintainers; [ akru xrelkd ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update `parity` and `parity-beta` to the latest releases.

- https://github.com/paritytech/parity-ethereum/releases/tag/v2.5.5
- https://github.com/paritytech/parity-ethereum/releases/tag/v2.6.0

**Note**: This PR depends on #65385. We need the commit [`626ccd7`](https://github.com/NixOS/nixpkgs/commit/626ccd7121adad49e605f310cb5e557fc5265c57) to build `parity-beta`.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @akru 
