### PR TITLE
grpc: 1.19.1 -> 1.22.0

### DIFF
--- a/pkgs/development/libraries/grpc/default.nix
+++ b/pkgs/development/libraries/grpc/default.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation rec {
       "-DgRPC_PROTOBUF_PROVIDER=package"
       "-DgRPC_GFLAGS_PROVIDER=package"
       "-DBUILD_SHARED_LIBS=ON"
+      "-DCMAKE_SKIP_BUILD_RPATH=OFF"
     ];
 
   # CMake creates a build directory by default, this conflicts with the

--- a/pkgs/development/libraries/grpc/default.nix
+++ b/pkgs/development/libraries/grpc/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchFromGitHub, cmake, zlib, c-ares, pkgconfig, openssl, protobuf, gflags }:
 
 stdenv.mkDerivation rec {
-  version = "1.19.1";
+  version = "1.22.0";
   name = "grpc-${version}";
   src = fetchFromGitHub {
     owner = "grpc";
     repo = "grpc";
     rev = "v${version}";
-    sha256 = "0c0jra4qnd86gyr4rlblic3igb5dpgrldac35myk5i5ia547fdhj";
+    sha256 = "10wf9sakkxpcvc09n1h91x6slwwhxblghs4zn95klyc4m6py1gfg";
   };
   nativeBuildInputs = [ cmake pkgconfig ];
   buildInputs = [ zlib c-ares c-ares.cmake-config openssl protobuf gflags ];

--- a/pkgs/development/python-modules/grpcio-tools/default.nix
+++ b/pkgs/development/python-modules/grpcio-tools/default.nix
@@ -1,24 +1,24 @@
-{ stdenv, buildPythonPackage, fetchPypi, lib, grpcio}:
+{ stdenv, buildPythonPackage, fetchPypi, protobuf, grpcio }:
 
 buildPythonPackage rec {
   pname = "grpcio-tools";
-  version = "1.18.0";
+  version = "1.22.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "77ec4d3c92ccbbe3de37c457e3c72962e519c36cafb96abe5842bced8eb926fa";
+    sha256 = "b5c0fe51a155625c9d1132ab8deb56b3015e111a6961e48aeb9dd89bd7c670ab";
   };
 
   enableParallelBuilding = true;
 
-  propagatedBuildInputs = [ grpcio ];
+  propagatedBuildInputs = [ protobuf grpcio ];
 
   # no tests in the package
   doCheck = false;
 
   meta = with stdenv.lib; {
     description = "Protobuf code generator for gRPC";
-    license = lib.licenses.asl20;
+    license = licenses.asl20;
     homepage = "https://grpc.io/grpc/python/";
     maintainers = with maintainers; [ vanschelven ];
   };

--- a/pkgs/development/python-modules/grpcio/default.nix
+++ b/pkgs/development/python-modules/grpcio/default.nix
@@ -1,32 +1,30 @@
-{ stdenv, buildPythonPackage, fetchFromGitHub, lib, darwin
-, six, protobuf, enum34, futures, isPy27, isPy34, pkgconfig
+{ stdenv, buildPythonPackage, fetchFromGitHub, darwin
+, six, protobuf, enum34, futures, isPy27, pkgconfig
 , cython}:
 
-with stdenv.lib;
 buildPythonPackage rec {
   pname = "grpcio";
-  version = "1.18.0";
+  version = "1.22.0";
 
   src = fetchFromGitHub {
     owner = "grpc";
     repo = "grpc";
     rev = "v${version}";
     fetchSubmodules = true;
-    sha256 = "0cilbhk35gv46mk40jl5f3iqa94x14qyxbavpfq0kh0rld82nx4m";
+    sha256 = "093w8mgvl8ylqlqnfz06ijkmlnkxcjszf9zg6k5ybjw7dwal0jhz";
   };
 
   nativeBuildInputs = [ cython pkgconfig ]
-                    ++ optional stdenv.isDarwin darwin.cctools;
+                    ++ stdenv.lib.optional stdenv.isDarwin darwin.cctools;
 
   propagatedBuildInputs = [ six protobuf ]
-                        ++ lib.optionals (isPy27 || isPy34) [ enum34 ]
-                        ++ lib.optionals (isPy27) [ futures ];
+                        ++ stdenv.lib.optionals (isPy27) [ enum34 futures ];
 
-  preBuild = optionalString stdenv.isDarwin "unset AR";
+  preBuild = stdenv.lib.optionalString stdenv.isDarwin "unset AR";
 
   meta = with stdenv.lib; {
     description = "HTTP/2-based RPC framework";
-    license = lib.licenses.asl20;
+    license = licenses.asl20;
     homepage = "https://grpc.io/grpc/python/";
     maintainers = with maintainers; [ vanschelven ];
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
fixes https://github.com/NixOS/nixpkgs/issues/65552
closes: https://github.com/NixOS/nixpkgs/pull/62428
cc: @Kaali 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
