### PR TITLE
scream-receivers: init at 3.3

### DIFF
--- a/pkgs/misc/scream-receivers/default.nix
+++ b/pkgs/misc/scream-receivers/default.nix
@@ -1,0 +1,56 @@
+{ stdenv, lib, fetchFromGitHub, alsaLib
+, pulseSupport ? false, libpulseaudio ? null
+}:
+
+stdenv.mkDerivation rec {
+  pname = "scream-receivers";
+  version = "3.3";
+
+  src = fetchFromGitHub {
+    owner = "duncanthrax";
+    repo = "scream";
+    rev = "${version}";
+    sha256 = "1iqhs7m0fv3vfld7h288j5j0jc5xdihaghd0jd9qrk68mj2g6g9w";
+  };
+
+  buildInputs = [ alsaLib ] ++ lib.optional pulseSupport libpulseaudio;
+
+  buildPhase = ''
+    (cd Receivers/alsa && make)
+    (cd Receivers/alsa-ivshmem && make)
+  '' + lib.optionalString pulseSupport ''
+    (cd Receivers/pulseaudio && make)
+    (cd Receivers/pulseaudio-ivshmem && make)
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mv ./Receivers/alsa/scream-alsa $out/bin/
+    mv ./Receivers/alsa-ivshmem/scream-ivshmem-alsa $out/bin/
+  '' + lib.optionalString pulseSupport ''
+    mv ./Receivers/pulseaudio/scream-pulse $out/bin/
+    mv ./Receivers/pulseaudio-ivshmem/scream-ivshmem-pulse $out/bin/
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    export PATH=$PATH:$out/bin
+    set -o verbose
+    set +o pipefail
+
+    # Programs exit with code 1 when testing help, so grep for a string
+    scream-alsa -h 2>&1 | grep -q Usage:
+    scream-ivshmem-alsa 2>&1 | grep -q Usage:
+  '' + lib.optionalString pulseSupport ''
+    scream-pulse -h 2>&1 | grep -q Usage:
+    scream-ivshmem-pulse 2>&1 | grep -q Usage:
+  '';
+
+  meta = with lib; {
+    description = "Audio receivers for the Scream virtual network sound card";
+    homepage = "https://github.com/duncanthrax/scream";
+    license = licenses.mspl;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.ivan ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5881,6 +5881,10 @@ in
 
   scdoc = callPackage ../tools/typesetting/scdoc { };
 
+  scream-receivers = callPackage ../misc/scream-receivers {
+    pulseSupport = config.pulseaudio or false;
+  };
+
   screen = callPackage ../tools/misc/screen {
     inherit (darwin.apple_sdk.libs) utmp;
   };


### PR DESCRIPTION
#### Motivation for this change

Add the [Scream](https://github.com/duncanthrax/scream) audio receivers for receiving audio output from a Windows machine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I confirmed that these receivers work and play audio from a Windows 10 1903 running in qemu:

- `scream-alsa`
- `scream-ivshmem-alsa`
- `scream-ivshmem-pulse` (tested with apulse because I don't use pulseaudio)