### PR TITLE
pythonPackages.textacy: mark as broken

### DIFF
--- a/pkgs/development/python-modules/textacy/default.nix
+++ b/pkgs/development/python-modules/textacy/default.nix
@@ -30,8 +30,6 @@ buildPythonPackage rec {
     sha256 = "50402545ac92b1a931c2365e341cb35c4ebe5575525f1dcc5265901ff3895a5f";
   };
 
-  disabled = isPy27; # 2.7 requires backports.csv
-
   propagatedBuildInputs = [
     cachetools
     cld2-cffi
@@ -64,5 +62,8 @@ buildPythonPackage rec {
     homepage = "http://textacy.readthedocs.io/";
     license = licenses.asl20;
     maintainers = with maintainers; [ rvl ];
+    # ftfy and jellyfish no longer support python2
+    # latest scikitlearn not supported for this: https://github.com/chartbeat-labs/textacy/issues/260
+    broken = true;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Package is now broken due to incompatible dependencies.

Some dependencies dropped support for python2, then scikitlearn did some breaking changes and the package won't be fixed upstream [anytime soon](https://github.com/chartbeat-labs/textacy/issues/260)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
