### PR TITLE
pure-prompt: init at 1.12.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3961,6 +3961,12 @@
     github = "oyren";
     name = "Moritz Scheuren";
   };
+  pablovsky = {
+    email = "dealberapablo07@gmail.com";
+    github = "pablo1107";
+    githubId = 17091659;
+    name = "Pablo Andres Dealbera";
+  };
   pacien = {
     email = "b4gx3q.nixpkgs@pacien.net";
     github = "pacien";

--- a/pkgs/shells/zsh/pure-prompt/default.nix
+++ b/pkgs/shells/zsh/pure-prompt/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub }:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  pname = "pure-prompt";
+  version = "1.12.0";
+
+  src = fetchFromGitHub {
+    owner = "sindresorhus";
+    repo = "pure";
+    rev = "v${version}";
+    sha256 = "1h04z7rxmca75sxdfjgmiyf1b5z2byfn6k4srls211l0wnva2r5y";
+  };
+
+  installPhase = ''
+    OUTDIR="$out/share/zsh/site-functions"
+    mkdir -p "$OUTDIR"
+    cp pure.zsh "$OUTDIR/prompt_pure_setup"
+    cp async.zsh "$OUTDIR/async"
+  '';
+
+  meta = {
+    description = "Pretty, minimal and fast ZSH prompt";
+    homepage = https://github.com/sindresorhus/pure;
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ pacien ];
+  };
+}

--- a/pkgs/shells/zsh/pure-prompt/default.nix
+++ b/pkgs/shells/zsh/pure-prompt/default.nix
@@ -25,6 +25,6 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/sindresorhus/pure;
     license = licenses.mit;
     platforms = platforms.all;
-    maintainers = with maintainers; [ pacien ];
+    maintainers = with maintainers; [ pacien pablovsky ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5551,6 +5551,8 @@ in
 
   pubs = callPackage ../tools/misc/pubs {};
 
+  pure-prompt = callPackage ../shells/zsh/pure-prompt { };
+
   pv = callPackage ../tools/misc/pv { };
 
   pwgen = callPackage ../tools/security/pwgen { };


### PR DESCRIPTION
###### Motivation for this change

This PR adds a package for [pure](https://github.com/sindresorhus/pure), a "pretty, minimal and fast ZSH prompt".


Usage example that might be useful to users and reviewers:

```nix
{
  programs.zsh = {
    interactiveShellInit = ''
      fpath+=("${pkgs.pure-prompt}/share/zsh/site-functions")
    '';
    promptInit = ''
      if [ "$TERM" != dumb ]; then
        autoload -U promptinit && promptinit && prompt pure
      fi
    '';
  };
}
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).