### PR TITLE
 pythonPackages.sepaxml: 2.0.0 -> 2.1.0

### DIFF
--- a/pkgs/development/python-modules/elementpath/default.nix
+++ b/pkgs/development/python-modules/elementpath/default.nix
@@ -1,0 +1,26 @@
+{ buildPythonPackage
+, lib
+, fetchFromGitHub
+}:
+
+buildPythonPackage rec {
+  version = "1.1.8";
+  pname = "elementpath";
+
+  src = fetchFromGitHub {
+    owner = "sissaschool";
+    repo = "elementpath";
+    rev = "v${version}";
+    sha256 = "0krczvf8r6pb3hb8qaxl9h2b4qwg180xk66gyxjf002im7ri75aj";
+  };
+
+  # avoid circular dependency with xmlschema which directly depends on this
+  doCheck = false;
+
+  meta = with lib; {
+    description = "XPath 1.0/2.0 parsers and selectors for ElementTree and lxml";
+    homepage = "https://github.com/sissaschool/elementpath";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/development/python-modules/fints/default.nix
+++ b/pkgs/development/python-modules/fints/default.nix
@@ -1,20 +1,36 @@
-{ stdenv, buildPythonPackage, fetchPypi,
-  requests, mt-940, sepaxml, bleach, isPy3k }:
+{ stdenv, buildPythonPackage, fetchFromGitHub, isPy27
+, bleach
+, mt-940
+, pytest
+, requests
+, sepaxml
+}:
 
 buildPythonPackage rec {
-  version = "2.1.1";
+  version = "2.2.0";
   pname = "fints";
-  disabled = !isPy3k;
+  disabled = isPy27;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "06p6p0xxw0n10hmf7z4k1l29fya0sja433s6lasjr1bal5asdhaq";
+  src = fetchFromGitHub {
+    owner = "raphaelm";
+    repo = "python-fints";
+    rev = "v${version}";
+    sha256 = "1gx173dzdprf3jsc7dss0xax8s6l2hr02qg9m5c4rksb3dl5fl8w";
   };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace 'sepaxml==2.0.*' 'sepaxml~=2.0'
+  '';
 
   propagatedBuildInputs = [ requests mt-940 sepaxml bleach ];
 
-  # no tests included in PyPI package
-  doCheck = false;
+  checkInputs = [ pytest ];
+
+  # ignore network calls and broken fixture
+  checkPhase = ''
+    pytest . --ignore=tests/test_client.py -k 'not robust_mode'
+  '';
 
   meta = with stdenv.lib; {
     homepage = https://github.com/raphaelm/python-fints/;

--- a/pkgs/development/python-modules/sepaxml/default.nix
+++ b/pkgs/development/python-modules/sepaxml/default.nix
@@ -1,17 +1,32 @@
-{ stdenv, buildPythonPackage, fetchPypi, isPy3k }:
+{ stdenv, buildPythonPackage, fetchFromGitHub, isPy27
+, lxml
+, pytest
+, text-unidecode
+, xmlschema
+}:
 
 buildPythonPackage rec {
-  version = "2.0.0";
+  version = "2.1.0";
   pname = "sepaxml";
-  disabled = !isPy3k;
+  disabled = isPy27;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "0jhj8fa0lbyaw15q485kyyli9qgrmqr47a6z6pgqm40kwmjghiyc";
+  src = fetchFromGitHub {
+    owner = "raphaelm";
+    repo = "python-sepaxml";
+    rev = version;
+    sha256 = "0lkb0nnyxmwvm6gkwls8w2290b66lwz9bv8p39wwcn7flabviwhj";
   };
 
-  # no tests included in PyPI package
-  doCheck = false;
+  propagatedBuildInputs = [
+    text-unidecode
+    xmlschema
+  ];
+
+  checkInputs = [ pytest lxml ];
+
+  checkPhase = ''
+    pytest
+  '';
 
   meta = with stdenv.lib; {
     homepage = https://github.com/raphaelm/python-sepaxml/;

--- a/pkgs/development/python-modules/xmlschema/default.nix
+++ b/pkgs/development/python-modules/xmlschema/default.nix
@@ -1,0 +1,39 @@
+{ lib, buildPythonPackage, fetchFromGitHub
+, elementpath
+, pytest
+}:
+
+buildPythonPackage rec {
+  version = "1.0.13";
+  pname = "xmlschema";
+
+  src = fetchFromGitHub {
+    owner = "sissaschool";
+    repo = "xmlschema";
+    rev = "v${version}";
+    sha256 = "182439gqhlxhr9rdi9ak33z4ffy1w9syhykkckkl6mq050c80qdr";
+  };
+
+  propagatedBuildInputs = [ elementpath ];
+
+  checkInputs = [ pytest ];
+
+  # Ignore broken fixtures, and tests for files which don't exist.
+  # For darwin, we need to explicity say we can't reach network
+  checkPhase = ''
+    substituteInPlace xmlschema/tests/__init__.py \
+      --replace "SKIP_REMOTE_TESTS = " "SKIP_REMOTE_TESTS = True #"
+    pytest . \
+      --ignore=xmlschema/tests/test_factory.py \
+      --ignore=xmlschema/tests/test_validators.py \
+      --ignore=xmlschema/tests/test_schemas.py \
+      -k 'not element_tree_import_script'
+  '';
+
+  meta = with lib; {
+    description = "XML Schema validator and data conversion library for Python";
+    homepage = "https://github.com/sissaschool/xmlschema";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4949,6 +4949,8 @@ in {
 
   xml2rfc = callPackage ../development/python-modules/xml2rfc { };
 
+  xmlschema = callPackage ../development/python-modules/xmlschema { };
+
   xmltodict = callPackage ../development/python-modules/xmltodict { };
 
   xarray = callPackage ../development/python-modules/xarray { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2178,6 +2178,8 @@ in {
 
   elasticsearch-curator = callPackage ../development/python-modules/elasticsearch-curator { };
 
+  elementpath = callPackage ../development/python-modules/elementpath { };
+
   entrypoints = callPackage ../development/python-modules/entrypoints { };
 
   enzyme = callPackage ../development/python-modules/enzyme {};


### PR DESCRIPTION
###### Motivation for this change
Noticed it was out of date. Also, enabled tests.

More work than I was expecting.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @elohmeier 


```
$ nix build --no-link --keep-going --max-jobs 8 --option build-use-sandbox true -f /home/jon/.cache/nix-review/pr-65750-2/build.nix
https://github.com/NixOS/nixpkgs/pull/65750
6 package were build:
python27Packages.elementpath python27Packages.xmlschema python37Packages.elementpath python37Packages.fints python37Packages.sepaxml python37Packages.xmlschema
```