### PR TITLE
pythonPackages.python-lz4: 2.1.2 -> 2.1.6

### DIFF
--- a/pkgs/development/python-modules/python-lz4/default.nix
+++ b/pkgs/development/python-modules/python-lz4/default.nix
@@ -1,29 +1,30 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, pytestrunner
-, pytest
-, psutil
-, setuptools_scm
-, pkgconfig
-, isPy3k
 , future
+, isPy3k
+, pkgconfig
+, psutil
+, pytest
+, pytestcov
+, pytestrunner
+, setuptools_scm
 }:
 
 buildPythonPackage rec {
   pname = "python-lz4";
-  version = "2.1.2";
+  version = "2.1.6";
 
   # get full repository inorder to run tests
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "1kzzdfkrq9nnlh0wssa6ccncvv0sk4wmhivhgyndjxz6d6przl5d";
+    sha256 = "1gx228946c2w645sh190m7ixfd0zfkdl3i8ybga77jz2sn1chzdi";
   };
 
   buildInputs = [ setuptools_scm pkgconfig pytestrunner ];
-  checkInputs = [ pytest psutil ];
+  checkInputs = [ pytest pytestcov psutil ];
   propagatedBuildInputs = lib.optionals (!isPy3k) [ future ];
 
   # give a hint to setuptools_scm on package version


### PR DESCRIPTION
###### Motivation for this change
noticed it was out of date on repology.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @