### PR TITLE
wire-desktop: add a proper throw

### DIFF
--- a/pkgs/applications/networking/instant-messengers/wire-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/wire-desktop/default.nix
@@ -13,17 +13,19 @@ let
 
   inherit (stdenv.hostPlatform) system;
 
+  throwSystem = throw "Unsupported system: ${system}";
+
   pname = "wire-desktop";
 
   version = {
     "x86_64-linux" = "3.9.2895";
     "x86_64-darwin" = "3.9.2943";
-  }.${system} or "";
+  }.${system} or throwSystem;
 
   sha256 = {
     "x86_64-linux" = "0wrn95m64j4b7ym44h9zawq13kg4m12aixlyyzp56bfyczmjq4a5";
     "x86_64-darwin" = "1y1bzsjmjrj518q29xfx6gg1nhdbaz7y5hzaqrp241az6plp090k";
-  }.${system};
+  }.${system} or throwSystem;
 
   meta = with stdenv.lib; {
     description = "A modern, secure messenger for everyone";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
cc @toonn. I guess this was the one little detail we forgot https://github.com/NixOS/nixpkgs/commit/854b43404f5c3a62ca1aeafc34a6860980fb3dc1.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
