### PR TITLE
Add Crossfire and Deliantra multiplayer RPG servers

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -379,6 +379,7 @@
   ./services/editors/emacs.nix
   ./services/editors/infinoted.nix
   ./services/games/crossfire-server.nix
+  ./services/games/deliantra-server.nix
   ./services/games/factorio.nix
   ./services/games/freeciv.nix
   ./services/games/minecraft-server.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -378,6 +378,7 @@
   ./services/display-managers/greetd.nix
   ./services/editors/emacs.nix
   ./services/editors/infinoted.nix
+  ./services/games/crossfire-server.nix
   ./services/games/factorio.nix
   ./services/games/freeciv.nix
   ./services/games/minecraft-server.nix

--- a/nixos/modules/services/games/crossfire-server.nix
+++ b/nixos/modules/services/games/crossfire-server.nix
@@ -1,0 +1,177 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.crossfire-server;
+  serverPort = 13327;
+in {
+  options.services.crossfire-server = {
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        If enabled, the Crossfire game server will be started at boot.
+      '';
+    };
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.crossfire-server;
+      defaultText = "pkgs.crossfire-server";
+      description = ''
+        The package to use for the Crossfire server (and map/arch data, if you
+        don't change dataDir).
+      '';
+    };
+
+    dataDir = mkOption {
+      type = types.str;
+      default = "${cfg.package}/share/crossfire";
+      defaultText = "\${config.services.crossfire.package}/share/crossfire";
+      description = ''
+        Where to load readonly data from -- maps, archetypes, treasure tables,
+        and the like. If you plan to edit the data on the live server (rather
+        than overlaying the crossfire-maps and crossfire-arch packages and
+        nixos-rebuilding), point this somewhere read-write and copy the data
+        there before starting the server.
+      '';
+    };
+
+    stateDir = mkOption {
+      type = types.str;
+      default = "/var/lib/crossfire";
+      description = ''
+        Where to store runtime data (save files, persistent items, etc).
+
+        If left at the default, this will be automatically created on server
+        startup if it does not already exist. If changed, it is the admin's
+        responsibility to make sure that the directory exists and is writeable
+        by the `crossfire` user.
+      '';
+    };
+
+    openFirewall = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to open ports in the firewall for the server.
+      '';
+    };
+
+    configFiles = mkOption {
+      type = types.attrsOf types.str;
+      description = ''
+        Text to append to the corresponding configuration files. Note that the
+        files given in the example are *not* the complete set of files available
+        to customize; look in /etc/crossfire after enabling the server to see
+        the available files, and read the comments in each file for detailed
+        documentation on the format and what settings are available.
+
+        Note that the motd, rules, and news files, if configured here, will
+        overwrite the example files that come with the server, rather than being
+        appended to them as the other configuration files are.
+      '';
+      example = literalExample ''
+        dm_file = '''
+          admin:secret_password:localhost
+          jane:xyzzy:*
+        ''';
+        ban_file = '''
+          # Bob is a jerk
+          bob@*
+          # So is everyone on 192.168.86.255/24
+          *@192.168.86.
+        ''';
+        metaserver2 = '''
+          metaserver2_notification on
+          localhostname crossfire.example.net
+        ''';
+        motd = "Welcome to CrossFire!";
+        news = "No news yet.";
+        rules = "Don't be a jerk.";
+        settings = '''
+          # be nicer to newbies and harsher to experienced players
+          balanced_stat_loss true
+          # don't let players pick up and use admin-created items
+          real_wiz false
+        ''';
+      '';
+      default = {};
+    };
+  };
+
+  config = mkIf cfg.enable {
+    users.users.crossfire = {
+      description     = "Crossfire server daemon user";
+      home            = cfg.stateDir;
+      createHome      = false;
+      isSystemUser    = true;
+      group           = "crossfire";
+    };
+    users.groups.crossfire = {};
+
+    # Merge the cfg.configFiles setting with the default files shipped with
+    # Crossfire.
+    # For most files this consists of reading ${crossfire}/etc/crossfire/${name}
+    # and appending the user setting to it; the motd, news, and rules are handled
+    # specially, with user-provided values completely replacing the original.
+    environment.etc = lib.attrsets.mapAttrs'
+      (name: value: lib.attrsets.nameValuePair "crossfire/${name}" {
+        mode = "0644";
+        text =
+          (optionalString (!elem name ["motd" "news" "rules"])
+            (fileContents "${cfg.package}/etc/crossfire/${name}"))
+          + "\n${value}";
+      }) ({
+        ban_file = "";
+        dm_file = "";
+        exp_table = "";
+        forbid = "";
+        metaserver2 = "";
+        motd = (fileContents "${cfg.package}/etc/crossfire/motd");
+        news = (fileContents "${cfg.package}/etc/crossfire/news");
+        rules = (fileContents "${cfg.package}/etc/crossfire/rules");
+        settings = "";
+        stat_bonus = "";
+      } // cfg.configFiles);
+
+    systemd.services.crossfire-server = {
+      description   = "Crossfire Server Daemon";
+      wantedBy      = [ "multi-user.target" ];
+      after         = [ "network.target" ];
+
+      serviceConfig = mkMerge [
+        {
+          ExecStart = "${cfg.package}/bin/crossfire-server -conf /etc/crossfire -local '${cfg.stateDir}' -data '${cfg.dataDir}'";
+          Restart = "always";
+          User = "crossfire";
+          Group = "crossfire";
+          WorkingDirectory = cfg.stateDir;
+        }
+        (mkIf (cfg.stateDir == "/var/lib/crossfire") {
+          StateDirectory = "crossfire";
+        })
+      ];
+
+      # The crossfire server needs access to a bunch of files at runtime that
+      # are not created automatically at server startup; they're meant to be
+      # installed in $PREFIX/var/crossfire by `make install`. And those files
+      # need to be writeable, so we can't just point at the ones in the nix
+      # store. Instead we take the approach of copying them out of the store
+      # on first run. If `bookarch` already exists, we assume the rest of the
+      # files do as well, and copy nothing -- otherwise we risk ovewriting
+      # server state information every time the server is upgraded.
+      preStart = ''
+        if [ ! -e "${cfg.stateDir}"/bookarch ]; then
+          ${pkgs.rsync}/bin/rsync -a --chmod=u=rwX,go=rX \
+            "${cfg.package}/var/crossfire/" "${cfg.stateDir}/"
+        fi
+      '';
+    };
+
+    networking.firewall = mkIf cfg.openFirewall {
+      allowedTCPPorts = [ serverPort ];
+    };
+  };
+}

