### PR TITLE
plan9port: use C compiler from Nix

### DIFF
--- a/pkgs/tools/system/plan9port/builder.sh
+++ b/pkgs/tools/system/plan9port/builder.sh
@@ -3,11 +3,40 @@ source $stdenv/setup
 export PLAN9=$out/plan9
 export PLAN9_TARGET=$PLAN9
 
+plan9portLinkFlags()
+{
+    local -a linkFlags=()
+    eval set -- "$NIX_LDFLAGS"
+    while (( $# > 0 )); do
+        if [[ $1 = -rpath ]]; then
+            linkFlags+=( "-Wl,-rpath,$2" )
+            shift 2
+        else
+            linkFlags+=( "$1" )
+            shift
+        fi
+    done
+    echo "${linkFlags[*]}"
+}
+
 configurePhase()
 {
-    echo CFLAGS=\"-I${fontconfig_dev}/include -I${xorgproto_exp}/include -I${libX11_dev}/include -I${libXt_dev}/include -I${libXext_dev}/include -I${freetype_dev}/include -I${zlib_dev}/include\" > LOCAL.config
-    echo LDFLAGS=\"-L${fontconfig_lib}/lib -L${xorgproto_exp}/lib -L${libX11_exp}/lib -L${libXt_exp}/lib -L${libXext_exp}/lib -L${freetype_exp}/lib -L${zlib_exp}/lib\" >> LOCAL.config    
-    echo X11=\"${libXt_dev}/include\" >> LOCAL.config
+    (
+        echo CC9=\"$(which $CC)\"
+        echo CFLAGS=\"$NIX_CFLAGS_COMPILE\"
+        echo LDFLAGS=\"$(plan9portLinkFlags)\"
+        echo X11=\"${libXt_dev}/include\"
+        case "$system" in
+          x86_64-*) echo OBJTYPE=x86_64;;
+          i?86-*)   echo OBJTYPE=386;;
+          *power*)  echo OBJTYPE=power;;
+          *sparc*)  echo OBJTYPE=sparc;;
+          *) exit 12
+        esac
+        if [[ $system =~ .*linux.* ]]; then
+          echo SYSVERSION=2.6.x
+        fi
+    ) >config
 
     for f in `grep -l -r /usr/local/plan9`; do
         sed "s,/usr/local/plan9,${PLAN9},g" -i $f
