### PR TITLE
WIP: enable `__structuredAttrs` in `stdenv.mkDerivation`

### DIFF
--- a/pkgs/stdenv/generic/builder.sh
+++ b/pkgs/stdenv/generic/builder.sh
@@ -1,3 +1,5 @@
+source .attrs.sh
+
 export PATH=
 for i in $initialPath; do
     if [ "$i" = / ]; then i=; fi

--- a/pkgs/stdenv/generic/default-builder.sh
+++ b/pkgs/stdenv/generic/default-builder.sh
@@ -1,2 +1,3 @@
+source .attrs.sh
 source $stdenv/setup
 genericBuild

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -79,6 +79,7 @@ let
       builder = shell;
 
       args = ["-e" ./builder.sh];
+      __structuredAttrs = true;
 
       setup = setupScript;
 

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -199,6 +199,7 @@ in rec {
           builder = attrs.realBuilder or stdenv.shell;
           args = attrs.args or ["-e" (attrs.builder or ./default-builder.sh)];
           inherit stdenv;
+          __structuredAttrs = true;
 
           # The `system` attribute of a derivation has special meaning to Nix.
           # Derivations set it to choose what sort of machine could be used to

--- a/pkgs/stdenv/linux/bootstrap-tools/default.nix
+++ b/pkgs/stdenv/linux/bootstrap-tools/default.nix
@@ -3,11 +3,12 @@
 derivation {
   name = "bootstrap-tools";
 
-  builder = bootstrapFiles.busybox;
+  builder = "${bootstrapFiles.busybox}";
 
   args = [ "ash" "-e" ./scripts/unpack-bootstrap-tools.sh ];
 
   tarball = bootstrapFiles.bootstrapTools;
+#   __structuredAttrs = true;
 
   inherit system;
 

--- a/pkgs/stdenv/linux/bootstrap-tools/scripts/unpack-bootstrap-tools.sh
+++ b/pkgs/stdenv/linux/bootstrap-tools/scripts/unpack-bootstrap-tools.sh
@@ -1,5 +1,6 @@
 # Unpack the bootstrap tools tarball.
 echo Unpacking the bootstrap tools...
+# . ./.attrs.sh
 $builder mkdir $out
 < $tarball $builder unxz | $builder tar x -C $out
 

--- a/pkgs/stdenv/linux/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools.nix
@@ -217,6 +217,7 @@ in with pkgs; rec {
     inherit (stdenv.hostPlatform) system; # We cannot "cross test"
     builder = bootstrapFiles.busybox;
     args = [ "ash" "-e" "-c" "eval \"$buildCommand\"" ];
+    __structuredAttrs = true;
 
     buildCommand = ''
       export PATH=${bootstrapTools}/bin


### PR DESCRIPTION
This is an attempt at adding support for `__structuredAttrs`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
