### PR TITLE
mininet: 2.3.0d4 -> 2.3.0d6

### DIFF
--- a/pkgs/tools/virtualization/mininet/default.nix
+++ b/pkgs/tools/virtualization/mininet/default.nix
@@ -8,8 +8,8 @@ let
   pyEnv = python.withPackages(ps: [ ps.setuptools ]);
 in
 stdenv.mkDerivation rec {
-  name = "mininet-${version}";
-  version = "2.3.0d4";
+  pname = "mininet";
+  version = "2.3.0d6";
 
   outputs = [ "out" "py" ];
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     owner = "mininet";
     repo = "mininet";
     rev = version;
-    sha256 = "02hsqa7r5ykj8m1ycl32xwn1agjrw78wkq87xif0dl2vkzln41i4";
+    sha256 = "0wc6gni9dxj9jjnw66a28jdvcfm8bxv1i776m5dh002bn5wjcl6x";
   };
 
   buildFlags = [ "mnexec" ];
@@ -40,8 +40,9 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Emulator for rapid prototyping of Software Defined Networks";
     license = {
-      fullName = "Mininet 2.3.0d4 License";
+      fullName = "Mininet 2.3.0d6 License";
     };
+    platforms = platforms.linux;
     homepage = https://github.com/mininet/mininet;
     maintainers = with maintainers; [ teto ];
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
