### PR TITLE
ripgrep-all: init at 0.9.2

### DIFF
--- a/pkgs/tools/text/ripgrep-all/default.nix
+++ b/pkgs/tools/text/ripgrep-all/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, lib, fetchFromGitHub, rustPlatform, makeWrapper, ffmpeg
+, pandoc, poppler_utils, ripgrep, Security
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "ripgrep-all";
+  version = "0.9.2";
+
+  src = fetchFromGitHub {
+    owner = "phiresky";
+    repo = pname;
+    rev = version;
+    sha256 = "1knv0gpanrid9i9mxg7zwqh9igdksp1623wl9iwmysiyaajlbif2";
+  };
+
+  cargoSha256 = "0xwsx0x9n766bxamhnpzibrnvnqsxz3wh1f0rj29kbl32xl8yyfg";
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = lib.optional stdenv.isDarwin Security;
+
+  postInstall = ''
+    wrapProgram $out/bin/rga \
+      --prefix PATH ":" "${lib.makeBinPath [ ffmpeg pandoc poppler_utils ripgrep ]}"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Ripgrep, but also search in PDFs, E-Books, Office documents, zip, tar.gz, and more";
+    longDescription = ''
+      Ripgrep, but also search in PDFs, E-Books, Office documents, zip, tar.gz, etc.
+
+      rga is a line-oriented search tool that allows you to look for a regex in
+      a multitude of file types. rga wraps the awesome ripgrep and enables it
+      to search in pdf, docx, sqlite, jpg, movie subtitles (mkv, mp4), etc.
+    '';
+    homepage = https://github.com/phiresky/ripgrep-all;
+    license = with licenses; [ agpl3Plus ];
+    maintainers = with maintainers; [ zaninime ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3477,6 +3477,10 @@ in
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  ripgrep-all = callPackage ../tools/text/ripgrep-all {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   grive2 = callPackage ../tools/filesystems/grive2 { };
 
   groff = callPackage ../tools/text/groff {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

N/A