### PR TITLE
pythonPackages.vdf: 3.1 -> 3.2

### DIFF
--- a/pkgs/development/python-modules/vdf/default.nix
+++ b/pkgs/development/python-modules/vdf/default.nix
@@ -3,13 +3,13 @@
 
 buildPythonPackage rec {
   pname = "vdf";
-  version = "3.1";
+  version = "3.2";
 
   src = fetchFromGitHub {
     owner = "ValvePython";
     repo = pname;
     rev = "v${version}";
-    sha256 = "19xqjq2159w2l9vaxlkickvy3zksp9ssdkvbfcfggxz31miwp1zr";
+    sha256 = "08rb982hcwc9pr9gl0zfk9266h84fwbz097qjfkss3srwghr1247";
   };
 
   checkInputs = [ pytest pytestcov mock ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Upgrade vdf (dependency of protontricks)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