--- a/nixos/modules/services/games/deliantra-server.nix
+++ b/nixos/modules/services/games/deliantra-server.nix
@@ -1,0 +1,170 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.deliantra-server;
+  serverPort = 13327;
+in {
+  options.services.deliantra-server = {
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        If enabled, the Deliantra game server will be started at boot.
+      '';
+    };
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.deliantra-server;
+      defaultText = "pkgs.deliantra-server";
+      description = ''
+        The package to use for the Deliantra server (and map/arch data, if you
+        don't change dataDir).
+      '';
+    };
+
+    dataDir = mkOption {
+      type = types.str;
+      default = "${pkgs.deliantra-data}";
+      defaultText = "\${pkgs.deliantra-data}";
+      description = ''
+        Where to store readonly data (maps, archetypes, sprites, etc).
+        Note that if you plan to use the live map editor (rather than editing
+        the maps offline and then nixos-rebuilding), THIS MUST BE WRITEABLE --
+        copy the deliantra-data someplace writeable (say,
+        /var/lib/deliantra/data) and update this option accordingly.
+      '';
+    };
+
+    stateDir = mkOption {
+      type = types.str;
+      default = "/var/lib/deliantra";
+      description = ''
+        Where to store runtime data (save files, persistent items, etc).
+
+        If left at the default, this will be automatically created on server
+        startup if it does not already exist. If changed, it is the admin's
+        responsibility to make sure that the directory exists and is writeable
+        by the `crossfire` user.
+      '';
+    };
+
+    openFirewall = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to open ports in the firewall for the server.
+      '';
+    };
+
+    configFiles = mkOption {
+      type = types.attrsOf types.str;
+      description = ''
+        Contents of the server configuration files. These will be appended to
+        the example configurations the server comes with and overwrite any
+        default settings defined therein.
+
+        The example here is not comprehensive. See the files in
+        /etc/deliantra-server after enabling this module for full documentation.
+      '';
+      example = literalExample ''
+        dm_file = '''
+          admin:secret_password:localhost
+          jane:xyzzy:*
+        ''';
+        motd = "Welcome to Deliantra!";
+        settings = '''
+          # Settings for game mechanics.
+          stat_loss_on_death true
+          armor_max_enchant 7
+        ''';
+        config = '''
+          # Settings for the server daemon.
+          hiscore_url https://deliantra.example.net/scores/
+          max_map_reset 86400
+        ''';
+      '';
+      default = {
+        motd = "";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    users.users.deliantra = {
+      description     = "Deliantra server daemon user";
+      home            = cfg.stateDir;
+      createHome      = false;
+      isSystemUser    = true;
+      group           = "deliantra";
+    };
+    users.groups.deliantra = {};
+
+    # Merge the cfg.configFiles setting with the default files shipped with
+    # Deliantra.
+    # For most files this consists of reading
+    # ${deliantra}/etc/deliantra-server/${name} and appending the user setting
+    # to it.
+    environment.etc = lib.attrsets.mapAttrs'
+      (name: value: lib.attrsets.nameValuePair "deliantra-server/${name}" {
+        mode = "0644";
+        text =
+          # Deliantra doesn't come with a motd file, but respects it if present
+          # in /etc.
+          (optionalString (name != "motd")
+            (fileContents "${cfg.package}/etc/deliantra-server/${name}"))
+          + "\n${value}";
+      }) ({
+        motd = "";
+        settings = "";
+        config = "";
+        dm_file = "";
+      } // cfg.configFiles);
+
+    systemd.services.deliantra-server = {
+      description   = "Deliantra Server Daemon";
+      wantedBy      = [ "multi-user.target" ];
+      after         = [ "network.target" ];
+
+      environment = {
+        DELIANTRA_DATADIR="${cfg.dataDir}";
+        DELIANTRA_LOCALDIR="${cfg.stateDir}";
+        DELIANTRA_CONFDIR="/etc/deliantra-server";
+      };
+
+      serviceConfig = mkMerge [
+        {
+          ExecStart = "${cfg.package}/bin/deliantra-server";
+          Restart = "always";
+          User = "deliantra";
+          Group = "deliantra";
+          WorkingDirectory = cfg.stateDir;
+        }
+        (mkIf (cfg.stateDir == "/var/lib/deliantra") {
+          StateDirectory = "deliantra";
+        })
+      ];
+
+      # The deliantra server needs access to a bunch of files at runtime that
+      # are not created automatically at server startup; they're meant to be
+      # installed in $PREFIX/var/deliantra-server by `make install`. And those
+      # files need to be writeable, so we can't just point at the ones in the
+      # nix store. Instead we take the approach of copying them out of the store
+      # on first run. If `bookarch` already exists, we assume the rest of the
+      # files do as well, and copy nothing -- otherwise we risk ovewriting
+      # server state information every time the server is upgraded.
+      preStart = ''
+        if [ ! -e "${cfg.stateDir}"/bookarch ]; then
+          ${pkgs.rsync}/bin/rsync -a --chmod=u=rwX,go=rX \
+            "${cfg.package}/var/deliantra-server/" "${cfg.stateDir}/"
+        fi
+      '';
+    };
+
+    networking.firewall = mkIf cfg.openFirewall {
+      allowedTCPPorts = [ serverPort ];
+    };
+  };
+}

--- a/pkgs/development/libraries/blitz/default.nix
+++ b/pkgs/development/libraries/blitz/default.nix
@@ -1,0 +1,67 @@
+{ stdenv, lib, fetchFromGitHub, pkg-config, gfortran, texinfo, python, boost
+# Select SIMD alignment width (in bytes) for vectorization.
+, simdWidth ? 1
+# Pad arrays to simdWidth by default?
+# Note: Only useful if simdWidth > 1
+, enablePadding ? false
+# Activate serialization through Boost.Serialize?
+, enableSerialization ? true
+# Activate test-suite?
+# WARNING: Some of the tests require up to 1700MB of memory to compile.
+, doCheck ? true
+}:
+
+let
+  inherit (lib) optional optionals;
+in
+stdenv.mkDerivation rec {
+  pname = "blitz++";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "blitzpp";
+    repo = "blitz";
+    rev = "1.0.1";
+    sha256 = "0nq84vwvvbq7m0my6h835ijfw53bxdp42qjc6kjhk436888qy9rh";
+  };
+
+  nativeBuildInputs = [ pkg-config python texinfo ];
+  buildInputs = [ gfortran texinfo boost ];
+
+  configureFlags =
+    [ "--enable-shared"
+      "--disable-static"
+      "--enable-fortran"
+      "--enable-optimize"
+      "--with-pic=yes"
+      "--enable-html-docs"
+      "--disable-doxygen"
+      "--disable-dot"
+      "--disable-latex-docs"
+      "--enable-simd-width=${toString simdWidth}"
+      "--with-boost=${boost.dev}"
+      "--with-boost-libdir=${boost.out}/lib"
+    ] ++ optional enablePadding "--enable-array-length-padding"
+    ++ optional enableSerialization "--enable-serialization"
+    ++ optional stdenv.is64bit "--enable-64bit";
+
+  enableParallelBuilding = true;
+
+  inherit doCheck;
+  checkTarget = "check-testsuite check-examples";
+
+  meta = with lib; {
+    description = "Fast multi-dimensional array library for C++";
+    homepage = https://sourceforge.net/projects/blitz/;
+    license = licenses.lgpl3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ ToxicFrog ];
+    longDescription = ''
+      Blitz++ is a C++ class library for scientific computing which provides
+      performance on par with Fortran 77/90. It uses template techniques to
+      achieve high performance. Blitz++ provides dense arrays and vectors,
+      random number generators, and small vectors (useful for representing
+      multicomponent or vector fields).
+    '';
+  };
+}

