### PR TITLE
disper: 0.3.1 -> 0.3.1.1

### DIFF
--- a/pkgs/tools/misc/disper/default.nix
+++ b/pkgs/tools/misc/disper/default.nix
@@ -1,9 +1,19 @@
-{stdenv, fetchurl, python, xorg, makeWrapper}:
+{ stdenv, fetchFromGitHub, python, xorg, makeWrapper }:
 
 stdenv.mkDerivation rec {
-  name = "disper-0.3.1";
+  pname = "disper";
+  version = "0.3.1.1";
 
-  buildInputs = [python makeWrapper];
+  src = fetchFromGitHub {
+    owner = "apeyser";
+    repo = pname;
+    rev = "${pname}-${version}";
+    sha256 = "1kl4py26n95q0690npy5mc95cv1cyfvh6kxn8rvk62gb8scwg9zn";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [ python ];
 
   preConfigure = ''
     export makeFlags="PREFIX=$out"
@@ -13,11 +23,6 @@ stdenv.mkDerivation rec {
       wrapProgram $out/bin/disper \
         --prefix "LD_LIBRARY_PATH" : "${stdenv.lib.makeLibraryPath [ xorg.libXrandr xorg.libX11 ]}"
   '';
-
-  src = fetchurl {
-    url = http://ppa.launchpad.net/disper-dev/ppa/ubuntu/pool/main/d/disper/disper_0.3.1.tar.gz;
-    sha256 = "1l8brcpfn4iascb454ym0wrv5kqyz4f0h8k6db54nc3zhfwy7vvw";
-  };
 
   meta = {
     description = "On-the-fly display switch utility";


### PR DESCRIPTION
###### Motivation for this change
was going through rryantm logs, looking for failures.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
