### PR TITLE
roon-server: disable DynamicUser

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -340,6 +340,7 @@
       cockroachdb = 313;
       zoneminder = 314;
       paperless = 315;
+      roon-server = 316;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -640,6 +641,7 @@
       cockroachdb = 313;
       zoneminder = 314;
       paperless = 315;
+      roon-server = 316;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -340,7 +340,6 @@
       cockroachdb = 313;
       zoneminder = 314;
       paperless = 315;
-      roon-server = 316;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -641,7 +640,6 @@
       cockroachdb = 313;
       zoneminder = 314;
       paperless = 315;
-      roon-server = 316;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/services/audio/roon-server.nix
+++ b/nixos/modules/services/audio/roon-server.nix
@@ -63,6 +63,7 @@ in {
     };
     users.users = singleton {
       name = cfg.user;
+      isSystemUser = true;
       description = "Roon Server user";
       groups = [ cfg.group "audio" ];
     };

--- a/nixos/modules/services/audio/roon-server.nix
+++ b/nixos/modules/services/audio/roon-server.nix
@@ -48,6 +48,7 @@ in {
         ExecStart = "${pkgs.roon-server}/opt/start.sh";
         LimitNOFILE = 8192;
         User = cfg.user;
+        Group = cfg.group;
       };
     };
     
@@ -58,14 +59,14 @@ in {
       allowedUDPPorts = [ 9003 ];
     };
 
-    users.groups = singleton {
-      name = cfg.group;
-    };
-    users.users = singleton {
-      name = cfg.user;
-      isSystemUser = true;
-      description = "Roon Server user";
-      groups = [ cfg.group "audio" ];
-    };
+    
+    users.groups."${cfg.group}" = {};
+    users.users."${cfg.user}" =
+      if cfg.user == "roon-server" then {
+        isSystemUser = true;
+        description = "Roon Server user";
+        groups = [ cfg.group "audio" ];
+      }
+      else {};
   };
 }

--- a/nixos/modules/services/audio/roon-server.nix
+++ b/nixos/modules/services/audio/roon-server.nix
@@ -60,12 +60,10 @@ in {
 
     users.groups = singleton {
       name = cfg.group;
-      gid = config.ids.gids.roon-server;
     };
     users.users = singleton {
       name = cfg.user;
       description = "Roon Server user";
-      uid = config.ids.uids.roon-server;
       groups = [ cfg.group "audio" ];
     };
   };

--- a/nixos/modules/services/audio/roon-server.nix
+++ b/nixos/modules/services/audio/roon-server.nix
@@ -33,9 +33,7 @@ in {
       serviceConfig = {
         ExecStart = "${pkgs.roon-server}/opt/start.sh";
         LimitNOFILE = 8192;
-        DynamicUser = true;
         SupplementaryGroups = "audio";
-        StateDirectory = name;
       };
     };
     

--- a/nixos/modules/services/audio/roon-server.nix
+++ b/nixos/modules/services/audio/roon-server.nix
@@ -20,14 +20,14 @@ in {
         '';
       };
       user = mkOption {
-        type = types.string;
+        type = types.str;
         default = "roon-server";
         description = ''
           User to run the Roon Server as.
         '';
       };
       group = mkOption {
-        type = types.string;
+        type = types.str;
         default = "roon-server";
         description = ''
           Group to run the Roon Server as.

--- a/nixos/modules/services/audio/roon-server.nix
+++ b/nixos/modules/services/audio/roon-server.nix
@@ -19,6 +19,20 @@ in {
           TCP: 9100 - 9200
         '';
       };
+      user = mkOption {
+        type = types.string;
+        default = "roon-server";
+        description = ''
+          User to run the Roon Server as.
+        '';
+      };
+      group = mkOption {
+        type = types.string;
+        default = "roon-server";
+        description = ''
+          Group to run the Roon Server as.
+        '';
+      };
     };
   };
 
@@ -33,7 +47,7 @@ in {
       serviceConfig = {
         ExecStart = "${pkgs.roon-server}/opt/start.sh";
         LimitNOFILE = 8192;
-        SupplementaryGroups = "audio";
+        User = cfg.user;
       };
     };
     
@@ -42,6 +56,17 @@ in {
         { from = 9100; to = 9200; }
       ];
       allowedUDPPorts = [ 9003 ];
+    };
+
+    users.groups = singleton {
+      name = cfg.group;
+      gid = config.ids.gids.roon-server;
+    };
+    users.users = singleton {
+      name = cfg.user;
+      description = "Roon Server user";
+      uid = config.ids.uids.roon-server;
+      groups = [ cfg.group "audio" ];
     };
   };
 }

--- a/nixos/modules/services/audio/roon-server.nix
+++ b/nixos/modules/services/audio/roon-server.nix
@@ -49,6 +49,7 @@ in {
         LimitNOFILE = 8192;
         User = cfg.user;
         Group = cfg.group;
+        StateDirectory = name;
       };
     };
     


### PR DESCRIPTION
###### Motivation for this change
DynamicUser currently breaks the backup functionality provided by roon,
as the roon server cannot write to non-canonical directories and the
recycled UIDs/GIDs would make managing permissions for the directory
impossible. On top of that, it would break the ability to manage the
local music library files (as it would not be able to delete them).

###### Things done


- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).