### PR TITLE
cht.sh: unstable-2018-11-02 -> unstable-2019-08-06

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1698,6 +1698,11 @@
       fingerprint = "67FE 98F2 8C44 CF22 1828  E12F D57E FA62 5C9A 925F";
     }];
   };
+  evanjs = {
+    email = "evanjsx@gmail.com";
+    github = "evanjs";
+    name = "Evan Stoll";
+  };
   evck = {
     email = "eric@evenchick.com";
     github = "ericevenchick";

--- a/pkgs/tools/misc/cht.sh/default.nix
+++ b/pkgs/tools/misc/cht.sh/default.nix
@@ -9,15 +9,15 @@
 
 stdenv.mkDerivation rec {
   name = "cht.sh-${version}";
-  version = "unstable-2018-11-02";
+  version = "unstable-2019-08-06";
 
   nativeBuildInputs = [ makeWrapper ];
 
   src = fetchFromGitHub {
     owner = "chubin";
     repo = "cheat.sh";
-    rev = "9595805ac68b3c096f7c51fa024dcb97a7dfac44";
-    sha256 = "11g8say5fksg0zg0bqrgl92rprn4lwp20g9rz1i0r38f0jy3nyrf";
+    rev = "f507ba51d6bc1ae6c7df808cadbe4f8603951b6b";
+    sha256 = "0r7x9a3qzzkbd1m5zdlkpmhx0p7b7ja42190s7fidls3dsm710g0";
   };
 
   # Fix ".cht.sh-wrapped" in the help message
@@ -25,6 +25,12 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     install -m755 -D share/cht.sh.txt "$out/bin/cht.sh"
+
+    # install shell completion files
+    mkdir -p $out/share/bash-completion/completions $out/share/zsh/site-functions
+    mv share/bash_completion.txt $out/share/bash-completion/completions/cht.sh
+    cp share/zsh.txt $out/share/zsh/site-functions/_cht
+
     wrapProgram "$out/bin/cht.sh" \
       --prefix PATH : "${stdenv.lib.makeBinPath [ curl rlwrap ncurses xsel ]}"
   '';

--- a/pkgs/tools/misc/cht.sh/default.nix
+++ b/pkgs/tools/misc/cht.sh/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "CLI client for cheat.sh, a community driven cheat sheet";
     license = licenses.mit;
-    maintainers = with maintainers; [ fgaz ];
+    maintainers = with maintainers; [ fgaz evanjs ];
     homepage = https://github.com/chubin/cheat.sh;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Discovered [cht.sh](https://cht.sh/) but then realized the CLI doesn't have shell completions in the version available on nixpkgs.
They're sort of helpful when you get past 1,000 options.

Closure size:
```
/nix/store/plz5ab1xlgp1gkv26y3skrbf27w5ka26-cht.sh-unstable-2018-11-02     45469952
/nix/store/vy2xm234qaizjy1iz4p4xc08sp4v3bn5-cht.sh-unstable-2019-08-06     45481360
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @fgaz 