### PR TITLE
OCaml build support: add oasis build system

### DIFF
--- a/pkgs/build-support/ocaml/oasis.nix
+++ b/pkgs/build-support/ocaml/oasis.nix
@@ -1,11 +1,9 @@
-{ stdenv, ocaml_oasis, ocaml, findlib, ocamlbuild, camlp4 }:
+{ stdenv, ocaml_oasis, ocaml, findlib, ocamlbuild }:
 
 { name, version, buildInputs ? [], meta ? { platforms = ocaml.meta.platforms or []; },
   minimumOcamlVersion ? null,
   createFindlibDestdir ? true,
   dontStrip ? true,
-  hasSharedObjects ? false,
-  setupHook ? null,
   ...
 }@args:
 
@@ -13,9 +11,9 @@
           stdenv.lib.versionOlder minimumOcamlVersion ocaml.version;
 
 stdenv.mkDerivation (args // {
-  name = "ocaml-${name}-${version}";
+  name = "ocaml${ocaml.version}-${name}-${version}";
 
-  buildInputs = [ ocaml findlib ocamlbuild camlp4 ocaml_oasis ] ++ buildInputs;
+  buildInputs = [ ocaml findlib ocamlbuild ocaml_oasis ] ++ buildInputs;
 
   inherit createFindlibDestdir;
   inherit dontStrip;
@@ -42,11 +40,5 @@ stdenv.mkDerivation (args // {
     prefix=$OCAMLFIND_DESTDIR ocaml setup.ml -install
     runHook postInstall
   '';
-
-  setupHook = if setupHook == null && hasSharedObjects
-              then stdenv.writeText "setupHook.sh" ''
-              export CAML_LD_LIBRARY_PATH="''${CAML_LD_LIBRARY_PATH}''${CAML_LD_LIBRARY_PATH:+:}''$1/lib/ocaml/${ocaml.version}/site-lib/${name}/"
-              ''
-              else setupHook;
 
 })

--- a/pkgs/build-support/ocaml/oasis.nix
+++ b/pkgs/build-support/ocaml/oasis.nix
@@ -1,17 +1,19 @@
 { stdenv, ocaml_oasis, ocaml, findlib, ocamlbuild }:
 
