### PR TITLE
gnome-sharp: mono4 -> mono5

### DIFF
--- a/pkgs/development/libraries/gnome-sharp/default.nix
+++ b/pkgs/development/libraries/gnome-sharp/default.nix
@@ -27,6 +27,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ gtk2 mono gtk-sharp-2_0 ]
   ++ (with gnome2; [ libart_lgpl gnome_vfs libgnome libgnomecanvas libgnomeui ]);
 
+  patches = [ ./fix-mono-path.patch ];
+
   preConfigure = ''
     ./bootstrap-${lib.versions.majorMinor version}
   '';

--- a/pkgs/development/libraries/gnome-sharp/fix-mono-path.patch
+++ b/pkgs/development/libraries/gnome-sharp/fix-mono-path.patch
@@ -1,0 +1,13 @@
+diff --git a/sample/gconf/Makefile.am b/sample/gconf/Makefile.am
+index a0ee802..8260694 100644
+--- a/sample/gconf/Makefile.am
++++ b/sample/gconf/Makefile.am
+@@ -22,7 +22,7 @@ sample.exe: $(SCHEMA) $(srcdir)/sample.glade $(FILES) $(ASSEMBLIES)
+	$(CSC) /out:sample.exe $(FILES) $(REFERENCES) $(RESOURCES)
+ 
+ Settings.cs: $(SCHEMA)
+-	MONO_PATH=$(top_builddir)/gconf/GConf/gconf-sharp.dll:${MONO_PATH} $(RUNTIME) $(GCONFDIR)/tools/gconfsharp-schemagen.exe Sample $(SCHEMA) > Settings.cs
++	MONO_PATH=$(top_builddir)/gconf/GConf/:${MONO_PATH} $(RUNTIME) $(GCONFDIR)/tools/gconfsharp-schemagen.exe Sample $(SCHEMA) > Settings.cs
+ 
+ CLEANFILES = sample.exe Settings.cs
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11009,7 +11009,7 @@ in
 
   gdk-pixbuf = callPackage ../development/libraries/gdk-pixbuf { };
 
-  gnome-sharp = callPackage ../development/libraries/gnome-sharp { mono = mono4; };
+  gnome-sharp = callPackage ../development/libraries/gnome-sharp { };
 
   gnome-menus = callPackage ../development/libraries/gnome-menus { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Eliminate use of mono4 in gnome-sharp library.

Tested with

    % nix-env -i gconf
    nix-review ...
    open some PDF in pdfmod, open tomboy

Both applications would segfault on close, but other than that seemed to work ok. Same result I got with version in 19.03 release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @vbgl 
