### PR TITLE
cantata: use Qt mkDerivation

### DIFF
--- a/pkgs/applications/audio/cantata/default.nix
+++ b/pkgs/applications/audio/cantata/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, vlc
+{ mkDerivation, lib, fetchFromGitHub, cmake, pkgconfig, vlc
 , qtbase, qtmultimedia, qtsvg, qttools
 
 # Cantata doesn't build with cdparanoia enabled so we disable that
@@ -35,7 +35,7 @@ let
 
   withUdisks = (withTaglib && withDevices);
 
-in stdenv.mkDerivation rec {
+in mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchFromGitHub {
@@ -46,20 +46,20 @@ in stdenv.mkDerivation rec {
   };
 
   buildInputs = [ vlc qtbase qtmultimedia qtsvg ]
-    ++ stdenv.lib.optionals withTaglib [ taglib taglib_extras ]
-    ++ stdenv.lib.optionals withReplaygain [ ffmpeg speex mpg123 ]
-    ++ stdenv.lib.optional  withCdda cdparanoia
-    ++ stdenv.lib.optional  withCddb libcddb
-    ++ stdenv.lib.optional  withLame lame
-    ++ stdenv.lib.optional  withMtp libmtp
-    ++ stdenv.lib.optional  withMusicbrainz libmusicbrainz5
-    ++ stdenv.lib.optional  withUdisks udisks2;
+    ++ lib.optionals withTaglib [ taglib taglib_extras ]
+    ++ lib.optionals withReplaygain [ ffmpeg speex mpg123 ]
+    ++ lib.optional  withCdda cdparanoia
+    ++ lib.optional  withCddb libcddb
+    ++ lib.optional  withLame lame
+    ++ lib.optional  withMtp libmtp
+    ++ lib.optional  withMusicbrainz libmusicbrainz5
+    ++ lib.optional  withUdisks udisks2;
 
   nativeBuildInputs = [ cmake pkgconfig qttools ];
 
   enableParallelBuilding = true;
 
-  cmakeFlags = stdenv.lib.flatten [
+  cmakeFlags = lib.flatten [
     (fstats withTaglib        [ "TAGLIB" "TAGLIB_EXTRAS" ])
     (fstats withReplaygain    [ "FFMPEG" "MPG123" "SPEEXDSP" ])
     (fstat withCdda           "CDPARANOIA")
@@ -76,7 +76,7 @@ in stdenv.mkDerivation rec {
     "-DENABLE_HTTPS_SUPPORT=ON"
   ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage    = https://github.com/cdrummond/cantata;
     description = "A graphical client for MPD";
     license     = licenses.gpl3;


### PR DESCRIPTION
###### Motivation for this change

Fix runtime error:
```
qt.qpa.plugin: Could not find the Qt platform plugin "xcb" in ""
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
```

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @fuuzetsu, @peterhoeg 
