### PR TITLE
android: add missing arguments to `emulateApp` function

### DIFF
--- a/pkgs/development/mobile/androidenv/emulate-app.nix
+++ b/pkgs/development/mobile/androidenv/emulate-app.nix
@@ -1,6 +1,12 @@
 { composeAndroidPackages, stdenv, lib }:
 { name, app ? null
-, platformVersion ? "16", abiVersion ? "armeabi-v7a", systemImageType ? "default"
+, platformVersion ? "16"
+, abiVersion ? "armeabi-v7a"
+, systemImageType ? "default"
+, useGoogleAPIs ? false
+, includeExtras ? []
+, platformToolsVersion ? "28.0.1"
+, emulatorVersion ? "28.0.14"
 , enableGPU ? false, extraAVDFiles ? []
 , package ? null, activity ? null
 , avdHomeDir ? null, sdkExtraArgs ? {}
@@ -8,6 +14,7 @@
 
 let
   sdkArgs = {
+    inherit useGoogleAPIs includeExtras platformToolsVersion emulatorVersion;
     platformVersions = [ platformVersion ];
     includeEmulator = true;
     includeSystemImages = true;


### PR DESCRIPTION
###### Motivation for this change
The `emulateApp` function in `androidenv` was missing some arguments, that are subsequently passed to `composeAndroidPackages`.

I added:

- includeExtras
- platformToolsVersion
- emulatorVersion

Also the `useGoogleAPIs` argument was there, but not used, so I fixed that as well.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @svanderburg 
