### PR TITLE
pythonPackages.redis: 3.1.0 -> 3.3.4

### DIFF
--- a/pkgs/development/python-modules/redis/default.nix
+++ b/pkgs/development/python-modules/redis/default.nix
@@ -1,18 +1,20 @@
-{ fetchPypi, buildPythonPackage }:
+{ lib, fetchPypi, buildPythonPackage }:
+
 buildPythonPackage rec {
   pname = "redis";
-  version = "3.1.0";
+  version = "3.3.4";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "7ba8612bbfd966dea8c62322543fed0095da2834dbd5a7c124afbc617a156aa7";
+    sha256 = "18n6k113izfqsm8yysrw1a5ba6kv0vsgfz6ab5n0k6k65yvr690z";
   };
 
   # tests require a running redis
   doCheck = false;
 
-  meta = {
+  meta = with lib; {
     description = "Python client for Redis key-value store";
     homepage = "https://pypi.python.org/pypi/redis/";
+    license = with licenses; [ mit ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
out of date on repology.

Added license.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
