### PR TITLE
opencv: dont try cuda on 32 bit

### DIFF
--- a/pkgs/development/libraries/opencv/3.x.nix
+++ b/pkgs/development/libraries/opencv/3.x.nix
@@ -14,7 +14,8 @@
 , enableOpenblas  ? true, openblas
 , enableContrib   ? true
 
-, enableCuda      ? config.cudaSupport or false, cudatoolkit
+, enableCuda      ? (config.cudaSupport or false) &&
+                    stdenv.hostPlatform.isx86_64, cudatoolkit
 
 , enableUnfree    ? false
 , enableIpp       ? false

--- a/pkgs/development/libraries/opencv/4.x.nix
+++ b/pkgs/development/libraries/opencv/4.x.nix
@@ -14,7 +14,8 @@
 , enableOpenblas  ? true, openblas
 , enableContrib   ? true
 
-, enableCuda      ? config.cudaSupport or false, cudatoolkit
+, enableCuda      ? (config.cudaSupport or false) &&
+                    stdenv.hostPlatform.isx86_64, cudatoolkit
 
 , enableUnfree    ? false
 , enableIpp       ? false


### PR DESCRIPTION
config.cudaSupport can be true and cudatoolkit doesn't work with i686,
which can happen inside pkgsi686Linux wrapping.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

`enableCuda` is dependent on a global `config.cudaSupport` flag, but the pulled cudatoolkit only works with x86_64.
This is incompatible as a dependency via wine (defaulting to pkgsi686Linux wrapping) -> gstreamer (plugins bad) -> opencv.

This should rebuild nothing unless it's already broken, so it's probably somewhat safe.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
