### PR TITLE
libdrm: cross-compile fix

### DIFF
--- a/pkgs/development/libraries/libdrm/cross-build-nm-path.patch
+++ b/pkgs/development/libraries/libdrm/cross-build-nm-path.patch
@@ -1,0 +1,48 @@
+From 9e05fece7918edce9c6aa5a1f1ea375108e5b2be Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=C3=B6rg=20Thalheim?= <joerg@thalheim.io>
+Date: Fri, 2 Aug 2019 10:26:37 +0100
+Subject: [PATCH] meson: support for custom nm path
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+When cross-compiling target toolchains i.e. binutils are often
+prefixed by its target architecture. This patch gives the user
+to option to specify the nm used during the build process.
+
+Signed-off-by: Jörg Thalheim <joerg@thalheim.io>
+---
+ meson.build       | 2 +-
+ meson_options.txt | 6 ++++++
+ 2 files changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/meson.build b/meson.build
+index e292554a..64607139 100644
+--- a/meson.build
++++ b/meson.build
+@@ -327,7 +327,7 @@ pkg.generate(
+ )
+ 
+ env_test = environment()
+-env_test.set('NM', find_program('nm').path())
++env_test.set('NM', find_program(get_option('nm-path')).path())
+ 
+ if with_libkms
+   subdir('libkms')
+diff --git a/meson_options.txt b/meson_options.txt
+index 8af33f1c..b4f46a52 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -141,3 +141,9 @@ option(
+   value : false,
+   description : 'Enable support for using udev instead of mknod.',
+ )
++option(
++  'nm-path',
++  type : 'string',
++  description : 'path to nm',
++  value : 'nm'
++)
+-- 
+2.22.0
+

--- a/pkgs/development/libraries/libdrm/default.nix
+++ b/pkgs/development/libraries/libdrm/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig meson ninja ];
   buildInputs = [ libpthreadstubs libpciaccess valgrind-light ];
 
+  patches = [ ./cross-build-nm-path.patch ];
+
   postPatch = ''
     for a in */*-symbol-check ; do
       patchShebangs $a
@@ -21,7 +23,9 @@ stdenv.mkDerivation rec {
   '';
 
   mesonFlags =
-    [ "-Dinstall-test-programs=true" ]
+    [
+      "-Dnm-path=${stdenv.cc.targetPrefix}nm"
+      "-Dinstall-test-programs=true" ]
     ++ stdenv.lib.optionals (stdenv.isAarch32 || stdenv.isAarch64)
       [ "-Dtegra=true" "-Detnaviv=true" ]
     ++ stdenv.lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "-Dintel=false"


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @andir regarding upstreaming the patch.
