### PR TITLE
pythonPackages.nipype: 1.1.9 -> 1.2.0

### DIFF
--- a/pkgs/development/python-modules/bids-validator/default.nix
+++ b/pkgs/development/python-modules/bids-validator/default.nix
@@ -1,0 +1,23 @@
+{ buildPythonPackage
+, lib
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  version = "1.2.4";
+  pname = "bids-validator";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1mvp1mi1k6yqgyj7rxij8mlwclqlyfzq08s67v0qaycw44l68ifg";
+  };
+
+  propagatedBuildInputs = [ ];
+
+  meta = with lib; {
+    description = "Validator for the Brain Imaging Data Structure";
+    homepage = "https://github.com/bids-standard/bids-validator";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/development/python-modules/delegator-py/default.nix
+++ b/pkgs/development/python-modules/delegator-py/default.nix
@@ -1,0 +1,30 @@
+{ buildPythonPackage
+, lib
+, fetchFromGitHub
+, pexpect
+, pytest
+}:
+
+buildPythonPackage rec {
+  version = "0.1.1";
+  pname = "delegator.py";
+
+  src = fetchFromGitHub {
+    owner = "amitt001";
+    repo = "delegator.py";
+    rev = "v${version}";
+    sha256 = "17n9h3xzjsfxmwclh33vc4yg3c9yzh9hfhaj12kv5ah3fy8rklwb";
+  };
+
+  propagatedBuildInputs = [ pexpect ];
+
+  # no tests in github or pypi
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Subprocesses for Humans 2.0";
+    homepage = "https://github.com/amitt001/delegator.py";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/development/python-modules/nibabel/default.nix
+++ b/pkgs/development/python-modules/nibabel/default.nix
@@ -2,20 +2,20 @@
 , buildPythonPackage
 , fetchPypi
 , isPy3k
+, bz2file
+, mock
+, nose
 , numpy
 , six
-, bz2file
-, nose
-, mock
 }:
 
 buildPythonPackage rec {
   pname = "nibabel";
-  version = "2.4.1";
+  version = "2.5.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "f165ff1cb4464902d6594eb2694e2cfb6f8b9fe233b856c976c3cff623ee0e17";
+    sha256 = "07v1gsq1v43v0z06cnp82ij9sqx3972c9bc6vsdj7pa9ddpa2yjw";
   };
 
   propagatedBuildInputs = [
@@ -25,16 +25,8 @@ buildPythonPackage rec {
 
   checkInputs = [ nose mock ];
 
-  checkPhase = let
-    excludeTests = lib.optionals isPy3k [
-      # https://github.com/nipy/nibabel/issues/691
-      "nibabel.gifti.tests.test_giftiio.test_read_deprecated"
-      "nibabel.gifti.tests.test_parse_gifti_fast.test_parse_dataarrays"
-      "nibabel.tests.test_minc1.test_old_namespace"
-    ];
-  # TODO: Add --with-doctest once all doctests pass
-  in ''
-    nosetests ${lib.concatMapStrings (test: "-e '${test}' ") excludeTests}
+  checkPhase = ''
+    nosetests
   '';
 
   meta = with lib; {

--- a/pkgs/development/python-modules/nipype/default.nix
+++ b/pkgs/development/python-modules/nipype/default.nix
@@ -16,6 +16,7 @@
 , packaging
 , prov
 , psutil
+, pybids
 , pydot
 , pytest
 , pytest_xdist
@@ -44,11 +45,11 @@ in
 
 buildPythonPackage rec {
   pname = "nipype";
-  version = "1.1.9";
+  version = "1.2.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "f80096ec6cfd7cffc05764bba1749e424877140ef1373193f076bdd843f19016";
+    sha256 = "09azgfmb0992c3xqmi7n93pz95i4v37vc9kqmjh8c9jjxjzszdd5";
   };
 
   postPatch = ''
@@ -79,6 +80,7 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
+    pybids
     codecov
     glibcLocales
     mock
@@ -89,12 +91,10 @@ buildPythonPackage rec {
     which
   ];
 
+  # ignore tests which incorrect fail to detect xvfb
   checkPhase = ''
-    LC_ALL="en_US.UTF-8" pytest -v --doctest-modules nipype
+    LC_ALL="en_US.UTF-8" pytest -v nipype -k 'not display'
   '';
-
-  # See: https://github.com/nipy/nipype/issues/2839
-  doCheck = false;
 
   meta = with stdenv.lib; {
     homepage = https://nipy.org/nipype/;

--- a/pkgs/development/python-modules/num2words/default.nix
+++ b/pkgs/development/python-modules/num2words/default.nix
@@ -1,0 +1,35 @@
+{ buildPythonPackage
+, lib
+, fetchPypi
+, docopt
+, delegator-py
+, pytest
+}:
+
+buildPythonPackage rec {
+  version = "0.5.10";
+  pname = "num2words";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0myc27k087rhgpwn1a1dffzl32rwz6ngdbf3rm2i0zlgcxh4zk9p";
+  };
+
+  propagatedBuildInputs = [ docopt ];
+
+  checkInputs = [ delegator-py pytest ];
+
+  checkPhase = ''
+    pytest -k 'not cli_with_lang'
+  '';
+
+  meta = with lib; {
+    description = "Modules to convert numbers to words. 42 --> forty-two";
+    homepage = "https://github.com/savoirfairelinux/num2words";
+    license = licenses.lgpl21;
+    maintainers = with maintainers; [ jonringer ];
+
+    longDescription =
+    "num2words is a library that converts numbers like 42 to words like forty-two. It supports multiple languages (see the list below for full list of languages) and can even generate ordinal numbers like forty-second";
+  };
+}

--- a/pkgs/development/python-modules/pybids/default.nix
+++ b/pkgs/development/python-modules/pybids/default.nix
@@ -1,0 +1,49 @@
+{ buildPythonPackage
+, lib
+, fetchPypi
+, isPy27
+, num2words
+, numpy
+, scipy
+, pandas
+, nibabel
+, patsy
+, bids-validator
+, sqlalchemy
+, pytest
+, pathlib
+}:
+
+buildPythonPackage rec {
+  version = "0.9.2";
+  pname = "pybids";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "16c0v800yklp043prbrx1357vx1mq5gddxz5zqlcnf4akhzcqrxs";
+  };
+
+  propagatedBuildInputs = [
+    num2words
+    numpy
+    scipy
+    pandas
+    nibabel
+    patsy
+    bids-validator
+    sqlalchemy
+  ];
+
+  checkInputs = [ pytest ] ++ lib.optionals isPy27 [ pathlib ];
+
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with lib; {
+    description = "Python tools for querying and manipulating BIDS datasets";
+    homepage = https://github.com/bids-standard/pybids;
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1357,6 +1357,8 @@ in {
     gui = false;
   };
 
+  delegator-py = callPackage ../development/python-modules/delegator-py { };
+
   deluge-client = callPackage ../development/python-modules/deluge-client { };
 
   arrow = callPackage ../development/python-modules/arrow { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1455,6 +1455,8 @@ in {
 
   bidict = callPackage ../development/python-modules/bidict { };
 
+  bids-validator = callPackage ../development/python-modules/bids-validator { };
+
   binwalk = callPackage ../development/python-modules/binwalk { };
 
   binwalk-full = appendToName "full" (self.binwalk.override {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3862,6 +3862,8 @@ in {
 
   ntplib = callPackage ../development/python-modules/ntplib { };
 
+  num2words = callPackage ../development/python-modules/num2words { };
+
   numba = callPackage ../development/python-modules/numba { };
 
   numcodecs = callPackage ../development/python-modules/numcodecs { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -828,6 +828,8 @@ in {
 
   pyaxmlparser = callPackage ../development/python-modules/pyaxmlparser { };
 
+  pybids = callPackage ../development/python-modules/pybids { };
+
   pybind11 = callPackage ../development/python-modules/pybind11 { };
 
   pybullet = callPackage ../development/python-modules/pybullet { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
noticed nibabel was broken while doing a review.

Actions:
- bumped outdated
- enabled as many tests i could
- added missing dependencies

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @


nilearn fails due to scikit-learn broken on master. And I don't want to touch that with a 10ft pole.
```
[6 built (1 failed), 3 copied (30.8 MiB), 8.9 MiB DL]
error: build of '/nix/store/01s3v7971g9prd5v2zw2wiv6gjqz05p1-env.drv' failed
https://github.com/NixOS/nixpkgs/pull/66150
1 package failed to build:
python37Packages.nilearn

15 package were build:
python27Packages.bids-validator python27Packages.delegator-py python27Packages.nibabel python27Packages.nilearn python27Packages.nipy python27Packages.nipype python27Packages.num2words python27Packages.pybids python37Packages.bids-validator python37Packages.delegator-py python37Packages.nibabel python37Packages.nipy python37Packages.nipype python37Packages.num2words python37Packages.pybids
```