### PR TITLE
sympow: 1.018.1 -> 2.023.4

### DIFF
--- a/pkgs/applications/science/math/sage/patches/sympow-cache.patch
+++ b/pkgs/applications/science/math/sage/patches/sympow-cache.patch
@@ -1,0 +1,21 @@
+diff --git a/src/sage/lfunctions/sympow.py b/src/sage/lfunctions/sympow.py
+index 1640ac4f6a..03578be7b8 100644
+--- a/src/sage/lfunctions/sympow.py
++++ b/src/sage/lfunctions/sympow.py
+@@ -50,6 +50,7 @@ from __future__ import print_function, absolute_import
+ 
+ import os
+ 
++from sage.env import DOT_SAGE
+ from sage.structure.sage_object import SageObject
+ from sage.misc.all import pager, verbose
+ import sage.rings.all
+@@ -76,7 +77,7 @@ class Sympow(SageObject):
+         """
+         Used to call sympow with given args
+         """
+-        cmd = 'sympow %s'%args
++        cmd = 'env SYMPOW_CACHEDIR="%s/sympow///" sympow %s' % (DOT_SAGE, args)
+         v = os.popen(cmd).read().strip()
+         verbose(v, level=2)
+         return v

--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -100,6 +100,11 @@ stdenv.mkDerivation rec {
       rev = "c11d9cfa23ff9f77681a8f12742f68143eed4504";
       sha256 = "0xzra7mbgqvahk9v45bjwir2mqz73hrhhy314jq5nxrb35ysdxyi";
     })
+
+    # After updating smypow to (https://trac.sagemath.org/ticket/3360) we can
+    # now set the cache dir to be withing the .sage directory. This is not
+    # strictly necessary, but keeps us from littering in the user's HOME.
+    ./patches/sympow-cache.patch
   ];
 
   patches = nixPatches ++ bugfixPatches ++ packageUpgradePatches;

--- a/pkgs/applications/science/math/sage/sage-tests.nix
+++ b/pkgs/applications/science/math/sage/sage-tests.nix
@@ -3,7 +3,7 @@
 , sage-with-env
 , makeWrapper
 , files ? null # "null" means run all tests
-, longTests ? true # run tests marked as "long time" (roughly doubles runtime)
+, longTests ? false # run tests marked as "long time" (roughly doubles runtime)
 # Run as many tests as possible in approximately n seconds. This will give each
 # file to test a "time budget" and stop tests if it is exceeded. 300 is the
 # upstream default value.

