### PR TITLE
grc: leave /etc/grc.conf alone so we can override it

### DIFF
--- a/pkgs/tools/misc/grc/default.nix
+++ b/pkgs/tools/misc/grc/default.nix
@@ -1,8 +1,9 @@
-{ stdenv, fetchFromGitHub, python3Packages, makeWrapper }:
+{ stdenv, fetchFromGitHub, python3Packages }:
 
-stdenv.mkDerivation rec {
-  name    = "grc-${version}";
+python3Packages.buildPythonApplication rec {
+  pname = "grc";
   version = "1.11.3";
+  format = "other";
 
   src = fetchFromGitHub {
     owner  = "garabik";
@@ -11,22 +12,18 @@ stdenv.mkDerivation rec {
     sha256 = "0b3wx9zr7l642hizk93ysbdss7rfymn22b2ykj4kpkf1agjkbv35";
   };
 
-  buildInputs = with python3Packages; [ wrapPython makeWrapper ];
+  postPatch = ''
+    for f in grc grcat; do
+      substituteInPlace $f \
+        --replace /usr/local/ $out/
+    done
+  '';
 
   installPhase = ''
     runHook preInstall
 
     ./install.sh "$out" "$out"
-
-    for f in $out/bin/* ; do
-      patchPythonScript $f
-      substituteInPlace $f \
-        --replace ' /usr/bin/env python3' '${python3Packages.python.interpreter}' \
-        --replace "'/etc/grc.conf'"   "'$out/etc/grc.conf'" \
-        --replace "'/usr/share/grc/'" "'$out/share/grc/'"
-      wrapProgram $f \
-        --prefix PATH : $out/bin
-    done
+    install -Dm444 -t $out/share/zsh/vendor-completions _grc
 
     runHook postInstall
   '';


### PR DESCRIPTION
##### Motivation for this change

grc needs a config file - by default that is ```/etc/grc.conf``` but we patch that to ```/nix/store/....grc/etc```. The problem is that we cannot then provide custom config in ```/etc/grc.conf```, so instead patch the ```/usr/local/etc/grc.conf``` location to point to the store and leave ```/etc/grc.conf``` alone.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @lovek323 @AndersonTorres 
