### PR TITLE
gpx-viewer: avoid generating a mime database

### DIFF
--- a/pkgs/applications/misc/gpx-viewer/default.nix
+++ b/pkgs/applications/misc/gpx-viewer/default.nix
@@ -15,10 +15,10 @@ stdenv.mkDerivation rec {
   };
   patchFlags = [ "-p0" ];
 
+  configureFlags = [ "--disable-database-updates" ];
+
   nativeBuildInputs = [
     intltool pkgconfig
-    shared-mime-info # For update-mime-database
-    desktop-file-utils # For update-desktop-database
     wrapGAppsHook # Fix error: GLib-GIO-ERROR **: No GSettings schemas are installed on the system
   ];
   buildInputs = [ gdl libchamplain gnome3.adwaita-icon-theme libxml2 ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Installing this package conflicts with environments where the mime
database and the desktop database are already present.

Plus, there is no reason for a single package to generate such
databases. I guess the reason this is in the build system is to help dev
installing correctly the app in their (mutable) system.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @dotlambda (maintainer)