### PR TITLE
ghidra: 9.0.2 -> 9.0.4

### DIFF
--- a/pkgs/tools/security/ghidra/default.nix
+++ b/pkgs/tools/security/ghidra/default.nix
@@ -6,11 +6,11 @@
 
 in stdenv.mkDerivation {
 
-  name = "ghidra-9.0.2";
+  name = "ghidra-9.0.4";
 
   src = fetchurl {
-    url = https://ghidra-sre.org/ghidra_9.0.2_PUBLIC_20190403.zip;
-    sha256 = "10ffd65c266e9f5b631c8ed96786c41ef30e2de939c3c42770573bb3548f8e9f";
+    url = https://ghidra-sre.org/ghidra_9.0.4_PUBLIC_20190516.zip;
+    sha256 = "1gqqxk57hswwgr97qisqivcfgjdxjipfdshyh4r76dyrfpa0q3d5";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Updating binary package from Apr 03 release (9.0.2) to May 16 release (9.0.4).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @ck3d 
