### PR TITLE
freecad: use qt wrapper

### DIFF
--- a/pkgs/applications/graphics/freecad/default.nix
+++ b/pkgs/applications/graphics/freecad/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, ninja, coin3d, xercesc, ode, eigen, qt5, opencascade-occt, gts
+{ stdenv, mkDerivation, fetchurl, cmake, ninja, coin3d, xercesc, ode, eigen, qt5, opencascade-occt, gts
 , hdf5, vtk, medfile, zlib, python3Packages, swig, gfortran, libXmu
 , soqt, libf2c, libGLU, makeWrapper, pkgconfig
 , mpi ? null }:
@@ -7,7 +7,7 @@ assert mpi != null;
 
 let
   pythonPackages = python3Packages;
-in stdenv.mkDerivation rec {
+in mkDerivation rec {
   name = "freecad-${version}";
   version = "0.18.3";
 
@@ -46,12 +46,13 @@ in stdenv.mkDerivation rec {
   # Their main() removes PYTHONPATH=, and we rely on it.
   preConfigure = ''
     sed '/putenv("PYTHONPATH/d' -i src/Main/MainGui.cpp
+
+    qtWrapperArgs+=(--prefix PYTHONPATH : "$PYTHONPATH")
   '';
 
-  postInstall = ''
-    wrapProgram $out/bin/FreeCAD --prefix PYTHONPATH : $PYTHONPATH \
-      --set COIN_GL_NO_CURRENT_CONTEXT_CHECK 1
-  '';
+  qtWrapperArgs = [
+    "--set COIN_GL_NO_CURRENT_CONTEXT_CHECK 1"
+  ];
 
   postFixup = ''
     mv $out/share/doc $out
@@ -59,9 +60,9 @@ in stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "General purpose Open Source 3D CAD/MCAD/CAx/CAE/PLM modeler";
-    homepage = https://www.freecadweb.org/;
+    homepage = "https://www.freecadweb.org/";
     license = licenses.lgpl2Plus;
-    maintainers = [ maintainers.viric ];
+    maintainers = with maintainers; [ viric gebner ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18344,7 +18344,7 @@ in
 
   fractal = callPackage ../applications/networking/instant-messengers/fractal { };
 
-  freecad = callPackage ../applications/graphics/freecad { mpi = openmpi; };
+  freecad = qt5.callPackage ../applications/graphics/freecad { mpi = openmpi; };
 
   freemind = callPackage ../applications/misc/freemind { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

#65399.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @viric
