### PR TITLE
flare: 1.10 -> 1.11

### DIFF
--- a/pkgs/games/flare/default.nix
+++ b/pkgs/games/flare/default.nix
@@ -1,10 +1,10 @@
-{ lib, buildEnv, callPackage, makeWrapper }:
+{ lib, buildEnv, callPackage, makeWrapper, Cocoa }:
 
 buildEnv {
   name = "flare-1.11";
 
   paths = [
-    (callPackage ./engine.nix {})
+    (callPackage ./engine.nix { inherit Cocoa; })
     (callPackage ./game.nix {})
   ];
 

--- a/pkgs/games/flare/default.nix
+++ b/pkgs/games/flare/default.nix
@@ -1,7 +1,7 @@
 { lib, buildEnv, callPackage, makeWrapper }:
 
 buildEnv {
-  name = "flare-1.10";
+  name = "flare-1.11";
 
   paths = [
     (callPackage ./engine.nix {})

--- a/pkgs/games/flare/engine.nix
+++ b/pkgs/games/flare/engine.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, SDL2, SDL2_image, SDL2_mixer, SDL2_ttf }:
+{ stdenv, fetchFromGitHub, cmake, SDL2, SDL2_image, SDL2_mixer, SDL2_ttf, Cocoa }:
 
 stdenv.mkDerivation rec {
   pname = "flare-engine";
@@ -12,7 +12,8 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ SDL2 SDL2_image SDL2_mixer SDL2_ttf ];
+  buildInputs = [ SDL2 SDL2_image SDL2_mixer SDL2_ttf ]
+    ++ stdenv.lib.optional stdenv.isDarwin Cocoa;
 
   meta = with stdenv.lib; {
     description = "Free/Libre Action Roleplaying Engine";

--- a/pkgs/games/flare/engine.nix
+++ b/pkgs/games/flare/engine.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "flare-engine";
-  version = "1.10";
+  version = "1.11";
 
   src = fetchFromGitHub {
     owner = "flareteam";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0fm7jmxl86h8199nazdi9ivsrhcv9gcymhz1l5c6l2f4d0aqdqiq";
+    sha256 = "1j6raymz128miq517h9drks4gj79dajw3lsr0msqxz0z3zm6cc4n";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/games/flare/game.nix
+++ b/pkgs/games/flare/game.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "flare-game";
-  version = "1.10";
+  version = "1.11";
 
   src = fetchFromGitHub {
     owner = "flareteam";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1lfra4ww8za08vcgza2jvh3jrwi6zryk4ljyj32lpp9v4ws9hdh4";
+    sha256 = "18m2qfbbaqklm20gnr7wzrwbmylp1jh781a4p1dq0hymqcg92x5l";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2997,7 +2997,9 @@ in
 
   flannel = callPackage ../tools/networking/flannel { };
 
-  flare = callPackage ../games/flare { };
+  flare = callPackage ../games/flare {
+    inherit (darwin.apple_sdk.frameworks) Cocoa;
+  };
 
   flashbench = callPackage ../os-specific/linux/flashbench { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Minor version bump. Appears to be mostly translation updates/spelling corrections. Clicked around in a new game, everything seemed fine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
