### PR TITLE
libextractor: add support for gstreamer plugin

### DIFF
--- a/pkgs/development/libraries/libextractor/default.nix
+++ b/pkgs/development/libraries/libextractor/default.nix
@@ -1,8 +1,21 @@
-{ fetchurl, stdenv, libtool, gettext, zlib, bzip2, flac, libvorbis
+{ fetchurl, stdenv, substituteAll
+, libtool, gettext, zlib, bzip2, flac, libvorbis
 , exiv2, libgsf, rpm, pkgconfig, fetchpatch
+, gstreamerSupport ? true, gst_all_1 ? null
+# ^ Needed e.g. for proper id3 and FLAC support.
+#   Set to `false` to decrease package closure size by about 87 MB (53%).
+, gstPlugins ? (gst: [ gst.gst-plugins-base gst.gst-plugins-good ])
+# If an application needs additional gstreamer plugins it can also make them
+# available by adding them to the environment variable
+# GST_PLUGIN_SYSTEM_PATH_1_0, e.g. like this:
+# postInstall = ''
+#   wrapProgram $out/bin/extract --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0"
+# '';
+# See also <https://nixos.org/nixpkgs/manual/#sec-language-gnome>.
 , gtkSupport ? true, glib ? null, gtk3 ? null
 , videoSupport ? true, ffmpeg ? null, libmpeg2 ? null}:
 
+assert gstreamerSupport -> gst_all_1 != null && builtins.isList (gstPlugins gst_all_1);
 assert gtkSupport -> glib != null && gtk3 != null;
 assert videoSupport -> ffmpeg != null && libmpeg2 != null;
 
@@ -28,6 +41,15 @@ stdenv.mkDerivation rec {
       sha256 = "01xhcjbzv6p53wz7y2ii76kb8m9iwvnm4ip9w4a0bpgaxqz4b9fw";
       excludes = [ "ChangeLog" ];
     })
+  ] ++ stdenv.lib.optionals gstreamerSupport [
+
+    # Libraries cannot be wrapped so we need to hardcode the plug-in paths.
+    (substituteAll {
+      src = ./gst-hardcode-plugins.patch;
+      load_gst_plugins = stdenv.lib.concatMapStrings
+        (plugin: ''gst_registry_scan_path(gst_registry_get(), "${plugin}/lib/gstreamer-1.0");'')
+        (gstPlugins gst_all_1);
+    })
   ];
 
   preConfigure =
@@ -40,7 +62,9 @@ stdenv.mkDerivation rec {
    [ libtool gettext zlib bzip2 flac libvorbis exiv2
      libgsf rpm
      pkgconfig
-   ] ++ stdenv.lib.optionals gtkSupport [ glib gtk3 ]
+   ] ++ stdenv.lib.optionals gstreamerSupport
+          ([ gst_all_1.gstreamer ] ++ gstPlugins gst_all_1)
+     ++ stdenv.lib.optionals gtkSupport [ glib gtk3 ]
      ++ stdenv.lib.optionals videoSupport [ ffmpeg libmpeg2 ];
 
   configureFlags = [

--- a/pkgs/development/libraries/libextractor/gst-hardcode-plugins.patch
+++ b/pkgs/development/libraries/libextractor/gst-hardcode-plugins.patch
@@ -1,0 +1,11 @@
+--- a/src/plugins/gstreamer_extractor.c
++++ b/src/plugins/gstreamer_extractor.c
+@@ -2215,6 +2215,7 @@ void __attribute__ ((constructor))
+ gstreamer_init ()
+ {
+   gst_init (NULL, NULL);
++  @load_gst_plugins@
+   g_log_set_default_handler (&log_handler, NULL);
+   g_log_set_handler (NULL, G_LOG_LEVEL_MASK | G_LOG_FLAG_FATAL | G_LOG_FLAG_RECURSION,
+                     &log_handler, NULL);
+


### PR DESCRIPTION
###### Motivation for this change

The gstreamer plugin provides support for additional common
file/tagging formats like id3 tags in mp3 files. In addition, it
e.g. exposes more tags than the FLAC plugin for FLAC files.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"` (last successful run on 2020-04-28)
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size: **86.71 MB (52.8%)**
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
  *(apart from having no maintainer as before this change)*

###### Notify maintainers

*package has no maintainer*

###### Questions

The impact on the package closure size is quite substantial. Should `gstreamerSupport` be `false` by default? *I'll leave it true but added a comment about it.*
