### PR TITLE
spidermonkey_{38,60}: fix cross compilation

### DIFF
--- a/pkgs/applications/networking/browsers/elinks/default.nix
+++ b/pkgs/applications/networking/browsers/elinks/default.nix
@@ -4,7 +4,7 @@
   enableGuile        ? false,                                         guile ? null
 , enablePython       ? false,                                         python ? null
 , enablePerl         ? (stdenv.hostPlatform == stdenv.buildPlatform), perl ? null
-, enableSpidermonkey ? (stdenv.hostPlatform == stdenv.buildPlatform), spidermonkey_1_8_5 ? null
+, enableSpidermonkey ? (stdenv.hostPlatform == stdenv.buildPlatform), spidermonkey ? null
 }:
 
 assert enableGuile -> guile != null;
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   patches = [ ./gc-init.patch ];
 
-  buildInputs = [ ncurses xlibsWrapper bzip2 zlib openssl spidermonkey_1_8_5 gpm ]
+  buildInputs = [ ncurses xlibsWrapper bzip2 zlib openssl spidermonkey gpm ]
     ++ stdenv.lib.optional enableGuile guile
     ++ stdenv.lib.optional enablePython python
     ++ stdenv.lib.optional enablePerl perl
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   ] ++ stdenv.lib.optional enableGuile        "--with-guile"
     ++ stdenv.lib.optional enablePython       "--with-python"
     ++ stdenv.lib.optional enablePerl         "--with-perl"
-    ++ stdenv.lib.optional enableSpidermonkey "--with-spidermonkey=${spidermonkey_1_8_5}"
+    ++ stdenv.lib.optional enableSpidermonkey "--with-spidermonkey=${spidermonkey}"
     ;
 
   meta = {

--- a/pkgs/development/interpreters/spidermonkey/38.nix
+++ b/pkgs/development/interpreters/spidermonkey/38.nix
@@ -1,5 +1,7 @@
-{ stdenv, fetchurl, pkgconfig, gnused_422, perl, python2, zip, libffi, readline, icu, zlib, nspr
+{ stdenv, fetchurl, pkgconfig, gnused_422, perl, python2, zip, libffi, readline, icu, zlib, buildPackages
 , libobjc }:
+
+with stdenv.lib;
 
 stdenv.mkDerivation rec {
   version = "38.8.0";
@@ -10,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "10lrync6cxnjlnadc0j3vg8r2dq9b3wwanw8qj1h6ncxwb7asxcl";
   };
 
-  buildInputs = [ libffi readline icu zlib nspr ]
+  buildInputs = [ libffi readline icu zlib ]
                ++ stdenv.lib.optional stdenv.isDarwin libobjc;
   nativeBuildInputs = [ pkgconfig perl python2 zip gnused_422 ];
 
@@ -19,13 +21,13 @@ stdenv.mkDerivation rec {
   preConfigure = ''
     export CXXFLAGS="-fpermissive"
     export LIBXUL_DIST=$out
-    export PYTHON="${python2.interpreter}"
+    export PYTHON="${buildPackages.python2.interpreter}"
   '';
 
   configureFlags = [
     "--enable-threadsafe"
     "--with-system-ffi"
-    "--with-system-nspr"
+    "--enable-posix-nspr-emulation"
     "--with-system-zlib"
     "--with-system-icu"
     "--enable-readline"
@@ -34,7 +36,16 @@ stdenv.mkDerivation rec {
     # not be good defaults for other uses.
     "--enable-gcgenerational"
     "--enable-shared-js"
+  ] ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    # Spidermonkey seems to use different host/build terminology for cross
+    # compilation here.
+    "--host=${stdenv.buildPlatform.config}"
+    "--target=${stdenv.hostPlatform.config}"
   ];
+
+  configurePlatforms = [];
+
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
 
   # This addresses some build system bug. It's quite likely to be safe
   # to re-enable parallel builds if the source revision changes.

--- a/pkgs/development/interpreters/spidermonkey/60.nix
+++ b/pkgs/development/interpreters/spidermonkey/60.nix
@@ -1,5 +1,7 @@
-{ stdenv, fetchurl, fetchpatch, autoconf213, pkgconfig, perl, python2, zip
+{ stdenv, fetchurl, fetchpatch, autoconf213, pkgconfig, perl, python2, zip, buildPackages
 , which, readline, zlib, icu }:
+
+with stdenv.lib;
 
 let
   version = "60.4.0";
@@ -24,7 +26,7 @@ in stdenv.mkDerivation rec {
   preConfigure = ''
     export CXXFLAGS="-fpermissive"
     export LIBXUL_DIST=$out
-    export PYTHON="${python2.interpreter}"
+    export PYTHON="${buildPackages.python2.interpreter}"
 
     # We can't build in js/src/, so create a build dir
     mkdir obj
@@ -45,7 +47,16 @@ in stdenv.mkDerivation rec {
     # https://src.fedoraproject.org/rpms/mozjs38/c/761399aba092bcb1299bb4fccfd60f370ab4216e
     "--enable-optimize"
     "--enable-release"
+  ] ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    # Spidermonkey seems to use different host/build terminology for cross
+    # compilation here.
+    "--host=${stdenv.buildPlatform.config}"
+    "--target=${stdenv.hostPlatform.config}"
   ];
+
+  configurePlatforms = [];
+
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
 
   # Remove unnecessary static lib
   preFixup = ''

--- a/pkgs/servers/mediatomb/default.nix
+++ b/pkgs/servers/mediatomb/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchgit
-, sqlite, expat, mp4v2, flac, spidermonkey_1_8_5, taglib, libexif, curl, ffmpeg, file
+, sqlite, expat, mp4v2, flac, spidermonkey, taglib, libexif, curl, ffmpeg, file
 , pkgconfig, autoreconfHook }:
 
 stdenv.mkDerivation rec {
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "1mimslr4q6mky865y6561rr64cbn4gf0qc2dhgb31hxp4rc1kmzd";
   };
 
-  buildInputs = [ sqlite expat spidermonkey_1_8_5 taglib libexif curl ffmpeg file mp4v2 flac
+  buildInputs = [ sqlite expat spidermonkey taglib libexif curl ffmpeg file mp4v2 flac
                   pkgconfig autoreconfHook ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Fix cross compilation.

###### Things done

- I redid what was done in 65f2b0a2a32bb0d84f55ca7bb8c9a33e8ba28713 for `52`, but for `38` and `60`.
- For `38` I also set `--enable-posix-nspr-emulation`, as it would otherwise complain about a wrong NSPR version and that trick seemed to be successful in `60` anyway.

Also I removed some version bounds on `mediatomb` and `elinks` as I didn't manage to cross compile `spidermonkey_1_8_5`. These two packages still don't cross compile, but i guess this brings them one step further on doing so.

While working on this I figured that we probably don't need that many versions of `spidermonkey` or that one could at least remove some redundancy be creating a `generic.nix`. But I guess that should better be done in a separate PR.

#51134 can be closed btw.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @cillianderoiste @abbradar @Phreedom 
