### PR TITLE
wavpack: CVE-2019-1010317 CVE-2019-1010319

### DIFF
--- a/pkgs/development/libraries/wavpack/default.nix
+++ b/pkgs/development/libraries/wavpack/default.nix
@@ -59,6 +59,11 @@ stdenv.mkDerivation rec {
       name = "CVE-2018-19841.patch";
       sha256 = "08gx5xx51bi86cqqy7cv1d25k669a7wnkksasjspphwkpwkcxymy";
     })
+    (fetchpatch {
+      url = "https://github.com/dbry/WavPack/commit/f68a9555b548306c5b1ee45199ccdc4a16a6101b.patch";
+      name = "CVE-2019-1010317.patch";
+      sha256 = "0v748nd9408v6ah37cn8wr0k0m0ny1g884q8q92j1dhwad69kfid";
+    })
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/wavpack/default.nix
+++ b/pkgs/development/libraries/wavpack/default.nix
@@ -64,6 +64,11 @@ stdenv.mkDerivation rec {
       name = "CVE-2019-1010317.patch";
       sha256 = "0v748nd9408v6ah37cn8wr0k0m0ny1g884q8q92j1dhwad69kfid";
     })
+    (fetchpatch {
+      url = "https://github.com/dbry/WavPack/commit/33a0025d1d63ccd05d9dbaa6923d52b1446a62fe.patch";
+      name = "CVE-2019-1010319.patch";
+      sha256 = "011sqdgpykilaj2c4ns298z7aad03yprpva0dqr39nx88ji6jnrb";
+    })
   ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Fixes #65655

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @codyopel
