### PR TITLE
libfive: 2018-07-01 -> 2019-08-05

### DIFF
--- a/pkgs/development/libraries/libfive/default.nix
+++ b/pkgs/development/libraries/libfive/default.nix
@@ -4,13 +4,13 @@ zlib, libpng, boost, qt5, guile
 
 stdenv.mkDerivation rec {
   name = "libfive-${version}";
-  version = "2018-07-01";
+  version = "2019-08-05";
 
   src = fetchFromGitHub {
     owner  = "libfive";
     repo   = "libfive";
-    rev    = "0f517dde9521d751310a22f85ee69b2c84690267";
-    sha256 = "0bfxysf5f4ripgcv546il8wnw5p0d4s75kdjlwvj32549537hlz0";
+    rev    = "d0e6401";
+    sha256 = "0f8cyc04gjqlzs71cm2l1j6lf4kkksf0sqgz9jfpfsvdvs3q3n6w";
   };
   nativeBuildInputs = [ cmake ninja pkgconfig ];
   buildInputs = [ eigen zlib libpng boost qt5.qtimageformats guile ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Updating libfive to a newer version, closer to their last release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