--- a/pkgs/games/crossfire/crossfire-arch.nix
+++ b/pkgs/games/crossfire/crossfire-arch.nix
@@ -1,0 +1,27 @@
+{ stdenv, lib, fetchsvn,
+  version, rev, sha256 }:
+
+stdenv.mkDerivation rec {
+  pname = "crossfire-arch";
+  version = "r${toString rev}";
+
+  src = fetchsvn {
+    url = "http://svn.code.sf.net/p/crossfire/code/arch/trunk/";
+    sha256 = sha256;
+    rev = rev;
+  };
+
+  installPhase = ''
+    mkdir -p "$out"
+    cp -a . "$out/"
+  '';
+
+  meta = with lib; {
+    description = "Archetype data for the Crossfire free MMORPG";
+    homepage = "http://crossfire.real-time.com/";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    hydraPlatforms = [];
+    maintainers = with maintainers; [ ToxicFrog ];
+  };
+}

--- a/pkgs/games/crossfire/crossfire-client.nix
+++ b/pkgs/games/crossfire/crossfire-client.nix
@@ -1,0 +1,32 @@
+{ stdenv, lib, fetchsvn
+, cmake, pkg-config, perl, vala
+, gtk2, pcre, zlib, libpng, fribidi, harfbuzzFull, xorg, util-linux, curl
+, SDL, SDL_image, SDL_mixer, libselinux, libsepol
+, version, rev, sha256
+}:
+
+stdenv.mkDerivation rec {
+  pname = "crossfire-client";
+  version = "r${toString rev}";
+
+  src = fetchsvn {
+    url = "http://svn.code.sf.net/p/crossfire/code/client/trunk/";
+    sha256 = sha256;
+    rev = rev;
+  };
+
+  nativeBuildInputs = [ cmake pkg-config perl vala ];
+  buildInputs = [
+    gtk2 pcre zlib libpng fribidi harfbuzzFull xorg.libpthreadstubs
+    xorg.libXdmcp curl SDL SDL_image SDL_mixer util-linux libselinux libsepol
+  ];
+  hardeningDisable = [ "format" ];
+
+  meta = with lib; {
+    description = "GTKv2 client for the Crossfire free MMORPG";
+    homepage = "http://crossfire.real-time.com/";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ ToxicFrog ];
+  };
+}

