### PR TITLE
pythonPackages.cadquery: init at 2.0RC0 & cq-editor: init at 0.1RC1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4163,6 +4163,12 @@
     githubId = 34086;
     name = "Marc Weber";
   };
+  marcus7070 = {
+    email = "marcus@geosol.com.au";
+    github = "marcus7070";
+    githubId = 50230945;
+    name = "Marcus Boyd";
+  };
 	marenz = {
 		email = "marenz@arkom.men";
 		github = "marenz2569";

--- a/pkgs/applications/graphics/cq-editor/default.nix
+++ b/pkgs/applications/graphics/cq-editor/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, mkDerivationWith
+, python3Packages
+, fetchFromGitHub
+}:
+
+mkDerivationWith python3Packages.buildPythonApplication rec {
+  pname = "cq-editor";
+  version = "0.1RC1";
+
+  src = fetchFromGitHub {
+    owner = "CadQuery";
+    repo = "CQ-editor";
+    rev = version;
+    sha256 = "0iwcpnj15s64k16948sakvkn1lb4mqwrhmbxk3r03bczs0z33zax";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    cadquery
+    Logbook
+    pyqt5
+    pyparsing
+    pyqtgraph
+    spyder
+    pathpy
+    qtconsole
+    requests
+  ];
+
+  postFixup = ''
+    wrapQtApp "$out/bin/cq-editor"
+  '';
+
+  checkInputs = with python3Packages; [
+    pytest
+    pytest-xvfb
+    pytest-mock
+    pytestcov
+    pytest-repeat
+    pytest-qt
+  ];
+
+  checkPhase = ''
+    pytest --no-xvfb
+  '';
+
+  # requires X server
+  doCheck = false;
+
+  meta = with lib; {
+    description = "CadQuery GUI editor based on PyQT";
+    homepage = "https://github.com/CadQuery/CQ-editor";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ costrouc marcus7070 ];
+  };
+
+}

