### PR TITLE
django-postgresql-netfields: init at 1.2.2

### DIFF
--- a/pkgs/development/python-modules/django-postgresql-netfields/default.nix
+++ b/pkgs/development/python-modules/django-postgresql-netfields/default.nix
@@ -1,0 +1,49 @@
+{ stdenv
+, buildPythonPackage
+, django
+, netaddr
+, six
+, fetchFromGitHub
+# required for tests
+#, djangorestframework
+#, psycopg2
+#, unittest2
+}:
+
+buildPythonPackage rec {
+  version = "1.2.2";
+  pname = "django-postgresql-netfields";
+
+  src = fetchFromGitHub {
+    owner = "jimfunk";
+    repo = "${pname}";
+    rev = "v${version}";
+    sha256 = "1rrh38f3zl3jk5ijs6g75dxxvxygf4lczbgc7ahrgzf58g4a48lm";
+  };
+
+  # tests need a postgres database
+  doCheck = false;
+
+  # keeping the dependencies below as comment for reference
+  # checkPhase = ''
+    # python manage.py test
+  # '';
+
+  # buildInputs = [
+    # djangorestframework
+    # psycopg2
+    # unittest2
+  # ];
+
+  propagatedBuildInputs = [
+    django
+    netaddr
+    six
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Django PostgreSQL netfields implementation";
+    homepage = https://github.com/jimfunk/django-postgresql-netfields;
+    license = licenses.bsd2;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3160,6 +3160,8 @@ in {
 
   django_polymorphic = callPackage ../development/python-modules/django-polymorphic { };
 
+  django-postgresql-netfields = callPackage ../development/python-modules/django-postgresql-netfields { };
+
   django-rest-auth = callPackage ../development/python-modules/django-rest-auth { };
 
   django-sampledatahelper = callPackage ../development/python-modules/django-sampledatahelper { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Adding a missing django module

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
