### PR TITLE
qtpass: use qt5's mkDerivation

### DIFF
--- a/pkgs/applications/misc/qtpass/default.nix
+++ b/pkgs/applications/misc/qtpass/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, git, gnupg, pass, qtbase, qtsvg, qttools, qmake, makeWrapper }:
+{ stdenv, mkDerivation, fetchFromGitHub, git, gnupg, pass, qtbase, qtsvg, qttools, qmake, makeWrapper }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "qtpass";
   version = "1.2.3";
 
@@ -17,13 +17,15 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  qtWrapperArgs = [
+    "--suffix PATH : ${git}/bin"
+    "--suffix PATH : ${gnupg}/bin"
+    "--suffix PATH : ${pass}/bin"
+  ];
+
   postInstall = ''
     install -D qtpass.desktop $out/share/applications/qtpass.desktop
     install -D artwork/icon.svg $out/share/icons/hicolor/scalable/apps/qtpass-icon.svg
-    wrapProgram $out/bin/qtpass \
-      --suffix PATH : ${git}/bin \
-      --suffix PATH : ${gnupg}/bin \
-      --suffix PATH : ${pass}/bin
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

See #65399

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @hrdinka
