### PR TITLE
mysql57: 5.7.25 -> 5.7.27 

### DIFF
--- a/nixos/tests/mysql.nix
+++ b/nixos/tests/mysql.nix
@@ -19,7 +19,7 @@ import ./make-test.nix ({ pkgs, ...} : {
         services.mysql.initialScript = pkgs.writeText "mysql-init.sql" ''
           CREATE USER 'passworduser'@'localhost' IDENTIFIED BY 'password123';
         '';
-        services.mysql.package = pkgs.mysql;
+        services.mysql.package = pkgs.mysql57;
       };
 
     mariadb =

--- a/pkgs/servers/sql/mysql/5.7.x.nix
+++ b/pkgs/servers/sql/mysql/5.7.x.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, bison
+{ stdenv, fetchurl, cmake, bison, pkgconfig
 , boost, libedit, libevent, lz4, ncurses, openssl, protobuf, readline, zlib, perl
 , cctools, CoreServices, developer_cmds }:
 
@@ -6,12 +6,12 @@
 
 let
 self = stdenv.mkDerivation rec {
-  name = "mysql-${version}";
-  version = "5.7.25";
+  pname = "mysql";
+  version = "5.7.27";
 
   src = fetchurl {
-    url = "mirror://mysql/MySQL-5.7/${name}.tar.gz";
-    sha256 = "0gvjcdnba7nf2dx3fbqk1qyg49zclfvaihb78l8h6qc08di1qxak";
+    url = "mirror://mysql/MySQL-5.7/${pname}-${version}.tar.gz";
+    sha256 = "1fhv16zr46pxm1j8vb8x8mh3nwzglg01arz8gnazbmjqldr5idpq";
   };
 
   preConfigure = stdenv.lib.optional stdenv.isDarwin ''
@@ -19,12 +19,10 @@ self = stdenv.mkDerivation rec {
     export PATH=$PATH:$TMPDIR
   '';
 
-  nativeBuildInputs = [ cmake bison ];
+  nativeBuildInputs = [ cmake bison pkgconfig ];
 
   buildInputs = [ boost libedit libevent lz4 ncurses openssl protobuf readline zlib ]
      ++ stdenv.lib.optionals stdenv.isDarwin [ perl cctools CoreServices developer_cmds ];
-
-  enableParallelBuilding = true;
 
   outputs = [ "out" "static" ];
 
@@ -76,7 +74,7 @@ self = stdenv.mkDerivation rec {
   };
 
   meta = with stdenv.lib; {
-    homepage = https://www.mysql.com/;
+    homepage = "https://www.mysql.com/";
     description = "The world's most popular open source database";
     platforms = platforms.unix;
     license = with licenses; [


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
- minor version bump
- [CVE-2019-2566](https://broken.sh/issues/CVE-2019-2566)
- [CVE-2019-2581](https://broken.sh/issues/CVE-2019-2581)
- [CVE-2019-2592](https://broken.sh/issues/CVE-2019-2592)
- [CVE-2019-2614](https://broken.sh/issues/CVE-2019-2614)
- [CVE-2019-2627](https://broken.sh/issues/CVE-2019-2627)
- [CVE-2019-2628](https://broken.sh/issues/CVE-2019-2628)
- [CVE-2019-2632](https://broken.sh/issues/CVE-2019-2632)
- [CVE-2019-2683](https://broken.sh/issues/CVE-2019-2683)
- [CVE-2019-2737](https://broken.sh/issues/CVE-2019-2737)
- [CVE-2019-2738](https://broken.sh/issues/CVE-2019-2738)
- [CVE-2019-2739](https://broken.sh/issues/CVE-2019-2739)
- [CVE-2019-2740](https://broken.sh/issues/CVE-2019-2740)
- [CVE-2019-2741](https://broken.sh/issues/CVE-2019-2741)
- [CVE-2019-2755](https://broken.sh/issues/CVE-2019-2755)
- [CVE-2019-2757](https://broken.sh/issues/CVE-2019-2757)
- [CVE-2019-2758](https://broken.sh/issues/CVE-2019-2758)
- [CVE-2019-2774](https://broken.sh/issues/CVE-2019-2774)
- [CVE-2019-2778](https://broken.sh/issues/CVE-2019-2778)
- [CVE-2019-2791](https://broken.sh/issues/CVE-2019-2791)
- [CVE-2019-2797](https://broken.sh/issues/CVE-2019-2797)
- [CVE-2019-2805](https://broken.sh/issues/CVE-2019-2805)
- [CVE-2019-2819](https://broken.sh/issues/CVE-2019-2819)

[Changelog](https://dev.mysql.com/doc/relnotes/mysql/5.7/en/)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
