### PR TITLE
dpdk update and dpdk 17.11 lts init

### DIFF
--- a/pkgs/os-specific/linux/dpdk/default.nix
+++ b/pkgs/os-specific/linux/dpdk/default.nix
@@ -8,11 +8,11 @@ let
 
 in stdenv.mkDerivation rec {
   name = "dpdk-${version}" + lib.optionalString mod "-${kernel.version}";
-  version = "17.11.2";
+  version = "19.05";
 
   src = fetchurl {
     url = "https://fast.dpdk.org/rel/dpdk-${version}.tar.xz";
-    sha256 = "19m5l3jkrns8r1zbjb6ry18w50ff36kbl5b5g6pfcp9p57sfisd2";
+    sha256 = "1pvxyjx2fpsf15fi8vz7zfkaywihck2yd4ck525w76fl15irw3f8";
   };
 
   nativeBuildInputs = [ pkgconfig ];
@@ -59,6 +59,6 @@ EOF
     homepage = http://dpdk.org/;
     license = with licenses; [ lgpl21 gpl2 bsd2 ];
     platforms =  [ "x86_64-linux" ];
-    maintainers = with maintainers; [ domenkozar orivej ];
+    maintainers = with maintainers; [ domenkozar magenbluten orivej ];
   };
 }

--- a/pkgs/os-specific/linux/odp-dpdk/default.nix
+++ b/pkgs/os-specific/linux/odp-dpdk/default.nix
@@ -1,8 +1,16 @@
 { stdenv, fetchurl, autoreconfHook, pkgconfig
 , dpdk, libconfig, libpcap, numactl, openssl
-}:
+}: let
 
-stdenv.mkDerivation rec {
+  dpdk_17_11 = dpdk.overrideAttrs (old: rec {
+    version = "17.11.6";
+    src = fetchurl {
+      url = "https://fast.dpdk.org/rel/dpdk-${version}.tar.xz";
+      sha256 = "0g4l6yjcn17n18c7q1pxkmnj4fg2kiv0krz7n2vjjsb8s6gmbps2";
+    };
+  });
+
+in stdenv.mkDerivation rec {
   pname = "odp-dpdk";
   version = "1.19.0.0_DPDK_17.11";
 
@@ -12,16 +20,16 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
-  buildInputs = [ dpdk libconfig libpcap numactl openssl ];
+  buildInputs = [ dpdk_17_11 libconfig libpcap numactl openssl ];
 
-  RTE_SDK = "${dpdk}/share/dpdk";
+  RTE_SDK = "${dpdk_17_11}/share/dpdk";
   RTE_TARGET = "x86_64-native-linuxapp-gcc";
 
   dontDisableStatic = true;
 
   configureFlags = [
     "--disable-shared"
-    "--with-dpdk-path=${dpdk}"
+    "--with-dpdk-path=${dpdk_17_11}"
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/os-specific/linux/pktgen/default.nix
+++ b/pkgs/os-specific/linux/pktgen/default.nix
@@ -1,33 +1,23 @@
 { stdenv, lib, fetchurl, pkgconfig
-, dpdk, libpcap, numactl, utillinux
-, gtk2, withGtk ? false
+, dpdk, libpcap, lua5_3, numactl, utillinux
+, gtk2, which, withGtk ? false
 }:
 
 let
 
-  # pktgen needs a specific version of lua to apply its patch (see lib/lua/Makefile).
-  lua = rec {
-    name = "lua-5.3.4";
-    basename = name + ".tar.gz";
-    src = fetchurl {
-      url = "https://www.lua.org/ftp/${basename}";
-      sha256 = "0320a8dg3aci4hxla380dx1ifkw8gj4gbw5c4dz41g1kh98sm0gn";
-    };
-  };
-
 in stdenv.mkDerivation rec {
   pname = "pktgen";
-  version = "3.5.0";
+  version = "3.7.2";
 
   src = fetchurl {
-    url = "http://dpdk.org/browse/apps/pktgen-dpdk/snapshot/pktgen-${version}.tar.xz";
-    sha256 = "1gy99jr9dbwzi9pd3w5k673h3pfnbkz6rbzmrkwcyis72pnphy5z";
+    url = "http://dpdk.org/browse/apps/pktgen-dpdk/snapshot/${pname}-${version}.tar.xz";
+    sha256 = "03k7h4j2lsrh6b7477hgn87ljrjh2673ncffx9v261bx1ns54y7w";
   };
 
-  nativeBuildInputs = stdenv.lib.optionals withGtk [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig ];
 
   buildInputs =
-    [ dpdk libpcap numactl ]
+    [ dpdk libpcap lua5_3 numactl which ]
     ++ stdenv.lib.optionals withGtk [gtk2];
 
   RTE_SDK = "${dpdk}/share/dpdk";
@@ -37,19 +27,13 @@ in stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = [ "-msse3" ];
 
   postPatch = let dpdkMajor = lib.versions.major dpdk.version; in ''
-    substituteInPlace app/Makefile --replace 'yy :=' 'yy := ${dpdkMajor} #'
     substituteInPlace lib/common/lscpu.h --replace /usr/bin/lscpu ${utillinux}/bin/lscpu
-
-    ln -s ${lua.src} lib/lua/${lua.basename}
-    make -C lib/lua get_tarball # unpack and patch
-    substituteInPlace lib/lua/${lua.name}/src/luaconf.h --replace /usr/local $out
   '';
 
   installPhase = ''
     install -d $out/bin
     install -m 0755 app/${RTE_TARGET}/pktgen $out/bin
-    install -d $out/lib/lua/5.3
-    install -m 0644 Pktgen.lua $out/lib/lua/5.3
+    install -m 0644 Pktgen.lua $out/bin
   '';
 
   enableParallelBuilding = true;


### PR DESCRIPTION
update `dpdk` to the current version. in order to not break the `odp-dpdk` package an aditional dpdk_17_11 package was introduced.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @abuibrahim @Lassulus 
