### PR TITLE
Increase the system user id range

### DIFF
--- a/nixos/modules/config/update-users-groups.pl
+++ b/nixos/modules/config/update-users-groups.pl
@@ -56,12 +56,12 @@ sub allocGid {
         $gidsUsed{$prevGid} = 1;
         return $prevGid;
     }
-    return allocId(\%gidsUsed, \%gidsPrevUsed, 400, 499, 0, sub { my ($gid) = @_; getgrgid($gid) });
+    return allocId(\%gidsUsed, \%gidsPrevUsed, 400, 999, 0, sub { my ($gid) = @_; getgrgid($gid) });
 }
 
 sub allocUid {
     my ($name, $isSystemUser) = @_;
-    my ($min, $max, $up) = $isSystemUser ? (400, 499, 0) : (1000, 29999, 1);
+    my ($min, $max, $up) = $isSystemUser ? (400, 999, 0) : (1000, 29999, 1);
     my $prevUid = $uidMap->{$name};
     if (defined $prevUid && $prevUid >= $min && $prevUid <= $max && !defined $uidsUsed{$prevUid}) {
         print STDERR "reviving user '$name' with UID $prevUid\n";

--- a/nixos/modules/programs/shadow.nix
+++ b/nixos/modules/programs/shadow.nix
@@ -6,17 +6,27 @@ with lib;
 
 let
 
+  /*
+  There are three different sources for user/group id ranges, each of which gets
+  used by different programs:
+  - The login.defs file, used by the useradd, groupadd and newusers commands
+  - The update-users-groups.pl file, used by NixOS in the activation phase to
+    decide on which ids to use for declaratively defined users without a static
+    id
+  - Systemd compile time options -Dsystem-uid-max= and -Dsystem-gid-max=, used
+    by systemd for features like ConditionUser=@system and systemd-sysusers
+  */
   loginDefs =
     ''
       DEFAULT_HOME yes
 
       SYS_UID_MIN  400
-      SYS_UID_MAX  499
+      SYS_UID_MAX  999
       UID_MIN      1000
       UID_MAX      29999
 
       SYS_GID_MIN  400
-      SYS_GID_MAX  499
+      SYS_GID_MAX  999
       GID_MIN      1000
       GID_MAX      29999
 

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -84,8 +84,18 @@ stdenv.mkDerivation {
     "-Dldconfig=false"
     "-Dsmack=true"
     "-Db_pie=true"
-    "-Dsystem-uid-max=499" #TODO: debug why awking around in /etc/login.defs doesn't work
-    "-Dsystem-gid-max=499"
+    /*
+    As of now, systemd doesn't allow runtime configuration of these values. So
+    the settings in /etc/login.defs have no effect on it. Many people think this
+    should be supported however, see
+    - https://github.com/systemd/systemd/issues/3855
+    - https://github.com/systemd/systemd/issues/4850
+    - https://github.com/systemd/systemd/issues/9769
+    - https://github.com/systemd/systemd/issues/9843
+    - https://github.com/systemd/systemd/issues/10184
+    */
+    "-Dsystem-uid-max=999"
+    "-Dsystem-gid-max=999"
     # "-Dtime-epoch=1"
 
     (if !stdenv.hostPlatform.isEfi then "-Dgnu-efi=false" else "-Dgnu-efi=true")


### PR DESCRIPTION
**This is now a full RFC at NixOS/rfcs#52**

This enlarges the system uid/gid range 6-fold, from 100 to 600 ids. This
is a preventative measure against running out of dynamically allocated
ids for NixOS services with `isSystemUser`, which should become the
preferred way of allocating uids for non-real users if `DynamicUser` isn't applicable.

#### Motivation for this change
We're running out of static uid/gid's in the standard range from 0 to 400, only ~85 are left: https://github.com/NixOS/nixpkgs/blob/9fe0552e4db1253e0a714ed50e288cde217ddab1/nixos/modules/misc/ids.nix#L341-L344

While it might be possible to assign another range for static id's, that's just an ugly solution, and having to declare static id's has always been a bit of a pain.

A better solution is to not assign static id's for services, but to use NixOS dynamic user allocation (happening by default, when `uid/gid = null`). Specifically with `isSystemUser = true` such that ids get allocated in the range `SYS_{U,G}ID_MIN` (400) - `SYS_{U,G}ID_MAX` (499 before this change, 999 after), meaning the range above 1000 can be used exclusively by real users.

Why extend it to 999? Because a limit of 100 ids means that over the lifetime of a NixOS system, users can only ever run 100 different services, since id's aren't repurposed after a service is disabled (See a57bcd38b49bfe9d048b12de3c839bc72b298d2e), which is a bit on the low side. And 999 (=`{U,G}ID_MIN-1`) is also the default value anyways, see `man login.defs`.

This means that instead of having a limit of 400 static uids for *all* NixOS services in nixpkgs, we have a limit of 600 dynamic uids for all NixOS services *ever enable* on a single system.

##### But isn't it bad to not use static id's for services?

I don't think so. One reason I can think of for having static id's is for some service that needs to transfer its files across NixOS machines, but this is not the case for most services. Another reason might be that loading data from backups into a new NixOS installation will make services not work due the mismatch of data and service ids. This is however not a problem if `/var/lib/{u,g}id-map` gets restored as well, and also not a problem if services use `StateDirectory` or `systemd.tmpfiles` which fixes permissions on service start.

See https://github.com/NixOS/nixpkgs/issues/60732#issuecomment-510027542 for a previous discussion

cc @ryantm @arianvp @aanderse @edolstra 