--- a/pkgs/development/python-modules/cadquery/default.nix
+++ b/pkgs/development/python-modules/cadquery/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pyparsing
+, opencascade_oce
+, pythonocc-core
+}:
+
+buildPythonPackage rec {
+  pname = "cadquery";
+  version = "2.0RC0";
+
+  src = fetchFromGitHub {
+    owner = "CadQuery";
+    repo = pname;
+    rev = version;
+    sha256 = "1s5arr8w1mn60isaf44diqf72vyscy5ihns3072h16ysbl0b509s";
+  };
+
+  buildInputs = [
+    opencascade_oce
+  ];
+
+  propagatedBuildInputs = [
+    pyparsing
+    pythonocc-core
+  ];
+
+  meta = with lib; {
+    description = "Parametric scripting language for creating and traversing CAD models";
+    homepage = https://github.com/CadQuery/cadquery;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/cadquery/default.nix
+++ b/pkgs/development/python-modules/cadquery/default.nix
@@ -1,35 +1,93 @@
 { lib
-, buildPythonPackage
-, fetchFromGitHub
-, pyparsing
-, opencascade_oce
-, pythonocc-core
+  , buildPythonPackage
+  , isPy3k
+  , pythonOlder
+  , fetchFromGitHub
+  , pyparsing
+  , opencascade
+  , stdenv
+  , python
+  , cmake
+  , swig
+  , ninja
+  , smesh
+  , freetype
+  , libGL
+  , libGLU
+  , libX11
+  , six
 }:
 
-buildPythonPackage rec {
-  pname = "cadquery";
-  version = "2.0RC0";
+let 
+  pythonocc-core-cadquery = stdenv.mkDerivation {
+    pname = "pythonocc-core-cadquery";
+    version = "0.18.2";
 
-  src = fetchFromGitHub {
-    owner = "CadQuery";
-    repo = pname;
-    rev = version;
-    sha256 = "1s5arr8w1mn60isaf44diqf72vyscy5ihns3072h16ysbl0b509s";
+    src = fetchFromGitHub {
+      owner = "CadQuery";
+      repo = "pythonocc-core";
+      # no proper release to to use, this commit copied from the Anaconda receipe
+      rev = "701e924ae40701cbe6f9992bcbdc2ef22aa9b5ab";
+      sha256 = "07zmiiw74dyj4v0ar5vqkvk30wzcpjjzbi04nsdk5mnlzslmyi6c";
+    };
+
+    nativeBuildInputs = [ 
+      cmake
+      swig
+      ninja
+    ];
+
+    buildInputs = [
+      python
+      opencascade
+      smesh
+      freetype
+      libGL
+      libGLU
+      libX11
+    ];
+
+    propagatedBuildInputs = [
+      six
+    ];
+
+    cmakeFlags = [
+      "-Wno-dev"
+      "-DPYTHONOCC_INSTALL_DIRECTORY=${placeholder "out"}/${python.sitePackages}/OCC"
+      "-DSMESH_INCLUDE_PATH=${smesh}/include/smesh"
+      "-DSMESH_LIB_PATH=${smesh}/lib"
+      "-DPYTHONOCC_WRAP_SMESH=TRUE"
+    ];
   };
 
-  buildInputs = [
-    opencascade_oce
-  ];
-
-  propagatedBuildInputs = [
-    pyparsing
-    pythonocc-core
-  ];
-
-  meta = with lib; {
-    description = "Parametric scripting language for creating and traversing CAD models";
-    homepage = https://github.com/CadQuery/cadquery;
-    license = licenses.asl20;
-    maintainers = [ maintainers.costrouc ];
-  };
-}
+in
+  buildPythonPackage rec {
+    pname = "cadquery";
+    version = "2.0RC0";
+  
+    src = fetchFromGitHub {
+      owner = "CadQuery";
+      repo = pname;
+      rev = version;
+      sha256 = "1xgd00rih0gjcnlrf9s6r5a7ypjkzgf2xij2b6436i76h89wmir3";
+    };
+  
+    buildInputs = [
+      opencascade
+    ];
+  
+    propagatedBuildInputs = [
+      pyparsing
+      pythonocc-core-cadquery
+    ];
+  
+    # Build errors on 2.7 and >=3.8 (officially only supports 3.6 and 3.7).
+    disabled = !(isPy3k && (pythonOlder "3.8"));
+  
+    meta = with lib; {
+      description = "Parametric scripting language for creating and traversing CAD models";
+      homepage = "https://github.com/CadQuery/cadquery";
+      license = licenses.asl20;
+      maintainers = with maintainers; [ costrouc marcus7070 ];
+    };
+  }

--- a/pkgs/development/python-modules/pyscreenshot/default.nix
+++ b/pkgs/development/python-modules/pyscreenshot/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, EasyProcess
+}:
+
+buildPythonPackage rec {
+  pname = "pyscreenshot";
+  version = "0.5.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "19ec6d17a61c0cd4e7fcf3ab2685598a54b53dc781755393cc5f76dcb7bf359c";
+  };
+
+  propagatedBuildInputs = [
+    EasyProcess
+  ];
+
+  # recursive dependency on pyvirtualdisplay
+  doCheck = false;
+
+  meta = with lib; {
+    description = "python screenshot";
+    homepage = "https://github.com/ponty/pyscreenshot";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-qt/default.nix
+++ b/pkgs/development/python-modules/pytest-qt/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, setuptools_scm
+, pytest
+, pyqt5
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-qt";
+  version = "3.2.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "f6ecf4b38088ae1092cbd5beeaf714516d1f81f8938626a2eac546206cdfe7fa";
+  };
+
+  nativeBuildInputs = [
+    setuptools_scm
+  ];
+
+  propagatedBuildInputs = [
+    pytest
+  ];
+
+  checkInputs = [
+    pyqt5
+  ];
+
+  # tests require X server
+  doCheck = false;
+
+  meta = with lib; {
+    description = "pytest support for PyQt and PySide applications";
+    homepage = "https://github.com/pytest-dev/pytest-qt";
+    license = licenses.mit;
+    maintainers = with maintainers; [ costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-repeat/default.nix
+++ b/pkgs/development/python-modules/pytest-repeat/default.nix
@@ -8,33 +8,29 @@
 
 buildPythonPackage rec {
   pname = "pytest-repeat";
-  version = "0.7.0";
+  version = "0.8.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0axbrpqal3cqw9zq6dakdbg49pnf5gvyvq6yn93hp1ayc7fnhzk3";
+    sha256 = "1nbdmklpi0ra1jnfm032wz96y9nxdlcr4m9sjlnffwm7n4x43g2j";
   };
 
-  # fixes support for pytest >3.6. Should be droppable during the
-  # next bump.
-  patches = [
-    (fetchpatch {
-      url = https://github.com/pytest-dev/pytest-repeat/commit/f94b6940e3651b7593aca5a7a987eb56abe04cb1.patch;
-      sha256 = "00da1gmpq9pslcmm8pw93jcbp8j2zymzqdsm6jq3xinkvjpsbmny";
-    })
+  nativeBuildInputs = [
+    setuptools_scm
   ];
 
-  buildInputs = [ setuptools_scm ];
-  checkInputs = [ pytest ];
+  checkInputs = [
+    pytest
+  ];
 
   checkPhase = ''
-    py.test
+    pytest
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Pytest plugin for repeating tests";
-    homepage = https://github.com/pytest-dev/pytest-repeat;
-    maintainers = with lib.maintainers; [ costrouc ];
-    license = lib.licenses.mpl20;
+    homepage = "https://github.com/pytest-dev/pytest-repeat";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ costrouc ];
   };
 }

--- a/pkgs/development/python-modules/pytest-xvfb/default.nix
+++ b/pkgs/development/python-modules/pytest-xvfb/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytest
+, virtual-display
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-xvfb";
+  version = "1.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "a7544ca8d0c7c40db4b40d7a417a7b071c68d6ef6bdf9700872d7a167302f979";
+  };
+
+  propagatedBuildInputs = [
+    pytest
+    virtual-display
+  ];
+
+  meta = with lib; {
+    description = "A pytest plugin to run Xvfb for tests";
+    homepage = "https://github.com/The-Compiler/pytest-xvfb";
+    license = licenses.mit;
+    maintainers = with maintainers; [ costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/tinydb/default.nix
+++ b/pkgs/development/python-modules/tinydb/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytest
+, pytestcov
+, pytestrunner
+, pycodestyle
+, pyyaml
+}:
+
+buildPythonPackage rec {
+  pname = "tinydb";
+  version = "v3.14.1";
+
+  src = fetchFromGitHub {
+    owner = "msiemens";
+    repo = pname;
+    rev = version;
+    sha256 = "02idbvrm8j4mwsjfkzy11f4png19k307p53s4qa2ifzssysxpb96";
+  };
+
+  nativeBuildInputs = [
+    pytestrunner
+  ];
+
+  checkInputs = [
+    pytest
+    pytestcov
+    pycodestyle
+    pyyaml
+  ];
+
+  meta = with lib; {
+    description = "A lightweight document oriented database written in pure Python with no external dependencies";
+    homepage = "https://github.com/msiemens/tinydb";
+    license = licenses.asl20;                                                                                                                                                                      
+    maintainers = with maintainers; [ marcus7070 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18282,6 +18282,8 @@ in
 
   coyim = callPackage ../applications/networking/instant-messengers/coyim {};
 
+  cq-editor = libsForQt5.callPackage ../applications/graphics/cq-editor { };
+
   cpp_ethereum = callPackage ../applications/misc/cpp-ethereum { };
 
   crun = callPackage ../applications/virtualization/crun {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5270,6 +5270,8 @@ in {
 
   tiros = callPackage ../development/python-modules/tiros { };
 
+  tinydb = callPackage ../development/python-modules/tinydb { };
+
   tifffile = callPackage ../development/python-modules/tifffile { };
 
   tmdb3 = callPackage ../development/python-modules/tmdb3 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -497,6 +497,8 @@ in {
 
   cachy = callPackage ../development/python-modules/cachy { };
 
+  cadquery = callPackage ../development/python-modules/cadquery { };
+
   catalogue = callPackage ../development/python-modules/catalogue { };
 
   cdecimal = callPackage ../development/python-modules/cdecimal { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1159,6 +1159,8 @@ in {
 
   pytest-pylint = callPackage ../development/python-modules/pytest-pylint { };
 
+  pytest-qt = callPackage ../development/python-modules/pytest-qt { };
+
   pytest-testmon = callPackage ../development/python-modules/pytest-testmon { };
 
   pytest-tornado = callPackage ../development/python-modules/pytest-tornado { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1101,6 +1101,8 @@ in {
 
   pyschedule = callPackage ../development/python-modules/pyschedule { };
 
+  pyscreenshot = callPackage ../development/python-modules/pyscreenshot { };
+
   pyside = callPackage ../development/python-modules/pyside {
     inherit (pkgs) mesa;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1165,6 +1165,8 @@ in {
 
   pytest-xprocess = callPackage ../development/python-modules/pytest-xprocess { };
 
+  pytest-xvfb = callPackage ../development/python-modules/pytest-xvfb { };
+
   pytmx = callPackage ../development/python-modules/pytmx { };
 
   python-binance = callPackage ../development/python-modules/python-binance { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

edit: Got cq-editor working, updated pull request.

###### Motivation for this change
Init pythonPackages.cadquery and prepare dependencies for packaging cq-editor in the future (I've given up on getting cq-editor working for the moment, I'll get back to it sometime soon). Partial resolution of #65830.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @costrouc 
