### PR TITLE
gopass: fix build on darwin

### DIFF
--- a/pkgs/tools/security/gopass/default.nix
+++ b/pkgs/tools/security/gopass/default.nix
@@ -19,7 +19,7 @@ buildGoPackage rec {
     git
     gnupg
     xclip
-  ] ++ stdenv.lib.optional stdenv.isLinux wl-clipboard );
+  ] ++ stdenv.lib.optional stdenv.isLinux wl-clipboard);
 
   postInstall = ''
     mkdir -p \

--- a/pkgs/tools/security/gopass/default.nix
+++ b/pkgs/tools/security/gopass/default.nix
@@ -15,12 +15,11 @@ buildGoPackage rec {
     sha256 = "0v3sx9hb03bdn4rvsv2r0jzif6p1rx47hrkpsbnwva31k396mck2";
   };
 
-  wrapperPath = with stdenv.lib; makeBinPath ([
+  wrapperPath = stdenv.lib.makeBinPath ([
     git
     gnupg
     xclip
-    wl-clipboard
-  ]);
+  ] ++ stdenv.lib.optional stdenv.isLinux wl-clipboard );
 
   postInstall = ''
     mkdir -p \


### PR DESCRIPTION
##### Motivation for this change

Gopass cannot be built on Darwin since #65284 which bumped the version number but crucially included `wl-clipboard` in the wrapper path. wl-clipboard is made for wayland and should only be necessary on Linux. Because wl-clipboard only builds on Linux, building the latest gopass fails on Darwin as wl-clipboard cannot be built. This PR removes wl-clipboard when the hostPlatform is Darwin.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @andir 
