### PR TITLE
pythonPackages.gtimelog: 0.9.1 -> unstable-2020-05-16

### DIFF
--- a/pkgs/development/python-modules/gtimelog/default.nix
+++ b/pkgs/development/python-modules/gtimelog/default.nix
@@ -1,43 +1,60 @@
-{ stdenv
-, buildPythonPackage
-, pkgs
-, python
-, pygobject3
+{ stdenv, fetchFromGitHub, makeWrapper
+, glibcLocales, gobject-introspection, gtk3, libsoup, libsecret
+, buildPythonPackage, python
+, pygobject3, freezegun, mock
 }:
 
 buildPythonPackage rec {
   pname = "gtimelog";
-  version = "0.9.1";
+  version = "unstable-2020-05-16";
 
-  src = pkgs.fetchurl {
-    url = "https://github.com/gtimelog/gtimelog/archive/${version}.tar.gz";
-    sha256 = "0qk8fv8cszzqpdi3wl9vvkym1jil502ycn6sic4jrxckw5s9jsfj";
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "80682ddbf9e0d68b8c67257289784f3b49b543d8";
+    sha256 = "0qv2kv7vc3qqlzxsisgg31cmrkkqgnmxspbj10c5fhdmwzzwi0i9";
   };
 
-  buildInputs = [ pkgs.glibcLocales ];
+  buildInputs = [
+    makeWrapper
+    glibcLocales gobject-introspection gtk3 libsoup libsecret
+  ];
 
-  LC_ALL="en_US.UTF-8";
-
-  # TODO: AppIndicator
-  propagatedBuildInputs = [ pkgs.gobject-introspection pygobject3 pkgs.makeWrapper pkgs.gtk3 ];
+  propagatedBuildInputs = [
+    pygobject3 freezegun mock
+  ];
 
   checkPhase = ''
-    substituteInPlace runtests --replace "/usr/bin/env python" "${python}/bin/${python.executable}"
+    substituteInPlace runtests --replace "/usr/bin/env python3" "${python.interpreter}"
     ./runtests
   '';
 
+  pythonImportsCheck = [ "gtimelog" ];
+
   preFixup = ''
-      wrapProgram $out/bin/gtimelog \
-        --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH" \
-        --prefix LD_LIBRARY_PATH ":" "${pkgs.gtk3.out}/lib" \
+    wrapProgram $out/bin/gtimelog \
+      --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH" \
+      --prefix LD_LIBRARY_PATH ":" "${gtk3.out}/lib" \
   '';
 
   meta = with stdenv.lib; {
-    description = "A small GTK app for keeping track of your time. It's main goal is to be as unintrusive as possible";
-    homepage = "https://mg.pov.lt/gtimelog/";
+    description = "A time tracking app";
+    longDescription = ''
+      GTimeLog is a small time tracking application for GNOME.
+      It's main goal is to be as unintrusive as possible.
+
+      To run gtimelog successfully on a system that does not have full GNOME 3
+      installed, the following NixOS options should be set:
+      - programs.dconf.enable = true;
+      - services.gnome3.gnome-keyring.enable = true;
+
+      In addition, the following packages should be added to the environment:
+      - gnome3.adwaita-icon-theme
+      - gnome3.dconf
+    '';
+    homepage = "https://gtimelog.org/";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ ocharles ];
+    maintainers = with maintainers; [ ocharles oxzi ];
     platforms = platforms.unix;
   };
-
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
The content of this PR is the update of the gtimelog package.

Here it was updated from the outdated 0.9.1 version to the current HEAD, because the last release is a bit old and in the meantime SMTP support has been added. As soon as the next stable version is released, I would again set a release as a version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @ocharles 
