### PR TITLE
boehmgc: add pkgsStatic override

### DIFF
--- a/pkgs/development/libraries/boehm-gc/default.nix
+++ b/pkgs/development/libraries/boehm-gc/default.nix
@@ -1,5 +1,7 @@
 { lib, stdenv, fetchurl
 , enableLargeConfig ? false # doc: https://github.com/ivmai/bdwgc/blob/v7.6.6/doc/README.macros#L179
+, enableShared ? true
+, enableStatic ? false
 }:
 
 stdenv.mkDerivation rec {
@@ -15,7 +17,7 @@ stdenv.mkDerivation rec {
   };
 
   outputs = [ "out" "dev" "doc" ];
-  separateDebugInfo = stdenv.isLinux;
+  separateDebugInfo = stdenv.isLinux && stdenv.hostPlatform.libc != "musl";
 
   preConfigure = stdenv.lib.optionalString (stdenv.hostPlatform.libc == "musl") ''
     export NIX_CFLAGS_COMPILE+=" -D_GNU_SOURCE -DUSE_MMAP -DHAVE_DL_ITERATE_PHDR"
@@ -28,7 +30,8 @@ stdenv.mkDerivation rec {
   configureFlags =
     [ "--enable-cplusplus" "--with-libatomic-ops=none" ]
     ++ lib.optional enableLargeConfig "--enable-large-config"
-    ++ lib.optional (stdenv.hostPlatform.libc == "musl") "--disable-static";
+    ++ lib.optional (!enableShared) "--disable-shared"
+    ++ lib.optional enableStatic "--enable-static";
 
   doCheck = true; # not cross;
 

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -60,6 +60,11 @@ in {
       haskellStaticAdapter;
   };
 
+  boehmgc = super.boehmgc.override {
+    enableShared = false;
+    enableStatic = true;
+  };
+
   ncurses = super.ncurses.override {
     enableStatic = true;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

- Add `enableShared` and `enableStatic` arguments for `boehmgc`, along with `configureFlags` additions overriding the default flags when those arguments are overridden.
- Remove the musl-dependent `--disable-static` option, as that is the default behavior.
- Building with `pkgsStatic` or `pkgsMusl` was failing to produce the `debug` output, so disable `separateDebugInfo` for musl hosts.
- Add an override to `pkgsStatic` which builds `boehmgc` with `enableShared` disabled and `enableStatic` enabled.

I haven't really tested any of this yet, because other packages in the dependency graph for my project do not build using `pkgsStatic`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
