### PR TITLE
dogecoin: 1.10.0 -> 1.14.1

### DIFF
--- a/pkgs/applications/altcoins/dogecoin.nix
+++ b/pkgs/applications/altcoins/dogecoin.nix
@@ -2,23 +2,23 @@
 , pkgconfig, autoreconfHook
 , db5, openssl, boost, zlib, miniupnpc
 , protobuf, utillinux, qt4, qrencode
-, withGui }:
+, withGui, libevent }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "dogecoin" + (toString (optional (!withGui) "d")) + "-" + version;
-  version = "1.10.0";
+  version = "1.14.1";
 
   src = fetchFromGitHub {
     owner = "dogecoin";
     repo = "dogecoin";
     rev = "v${version}";
-    sha256 = "04rddx20d4fps2w3h1jxa2j8iyqpjv2fh897z0z3r06qjvjzf7rr";
+    sha256 = "0nmbi5gmms16baqs3fmdp2xm0yf8wawnyz80gcmca4j5ph2zka1v";
   };
 
   nativeBuildInputs = [ pkgconfig autoreconfHook ];
   buildInputs = [ openssl db5 openssl utillinux
-                  protobuf boost zlib miniupnpc ]
+                  protobuf boost zlib miniupnpc libevent ]
                   ++ optionals withGui [ qt4 qrencode ];
 
   configureFlags = [ "--with-incompatible-bdb"


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

https://github.com/dogecoin/dogecoin/releases

###### Things done

`update-source-version altcoins.dogecoin 1.14.1` + add libevent

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @edwtjo @offline @AndersonTorres
