### PR TITLE
urh: add support for Pluto, soundcards, and optionally USRP

### DIFF
--- a/pkgs/applications/radio/urh/default.nix
+++ b/pkgs/applications/radio/urh/default.nix
@@ -1,5 +1,6 @@
-{ stdenv, fetchFromGitHub, python3Packages
-, hackrf, rtl-sdr, airspy, limesuite }:
+{ stdenv, lib, fetchFromGitHub, python3Packages
+, hackrf, rtl-sdr, airspy, limesuite, libiio
+, USRPSupport ? false, uhd }:
 
 python3Packages.buildPythonApplication rec {
   pname = "urh";
@@ -12,14 +13,16 @@ python3Packages.buildPythonApplication rec {
     sha256 = "1jrrj9c4ddm37m8j0g693xjimpnlvx7lan5kxish5p14xpwdak35";
   };
 
-  buildInputs = [ hackrf rtl-sdr airspy limesuite ];
+  buildInputs = [ hackrf rtl-sdr airspy limesuite libiio ]
+    ++ lib.optional USRPSupport uhd;
+
   propagatedBuildInputs = with python3Packages; [
-    pyqt5 numpy psutil cython pyzmq
+    pyqt5 numpy psutil cython pyzmq pyaudio
   ];
 
   doCheck = false;
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "https://github.com/jopohl/urh";
     description = "Universal Radio Hacker: investigate wireless protocols like a boss";
     license = licenses.gpl3;

--- a/pkgs/development/libraries/libiio/default.nix
+++ b/pkgs/development/libraries/libiio/default.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchFromGitHub
 , cmake, flex, bison
 , libxml2, python
+, libusb1, runtimeShell
 }:
 
 stdenv.mkDerivation rec {
@@ -17,7 +18,17 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "lib" "dev" "python" ];
 
   nativeBuildInputs = [ cmake flex bison ];
-  buildInputs = [ libxml2 ];
+  buildInputs = [ libxml2 libusb1 ];
+
+  postPatch = ''
+    substituteInPlace libiio.rules.cmakein \
+      --replace /bin/sh ${runtimeShell}
+  '';
+
+  # since we can't expand $out in cmakeFlags
+  preConfigure = ''
+    cmakeFlags="$cmakeFlags -DUDEV_RULES_INSTALL_DIR=$out/etc/udev/rules.d"
+  '';
 
   postInstall = ''
     mkdir -p $python/lib/${python.libPrefix}/site-packages/


### PR DESCRIPTION
This adds native support of Pluto SDR in URH.
- libusb-1 support is needed and added in libiio
- this triggers installation of an udev rule that needed some patches
- Libiio is added in urh dependencies to enable native PlutoSDR support

I have tested basic functionalities with a Pluto SDR I own under NixOS.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @fpletz @thoughtpolice @markuskowa 
