### PR TITLE
pythonPackages.pyproj: 2.2.1 -> 2.2.2

### DIFF
--- a/pkgs/development/python-modules/pyproj/default.nix
+++ b/pkgs/development/python-modules/pyproj/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, python, pkgs, pythonOlder, substituteAll
+{ lib, buildPythonPackage, fetchFromGitHub, python, pkgs, pythonOlder, substituteAll
 , aenum
 , cython
 , pytest
@@ -8,11 +8,13 @@
 
 buildPythonPackage rec {
   pname = "pyproj";
-  version = "2.2.1";
+  version = "2.2.2";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "0yigcxwmx5cczipf2mpmy2gq1dnl0635yjvjq86ay47j1j5fd2gc";
+  src = fetchFromGitHub {
+    owner = "pyproj4";
+    repo = "pyproj";
+    rev = "v${version}rel";
+    sha256 = "0mb0jczgqh3sma69k7237i38h09gxgmvmddls9hpw4f3131f5ax7";
   };
 
   # force pyproj to use ${pkgs.proj}


### PR DESCRIPTION
##### Motivation for this change
Noticed it was out of date on repology.

They haven't released to pypi yet, so I used github.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @


```
$ nix path-info -Sh ./result
/nix/store/ijp2jrsvrj4gby3yxpsw9spvf2lp3h0g-python2.7-pyproj-2.2.2       163.6M
```

qgis is broken on master, but the other packages are still able to build
```
[11 built (1 failed), 29 copied (890.0 MiB), 187.7 MiB DL]
error: build of '/nix/store/4m6brw0dnk3aw40xcnp06xpp74a3bxjn-env.drv' failed
https://github.com/NixOS/nixpkgs/pull/65740
2 package failed to build:
qgis qgis-unwrapped

12 package were build:
python27Packages.basemap python27Packages.cartopy python27Packages.geopandas python27Packages.owslib python27Packages.pyproj python27Packages.pyspread python37Packages.basemap python37Packages.cartopy python37Packages.geopandas python37Packages.osmnx python37Packages.owslib python37Packages.pyproj
```
