### PR TITLE
litecli: 1.0.0 -> 1.1.0

### DIFF
--- a/pkgs/development/tools/database/litecli/default.nix
+++ b/pkgs/development/tools/database/litecli/default.nix
@@ -2,7 +2,7 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "litecli";
-  version = "1.0.0";
+  version = "1.1.0";
 
   # Python 2 won't have prompt_toolkit 2.x.x
   # See: https://github.com/NixOS/nixpkgs/blob/f49e2ad3657dede09dc998a4a98fd5033fb52243/pkgs/top-level/python-packages.nix#L3408
@@ -10,14 +10,8 @@ python3Packages.buildPythonApplication rec {
 
   src = python3Packages.fetchPypi {
     inherit pname version;
-    sha256 = "0s5a6r5q09144cc5169snwis5i2jrh3z2g4mw9wi2fsjxyhgpwq5";
+    sha256 = "0cqil2cmnbw0jvb14v6kbr7l9yarfgy253cbb8v9znp0l4qfs7ra";
   };
-
-  # fixes tests https://github.com/dbcli/litecli/pull/53
-  postPatch = ''
-    substituteInPlace litecli/main.py \
-      --replace 'except FileNotFoundError:' 'except (FileNotFoundError, OSError):'
-  '';
 
   propagatedBuildInputs = with python3Packages; [
     cli-helpers


### PR DESCRIPTION
###### Motivation for this change
https://hydra.nixos.org/build/97193125/nixlog/1
Fixes the tests.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Scriptkiddi 
