### PR TITLE
tendermint: init at 0.32.2

### DIFF
--- a/pkgs/tools/networking/tendermint/default.nix
+++ b/pkgs/tools/networking/tendermint/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, buildGoModule }:
+
+buildGoModule rec {
+  pname = "tendermint";
+  version = "0.32.2";
+
+  src = fetchFromGitHub {
+    owner = "tendermint";
+    repo = pname;
+    rev = "d70135ec71979e7588c649c80f2acea65346a99a";
+    sha256 = "062lzc1c96nwg22ql10mwjkxhq68lyak7s0id5y4f9mmj6d4rd69";
+  };
+
+  modSha256 = "0hl8ly2qx0fv9diipqkcrlaz3ncsb2h81i0ccf5gn9cmyl37x0yk";
+
+  meta = with stdenv.lib; {
+    description = "Byzantine-Fault Tolerant State Machines. Or Blockchain, for short.";
+    homepage = https://tendermint.com/;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ alexfmpe ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20703,6 +20703,8 @@ in
 
   telepathy-idle = callPackage ../applications/networking/instant-messengers/telepathy/idle {};
 
+  tendermint = callPackage ../tools/networking/tendermint {};
+
   termdown = (newScope pythonPackages) ../applications/misc/termdown { };
 
   terminal-notifier = callPackage ../applications/misc/terminal-notifier {};


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
