### PR TITLE
nixos/nilfs2: init module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -901,6 +901,7 @@
   ./tasks/filesystems/f2fs.nix
   ./tasks/filesystems/jfs.nix
   ./tasks/filesystems/nfs.nix
+  ./tasks/filesystems/nilfs2.nix
   ./tasks/filesystems/ntfs.nix
   ./tasks/filesystems/reiserfs.nix
   ./tasks/filesystems/unionfs-fuse.nix

--- a/nixos/modules/tasks/filesystems/nilfs2.nix
+++ b/nixos/modules/tasks/filesystems/nilfs2.nix
@@ -1,0 +1,17 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  inInitrd = any (fs: fs == "nilfs2") config.boot.initrd.supportedFilesystems;
+  inSystem = any (fs: fs == "nilfs2") config.boot.supportedFilesystems;
+  enableNilfs2 = inInitrd || inSystem;
+
+in
+{
+  config = mkIf enableNilfs2 {
+    system.fsPackages = [ pkgs.nilfs-utils ];
+    boot.initrd.kernelModules = mkIf inInitrd [ "nilfs2" ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change
Stab at implementing proper support for nilfs2 in the `initrd` (see #65548).

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
