### PR TITLE
glib,gtk: correct CLAGS for plain buildtype

### DIFF
--- a/pkgs/desktops/gnome-3/core/gnome-settings-daemon/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-settings-daemon/default.nix
@@ -95,6 +95,12 @@ stdenv.mkDerivation rec {
     "-Dudev_dir=${placeholder "out"}/lib/udev"
   ];
 
+  NIX_CFLAGS_COMPILE = [
+    # Default for release buildtype but passed manually because
+    # we're using plain
+    "-DG_DISABLE_CAST_CHECKS"
+  ];
+
   # So the polkit policy can reference /run/current-system/sw/bin/gnome-settings-daemon/gsd-backlight-helper
   postFixup = ''
     mkdir -p $out/bin/gnome-settings-daemon

--- a/pkgs/desktops/pantheon/services/elementary-settings-daemon/default.nix
+++ b/pkgs/desktops/pantheon/services/elementary-settings-daemon/default.nix
@@ -150,6 +150,12 @@ stdenv.mkDerivation rec {
     "-Dudev_dir=${placeholder "out"}/lib/udev"
   ];
 
+  NIX_CFLAGS_COMPILE = [
+    # Default for release buildtype but passed manually because
+    # we're using plain
+    "-DG_DISABLE_CAST_CHECKS"
+  ];
+
   passthru = {
     updateScript = gnome3.updateScript {
       packageName = projectName;

--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -98,8 +98,12 @@ stdenv.mkDerivation rec {
 
   LC_ALL = "en_US.UTF-8";
 
-  NIX_CFLAGS_COMPILE = (optional stdenv.isSunOS "-DBSD_COMP")
-    ++ [ "-Wno-error=nonnull" ];
+  NIX_CFLAGS_COMPILE = [
+    "-Wno-error=nonnull"
+    # Default for release buildtype but passed manually because
+    # we're using plain
+    "-DG_DISABLE_CAST_CHECKS"
+  ] ++ optional stdenv.isSunOS "-DBSD_COMP";
 
   postPatch = ''
     # substitute fix-gio-launch-desktop-path.patch

--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -103,7 +103,7 @@ stdenv.mkDerivation rec {
     # Default for release buildtype but passed manually because
     # we're using plain
     "-DG_DISABLE_CAST_CHECKS"
-  ] ++ optional stdenv.isSunOS "-DBSD_COMP";
+  ];
 
   postPatch = ''
     # substitute fix-gio-launch-desktop-path.patch

--- a/pkgs/development/libraries/gtk+/3.x.nix
+++ b/pkgs/development/libraries/gtk+/3.x.nix
@@ -77,6 +77,13 @@ stdenv.mkDerivation rec {
     "-Dtests=false"
   ];
 
+  # These are the defines that'd you'd get with --enable-debug=minimum (default).
+  # See: https://developer.gnome.org/gtk3/stable/gtk-building.html#extra-configuration-options
+  NIX_CFLAGS_COMPILE = [
+    "-DG_ENABLE_DEBUG"
+    "-DG_DISABLE_CAST_CHECKS"
+  ];
+
   postPatch = ''
     files=(
       build-aux/meson/post-install.py


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
A little fallout from #58310 but this should correct things to what
I believe they were or should have been.

Noticed this fairly quickly because of https://github.com/NixOS/nixpkgs/issues/65843.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).