### PR TITLE
maintainers: add github user IDs in service to NixOS/rfcs#39

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -44,6 +44,7 @@
     email = "0x4A6F@shackspace.de";
     name = "Joachim Ernst";
     github = "0x4A6F";
+    githubId = 9675338;
     keys = [{
       longkeyid = "rsa8192/0x87027528B006D66D";
       fingerprint = "F466 A548 AD3F C1F1 8C88  4576 8702 7528 B006 D66D";
@@ -52,36 +53,43 @@
   "1000101" = {
     email = "jan.hrnko@satoshilabs.com";
     github = "1000101";
+    githubId = 791309;
     name = "Jan Hrnko";
   };
   a1russell = {
     email = "adamlr6+pub@gmail.com";
     github = "a1russell";
+    githubId = 241628;
     name = "Adam Russell";
   };
   aanderse = {
     email = "aaron@fosslib.net";
     github = "aanderse";
+    githubId = 7755101;
     name = "Aaron Andersen";
   };
   aaronjanse = {
     email = "aaron@ajanse.me";
     github = "aaronjanse";
+    githubId = 16829510;
     name = "Aaron Janse";
   };
   aaronschif = {
     email = "aaronschif@gmail.com";
     github = "aaronschif";
+    githubId = 2258953;
     name = "Aaron Schif";
   };
   abaldeau = {
     email = "andreas@baldeau.net";
     github = "baldo";
+    githubId = 178750;
     name = "Andreas Baldeau";
   };
   abbe = {
     email = "ashish.is@lostca.se";
     github = "wahjava";
+    githubId = 2255192;
     name = "Ashish SHUKLA";
     keys = [{
       longkeyid = "rsa4096/0xC746CFA9E74FA4B0";
@@ -96,31 +104,37 @@
   abhi18av = {
     email = "abhi18av@gmail.com";
     github = "abhi18av";
+    githubId = 12799326;
     name = "Abhinav Sharma";
   };
   abigailbuccaneer = {
     email = "abigailbuccaneer@gmail.com";
     github = "abigailbuccaneer";
+    githubId = 908758;
     name = "Abigail Bunyan";
   };
   aborsu = {
     email = "a.borsu@gmail.com";
     github = "aborsu";
+    githubId = 5033617;
     name = "Augustin Borsu";
   };
   aboseley = {
     email = "adam.boseley@gmail.com";
     github = "aboseley";
+    githubId = 13504599;
     name = "Adam Boseley";
   };
   abuibrahim = {
     email = "ruslan@babayev.com";
     github = "abuibrahim";
+    githubId = 2321000;
     name = "Ruslan Babayev";
   };
   acowley = {
     email = "acowley@gmail.com";
     github = "acowley";
+    githubId = 124545;
     name = "Anthony Cowley";
   };
   adamt = {
@@ -131,61 +145,73 @@
   adelbertc = {
     email = "adelbertc@gmail.com";
     github = "adelbertc";
+    githubId = 1332980;
     name = "Adelbert Chang";
   };
   adev = {
     email = "adev@adev.name";
     github = "adevress";
+    githubId = 1773511;
     name = "Adrien Devresse";
   };
   adisbladis = {
     email = "adis@blad.is";
     github = "adisbladis";
+    githubId = 63286;
     name = "Adam Hose";
   };
   Adjective-Object = {
     email = "mhuan13@gmail.com";
     github = "Adjective-Object";
+    githubId = 1174858;
     name = "Maxwell Huang-Hobbs";
   };
   adnelson = {
     email = "ithinkican@gmail.com";
     github = "adnelson";
+    githubId = 5091511;
     name = "Allen Nelson";
   };
   adolfogc = {
     email = "adolfo.garcia.cr@gmail.com";
     github = "adolfogc";
+    githubId = 1250775;
     name = "Adolfo E. García Castro";
   };
   aepsil0n = {
     email = "eduard.bopp@aepsil0n.de";
     github = "aepsil0n";
+    githubId = 3098430;
     name = "Eduard Bopp";
   };
   aerialx = {
     email = "aaron+nixos@aaronlindsay.com";
     github = "AerialX";
+    githubId = 117295;
     name = "Aaron Lindsay";
   };
   aespinosa = {
     email = "allan.espinosa@outlook.com";
     github = "aespinosa";
+    githubId = 58771;
     name = "Allan Espinosa";
   };
   aethelz = {
     email = "aethelz@protonmail.com";
     github = "aethelz";
+    githubId = 10677343;
     name = "Eugene";
   };
   aflatter = {
     email = "flatter@fastmail.fm";
     github = "aflatter";
+    githubId = 168;
     name = "Alexander Flatter";
   };
   afldcr = {
     email = "alex@fldcr.com";
     github = "afldcr";
+    githubId = 335271;
     name = "James Alexander Feldman-Crough";
   };
   aforemny = {
@@ -196,36 +222,43 @@
   afranchuk = {
     email = "alex.franchuk@gmail.com";
     github = "afranchuk";
+    githubId = 4296804;
     name = "Alex Franchuk";
   };
   aherrmann = {
     email = "andreash87@gmx.ch";
     github = "aherrmann";
+    githubId = 732652;
     name = "Andreas Herrmann";
   };
   ahmedtd = {
     email = "ahmed.taahir@gmail.com";
     github = "ahmedtd";
+    githubId = 1017202;
     name = "Taahir Ahmed";
   };
   ahuzik = {
     email = "ales.guzik@gmail.com";
     github = "alesguzik";
+    githubId = 209175;
     name = "Ales Huzik";
   };
   aij = {
     email = "aij+git@mrph.org";
     github = "aij";
+    githubId = 4732885;
     name = "Ivan Jager";
   };
   ajs124 = {
     email = "nix@ajs124.de";
     github = "ajs124";
+    githubId = 1229027;
     name = "Andreas Schrägle";
   };
   ajgrf = {
     email = "a@ajgrf.com";
     github = "ajgrf";
+    githubId = 10733175;
     name = "Alex Griffin";
   };
   ak = {
@@ -236,41 +269,49 @@
   akavel = {
     email = "czapkofan@gmail.com";
     github = "akavel";
+    githubId = 273837;
     name = "Mateusz Czapliński";
   };
   akaWolf = {
     email = "akawolf0@gmail.com";
     github = "akaWolf";
+    githubId = 5836586;
     name = "Artjom Vejsel";
   };
   akc = {
     email = "akc@akc.is";
     github = "akc";
+    githubId = 1318982;
     name = "Anders Claesson";
   };
   akru = {
     email = "mail@akru.me";
     github = "akru";
+    githubId = 786394;
     name = "Alexander Krupenkin ";
   };
   alexarice = {
     email = "alexrice999@hotmail.co.uk";
     github = "alexarice";
+    githubId = 17208985;
     name = "Alex Rice";
   };
   alexchapman = {
     email = "alex@farfromthere.net";
     github = "AJChapman";
+    githubId = 8316672;
     name = "Alex Chapman";
   };
   alexfmpe = {
     email = "alexandre.fmp.esteves@gmail.com";
     github = "alexfmpe";
+    githubId = 2335822;
     name = "Alexandre Esteves";
   };
   alexvorobiev = {
     email = "alexander.vorobiev@gmail.com";
     github = "alexvorobiev";
+    githubId = 782180;
     name = "Alex Vorobiev";
   };
   algorith = {
@@ -280,6 +321,7 @@
   alibabzo = {
     email = "alistair.bill@gmail.com";
     github = "alibabzo";
+    githubId = 2822871;
     name = "Alistair Bill";
   };
   all = {
@@ -289,6 +331,7 @@
   allonsy = {
     email = "linuxbash8@gmail.com";
     github = "allonsy";
+    githubId = 5892756;
     name = "Alec Snyder";
   };
   alunduil = {
@@ -299,6 +342,7 @@
   amar1729 = {
     email = "amar.paul16@gmail.com";
     github = "amar1729";
+    githubId = 15623522;
     name = "Amar Paul";
   };
   ambrop72 = {
@@ -309,11 +353,13 @@
   amiddelk = {
     email = "amiddelk@gmail.com";
     github = "amiddelk";
+    githubId = 1358320;
     name = "Arie Middelkoop";
   };
   amiloradovsky = {
     email = "miloradovsky@gmail.com";
     github = "amiloradovsky";
+    githubId = 20530052;
     name = "Andrew Miloradovsky";
   };
   aminb = {
@@ -324,36 +370,43 @@
   aminechikhaoui = {
     email = "amine.chikhaoui91@gmail.com";
     github = "AmineChikhaoui";
+    githubId = 5149377;
     name = "Amine Chikhaoui";
   };
   amorsillo = {
     email = "andrew.morsillo@gmail.com";
     github = "AndrewMorsillo";
+    githubId = 858965;
     name = "Andrew Morsillo";
   };
   andersk = {
     email = "andersk@mit.edu";
     github = "andersk";
+    githubId = 26471;
     name = "Anders Kaseorg";
   };
   anderslundstedt = {
     email = "git@anderslundstedt.se";
     github = "anderslundstedt";
+    githubId = 4514101;
     name = "Anders Lundstedt";
   };
   AndersonTorres = {
     email = "torres.anderson.85@protonmail.com";
     github = "AndersonTorres";
+    githubId = 5954806;
     name = "Anderson Torres";
   };
   anderspapitto = {
     email = "anderspapitto@gmail.com";
     github = "anderspapitto";
+    githubId = 1388690;
     name = "Anders Papitto";
   };
   andir = {
     email = "andreas@rammhold.de";
     github = "andir";
+    githubId = 638836;
     name = "Andreas Rammhold";
   };
   andreabedini = {
@@ -369,21 +422,25 @@
   andrestylianos = {
     email = "andre.stylianos@gmail.com";
     github = "andrestylianos";
+    githubId = 7112447;
     name = "Andre S. Ramos";
   };
   andrew-d = {
     email = "andrew@du.nham.ca";
     github = "andrew-d";
+    githubId = 1079173;
     name = "Andrew Dunham";
   };
   andrewchambers = {
     email = "ac@acha.ninja";
     github = "andrewchambers";
+    githubId = 962885;
     name = "Andrew Chambers";
   };
   andrewrk = {
     email = "superjoe30@gmail.com";
     github = "andrewrk";
+    githubId = 106511;
     name = "Andrew Kelley";
   };
   andsild = {
@@ -394,31 +451,37 @@
   aneeshusa = {
     email = "aneeshusa@gmail.com";
     github = "aneeshusa";
+    githubId = 2085567;
     name = "Aneesh Agrawal";
   };
   angristan = {
     email = "angristan@pm.me";
     github = "angristan";
+    githubId = 11699655;
     name = "Stanislas Lange";
   };
   ankhers = {
     email = "justin.k.wood@gmail.com";
     github = "ankhers";
+    githubId = 750786;
     name = "Justin Wood";
   };
   anpryl = {
     email = "anpryl@gmail.com";
     github = "anpryl";
+    githubId = 5327697;
     name = "Anatolii Prylutskyi";
   };
   anton-dessiatov = {
     email = "anton.dessiatov@gmail.com";
     github = "anton-dessiatov";
+    githubId = 2873280;
     name = "Anton Desyatov";
   };
   Anton-Latukha = {
     email = "anton.latuka+nixpkgs@gmail.com";
     github = "Anton-Latukha";
+    githubId = 20933385;
     name = "Anton Latukha";
   };
   antono = {
@@ -429,51 +492,61 @@
   antonxy = {
     email = "anton.schirg@posteo.de";
     github = "antonxy";
+    githubId = 4194320;
     name = "Anton Schirg";
   };
   apeschar = {
     email = "albert@peschar.net";
     github = "apeschar";
+    githubId = 122977;
     name = "Albert Peschar";
   };
   apeyroux = {
     email = "alex@px.io";
     github = "apeyroux";
+    githubId = 1078530;
     name = "Alexandre Peyroux";
   };
   ar1a = {
     email = "aria@ar1as.space";
     github = "ar1a";
+    githubId = 8436007;
     name = "Aria Edmonds";
   };
   arcadio = {
     email = "arc@well.ox.ac.uk";
     github = "arcadio";
+    githubId = 56009;
     name = "Arcadio Rubio García";
   };
   ardumont = {
     email = "eniotna.t@gmail.com";
     github = "ardumont";
+    githubId = 718812;
     name = "Antoine R. Dumont";
   };
   aristid = {
     email = "aristidb@gmail.com";
     github = "aristidb";
+    githubId = 30712;
     name = "Aristid Breitkreuz";
   };
   ariutta = {
     email = "anders.riutta@gmail.com";
     github = "ariutta";
+    githubId = 1296771;
     name = "Anders Riutta";
   };
   arobyn = {
     email = "shados@shados.net";
     github = "shados";
+    githubId = 338268;
     name = "Alexei Robyn";
   };
   artemist = {
     email = "me@artem.ist";
     github = "artemist";
+    githubId = 1226638;
     name = "Artemis Tosini";
     keys = [{
       longkeyid = "rsa4096/0x4FDC96F161E7BA8A";
@@ -483,56 +556,67 @@
   artuuge = {
     email = "artuuge@gmail.com";
     github = "artuuge";
+    githubId = 10285250;
     name = "Artur E. Ruuge";
   };
   ashalkhakov = {
     email = "artyom.shalkhakov@gmail.com";
     github = "ashalkhakov";
+    githubId = 1270502;
     name = "Artyom Shalkhakov";
   };
   ashgillman = {
     email = "gillmanash@gmail.com";
     github = "ashgillman";
+    githubId = 816777;
     name = "Ashley Gillman";
   };
   aske = {
     email = "aske@fmap.me";
     github = "aske";
+    githubId = 869771;
     name = "Kirill Boltaev";
   };
   asppsa = {
     email = "asppsa@gmail.com";
     github = "asppsa";
+    githubId = 453170;
     name = "Alastair Pharo";
   };
   astro = {
     email = "astro@spaceboyz.net";
     github = "astro";
+    githubId = 12923;
     name = "Astro";
   };
   astsmtl = {
     email = "astsmtl@yandex.ru";
     github = "astsmtl";
+    githubId = 2093941;
     name = "Alexander Tsamutali";
   };
   asymmetric = {
     email = "lorenzo@mailbox.org";
     github = "asymmetric";
+    githubId = 101816;
     name = "Lorenzo Manacorda";
   };
   aszlig = {
     email = "aszlig@nix.build";
     github = "aszlig";
+    githubId = 192147;
     name = "aszlig";
   };
   athas = {
     email = "athas@sigkill.dk";
     github = "athas";
+    githubId = 55833;
     name = "Troels Henriksen";
   };
   atnnn = {
     email = "etienne@atnnn.com";
     github = "atnnn";
+    githubId = 706854;
     name = "Etienne Laurin";
   };
   auntie = {
@@ -543,11 +627,13 @@
   avaq = {
     email = "avaq+nixos@xs4all.nl";
     github = "avaq";
+    githubId = 1217745;
     name = "Aldwin Vlasblom";
   };
   avery = {
     email = "averyl+nixos@protonmail.com";
     github = "AveryLychee";
+    githubId = 9147625;
     name = "Avery Lychee";
   };
   averelld = {
@@ -558,6 +644,7 @@
   avitex = {
     email = "theavitex@gmail.com";
     github = "avitex";
+    githubId = 5110816;
     name = "avitex";
     keys = [{
       longkeyid = "rsa4096/0x8B366C443CABE942";
@@ -567,26 +654,31 @@
   avnik = {
     email = "avn@avnik.info";
     github = "avnik";
+    githubId = 153538;
     name = "Alexander V. Nikolaev";
   };
   aw = {
     email = "aw-nixos@meterriblecrew.net";
     github = "herrwiese";
+    githubId = 206242;
     name = "Andreas Wiese";
   };
   aycanirican = {
     email = "iricanaycan@gmail.com";
     github = "aycanirican";
+    githubId = 135230;
     name = "Aycan iRiCAN";
   };
   babariviere = {
     email = "babariviere@protonmail.com";
     github = "babariviere";
+    githubId = 12128029;
     name = "babariviere";
   };
   bachp = {
     email = "pascal.bach@nextrem.ch";
     github = "bachp";
+    githubId = 333807;
     name = "Pascal Bach";
   };
   backuitist = {
@@ -606,96 +698,115 @@
   balsoft = {
     email = "balsoft75@gmail.com";
     github = "balsoft";
+    githubId = 18467667;
     name = "Alexander Bantyev";
   };
   bandresen = {
     email = "bandresen@gmail.com";
     github = "bandresen";
+    githubId = 80325;
     name = "Benjamin Andresen";
   };
   baracoder = {
     email = "baracoder@googlemail.com";
     github = "baracoder";
+    githubId = 127523;
     name = "Herman Fries";
   };
   barrucadu = {
     email = "mike@barrucadu.co.uk";
     github = "barrucadu";
+    githubId = 75235;
     name = "Michael Walker";
   };
   basvandijk = {
     email = "v.dijk.bas@gmail.com";
     github = "basvandijk";
+    githubId = 576355;
     name = "Bas van Dijk";
   };
   Baughn = {
     email = "sveina@gmail.com";
     github = "Baughn";
+    githubId = 45811;
     name = "Svein Ove Aas";
   };
   bb010g = {
     email = "me@bb010g.com";
     github = "bb010g";
+    githubId = 340132;
     name = "Brayden Banks";
   };
   bbarker = {
     email = "brandon.barker@gmail.com";
     github = "bbarker";
+    githubId = 916366;
     name = "Brandon Elam Barker";
   };
   bbigras = {
     email = "bigras.bruno@gmail.com";
     github = "bbigras";
+    githubId = 24027;
     name = "Bruno Bigras";
   };
   bcarrell = {
     email = "brandoncarrell@gmail.com";
     github = "bcarrell";
+    githubId = 1015044;
     name = "Brandon Carrell";
   };
   bcdarwin = {
     email = "bcdarwin@gmail.com";
     github = "bcdarwin";
+    githubId = 164148;
     name = "Ben Darwin";
   };
   bdesham = {
     email = "benjamin@esham.io";
     github = "bdesham";
+    githubId = 354230;
     name = "Benjamin Esham";
   };
   bdimcheff = {
     email = "brandon@dimcheff.com";
     github = "bdimcheff";
+    githubId = 14111;
     name = "Brandon Dimcheff";
   };
   bendlas = {
     email = "herwig@bendlas.net";
     github = "bendlas";
+    githubId = 214787;
     name = "Herwig Hochleitner";
   };
   benley = {
     email = "benley@gmail.com";
     github = "benley";
+    githubId = 1432730;
     name = "Benjamin Staffin";
   };
   bennofs = {
     email = "benno.fuenfstueck@gmail.com";
     github = "bennofs";
+    githubId = 3192959;
     name = "Benno Fünfstück";
   };
   benpye = {
     email = "ben@curlybracket.co.uk";
     github = "benpye";
+    githubId = 442623;
     name = "Ben Pye";
   };
   benwbooth = {
     email = "benwbooth@gmail.com";
     github = "benwbooth";
+    githubId = 75972;
     name = "Ben Booth";
   };
   berce = {
     email = "bert.moens@gmail.com";
     github = "berce";
+    githubId = 10439709;
     name = "Bert Moens";
   };
   berdario = {
@@ -706,36 +817,43 @@
   bergey = {
     email = "bergey@teallabs.org";
     github = "bergey";
+    githubId = 251106;
     name = "Daniel Bergey";
   };
   betaboon = {
     email = "betaboon@0x80.ninja";
     github = "betaboon";
+    githubId = 7346933;
     name = "betaboon";
   };
   bfortz = {
     email = "bernard.fortz@gmail.com";
     github = "bfortz";
+    githubId = 16426882;
     name = "Bernard Fortz";
   };
   bgamari = {
     email = "ben@smart-cactus.org";
     github = "bgamari";
+    githubId = 1010174;
     name = "Ben Gamari";
   };
   bhall = {
     email = "brendan.j.hall@bath.edu";
     github = "brendan-hall";
+    githubId = 34919100;
     name = "Brendan Hall";
   };
   bhipple = {
     email = "bhipple@protonmail.com";
     github = "bhipple";
+    githubId = 2071583;
     name = "Benjamin Hipple";
   };
   binarin = {
     email = "binarin@binarin.ru";
     github = "binarin";
+    githubId = 185443;
     name = "Alexey Lebedeff";
   };
   bjg = {
@@ -745,11 +863,13 @@
   bjornfor = {
     email = "bjorn.forsman@gmail.com";
     github = "bjornfor";
+    githubId = 133602;
     name = "Bjørn Forsman";
   };
   bkchr = {
     email = "nixos@kchr.de";
     github = "bkchr";
+    githubId = 5718007;
     name = "Bastian Köcher";
   };
   bluescreen303 = {
@@ -760,21 +880,25 @@
   bobakker = {
     email = "bobakk3r@gmail.com";
     github = "bobakker";
+    githubId = 10221570;
     name = "Bo Bakker";
   };
   bobvanderlinden = {
     email = "bobvanderlinden@gmail.com";
     github = "bobvanderlinden";
+    githubId = 6375609;
     name = "Bob van der Linden";
   };
   bodil = {
     email = "nix@bodil.org";
     github = "bodil";
+    githubId = 17880;
     name = "Bodil Stokke";
   };
   boj = {
     email = "brian@uncannyworks.com";
     github = "boj";
+    githubId = 50839;
     name = "Brian Jones";
   };
   boothead = {
@@ -785,151 +909,181 @@
   borisbabic = {
     email = "boris.ivan.babic@gmail.com";
     github = "borisbabic";
+    githubId = 1743184;
     name = "Boris Babić";
   };
   bosu = {
     email = "boriss@gmail.com";
     github = "bosu";
+    githubId = 3465841;
     name = "Boris Sukholitko";
   };
   bradediger = {
     email = "brad@bradediger.com";
     github = "bradediger";
+    githubId = 4621;
     name = "Brad Ediger";
   };
   brainrape = {
     email = "martonboros@gmail.com";
     github = "brainrape";
+    githubId = 302429;
     name = "Marton Boros";
   };
   bramd = {
     email = "bram@bramd.nl";
     github = "bramd";
+    githubId = 86652;
     name = "Bram Duvigneau";
   };
   braydenjw = {
     email = "nixpkgs@willenborg.ca";
     github = "braydenjw";
+    githubId = 2506621;
     name = "Brayden Willenborg";
   };
   brian-dawn = {
     email = "brian.t.dawn@gmail.com";
     github = "brian-dawn";
+    githubId = 1274409;
     name = "Brian Dawn";
   };
   brianhicks = {
     email = "brian@brianthicks.com";
     github = "BrianHicks";
+    githubId = 355401;
     name = "Brian Hicks";
   };
   bricewge = {
     email = "bricewge@gmail.com";
     github = "bricewge";
+    githubId = 5525646;
     name = "Brice Waegeneire";
   };
   bstrik = {
     email = "dutchman55@gmx.com";
     github = "bstrik";
+    githubId = 7716744;
     name = "Berno Strik";
   };
   buffet = {
     email = "niclas@countingsort.com";
     github = "buffet";
+    githubId = 33751841;
     name = "Niclas Meyer";
   };
   bugworm = {
     email = "bugworm@zoho.com";
     github = "bugworm";
+    githubId = 7214361;
     name = "Roman Gerasimenko";
   };
   bzizou = {
     email = "Bruno@bzizou.net";
     github = "bzizou";
+    githubId = 2647566;
     name = "Bruno Bzeznik";
   };
   c0bw3b = {
     email = "c0bw3b@gmail.com";
     github = "c0bw3b";
+    githubId = 24417923;
     name = "Renaud";
   };
   c0deaddict = {
     email = "josvanbakel@protonmail.com";
     github = "c0deaddict";
+    githubId = 510553;
     name = "Jos van Bakel";
   };
   calbrecht = {
     email = "christian.albrecht@mayflower.de";
     github = "calbrecht";
+    githubId = 1516457;
     name = "Christian Albrecht";
   };
   callahad = {
     email = "dan.callahan@gmail.com";
     github = "callahad";
+    githubId = 24193;
     name = "Dan Callahan";
   };
   calvertvl = {
     email = "calvertvl@gmail.com";
     github = "calvertvl";
+    githubId = 7435854;
     name = "Victor Calvert";
   };
   campadrenalin = {
     email = "campadrenalin@gmail.com";
     github = "campadrenalin";
+    githubId = 289492;
     name = "Philip Horger";
   };
   candeira = {
     email = "javier@candeira.com";
     github = "candeira";
+    githubId = 91694;
     name = "Javier Candeira";
   };
   canndrew = {
     email = "shum@canndrew.org";
     github = "canndrew";
+    githubId = 5555066;
     name = "Andrew Cann";
   };
   carlosdagos = {
     email = "m@cdagostino.io";
     github = "carlosdagos";
+    githubId = 686190;
     name = "Carlos D'Agostino";
   };
   carlsverre = {
     email = "accounts@carlsverre.com";
     github = "carlsverre";
+    githubId = 82591;
     name = "Carl Sverre";
   };
   cartr = {
     email = "carter.sande@duodecima.technology";
     github = "cartr";
+    githubId = 5241813;
     name = "Carter Sande";
   };
   casey = {
     email = "casey@rodarmor.net";
     github = "casey";
+    githubId = 1945;
     name = "Casey Rodarmor";
   };
   catern = {
     email = "sbaugh@catern.com";
     github = "catern";
+    githubId = 5394722;
     name = "Spencer Baugh";
   };
   caugner = {
     email = "nixos@caugner.de";
     github = "caugner";
+    githubId = 495429;
     name = "Claas Augner";
   };
   cbley = {
     email = "claudio.bley@gmail.com";
     github = "avdv";
+    githubId = 3471749;
     name = "Claudio Bley";
   };
   cdepillabout = {
     email = "cdep.illabout@gmail.com";
     github = "cdepillabout";
+    githubId = 64804;
     name = "Dennis Gosnell";
   };
   ceedubs = {
     email = "ceedubs@gmail.com";
     github = "ceedubs";
+    githubId = 977929;
     name = "Cody Allen";
   };
   cf6b88f = {
@@ -939,26 +1093,31 @@
   cfouche = {
     email = "chaddai.fouche@gmail.com";
     github = "Chaddai";
+    githubId = 5771456;
     name = "Chaddaï Fouché";
   };
   chaduffy = {
     email = "charles@dyfis.net";
     github = "charles-dyfis-net";
+    githubId = 22370;
     name = "Charles Duffy";
   };
   changlinli = {
     email = "mail@changlinli.com";
     github = "changlinli";
+    githubId = 1762540;
     name = "Changlin Li";
   };
   CharlesHD = {
     email = "charleshdespointes@gmail.com";
     github = "CharlesHD";
+    githubId = 6608071;
     name = "Charles Huyghues-Despointes";
   };
   chaoflow = {
     email = "flo@chaoflow.net";
     github = "chaoflow";
+    githubId = 89596;
     name = "Florian Friesdorf";
   };
   chattered = {
@@ -968,106 +1127,127 @@
   ChengCat = {
     email = "yu@cheng.cat";
     github = "ChengCat";
+    githubId = 33503784;
     name = "Yucheng Zhang";
   };
   chessai = {
     email = "chessai1996@gmail.com";
     github = "chessai";
+    githubId = 18648043;
     name = "Daniel Cartwright";
   };
   chiiruno = {
     email = "okinan@protonmail.com";
     github = "chiiruno";
+    githubId = 30435868;
     name = "Okina Matara";
   };
   choochootrain = {
     email = "hurshal@imap.cc";
     github = "choochootrain";
+    githubId = 803961;
     name = "Hurshal Patel";
   };
   chpatrick = {
     email = "chpatrick@gmail.com";
     github = "chpatrick";
+    githubId = 832719;
     name = "Patrick Chilton";
   };
   chreekat = {
     email = "b@chreekat.net";
     github = "chreekat";
+    githubId = 538538;
     name = "Bryan Richter";
   };
   chris-martin = {
     email = "ch.martin@gmail.com";
     github = "chris-martin";
+    githubId = 399718;
     name = "Chris Martin";
   };
   chrisaw = {
     email = "home@chrisaw.com";
     github = "cawilliamson";
+    githubId = 1141769;
     name = "Christopher A. Williamson";
   };
   chrisjefferson = {
     email = "chris@bubblescope.net";
     github = "chrisjefferson";
+    githubId = 811527;
     name = "Christopher Jefferson";
   };
   chrisrosset = {
     email = "chris@rosset.org.uk";
     github = "chrisrosset";
+    githubId = 1103294;
     name = "Christopher Rosset";
   };
   christopherpoole = {
     email = "mail@christopherpoole.net";
     github = "christopherpoole";
+    githubId = 2245737;
     name = "Christopher Mark Poole";
   };
   ciil = {
     email = "simon@lackerbauer.com";
     github = "ciil";
+    githubId = 3956062;
     name = "Simon Lackerbauer";
   };
   ck3d = {
     email = "ck3d@gmx.de";
     github = "ck3d";
+    githubId = 25088352;
     name = "Christian Kögler";
   };
   ckampka = {
     email = "christian@kampka.net";
     github = "kampka";
+    githubId = 422412;
     name = "Christian Kampka";
   };
   ckauhaus = {
     email = "kc@flyingcircus.io";
     github = "ckauhaus";
+    githubId = 1448923;
     name = "Christian Kauhaus";
   };
   cko = {
     email = "christine.koppelt@gmail.com";
     github = "cko";
+    githubId = 68239;
     name = "Christine Koppelt";
   };
   clacke = {
     email = "claes.wallin@greatsinodevelopment.com";
     github = "clacke";
+    githubId = 199180;
     name = "Claes Wallin";
   };
   cleverca22 = {
     email = "cleverca22@gmail.com";
     github = "cleverca22";
+    githubId = 848609;
     name = "Michael Bishop";
   };
   cmcdragonkai = {
     email = "roger.qiu@matrix.ai";
     github = "cmcdragonkai";
+    githubId = 640797;
     name = "Roger Qiu";
   };
   cmfwyp = {
     email = "cmfwyp@riseup.net";
     github = "cmfwyp";
+    githubId = 20808761;
     name = "cmfwyp";
   };
   cobbal = {
     email = "andrew.cobb@gmail.com";
     github = "cobbal";
+    githubId = 180339;
     name = "Andrew Cobb";
   };
   coconnor = {
@@ -1078,56 +1258,67 @@
   codsl = {
     email = "codsl@riseup.net";
     github = "codsl";
+    githubId = 6402559;
     name = "codsl";
   };
   codyopel = {
     email = "codyopel@gmail.com";
     github = "codyopel";
+    githubId = 5561189;
     name = "Cody Opel";
   };
   cohencyril = {
     email = "cyril.cohen@inria.fr";
     github = "CohenCyril";
+    githubId = 298705;
     name = "Cyril Cohen";
   };
   colemickens = {
     email = "cole.mickens@gmail.com";
     github = "colemickens";
+    githubId = 327028;
     name = "Cole Mickens";
   };
   colescott = {
     email = "colescottsf@gmail.com";
     github = "colescott";
+    githubId = 5684605;
     name = "Cole Scott";
   };
   copumpkin = {
     email = "pumpkingod@gmail.com";
     github = "copumpkin";
+    githubId = 2623;
     name = "Dan Peebles";
   };
   corngood = {
     email = "corngood@gmail.com";
     github = "corngood";
+    githubId = 3077118;
     name = "David McFarland";
   };
   coroa = {
     email = "jonas@chaoflow.net";
     github = "coroa";
+    githubId = 2552981;
     name = "Jonas Hörsch";
   };
   costrouc = {
     email = "chris.ostrouchov@gmail.com";
     github = "costrouc";
+    githubId = 1740337;
     name = "Chris Ostrouchov";
   };
   couchemar = {
     email = "couchemar@yandex.ru";
     github = "couchemar";
+    githubId = 1573344;
     name = "Andrey Pavlov";
   };
   cpages = {
     email = "page@ruiec.cat";
     github = "cpages";
+    githubId = 411324;
     name = "Carles Pagès";
   };
   cransom = {
@@ -1138,36 +1329,43 @@
   CrazedProgrammer = {
     email = "crazedprogrammer@gmail.com";
     github = "CrazedProgrammer";
+    githubId = 12202789;
     name = "CrazedProgrammer";
   };
   cryptix = {
     email = "cryptix@riseup.net";
     github = "cryptix";
+    githubId = 111202;
     name = "Henry Bubert";
   };
   CrystalGamma = {
     email = "nixos@crystalgamma.de";
     github = "CrystalGamma";
+    githubId = 6297001;
     name = "Jona Stubbe";
   };
   csingley = {
     email = "csingley@gmail.com";
     github = "csingley";
+    githubId = 398996;
     name = "Christopher Singley";
   };
   cstrahan = {
     email = "charles@cstrahan.com";
     github = "cstrahan";
+    githubId = 143982;
     name = "Charles Strahan";
   };
   cwoac = {
     email = "oliver@codersoffortune.net";
     github = "cwoac";
+    githubId = 1382175;
     name = "Oliver Matthews";
   };
   cypherpunk2140 = {
     email = "stefan.mihaila@pm.me";
     github = "cypherpunk2140";
+    githubId = 2217136;
     name = "Ștefan D. Mihăilă";
     keys = [
       { longkeyid = "rsa4096/6E68A39BF16A3ECB";
@@ -1181,46 +1379,55 @@
   dalance = {
     email = "dalance@gmail.com";
     github = "dalance";
+    githubId = 4331004;
     name = "Naoya Hatta";
   };
   DamienCassou = {
     email = "damien@cassou.me";
     github = "DamienCassou";
+    githubId = 217543;
     name = "Damien Cassou";
   };
   danbst = {
     email = "abcz2.uprola@gmail.com";
     github = "danbst";
+    githubId = 743057;
     name = "Danylo Hlynskyi";
   };
   dancek = {
     email = "hannu.hartikainen@gmail.com";
     github = "dancek";
+    githubId = 245394;
     name = "Hannu Hartikainen";
   };
   danharaj = {
     email = "dan@obsidian.systems";
     github = "danharaj";
+    githubId = 23366017;
     name = "Dan Haraj";
   };
   danieldk = {
     email = "me@danieldk.eu";
     github = "danieldk";
+    githubId = 49398;
     name = "Daniël de Kok";
   };
   danielfullmer = {
     email = "danielrf12@gmail.com";
     github = "danielfullmer";
+    githubId = 1298344;
     name = "Daniel Fullmer";
   };
   das-g = {
     email = "nixpkgs@raphael.dasgupta.ch";
     github = "das-g";
+    githubId = 97746;
     name = "Raphael Das Gupta";
   };
   das_j = {
     email = "janne@hess.ooo";
     github = "dasJ";
+    githubId = 4971975;
     name = "Janne Heß";
   };
   dasuxullebt = {
@@ -1230,11 +1437,13 @@
   david50407 = {
     email = "me@davy.tw";
     github = "david50407";
+    githubId = 841969;
     name = "David Kuo";
   };
   davidak = {
     email = "post@davidak.de";
     github = "davidak";
+    githubId = 91113;
     name = "David Kleuker";
   };
   davidrusu = {
@@ -1245,61 +1454,73 @@
   davorb = {
     email = "davor@davor.se";
     github = "davorb";
+    githubId = 798427;
     name = "Davor Babic";
   };
   dawidsowa = {
     email = "dawid_sowa@posteo.net";
     github = "dawidsowa";
+    githubId = 49904992;
     name = "Dawid Sowa";
   };
   dbohdan = {
     email = "dbohdan@dbohdan.com";
     github = "dbohdan";
+    githubId = 3179832;
     name = "D. Bohdan";
   };
   dbrock = {
     email = "daniel@brockman.se";
     github = "dbrock";
+    githubId = 14032;
     name = "Daniel Brockman";
   };
   deepfire = {
     email = "_deepfire@feelingofgreen.ru";
     github = "deepfire";
+    githubId = 452652;
     name = "Kosyrev Serge";
   };
   delan = {
     name = "Delan Azabani";
     email = "delan@azabani.com";
     github = "delan";
+    githubId = 465303;
   };
   delroth = {
     email = "delroth@gmail.com";
     github = "delroth";
+    githubId = 202798;
     name = "Pierre Bourdon";
   };
   deltaevo = {
     email = "deltaduartedavid@gmail.com";
     github = "DeltaEvo";
+    githubId = 8864716;
     name = "Duarte David";
   };
   demin-dmitriy = {
     email = "demindf@gmail.com";
     github = "demin-dmitriy";
+    githubId = 5503422;
     name = "Dmitriy Demin";
   };
   demize = {
     email = "johannes@kyriasis.com";
     github = "kyrias";
+    githubId = 2285387;
     name = "Johannes Löthberg";
   };
   demyanrogozhin = {
     email = "demyan.rogozhin@gmail.com";
     github = "demyanrogozhin";
+    githubId = 62989;
     name = "Demyan Rogozhin";
   };
   derchris = {
     email = "derchris@me.com";
     github = "derchrisuk";
+    githubId = 706758;
     name = "Christian Gerbrandt";
   };
   DerGuteMoritz = {
@@ -1310,11 +1531,13 @@
   dermetfan = {
     email = "serverkorken@gmail.com";
     github = "dermetfan";
+    githubId = 4956158;
     name = "Robin Stumm";
   };
   DerTim1 = {
     email = "tim.digel@active-group.de";
     github = "DerTim1";
+    githubId = 21953890;
     name = "Tim Digel";
   };
   desiderius = {
@@ -1325,21 +1548,25 @@
   devhell = {
     email = "\"^\"@regexmail.net";
     github = "devhell";
+    githubId = 896182;
     name = "devhell";
   };
   dezgeg = {
     email = "tuomas.tynkkynen@iki.fi";
     github = "dezgeg";
+    githubId = 579369;
     name = "Tuomas Tynkkynen";
   };
   dfordivam = {
     email = "dfordivam+nixpkgs@gmail.com";
     github = "dfordivam";
+    githubId = 681060;
     name = "Divam";
   };
   dfoxfranke = {
     email = "dfoxfranke@gmail.com";
     github = "dfoxfranke";
+    githubId = 4708206;
     name = "Daniel Fox Franke";
   };
   dgonyeo = {
@@ -1350,71 +1577,85 @@
   dhkl = {
     email = "david@davidslab.com";
     github = "dhl";
+    githubId = 265220;
     name = "David Leung";
   };
   dipinhora = {
     email = "dipinhora+github@gmail.com";
     github = "dipinhora";
+    githubId = 11946442;
     name = "Dipin Hora";
   };
   disassembler = {
     email = "disasm@gmail.com";
     github = "disassembler";
+    githubId = 651205;
     name = "Samuel Leathers";
   };
   disserman = {
     email = "disserman@gmail.com";
     github = "divi255";
+    githubId = 40633781;
     name = "Sergei S.";
   };
   dizfer = {
     email = "david@izquierdofernandez.com";
     github = "dizfer";
+    githubId = 8852888;
     name = "David Izquierdo";
   };
   Dje4321 = {
     email = "dje4321@gmail.com";
     github = "dje4321";
+    githubId = 10913120;
     name = "Dje4321";
   };
   dmalikov = {
     email = "malikov.d.y@gmail.com";
     github = "dmalikov";
+    githubId = 997543;
     name = "Dmitry Malikov";
   };
   DmitryTsygankov = {
     email = "dmitry.tsygankov@gmail.com";
     github = "DmitryTsygankov";
+    githubId = 425354;
     name = "Dmitry Tsygankov";
   };
   dmjio = {
     email = "djohnson.m@gmail.com";
     github = "dmjio";
+    githubId = 875324;
     name = "David Johnson";
   };
   dmvianna = {
     email = "dmlvianna@gmail.com";
     github = "dmvianna";
+    githubId = 1708810;
     name = "Daniel Vianna";
   };
   dochang = {
     email = "dochang@gmail.com";
     github = "dochang";
+    githubId = 129093;
     name = "Desmond O. Chang";
   };
   domenkozar = {
     email = "domen@dev.si";
     github = "domenkozar";
+    githubId = 126339;
     name = "Domen Kozar";
   };
   doronbehar = {
     email = "me@doronbehar.com";
     github = "doronbehar";
+    githubId = 10998835;
     name = "Doron Behar";
   };
   dotlambda = {
     email = "rschuetz17@gmail.com";
     github = "dotlambda";
+    githubId = 6806011;
     name = "Robert Schütz";
   };
   doublec = {
@@ -1425,16 +1666,19 @@
   dpaetzel = {
     email = "david.a.paetzel@gmail.com";
     github = "dpaetzel";
+    githubId = 974130;
     name = "David Pätzel";
   };
   dpflug = {
     email = "david@pflug.email";
     github = "dpflug";
+    githubId = 108501;
     name = "David Pflug";
   };
   drets = {
     email = "dmitryrets@gmail.com";
     github = "drets";
+    githubId = 6199462;
     name = "Dmytro Rets";
   };
   drewkett = {
@@ -1444,11 +1688,13 @@
   dsferruzza = {
     email = "david.sferruzza@gmail.com";
     github = "dsferruzza";
+    githubId = 1931963;
     name = "David Sferruzza";
   };
   dtzWill = {
     email = "w@wdtz.org";
     github = "dtzWill";
+    githubId = 817330;
     name = "Will Dietz";
     keys = [{
       longkeyid = "rsa4096/0xFD42C7D0D41494C8";
@@ -1463,51 +1709,61 @@
   dysinger = {
     email = "tim@dysinger.net";
     github = "dysinger";
+    githubId = 447;
     name = "Tim Dysinger";
   };
   dywedir = {
     email = "dywedir@gra.red";
     github = "dywedir";
+    githubId = 399312;
     name = "Vladyslav M.";
   };
   dzabraev = {
     email = "dzabraew@gmail.com";
     github = "dzabraev";
+    githubId = 15128988;
     name = "Maksim Dzabraev";
   };
   e-user = {
     email = "nixos@sodosopa.io";
     github = "e-user";
+    githubId = 93086;
     name = "Alexander Kahl";
   };
   eadwu = {
     email = "edmund.wu@protonmail.com";
     github = "eadwu";
+    githubId = 22758444;
     name = "Edmund Wu";
   };
   ealasu = {
     email = "emanuel.alasu@gmail.com";
     github = "ealasu";
+    githubId = 1362096;
     name = "Emanuel Alasu";
   };
   eamsden = {
     email = "edward@blackriversoft.com";
     github = "eamsden";
+    githubId = 54573;
     name = "Edward Amsden";
   };
   earldouglas = {
     email = "james@earldouglas.com";
     github = "earldouglas";
+    githubId = 424946;
     name = "James Earl Douglas";
   };
   earvstedt = {
     email = "erik.arvstedt@gmail.com";
     github = "erikarvstedt";
+    githubId = 36110478;
     name = "Erik Arvstedt";
   };
   ebzzry = {
     email = "ebzzry@ebzzry.io";
     github = "ebzzry";
+    githubId = 7875;
     name = "Rommel Martinez";
   };
   edanaher = {
@@ -1518,46 +1774,55 @@
   edef = {
     email = "edef@edef.eu";
     github = "edef1c";
+    githubId = 50854;
     name = "edef";
   };
   embr = {
     email = "hi@liclac.eu";
     github = "liclac";
+    githubId = 428026;
     name = "embr";
   };
   emily = {
     email = "nixpkgs@emily.moe";
     github = "emilazy";
+    githubId = 18535642;
     name = "Emily";
   };
   ederoyd46 = {
     email = "matt@ederoyd.co.uk";
     github = "ederoyd46";
+    githubId = 119483;
     name = "Matthew Brown";
   };
   eduarrrd = {
     email = "e.bachmakov@gmail.com";
     github = "eduarrrd";
+    githubId = 1181393;
     name = "Eduard Bachmakov";
   };
   edude03 = {
     email = "michael@melenion.com";
     github = "edude03";
+    githubId = 494483;
     name = "Michael Francis";
   };
   edwtjo = {
     email = "ed@cflags.cc";
     github = "edwtjo";
+    githubId = 54799;
     name = "Edward Tjörnhammar";
   };
   eelco = {
     email = "eelco.dolstra@logicblox.com";
     github = "edolstra";
+    githubId = 1148549;
     name = "Eelco Dolstra";
   };
   ehegnes = {
     email = "eric.hegnes@gmail.com";
     github = "ehegnes";
+    githubId = 884970;
     name = "Eric Hegnes";
   };
   ehmry = {
@@ -1567,56 +1832,67 @@
   eikek = {
     email = "eike.kettner@posteo.de";
     github = "eikek";
+    githubId = 701128;
     name = "Eike Kettner";
   };
   ekleog = {
     email = "leo@gaspard.io";
     github = "ekleog";
+    githubId = 411447;
     name = "Leo Gaspard";
   };
   elasticdog = {
     email = "aaron@elasticdog.com";
     github = "elasticdog";
+    githubId = 4742;
     name = "Aaron Bull Schaefer";
   };
   eleanor = {
     email = "dejan@proteansec.com";
     github = "proteansec";
+    githubId = 1753498;
     name = "Dejan Lukan";
   };
   eliasp = {
     email = "mail@eliasprobst.eu";
     github = "eliasp";
+    githubId = 48491;
     name = "Elias Probst";
   };
   elijahcaine = {
     email = "elijahcainemv@gmail.com";
     github = "pop";
+    githubId = 1897147;
     name = "Elijah Caine";
   };
   elitak = {
     email = "elitak@gmail.com";
     github = "elitak";
+    githubId = 769073;
     name = "Eric Litak";
   };
   ellis = {
     email = "nixos@ellisw.net";
     github = "ellis";
+    githubId = 97852;
     name = "Ellis Whitehead";
   };
   elohmeier = {
     email = "elo-nixos@nerdworks.de";
     github = "elohmeier";
+    githubId = 2536303;
     name = "Enno Lohmeier";
   };
   elseym = {
     email = "elseym@me.com";
     github = "elseym";
+    githubId = 907478;
     name = "Simon Waibl";
   };
   elvishjerricco = {
     email = "elvishjerricco@gmail.com";
     github = "ElvishJerricco";
+    githubId = 1365692;
     name = "Will Fancher";
   };
   emmanuelrosa = {
@@ -1627,21 +1903,25 @@
   endgame = {
     email = "jack@jackkelly.name";
     github = "endgame";
+    githubId = 231483;
     name = "Jack Kelly";
   };
   enorris = {
       name = "Eric Norris";
       email = "erictnorris@gmail.com";
       github = "ericnorris";
+      githubId = 1906605;
   };
   enzime = {
     email = "enzime@users.noreply.github.com";
     github = "enzime";
+    githubId = 10492681;
     name = "Michael Hoang";
   };
   eperuffo = {
     email = "info@emanueleperuffo.com";
     github = "emanueleperuffo";
+    githubId = 5085029;
     name = "Emanuele Peruffo";
   };
   epitrochoid = {
@@ -1651,16 +1931,19 @@
   eqyiel = {
     email = "ruben@maher.fyi";
     github = "eqyiel";
+    githubId = 3422442;
     name = "Ruben Maher";
   };
   eraserhd = {
     email = "jason.m.felice@gmail.com";
     github = "eraserhd";
+    githubId = 147284;
     name = "Jason Felice";
   };
   ericbmerritt = {
     email = "eric@afiniate.com";
     github = "ericbmerritt";
+    githubId = 4828;
     name = "Eric Merritt";
   };
   ericsagnes = {
@@ -1671,11 +1954,13 @@
   ericson2314 = {
     email = "John.Ericson@Obsidian.Systems";
     github = "ericson2314";
+    githubId = 1055245;
     name = "John Ericson";
   };
   erictapen = {
     email = "justin.humm@posteo.de";
     github = "erictapen";
+    githubId = 11532355;
     name = "Justin Humm";
     keys = [{
       longkeyid = "rsa4096/0x438871E000AA178E";
@@ -1685,11 +1970,13 @@
   erikryb = {
     email = "erik.rybakken@math.ntnu.no";
     github = "erikryb";
+    githubId = 3787281;
     name = "Erik Rybakken";
   };
   erosennin = {
     email = "ag@sologoc.com";
     github = "erosennin";
+    githubId = 1583484;
     name = "Andrey Golovizin";
   };
   ertes = {
@@ -1704,11 +1991,13 @@
   ethercrow = {
     email = "ethercrow@gmail.com";
     github = "ethercrow";
+    githubId = 222467;
     name = "Dmitry Ivanov";
   };
   etu = {
     email = "elis@hirwing.se";
     github = "etu";
+    githubId = 461970;
     name = "Elis Hirwing";
     keys = [{
       longkeyid = "rsa4096/0xD57EFA625C9A925F";
@@ -1718,56 +2007,67 @@
   evanjs = {
     email = "evanjsx@gmail.com";
     github = "evanjs";
+    githubId = 1847524;
     name = "Evan Stoll";
   };
   evck = {
     email = "eric@evenchick.com";
     github = "ericevenchick";
+    githubId = 195032;
     name = "Eric Evenchick";
   };
   exfalso = {
     email = "0slemi0@gmail.com";
     github = "exfalso";
+    githubId = 1042674;
     name = "Andras Slemmer";
   };
   exi = {
     email = "nixos@reckling.org";
     github = "exi";
+    githubId = 449463;
     name = "Reno Reckling";
   };
   exlevan = {
     email = "exlevan@gmail.com";
     github = "exlevan";
+    githubId = 873530;
     name = "Alexey Levan";
   };
   expipiplus1 = {
     email = "nix@monoid.al";
     github = "expipiplus1";
+    githubId = 857308;
     name = "Joe Hermaszewski";
   };
   eyjhb = {
     email = "eyjhbb@gmail.com";
     github = "eyJhb";
+    githubId = 25955146;
     name = "eyJhb";
   };
   f--t = {
     email = "git@f-t.me";
     github = "f--t";
+    githubId = 2817965;
     name = "f--t";
   };
   f-breidenstein = {
     email = "mail@felixbreidenstein.de";
     github = "fleaz";
+    githubId = 2489598;
     name = "Felix Breidenstein";
   };
   fadenb = {
     email = "tristan.helmich+nixos@gmail.com";
     github = "fadenb";
+    githubId = 878822;
     name = "Tristan Helmich";
   };
   falsifian = {
     email = "james.cook@utoronto.ca";
     github = "falsifian";
+    githubId = 225893;
     name = "James Cook";
   };
   fare = {
@@ -1778,6 +2078,7 @@
   farlion = {
     email = "florian.peter@gmx.at";
     github = "workflow";
+    githubId = 1276854;
     name = "Florian Peter";
   };
   fdns = {
@@ -1788,66 +2089,79 @@
   ffinkdevs = {
     email = "fink@h0st.space";
     github = "ffinkdevs";
+    githubId = 45924649;
     name = "Fabian Fink";
   };
   fgaz = {
     email = "fgaz@fgaz.me";
     github = "fgaz";
+    githubId = 8182846;
     name = "Francesco Gazzetta";
   };
   FireyFly = {
     email = "nix@firefly.nu";
     github = "FireyFly";
+    githubId = 415760;
     name = "Jonas Höglund";
   };
   flexw = {
     email = "felix.weilbach@t-online.de";
     github = "FlexW";
+    githubId = 19961516;
     name = "Felix Weilbach";
   };
   flokli = {
     email = "flokli@flokli.de";
     github = "flokli";
+    githubId = 183879;
     name = "Florian Klink";
   };
   FlorianFranzen = {
     email = "Florian.Franzen@gmail.com";
     github = "FlorianFranzen";
+    githubId = 781077;
     name = "Florian Franzen";
   };
   florianjacob = {
     email = "projects+nixos@florianjacob.de";
     github = "florianjacob";
+    githubId = 1109959;
     name = "Florian Jacob";
   };
   flosse = {
     email = "mail@markus-kohlhase.de";
     github = "flosse";
+    githubId = 276043;
     name = "Markus Kohlhase";
   };
   fluffynukeit = {
     email = "dan@fluffynukeit.com";
     github = "fluffynukeit";
+    githubId = 844574;
     name = "Daniel Austin";
   };
   fmthoma = {
     email = "f.m.thoma@googlemail.com";
     github = "fmthoma";
+    githubId = 5918766;
     name = "Franz Thoma";
   };
   forkk = {
     email = "forkk@forkk.net";
     github = "forkk";
+    githubId = 1300078;
     name = "Andrew Okin";
   };
   fornever = {
     email = "friedrich@fornever.me";
     github = "fornever";
+    githubId = 92793;
     name = "Friedrich von Never";
   };
   fpletz = {
     email = "fpletz@fnordicwalking.de";
     github = "fpletz";
+    githubId = 114159;
     name = "Franz Pletz";
     keys = [{
       longkeyid = "rsa4096/0x846FDED7792617B4";
@@ -1857,6 +2171,7 @@
   fps = {
     email = "mista.tapas@gmx.net";
     github = "fps";
+    githubId = 84968;
     name = "Florian Paul Schmidt";
   };
 
@@ -1869,11 +2184,13 @@
   fredeb = {
     email = "im@fredeb.dev";
     github = "fredeeb";
+    githubId = 7551358;
     name = "Frede Emil";
   };
   freepotion = {
     email = "free.potion@yandex.ru";
     github = "freepotion";
+    githubId = 42352817;
     name = "Free Potion";
   };
   freezeboy = {
@@ -1889,31 +2206,37 @@
   fridh = {
     email = "fridh@fridh.nl";
     github = "fridh";
+    githubId = 2129135;
     name = "Frederik Rietdijk";
   };
   frlan = {
     email = "frank@frank.uvena.de";
     github = "frlan";
+    githubId = 1010248;
     name = "Frank Lanitz";
   };
   fro_ozen = {
     email = "fro_ozen@gmx.de";
     github = "froozen";
+    githubId = 1943632;
     name = "fro_ozen";
   };
   frontsideair = {
     email = "photonia@gmail.com";
     github = "frontsideair";
+    githubId = 868283;
     name = "Fatih Altinok";
   };
   ftrvxmtrx = {
     email = "ftrvxmtrx@gmail.com";
     github = "ftrvxmtrx";
+    githubId = 248148;
     name = "Siarhei Zirukin";
   };
   fuerbringer = {
     email = "severin@fuerbringer.info";
     github = "fuerbringer";
+    githubId = 10528737;
     name = "Severin Fürbringer";
   };
   funfunctor = {
@@ -1923,16 +2246,19 @@
   fusion809 = {
     email = "brentonhorne77@gmail.com";
     github = "fusion809";
+    githubId = 4717341;
     name = "Brenton Horne";
   };
   fuuzetsu = {
     email = "fuuzetsu@fuuzetsu.co.uk";
     github = "fuuzetsu";
+    githubId = 893115;
     name = "Mateusz Kowalczyk";
   };
   fuwa = {
     email = "echowss@gmail.com";
     github = "fuwa0529";
+    githubId = 40521440;
     name = "Haruka Akiyama";
   };
   fuzzy-id = {
@@ -1942,16 +2268,19 @@
   fxfactorial = {
     email = "edgar.factorial@gmail.com";
     github = "fxfactorial";
+    githubId = 3036816;
     name = "Edgar Aroutiounian";
   };
   gabesoft = {
     email = "gabesoft@gmail.com";
     github = "gabesoft";
+    githubId = 606000;
     name = "Gabriel Adomnicai";
   };
   gal_bolle = {
     email = "florent.becker@ens-lyon.org";
     github = "FlorentBecker";
+    githubId = 7047019;
     name = "Florent Becker";
   };
   garbas = {
@@ -1962,6 +2291,7 @@
   garrison = {
     email = "jim@garrison.cc";
     github = "garrison";
+    githubId = 91987;
     name = "Jim Garrison";
   };
   gavin = {
@@ -1972,91 +2302,109 @@
   gebner = {
     email = "gebner@gebner.org";
     github = "gebner";
+    githubId = 313929;
     name = "Gabriel Ebner";
   };
   geistesk = {
     email = "post@0x21.biz";
     github = "geistesk";
+    githubId = 8402811;
     name = "Alvar Penning";
   };
   genesis = {
     email = "ronan@aimao.org";
     github = "bignaux";
+    githubId = 149484;
     name = "Ronan Bignaux";
   };
   georgewhewell = {
     email = "georgerw@gmail.com";
     github = "georgewhewell";
+    githubId = 1176131;
     name = "George Whewell";
   };
   gerschtli = {
     email = "tobias.happ@gmx.de";
     github = "Gerschtli";
+    githubId = 10353047;
     name = "Tobias Happ";
   };
   ggpeti = {
     email = "ggpeti@gmail.com";
     github = "ggpeti";
+    githubId = 3217744;
     name = "Peter Ferenczy";
   };
   gilligan = {
     email = "tobias.pflug@gmail.com";
     github = "gilligan";
+    githubId = 27668;
     name = "Tobias Pflug";
   };
   giogadi = {
     email = "lgtorres42@gmail.com";
     github = "giogadi";
+    githubId = 1713676;
     name = "Luis G. Torres";
   };
   gleber = {
     email = "gleber.p@gmail.com";
     github = "gleber";
+    githubId = 33185;
     name = "Gleb Peregud";
   };
   glenns = {
     email = "glenn.searby@gmail.com";
     github = "glenns";
+    githubId = 615606;
     name = "Glenn Searby";
   };
   gloaming = {
     email = "ch9871@gmail.com";
     github = "gloaming";
+    githubId = 10156748;
     name = "Craig Hall";
   };
   globin = {
     email = "mail@glob.in";
     github = "globin";
+    githubId = 1447245;
     name = "Robin Gloster";
   };
   gnidorah = {
     email = "gnidorah@yandex.com";
     github = "gnidorah";
+    githubId = 12064730;
     name = "Alex Ivanov";
   };
   goibhniu = {
     email = "cillian.deroiste@gmail.com";
     github = "cillianderoiste";
+    githubId = 643494;
     name = "Cillian de Róiste";
   };
   Gonzih = {
     email = "gonzih@gmail.com";
     github = "Gonzih";
+    githubId = 266275;
     name = "Max Gonzih";
   };
   goodrone = {
     email = "goodrone@gmail.com";
     github = "goodrone";
+    githubId = 1621335;
     name = "Andrew Trachenko";
   };
   gpyh = {
     email = "yacine.hmito@gmail.com";
     github = "yacinehmito";
+    githubId = 6893840;
     name = "Yacine Hmito";
   };
   grahamc = {
     email = "graham@grahamc.com";
     github = "grahamc";
+    githubId = 76716;
     name = "Graham Christensen";
   };
   grburst = {
@@ -2067,6 +2415,7 @@
   greydot = {
     email = "lanablack@amok.cc";
     github = "greydot";
+    githubId = 7385287;
     name = "Lana Black";
   };
   gridaphobe = {
@@ -2077,106 +2426,127 @@
   guibert = {
     email = "david.guibert@gmail.com";
     github = "dguibert";
+    githubId = 1178864;
     name = "David Guibert";
   };
   groodt = {
     email = "groodt@gmail.com";
     github = "groodt";
+    githubId = 343415;
     name = "Greg Roodt";
   };
   guibou = {
     email = "guillaum.bouchard@gmail.com";
     github = "guibou";
+    githubId = 9705357;
     name = "Guillaume Bouchard";
   };
   guillaumekoenig = {
     email = "guillaume.edward.koenig@gmail.com";
     github = "guillaumekoenig";
+    githubId = 10654650;
     name = "Guillaume Koenig";
   };
   guyonvarch = {
     email = "joris@guyonvarch.me";
     github = "guyonvarch";
+    githubId = 6768842;
     name = "Joris Guyonvarch";
   };
   hakuch = {
     email = "hakuch@gmail.com";
     github = "hakuch";
+    githubId = 1498782;
     name = "Jesse Haber-Kucharsky";
   };
   hamhut1066 = {
     email = "github@hamhut1066.com";
     github = "moredhel";
+    githubId = 1742172;
     name = "Hamish Hutchings";
   };
   hansjoergschurr = {
     email = "commits@schurr.at";
     github = "hansjoergschurr";
+    githubId = 9850776;
     name = "Hans-Jörg Schurr";
     };
   HaoZeke = {
     email = "r95g10@gmail.com";
     github = "haozeke";
+    githubId = 4336207;
     name = "Rohit Goswami";
   };
   haslersn = {
     email = "haslersn@fius.informatik.uni-stuttgart.de";
     github = "haslersn";
+    githubId = 33969028;
     name = "Sebastian Hasler";
   };
   havvy = {
     email = "ryan.havvy@gmail.com";
     github = "havvy";
+    githubId = 731722;
     name = "Ryan Scheel";
   };
   hax404 = {
     email = "hax404foogit@hax404.de";
     github = "hax404";
+    githubId = 1379411;
     name = "Georg Haas";
   };
   hbunke = {
     email = "bunke.hendrik@gmail.com";
     github = "hbunke";
+    githubId = 1768793;
     name = "Hendrik Bunke";
   };
   hce = {
     email = "hc@hcesperer.org";
     github = "hce";
+    githubId = 147689;
     name = "Hans-Christian Esperer";
   };
   hectorj = {
     email = "hector.jusforgues+nixos@gmail.com";
     github = "hectorj";
+    githubId = 2427959;
     name = "Hector Jusforgues";
   };
   hedning = {
     email = "torhedinbronner@gmail.com";
     github = "hedning";
+    githubId = 71978;
     name = "Tor Hedin Brønner";
   };
   heel = {
     email = "parizhskiy@gmail.com";
     github = "heel";
+    githubId = 287769;
     name = "Sergii Paryzhskyi";
   };
   helkafen = {
     email = "arnaudpourseb@gmail.com";
     github = "Helkafen";
+    githubId = 2405974;
     name = "Sébastian Méric de Bellefon";
   };
   henrytill = {
     email = "henrytill@gmail.com";
     github = "henrytill";
+    githubId = 6430643;
     name = "Henry Till";
   };
   herberteuler = {
     email = "herberteuler@gmail.com";
     github = "herberteuler";
+    githubId = 1401179;
     name = "Guanpeng Xu";
   };
   hhm = {
     email = "heehooman+nixpkgs@gmail.com";
     github = "hhm0";
+    githubId = 3656888;
     name = "hhm";
   };
   hinton = {
@@ -2186,101 +2556,121 @@
   hlolli = {
     email = "hlolli@gmail.com";
     github = "hlolli";
+    githubId = 6074754;
     name = "Hlodver Sigurdsson";
   };
   hugoreeves = {
     email = "hugolreeves@gmail.com";
     github = "hugoreeves";
+    githubId = 20039091;
     name = "Hugo Reeves";
   };
   hodapp = {
     email = "hodapp87@gmail.com";
     github = "Hodapp87";
+    githubId = 896431;
     name = "Chris Hodapp";
   };
   hrdinka = {
     email = "c.nix@hrdinka.at";
     github = "hrdinka";
+    githubId = 1436960;
     name = "Christoph Hrdinka";
   };
   hschaeidt = {
     email = "he.schaeidt@gmail.com";
     github = "hschaeidt";
+    githubId = 1614615;
     name = "Hendrik Schaeidt";
   };
   htr = {
     email = "hugo@linux.com";
     github = "htr";
+    githubId = 39689;
     name = "Hugo Tavares Reis";
   };
   hyphon81 = {
     email = "zero812n@gmail.com";
     github = "hyphon81";
+    githubId = 12491746;
     name = "Masato Yonekawa";
   };
   iand675 = {
     email = "ian@iankduncan.com";
     github = "iand675";
+    githubId = 69209;
     name = "Ian Duncan";
   };
   ianwookim = {
     email = "ianwookim@gmail.com";
     github = "wavewave";
+    githubId = 1031119;
     name = "Ian-Woo Kim";
   };
   iblech = {
     email = "iblech@speicherleck.de";
     github = "iblech";
+    githubId = 3661115;
     name = "Ingo Blechschmidt";
   };
   idontgetoutmuch = {
     email = "dominic@steinitz.org";
     github = "idontgetoutmuch";
+    githubId = 1550265;
     name = "Dominic Steinitz";
   };
   igsha = {
     email = "igor.sharonov@gmail.com";
     github = "igsha";
+    githubId = 5345170;
     name = "Igor Sharonov";
   };
   iimog = {
     email = "iimog@iimog.org";
     github = "iimog";
+    githubId = 7403236;
     name = "Markus J. Ankenbrand";
   };
   ikervagyok = {
     email = "ikervagyok@gmail.com";
     github = "ikervagyok";
+    githubId = 7481521;
     name = "Balázs Lengyel";
   };
   ilikeavocadoes = {
     email = "ilikeavocadoes@hush.com";
     github = "ilikeavocadoes";
+    githubId = 36193715;
     name = "Lassi Haasio";
   };
   illegalprime = {
     email = "themichaeleden@gmail.com";
     github = "illegalprime";
+    githubId = 4401220;
     name = "Michael Eden";
   };
   ilya-kolpakov = {
     email = "ilya.kolpakov@gmail.com";
     github = "ilya-kolpakov";
+    githubId = 592849;
     name = "Ilya Kolpakov";
   };
   imalison = {
     email = "IvanMalison@gmail.com";
     github = "IvanMalison";
+    githubId = 1246619;
     name = "Ivan Malison";
   };
   imalsogreg = {
     email = "imalsogreg@gmail.com";
     github = "imalsogreg";
+    githubId = 993484;
     name = "Greg Hale";
   };
   imuli = {
     email = "i@imu.li";
     github = "imuli";
+    githubId = 4085046;
     name = "Imuli";
   };
   infinisil = {
@@ -2291,16 +2681,19 @@
   ingenieroariel = {
     email = "ariel@nunez.co";
     github = "ingenieroariel";
+    githubId = 54999;
     name = "Ariel Nunez";
   };
   ironpinguin = {
     email = "michele@catalano.de";
     github = "ironpinguin";
+    githubId = 137306;
     name = "Michele Catalano";
   };
   ivan = {
     email = "ivan@ludios.org";
     github = "ivan";
+    githubId = 4458;
     name = "Ivan Kozik";
   };
   ivan-tkatchev = {
@@ -2310,6 +2703,7 @@
   ivanbrennan = {
     email = "ivan.brennan@gmail.com";
     github = "ivanbrennan";
+    githubId = 1672874;
     name = "Ivan Brennan";
     keys = [{
       longkeyid = "rsa4096/0x79C3C47DC652EA54";
@@ -2319,6 +2713,7 @@
   ivegotasthma = {
     email = "ivegotasthma@protonmail.com";
     github = "ivegotasthma";
+    githubId = 2437675;
     name = "John Doe";
     keys = [{
       longkeyid = "rsa4096/09AC52AEA87817A4";
@@ -2328,21 +2723,25 @@
   ixmatus = {
     email = "parnell@digitalmentat.com";
     github = "ixmatus";
+    githubId = 30714;
     name = "Parnell Springmeyer";
   };
   ixxie = {
     email = "matan@fluxcraft.net";
     github = "ixxie";
+    githubId = 20320695;
     name = "Matan Bendix Shenhav";
   };
   izorkin = {
     email = "Izorkin@gmail.com";
     github = "izorkin";
+    githubId = 26877687;
     name = "Yurii Izorkin";
   };
   j-keck = {
     email = "jhyphenkeck@gmail.com";
     github = "j-keck";
+    githubId = 3081095;
     name = "Jürgen Keck";
   };
   j03 = {
@@ -2353,51 +2752,61 @@
   jagajaga = {
     email = "ars.seroka@gmail.com";
     github = "jagajaga";
+    githubId = 2179419;
     name = "Arseniy Seroka";
   };
   jakelogemann = {
     email = "jake.logemann@gmail.com";
     github = "jakelogemann";
+    githubId = 820715;
     name = "Jake Logemann";
   };
   jakewaksbaum = {
     email = "jake.waksbaum@gmail.com";
     github = "jbaum98";
+    githubId = 5283991;
     name = "Jake Waksbaum";
   };
   jammerful = {
     email = "jammerful@gmail.com";
     github = "jammerful";
+    githubId = 20176306;
     name = "jammerful";
   };
   jansol = {
     email = "jan.solanti@paivola.fi";
     github = "jansol";
+    githubId = 2588851;
     name = "Jan Solanti";
   };
   javaguirre = {
     email = "contacto@javaguirre.net";
     github = "javaguirre";
+    githubId = 488556;
     name = "Javier Aguirre";
   };
   jb55 = {
     email = "jb55@jb55.com";
     github = "jb55";
+    githubId = 45598;
     name = "William Casarin";
   };
   jbedo = {
     email = "cu@cua0.org";
     github = "jbedo";
+    githubId = 372912;
     name = "Justin Bedő";
   };
   jbgi = {
     email = "jb@giraudeau.info";
     github = "jbgi";
+    githubId = 221929;
     name = "Jean-Baptiste Giraudeau";
   };
   jchw = {
     email = "johnwchadwick@gmail.com";
     github = "jchv";
+    githubId = 938744;
     name = "John Chadwick";
   };
   jcumming = {
@@ -2407,31 +2816,37 @@
   jD91mZM2 = {
     email = "me@krake.one";
     github = "jD91mZM2";
+    githubId = 12830969;
     name = "jD91mZM2";
   };
   jdagilliland = {
     email = "jdagilliland@gmail.com";
     github = "jdagilliland";
+    githubId = 1383440;
     name = "Jason Gilliland";
   };
   jdehaas = {
     email = "qqlq@nullptr.club";
     github = "jeroendehaas";
+    githubId = 117874;
     name = "Jeroen de Haas";
   };
   jefdaj = {
     email = "jefdaj@gmail.com";
     github = "jefdaj";
+    githubId = 1198065;
     name = "Jeffrey David Johnson";
   };
   jensbin = {
     email = "jensbin+git@pm.me";
     github = "jensbin";
+    githubId = 1608697;
     name = "Jens Binkert";
   };
   jerith666 = {
     email = "github@matt.mchenryfamily.org";
     github = "jerith666";
+    githubId = 854319;
     name = "Matt McHenry";
   };
   jeschli = {
@@ -2442,6 +2857,7 @@
   jethro = {
     email = "jethrokuan95@gmail.com";
     github = "jethrokuan";
+    githubId = 1667473;
     name = "Jethro Kuan";
   };
   jfb = {
@@ -2452,71 +2868,85 @@
   jflanglois = {
     email = "yourstruly@julienlanglois.me";
     github = "jflanglois";
+    githubId = 18501;
     name = "Julien Langlois";
   };
   jfrankenau = {
     email = "johannes@frankenau.net";
     github = "jfrankenau";
+    githubId = 2736480;
     name = "Johannes Frankenau";
   };
   jgeerds = {
     email = "jascha@geerds.org";
     github = "jgeerds";
+    githubId = 1473909;
     name = "Jascha Geerds";
   };
   jgertm = {
     email = "jger.tm@gmail.com";
     github = "jgertm";
+    githubId = 6616642;
     name = "Tim Jaeger";
   };
   jgillich = {
     email = "jakob@gillich.me";
     github = "jgillich";
+    githubId = 347965;
     name = "Jakob Gillich";
   };
   jglukasik = {
     email = "joseph@jgl.me";
     github = "jglukasik";
+    githubId = 6445082;
     name = "Joseph Lukasik";
   };
   jhhuh = {
     email = "jhhuh.note@gmail.com";
     github = "jhhuh";
+    githubId = 5843245;
     name = "Ji-Haeng Huh";
   };
   jhillyerd = {
     email = "james+nixos@hillyerd.com";
     github = "jhillyerd";
+    githubId = 2502736;
     name = "James Hillyerd";
   };
   jirkamarsik = {
     email = "jiri.marsik89@gmail.com";
     github = "jirkamarsik";
+    githubId = 184898;
     name = "Jirka Marsik";
   };
   jlesquembre = {
     email = "jl@lafuente.me";
     github = "jlesquembre";
+    githubId = 1058504;
     name = "José Luis Lafuente";
   };
   jluttine = {
     email = "jaakko.luttinen@iki.fi";
     github = "jluttine";
+    githubId = 2195834;
     name = "Jaakko Luttinen";
   };
   jmagnusj = {
     email = "jmagnusj@gmail.com";
     github = "magnusjonsson";
+    githubId = 8900;
     name = "Johan Magnus Jonsson";
   };
   jmettes = {
     email = "jonathan@jmettes.com";
     github = "jmettes";
+    githubId = 587870;
     name = "Jonathan Mettes";
   };
   joachifm = {
     email = "joachifm@fastmail.fm";
     github = "joachifm";
+    githubId = 41977;
     name = "Joachim Fasting";
   };
   joamaki = {
@@ -2527,11 +2957,13 @@
   joelburget = {
     email = "joelburget@gmail.com";
     github = "joelburget";
+    githubId = 310981;
     name = "Joel Burget";
   };
   joelmo = {
     email = "joel.moberg@gmail.com";
     github = "joelmo";
+    githubId = 336631;
     name = "Joel Moberg";
   };
   joelteon = {
@@ -2546,36 +2978,43 @@
   johanot = {
     email = "write@ownrisk.dk";
     github = "johanot";
+    githubId = 998763;
     name = "Johan Thomsen";
   };
   johbo = {
     email = "johannes@bornhold.name";
     github = "johbo";
+    githubId = 117805;
     name = "Johannes Bornhold";
   };
   johnazoidberg = {
     email = "git@danielschaefer.me";
     github = "johnazoidberg";
+    githubId = 5307138;
     name = "Daniel Schäfer";
   };
   johnchildren = {
     email = "john.a.children@gmail.com";
     github = "johnchildren";
+    githubId = 32305209;
     name = "John Children";
   };
   johnmh = {
     email = "johnmh@openblox.org";
     github = "johnmh";
+    githubId = 2576152;
     name = "John M. Harris, Jr.";
   };
   johnramsden = {
     email = "johnramsden@riseup.net";
     github = "johnramsden";
+    githubId = 8735102;
     name = "John Ramsden";
   };
   joko = {
     email = "ioannis.koutras@gmail.com";
     github = "jokogr";
+    githubId = 1252547;
     keys = [{
       # compare with https://keybase.io/joko
       longkeyid = "rsa2048/0x85EAE7D9DF56C5CA";
@@ -2586,71 +3025,85 @@
   jonafato = {
     email = "jon@jonafato.com";
     github = "jonafato";
+    githubId = 392720;
     name = "Jon Banafato";
   };
   jonathanreeve = {
     email = "jon.reeve@gmail.com";
     github = "JonathanReeve";
+    githubId = 1843676;
     name = "Jonathan Reeve";
   };
   joncojonathan = {
     email = "joncojonathan@gmail.com";
     github = "joncojonathan";
+    githubId = 11414454;
     name = "Jonathan Haddock";
   };
   jonringer = {
     email = "jonringer117@gmail.com";
     github = "jonringer";
+    githubId = 7673602;
     name = "Jonathan Ringer";
   };
   jorise = {
     email = "info@jorisengbers.nl";
     github = "JorisE";
+    githubId = 1767283;
     name = "Joris Engbers";
   };
   jorsn = {
     name = "Johannes Rosenberger";
     email = "johannes@jorsn.eu";
     github = "jorsn";
+    githubId = 4646725;
   };
   jpdoyle = {
     email = "joethedoyle@gmail.com";
     github = "jpdoyle";
+    githubId = 1918771;
     name = "Joe Doyle";
   };
   jpierre03 = {
     email = "nix@prunetwork.fr";
     github = "jpierre03";
+    githubId = 954536;
     name = "Jean-Pierre PRUNARET";
   };
   jpotier = {
     email = "jpo.contributes.to.nixos@marvid.fr";
     github = "jpotier";
+    githubId = 752510;
     name = "Martin Potier";
   };
   jqueiroz = {
     email = "nixos@johnjq.com";
     github = "jqueiroz";
+    githubId = 4968215;
     name = "Jonathan Queiroz";
   };
   jraygauthier = {
     email = "jraygauthier@gmail.com";
     github = "jraygauthier";
+    githubId = 4611077;
     name = "Raymond Gauthier";
   };
   jtobin = {
     email = "jared@jtobin.io";
     github = "jtobin";
+    githubId = 1414434;
     name = "Jared Tobin";
   };
   jtojnar = {
     email = "jtojnar@gmail.com";
     github = "jtojnar";
+    githubId = 705123;
     name = "Jan Tojnar";
   };
   juaningan = {
     email = "juaningan@gmail.com";
     github = "juaningan";
+    githubId = 810075;
     name = "Juan Rodal";
   };
   juliendehos = {
@@ -2661,11 +3114,13 @@
   justinwoo = {
     email = "moomoowoo@gmail.com";
     github = "justinwoo";
+    githubId = 2396926;
     name = "Justin Woo";
   };
   jwiegley = {
     email = "johnw@newartisans.com";
     github = "jwiegley";
+    githubId = 8460;
     name = "John Wiegley";
   };
   jwilberding = {
@@ -2680,21 +3135,25 @@
   jzellner = {
     email = "jeffz@eml.cc";
     github = "sofuture";
+    githubId = 66669;
     name = "Jeff Zellner";
   };
   kaiha = {
     email = "kai.harries@gmail.com";
     github = "kaiha";
+    githubId = 6544084;
     name = "Kai Harries";
   };
   kalbasit = {
     email = "wael.nasreddine@gmail.com";
     github = "kalbasit";
+    githubId = 87115;
     name = "Wael Nasreddine";
   };
   kamilchm = {
     email = "kamil.chm@gmail.com";
     github = "kamilchm";
+    githubId = 1621930;
     name = "Kamil Chmielewski";
   };
   kampfschlaefer = {
@@ -2709,66 +3168,79 @@
   kazcw = {
     email = "kaz@lambdaverse.org";
     github = "kazcw";
+    githubId = 1047859;
     name = "Kaz Wesley";
   };
   kentjames = {
     email = "jameschristopherkent@gmail.com";
     github = "kentjames";
+    githubId = 2029444;
     name = "James Kent";
   };
   kevincox = {
     email = "kevincox@kevincox.ca";
     github = "kevincox";
+    githubId = 494012;
     name = "Kevin Cox";
   };
   khumba = {
     email = "bog@khumba.net";
     github = "khumba";
+    githubId = 788813;
     name = "Bryan Gardiner";
   };
   KibaFox = {
     email = "kiba.fox@foxypossibilities.com";
     github = "KibaFox";
+    githubId = 16481032;
     name = "Kiba Fox";
   };
   kierdavis = {
     email = "kierdavis@gmail.com";
     github = "kierdavis";
+    githubId = 845652;
     name = "Kier Davis";
   };
   killercup = {
     email = "killercup@gmail.com";
     github = "killercup";
+    githubId = 20063;
     name = "Pascal Hertleif";
   };
   kiloreux = {
     email = "kiloreux@gmail.com";
     github = "kiloreux";
+    githubId = 6282557;
     name = "Kiloreux Emperex";
   };
   kimburgess = {
     email = "kim@acaprojects.com";
     github = "kimburgess";
+    githubId = 843652;
     name = "Kim Burgess";
   };
   kini = {
     email = "keshav.kini@gmail.com";
     github = "kini";
+    githubId = 691290;
     name = "Keshav Kini";
   };
   kirelagin = {
     email = "kirelagin@gmail.com";
     github = "kirelagin";
+    githubId = 451835;
     name = "Kirill Elagin";
   };
   kisonecat = {
     email = "kisonecat@gmail.com";
     github = "kisonecat";
+    githubId = 148352;
     name = "Jim Fowler";
   };
   kiwi = {
     email = "envy1988@gmail.com";
     github = "Kiwi";
+    githubId = 35715;
     name = "Robert Djubek";
     keys = [{
       longkeyid = "rsa4096/0x156C88A5B0A04B2A";
@@ -2778,6 +3250,7 @@
   kjuvi = {
     email = "quentin.vaucher@pm.me";
     github = "kjuvi";
+    githubId = 17534323;
     name = "Quentin Vaucher";
   };
   kkallio = {
@@ -2788,37 +3261,44 @@
     email = "klntsky@gmail.com";
     name = "Vladimir Kalnitsky";
     github = "klntsky";
+    githubId = 18447310;
   };
   kmeakin = {
     email = "karlwfmeakin@gmail.com";
     name = "Karl Meakin";
     github = "Kmeakin";
+    githubId = 19665139;
   };
 
   kmein = {
     email = "kieran.meinhardt@gmail.com";
     name = "Kierán Meinhardt";
     github = "kmein";
+    githubId = 10352507;
   };
 
   knedlsepp = {
     email = "josef.kemetmueller@gmail.com";
     github = "knedlsepp";
+    githubId = 3287933;
     name = "Josef Kemetmüller";
   };
   knl = {
     email = "nikola@knezevic.co";
     github = "knl";
+    githubId = 361496;
     name = "Nikola Knežević";
   };
   kolaente = {
     email = "k@knt.li";
     github = "kolaente";
+    githubId = 13721712;
     name = "Konrad Langenberg";
   };
   konimex = {
     email = "herdiansyah@netc.eu";
     github = "konimex";
+    githubId = 15692230;
     name = "Muhammad Herdiansyah";
   };
   koral = {
@@ -2829,61 +3309,73 @@
   kovirobi = {
     email = "kovirobi@gmail.com";
     github = "kovirobi";
+    githubId = 1903418;
     name = "Kovacsics Robert";
   };
   kquick = {
     email = "quick@sparq.org";
     github = "kquick";
+    githubId = 787421;
     name = "Kevin Quick";
   };
   kragniz = {
     email = "louis@kragniz.eu";
     github = "kragniz";
+    githubId = 735008;
     name = "Louis Taylor";
   };
   krav = {
     email = "kristoffer@microdisko.no";
     github = "krav";
+    githubId = 4032;
     name = "Kristoffer Thømt Ravneberg";
   };
   kroell = {
     email = "nixosmainter@makroell.de";
     github = "rokk4";
+    githubId = 17659803;
     name = "Matthias Axel Kröll";
   };
   kristoff3r = {
     email = "k.soeholm@gmail.com";
     github = "kristoff3r";
+    githubId = 160317;
     name = "Kristoffer Søholm";
   };
   ktf = {
     email = "giulio.eulisse@cern.ch";
     github = "ktf";
+    githubId = 10544;
     name = "Giuluo Eulisse";
   };
   ktosiek = {
     email = "tomasz.kontusz@gmail.com";
     github = "ktosiek";
+    githubId = 278013;
     name = "Tomasz Kontusz";
   };
   kuznero = {
     email = "roman@kuznero.com";
     github = "kuznero";
+    githubId = 449813;
     name = "Roman Kuznetsov";
   };
   kylewlacy = {
     email = "kylelacy+nix@pm.me";
     github = "kylewlacy";
+    githubId = 1362179;
     name = "Kyle Lacy";
   };
   lasandell = {
     email = "lasandell@gmail.com";
     github = "lasandell";
+    githubId = 2034420;
     name = "Luke Sandell";
   };
   lambda-11235 = {
     email = "taranlynn0@gmail.com";
     github = "lambda-11235";
+    githubId = 16354815;
     name = "Taran Lynn";
   };
   lassulus = {
@@ -2894,26 +3386,31 @@
   layus = {
     email = "layus.on@gmail.com";
     github = "layus";
+    githubId = 632767;
     name = "Guillaume Maudoux";
   };
   lblasc = {
     email = "lblasc@znode.net";
     github = "lblasc";
+    githubId = 32152;
     name = "Luka Blaskovic";
   };
   ldesgoui = {
     email = "ldesgoui@gmail.com";
     github = "ldesgoui";
+    githubId = 2472678;
     name = "Lucas Desgouilles";
   };
   league = {
     email = "league@contrapunctus.net";
     github = "league";
+    githubId = 50286;
     name = "Christopher League";
   };
   leahneukirchen = {
     email = "leah@vuxu.org";
     github = "leahneukirchen";
+    githubId = 139;
     name = "Leah Neukirchen";
   };
   lebastr = {
@@ -2924,26 +3421,31 @@
   ledif = {
     email = "refuse@gmail.com";
     github = "ledif";
+    githubId = 307744;
     name = "Adam Fidel";
   };
   leemachin = {
     email = "me@mrl.ee";
     github = "leemachin";
+    githubId = 736291;
     name = "Lee Machin";
   };
   leenaars = {
     email = "ml.software@leenaa.rs";
     github = "leenaars";
+    githubId = 4158274;
     name = "Michiel Leenaars";
   };
   lejonet = {
     email = "daniel@kuehn.se";
     github = "lejonet";
+    githubId = 567634;
     name = "Daniel Kuehn";
   };
   leo60228 = {
     email = "iakornfeld@gmail.com";
     github = "leo60228";
+    githubId = 8355305;
     name = "leo60228";
   };
   leonardoce = {
@@ -2954,66 +3456,79 @@
   lethalman = {
     email = "lucabru@src.gnome.org";
     github = "lethalman";
+    githubId = 480920;
     name = "Luca Bruno";
   };
   lewo = {
     email = "lewo@abesis.fr";
     github = "nlewo";
+    githubId = 3425311;
     name = "Antoine Eiche";
   };
   lheckemann = {
     email = "git@sphalerite.org";
     github = "lheckemann";
+    githubId = 341954;
     name = "Linus Heckemann";
   };
   lhvwb = {
     email = "nathaniel.baxter@gmail.com";
     github = "nathanielbaxter";
+    githubId = 307589;
     name = "Nathaniel Baxter";
   };
   lightdiscord = {
     email = "root@arnaud.sh";
     github = "lightdiscord";
+    githubId = 24509182;
     name = "Arnaud Pascal";
   };
   lihop = {
     email = "nixos@leroy.geek.nz";
     github = "lihop";
+    githubId = 3696783;
     name = "Leroy Hopson";
   };
   lilyball = {
     email = "lily@sb.org";
     github = "lilyball";
+    githubId = 714;
     name = "Lily Ballard";
   };
   limeytexan = {
     email = "limeytexan@gmail.com";
     github = "limeytexan";
+    githubId = 36448130;
     name = "Michael Brantley";
   };
   linarcx = {
     email = "linarcx@gmail.com";
     github = "linarcx";
+    githubId = 10884422;
     name = "Kaveh Ahangar";
   };
   linc01n = {
     email = "git@lincoln.hk";
     github = "linc01n";
+    githubId = 667272;
     name = "Lincoln Lee";
   };
   linquize = {
     email = "linquize@yahoo.com.hk";
     github = "linquize";
+    githubId = 791115;
     name = "Linquize";
   };
   linus = {
     email = "linusarver@gmail.com";
     github = "listx";
+    githubId = 725613;
     name = "Linus Arver";
   };
   livnev = {
     email = "lev@liv.nev.org.uk";
     github = "livnev";
+    githubId = 3964494;
     name = "Lev Livnev";
     keys = [{
       longkeyid = "rsa2048/0x68FF81E6A7850F49";
@@ -3023,41 +3538,49 @@
   luis = {
       email = "luis.nixos@gmail.com";
       github = "Luis-Hebendanz";
+      githubId = 22085373;
       name = "Luis Hebendanz";
   };
   lionello = {
     email = "lio@lunesu.com";
     github = "lionello";
+    githubId = 591860;
     name = "Lionello Lunesu";
   };
   lluchs = {
     email = "lukas.werling@gmail.com";
     github = "lluchs";
+    githubId = 516527;
     name = "Lukas Werling";
   };
   lnl7 = {
     email = "daiderd@gmail.com";
     github = "lnl7";
+    githubId = 689294;
     name = "Daiderd Jordan";
   };
   lo1tuma = {
     email = "schreck.mathias@gmail.com";
     github = "lo1tuma";
+    githubId = 169170;
     name = "Mathias Schreck";
   };
   loewenheim = {
     email = "loewenheim@mailbox.org";
     github = "loewenheim";
+    githubId = 7622248;
     name = "Sebastian Zivota";
   };
   lopsided98 = {
     email = "benwolsieffer@gmail.com";
     github = "lopsided98";
+    githubId = 5624721;
     name = "Ben Wolsieffer";
   };
   loskutov = {
     email = "ignat.loskutov@gmail.com";
     github = "loskutov";
+    githubId = 1202012;
     name = "Ignat Loskutov";
   };
   lovek323 = {
@@ -3068,16 +3591,19 @@
   lowfatcomputing = {
     email = "andreas.wagner@lowfatcomputing.org";
     github = "lowfatcomputing";
+    githubId = 10626;
     name = "Andreas Wagner";
   };
   lschuermann = {
     email = "leon.git@is.currently.online";
     github = "lschuermann";
+    githubId = 5341193;
     name = "Leon Schuermann";
   };
   lsix = {
     email = "lsix@lancelotsix.com";
     github = "lsix";
+    githubId = 724339;
     name = "Lancelot SIX";
   };
   ltavard = {
@@ -3088,51 +3614,61 @@
   lucas8 = {
     email = "luc.linux@mailoo.org";
     github = "lucas8";
+    githubId = 2025623;
     name = "Luc Chabassier";
   };
   lucus16 = {
     email = "lars.jellema@gmail.com";
     github = "Lucus16";
+    githubId = 2487922;
     name = "Lars Jellema";
   };
   ludo = {
     email = "ludo@gnu.org";
     github = "civodul";
+    githubId = 1168435;
     name = "Ludovic Courtès";
   };
   lufia = {
     email = "lufia@lufia.org";
     github = "lufia";
+    githubId = 1784379;
     name = "Kyohei Kadota";
   };
   luispedro = {
     email = "luis@luispedro.org";
     github = "luispedro";
+    githubId = 79334;
     name = "Luis Pedro Coelho";
   };
   lukeadams = {
     email = "luke.adams@belljar.io";
     github = "lukeadams";
+    githubId = 3508077;
     name = "Luke Adams";
   };
   lukebfox = {
     email = "lbentley-fox1@sheffield.ac.uk";
     github = "lukebfox";
+    githubId = 34683288;
     name = "Luke Bentley-Fox";
   };
   lukego = {
     email = "luke@snabb.co";
     github = "lukego";
+    githubId = 13791;
     name = "Luke Gorrie";
   };
   luz = {
     email = "luz666@daum.net";
     github = "Luz";
+    githubId = 208297;
     name = "Luz";
   };
   lw = {
     email = "lw@fmap.me";
     github = "lolwat97";
+    githubId = 2057309;
     name = "Sergey Sofeychuk";
   };
   lyt = {
@@ -3146,71 +3682,85 @@
   ma27 = {
     email = "maximilian@mbosch.me";
     github = "ma27";
+    githubId = 6025220;
     name = "Maximilian Bosch";
   };
   ma9e = {
     email = "sean@lfo.team";
     github = "furrycatherder";
+    githubId = 36235154;
     name = "Sean Haugh";
   };
   madjar = {
     email = "georges.dubus@compiletoi.net";
     github = "madjar";
+    githubId = 109141;
     name = "Georges Dubus";
   };
   mafo = {
     email = "Marc.Fontaine@gmx.de";
     github = "MarcFontaine";
+    githubId = 1433367;
     name = "Marc Fontaine";
   };
   magenbluten = {
     email = "magenbluten@codemonkey.cc";
     github = "magenbluten";
+    githubId = 1140462;
     name = "magenbluten";
   };
   magnetophon = {
     email = "bart@magnetophon.nl";
     github = "magnetophon";
+    githubId = 7645711;
     name = "Bart Brouns";
   };
   mahe = {
     email = "matthias.mh.herrmann@gmail.com";
     github = "2chilled";
+    githubId = 1238350;
     name = "Matthias Herrmann";
   };
   makefu = {
     email = "makefu@syntax-fehler.de";
     github = "makefu";
+    githubId = 115218;
     name = "Felix Richter";
   };
   malyn = {
     email = "malyn@strangeGizmo.com";
     github = "malyn";
+    githubId = 346094;
     name = "Michael Alyn Miller";
   };
   manveru = {
     email = "m.fellinger@gmail.com";
     github = "manveru";
+    githubId = 3507;
     name = "Michael Fellinger";
   };
   marcweber = {
     email = "marco-oweber@gmx.de";
     github = "marcweber";
+    githubId = 34086;
     name = "Marc Weber";
   };
 	marenz = {
 		email = "marenz@arkom.men";
 		github = "marenz2569";
+		githubId = 12773269;
 		name = "Markus Schmidl";
 	};
   markus1189 = {
     email = "markus1189@gmail.com";
     github = "markus1189";
+    githubId = 591567;
     name = "Markus Hauck";
   };
   markuskowa = {
     email = "markus.kowalewski@gmail.com";
     github = "markuskowa";
+    githubId = 26470037;
     name = "Markus Kowalewski";
   };
   markWot = {
@@ -3221,25 +3771,30 @@
     email = "mariusdavid@laposte.net";
     name = "Marius David";
     github = "marius851000";
+    githubId = 22586596;
   };
   marsam = {
     email = "marsam@users.noreply.github.com";
     github = "marsam";
+    githubId = 65531;
     name = "Mario Rodas";
   };
   martijnvermaat = {
     email = "martijn@vermaat.name";
     github = "martijnvermaat";
+    githubId = 623509;
     name = "Martijn Vermaat";
   };
   martingms = {
     email = "martin@mg.am";
     github = "martingms";
+    githubId = 458783;
     name = "Martin Gammelsæter";
   };
   marzipankaiser = {
     email = "nixos@gaisseml.de";
     github = "marzipankaiser";
+    githubId = 2551444;
     name = "Marcial Gaißert";
     keys = [{
       longkeyid = "rsa2048/0xB629036BE399EEE9";
@@ -3249,16 +3804,19 @@
   matejc = {
     email = "cotman.matej@gmail.com";
     github = "matejc";
+    githubId = 854770;
     name = "Matej Cotman";
   };
   mathnerd314 = {
     email = "mathnerd314.gph+hs@gmail.com";
     github = "mathnerd314";
+    githubId = 322214;
     name = "Mathnerd314";
   };
   matklad = {
     email = "aleksey.kladov@gmail.com";
     github = "matklad";
+    githubId = 1711539;
     name = "matklad";
   };
   matthewbauer = {
@@ -3269,6 +3827,7 @@
   matthiasbeyer = {
     email = "mail@beyermatthias.de";
     github = "matthiasbeyer";
+    githubId = 427866;
     name = "Matthias Beyer";
   };
   matti-kariluoma = {
@@ -3279,76 +3838,91 @@
   maurer = {
     email = "matthew.r.maurer+nix@gmail.com";
     github = "maurer";
+    githubId = 136037;
     name = "Matthew Maurer";
   };
   mbakke = {
     email = "mbakke@fastmail.com";
     github = "mbakke";
+    githubId = 1269099;
     name = "Marius Bakke";
   };
   mbbx6spp = {
     email = "me@susanpotter.net";
     github = "mbbx6spp";
+    githubId = 564;
     name = "Susan Potter";
   };
   mbe = {
     email = "brandonedens@gmail.com";
     github = "brandonedens";
+    githubId = 396449;
     name = "Brandon Edens";
   };
   mbode = {
     email = "maxbode@gmail.com";
     github = "mbode";
+    githubId = 9051309;
     name = "Maximilian Bode";
   };
   mboes = {
     email = "mboes@tweag.net";
     github = "mboes";
+    githubId = 51356;
     name = "Mathieu Boespflug";
   };
   mbrgm = {
     email = "marius@yeai.de";
     github = "mbrgm";
+    githubId = 2971615;
     name = "Marius Bergmann";
   };
   mcmtroffaes = {
     email = "matthias.troffaes@gmail.com";
     github = "mcmtroffaes";
+    githubId = 158568;
     name = "Matthias C. M. Troffaes";
   };
   mdaiter = {
     email = "mdaiter8121@gmail.com";
     github = "mdaiter";
+    githubId = 1377571;
     name = "Matthew S. Daiter";
   };
   mdevlamynck = {
     email = "matthias.devlamynck@mailoo.org";
     github = "mdevlamynck";
+    githubId = 4378377;
     name = "Matthias Devlamynck";
   };
   meditans = {
     email = "meditans@gmail.com";
     github = "meditans";
+    githubId = 4641445;
     name = "Carlo Nucera";
   };
   megheaiulian = {
     email = "iulian.meghea@gmail.com";
     github = "megheaiulian";
+    githubId = 1788114;
     name = "Meghea Iulian";
   };
   mehandes = {
     email = "niewskici@gmail.com";
     github = "mehandes";
+    githubId = 32581276;
     name = "Matt Deming";
   };
   meisternu = {
     email = "meister@krutt.org";
     github = "meisternu";
+    githubId = 8263431;
     name = "Matt Miemiec";
   };
   melchips = {
     email = "truphemus.francois@gmail.com";
     github = "melchips";
+    githubId = 365721;
     name = "Francois Truphemus";
   };
   melsigl = {
@@ -3359,6 +3933,7 @@
   melkor333 = {
     email = "samuel@ton-kunst.ch";
     github = "melkor333";
+    githubId = 6412377;
     name = "Samuel Ruprecht";
   };
   metabar = {
@@ -3369,40 +3944,48 @@
     email = "kira.bruneau@gmail.com";
     name = "Kira Bruneau";
     github = "metadark";
+    githubId = 382041;
   };
   mfossen = {
     email = "msfossen@gmail.com";
     github = "mfossen";
+    githubId = 3300322;
     name = "Mitchell Fossen";
   };
   mgdelacroix = {
     email = "mgdelacroix@gmail.com";
     github = "mgdelacroix";
+    githubId = 223323;
     name = "Miguel de la Cruz";
   };
   mgregoire = {
     email = "gregoire@martinache.net";
     github = "M-Gregoire";
+    githubId = 9469313;
     name = "Gregoire Martinache";
   };
   mgttlinger = {
     email = "megoettlinger@gmail.com";
     github = "mgttlinger";
+    githubId = 5120487;
     name = "Merlin Göttlinger";
   };
   mguentner = {
     email = "code@klandest.in";
     github = "mguentner";
+    githubId = 668926;
     name = "Maximilian Güntner";
   };
    mhaselsteiner = {
     email = "magdalena.haselsteiner@gmx.at";
     github = "mhaselsteiner";
+    githubId = 20536514;
     name = "Magdalena Haselsteiner";
   };
   mic92 = {
     email = "joerg@thalheim.io";
     github = "mic92";
+    githubId = 96200;
     name = "Jörg Thalheim";
     keys = [{
       # compare with https://keybase.io/Mic92
@@ -3418,6 +4001,7 @@
   michalrus = {
     email = "m@michalrus.com";
     github = "michalrus";
+    githubId = 4366292;
     name = "Michal Rus";
   };
   michelk = {
@@ -3428,26 +4012,31 @@
   michojel = {
     email = "mic.liamg@gmail.com";
     github = "michojel";
+    githubId = 21156022;
     name = "Michal Minář";
   };
   mickours = {
     email = "mickours@gmail.com<";
     github = "mickours";
+    githubId = 837312;
     name = "Michael Mercier";
   };
   midchildan = {
     email = "midchildan+nix@gmail.com";
     github = "midchildan";
+    githubId = 7343721;
     name = "midchildan";
   };
   mikefaille = {
     email = "michael@faille.io";
     github = "mikefaille";
+    githubId = 978196;
     name = "Michaël Faille";
   };
   mikoim = {
     email = "ek@esh.ink";
     github = "mikoim";
+    githubId = 3958340;
     name = "Eshin Kunishima";
   };
   miltador = {
@@ -3457,6 +4046,7 @@
   mimadrid = {
     email = "mimadrid@ucm.es";
     github = "mimadrid";
+    githubId = 3269878;
     name = "Miguel Madrid";
   };
   minijackson = {
@@ -3472,36 +4062,43 @@
   mirrexagon = {
     email = "mirrexagon@mirrexagon.com";
     github = "mirrexagon";
+    githubId = 1776903;
     name = "Andrew Abbott";
   };
   mjanczyk = {
     email = "m@dragonvr.pl";
     github = "mjanczyk";
+    githubId = 1001112;
     name = "Marcin Janczyk";
   };
   mjp = {
     email = "mike@mythik.co.uk";
     github = "MikePlayle";
+    githubId = 16974598;
     name = "Mike Playle";
   };
   mkazulak = {
     email = "kazulakm@gmail.com";
     github = "mulderr";
+    githubId = 5698461;
     name = "Maciej Kazulak";
   };
   mkg = {
     email = "mkg@vt.edu";
     github = "mkgvt";
+    githubId = 22477669;
     name = "Mark K Gardner";
   };
   mlieberman85 = {
     email = "mlieberman85@gmail.com";
     github = "mlieberman85";
+    githubId = 622577;
     name = "Michael Lieberman";
   };
   mmahut = {
     email = "marek.mahut@gmail.com";
     github = "mmahut";
+    githubId = 104795;
     name = "Marek Mahut";
   };
   mmlb = {
@@ -3512,21 +4109,25 @@
   mnacamura = {
     email = "m.nacamura@gmail.com";
     github = "mnacamura";
+    githubId = 45770;
     name = "Mitsuhiro Nakamura";
   };
   moaxcp = {
     email = "moaxcp@gmail.com";
     github = "moaxcp";
+    githubId = 7831184;
     name = "John Mercier";
   };
   modulistic = {
     email = "modulistic@gmail.com";
     github = "modulistic";
+    githubId = 1902456;
     name = "Pablo Costa";
   };
   mog = {
     email = "mog-lists@rldn.net";
     github = "mogorman";
+    githubId = 64710;
     name = "Matthew O'Gorman";
   };
   Mogria = {
@@ -3537,36 +4138,43 @@
   monsieurp = {
     email = "monsieurp@gentoo.org";
     github = "monsieurp";
+    githubId = 350116;
     name = "Patrice Clement";
   };
   montag451 = {
     email = "montag451@laposte.net";
     github = "montag451";
+    githubId = 249317;
     name = "montag451";
   };
   moosingin3space = {
     email = "moosingin3space@gmail.com";
     github = "moosingin3space";
+    githubId = 830082;
     name = "Nathan Moos";
   };
   moredread = {
     email = "code@apb.name";
     github = "moredread";
+    githubId = 100848;
     name = "André-Patrick Bubel";
   };
   moretea = {
     email = "maarten@moretea.nl";
     github = "moretea";
+    githubId = 99988;
     name = "Maarten Hoogendoorn";
   };
   MostAwesomeDude = {
     email = "cds@corbinsimpson.com";
     github = "MostAwesomeDude";
+    githubId = 118035;
     name = "Corbin Simpson";
   };
   mounium = {
     email = "muoniurn@gmail.com";
     github = "mounium";
+    githubId = 20026143;
     name = "Katona László";
   };
   MP2E = {
@@ -3577,16 +4185,19 @@
   mpcsh = {
     email = "m@mpc.sh";
     github = "mpcsh";
+    githubId = 2894019;
     name = "Mark Cohen";
   };
   mpickering = {
     email = "matthewtpickering@gmail.com";
     github = "mpickering";
+    githubId = 1216657;
     name = "Matthew Pickering";
   };
   mpoquet = {
     email = "millian.poquet@gmail.com";
     github = "mpoquet";
+    githubId = 3502831;
     name = "Millian Poquet";
   };
   mpscholten = {
@@ -3597,6 +4208,7 @@
   mpsyco = {
     email = "fr.st-amour@gmail.com";
     github = "fstamour";
+    githubId = 2881922;
     name = "Francis St-Amour";
   };
   mredaelli = {
@@ -3607,16 +4219,19 @@
   mrkkrp = {
     email = "markkarpov92@gmail.com";
     github = "mrkkrp";
+    githubId = 8165792;
     name = "Mark Karpov";
   };
   mrmebelman = {
     email = "burzakovskij@protonmail.com";
     github = "MrMebelMan";
+    githubId = 15896005;
     name = "Vladyslav Burzakovskyy";
   };
   mrVanDalo = {
     email = "contact@ingolf-wagner.de";
     github = "mrVanDalo";
+    githubId = 839693;
     name = "Ingolf Wanger";
   };
   msackman = {
@@ -3630,26 +4245,31 @@
   mschristiansen = {
     email = "mikkel@rheosystems.com";
     github = "mschristiansen";
+    githubId = 437005;
     name = "Mikkel Christiansen";
   };
   msiedlarek = {
     email = "mikolaj@siedlarek.pl";
     github = "msiedlarek";
+    githubId = 133448;
     name = "Mikołaj Siedlarek";
   };
   mstarzyk = {
     email = "mstarzyk@gmail.com";
     github = "mstarzyk";
+    githubId = 111304;
     name = "Maciek Starzyk";
   };
   msteen = {
     email = "emailmatthijs@gmail.com";
     github = "msteen";
+    githubId = 788953;
     name = "Matthijs Steen";
   };
   mt-caret = {
     email = "mtakeda.enigsol@gmail.com";
     github = "mt-caret";
+    githubId = 4996739;
     name = "Masayuki Takeda";
   };
   MtP = {
@@ -3660,46 +4280,55 @@
   mtreskin = {
     email = "zerthurd@gmail.com";
     github = "Zert";
+    githubId = 39034;
     name = "Max Treskin";
   };
   mudri = {
     email = "lamudri@gmail.com";
     github = "laMudri";
+    githubId = 5139265;
     name = "James Wood";
   };
   muflax = {
     email = "mail@muflax.com";
     github = "muflax";
+    githubId = 69918;
     name = "Stefan Dorn";
   };
   mvnetbiz = {
     email = "mvnetbiz@gmail.com";
     github = "mvnetbiz";
+    githubId = 6455574;
     name = "Matt Votava";
   };
   mwilsoninsight = {
     email = "max.wilson@insight.com";
     github = "mwilsoninsight";
+    githubId = 47782621;
     name = "Max Wilson";
   };
   myrl = {
     email = "myrl.0xf@gmail.com";
     github = "myrl";
+    githubId = 9636071;
     name = "Myrl Hex";
   };
   nadrieril = {
     email = "nadrieril@gmail.com";
     github = "nadrieril";
+    githubId = 6783654;
     name = "Nadrieril Feneanar";
   };
   nalbyuites = {
     email = "ashijit007@gmail.com";
     github = "nalbyuites";
+    githubId = 1009523;
     name = "Ashijit Pramanik";
   };
   namore = {
     email = "namor@hemio.de";
     github = "namore";
+    githubId = 1222539;
     name = "Roman Naumann";
   };
   nand0p = {
@@ -3714,46 +4343,55 @@
   nathan-gs = {
     email = "nathan@nathan.gs";
     github = "nathan-gs";
+    githubId = 330943;
     name = "Nathan Bijnens";
   };
   nathyong = {
     email = "nathyong@noreply.github.com";
     github = "nathyong";
+    githubId = 818502;
     name = "Nathan Yong";
   };
   nckx = {
     email = "github@tobias.gr";
     github = "nckx";
+    githubId = 364510;
     name = "Tobias Geerinckx-Rice";
   };
   ndowens = {
     email = "ndowens04@gmail.com";
     github = "ndowens";
+    githubId = 117743;
     name = "Nathan Owens";
   };
   neeasade = {
     email = "nathanisom27@gmail.com";
     github = "neeasade";
+    githubId = 3747396;
     name = "Nathan Isom";
   };
   neonfuz = {
     email = "neonfuz@gmail.com";
     github = "neonfuz";
+    githubId = 2590830;
     name = "Sage Raflik";
   };
   nequissimus = {
     email = "tim@nequissimus.com";
     github = "nequissimus";
+    githubId = 628342;
     name = "Tim Steinbach";
   };
   netixx = {
     email = "dev.espinetfrancois@gmail.com";
     github = "netixx";
+    githubId = 1488603;
     name = "François Espinet";
   };
   nikitavoloboev = {
     email = "nikita.voloboev@gmail.com";
     github = "nikitavoloboev";
+    githubId = 6391776;
     name = "Nikita Voloboev";
   };
   nfjinjing = {
@@ -3763,96 +4401,115 @@
   nh2 = {
     email = "mail@nh2.me";
     github = "nh2";
+    githubId = 399535;
     name = "Niklas Hambüchen";
   };
   nhooyr = {
     email = "anmol@aubble.com";
     github = "nhooyr";
+    githubId = 10180857;
     name = "Anmol Sethi";
   };
   nickhu = {
     email = "me@nickhu.co.uk";
     github = "nickhu";
+    githubId = 450276;
     name = "Nick Hu";
   };
   nicknovitski = {
     email = "nixpkgs@nicknovitski.com";
     github = "nicknovitski";
+    githubId = 151337;
     name = "Nick Novitski";
   };
   nico202 = {
     email = "anothersms@gmail.com";
     github = "nico202";
+    githubId = 8214542;
     name = "Nicolò Balzarotti";
   };
   NikolaMandic = {
     email = "nikola@mandic.email";
     github = "NikolaMandic";
+    githubId = 4368690;
     name = "Ratko Mladic";
   };
   ninjatrappeur = {
     email = "felix@alternativebit.fr";
     github = "ninjatrappeur";
+    githubId = 1219785;
     name = "Félix Baylac-Jacqué";
   };
   nioncode = {
     email = "nioncode+github@gmail.com";
     github = "nioncode";
+    githubId = 3159451;
     name = "Nicolas Schneider";
   };
   nipav = {
     email = "niko.pavlinek@gmail.com";
     github = "nipav";
+    githubId = 16385648;
     name = "Niko Pavlinek";
   };
   nixy = {
     email = "nixy@nixy.moe";
     github = "nixy";
+    githubId = 7588406;
     name = "Andrew R. M.";
   };
   nmattia = {
     email = "nicolas@nmattia.com";
     github = "nmattia";
+    githubId = 6930756;
     name = "Nicolas Mattia";
   };
   nocent = {
     email = "nocent@protonmail.ch";
     github = "nocent";
+    githubId = 25505957;
     name = "nocent";
   };
   nocoolnametom = {
     email = "nocoolnametom@gmail.com";
     github = "nocoolnametom";
+    githubId = 810877;
     name = "Tom Doggett";
   };
   nomeata = {
     email = "mail@joachim-breitner.de";
     github = "nomeata";
+    githubId = 148037;
     name = "Joachim Breitner";
   };
   noneucat = {
     email = "andy@lolc.at";
     github = "noneucat";
+    githubId = 40049608;
     name = "Andy Chun";
   };
   notthemessiah = {
     email = "brian.cohen.88@gmail.com";
     github = "notthemessiah";
+    githubId = 2946283;
     name = "Brian Cohen";
   };
   np = {
     email = "np.nix@nicolaspouillard.fr";
     github = "np";
+    githubId = 5548;
     name = "Nicolas Pouillard";
   };
   nphilou = {
     email = "nphilou@gmail.com";
     github = "nphilou";
+    githubId = 9939720;
     name = "Philippe Nguyen";
   };
   nshalman = {
     email = "nahamu@gmail.com";
     github = "nshalman";
+    githubId = 20391;
     name = "Nahum Shalman";
   };
   nslqqq = {
@@ -3862,51 +4519,61 @@
   nthorne = {
     email = "notrupertthorne@gmail.com";
     github = "nthorne";
+    githubId = 1839979;
     name = "Niklas Thörne";
   };
   numinit = {
     email = "me@numin.it";
     github = "numinit";
+    githubId = 369111;
     name = "Morgan Jones";
   };
   nyanloutre = {
     email = "paul@nyanlout.re";
     github = "nyanloutre";
+    githubId = 7677321;
     name = "Paul Trehiou";
   };
   nyarly = {
     email = "nyarly@gmail.com";
     github = "nyarly";
+    githubId = 127548;
     name = "Judson Lester";
   };
   nzhang-zh = {
     email = "n.zhang.hp.au@gmail.com";
     github = "nzhang-zh";
+    githubId = 30825096;
     name = "Ning Zhang";
   };
   obadz = {
     email = "obadz-nixos@obadz.com";
     github = "obadz";
+    githubId = 3359345;
     name = "obadz";
   };
   ocharles = {
     email = "ollie@ocharles.org.uk";
     github = "ocharles";
+    githubId = 20878;
     name = "Oliver Charles";
   };
   odi = {
     email = "oliver.dunkl@gmail.com";
     github = "odi";
+    githubId = 158758;
     name = "Oliver Dunkl";
   };
   offline = {
     email = "jaka@x-truder.net";
     github = "offlinehacker";
+    githubId = 585547;
     name = "Jaka Hudoklin";
   };
   oida = {
     email = "oida@posteo.de";
     github = "oida";
+    githubId = 7249506;
     name = "oida";
   };
   okasu = {
@@ -3916,11 +4583,13 @@
   olcai = {
     email = "dev@timan.info";
     github = "olcai";
+    githubId = 20923;
     name = "Erik Timan";
   };
   olejorgenb = {
     email = "olejorgenb@yahoo.no";
     github = "olejorgenb";
+    githubId = 72201;
     name = "Ole Jørgen Brønner";
   };
   olynch = {
@@ -3931,16 +4600,19 @@
   omnipotententity = {
     email = "omnipotententity@gmail.com";
     github = "omnipotententity";
+    githubId = 1538622;
     name = "Michael Reilly";
   };
   OPNA2608 = {
     email = "christoph.neidahl@gmail.com";
     github = "OPNA2608";
+    githubId = 23431373;
     name = "Christoph Neidahl";
   };
   orbekk = {
     email = "kjetil.orbekk@gmail.com";
     github = "orbekk";
+    githubId = 19862;
     name = "KJ Ørbekk";
   };
   orbitz = {
@@ -3951,21 +4623,25 @@
   orivej = {
     email = "orivej@gmx.fr";
     github = "orivej";
+    githubId = 101514;
     name = "Orivej Desh";
   };
   osener = {
     email = "ozan@ozansener.com";
     github = "osener";
+    githubId = 111265;
     name = "Ozan Sener";
   };
   otwieracz = {
     email = "slawek@otwiera.cz";
     github = "otwieracz";
+    githubId = 108072;
     name = "Slawomir Gonet";
   };
   oxij = {
     email = "oxij@oxij.org";
     github = "oxij";
+    githubId = 391919;
     name = "Jan Malakhovski";
     keys = [{
       longkeyid = "rsa2048/0x0E6CA66E5C557AA8";
@@ -3975,66 +4651,79 @@
   oyren = {
     email = "m.scheuren@oyra.eu";
     github = "oyren";
+    githubId = 15930073;
     name = "Moritz Scheuren";
   };
   pacien = {
     email = "b4gx3q.nixpkgs@pacien.net";
     github = "pacien";
+    githubId = 1449319;
     name = "Pacien Tran-Girard";
   };
   paddygord = {
     email = "pgpatrickgordon@gmail.com";
     github = "paddygord";
+    githubId = 10776658;
     name = "Patrick Gordon";
   };
   paholg = {
     email = "paho@paholg.com";
     github = "paholg";
+    githubId = 4908217;
     name = "Paho Lurie-Gregg";
   };
   pakhfn = {
     email = "pakhfn@gmail.com";
     github = "pakhfn";
+    githubId = 11016164;
     name = "Fedor Pakhomov";
   };
   panaeon = {
     email = "vitalii.voloshyn@gmail.com";
     github = "panaeon";
+    githubId = 686076;
     name = "Vitalii Voloshyn";
   };
   pandaman = {
     email = "kointosudesuyo@infoseek.jp";
     github = "pandaman64";
+    githubId = 1788628;
     name = "pandaman";
   };
   paperdigits = {
     email = "mica@silentumbrella.com";
     github = "paperdigits";
+    githubId = 71795;
     name = "Mica Semrick";
   };
   paraseba = {
     email = "paraseba@gmail.com";
     github = "paraseba";
+    githubId = 20792;
     name = "Sebastian Galkin";
   };
   pashev = {
     email = "pashev.igor@gmail.com";
     github = "ip1981";
+    githubId = 131844;
     name = "Igor Pashev";
   };
   patternspandemic = {
     email = "patternspandemic@live.com";
     github = "patternspandemic";
+    githubId = 15645854;
     name = "Brad Christensen";
   };
   pawelpacana = {
     email = "pawel.pacana@gmail.com";
     github = "pawelpacana";
+    githubId = 116740;
     name = "Paweł Pacana";
   };
   pbogdan = {
     email = "ppbogdan@gmail.com";
     github = "pbogdan";
+    githubId = 157610;
     name = "Piotr Bogdan";
   };
   pcarrier = {
@@ -4045,81 +4734,97 @@
   periklis = {
     email = "theopompos@gmail.com";
     github = "periklis";
+    githubId = 152312;
     name = "Periklis Tsirakidis";
   };
   pesterhazy = {
     email = "pesterhazy@gmail.com";
     github = "pesterhazy";
+    githubId = 106328;
     name = "Paulus Esterhazy";
   };
   petabyteboy = {
     email = "me@pbb.lc";
     github = "petabyteboy";
+    githubId = 3250809;
     name = "Milan Pässler";
   };
   peterhoeg = {
     email = "peter@hoeg.com";
     github = "peterhoeg";
+    githubId = 722550;
     name = "Peter Hoeg";
   };
   peterromfeldhk = {
     email = "peter.romfeld.hk@gmail.com";
     github = "peterromfeldhk";
+    githubId = 5515707;
     name = "Peter Romfeld";
   };
   peti = {
     email = "simons@cryp.to";
     github = "peti";
+    githubId = 28323;
     name = "Peter Simons";
   };
   philandstuff = {
     email = "philip.g.potter@gmail.com";
     github = "philandstuff";
+    githubId = 581269;
     name = "Philip Potter";
   };
   phile314 = {
     email = "nix@314.ch";
     github = "phile314";
+    githubId = 1640697;
     name = "Philipp Hausmann";
   };
   Phlogistique = {
     email = "noe.rubinstein@gmail.com";
     github = "Phlogistique";
+    githubId = 421510;
     name = "Noé Rubinstein";
   };
   phreedom = {
     email = "phreedom@yandex.ru";
     github = "phreedom";
+    githubId = 62577;
     name = "Evgeny Egorochkin";
   };
   phryneas = {
     email = "mail@lenzw.de";
     github = "phryneas";
+    githubId = 4282439;
     name = "Lenz Weber";
   };
   phunehehe = {
     email = "phunehehe@gmail.com";
     github = "phunehehe";
+    githubId = 627831;
     name = "Hoang Xuan Phu";
   };
   pierrechevalier83 = {
     email = "pierrechevalier83@gmail.com";
     github = "pierrechevalier83";
+    githubId = 5790907;
     name = "Pierre Chevalier";
   };
   pierreis = {
     email = "pierre@pierre.is";
     github = "pierreis";
+    githubId = 203973;
     name = "Pierre Matri";
   };
   pierrer = {
     email = "pierrer@pi3r.be";
     github = "pierrer";
+    githubId = 93115;
     name = "Pierre Radermecker";
   };
   pierron = {
     email = "nixos@nbp.name";
     github = "nbp";
+    githubId = 1179566;
     name = "Nicolas B. Pierron";
   };
   piotr = {
@@ -4129,16 +4834,19 @@
   pjbarnoy = {
     email = "pjbarnoy@gmail.com";
     github = "pjbarnoy";
+    githubId = 119460;
     name = "Perry Barnoy";
   };
   pjones = {
     email = "pjones@devalot.com";
     github = "pjones";
+    githubId = 3737;
     name = "Peter Jones";
   };
   pkmx = {
     email = "pkmx.tw@gmail.com";
     github = "pkmx";
+    githubId = 610615;
     name = "Chih-Mao Chen";
   };
   plchldr = {
@@ -4149,16 +4857,19 @@
   plcplc = {
     email = "plcplc@gmail.com";
     github = "plcplc";
+    githubId = 358550;
     name = "Philip Lykke Carlsen";
   };
   plumps = {
     email = "maks.bronsky@web.de";
     github = "plumps";
+    githubId = 13000278;
     name = "Maksim Bronsky";
   };
   pmahoney = {
     email = "pat@polycrystal.org";
     github = "pmahoney";
+    githubId = 103822;
     name = "Patrick Mahoney";
   };
   pmeunier = {
@@ -4169,21 +4880,25 @@
   pmiddend = {
     email = "pmidden@secure.mailbox.org";
     github = "pmiddend";
+    githubId = 178496;
     name = "Philipp Middendorf";
   };
   pmyjavec = {
     email = "pauly@myjavec.com";
     github = "pmyjavec";
+    githubId = 315096;
     name = "Pauly Myjavec";
   };
   pnelson = {
     email = "me@pnelson.ca";
     github = "pnelson";
+    githubId = 579773;
     name = "Philip Nelson";
   };
   pneumaticat = {
     email = "kevin@potatofrom.space";
     github = "pneumaticat";
+    githubId = 11365056;
     name = "Kevin Liu";
   };
   polyrod = {
@@ -4194,16 +4909,19 @@
   pombeirp = {
     email = "nix@endgr.33mail.com";
     github = "PombeirP";
+    githubId = 138074;
     name = "Pedro Pombeiro";
   };
   pradeepchhetri = {
     email = "pradeep.chhetri89@gmail.com";
     github = "pradeepchhetri";
+    githubId = 2232667;
     name = "Pradeep Chhetri";
   };
   pradyuman = {
     email = "me@pradyuman.co";
     github = "pradyuman";
+    githubId = 9904569;
     name = "Pradyuman Vig";
     keys = [
       { longkeyid = "rsa4096/4F74D5361C4CA31E";
@@ -4214,11 +4932,13 @@
   prikhi = {
     email = "pavan.rikhi@gmail.com";
     github = "prikhi";
+    githubId = 1304102;
     name = "Pavan Rikhi";
   };
   primeos = {
     email = "dev.primeos@gmail.com";
     github = "primeos";
+    githubId = 7537109;
     name = "Michael Weiss";
     keys = [
       { longkeyid = "ed25519/0x130826A6C2A389FD"; # Git only
@@ -4232,21 +4952,25 @@
   Profpatsch = {
     email = "mail@profpatsch.de";
     github = "Profpatsch";
+    githubId = 3153638;
     name = "Profpatsch";
   };
   proglodyte = {
     email = "proglodyte23@gmail.com";
     github = "proglodyte";
+    githubId = 18549627;
     name = "Proglodyte";
   };
   protoben = {
     email = "protob3n@gmail.com";
     github = "protoben";
+    githubId = 4633847;
     name = "Ben Hamlin";
   };
   prusnak = {
     email = "pavol@rusnak.io";
     github = "prusnak";
+    githubId = 42201;
     name = "Pavol Rusnak";
     keys = [{
       longkeyid = "rsa4096/0x91F3B339B9A02A3D";
@@ -4256,11 +4980,13 @@
   pshendry = {
     email = "paul@pshendry.com";
     github = "pshendry";
+    githubId = 1829032;
     name = "Paul Hendry";
   };
   psibi = {
     email = "sibi@psibi.in";
     github = "psibi";
+    githubId = 737477;
     name = "Sibi";
   };
   pstn = {
@@ -4270,26 +4996,31 @@
   pSub = {
     email = "mail@pascal-wittmann.de";
     github = "pSub";
+    githubId = 83842;
     name = "Pascal Wittmann";
   };
   psyanticy = {
     email = "iuns@outlook.fr";
     github = "PsyanticY";
+    githubId = 20524473;
     name = "Psyanticy";
   };
   ptival = {
     email = "valentin.robert.42@gmail.com";
     github = "Ptival";
+    githubId = 478606;
     name = "Valentin Robert";
   };
   ptrhlm = {
     email = "ptrhlm0@gmail.com";
     github = "ptrhlm";
+    githubId = 9568176;
     name = "Piotr Halama";
   };
   puffnfresh = {
     email = "brian@brianmckenna.org";
     github = "puffnfresh";
+    githubId = 37715;
     name = "Brian McKenna";
   };
   pxc = {
@@ -4299,26 +5030,31 @@
   pyrolagus = {
     email = "pyrolagus@gmail.com";
     github = "PyroLagus";
+    githubId = 4579165;
     name = "Danny Bautista";
   };
   q3k = {
     email = "q3k@q3k.org";
     github = "q3k";
+    githubId = 315234;
     name = "Serge Bazanski";
   };
   qknight = {
     email = "js@lastlog.de";
     github = "qknight";
+    githubId = 137406;
     name = "Joachim Schiele";
   };
   qoelet = {
     email = "kenny@machinesung.com";
     github = "qoelet";
+    githubId = 115877;
     name = "Kenny Shen";
   };
   qyliss = {
     email = "hi@alyssa.is";
     github = "alyssais";
+    githubId = 2768870;
     name = "Alyssa Ross";
     keys = [{
       longkeyid = "rsa4096/736CCDF9EF51BD97";
@@ -4333,36 +5069,43 @@
   raquelgb = {
     email = "raquel.garcia.bautista@gmail.com";
     github = "raquelgb";
+    githubId = 1246959;
     name = "Raquel García";
   };
   ragge = {
     email = "r.dahlen@gmail.com";
     github = "ragnard";
+    githubId = 882;
     name = "Ragnar Dahlen";
   };
   ralith = {
     email = "ben.e.saunders@gmail.com";
     github = "ralith";
+    githubId = 104558;
     name = "Benjamin Saunders";
   };
   ramkromberg = {
     email = "ramkromberg@mail.com";
     github = "ramkromberg";
+    githubId = 14829269;
     name = "Ram Kromberg";
   };
   rardiol = {
     email = "ricardo.ardissone@gmail.com";
     github = "rardiol";
+    githubId = 11351304;
     name = "Ricardo Ardissone";
   };
   rasendubi = {
     email = "rasen.dubi@gmail.com";
     github = "rasendubi";
+    githubId = 1366419;
     name = "Alexey Shmalko";
   };
   raskin = {
     email = "7c6f434c@mail.ru";
     github = "7c6f434c";
+    githubId = 1891350;
     name = "Michael Raskin";
   };
   ravloony = {
@@ -4372,101 +5115,121 @@
   rawkode = {
     email = "david.andrew.mckay@gmail.com";
     github = "rawkode";
+    githubId = 145816;
     name = "David McKay";
   };
   razvan = {
     email = "razvan.panda@gmail.com";
     github = "razvan-panda";
+    githubId = 1758708;
     name = "Răzvan Flavius Panda";
   };
   rbasso = {
     email = "rbasso@sharpgeeks.net";
     github = "rbasso";
+    githubId = 16487165;
     name = "Rafael Basso";
   };
   rbrewer = {
     email = "rwb123@gmail.com";
     github = "rbrewer123";
+    githubId = 743058;
     name = "Rob Brewer";
   };
   rdnetto = {
     email = "rdnetto@gmail.com";
     github = "rdnetto";
+    githubId = 1973389;
     name = "Reuben D'Netto";
   };
   redbaron = {
     email = "ivanov.maxim@gmail.com";
     github = "redbaron";
+    githubId = 16624;
     name = "Maxim Ivanov";
   };
   redfish64 = {
     email = "engler@gmail.com";
     github = "redfish64";
+    githubId = 1922770;
     name = "Tim Engler";
   };
   redvers = {
     email = "red@infect.me";
     github = "redvers";
+    githubId = 816465;
     name = "Redvers Davies";
   };
   refnil = {
     email = "broemartino@gmail.com";
     github = "refnil";
+    githubId = 1142322;
     name = "Martin Lavoie";
   };
   regnat = {
     email = "regnat@regnat.ovh";
     github = "regnat";
+    githubId = 7226587;
     name = "Théophane Hufschmitt";
   };
   relrod = {
     email = "ricky@elrod.me";
     github = "relrod";
+    githubId = 43930;
     name = "Ricky Elrod";
   };
   rembo10 = {
     email = "rembo10@users.noreply.github.com";
     github = "rembo10";
+    githubId = 801525;
     name = "rembo10";
   };
   renatoGarcia = {
     email = "fgarcia.renato@gmail.com";
     github = "renatoGarcia";
+    githubId = 220211;
     name = "Renato Garcia";
   };
   rencire = {
     email = "546296+rencire@users.noreply.github.com";
     github = "rencire";
+    githubId = 546296;
     name = "Eric Ren";
   };
   renzo = {
     email = "renzocarbonara@gmail.com";
     github = "k0001";
+    githubId = 3302;
     name = "Renzo Carbonara";
   };
   retrry = {
     email = "retrry@gmail.com";
     github = "retrry";
+    githubId = 500703;
     name = "Tadas Barzdžius";
   };
   rexim = {
     email = "reximkut@gmail.com";
     github = "rexim";
+    githubId = 165283;
     name = "Alexey Kutepov";
   };
   rht = {
     email = "rhtbot@protonmail.com";
     github = "rht";
+    githubId = 395821;
     name = "rht";
   };
   richardipsum = {
     email = "richardipsum@fastmail.co.uk";
     github = "richardipsum";
+    githubId = 10631029;
     name = "Richard Ipsum";
   };
   rick68 = {
     email = "rick68@gmail.com";
     github = "rick68";
+    githubId = 42619;
     name = "Wei-Ming Yang";
   };
   rickynils = {
@@ -4477,31 +5240,37 @@
   ris = {
     email = "code@humanleg.org.uk";
     github = "risicle";
+    githubId = 807447;
     name = "Robert Scott";
   };
   rittelle = {
     email = "rittelle@posteo.de";
     github = "rittelle";
+    githubId = 33598633;
     name = "Lennart Rittel";
   };
   rixed = {
     email = "rixed-github@happyleptic.org";
     github = "rixed";
+    githubId = 449990;
     name = "Cedric Cellier";
   };
   rkoe = {
     email = "rk@simple-is-better.org";
     github = "rkoe";
+    githubId = 2507744;
     name = "Roland Koebler";
   };
   rlupton20 = {
     email = "richard.lupton@gmail.com";
     github = "rlupton20";
+    githubId = 13752145;
     name = "Richard Lupton";
   };
   rnhmjoj = {
     email = "micheleguerinirocco@me.com";
     github = "rnhmjoj";
+    githubId = 2817565;
     name = "Michele Guerini Rocco";
   };
   rob = {
@@ -4517,91 +5286,109 @@
   robbinch = {
     email = "robbinch33@gmail.com";
     github = "robbinch";
+    githubId = 12312980;
     name = "Robbin C.";
   };
   roberth = {
     email = "nixpkgs@roberthensing.nl";
     github = "roberth";
+    githubId = 496447;
     name = "Robert Hensing";
   };
   robertodr = {
     email = "roberto.diremigio@gmail.com";
     github = "robertodr";
+    githubId = 3708689;
     name = "Roberto Di Remigio";
   };
   robgssp = {
     email = "robgssp@gmail.com";
     github = "robgssp";
+    githubId = 521306;
     name = "Rob Glossop";
   };
   roblabla = {
     email = "robinlambertz+dev@gmail.com";
     github = "roblabla";
+    githubId = 1069318;
     name = "Robin Lambertz";
   };
   roconnor = {
     email = "roconnor@theorem.ca";
     github = "roconnor";
+    githubId = 852967;
     name = "Russell O'Connor";
   };
   romildo = {
     email = "malaquias@gmail.com";
     github = "romildo";
+    githubId = 1217934;
     name = "José Romildo Malaquias";
   };
   rongcuid = {
     email = "rongcuid@outlook.com";
     github = "rongcuid";
+    githubId = 1312525;
     name = "Rongcui Dong";
   };
   roosemberth = {
     email = "roosembert.palacios+nixpkgs@gmail.com";
     github = "roosemberth";
+    githubId = 3621083;
     name = "Roosembert (Roosemberth) Palacios";
   };
   royneary = {
     email = "christian@ulrich.earth";
     github = "royneary";
+    githubId = 1942810;
     name = "Christian Ulrich";
   };
   rprospero = {
     email = "rprospero+nix@gmail.com";
     github = "rprospero";
+    githubId = 1728853;
     name = "Adam Washington";
   };
   rps = {
     email = "robbpseaton@gmail.com";
     github = "robertseaton";
+    githubId = 221121;
     name = "Robert P. Seaton";
   };
   rszibele = {
     email = "richard@szibele.com";
     github = "rszibele";
+    githubId = 1387224;
     name = "Richard Szibele";
   };
   rtreffer = {
     email = "treffer+nixos@measite.de";
     github = "rtreffer";
+    githubId = 61306;
     name = "Rene Treffer";
   };
   rushmorem = {
     email = "rushmore@webenchanter.com";
     github = "rushmorem";
+    githubId = 4958190;
     name = "Rushmore Mushambi";
   };
   ruuda = {
     email = "dev+nix@veniogames.com";
     github = "ruuda";
+    githubId = 506953;
     name = "Ruud van Asseldonk";
   };
   rvl = {
     email = "dev+nix@rodney.id.au";
     github = "rvl";
+    githubId = 1019641;
     name = "Rodney Lorrimar";
   };
   rvlander = {
     email = "rvlander@gaetanandre.eu";
     github = "rvlander";
+    githubId = 5236428;
     name = "Gaëtan André";
   };
   rvolosatovs = {
@@ -4612,6 +5399,7 @@
   ryanartecona = {
     email = "ryanartecona@gmail.com";
     github = "ryanartecona";
+    githubId = 889991;
     name = "Ryan Artecona";
   };
   ryansydnor = {
@@ -4622,21 +5410,25 @@
   ryantm = {
     email = "ryan@ryantm.com";
     github = "ryantm";
+    githubId = 4804;
     name = "Ryan Mulligan";
   };
   ryantrinkle = {
     email = "ryan.trinkle@gmail.com";
     github = "ryantrinkle";
+    githubId = 1156448;
     name = "Ryan Trinkle";
   };
   rybern = {
     email = "ryan.bernstein@columbia.edu";
     github = "rybern";
+    githubId = 4982341;
     name = "Ryan Bernstein";
   };
   rycee = {
     email = "robert@rycee.net";
     github = "rycee";
+    githubId = 798147;
     name = "Robert Helgesson";
     keys = [{
       longkeyid = "rsa4096/0x3573356C25C424D4";
@@ -4646,31 +5438,37 @@
   ryneeverett = {
     email = "ryneeverett@gmail.com";
     github = "ryneeverett";
+    githubId = 3280280;
     name = "Ryne Everett";
   };
   rzetterberg = {
     email = "richard.zetterberg@gmail.com";
     github = "rzetterberg";
+    githubId = 766350;
     name = "Richard Zetterberg";
   };
   samdroid-apps = {
     email = "sam@sam.today";
     github = "samdroid-apps";
+    githubId = 6022042;
     name = "Sam Parkinson";
   };
   samrose = {
    email = "samuel.rose@gmail.com";
    github = "samrose";
+   githubId = 115821;
    name = "Sam Rose";
   };
   samueldr = {
     email = "samuel@dionne-riel.com";
     github = "samueldr";
+    githubId = 132835;
     name = "Samuel Dionne-Riel";
   };
   samuelrivas = {
     email = "samuelrivas@gmail.com";
     github = "samuelrivas";
+    githubId = 107703;
     name = "Samuel Rivas";
   };
   sander = {
@@ -4681,26 +5479,31 @@
   sargon = {
     email = "danielehlers@mindeye.net";
     github = "sargon";
+    githubId = 178904;
     name = "Daniel Ehlers";
   };
   saschagrunert = {
     email = "mail@saschagrunert.de";
     github = "saschagrunert";
+    githubId = 695473;
     name = "Sascha Grunert";
   };
   sauyon = {
     email = "s@uyon.co";
     github = "sauyon";
+    githubId = 2347889;
     name = "Sauyon Lee";
   };
   sb0 = {
     email = "sb@m-labs.hk";
     github = "sbourdeauducq";
+    githubId = 720864;
     name = "Sébastien Bourdeauducq";
   };
   sboosali = {
     email = "SamBoosalis@gmail.com";
     github = "sboosali";
+    githubId = 2320433;
     name = "Sam Boosalis";
   };
   scalavision = {
@@ -4711,6 +5514,7 @@
   schmitthenner = {
     email = "development@schmitthenner.eu";
     github = "fkz";
+    githubId = 354463;
     name = "Fabian Schmitthenner";
   };
   schmittlauch = {
@@ -4720,6 +5524,7 @@
   schneefux = {
     email = "schneefux+nixos_pkg@schneefux.xyz";
     github = "schneefux";
+    githubId = 15379000;
     name = "schneefux";
   };
   schristo = {
@@ -4729,21 +5534,25 @@
   scode = {
     email = "peter.schuller@infidyne.com";
     github = "scode";
+    githubId = 59476;
     name = "Peter Schuller";
   };
   scolobb = {
     email = "sivanov@colimite.fr";
     github = "scolobb";
+    githubId = 11320;
     name = "Sergiu Ivanov";
   };
   screendriver = {
     email = "nix@echooff.de";
     github = "screendriver";
+    githubId = 149248;
     name = "Christian Rackerseder";
   };
   Scriptkiddi = {
     email = "nixos@scriptkiddi.de";
     github = "scriptkiddi";
+    githubId = 3598650;
     name = "Fritz Otlinghaus";
   };
   scubed2 = {
@@ -4754,61 +5563,73 @@
   sdll = {
     email = "sasha.delly@gmail.com";
     github = "sdll";
+    githubId = 17913919;
     name = "Sasha Illarionov";
   };
   SeanZicari = {
     email = "sean.zicari@gmail.com";
     github = "SeanZicari";
+    githubId = 2343853;
     name = "Sean Zicari";
   };
   sellout = {
     email = "greg@technomadic.org";
     github = "sellout";
+    githubId = 33031;
     name = "Greg Pfeil";
   };
   sengaya = {
     email = "tlo@sengaya.de";
     github = "sengaya";
+    githubId = 1286668;
     name = "Thilo Uttendorfer";
   };
   sephalon = {
     email = "me@sephalon.net";
     github = "sephalon";
+    githubId = 893474;
     name = "Stefan Wiehler";
   };
   sepi = {
     email = "raffael@mancini.lu";
     github = "sepi";
+    githubId = 529649;
     name = "Raffael Mancini";
   };
   seppeljordan = {
     email = "sebastian.jordan.mail@googlemail.com";
     github = "seppeljordan";
+    githubId = 4805746;
     name = "Sebastian Jordan";
   };
   seqizz = {
     email = "seqizz@gmail.com";
     github = "seqizz";
+    githubId = 307899;
     name = "Gurkan Gur";
   };
   sfrijters = {
     email = "sfrijters@gmail.com";
     github = "sfrijters";
+    githubId = 918365;
     name = "Stefan Frijters";
   };
   sgraf = {
     email = "sgraf1337@gmail.com";
     github = "sgraf812";
+    githubId = 1151264;
     name = "Sebastian Graf";
   };
   shanemikel = {
     email = "shanemikel1@gmail.com";
     github = "shanemikel";
+    githubId = 6720672;
     name = "Shane Pearlman";
   };
   shawndellysse = {
     email = "sdellysse@gmail.com";
     github = "shawndellysse";
+    githubId = 293035;
     name = "Shawn Dellysse";
   };
   shazow = {
@@ -4819,16 +5640,19 @@
   sheenobu = {
     email = "sheena.artrip@gmail.com";
     github = "sheenobu";
+    githubId = 1443459;
     name = "Sheena Artrip";
   };
   sheganinans = {
     email = "sheganinans@gmail.com";
     github = "sheganinans";
+    githubId = 2146203;
     name = "Aistis Raulinaitis";
   };
   shell = {
     email = "cam.turn@gmail.com";
     github = "VShell";
+    githubId = 251028;
     name = "Shell Turner";
   };
   shlevy = {
@@ -4844,51 +5668,61 @@
   shou = {
     email = "x+g@shou.io";
     github = "Shou";
+    githubId = 819413;
     name = "Benedict Aas";
   };
   siddharthist = {
     email = "langston.barrett@gmail.com";
     github = "langston-barrett";
+    githubId = 4294323;
     name = "Langston Barrett";
   };
   siers = {
     email = "veinbahs+nixpkgs@gmail.com";
     github = "siers";
+    githubId = 235147;
     name = "Raitis Veinbahs";
   };
   sifmelcara = {
     email = "ming@culpring.com";
     github = "sifmelcara";
+    githubId = 10496191;
     name = "Ming Chuan";
   };
   sigma = {
     email = "yann.hodique@gmail.com";
     github = "sigma";
+    githubId = 16090;
     name = "Yann Hodique";
   };
   sikmir = {
     email = "sikmir@gmail.com";
     github = "sikmir";
+    githubId = 688044;
     name = "Nikolay Korotkiy";
   };
   simonvandel = {
     email = "simon.vandel@gmail.com";
     github = "simonvandel";
+    githubId = 2770647;
     name = "Simon Vandel Sillesen";
   };
   sivteck = {
     email = "sivaram1992@gmail.com";
     github = "sivteck";
+    githubId = 8017899;
     name = "Sivaram Balakrishnan";
   };
   sjagoe = {
     email = "simon@simonjagoe.com";
     github = "sjagoe";
+    githubId = 80012;
     name = "Simon Jagoe";
   };
   sjau = {
     email = "nixos@sjau.ch";
     github = "sjau";
+    githubId = 848812;
     name = "Stephan Jau";
   };
   sjmackenzie = {
@@ -4903,6 +5737,7 @@
   skeidel = {
     email = "svenkeidel@gmail.com";
     github = "svenkeidel";
+    githubId = 266500;
     name = "Sven Keidel";
   };
   skrzyp = {
@@ -4912,11 +5747,13 @@
   sleexyz = {
     email = "freshdried@gmail.com";
     github = "sleexyz";
+    githubId = 1505617;
     name = "Sean Lee";
   };
   smakarov = {
     email = "setser200018@gmail.com";
     github = "setser";
+    githubId = 12733495;
     name = "Sergey Makarov";
     keys = [{
       longkeyid = "rsa2048/6AA23A1193B7064B";
@@ -4926,6 +5763,7 @@
   smaret = {
     email = "sebastien.maret@icloud.com";
     github = "smaret";
+    githubId = 95471;
     name = "Sébastien Maret";
     keys = [{
       longkeyid = "rsa4096/0x86E30E5A0F5FC59C";
@@ -4935,31 +5773,37 @@
   smironov = {
     email = "grrwlf@gmail.com";
     github = "grwlf";
+    githubId = 4477729;
     name = "Sergey Mironov";
   };
   sna = {
     email = "abouzahra.9@wright.edu";
     github = "s-na";
+    githubId = 20214715;
     name = "S. Nordin Abouzahra";
   };
   snaar = {
     email = "snaar@snaar.net";
     github = "snaar";
+    githubId = 602439;
     name = "Serguei Narojnyi";
   };
   snyh = {
     email = "snyh@snyh.org";
     github = "snyh";
+    githubId = 1437166;
     name = "Xia Bin";
   };
   solson = {
     email = "scott@solson.me";
     github = "solson";
+    githubId = 26806;
     name = "Scott Olson";
   };
   sondr3 = {
     email = "nilsen.sondre@gmail.com";
     github = "sondr3";
+    githubId = 2280539;
     name = "Sondre Nilsen";
     keys = [{
       longkeyid = "ed25519/0x25676BCBFFAD76B1";
@@ -4969,31 +5813,37 @@
   sorki = {
     email = "srk@48.io";
     github = "sorki";
+    githubId = 115308;
     name = "Richard Marko";
   };
   sorpaas = {
     email = "hi@that.world";
     github = "sorpaas";
+    githubId = 6277322;
     name = "Wei Tang";
   };
   spacefrogg = {
     email = "spacefrogg-nixos@meterriblecrew.net";
     github = "spacefrogg";
+    githubId = 167881;
     name = "Michael Raitza";
   };
   spacekookie = {
     email = "kookie@spacekookie.de";
     github = "spacekookie";
+    githubId = 7669898;
     name = "Katharina Fey";
   };
   spencerjanssen = {
     email = "spencerjanssen@gmail.com";
     github = "spencerjanssen";
+    githubId = 2600039;
     name = "Spencer Janssen";
   };
   spinus = {
     email = "tomasz.czyz@gmail.com";
     github = "spinus";
+    githubId = 950799;
     name = "Tomasz Czyż";
   };
   sprock = {
@@ -5004,6 +5854,7 @@
   spwhitt = {
     email = "sw@swhitt.me";
     github = "spwhitt";
+    githubId = 1414088;
     name = "Spencer Whitt";
   };
   srghma = {
@@ -5014,37 +5865,44 @@
   srgom = {
     email = "srgom@users.noreply.github.com";
     github = "srgom";
+    githubId = 8103619;
     name = "SRGOM";
   };
   srhb = {
     email = "sbrofeldt@gmail.com";
     github = "srhb";
+    githubId = 219362;
     name = "Sarah Brofeldt";
   };
   SShrike = {
     email = "severen@shrike.me";
     github = "severen";
+    githubId = 4061736;
     name = "Severen Redwood";
   };
   steell = {
     email = "steve@steellworks.com";
     github = "Steell";
+    githubId = 1699155;
     name = "Steve Elliott";
   };
   stephenmw = {
     email = "stephen@q5comm.com";
     github = "stephenmw";
+    githubId = 231788;
     name = "Stephen Weinberg";
   };
   sternenseemann = {
     email = "post@lukasepple.de";
     github = "sternenseemann";
+    githubId = 3154475;
     name = "Lukas Epple";
   };
   steshaw = {
     name = "Steven Shaw";
     email = "steven@steshaw.org";
     github = "steshaw";
+    githubId = 45735;
     keys = [{
       longkeyid = "rsa4096/0x1D9A17DFD23DCB91";
       fingerprint = "0AFE 77F7 474D 1596 EE55  7A29 1D9A 17DF D23D CB91";
@@ -5053,111 +5911,133 @@
   stesie = {
     email = "stesie@brokenpipe.de";
     github = "stesie";
+    githubId = 113068;
     name = "Stefan Siegl";
   };
   steve-chavez = {
     email = "stevechavezast@gmail.com";
     github = "steve-chavez";
+    githubId = 1829294;
     name = "Steve Chávez";
   };
   steveej = {
     email = "mail@stefanjunker.de";
     github = "steveej";
+    githubId = 1181362;
     name = "Stefan Junker";
   };
   StijnDW = {
     email = "stekke@airmail.cc";
     github = "StijnDW";
+    githubId = 1751956;
     name = "Stijn DW";
   };
   StillerHarpo = {
     email = "florianengel39@gmail.com";
     github = "StillerHarpo";
+    githubId = 25526706;
     name = "Florian Engel";
   };
   stites = {
     email = "sam@stites.io";
     github = "stites";
+    githubId = 1694705;
     name = "Sam Stites";
   };
   stumoss = {
     email = "samoss@gmail.com";
     github = "stumoss";
+    githubId = 638763;
     name = "Stuart Moss";
   };
   suhr = {
     email = "suhr@i2pmail.org";
     github = "suhr";
+    githubId = 65870;
     name = "Сухарик";
   };
   SuprDewd = {
     email = "suprdewd@gmail.com";
     github = "SuprDewd";
+    githubId = 187109;
     name = "Bjarki Ágúst Guðmundsson";
   };
   suvash = {
     email = "suvash+nixpkgs@gmail.com";
     github = "suvash";
+    githubId = 144952;
     name = "Suvash Thapaliya";
   };
   sveitser = {
     email = "sveitser@gmail.com";
     github = "sveitser";
+    githubId = 1040871;
     name = "Mathis Antony";
   };
   svsdep = {
     email = "svsdep@gmail.com";
     github = "svsdep";
+    githubId = 36695359;
     name = "Vasyl Solovei";
   };
   swarren83 = {
     email = "shawn.w.warren@gmail.com";
     github = "swarren83";
+    githubId = 4572854;
     name = "Shawn Warren";
   };
   swdunlop = {
     email = "swdunlop@gmail.com";
     github = "swdunlop";
+    githubId = 120188;
     name = "Scott W. Dunlop";
   };
   swflint = {
     email = "swflint@flintfam.org";
     github = "swflint";
+    githubId = 1771109;
     name = "Samuel W. Flint";
   };
   swistak35 = {
     email = "me@swistak35.com";
     github = "swistak35";
+    githubId = 332289;
     name = "Rafał Łasocha";
   };
   symphorien = {
     email = "symphorien_nixpkgs@xlumurb.eu";
     github = "symphorien";
+    githubId = 12595971;
     name = "Guillaume Girol";
   };
   synthetica = {
     email = "nix@hilhorst.be";
     github = "Synthetica9";
+    githubId = 7075751;
     name = "Patrick Hilhorst";
   };
   szczyp = {
     email = "qb@szczyp.com";
     github = "szczyp";
+    githubId = 203195;
     name = "Szczyp";
   };
   sztupi = {
     email = "attila.sztupak@gmail.com";
     github = "sztupi";
+    githubId = 143103;
     name = "Attila Sztupak";
   };
   t184256 = {
     email = "monk@unboiled.info";
     github = "t184256";
+    githubId = 5991987;
     name = "Alexander Sosedkin";
   };
   tadeokondrak = {
     email = "me@tadeo.ca";
     github = "tadeokondrak";
+    githubId = 4098453;
     name = "Tadeo Kondrak";
     keys = [{
       longkeyid = "ed25519/0xFBE607FCC49516D3";
@@ -5167,11 +6047,13 @@
   tadfisher = {
     email = "tadfisher@gmail.com";
     github = "tadfisher";
+    githubId = 129148;
     name = "Tad Fisher";
   };
   taeer = {
     email = "taeer@necsi.edu";
     github = "Radvendii";
+    githubId = 1239929;
     name = "Taeer Bar-Yam";
   };
   taha = {
@@ -5182,76 +6064,91 @@
   tailhook = {
     email = "paul@colomiets.name";
     github = "tailhook";
+    githubId = 321799;
     name = "Paul Colomiets";
   };
   taketwo = {
     email = "alexandrov88@gmail.com";
     github = "taketwo";
+    githubId = 1241736;
     name = "Sergey Alexandrov";
   };
   takikawa = {
     email = "asumu@igalia.com";
     github = "takikawa";
+    githubId = 64192;
     name = "Asumu Takikawa";
   };
   taktoa = {
     email = "taktoa@gmail.com";
     github = "taktoa";
+    githubId = 553443;
     name = "Remy Goldschmidt";
   };
   taku0 = {
     email = "mxxouy6x3m_github@tatapa.org";
     github = "taku0";
+    githubId = 870673;
     name = "Takuo Yonezawa";
   };
   talyz = {
     email = "kim.lindberger@gmail.com";
     github = "talyz";
+    githubId = 63433;
     name = "Kim Lindberger";
   };
   taneb = {
     email = "nvd1234@gmail.com";
     github = "Taneb";
+    githubId = 1901799;
     name = "Nathan van Doorn";
   };
   tari = {
     email = "peter@taricorp.net";
     github = "tari";
+    githubId = 506181;
     name = "Peter Marheine";
   };
   tavyc = {
     email = "octavian.cerna@gmail.com";
     github = "tavyc";
+    githubId = 3650609;
     name = "Octavian Cerna";
   };
   tazjin = {
     email = "mail@tazj.in";
     github = "tazjin";
+    githubId = 1552853;
     name = "Vincent Ambo";
   };
   tbenst = {
     email = "nix@tylerbenster.com";
     github = "tbenst";
+    githubId = 863327;
     name = "Tyler Benster";
   };
   teh = {
     email = "tehunger@gmail.com";
     github = "teh";
+    githubId = 139251;
     name = "Tom Hunger";
   };
   telotortium = {
     email = "rirelan@gmail.com";
     github = "telotortium";
+    githubId = 1755789;
     name = "Robert Irelan";
   };
   teozkr = {
     email = "teo@nullable.se";
     github = "teozkr";
+    githubId = 649832;
     name = "Teo Klestrup Röijezon";
   };
   terlar = {
     email = "terlar@gmail.com";
     github = "terlar";
+    githubId = 280235;
     name = "Terje Larsen";
   };
   tesq0 = {
@@ -5267,26 +6164,31 @@
   tex = {
     email = "milan.svoboda@centrum.cz";
     github = "tex";
+    githubId = 27386;
     name = "Milan Svoboda";
   };
   tg-x = {
     email = "*@tg-x.net";
     github = "tg-x";
+    githubId = 378734;
     name = "TG ⊗ Θ";
   };
   thall = {
     email = "niclas.thall@gmail.com";
     github = "thall";
+    githubId = 102452;
     name = "Niclas Thall";
   };
   thammers = {
     email = "jawr@gmx.de";
     github = "tobias-hammerschmidt";
+    githubId = 2543259;
     name = "Tobias Hammerschmidt";
   };
   thanegill = {
     email = "me@thanegill.com";
     github = "thanegill";
+    githubId = 1141680;
     name = "Thane Gill";
   };
   the-kenny = {
@@ -5297,16 +6199,19 @@
   thedavidmeister = {
     email = "thedavidmeister@gmail.com";
     github = "thedavidmeister";
+    githubId = 629710;
     name = "David Meister";
   };
   thefloweringash = {
     email = "lorne@cons.org.nz";
     github = "thefloweringash";
+    githubId = 42933;
     name = "Andrew Childs";
   };
   thesola10 = {
     email = "thesola10@bobile.fr";
     github = "thesola10";
+    githubId = 7287268;
     keys = [{
       longkeyid = "rsa4096/0x89245619BEBB95BA";
       fingerprint = "1D05 13A6 1AC4 0D8D C6D6  5F2C 8924 5619 BEBB 95BA";
@@ -5316,31 +6221,37 @@
   theuni = {
     email = "ct@flyingcircus.io";
     github = "ctheune";
+    githubId = 1220572;
     name = "Christian Theune";
   };
   thiagokokada = {
     email = "thiagokokada@gmail.com";
     github = "thiagokokada";
+    githubId = 844343;
     name = "Thiago K. Okada";
   };
   ThomasMader = {
     email = "thomas.mader@gmail.com";
     github = "ThomasMader";
+    githubId = 678511;
     name = "Thomas Mader";
   };
   thoughtpolice = {
     email = "aseipp@pobox.com";
     github = "thoughtpolice";
+    githubId = 3416;
     name = "Austin Seipp";
   };
   thpham = {
     email = "thomas.pham@ithings.ch";
     github = "thpham";
+    githubId = 224674;
     name = "Thomas Pham";
   };
   tilpner = {
     email = "till@hoeppner.ws";
     github = "tilpner";
+    githubId = 4322055;
     name = "Till Höppner";
   };
   timbertson = {
@@ -5351,31 +6262,37 @@
   timokau = {
     email = "timokau@zoho.com";
     github = "timokau";
+    githubId = 3799330;
     name = "Timo Kaufmann";
   };
   timor = {
     email = "timor.dd@googlemail.com";
     github = "timor";
+    githubId = 174156;
     name = "timor";
   };
   timput = {
     email = "tim@timput.com";
     github = "TimPut";
+    githubId = 2845239;
     name = "Tim Put";
   };
   tiramiseb = {
     email = "sebastien@maccagnoni.eu";
     github = "tiramiseb";
+    githubId = 1292007;
     name = "Sébastien Maccagnoni";
   };
   titanous = {
     email = "jonathan@titanous.com";
     github = "titanous";
+    githubId = 13026;
     name = "Jonathan Rudenberg";
   };
   tmplt = {
     email = "tmplt@dragons.rocks";
     github = "tmplt";
+    githubId = 6118602;
     name = "Viktor";
   };
   tnias = {
@@ -5386,66 +6303,79 @@
   tobim = {
     email = "nix@tobim.fastmail.fm";
     github = "tobim";
+    githubId = 858790;
     name = "Tobias Mayer";
   };
   tobiasBora = {
     email = "tobias.bora.list@gmail.com";
     github = "tobiasBora";
+    githubId = 2164118;
     name = "Tobias Bora";
   };
   tohl = {
     email = "tom@logand.com";
     github = "tohl";
+    githubId = 12159013;
     name = "Tomas Hlavaty";
   };
   tokudan = {
     email = "git@danielfrank.net";
     github = "tokudan";
+    githubId = 692610;
     name = "Daniel Frank";
   };
   tomahna = {
     email = "kevin.rauscher@tomahna.fr";
     github = "Tomahna";
+    githubId = 8577941;
     name = "Kevin Rauscher";
   };
   tomberek = {
     email = "tomberek@gmail.com";
     github = "tomberek";
+    githubId = 178444;
     name = "Thomas Bereknyei";
   };
   tomsmeets = {
     email = "tom.tsmeets@gmail.com";
     github = "tomsmeets";
+    githubId = 6740669;
     name = "Tom Smeets";
   };
   toonn = {
     email = "nnoot@toonn.io";
     github = "toonn";
+    githubId = 1486805;
     name = "Toon Nolten";
   };
   travisbhartwell = {
     email = "nafai@travishartwell.net";
     github = "travisbhartwell";
+    githubId = 10110;
     name = "Travis B. Hartwell";
   };
   treemo = {
     email = "matthieu.chevrier@treemo.fr";
     github = "treemo";
+    githubId = 207457;
     name = "Matthieu Chevrier";
   };
   trevorj = {
     email = "nix@trevor.joynson.io";
     github = "akatrevorjay";
+    githubId = 1312290;
     name = "Trevor Joynson";
   };
   trino = {
     email = "muehlhans.hubert@ekodia.de";
     github = "hmuehlhans";
+    githubId = 9870613;
     name = "Hubert Mühlhans";
   };
   troydm = {
     email = "d.geurkov@gmail.com";
     github = "troydm";
+    githubId = 483735;
     name = "Dmitry Geurkov";
   };
   tstrobel = {
@@ -5455,11 +6385,13 @@
   ttuegel = {
     email = "ttuegel@mailbox.org";
     github = "ttuegel";
+    githubId = 563054;
     name = "Thomas Tuegel";
   };
   tv = {
     email = "tv@krebsco.de";
     github = "4z3";
+    githubId = 427872;
     name = "Tomislav Viljetić";
   };
   tvestelind = {
@@ -5470,6 +6402,7 @@
   tvorog = {
     email = "marszaripov@gmail.com";
     github = "tvorog";
+    githubId = 1325161;
     name = "Marsel Zaripov";
   };
   tweber = {
@@ -5486,6 +6419,7 @@
     name = "Tyson Whitehead";
     email = "twhitehead@gmail.com";
     github = "twhitehead";
+    githubId = 787843;
     keys = [{
       longkeyid = "rsa2048/0x594258F0389D2802";
       fingerprint = "E631 8869 586F 99B4 F6E6  D785 5942 58F0 389D 2802";
@@ -5494,41 +6428,49 @@
   typetetris = {
     email = "ericwolf42@mail.com";
     github = "typetetris";
+    githubId = 1983821;
     name = "Eric Wolf";
   };
   udono = {
     email = "udono@virtual-things.biz";
     github = "udono";
+    githubId = 347983;
     name = "Udo Spallek";
   };
   unode = {
     email = "alves.rjc@gmail.com";
     github = "unode";
+    githubId = 122319;
     name = "Renato Alves";
   };
   uralbash = {
     email = "root@uralbash.ru";
     github = "uralbash";
+    githubId = 619015;
     name = "Svintsov Dmitry";
   };
   uri-canva = {
     email = "uri@canva.com";
     github = "uri-canva";
+    githubId = 33242106;
     name = "Uri Baghin";
   };
   uskudnik = {
     email = "urban.skudnik@gmail.com";
     github = "uskudnik";
+    githubId = 120451;
     name = "Urban Skudnik";
   };
   utdemir = {
     email = "me@utdemir.com";
     github = "utdemir";
+    githubId = 928084;
     name = "Utku Demir";
   };
   uvnikita = {
     email = "uv.nikita@gmail.com";
     github = "uvNikita";
+    githubId = 1084748;
     name = "Nikita Uvarov";
   };
   uwap = {
@@ -5539,11 +6481,13 @@
   va1entin = {
     email = "github@valentinsblog.com";
     github = "va1entin";
+    githubId = 31535155;
     name = "Valentin Heidelberger";
   };
   vaibhavsagar = {
     email = "vaibhavsagar@gmail.com";
     github = "vaibhavsagar";
+    githubId = 1525767;
     name = "Vaibhav Sagar";
   };
   valeriangalliat = {
@@ -5554,37 +6498,44 @@
   vandenoever = {
     email = "jos@vandenoever.info";
     github = "vandenoever";
+    githubId = 608417;
     name = "Jos van den Oever";
   };
   vanschelven = {
     email = "klaas@vanschelven.com";
     github = "vanschelven";
+    githubId = 223833;
     name = "Klaas van Schelven";
   };
   vanzef = {
     email = "vanzef@gmail.com";
     github = "vanzef";
+    githubId = 12428837;
     name = "Ivan Solyankin";
   };
   varunpatro = {
     email = "varun.kumar.patro@gmail.com";
     github = "varunpatro";
+    githubId = 6943308;
     name = "Varun Patro";
   };
   vbgl = {
     email = "Vincent.Laporte@gmail.com";
     github = "vbgl";
+    githubId = 2612464;
     name = "Vincent Laporte";
   };
   vbmithr = {
     email = "vb@luminar.eu.org";
     github = "vbmithr";
+    githubId = 797581;
     name = "Vincent Bernardoff";
   };
   vcunat = {
     name = "Vladimír Čunát";
     email = "v@cunat.cz"; # vcunat@gmail.com predominated in commits before 2019/03
     github = "vcunat";
+    githubId = 1785925;
     keys = [{
       longkeyid = "rsa4096/0xE747DF1F9575A3AA";
       fingerprint = "B600 6460 B60A 80E7 8206  2449 E747 DF1F 9575 A3AA";
@@ -5593,31 +6544,37 @@
   vdemeester = {
     email = "vincent@sbr.pm";
     github = "vdemeester";
+    githubId = 6508;
     name = "Vincent Demeester";
   };
   velovix = {
     email = "xaviosx@gmail.com";
     github = "velovix";
+    githubId = 2856634;
     name = "Tyler Compton";
   };
   veprbl = {
     email = "veprbl@gmail.com";
     github = "veprbl";
+    githubId = 245573;
     name = "Dmitry Kalinkin";
   };
   vidbina = {
     email = "vid@bina.me";
     github = "vidbina";
+    githubId = 335406;
     name = "David Asabina";
   };
   vifino = {
     email = "vifino@tty.sh";
     github = "vifino";
+    githubId = 5837359;
     name = "Adrian Pistol";
   };
   vinymeuh = {
     email = "vinymeuh@gmail.com";
     github = "vinymeuh";
+    githubId = 118959;
     name = "VinyMeuh";
   };
   viric = {
@@ -5628,6 +6585,7 @@
   virusdave = {
     email = "dave.nicponski@gmail.com";
     github = "virusdave";
+    githubId = 6148271;
     name = "Dave Nicponski";
   };
   vizanto = {
@@ -5638,21 +6596,25 @@
   vklquevs = {
     email = "vklquevs@gmail.com";
     github = "vklquevs";
+    githubId = 1771234;
     name = "vklquevs";
   };
   vlaci = {
     email = "laszlo.vasko@outlook.com";
     github = "vlaci";
+    githubId = 1771332;
     name = "László Vaskó";
   };
   vlstill = {
     email = "xstill@fi.muni.cz";
     github = "vlstill";
+    githubId = 4070422;
     name = "Vladimír Štill";
   };
   vmandela = {
     email = "venkat.mandela@gmail.com";
     github = "vmandela";
+    githubId = 849772;
     name = "Venkateswara Rao Mandela";
   };
   vmchale = {
@@ -5663,11 +6625,13 @@
   volhovm = {
     email = "volhovm.cs@gmail.com";
     github = "volhovm";
+    githubId = 5604643;
     name = "Mikhail Volkhov";
   };
   volth = {
     email = "jaroslavas@volth.com";
     github = "volth";
+    githubId = 508305;
     name = "Jaroslavas Pocepko";
   };
   vozz = {
@@ -5677,31 +6641,37 @@
   vrthra = {
     email = "rahul@gopinath.org";
     github = "vrthra";
+    githubId = 70410;
     name = "Rahul Gopinath";
   };
   vskilet = {
     email = "victor@sene.ovh";
     github = "vskilet";
+    githubId = 7677567;
     name = "Victor SENE";
   };
   vyorkin = {
     email = "vasiliy.yorkin@gmail.com";
     github = "vyorkin";
+    githubId = 988849;
     name = "Vasiliy Yorkin";
   };
   vyp = {
     email = "elisp.vim@gmail.com";
     github = "vyp";
+    githubId = 3889405;
     name = "vyp";
   };
   waynr = {
     name = "Wayne Warren";
     email = "wayne.warren.s@gmail.com";
     github = "waynr";
+    githubId = 1441126;
   };
   wchresta = {
     email = "wchresta.nix@chrummibei.ch";
     github = "wchresta";
+    githubId = 34962284;
     name = "wchresta";
   };
   wedens = {
@@ -5711,6 +6681,7 @@
   willibutz = {
     email = "willibutz@posteo.de";
     github = "willibutz";
+    githubId = 20464732;
     name = "Willi Butz";
   };
   willtim = {
@@ -5724,36 +6695,43 @@
   winpat = {
     email = "patrickwinter@posteo.ch";
     github = "winpat";
+    githubId = 6016963;
     name = "Patrick Winter";
   };
   wizeman = {
     email = "rcorreia@wizy.org";
     github = "wizeman";
+    githubId = 168610;
     name = "Ricardo M. Correia";
   };
   wjlroe = {
     email = "willroe@gmail.com";
     github = "wjlroe";
+    githubId = 43315;
     name = "William Roe";
   };
   wmertens = {
     email = "Wout.Mertens@gmail.com";
     github = "wmertens";
+    githubId = 54934;
     name = "Wout Mertens";
   };
   woffs = {
     email = "github@woffs.de";
     github = "woffs";
+    githubId = 895853;
     name = "Frank Doepper";
   };
   womfoo = {
     email = "kranium@gikos.net";
     github = "womfoo";
+    githubId = 1595132;
     name = "Kranium Gikos Mendoza";
   };
   worldofpeace = {
     email = "worldofpeace@protonmail.ch";
     github = "worldofpeace";
+    githubId = 28888242;
     name = "Worldofpeace";
   };
   wscott = {
@@ -5764,31 +6742,37 @@
   wucke13 = {
     email = "info@wucke13.de";
     github = "wucke13";
+    githubId = 20400405;
     name = "Wucke";
   };
   wykurz = {
     email = "wykurz@gmail.com";
     github = "wykurz";
+    githubId = 483465;
     name = "Mateusz Wykurz";
   };
   wyvie = {
     email = "elijahrum@gmail.com";
     github = "wyvie";
+    githubId = 3992240;
     name = "Elijah Rum";
   };
   xaverdh = {
     email = "hoe.dom@gmx.de";
     github = "xaverdh";
+    githubId = 11050617;
     name = "Dominik Xaver Hörl";
   };
   xbreak = {
     email = "xbreak@alphaware.se";
     github = "xbreak";
+    githubId = 13489144;
     name = "Calle Rosenquist";
   };
   xeji = {
     email = "xeji@cat3.de";
     github = "xeji";
+    githubId = 36407913;
     name = "Uli Baum";
   };
   xnaveira = {
@@ -5799,31 +6783,37 @@
   xnwdd = {
     email = "nwdd+nixos@no.team";
     github = "xnwdd";
+    githubId = 3028542;
     name = "Guillermo NWDD";
   };
   xrelkd = {
     email = "46590321+xrelkd@users.noreply.github.com";
     github = "xrelkd";
+    githubId = 46590321;
     name = "xrelkd";
   };
   xurei = {
     email = "olivier.bourdoux@gmail.com";
     github = "xurei";
+    githubId = 621695;
     name = "Olivier Bourdoux";
   };
   xvapx = {
     email = "marti.serra.coscollano@gmail.com";
     github = "xvapx";
+    githubId = 11824817;
     name = "Marti Serra";
   };
   xwvvvvwx = {
     email = "davidterry@posteo.de";
     github = "xwvvvvwx";
+    githubId = 6689924;
     name = "David Terry";
   };
   xzfc = {
     email = "xzfcpw@gmail.com";
     github = "xzfc";
+    githubId = 5121426;
     name = "Albert Safin";
   };
   y0no = {
@@ -5834,71 +6824,85 @@
   yarny = {
     email = "41838844+Yarny0@users.noreply.github.com";
     github = "Yarny0";
+    githubId = 41838844;
     name = "Yarny";
   };
   yarr = {
     email = "savraz@gmail.com";
     github = "Eternity-Yarr";
+    githubId = 3705333;
     name = "Dmitry V.";
   };
   yegortimoshenko = {
     email = "yegortimoshenko@riseup.net";
     github = "yegortimoshenko";
+    githubId = 1643293;
     name = "Yegor Timoshenko";
   };
   yesbox = {
     email = "jesper.geertsen.jonsson@gmail.com";
     github = "yesbox";
+    githubId = 4113027;
     name = "Jesper Geertsen Jonsson";
   };
   ylwghst = {
     email = "ylwghst@onionmail.info";
     github = "ylwghst";
+    githubId = 26011724;
     name = "Burim Augustin Berisa";
   };
   yochai = {
     email = "yochai@titat.info";
     github = "yochai";
+    githubId = 1322201;
     name = "Yochai";
   };
   yorickvp = {
     email = "yorickvanpelt@gmail.com";
     github = "yorickvp";
+    githubId = 647076;
     name = "Yorick van Pelt";
   };
   yrashk = {
     email = "yrashk@gmail.com";
     github = "yrashk";
+    githubId = 452;
     name = "Yurii Rashkovskii";
   };
   ysndr = {
     email = "me@ysndr.de";
     github = "ysndr";
+    githubId = 7040031;
     name = "Yannik Sander";
   };
   yuriaisaka = {
     email = "yuri.aisaka+nix@gmail.com";
     github = "yuriaisaka";
+    githubId = 687198;
     name = "Yuri Aisaka";
   };
   yurrriq = {
     email = "eric@ericb.me";
     github = "yurrriq";
+    githubId = 1866448;
     name = "Eric Bailey";
   };
   z77z = {
     email = "maggesi@math.unifi.it";
     github = "maggesi";
+    githubId = 1809783;
     name = "Marco Maggesi";
   };
   zachcoyle = {
     email = "zach.coyle@gmail.com";
     github = "zachcoyle";
+    githubId = 908716;
     name = "Zach Coyle";
   };
   zagy = {
     email = "cz@flyingcircus.io";
     github = "zagy";
+    githubId = 568532;
     name = "Christian Zagrodnick";
   };
   zalakain = {
@@ -5909,16 +6913,19 @@
   zaninime = {
     email = "francesco@zanini.me";
     github = "zaninime";
+    githubId = 450885;
     name = "Francesco Zanini";
   };
   zarelit = {
     email = "david@zarel.net";
     github = "zarelit";
+    githubId = 3449926;
     name = "David Costa";
   };
   zauberpony = {
     email = "elmar@athmer.org";
     github = "zauberpony";
+    githubId = 250877;
     name = "Elmar Athmer";
   };
   zef = {
@@ -5928,61 +6935,73 @@
   zgrannan = {
     email = "zgrannan@gmail.com";
     github = "zgrannan";
+    githubId = 1141948;
     name = "Zack Grannan";
   };
   zimbatm = {
     email = "zimbatm@zimbatm.com";
     github = "zimbatm";
+    githubId = 3248;
     name = "zimbatm";
   };
   Zimmi48 = {
     email = "theo.zimmermann@univ-paris-diderot.fr";
     github = "Zimmi48";
+    githubId = 1108325;
     name = "Théo Zimmermann";
   };
   zohl = {
     email = "zohl@fmap.me";
     github = "zohl";
+    githubId = 6067895;
     name = "Al Zohali";
   };
   zookatron = {
     email = "tim@zookatron.com";
     github = "zookatron";
+    githubId = 1772064;
     name = "Tim Zook";
   };
   zoomulator = {
     email = "zoomulator@gmail.com";
     github = "zoomulator";
+    githubId = 1069303;
     name = "Kim Simmons";
   };
   zraexy = {
     email = "zraexy@gmail.com";
     github = "zraexy";
+    githubId = 8100652;
     name = "David Mell";
   };
   zx2c4 = {
     email = "Jason@zx2c4.com";
     github = "zx2c4";
+    githubId = 10643;
     name = "Jason A. Donenfeld";
   };
   zzamboni = {
     email = "diego@zzamboni.org";
     github = "zzamboni";
+    githubId = 32876;
     name = "Diego Zamboni";
   };
   turbomack = {
     email = "marek.faj@gmail.com";
     github = "turboMaCk";
+    githubId = 2130305;
     name = "Marek Fajkus";
   };
   melling = {
     email = "mattmelling@fastmail.com";
     github = "mattmelling";
+    githubId = 1215331;
     name = "Matt Melling";
   };
   wd15 = {
     email = "daniel.wheeler2@gmail.com";
     github = "wd15";
+    githubId = 1986844;
     name = "Daniel Wheeler";
   };
 }

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5387,7 +5387,7 @@
   };
   tobim = {
     email = "nix@tobim.fastmail.fm";
-    github = "tobimpub";
+    github = "tobim";
     name = "Tobias Mayer";
   };
   tobiasBora = {

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3151,7 +3151,7 @@
   };
   ma9e = {
     email = "sean@lfo.team";
-    github = "ma9e";
+    github = "furrycatherder";
     name = "Sean Haugh";
   };
   madjar = {

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1758,7 +1758,7 @@
   };
   f-breidenstein = {
     email = "mail@felixbreidenstein.de";
-    github = "f-breidenstein";
+    github = "fleaz";
     name = "Felix Breidenstein";
   };
   fadenb = {

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2107,7 +2107,7 @@
   };
   hamhut1066 = {
     email = "github@hamhut1066.com";
-    github = "hamhut1066";
+    github = "moredhel";
     name = "Hamish Hutchings";
   };
   hansjoergschurr = {

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4850,7 +4850,7 @@
   };
   siddharthist = {
     email = "langston.barrett@gmail.com";
-    github = "siddharthist";
+    github = "langston-barrett";
     name = "Langston Barrett";
   };
   siers = {

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7,6 +7,7 @@
 
       # Optional
       github = "GithubUsername";
+      githubId = your-github-id;
       keys = [{
         longkeyid = "rsa2048/0x0123456789ABCDEF";
         fingerprint = "AAAA BBBB CCCC DDDD EEEE  FFFF 0000 1111 2222 3333";
@@ -19,6 +20,7 @@
   - `name` is your, preferably real, name,
   - `email` is your maintainer email address, and
   - `github` is your GitHub handle (as it appears in the URL of your profile page, `https://github.com/<userhandle>`),
+  - `githubId` is your GitHub user ID, which can be found at `https://api.github.com/users/<userhandle>`,
   - `keys` is a list of your PGP/GPG key IDs and fingerprints.
 
   `handle == github` is strongly preferred whenever `github` is an acceptable attribute name and is short and convenient.

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3758,7 +3758,6 @@
   };
   nfjinjing = {
     email = "nfjinjing@gmail.com";
-    github = "nfjinjing";
     name = "Jinjing Wang";
   };
   nh2 = {

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -934,7 +934,6 @@
   };
   cf6b88f = {
     email = "elmo.todurov@eesti.ee";
-    github = "cf6b88f";
     name = "Elmo Todurov";
   };
   cfouche = {


### PR DESCRIPTION
##### Motivation for this change

Begin implementing NixOS/rfcs#39 : unprivileged maintainer team.

Step one: Track user's GitHub IDs alongside their github username (re: https://github.com/NixOS/rfcs/blob/master/rfcs/0039-unprivileged-maintainer-teams.md#changes-to-maintainersmaintainer-listnix)

This list is generated by taking the usernames in the list and looking up their ID, via https://github.com/grahamc/rfc39/blob/master/src/main.rs#L79

There is a question of have any of these usernames changed hands? Hard to verify. I can tell you these errors do occur:

```
Aug 09 00:05:51.420 INFO Getting ID for user, github_account: hamhut1066, exec-mode: BackfillIDs, module: rfc39:100
Aug 09 00:05:51.633 WARN Error fetching ID for user, e: 404 Not Found: 'Not Found', github_account: hamhut1066, exec-mode: BackfillIDs, module: rfc39:112
Aug 09 00:05:51.634 INFO Getting ID for user, github_account: siddharthist, exec-mode: BackfillIDs, module: rfc39:100
Aug 09 00:05:51.693 WARN Error fetching ID for user, e: 404 Not Found: 'Not Found', github_account: siddharthist, exec-mode: BackfillIDs, module: rfc39:112
Aug 09 00:05:51.694 INFO Getting ID for user, github_account: tobimpub, exec-mode: BackfillIDs, module: rfc39:100
Aug 09 00:05:51.768 WARN Error fetching ID for user, e: 404 Not Found: 'Not Found', github_account: tobimpub, exec-mode: BackfillIDs, module: rfc39:112
Aug 09 00:05:51.769 INFO Getting ID for user, github_account: f-breidenstein, exec-mode: BackfillIDs, module: rfc39:100
Aug 09 00:05:51.840 WARN Error fetching ID for user, e: 404 Not Found: 'Not Found', github_account: f-breidenstein, exec-mode: BackfillIDs, module: rfc39:112
Aug 09 00:05:51.841 INFO Getting ID for user, github_account: ma9e, exec-mode: BackfillIDs, module: rfc39:100
Aug 09 00:05:51.909 WARN Error fetching ID for user, e: 404 Not Found: 'Not Found', github_account: ma9e, exec-mode: BackfillIDs, module: rfc39:112
Aug 09 00:05:51.910 INFO Getting ID for user, github_account: cf6b88f, exec-mode: BackfillIDs, module: rfc39:100
Aug 09 00:05:51.980 WARN Error fetching ID for user, e: 404 Not Found: 'Not Found', github_account: cf6b88f, exec-mode: BackfillIDs, module: rfc39:112
Aug 09 00:05:51.981 INFO Getting ID for user, github_account: nfjinjing, exec-mode: BackfillIDs, module: rfc39:100
Aug 09 00:05:52.052 WARN Error fetching ID for user, e: 404 Not Found: 'Not Found', github_account: nfjinjing, exec-mode: BackfillIDs, module: rfc39:112
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
