### PR TITLE
arrow-cpp: 0.13.0 -> 0.14.1

### DIFF
--- a/pkgs/development/libraries/arrow-cpp/default.nix
+++ b/pkgs/development/libraries/arrow-cpp/default.nix
@@ -4,28 +4,29 @@ let
   parquet-testing = fetchFromGitHub {
     owner = "apache";
     repo = "parquet-testing";
-    rev = "8991d0b58d5a59925c87dd2a0bdb59a5a4a16bd4";
-    sha256 = "00js5d1s98y3ianrvh1ggrd157yfmia4g55jx9xmfcz4a8mcbawx";
-  };
-
-  # Enable non-bundled uriparser
-  # Introduced in https://github.com/apache/arrow/pull/4092
-  Finduriparser_cmake = fetchurl {
-    url = https://raw.githubusercontent.com/apache/arrow/af4f52961209a5f1b43a19483536285c957e3bed/cpp/cmake_modules/Finduriparser.cmake;
-    sha256 = "1cylrw00n2nkc2c49xk9j3rrza351rpravxgpw047vimcw0sk93s";
+    rev = "a277dc4e55ded3e3ea27dab1e4faf98c112442df";
+    sha256 = "1yh5a8l4ship36hwmgmp2kl72s5ac9r8ly1qcs650xv2g9q7yhnq";
   };
 in
 
 stdenv.mkDerivation rec {
   name = "arrow-cpp-${version}";
-  version = "0.13.0";
+  version = "0.14.1";
 
   src = fetchurl {
     url = "mirror://apache/arrow/arrow-${version}/apache-arrow-${version}.tar.gz";
-    sha256 = "06irh5zx6lc7jjf6hpz1vzk0pvbdx08lcirc8cp8ksb8j7fpfamc";
+    sha256 = "0a0xrsbr7dd1yp34yw82jw7psfkfvm935jhd5mam32vrsjvdsj4r";
   };
 
   sourceRoot = "apache-arrow-${version}/cpp";
+
+  ARROW_JEMALLOC_URL = fetchurl {
+    # From
+    # ./cpp/cmake_modules/ThirdpartyToolchain.cmake
+    # ./cpp/thirdparty/versions.txt
+    url = "https://github.com/jemalloc/jemalloc/releases/download/5.2.0/jemalloc-5.2.0.tar.bz2";
+    sha256 = "1d73a5c5qdrwck0fa5pxz0myizaf3s9alsvhiqwrjahdlr29zgkl";
+  };
 
   patches = [
     # patch to fix python-test
@@ -41,8 +42,6 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
     substituteInPlace cmake_modules/FindLz4.cmake --replace CMAKE_STATIC_LIBRARY CMAKE_SHARED_LIBRARY
-
-    cp ${Finduriparser_cmake} cmake_modules/Finduriparser.cmake
 
     patchShebangs build-support/
 
@@ -64,7 +63,7 @@ stdenv.mkDerivation rec {
   PARQUET_TEST_DATA = if doInstallCheck then "${parquet-testing}/data" else null;
   installCheckInputs = [ perl which ];
   installCheckPhase = (stdenv.lib.optionalString stdenv.isDarwin ''
-    for f in release/*-test; do
+    for f in release/*test; do
       install_name_tool -add_rpath "$out"/lib  "$f"
     done
   '') + ''

--- a/pkgs/development/python-modules/awkward/default.nix
+++ b/pkgs/development/python-modules/awkward/default.nix
@@ -11,11 +11,11 @@
 
 buildPythonPackage rec {
   pname = "awkward";
-  version = "0.11.1";
+  version = "0.12.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "07m797jc5lpaj6m8469d67l2s43jf8w0mfhy0hfvbfs4mk0cjix0";
+    sha256 = "0xvphwpa1n5q7kim4dw6fmsg9h5kkk7nd51bv9b36i3n4hilmq32";
   };
 
   nativeBuildInputs = [ pytestrunner ];


### PR DESCRIPTION
pythonPackages.pyarrow: 0.13.0 -> 0.14.1

Replace *-test with *test because of misnamed test executable
"arrow-dataset-file_test".

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
