### PR TITLE
xteddy: 2.2 -> 2.2-5 (use debian sources and patches)

### DIFF
--- a/pkgs/applications/misc/xteddy/default.nix
+++ b/pkgs/applications/misc/xteddy/default.nix
@@ -1,19 +1,22 @@
-{ stdenv, fetchzip, pkg-config, xorg, imlib2, makeWrapper }:
+{ stdenv, fetchFromGitLab, pkg-config, xorg, imlib2, makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "xteddy-${version}";
-  version = "2.2";
-  src = fetchzip {
-    url = "https://deb.debian.org/debian/pool/main/x/xteddy/xteddy_${version}.orig.tar.gz";
-    sha256 = "0sap4fqvs0888ymf5ga10p3n7n5kr35j38kfsfd7nj0xm4hmcma3";
+  version = "2.2-5";
+  src = fetchFromGitLab {
+    domain = "salsa.debian.org";
+    owner = "games-team";
+    repo = "xteddy";
+    rev = "debian%2F${version}"; # %2F = urlquote("/");
+    sha256 = "0rm7w78d6qajq4fvi4agyqm0c70f3c1i0cy2jdb6kqql2k8w78qy";
   };
+
   nativeBuildInputs = [ pkg-config makeWrapper ];
   buildInputs = [ imlib2 xorg.libX11 xorg.libXext ];
 
-  makeFlags = [ "LIBS=-lXext" ];
+  patches = [ "${src}/debian/patches/10_libXext.patch" "${src}/debian/patches/wrong-man-page-section.patch" ];
 
   postPatch = ''
-    sed -i 's/man 1 xteddy/man 6 xteddy/' xteddy.c
     sed -i "s:/usr/games/xteddy:$out/bin/xteddy:" xtoys
     sed -i "s:/usr/share/xteddy:$out/share/xteddy:" xtoys
   '';
@@ -32,7 +35,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Cuddly teddy bear for your X desktop";
-    homepage = https://weber.itn.liu.se/~stegu/xteddy/;
+    homepage = "https://weber.itn.liu.se/~stegu/xteddy/";
     license = licenses.gpl2;
     maintainers = [ maintainers.xaverdh ];
     platforms = platforms.linux;


### PR DESCRIPTION
#### Motivation for this change

Change the sources to use the debian git repository at `salsa.debian.org`. The code there contains more up to date patches, and could be considered the new upstream.
While at it, quote the homepage url.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
