### PR TITLE
python3Packages.boltztrap2: 19.1.1 -> 19.7.3

### DIFF
--- a/pkgs/development/python-modules/boltztrap2/default.nix
+++ b/pkgs/development/python-modules/boltztrap2/default.nix
@@ -14,16 +14,16 @@
 }:
 
 buildPythonPackage rec {
-  version = "19.1.1";
+  version = "19.7.3";
   pname = "BoltzTraP2";
   disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "81e8a5ef8240c6a2205463fa7bc643b8033125237927f5492dab0b5d1aadb35a";
+    sha256 = "1hambr925ml2v2zcxnmnpi39395gl2928yac4p2kghk9xicymraw";
   };
 
-  buildInputs = [ cython cmake ];
+  nativeBuildInputs = [ cmake cython ];
   checkInputs = [ pytest ];
   propagatedBuildInputs = [ spglib numpy scipy matplotlib ase netcdf4 ];
 


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken on master while reviewing #66023

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[3 built, 4 copied (19.1 MiB), 3.7 MiB DL]
https://github.com/NixOS/nixpkgs/pull/66035
1 package were build:
python37Packages.boltztrap2
```
```
./results/python37Packages.boltztrap2/bin/btp2 --help
you can install pyfftw to get better FFT performance
vtk not found. The 'fermisurface' command will be disabled
usage: btp2 [-h] [-v] [-n NWORKERS] [-V] command [options] ... ...
```
bunch of scientific libraries, large closure is expected.
```
$ nix path-info -Sh ./results/python37Packages.boltztrap2
/nix/store/l2cyqahdg6m9z8j4lmlzy1dwlkf3k7mf-python3.7-BoltzTraP2-19.7.3  551.6M
```