### PR TITLE
mixxx: use qt5.mkDerivation

### DIFF
--- a/pkgs/applications/audio/mixxx/default.nix
+++ b/pkgs/applications/audio/mixxx/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, makeWrapper, chromaprint
+{ stdenv, mkDerivation, fetchFromGitHub, makeWrapper, chromaprint
 , fftw, flac, faad2, glibcLocales, mp4v2
 , libid3tag, libmad, libopus, libshout, libsndfile, libusb1, libvorbis
 , libGLU, libxcb, lilv, lv2, opusfile
@@ -6,7 +6,7 @@
 , qtx11extras, rubberband, scons, sqlite, taglib, upower, vampSDK
 }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   name = "mixxx-${version}";
   version = "2.2.1";
 


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/issues/65399.

Fixes https://github.com/NixOS/nixpkgs/issues/65667.