### PR TITLE
maestral: init at 0.2.6

### DIFF
--- a/pkgs/applications/networking/maestral/default.nix
+++ b/pkgs/applications/networking/maestral/default.nix
@@ -1,0 +1,38 @@
+{ lib, python3Packages, fetchFromGitHub
+, withGui ? false, wrapQtAppsHook ? null }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "maestral${lib.optionalString withGui "-gui"}";
+  version = "0.2.6";
+
+  src = fetchFromGitHub {
+    owner = "SamSchott";
+    repo = "maestral-dropbox";
+    rev = "v${version}";
+    sha256 = "1nfjm58f6hnqbx9xnz2h929s2175ka1yf5jjlk4i60v0wppnrrdf";
+  };
+
+  disabled = python3Packages.pythonOlder "3.6";
+
+  propagatedBuildInputs = (with python3Packages; [
+    blinker click dropbox keyring keyrings-alt requests u-msgpack-python watchdog
+  ] ++ lib.optional withGui pyqt5);
+
+  nativeBuildInputs = lib.optional withGui wrapQtAppsHook;
+
+  postInstall = lib.optionalString withGui ''
+    makeQtWrapper $out/bin/maestral $out/bin/maestral-gui \
+      --add-flags gui
+  '';
+
+  # no tests
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Open-source Dropbox client for macOS and Linux";
+    license = licenses.mit;
+    maintainers = with maintainers; [ peterhoeg ];
+    platforms = platforms.unix;
+    inherit (src.meta) homepage;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20391,6 +20391,10 @@ in
 
   dropbox-cli = callPackage ../applications/networking/dropbox/cli.nix { };
 
+  maestral = callPackage ../applications/networking/maestral { };
+
+  maestral-gui = libsForQt5.callPackage ../applications/networking/maestral { withGui = true; };
+
   insync = callPackage ../applications/networking/insync { };
 
   libstrangle = callPackage ../tools/X11/libstrangle {


### PR DESCRIPTION
###### Motivation for this change

Open Source dropbox client - works great!

Cc: @ttuegel

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
