### PR TITLE
zsh/pth/zsync: cross fixes

### DIFF
--- a/pkgs/development/libraries/pth/default.nix
+++ b/pkgs/development/libraries/pth/default.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
 
   preConfigure = stdenv.lib.optionalString stdenv.isAarch32 ''
     configureFlagsArray=("CFLAGS=-DJB_SP=8 -DJB_PC=9")
+  '' + stdenv.lib.optionalString (stdenv.hostPlatform.libc == "glibc") ''
+    configureFlagsArray+=("ac_cv_check_sjlj=ssjlj")
   '';
 
   meta = with stdenv.lib; {
@@ -17,6 +19,5 @@ stdenv.mkDerivation rec {
     homepage = https://www.gnu.org/software/pth;
     license = licenses.lgpl21Plus;
     platforms = platforms.all;
-    broken = stdenv.hostPlatform != stdenv.buildPlatform && stdenv.hostPlatform.isAarch64;
   };
 }

--- a/pkgs/shells/zsh/default.nix
+++ b/pkgs/shells/zsh/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ncurses, pcre }:
+{ stdenv, fetchurl, ncurses, pcre, buildPackages }:
 
 let
   version = "5.7.1";
@@ -7,7 +7,6 @@ let
     url = "mirror://sourceforge/zsh/zsh-${version}-doc.tar.xz";
     sha256 = "1d1r88n1gfdavx4zy3svl1gljrvzim17jb2r834hafg2a016flrh";
   };
-
 in
 
 stdenv.mkDerivation {
@@ -61,7 +60,11 @@ else
   fi
 fi
 EOF
-    $out/bin/zsh -c "zcompile $out/etc/zprofile"
+    ${if stdenv.hostPlatform == stdenv.buildPlatform then ''
+      $out/bin/zsh -c "zcompile $out/etc/zprofile"
+    '' else ''
+      ${stdenv.lib.getBin buildPackages.zsh}/bin/zsh -c "zcompile $out/etc/zprofile"
+    ''}
     mv $out/etc/zprofile $out/etc/zprofile_zwc_is_used
   '';
   # XXX: patch zsh to take zwc if newer _or equal_

--- a/pkgs/tools/compression/zsync/default.nix
+++ b/pkgs/tools/compression/zsync/default.nix
@@ -8,6 +8,8 @@ stdenv.mkDerivation rec {
     sha256 = "1wjslvfy76szf0mgg2i9y9q30858xyjn6v2acc24zal76d1m778b";
   };
 
+  makeFlags = [ "AR=${stdenv.cc.bintools.targetPrefix}ar" ];
+
   meta = {
     homepage = http://zsync.moria.org.uk/;
     description = "File distribution system using the rsync algorithm";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
