### PR TITLE
i3lock: 2.10 -> 2.12

### DIFF
--- a/pkgs/applications/window-managers/i3/lock.nix
+++ b/pkgs/applications/window-managers/i3/lock.nix
@@ -1,18 +1,18 @@
 { fetchurl, stdenv, which, pkgconfig, libxcb, xcbutilkeysyms, xcbutilimage,
-  pam, libX11, libev, cairo, libxkbcommon, libxkbfile }:
+  xcbutilxrm, pam, libX11, libev, cairo, libxkbcommon, libxkbfile }:
 
 stdenv.mkDerivation rec {
   name = "i3lock-${version}";
-  version = "2.10";
+  version = "2.12";
 
   src = fetchurl {
     url = "https://i3wm.org/i3lock/${name}.tar.bz2";
-    sha256 = "1vn8828ih7mpdl58znfnzpdwdgwksq16rghm5qlppbbz66zk5sr9";
+    sha256 = "02dwaqxpclcwiwvpvq7zwz4sxcv9c15dbf17ifalj1p8djls3cnh";
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ which libxcb xcbutilkeysyms xcbutilimage pam libX11
-    libev cairo libxkbcommon libxkbfile ];
+  buildInputs = [ which libxcb xcbutilkeysyms xcbutilimage xcbutilxrm
+    pam libX11 libev cairo libxkbcommon libxkbfile ];
 
   makeFlags = "all";
   installFlags = "PREFIX=\${out} SYSCONFDIR=\${out}/etc";


### PR DESCRIPTION
###### Motivation for this change

[CHANGELOG](https://github.com/i3/i3lock/blob/master/CHANGELOG)

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @malyn, @domenkozar
