### PR TITLE
pyload: fix build

### DIFF
--- a/pkgs/applications/networking/pyload/default.nix
+++ b/pkgs/applications/networking/pyload/default.nix
@@ -45,16 +45,16 @@ in pythonPackages.buildPythonApplication rec {
   '';
 
   preBuild = ''
-    paver generate_setup
+    ${pythonPackages.paver}/bin/paver generate_setup
   '';
 
   doCheck = false;
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Free and open source downloader for 1-click-hosting sites";
     homepage = https://github.com/pyload/pyload;
-    license = stdenv.lib.licenses.gpl3;
-    maintainers = [ stdenv.lib.maintainers.mahe ];
-    platforms = stdenv.lib.platforms.all;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.mahe ];
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken while doing a review of #65745 

cleaned up the meta info a bit.

```
nix-review wip
...
[2 built, 0.0 MiB DL]
1 package were build:
pyload
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers
