### PR TITLE
iptables: CVE-2019-11360 (release-19.03)

### DIFF
--- a/pkgs/os-specific/linux/iptables/default.nix
+++ b/pkgs/os-specific/linux/iptables/default.nix
@@ -36,6 +36,11 @@ stdenv.mkDerivation rec {
       url = "https://git.netfilter.org/iptables/patch/?id=2908eda10bf9fc81119d4f3ad672c67918ab5955";
       sha256 = "1dci4c8b7gcdrf77l2aicrcwlbp320xjz76fhavams0b4kgs6yr3";
     })
+    (fetchpatch {
+      url = "https://git.netfilter.org/iptables/patch/iptables/xshared.c?id=2ae1099a42e6a0f06de305ca13a842ac83d4683e";
+      name = "CVE-2019-11360.patch";
+      sha256 = "0ssk2ad5lfb1ifa6jgk76s4mm68hdkz7g8bjmdzi2yv3l06lf2dp";
+    })
   ];
 
   nativeBuildInputs = [ bison flex pkgconfig pruneLibtoolFiles ];


### PR DESCRIPTION
###### Motivation for this change

Fixes #65647.

We need to discuss whatever back-porting this makes sense at this severity.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @fpletz
