### PR TITLE
intake: 0.4.4 -> 0.5.3

### DIFF
--- a/pkgs/development/python-modules/bokeh/default.nix
+++ b/pkgs/development/python-modules/bokeh/default.nix
@@ -7,6 +7,7 @@
 , lib
 , mock
 , numpy
+, nodejs
 , pillow
 , pytest
 , python
@@ -14,6 +15,7 @@
 , pyyaml
 , selenium
 , six
+, substituteAll
 , tornado
 }:
 
@@ -25,6 +27,14 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "0m27j29jpi977y95k272xc24qkl5bkniy046cil116hrbgnppng2";
   };
+
+  patches = [
+    (substituteAll {
+      src = ./hardcode-nodejs-npmjs-paths.patch;
+      node_bin = "${nodejs}/bin/node";
+      npm_bin = "${nodejs}/bin/npm";
+    })
+  ];
 
   disabled = isPyPy;
 

--- a/pkgs/development/python-modules/bokeh/default.nix
+++ b/pkgs/development/python-modules/bokeh/default.nix
@@ -1,74 +1,45 @@
-{ lib
-, buildPythonPackage
+{ buildPythonPackage
 , fetchPypi
-, isPyPy
-, mock
-, pytest
-, flask
-, jinja2
-, markupsafe
-, werkzeug
-, itsdangerous
-, dateutil
-, requests
-, six
-, pygments
-, pystache
-, markdown
-, pyyaml
-, pyzmq
-, tornado
-, colorama
-, isPy3k
 , futures
-, websocket_client
+, isPy3k
+, isPyPy
+, jinja2
+, lib
+, mock
 , numpy
-, pandas
-, greenlet
-, python
-, bkcharts
 , pillow
+, pytest
+, python
+, python-dateutil
+, pyyaml
 , selenium
+, six
+, tornado
 }:
 
 buildPythonPackage rec {
   pname = "bokeh";
-  version = "1.0.4";
+  version = "1.3.4";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "ceeb6a75afc1b2de00c2b8b6da121dec3fb77031326897b80d4375a70e96aebf";
+    sha256 = "0m27j29jpi977y95k272xc24qkl5bkniy046cil116hrbgnppng2";
   };
 
   disabled = isPyPy;
-
-  # Some test that uses tornado fails
-#   doCheck = false;
 
   checkInputs = [ mock pytest pillow selenium ];
 
   propagatedBuildInputs = [
     pillow
-    flask
     jinja2
-    markupsafe
-    werkzeug
-    itsdangerous
-    dateutil
-    requests
+    python-dateutil
     six
-    pygments
-    pystache
-    markdown
     pyyaml
-    pyzmq
     tornado
-    colorama
-    bkcharts
+    numpy
   ]
-  ++ lib.optionals ( !isPy3k ) [ futures ]
-  ++ lib.optionals ( !isPy3k && !isPyPy ) [ websocket_client ]
-  ++ lib.optionals ( !isPyPy ) [ numpy pandas greenlet ];
+  ++ lib.optionals ( !isPy3k ) [ futures ];
 
   checkPhase = ''
     ${python.interpreter} -m unittest discover -s bokeh/tests

--- a/pkgs/development/python-modules/bokeh/hardcode-nodejs-npmjs-paths.patch
+++ b/pkgs/development/python-modules/bokeh/hardcode-nodejs-npmjs-paths.patch
@@ -1,0 +1,15 @@
+diff --git a/bokeh/util/compiler.py b/bokeh/util/compiler.py
+index a752aad7d..8af05ff63 100644
+--- a/bokeh/util/compiler.py
++++ b/bokeh/util/compiler.py
+@@ -442,8 +442,8 @@ def _detect_nodejs():
+     raise RuntimeError('node.js v%s or higher is needed to allow compilation of custom models ' % version +
+                        '("conda install nodejs" or follow https://nodejs.org/en/download/)')
+ 
+-_nodejs = None
+-_npmjs = None
++_nodejs = "@node_bin@"
++_npmjs = "@npm_bin@"
+ 
+ def _nodejs_path():
+     global _nodejs

--- a/pkgs/development/python-modules/intake/default.nix
+++ b/pkgs/development/python-modules/intake/default.nix
@@ -4,28 +4,31 @@
 , appdirs
 , dask
 , holoviews
+, hvplot
 , jinja2
 , msgpack-numpy
 , msgpack-python
 , numpy
 , pandas
+, panel
 , python-snappy
 , requests
 , ruamel_yaml
 , six
 , tornado
 , pytest
-, isPy27
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "intake";
-  version = "0.4.4";
-  disabled = isPy27;
+  version = "0.5.3";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "3fc1b7c2949c9b4200ecbbfdff17da126981a1d8d95ccb7b7bcca3e3dd849d5e";
+    sha256 = "1mbjr4xl4i523bg8k08s5986v2289fznd8cr3j3czn5adi8519j7";
   };
 
   checkInputs = [ pytest ];
@@ -33,11 +36,13 @@ buildPythonPackage rec {
     appdirs
     dask
     holoviews
+    hvplot
     jinja2
     msgpack-numpy
     msgpack-python
     numpy
     pandas
+    panel
     python-snappy
     requests
     ruamel_yaml
@@ -45,10 +50,15 @@ buildPythonPackage rec {
     tornado
   ];
 
+  postPatch = ''
+    # Is in setup_requires but not used in setup.py...
+    substituteInPlace setup.py --replace "'pytest-runner'" ""
+  '';
+
+  # test_discover requires driver_with_entrypoints-0.1.dist-info, which is not included in tarball
+  # test_filtered_compressed_cache requires calvert_uk_filter.tar.gz, which is not included in tarball
   checkPhase = ''
-    # test_filtered_compressed_cache requires calvert_uk_filter.tar.gz, which is not included in tarball
-    # test_which assumes python for executable name
-    PATH=$out/bin:$PATH HOME=$(mktemp -d) pytest -k "not test_filtered_compressed_cache and not test_which"
+    PATH=$out/bin:$PATH HOME=$(mktemp -d) pytest -k "not test_discover and not test_filtered_compressed_cache"
   '';
 
   meta = with lib; {

--- a/pkgs/development/python-modules/panel/default.nix
+++ b/pkgs/development/python-modules/panel/default.nix
@@ -11,17 +11,12 @@
 
 buildPythonPackage rec {
   pname = "panel";
-  version = "0.4.0";
+  version = "0.6.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "21fc6729909dba4ba8c9a84b7fadd293322cc2594d15ac73b0f66a5ceffd1f98";
+    sha256 = "04w8jjlf7yz3k84xnacahczc9mmddqyp756rj3n8hclks9c1ww40";
   };
-
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "testpath<0.4" "testpath"
-  '';
 
   propagatedBuildInputs = [
     bokeh

--- a/pkgs/development/python-modules/param/default.nix
+++ b/pkgs/development/python-modules/param/default.nix
@@ -7,11 +7,11 @@
 
 buildPythonPackage rec {
   pname = "param";
-  version = "1.8.2";
+  version = "1.9.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "49927979d4f6c994bcd8f6f7f2b34e3a0a7f0d62404dca6bcae5acde0192bb01";
+    sha256 = "1dbnviszdq3d2k3dfwpimb0adf27yzwm4iyv42rk8xvd8c6p9gdi";
   };
 
   checkInputs = [ flake8 nose ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fixing the intake package broken by #66348.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @costrouc @jonringer @pierothebear 
