### PR TITLE
vagrant: add update script

### DIFF
--- a/pkgs/development/tools/vagrant/default.nix
+++ b/pkgs/development/tools/vagrant/default.nix
@@ -96,6 +96,7 @@ in buildRubyGem rec {
 
   passthru = {
     inherit ruby deps;
+    updateScript = ./update.sh;
   };
 
   meta = with lib; {

--- a/pkgs/development/tools/vagrant/default.nix
+++ b/pkgs/development/tools/vagrant/default.nix
@@ -103,7 +103,7 @@ in buildRubyGem rec {
     description = "A tool for building complete development environments";
     homepage = https://www.vagrantup.com/;
     license = licenses.mit;
-    maintainers = with maintainers; [ aneeshusa ];
+    maintainers = with maintainers; [ aneeshusa angristan ];
     platforms = with platforms; linux ++ darwin;
   };
 }

--- a/pkgs/development/tools/vagrant/update.sh
+++ b/pkgs/development/tools/vagrant/update.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p common-updater-scripts
+
+set -eu -o pipefail
+
+oldVersion="$(nix-instantiate --eval -E "with import ./. {}; vagrant.version or (builtins.parseDrvName vagrant.name).version" | tr -d '"')"
+latestTag="$(git ls-remote --tags --sort="v:refname" git://github.com/hashicorp/vagrant.git | grep -v '\{\}' | grep -v '\-rc' | tail -1 | sed 's|^.*/v\(.*\)|\1|')"
+
+if [ ! "${oldVersion}" = "${latestTag}" ]; then
+
+    update-source-version vagrant "${latestTag}"
+
+    nixpkgs="$(git rev-parse --show-toplevel)"
+    default_nix="$nixpkgs/pkgs/development/tools/vagrant/default.nix"
+    tmp_dir=$(mktemp -d -t nixpkgs-vagrant-XXXXXXX)
+
+    git clone https://github.com/hashicorp/vagrant.git "$tmp_dir"
+    cd "$tmp_dir"
+    git checkout $(git describe --tags $(git rev-list --tags --max-count=1))
+
+    nix-shell -p bundler --run 'bundle lock'
+    nix-shell -p bundix --run 'bundix'
+
+    cd "$nixpkgs/pkgs/development/tools/vagrant/"
+    cp "$tmp_dir/gemset.nix" .
+
+    rm -rf "$tmp_dir"
+
+    echo "vagrant has been updated to $latestTag."
+
+else
+    echo "vagrant is already up-to-date"
+fi


### PR DESCRIPTION
Since Gemfile and Gemfile.lock were removed in 16a8e49ae9c54e05e76a486457c42e31eee264de, we need an easy to update the gemset.nix using the Vagrant source.

This update.sh script updates the version and hash of vagrant and generates a new gemset.nix using a temporary copy of the vagrant source code.

See discussion in #64302

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @aneeshusa
