### PR TITLE
python3Packages.mpv: 0.1 -> 0.3.9

### DIFF
--- a/pkgs/development/python-modules/mps-youtube/default.nix
+++ b/pkgs/development/python-modules/mps-youtube/default.nix
@@ -1,20 +1,17 @@
-{ stdenv
-, buildPythonPackage
-, fetchFromGitHub
-, isPy3k
+{ lib, buildPythonPackage, fetchFromGitHub, isPy3k
 , pafy
 }:
 
 buildPythonPackage rec {
-  name = "mps-youtube-${version}";
-  version = "0.2.7.1";
+  pname = "mps-youtube";
+  version = "0.2.8";
   disabled = (!isPy3k);
 
   src = fetchFromGitHub {
     owner = "mps-youtube";
     repo = "mps-youtube";
     rev = "v${version}";
-    sha256 = "16zn5gwb3568w95lr21b88zkqlay61p1541sa9c3x69zpi8v0pys";
+    sha256 = "1w1jhw9rg3dx7vp97cwrk5fymipkcy2wrbl1jaa38ivcjhqg596y";
   };
 
   propagatedBuildInputs = [ pafy ];
@@ -29,11 +26,10 @@ buildPythonPackage rec {
     export XDG_CONFIG_HOME=$(pwd)/check-phase
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Terminal based YouTube player and downloader";
     homepage = https://github.com/np1/mps-youtube;
     license = licenses.gpl3;
     maintainers = with maintainers; [ odi ];
   };
-
 }

--- a/pkgs/development/python-modules/mpv/default.nix
+++ b/pkgs/development/python-modules/mpv/default.nix
@@ -1,25 +1,33 @@
-{ stdenv
-, buildPythonPackage
-, fetchPypi
-, pkgs
+{ stdenv, buildPythonPackage, fetchFromGitHub, python, isPy27
+, mpv
 }:
 
 buildPythonPackage rec {
   pname = "mpv";
-  version = "0.1";
+  version = "0.3.9";
+  disabled = isPy27;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "0b9kd70mshdr713f3l1lbnz1q0vlg2y76h5d8liy1bzqm7hjcgfw";
+  src = fetchFromGitHub {
+    owner = "jaseg";
+    repo = "python-mpv";
+    rev = "v${version}";
+    sha256 = "112kr9wppcyy3shsb7v7kq0s1pdw6vw3v2fvqicm7qb2f49y2p4q";
   };
 
-  buildInputs = [ pkgs.mpv ];
-  patchPhase = "substituteInPlace mpv.py --replace libmpv.so ${pkgs.mpv}/lib/libmpv.so";
+  buildInputs = [ mpv ];
+
+  postPatch = ''
+    substituteInPlace mpv.py \
+      --replace "sofile = ctypes.util.find_library('mpv')" \
+                'sofile = "${mpv}/lib/libmpv${stdenv.targetPlatform.extensions.sharedLibrary}"'
+  '';
+
+  # tests impure, will error if it can't load libmpv.so
+  checkPhase = "${python.interpreter} -c 'import mpv'";
 
   meta = with stdenv.lib; {
     description = "A python interface to the mpv media player";
     homepage = "https://github.com/jaseg/python-mpv";
     license = licenses.agpl3;
   };
-
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3712,7 +3712,7 @@ in {
 
   mpd2 = callPackage ../development/python-modules/mpd2 { };
 
-  mpv = callPackage ../development/python-modules/mpv { };
+  mpv = callPackage ../development/python-modules/mpv { mpv = pkgs.mpv; };
 
   mrbob = callPackage ../development/python-modules/mrbob {};
 


### PR DESCRIPTION
###### Motivation for this change
trying to close old tickets.

closes #29017

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @oxij

```
[1 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/66351
2 package were build:
python37Packages.mps-youtube python37Packages.mpv
```
both have large multimedia dependencies, the large size is expected.
```
[nix-shell:~/.cache/nix-review/pr-66351]$ nix path-info -Sh ./results/python37Packages.mpv
/nix/store/gymggqpcgkkk4qa3a9ic5x29mp8s8dbl-python3.7-mpv-0.3.9  271.2M

[nix-shell:~/.cache/nix-review/pr-66351]$ nix path-info -Sh ./results/python37Packages.mps-youtube
/nix/store/x25dq78m7zmm5bp9586rjnz9m7hmcv4s-python3.7-mps-youtube-0.2.8  231.5M
```