### PR TITLE
installer: Don't run as root

### DIFF
--- a/nixos/doc/manual/installation/installing.xml
+++ b/nixos/doc/manual/installation/installing.xml
@@ -29,13 +29,14 @@
   </para>
 
   <para>
-   You are logged-in automatically as <literal>root</literal>. (The
-   <literal>root</literal> user account has an empty password.)
+   You are logged-in automatically as <literal>nixos</literal>.
+   The <literal>nixos</literal> user account has an empty password so you
+   can use <command>sudo</command> without a password.
   </para>
 
   <para>
    If you downloaded the graphical ISO image, you can run <command>systemctl
-   start display-manager</command> to start KDE. If you want to continue on the
+   start display-manager</command> to start the desktop environment. If you want to continue on the
    terminal, you can use <command>loadkeys</command> to switch to your
    preferred keyboard layout. (We even provide neo2 via <command>loadkeys de
    neo</command>!)
@@ -65,9 +66,9 @@
 
    <para>
     If you would like to continue the installation from a different machine you
-    need to activate the SSH daemon via <literal>systemctl start
-    sshd</literal>. In order to be able to login you also need to set a
-    password for <literal>root</literal> using <literal>passwd</literal>.
+    need to activate the SSH daemon via <command>systemctl start
+    sshd</command>. You then must set a password for either <literal>root</literal> or
+    <literal>nixos</literal> with <command>passwd></command> to be able to login.
    </para>
   </section>
  </section>

--- a/nixos/doc/manual/release-notes/rl-1909.xml
+++ b/nixos/doc/manual/release-notes/rl-1909.xml
@@ -42,6 +42,12 @@
        set up binfmt interpreters for each of those listed systems.
      </para>
    </listitem>