--- a/pkgs/games/crossfire/crossfire-maps.nix
+++ b/pkgs/games/crossfire/crossfire-maps.nix
@@ -1,0 +1,27 @@
+{ stdenv, lib, fetchsvn,
+  version, rev, sha256 }:
+
+stdenv.mkDerivation rec {
+  pname = "crossfire-maps";
+  version = "r${toString rev}";
+
+  src = fetchsvn {
+    url = "http://svn.code.sf.net/p/crossfire/code/maps/trunk/";
+    sha256 = sha256;
+    rev = rev;
+  };
+
+  installPhase = ''
+    mkdir -p "$out"
+    cp -a . "$out/"
+  '';
+
+  meta = with lib; {
+    description = "Map data for the Crossfire free MMORPG";
+    homepage = "http://crossfire.real-time.com/";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    hydraPlatforms = [];
+    maintainers = with maintainers; [ ToxicFrog ];
+  };
+}

--- a/pkgs/games/crossfire/crossfire-server.nix
+++ b/pkgs/games/crossfire/crossfire-server.nix
@@ -1,0 +1,37 @@
+{ stdenv, lib, fetchsvn, autoreconfHook,
+  autoconf, automake, libtool, flex, perl, check, pkg-config, python3,
+  version, rev, sha256, maps, arch }:
+
+stdenv.mkDerivation rec {
+  pname = "crossfire-server";
+  version = "r${toString rev}";
+
+  src = fetchsvn {
+    url = "http://svn.code.sf.net/p/crossfire/code/server/trunk/";
+    sha256 = sha256;
+    rev = rev;
+  };
+
+  nativeBuildInputs = [ autoconf automake libtool flex perl check pkg-config python3 ];
+  hardeningDisable = [ "format" ];
+
+  preConfigure = ''
+    ln -s ${arch} lib/arch
+    ln -s ${maps} lib/maps
+    sh autogen.sh
+  '';
+
+  configureFlags = [ "--with-python=${python3}" ];
+
+  postInstall = ''
+    ln -s ${maps} "$out/share/crossfire/maps"
+  '';
+
+  meta = with lib; {
+    description = "Server for the Crossfire free MMORPG";
+    homepage = "http://crossfire.real-time.com/";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ ToxicFrog ];
+  };
+}

