### PR TITLE
pythonPackages.dask: 1.2.2 -> 2.2.0

### DIFF
--- a/pkgs/development/python-modules/dask/default.nix
+++ b/pkgs/development/python-modules/dask/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , pytest
+, pythonOlder
 , cloudpickle
 , numpy
 , toolz
@@ -13,6 +14,8 @@
 buildPythonPackage rec {
   pname = "dask";
   version = "1.2.2";
+
+  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/dask/default.nix
+++ b/pkgs/development/python-modules/dask/default.nix
@@ -1,6 +1,8 @@
 { lib
+, bokeh
 , buildPythonPackage
 , fetchPypi
+, fsspec
 , pytest
 , pythonOlder
 , cloudpickle
@@ -13,17 +15,18 @@
 
 buildPythonPackage rec {
   pname = "dask";
-  version = "1.2.2";
+  version = "2.2.0";
 
   disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "5e7876bae2a01b355d1969b73aeafa23310febd8c353163910b73e93dc7e492c";
+    sha256 = "0wkiqkckwy7fv6m86cs3m3g6jdikkkw84ki9hiwp60xpk5xngnf0";
   };
 
   checkInputs = [ pytest ];
-  propagatedBuildInputs = [ cloudpickle  numpy toolz dill pandas partd ];
+  propagatedBuildInputs = [
+    bokeh cloudpickle dill fsspec numpy pandas partd toolz ];
 
   checkPhase = ''
     py.test dask

--- a/pkgs/development/python-modules/fsspec/default.nix
+++ b/pkgs/development/python-modules/fsspec/default.nix
@@ -1,0 +1,26 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "fsspec";
+  version = "0.4.1";
+
+  disabled = pythonOlder "3.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0fvm1kdnnbf0pppv23mlfdqh220gcldmv72w2rdxp6ks1rcphzg3";
+  };
+
+  # no tests
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A specification that python filesystems should adhere to.";
+    homepage = "https://github.com/intake/filesystem_spec";
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -579,6 +579,8 @@ in {
 
   filemagic = callPackage ../development/python-modules/filemagic { };
 
+  fsspec = callPackage ../development/python-modules/fsspec { };
+
   fuse = callPackage ../development/python-modules/fuse-python {
     inherit (pkgs) fuse pkgconfig;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
This Pull Request upgrades the dask package to 2.2.0.

###### Things done
Updated the default.nix of the package, compiled on MacOS X and obtained the `sha256` number. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
@kalbasit 