### PR TITLE
pythonPackages.nbval: 0.9.1 -> 0.9.2

### DIFF
--- a/pkgs/development/python-modules/nbval/default.nix
+++ b/pkgs/development/python-modules/nbval/default.nix
@@ -15,19 +15,20 @@
 
 buildPythonPackage rec {
   pname = "nbval";
-  version = "0.9.1";
+  version = "0.9.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "3f18b87af4e94ccd073263dd58cd3eebabe9f5e4d6ab535b39d3af64811c7eda";
+    sha256 = "0g8xl4158ngyhiynrkk72jpawnk4isznbijz0w085g269fps0vp2";
   };
 
   LC_ALL = "en_US.UTF-8";
 
   buildInputs = [ glibcLocales ];
-  checkInputs = [ matplotlib sympy pytestcov ];
+  checkInputs = [ matplotlib sympy pytestcov pytest ];
   propagatedBuildInputs = [ coverage ipykernel jupyter_client nbformat pytest six ];
 
+  # ignore impure tests
   checkPhase = ''
     pytest tests --current-env --ignore tests/test_timeouts.py
   '';


### PR DESCRIPTION
###### Motivation for this change
Noticed it was broken while reviewing another pr.

Also noticed it was out of date, so i bumped it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @costrouc

original failure log:
```
running install tests
  /nix/store/z31z45vbgirlw8zkkwih3qcf5zwazaw1-stdenv-linux/setup: line 1319: pytest: command not found
```