--- a/pkgs/games/crossfire/default.nix
+++ b/pkgs/games/crossfire/default.nix
@@ -1,0 +1,22 @@
+{ callPackage, ... }:
+
+rec {
+  crossfire-server = callPackage ./crossfire-server.nix {
+    version = "latest";
+    rev = 22111;
+    sha256 = "04fjif6zv642n2zlw27cgzkak2kknwrxqzg42bvzl7q901bsr9l7";
+    maps = crossfire-maps; arch = crossfire-arch;
+  };
+
+  crossfire-arch = callPackage ./crossfire-arch.nix {
+    version = "latest";
+    rev = 22111;
+    sha256 = "0l4rp3idvbhknpxxs0w4i4nqfg01wblzm4v4j375xwxxbf00j0ms";
+  };
+
+  crossfire-maps = callPackage ./crossfire-maps.nix {
+    version = "latest";
+    rev = 22111;
+    sha256 = "1dwfc84acjvbjgjakkb8z8pdlksbsn90j0z8z8rq37lqx0kx1sap";
+  };
+}

--- a/pkgs/games/crossfire/default.nix
+++ b/pkgs/games/crossfire/default.nix
@@ -1,6 +1,12 @@
 { callPackage, ... }:
 
 rec {
+  crossfire-client = callPackage ./crossfire-client.nix {
+    version = "1.75.0";
+    rev = 21760;
+    sha256 = "0b42sak8hj60nywfswkps777asy9p8r9wsn7pmj2nqbd29ng1p9d";
+  };
+
   crossfire-server = callPackage ./crossfire-server.nix {
     version = "latest";
     rev = 22111;

--- a/pkgs/games/deliantra/0001-abs.patch
+++ b/pkgs/games/deliantra/0001-abs.patch
@@ -1,0 +1,17 @@
+--- a/utils/cfhq2xa.C
++++ b/utils/cfhq2xa.C
+@@ -182,10 +182,10 @@ static inline bool Diff (pixel w1, pixel w2)
+   pixel YUV1 = RGBAtoYUVA (w1);
+   pixel YUV2 = RGBAtoYUVA (w2);
+
+-  return ((abs (((YUV1 >> Rshift) & Cmask) - ((YUV2 >> Rshift) & Cmask)) > trY) ||
+-          (abs (((YUV1 >> Gshift) & Cmask) - ((YUV2 >> Gshift) & Cmask)) > trU) ||
+-          (abs (((YUV1 >> Bshift) & Cmask) - ((YUV2 >> Bshift) & Cmask)) > trV) ||
+-          (abs (((YUV1 >> Ashift) & Cmask) - ((YUV2 >> Ashift) & Cmask)) > trA) );
++  return ((abs ((signed int)((YUV1 >> Rshift) & Cmask) - (signed int)((YUV2 >> Rshift) & Cmask)) > trY) ||
++          (abs ((signed int)((YUV1 >> Gshift) & Cmask) - (signed int)((YUV2 >> Gshift) & Cmask)) > trU) ||
++          (abs ((signed int)((YUV1 >> Bshift) & Cmask) - (signed int)((YUV2 >> Bshift) & Cmask)) > trV) ||
++          (abs ((signed int)((YUV1 >> Ashift) & Cmask) - (signed int)((YUV2 >> Ashift) & Cmask)) > trA) );
+ }
+
+ static void

--- a/pkgs/games/deliantra/0002-datadir.patch
+++ b/pkgs/games/deliantra/0002-datadir.patch
@@ -1,0 +1,11 @@
+--- a/utils/cfutil.in
++++ b/utils/cfutil.in
+@@ -27,7 +27,7 @@ use common::sense;
+ my $prefix      = "@prefix@";
+ my $exec_prefix = "@exec_prefix@";
+ my $datarootdir = "@datarootdir@";
+-my $DATADIR     = "@datadir@/@PACKAGE@";
++my $DATADIR     = $ENV{'DELIANTRA_DATADIR'} || "@datadir@/@PACKAGE@";
+
+ my $CONVERT  = "@CONVERT@";
+ my $IDENTIFY = "@IDENTIFY@";

--- a/pkgs/games/deliantra/default.nix
+++ b/pkgs/games/deliantra/default.nix
@@ -1,0 +1,10 @@
+pkgs:
+
+let
+  callPackage = pkgs.callPackage;
+in {
+  deliantra-server = callPackage ./deliantra-server.nix {};
+  deliantra-arch = callPackage ./deliantra-arch.nix {};
+  deliantra-maps = callPackage ./deliantra-maps.nix {};
+  deliantra-data = callPackage ./deliantra-data.nix {};
+}

--- a/pkgs/games/deliantra/deliantra-arch.nix
+++ b/pkgs/games/deliantra/deliantra-arch.nix
@@ -1,0 +1,25 @@
+{ stdenv, lib, fetchurl, deliantra-server }:
+
+stdenv.mkDerivation rec {
+  pname = "deliantra-arch";
+  version = "3.1";
+
+  src = fetchurl {
+    url = "http://dist.schmorp.de/deliantra/${pname}-${version}.tar.xz";
+    sha256 = "1xzhv48g90hwkzgx9nfjm81ivg6hchkik9ldimi8ijb4j393kvsz";
+  };
+
+  installPhase = ''
+    mkdir -p "$out"
+    export DELIANTRA_DATADIR="$out"
+    ${deliantra-server}/bin/cfutil --install-arch .
+  '';
+
+  meta = with lib; {
+    description = "Archetype data for the Deliantra free MMORPG";
+    homepage = "http://www.deliantra.net/";
+    license = with licenses; [ gpl2Plus agpl3Plus ];
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ ToxicFrog ];
+  };
+}

