### PR TITLE
Add bluez-qt as an explicit dependency of plasma5

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -178,7 +178,7 @@ in
         ++ lib.optional (cfg.phononBackend == "vlc" && cfg.enableQt4Support) pkgs.phonon-backend-vlc
 
         # Optional hardware support features
-        ++ lib.optional config.hardware.bluetooth.enable bluedevil
+        ++ lib.optionals config.hardware.bluetooth.enable [ bluedevil bluez-qt ]
         ++ lib.optional config.networking.networkmanager.enable plasma-nm
         ++ lib.optional config.hardware.pulseaudio.enable plasma-pa
         ++ lib.optional config.powerManagement.enable powerdevil


### PR DESCRIPTION
When bluetooth is enabled, we install bluedevil, but
its applet cannot work without the qml components in
bluez-qt.

Superseedes #65440 that failed to address the issue.


### Before

> $ nix-store --query --references /nix/store/5ifkwg7dd3shx0b2mdkblndkciijzdsj-system-path | grep blue
> /nix/store/gxr9ghrlykn6ckbpzbhzg1rnpv8k6kd7-bluez-5.50
> /nix/store/fgc6w3p2cg2376bmydsby1i2j57d5d4x-bluedevil-5.15.5

### After

> $ nix-store --query --references /nix/store/qsf5zfsv512xv48xl8r12nsd3mwdp8np-system-path.drv | grep blue
> /nix/store/4jlnp6bbhkl6awy79npd679nbmr7nxni-bluez-qt-5.58.0.drv
> /nix/store/frzjhks2hajprx4xfryr039q27ph6sx6-bluez-5.50.drv
> /nix/store/xjmx891ndia8696n9xw6q61hybiib4z0-bluedevil-5.15.5.drv

###### Notify maintainers

cc @ttuegel 
