### PR TITLE
Backport "Remove default value for nixpkgs.system" to release-19.03

### DIFF
--- a/nixos/modules/misc/nixpkgs.nix
+++ b/nixos/modules/misc/nixpkgs.nix
@@ -195,7 +195,6 @@ in
     system = mkOption {
       type = types.str;
       example = "i686-linux";
-      default = { system = builtins.currentSystem; };
       description = ''
         Specifies the Nix platform type on which NixOS should be built.
         It is better to specify <code>nixpkgs.localSystem</code> instead.


### PR DESCRIPTION
@edolstra, @samueldr, @sphalerite this backports https://github.com/NixOS/nixpkgs/commit/7eb332af5d6e4ed76030f84d68bb62eaca7fdac2 to `release-19.03`.

Without this, building a custom installation ISO image on MacOS results in a different derivation than when it's build on my Linux-based Hydra. Even when I set the `system` parameter of `<nixpkgs>` to "x86_64-linux".

This is happening because the `nixpkgs.system` NixOS option has the default `builtins.currentSystem` which means that the generated manual has the string "x86_64-darwin" on my system but "x86_64-linux" on Hydra.

This prevents getting the image from my nix cache.

Backporting this should be save because `nixpkgs.system` is [set to a default anyway in `/nixos/lib/eval-config.nix`](https://github.com/basvandijk/nixpkgs/blob/7c375966f0d7d6db2ae05039fc4ff960d831bc17/nixos/lib/eval-config.nix#L43).

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