@@ -17,15 +46,29 @@ configurePhase()
 buildPhase()
 {
     mkdir -p $PLAN9
-    ./INSTALL -b
+
+    # Copy sources, some necessary bin scripts
+    cp -R * $PLAN9
+
+    local originalPath="$PATH"
+    export PATH="$PLAN9/bin:$PATH"
+    export NPROC=$NIX_BUILD_CORES
+    pushd src
+    ../dist/buildmk
+    mk clean
+    mk libs-nuke
+    mk all
+    mk -k install
+    if [[ -f $PLAN9/bin/quote1 ]]; then
+        cp $PLAN9/bin/quote1 $PLAN9/bin/'"'
+        cp $PLAN9/bin/quote2 $PLAN9/bin/'""'
+    fi
+    popd
+    export PATH="$originalPath"
 }
 
 installPhase()
 {
-    ./INSTALL -c
-    # Copy sources
-    cp -R * $PLAN9
-
     # Copy the `9' utility. This way you can use
     # $ 9 awk
     # to use the plan 9 awk

--- a/pkgs/tools/system/plan9port/darwin-cfframework.patch
+++ b/pkgs/tools/system/plan9port/darwin-cfframework.patch
@@ -1,0 +1,24 @@
+From d1f0bd3de7d3d54523aeefd9731ea850d20eaab4 Mon Sep 17 00:00:00 2001
+From: Jason Felice <jason.m.felice@gmail.com>
+Date: Tue, 2 Jul 2019 13:19:23 -0400
+Subject: [PATCH] Need CoreFoundation
+
+---
+ src/cmd/devdraw/cocoa-screen.m | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/cmd/devdraw/cocoa-screen.m b/src/cmd/devdraw/cocoa-screen.m
+index 97128da2..0e380dd3 100644
+--- a/src/cmd/devdraw/cocoa-screen.m
++++ b/src/cmd/devdraw/cocoa-screen.m
+@@ -56,6 +56,7 @@
+ #endif
+ 
+ AUTOFRAMEWORK(Cocoa)
++AUTOFRAMEWORK(CoreFoundation)
+ 
+ #define LOG	if(0)NSLog
+ #define panic	sysfatal
+-- 
+2.21.0
+

--- a/pkgs/tools/system/plan9port/darwin-sw_vers.patch
+++ b/pkgs/tools/system/plan9port/darwin-sw_vers.patch
@@ -1,0 +1,47 @@
+From d21d082275f04f88eabcc8ecdb03ee932c71ebf1 Mon Sep 17 00:00:00 2001
+From: Jason Felice <jason.m.felice@gmail.com>
+Date: Mon, 1 Jul 2019 15:23:19 -0400
+Subject: [PATCH 2/3] Build for 10.12
+
+---
+ bin/osxvers                    | 3 +--
+ src/cmd/devdraw/mkwsysrules.sh | 4 ++--
+ 2 files changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/bin/osxvers b/bin/osxvers
+index 4af44da2..3be7e6e9 100755
+--- a/bin/osxvers
++++ b/bin/osxvers
+@@ -2,6 +2,5 @@
+ 
+ u=`uname`
+ case "$u" in
+-Darwin)
+-	sw_vers | awk '$1 == "ProductVersion:" {print $2}' | awk -F. '{printf("CFLAGS=$CFLAGS -DOSX_VERSION=%d%02d%02d\n", $1, $2, $3)}'
++Darwin) printf 'CFLAGS=$CFLAGS -DOSX_VERSION=101200\n';;
+ esac
+diff --git a/src/cmd/devdraw/mkwsysrules.sh b/src/cmd/devdraw/mkwsysrules.sh
+index e94afbd3..40e632db 100644
+--- a/src/cmd/devdraw/mkwsysrules.sh
++++ b/src/cmd/devdraw/mkwsysrules.sh
+@@ -22,7 +22,7 @@ fi
+ 
+ if [ "x$WSYSTYPE" = "x" ]; then
+ 	if [ "x`uname`" = "xDarwin" ]; then
+-		if sw_vers | grep 'ProductVersion:	10\.[0-5]\.' >/dev/null; then
++		if false; then
+ 			echo 1>&2 'OS X 10.5 and older are not supported'
+ 			exit 1
+ 		else
+@@ -54,7 +54,7 @@ if [ $WSYSTYPE = x11 ]; then
+ 	XO=`ls x11-*.c 2>/dev/null | sed 's/\.c$/.o/'`
+ 	echo 'WSYSOFILES=$WSYSOFILES '$XO
+ elif [ $WSYSTYPE = osx-cocoa ]; then
+-	if sw_vers|awk '/ProductVersion/{split($2,a,".");exit(a[2]<14)}' >/dev/null; then	# 0 is true in sh.
++	if false; then
+ 		echo 'OBJCFLAGS=$OBJCFLAGS -fobjc-arc'
+ 		echo 'WSYSOFILES=$WSYSOFILES osx-draw.o cocoa-screen-metal-objc.o cocoa-srv.o cocoa-thread.o'
+ 	else
+-- 
+2.21.0
+

