### PR TITLE
pythonPackages.colorcet: fix build on darwin

### DIFF
--- a/pkgs/development/python-modules/colorcet/default.nix
+++ b/pkgs/development/python-modules/colorcet/default.nix
@@ -1,4 +1,4 @@
-{ lib
+{ stdenv
 , buildPythonPackage
 , fetchPypi
 , param
@@ -35,10 +35,11 @@ buildPythonPackage rec {
     mkdir -p $HOME/.config/matplotlib
     echo "backend: ps" > $HOME/.config/matplotlib/matplotlibrc
 
-    pytest colorcet
+    # disable matplotlib tests on darwin, because it requires a framework build of Python
+    pytest ${stdenv.lib.optionalString stdenv.isDarwin "--ignore=colorcet/tests/test_matplotlib.py"} colorcet
   '';
 
-  meta = with lib; {
+  meta = with stdenv.lib; {
     description = "Collection of perceptually uniform colormaps";
     homepage = https://colorcet.pyviz.org;
     license = licenses.cc-by-40;

--- a/pkgs/development/python-modules/pytest-mpl/default.nix
+++ b/pkgs/development/python-modules/pytest-mpl/default.nix
@@ -1,4 +1,4 @@
-{ lib
+{ stdenv
 , buildPythonPackage
 , fetchPypi
 , pytest
@@ -15,6 +15,8 @@ buildPythonPackage rec {
     sha256 = "7006e63bf1ca9c50bea3d189c0f862751a16ce40bb373197b218f57af5b837c0";
   };
 
+  buildInputs = [ pytest ];
+
   propagatedBuildInputs = [
     matplotlib
     nose
@@ -24,6 +26,9 @@ buildPythonPackage rec {
     pytest
   ];
 
+  # disable tests on darwin, because it requires a framework build of Python
+  doCheck = !stdenv.isDarwin;
+
   checkPhase = ''
     export HOME=$(mktemp -d)
     mkdir -p $HOME/.config/matplotlib
@@ -32,7 +37,7 @@ buildPythonPackage rec {
     pytest
   '';
 
-  meta = with lib; {
+  meta = with stdenv.lib; {
     description = "Pytest plugin to help with testing figures output from Matplotlib";
     homepage = https://github.com/matplotlib/pytest-mpl;
     license = licenses.bsd3;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
https://github.com/NixOS/nixpkgs/pull/65696#issuecomment-519127597

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
