### PR TITLE
chromium: 76.0.3809.87 -> 76.0.3809.100

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/upstream-info.nix
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.nix
@@ -11,8 +11,8 @@
     version = "77.0.3860.5";
   };
   stable = {
-    sha256 = "1521vh38mfgy7aj1lw1vpbdm8m6wyh52d5p7bz4x6kvvxsnacp11";
-    sha256bin64 = "0hnfn2zxdrp96a4p98r08w4krzwkpb1kp4rjk03754akjyg1b3xx";
-    version = "76.0.3809.87";
+    sha256 = "0vfjfxsqf8jrmd7y08ln1lpbilwi150875zn2bawwdq87vd3mncc";
+    sha256bin64 = "1c5rlqgshv5295wg5cji12z2b38l6a81l94spmzr46h5z9nn1gqx";
+    version = "76.0.3809.100";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

https://chromereleases.googleblog.com/2019/08/stable-channel-update-for-desktop.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @andir @samueldr @bendlas