--- a/pkgs/tools/system/plan9port/default.nix
+++ b/pkgs/tools/system/plan9port/default.nix
@@ -31,10 +31,14 @@ stdenv.mkDerivation rec {
     #hardcoded path
     substituteInPlace src/cmd/acme/acme.c \
       --replace /lib/font/bit $out/plan9/font
+
     #deprecated flags
     find . -type f \
       -exec sed -i -e 's/_SVID_SOURCE/_DEFAULT_SOURCE/g' {} \; \
       -exec sed -i -e 's/_BSD_SOURCE/_DEFAULT_SOURCE/g' {} \;
+
+    substituteInPlace bin/9c \
+      --replace 'which uniq' '${which}/bin/which uniq'
   '' + stdenv.lib.optionalString (!stdenv.isDarwin) ''
     #add missing ctrl+c\z\x\v keybind for non-Darwin
     substituteInPlace src/cmd/acme/text.c \
@@ -45,7 +49,7 @@ stdenv.mkDerivation rec {
   '';
 
   buildInputs = [
-    which perl
+    perl
   ] ++ stdenv.lib.optionals (!stdenv.isDarwin) [
     xorgproto libX11 libXext libXt fontconfig
     freetype # fontsrv wants ft2build.h provides system fonts for acme and sam.

--- a/pkgs/tools/system/plan9port/default.nix
+++ b/pkgs/tools/system/plan9port/default.nix
@@ -1,7 +1,11 @@
-{ stdenv, fetchFromGitHub, which, libX11, libXt, fontconfig, freetype
+{ stdenv, fetchFromGitHub, which
+, darwin ? null
 , xorgproto ? null
+, libX11
 , libXext ? null
-, zlib ? null
+, libXt ? null
+, fontconfig ? null
+, freetype ? null
 , perl ? null  # For building web manuals
 }:
 
@@ -16,6 +20,12 @@ stdenv.mkDerivation rec {
     rev = "047fd921744f39a82a86d9370e03f7af511e6e84";
     sha256 = "1lp17948q7vpl8rc2bf5a45bc8jqyj0s3zffmks9r25ai42vgb43";
   };
+
+  patches = [
+    ./tmpdir.patch
+    ./darwin-sw_vers.patch
+    ./darwin-cfframework.patch
+  ];
 
   postPatch = ''
     #hardcoded path
@@ -35,30 +45,16 @@ stdenv.mkDerivation rec {
   '';
 
   buildInputs = [
-    which perl libX11 fontconfig xorgproto libXt libXext
+    which perl
+  ] ++ stdenv.lib.optionals (!stdenv.isDarwin) [
+    xorgproto libX11 libXext libXt fontconfig
     freetype # fontsrv wants ft2build.h provides system fonts for acme and sam.
-  ];
+  ] ++ stdenv.lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
+    darwin.cf-private Carbon Cocoa IOKit Metal QuartzCore
+  ]);
 
   builder = ./builder.sh;
-
-  libX11_dev = libX11.dev;
   libXt_dev = libXt.dev;
-  libXext_dev = libXext.dev;
-  fontconfig_dev = fontconfig.dev;
-  freetype_dev = freetype.dev;
-  zlib_dev = zlib.dev;
-
-  xorgproto_exp = xorgproto;
-  libX11_exp = libX11;
-  libXt_exp = libXt;
-  libXext_exp = libXext;
-  freetype_exp = freetype;
-  zlib_exp = zlib;
-
-  fontconfig_lib = fontconfig.lib;
-
-  NIX_LDFLAGS="-lgcc_s";
-  enableParallelBuilding = true;
 
   doInstallCheck = true;
   installCheckPhase = ''

--- a/pkgs/tools/system/plan9port/tmpdir.patch
+++ b/pkgs/tools/system/plan9port/tmpdir.patch
@@ -1,0 +1,41 @@
+From c762625549ff367b54bcd8281d1ce248a69b4401 Mon Sep 17 00:00:00 2001
+From: Jason Felice <jason.m.felice@gmail.com>
+Date: Mon, 1 Jul 2019 15:01:21 -0400
+Subject: [PATCH] Use $TMPDIR if available
+
+NixOS sandboxed builds (at least on Mac) don't have access to /tmp,
+and this should be better POSIX.
+---
+ bin/9c | 2 +-
+ bin/9l | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/bin/9c b/bin/9c
+index 3ffb716c..88c47887 100755
+--- a/bin/9c
++++ b/bin/9c
+@@ -133,7 +133,7 @@ case "$tag" in
+ esac
+ 
+ # N.B. Must use temp file to avoid pipe; pipe loses status.
+-xtmp=/tmp/9c.$$.$USER.out
++xtmp=${TMPDIR-/tmp}/9c.$$.$USER.out
+ $cc -DPLAN9PORT -I$PLAN9/include $cflags "$@" 2>$xtmp
+ status=$?
+ quiet $xtmp
+diff --git a/bin/9l b/bin/9l
+index 6195815f..717a540a 100755
+--- a/bin/9l
++++ b/bin/9l
+@@ -346,7 +346,7 @@ then
+ 	echo $ld -L$PLAN9/lib "$@" $libsl $extralibs $frameworks
+ fi
+ 
+-xtmp=/tmp/9l.$$.$USER.out
++xtmp="${TMPDIR-/tmp}/9l.$$.$USER.out"
+ xxout() {
+ 	sed 's/.*: In function `[^:]*: *//' $xtmp | egrep . | 
+ 	egrep -v 'is (often|almost always) misused|is dangerous, better use|text-based stub' 
+-- 
+2.21.0
+


### PR DESCRIPTION
The install script was escaping the Nix environment on Mac OS by using `xcrun -sdk macos clang` as its C compiler.  Using the Nix compiler required declaring the necessary frameworks as inputs and patching build scripts to assume MacOS 10.12 (and not try to detect).

So cached derivations prior to this would probably not work on all intended target machines.

This *should* also fix installCheck on Darwin on Hydra.

Other minor fixes:

* Disable parallel building due to a race with a missing y.tab.h
* Use NIX_CFLAGS_COMPILE/NIX_LDFLAGS instead of trying to synthesize something like them.
* X11 dependencies aren't used on Darwin when the windowing system is correctly detected

###### Motivation for this change

Making the Mac plan9port pure.  On Darwin, the package now builds with correct clang 7
instead of Apple's clang 10.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

| System | Before      | After       | Delta        |
| ------ | ----------- | ----------- | ------------ |
| Mac OS | 215,153,296 | 885,944,392 | +670,791,096 |
| NixOS  | 454,124,224 | 488,735,616 | +34,611,392  |

###### Notify maintainers

cc @AndersonTorres @bbarker @ftrvxmtrx @kovirobi (and @alyssais)