### PR TITLE
pythonPackages.paramiko: 2.4.2 -> 2.6.0

### DIFF
--- a/pkgs/development/python-modules/paramiko/default.nix
+++ b/pkgs/development/python-modules/paramiko/default.nix
@@ -12,11 +12,11 @@
 
 buildPythonPackage rec {
   pname = "paramiko";
-  version = "2.4.2";
+  version = "2.6.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "a8975a7df3560c9f1e2b43dc54ebd40fd00a7017392ca5445ce7df409f900fcb";
+    sha256 = "0h9hb2kp07zdfbanad527ll90n9ji7isf7m39jyp0sr21pxfvcpl";
   };
 
   checkInputs = [ pytest mock pytest-relaxed ];


### PR DESCRIPTION
###### Motivation for this change
noticed it was out of date.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @aszlig 

failed packages were because i couldn't d/l from oracle
```
[53 built (3 failed), 563 copied (961.1 MiB), 141.4 MiB DL]
error: build of '/nix/store/fy798da7an4p8k3gvq411lqqv5nr3cz0-env.drv' failed
https://github.com/NixOS/nixpkgs/pull/65827
1 package failed to build:
python37Packages.patator

44 package were build:
Fabric ansible ansible-lint...
```