### PR TITLE
pythonPackages.application: 2.0.2 -> 2.7

### DIFF
--- a/pkgs/development/python-modules/application/default.nix
+++ b/pkgs/development/python-modules/application/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonPackage rec {
   pname = "python-application";
-  version = "2.0.2";
+  version = "2.7.0";
   disabled = isPy3k;
 
   src = fetchdarcs {
     url = "http://devel.ag-projects.com/repositories/${pname}";
     rev = "release-${version}";
-    sha256 = "19dszv44py8qrq0jcjdycxpa7z2p8hi3ijq9gnqdsazbbjzf9svn";
+    sha256 = "1xpyk2v3naxkjhpyris58dxg1lxbraxgjd6f7w1sah5j0sk7psla";
   };
 
   buildInputs = [ zope_interface ];


### PR DESCRIPTION
### Motivation for this change

Simple version bump of a dependency for this pull request: 

https://github.com/NixOS/nixpkgs/pull/61756

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

No maintainer.