### PR TITLE
cpp-netlib: 0.12.0 -> 0.13.0-final

### DIFF
--- a/pkgs/development/libraries/cpp-netlib/default.nix
+++ b/pkgs/development/libraries/cpp-netlib/default.nix
@@ -1,12 +1,15 @@
-{ stdenv, fetchurl, cmake, boost, openssl, asio }:
+{ stdenv, fetchFromGitHub, cmake, boost, openssl, asio }:
 
 stdenv.mkDerivation rec {
-  name = "cpp-netlib-${version}";
-  version = "0.12.0";
+  pname = "cpp-netlib";
+  version = "0.13.0-final";
 
-  src = fetchurl {
-    url = "http://downloads.cpp-netlib.org/${version}/${name}-final.tar.bz2";
-    sha256 = "0h7gyrbr3madycnj8rl8k1jzk2hd8np2k5ad9mijlh0fizzzk3h8";
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "${pname}-${version}";
+    sha256 = "18782sz7aggsl66b4mmi1i0ijwa76iww337fi9sygnplz2hs03a3";
+    fetchSubmodules = true;
   };
 
   buildInputs = [ cmake boost openssl ];


### PR DESCRIPTION
###### Motivation for this change
fixing packages unable to be updated by rryantm

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
