### PR TITLE
tilix: 1.9.3 -> 2019-08-03

### DIFF
--- a/pkgs/applications/misc/tilix/default.nix
+++ b/pkgs/applications/misc/tilix/default.nix
@@ -1,51 +1,83 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, dmd, gnome3, dbus
-, gsettings-desktop-schemas, desktop-file-utils, gettext, gtkd, libsecret
-, glib, perlPackages, wrapGAppsHook, xdg_utils }:
+{ stdenv
+, fetchFromGitHub
+, fetchpatch
+, meson
+, ninja
+, python3
+, pkgconfig
+, dmd
+, gnome3
+, dbus
+, gsettings-desktop-schemas
+, desktop-file-utils
+, gettext
+, gtkd
+, libsecret
+, glib
+, wrapGAppsHook
+, libunwind
+}:
 
 stdenv.mkDerivation rec {
   pname = "tilix";
-  version = "1.9.3";
+  version = "unstable-2019-08-03";
 
   src = fetchFromGitHub {
     owner = "gnunn1";
     repo = "tilix";
-    rev = version;
-    sha256 = "0mg9y4xd2pnv0smibg7dyy733jarvx6qpdqap3sj7fpyni0jvpph";
+    rev = "09ec4e8e113703ca795946d8d2a83091e7b741e4";
+    sha256 = "1vvp6l25xygzhbhscg8scik8y59nl8a92ri024ijk0c0lclga05m";
   };
 
+  # Default upstream else LDC fails to link
+  mesonBuildType = [
+    "debugoptimized"
+  ];
+
   nativeBuildInputs = [
-    autoreconfHook dmd desktop-file-utils perlPackages.Po4a pkgconfig xdg_utils
+    desktop-file-utils
+    dmd
+    meson
+    ninja
+    pkgconfig
+    python3
     wrapGAppsHook
   ];
 
-  buildInputs = [ gnome3.dconf gettext gsettings-desktop-schemas gtkd dbus libsecret ];
+  buildInputs = [
+    dbus
+    gettext
+    gnome3.dconf
+    gsettings-desktop-schemas
+    gtkd
+    libsecret
+    libunwind
+  ];
 
-  preBuild = ''
-    makeFlagsArray=(
-      DCFLAGS='-O -inline -release -version=StdLoggerDisableTrace'
-    )
-  '';
+  patches = [
+    # Depends on libsecret optionally
+    # https://github.com/gnunn1/tilix/pull/1745
+    (fetchpatch {
+      url = "https://github.com/gnunn1/tilix/commit/e38dd182bfb92419d70434926ef9c0530189aab8.patch";
+      sha256 = "1ws4iyzi67crzlp9p7cw8jr752b3phcg5ymx5aj0bh6321g38kfk";
+    })
+  ];
 
-  postInstall = ''
-    ${glib.dev}/bin/glib-compile-schemas $out/share/glib-2.0/schemas
+  postPatch = ''
+    chmod +x meson_post_install.py
+    patchShebangs meson_post_install.py
   '';
 
   preFixup = ''
-    gappsWrapperArgs+=(--prefix LD_LIBRARY_PATH ":" "${libsecret}/lib")
-
     substituteInPlace $out/share/applications/com.gexperts.Tilix.desktop \
       --replace "Exec=tilix" "Exec=$out/bin/tilix"
-
-    # TODO: Won't be needed after the switch to Meson
-    substituteInPlace $out/share/dbus-1/services/com.gexperts.Tilix.service \
-     --replace "/usr/bin/tilix" "$out/bin/tilix"
   '';
 
   meta = with stdenv.lib; {
     description = "Tiling terminal emulator following the Gnome Human Interface Guidelines";
     homepage = https://gnunn1.github.io/tilix-web;
     license = licenses.mpl20;
-    maintainers = with maintainers; [ midchildan ];
+    maintainers = with maintainers; [ midchildan worldofpeace ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
Mainly switch to meson, this requried upstream contributions
because of various issues.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Mainly didn't want `LD_LIBRARY_PATH` to be set on the terminal since
it introduces an impurity.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
