### PR TITLE
elm-format: 0.8.1 -> 0.8.2

### DIFF
--- a/pkgs/development/compilers/elm/packages/elm-format.nix
+++ b/pkgs/development/compilers/elm/packages/elm-format.nix
@@ -1,24 +1,28 @@
 { mkDerivation, fetchgit, ansi-terminal, ansi-wl-pprint, base, binary
-, bytestring, Cabal, cmark, containers, directory, filepath, free
-, HUnit, indents, json, mtl, optparse-applicative, parsec, process
+, bytestring, cmark, containers, directory, filepath, free, HUnit
+, indents, json, mtl, optparse-applicative, parsec, process
 , QuickCheck, quickcheck-io, split, stdenv, tasty, tasty-golden
 , tasty-hunit, tasty-quickcheck, text
 }:
 mkDerivation {
   pname = "elm-format";
-  version = "0.8.1";
+  version = "0.8.2";
   src = fetchgit {
     url = "https://github.com/avh4/elm-format";
-    sha256 = "0p1dy1m6illsl7i04zsv5jqw7i4znv7pfpdfm53zy0k7mq0fk09j";
-    rev = "89694e858664329e3cbdaeb71b15c4456fd739ff";
+    sha256 = "0ly37fszrfviwqgrww57ikdcr7i8lcpczhqm8xqp5s7mrlpdxv7z";
+    rev = "ab3627cce01e5556b3fe8c2b5e3d92b80bfc74af";
   };
   postPatch = ''
-    sed -i "s|desc <-.*||" ./Setup.hs
-    sed -i "s|gitDescribe = .*|gitDescribe = \\\\\"0.8.1\\\\\"\"|" ./Setup.hs
+    mkdir -p ./generated
+    cat <<EOHS > ./generated/Build_elm_format.hs
+    module Build_elm_format where
+
+    gitDescribe :: String
+    gitDescribe = "0.8.2"
+    EOHS
   '';
-  isLibrary = true;
+  isLibrary = false;
   isExecutable = true;
-  setupHaskellDepends = [ base Cabal directory filepath process ];
   libraryHaskellDepends = [
     ansi-terminal ansi-wl-pprint base binary bytestring containers
     directory filepath free indents json mtl optparse-applicative


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Motivation for this change

New version of elm-format (https://github.com/avh4/elm-format/blob/0.8.2/CHANGELOG.md#082)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
