### PR TITLE
kustomize: 3.0.0 -> 3.1.0

### DIFF
--- a/pkgs/development/tools/kustomize/default.nix
+++ b/pkgs/development/tools/kustomize/default.nix
@@ -2,9 +2,9 @@
 
 buildGoModule rec {
   name = "kustomize-${version}";
-  version = "3.0.0";
-  # rev is the 3.0.0 commit, mainly for kustomize version command output
-  rev = "e0bac6ad192f33d993f11206e24f6cda1d04c4ec";
+  version = "3.1.0";
+  # rev is the 3.1.0 commit, mainly for kustomize version command output
+  rev = "95f3303493fdea243ae83b767978092396169baf";
 
   goPackagePath = "sigs.k8s.io/kustomize";
   subPackages = [ "cmd/kustomize" ];
@@ -17,7 +17,7 @@ buildGoModule rec {
   '';
 
   src = fetchFromGitHub {
-    sha256 = "1ywppn97gfgrwlq1nrj4kdvrdanq5ahqaa636ynyp9yiv9ibziq6";
+    sha256 = "0kigcirkjvnj3xi1p28p9yp3s0lff24q5qcvf8ahjwvpbwka14sh";
     rev = "v${version}";
     repo = "kustomize";
     owner = "kubernetes-sigs";

--- a/pkgs/development/tools/kustomize/default.nix
+++ b/pkgs/development/tools/kustomize/default.nix
@@ -1,7 +1,7 @@
 { lib, buildGoModule, fetchFromGitHub }:
 
 buildGoModule rec {
-  name = "kustomize-${version}";
+  pname = "kustomize";
   version = "3.1.0";
   # rev is the 3.1.0 commit, mainly for kustomize version command output
   rev = "95f3303493fdea243ae83b767978092396169baf";
@@ -9,7 +9,7 @@ buildGoModule rec {
   goPackagePath = "sigs.k8s.io/kustomize";
   subPackages = [ "cmd/kustomize" ];
 
-  buildFlagsArray = let t = "${goPackagePath}/pkg/commands/misc"; in ''
+  buildFlagsArray = let t = "${goPackagePath}/v3/pkg/commands/misc"; in ''
     -ldflags=
       -s -X ${t}.kustomizeVersion=${version}
          -X ${t}.gitCommit=${rev}
@@ -19,7 +19,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     sha256 = "0kigcirkjvnj3xi1p28p9yp3s0lff24q5qcvf8ahjwvpbwka14sh";
     rev = "v${version}";
-    repo = "kustomize";
+    repo = pname;
     owner = "kubernetes-sigs";
   };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Bump to latest release : [release notes](https://github.com/kubernetes-sigs/kustomize/blob/master/docs/v3.1.0.md).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @vdemeester
