### PR TITLE
cmatrix: 1.2a -> 2.0

### DIFF
--- a/pkgs/applications/misc/cmatrix/default.nix
+++ b/pkgs/applications/misc/cmatrix/default.nix
@@ -1,25 +1,24 @@
-{ stdenv, fetchurl, pkgconfig, ncurses }:
+{ stdenv, fetchFromGitHub, autoreconfHook, ncurses }:
 
-let
-  version = "1.2a";
-in with stdenv.lib;
 stdenv.mkDerivation rec {
+  pname = "cmatrix";
+  version = "2.0";
 
-  name = "cmatrix-${version}";
-
-  src = fetchurl{
-    url = "http://www.asty.org/cmatrix/dist/${name}.tar.gz";
-    sha256 = "0k06fw2n8nzp1pcdynhajp5prba03gfgsbj91bknyjr5xb5fd9hz";
+  src = fetchFromGitHub {
+    owner = "abishekvashok";
+    repo = "cmatrix";
+    rev = "v${version}";
+    sha256 = "1h9jz4m4s5l8c3figaq46ja0km1gimrkfxm4dg7mf4s84icmasbm";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ ncurses ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Simulates the falling characters theme from The Matrix movie";
     longDescription = ''
       CMatrix simulates the display from "The Matrix" and is based
-      on the screensaver from the movie's website.  
+      on the screensaver from the movie's website.
     '';
     homepage = http://www.asty.org/cmatrix/;
     platforms = ncurses.meta.platforms;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
fixing packages rryantm can't update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @AndersonTorres 
