### PR TITLE
flexibee: init at 2019.2.5

### DIFF
--- a/pkgs/applications/office/flexibee/default.nix
+++ b/pkgs/applications/office/flexibee/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchurl, makeWrapper, jre }:
+
+let
+  version = "2019.2.5";
+  majorVersion = builtins.substring 0 6 version;
+in
+
+stdenv.mkDerivation rec {
+  pname = "flexibee";
+  inherit version;
+
+  src = fetchurl {
+    url = "http://download.flexibee.eu/download/${majorVersion}/${version}/${pname}-${version}.tar.gz";
+    sha256 = "0k94y4x6lj1vcb89a95v9mzl95mkpwp9n4a2gwvq0g90zpbnn493";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+    cp -R usr/share/flexibee/ $out/
+    install -Dm755 usr/bin/flexibee $out/bin/flexibee
+    wrapProgram  $out/bin/flexibee --set JAVA_HOME "${jre}"
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Client for an accouting economic system";
+    homepage = "https://www.flexibee.eu/";
+    license = licenses.unfree;
+    maintainers = [ maintainers.mmahut ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9418,6 +9418,8 @@ in
   flex_2_5_35 = callPackage ../development/tools/parsing/flex/2.5.35.nix { };
   flex = callPackage ../development/tools/parsing/flex { };
 
+  flexibee = callPackage ../applications/office/flexibee { };
+
   flexcpp = callPackage ../development/tools/parsing/flexc++ { };
 
   geis = callPackage ../development/libraries/geis {


### PR DESCRIPTION
###### Motivation for this change

flexibee: init at 2019.2.5

I had to move the share content directly into the root path, as these seems to be harded directly into the jar file itself.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).