### PR TITLE
steam chrootenv: add lsb-release

### DIFF
--- a/pkgs/games/steam/chrootenv.nix
+++ b/pkgs/games/steam/chrootenv.nix
@@ -16,6 +16,9 @@ let
   commonTargetPkgs = pkgs: with pkgs;
     [
       steamPackages.steam-fonts
+      # Needed for operating system detection until
+      # https://github.com/ValveSoftware/steam-for-linux/issues/5909 is resolved
+      lsb-release
       # Errors in output without those
       pciutils
       python2


### PR DESCRIPTION
###### Motivation for this change

Fixes #63839

issue with operating system detection
sh: lsb_release: command not found

With this change it works!

![steam-nixos](https://user-images.githubusercontent.com/91113/62402228-088a3b00-b587-11e9-9621-d1dabd82e768.png)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @abbradar 
