### PR TITLE
wpa_supplicant/gui: fix qt wrapping

### DIFF
--- a/pkgs/os-specific/linux/wpa_supplicant/gui.nix
+++ b/pkgs/os-specific/linux/wpa_supplicant/gui.nix
@@ -1,6 +1,6 @@
-{ stdenv, qtbase, qmake, inkscape, imagemagick, wpa_supplicant }:
+{ stdenv, mkDerivation, qtbase, qmake, inkscape, imagemagick, wpa_supplicant }:
 
-stdenv.mkDerivation {
+mkDerivation {
   name = "wpa_gui-${wpa_supplicant.version}";
 
   inherit (wpa_supplicant) src;


### PR DESCRIPTION
Import mkDerivation explicitly instead of using stdenv.mkDerivation, to
allow proper wrapping. See #65399

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
