### PR TITLE
pgsolver: init at 4.1

### DIFF
--- a/pkgs/development/ocaml-modules/pgsolver/default.nix
+++ b/pkgs/development/ocaml-modules/pgsolver/default.nix
@@ -1,0 +1,25 @@
+{ lib, fetchFromGitHub, buildOasisPackage, ounit, minisat, tcslib, ocaml-sat-solvers, num, ocaml_extlib }:
+
+buildOasisPackage rec {
+  pname = "pgsolver";
+  version = "4.1";
+
+  minimumSupportedOCamlVersion = "4.03.0";
+
+  src = fetchFromGitHub {
+    owner  = "tcsprojects";
+    repo   = "pgsolver";
+    rev    = "v${version}";
+    sha256 = "16skrn8qql9djpray25xv66rjgfl20js5wqnxyq1763nmyizyj8a";
+  };
+
+  buildInputs = [ ounit ];
+  propagatedBuildInputs = [ num tcslib ocaml_extlib ocaml-sat-solvers minisat ];
+
+  meta = {
+    homepage = https://github.com/tcsprojects/pgsolver;
+    description = "A collection of tools for generating, manipulating and - most of all - solving parity games";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ mgttlinger ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -577,6 +577,8 @@ let
 
     ounit = callPackage ../development/ocaml-modules/ounit { };
 
+    pgsolver = callPackage ../development/ocaml-modules/pgsolver { };
+
     piqi = callPackage ../development/ocaml-modules/piqi {
       base64 = base64_2;
     };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

New package for nixpkgs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).