--- a/pkgs/development/libraries/science/math/sympow/default.nix
+++ b/pkgs/development/libraries/science/math/sympow/default.nix
@@ -1,89 +1,74 @@
 { stdenv
-, fetchurl
-, fetchpatch
+, fetchFromGitLab
 , makeWrapper
+, which
+, autoconf
+, help2man
+, file
+, pari
 }:
 
 stdenv.mkDerivation rec {
-  version = "1.018.1";
+  version = "2.023.4";
   name = "sympow-${version}";
 
-  src = fetchurl {
-    # Original website no longer reachable
-    url = "mirror://sageupstream/sympow/sympow-${version}.tar.bz2";
-    sha256 = "0hphs7ia1wr5mydf288zvwj4svrymfpadcg3pi6w80km2yg5bm3c";
+  src = fetchFromGitLab {
+    group = "rezozer";
+    owner = "forks";
+    repo = "sympow";
+    rev = "v${version}";
+    sha256 = "0j2qdw9csbr081h8arhlx1z7ibgi5am4ndmvyc8y4hccfa8n4w1y";
   };
+
+  postUnpack = ''
+    patchShebangs .
+  '';
 
   nativeBuildInputs = [
     makeWrapper
+    which
+    autoconf
+    help2man
+    file
+    pari
   ];
 
   configurePhase = ''
     runHook preConfigure
+    export PREFIX="$out"
+    export VARPREFIX="$out" # see comment on postInstall
     ./Configure # doesn't take any options
     runHook postConfigure
   '';
 
-  installPhase = ''
-    runHook preInstall
-    install -D datafiles/* --target-directory "$out/share/sympow/datafiles/"
-    install *.gp "$out/share/sympow/"
-    install -Dm755 sympow "$out/share/sympow/sympow"
-    install -D new_data "$out/bin/new_data"
-
-    makeWrapper "$out/share/sympow/sympow" "$out/bin/sympow" \
-      --run 'export SYMPOW_LOCAL="$HOME/.local/share/sympow"' \
-      --run 'if [ ! -d "$SYMPOW_LOCAL" ]; then
-        mkdir -p "$SYMPOW_LOCAL" 
-        cp -r ${placeholder "out"}/share/sympow/* "$SYMPOW_LOCAL"
-        chmod -R +xw "$SYMPOW_LOCAL"
-    fi' \
-      --run 'cd "$SYMPOW_LOCAL"'
-    runHook postInstall
+  # Usually, sympow has 3 levels of caching: statically distributed in /usr/,
+  # shared in /var and per-user in ~/.sympow. The shared cache assumes trust in
+  # other users and a shared /var is not compatible with nix's approach, so we
+  # set VARPREFIX to the read-only $out. This effectively disables shared
+  # caching. See https://trac.sagemath.org/ticket/3360#comment:36 and sympow's
+  # README for more details on caching.
+  # sympow will complain at runtime about the lack of write-permissions on the
+  # shared cache. We pass the `-quiet` flag by default to disable this.
+  postInstall = ''
+    wrapProgram "$out/bin/sympow" --add-flags '-quiet'
   '';
 
-  patches = [
-    # don't hardcode paths
-    (fetchpatch {
-      name = "do_not_hardcode_paths.patch";
-      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/sympow/patches/Configure.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
-      sha256 = "1611p8ra8zkxvmxn3gm2l64bd4ma4m6r4vd6vwswcic91k1fci04";
-    })
-
-    # bug on some platforms in combination with a newer gcc:
-    # https://trac.sagemath.org/ticket/11920
-    (fetchpatch {
-      name = "fix_newer_gcc1.patch";
-      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/sympow/patches/fpu.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
-      sha256 = "14gfa56w3ddfmd4d5ir9a40y2zi43cj1i4d2l2ij9l0qlqdy9jyx";
-    })
-    (fetchpatch {
-      name = "fix_newer_gcc2.patch";
-      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/sympow/patches/execlp.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
-      sha256 = "190gqhgz9wgw4lqwz0nwb1izc9zffx34bazsiw2a2sz94bmgb54v";
-    })
-
-    # fix pointer initialization bug (https://trac.sagemath.org/ticket/22862)
-    (fetchpatch {
-      name = "fix_pointer_initialization1.patch";
-      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/sympow/patches/initialize-tacks.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
-      sha256 = "02341vdbbidfs39s26vi4n5wigz619sw8fdbl0h9qsmwwhscgf85";
-    })
-    (fetchpatch {
-      name = "fix_pointer_initialization2.patch";
-      url = "https://git.archlinux.org/svntogit/community.git/plain/trunk/sympow-datafiles.patch?h=packages/sympow&id=5088e641a45b23d0385d8e63be65315129b4cf58";
-      sha256 = "1m0vz048layb47r1jjf7fplw650ccc9x0w3l322iqmppzmv3022a";
-    })
-  ];
+  # Example from the README as a sanity check.
+  doInstallCheck = true;
+  installCheckPhase = ''
+    export HOME="$TMP/home"
+    mkdir -p "$HOME"
+    "$out/bin/sympow" -sp 2p16 -curve "[1,2,3,4,5]" | grep '8.3705'
+  '';
 
   meta = with stdenv.lib; {
-    description = "A package to compute special values of symmetric power elliptic curve L-functions";
+    description = "Compute special values of symmetric power elliptic curve L-functions";
     license = {
       shortName = "sympow";
       fullName = "Custom, BSD-like. See COPYING file.";
       free = true;
     };
     maintainers = with maintainers; [ timokau ];
-    platforms = platforms.all;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Maintenance taken over by debian package maintainer jgmbenoit:
https://trac.sagemath.org/ticket/3360#comment:17

This moves sympow to his fork, since there is no offical
version-controlled source repository from the original author and they
do not seem to maintain sympow anymore. We had already accumulated quite
some patches from debian, who have effectively maintained sympow for a
while now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc me
