### PR TITLE
qjackctl: use qt5.mkDerivation

### DIFF
--- a/pkgs/applications/audio/qjackctl/default.nix
+++ b/pkgs/applications/audio/qjackctl/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, pkgconfig, alsaLib, libjack2, dbus, qtbase, qttools, qtx11extras }:
+{ stdenv, mkDerivation, fetchurl, pkgconfig, alsaLib, libjack2, dbus, qtbase, qttools, qtx11extras }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   version = "0.5.9";
   name = "qjackctl-${version}";
 


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/issues/65399.