### PR TITLE
proot-termux: init at 20190505 (termux fork of proot)

### DIFF
--- a/pkgs/tools/system/proot/termux.nix
+++ b/pkgs/tools/system/proot/termux.nix
@@ -1,0 +1,23 @@
+{ proot, stdenv, fetchFromGitHub, ... }@args:
+
+let
+  # Enable overriding of proot arguments via proot-termux.override.
+  # Proot is not a function of `proot`, so this must be filtered out.
+  vanilla = proot.override
+    (stdenv.lib.filterAttrs (n: _: n != "proot") args);
+in vanilla.overrideAttrs (old: {
+  pname = "proot-termux";
+  version = "20190505";
+
+  src = fetchFromGitHub {
+    repo = "proot";
+    owner = "termux";
+    rev = "0717de26d1394fec3acf90efdc1d172e01bc932b";
+    sha256 = "1g0r3a67x94sgffz3gksyqk8r06zynfcgfdi33w6kzxnb03gbm4m";
+  };
+
+  meta.homepage = https://github.com/termux/proot;
+  meta.description = "Termux fork of proot, a user-space implementation of "
+    + "chroot, mount --bind and binfmt_misc";
+  meta.maintainers = [ stdenv.lib.maintainers.jorsn ] ++ old.meta.maintainers;
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5489,6 +5489,7 @@ in
   projectm = callPackage ../applications/audio/projectm { };
 
   proot = callPackage ../tools/system/proot { };
+  proot-termux = callPackage ../tools/system/proot/termux.nix { };
 
   prototypejs = callPackage ../development/libraries/prototypejs { };
 


### PR DESCRIPTION
###### Motivation for this change

proot-termux is needed in some situations to install nix using proot.
This is due to some bug related to file moving, probably to the system call
`renameat2`. This is also reported [in the nixos wiki][1].

[1]: https://nixos.wiki/wiki/Nix_Installation_Guide#PRoot

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @wavewave @makefu @veprbl @dtzWill
