### PR TITLE
pythonPackages.send2trash: 1.4.2 -> 1.5.0

### DIFF
--- a/pkgs/development/python-modules/send2trash/default.nix
+++ b/pkgs/development/python-modules/send2trash/default.nix
@@ -1,15 +1,12 @@
 { stdenv
-, lib
 , buildPythonPackage
 , fetchFromGitHub
 , pytest
-, configparser
-, isPy3k
 }:
 
 buildPythonPackage rec {
   pname = "Send2Trash";
-  version = "1.4.2";
+  version = "1.5.0";
 
   src = fetchFromGitHub {
     owner = "hsoft";
@@ -19,10 +16,10 @@ buildPythonPackage rec {
   };
 
   doCheck = !stdenv.isDarwin;
-  checkPhase = "HOME=. py.test";
-  checkInputs = [ pytest ] ++ lib.optional (!isPy3k) configparser;
+  checkPhase = "HOME=$TMPDIR pytest";
+  checkInputs = [ pytest ];
 
-  meta = with lib; {
+  meta = with stdenv.lib; {
     description = "Send file to trash natively under macOS, Windows and Linux";
     homepage = https://github.com/hsoft/send2trash;
     license = licenses.bsd3;


### PR DESCRIPTION
###### Motivation for this change
noticed it was out of date on repology.

cleaned up the expression a bit.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
