### PR TITLE
lib/modules: Use options `apply` function even if no values are defined

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -323,16 +323,14 @@ rec {
         else
           mergeDefinitions loc opt.type defs';
 
-      # Check whether the option is defined, and apply the ‘apply’
-      # function to the merged value.  This allows options to yield a
-      # value computed from the definitions.
-      value =
-        if !res.isDefined then
-          throw "The option `${showOption loc}' is used but not defined."
-        else if opt ? apply then
-          opt.apply res.mergedValue
-        else
-          res.mergedValue;
+
+      # The value with a check that it is defined
+      valueDefined = if res.isDefined then res.mergedValue else
+        throw "The option `${showOption loc}' is used but not defined.";
+
+      # Apply the 'apply' function to the merged value. This allows options to
+      # yield a value computed from the definitions
+      value = if opt ? apply then opt.apply valueDefined else valueDefined;
 
     in opt //
       { value = builtins.addErrorContext "while evaluating the option `${showOption loc}':" value;


### PR DESCRIPTION
##### Motivation for this change
This allows `apply` functions to return a valid value if they completely
ignore their argument, which is the case for the option renaming
functions like `mkAliasOptionModule`. Therefore this fixes #63693, meaning the more intrusive fix in #63719 won't be needed

This is a 100% guaranteed backwards compatible change (aka, what succeeded previously will continue to succeed) and doesn't increase the module API surface

Ping @nbp @Profpatsch @j-piecuch @rycee 

###### Things done

- [x] Ran `lib/tests/modules.sh` successfully
