### PR TITLE
kdeFrameworks.ktexteditor: compile with editorconfig-core-c

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/ktexteditor.nix
+++ b/pkgs/development/libraries/kde-frameworks/ktexteditor.nix
@@ -2,7 +2,8 @@
   mkDerivation, lib,
   extra-cmake-modules, perl,
   karchive, kconfig, kguiaddons, ki18n, kiconthemes, kio, kparts, libgit2,
-  qtscript, qtxmlpatterns, sonnet, syntax-highlighting, qtquickcontrols
+  qtscript, qtxmlpatterns, sonnet, syntax-highlighting, qtquickcontrols,
+  editorconfig-core-c
 }:
 
 mkDerivation {
@@ -12,6 +13,7 @@ mkDerivation {
   buildInputs = [
     karchive kconfig kguiaddons ki18n kiconthemes kio libgit2 qtscript
     qtxmlpatterns sonnet syntax-highlighting qtquickcontrols
+    editorconfig-core-c
   ];
   propagatedBuildInputs = [ kparts ];
 }


### PR DESCRIPTION
###### Motivation for this change

Add this new dependency to ktexteditor to make it support the [.editorconfig configuration format](https://editorconfig.org/).

This should propagate the feature to the editors using this lib, namely kate, kile and kdevelop. I tested it by building kate from this branch via:

> nix-env -i kate -f ~/git/nixpkgs/


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @ttuegel , I hope I'm not pinging you too much :bowing_man: 
