### PR TITLE
pythonPackages.msreset: 0.6.8 -> 0.6.9

### DIFF
--- a/pkgs/development/python-modules/msrest/default.nix
+++ b/pkgs/development/python-modules/msrest/default.nix
@@ -18,7 +18,7 @@
 }:
 
 buildPythonPackage rec {
-  version = "0.6.8";
+  version = "0.6.9";
   pname = "msrest";
 
   # no tests in PyPI tarball
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     owner = "Azure";
     repo = "msrest-for-python";
     rev = "v${version}";
-    sha256 = "1vnh0y68vqf7hwhghbf6bjadrzlv98aj4vfz6g592lww3ijpy77w";
+    sha256 = "0540dmxz90jsmwvd4q06cr1ficixknjk8q06f2dqcp06w92vnl8r";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
Noticed it was out of date according to repology.

nixops_1_6_1 is broken on master, otherwise all other packages build on NixOS

```
[148 built (1 failed), 120 copied (416.2 MiB), 32.6 MiB DL]
error: build of '/nix/store/9ygpv4r7z6mljhr76zwi8dma2jvc9nd1-env.drv' failed
1 package failed to build:
nixops_1_6_1

144 package were build:
python27Packages.azure-applicationinsights ....
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
