### PR TITLE
yubikey-personalization-gui: use qt wrapped mkDerivation

### DIFF
--- a/pkgs/tools/misc/yubikey-personalization-gui/default.nix
+++ b/pkgs/tools/misc/yubikey-personalization-gui/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, pkgconfig, yubikey-personalization, qtbase, qmake, libyubikey }:
+{ stdenv, fetchurl, mkDerivation, pkgconfig, yubikey-personalization, qtbase, qmake, libyubikey }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   name = "yubikey-personalization-gui-3.1.25";
 
   src = fetchurl {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
`yubikey-personalization-gui` is currently broken due to not using the new QT guidelines.

###### Things done
Using the new mkDerivation wrapper for QT apps.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

None
