### PR TITLE
pythonPackages.soupsieve: 1.7.3 -> 1.9.3

### DIFF
--- a/pkgs/development/python-modules/soupsieve/default.nix
+++ b/pkgs/development/python-modules/soupsieve/default.nix
@@ -9,11 +9,11 @@
 
 buildPythonPackage rec {
   pname = "soupsieve";
-  version = "1.7.3";
+  version = "1.9.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "87db12ae79194f0ff9808d2b1641c4f031ae39ffa3cab6b907ea7c1e5e5ed445";
+    sha256 = "14hs982wbb0rshnfiwjzda2zv6pcxcdr4bsfxjfpgn5qcqrq8ql6";
   };
 
   checkPhase = ''


### PR DESCRIPTION
###### Motivation for this change
Noticed it was out of date.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @


most of the broken builds are broken on master, some of the PRs to fix the broken packages:
 #66243 (vega_datasets, altair, papis)
there's another for calibre, can't find it. (found it #66229)
```
nix-review pr 65757
...
[256 built (15 failed), 895 copied (6286.1 MiB), 2401.8 MiB DL]
error: build of '/nix/store/zak8ns55h5l9d5byzhnrpqvw6lc7vxnp-env.drv' failed
https://github.com/NixOS/nixpkgs/pull/65757
10 package are marked as broken and were skipped:
bareos ceph ceph-dev devpi-client libceph python27Packages.imgaug python27Packages.serversyncstorage python37Packages.imgaug samba4Full sambaFull

33 package failed to build:
calibre csvs-to-sqlite fedpkg papis python27Packages.WSME python37Packages.acoustics python37Packages.altair python37Packages.aplpy python37Packages.astroquery python37Packages.awkward python37Packages.blaze python37Packages.dask-glm python37Packages.dask-ml python37Packages.dask-xgboost python37Packages.datashader python37Packages.dftfit python37Packages.google_cloud_bigquery python37Packages.ibis-framework python37Packages.imbalanced-learn python37Packages.odo python37Packages.optuna python37Packages.osmnx python37Packages.pyarrow python37Packages.rl-coach python37Packages.scikit-bio python37Packages.starfish python37Packages.streamz python37Packages.sunpy python37Packages.trackpy python37Packages.uproot python37Packages.uproot-methods python37Packages.vega_datasets python37Packages.xgboost

238 package were build:
anki aws-google-auth beancount beets buildbot buildbot-full buildbot-ui buku conan coursera-dl cubicsdr cum datasette devpi-server eolie errbot fanficfare fava flexget gnomecast gnss-sdr gnuradio gnuradio-with-packages gqrx gr-ais gr-gsm gr-limesdr gr-nacl gr-osmosdr gr-rds inspectrum ledger-autosync lollypop mailman-rss mitmproxy mnemosyne nagstamon ocropus pepper pirate-get poretools pubs pyload python27Packages.MechanicalSoup python27Packages.Quandl python27Packages.altair python27Packages.atomman python27Packages.awkward python27Packages.beaker python27Packages.beautifulsoup4 python27Packages.bkcharts python27Packages.blaze python27Packages.bokeh python27Packages.bugseverywhere python27Packages.caffe python27Packages.cherrypy python27Packages.colorcet python27Packages.cornice python27Packages.csvs-to-sqlite python27Packages.cufflinks python27Packages.dask python27Packages.dask-glm python27Packages.dask-image python27Packages.dask-jobqueue python27Packages.dask-ml python27Packages.dask-mpi python27Packages.deform python27Packages.distributed python27Packages.drms python27Packages.fastparquet python27Packages.favicon python27Packages.geeknote python27Packages.geopandas python27Packages.glymur python27Packages.gmusicapi python27Packages.google_cloud_bigquery python27Packages.google_cloud_monitoring python27Packages.histbook python27Packages.holoviews python27Packages.hvplot python27Packages.image-match python27Packages.imbalanced-learn python27Packages.infoqscraper python27Packages.mapsplotlib python27Packages.mezzanine python27Packages.micawber python27Packages.mozsvc python27Packages.nbsmoke python27Packages.odo python27Packages.ofxclient python27Packages.ofxparse python27Packages.pandas python27Packages.panel python27Packages.partd python27Packages.pecan python27Packages.pelican python27Packages.pims python27Packages.pvlib python27Packages.pyalgotrade python27Packages.pyarrow python27Packages.pyfftw python27Packages.pyjade python27Packages.pymatgen python27Packages.pyramid python27Packages.pyramid_beaker python27Packages.pyramid_chameleon python27Packages.pyramid_exclog python27Packages.pyramid_hawkauth python27Packages.pyramid_jinja2 python27Packages.pyramid_mako python27Packages.pyramid_multiauth python27Packages.python_fedora python27Packages.routes python27Packages.scikitimage python27Packages.seaborn python27Packages.slicedimage python27Packages.soupsieve python27Packages.statsmodels python27Packages.streamz python27Packages.subliminal python27Packages.sumo python27Packages.suseapi python27Packages.tablib python27Packages.tokenserver python27Packages.trackpy python27Packages.uproot python27Packages.uproot-methods python27Packages.vega python27Packages.vega_datasets python27Packages.vidstab python27Packages.webhelpers python27Packages.webtest python27Packages.wikipedia python27Packages.ws4py python27Packages.zerobin python37Packages.MechanicalSoup python37Packages.Quandl python37Packages.atomman python37Packages.beaker python37Packages.beautifulsoup4 python37Packages.bkcharts python37Packages.bokeh python37Packages.bugseverywhere python37Packages.buildbot-plugins.console-view python37Packages.buildbot-plugins.grid-view python37Packages.buildbot-plugins.waterfall-view python37Packages.buildbot-plugins.wsgi-dashboards python37Packages.caffe python37Packages.cherrypy python37Packages.colorcet python37Packages.cornice python37Packages.cufflinks python37Packages.dask python37Packages.dask-image python37Packages.dask-jobqueue python37Packages.dask-mpi python37Packages.deform python37Packages.distributed python37Packages.drms python37Packages.fastparquet python37Packages.favicon python37Packages.geopandas python37Packages.glymur python37Packages.gmusicapi python37Packages.google_cloud_monitoring python37Packages.histbook python37Packages.holoviews python37Packages.hvplot python37Packages.image-match python37Packages.infoqscraper python37Packages.intake python37Packages.lammps-cython python37Packages.mezzanine python37Packages.micawber python37Packages.nbsmoke python37Packages.ofxclient python37Packages.ofxparse python37Packages.pandas python37Packages.panel python37Packages.partd python37Packages.pecan python37Packages.pelican python37Packages.pims python37Packages.pvlib python37Packages.pyalgotrade python37Packages.pycaption python37Packages.pyfftw python37Packages.pyjade python37Packages.pymatgen python37Packages.pymatgen-lammps python37Packages.pymc3 python37Packages.pyramid python37Packages.pyramid_beaker python37Packages.pyramid_chameleon python37Packages.pyramid_exclog python37Packages.pyramid_hawkauth python37Packages.pyramid_jinja2 python37Packages.pyramid_mako python37Packages.pyramid_multiauth python37Packages.python_fedora python37Packages.routes python37Packages.sanic python37Packages.scikitimage python37Packages.seaborn python37Packages.slicedimage snscrape python37Packages.soupsieve python37Packages.statsmodels python37Packages.stumpy python37Packages.subliminal python37Packages.sumo python37Packages.tablib python37Packages.vega python37Packages.vidstab python37Packages.webhelpers python37Packages.webtest python37Packages.wikipedia python37Packages.wrf-python python37Packages.ws4py python37Packages.xarray python37Packages.zerobin qradiolink qutebrowser rss2email rst2html5 rtl_433 rtv soapysdr-with-plugins soapyuhd syncserver theharvester toot tribler uhd virtinst visidata welle-io wikicurses
```
