### PR TITLE
pythonPackages.pytrends: init at 4.6.0

### DIFF
--- a/pkgs/development/python-modules/pytrends/default.nix
+++ b/pkgs/development/python-modules/pytrends/default.nix
@@ -1,0 +1,29 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, requests
+, lxml
+, pandas
+}:
+
+buildPythonPackage rec {
+  pname = "pytrends";
+  version = "4.6.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "03gnn2mgjvpc7pbcijy7xilrhgjg7x2pp6ci96pdyqnhkqv02d3n";
+  };
+
+  doCheck = false;
+
+  propagatedBuildInputs = [ requests lxml pandas ];
+
+  meta = with stdenv.lib; {
+    description = "Pseudo API for Google Trends";
+    homepage = "https://github.com/GeneralMills/pytrends";
+    license = [ licenses.asl20 ];
+    maintainers = [ maintainers.mmahut ];
+  };
+
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1063,6 +1063,8 @@ in {
 
   pytricia =  callPackage ../development/python-modules/pytricia { };
 
+  pytrends = callPackage ../development/python-modules/pytrends { };
+
   py-vapid = callPackage ../development/python-modules/py-vapid { };
 
   PyWebDAV = callPackage ../development/python-modules/pywebdav { };


### PR DESCRIPTION
###### Motivation for this change

pythonPackages.pytrends: init at 4.6.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).