### PR TITLE
icedtea_web: 1.7.1 -> 1.8.3 (fixes CVE-2019-10185, CVE-2019-10181, CVE-2019-10182)

### DIFF
--- a/pkgs/development/compilers/icedtea-web/default.nix
+++ b/pkgs/development/compilers/icedtea-web/default.nix
@@ -46,6 +46,11 @@ stdenv.mkDerivation rec {
 
   mozillaPlugin = "/lib";
 
+  postInstall = ''
+    mkdir -p $out/share/applications
+    cp javaws.desktop itweb-settings.desktop policyeditor.desktop $out/share/applications
+  '';
+
   meta = {
     description = "Java web browser plugin and an implementation of Java Web Start";
     longDescription = ''

--- a/pkgs/development/compilers/icedtea-web/default.nix
+++ b/pkgs/development/compilers/icedtea-web/default.nix
@@ -1,24 +1,45 @@
-{ stdenv, fetchurl, jdk, gtk2, xulrunner, zip, pkgconfig, perl, npapi_sdk, bash, bc }:
+{ stdenv, fetchFromGitHub, cargo, rustc, autoreconfHook, jdk, gtk2, xulrunner, zip, pkgconfig, npapi_sdk, bash, bc }:
 
 stdenv.mkDerivation rec {
   name = "icedtea-web-${version}";
 
-  version = "1.7.1";
+  version = "1.8.3";
 
-  src = fetchurl {
-    url = "http://icedtea.wildebeest.org/download/source/${name}.tar.gz";
-    sha256 = "1b9z0i9b1dsc2qpfdzbn2fi4vi3idrhm7ig45g1ny40ymvxcwwn9";
+  src = fetchFromGitHub {
+    owner = "AdoptOpenJDK";
+    repo = "IcedTea-Web";
+    rev = name;
+    sha256 = "0bm5k11i2vgb54ch1bawsmjbwnqnp04saadwm2f2mggmmdc6b1qq";
   };
 
-  nativeBuildInputs = [ pkgconfig bc perl ];
-  buildInputs = [ gtk2 xulrunner zip npapi_sdk ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig bc ];
+  buildInputs = [ cargo rustc gtk2 xulrunner zip npapi_sdk ];
 
   preConfigure = ''
     #patchShebangs javac.in
     configureFlagsArray+=("BIN_BASH=${bash}/bin/bash")
   '';
 
+  patches = [ ./patches/0001-make-cargo-work-with-nix-build-on-linux.patch ];
+
+  doCheck = true;
+  preCheck = ''
+    # Needed for the below rust-launcher tests to pass
+    # dirs_paths_helper::tests::check_config_files_paths
+    # dirs_paths_helper::tests::check_legacy_config_files_paths
+
+    mkdir -p $HOME/.icedtea
+    touch $HOME/.icedtea/deployment.properties
+
+    mkdir -p $XDG_CONFIG_HOME/icedtea-web
+    touch $XDG_CONFIG_HOME/icedtea-web/deployment.properties
+  '';
+
+  HOME = "/build";
+  XDG_CONFIG_HOME = "/build";
+
   configureFlags = [
+    "--with-itw-libs=DISTRIBUTION"
     "--with-jdk-home=${jdk.home}"
     "--disable-docs"
   ];

--- a/pkgs/development/compilers/icedtea-web/default.nix
+++ b/pkgs/development/compilers/icedtea-web/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
       programming language and an implementation of Java Web Start, originally
       based on the NetX project.
     '';
-    homepage = http://icedtea.classpath.org/wiki/IcedTea-Web;
+    homepage = https://github.com/adoptopenjdk/icedtea-web;
     maintainers = with stdenv.lib.maintainers; [ wizeman ];
     platforms = stdenv.lib.platforms.linux;
   };

--- a/pkgs/development/compilers/icedtea-web/default.nix
+++ b/pkgs/development/compilers/icedtea-web/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cargo, rustc, autoreconfHook, jdk, gtk2, xulrunner, zip, pkgconfig, npapi_sdk, bash, bc }:
+{ stdenv, fetchFromGitHub, cargo, rustc, autoreconfHook, jdk, glib, xulrunner, zip, pkgconfig, npapi_sdk, bash, bc }:
 
 stdenv.mkDerivation rec {
   name = "icedtea-web-${version}";
@@ -13,10 +13,9 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig bc ];
-  buildInputs = [ cargo rustc gtk2 xulrunner zip npapi_sdk ];
+  buildInputs = [ cargo rustc glib xulrunner zip npapi_sdk ];
 
   preConfigure = ''
-    #patchShebangs javac.in
     configureFlagsArray+=("BIN_BASH=${bash}/bin/bash")
   '';
 

--- a/pkgs/development/compilers/icedtea-web/patches/0001-make-cargo-work-with-nix-build-on-linux.patch
+++ b/pkgs/development/compilers/icedtea-web/patches/0001-make-cargo-work-with-nix-build-on-linux.patch
@@ -1,0 +1,46 @@
+Subject: [PATCH] make cargo work with nix-build on linux
+
+---
+ .cargo/config            | 2 ++
+ rust-launcher/Cargo.lock | 4 ++++
+ rust-launcher/Cargo.toml | 7 ++++---
+ 3 files changed, 10 insertions(+), 3 deletions(-)
+ create mode 100644 .cargo/config
+ create mode 100644 rust-launcher/Cargo.lock
+
+diff --git a/.cargo/config b/.cargo/config
+new file mode 100644
+index 0000000..03ec4a2
+--- /dev/null
++++ b/.cargo/config
+@@ -0,0 +1,2 @@
++[net]
++offline=true
+diff --git a/rust-launcher/Cargo.lock b/rust-launcher/Cargo.lock
+new file mode 100644
+index 0000000..6055cc0
+--- /dev/null
++++ b/rust-launcher/Cargo.lock
+@@ -0,0 +1,4 @@
++[[package]]
++name = "launcher"
++version = "1.8.0"
++
+diff --git a/rust-launcher/Cargo.toml b/rust-launcher/Cargo.toml
+index 61ee308..5e6e91b 100644
+--- a/rust-launcher/Cargo.toml
++++ b/rust-launcher/Cargo.toml
+@@ -3,6 +3,7 @@ name = "launcher"
+ version = "1.8.0"
+ authors = ["https://icedtea.classpath.org/wiki/IcedTea-Web"]
+ 
+-[dependencies]
+-[target.'cfg(windows)'.dependencies]
+-dunce = "0.1.1"
++[workspace]
++# We need this too or cargo will fail.  Some files seem to be copied around and
++# cargo thinks we are in a workspace, so let's exclude everything.
++exclude = ["*"]
+-- 
+2.19.2
+


### PR DESCRIPTION
Use the new official repository on GitHub and build the new launcher written in
Rust.

Also fixes the following security vulnerabilities:

- CVE-2019-10185: zip-slip attack during auto-extraction of a JAR file.

- CVE-2019-10181: executable code could be injected in a JAR file without
  compromising the signature verification.

- CVE-2019-10182: improper path sanitization from <jar/> elements in JNLP
  files.

References:
https://github.com/AdoptOpenJDK/IcedTea-Web/issues/327

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Manual testing:

- download JNLP examples from https://docs.oracle.com/javase/tutorial/deployment/webstart/examplesIndex.html
- run examples with `./result/bin/javaws <path to JNLP file>`
- verified that `./result/bin/itweb-settings` launches with no errors
- verified that `./result/bin/policyeditor` launches with no errors

###### Notify maintainers

cc @grahamc (NixOS security team)
