### PR TITLE
stlink: 1.3.0 -> 1.5.1

### DIFF
--- a/pkgs/development/tools/misc/stlink/default.nix
+++ b/pkgs/development/tools/misc/stlink/default.nix
@@ -1,17 +1,19 @@
-{ stdenv, fetchurl, cmake, libusb1 }:
+{ stdenv, fetchFromGitHub, cmake, libusb1 }:
 
 # IMPORTANT: You need permissions to access the stlink usb devices. 
 # Add services.udev.pkgs = [ pkgs.stlink ] to your configuration.nix
 
 let
-  version = "1.3.0";
+  version = "1.5.1";
 in
 stdenv.mkDerivation {
   name = "stlink-${version}";
 
-  src = fetchurl {
-    url = "https://github.com/texane/stlink/archive/${version}.tar.gz";
-    sha256 = "3e8cba21744d2c38a0557f6835a05189e1b98202931bb0183d22efc462c893dd";
+  src = fetchFromGitHub {
+    owner = "texane";
+    repo = "stlink";
+    rev = "v1.5.1";
+    sha256 = "1d5gxiqpsm8fc105cxlp27af9fk339fap5h6nay21x5a7n61jgyc";
   };
 
   buildInputs = [ cmake libusb1 ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Version bump

###### Things done

Version bumped 1.3.0 to 1.5.1
Changed nix expression to more modern style (fetchurl → fetchFromGitHub)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @bjornfor @rongcuid 
