### PR TITLE
Refactor and fix Mumble

### DIFF
--- a/pkgs/applications/networking/mumble/default.nix
+++ b/pkgs/applications/networking/mumble/default.nix
@@ -14,7 +14,7 @@ assert iceSupport -> zeroc_ice != null;
 
 with stdenv.lib;
 let
-  generic = overrides: source: stdenv.mkDerivation (source // overrides // {
+  generic = overrides: source: (if source.qtVersion == 5 then qt5.mkDerivation else stdenv.mkDerivation) (source // overrides // {
     name = "${overrides.type}-${source.version}";
 
     patches = (source.patches or []) ++ optional jackSupport ./mumble-jack-support.patch;
@@ -26,7 +26,7 @@ let
     # protobuf is freezed to 3.6 because of this bug: https://github.com/mumble-voip/mumble/issues/3617
     # this could be reverted to the latest version in a future release of mumble as it is already fixed in master
     buildInputs = [ boost protobuf3_6 avahi ]
-      ++ { qt4 = [ qt4 ]; qt5 = [ qt5.qtbase ]; }."qt${toString source.qtVersion}"
+      ++ optional (source.qtVersion == 4) qt4
       ++ (overrides.buildInputs or [ ]);
 
     qmakeFlags = [
@@ -45,20 +45,23 @@ let
       ++ (overrides.configureFlags or [ ]);
 
     preConfigure = ''
-       qmakeFlags="$qmakeFlags DEFINES+=PLUGIN_PATH=$out/lib"
+       qmakeFlags="$qmakeFlags DEFINES+=PLUGIN_PATH=$out/lib/mumble"
        patchShebangs scripts
     '';
 
     makeFlags = [ "release" ];
 
     installPhase = ''
-      mkdir -p $out/{lib,bin}
-      find release -type f -not -name \*.\* -exec cp {} $out/bin \;
-      find release -type f -name \*.\* -exec cp {} $out/lib \;
+      runHook preInstall
 
+      ${overrides.installPhase}
+
+      # doc stuff
       mkdir -p $out/share/man/man1
-      cp man/mum* $out/share/man/man1
-    '' + (overrides.installPhase or "");
+      install -Dm644 man/mum* $out/share/man/man1/
+
+      runHook postInstall
+    '';
 
     enableParallelBuilding = true;
 
@@ -74,7 +77,7 @@ let
   client = source: generic {
     type = "mumble";
 
-    nativeBuildInputs = optionals (source.qtVersion == 5) [ qt5.qttools ];
+    nativeBuildInputs = optional (source.qtVersion == 5) qt5.qttools;
     buildInputs = [ libopus libsndfile speex ]
       ++ optional (source.qtVersion == 5) qt5.qtsvg
       ++ optional stdenv.isLinux alsaLib
@@ -89,12 +92,19 @@ let
     NIX_CFLAGS_COMPILE = optional speechdSupport "-I${speechd}/include/speech-dispatcher";
 
     installPhase = ''
-      mkdir -p $out/share/applications
-      cp scripts/mumble.desktop $out/share/applications
+      # bin stuff
+      install -Dm755 release/mumble $out/bin/mumble
+      install -Dm755 scripts/mumble-overlay $out/bin/mumble-overlay
 
-      mkdir -p $out/share/icons{,/hicolor/scalable/apps}
-      cp icons/mumble.svg $out/share/icons
-      ln -s $out/share/icons/mumble.svg $out/share/icons/hicolor/scalable/apps
+      # lib stuff
+      mkdir -p $out/lib/mumble
+      cp -P release/libmumble.so* $out/lib
+      cp -P release/libcelt* $out/lib/mumble
+      cp -P release/plugins/* $out/lib/mumble
+
+      # icons
+      install -Dm644 scripts/mumble.desktop $out/share/applications/mumble.desktop
+      install -Dm644 icons/mumble.svg $out/share/icons/hicolor/scalable/apps/mumble.svg
     '';
   } source;
 
@@ -110,6 +120,11 @@ let
     ];
 
     buildInputs = [ libcap ] ++ optional iceSupport zeroc_ice;
+
+    installPhase = ''
+      # bin stuff
+      install -Dm755 release/murmurd $out/bin/murmurd
+    '';
   };
 
   stableSource = rec {
@@ -138,26 +153,24 @@ let
     ];
   };
 
-  gitSource = rec {
-    version = "2019-07-10";
+  rcSource = rec {
+    version = "1.3.0-rc2";
     qtVersion = 5;
 
     # Needs submodules
     src = fetchFromGitHub {
       owner = "mumble-voip";
       repo = "mumble";
-      rev = "41b265584654c7ac216fd3ccb9c141734d3f839b";
+      rev = version;
       sha256 = "00irlzz5q4drmsfbwrkyy7p7w8a5fc1ip5vyicq3g3cy58dprpqr";
       fetchSubmodules = true;
     };
   };
 in {
   mumble     = client stableSource;
-  mumble_git = client gitSource;
+  mumble_rc  = client rcSource;
   murmur     = server stableSource;
-  murmur_git = (server gitSource).overrideAttrs (old: {
+  murmur_rc  = (server rcSource).overrideAttrs (old: {
     meta = old.meta // { broken = iceSupport; };
-
-    nativeBuildInputs = old.nativeBuildInputs or [] ++ [ qt5.wrapQtAppsHook ];
   });
 }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -418,6 +418,10 @@ mapAliases ({
     gst-plugins-good = pkgs.gst-plugins-good;
     gst-plugins-ugly = pkgs.gst-plugins-ugly;
   };
+
+  # added 2019-08-01
+  mumble_git = pkgs.mumble_rc;
+  murmur_git = pkgs.murmur_rc;
 } // (with ocaml-ng; { # added 2016-09-14
   ocaml_4_00_1 = ocamlPackages_4_00_1.ocaml;
   ocaml_4_01_0 = ocamlPackages_4_01_0.ocaml;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19367,7 +19367,7 @@ in
       speechdSupport = config.mumble.speechdSupport or false;
       pulseSupport = config.pulseaudio or false;
       iceSupport = config.murmur.iceSupport or true;
-    }) mumble mumble_git murmur;
+    }) mumble mumble_rc murmur;
 
   inherit (callPackages ../applications/networking/mumble {
       avahi = avahi-compat;
@@ -19375,7 +19375,7 @@ in
       speechdSupport = config.mumble.speechdSupport or false;
       pulseSupport = config.pulseaudio or false;
       iceSupport = false;
-    }) murmur_git;
+    }) murmur_rc;
 
   mumble_overlay = callPackage ../applications/networking/mumble/overlay.nix {
     mumble_i686 = if stdenv.hostPlatform.system == "x86_64-linux"


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fix Qt 5 version of Mumble and cleanup stuff along the way.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Install code is mostly taken from Arch's PKGBUILDS:
* https://git.archlinux.org/svntogit/community.git/tree/trunk/PKGBUILD?h=packages/mumble
* https://git.archlinux.org/svntogit/community.git/tree/trunk/PKGBUILD?h=packages/murmur