### PR TITLE
unison-ucm: init at 1.0.M1c alpha

### DIFF
--- a/pkgs/development/compilers/unison/default.nix
+++ b/pkgs/development/compilers/unison/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchurl, autoPatchelfHook
+, ncurses5, zlib, gmp
+}:
+
+stdenv.mkDerivation rec {
+  pname = "unison-code-manager";
+  milestone_id = "M1c";
+  version = "1.0.${milestone_id}-alpha";
+
+  src = if (stdenv.isDarwin) then
+    fetchurl {
+      url = "https://github.com/unisonweb/unison/releases/download/release/${milestone_id}/unison-osx.tar.gz";
+      sha256 = "03q02r7qc7ybqz16kmpk2d8l9vx28kaj9x59mlxzi8a4mr0j3vzb";
+    }
+  else
+    fetchurl {
+      url = "https://github.com/unisonweb/unison/releases/download/release/${milestone_id}/unison-linux64.tar.gz";
+      sha256 = "1iwynqnp1i39pyq9wc01x7y22y1qa0rrjlx40jjdgnj23y1r6jk4";
+    };
+
+  # The tarball is just the prebuilt binary, in the archive root.
+  sourceRoot = ".";
+  dontBuild = true;
+  dontConfigure = true;
+
+  nativeBuildInputs = stdenv.lib.optional (!stdenv.isDarwin) autoPatchelfHook;
+  buildInputs = stdenv.lib.optionals (!stdenv.isDarwin) [ ncurses5 zlib gmp ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mv ucm $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Modern, statically-typed purely functional language";
+    homepage = http://unisonweb.org/posts/;
+    license = licenses.free;
+    maintainers = [ maintainers.virusdave ];
+    platforms = [ "x86_64-darwin" "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20878,6 +20878,8 @@ in
 
   unpaper = callPackage ../tools/graphics/unpaper { };
 
+  unison-ucm = callPackage ../development/compilers/unison { };
+
   urh = callPackage ../applications/radio/urh { };
 
   uuagc = haskell.lib.justStaticExecutables haskellPackages.uuagc;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Introducing the unison code manager.  Previously available via homebrew only.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
