### PR TITLE
Properly deprecate types.string

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -217,7 +217,8 @@ rec {
 
     # Deprecated; should not be used because it quietly concatenates
     # strings, which is usually not what you want.
-    string = separatedString "";
+    string = warn "types.string is deprecated because it quietly concatenates strings"
+      (separatedString "");
 
     attrs = mkOptionType {
       name = "attrs";

--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -181,7 +181,7 @@ let
       };
 
       hashedPassword = mkOption {
-        type = with types; uniq (nullOr str);
+        type = with types; nullOr str;
         default = null;
         description = ''
           Specifies the hashed password for the user.
@@ -191,7 +191,7 @@ let
       };
 
       password = mkOption {
-        type = with types; uniq (nullOr str);
+        type = with types; nullOr str;
         default = null;
         description = ''
           Specifies the (clear text) password for the user.
@@ -203,7 +203,7 @@ let
       };
 
       passwordFile = mkOption {
-        type = with types; uniq (nullOr string);
+        type = with types; nullOr str;
         default = null;
         description = ''
           The full path to a file that contains the user's password. The password
@@ -215,7 +215,7 @@ let
       };
 
       initialHashedPassword = mkOption {
-        type = with types; uniq (nullOr str);
+        type = with types; nullOr str;
         default = null;
         description = ''
           Specifies the initial hashed password for the user, i.e. the
@@ -230,7 +230,7 @@ let
       };
 
       initialPassword = mkOption {
-        type = with types; uniq (nullOr str);
+        type = with types; nullOr str;
         default = null;
         description = ''
           Specifies the initial password for the user, i.e. the
@@ -304,7 +304,7 @@ let
       };
 
       members = mkOption {
-        type = with types; listOf string;
+        type = with types; listOf str;
         default = [];
         description = ''
           The user names of the group members, added to the

--- a/nixos/modules/hardware/video/nvidia.nix
+++ b/nixos/modules/hardware/video/nvidia.nix
@@ -88,7 +88,7 @@ in
     };
 
     hardware.nvidia.optimus_prime.nvidiaBusId = lib.mkOption {
-      type = lib.types.string;
+      type = lib.types.str;
       default = "";
       example = "PCI:1:0:0";
       description = ''
@@ -98,7 +98,7 @@ in
     };
 
     hardware.nvidia.optimus_prime.intelBusId = lib.mkOption {
-      type = lib.types.string;
+      type = lib.types.str;
       default = "";
       example = "PCI:0:2:0";
       description = ''

--- a/nixos/modules/installer/cd-dvd/sd-image.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image.nix
@@ -54,7 +54,7 @@ in
     };
 
     firmwarePartitionID = mkOption {
-      type = types.string;
+      type = types.str;
       default = "0x2178694e";
       description = ''
         Volume ID for the /boot/firmware partition on the SD card. This value
@@ -63,7 +63,7 @@ in
     };
 
     rootPartitionUUID = mkOption {
-      type = types.nullOr types.string;
+      type = types.nullOr types.str;
       default = null;
       example = "14e19a7b-0ae0-484d-9d54-43bd6fdc20c7";
       description = ''

--- a/nixos/modules/programs/thefuck.nix
+++ b/nixos/modules/programs/thefuck.nix
@@ -17,7 +17,7 @@ in
 
         alias = mkOption {
           default = "fuck";
-          type = types.string;
+          type = types.str;
 
           description = ''
             `thefuck` needs an alias to be configured.

--- a/nixos/modules/programs/xss-lock.nix
+++ b/nixos/modules/programs/xss-lock.nix
@@ -12,7 +12,7 @@ in
     lockerCommand = mkOption {
       default = "${pkgs.i3lock}/bin/i3lock";
       example = literalExample ''''${pkgs.i3lock-fancy}/bin/i3lock-fancy'';
-      type = types.string;
+      type = types.separatedString " ";
       description = "Locker to be used with xsslock";
     };
 

--- a/nixos/modules/programs/yabar.nix
+++ b/nixos/modules/programs/yabar.nix
@@ -76,7 +76,7 @@ in
             font = mkOption {
               default = "sans bold 9";
               example = "Droid Sans, FontAwesome Bold 9";
-              type = types.string;
+              type = types.str;
 
               description = ''
                 The font that will be used to draw the status bar.
@@ -95,7 +95,7 @@ in
 
             extra = mkOption {
               default = {};
-              type = types.attrsOf types.string;
+              type = types.attrsOf types.str;
 
               description = ''
                 An attribute set which contains further attributes of a bar.
@@ -107,7 +107,7 @@ in
               type = types.attrsOf(types.submodule {
                 options.exec = mkOption {
                   example = "YABAR_DATE";
-                  type = types.string;
+                  type = types.str;
                   description = ''
                      The type of the indicator to be executed.
                   '';
@@ -125,7 +125,7 @@ in
 
                 options.extra = mkOption {
                   default = {};
-                  type = types.attrsOf (types.either types.string types.int);
+                  type = types.attrsOf (types.either types.str types.int);
 
                   description = ''
                     An attribute set which contains further attributes of a indicator.

--- a/nixos/modules/programs/zsh/zsh-syntax-highlighting.nix
+++ b/nixos/modules/programs/zsh/zsh-syntax-highlighting.nix
@@ -33,7 +33,7 @@ in
 
       patterns = mkOption {
         default = {};
-        type = types.attrsOf types.string;
+        type = types.attrsOf types.str;
 
         example = literalExample ''
           {
@@ -50,7 +50,7 @@ in
       };
       styles = mkOption {
         default = {};
-        type = types.attrsOf types.string;
+        type = types.attrsOf types.str;
 
         example = literalExample ''
           {

--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -685,7 +685,7 @@ in
       };
       id = mkOption {
         example = "42";
-        type = types.string;
+        type = types.str;
         description = "client id";
       };
 

--- a/nixos/modules/security/sudo.nix
+++ b/nixos/modules/security/sudo.nix
@@ -91,7 +91,7 @@ in
       type = with types; listOf (submodule {
         options = {
           users = mkOption {
-            type = with types; listOf (either string int);
+            type = with types; listOf (either str int);
             description = ''
               The usernames / UIDs this rule should apply for.
             '';
@@ -99,7 +99,7 @@ in
           };
 
           groups = mkOption {
-            type = with types; listOf (either string int);
+            type = with types; listOf (either str int);
             description = ''
               The groups / GIDs this rule should apply for.
             '';
@@ -107,7 +107,7 @@ in
           };
 
           host = mkOption {
-            type = types.string;
+            type = types.str;
             default = "ALL";
             description = ''
               For what host this rule should apply.
@@ -115,7 +115,7 @@ in
           };
 
           runAs = mkOption {
-            type = with types; string;
+            type = with types; str;
             default = "ALL:ALL";
             description = ''
               Under which user/group the specified command is allowed to run.
@@ -130,11 +130,11 @@ in
             description = ''
               The commands for which the rule should apply.
             '';
-            type = with types; listOf (either string (submodule {
+            type = with types; listOf (either str (submodule {
 
               options = {
                 command = mkOption {
-                  type = with types; string;
+                  type = with types; str;
                   description = ''
                     A command being either just a path to a binary to allow any arguments,
                     the full command with arguments pre-set or with <code>""</code> used as the argument,

--- a/nixos/modules/services/amqp/activemq/default.nix
+++ b/nixos/modules/services/amqp/activemq/default.nix
@@ -40,7 +40,7 @@ in {
         '';
       };
       configurationURI = mkOption {
-        type = types.string;
+        type = types.str;
         default = "xbean:activemq.xml";
         description = ''
           The URI that is passed along to the BrokerFactory to
@@ -51,7 +51,7 @@ in {
         '';
       };
       baseDir = mkOption {
-        type = types.string;
+        type = types.str;
         default = "/var/activemq";
         description = ''
           The base directory where ActiveMQ stores its persistent data and logs.
@@ -81,7 +81,7 @@ in {
         '';
       };
       extraJavaOptions = mkOption {
-        type = types.string;
+        type = types.separatedString " ";
         default = "";
         example = "-Xmx2G -Xms2G -XX:MaxPermSize=512M";
         description = ''

--- a/nixos/modules/services/audio/alsa.nix
+++ b/nixos/modules/services/audio/alsa.nix
@@ -64,7 +64,7 @@ in
         };
 
         volumeStep = mkOption {
-          type = types.string;
+          type = types.str;
           default = "1";
           example = "1%";
           description = ''

--- a/nixos/modules/services/audio/ympd.nix
+++ b/nixos/modules/services/audio/ympd.nix
@@ -23,7 +23,7 @@ in {
 
       mpd = {
         host = mkOption {
-          type = types.string;
+          type = types.str;
           default = "localhost";
           description = "The host where MPD is listening.";
           example = "localhost";

--- a/nixos/modules/services/backup/postgresql-backup.nix
+++ b/nixos/modules/services/backup/postgresql-backup.nix
@@ -81,7 +81,7 @@ in {
       };
 
       pgdumpOptions = mkOption {
-        type = types.string;
+        type = types.separatedString " ";
         default = "-Cbo";
         description = ''
           Command line options for pg_dump. This options is not used

--- a/nixos/modules/services/backup/rsnapshot.nix
+++ b/nixos/modules/services/backup/rsnapshot.nix
@@ -2,7 +2,7 @@
 
 with lib;
 
-let 
+let
   cfg = config.services.rsnapshot;
   cfgfile = pkgs.writeText "rsnapshot.conf" ''
     config_version	1.2
@@ -52,7 +52,7 @@ in
       cronIntervals = mkOption {
         default = {};
         example = { hourly = "0 * * * *"; daily = "50 21 * * *"; };
-        type = types.attrsOf types.string;
+        type = types.attrsOf types.str;
         description = ''
           Periodicity at which intervals should be run by cron.
           Note that the intervals also have to exist in configuration

--- a/nixos/modules/services/databases/cassandra.nix
+++ b/nixos/modules/services/databases/cassandra.nix
@@ -259,7 +259,7 @@ in {
         '';
     };
     incrementalRepairOptions = mkOption {
-      type = types.listOf types.string;
+      type = types.listOf types.str;
       default = [];
       example = [ "--partitioner-range" ];
       description = ''
@@ -267,7 +267,7 @@ in {
         '';
     };
     maxHeapSize = mkOption {
-      type = types.nullOr types.string;
+      type = types.nullOr types.str;
       default = null;
       example = "4G";
       description = ''
@@ -287,7 +287,7 @@ in {
       '';
     };
     heapNewSize = mkOption {
-      type = types.nullOr types.string;
+      type = types.nullOr types.str;
       default = null;
       example = "800M";
       description = ''
@@ -352,11 +352,11 @@ in {
       type = types.listOf (types.submodule {
         options = {
           username = mkOption {
-            type = types.string;
+            type = types.str;
             description = "Username for JMX";
           };
           password = mkOption {
-            type = types.string;
+            type = types.str;
             description = "Password for JMX";
           };
         };

--- a/nixos/modules/services/databases/couchdb.nix
+++ b/nixos/modules/services/databases/couchdb.nix
@@ -56,7 +56,7 @@ in {
 
 
       user = mkOption {
-        type = types.string;
+        type = types.str;
         default = "couchdb";
         description = ''
           User account under which couchdb runs.
@@ -64,7 +64,7 @@ in {
       };
 
       group = mkOption {
-        type = types.string;
+        type = types.str;
         default = "couchdb";
         description = ''
           Group account under which couchdb runs.
@@ -106,7 +106,7 @@ in {
       };
 
       bindAddress = mkOption {
-        type = types.string;
+        type = types.str;
         default = "127.0.0.1";
         description = ''
           Defines the IP address by which CouchDB will be accessible.
@@ -138,7 +138,7 @@ in {
       };
 
       configFile = mkOption {
-        type = types.string;
+        type = types.path;
         description = ''
           Configuration file for persisting runtime changes. File
           needs to be readable and writable from couchdb user/group.

--- a/nixos/modules/services/databases/foundationdb.nix
+++ b/nixos/modules/services/databases/foundationdb.nix
@@ -140,7 +140,7 @@ in
     };
 
     logSize = mkOption {
-      type        = types.string;
+      type        = types.str;
       default     = "10MiB";
       description = ''
         Roll over to a new log file after the current log file
@@ -149,7 +149,7 @@ in
     };
 
     maxLogSize = mkOption {
-      type        = types.string;
+      type        = types.str;
       default     = "100MiB";
       description = ''
         Delete the oldest log file when the total size of all log
@@ -171,7 +171,7 @@ in
     };
 
     memory = mkOption {
-      type        = types.string;
+      type        = types.str;
       default     = "8GiB";
       description = ''
         Maximum memory used by the process. The default value is
@@ -193,7 +193,7 @@ in
     };
 
     storageMemory = mkOption {
-      type        = types.string;
+      type        = types.str;
       default     = "1GiB";
       description = ''
         Maximum memory used for data storage. The default value is

--- a/nixos/modules/services/databases/hbase.nix
+++ b/nixos/modules/services/databases/hbase.nix
@@ -53,7 +53,7 @@ in {
 
 
       user = mkOption {
-        type = types.string;
+        type = types.str;
         default = "hbase";
         description = ''
           User account under which HBase runs.
@@ -61,7 +61,7 @@ in {
       };
 
       group = mkOption {
-        type = types.string;
+        type = types.str;
         default = "hbase";
         description = ''
           Group account under which HBase runs.

--- a/nixos/modules/services/databases/influxdb.nix
+++ b/nixos/modules/services/databases/influxdb.nix
@@ -129,13 +129,13 @@ in
       user = mkOption {
         default = "influxdb";
         description = "User account under which influxdb runs";
-        type = types.string;
+        type = types.str;
       };
 
       group = mkOption {
         default = "influxdb";
         description = "Group under which influxdb runs";
-        type = types.string;
+        type = types.str;
       };
 
       dataDir = mkOption {

--- a/nixos/modules/services/databases/mongodb.nix
+++ b/nixos/modules/services/databases/mongodb.nix
@@ -65,9 +65,9 @@ in
         default = false;
         description = "Enable client authentication. Creates a default superuser with username root!";
       };
-      
+
       initialRootPassword = mkOption {
-        type = types.nullOr types.string;
+        type = types.nullOr types.str;
         default = null;
         description = "Password for the root user if auth is enabled.";
       };

--- a/nixos/modules/services/databases/openldap.nix
+++ b/nixos/modules/services/databases/openldap.nix
@@ -47,26 +47,26 @@ in
       };
 
       user = mkOption {
-        type = types.string;
+        type = types.str;
         default = "openldap";
         description = "User account under which slapd runs.";
       };
 
       group = mkOption {
-        type = types.string;
+        type = types.str;
         default = "openldap";
         description = "Group account under which slapd runs.";
       };
 
       urlList = mkOption {
-        type = types.listOf types.string;
+        type = types.listOf types.str;
         default = [ "ldap:///" ];
         description = "URL list slapd should listen on.";
         example = [ "ldaps:///" ];
       };
 
       dataDir = mkOption {
-        type = types.string;
+        type = types.path;
         default = "/var/db/openldap";
         description = "The database directory.";
       };

--- a/nixos/modules/services/databases/opentsdb.nix
+++ b/nixos/modules/services/databases/opentsdb.nix
@@ -34,7 +34,7 @@ in {
       };
 
       user = mkOption {
-        type = types.string;
+        type = types.str;
         default = "opentsdb";
         description = ''
           User account under which OpenTSDB runs.
@@ -42,7 +42,7 @@ in {
       };
 
       group = mkOption {
-        type = types.string;
+        type = types.str;
         default = "opentsdb";
         description = ''
           Group account under which OpenTSDB runs.

--- a/nixos/modules/services/databases/riak.nix
+++ b/nixos/modules/services/databases/riak.nix
@@ -29,7 +29,7 @@ in
       };
 
       nodeName = mkOption {
-        type = types.string;
+        type = types.str;
         default = "riak@127.0.0.1";
         description = ''
           Name of the Erlang node.
@@ -37,7 +37,7 @@ in
       };
 
       distributedCookie = mkOption {
-        type = types.string;
+        type = types.str;
         default = "riak";
         description = ''
           Cookie for distributed node communication.  All nodes in the

--- a/nixos/modules/services/games/factorio.nix
+++ b/nixos/modules/services/games/factorio.nix
@@ -55,7 +55,7 @@ in
         '';
       };
       saveName = mkOption {
-        type = types.string;
+        type = types.str;
         default = "default";
         description = ''
           The name of the savegame that will be used by the server.
@@ -81,7 +81,7 @@ in
         '';
       };
       stateDirName = mkOption {
-        type = types.string;
+        type = types.str;
         default = "factorio";
         description = ''
           Name of the directory under /var/lib holding the server's data.
@@ -102,14 +102,14 @@ in
         '';
       };
       game-name = mkOption {
-        type = types.nullOr types.string;
+        type = types.nullOr types.str;
         default = "Factorio Game";
         description = ''
           Name of the game as it will appear in the game listing.
         '';
       };
       description = mkOption {
-        type = types.nullOr types.string;
+        type = types.nullOr types.str;
         default = "";
         description = ''
           Description of the game that will appear in the listing.
@@ -130,28 +130,28 @@ in
         '';
       };
       username = mkOption {
-        type = types.nullOr types.string;
+        type = types.nullOr types.str;
         default = null;
         description = ''
           Your factorio.com login credentials. Required for games with visibility public.
         '';
       };
       password = mkOption {
-        type = types.nullOr types.string;
+        type = types.nullOr types.str;
         default = null;
         description = ''
           Your factorio.com login credentials. Required for games with visibility public.
         '';
       };
       token = mkOption {
-        type = types.nullOr types.string;
+        type = types.nullOr types.str;
         default = null;
         description = ''
           Authentication token. May be used instead of 'password' above.
         '';
       };
       game-password = mkOption {
-        type = types.nullOr types.string;
+        type = types.nullOr types.str;
         default = null;
         description = ''
           Game password.

--- a/nixos/modules/services/hardware/freefall.nix
+++ b/nixos/modules/services/hardware/freefall.nix
@@ -28,7 +28,7 @@ in {
     };
 
     devices = mkOption {
-      type = types.listOf types.string;
+      type = types.listOf types.str;
       default = [ "/dev/sda" ];
       description = ''
         Device paths to all internal spinning hard drives.

--- a/nixos/modules/services/hardware/fwupd.nix
+++ b/nixos/modules/services/hardware/fwupd.nix
@@ -43,7 +43,7 @@ in {
       };
 
       blacklistDevices = mkOption {
-        type = types.listOf types.string;
+        type = types.listOf types.str;
         default = [];
         example = [ "2082b5e0-7a64-478a-b1b2-e3404fab6dad" ];
         description = ''
@@ -52,7 +52,7 @@ in {
       };
 
       blacklistPlugins = mkOption {
-        type = types.listOf types.string;
+        type = types.listOf types.str;
         default = [ "test" ];
         example = [ "udev" ];
         description = ''

--- a/nixos/modules/services/hardware/sane.nix
+++ b/nixos/modules/services/hardware/sane.nix
@@ -76,7 +76,7 @@ in
     };
 
     hardware.sane.configDir = mkOption {
-      type = types.string;
+      type = types.str;
       internal = true;
       description = "The value of SANE_CONFIG_DIR.";
     };

--- a/nixos/modules/services/hardware/tcsd.nix
+++ b/nixos/modules/services/hardware/tcsd.nix
@@ -49,13 +49,13 @@ in
 
       user = mkOption {
         default = "tss";
-        type = types.string;
+        type = types.str;
         description = "User account under which tcsd runs.";
       };
 
       group = mkOption {
         default = "tss";
-        type = types.string;
+        type = types.str;
         description = "Group account under which tcsd runs.";
       };
 
@@ -65,19 +65,19 @@ in
         description = ''
           The location of the system persistent storage file.
           The system persistent storage file holds keys and data across
-          restarts of the TCSD and system reboots. 
+          restarts of the TCSD and system reboots.
         '';
       };
 
       firmwarePCRs = mkOption {
         default = "0,1,2,3,4,5,6,7";
-        type = types.string;
+        type = types.str;
         description = "PCR indices used in the TPM for firmware measurements.";
       };
 
       kernelPCRs = mkOption {
         default = "8,9,10,11,12";
-        type = types.string;
+        type = types.str;
         description = "PCR indices used in the TPM for kernel measurements.";
       };
 

--- a/nixos/modules/services/logging/SystemdJournal2Gelf.nix
+++ b/nixos/modules/services/logging/SystemdJournal2Gelf.nix
@@ -16,7 +16,7 @@ in
       };
 
       graylogServer = mkOption {
-        type = types.string;
+        type = types.str;
         example = "graylog2.example.com:11201";
         description = ''
           Host and port of your graylog2 input. This should be a GELF
@@ -25,7 +25,7 @@ in
       };
 
       extraOptions = mkOption {
-        type = types.string;
+        type = types.separatedString " ";
         default = "";
         description = ''
           Any extra flags to pass to SystemdJournal2Gelf. Note that

--- a/nixos/modules/services/logging/awstats.nix
+++ b/nixos/modules/services/logging/awstats.nix
@@ -32,7 +32,7 @@ in
     };
 
     updateAt = mkOption {
-      type = types.nullOr types.string;
+      type = types.nullOr types.str;
       default = null;
       example = "hourly";
       description = ''
@@ -50,7 +50,7 @@ in
         description = ''Enable the awstats web service. This switches on httpd.'';
       };
       urlPrefix = mkOption {
-        type = types.string;
+        type = types.str;
         default = "/awstats";
         description = "The URL prefix under which the awstats service appears.";
       };

--- a/nixos/modules/services/logging/logcheck.nix
+++ b/nixos/modules/services/logging/logcheck.nix
@@ -155,7 +155,7 @@ in
 
       config = mkOption {
         default = "FQDN=1";
-        type = types.string;
+        type = types.lines;
         description = ''
           Config options that you would like in logcheck.conf.
         '';

--- a/nixos/modules/services/logging/rsyslogd.nix
+++ b/nixos/modules/services/logging/rsyslogd.nix
@@ -46,7 +46,7 @@ in
       };
 
       defaultConfig = mkOption {
-        type = types.string;
+        type = types.lines;
         default = defaultConf;
         description = ''
           The default <filename>syslog.conf</filename> file configures a
@@ -56,7 +56,7 @@ in
       };
 
       extraConfig = mkOption {
-        type = types.string;
+        type = types.lines;
         default = "";
         example = "news.* -/var/log/news";
         description = ''

--- a/nixos/modules/services/mail/exim.nix
+++ b/nixos/modules/services/mail/exim.nix
@@ -21,7 +21,7 @@ in
       };
 
       config = mkOption {
-        type = types.string;
+        type = types.lines;
         default = "";
         description = ''
           Verbatim Exim configuration.  This should not contain exim_user,
@@ -30,7 +30,7 @@ in
       };
 
       user = mkOption {
-        type = types.string;
+        type = types.str;
         default = "exim";
         description = ''
           User to use when no root privileges are required.
@@ -42,7 +42,7 @@ in
       };
 
       group = mkOption {
-        type = types.string;
+        type = types.str;
         default = "exim";
         description = ''
           Group to use when no root privileges are required.
@@ -50,7 +50,7 @@ in
       };
 
       spoolDir = mkOption {
-        type = types.string;
+        type = types.path;
         default = "/var/spool/exim";
         description = ''
           Location of the spool directory of exim.

--- a/nixos/modules/services/mail/nullmailer.nix
+++ b/nixos/modules/services/mail/nullmailer.nix
@@ -14,7 +14,7 @@ with lib;
       };
 
       user = mkOption {
-        type = types.string;
+        type = types.str;
         default = "nullmailer";
         description = ''
           User to use to run nullmailer-send.
@@ -22,7 +22,7 @@ with lib;
       };
 
       group = mkOption {
-        type = types.string;
+        type = types.str;
         default = "nullmailer";
         description = ''
           Group to use to run nullmailer-send.

--- a/nixos/modules/services/mail/postfix.nix
+++ b/nixos/modules/services/mail/postfix.nix
@@ -509,7 +509,7 @@ in
       };
 
       localRecipients = mkOption {
-        type = with types; nullOr (listOf string);
+        type = with types; nullOr (listOf str);
         default = null;
         description = ''
           List of accepted local users. Specify a bare username, an
@@ -530,7 +530,7 @@ in
 
       dnsBlacklists = mkOption {
         default = [];
-        type = with types; listOf string;
+        type = with types; listOf str;
         description = "dns blacklist servers to use with smtpd_client_restrictions";
       };
 

--- a/nixos/modules/services/mail/postgrey.nix
+++ b/nixos/modules/services/mail/postgrey.nix
@@ -12,7 +12,7 @@ with lib; let
   inetSocket = with types; {
     options = {
       addr = mkOption {
-        type = nullOr string;
+        type = nullOr str;
         default = null;
         example = "127.0.0.1";
         description = "The address to bind to. Localhost if null";
@@ -34,7 +34,7 @@ with lib; let
       };
 
       mode = mkOption {
-        type = string;
+        type = str;
         default = "0777";
         description = "Mode of the unix socket";
       };
@@ -63,17 +63,17 @@ in {
         description = "Socket to bind to";
       };
       greylistText = mkOption {
-        type = string;
+        type = str;
         default = "Greylisted for %%s seconds";
         description = "Response status text for greylisted messages; use %%s for seconds left until greylisting is over and %%r for mail domain of recipient";
       };
       greylistAction = mkOption {
-        type = string;
+        type = str;
         default = "DEFER_IF_PERMIT";
         description = "Response status for greylisted messages (see access(5))";
       };
       greylistHeader = mkOption {
-        type = string;
+        type = str;
         default = "X-Greylist: delayed %%t seconds by postgrey-%%v at %%h; %%d";
         description = "Prepend header to greylisted mails; use %%t for seconds delayed due to greylisting, %%v for the version of postgrey, %%d for the date, and %%h for the host";
       };
@@ -88,7 +88,7 @@ in {
         description = "Delete entries from whitelist if they haven't been seen for N days";
       };
       retryWindow = mkOption {
-        type = either string natural;
+        type = either str natural;
         default = 2;
         example = "12h";
         description = "Allow N days for the first retry. Use string with appended 'h' to specify time in hours";

--- a/nixos/modules/services/mail/rspamd.nix
+++ b/nixos/modules/services/mail/rspamd.nix
@@ -308,7 +308,7 @@ in
       };
 
       user = mkOption {
-        type = types.string;
+        type = types.str;
         default = "rspamd";
         description = ''
           User to use when no root privileges are required.
@@ -316,7 +316,7 @@ in
       };
 
       group = mkOption {
-        type = types.string;
+        type = types.str;
         default = "rspamd";
         description = ''
           Group to use when no root privileges are required.

--- a/nixos/modules/services/misc/airsonic.nix
+++ b/nixos/modules/services/misc/airsonic.nix
@@ -34,7 +34,7 @@ in {
       };
 
       listenAddress = mkOption {
-        type = types.string;
+        type = types.str;
         default = "127.0.0.1";
         description = ''
           The host name or IP address on which to bind Airsonic.

--- a/nixos/modules/services/misc/apache-kafka.nix
+++ b/nixos/modules/services/misc/apache-kafka.nix
@@ -46,7 +46,7 @@ in {
     hostname = mkOption {
       description = "Hostname the broker should bind to.";
       default = "localhost";
-      type = types.string;
+      type = types.str;
     };
 
     logDirs = mkOption {
@@ -54,13 +54,13 @@ in {
       default = [ "/tmp/kafka-logs" ];
       type = types.listOf types.path;
     };
-    
+
     zookeeper = mkOption {
       description = "Zookeeper connection string";
       default = "localhost:2181";
-      type = types.string;
+      type = types.str;
     };
- 
+
     extraProperties = mkOption {
       description = "Extra properties for server.properties.";
       type = types.nullOr types.lines;
@@ -79,8 +79,8 @@ in {
     log4jProperties = mkOption {
       description = "Kafka log4j property configuration.";
       default = ''
-        log4j.rootLogger=INFO, stdout 
-        
+        log4j.rootLogger=INFO, stdout
+
         log4j.appender.stdout=org.apache.log4j.ConsoleAppender
         log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
         log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n

--- a/nixos/modules/services/misc/cpuminer-cryptonight.nix
+++ b/nixos/modules/services/misc/cpuminer-cryptonight.nix
@@ -28,15 +28,15 @@ in
         '';
       };
       url = mkOption {
-        type = types.string;
+        type = types.str;
         description = "URL of mining server";
       };
       user = mkOption {
-        type = types.string;
+        type = types.str;
         description = "Username for mining server";
       };
       pass = mkOption {
-        type = types.string;
+        type = types.str;
         default = "x";
         description = "Password for mining server";
       };

--- a/nixos/modules/services/misc/exhibitor.nix
+++ b/nixos/modules/services/misc/exhibitor.nix
@@ -252,7 +252,7 @@ in
         example = ["host1:2181" "host2:2181"];
       };
       zkConfigExhibitorPath = mkOption {
-        type = types.string;
+        type = types.str;
         description = ''
           If the ZooKeeper shared config is also running Exhibitor, the URI path for the REST call
         '';

--- a/nixos/modules/services/misc/fstrim.nix
+++ b/nixos/modules/services/misc/fstrim.nix
@@ -14,7 +14,7 @@ in {
       enable = mkEnableOption "periodic SSD TRIM of mounted partitions in background";
 
       interval = mkOption {
-        type = types.string;
+        type = types.str;
         default = "weekly";
         description = ''
           How often we run fstrim. For most desktop and server systems

--- a/nixos/modules/services/misc/logkeys.nix
+++ b/nixos/modules/services/misc/logkeys.nix
@@ -11,7 +11,7 @@ in {
     device = mkOption {
       description = "Use the given device as keyboard input event device instead of /dev/input/eventX default.";
       default = null;
-      type = types.nullOr types.string;
+      type = types.nullOr types.str;
       example = "/dev/input/event15";
     };
   };

--- a/nixos/modules/services/misc/mediatomb.nix
+++ b/nixos/modules/services/misc/mediatomb.nix
@@ -163,7 +163,7 @@ in {
       };
 
       serverName = mkOption {
-        type = types.string;
+        type = types.str;
         default = "mediatomb";
         description = ''
           How to identify the server on the network.

--- a/nixos/modules/services/misc/paperless.nix
+++ b/nixos/modules/services/misc/paperless.nix
@@ -50,7 +50,7 @@ in
     };
 
     ocrLanguages = mkOption {
-      type = with types; nullOr (listOf string);
+      type = with types; nullOr (listOf str);
       default = null;
       description = ''
         Languages available for OCR via Tesseract, specified as

--- a/nixos/modules/services/misc/subsonic.nix
+++ b/nixos/modules/services/misc/subsonic.nix
@@ -17,7 +17,7 @@ let cfg = config.services.subsonic; in {
       };
 
       listenAddress = mkOption {
-        type = types.string;
+        type = types.str;
         default = "0.0.0.0";
         description = ''
           The host name or IP address on which to bind Subsonic.

--- a/nixos/modules/services/misc/uhub.nix
+++ b/nixos/modules/services/misc/uhub.nix
@@ -51,7 +51,7 @@ in
       };
 
       address = mkOption {
-        type = types.string;
+        type = types.str;
         default = "any";
 	description = "Address to bind the hub to.";
       };
@@ -83,7 +83,7 @@ in
             description = "Whether to enable the Sqlite authentication database plugin";
 	  };
           file = mkOption {
-            type = types.string;
+            type = types.path;
             example = "/var/db/uhub-users";
             description = "Path to user database. Use the uhub-passwd utility to create the database and add/remove users.";
           };
@@ -96,7 +96,7 @@ in
             description = "Whether to enable the logging plugin.";
           };
           file = mkOption {
-            type = types.string;
+            type = types.str;
             default = "";
             description = "Path of log file.";
           };
@@ -117,7 +117,7 @@ in
             default = "";
             type = types.lines;
             description = ''
-              Welcome message displayed to clients after connecting 
+              Welcome message displayed to clients after connecting
               and with the <literal>!motd</literal> command.
             '';
           };

--- a/nixos/modules/services/monitoring/apcupsd.nix
+++ b/nixos/modules/services/monitoring/apcupsd.nix
@@ -91,7 +91,7 @@ in
           BATTERYLEVEL 50
           MINUTES 5
         '';
-        type = types.string;
+        type = types.lines;
         description = ''
           Contents of the runtime configuration file, apcupsd.conf. The default
           settings makes apcupsd autodetect USB UPSes, limit network access to
@@ -106,7 +106,7 @@ in
         example = {
           doshutdown = ''# shell commands to notify that the computer is shutting down'';
         };
-        type = types.attrsOf types.string;
+        type = types.attrsOf types.lines;
         description = ''
           Each attribute in this option names an apcupsd event and the string
           value it contains will be executed in a shell, in response to that

--- a/nixos/modules/services/monitoring/bosun.nix
+++ b/nixos/modules/services/monitoring/bosun.nix
@@ -41,7 +41,7 @@ in {
       };
 
       user = mkOption {
-        type = types.string;
+        type = types.str;
         default = "bosun";
         description = ''
           User account under which bosun runs.
@@ -49,7 +49,7 @@ in {
       };
 
       group = mkOption {
-        type = types.string;
+        type = types.str;
         default = "bosun";
         description = ''
           Group account under which bosun runs.
@@ -57,7 +57,7 @@ in {
       };
 
       opentsdbHost = mkOption {
-        type = types.nullOr types.string;
+        type = types.nullOr types.str;
         default = "localhost:4242";
         description = ''
           Host and port of the OpenTSDB database that stores bosun data.
@@ -66,7 +66,7 @@ in {
       };
 
       influxHost = mkOption {
-        type = types.nullOr types.string;
+        type = types.nullOr types.str;
         default = null;
         example = "localhost:8086";
         description = ''
@@ -75,7 +75,7 @@ in {
       };
 
       listenAddress = mkOption {
-        type = types.string;
+        type = types.str;
         default = ":8070";
         description = ''
           The host address and port that bosun's web interface will listen on.

--- a/nixos/modules/services/monitoring/datadog-agent.nix
+++ b/nixos/modules/services/monitoring/datadog-agent.nix
@@ -87,7 +87,7 @@ in {
       description = "The hostname to show in the Datadog dashboard (optional)";
       default = null;
       example = "mymachine.mydomain";
-      type = types.uniq (types.nullOr types.string);
+      type = types.nullOr types.str;
     };
 
     logLevel = mkOption {

--- a/nixos/modules/services/monitoring/dd-agent/dd-agent.nix
+++ b/nixos/modules/services/monitoring/dd-agent/dd-agent.nix
@@ -145,41 +145,40 @@ in {
       description = "The hostname to show in the Datadog dashboard (optional)";
       default = null;
       example = "mymachine.mydomain";
-      type = types.uniq (types.nullOr types.string);
+      type = types.nullOr types.str;
     };
 
     postgresqlConfig = mkOption {
       description = "Datadog PostgreSQL integration configuration";
       default = null;
-      type = types.uniq (types.nullOr types.string);
+      type = types.nullOr types.lines;
     };
 
     nginxConfig = mkOption {
       description = "Datadog nginx integration configuration";
       default = null;
-      type = types.uniq (types.nullOr types.string);
+      type = types.nullOr types.lines;
     };
 
     mongoConfig = mkOption {
       description = "MongoDB integration configuration";
       default = null;
-      type = types.uniq (types.nullOr types.string);
+      type = types.nullOr types.lines;
     };
 
     jmxConfig = mkOption {
       description = "JMX integration configuration";
       default = null;
-      type = types.uniq (types.nullOr types.string);
+      type = types.nullOr types.lines;
     };
 
     processConfig = mkOption {
       description = ''
         Process integration configuration
-
-        See http://docs.datadoghq.com/integrations/process/
+        See <link xlink:href="https://docs.datadoghq.com/integrations/process/"/>
       '';
       default = null;
-      type = types.uniq (types.nullOr types.string);
+      type = types.nullOr types.lines;
     };
 
   };

--- a/nixos/modules/services/monitoring/graphite.nix
+++ b/nixos/modules/services/monitoring/graphite.nix
@@ -11,7 +11,7 @@ let
 
   graphiteLocalSettingsDir = pkgs.runCommand "graphite_local_settings" {
       inherit graphiteLocalSettings;
-      preferLocalBuild = true; 
+      preferLocalBuild = true;
     } ''
     mkdir -p $out
     ln -s $graphiteLocalSettings $out/graphite_local_settings.py
@@ -215,7 +215,7 @@ in {
       storageAggregation = mkOption {
         description = "Defines how to aggregate data to lower-precision retentions.";
         default = null;
-        type = types.uniq (types.nullOr types.string);
+        type = types.nullOr types.str;
         example = ''
           [all_min]
           pattern = \.min$
@@ -227,7 +227,7 @@ in {
       storageSchemas = mkOption {
         description = "Defines retention rates for storing metrics.";
         default = "";
-        type = types.uniq (types.nullOr types.string);
+        type = types.nullOr types.str;
         example = ''
           [apache_busyWorkers]
           pattern = ^servers\.www.*\.workers\.busyWorkers$
@@ -238,14 +238,14 @@ in {
       blacklist = mkOption {
         description = "Any metrics received which match one of the experssions will be dropped.";
         default = null;
-        type = types.uniq (types.nullOr types.string);
+        type = types.nullOr types.str;
         example = "^some\.noisy\.metric\.prefix\..*";
       };
 
       whitelist = mkOption {
         description = "Only metrics received which match one of the experssions will be persisted.";
         default = null;
-        type = types.uniq (types.nullOr types.string);
+        type = types.nullOr types.str;
         example = ".*";
       };
 
@@ -255,7 +255,7 @@ in {
           in a search and replace fashion.
         '';
         default = null;
-        type = types.uniq (types.nullOr types.string);
+        type = types.nullOr types.str;
         example = ''
           [post]
           _sum$ =
@@ -272,7 +272,7 @@ in {
       relayRules = mkOption {
         description = "Relay rules are used to send certain metrics to a certain backend.";
         default = null;
-        type = types.uniq (types.nullOr types.string);
+        type = types.nullOr types.str;
         example = ''
           [example]
           pattern = ^mydata\.foo\..+
@@ -289,7 +289,7 @@ in {
       aggregationRules = mkOption {
         description = "Defines if and how received metrics will be aggregated.";
         default = null;
-        type = types.uniq (types.nullOr types.string);
+        type = types.nullOr types.str;
         example = ''
           <env>.applications.<app>.all.requests (60) = sum <env>.applications.<app>.*.requests
           <env>.applications.<app>.all.latency (60) = avg <env>.applications.<app>.*.latency

--- a/nixos/modules/services/monitoring/heapster.nix
+++ b/nixos/modules/services/monitoring/heapster.nix
@@ -15,19 +15,19 @@ in {
     source = mkOption {
       description = "Heapster metric source";
       example = "kubernetes:https://kubernetes.default";
-      type = types.string;
+      type = types.str;
     };
 
     sink = mkOption {
       description = "Heapster metic sink";
       example = "influxdb:http://localhost:8086";
-      type = types.string;
+      type = types.str;
     };
 
     extraOpts = mkOption {
       description = "Heapster extra options";
       default = "";
-      type = types.string;
+      type = types.separatedString " ";
     };
 
     package = mkOption {

--- a/nixos/modules/services/monitoring/kapacitor.nix
+++ b/nixos/modules/services/monitoring/kapacitor.nix
@@ -116,17 +116,17 @@ in
       url = mkOption {
         description = "The URL to an InfluxDB server that serves as the default database";
         example = "http://localhost:8086";
-        type = types.string;
+        type = types.str;
       };
 
       username = mkOption {
         description = "The username to connect to the remote InfluxDB server";
-        type = types.string;
+        type = types.str;
       };
 
       password = mkOption {
         description = "The password to connect to the remote InfluxDB server";
-        type = types.string;
+        type = types.str;
       };
     };
 
@@ -137,7 +137,7 @@ in
         description = "The URL to the Alerta REST API";
         default = "http://localhost:5000";
         example = "http://localhost:5000";
-        type = types.string;
+        type = types.str;
       };
 
       token = mkOption {

--- a/nixos/modules/services/monitoring/munin.nix
+++ b/nixos/modules/services/monitoring/munin.nix
@@ -233,7 +233,7 @@ in
         # In the meantime this at least suppresses a useless graph full of
         # NaNs in the output.
         default = [ "munin_stats" ];
-        type = with types; listOf string;
+        type = with types; listOf str;
         description = ''
           Munin plugins to disable, even if
           <literal>munin-node-configure --suggest</literal> tries to enable

--- a/nixos/modules/services/monitoring/prometheus/exporters/node.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/node.nix
@@ -9,7 +9,7 @@ in
   port = 9100;
   extraOpts = {
     enabledCollectors = mkOption {
-      type = types.listOf types.string;
+      type = types.listOf types.str;
       default = [];
       example = ''[ "systemd" ]'';
       description = ''

--- a/nixos/modules/services/monitoring/riemann-tools.nix
+++ b/nixos/modules/services/monitoring/riemann-tools.nix
@@ -35,7 +35,7 @@ in {
         '';
       };
       extraArgs = mkOption {
-        type = types.listOf types.string;
+        type = types.listOf types.str;
         default = [];
         description = ''
           A list of commandline-switches forwarded to a riemann-tool.

--- a/nixos/modules/services/monitoring/scollector.nix
+++ b/nixos/modules/services/monitoring/scollector.nix
@@ -51,7 +51,7 @@ in {
       };
 
       user = mkOption {
-        type = types.string;
+        type = types.str;
         default = "scollector";
         description = ''
           User account under which scollector runs.
@@ -59,7 +59,7 @@ in {
       };
 
       group = mkOption {
-        type = types.string;
+        type = types.str;
         default = "scollector";
         description = ''
           Group account under which scollector runs.
@@ -67,7 +67,7 @@ in {
       };
 
       bosunHost = mkOption {
-        type = types.string;
+        type = types.str;
         default = "localhost:8070";
         description = ''
           Host and port of the bosun server that will store the collected

--- a/nixos/modules/services/monitoring/ups.nix
+++ b/nixos/modules/services/monitoring/ups.nix
@@ -55,7 +55,7 @@ let
 
       description = mkOption {
         default = "";
-        type = types.string;
+        type = types.str;
         description = ''
           Description of the UPS.
         '';
@@ -71,7 +71,7 @@ let
 
       summary = mkOption {
         default = "";
-        type = types.string;
+        type = types.lines;
         description = ''
           Lines which would be added inside ups.conf for handling this UPS.
         '';

--- a/nixos/modules/services/monitoring/uptime.nix
+++ b/nixos/modules/services/monitoring/uptime.nix
@@ -57,7 +57,7 @@ in {
     nodeEnv = mkOption {
       description = "The node environment to run in (development, production, etc.)";
 
-      type = types.string;
+      type = types.str;
 
       default = "production";
     };

--- a/nixos/modules/services/network-filesystems/davfs2.nix
+++ b/nixos/modules/services/network-filesystems/davfs2.nix
@@ -21,7 +21,7 @@ in
     };
 
     davUser = mkOption {
-      type = types.string;
+      type = types.str;
       default = "davfs2";
       description = ''
         When invoked by root the mount.davfs daemon will run as this user.
@@ -30,7 +30,7 @@ in
     };
 
     davGroup = mkOption {
-      type = types.string;
+      type = types.str;
       default = "davfs2";
       description = ''
         The group of the running mount.davfs daemon. Ordinary users must be

--- a/nixos/modules/services/network-filesystems/drbd.nix
+++ b/nixos/modules/services/network-filesystems/drbd.nix
@@ -23,7 +23,7 @@ let cfg = config.services.drbd; in
 
     services.drbd.config = mkOption {
       default = "";
-      type = types.string;
+      type = types.lines;
       description = ''
         Contents of the <filename>drbd.conf</filename> configuration file.
       '';

--- a/nixos/modules/services/network-filesystems/rsyncd.nix
+++ b/nixos/modules/services/network-filesystems/rsyncd.nix
@@ -35,7 +35,7 @@ in
       };
 
       motd = mkOption {
-        type = types.string;
+        type = types.str;
         default = "";
         description = ''
           Message of the day to display to clients on each connect.

--- a/nixos/modules/services/network-filesystems/yandex-disk.nix
+++ b/nixos/modules/services/network-filesystems/yandex-disk.nix
@@ -29,7 +29,7 @@ in
 
       username = mkOption {
         default = "";
-        type = types.string;
+        type = types.str;
         description = ''
           Your yandex.com login name.
         '';
@@ -37,7 +37,7 @@ in
 
       password = mkOption {
         default = "";
-        type = types.string;
+        type = types.str;
         description = ''
           Your yandex.com password. Warning: it will be world-readable in /nix/store.
         '';
@@ -57,7 +57,7 @@ in
 
       excludes = mkOption {
         default = "";
-        type = types.string;
+        type = types.commas;
         example = "data,backup";
         description = ''
           Comma-separated list of directories which are excluded from synchronization.

--- a/nixos/modules/services/networking/aria2.nix
+++ b/nixos/modules/services/networking/aria2.nix
@@ -47,8 +47,8 @@ in
         '';
       };
       downloadDir = mkOption {
-        type = types.string;
-        default = "${downloadDir}";
+        type = types.path;
+        default = downloadDir;
         description = ''
           Directory to store downloaded files.
         '';
@@ -66,7 +66,7 @@ in
         description = "Specify a port number for JSON-RPC/XML-RPC server to listen to. Possible Values: 1024-65535";
       };
       rpcSecret = mkOption {
-        type = types.string;
+        type = types.str;
         default = "aria2rpc";
         description = ''
           Set RPC secret authorization token.
@@ -74,7 +74,7 @@ in
         '';
       };
       extraArguments = mkOption {
-        type = types.string;
+        type = types.separatedString " ";
         example = "--rpc-listen-all --remote-time=true";
         default = "";
         description = ''

--- a/nixos/modules/services/networking/autossh.nix
+++ b/nixos/modules/services/networking/autossh.nix
@@ -20,12 +20,12 @@ in
         type = types.listOf (types.submodule {
           options = {
             name = mkOption {
-              type = types.string;
+              type = types.str;
               example = "socks-peer";
               description = "Name of the local AutoSSH session";
             };
             user = mkOption {
-              type = types.string;
+              type = types.str;
               example = "bill";
               description = "Name of the user the AutoSSH session should run as";
             };
@@ -40,7 +40,7 @@ in
               '';
             };
             extraArguments = mkOption {
-              type = types.string;
+              type = types.separatedString " ";
               example = "-N -D4343 bill@socks.example.net";
               description = ''
                 Arguments to be passed to AutoSSH and retransmitted to SSH

--- a/nixos/modules/services/networking/charybdis.nix
+++ b/nixos/modules/services/networking/charybdis.nix
@@ -21,14 +21,14 @@ in
       enable = mkEnableOption "Charybdis IRC daemon";
 
       config = mkOption {
-        type = types.string;
+        type = types.str;
         description = ''
           Charybdis IRC daemon configuration file.
         '';
       };
 
       statedir = mkOption {
-        type = types.string;
+        type = types.path;
         default = "/var/lib/charybdis";
         description = ''
           Location of the state directory of charybdis.
@@ -36,7 +36,7 @@ in
       };
 
       user = mkOption {
-        type = types.string;
+        type = types.str;
         default = "ircd";
         description = ''
           Charybdis IRC daemon user.
@@ -44,7 +44,7 @@ in
       };
 
       group = mkOption {
-        type = types.string;
+        type = types.str;
         default = "ircd";
         description = ''
           Charybdis IRC daemon group.
@@ -101,7 +101,7 @@ in
       };
 
     }
-    
+
     (mkIf (cfg.motd != null) {
       environment.etc."charybdis/ircd.motd".text = cfg.motd;
     })

--- a/nixos/modules/services/networking/connman.nix
+++ b/nixos/modules/services/networking/connman.nix
@@ -45,7 +45,7 @@ in {
       };
 
       networkInterfaceBlacklist = mkOption {
-        type = with types; listOf string;
+        type = with types; listOf str;
         default = [ "vmnet" "vboxnet" "virbr" "ifb" "ve" ];
         description = ''
           Default blacklisted interfaces, this includes NixOS containers interfaces (ve).
@@ -53,7 +53,7 @@ in {
       };
 
       extraFlags = mkOption {
-        type = with types; listOf string;
+        type = with types; listOf str;
         default = [ ];
         example = [ "--nodnsproxy" ];
         description = ''

--- a/nixos/modules/services/networking/gogoclient.nix
+++ b/nixos/modules/services/networking/gogoclient.nix
@@ -34,7 +34,7 @@ in
 
       password = mkOption {
         default = "";
-        type = types.string;
+        type = types.str;
         description = ''
           Path to a file (as a string), containing your gogoNET password, if any.
         '';

--- a/nixos/modules/services/networking/hostapd.nix
+++ b/nixos/modules/services/networking/hostapd.nix
@@ -81,7 +81,7 @@ in
       driver = mkOption {
         default = "nl80211";
         example = "hostapd";
-        type = types.string;
+        type = types.str;
         description = ''
           Which driver <command>hostapd</command> will use.
           Most applications will probably use the default.
@@ -91,7 +91,7 @@ in
       ssid = mkOption {
         default = "nixos";
         example = "mySpecialSSID";
-        type = types.string;
+        type = types.str;
         description = "SSID to be used in IEEE 802.11 management frames.";
       };
 
@@ -119,7 +119,7 @@ in
       group = mkOption {
         default = "wheel";
         example = "network";
-        type = types.string;
+        type = types.str;
         description = ''
           Members of this group can control <command>hostapd</command>.
         '';
@@ -135,7 +135,7 @@ in
       wpaPassphrase = mkOption {
         default = "my_sekret";
         example = "any_64_char_string";
-        type = types.string;
+        type = types.str;
         description = ''
           WPA-PSK (pre-shared-key) passphrase. Clients will need this
           passphrase to associate with this access point.

--- a/nixos/modules/services/networking/jormungandr.nix
+++ b/nixos/modules/services/networking/jormungandr.nix
@@ -54,7 +54,7 @@ in {
      };
 
       genesisBlockHash = mkOption {
-        type = types.nullOr types.string;
+        type = types.nullOr types.str;
         default = null;
         example = "d70495af81ae8600aca3e642b2427327cb6001ec4d7a0037e96a00dabed163f9";
         description = ''

--- a/nixos/modules/services/networking/kippo.nix
+++ b/nixos/modules/services/networking/kippo.nix
@@ -26,22 +26,22 @@ rec {
       };
       hostname = mkOption {
         default = "nas3";
-        type = types.string;
+        type = types.str;
         description = ''Hostname for kippo to present to SSH login'';
       };
       varPath = mkOption {
         default = "/var/lib/kippo";
-        type = types.string;
+        type = types.path;
         description = ''Path of read/write files needed for operation and configuration.'';
       };
       logPath = mkOption {
         default = "/var/log/kippo";
-        type = types.string;
+        type = types.path;
         description = ''Path of log files needed for operation and configuration.'';
       };
       pidPath = mkOption {
         default = "/run/kippo";
-        type = types.string;
+        type = types.path;
         description = ''Path of pid files needed for operation.'';
       };
       extraConfig = mkOption {
@@ -109,8 +109,8 @@ rec {
 
       serviceConfig.ExecStart = "${pkgs.kippo.twisted}/bin/twistd -y ${pkgs.kippo}/src/kippo.tac --syslog --rundir=${cfg.varPath}/ --pidfile=${cfg.pidPath}/kippo.pid --prefix=kippo -n";
       serviceConfig.PermissionsStartOnly = true;
-      serviceConfig.User = "kippo"; 
-      serviceConfig.Group = "kippo"; 
+      serviceConfig.User = "kippo";
+      serviceConfig.Group = "kippo";
     };
 };
 }

--- a/nixos/modules/services/networking/morty.nix
+++ b/nixos/modules/services/networking/morty.nix
@@ -27,7 +27,7 @@ in
       };
 
       key = mkOption {
-        type = types.string;
+        type = types.str;
         default = "";
         description = "HMAC url validation key (hexadecimal encoded).
 	Leave blank to disable. Without validation key, anyone can
@@ -56,7 +56,7 @@ in
       };
 
       listenAddress = mkOption {
-        type = types.string;
+        type = types.str;
         default = "127.0.0.1";
         description = "The address on which the service listens";
         defaultText = "127.0.0.1 (localhost)";

--- a/nixos/modules/services/networking/mosquitto.nix
+++ b/nixos/modules/services/networking/mosquitto.nix
@@ -49,7 +49,7 @@ in
       host = mkOption {
         default = "127.0.0.1";
         example = "0.0.0.0";
-        type = types.string;
+        type = types.str;
         description = ''
           Host to listen on without SSL.
         '';
@@ -88,7 +88,7 @@ in
         host = mkOption {
           default = "0.0.0.0";
           example = "localhost";
-          type = types.string;
+          type = types.str;
           description = ''
             Host to listen on with SSL.
           '';
@@ -135,7 +135,7 @@ in
             };
 
             acl = mkOption {
-              type = types.listOf types.string;
+              type = types.listOf types.str;
               example = [ "topic read A/B" "topic A/#" ];
               description = ''
                 Control client access to topics on the broker.

--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -156,7 +156,7 @@ in {
       };
 
       unmanaged = mkOption {
-        type = types.listOf types.string;
+        type = types.listOf types.str;
         default = [];
         description = ''
           List of interfaces that will not be managed by NetworkManager.

--- a/nixos/modules/services/networking/nix-serve.nix
+++ b/nixos/modules/services/networking/nix-serve.nix
@@ -19,7 +19,7 @@ in
       };
 
       bindAddress = mkOption {
-        type = types.string;
+        type = types.str;
         default = "0.0.0.0";
         description = ''
           IP address where nix-serve will bind its listening socket.
@@ -44,7 +44,7 @@ in
       };
 
       extraParams = mkOption {
-        type = types.string;
+        type = types.separatedString " ";
         default = "";
         description = ''
           Extra command line parameters for nix-serve.

--- a/nixos/modules/services/networking/nylon.nix
+++ b/nixos/modules/services/networking/nylon.nix
@@ -65,7 +65,7 @@ let
       };
 
       acceptInterface = mkOption {
-        type = types.string;
+        type = types.str;
         default = "lo";
         description = ''
           Tell nylon which interface to listen for client requests on, default is "lo".
@@ -73,7 +73,7 @@ let
       };
 
       bindInterface = mkOption {
-        type = types.string;
+        type = types.str;
         default = "enp3s0f0";
         description = ''
           Tell nylon which interface to use as an uplink, default is "enp3s0f0".
@@ -89,7 +89,7 @@ let
       };
 
       allowedIPRanges = mkOption {
-        type = with types; listOf string;
+        type = with types; listOf str;
         default = [ "192.168.0.0/16" "127.0.0.1/8" "172.16.0.1/12" "10.0.0.0/8" ];
         description = ''
            Allowed client IP ranges are evaluated first, defaults to ARIN IPv4 private ranges:
@@ -98,7 +98,7 @@ let
       };
 
       deniedIPRanges = mkOption {
-        type = with types; listOf string;
+        type = with types; listOf str;
         default = [ "0.0.0.0/0" ];
         description = ''
           Denied client IP ranges, these gets evaluated after the allowed IP ranges, defaults to all IPv4 addresses:

--- a/nixos/modules/services/networking/openntpd.nix
+++ b/nixos/modules/services/networking/openntpd.nix
@@ -40,7 +40,7 @@ in
     };
 
     extraOptions = mkOption {
-      type = with types; string;
+      type = with types; separatedString " ";
       default = "";
       example = "-s";
       description = ''

--- a/nixos/modules/services/networking/openvpn.nix
+++ b/nixos/modules/services/networking/openvpn.nix
@@ -182,12 +182,12 @@ in
               options = {
                 username = mkOption {
                   description = "The username to store inside the credentials file.";
-                  type = types.string;
+                  type = types.str;
                 };
 
                 password = mkOption {
                   description = "The password to store inside the credentials file.";
-                  type = types.string;
+                  type = types.str;
                 };
               };
             });

--- a/nixos/modules/services/networking/ostinato.nix
+++ b/nixos/modules/services/networking/ostinato.nix
@@ -50,7 +50,7 @@ in
 
       rpcServer = {
         address = mkOption {
-          type = types.string;
+          type = types.str;
           default = "0.0.0.0";
           description = ''
             By default, the Drone RPC server will listen on all interfaces and
@@ -63,7 +63,7 @@ in
 
       portList = {
         include = mkOption {
-          type = types.listOf types.string;
+          type = types.listOf types.str;
           default = [];
           example = ''[ "eth*" "lo*" ]'';
           description = ''

--- a/nixos/modules/services/networking/polipo.nix
+++ b/nixos/modules/services/networking/polipo.nix
@@ -30,7 +30,7 @@ in
       };
 
       proxyAddress = mkOption {
-        type = types.string;
+        type = types.str;
         default = "127.0.0.1";
         description = "IP address on which Polipo will listen.";
       };
@@ -51,7 +51,7 @@ in
       };
 
       parentProxy = mkOption {
-        type = types.string;
+        type = types.str;
         default = "";
         example = "localhost:8124";
         description = ''
@@ -61,7 +61,7 @@ in
       };
 
       socksParentProxy = mkOption {
-        type = types.string;
+        type = types.str;
         default = "";
         example = "localhost:9050";
         description = ''
@@ -74,7 +74,7 @@ in
         type = types.lines;
         default = "";
         description = ''
-          Polio configuration. Contents will be added 
+          Polio configuration. Contents will be added
           verbatim to the configuration file.
         '';
       };

--- a/nixos/modules/services/networking/pptpd.nix
+++ b/nixos/modules/services/networking/pptpd.nix
@@ -8,13 +8,13 @@ with lib;
       enable = mkEnableOption "pptpd, the Point-to-Point Tunneling Protocol daemon";
 
       serverIp = mkOption {
-        type        = types.string;
+        type        = types.str;
         description = "The server-side IP address.";
         default     = "10.124.124.1";
       };
 
       clientIpRange = mkOption {
-        type        = types.string;
+        type        = types.str;
         description = "The range from which client IPs are drawn.";
         default     = "10.124.124.2-11";
       };

--- a/nixos/modules/services/networking/prosody.nix
+++ b/nixos/modules/services/networking/prosody.nix
@@ -297,7 +297,7 @@ in
       };
 
       dataDir = mkOption {
-        type = types.string;
+        type = types.path;
         description = "Directory where Prosody stores its data";
         default = "/var/lib/prosody";
       };

--- a/nixos/modules/services/networking/radicale.nix
+++ b/nixos/modules/services/networking/radicale.nix
@@ -41,7 +41,7 @@ in
     };
 
     services.radicale.config = mkOption {
-      type = types.string;
+      type = types.str;
       default = "";
       description = ''
         Radicale configuration, this will set the service
@@ -50,7 +50,7 @@ in
     };
 
     services.radicale.extraArgs = mkOption {
-      type = types.listOf types.string;
+      type = types.listOf types.str;
       default = [];
       description = "Extra arguments passed to the Radicale daemon.";
     };

--- a/nixos/modules/services/networking/shout.nix
+++ b/nixos/modules/services/networking/shout.nix
@@ -35,7 +35,7 @@ in {
     };
 
     listenAddress = mkOption {
-      type = types.string;
+      type = types.str;
       default = "0.0.0.0";
       description = "IP interface to listen on for http connections.";
     };

--- a/nixos/modules/services/networking/smokeping.nix
+++ b/nixos/modules/services/networking/smokeping.nix
@@ -55,7 +55,7 @@ in
         description = "Enable the smokeping service";
       };
       alertConfig = mkOption {
-        type = types.string;
+        type = types.lines;
         default = ''
           to = root@localhost
           from = smokeping@localhost
@@ -73,19 +73,20 @@ in
         description = "Configuration for alerts.";
       };
       cgiUrl = mkOption {
-        type = types.string;
-        default = "http://${cfg.hostName}:${builtins.toString cfg.port}/smokeping.cgi";
+        type = types.str;
+        default = "http://${cfg.hostName}:${toString cfg.port}/smokeping.cgi";
+        defaultText = "http://\${hostName}:\${toString port}/smokeping.cgi";
         example = "https://somewhere.example.com/smokeping.cgi";
         description = "URL to the smokeping cgi.";
       };
       config = mkOption {
-        type = types.nullOr types.string;
+        type = types.nullOr types.lines;
         default = null;
         description = "Full smokeping config supplied by the user. Overrides " +
           "and replaces any other configuration supplied.";
       };
       databaseConfig = mkOption {
-        type = types.string;
+        type = types.lines;
         default = ''
           step     = 300
           pings    = 20
@@ -122,14 +123,15 @@ in
         description = "Any additional customization not already included.";
       };
       hostName = mkOption {
-        type = types.string;
+        type = types.str;
         default = config.networking.hostName;
         example = "somewhere.example.com";
         description = "DNS name for the urls generated in the cgi.";
       };
       imgUrl = mkOption {
-        type = types.string;
-        default = "http://${cfg.hostName}:${builtins.toString cfg.port}/cache";
+        type = types.str;
+        default = "http://${cfg.hostName}:${toString cfg.port}/cache";
+        defaultText = "http://\${hostName}:\${toString port}/cache";
         example = "https://somewhere.example.com/cache";
         description = "Base url for images generated in the cgi.";
       };
@@ -140,19 +142,19 @@ in
         description = "DNS name for the urls generated in the cgi.";
       };
       mailHost = mkOption {
-        type = types.string;
+        type = types.str;
         default = "";
         example = "localhost";
         description = "Use this SMTP server to send alerts";
       };
       owner = mkOption {
-        type = types.string;
+        type = types.str;
         default = "nobody";
         example = "Joe Admin";
         description = "Real name of the owner of the instance";
       };
       ownerEmail = mkOption {
-        type = types.string;
+        type = types.str;
         default = "no-reply@${cfg.hostName}";
         example = "no-reply@yourdomain.com";
         description = "Email contact for owner";
@@ -170,7 +172,7 @@ in
         description = "TCP port to use for the web server.";
       };
       presentationConfig = mkOption {
-        type = types.string;
+        type = types.lines;
         default = ''
           + charts
           menu = Charts
@@ -211,12 +213,12 @@ in
         description = "presentation graph style";
       };
       presentationTemplate = mkOption {
-        type = types.string;
+        type = types.str;
         default = "${pkgs.smokeping}/etc/basepage.html.dist";
         description = "Default page layout for the web UI.";
       };
       probeConfig = mkOption {
-        type = types.string;
+        type = types.lines;
         default = ''
           + FPing
           binary = ${config.security.wrapperDir}/fping
@@ -230,12 +232,12 @@ in
         description = "Use this sendmail compatible script to deliver alerts";
       };
       smokeMailTemplate = mkOption {
-        type = types.string;
+        type = types.str;
         default = "${cfg.package}/etc/smokemail.dist";
         description = "Specify the smokemail template for alerts.";
       };
       targetConfig = mkOption {
-        type = types.string;
+        type = types.lines;
         default = ''
 					probe = FPing
 					menu = Top
@@ -253,7 +255,7 @@ in
         description = "Target configuration";
       };
       user = mkOption {
-        type = types.string;
+        type = types.str;
         default = "smokeping";
         description = "User that runs smokeping and (optionally) thttpd";
       };

--- a/nixos/modules/services/networking/softether.nix
+++ b/nixos/modules/services/networking/softether.nix
@@ -50,7 +50,7 @@ in
       };
 
       dataDir = mkOption {
-        type = types.string;
+        type = types.path;
         default = "/var/lib/softether";
         description = ''
           Data directory for SoftEther VPN.

--- a/nixos/modules/services/networking/stunnel.nix
+++ b/nixos/modules/services/networking/stunnel.nix
@@ -35,12 +35,12 @@ let
   clientConfig = {
     options = {
       accept = mkOption {
-        type = types.string;
+        type = types.str;
         description = "IP:Port on which connections should be accepted.";
       };
 
       connect = mkOption {
-        type = types.string;
+        type = types.str;
         description = "IP:Port destination to connect to.";
       };
 
@@ -63,7 +63,7 @@ let
       };
 
       verifyHostname = mkOption {
-        type = with types; nullOr string;
+        type = with types; nullOr str;
         default = null;
         description = "If set, stunnel checks if the provided certificate is valid for the given hostname.";
       };
@@ -88,13 +88,13 @@ in
       };
 
       user = mkOption {
-        type = with types; nullOr string;
+        type = with types; nullOr str;
         default = "nobody";
         description = "The user under which stunnel runs.";
       };
 
       group = mkOption {
-        type = with types; nullOr string;
+        type = with types; nullOr str;
         default = "nogroup";
         description = "The group under which stunnel runs.";
       };

--- a/nixos/modules/services/networking/toxvpn.nix
+++ b/nixos/modules/services/networking/toxvpn.nix
@@ -8,7 +8,7 @@ with lib;
       enable = mkEnableOption "toxvpn running on startup";
 
       localip = mkOption {
-        type        = types.string;
+        type        = types.str;
         default     = "10.123.123.1";
         description = "your ip on the vpn";
       };
@@ -20,7 +20,7 @@ with lib;
       };
 
       auto_add_peers = mkOption {
-        type        = types.listOf types.string;
+        type        = types.listOf types.str;
         default     = [];
         example     = ''[ "toxid1" "toxid2" ]'';
         description = "peers to automacally connect to on startup";

--- a/nixos/modules/services/networking/vsftpd.nix
+++ b/nixos/modules/services/networking/vsftpd.nix
@@ -164,7 +164,7 @@ in
       };
 
       anonymousUmask = mkOption {
-        type = types.string;
+        type = types.str;
         default = "077";
         example = "002";
         description = "Anonymous write umask.";

--- a/nixos/modules/services/networking/xinetd.nix
+++ b/nixos/modules/services/networking/xinetd.nix
@@ -53,7 +53,7 @@ in
 
     services.xinetd.extraDefaults = mkOption {
       default = "";
-      type = types.string;
+      type = types.lines;
       description = ''
         Additional configuration lines added to the default section of xinetd's configuration.
       '';
@@ -70,13 +70,13 @@ in
         options = {
 
           name = mkOption {
-            type = types.string;
+            type = types.str;
             example = "login";
             description = "Name of the service.";
           };
 
           protocol = mkOption {
-            type = types.string;
+            type = types.str;
             default = "tcp";
             description =
               "Protocol of the service.  Usually <literal>tcp</literal> or <literal>udp</literal>.";
@@ -90,25 +90,25 @@ in
           };
 
           user = mkOption {
-            type = types.string;
+            type = types.str;
             default = "nobody";
             description = "User account for the service";
           };
 
           server = mkOption {
-            type = types.string;
+            type = types.str;
             example = "/foo/bin/ftpd";
             description = "Path of the program that implements the service.";
           };
 
           serverArgs = mkOption {
-            type = types.string;
+            type = types.separatedString " ";
             default = "";
             description = "Command-line arguments for the server program.";
           };
 
           flags = mkOption {
-            type = types.string;
+            type = types.str;
             default = "";
             description = "";
           };

--- a/nixos/modules/services/networking/xl2tpd.nix
+++ b/nixos/modules/services/networking/xl2tpd.nix
@@ -8,13 +8,13 @@ with lib;
       enable = mkEnableOption "xl2tpd, the Layer 2 Tunnelling Protocol Daemon";
 
       serverIp = mkOption {
-        type        = types.string;
+        type        = types.str;
         description = "The server-side IP address.";
         default     = "10.125.125.1";
       };
 
       clientIpRange = mkOption {
-        type        = types.string;
+        type        = types.str;
         description = "The range from which client IPs are drawn.";
         default     = "10.125.125.2-11";
       };

--- a/nixos/modules/services/security/haka.nix
+++ b/nixos/modules/services/security/haka.nix
@@ -69,7 +69,7 @@ in
       configFile = mkOption {
         default = "empty.lua";
         example = "/srv/haka/myfilter.lua";
-        type = types.string;
+        type = types.str;
         description = ''
           Specify which configuration file Haka uses.
           It can be absolute path or a path relative to the sample directory of
@@ -80,7 +80,7 @@ in
       interfaces = mkOption {
         default = [ "eth0" ];
         example = [ "any" ];
-        type = with types; listOf string;
+        type = with types; listOf str;
         description = ''
           Specify which interface(s) Haka listens to.
           Use 'any' to listen to all interfaces.

--- a/nixos/modules/services/security/munge.nix
+++ b/nixos/modules/services/security/munge.nix
@@ -19,7 +19,7 @@ in
 
       password = mkOption {
         default = "/etc/munge/munge.key";
-        type = types.string;
+        type = types.path;
         description = ''
           The path to a daemon's secret key.
         '';

--- a/nixos/modules/services/security/oauth2_proxy.nix
+++ b/nixos/modules/services/security/oauth2_proxy.nix
@@ -284,7 +284,7 @@ in
     ####################################################
     # UPSTREAM Configuration
     upstream = mkOption {
-      type = with types; coercedTo string (x: [x]) (listOf string);
+      type = with types; coercedTo str (x: [x]) (listOf str);
       default = [];
       description = ''
         The http url(s) of the upstream endpoint or <literal>file://</literal>
@@ -523,7 +523,7 @@ in
     };
 
     keyFile = mkOption {
-      type = types.nullOr types.string;
+      type = types.nullOr types.path;
       default = null;
       description = ''
         oauth2_proxy allows passing sensitive configuration via environment variables.

--- a/nixos/modules/services/security/oauth2_proxy_nginx.nix
+++ b/nixos/modules/services/security/oauth2_proxy_nginx.nix
@@ -6,14 +6,14 @@ in
 {
   options.services.oauth2_proxy.nginx = {
     proxy = mkOption {
-      type = types.string;
+      type = types.str;
       default = config.services.oauth2_proxy.httpAddress;
       description = ''
         The address of the reverse proxy endpoint for oauth2_proxy
       '';
     };
     virtualHosts = mkOption {
-      type = types.listOf types.string;
+      type = types.listOf types.str;
       default = [];
       description = ''
         A list of nginx virtual hosts to put behind the oauth2 proxy

--- a/nixos/modules/services/torrent/flexget.nix
+++ b/nixos/modules/services/torrent/flexget.nix
@@ -19,7 +19,7 @@ in {
       user = mkOption {
         default = "deluge";
         example = "some_user";
-        type = types.string;
+        type = types.str;
         description = "The user under which to run flexget.";
       };
 
@@ -33,7 +33,7 @@ in {
       interval = mkOption {
         default = "10m";
         example = "1h";
-        type = types.string;
+        type = types.str;
         description = "When to perform a <command>flexget</command> run. See <command>man 7 systemd.time</command> for the format.";
       };
 

--- a/nixos/modules/services/web-apps/youtrack.nix
+++ b/nixos/modules/services/web-apps/youtrack.nix
@@ -28,28 +28,28 @@ in
         The interface youtrack will listen on.
       '';
       default = "127.0.0.1";
-      type = types.string;
+      type = types.str;
     };
 
     baseUrl = mkOption {
       description = ''
         Base URL for youtrack. Will be auto-detected and stored in database.
       '';
-      type = types.nullOr types.string;
+      type = types.nullOr types.str;
       default = null;
     };
 
     extraParams = mkOption {
       default = {};
       description = ''
-        Extra parameters to pass to youtrack. See 
+        Extra parameters to pass to youtrack. See
         https://www.jetbrains.com/help/youtrack/standalone/YouTrack-Java-Start-Parameters.html
         for more information.
       '';
       example = {
         "jetbrains.youtrack.overrideRootPassword" = "tortuga";
       };
-      type = types.attrsOf types.string;
+      type = types.attrsOf types.str;
     };
 
     package = mkOption {
@@ -73,7 +73,7 @@ in
       description = ''
         Where to keep the youtrack database.
       '';
-      type = types.string;
+      type = types.path;
       default = "/var/lib/youtrack";
     };
 
@@ -83,7 +83,7 @@ in
         If null, do not setup anything.
       '';
       default = null;
-      type = types.nullOr types.string;
+      type = types.nullOr types.str;
     };
 
     jvmOpts = mkOption {
@@ -92,7 +92,7 @@ in
         See https://www.jetbrains.com/help/youtrack/standalone/Configure-JVM-Options.html
         for more information.
       '';
-      type = types.string;
+      type = types.separatedString " ";
       example = "-XX:MetaspaceSize=250m";
       default = "";
     };
@@ -101,7 +101,7 @@ in
       description = ''
         Maximum Java heap size
       '';
-      type = types.string;
+      type = types.str;
       default = "1g";
     };
 
@@ -109,7 +109,7 @@ in
       description = ''
         Maximum java Metaspace memory.
       '';
-      type = types.string;
+      type = types.str;
       default = "350m";
     };
   };

--- a/nixos/modules/services/web-servers/apache-httpd/per-server-options.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/per-server-options.nix
@@ -33,7 +33,7 @@ with lib;
                 description = "port to listen on";
               };
               ip = mkOption {
-                type = types.string;
+                type = types.str;
                 default = "*";
                 description = "Ip to listen on. 0.0.0.0 for ipv4 only, * for all.";
               };

--- a/nixos/modules/services/web-servers/caddy.nix
+++ b/nixos/modules/services/web-servers/caddy.nix
@@ -27,13 +27,13 @@ in {
     ca = mkOption {
       default = "https://acme-v02.api.letsencrypt.org/directory";
       example = "https://acme-staging-v02.api.letsencrypt.org/directory";
-      type = types.string;
+      type = types.str;
       description = "Certificate authority ACME server. The default (Let's Encrypt production server) should be fine for most people.";
     };
 
     email = mkOption {
       default = "";
-      type = types.string;
+      type = types.str;
       description = "Email address (for Let's Encrypt certificate)";
     };
 

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -473,7 +473,7 @@ in
       };
 
       clientMaxBodySize = mkOption {
-        type = types.string;
+        type = types.str;
         default = "10m";
         description = "Set nginx global client_max_body_size.";
       };

--- a/nixos/modules/services/web-servers/traefik.nix
+++ b/nixos/modules/services/web-servers/traefik.nix
@@ -67,7 +67,7 @@ in {
 
     group = mkOption {
       default = "traefik";
-      type = types.string;
+      type = types.str;
       example = "docker";
       description = ''
         Set the group that traefik runs under.

--- a/nixos/modules/services/web-servers/uwsgi.nix
+++ b/nixos/modules/services/web-servers/uwsgi.nix
@@ -72,7 +72,7 @@ in {
       };
 
       runDir = mkOption {
-        type = types.string;
+        type = types.path;
         default = "/run/uwsgi";
         description = "Where uWSGI communication sockets can live";
       };

--- a/nixos/modules/services/web-servers/zope2.nix
+++ b/nixos/modules/services/web-servers/zope2.nix
@@ -11,7 +11,7 @@ let
 
       name = mkOption {
         default = "${name}";
-        type = types.string;
+        type = types.str;
         description = "The name of the zope2 instance. If undefined, the name of the attribute set will be used.";
       };
 
@@ -23,19 +23,19 @@ let
 
       http_address = mkOption {
         default = "localhost:8080";
-        type = types.string;
+        type = types.str;
         description = "Give a port and address for the HTTP server.";
       };
 
       user = mkOption {
         default = "zope2";
-        type = types.string;
+        type = types.str;
         description = "The name of the effective user for the Zope process.";
       };
 
       clientHome = mkOption {
         default = "/var/lib/zope2/${name}";
-        type = types.string;
+        type = types.path;
         description = "Home directory of zope2 instance.";
       };
       extra = mkOption {
@@ -52,7 +52,7 @@ let
             </blobstorage>
           </zodb_db>
           '';
-        type = types.string;
+        type = types.lines;
         description = "Extra zope.conf";
       };
 

--- a/nixos/modules/services/x11/desktop-managers/surf-display.nix
+++ b/nixos/modules/services/x11/desktop-managers/surf-display.nix
@@ -48,7 +48,7 @@ in {
       enable = mkEnableOption "surf-display as a kiosk browser session";
 
       defaultWwwUri = mkOption {
-        type = types.string;
+        type = types.str;
         default = "${pkgs.surf-display}/share/surf-display/empty-page.html";
         example = "https://www.example.com/";
         description = "Default URI to display.";
@@ -69,7 +69,7 @@ in {
       };
 
       screensaverSettings = mkOption {
-        type = types.string;
+        type = types.separatedString " ";
         default = "";
         description = ''
           Screensaver settings, see <literal>man 1 xset</literal> for possible options.
@@ -77,7 +77,7 @@ in {
       };
 
       pointerButtonMap = mkOption {
-        type = types.string;
+        type = types.str;
         default = "1 0 0 4 5 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0";
         description = ''
           Disable right and middle pointer device click in browser sessions
@@ -87,14 +87,14 @@ in {
       };
 
       hideIdlePointer = mkOption {
-        type = types.string;
+        type = types.str;
         default = "yes";
         example = "no";
         description = "Hide idle mouse pointer.";
       };
 
       extraConfig = mkOption {
-        type = types.string;
+        type = types.lines;
         default = "";
         example = ''
           # Enforce fixed resolution for all displays (default: not set):

--- a/nixos/modules/services/x11/display-managers/lightdm.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm.nix
@@ -114,7 +114,7 @@ in
 
         };
         name = mkOption {
-          type = types.string;
+          type = types.str;
           description = ''
             The name of a .desktop file in the directory specified
             in the 'package' option.

--- a/nixos/modules/services/x11/hardware/libinput.nix
+++ b/nixos/modules/services/x11/hardware/libinput.nix
@@ -41,13 +41,13 @@ in {
       };
 
       accelSpeed = mkOption {
-        type = types.nullOr types.string;
+        type = types.nullOr types.str;
         default = null;
         description = "Cursor acceleration (how fast speed increases from minSpeed to maxSpeed).";
       };
 
       buttonMapping = mkOption {
-        type = types.nullOr types.string;
+        type = types.nullOr types.str;
         default = null;
         description =
           ''
@@ -61,7 +61,7 @@ in {
       };
 
       calibrationMatrix = mkOption {
-        type = types.nullOr types.string;
+        type = types.nullOr types.str;
         default = null;
         description =
           ''

--- a/nixos/modules/services/x11/hardware/synaptics.nix
+++ b/nixos/modules/services/x11/hardware/synaptics.nix
@@ -44,19 +44,19 @@ in {
       };
 
       accelFactor = mkOption {
-        type = types.nullOr types.string;
+        type = types.nullOr types.str;
         default = "0.001";
         description = "Cursor acceleration (how fast speed increases from minSpeed to maxSpeed).";
       };
 
       minSpeed = mkOption {
-        type = types.nullOr types.string;
+        type = types.nullOr types.str;
         default = "0.6";
         description = "Cursor speed factor for precision finger motion.";
       };
 
       maxSpeed = mkOption {
-        type = types.nullOr types.string;
+        type = types.nullOr types.str;
         default = "1.0";
         description = "Cursor speed factor for highest-speed finger motion.";
       };

--- a/nixos/modules/services/x11/window-managers/xmonad.nix
+++ b/nixos/modules/services/x11/window-managers/xmonad.nix
@@ -59,7 +59,7 @@ in
 
       config = mkOption {
         default = null;
-        type = with lib.types; nullOr (either path string);
+        type = with lib.types; nullOr (either path str);
         description = ''
           Configuration from which XMonad gets compiled. If no value
           is specified, the xmonad config from $HOME/.xmonad is taken.

--- a/nixos/modules/system/boot/binfmt.nix
+++ b/nixos/modules/system/boot/binfmt.nix
@@ -239,7 +239,7 @@ in {
           List of systems to emulate. Will also configure Nix to
           support your new systems.
         '';
-        type = types.listOf types.string;
+        type = types.listOf types.str;
       };
     };
   };

--- a/nixos/modules/system/boot/loader/grub/grub.nix
+++ b/nixos/modules/system/boot/loader/grub/grub.nix
@@ -8,7 +8,7 @@ let
 
   efi = config.boot.loader.efi;
 
-  grubPkgs = 
+  grubPkgs =
     # Package set of targeted architecture
     if cfg.forcei686 then pkgs.pkgsi686Linux else pkgs;
 
@@ -333,7 +333,7 @@ in
       };
 
       backgroundColor = mkOption {
-        type = types.nullOr types.string;
+        type = types.nullOr types.str;
         example = "#7EBAE4";
         default = null;
         description = ''
@@ -399,7 +399,7 @@ in
         example = "text";
         type = types.str;
         description = ''
-          The gfxpayload to pass to GRUB when loading a graphical boot interface under EFI. 
+          The gfxpayload to pass to GRUB when loading a graphical boot interface under EFI.
         '';
       };
 
@@ -408,7 +408,7 @@ in
         example = "keep";
         type = types.str;
         description = ''
-          The gfxpayload to pass to GRUB when loading a graphical boot interface under BIOS. 
+          The gfxpayload to pass to GRUB when loading a graphical boot interface under BIOS.
         '';
       };
 
@@ -535,7 +535,7 @@ in
         default = false;
         type = types.bool;
         description = ''
-          Whether to force the use of a ia32 boot loader on x64 systems. Required 
+          Whether to force the use of a ia32 boot loader on x64 systems. Required
           to install and run NixOS on 64bit x86 systems with 32bit (U)EFI.
         '';
       };
@@ -554,7 +554,7 @@ in
         systemHasTPM = mkOption {
           default = "";
           example = "YES_TPM_is_activated";
-          type = types.string;
+          type = types.str;
           description = ''
             Assertion that the target system has an activated TPM. It is a safety
             check before allowing the activation of 'trustedBoot.enable'. TrustedBoot

--- a/nixos/modules/system/boot/loader/raspberrypi/raspberrypi.nix
+++ b/nixos/modules/system/boot/loader/raspberrypi/raspberrypi.nix
@@ -10,7 +10,7 @@ let
   builderUboot = import ./uboot-builder.nix { inherit pkgs configTxt; inherit (cfg) version; };
   builderGeneric = import ./raspberrypi-builder.nix { inherit pkgs configTxt; };
 
-  builder = 
+  builder =
     if cfg.uboot.enable then
       "${builderUboot} -g ${toString cfg.uboot.configurationLimit} -t ${timeoutStr} -c"
     else
@@ -86,7 +86,7 @@ in
 
       firmwareConfig = mkOption {
         default = null;
-        type = types.nullOr types.string;
+        type = types.nullOr types.lines;
         description = ''
           Extra options that will be appended to <literal>/boot/config.txt</literal> file.
           For possible values, see: https://www.raspberrypi.org/documentation/configuration/config-txt/

--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -836,7 +836,7 @@ in
         options = {
 
           device = mkOption {
-            type = types.string;
+            type = types.str;
             example = "wlp6s0";
             description = "The name of the underlying hardware WLAN device as assigned by <literal>udev</literal>.";
           };
@@ -852,7 +852,7 @@ in
           };
 
           meshID = mkOption {
-            type = types.nullOr types.string;
+            type = types.nullOr types.str;
             default = null;
             description = "MeshID of interface with type <literal>mesh</literal>.";
           };

--- a/nixos/modules/virtualisation/anbox.nix
+++ b/nixos/modules/virtualisation/anbox.nix
@@ -56,7 +56,7 @@ in
 
       dns = mkOption {
         default = "1.1.1.1";
-        type = types.string;
+        type = types.str;
         description = ''
           Container DNS server.
         '';

--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -337,7 +337,7 @@ let
 
   networkOptions = {
     hostBridge = mkOption {
-      type = types.nullOr types.string;
+      type = types.nullOr types.str;
       default = null;
       example = "br0";
       description = ''
@@ -387,7 +387,7 @@ let
     };
 
     hostAddress6 = mkOption {
-      type = types.nullOr types.string;
+      type = types.nullOr types.str;
       default = null;
       example = "fc00::1";
       description = ''
@@ -409,7 +409,7 @@ let
     };
 
     localAddress6 = mkOption {
-      type = types.nullOr types.string;
+      type = types.nullOr types.str;
       default = null;
       example = "fc00::2";
       description = ''
@@ -565,7 +565,7 @@ in
             };
 
             interfaces = mkOption {
-              type = types.listOf types.string;
+              type = types.listOf types.str;
               default = [];
               example = [ "eth1" "eth2" ];
               description = ''

--- a/nixos/modules/virtualisation/kvmgt.nix
+++ b/nixos/modules/virtualisation/kvmgt.nix
@@ -9,7 +9,7 @@ let
 
   vgpuOptions = {
     uuid = mkOption {
-      type = types.string;
+      type = types.str;
       description = "UUID of VGPU device. You can generate one with <package>libossp_uuid</package>.";
     };
   };
@@ -23,7 +23,7 @@ in {
       '';
       # multi GPU support is under the question
       device = mkOption {
-        type = types.string;
+        type = types.str;
         default = "0000:00:02.0";
         description = "PCI ID of graphics card. You can figure it with <command>ls /sys/class/mdev_bus</command>.";
       };

--- a/nixos/modules/virtualisation/xen-dom0.nix
+++ b/nixos/modules/virtualisation/xen-dom0.nix
@@ -119,7 +119,7 @@ in
 
     virtualisation.xen.domains = {
         extraConfig = mkOption {
-          type = types.string;
+          type = types.lines;
           default = "";
           description =
             ''

--- a/pkgs/build-support/writers/default.nix
+++ b/pkgs/build-support/writers/default.nix
@@ -10,12 +10,12 @@ rec {
   #   makeScriptWriter { interpreter = "${pkgs.dash}/bin/dash"; } "hello" "echo hello world"
   makeScriptWriter = { interpreter, check ? "" }: nameOrPath: content:
     assert lib.or (types.path.check nameOrPath) (builtins.match "([0-9A-Za-z._])[0-9A-Za-z._-]*" nameOrPath != null);
-    assert lib.or (types.path.check content) (types.string.check content);
+    assert lib.or (types.path.check content) (types.str.check content);
     let
       name = last (builtins.split "/" nameOrPath);
     in
 
-    pkgs.runCommand name (if (types.string.check content) then {
+    pkgs.runCommand name (if (types.str.check content) then {
       inherit content interpreter;
       passAsFile = [ "content" ];
     } else {
@@ -42,11 +42,11 @@ rec {
   #   writeSimpleC = makeBinWriter { compileScript = name: "gcc -o $out $contentPath"; }
   makeBinWriter = { compileScript }: nameOrPath: content:
     assert lib.or (types.path.check nameOrPath) (builtins.match "([0-9A-Za-z._])[0-9A-Za-z._-]*" nameOrPath != null);
-    assert lib.or (types.path.check content) (types.string.check content);
+    assert lib.or (types.path.check content) (types.str.check content);
     let
       name = last (builtins.split "/" nameOrPath);
     in
-    pkgs.runCommand name (if (types.string.check content) then {
+    pkgs.runCommand name (if (types.str.check content) then {
       inherit content;
       passAsFile = [ "content" ];
     } else {


### PR DESCRIPTION
##### Motivation for this change

For almost 6 (!) years now, `types.string` has been marked as deprecated in the comment above its definition. People keep using this type regardless, and it's getting annoying while reviewing PRs to constantly have to remind people to not use it.

This PR does following things:
- Remove all usages of `types.string` in nixpkgs and replace them with a more appropriate type
- Make `types.string` emit a warning upon use

The mass replacement was done all manually, because I needed to decide what the replacement type should be. This was either
- `types.str` when merging doesn't make sense (e.g. `user` options)
- `types.separatedString " "` if its an option representing command line arguments (ideally it should be `listOf str` for new modules)
- `types.lines` if it's a line-based configuration format (where joining with newlines makes sense)
- `types.str` if it's a different configuration format where concatenation doesn't work

Ping @Profpatsch @rycee @aanderse @danbst 

###### Things done

I have **not** tested any of the modules. While there's a very low chance of any of these changes breaking anything, I might have made a mistake somewhere. A double-check would therefore be good. 

- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
