### PR TITLE
🐉🔥💀 (draft) (WIP) wireguard: allow whole-internet VPN configuration (do not merge) 💀🔥🐉

### DIFF
--- a/nixos/modules/services/networking/wireguard.nix
+++ b/nixos/modules/services/networking/wireguard.nix
@@ -342,8 +342,8 @@ let
 
         postStop = ''
           ${optionalString (values.fwmark != null) ''
-            ip rule delete not fwmark "${toString values.fwmark}" table "${toString values.table}"
-            ip rule delete table "${values.table}" suppress_prefixlength 0
+            ip rule delete not fwmark "${toString values.fwmark}" table "${toString values.table}" || true
+            ip rule delete table "${values.table}" suppress_prefixlength 0 || true
           ''}
           ip link del dev ${name}
           ${values.postShutdown}


### PR DESCRIPTION
Mimick wg-quick's fwmark business.

wg-quick enables loose reverse path checking, so we do the same here.

To setup a whole-internet VPN with Wireguard after this commit, on
your "client" peer, add these settings:

    networking.nameservers = [ "4.2.2.2" "4.2.2.3" ];
    networking.wireguard.wg0.fwmark = 51820;
    networking.wireguard.wg0.table = "51820";

and still on your client's configuration, set your "server" peer's
entry to:

    networking.wireguard.wg0.peers = [
      ...
      {
        ...
        allowedIPs = [ "0.0.0.0/0" ];
      }
    ];

On your server, you need:

    boot.kernel.sysctl."net.ipv4.ip_forward" = "1";

and to run (not sure how to best represent it in NixOS config):

    sudo iptables -t nat -A POSTROUTING -j MASQUERADE

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
