### PR TITLE
pythonPackages.bugwarrior: depend on jira, remove unused test deps

### DIFF
--- a/pkgs/development/python-modules/bugwarrior/default.nix
+++ b/pkgs/development/python-modules/bugwarrior/default.nix
@@ -1,31 +1,31 @@
-{ stdenv, buildPythonPackage, fetchPypi
-, mock, unittest2, nose
+{ stdenv, buildPythonPackage, fetchPypi, pythonOlder, setuptools
 , twiggy, requests, offtrac, bugzilla, taskw, dateutil, pytz, keyring, six
-, jinja2, pycurl, dogpile_cache, lockfile, click, pyxdg, future }:
+, jinja2, pycurl, dogpile_cache, lockfile, click, pyxdg, future, jira }:
 
 buildPythonPackage rec {
   pname = "bugwarrior";
   version = "1.7.0";
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "1pmznka5dxcdjfak0p1yh7lhfbfazmx8g9ysv57lsrkqy4n61qks";
   };
 
-  buildInputs = [ mock unittest2 nose /* jira megaplan */ ];
   propagatedBuildInputs = [
+    setuptools
     twiggy requests offtrac bugzilla taskw dateutil pytz keyring six
-    jinja2 pycurl dogpile_cache lockfile click pyxdg future
+    jinja2 pycurl dogpile_cache lockfile click pyxdg future jira
   ];
 
-  # for the moment jira>=0.22 and megaplan>=1.4 are missing for running the test suite.
+  # for the moment oauth2client <4.0.0 and megaplan>=1.4 are missing for running the test suite.
   doCheck = false;
 
   meta = with stdenv.lib; {
-    homepage =  https://github.com/ralphbean/bugwarrior;
+    homepage = https://github.com/ralphbean/bugwarrior;
     description = "Sync github, bitbucket, bugzilla, and trac issues with taskwarrior";
     license = licenses.gpl3Plus;
     platforms = platforms.all;
-    maintainers = with maintainers; [ pierron ];
+    maintainers = with maintainers; [ pierron yurrriq ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

- Add Jira support
- Comment out unused test dependencies
- Drop Python 2.7 support, [per upstream](https://github.com/ralphbean/bugwarrior/commit/f43cd6026c000bcd4b9794b115b63fa4f42b3eaf)

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).