### PR TITLE
zathura: drop broken synctexSupport option

### DIFF
--- a/pkgs/applications/misc/zathura/core/default.nix
+++ b/pkgs/applications/misc/zathura/core/default.nix
@@ -3,10 +3,8 @@
 , gtk, girara, gettext, libxml2, check
 , sqlite, glib, texlive, libintl, libseccomp
 , file, librsvg
-, gtk-mac-integration, synctexSupport ? true
+, gtk-mac-integration
 }:
-
-assert synctexSupport -> texlive != null;
 
 with stdenv.lib;
 
@@ -29,7 +27,8 @@ stdenv.mkDerivation rec {
     # "-Dseccomp=enabled"
     "-Dmanpages=enabled"
     "-Dconvert-icon=enabled"
-  ] ++ optional synctexSupport "-Dsynctex=enabled";
+    "-Dsynctex=enabled"
+  ];
 
   nativeBuildInputs = [
     meson ninja pkgconfig desktop-file-utils python3.pkgs.sphinx
@@ -38,8 +37,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     gtk girara libintl sqlite glib file librsvg
-  ] ++ optional synctexSupport texlive.bin.core
-    ++ optional stdenv.isLinux libseccomp
+    texlive.bin.core
+  ] ++ optional stdenv.isLinux libseccomp
     ++ optional stdenv.isDarwin gtk-mac-integration;
 
   doCheck = true;

--- a/pkgs/applications/misc/zathura/default.nix
+++ b/pkgs/applications/misc/zathura/default.nix
@@ -1,7 +1,6 @@
 { config, pkgs
 # zathura_pdf_mupdf fails to load _opj_create_decompress at runtime on Darwin (https://github.com/NixOS/nixpkgs/pull/61295#issue-277982980)
-, useMupdf ? config.zathura.useMupdf or (!pkgs.stdenv.isDarwin)
-, synctexSupport ? true }:
+, useMupdf ? config.zathura.useMupdf or (!pkgs.stdenv.isDarwin) }:
 
 let
   callPackage = pkgs.newScope self;
@@ -9,9 +8,7 @@ let
   self = rec {
     gtk = pkgs.gtk3;
 
-    zathura_core = callPackage ./core {
-      inherit synctexSupport;
-    };
+    zathura_core = callPackage ./core { };
 
     zathura_pdf_poppler = callPackage ./pdf-poppler { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Resolves #65553
The option was not tested since its introduction in b21329e0e04a7f7a6f37686f75ced7207750885e. It is currently broken.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @