### PR TITLE
ocaml-minisat: init at 0.2

### DIFF
--- a/pkgs/development/ocaml-modules/minisat/default.nix
+++ b/pkgs/development/ocaml-modules/minisat/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildDunePackage, fetchFromGitHub }:
+
+buildDunePackage rec {
+  pname = "minisat";
+  version = "0.2";
+
+  minimumOCamlVersion = "4.05";
+
+  src = fetchFromGitHub {
+    owner  = "c-cube";
+    repo   = "ocaml-minisat";
+    rev    = version;
+    sha256 = "1jibylmb1ww0x42n6wl8bdwicaysgxp0ag244x7w5m3jifq3xs6q";
+  };
+
+  meta = {
+    homepage = https://c-cube.github.io/ocaml-minisat/;
+    description = "Simple bindings to Minisat-C";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ mgttlinger ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -444,6 +444,8 @@ let
 
     mezzo = callPackage ../development/compilers/mezzo { };
 
+    minisat = callPackage ../development/ocaml-modules/minisat { };
+
     mlgmp =  callPackage ../development/ocaml-modules/mlgmp { };
 
     mlgmpidl =  callPackage ../development/ocaml-modules/mlgmpidl { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The OCaml lib for minisat was not available yet.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).