### PR TITLE
python3Packages.xgboost: fix the build on Darwin

### DIFF
--- a/pkgs/development/python-modules/xgboost/default.nix
+++ b/pkgs/development/python-modules/xgboost/default.nix
@@ -3,6 +3,7 @@
 , nose
 , scipy
 , scikitlearn
+, stdenv
 , xgboost
 , substituteAll
 , pandas
@@ -19,6 +20,7 @@ buildPythonPackage rec {
     (substituteAll {
       src = ./lib-path-for-python.patch;
       libpath = "${xgboost}/lib";
+      extention = stdenv.hostPlatform.extensions.sharedLibrary;
     })
   ];
 

--- a/pkgs/development/python-modules/xgboost/lib-path-for-python.patch
+++ b/pkgs/development/python-modules/xgboost/lib-path-for-python.patch
@@ -35,4 +35,4 @@ index d87922c0..859a30fb 100644
 -            'did you install compilers and run build.sh in root path?\n'
 -            'List of candidates:\n' + ('\n'.join(dll_path)))
 -    return lib_path
-+    return ["@libpath@/libxgboost.so"]
++    return ["@libpath@/libxgboost@extention@"]


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).