### PR TITLE
scribusUnstable: 2019-01-16 -> 1.5.5

### DIFF
--- a/pkgs/applications/office/scribus/unstable.nix
+++ b/pkgs/applications/office/scribus/unstable.nix
@@ -1,26 +1,24 @@
-{ stdenv, fetchsvn, wrapQtAppsHook, pkgconfig, cmake, qtbase, cairo, pixman,
+{ stdenv, fetchurl, mkDerivation, pkgconfig, cmake, qtbase, cairo, pixman,
 boost, cups, fontconfig, freetype, hunspell, libjpeg, libtiff, libxml2, lcms2,
 podofo, poppler, poppler_data, python2, harfbuzz, qtimageformats, qttools }:
 
 let
   pythonEnv = python2.withPackages(ps: [ps.tkinter ps.pillow]);
-  revision = "22806";
 in
-stdenv.mkDerivation rec {
-  name = "scribus-unstable-${version}";
-  version = "2019-01-16";
+mkDerivation rec {
+  pname = "scribus";
+  version = "1.5.5";
 
-  src = fetchsvn {
-    url = "svn://scribus.net/trunk/Scribus";
-    rev = revision;
-    sha256 = "16xpsbp6kca78jf48n6zdmyjras38xr11paan839hgy4ik83ncn0";
+  src = fetchurl {
+    url = "mirror://sourceforge/${pname}/${pname}-devel/${pname}-${version}.tar.xz";
+    sha256 = "eQiyGmzoQyafWM7fX495GJMlfmIBzOX73ccNrKL+P3E=";
   };
 
   enableParallelBuilding = true;
 
-  nativeBuildInputs = [ wrapQtAppsHook ];
+  nativeBuildInputs = [ pkgconfig cmake  ];
   buildInputs = [
-    pkgconfig cmake qtbase cairo pixman boost cups fontconfig
+    qtbase cairo pixman boost cups fontconfig
     freetype hunspell libjpeg libtiff libxml2 lcms2 podofo poppler
     poppler_data pythonEnv harfbuzz qtimageformats qttools
   ];


### PR DESCRIPTION
[changelog](https://bugs.scribus.net/changelog_page.php?version_id=106)

Also changed the pname from `scribus-unstable` to just `scribus`, as this seems to be the more widely used pattern.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
