### PR TITLE
gnss-sdr: 0.0.9 -> 0.0.11

### DIFF
--- a/pkgs/applications/radio/gnss-sdr/default.nix
+++ b/pkgs/applications/radio/gnss-sdr/default.nix
@@ -11,17 +11,22 @@
 , pkgconfig
 , pythonPackages
 , uhd
+, log4cpp
+, openblas
+, matio
+, pugixml
+, protobuf
 }:
 
 stdenv.mkDerivation rec {
   name = "gnss-sdr-${version}";
-  version = "0.0.9";
+  version = "0.0.11";
 
   src = fetchFromGitHub {
     owner = "gnss-sdr";
     repo = "gnss-sdr";
     rev = "v${version}";
-    sha256 = "0gis932ly3vk7d5qvznffp54pkmbw3m6v60mxjfdj5dd3r7vf975";
+    sha256 = "0ajj0wx68yyzigppxxa1wag3hzkrjj8dqq8k28rj0jhp8a6bw2q7";
   };
 
   buildInputs = [
@@ -40,6 +45,11 @@ stdenv.mkDerivation rec {
     # UHD support is optional, but gnuradio is built with it, so there's
     # nothing to be gained by leaving it out.
     uhd
+    log4cpp
+    openblas
+    matio
+    pugixml
+    protobuf
   ];
 
   enableParallelBuilding = true;
@@ -53,6 +63,8 @@ stdenv.mkDerivation rec {
     # armadillo is built using both, so skip checking for them.
     "-DBLAS=YES"
     "-DLAPACK=YES"
+    "-DBLAS_LIBRARIES=-lopenblas"
+    "-DLAPACK_LIBRARIES=-lopenblas"
 
     # Similarly, it doesn't actually use gfortran despite checking for
     # its presence.


### PR DESCRIPTION
###### Motivation for this change
Update and un-break. Closes https://github.com/NixOS/nixpkgs/pull/62704.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers


