### PR TITLE
zoom-us: use flathub desktop integration 

### DIFF
--- a/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
+++ b/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, mkDerivation, makeWrapper, makeDesktopItem, autoPatchelfHook
-, wrapQtAppsHook
+{ stdenv, fetchurl, mkDerivation, makeWrapper, autoPatchelfHook
+, wrapQtAppsHook, fetchFromGitHub
 # Dynamic libraries
 , dbus, glib, libGL, libX11, libXfixes, libuuid, libxcb, qtbase, qtdeclarative
 , qtimageformats, qtlocation, qtquickcontrols, qtquickcontrols2, qtscript, qtsvg
@@ -20,6 +20,14 @@ let
       url = "https://zoom.us/client/${version}/zoom_x86_64.tar.xz";
       sha256 = "1wg5yw8g0c6p9y0wcqxr1rndgclasg7v1ybbx8s1a2p98izjkcaa";
     };
+  };
+
+  # Used for icons, appdata, and desktop file.
+  desktopIntegration = fetchFromGitHub {
+    owner = "flathub";
+    repo = "us.zoom.Zoom";
+    rev = "0d294e1fdd2a4ef4e05d414bc680511f24d835d7";
+    sha256 = "0rm188844a10v8d6zgl2pnwsliwknawj09b02iabrvjw5w1lp6wl";
   };
 
 in mkDerivation {
@@ -66,15 +74,26 @@ in mkDerivation {
       runHook postInstall
     '';
 
-  postInstall = (makeDesktopItem {
-    name = "zoom-us";
-    exec = "$out/bin/zoom-us %U";
-    icon = "$out/share/zoom-us/application-x-zoom.png";
-    desktopName = "Zoom";
-    genericName = "Video Conference";
-    categories = "Network;Application;";
-    mimeType = "x-scheme-handler/zoommtg;";
-  }).buildCommand + ''
+  postInstall = ''
+    mkdir -p $out/share/{applications,appdata,icons}
+
+    # Desktop File
+    cp ${desktopIntegration}/us.zoom.Zoom.desktop $out/share/applications
+    substituteInPlace $out/share/applications/us.zoom.Zoom.desktop \
+        --replace "Exec=zoom" "Exec=$out/bin/zoom-us"
+
+    # Appdata
+    cp ${desktopIntegration}/us.zoom.Zoom.appdata.xml $out/share/appdata
+
+    # Icons
+    for icon_size in 64 96 128 256; do
+        path=$icon_size'x'$icon_size
+        icon=${desktopIntegration}/us.zoom.Zoom.$icon_size.png
+
+        mkdir -p $out/share/icons/hicolor/$path/apps
+        cp $icon $out/share/icons/hicolor/$path/apps/us.zoom.Zoom.png
+    done
+
     ln -s $out/share/zoom-us/zoom $out/bin/zoom-us
   '';
 

--- a/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
+++ b/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, mkDerivation, makeWrapper, autoPatchelfHook
-, wrapQtAppsHook, fetchFromGitHub
+{ stdenv, fetchurl, mkDerivation, autoPatchelfHook
+, fetchFromGitHub
 # Dynamic libraries
 , dbus, glib, libGL, libX11, libXfixes, libuuid, libxcb, qtbase, qtdeclarative
 , qtimageformats, qtlocation, qtquickcontrols, qtquickcontrols2, qtscript, qtsvg
@@ -35,7 +35,7 @@ in mkDerivation {
 
   src = srcs.${stdenv.hostPlatform.system};
 
-  nativeBuildInputs = [ autoPatchelfHook makeWrapper wrapQtAppsHook ];
+  nativeBuildInputs = [ autoPatchelfHook ];
 
   buildInputs = [
     dbus glib libGL libX11 libXfixes libuuid libxcb libjpeg_turbo


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Fixes #65678

###### Things done
Successfully launched `zoom-us` with the new desktop file.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).