### PR TITLE
[WIP] pgcli: 2.0.2 -> 2.1.1

### DIFF
--- a/pkgs/development/python-modules/sqlparse/default.nix
+++ b/pkgs/development/python-modules/sqlparse/default.nix
@@ -7,11 +7,11 @@
 
 buildPythonPackage rec {
   pname = "sqlparse";
-  version = "0.2.4";
+  version = "0.3.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "ce028444cfab83be538752a2ffdb56bc417b7784ff35bb9a3062413717807dec";
+    sha256 = "0wxqrm9fpn4phz6rqm7kfd1wwkwzx376gs27nnalwx12q0lwlgbw";
   };
 
   checkInputs = [ pytest ];

--- a/pkgs/development/tools/database/pgcli/default.nix
+++ b/pkgs/development/tools/database/pgcli/default.nix
@@ -2,7 +2,7 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "pgcli";
-  version = "2.0.2";
+  version = "2.1.1";
 
   # Python 2 won't have prompt_toolkit 2.x.x
   # See: https://github.com/NixOS/nixpkgs/blob/f49e2ad3657dede09dc998a4a98fd5033fb52243/pkgs/top-level/python-packages.nix#L3408
@@ -10,18 +10,8 @@ python3Packages.buildPythonApplication rec {
 
   src = python3Packages.fetchPypi {
     inherit pname version;
-    sha256 = "1p4j2dbcfxd3kz86qi519jkqjx1mg5wdgn1gxdjx3lk1vpsd7x04";
+    sha256 = "1jmnb8izsdjmq9cgajhfapr31wlhvcml4lakz2mcmjn355x83q44";
   };
-
-  patches = [
-    (fetchpatch {
-      # TODO: Remove with next pgcli release. Fixes TypeError in tests
-      # https://github.com/dbcli/pgcli/pull/1006
-      url = https://github.com/dbcli/pgcli/commit/351135b61ef9ad3184c49a406544708daf589fe3.patch;
-      sha256 = "08131y0lv1v760i0ypcx2hljx066ks93kp96xkv3bycxnavvcl53";
-      excludes = [ "changelog.rst" ];
-    })
-  ];
 
   propagatedBuildInputs = with python3Packages; [
     cli-helpers click configobj humanize prompt_toolkit psycopg2


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Currently, the tests are breaking, and I'm not quite sure why yet.
```
=================================== FAILURES ===================================
____________________________ test_multihost_db_uri _____________________________

tmpdir = local('/build/pytest-of-nixbld/pytest-0/test_multihost_db_uri0')

    def test_multihost_db_uri(tmpdir):
        with mock.patch.object(PGCli, "connect") as mock_connect:
            cli = PGCli(pgclirc_file=str(tmpdir.join("rcfile")))
            cli.connect_uri(
                "postgres://bar:foo@baz1.com:2543,baz2.com:2543,baz3.com:2543/testdb"
            )
        mock_connect.assert_called_with(
            database="testdb",
            host="baz1.com,baz2.com,baz3.com",
            user="bar",
            passwd="foo",
>           port="2543,2543,2543",
        )

tests/test_main.py:326:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/nix/store/zi1b5igc0ajfhj0z4mbvysc9aizf8ky1-python3.7-mock-2.0.0/lib/python3.7/site-packages/mock/mock.py:937: in assert_called_with
    six.raise_from(AssertionError(_error_message(cause)), cause)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

value = None, from_value = None

>   ???
E   AssertionError: Expected call: connect(database='testdb', host='baz1.com,baz2.com,baz3.com', passwd='foo', port='2543,2543,2543', user='bar')
E   Actual call: connect(database='testdb', host='baz1.com', passwd='foo', port='2543,baz2.com:2543,baz3.com:2543', user='bar')

<string>:3: AssertionError
```