### PR TITLE
coinomi: init at 1.0.11

### DIFF
--- a/pkgs/applications/altcoins/coinomi/default.nix
+++ b/pkgs/applications/altcoins/coinomi/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchurl, jre, makeWrapper }:
+
+let
+  rpath = stdenv.lib.makeLibraryPath [ stdenv.cc.cc ];
+in
+  stdenv.mkDerivation rec {
+    pname = "coinomi";
+    version = "1.0.11";
+
+    src = fetchurl {
+      url = "https://binaries.coinomi.com/desktop/coinomi-wallet-${version}-linux64.tar.gz";
+      sha256 = "2547c71103c20699f4325098fbe5e6be4bbf1949a3ad71a3c7c66e0f09fa1819";
+    };
+
+    sourceRoot = ".";
+
+    nativeBuildInputs = [ makeWrapper ];
+
+    installPhase = ''
+      mkdir -p $out/bin $out/share/applications
+      cd Coinomi
+      cp -r . $out
+      ln -s $out/Coinomi $out/bin/Coinomi
+      ln -s $out/coinomi-wallet.desktop $out/share/applications
+    '';
+
+    postFixup = ''
+      patchelf --set-interpreter "${stdenv.cc.bintools.dynamicLinker}" $out/Coinomi
+      patchelf --set-rpath "${rpath}" $out/Coinomi
+    '';
+
+    meta = with stdenv.lib; {
+      homepage = "https://www.coinomi.com/";
+      description = "Securely store, manage and exchange Bitcoin, Ethereum, and more than 1,500 other blockchain assets.";
+      license = licenses.unfree;
+      platforms = platforms.linux;
+      maintainers = [ maintainers.angristan ];
+    };
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2369,6 +2369,8 @@ in
 
   cocoapods-beta = lowPrio (callPackage ../development/mobile/cocoapods { beta = true; });
 
+  coinomi = callPackage ../applications/altcoins/coinomi { };
+
   compass = callPackage ../development/tools/compass { };
 
   conda = callPackage ../tools/package-management/conda { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

#65799

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

