### PR TITLE
pythonPackages.boltons: 2019-01-07 -> 19.1.0

### DIFF
--- a/pkgs/development/python-modules/boltons/default.nix
+++ b/pkgs/development/python-modules/boltons/default.nix
@@ -2,14 +2,14 @@
 
 buildPythonPackage rec {
   pname = "boltons";
-  version = "2019-01-07";
+  version = "19.1.0";
 
   # No tests in PyPi Tarball
   src = fetchFromGitHub {
     owner = "mahmoud";
     repo = "boltons";
-    rev = "3584ac9399f227a2a11b74153140ee171fd49783";
-    sha256 = "13xngjw249sk4vmr5kqqnia0npw0kpa0gm020a4dqid0cjyvj0rv";
+    rev = version;
+    sha256 = "0b55wly0ksviyl3a4dmih9vzd7bj3p10gr6la4722cs9cx4128q5";
   };
 
   checkInputs = [ pytest ];


### PR DESCRIPTION
###### Motivation for this change
fixing "problematic" repology package.

19.1.0 is a later version, it was released in feburary.

https://github.com/mahmoud/boltons/blob/master/CHANGELOG.md

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Twey 
