### PR TITLE
openxr-loader: init at 1.0.1

### DIFF
--- a/pkgs/development/libraries/openxr-loader/default.nix
+++ b/pkgs/development/libraries/openxr-loader/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchFromGitHub, cmake, python3, libX11, libXxf86vm, libXrandr }:
+
+stdenv.mkDerivation rec {
+  pname = "openxr-loader";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "KhronosGroup";
+    repo = "OpenXR-SDK-Source";
+    rev = "release-${version}";
+    sha256 = "1sif2w2vm793j6493364i6pp6s6yqi7fwa6iky5abzmzda51cg5q";
+  };
+
+  nativeBuildInputs = [ cmake python3 ];
+  buildInputs = [ libX11 libXxf86vm libXrandr ];
+  enableParallelBuilding = true;
+
+  cmakeFlags = [ "-DBUILD_TESTS=OFF" ];
+
+  outputs = [ "out" "dev" "layers" ];
+
+  postInstall = ''
+    mkdir -p "$layers/share"
+    mv "$out/share/openxr" "$layers/share"
+    # Use absolute paths in manifests so no LD_LIBRARY_PATH shenanigans are necessary
+    for file in "$layers/share/openxr/1/api_layers/explicit.d/"*; do
+        substituteInPlace "$file" --replace '"library_path": "lib' "\"library_path\": \"$layers/lib/lib"
+    done
+    mkdir -p "$layers/lib"
+    mv "$out/lib/libXrApiLayer"* "$layers/lib"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Khronos OpenXR loader";
+    homepage    = https://www.khronos.org/openxr;
+    platforms   = platforms.linux;
+    license     = licenses.asl20;
+    maintainers = [ maintainers.ralith ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14650,6 +14650,8 @@ in
 
   openxpki = callPackage ../servers/openxpki { };
 
+  openxr-loader = callPackage ../development/libraries/openxr-loader { };
+
   osrm-backend = callPackage ../servers/osrm-backend { };
 
   p910nd = callPackage ../servers/p910nd { };


### PR DESCRIPTION
###### Motivation for this change
Infrastructure to allow OpenXR applications to find a runtime like [Monado](https://gitlab.freedesktop.org/monado/monado) or a future version of SteamVR, and headers to allow C/C++ OpenXR applications to be built.

I'm not sure if a custom output for the layers is idiomatic. These are mainly useful when testing OpenXR applications during development, and are not of interest to typical users or builds.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).