### PR TITLE
xcbuild: fix darwin build

### DIFF
--- a/pkgs/development/tools/xcbuild/default.nix
+++ b/pkgs/development/tools/xcbuild/default.nix
@@ -36,10 +36,15 @@ in stdenv.mkDerivation rec {
     cp -r --no-preserve=all ${linenoise} ThirdParty/linenoise
   '';
 
-  # Avoid a glibc >= 2.25 deprecation warning that gets fatal via -Werror.
   postPatch = stdenv.lib.optionalString (!stdenv.isDarwin) ''
+    # Avoid a glibc >= 2.25 deprecation warning that gets fatal via -Werror.
     sed 1i'#include <sys/sysmacros.h>' \
       -i Libraries/xcassets/Headers/xcassets/Slot/SystemVersion.h
+  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+    # Apple Open Sourced LZFSE, but not libcompression, and it isn't
+    # part of an impure framework we can add
+    sed '/#define HAVE_LIBCOMPRESSION 1/d' \
+      -i Libraries/libcar/Sources/Rendition.cpp
   '';
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Bumping the MacOS target version to 10.12 signalled xcbuild that libcompression is available on Darwin, but libcompression is not OSS (even though an LZFSE reference implementation is), and it is not part of a framework for us to make impure, so this patch disables it.

I can't think of a way to get these deps otherwise: `compression.h` is at `/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/compression.h` and `libcompression.dylib` is at `/usr/lib/libcompression.dylib`

###### Motivation for this change

Make it build again.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @copumpkin @matthewbauer