### PR TITLE
nixos/beegfs: mark as broken

### DIFF
--- a/pkgs/os-specific/linux/beegfs/default.nix
+++ b/pkgs/os-specific/linux/beegfs/default.nix
@@ -159,5 +159,8 @@ in stdenv.mkDerivation rec {
       free = false;
     };
     maintainers = with maintainers; [ markuskowa ];
+    # 2019-08-09
+    # fails to build and had stability issues earlier
+    broken = true;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
BeeGFS is a fantastic high performance file system. However, after running it for a few months last year the meta data daemon kept crashing randomly in production use (support from the manufacturer requires a paid support contract). The current version that is nixpkgs is outdated and I don not want to maintain it any longer. The build system is purely based on make file and is hard to maintain.

###### Things done

Mark beegfs as broken.

~~Removed the following items:~~
* ~~the main package~~
* ~~the kernel module~~
* ~~nixos module~~
* ~~tests~~

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
