### PR TITLE
pythonPackages.jsonpickle: 1.1 -> 1.2

### DIFF
--- a/pkgs/development/python-modules/jsonpickle/default.nix
+++ b/pkgs/development/python-modules/jsonpickle/default.nix
@@ -1,18 +1,21 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, pytest
 }:
 
 buildPythonPackage rec {
   pname = "jsonpickle";
-  version = "1.1";
+  version = "1.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "625098cc8e5854b8c23b587aec33bc8e33e0e597636bfaca76152249c78fe5c1";
+    sha256 = "16xj4r31pnd90slax5mmd5wps5s73wp9mn6sy9nhkl5ih7bj5sfk";
   };
 
-  doCheck = false;
+  checkInputs = [ pytest ];
+
+  checkPhase = "pytest tests/jsonpickle_test.py";
 
   meta = {
     description = "Python library for serializing any arbitrary object graph into JSON";


### PR DESCRIPTION
###### Motivation for this change
Noticed it was out of date.

Enabled unit tests. Other tests are quite extensive to setup, such as numpy, bson, and others.

The one broken package in nix-review is being fixed here: https://github.com/NixOS/nixpkgs/pull/65823

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[45 built (1 failed), 414 copied (2601.3 MiB), 650.7 MiB DL]
error: build of '/nix/store/03wkq2jzydbb4dfb49q9887fb3xklr6v-env.drv' failed
https://github.com/NixOS/nixpkgs/pull/65819
1 package failed to build:
python37Packages.nbval

41 package were build:
jupyter python37Packages.Nikola ...
```
