### PR TITLE
pythonPackages.simplejson: 3.16.0 -> 3.16.1

### DIFF
--- a/pkgs/development/python-modules/simplejson/default.nix
+++ b/pkgs/development/python-modules/simplejson/default.nix
@@ -1,18 +1,20 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , stdenv
 , pytest
 }:
 
 buildPythonPackage rec {
   pname = "simplejson";
-  version = "3.16.0";
+  version = "3.16.1";
   doCheck = !stdenv.isDarwin;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "b1f329139ba647a9548aa05fb95d046b4a677643070dc2afc05fa2e975d09ca5";
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1v80dbk3ajhgz7q5cc8k0dd22zj9rrlz838c90l5g3w1i280r1iq";
   };
 
   # Package does not need pytest, but its a bit easier debugging.


### PR DESCRIPTION
###### Motivation for this change
Noticed it was out of date.

Package wasn't uploaded to pypi, using github instead.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
