### PR TITLE
ocamlPackages.camomile: 1.0.1 -> 1.0.2

### DIFF
--- a/pkgs/development/ocaml-modules/camomile/default.nix
+++ b/pkgs/development/ocaml-modules/camomile/default.nix
@@ -1,27 +1,19 @@
-{ stdenv, fetchFromGitHub, ocaml, dune, cppo, findlib }:
+{ stdenv, fetchFromGitHub, buildDunePackage, cppo }:
 
-stdenv.mkDerivation rec {
+buildDunePackage rec {
   pname = "camomile";
-	version = "1.0.1";
+	version = "1.0.2";
 
 	src = fetchFromGitHub {
 		owner = "yoriyuki";
 		repo = pname;
 		rev = version;
-		sha256 = "1pfxr9kzkpd5bsdqrpxasfxkawwkg4cpx3m1h6203sxi7qv1z3fn";
+		sha256 = "00i910qjv6bpk0nkafp5fg97isqas0bwjf7m6rz11rsxilpalzad";
 	};
 
-	buildInputs = [ ocaml dune findlib cppo ];
+	buildInputs = [ cppo ];
 
 	configurePhase = "ocaml configure.ml --share $out/share/camomile";
-
-  # Use jbuilder executable because it breaks on dune>=1.10
-  # https://github.com/yoriyuki/Camomile/commit/505202b58e22628f80bbe15ee76b9470a5bd2f57#r33816944
-  buildPhase = ''
-    jbuilder build -p ${pname}
-  '';
-
-  inherit (dune) installPhase;
 
 	meta = {
 		inherit (src.meta) homepage;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Changelog: https://github.com/yoriyuki/Camomile/releases/tag/1.0.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
