### PR TITLE
mono: remove outdated workaround; pythonPackages.pythonnet: 2.3.0 -> 2.4.0

### DIFF
--- a/pkgs/development/compilers/mono/generic.nix
+++ b/pkgs/development/compilers/mono/generic.nix
@@ -22,9 +22,6 @@ stdenv.mkDerivation rec {
 
   NIX_LDFLAGS = if stdenv.isDarwin then "" else "-lgcc_s" ;
 
-  # To overcome the bug https://bugzilla.novell.com/show_bug.cgi?id=644723
-  dontDisableStatic = true;
-
   configureFlags = [
     "--x-includes=${libX11.dev}/include"
     "--x-libraries=${libX11.out}/lib"

--- a/pkgs/development/python-modules/pythonnet/default.nix
+++ b/pkgs/development/python-modules/pythonnet/default.nix
@@ -5,6 +5,7 @@
 , python
 , pytest
 , pycparser
+, psutil
 , pkgconfig
 , dotnetbuildhelpers
 , clang
@@ -20,10 +21,10 @@ let
     outputFiles = [ "*" ];
   };
 
-  NUnit360 = fetchNuGet {
+  NUnit371 = fetchNuGet {
     baseName = "NUnit";
-    version = "3.6.0";
-    sha256 = "0wz4sb0hxlajdr09r22kcy9ya79lka71w0k1jv5q2qj3d6g2frz1";
+    version = "3.7.1";
+    sha256 = "1yc6dwaam4w2ss1193v735nnl79id78yswmpvmjr1w4bgcbdza4l";
     outputFiles = [ "*" ];
   };
 
@@ -31,11 +32,11 @@ in
 
 buildPythonPackage rec {
   pname = "pythonnet";
-  version = "2.3.0";
+  version = "2.4.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1hxnkrfj8ark9sbamcxzd63p98vgljfvdwh79qj3ac8pqrgghq80";
+    sha256 = "1ach9jic7a9rd3vmc4bphkr9fq01a0qk81f8a7gr9npwzmkqx8x3";
   };
 
   postPatch = ''
@@ -55,20 +56,26 @@ buildPythonPackage rec {
     dotnetbuildhelpers
     clang
 
-    NUnit360
+    mono
+
+    NUnit371
     UnmanagedExports127
   ];
 
   buildInputs = [
     mono
+    psutil # needed for memory leak tests
   ];
 
   preBuild = ''
     rm -rf packages
     mkdir packages
 
-    ln -s ${NUnit360}/lib/dotnet/NUnit/ packages/NUnit.3.6.0
+    ln -s ${NUnit371}/lib/dotnet/NUnit/ packages/NUnit.3.7.1
     ln -s ${UnmanagedExports127}/lib/dotnet/NUnit/ packages/UnmanagedExports.1.2.7
+
+    # Setting TERM=xterm fixes an issue with terminfo in mono: System.Exception: Magic number is wrong: 542
+    export TERM=xterm
   '';
 
   checkPhase = ''


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
New major release of Mono. Fix previously broken pythonPackages.pythonnet. The release notes for 2.4.0 newly mention support for Python 3.7.

The following packages are still failing to build in nix-review, but they were failing even before this change and I don't know how to fix them quickly.

* dotnetPackages.ExtCore
* dotnetPackages.FSharpAutoComplete
* dotnetPackages.FSharpCompilerService
* gdata-sharp
* mono-zeroconf

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @thoughtpolice @obadz @vrthra @jraygauthier 
