### PR TITLE
runwayml: init at 0.8.1

### DIFF
--- a/pkgs/applications/graphics/runwayml/default.nix
+++ b/pkgs/applications/graphics/runwayml/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, fetchurl
+, appimageTools
+, symlinkJoin
+}:
+
+let
+  pname = "runwayml";
+  version = "0.8.1";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "https://runway-releases.s3.amazonaws.com/Runway%20${version}.AppImage";
+    sha256 = "0pqnlwk804cly2x9kph39g9ps5dv75ybi2v1fgrvmhk3wbmwmpb0";
+    name="${pname}-${version}.AppImage";
+  };
+
+  binary = appimageTools.wrapType2 {
+    name = "${pname}";
+    inherit src;
+  };
+  # we only use this to extract the icon
+  appimage-contents = appimageTools.extractType2 {
+    inherit name src;
+  };
+
+in
+  symlinkJoin {
+    inherit name;
+    paths = [ binary ];
+
+    postBuild = ''
+      mkdir -p $out/share/pixmaps/ $out/share/applications
+      cp ${appimage-contents}/usr/share/icons/hicolor/1024x1024/apps/runway.png $out/share/pixmaps/runway.png
+      sed 's:Exec=AppRun:Exec=runwayml:' ${appimage-contents}/runway.desktop > $out/share/applications/runway.desktop
+    '';
+
+  meta = with lib; {
+    description = "Machine learning for creators";
+    homepage = https://runwayml.com/;
+    license = licenses.unfree;
+    maintainers = with maintainers; [ prusnak ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24572,4 +24572,6 @@ in
   kube3d =  callPackage ../applications/networking/cluster/kube3d {};
 
   zfs-replicate = python3Packages.callPackage ../tools/backup/zfs-replicate { };
+
+  runwayml = callPackage ../applications/graphics/runwayml {};
 }


### PR DESCRIPTION
###### Motivation for this change

RunwayML is a machine learning tool for creators. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
