### PR TITLE
[staging]pythonPackages.sqlalchemy: 1.2.14 -> 1.3.6

### DIFF
--- a/pkgs/development/python-modules/sqlalchemy/default.nix
+++ b/pkgs/development/python-modules/sqlalchemy/default.nix
@@ -1,42 +1,24 @@
-{ lib
-, fetchPypi
-, fetchpatch
-, buildPythonPackage
-, pytest
+{ lib, fetchPypi, buildPythonPackage, isPy3k
 , mock
-, isPy3k
 , pysqlite
+, pytest
+, pytest_xdist
 }:
 
 buildPythonPackage rec {
   pname = "SQLAlchemy";
-  version = "1.2.14";
+  version = "1.3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "9de7c7dabcf06319becdb7e15099c44e5e34ba7062f9ba10bc00e562f5db3d04";
+    sha256 = "1zxhabcgzspwrh9l7b68p57kqx4h664a1dp9xr8mi84r472pyzi1";
   };
-
-  patches = [
-    # fix for failing doc tests
-    # https://bitbucket.org/zzzeek/sqlalchemy/issues/4370/sqlite-325x-docs-tutorialrst-doctests-fail
-    (fetchpatch {
-      name = "doc-test-fixes.patch";
-      url = https://bitbucket.org/zzzeek/sqlalchemy/commits/63279a69e2b9277df5e97ace161fa3a1bb4f29cd/raw;
-      sha256 = "1x25aj5hqmgjdak4hllya0rf0srr937k1hwaxb24i9ban607hjri";
-    })
-  ];
 
   checkInputs = [
     pytest
     mock
-#     Disable pytest_xdist tests for now, because our version seems to be too new.
-#     pytest_xdist
+    pytest_xdist
   ] ++ lib.optional (!isPy3k) pysqlite;
-
-  checkPhase = ''
-    py.test -k "not test_round_trip_direct_type_affinity"
-  '';
 
   meta = with lib; {
     homepage = http://www.sqlalchemy.org/;


### PR DESCRIPTION
###### Motivation for this change
noticed it was out of date while reviewing another package.

~2000 rebuilds, so I'm doing this against staging

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
