### PR TITLE
pythonPackages.pyqt5: upgrade and solve qml issue

### DIFF
--- a/pkgs/applications/networking/browsers/qutebrowser/default.nix
+++ b/pkgs/applications/networking/browsers/qutebrowser/default.nix
@@ -46,7 +46,7 @@ in python3Packages.buildPythonApplication rec {
   ];
 
   propagatedBuildInputs = with python3Packages; [
-    pyyaml pyqt5 jinja2 pygments
+    pyyaml pyqt5 pyqtwebengine jinja2 pygments
     pypeg2 cssutils pyopengl attrs
     # scripts and userscripts libs
     tldextract beautifulsoup4

--- a/pkgs/development/python-modules/pyqt/5.x.nix
+++ b/pkgs/development/python-modules/pyqt/5.x.nix
@@ -1,5 +1,10 @@
 { lib, fetchurl, pythonPackages, pkgconfig
-, qmake, lndir, qtbase, qtsvg, qtwebengine, dbus
+, dbus
+, qmake, lndir
+, qtbase
+, qtsvg
+, qtdeclarative
+, qtwebchannel
 , withConnectivity ? false, qtconnectivity
 , withWebKit ? false, qtwebkit
 , withWebSockets ? false, qtwebsockets
@@ -9,35 +14,71 @@ let
 
   inherit (pythonPackages) buildPythonPackage python isPy3k dbus-python enum34;
 
-  sip = pythonPackages.sip.override { sip-module = "PyQt5.sip"; };
+  sip = (pythonPackages.sip.override { sip-module = "PyQt5.sip"; }).overridePythonAttrs(oldAttrs: {
+    # If we install sip in another folder, then we need to create a __init__.py as well
+    # if we want to be able to import it with Python 2.
+    # Python 3 could rely on it being an implicit namespace package, however,
+    # PyQt5 we made an explicit namespace package so sip should be as well.
+    postInstall = ''
+      cat << EOF > $out/${python.sitePackages}/PyQt5/__init__.py
+      from pkgutil import extend_path
+      __path__ = extend_path(__path__, __name__)
+      EOF
+    '';
+  });
 
 in buildPythonPackage rec {
-  pname = "PyQt";
-  version = "5.11.3";
+  pname = "pyqt";
+  version = "5.13.0";
   format = "other";
 
   src = fetchurl {
-    url = "mirror://sourceforge/pyqt/PyQt5/PyQt-${version}/PyQt5_gpl-${version}.tar.gz";
-    sha256 = "0wqh4srqkcc03rvkwrcshaa028psrq58xkys6npnyhqxc0apvdf9";
+    url = "https://www.riverbankcomputing.com/static/Downloads/PyQt5/${version}/PyQt5_gpl-${version}.tar.gz";
+    sha256 = "1ydgdz28f1v17qqz3skyv26k5l0w63fr4dncc5xm49jr2gjzznqc";
   };
 
   outputs = [ "out" "dev" ];
 
-  nativeBuildInputs = [ pkgconfig qmake lndir sip ];
-
-  buildInputs = [ dbus sip ];
-
-  propagatedBuildInputs = [ qtbase qtsvg qtwebengine dbus-python ]
-    ++ lib.optional (!isPy3k) enum34
+  nativeBuildInputs = [
+    pkgconfig
+    qmake
+    lndir
+    sip
+    qtbase
+    qtsvg
+    qtdeclarative
+    qtwebchannel
+  ]
     ++ lib.optional withConnectivity qtconnectivity
     ++ lib.optional withWebKit qtwebkit
-    ++ lib.optional withWebSockets qtwebsockets;
+    ++ lib.optional withWebSockets qtwebsockets
+  ;
+
+  buildInputs = [
+    dbus
+    qtbase
+    qtsvg
+    qtdeclarative
+  ]
+    ++ lib.optional withConnectivity qtconnectivity
+    ++ lib.optional withWebKit qtwebkit
+    ++ lib.optional withWebSockets qtwebsockets
+  ;
+
+  propagatedBuildInputs = [
+    dbus-python
+    sip
+  ] ++ lib.optional (!isPy3k) enum34;
 
   patches = [
     # Fix some wrong assumptions by ./configure.py
     # TODO: figure out how to send this upstream
     ./pyqt5-fix-dbus-mainloop-support.patch
   ];
+
+  passthru = {
+    inherit sip;
+  };
 
   configurePhase = ''
     runHook preConfigure
@@ -62,7 +103,33 @@ in buildPythonPackage rec {
     for i in $out/bin/*; do
       wrapProgram $i --prefix PYTHONPATH : "$PYTHONPATH"
     done
+
+    # Let's make it a namespace package
+    cat << EOF > $out/${python.sitePackages}/PyQt5/__init__.py
+    from pkgutil import extend_path
+    __path__ = extend_path(__path__, __name__)
+    EOF
   '';
+
+  installCheckPhase = let
+    modules = [
+      "PyQt5"
+      "PyQt5.QtCore"
+      "PyQt5.QtQml"
+      "PyQt5.QtWidgets"
+      "PyQt5.QtGui"
+    ]
+    ++ lib.optional withWebSockets "PyQt5.QtWebSockets"
+    ++ lib.optional withWebKit "PyQt5.QtWebKit"
+    ++ lib.optional withConnectivity "PyQt5.QtConnectivity"
+    ;
+    imports = lib.concatMapStrings (module: "import ${module};") modules;
+  in ''
+    echo "Checking whether modules can be imported..."
+    ${python.interpreter} -c "${imports}"
+  '';
+
+  doCheck = true;
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/python-modules/pyqtwebengine/default.nix
+++ b/pkgs/development/python-modules/pyqtwebengine/default.nix
@@ -1,0 +1,89 @@
+{ lib, fetchurl, pythonPackages, pkgconfig
+, qmake, qtbase, qtsvg, qtwebengine
+}:
+
+let
+
+  inherit (pythonPackages) buildPythonPackage python isPy3k pyqt5 enum34;
+  inherit (pyqt5) sip;
+
+in buildPythonPackage rec {
+  pname = "pyqtwebengine";
+  version = "5.12.1";
+  format = "other";
+
+  src = fetchurl {
+    url = "https://www.riverbankcomputing.com/static/Downloads/PyQtWebEngine/${version}/PyQtWebEngine_gpl-${version}.tar.gz";
+    sha256 = "0wylkd7fh2g27y3710rpxmj9wx0wpi3z7qbv6khiddm15rkh81w6";
+  };
+
+  outputs = [ "out" "dev" ];
+
+  nativeBuildInputs = [
+    pkgconfig
+    qmake
+    sip
+    qtbase
+    qtsvg
+    qtwebengine
+  ];
+
+  buildInputs = [
+    sip
+    qtbase
+    qtsvg
+    qtwebengine
+  ];
+
+  propagatedBuildInputs = [ pyqt5 ]
+    ++ lib.optional (!isPy3k) enum34;
+
+  configurePhase = ''
+    runHook preConfigure
+
+    mkdir -p "$out/share/sip/PyQt5"
+
+    # FIXME: Without --no-dist-info, I get
+    #     unable to create /nix/store/yv4pzx3lxk3lscq0pw3hqzs7k4x76xsm-python3-3.7.2/lib/python3.7/site-packages/PyQtWebEngine-5.12.dist-info
+    ${python.executable} configure.py -w \
+      --destdir="$out/${python.sitePackages}/PyQt5" \
+      --no-dist-info \
+      --apidir="$out/api/${python.libPrefix}" \
+      --sipdir="$out/share/sip/PyQt5" \
+      --pyqt-sipdir="${pyqt5}/share/sip/PyQt5" \
+      --stubsdir="$out/${python.sitePackages}/PyQt5"
+
+    runHook postConfigure
+  '';
+
+  postInstall = ''
+    # Let's make it a namespace package
+    cat << EOF > $out/${python.sitePackages}/PyQt5/__init__.py
+    from pkgutil import extend_path
+    __path__ = extend_path(__path__, __name__)
+    EOF
+  '';
+
+  installCheckPhase = let
+    modules = [
+      "PyQt5.QtWebEngine"
+      "PyQt5.QtWebEngineWidgets"
+    ];
+    imports = lib.concatMapStrings (module: "import ${module};") modules;
+  in ''
+    echo "Checking whether modules can be imported..."
+    PYTHONPATH=$PYTHONPATH:$out/${python.sitePackages} ${python.interpreter} -c "${imports}"
+  '';
+
+  doCheck = true;
+
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    description = "Python bindings for Qt5";
+    homepage    = http://www.riverbankcomputing.co.uk;
+    license     = licenses.gpl3;
+    platforms   = platforms.mesaPlatforms;
+  };
+}

--- a/pkgs/development/python-modules/sip/default.nix
+++ b/pkgs/development/python-modules/sip/default.nix
@@ -2,14 +2,14 @@
 
 buildPythonPackage rec {
   pname = sip-module;
-  version = "4.19.13";
+  version = "4.19.14";
   format = "other";
 
   disabled = isPyPy;
 
   src = fetchurl {
-    url = "mirror://sourceforge/pyqt/sip/sip-${version}/sip-${version}.tar.gz";
-    sha256 = "0pniq03jk1n5bs90yjihw3s3rsmjd8m89y9zbnymzgwrcl2sflz3";
+    url = "https://www.riverbankcomputing.com/static/Downloads/sip/${version}/sip-${version}.tar.gz";
+    sha256 = "11xgs3rf5qh5qh459biwnc2j5y08jps3j0p6hcgi7f63pifpdwqf";
   };
 
   configurePhase = ''

--- a/pkgs/development/python-modules/sip/default.nix
+++ b/pkgs/development/python-modules/sip/default.nix
@@ -2,24 +2,37 @@
 
 buildPythonPackage rec {
   pname = sip-module;
-  version = "4.19.14";
+  version = "4.19.18";
   format = "other";
 
   disabled = isPyPy;
 
   src = fetchurl {
     url = "https://www.riverbankcomputing.com/static/Downloads/sip/${version}/sip-${version}.tar.gz";
-    sha256 = "11xgs3rf5qh5qh459biwnc2j5y08jps3j0p6hcgi7f63pifpdwqf";
+    sha256 = "07kyd56xgbb40ljb022rq82shgxprlbl0z27mpf1b6zd00w8dgf0";
   };
 
   configurePhase = ''
     ${python.executable} ./configure.py \
       --sip-module ${sip-module} \
-      -d $out/lib/${python.libPrefix}/site-packages \
+      -d $out/${python.sitePackages} \
       -b $out/bin -e $out/include
   '';
 
   enableParallelBuilding = true;
+
+  installCheckPhase = let
+    modules = [
+      sip-module
+      "sipconfig"
+    ];
+    imports = lib.concatMapStrings (module: "import ${module};") modules;
+  in ''
+    echo "Checking whether modules can be imported..."
+    PYTHONPATH=$out/${python.sitePackages}:$PYTHONPATH ${python.interpreter} -c "${imports}"
+  '';
+
+  doCheck = true;
 
   meta = with lib; {
     description = "Creates C++ bindings for Python modules";

--- a/pkgs/development/python-modules/spyder-kernels/default.nix
+++ b/pkgs/development/python-modules/spyder-kernels/default.nix
@@ -3,11 +3,11 @@
 
 buildPythonPackage rec {
   pname = "spyder-kernels";
-  version = "0.4.4";
+  version = "0.5.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0g3754s71cnh7kygps6gbzrhs5gb47p3pblr7hcvxk1mzl3xw94r";
+    sha256 = "7e124fad5203b748005e952cf33b44695dbb9d92f5e0dc5443e7ca0db817f400";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/spyder/default.nix
+++ b/pkgs/development/python-modules/spyder/default.nix
@@ -1,21 +1,23 @@
 { stdenv, buildPythonPackage, fetchPypi, makeDesktopItem, jedi, pycodestyle,
   psutil, pyflakes, rope, numpy, scipy, matplotlib, pylint, keyring, numpydoc,
   qtconsole, qtawesome, nbconvert, mccabe, pyopengl, cloudpickle, pygments,
-  spyder-kernels, qtpy, pyzmq, chardet }:
+  spyder-kernels, qtpy, pyzmq, chardet
+, pyqtwebengine
+}:
 
 buildPythonPackage rec {
   pname = "spyder";
-  version = "3.3.4";
+  version = "3.3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1fa5yhw0sjk5qydydp76scyxd8lvyciknq0vajnq0mxhhvfig3ra";
+    sha256 = "1z7qw1h3rhca12ycv8xrzw6z2gf81v0j6lfq9kpwh472w4vk75v1";
   };
 
   propagatedBuildInputs = [
     jedi pycodestyle psutil pyflakes rope numpy scipy matplotlib pylint keyring
     numpydoc qtconsole qtawesome nbconvert mccabe pyopengl cloudpickle spyder-kernels
-    pygments qtpy pyzmq chardet
+    pygments qtpy pyzmq chardet pyqtwebengine
   ];
 
   # There is no test for spyder
@@ -35,6 +37,7 @@ buildPythonPackage rec {
     # remove dependency on pyqtwebengine
     # this is still part of the pyqt 5.11 version we have in nixpkgs
     sed -i /pyqtwebengine/d setup.py
+    substituteInPlace setup.py --replace "pyqt5<5.13" "pyqt5"
   '';
 
   # Create desktop item

--- a/pkgs/games/anki/default.nix
+++ b/pkgs/games/anki/default.nix
@@ -7,7 +7,7 @@
 , lame
 , mplayer
 , libpulseaudio
-, pyqt5
+, pyqtwebengine
 , decorator
 , beautifulsoup4
 , sqlalchemy
@@ -83,7 +83,7 @@ buildPythonApplication rec {
     outputs = [ "out" "doc" "man" ];
 
     propagatedBuildInputs = [
-      pyqt5 sqlalchemy beautifulsoup4 send2trash pyaudio requests decorator
+      pyqtwebengine sqlalchemy beautifulsoup4 send2trash pyaudio requests decorator
       markdown
     ]
       ++ lib.optional plotsSupport matplotlib

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -949,6 +949,10 @@ in {
   */
   pyqt5_with_qtwebkit = self.pyqt5.override { withWebKit = true; };
 
+  pyqtwebengine = pkgs.libsForQt5.callPackage ../development/python-modules/pyqtwebengine {
+    pythonPackages = self;
+  };
+
   pysc2 = callPackage ../development/python-modules/pysc2 { };
 
   pyscard = callPackage ../development/python-modules/pyscard { inherit (pkgs.darwin.apple_sdk.frameworks) PCSC; };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This PR upgrades `.pyqt5` and `.pyqtwebengine` and fixes their build. During build-time many Qt modules were not detected and thus not included in the build. Apparently they also need to be added to `nativeBuildInputs`. I suppose this is because of qmake?

Anyway, both packages work fine when using with `python3.withPackages`. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
