### PR TITLE
python3Packages.ase: 3.17.0 -> 3.18.0

### DIFF
--- a/pkgs/development/python-modules/ase/3.17.nix
+++ b/pkgs/development/python-modules/ase/3.17.nix
@@ -1,0 +1,36 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+, numpy
+, scipy
+, matplotlib
+, flask
+, pillow
+, psycopg2
+}:
+
+buildPythonPackage rec {
+  pname = "ase";
+  version = "3.17.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1d4gxypaahby45zcpl0rffcn2z7n55dg9lcd8sv6jjsmbbf9vr4g";
+  };
+
+  propagatedBuildInputs = [ numpy scipy matplotlib flask pillow psycopg2 ];
+
+  checkPhase = ''
+    $out/bin/ase test
+  '';
+
+  # tests just hang most likely due to something with subprocesses and cli
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Atomic Simulation Environment";
+    homepage = https://wiki.fysik.dtu.dk/ase/;
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/ase/default.nix
+++ b/pkgs/development/python-modules/ase/default.nix
@@ -1,6 +1,7 @@
 { lib
 , fetchPypi
 , buildPythonPackage
+, isPy27
 , numpy
 , scipy
 , matplotlib
@@ -11,11 +12,12 @@
 
 buildPythonPackage rec {
   pname = "ase";
-  version = "3.17.0";
+  version = "3.18.0";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1d4gxypaahby45zcpl0rffcn2z7n55dg9lcd8sv6jjsmbbf9vr4g";
+    sha256 = "1ycp1yksysiiz902gn762030sfmirxm950pwpw2rcrpjvq95zm1r";
   };
 
   propagatedBuildInputs = [ numpy scipy matplotlib flask pillow psycopg2 ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -183,7 +183,10 @@ in {
 
   asciitree = callPackage ../development/python-modules/asciitree { };
 
-  ase = callPackage ../development/python-modules/ase { };
+  ase = if isPy27 then
+          callPackage ../development/python-modules/ase/3.17.nix { }
+        else
+          callPackage ../development/python-modules/ase { };
 
   asn1crypto = callPackage ../development/python-modules/asn1crypto { };
 


### PR DESCRIPTION
###### Motivation for this change
noticed the python2 build was broken in #66023

froze python2 version at 3.17, as 3.18 dropped support of python<3.5

the boltztrap2 package is being fixed here: #66035
and scikit-learn is broken on master (and I don't want to touch that), so i can't fix dtffit package.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @costrouc

closes #66023