### PR TITLE
slrn: 1.0.2 -> 1.0.3a

### DIFF
--- a/pkgs/applications/networking/newsreaders/slrn/default.nix
+++ b/pkgs/applications/networking/newsreaders/slrn/default.nix
@@ -1,14 +1,13 @@
 { stdenv, fetchurl
 , slang, ncurses, openssl }:
 
-let version = "1.0.2"; in
-
-stdenv.mkDerivation {
-  name = "slrn-${version}";
+stdenv.mkDerivation rec {
+  pname = "slrn";
+  version = "1.0.3a";
 
   src = fetchurl {
-    url = "http://www.jedsoft.org/releases/slrn/slrn-${version}.tar.gz";
-    sha256 = "1gn6m2zha2nnnrh9lz3m3nrqk6fgfij1wc53pg25j7sdgvlziv12";
+    url = "http://www.jedsoft.org/releases/slrn/slrn-${version}.tar.bz2";
+    sha256 = "1b1d9iikr60w0vq86y9a0l4gjl0jxhdznlrdp3r405i097as9a1v";
   };
 
   preConfigure = ''


### PR DESCRIPTION
###### Motivation for this change

Update to latest version

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @ehmry 
