### PR TITLE
setup.sh: rewrite stripHash

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -802,14 +802,17 @@ dumpVars() {
 # Utility function: echo the base name of the given path, with the
 # prefix `HASH-' removed, if present.
 stripHash() {
-    local strippedName
+    local strippedName casematchOpt=0
     # On separate line for `set -e`
-    strippedName="$(basename "$1")"
-    if echo "$strippedName" | grep -q '^[a-z0-9]\{32\}-'; then
-        echo "$strippedName" | cut -c34-
+    strippedName="$(basename -- "$1")"
+    shopt -q nocasematch && casematchOpt=1
+    shopt -u nocasematch
+    if [[ "$strippedName" =~ ^[a-z0-9]{32}- ]]; then
+        echo "${strippedName:33}"
     else
         echo "$strippedName"
     fi
+    if (( casematchOpt )); then shopt -s nocasematch; fi
 }
 
 


### PR DESCRIPTION
###### Motivation for this change
It really bugged me when I discovered that `stripHash --foo` failed with an error so I decided to fix it. While I was at it, I figured I could get rid of the external command invocation as Bash is perfectly capable of doing the necessary string manipulation itself.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I tested the new `stripHash` function in isolation using `nixpkgs.bash` and in all cases I tested it matches behavior with the old one (except for the case where the argument starts with `--`, which simply failed in the old one but works in the new).

I have not actually run any builds with this as it requires rebuilding the entire world (due to changing stdenv) and I don't have the patience to do that locally. I'm not sure if there's any packages that can serve as a simple testbed for stdenv changes.

I realize the changes outside of `basename --` may be a little arcane, but it just bugged me to run two external commands when I could get rid of all additional processes outside of `basename` altogether. On my machine direct manipulation is ~70x faster than invoking an external command.