### PR TITLE
[19.03] doc: fix passthru.updateScript help command

### DIFF
--- a/doc/stdenv.xml
+++ b/doc/stdenv.xml
@@ -704,7 +704,7 @@ passthru.updateScript = [ ../../update.sh pname "--requested-release=unstable" ]
 
      <para>
       For information about how to run the updates, execute
-      <cmdsynopsis><command>nix-shell</command> <arg>maintainers/scripts/update.nix</arg></cmdsynopsis>.
+      <command>nix-shell maintainers/scripts/update.nix</command>.
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
###### Motivation for this change

Currently, the doc looks like this:

![Screenshot from 2019-08-02 15-58-33](https://user-images.githubusercontent.com/91113/62375380-75c5ae00-b53e-11e9-890c-a2418960249a.png)

When i execute that, i get an error:

![Screenshot from 2019-08-02 15-59-55](https://user-images.githubusercontent.com/91113/62375446-9d1c7b00-b53e-11e9-81bb-81df6860324b.png)

But there is a fix in master. So i backported it.

###### Things done

I build the manual as described in the docs.

The results looks completely different than the online doc.

![Screenshot from 2019-08-02 16-01-59](https://user-images.githubusercontent.com/91113/62375630-069c8980-b53f-11e9-90ef-ae7d97e1ead8.png)

I think it **should** be fine, but i see again that contributing to the manual is annoying and inefficient.

It took me 17 minutes to check after making the commit!

###### Notify maintainers

cc @
