### PR TITLE
calibre: fix build

### DIFF
--- a/pkgs/applications/misc/calibre/default.nix
+++ b/pkgs/applications/misc/calibre/default.nix
@@ -49,8 +49,7 @@ stdenv.mkDerivation rec {
   ]);
 
   qtWrapperArgs = [
-    "--prefix PYTHONPATH: $PYTHONPATH"
-    "--prefix PATH: ${poppler_utils.out}/bin}"
+    "--prefix PATH : ${poppler_utils.out}/bin"
   ];
 
   installPhase = ''
@@ -76,7 +75,7 @@ stdenv.mkDerivation rec {
     sed -i "2i import sys; sys.argv[0] = 'calibre'" $out/bin/calibre
 
     for program in $out/bin/*; do
-      wrapQtApp $program
+      wrapQtApp $program --prefix PYTHONPATH : $PYTHONPATH
     done
 
     # Replace @out@ by the output path.


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Makes calibre compile again, fixing #65313 No real testing done, but it starts again for me, and the viewer works. 
Fix maybe technically uncool, splitting qtWrapperArgs, but i don't see how to get PYTHONPATH properly interpolated otherwise. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @ToxicFrog 