### PR TITLE
pptp: Fix shebangs

### DIFF
--- a/pkgs/tools/networking/pptp/default.nix
+++ b/pkgs/tools/networking/pptp/default.nix
@@ -1,26 +1,29 @@
-{ stdenv, fetchurl, perl, ppp, iproute, which }:
+{ stdenv, fetchurl, perl, ppp, iproute }:
 
 stdenv.mkDerivation rec {
-  name = "pptp-${version}";
+  pname = "pptp";
   version = "1.10.0";
 
   src = fetchurl {
-    url = "mirror://sourceforge/pptpclient/${name}.tar.gz";
+    url = "mirror://sourceforge/pptpclient/${pname}-${version}.tar.gz";
     sha256 = "1x2szfp96w7cag2rcvkdqbsl836ja5148zzfhaqp7kl7wjw2sjc2";
   };
 
-  patchPhase =
-    ''
-      sed -e 's/install -o root/install/' -i Makefile
-    '';
-  preConfigure =
-    ''
-      makeFlagsArray=( IP=${iproute}/bin/ip PPPD=${ppp}/sbin/pppd \
-                       BINDIR=$out/sbin MANDIR=$out/share/man/man8 \
-                       PPPDIR=$out/etc/ppp )
-    '';
+  prePatch = ''
+    substituteInPlace Makefile --replace 'install -o root' 'install'
+  '';
 
-  nativeBuildInputs = [ perl which ];
+  preConfigure = ''
+    makeFlagsArray=( IP=${iproute}/bin/ip PPPD=${ppp}/sbin/pppd \
+                     BINDIR=$out/sbin MANDIR=$out/share/man/man8 \
+                     PPPDIR=$out/etc/ppp )
+  '';
+
+  buildInputs = [ perl ];
+
+  postFixup = ''
+    patchShebangs $out
+  '';
 
   meta = with stdenv.lib; {
     description = "PPTP client for Linux";


### PR DESCRIPTION
###### Motivation for this change
- Remove `which` as build-time input
- Use substituteInPlace instead of sed (warns if it fails to replace)
- Use perl in buildInputs as it's a run-time dependency
- Patch shebangs manually, not sure why fixupPhase doesn't do it

Fixes #11563 
---

You can test whether it's not completely broken with:
```
$ sudo mkdir -p /etc/ppp/peers
$ sudo ./result/bin/pptpsetup --create TUNNEL --server SERVER --username USER --password PASSWOWRD

$ ./result/bin/pptp localhost
anon warn[pptp_gre_bind:pptp_gre.c:102]: socket: Operation not permitted
anon fatal[main:pptp.c:360]: Cannot bind GRE socket, aborting.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).