### PR TITLE
zsh-better-npm-completion: init at 2017-07-02

### DIFF
--- a/pkgs/shells/zsh/zsh-better-npm-completion/default.nix
+++ b/pkgs/shells/zsh/zsh-better-npm-completion/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "zsh-better-npm-completion";
+  version = "unstable-2017-07-02";
+
+  src = fetchFromGitHub {
+    owner = "lukechilds";
+    repo = pname;
+    rev = "b61f6bb4e640728c42ae84ca55a575ee88c60fe8";
+    sha256 = "00c1gdsam0z6v09fvz7hyl0zgmgnwbf59i1yrbkrz08frjlr16ax";
+  };
+
+  installPhase = ''
+    install -D -m 0444 zsh-better-npm-completion.plugin.zsh \
+      $out/share/zsh/plugins/zsh-better-npm-completion/zsh-better-npm-completion.plugin.zsh
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Better completion for npm";
+    homepage = https://github.com/lukechilds/zsh-better-npm-completion;
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ gerschtli ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7106,6 +7106,8 @@ in
 
   zsh-autoenv = callPackage ../tools/misc/zsh-autoenv { };
 
+  zsh-better-npm-completion = callPackage ../shells/zsh/zsh-better-npm-completion { };
+
   zsh-git-prompt = callPackage ../shells/zsh/zsh-git-prompt { };
 
   zsh-history-substring-search = callPackage ../shells/zsh/zsh-history-substring-search { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Init zsh plugin `zsh-better-npm-completion` at last available commit, unfortunately there are now tags in the upstream repo.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
