### PR TITLE
golden-cheetah: use qt5's mkDerivation

### DIFF
--- a/pkgs/applications/misc/golden-cheetah/default.nix
+++ b/pkgs/applications/misc/golden-cheetah/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl
+{ stdenv, mkDerivation, fetchurl
 , qtbase, qtsvg, qtserialport, qtwebkit, qtmultimedia, qttools, qtconnectivity
 , yacc, flex, zlib, qmake, makeDesktopItem, makeWrapper
 }:
@@ -13,7 +13,7 @@ let
     comment = "Performance software for cyclists, runners and triathletes";
     categories = "Application;Utility;";
   };
-in stdenv.mkDerivation rec {
+in mkDerivation rec {
   name = "golden-cheetah-${version}";
   version = "3.4";
   src = fetchurl {
@@ -29,6 +29,9 @@ in stdenv.mkDerivation rec {
   NIX_LDFLAGS = [
     "-lz"
   ];
+
+  qtWrapperArgs = [ "--set LD_LIBRARY_PATH ${zlib.out}/lib" ];
+
   preConfigure = ''
     cp src/gcconfig.pri.in src/gcconfig.pri
     cp qwt/qwtconfig.pri.in qwt/qwtconfig.pri
@@ -40,7 +43,6 @@ in stdenv.mkDerivation rec {
 
     mkdir -p $out/bin
     cp src/GoldenCheetah $out/bin
-    wrapProgram $out/bin/GoldenCheetah --set LD_LIBRARY_PATH "${zlib.out}/lib"
     install -Dm644 "${desktopItem}/share/applications/"* -t $out/share/applications/
     install -Dm644 src/Resources/images/gc.png $out/share/pixmaps/goldencheetah.png
 


### PR DESCRIPTION
###### Motivation for this change

See #65399

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @ocharles
