### PR TITLE
pythonPackage.xapian: init at 1.4.12

### DIFF
--- a/pkgs/development/python-modules/xapian/default.nix
+++ b/pkgs/development/python-modules/xapian/default.nix
@@ -1,0 +1,43 @@
+{ lib, buildPythonPackage, fetchurl, python
+, sphinx
+, xapian
+}:
+
+let
+  pythonSuffix = lib.optionalString python.isPy3k "3";
+in
+buildPythonPackage rec {
+  pname = "xapian";
+  inherit (xapian) version;
+  format = "other";
+
+  src = fetchurl {
+    url = "https://oligarchy.co.uk/xapian/${version}/xapian-bindings-${version}.tar.xz";
+    sha256 = "0j9awiiw9zf97r60m848absq43k37gghpyw7acxqjazfzd71fxvm";
+  };
+
+  configureFlags = [
+    "--with-python${pythonSuffix}"
+    "PYTHON${pythonSuffix}_LIB=${placeholder "out"}/${python.sitePackages}"
+  ];
+
+  preConfigure = ''
+    export XAPIAN_CONFIG=${xapian}/bin/xapian-config
+  '';
+
+  buildInputs = [ sphinx xapian ];
+
+  doCheck = true;
+
+  checkPhase = ''
+    ${python.interpreter} python${pythonSuffix}/smoketest.py
+    ${python.interpreter} python${pythonSuffix}/pythontest.py
+  '';
+
+  meta = with lib; {
+    description = "Python Bindings for Xapian";
+    homepage = https://xapian.org/;
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4991,6 +4991,8 @@ in {
 
   xarray = callPackage ../development/python-modules/xarray { };
 
+  xapian = callPackage ../development/python-modules/xapian { xapian = pkgs.xapian; };
+
   xlwt = callPackage ../development/python-modules/xlwt { };
 
   xxhash = callPackage ../development/python-modules/xxhash { };


### PR DESCRIPTION
###### Motivation for this change
trying to close old tickets. closes #49662

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
$ nix path-info -Sh ./result
/nix/store/yp01ykz45mhdidya3hw8n0l75vgp9ssv-python3.7-xapian-1.4.12      111.7M
```
everything is linked alright
```
$ ldd ./result/lib/python3.7/site-packages/xapian/_xapian.cpython-37m-x86_64-linux-gnu.so
        linux-vdso.so.1 (0x00007ffd74d1f000)
        libxapian.so.30 => /nix/store/pwk48a4z62zapl66hhammjb7r55bwzma-xapian-1.4.12/lib/libxapian.so.30 (0x00007f2871d0f000)
        libstdc++.so.6 => /nix/store/pjx3f50x0qziyivs7rbg5s12p99nn2np-gcc-7.4.0-lib/lib/../lib64/libstdc++.so.6 (0x00007f2871b85000)
        libm.so.6 => /nix/store/iykxb0bmfjmi7s53kfg6pjbfpd8jmza6-glibc-2.27/lib/libm.so.6 (0x00007f28719ef000)
        libc.so.6 => /nix/store/iykxb0bmfjmi7s53kfg6pjbfpd8jmza6-glibc-2.27/lib/libc.so.6 (0x00007f2871839000)
        /nix/store/iykxb0bmfjmi7s53kfg6pjbfpd8jmza6-glibc-2.27/lib64/ld-linux-x86-64.so.2 (0x00007f2872060000)
        libgcc_s.so.1 => /nix/store/pjx3f50x0qziyivs7rbg5s12p99nn2np-gcc-7.4.0-lib/lib/../lib64/libgcc_s.so.1 (0x00007f2871820000)
        librt.so.1 => /nix/store/iykxb0bmfjmi7s53kfg6pjbfpd8jmza6-glibc-2.27/lib/librt.so.1 (0x00007f2871814000)
        libz.so.1 => /nix/store/w3wqang215is14xqajycbxmd52b44qkw-zlib-1.2.11/lib/libz.so.1 (0x00007f28717f5000)
        libuuid.so.1 => /nix/store/37rzlcp0v8c9ifmbjix17g5rfk4lrvnp-util-linux-2.33.2/lib/libuuid.so.1 (0x00007f28717ec000)
        libpthread.so.0 => /nix/store/iykxb0bmfjmi7s53kfg6pjbfpd8jmza6-glibc-2.27/lib/libpthread.so.0 (0x00007f28717cb000)
```
not sure if i should remove the docs that get built though, it's about half of the package size
```
$ du -hd0 ./result/*
2.5M    ./result/lib
8.0K    ./result/nix-support
2.2M    ./result/share
```
structure
```
$ tree -L 5 ./result
./result
├── lib
│   └── python3.7
│       └── site-packages
│           └── xapian
│               ├── __init__.cpython-37.opt-1.pyc
│               ├── __init__.cpython-37.pyc
│               ├── __init__.py
│               └── _xapian.cpython-37m-x86_64-linux-gnu.so
├── nix-support
│   └── propagated-build-inputs
└── share
    └── doc
        └── xapian-bindings
            └── python3
                ├── examples
                └── html
```
```
nix-review pr 66356
...
[1 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/66356
2 package were build:
python27Packages.xapian python37Packages.xapian
```