### PR TITLE
pythonPackages.webrtcvad: init at 2.0.10

### DIFF
--- a/pkgs/development/python-modules/webrtcvad/default.nix
+++ b/pkgs/development/python-modules/webrtcvad/default.nix
@@ -1,0 +1,24 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "webrtcvad";
+  version = "2.0.10";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "f1bed2fb25b63fb7b1a55d64090c993c9c9167b28485ae0bcdd81cf6ede96aea";
+  };
+
+  # required WAV files for testing are not included in the tarball
+  doCheck = false;
+
+  meta = {
+    description = "Interface to the Google WebRTC Voice Activity Detector (VAD)";
+    homepage = https://github.com/wiseman/py-webrtcvad;
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ prusnak ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6094,6 +6094,8 @@ in {
   fastapi = callPackage ../development/python-modules/fastapi { };
 
   stringcase = callPackage ../development/python-modules/stringcase { };
+
+  webrtcvad = callPackage ../development/python-modules/webrtcvad { };
 });
 
 in fix' (extends overrides packages)


### PR DESCRIPTION
###### Motivation for this change

This commits adds a new python package `webrtcvad`. A Python interface to the Google WebRTC Voice Activity Detector (VAD).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
