### PR TITLE
pythonPackages.jsonschema: 2.6.0 -> 3.0.2

### DIFF
--- a/pkgs/development/python-modules/jsonschema/default.nix
+++ b/pkgs/development/python-modules/jsonschema/default.nix
@@ -1,25 +1,30 @@
-{ stdenv, buildPythonPackage, fetchPypi, python
-, nose, mock, vcversioner, functools32 }:
+{ stdenv, buildPythonPackage, fetchPypi, python, pythonOlder
+, attrs, pyrsistent, six, functools32, twisted }:
 
 buildPythonPackage rec {
   pname = "jsonschema";
-  version = "2.6.0";
+  version = "3.0.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "00kf3zmpp9ya4sydffpifn0j0mzm342a2vzh82p6r0vh10cg7xbg";
+    sha256 = "8d4a2b7b6c2237e0199c8ea1a6d3e05bf118e289ae2b9d7ba444182a2959560d";
   };
 
-  checkInputs = [ nose mock vcversioner ];
-  propagatedBuildInputs = [ functools32 ];
-
-  postPatch = ''
-    substituteInPlace jsonschema/tests/test_jsonschema_test_suite.py \
-      --replace "python" "${python.pythonForBuild.interpreter}"
-  '';
+  checkInputs = [ twisted ];
+  propagatedBuildInputs =
+    [ attrs pyrsistent six ]
+    ++ stdenv.lib.optional (pythonOlder "3") functools32;
 
   checkPhase = ''
-    nosetests
+    # jsonschema.tests.test_cli fails, and I don't know how to skip tests with
+    # twisted. So we list all the other ones.
+    python -m twisted.trial \
+      jsonschema.tests.test_exceptions \
+      jsonschema.tests.test_format \
+      jsonschema.tests.test_jsonschema_test_suite \
+      jsonschema.tests.test_types \
+      jsonschema.tests.test_validators
+    python -m doctest README.rst
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update `jsonschema` to the latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @domenkozar 
