### PR TITLE
bitwarden: init at 1.15.2

### DIFF
--- a/pkgs/tools/security/bitwarden/default.nix
+++ b/pkgs/tools/security/bitwarden/default.nix
@@ -1,0 +1,87 @@
+{ atomEnv
+, autoPatchelfHook
+, dpkg
+, fetchurl
+, libsecret
+, makeDesktopItem
+, makeWrapper
+, stdenv
+, udev
+, wrapGAppsHook
+}:
+
+let
+  inherit (stdenv.hostPlatform) system;
+
+  pname = "bitwarden";
+
+  version = {
+    "x86_64-linux" = "1.15.2";
+  }.${system} or "";
+
+  sha256 = {
+    "x86_64-linux" = "0yz4hkqqwq2zrdjfxk5kybhs90n80k6bkn0625m47b09lwl2di4f";
+  }.${system} or "";
+
+  meta = with stdenv.lib; {
+    description = "A secure and free password manager for all of your devices";
+    homepage = "https://bitwarden.com";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ kiwi ];
+    platforms = [ "x86_64-linux" ];
+  };
+
+  linux = stdenv.mkDerivation rec {
+    inherit pname version meta;
+
+    src = fetchurl {
+      url = "https://github.com/bitwarden/desktop/releases/download/"
+      + "v${version}/Bitwarden-${version}-amd64.deb";
+      inherit sha256;
+    };
+
+    desktopItem = makeDesktopItem {
+      name = "bitwarden";
+      exec = "bitwarden %U";
+      icon = "bitwarden";
+      comment = "A secure and free password manager for all of your devices";
+      desktopName = "Bitwarden";
+      categories = "Utility";
+    };
+
+    dontBuild = true;
+    dontConfigure = true;
+    dontPatchElf = true;
+    dontWrapGApps = true;
+
+    buildInputs = [ libsecret ] ++ atomEnv.packages;
+
+    nativeBuildInputs = [ dpkg makeWrapper autoPatchelfHook wrapGAppsHook ];
+
+    unpackPhase = "dpkg-deb -x $src .";
+
+    installPhase = ''
+      mkdir -p "$out/bin"
+      cp -R "opt" "$out"
+      cp -R "usr/share" "$out/share"
+      chmod -R g-w "$out"
+
+      # Desktop file
+      mkdir -p "$out/share/applications"
+      cp "${desktopItem}/share/applications/"* "$out/share/applications"
+    '';
+
+    runtimeDependencies = [
+      udev.lib
+    ];
+
+    postFixup = ''
+      makeWrapper $out/opt/Bitwarden/bitwarden $out/bin/bitwarden \
+        --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [ libsecret stdenv.cc.cc ] }" \
+        "''${gappsWrapperArgs[@]}"
+    '';
+  };
+
+in if stdenv.isDarwin
+then throw "Bitwarden has not been packaged for macOS yet"
+else linux

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -700,13 +700,15 @@ in
 
   bcachefs-tools = callPackage ../tools/filesystems/bcachefs-tools { };
 
+  bitwarden = callPackage ../tools/security/bitwarden { };
+
+  bitwarden-cli = callPackage ../tools/security/bitwarden-cli { };
+
   bitwarden_rs = callPackage ../tools/security/bitwarden_rs {
     inherit (darwin.apple_sdk.frameworks) Security CoreServices;
   };
 
   bitwarden_rs-vault = callPackage ../tools/security/bitwarden_rs/vault.nix { };
-
-  bitwarden-cli = callPackage ../tools/security/bitwarden-cli { };
 
   bmap-tools = callPackage ../tools/misc/bmap-tools { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Started using bitwarden and it's really nice so I thought I'd add the GUI (someone else asked for it already as well https://github.com/NixOS/nixpkgs/issues/51212 )

EDIT for posterity: this was fixed by packaging it differently (it does it when run with electron binary)

~~There's a weird thing that happens and I'm not sure if it's something I did or intentional on the developers part (I'm not sure I've done the expression right anyway) in that it launches the app with the devtools panel open. F12 and it goes away or close it. *shrug* If someone knows a better way to package electron apps I'd be glad for suggestions. Other than that it seems to work fine.~~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
