### PR TITLE
perl: 5.28.2 -> 5.30.0

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14251,8 +14251,8 @@ in
   perl530Packages = recurseIntoAttrs perl530.pkgs;
   perldevelPackages = perldevel.pkgs;
 
-  perl = perl528;
-  perlPackages = perl528Packages;
+  perl = perl530;
+  perlPackages = perl530Packages;
 
   ack = perlPackages.ack;
 


### PR DESCRIPTION
It works for me, but as it affects everything I cannot say that it is fully tested.
At least we will have time to test before making decision which `perl` will be default in `19.09`

`5.30.0` is about 3 month old and there were no urgent bugfixes or something like that, so it should be stable and already tested on bleeding edge distros.
