### PR TITLE
cdo: 1.9.0 -> 1.9.7.1

### DIFF
--- a/pkgs/development/libraries/cdo/default.nix
+++ b/pkgs/development/libraries/cdo/default.nix
@@ -5,15 +5,15 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "1.9.0";
-  name = "cdo-${version}";
+  pname = "cdo";
+  version = "1.9.7.1";
 
   # Dependencies
   buildInputs = [ curl netcdf hdf5 ];
 
   src = fetchurl {
-    url = "https://code.mpimet.mpg.de/attachments/download/15187/${name}.tar.gz";
-    sha256 = "024hsr6qfg2dicwvm0vvkg3fr998bchf0qgwpj2v0jmz7a67ydnz";
+    url = "https://code.mpimet.mpg.de/attachments/download/20124/${pname}-${version}.tar.gz";
+    sha256 = "0b4n8dwxfsdbz4jflsx0b75hwapdf1rp14p48dfr7ksv0qp9aw9p";
   };
 
  # Configure phase
@@ -23,15 +23,15 @@ stdenv.mkDerivation rec {
    ++ stdenv.lib.optional (enable_all_static) "--enable-all-static"
    ++ stdenv.lib.optional (enable_cxx) "--enable-cxx";
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Collection of command line Operators to manipulate and analyse Climate and NWP model Data";
     longDescription = ''
       Supported data formats are GRIB 1/2, netCDF 3/4, SERVICE, EXTRA and IEG.
       There are more than 600 operators available.
     '';
     homepage = https://code.mpimet.mpg.de/projects/cdo/;
-    license = stdenv.lib.licenses.gpl2;
-    maintainers = [ stdenv.lib.maintainers.ltavard ];
-    platforms = with stdenv.lib.platforms; linux ++ darwin;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.ltavard ];
+    platforms = with platforms; linux ++ darwin;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10204,9 +10204,7 @@ in
 
   cdk = callPackage ../development/libraries/cdk {};
 
-  cdo = callPackage ../development/libraries/cdo {
-    stdenv = gccStdenv;
-  };
+  cdo = callPackage ../development/libraries/cdo { };
 
   cimg = callPackage  ../development/libraries/cimg { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
updating packages that rryantm can't

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @ltavard 

```
[1 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/66190
1 package were build:
cdo
```