+   <listitem>
+     <para>
+     The installer now uses a less privileged <literal>nixos</literal> user whereas before we logged in as root.
+     To gain root privileges use <literal>sudo -i</literal> without a password.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-base.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-base.nix
@@ -8,16 +8,30 @@ with lib;
 {
   imports = [ ./installation-cd-base.nix ];
 
+  # Whitelist wheel users to do anything
+  # This is useful for things like pkexec
+  #
+  # WARNING: this is dangerous for systems
+  # outside the installation-cd and shouldn't
+  # be used anywhere else.
+  security.polkit.extraConfig = ''
+    polkit.addRule(function(action, subject) {
+      if (subject.isInGroup("wheel")) {
+        return polkit.Result.YES;
+      }
+    });
+  '';
+
   services.xserver = {
     enable = true;
 
     # Don't start the X server by default.
     autorun = mkForce false;
 
-    # Automatically login as root.
+    # Automatically login as nixos.
     displayManager.slim = {
       enable = true;
-      defaultUser = "root";
+      defaultUser = "nixos";
       autoLogin = true;
     };
 
@@ -33,7 +47,6 @@ with lib;
 
   # Enable sound in graphical iso's.
   hardware.pulseaudio.enable = true;
-  hardware.pulseaudio.systemWide = true; # Needed since we run plasma as root.
 
   environment.systemPackages = [
     # Include gparted for partitioning disks.

--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-kde.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-kde.nix
@@ -1,5 +1,5 @@
 # This module defines a NixOS installation CD that contains X11 and
-# Plasma5.
+# Plasma 5.
 
 { config, lib, pkgs, ... }:
 
@@ -30,15 +30,20 @@ with lib;
       Version=1.0
       Type=Application
       Name=NixOS Manual
-      Exec=firefox ${config.system.build.manual.manualHTMLIndex}
+      Exec=firefox ${config.system.build.manual.manual}/share/doc/nixos/index.html
       Icon=text-html
     '';
 
+    homeDir = "/home/nixos/";
+    desktopDir = homeDir + "Desktop/";
+
   in ''
-    mkdir -p /root/Desktop
-    ln -sfT ${manualDesktopFile} /root/Desktop/nixos-manual.desktop
-    ln -sfT ${pkgs.konsole}/share/applications/org.kde.konsole.desktop /root/Desktop/org.kde.konsole.desktop
-    ln -sfT ${pkgs.gparted}/share/applications/gparted.desktop /root/Desktop/gparted.desktop
+    mkdir -p ${desktopDir}
+    chown nixos ${homeDir} ${desktopDir}
+
+    ln -sfT ${manualDesktopFile} ${desktopDir + "nixos-manual.desktop"}
+    ln -sfT ${pkgs.gparted}/share/applications/gparted.desktop ${desktopDir + "gparted.desktop"}
+    ln -sfT ${pkgs.konsole}/share/applications/org.kde.konsole.desktop ${desktopDir + "org.kde.konsole.desktop"}
   '';
 
 }

--- a/nixos/modules/profiles/installation-device.nix
+++ b/nixos/modules/profiles/installation-device.nix
@@ -32,19 +32,35 @@ with lib;
     #services.rogue.enable = true;
 
     # Disable some other stuff we don't need.
-    security.sudo.enable = mkDefault false;
     services.udisks2.enable = mkDefault false;
 
+    # Use less privileged nixos user
+    users.users.nixos = {
+      isNormalUser = true;
+      extraGroups = [ "wheel" "networkmanager" "video" ];
+      # Allow the graphical user to login without password
+      initialHashedPassword = "";
+    };
+
+    # Allow the user to log in as root without a password.
+    users.users.root.initialHashedPassword = "";
+
+    # Allow passwordless sudo from nixos user
+    security.sudo = {
+      enable = mkDefault true;
+      wheelNeedsPassword = mkForce false;
+    };
+
     # Automatically log in at the virtual consoles.
-    services.mingetty.autologinUser = "root";
+    services.mingetty.autologinUser = "nixos";
 
     # Some more help text.
     services.mingetty.helpLine =
       ''
 
-        The "root" account has an empty password.  ${
+        The "nixos" and "root" account have empty passwords.  ${
           optionalString config.services.xserver.enable
-            "Type `systemctl start display-manager' to\nstart the graphical user interface."}
+            "Type `sudo systemctl start display-manager' to\nstart the graphical user interface."}
       '';
 
     # Allow sshd to be started manually through "systemctl start sshd".
@@ -86,8 +102,5 @@ with lib;
     # because we have the firewall enabled. This makes installs from the
     # console less cumbersome if the machine has a public IP.
     networking.firewall.logRefusedConnections = mkDefault false;
-
-    # Allow the user to log in as root without a password.
-    users.users.root.initialHashedPassword = "";
   };
 }

--- a/pkgs/tools/misc/gparted/default.nix
+++ b/pkgs/tools/misc/gparted/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, intltool, gettext, makeWrapper, coreutils, gnused
+{ stdenv, fetchurl, intltool, gettext, makeWrapper, coreutils, gnused, gnome3
 , gnugrep, parted, glib, libuuid, pkgconfig, gtkmm3, libxml2, hicolor-icon-theme
 , gpart, hdparm, procps, utillinux, polkit, wrapGAppsHook, substituteAll
 }:
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [ "--disable-doc" ];
 
-  buildInputs = [ parted glib libuuid gtkmm3 libxml2 hicolor-icon-theme polkit.bin  ];
+  buildInputs = [ parted glib libuuid gtkmm3 libxml2 hicolor-icon-theme polkit.bin gnome3.adwaita-icon-theme  ];
   nativeBuildInputs = [ intltool gettext pkgconfig wrapGAppsHook ];
 
   preFixup = ''

