### PR TITLE
chicken: fixes for chicken 5.1.0

### DIFF
--- a/pkgs/development/compilers/chicken/5/chicken.nix
+++ b/pkgs/development/compilers/chicken/5/chicken.nix
@@ -13,7 +13,7 @@ in
 stdenv.mkDerivation {
   name = "chicken-${version}";
 
-  binaryVersion = 9;
+  binaryVersion = 11;
 
   src = fetchurl {
     url = "https://code.call-cc.org/releases/${version}/chicken-${version}.tar.gz";
@@ -22,8 +22,8 @@ stdenv.mkDerivation {
 
   setupHook = lib.ifEnable (bootstrap-chicken != null) ./setup-hook.sh;
 
-  buildFlags = "PLATFORM=${platform} PREFIX=$(out) VARDIR=$(out)/var/lib";
-  installFlags = "PLATFORM=${platform} PREFIX=$(out) VARDIR=$(out)/var/lib";
+  buildFlags = "PLATFORM=${platform} PREFIX=$(out)";
+  installFlags = "PLATFORM=${platform} PREFIX=$(out)";
 
   buildInputs = [
     makeWrapper
@@ -37,10 +37,6 @@ stdenv.mkDerivation {
       wrapProgram $f \
         --prefix PATH : ${stdenv.cc}/bin
     done
-
-    mv $out/var/lib/chicken $out/lib
-    rmdir $out/var/lib
-    rmdir $out/var
   '';
 
   # TODO: Assert csi -R files -p '(pathname-file (repository-path))' == binaryVersion

--- a/pkgs/development/compilers/chicken/5/eggs.nix
+++ b/pkgs/development/compilers/chicken/5/eggs.nix
@@ -1,4 +1,4 @@
-{ pkgs }:
+{ pkgs, stdenv }:
 rec {
   inherit (pkgs) eggDerivation fetchegg;
 
@@ -33,12 +33,12 @@ rec {
   };
 
   srfi-1 = eggDerivation {
-    name = "srfi-1-0.5";
+    name = "srfi-1-0.5.1";
 
     src = fetchegg {
       name = "srfi-1";
-      version = "0.5";
-      sha256 = "0gh1h406xbxwm5gvc5znc93nxp9xjbhyqf7zzga08k5y6igxrlvk";
+      version = "0.5.1";
+      sha256 = "15x0ajdkw5gb3vgs8flzh5g0pzl3wmcpf11iimlm67mw6fxc8p7j";
     };
 
     buildInputs = [
@@ -47,12 +47,12 @@ rec {
   };
 
   srfi-13 = eggDerivation {
-    name = "srfi-13-0.2";
+    name = "srfi-13-0.2.1";
 
     src = fetchegg {
       name = "srfi-13";
-      version = "0.2";
-      sha256 = "0jazbdnn9bjm7wwxqq7xzqxc9zfvaapq565rf1czj6ayl96yvk3n";
+      version = "0.2.1";
+      sha256 = "0204i7fhc4dy0l89lbi2lv9cjndrvwyrk68z3wy7x445jb4ky1gq";
     };
 
     buildInputs = [
@@ -61,12 +61,12 @@ rec {
   };
 
   srfi-14 = eggDerivation {
-    name = "srfi-14-0.2";
+    name = "srfi-14-0.2.1";
 
     src = fetchegg {
       name = "srfi-14";
-      version = "0.2";
-      sha256 = "13nm4nn1d52nkvhjizy26z3s6q41x1ml4zm847xzf86x1zwvymni";
+      version = "0.2.1";
+      sha256 = "0gc33cx4xll9vsf7fm8jvn3gc0604kn3bbi6jfn6xscqp86kqb9p";
     };
 
     buildInputs = [

--- a/pkgs/development/compilers/chicken/5/setup-hook.sh
+++ b/pkgs/development/compilers/chicken/5/setup-hook.sh
@@ -1,5 +1,5 @@
 addChickenRepositoryPath() {
-    addToSearchPathWithCustomDelimiter : CHICKEN_REPOSITORY_PATH "$1/lib/chicken/9/"
+    addToSearchPathWithCustomDelimiter : CHICKEN_REPOSITORY_PATH "$1/lib/chicken/11/"
     addToSearchPathWithCustomDelimiter : CHICKEN_INCLUDE_PATH "$1/share/"
 }
 


### PR DESCRIPTION
- fix incorrect binaryVersion
- upgrade chicken-5 eggs
- fix repository path

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
