### PR TITLE
buildOcaml: remove camlp4 dependency

### DIFF
--- a/pkgs/build-support/ocaml/default.nix
+++ b/pkgs/build-support/ocaml/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, writeText, ocaml, findlib, ocamlbuild, camlp4 }:
+{ stdenv, writeText, ocaml, findlib, ocamlbuild }:
 
 { name, version, buildInputs ? [],
   createFindlibDestdir ?  true,
@@ -19,7 +19,7 @@ in
 stdenv.mkDerivation (args // {
   name = "ocaml-${name}-${version}";
 
-  buildInputs = [ ocaml findlib ocamlbuild camlp4 ] ++ buildInputs;
+  buildInputs = [ ocaml findlib ocamlbuild ] ++ buildInputs;
 
   setupHook = if setupHook == null && hasSharedObjects
   then writeText "setupHook.sh" ''

--- a/pkgs/development/ocaml-modules/bin_prot/default.nix
+++ b/pkgs/development/ocaml-modules/bin_prot/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildOcaml, fetchurl, ocaml, type_conv }:
+{ stdenv, buildOcaml, fetchurl, ocaml, camlp4, type_conv }:
 
 if stdenv.lib.versionAtLeast ocaml.version "4.06"
 then throw "bin_prot-112.24.00 is not available for OCaml ${ocaml.version}"
@@ -15,6 +15,7 @@ buildOcaml rec {
     sha256 = "dc0c978a825c7c123990af3317637c218f61079e6f35dc878260651084f1adb4";
   };
 
+  buildInputs = [ camlp4 ];
   propagatedBuildInputs = [ type_conv ];
 
   hasSharedObjects = true;

--- a/pkgs/development/ocaml-modules/comparelib/default.nix
+++ b/pkgs/development/ocaml-modules/comparelib/default.nix
@@ -1,4 +1,4 @@
-{stdenv, buildOcaml, fetchurl, type_conv}:
+{stdenv, buildOcaml, fetchurl, camlp4, type_conv}:
 
 buildOcaml rec {
   name = "comparelib";
@@ -11,6 +11,7 @@ buildOcaml rec {
     sha256 = "02l343drgi4200flfx73nzdk61zajwidsqjk9n80b2d37lvhazlf";
   };
 
+  buildInputs = [ camlp4 ];
   propagatedBuildInputs = [ type_conv ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/ocaml-modules/herelib/default.nix
+++ b/pkgs/development/ocaml-modules/herelib/default.nix
@@ -1,4 +1,4 @@
-{stdenv, buildOcaml, fetchurl}:
+{stdenv, buildOcaml, fetchurl, camlp4}:
 
 buildOcaml rec {
   version = "112.35.00";
@@ -10,6 +10,8 @@ buildOcaml rec {
     url = "https://github.com/janestreet/herelib/archive/${version}.tar.gz";
     sha256 = "03rrlpjmnd8d1rzzmd112355m7a5bwn3vf90xkbc6gkxlad9cxbs";
   };
+
+  buildInputs = [ camlp4 ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/janestreet/herelib;

--- a/pkgs/development/ocaml-modules/pa_bench/default.nix
+++ b/pkgs/development/ocaml-modules/pa_bench/default.nix
@@ -1,4 +1,4 @@
-{stdenv, buildOcaml, fetchurl, type_conv, pa_ounit}:
+{stdenv, buildOcaml, fetchurl, camlp4, type_conv, pa_ounit}:
 
 buildOcaml rec {
   name = "pa_bench";
@@ -11,7 +11,7 @@ buildOcaml rec {
     sha256 = "1cd6291gdnk6h8ziclg6x3if8z5xy67nfz9gx8sx4k2cwv0j29k5";
   };
 
-  buildInputs = [ pa_ounit ];
+  buildInputs = [ camlp4 pa_ounit ];
   propagatedBuildInputs = [ type_conv ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/ocaml-modules/pa_ounit/default.nix
+++ b/pkgs/development/ocaml-modules/pa_ounit/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildOcaml, ocaml, fetchurl, ounit }:
+{ stdenv, buildOcaml, ocaml, fetchurl, camlp4, ounit }:
 
 if stdenv.lib.versionAtLeast ocaml.version "4.06"
 then throw "pa_ounit is not available for OCaml ${ocaml.version}"
@@ -12,6 +12,8 @@ buildOcaml rec {
     url = "https://github.com/janestreet/pa_ounit/archive/${version}.tar.gz";
     sha256 = "0vi0p2hxcrdsl0319c9s8mh9hmk2i4ir6c6vrj8axkc37zkgc437";
   };
+
+  buildInputs = [ camlp4 ];
 
   propagatedBuildInputs = [ ounit ];
 

--- a/pkgs/development/ocaml-modules/pgocaml/default.nix
+++ b/pkgs/development/ocaml-modules/pgocaml/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, buildOcaml, ocaml, calendar, csv, re }:
+{ stdenv, fetchurl, buildOcaml, ocaml, camlp4, calendar, csv, re }:
 
 if !stdenv.lib.versionAtLeast ocaml.version "4"
 then throw "pgocaml is not available for OCaml ${ocaml.version}"
@@ -12,7 +12,7 @@ buildOcaml {
     sha256 = "18lymxlvcf4nwxawkidq3pilsp5rhl0l8ifq6pjk3ssjlx9w53pg";
   };
 
-  buildInputs = [ ];
+  buildInputs = [ camlp4 ];
   propagatedBuildInputs = [ calendar csv re ];
 
   configureFlags = [ "--enable-p4" ];

--- a/pkgs/development/ocaml-modules/pipebang/default.nix
+++ b/pkgs/development/ocaml-modules/pipebang/default.nix
@@ -1,4 +1,4 @@
-{stdenv, buildOcaml, fetchurl}:
+{stdenv, buildOcaml, fetchurl, camlp4 }:
 
 buildOcaml rec {
   name = "pipebang";
@@ -10,6 +10,8 @@ buildOcaml rec {
     url = "https://github.com/janestreet/pipebang/archive/${version}.tar.gz";
     sha256 = "0acm2y8wxvnapa248lkgm0vcc44hlwhrjxqkx1awjxzcmarnxhfk";
   };
+
+  buildInputs = [ camlp4 ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/janestreet/pipebang;

--- a/pkgs/development/ocaml-modules/type_conv/112.01.01.nix
+++ b/pkgs/development/ocaml-modules/type_conv/112.01.01.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, buildOcaml}:
+{stdenv, fetchurl, buildOcaml, camlp4}:
 
 buildOcaml rec {
   minimumSupportedOcamlVersion = "4.02";
@@ -10,6 +10,8 @@ buildOcaml rec {
     url = "https://github.com/janestreet/type_conv/archive/${version}.tar.gz";
     sha256 = "1718yl2q8zandrs4xqffkfmssfld1iz62dzcqdm925735c1x01fk";
   };
+
+  buildInputs = [ camlp4 ];
 
   meta = {
     homepage = https://github.com/janestreet/type_conv/;

--- a/pkgs/development/ocaml-modules/typerep/default.nix
+++ b/pkgs/development/ocaml-modules/typerep/default.nix
@@ -1,4 +1,4 @@
-{stdenv, buildOcaml, fetchurl, type_conv}:
+{stdenv, buildOcaml, fetchurl, camlp4, type_conv}:
 
 buildOcaml rec {
   name = "typerep";
@@ -11,6 +11,7 @@ buildOcaml rec {
     sha256 = "4f1ab611a00aaf774e9774b26b687233e0c70d91f684415a876f094a9969eada";
   };
 
+  buildInputs = [ camlp4 ];
   propagatedBuildInputs = [ type_conv ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/ocaml-modules/variantslib/default.nix
+++ b/pkgs/development/ocaml-modules/variantslib/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildOcaml, ocaml, fetchurl, type_conv }:
+{ stdenv, buildOcaml, ocaml, fetchurl, camlp4, type_conv }:
 
 if stdenv.lib.versionAtLeast ocaml.version "4.06"
 then throw "variantslib-109.15.03 is not available for OCaml ${ocaml.version}"
@@ -15,6 +15,7 @@ buildOcaml rec {
     sha256 = "a948dcdd4ca54786fe0646386b6e37a9db03bf276c6557ea374d82740bf18055";
   };
 
+  buildInputs = [ camlp4 ];
   propagatedBuildInputs = [ type_conv ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

This removes the dependency on camlp4 for most packages that are built with `buildOcaml`, making it easier to test these packages on recent versions of OCaml where camlp4 might not yet be available.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Running `nix-shell -p nix-review --run "nix-review wip"` allowed to test this change against the following list of packages and their dependencies (but some OCaml packages have still probably been missed in the process):

alt-ergo framac fstar google-drive-ocamlfuse jackline libbap ocamlPackages.asn1-combinators ocamlPackages.async_ssl ocamlPackages.bap ocamlPackages.cryptokit ocamlPackages.ctypes ocamlPackages.eliom ocamlPackages.email_message ocamlPackages.erm_xmpp ocamlPackages.gapi_ocaml ocamlPackages.git ocamlPackages.git-http ocamlPackages.git-unix ocamlPackages.js_build_tools ocamlPackages.llvm ocamlPackages.merlin_extend ocamlPackages.nocrypto ocamlPackages.ocsigen-start ocamlPackages.ocsigen-toolkit ocamlPackages.ocsigen_server ocamlPackages.otr ocamlPackages.reason ocamlPackages.tls ocamlPackages.tsdl ocamlPackages.x509 ocamlPackages.zarith opa python27Packages.bap python37Packages.bap trv why3

###### Notify maintainers

cc @vbgl 