--- a/pkgs/tools/misc/gparted/default.nix
+++ b/pkgs/tools/misc/gparted/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, intltool, gettext, makeWrapper
-, parted, glib, libuuid, pkgconfig, gtkmm3, libxml2, hicolor-icon-theme
-, gpart, hdparm, procps, utillinux
+{ stdenv, fetchurl, intltool, gettext, makeWrapper, coreutils, gnused
+, gnugrep, parted, glib, libuuid, pkgconfig, gtkmm3, libxml2, hicolor-icon-theme
+, gpart, hdparm, procps, utillinux, polkit, wrapGAppsHook, substituteAll
 }:
 
 stdenv.mkDerivation rec {
@@ -11,16 +11,31 @@ stdenv.mkDerivation rec {
     sha256 = "0mdvn85jvy72ff7nds3dakx9kzknh8gx1z8i0w2sf970q03qp2z4";
   };
 
+  # Tries to run `pkexec --version` to get version.
+  # however the binary won't be suid so it returns
+  # an error preventing the program from detection
+  patches = [
+    (substituteAll {
+      src = ./polkit.patch;
+      polkit_version = polkit.version;
+    })
+  ];
+
   configureFlags = [ "--disable-doc" ];
 
-  buildInputs = [ parted glib libuuid gtkmm3 libxml2 hicolor-icon-theme ];
-  nativeBuildInputs = [ intltool gettext makeWrapper pkgconfig ];
+  buildInputs = [ parted glib libuuid gtkmm3 libxml2 hicolor-icon-theme polkit.bin  ];
+  nativeBuildInputs = [ intltool gettext pkgconfig wrapGAppsHook ];
 
+  preFixup = ''
+    gappsWrapperArgs+=(
+       --prefix PATH : "${stdenv.lib.makeBinPath [ gpart hdparm utillinux procps coreutils gnused gnugrep ]}"
+    )
+  '';
+
+  # Doesn't get installed automaticallly if PREFIX != /usr
   postInstall = ''
-    wrapProgram $out/bin/gparted \
-      --prefix PATH : "${procps}/bin"
-    wrapProgram $out/sbin/gpartedbin \
-      --prefix PATH : "${stdenv.lib.makeBinPath [ gpart hdparm utillinux ]}"
+    install -D -m0644 org.gnome.gparted.policy \
+      $out/share/polkit-1/actions/org.gnome.gparted.policy
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/misc/gparted/polkit.patch
+++ b/pkgs/tools/misc/gparted/polkit.patch
@@ -1,0 +1,12 @@
+diff -ru old/gparted-1.0.0/configure gparted-1.0.0/configure
+--- old/gparted-1.0.0/configure	2019-05-29 12:02:13.000000000 -0400
++++ gparted-1.0.0/configure	2019-08-08 18:09:52.792795781 -0400
+@@ -16145,7 +16145,7 @@
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for pkexec >= $PKEXEC_REQUIRED_VERSION" >&5
+ $as_echo_n "checking for pkexec >= $PKEXEC_REQUIRED_VERSION... " >&6; }
+ PKEXEC_REQUIRED_INT=`echo "$PKEXEC_REQUIRED_VERSION" | $AWK -F. '{print $1 * 10000 + $2}'`
+-PKEXEC_VERSION_OUTPUT=`pkexec --version 2> /dev/null` ||
++PKEXEC_VERSION_OUTPUT='pkexec version @polkit_version@' ||
+ 	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: not found" >&5
+ $as_echo "not found" >&6; }
+ if test "x$PKEXEC_VERSION_OUTPUT" != 'x'; then


### PR DESCRIPTION
###### Motivation for this change

There's many reason why it is and is going to
continue to be difficult to do this:

1. All display-managers (excluding slim) default PAM rules
   disallow root auto login.

2. We can't use wayland

3. We have to use system-wide pulseaudio

4. It could break applications in the session.
   This happened to dolphin in plasma5
   in the past.

This is a growing technical debt, let's just use
passwordless sudo.

---

This is a per-requisite to having a GNOME3 iso.
Broken up from #66313

I've supplied all the requested changes to what was raised on this commit.
In particular  https://github.com/NixOS/nixpkgs/pull/66313#pullrequestreview-272620860.


###### Things done

I've built `iso_minimal` and it auto logs in as `live` when tested
in qemu.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
