### PR TITLE
wt3: 3.3.11 -> 3.4.0, wt4: 4.0.5 -> 4.1.0

### DIFF
--- a/pkgs/development/libraries/wt/default.nix
+++ b/pkgs/development/libraries/wt/default.nix
@@ -34,7 +34,7 @@ let
       ];
 
       meta = with stdenv.lib; {
-        homepage = https://www.webtoolkit.eu/wt;
+        homepage = "https://www.webtoolkit.eu/wt";
         description = "C++ library for developing web applications";
         platforms = platforms.linux;
         license = licenses.gpl2;
@@ -43,8 +43,8 @@ let
     };
 in {
   wt3 = generic {
-    version = "3.3.11";
-    sha256 = "1s1bwg3s7brnspr9ya1vg5mr29dbvhf05s606fiv409b7ladqvxq";
+    version = "3.4.0";
+    sha256 = "0y0b2h9jf5cg1gdh48dj32pj5nsvipab1cgygncxf98c46ikhysg";
   };
 
   wt4 = generic {

--- a/pkgs/development/libraries/wt/default.nix
+++ b/pkgs/development/libraries/wt/default.nix
@@ -48,7 +48,7 @@ in {
   };
 
   wt4 = generic {
-    version = "4.0.5";
-    sha256 = "1gn8f30mjmn9aaxdazk49wijz37nglfww15ydrjiyhl6v5xhsjdv";
+    version = "4.1.0";
+    sha256 = "1a9nl5gs8m8pssf2l3z6kbl2rc9fw5ad7lfslw5yr3gzi0zqn05x";
   };
 }


### PR DESCRIPTION
###### Motivation for this change
New releases for [wt3](https://github.com/emweb/wt/releases/tag/3.4.0) and [wt4](https://github.com/emweb/wt/releases/tag/4.1.0)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested all pkgs that depend on this change
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).