### PR TITLE
udis86: init at 1.7.2

### DIFF
--- a/pkgs/development/tools/udis86/default.nix
+++ b/pkgs/development/tools/udis86/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, python }:
+
+stdenv.mkDerivation rec {
+  pname = "udis86";
+  version = "1.7.2";
+
+  src = fetchFromGitHub {
+    owner = "vmt";
+    repo = "udis86";
+    rev = "v${version}";
+    url = "https://github.com/vmt/udis86/archive/v${version}.tar.gz";
+    sha256 = "0c60zwimim6jrm4saw36s38w5sg5v8n9mr58pkqmjrlf7q9g6am1";
+  };
+
+  nativeBuildInputs = [ autoreconfHook python ];
+
+  configureFlags = [
+    "--enable-shared"
+  ];
+
+  outputs = [ "bin" "out" "dev" "lib" ];
+
+  meta = with stdenv.lib; {
+    homepage = "http://udis86.sourceforge.net";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ timor ];
+    description = ''
+      Easy-to-use, minimalistic x86 disassembler library (libudis86)
+    '';
+    platforms = platforms.all ;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9916,6 +9916,8 @@ in
     inherit (darwin.apple_sdk.frameworks) CoreFoundation;
   };
 
+  udis86 = callPackage  ../development/tools/udis86 { };
+
   uefi-firmware-parser = callPackage ../development/tools/analysis/uefi-firmware-parser { };
 
   uhd = callPackage ../applications/radio/uhd { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
This is a dependency for `factor-lang`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

