### PR TITLE
meteor: 1.5 -> 1.8.1

### DIFF
--- a/pkgs/servers/meteor/default.nix
+++ b/pkgs/servers/meteor/default.nix
@@ -1,22 +1,20 @@
 { stdenv, lib, fetchurl, zlib, patchelf, runtimeShell }:
 
 let
-  bootstrap = fetchurl {
-    url = "https://meteorinstall-4168.kxcdn.com/packages-bootstrap/1.5/meteor-bootstrap-os.linux.x86_64.tar.gz";
-    sha256 = "0cwwqv88h1ji7g4zmfz34xsrxkn640wr11ddjq5c6b9ygcljci3p";
-  };
+  version = "1.8.1";
 in
 
 stdenv.mkDerivation rec {
-  name = "meteor-${version}";
-  version = "1.5";
+  inherit version;
+  pname = "meteor";
+  src = fetchurl {
+    url = "https://static-meteor.netdna-ssl.com/packages-bootstrap/${version}/meteor-bootstrap-os.linux.x86_64.tar.gz";
+    sha256 = "1ql58j2d1pqhzpj7c9a6zrpmxxfmlgx743q7lw7g35vz2mpq34c6";
+  };
 
-  dontStrip = true;
+  #dontStrip = true;
 
-  unpackPhase = ''
-    tar xf ${bootstrap}
-    sourceRoot=.meteor
-  '';
+  sourceRoot = ".meteor";
 
   installPhase = ''
     mkdir $out
@@ -25,7 +23,6 @@ stdenv.mkDerivation rec {
     chmod -R +w $out/packages
 
     cp -r package-metadata $out
-    chmod -R +w $out/package-metadata
 
     devBundle=$(find $out/packages/meteor-tool -name dev_bundle)
     ln -s $devBundle $out/dev_bundle


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Meteor 1.5 is quite outdated (May 31, 2017). Let's bump it the latest release. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @cstrahan
