### PR TITLE
sage: add patch to debug transient issue

### DIFF
--- a/pkgs/applications/science/math/sage/dist-tests.nix
+++ b/pkgs/applications/science/math/sage/dist-tests.nix
@@ -1,0 +1,17 @@
+# Lists past failures and files associated with it. The intention is to build
+# up a subset of a testsuite that catches 95% of failures that are relevant for
+# distributions while only taking ~5m to run. This in turn makes it more
+# reasonable to re-test sage on dependency changes and makes it easier for
+# users to override the sage derivation.
+# This is an experiment for now. If it turns out that there really is a small
+# subset of files responsible for the vast majority of packaging tests, we can
+# think about moving this upstream.
+[
+	"src/sage/env.py" # [1]
+	"src/sage/misc/persist.pyx" # [1]
+	"src/sage/misc/inline_fortran.py" # [1]
+	"src/sage/repl/ipython_extension.py" # [1]
+]
+
+# Numbered list of past failures to annotate files with
+# [1] PYTHONPATH related issue https://github.com/NixOS/nixpkgs/commit/ec7f569211091282410050e89e68832d4fe60528

--- a/pkgs/applications/science/math/sage/patches/configurationpy-error-verbose.patch
+++ b/pkgs/applications/science/math/sage/patches/configurationpy-error-verbose.patch
@@ -1,0 +1,19 @@
+diff --git a/src/sage/repl/configuration.py b/src/sage/repl/configuration.py
+index 67d7d2accf..18279581e2 100644
+--- a/src/sage/repl/configuration.py
++++ b/src/sage/repl/configuration.py
+@@ -9,10 +9,11 @@ the IPython simple prompt is being used::
+     sage: cmd = 'print([sys.stdin.isatty(), sys.stdout.isatty()])'
+     sage: import pexpect
+     sage: output = pexpect.run(
+-    ....:     'bash -c \'echo "{0}" | sage\''.format(cmd),
++    ....:     'bash -c \'export SAGE_BANNER=no; echo "{0}" | sage\''.format(cmd),
+     ....: ).decode('utf-8', 'surrogateescape')
+-    sage: 'sage: [False, True]' in output
+-    True
++    sage: print(output)
++    sage...[False, True]
++    sage...Exiting Sage ...
+ """
+ 
+ #*****************************************************************************

--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -61,7 +61,11 @@ stdenv.mkDerivation rec {
   # Since sage unfortunately does not release bugfix releases, packagers must
   # fix those bugs themselves. This is for critical bugfixes, where "critical"
   # == "causes (transient) doctest failures / somebody complained".
-  bugfixPatches = [ ];
+  bugfixPatches = [
+    # To help debug the transient error in
+    # https://trac.sagemath.org/ticket/23087 when it next occurs.
+    ./patches/configurationpy-error-verbose.patch
+  ];
 
   # Patches needed because of package updates. We could just pin the versions of
   # dependencies, but that would lead to rebuilds, confusion and the burdons of

--- a/pkgs/applications/science/math/sage/sage-tests.nix
+++ b/pkgs/applications/science/math/sage/sage-tests.nix
@@ -51,6 +51,10 @@ stdenv.mkDerivation rec {
     export HOME="$TMPDIR/sage-home"
     mkdir -p "$HOME"
 
+    # avoid running out of memory with many threads in subprocesses, see
+    # https://github.com/NixOS/nixpkgs/pull/65802
+    export GLIBC_TUNABLES=glibc.malloc.arena_max=4
+
     echo "Running sage tests with arguments ${timeSpecifier} ${patienceSpecifier} ${testArgs}"
     "sage" -t --nthreads "$NIX_BUILD_CORES" --optional=sage ${timeSpecifier} ${patienceSpecifier} ${testArgs}
   '';


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

A transient [failure](https://trac.sagemath.org/ticket/23087) in configuration.py has occurred on hydra twice now. Unfortunately the error message is not helpful in debugging, so here I'm abusing the build servers a little to track this issue down.

The list of past failures is an experiment, doesn't seem worth creating a separate PR for.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc me