### PR TITLE
hedgewars: 0.9.25 -> 1.0.0-beta1

### DIFF
--- a/pkgs/games/hedgewars/default.nix
+++ b/pkgs/games/hedgewars/default.nix
@@ -1,20 +1,21 @@
 { SDL2_image, SDL2_ttf, SDL2_net, fpc, qt5, ghcWithPackages, ffmpeg, freeglut
-, stdenv, makeWrapper, fetchurl, cmake, pkgconfig, lua5_1, SDL2, SDL2_mixer
+, stdenv, makeWrapper, fetchhg, cmake, pkgconfig, lua5_1, SDL2, SDL2_mixer
 , zlib, libpng, libGLU_combined, physfs
 }:
 
 let
   ghc = ghcWithPackages (pkgs: with pkgs; [
-          network vector utf8-string /* broken: bytestring-show */ random hslogger
+          network vector utf8-string bytestring random hslogger
           SHA entropy pkgs.zlib sandi regex-tdfa
         ]);
 in
 stdenv.mkDerivation rec {
-  version = "0.9.25";
+  version = "1.0.0-beta1";
   name = "hedgewars-${version}";
-  src = fetchurl {
-    url = "https://www.hedgewars.org/download/releases/hedgewars-src-${version}.tar.bz2";
-    sha256 = "08x7fqpy0hpnbfq2k06g522xayi7s53bca819zfhalvqnqs76pdk";
+  src = fetchhg {
+    url = "https://hg.hedgewars.org/hedgewars/";
+    rev = "7ab5cf405686";
+    sha256 = "1yrspi82ym5zpavka4cv0vh86g3i2mbbg8ccfcsid4f38lgbb9y4";
   };
 
   nativeBuildInputs = [ pkgconfig ];
@@ -75,6 +76,5 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ kragniz fpletz ];
     platforms = ghc.meta.platforms;
     hydraPlatforms = [];
-    broken = true;  # depends on broken Haskell package bytestring-show
   };
 }


### PR DESCRIPTION
- unbreak build by bumping version to latest beta as that
removes the broken `bytestring-show` dependency

- beta needs to be fetched from Mercurial repo

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Hedgewars is currently broken due to depending on the abandoned and broken `bytestring-show` package.
In the latest [1.0.0 Beta 1](https://www.hedgewars.org/node/8962) release that dependency has been removed.
So I figure having a working beta version in nixpkgs to be better than having a broken stable release.

Please also backport to release-19.03, I've tested it successfully on stable. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @fpletz @kragniz 
