### PR TITLE
reuse: 0.3.4 -> 0.4.1

### DIFF
--- a/pkgs/development/python-modules/boolean-py/default.nix
+++ b/pkgs/development/python-modules/boolean-py/default.nix
@@ -1,0 +1,21 @@
+{ lib, buildPythonPackage, fetchFromGitHub
+}:
+
+buildPythonPackage rec {
+  pname = "boolean.py";
+  version = "3.6";
+
+  src = fetchFromGitHub {
+    owner = "bastikr";
+    repo = "boolean.py";
+    rev = "v${version}";
+    sha256 = "1wc89y73va58cj7dsx6c199zpxsy9q53dsffsdj6zmc90inqz6qs";
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/bastikr/boolean.py";
+    description = "Implements boolean algebra in one module";
+    license = licenses.bsd2;
+  };
+
+}

--- a/pkgs/development/python-modules/license-expression/default.nix
+++ b/pkgs/development/python-modules/license-expression/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildPythonPackage, fetchFromGitHub
+, boolean-py
+}:
+
+buildPythonPackage rec {
+  pname = "license-expression";
+  version = "0.999";
+
+  src = fetchFromGitHub {
+    owner = "nexB";
+    repo = "license-expression";
+    rev = "v${version}";
+    sha256 = "0q8sha38w7ajg7ar0rmbqrwv0n58l8yzyl96cqwcbvp578fn3ir0";
+  };
+
+  propagatedBuildInputs = [ boolean-py ];
+
+  meta = with lib; {
+    homepage = "https://github.com/nexB/license-expression";
+    description = "Utility library to parse, normalize and compare License expressions for Python using a boolean logic engine";
+    license = licenses.asl20;
+  };
+
+}

--- a/pkgs/tools/package-management/reuse/default.nix
+++ b/pkgs/tools/package-management/reuse/default.nix
@@ -1,30 +1,25 @@
-{ lib, python3Packages, fetchFromGitLab }:
+{ lib, python3Packages, fetchFromGitHub }:
 
 with python3Packages;
 
 buildPythonApplication rec {
   pname = "reuse";
-  version = "0.3.4";
+  version = "0.4.1";
 
-  src = fetchFromGitLab {
-    owner = "reuse";
-    repo = "reuse";
+  src = fetchFromGitHub {
+    owner = "fsfe";
+    repo = "reuse-tool";
     rev = "v${version}";
-    sha256 = "07acv02wignrsfhym2i3dhlcs501yj426lnff2cjampl6m5cgsk3";
+    sha256 = "0gwipwikhxsk0p8wvdl90xm7chfi2jywb1namzznyymifl1vsbgh";
   };
 
-  propagatedBuildInputs = [ chardet debian pygit2 ];
+  propagatedBuildInputs = [ debian license-expression requests ];
 
-  checkInputs = [ pytest jinja2 ];
-
-  # Some path based tests are currently broken under nix
-  checkPhase = ''
-    pytest tests -k "not test_lint_none and not test_lint_ignore_debian and not test_lint_twice_path"
-  '';
+  checkInputs = [ pytest ];
 
   meta = with lib; {
     description = "A tool for compliance with the REUSE Initiative recommendations";
-    license = with licenses; [ cc-by-sa-40 cc0 gpl3 ];
+    license = with licenses; [ asl20 cc-by-sa-40 cc0 gpl3 ];
     maintainers = [ maintainers.FlorianFranzen ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2450,6 +2450,8 @@ in {
 
   libthumbor = callPackage ../development/python-modules/libthumbor { };
 
+  license-expression = callPackage ../development/python-modules/license-expression { };
+
   lightblue = callPackage ../development/python-modules/lightblue { };
 
   lightgbm = callPackage ../development/python-modules/lightgbm { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1493,6 +1493,8 @@ in {
 
   boltztrap2 = callPackage ../development/python-modules/boltztrap2 { };
 
+  boolean-py = callPackage ../development/python-modules/boolean-py { };
+
   bumps = callPackage ../development/python-modules/bumps {};
 
   cached-property = callPackage ../development/python-modules/cached-property { };


### PR DESCRIPTION
* Add new Python packages (dependencies):
  * boolean.py
  * license-expression


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @FlorianFranzen