### PR TITLE
doc/qt: add note about wrapQtAppsHook ignoring scripts

### DIFF
--- a/doc/languages-frameworks/qt.xml
+++ b/doc/languages-frameworks/qt.xml
@@ -113,6 +113,15 @@ mkDerivation {
 </programlisting>
  </para>
 
+ <note>
+  <para>
+    <literal>wrapQtAppsHook</literal> ignores files that are non-ELF executables.
+    This means that scripts won't be automatically wrapped so you'll need to manually
+    wrap them as previously mentioned. An example of when you'd always need to do this
+    is with Python applications that use PyQT.
+  </para>
+ </note>
+
  <para>
   Libraries are built with every available version of Qt. Use the <literal>meta.broken</literal>
   attribute to disable the package for unsupported Qt versions:


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
This should be documented while we have to do this.

###### Screenshot
Before:
![Screenshot from 2019-08-08 09 05 04](https://user-images.githubusercontent.com/28888242/62705592-ab91e900-b9bb-11e9-90a5-e31fd24ccd5e.png)



After:
![Screenshot from 2019-08-08 09 00 40](https://user-images.githubusercontent.com/28888242/62705440-68d01100-b9bb-11e9-821f-a9822f4f1490.png)


###### Things done

I've build the manual.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
