### PR TITLE
mandelbulber: init at 2.20

### DIFF
--- a/pkgs/applications/graphics/mandelbulber/default.nix
+++ b/pkgs/applications/graphics/mandelbulber/default.nix
@@ -1,0 +1,64 @@
+{ lib
+, mkDerivation
+, fetchFromGitHub
+, libpng
+, gsl
+, libsndfile
+, lzo
+, qmake
+, qttools
+, qtbase
+, qtmultimedia
+, withOpenCL ? true
+, opencl-clhpp ? null
+, ocl-icd ? null
+}:
+
+assert withOpenCL -> opencl-clhpp != null;
+assert withOpenCL -> ocl-icd != null;
+
+mkDerivation rec {
+  pname = "mandelbulber";
+  version = "2.20";
+
+  src = fetchFromGitHub {
+    owner = "buddhi1980";
+    repo = "mandelbulber2";
+    rev = version;
+    sha256 = "043dks9fimhradyhdzqdc6lb9z0x9lkj3szj10751g424lppp207";
+  };
+
+  nativeBuildInputs = [
+    qmake
+    qttools
+  ];
+  buildInputs = [
+    qtbase
+    qtmultimedia
+    libpng
+    gsl
+    libsndfile
+    lzo
+  ] ++ lib.optionals withOpenCL [
+    opencl-clhpp
+    ocl-icd
+  ];
+
+  sourceRoot = "${src.name}/mandelbulber2";
+
+  qmakeFlags = [
+    "SHARED_PATH=${placeholder ''out''}"
+    (if withOpenCL
+      then "qmake/mandelbulber-opencl.pro"
+      else "qmake/mandelbulber.pro")
+  ];
+
+  meta = with lib; {
+    description = "A 3D fractal rendering engine";
+    longDescription = "Mandelbulber creatively generates three-dimensional fractals. Explore trigonometric, hyper-complex, Mandelbox, IFS, and many other 3D fractals.";
+    homepage = "https://mandelbulber.com";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ kovirobi ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19247,6 +19247,8 @@ in
 
   mako = callPackage ../applications/misc/mako { };
 
+  mandelbulber = libsForQt5.callPackage ../applications/graphics/mandelbulber { };
+
   mapmap = libsForQt5.callPackage ../applications/video/mapmap { };
 
   marathon = callPackage ../applications/networking/cluster/marathon { };


### PR DESCRIPTION
Tested on my machine (NixOS 19.03.173243.9ef3cb9b0ba, x86_64), see package request #52038

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the 
average time-to-merge for all of us. Thanks a lot if you do! -->

###### Motivation for this change
I wanted to generate pretty pictures.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
