### PR TITLE
pythonPackages.simplefix: init at 1.0.12

### DIFF
--- a/pkgs/development/python-modules/simplefix/default.nix
+++ b/pkgs/development/python-modules/simplefix/default.nix
@@ -1,0 +1,25 @@
+{ lib, python, buildPythonPackage, fetchFromGitHub }:
+
+buildPythonPackage rec {
+  pname = "simplefix";
+  version = "1.0.12";
+
+  src = fetchFromGitHub {
+    repo = "simplefix";
+    owner = "da4089";
+    rev = "v${version}";
+    sha256 = "0pnyqxpki1ija0kha7axi6irgiifcz4w77libagkv46b1z11cc4r";
+  };
+
+  checkPhase = ''
+    cd test
+    ${python.interpreter} -m unittest all
+  '';
+
+  meta = with lib; {
+    description = "Simple FIX Protocol implementation for Python";
+    homepage = https://github.com/da4089/simplefix;
+    license = licenses.mit;
+    maintainers = with maintainers; [ catern ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -984,6 +984,8 @@ in {
     inherit (pkgs) cmake qt5 llvmPackages;
   });
 
+  simplefix = callPackage ../development/python-modules/simplefix { };
+
   pyside2-tools = toPythonModule (callPackage ../development/python-modules/pyside2-tools {
     inherit (pkgs) cmake qt5;
   });


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

