### PR TITLE
solaar: unstable -> 1.0.1

### DIFF
--- a/pkgs/applications/misc/solaar/default.nix
+++ b/pkgs/applications/misc/solaar/default.nix
@@ -1,17 +1,14 @@
 { fetchFromGitHub, lib, gobject-introspection, gtk3, python3Packages }:
-
 # Although we copy in the udev rules here, you probably just want to use logitech-udev-rules instead of
 # adding this to services.udev.packages on NixOS
-
-python3Packages.buildPythonApplication {
-  pname = "solaar-unstable";
-  version = "2019-01-30";
-
+python3Packages.buildPythonApplication rec {
+  pname = "solaar";
+  version = "1.0.1";
   src = fetchFromGitHub {
-    owner = "pwr";
+    owner = "pwr-Solaar";
     repo = "Solaar";
-    rev = "c07c115ee379e82db84283aaa29dc53df033a8c8";
-    sha256 = "0xg181xcwzzs8pdqvjrkjyaaga7ir93hzjvd17j9g3ns8xfj2mvr";
+    rev = "${version}";
+    sha256 = "1ni3aimpl9vyhwzi61mvm8arkii52cmb6bzjma9cnkjyx328pkid";
   };
 
   propagatedBuildInputs = with python3Packages; [ gobject-introspection gtk3 pygobject3 pyudev ];
@@ -28,7 +25,6 @@ python3Packages.buildPythonApplication {
   '';
 
   enableParallelBuilding = true;
-
   meta = with lib; {
     description = "Linux devices manager for the Logitech Unifying Receiver";
     longDescription = ''
@@ -43,7 +39,7 @@ python3Packages.buildPythonApplication {
       To be able to use it, make sure you have access to /dev/hidraw* files.
     '';
     license = licenses.gpl2;
-    homepage = https://pwr.github.io/Solaar/;
+    homepage = https://pwr-solaar.github.io/Solaar/;
     platforms = platforms.linux;
     maintainers = with maintainers; [ spinus ysndr ];
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Keep track with the releases that were continued to be [issued](https://github.com/pwr-Solaar/Solaar/releases) by the solaar devs and contain the recent development.



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @ysndr 
