### PR TITLE
pythonPackages.jug: 1.6.8 -> 1.6.9

### DIFF
--- a/pkgs/development/python-modules/jug/default.nix
+++ b/pkgs/development/python-modules/jug/default.nix
@@ -5,7 +5,7 @@
 
 buildPythonPackage rec {
   pname = "Jug";
-  version = "1.6.8";
+  version = "1.6.9";
   buildInputs = [ nose numpy ];
   propagatedBuildInputs = [
     bottle
@@ -16,18 +16,9 @@ buildPythonPackage rec {
     zlib
   ];
 
-  patches = [
-    # Fix numpy usage. Remove with the next release
-    (fetchpatch {
-      url = "https://github.com/luispedro/jug/commit/814405ce1553d3d2e2e96cfbeae05d63dc4f2491.patch";
-      sha256 = "1l8sssp856dmhxbnv3pzxgwgpv6rb884l0in5x7q19czwn5a4vmv";
-      excludes = [ "ChangeLog" ];
-    })
-  ];
-
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0s1l1ln9s6mi2aa132gqr789nnhdpiw057j3sp54v1sbq2cwd42p";
+    sha256 = "0193hp8ap6caw57jdch3vw0hl5m8942lxhjdsfaxk4bfb239l5kz";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Removes the need to patch the code for NumPy 1.17.0


See the discussion at https://github.com/NixOS/nixpkgs/pull/66078

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
