### PR TITLE
nixos/unifi: create data directory with correct permissions

### DIFF
--- a/nixos/modules/services/networking/unifi.nix
+++ b/nixos/modules/services/networking/unifi.nix
@@ -148,7 +148,7 @@ in
 
     systemd.tmpfiles.rules = [
       "e '${stateDir}' 0700 unifi - - -"
-      "e '${stateDir}/data' 0700 unifi - - -"
+      "d '${stateDir}/data' 0700 unifi - - -"
     ];
 
     systemd.services.unifi = {


### PR DESCRIPTION
###### Motivation for this change
#66005

###### Things done
The cause of issue above seems to be the change introduced in #56265. Before that, the permissions of the `data` directory were fixed in the preStart script with `chown` and `permissionsStartOnly` set.

The data directory is bind-mounted via `systemd.mounts`, created if not already present and therefore had the wrong permissions which was fixed before with `chown`.
Now that tmpfiles.d is used with the `e`  type, the permissions would only be correctly set if the directory already existed (see `tmpfiles.d(5)`).
I suspect that tmpfiles.d runs before the bind mounts and does therefore not set the correct permissions.

I tried using the `uid` option for the bind mount of the data directory but somehow I didn't get it to work.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS (x86_64-linux & aarch64-linux)
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test (1)
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

(1): test I used for local testing
```nix
import ./make-test.nix ({ lib, pkgs, ... }:
{
  name = "unifi";
  machine = {
    services.unifi = { # same config as in issue #66005
      enable = true;
      openPorts = true;
      unifiPackage = pkgs.unifiStable;
    };
    nixpkgs.config.oraclejdk.accept_license = true;
  };
  testScript = ''
    $machine->start();
    $machine->waitForUnit("unifi.service");
    $machine->waitForOpenPort(8443);
    $machine->succeed("curl -k -sSf https://localhost:8443/manage/account/login");
  '';
})
```

cc @aanderse 
