### PR TITLE
coloursum: init at 0.1.0

### DIFF
--- a/pkgs/tools/text/coloursum/default.nix
+++ b/pkgs/tools/text/coloursum/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  name = "coloursum-${version}";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "ticky";
+    repo = "coloursum";
+    rev = "v${version}";
+    sha256 = "18ikwi0ihn0vadazrkh85jfz8a2f0dkfb3zns5jzh7p7mb0ylrr2";
+  };
+
+  cargoSha256 = "0f73vqa82w4ccr0cc95mxga3r8jgd92jnksshxzaffbpx4s334p3";
+
+  meta = with stdenv.lib; {
+    description = "Colourise your checksum output";
+    homepage = "https://github.com/ticky/coloursum";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ fgaz ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1367,6 +1367,8 @@ in
 
   colorls = callPackage ../tools/system/colorls { };
 
+  coloursum = callPackage ../tools/text/coloursum { };
+
   compsize = callPackage ../os-specific/linux/compsize { };
 
   coturn = callPackage ../servers/coturn { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
