### PR TITLE
grafana-loki: 0.1.0 -> 0.2.0

### DIFF
--- a/pkgs/servers/monitoring/loki/default.nix
+++ b/pkgs/servers/monitoring/loki/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, buildGoPackage, fetchFromGitHub }:
+{ stdenv, buildGoPackage, fetchFromGitHub, makeWrapper, systemd }:
 
 buildGoPackage rec {
-  version = "0.1.0";
+  version = "0.2.0";
   name = "grafana-loki-${version}";
   goPackagePath = "github.com/grafana/loki";
 
@@ -11,13 +11,21 @@ buildGoPackage rec {
     rev = "v${version}";
     owner = "grafana";
     repo = "loki";
-    sha256 = "18iysr8p84vd1sdjdnpc9cydd5rpw0azdjzpz8yjqhscqw9gk4w2";
+    sha256 = "1f4g5qiarhsa1r7vdx1z30zpqlypd4cf5anj4jp6nc9q6zmjwk91";
   };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ systemd.dev ];
+
+  preFixup = ''
+    wrapProgram $bin/bin/promtail \
+      --prefix LD_LIBRARY_PATH : "${systemd.lib}/lib"
+  '';
 
   meta = with stdenv.lib; {
     description = "Like Prometheus, but for logs.";
     license = licenses.asl20;
-    homepage = https://grafana.com/loki;
+    homepage = "https://grafana.com/loki";
     maintainers = with maintainers; [ willibutz ];
     platforms = platforms.linux;
   };


### PR DESCRIPTION
###### Motivation for this change
[New release](https://github.com/grafana/loki/releases)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS (x86_64-linux && aarch64-linux)
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).