### PR TITLE
nixos/qt5: init

### DIFF
--- a/nixos/modules/config/qt5.nix
+++ b/nixos/modules/config/qt5.nix
@@ -1,0 +1,102 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.qt5;
+
+  isQGnome = cfg.platformTheme == "gnome" && cfg.style == "adwaita";
+  isQtStyle = cfg.platformTheme == "gtk2" && cfg.style != "adwaita";
+
+  packages = if isQGnome then [ pkgs.qgnomeplatform pkgs.adwaita-qt ]
+    else if isQtStyle then [ pkgs.qtstyleplugins ]
+    else throw "`qt5.platformTheme` ${cfg.platformTheme} and `qt5.style` ${cfg.style} are not compatible.";
+
+in
+
+{
+
+  options = {
+    qt5 = {
+
+      enable = mkEnableOption "Qt5 theming configuration";
+
+      platformTheme = mkOption {
+        type = types.enum [
+          "gtk2"
+          "gnome"
+        ];
+        example = "gnome";
+        relatedPackages = [
+          "qgnomeplatform"
+          ["libsForQt5" "qtstyleplugins"]
+        ];
+        description = ''
+          Selects the platform theme to use for Qt5 applications.</para>
+          <para>The options are
+          <variablelist>
+            <varlistentry>
+              <term><literal>gtk</literal></term>
+              <listitem><para>Use GTK theme with
+                <link xlink:href="https://github.com/qt/qtstyleplugins">qtstyleplugins</link>
+              </para></listitem>
+            </varlistentry>
+            <varlistentry>
+              <term><literal>gnome</literal></term>
+              <listitem><para>Use GNOME theme with
+                <link xlink:href="https://github.com/FedoraQt/QGnomePlatform">qgnomeplatform</link>
+              </para></listitem>
+            </varlistentry>
+          </variablelist>
+        '';
+      };
+
+      style = mkOption {
+        type = types.enum [
+          "adwaita"
+          "cleanlooks"
+          "gtk2"
+          "motif"
+          "plastique"
+        ];
+        example = "adwaita";
+        relatedPackages = [
+          "adwaita-qt"
+          ["libsForQt5" "qtstyleplugins"]
+        ];
+        description = ''
+          Selects the style to use for Qt5 applications.</para>
+          <para>The options are
+          <variablelist>
+            <varlistentry>
+              <term><literal>adwaita</literal></term>
+              <listitem><para>Use Adwaita Qt style with
+                <link xlink:href="https://github.com/FedoraQt/adwaita-qt">adwaita</link>
+              </para></listitem>
+            </varlistentry>
+            <varlistentry>
+              <term><literal>cleanlooks</literal></term>
+              <term><literal>gtk2</literal></term>
+              <term><literal>motif</literal></term>
+              <term><literal>plastique</literal></term>
+              <listitem><para>Use styles from
+                <link xlink:href="https://github.com/qt/qtstyleplugins">qtstyleplugins</link>
+              </para></listitem>
+            </varlistentry>
+          </variablelist>
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    environment.variables.QT_QPA_PLATFORMTHEME = cfg.platformTheme;
+
+    environment.variables.QT_STYLE_OVERRIDE = cfg.style;
+
+    environment.systemPackages = packages;
+
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -27,6 +27,7 @@
   ./config/nsswitch.nix
   ./config/power-management.nix
   ./config/pulseaudio.nix
+  ./config/qt5.nix
   ./config/resolvconf.nix
   ./config/shells-environment.nix
   ./config/swap.nix


### PR DESCRIPTION
This module has the following options:
* platformTheme
* style

This allows us to configure the Qt5 theme engine and style.

###### Motivation for this change
#65913 

This is essentially a similar module from [home-manager](https://github.com/rycee/home-manager/blob/master/modules/misc/qt.nix) but it only supports `qt5` which allows us to configure this from environment variables.


###### Things done

I built a lightweight vm and verified that the environment variables were set to the correct
values I desired.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
