### PR TITLE
taisei: init at 1.3

### DIFF
--- a/pkgs/games/taisei/0001-lto-fix.patch
+++ b/pkgs/games/taisei/0001-lto-fix.patch
@@ -1,0 +1,13 @@
+diff --git a/meson.build b/meson.build
+index 80aa58d..c7e9d0a 100644
+--- a/meson.build
++++ b/meson.build
+@@ -17,7 +17,7 @@ project('taisei', 'c',
+         # You may want to change these for a debug build dir
+         'buildtype=release',
+         'strip=true',
+-        'b_lto=true',
++        'b_lto=false',
+         'b_ndebug=if-release',
+     ]
+ )

--- a/pkgs/games/taisei/default.nix
+++ b/pkgs/games/taisei/default.nix
@@ -1,0 +1,46 @@
+{ stdenv, fetchurl
+# Build depends
+, docutils, meson, ninja, pkgconfig, python3
+# Runtime depends
+, glfw, SDL2, SDL2_mixer
+, freetype, libpng, libwebp, libzip, zlib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "taisei";
+  version = "1.3";
+
+  src = fetchurl {
+    url = "https://github.com/taisei-project/${pname}/releases/download/v${version}/${pname}-v${version}.tar.xz";
+    sha256 = "0fl41cbjr8h6gmhc27l44cfkcnhg5c10b4fcfvnfsbjii8gdwvjd";
+  };
+
+  nativeBuildInputs = [
+    docutils meson ninja pkgconfig python3
+  ];
+
+  buildInputs = [
+    glfw SDL2 SDL2_mixer
+    freetype libpng libwebp libzip zlib
+  ];
+
+  patches = [ ./0001-lto-fix.patch ];
+
+  preConfigure = ''
+    patchShebangs .
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A free and open-source Touhou Project clone and fangame";
+    longDescription = ''
+      Taisei is an open clone of the Tōhō Project series. Tōhō is a one-man
+      project of shoot-em-up games set in an isolated world full of Japanese
+      folklore.
+    '';
+    homepage = https://taisei-project.org/;
+    license = [ licenses.mit licenses.cc-by-40 ];
+    maintainers = [ maintainers.lambda-11235 ];
+    platforms = platforms.all;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22200,6 +22200,8 @@ in
 
   t4kcommon = callPackage ../games/t4kcommon { };
 
+  taisei = callPackage ../games/taisei { };
+
   tcl2048 = callPackage ../games/tcl2048 { };
 
   the-powder-toy = callPackage ../games/the-powder-toy {


### PR DESCRIPTION
###### Motivation for this change

Add package for Taisei, an open source game based off of the Touhou series.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
