### PR TITLE
metabase: 0.32.9 -> 0.32.10

### DIFF
--- a/pkgs/servers/metabase/default.nix
+++ b/pkgs/servers/metabase/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, makeWrapper, jre }:
 
 stdenv.mkDerivation rec {
-  name = "metabase-${version}";
-  version = "0.32.9";
+  pname = "metabase";
+  version = "0.32.10";
 
   src = fetchurl {
     url = "http://downloads.metabase.com/v${version}/metabase.jar";
-    sha256 = "08iybb1m2pmimn0fs95kd948yf6c1xmg5kkzm9ykx4cpb9pn1yw0";
+    sha256 = "0dzwwwvsi9pr40xbqws02yzjgx89ygjiybjd0n73hj69v6j9f2rn";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -18,8 +18,8 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "The easy, open source way for everyone in your company to ask questions and learn from data.";
-    homepage    = https://metabase.com;
+    description = "The easy, open source way for everyone in your company to ask questions and learn from data";
+    homepage    = "https://metabase.com";
     license     = licenses.agpl3;
     platforms   = platforms.all;
     maintainers = with maintainers; [ schneefux thoughtpolice ];


### PR DESCRIPTION
###### Motivation for this change

metabase: 0.32.9 -> 0.32.10

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @thoughtpolice @schneefux
