### PR TITLE
pythonPackages.py: 1.7.0 -> 1.8.0

### DIFF
--- a/pkgs/development/python-modules/py/default.nix
+++ b/pkgs/development/python-modules/py/default.nix
@@ -1,11 +1,12 @@
 { stdenv, buildPythonPackage, fetchPypi, setuptools_scm }:
+
 buildPythonPackage rec {
   pname = "py";
-  version = "1.7.0";
+  version = "1.8.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "bf92637198836372b520efcba9e020c330123be8ce527e535d185ed4b6f45694";
+    sha256 = "0lsy1gajva083pzc7csj1cvbmminb7b4l6a0prdzyb3fd829nqyw";
   };
 
   # Circular dependency on pytest


### PR DESCRIPTION
###### Motivation for this change
Noticed it was out of date on repology.

Made against staging, since this is a significant rebuild of all python packages.

not really sure the difference between staging and staging-next. Just didnt want to push against master. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @FRidh 
