### PR TITLE
kdevelop, kdev-php, kdev-python: 5.3.3 -> 5.4.0

### DIFF
--- a/pkgs/applications/editors/kdevelop5/kdev-php.nix
+++ b/pkgs/applications/editors/kdevelop5/kdev-php.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "kdev-php";
-  version = "5.3.3";
+  version = "5.4.0";
 
   src = fetchurl {
     url = "https://github.com/KDE/${pname}/archive/v${version}.tar.gz";
-    sha256 = "0nn3yfbi60h7p7p1w2pvgg098qplbds79rk2iadyvhvl3sjd77wf";
+    sha256 = "1lfl8y1nmai7kp7jil8cykalw2ib0f3n47jvnz7302qsrs3lvhf2";
   };
 
   nativeBuildInputs = [ cmake extra-cmake-modules ];

--- a/pkgs/applications/editors/kdevelop5/kdev-python.nix
+++ b/pkgs/applications/editors/kdevelop5/kdev-python.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "kdev-python";
-  version = "5.3.3";
+  version = "5.4.0";
 
   src = fetchurl {
     url = "https://github.com/KDE/${pname}/archive/v${version}.tar.gz";
-    sha256 = "0bqsny2jgi6wi1cz65i2j9r1hiwna2x10mzy7vdk8bz7b4z766yg";
+    sha256 = "1bsls5gf8jcb5zmswz82x8whfqadpgcapfc8sxvpjv5yhnjknk8c";
   };
 
   cmakeFlags = [

--- a/pkgs/applications/editors/kdevelop5/kdevelop.nix
+++ b/pkgs/applications/editors/kdevelop5/kdevelop.nix
@@ -7,16 +7,13 @@
 , libksysguard, konsole, llvmPackages, makeWrapper, kpurpose, boost
 }:
 
-let
-  qtVersion = "5.${lib.versions.minor qtbase.version}";
-in
 mkDerivation rec {
   pname = "kdevelop";
-  version = "5.3.3";
+  version = "5.4.0";
 
   src = fetchurl {
     url = "mirror://kde/stable/${pname}/${version}/src/${pname}-${version}.tar.xz";
-    sha256 = "0778587qvi268ab2fgggfl40cv2swgr8q891q1paflp3m1xirpff";
+    sha256 = "0zi59xlw6facak1jfzlyviwmpjn98dmircmjyqiv3ac5xr30f0ll";
   };
 
   nativeBuildInputs = [
@@ -43,13 +40,6 @@ mkDerivation rec {
   ];
 
   dontWrapQtApps = true;
-
-  postPatch = ''
-    # FIXME: temporary until https://invent.kde.org/kde/kdevelop/merge_requests/8 is merged
-    substituteInPlace kdevplatform/language/backgroundparser/parsejob.cpp --replace \
-      'if (internalFilePath.startsWith(dataPath.canonicalPath() + QStringLiteral("/kdev"))) {' \
-      'if (internalFilePath.startsWith(dataPath.canonicalPath() + QStringLiteral("/kdev")) || localFile.startsWith(path + QStringLiteral("/kdev"))) {'
-  '';
 
   postInstall = ''
     # The kdevelop! script (shell environment) needs qdbus and kioclient5 in PATH.


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
version bump

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
