### PR TITLE
verilog: 2019.03.27 -> 2019.08.1

### DIFF
--- a/pkgs/applications/science/electronics/verilog/default.nix
+++ b/pkgs/applications/science/electronics/verilog/default.nix
@@ -1,31 +1,31 @@
 { stdenv, fetchFromGitHub, autoconf, gperf, flex, bison }:
 
 stdenv.mkDerivation rec {
-  name = "iverilog-${version}";
-  version = "2019.03.27";
+  pname = "iverilog";
+  version = "unstable-2019-08-01";
 
   src = fetchFromGitHub {
     owner  = "steveicarus";
-    repo   = "iverilog";
-    rev    = "a9388a895eb85a9d7f2924b89f839f94e1b6d7c4";
-    sha256 = "01d48sy3pzg9x1xpczqrsii2ckrvgnrfj720wiz22jdn90nirhhr";
+    repo = pname;
+    rev    = "c383d2048c0bd15f5db083f14736400546fb6215";
+    sha256 = "1zs0gyhws0qa315magz3w5m45v97knczdgbf2zn4d7bdb7cv417c";
   };
 
   enableParallelBuilding = true;
 
-  patchPhase = ''
+  preConfigure = ''
     chmod +x $PWD/autoconf.sh
     $PWD/autoconf.sh
   '';
 
   buildInputs = [ autoconf gperf flex bison ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Icarus Verilog compiler";
     repositories.git = https://github.com/steveicarus/iverilog.git;
-    homepage = http://www.icarus.com;
-    license = stdenv.lib.licenses.gpl2Plus;
-    maintainers = with stdenv.lib.maintainers; [winden];
-    platforms = with stdenv.lib.platforms; linux;
+    homepage = "http://iverilog.icarus.com/";
+    license = licenses.lgpl21;
+    maintainers = with maintainers; [ winden ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/science/electronics/verilog/default.nix
+++ b/pkgs/applications/science/electronics/verilog/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchFromGitHub, autoconf, gperf, flex, bison }:
+{ stdenv, fetchFromGitHub, autoconf, gperf, flex, bison, readline, ncurses
+, bzip2, zlib
+}:
 
 stdenv.mkDerivation rec {
   pname = "iverilog";
@@ -13,12 +15,19 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  prePatch = ''
+    substituteInPlace configure.in \
+      --replace "AC_CHECK_LIB(termcap, tputs)" "AC_CHECK_LIB(termcap, tputs)"
+  '';
+
   preConfigure = ''
     chmod +x $PWD/autoconf.sh
     $PWD/autoconf.sh
   '';
 
-  buildInputs = [ autoconf gperf flex bison ];
+  nativeBuildInputs = [ autoconf gperf flex bison ];
+
+  buildInputs = [ readline ncurses bzip2 zlib ];
 
   meta = with stdenv.lib; {
     description = "Icarus Verilog compiler";


### PR DESCRIPTION
###### Motivation for this change
Fixes the build, see: https://github.com/steveicarus/iverilog/issues/247

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers
Does somebody want to maintain this? Seems like the person who is listed as maintainer has never personally contributed to nixpkgs.