### PR TITLE
pythonPackages.wget: init at 3.2

### DIFF
--- a/pkgs/development/python-modules/wget/default.nix
+++ b/pkgs/development/python-modules/wget/default.nix
@@ -1,0 +1,22 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "wget";
+  version = "3.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "35e630eca2aa50ce998b9b1a127bb26b30dfee573702782aa982f875e3f16061";
+    extension = "zip";
+  };
+
+  meta = {
+    description = "Pure python download utility";
+    homepage = http://bitbucket.org/techtonik/python-wget/;
+    license = with lib.licenses; [ unlicense ];
+    maintainers = with lib.maintainers; [ prusnak ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6112,6 +6112,8 @@ in {
   stringcase = callPackage ../development/python-modules/stringcase { };
 
   webrtcvad = callPackage ../development/python-modules/webrtcvad { };
+
+  wget = callPackage ../development/python-modules/wget { };
 });
 
 in fix' (extends overrides packages)


### PR DESCRIPTION
###### Motivation for this change

This commit adds new package `pythonPackages.wget` - Pure python download utility.

A dependency of `pythonPackages.runway-python` in https://github.com/NixOS/nixpkgs/pull/65696

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