-{ name, version, buildInputs ? [], meta ? { platforms = ocaml.meta.platforms or []; },
-  minimumOcamlVersion ? null,
+{ pname, version, buildInputs ? [], meta ? { platforms = ocaml.meta.platforms or []; },
+  minimumOCamlVersion ? null,
   createFindlibDestdir ? true,
   dontStrip ? true,
   ...
 }@args:
 
- assert minimumOcamlVersion != null ->
-          stdenv.lib.versionOlder minimumOcamlVersion ocaml.version;
+if args ? minimumOCamlVersion &&
+   ! stdenv.lib.versionAtLeast ocaml.version args.minimumOCamlVersion
+then throw "${pname}-${version} is not available for OCaml ${ocaml.version}"
+else
 
 stdenv.mkDerivation (args // {
-  name = "ocaml${ocaml.version}-${name}-${version}";
+  name = "ocaml${ocaml.version}-${pname}-${version}";
 
   buildInputs = [ ocaml findlib ocamlbuild ocaml_oasis ] ++ buildInputs;
 

--- a/pkgs/build-support/ocaml/oasis.nix
+++ b/pkgs/build-support/ocaml/oasis.nix
@@ -1,0 +1,31 @@
+{ buildOcaml, ocaml_oasis }:
+
+{ name, version, buildInputs ? [], ...
+}@args:
+
+buildOcaml (args // {
+  buildInputs = [ ocaml_oasis ] ++ buildInputs;
+
+  buildPhase = ''
+    runHook preBuild
+    oasis setup
+    ocaml setup.ml -configure
+    ocaml setup.ml -build
+    runHook postBuild
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+    ocaml setup.ml -test
+    runHook postCheck
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out
+    sed -i s+/usr/local+$out+g setup.ml
+    sed -i s+/usr/local+$out+g setup.data
+    prefix=$OCAMLFIND_DESTDIR ocaml setup.ml -install
+    runHook postInstall
+  '';
+})

--- a/pkgs/build-support/ocaml/oasis.nix
+++ b/pkgs/build-support/ocaml/oasis.nix
@@ -1,6 +1,6 @@
 { buildOcaml, ocaml_oasis }:
 
-{ name, version, buildInputs ? [], ...
+{ buildInputs ? [], ...
 }@args:
 
 buildOcaml (args // {

--- a/pkgs/development/ocaml-modules/tcslib/default.nix
+++ b/pkgs/development/ocaml-modules/tcslib/default.nix
@@ -1,7 +1,7 @@
 { lib, fetchFromGitHub, ocamlPackages, buildOasisPackage, ounit, ocaml_extlib, num }:
 
 buildOasisPackage rec {
-  name = "tcslib";
+  pname = "tcslib";
   version = "0.3";
 
   minimumOCamlVersion = "4.03.0";

--- a/pkgs/development/ocaml-modules/tcslib/default.nix
+++ b/pkgs/development/ocaml-modules/tcslib/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, ocamlPackages, buildOasisPackage }:
+
+buildOasisPackage rec {
+  name = "tcslib";
+  version = "v0.3";
+
+  minimumSupportedOCamlVersion = "4.03.0";
+
+  src = fetchFromGitHub {
+    owner  = "tcsprojects";
+    repo   = "tcslib";
+    rev    = version;
+    sha256 = "05g6m82blsccq8wx8knxv6a5fzww7hi624jx91f9h87nk2fsplhi";
+  };
+
+  buildInputs = with ocamlPackages; [ ounit ];
+  propagatedBuildInputs = with ocamlPackages; [ ocaml_extlib num ];
+
+  meta = {
+    homepage = https://github.com/tcsprojects/tcslib;
+    description = "A multi-purpose library for OCaml";
+    license = stdenv.lib.licenses.bsd3;
+    maintainers = with stdenv.lib.maintainers; [ mgttlinger ];
+  };
+}

--- a/pkgs/development/ocaml-modules/tcslib/default.nix
+++ b/pkgs/development/ocaml-modules/tcslib/default.nix
@@ -1,25 +1,25 @@
-{ stdenv, fetchFromGitHub, ocamlPackages, buildOasisPackage }:
+{ lib, fetchFromGitHub, ocamlPackages, buildOasisPackage, ounit, ocaml_extlib, num }:
 
 buildOasisPackage rec {
   name = "tcslib";
-  version = "v0.3";
+  version = "0.3";
 
   minimumSupportedOCamlVersion = "4.03.0";
 
   src = fetchFromGitHub {
     owner  = "tcsprojects";
     repo   = "tcslib";
-    rev    = version;
+    rev    = "v${version}";
     sha256 = "05g6m82blsccq8wx8knxv6a5fzww7hi624jx91f9h87nk2fsplhi";
   };
 
-  buildInputs = with ocamlPackages; [ ounit ];
-  propagatedBuildInputs = with ocamlPackages; [ ocaml_extlib num ];
+  buildInputs = [ ounit ];
+  propagatedBuildInputs = [ ocaml_extlib num ];
 
   meta = {
     homepage = https://github.com/tcsprojects/tcslib;
     description = "A multi-purpose library for OCaml";
-    license = stdenv.lib.licenses.bsd3;
-    maintainers = with stdenv.lib.maintainers; [ mgttlinger ];
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ mgttlinger ];
   };
 }

--- a/pkgs/development/ocaml-modules/tcslib/default.nix
+++ b/pkgs/development/ocaml-modules/tcslib/default.nix
@@ -4,7 +4,7 @@ buildOasisPackage rec {
   name = "tcslib";
   version = "0.3";
 
-  minimumSupportedOCamlVersion = "4.03.0";
+  minimumOCamlVersion = "4.03.0";
 
   src = fetchFromGitHub {
     owner  = "tcsprojects";

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -721,6 +721,8 @@ let
 
     stringext = callPackage ../development/ocaml-modules/stringext { };
 
+    tcslib = callPackage ../development/ocaml-modules/tcslib { };
+
     toml = callPackage ../development/ocaml-modules/toml { };
 
     topkg = callPackage ../development/ocaml-modules/topkg { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -12,7 +12,7 @@ let
 
     buildOcaml = callPackage ../build-support/ocaml { };
 
-    buildOasisPackage = callPackage ../build-support/ocaml/oasis.nix { buildOcaml = buildOcaml; };
+    buildOasisPackage = callPackage ../build-support/ocaml/oasis.nix { };
 
     buildDunePackage = callPackage ../build-support/ocaml/dune.nix {};
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -12,6 +12,8 @@ let
 
     buildOcaml = callPackage ../build-support/ocaml { };
 
+    buildOasisPackage = callPackage ../build-support/ocaml/oasis.nix { buildOcaml = buildOcaml; };
+
     buildDunePackage = callPackage ../build-support/ocaml/dune.nix {};
 
     alcotest = callPackage ../development/ocaml-modules/alcotest {};


### PR DESCRIPTION
###### Motivation for this change

Some OCaml packages are built using oasis leading to a lot of repetition in the derivation code.

(I will create PRs for pgsolver and its dependencies once this change is merged)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
