### PR TITLE
kdenlive: add missing breeze and frei0r dependencies

### DIFF
--- a/pkgs/applications/kde/kdenlive.nix
+++ b/pkgs/applications/kde/kdenlive.nix
@@ -1,6 +1,8 @@
 { mkDerivation
 , lib
 , extra-cmake-modules
+, breeze-icons
+, breeze-qt5
 , kdoctools
 , kconfig
 , kcrash
@@ -19,7 +21,8 @@
 , shared-mime-info
 , libv4l
 , kfilemetadata
-, ffmpeg
+, ffmpeg-full
+, frei0r
 , phonon-backend-gstreamer
 , qtdeclarative
 , qtquickcontrols
@@ -37,6 +40,8 @@ mkDerivation {
     kdoctools
   ];
   buildInputs = [
+    breeze-icons
+    breeze-qt5
     kconfig
     kcrash
     kdbusaddons
@@ -59,7 +64,8 @@ mkDerivation {
     qtwebkit
     shared-mime-info
     libv4l
-    ffmpeg
+    ffmpeg-full
+    frei0r
     rttr
     kpurpose
     kdeclarative


### PR DESCRIPTION
#### Motivation for this change
On start kdenlive complains about missing breeze and frei0r plugins. This is a fix for #66157.

Edit: Also change ffmpeg to ffmpeg-full, as playback requires ffplay.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