--- a/pkgs/games/deliantra/deliantra-data.nix
+++ b/pkgs/games/deliantra/deliantra-data.nix
@@ -1,0 +1,21 @@
+{ stdenv, lib, fetchurl, deliantra-maps, deliantra-arch, deliantra-server, symlinkJoin }:
+
+symlinkJoin rec {
+  name = "deliantra-data-${version}";
+  version = "M${deliantra-maps.version}+A${deliantra-arch.version}";
+
+  paths = [
+    deliantra-maps
+    deliantra-arch
+    "${deliantra-server}/share/deliantra-server"
+  ];
+
+  meta = with lib; {
+    description = "Combined game data (maps + archetypes) for the Deliantra free MMORPG";
+    homepage = "http://www.deliantra.net/";
+    license = with licenses; [ gpl2Plus agpl3Plus ];
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ ToxicFrog ];
+    hydraPlatforms = [];
+  };
+}

--- a/pkgs/games/deliantra/deliantra-maps.nix
+++ b/pkgs/games/deliantra/deliantra-maps.nix
@@ -1,0 +1,25 @@
+{ stdenv, lib, fetchurl, deliantra-server }:
+
+stdenv.mkDerivation rec {
+  pname = "deliantra-maps";
+  version = "3.1";
+
+  src = fetchurl {
+    url = "http://dist.schmorp.de/deliantra/${pname}-${version}.tar.xz";
+    sha256 = "0zbwzya28s1xpnbrmqkqvfrzns03zdjd8a9w9nk665aif6rw2zbz";
+  };
+
+  installPhase = ''
+    mkdir -p "$out/maps"
+    export DELIANTRA_DATADIR="$out"
+    ${deliantra-server}/bin/cfutil --install-maps .
+  '';
+
+  meta = with lib; {
+    description = "Map data for the Deliantra free MMORPG";
+    homepage = "http://www.deliantra.net/";
+    license = with licenses; [ gpl2Plus agpl3Plus ];
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ ToxicFrog ];
+  };
+}

