### PR TITLE
libgpiod: unstable-2018-10-07 -> 1.4

### DIFF
--- a/pkgs/development/libraries/libgpiod/default.nix
+++ b/pkgs/development/libraries/libgpiod/default.nix
@@ -1,13 +1,12 @@
-{ stdenv, fetchgit, autoreconfHook, autoconf-archive, pkgconfig, kmod, enable-tools ? true }:
+{ stdenv, fetchurl, autoreconfHook, autoconf-archive, pkgconfig, kmod, enable-tools ? true }:
 
 stdenv.mkDerivation rec {
-  name = "libgpiod-unstable-${version}";
-  version = "2018-10-07";
+  pname = "libgpiod";
+  version = "1.4";
 
-  src = fetchgit {
-    url = "https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git";
-    rev = "4bf402d3a49336eacd33654441d575bd267780b8";
-    sha256 = "01f3jzb133z189sxdiz9qiy65p0bjqhynfllidbpxdr0cxkyyc1d";
+  src = fetchurl {
+    url = "https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/snapshot/libgpiod-${version}.tar.gz";
+    sha256 = "17qc2qbrnmaimxx9i3l30831hy890hp9s5a48iapni1dlr1z27p2";
   };
 
   buildInputs = [ kmod ];
@@ -20,7 +19,7 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--enable-tools=${if enable-tools then "yes" else "no"}"
     "--enable-bindings-cxx"
-    "--prefix=$(out)"
+    "--prefix=${placeholder ''out''}"
   ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
noticed it was in a bad state for https://repology.org/project/libgpiod/versions

used fetchurl instead of fetchgit, since it's a less-expensive operation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @expipiplus1 


```
nix-review wip
...
$ nix build --no-link --keep-going --max-jobs 4 --option build-use-sandbox true -f /home/jon/.cache/nix-review/rev-4e8a8a13ef6f730b7f785483a1ef79512a20a6fe-dirty/build.nix
[1 built, 0.0 MiB DL]
1 package were build:
libgpiod
```