### PR TITLE
goldendict: 2018-06-13 -> 2019-08-01

### DIFF
--- a/pkgs/applications/misc/goldendict/default.nix
+++ b/pkgs/applications/misc/goldendict/default.nix
@@ -1,25 +1,29 @@
-{ stdenv, fetchFromGitHub, pkgconfig, libXtst, libvorbis, hunspell
-, libao, ffmpeg, libeb, lzo, xz, libtiff
+{ mkDerivation, lib, fetchFromGitHub, pkgconfig, libXtst, libvorbis, hunspell
+, libao, ffmpeg, libeb, lzo, xz, libtiff, opencc
 , qtbase, qtsvg, qtwebkit, qtx11extras, qttools, qmake }:
-stdenv.mkDerivation rec {
+mkDerivation rec {
 
-  name = "goldendict-2018-06-13";
+  name = "goldendict-2019-08-01";
   src = fetchFromGitHub {
     owner = "goldendict";
     repo = "goldendict";
-    rev = "48e850c7ec11d83cba7499f7fdce377ef3849bbb";
-    sha256 = "0i4q4waqjv45hgwillvjik97pg26kwlmz4925djjkx8s6hxgjlq9";
+    rev = "0f951b06a55f3a201891cf645a556e773bda5f52";
+    sha256 = "1d1hn95vhvsmbq9q96l5adn90g0hg25dl01knb4y4v6v9x4yrl2x";
   };
 
   nativeBuildInputs = [ pkgconfig qmake ];
   buildInputs = [
     qtbase qtsvg qtwebkit qtx11extras qttools
-    libXtst libvorbis hunspell libao ffmpeg libeb lzo xz libtiff
+    libXtst libvorbis hunspell libao ffmpeg libeb lzo xz libtiff opencc
   ];
 
-  qmakeFlags = [ "CONFIG+=zim_support" ];
+  qmakeFlags = [
+    "goldendict.pro"
+    "CONFIG+=zim_support"
+    "CONFIG+=chinese_conversion_support"
+  ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = http://goldendict.org/;
     description = "A feature-rich dictionary lookup program";
     platforms = platforms.linux;


### PR DESCRIPTION
##### Motivation for this change

1. Fix runtime error:
```
qt.qpa.plugin: Could not find the Qt platform plugin "xcb" in ""
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
```
2. Add Chinese conversion support

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @gebner, @astsmtl 
