### PR TITLE
Reorganize GNOME tests, re-enable LightDM for release-combined

### DIFF
--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -69,6 +69,7 @@ in rec {
         (all nixos.tests.firefox)
         (all nixos.tests.firewall)
         (except ["aarch64-linux"] nixos.tests.gnome3-xorg)
+        (except ["aarch64-linux"] nixos.tests.gnome3)
         (except ["aarch64-linux"] nixos.tests.pantheon)
         nixos.tests.installer.zfsroot.x86_64-linux or [] # ZFS is 64bit only
         (except ["aarch64-linux"] nixos.tests.installer.lvm)

--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -68,8 +68,8 @@ in rec {
         nixos.tests.chromium.x86_64-linux or []
         (all nixos.tests.firefox)
         (all nixos.tests.firewall)
-        (except ["aarch64-linux"] nixos.tests.gnome3-xorg)
-        (except ["aarch64-linux"] nixos.tests.gnome3)
+        (all nixos.tests.gnome3-xorg)
+        (all nixos.tests.gnome3)
         (except ["aarch64-linux"] nixos.tests.pantheon)
         nixos.tests.installer.zfsroot.x86_64-linux or [] # ZFS is 64bit only
         (except ["aarch64-linux"] nixos.tests.installer.lvm)

--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -68,7 +68,7 @@ in rec {
         nixos.tests.chromium.x86_64-linux or []
         (all nixos.tests.firefox)
         (all nixos.tests.firewall)
-        (except ["aarch64-linux"] nixos.tests.gnome3)
+        (except ["aarch64-linux"] nixos.tests.gnome3-xorg)
         (except ["aarch64-linux"] nixos.tests.pantheon)
         nixos.tests.installer.zfsroot.x86_64-linux or [] # ZFS is 64bit only
         (except ["aarch64-linux"] nixos.tests.installer.lvm)

--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -70,7 +70,7 @@ in rec {
         (all nixos.tests.firewall)
         (all nixos.tests.gnome3-xorg)
         (all nixos.tests.gnome3)
-        (except ["aarch64-linux"] nixos.tests.pantheon)
+        (all nixos.tests.pantheon)
         nixos.tests.installer.zfsroot.x86_64-linux or [] # ZFS is 64bit only
         (except ["aarch64-linux"] nixos.tests.installer.lvm)
         (except ["aarch64-linux"] nixos.tests.installer.luksroot)

--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -104,7 +104,7 @@ in rec {
         #(all nixos.tests.keymap.neo)
         #(all nixos.tests.keymap.qwertz)
         (all nixos.tests.plasma5)
-        #(all nixos.tests.lightdm)
+        (all nixos.tests.lightdm)
         (all nixos.tests.login)
         (all nixos.tests.misc)
         (all nixos.tests.mutableUsers)

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -139,7 +139,7 @@ in
   ldap = handleTest ./ldap.nix {};
   leaps = handleTest ./leaps.nix {};
   lidarr = handleTest ./lidarr.nix {};
-  #lightdm = handleTest ./lightdm.nix {};
+  lightdm = handleTest ./lightdm.nix {};
   limesurvey = handleTest ./limesurvey.nix {};
   login = handleTest ./login.nix {};
   loki = handleTest ./loki.nix {};

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -94,7 +94,7 @@ in
   gitolite = handleTest ./gitolite.nix {};
   gjs = handleTest ./gjs.nix {};
   gnome3-xorg = handleTestOn ["x86_64-linux"] ./gnome3-xorg.nix {}; # libsmbios is unsupported on aarch64
-  gnome3-gdm = handleTestOn ["x86_64-linux"] ./gnome3-gdm.nix {}; # libsmbios is unsupported on aarch64
+  gnome3 = handleTestOn ["x86_64-linux"] ./gnome3.nix {}; # libsmbios is unsupported on aarch64
   gocd-agent = handleTest ./gocd-agent.nix {};
   gocd-server = handleTest ./gocd-server.nix {};
   google-oslogin = handleTest ./google-oslogin {};

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -93,8 +93,8 @@ in
   gitlab = handleTest ./gitlab.nix {};
   gitolite = handleTest ./gitolite.nix {};
   gjs = handleTest ./gjs.nix {};
-  gnome3-xorg = handleTestOn ["x86_64-linux"] ./gnome3-xorg.nix {}; # libsmbios is unsupported on aarch64
-  gnome3 = handleTestOn ["x86_64-linux"] ./gnome3.nix {}; # libsmbios is unsupported on aarch64
+  gnome3-xorg = handleTest ./gnome3-xorg.nix {};
+  gnome3 = handleTest ./gnome3.nix {};
   gocd-agent = handleTest ./gocd-agent.nix {};
   gocd-server = handleTest ./gocd-server.nix {};
   google-oslogin = handleTest ./google-oslogin {};

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -93,7 +93,7 @@ in
   gitlab = handleTest ./gitlab.nix {};
   gitolite = handleTest ./gitolite.nix {};
   gjs = handleTest ./gjs.nix {};
-  gnome3 = handleTestOn ["x86_64-linux"] ./gnome3.nix {}; # libsmbios is unsupported on aarch64
+  gnome3-xorg = handleTestOn ["x86_64-linux"] ./gnome3-xorg.nix {}; # libsmbios is unsupported on aarch64
   gnome3-gdm = handleTestOn ["x86_64-linux"] ./gnome3-gdm.nix {}; # libsmbios is unsupported on aarch64
   gocd-agent = handleTest ./gocd-agent.nix {};
   gocd-server = handleTest ./gocd-server.nix {};

--- a/nixos/tests/gnome3-xorg.nix
+++ b/nixos/tests/gnome3-xorg.nix
@@ -1,5 +1,5 @@
 import ./make-test.nix ({ pkgs, ...} : {
-  name = "gnome3";
+  name = "gnome3-xorg";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ domenkozar eelco lethalman ];
   };

--- a/nixos/tests/gnome3-xorg.nix
+++ b/nixos/tests/gnome3-xorg.nix
@@ -1,7 +1,7 @@
 import ./make-test.nix ({ pkgs, ...} : {
   name = "gnome3-xorg";
   meta = with pkgs.stdenv.lib.maintainers; {
-    maintainers = [ domenkozar eelco lethalman ];
+    maintainers = pkgs.gnome3.maintainers;
   };
 
   machine =

--- a/nixos/tests/gnome3.nix
+++ b/nixos/tests/gnome3.nix
@@ -1,7 +1,7 @@
 import ./make-test.nix ({ pkgs, ...} : {
   name = "gnome3";
   meta = with pkgs.stdenv.lib.maintainers; {
-    maintainers = [ lethalman ];
+    maintainers = pkgs.gnome3.maintainers;
   };
 
   machine =

--- a/nixos/tests/gnome3.nix
+++ b/nixos/tests/gnome3.nix
@@ -1,5 +1,5 @@
 import ./make-test.nix ({ pkgs, ...} : {
-  name = "gnome3-gdm";
+  name = "gnome3";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ lethalman ];
   };
@@ -18,6 +18,7 @@ import ./make-test.nix ({ pkgs, ...} : {
           user = "alice";
         };
       };
+
       services.xserver.desktopManager.gnome3.enable = true;
 
       virtualisation.memorySize = 1024;

--- a/nixos/tests/lightdm.nix
+++ b/nixos/tests/lightdm.nix
@@ -1,7 +1,7 @@
 import ./make-test.nix ({ pkgs, ...} : {
   name = "lightdm";
   meta = with pkgs.stdenv.lib.maintainers; {
-    maintainers = [ aszlig ];
+    maintainers = [ aszlig worldofpeace ];
   };
 
   machine = { ... }: {

--- a/pkgs/desktops/gnome-3/core/gnome-software/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-software/default.nix
@@ -3,6 +3,12 @@
 , gtk3, gsettings-desktop-schemas, gnome-desktop, libxmlb, gnome-online-accounts, hicolor-icon-theme
 , json-glib, libsecret, valgrind-light, docbook_xsl, docbook_xml_dtd_42, docbook_xml_dtd_43, gtk-doc, desktop-file-utils }:
 
+let
+
+  withFwupd = stdenv.isx86_64 || stdenv.isi686;
+
+in
+
 stdenv.mkDerivation rec {
   name = "gnome-software-${version}";
   version = "3.32.4";
@@ -29,13 +35,16 @@ stdenv.mkDerivation rec {
     gtk3 glib packagekit appstream-glib libsoup
     gsettings-desktop-schemas gnome-desktop
     gspell json-glib libsecret ostree
-    polkit flatpak fwupd
-    libxmlb gnome-online-accounts
+    polkit flatpak libxmlb gnome-online-accounts
+  ] ++ stdenv.lib.optionals withFwupd [
+    fwupd
   ];
 
   mesonFlags = [
     "-Dubuntu_reviews=false"
     "-Dgudev=false"
+  ] ++ stdenv.lib.optionals (!withFwupd) [
+    "-Dfwupd=false"
   ];
 
   passthru = {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Other than the name changes ~all the GNOME3 tests use GDM and~ we re-enabled the LightDM test
and GNOME and Pantheons tests are enabled for all platforms.

###### Things done
~quick hack, haven't tested anything yet~

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
