### PR TITLE
pythonPackages.git-revise: init at 0.4.2

### DIFF
--- a/pkgs/development/python-modules/git-revise/default.nix
+++ b/pkgs/development/python-modules/git-revise/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchPypi, buildPythonPackage
+, black, pylint, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "git-revise";
+  version = "0.4.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1mq1fh8m6jxl052d811cgpl378hiq20a8zrhdjn0i3dqmxrcb8vs";
+  };
+
+  checkInputs = [
+    black pylint pytest
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/mystor/git-revise;
+    license = [ licenses.mit ];
+    description = "A handy tool for doing efficient in-memory commit rebases & fixups";
+    maintainers = [ maintainers.mmlb ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2306,6 +2306,8 @@ in {
     inherit (pkgs.gitAndTools) git-annex;
   };
 
+  git-revise = callPackage ../development/python-modules/git-revise { };
+
   python-gitlab = callPackage ../development/python-modules/python-gitlab { };
 
   google-cloud-sdk = callPackage ../tools/admin/google-cloud-sdk { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
