### PR TITLE
ocamlPackages.mmap: init at 1.1.0

### DIFF
--- a/pkgs/development/ocaml-modules/mmap/default.nix
+++ b/pkgs/development/ocaml-modules/mmap/default.nix
@@ -1,0 +1,18 @@
+{ lib, buildDunePackage, fetchurl }:
+
+buildDunePackage rec {
+  pname = "mmap";
+  version = "1.1.0";
+
+  src = fetchurl {
+    url = "https://github.com/mirage/mmap/releases/download/v${version}/mmap-v${version}.tbz";
+    sha256 = "0l6waidal2n8mkdn74avbslvc10sf49f5d889n838z03pra5chsc";
+  };
+
+  meta = {
+    homepage = "https://github.com/mirage/mmap";
+    description = "Function for mapping files in memory";
+    license = lib.licenses.lgpl21;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -450,6 +450,8 @@ let
 
     mlgmpidl =  callPackage ../development/ocaml-modules/mlgmpidl { };
 
+    mmap =  callPackage ../development/ocaml-modules/mmap { };
+
     mparser =  callPackage ../development/ocaml-modules/mparser { };
 
     mstruct =  callPackage ../development/ocaml-modules/mstruct { };


### PR DESCRIPTION
###### Motivation for this change

Dependency of recent versions of LWT.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
