### PR TITLE
ocamlPackages.zarith: enable for OCaml 4.08

### DIFF
--- a/pkgs/development/ocaml-modules/zarith/default.nix
+++ b/pkgs/development/ocaml-modules/zarith/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildOcaml, fetchurl
+{ stdenv, fetchurl
 , ocaml, findlib, pkgconfig, perl
 , gmp
 }:
@@ -16,31 +16,27 @@ let source =
   };
 in
 
-buildOcaml rec {
-  name = "zarith";
+stdenv.mkDerivation rec {
+  name = "ocaml${ocaml.version}-zarith-${version}";
   inherit (source) version;
   src = fetchurl { inherit (source) url sha256; };
-
-  minimumSupportedOcamlVersion = "3.12.1";
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ ocaml findlib perl ];
   propagatedBuildInputs = [ gmp ];
 
-  # needed so setup-hook.sh sets CAML_LD_LIBRARY_PATH for dllzarith.so
-  hasSharedObjects = true;
-
   patchPhase = "patchShebangs ./z_pp.pl";
   configurePhase = ''
     ./configure -installdir $out/lib/ocaml/${ocaml.version}/site-lib
   '';
-  preInstall = "mkdir -p $out/lib/ocaml/${ocaml.version}/site-lib";
+
+  preInstall = "mkdir -p $out/lib/ocaml/${ocaml.version}/site-lib/stublibs";
 
   meta = with stdenv.lib; {
     description = "Fast, arbitrary precision OCaml integers";
     homepage    = "http://forge.ocamlcore.org/projects/zarith";
     license     = licenses.lgpl2;
-    platforms   = ocaml.meta.platforms or [];
+    inherit (ocaml.meta) platforms;
     maintainers = with maintainers; [ thoughtpolice vbgl ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Current derivation does not work for OCaml 4.08.

cc #65632 

I’ve successfully built lem and sail after this change: the findlib hook correctly sets the CAML_LD_LIBRARY_PATH environment variable.

ping @thoughtpolice

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

