### PR TITLE
frog: Fix build (icu64 -> icu60)

### DIFF
--- a/pkgs/development/libraries/languagemachines/packages.nix
+++ b/pkgs/development/libraries/languagemachines/packages.nix
@@ -1,13 +1,17 @@
-{ callPackage }:
+{ pkgs }:
+let
+  inherit (pkgs) callPackage;
+  icu = pkgs.icu60;
+in
 {
   ticcutils = callPackage ./ticcutils.nix { };
-  libfolia = callPackage ./libfolia.nix { };
-  ucto = callPackage ./ucto.nix { };
+  libfolia = callPackage ./libfolia.nix { inherit icu; };
+  ucto = callPackage ./ucto.nix { inherit icu; };
   uctodata = callPackage ./uctodata.nix { };
   timbl = callPackage ./timbl.nix { };
   timblserver = callPackage ./timblserver.nix { };
   mbt = callPackage ./mbt.nix { };
-  frog = callPackage ./frog.nix { };
+  frog = callPackage ./frog.nix { inherit icu; };
   frogdata = callPackage ./frogdata.nix { };
 
   test = callPackage ./test.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11268,7 +11268,9 @@ in
     stdenv = gccStdenv;
   };
 
-  languageMachines = recurseIntoAttrs (import ../development/libraries/languagemachines/packages.nix { inherit callPackage; });
+  languageMachines = recurseIntoAttrs (import ../development/libraries/languagemachines/packages.nix {
+    inherit pkgs;
+  });
 
   lasem = callPackage ../development/libraries/lasem { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Build was failing.

icu60 is the latest version that works.

Build the derivation languageMachines.test to test.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @roberth