### PR TITLE
notepadqq: use qt5's mkDerivation

### DIFF
--- a/pkgs/applications/editors/notepadqq/default.nix
+++ b/pkgs/applications/editors/notepadqq/default.nix
@@ -1,9 +1,8 @@
-{ stdenv, fetchFromGitHub, pkgconfig, which, qtbase, qtsvg, qttools, qtwebkit}:
+{ mkDerivation, lib, fetchFromGitHub, pkgconfig, which, qtbase, qtsvg, qttools, qtwebkit }:
 
-let
+mkDerivation rec {
+  pname = "notepadqq";
   version = "1.4.8";
-in stdenv.mkDerivation {
-  name = "notepadqq-${version}";
   src = fetchFromGitHub {
     owner = "notepadqq";
     repo = "notepadqq";
@@ -24,13 +23,19 @@ in stdenv.mkDerivation {
     export LRELEASE="lrelease"
   '';
 
+  dontWrapQtApps = true;
+
+  preFixup = ''
+    wrapQtApp $out/bin/notepadqq
+  '';
+
   enableParallelBuilding = true;
 
-  meta = {
+  meta = with lib; {
     homepage = https://notepadqq.com/;
     description = "Notepad++-like editor for the Linux desktop";
-    license = stdenv.lib.licenses.gpl3;
-    platforms = stdenv.lib.platforms.linux;
-    maintainers = with stdenv.lib.maintainers; [ rszibele ];
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.rszibele ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
See #65399

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @rszibele 
