### PR TITLE
add options for build idris package

### DIFF
--- a/doc/languages-frameworks/idris.section.md
+++ b/doc/languages-frameworks/idris.section.md
@@ -124,3 +124,21 @@ in another file (say `default.nix`) to be able to build it with
 ```
 $ nix-build -A yaml
 ```
+
+## Passing options to `idris` commands
+
+The `build-idris-package` function provides also optional input values to set additional options for the used `idris` commands.
+
+Specifically, you can set `idrisBuildOptions`, `idrisTestOptions`, `idrisInstallOptions` and `idrisDocOptions` to provide additional options to the `idris` command respectively when building, testing, installing and generating docs for your package.
+
+For example you could set
+
+```
+build-idris-package {
+  idrisBuildOptions = [ "--log" "1" "--verbose" ]
+
+  ...
+}
+```
+
+to require verbose output during `idris` build phase.

--- a/pkgs/development/idris-modules/build-idris-package.nix
+++ b/pkgs/development/idris-modules/build-idris-package.nix
@@ -7,6 +7,10 @@
   , version
   , ipkgName ? name
   , extraBuildInputs ? []
+  , idrisBuildOptions ? []
+  , idrisTestOptions ? []
+  , idrisInstallOptions ? []
+  , idrisDocOptions ? []
   , ...
   }@attrs:
 let
@@ -39,14 +43,14 @@ stdenv.mkDerivation ({
 
   buildPhase = ''
     runHook preBuild
-    idris --build ${ipkgName}.ipkg
+    idris --build ${ipkgName}.ipkg ${lib.escapeShellArgs idrisBuildOptions}
     runHook postBuild
   '';
 
   checkPhase = ''
     runHook preCheck
     if grep -q tests ${ipkgName}.ipkg; then
-      idris --testpkg ${ipkgName}.ipkg
+      idris --testpkg ${ipkgName}.ipkg ${lib.escapeShellArgs idrisTestOptions}
     fi
     runHook postCheck
   '';
@@ -54,9 +58,9 @@ stdenv.mkDerivation ({
   installPhase = ''
     runHook preInstall
 
-    idris --install ${ipkgName}.ipkg --ibcsubdir $out/libs
+    idris --install ${ipkgName}.ipkg --ibcsubdir $out/libs ${lib.escapeShellArgs idrisInstallOptions}
 
-    IDRIS_DOC_PATH=$out/doc idris --installdoc ${ipkgName}.ipkg || true
+    IDRIS_DOC_PATH=$out/doc idris --installdoc ${ipkgName}.ipkg ${lib.escapeShellArgs idrisDocOptions} || true
 
     # If the ipkg file defines an executable, install that
     executable=$(grep -Po '^executable = \K.*' ${ipkgName}.ipkg || true)


### PR DESCRIPTION
###### Motivation for this change

It could be helpful to provide additional options to `idris` commands while building, testing and install an `idris` package.

For my specific use case, I need to add a `--log` option to `idris` commands.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ x ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ x ] Ensured that relevant documentation is up to date
- [ x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).