### PR TITLE
cre2: 0.3.0 -> 0.3.6

### DIFF
--- a/pkgs/development/libraries/cre2/default.nix
+++ b/pkgs/development/libraries/cre2/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   name = "cre2-${version}";
-  version = "0.3.0";
-    
+  version = "0.3.6";
+
   src = fetchFromGitHub {
     owner = "marcomaggi";
     repo = "cre2";
-    rev = version;
-    sha256 = "12yrdad87jjqrhbqm02hzsayan2402vf61a9x1b2iabv6d1c1bnj";
+    rev = "v${version}";
+    sha256 = "1h9jwn6z8kjf4agla85b5xf7gfkdwncp0mfd8zwk98jkm8y2qx9q";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
fixing packages that rryantm is failing to upgrade

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
$ nix-review pr 66014
...
[1 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/66014
1 package were build:
cre2
```