### PR TITLE
sagittarius-scheme: init at 0.9.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -85,6 +85,15 @@
     github = "baldo";
     name = "Andreas Baldeau";
   };
+  abbe = {
+    email = "ashish.is@lostca.se";
+    github = "wahjava";
+    name = "Ashish SHUKLA";
+    keys = [{
+      longkeyid = "rsa4096/0xC746CFA9E74FA4B0";
+      fingerprint = "F682 CDCC 39DC 0FEA E116  20B6 C746 CFA9 E74F A4B0";
+    }];
+  };
   abbradar = {
     email = "ab@fmap.me";
     github = "abbradar";

--- a/pkgs/development/compilers/sagittarius-scheme/default.nix
+++ b/pkgs/development/compilers/sagittarius-scheme/default.nix
@@ -1,0 +1,58 @@
+{ stdenv
+, fetchurl
+, cmake
+, pkgconfig
+, libffi
+, boehmgc
+, openssl
+, zlib
+, odbcSupport ? true
+, libiodbc
+}:
+
+let platformLdLibraryPath = if stdenv.isDarwin then "DYLD_FALLBACK_LIBRARY_PATH"
+                            else if (stdenv.isLinux or stdenv.isBSD) then "LD_LIBRARY_PATH"
+                            else throw "unsupported platform";
+in
+stdenv.mkDerivation rec {
+  pname = "sagittarius-scheme";
+  version = "0.9.6";
+  src = fetchurl {
+    url = "https://bitbucket.org/ktakashi/${pname}/downloads/sagittarius-${version}.tar.gz";
+    sha256 = "03nvvvfd4gdlvq244zpnikxxajp6w8jj3ymw4bcq83x7zilb2imr";
+  };
+  preBuild = ''
+           # since we lack rpath during build, need to explicitly add build path
+           # to LD_LIBRARY_PATH so we can load libsagittarius.so as required to
+           # build extensions
+           export ${platformLdLibraryPath}="$(pwd)/build"
+           '';
+  nativeBuildInputs = [ pkgconfig cmake ];
+
+  buildInputs = [ libffi boehmgc openssl zlib ] ++ stdenv.lib.optional odbcSupport libiodbc;
+
+  meta = with stdenv.lib; {
+    description = "An R6RS/R7RS Scheme system";
+    longDescription = ''
+      Sagittarius Scheme is a free Scheme implementation supporting
+      R6RS/R7RS specification.
+
+      Features:
+
+      -  Builtin CLOS.
+      -  Common Lisp like reader macro.
+      -  Cryptographic libraries.
+      -  Customisable cipher and hash algorithm.
+      -  Custom codec mechanism.
+      -  CL like keyword lambda syntax (taken from Gauche).
+      -  Constant definition form. (define-constant form).
+      -  Builtin regular expression
+      -  mostly works O(n)
+      -  Replaceable reader
+    '';
+    homepage = "https://bitbucket.org/ktakashi/sagittarius-scheme";
+    license = licenses.bsd2;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ abbe ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8252,6 +8252,8 @@ in
     inherit (darwin.apple_sdk.frameworks) CoreServices Security;
   };
 
+  sagittarius-scheme = callPackage ../development/compilers/sagittarius-scheme {};
+
   sbclBootstrap = callPackage ../development/compilers/sbcl/bootstrap.nix {};
   sbcl = callPackage ../development/compilers/sbcl {};
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add package for Sagittarius Scheme

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).