### PR TITLE
pythonPackages.runway-python: init at 0.3.2

### DIFF
--- a/pkgs/development/python-modules/runway-python/default.nix
+++ b/pkgs/development/python-modules/runway-python/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, flask
+, flask-cors
+, numpy
+, pillow
+, gevent
+, wget
+, six
+, colorcet
+}:
+
+buildPythonPackage rec {
+  pname = "runway-python";
+  version = "0.3.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "ef15c0df60cfe7ea26b070bbe2ba522d67d247b157c20f3f191fe545c17d0b85";
+  };
+
+  propagatedBuildInputs = [ flask flask-cors numpy pillow gevent wget six colorcet ];
+
+  # tests are not packaged in the released tarball
+  doCheck = false;
+
+  meta = {
+    description = "Helper library for creating Runway models";
+    homepage = https://github.com/runwayml/model-sdk;
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ prusnak ];
+  };
+}

--- a/pkgs/development/python-modules/wget/default.nix
+++ b/pkgs/development/python-modules/wget/default.nix
@@ -1,0 +1,22 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "wget";
+  version = "3.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "35e630eca2aa50ce998b9b1a127bb26b30dfee573702782aa982f875e3f16061";
+    extension = "zip";
+  };
+
+  meta = {
+    description = "Pure python download utility";
+    homepage = http://bitbucket.org/techtonik/python-wget/;
+    license = with lib.licenses; [ unlicense ];
+    maintainers = with lib.maintainers; [ prusnak ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6112,6 +6112,8 @@ in {
   stringcase = callPackage ../development/python-modules/stringcase { };
 
   webrtcvad = callPackage ../development/python-modules/webrtcvad { };
+
+  wget = callPackage ../development/python-modules/wget { };
 });
 
 in fix' (extends overrides packages)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6114,6 +6114,8 @@ in {
   webrtcvad = callPackage ../development/python-modules/webrtcvad { };
 
   wget = callPackage ../development/python-modules/wget { };
+
+  runway-python = callPackage ../development/python-modules/runway-python { };
 });
 
 in fix' (extends overrides packages)


### PR DESCRIPTION
This commit adds new package `runway-python` which is a Runway Model SDK allowing you to port new and existing machine learning models to the Runway platform, more info at https://pypi.org/project/runway-python/

The commit also adds `wget` python package as its dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