--- a/pkgs/games/deliantra/deliantra-server.nix
+++ b/pkgs/games/deliantra/deliantra-server.nix
@@ -1,0 +1,48 @@
+{ stdenv, lib, fetchurl, perlPackages
+, autoconf, perl, gperf, optipng, pngnq, rsync, imagemagick, blitz
+, pkg-config, glib, boost, makeWrapper
+}:
+
+let
+  perl-deps = with perlPackages; [
+    AnyEvent AnyEventAIO AnyEventBDB AnyEventIRC
+    CompressLZF commonsense Coro CoroEV
+    Deliantra DigestSHA1 EV PodPOM SafeHole URI YAMLLibYAML
+  ];
+in
+stdenv.mkDerivation rec {
+  pname = "deliantra-server";
+  version = "3.1";
+
+  src = fetchurl {
+    url = "http://dist.schmorp.de/deliantra/${pname}-${version}.tar.xz";
+    sha256 = "0v0m2m9fxq143aknh7jb3qj8bnpjrs3bpbbx07c18516y3izr71d";
+  };
+
+  nativeBuildInputs = [
+    autoconf perl gperf optipng pngnq rsync imagemagick
+    pkg-config makeWrapper
+  ];
+  propagatedBuildInputs = perl-deps;
+  buildInputs = [
+    blitz boost glib
+  ];
+
+  hardeningDisable = [ "format" ];
+  patches = [
+    ./0001-abs.patch
+    ./0002-datadir.patch
+  ];
+  postFixup = ''
+    wrapProgram $out/bin/cfutil --prefix PERL5LIB : $PERL5LIB
+    wrapProgram $out/bin/deliantra-server --prefix PERL5LIB : $PERL5LIB
+  '';
+
+  meta = with lib; {
+    description = "Server for the Deliantra free MMORPG";
+    homepage = "http://www.deliantra.net/";
+    license = with licenses; [ gpl2Plus agpl3Plus ];
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ ToxicFrog ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1971,6 +1971,8 @@ in
 
   blink = libsForQt5.callPackage ../applications/networking/instant-messengers/blink { };
 
+  blitz = callPackage ../development/libraries/blitz { };
+
   blockbook = callPackage ../servers/blockbook { };
 
   blockhash = callPackage ../tools/graphics/blockhash { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29110,6 +29110,9 @@ in
 
   cuyo = callPackage ../games/cuyo { };
 
+  inherit (import ../games/deliantra pkgs)
+    deliantra-server deliantra-arch deliantra-maps deliantra-data;
+
   devilutionx = callPackage ../games/devilutionx {};
 
   dhewm3 = callPackage ../games/dhewm3 {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29096,6 +29096,9 @@ in
 
   crawl = callPackage ../games/crawl { };
 
+  inherit (import ../games/crossfire pkgs)
+    crossfire-server crossfire-arch crossfire-maps;
+
   crrcsim = callPackage ../games/crrcsim {};
 
   curseofwar = callPackage ../games/curseofwar { SDL = null; };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29097,7 +29097,7 @@ in
   crawl = callPackage ../games/crawl { };
 
   inherit (import ../games/crossfire pkgs)
-    crossfire-server crossfire-arch crossfire-maps;
+    crossfire-server crossfire-arch crossfire-maps crossfire-client;
 
   crrcsim = callPackage ../games/crrcsim {};
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -3818,6 +3818,23 @@ let
      };
   };
 
+  CoroEV = buildPerlPackage rec {
+    pname = "CoroEV";
+    version = "6.55";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/Coro-${version}.tar.gz";
+      sha256 = "43d79c027170fcda4ca0ee92734605bc95e122686f5071b94d90764c81ae8a30";
+    };
+    buildInputs = [ CanaryStability ];
+    propagatedBuildInputs = [ AnyEvent Coro EV Guard commonsense ];
+    meta = {
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
+    preConfigure = ''
+      cd EV
+    '';
+  };
+
   Corona = buildPerlPackage {
      pname = "Corona";
      version = "0.1004";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -457,6 +457,20 @@ let
     };
   };
 
+  AnyEventIRC = buildPerlPackage rec {
+    pname = "AnyEvent-IRC";
+    version = "0.97";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/E/EL/ELMEX/${pname}-${version}.tar.gz";
+      sha256 = "bfd7cf645c3c8c611471057128611447e20f1adf01516c69624cbd8bc77f5bf0";
+    };
+    propagatedBuildInputs = [ AnyEvent ObjectEvent commonsense ];
+    meta = {
+      description = "An event based IRC protocol client API";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   AnyEventRabbitMQ = buildPerlPackage {
     pname = "AnyEvent-RabbitMQ";
     version = "1.22";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -5598,6 +5598,19 @@ let
     };
   };
 
+  Deliantra = buildPerlPackage rec {
+    pname = "Deliantra";
+    version = "2.01";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/${pname}-${version}.tar.gz";
+      sha256 = "2716d9b1f05627d60942ce0634b9c1a25109b164818285d45b609ae8596e2b17";
+    };
+    propagatedBuildInputs = [ AnyEvent CompressLZF JSONXS commonsense ];
+    meta = {
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   DevelCaller = buildPerlPackage {
     pname = "Devel-Caller";
     version = "2.06";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -3289,6 +3289,18 @@ let
     };
   };
 
+   CompressLZF = buildPerlPackage rec {
+    pname = "Compress-LZF";
+    version = "3.8";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/${pname}-${version}.tar.gz";
+      sha256 = "5d1f5df48ce13b4dee1cc9f278ecdbf8177877b0b98815a4eb3c91c3466716f2";
+    };
+    meta = {
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   CompressRawBzip2 = buildPerlPackage {
     pname = "Compress-Raw-Bzip2";
     version = "2.096";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -16103,6 +16103,20 @@ let
     };
   };
 
+  ObjectEvent = buildPerlPackage rec {
+    pname = "Object-Event";
+    version = "1.23";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/E/EL/ELMEX/${pname}-${version}.tar.gz";
+      sha256 = "ab6bb80508f4fddaf2d51b20ca876aab038582a86b5228e6435411348af53c82";
+    };
+    propagatedBuildInputs = [ AnyEvent commonsense ];
+    meta = {
+      description = "A class that provides an event callback interface";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   ObjectInsideOut = buildPerlModule {
     pname = "Object-InsideOut";
     version = "4.05";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -6377,6 +6377,19 @@ let
     };
   };
 
+  DigestMD5 = buildPerlPackage rec {
+    pname = "Digest-MD5";
+    version = "2.55";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/G/GA/GAAS/${pname}-${version}.tar.gz";
+      sha256 = "03b198a2d14425d951e5e50a885d3818c3162c8fe4c21e18d7798a9a179d0e3c";
+    };
+    meta = {
+      description = "Perl interface to the MD-5 algorithm";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   DigestMD5File = buildPerlPackage {
     pname = "Digest-MD5-File";
     version = "0.08";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -5607,7 +5607,7 @@ let
     };
     propagatedBuildInputs = [ AnyEvent CompressLZF JSONXS commonsense ];
     meta = {
-      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -1290,6 +1290,22 @@ let
     '';
   };
 
+  BDB = buildPerlPackage rec {
+    pname = "BDB";
+    version = "1.92";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/${pname}-${version}.tar.gz";
+      sha256 = "a3f2ca9d2baefc1aaa40908b2f9cb9292fda3e7d797e38bbd78eabb9d9daeb6b";
+    };
+    NIX_CFLAGS_COMPILE = "-I${pkgs.db4.dev}/include";
+    NIX_CFLAGS_LINK = "-L${pkgs.db4.out}/lib -ldb";
+    buildInputs = [ pkgs.db4 ];
+    propagatedBuildInputs = [ commonsense ];
+    meta = {
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   BHooksEndOfScope = buildPerlPackage {
     pname = "B-Hooks-EndOfScope";
     version = "0.24";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -391,6 +391,20 @@ let
     };
   };
 
+  AnyEventBDB = buildPerlPackage rec {
+    pname = "AnyEvent-BDB";
+    version = "1.1";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/${pname}-${version}.tar.gz";
+      sha256 = "93e36010940464626e5f31b9faedd65e12ed8d1abf16ce052febf23f495aefc8";
+    };
+    buildInputs = [ CanaryStability ];
+    propagatedBuildInputs = [ BDB AnyEvent ];
+    meta = {
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   AnyEventCacheDNS = buildPerlModule {
     pname = "AnyEvent-CacheDNS";
     version = "0.08";


### PR DESCRIPTION
###### Motivation for this change

This adds the necessary packages and NixOS configuration options to self-host a Crossfire or Deliantra server (a fork of an older version of Crossfire, with changes focusing on UX and new-player experience). Or both! Crossfire -- which saw its last official release five years ago, but has been under constant development since -- gets both a `-stable` version for the latest release and a `-latest` version for the SVN build.

It also includes version 1.73.0 of the Crossfire GTK client.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
