### PR TITLE
liquidprompt: init at 2018-05-21

### DIFF
--- a/pkgs/shells/liquidprompt/default.nix
+++ b/pkgs/shells/liquidprompt/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "liquidprompt";
+  version = "unstable-2018-05-21";
+
+  src = fetchFromGitHub {
+    owner = "nojhan";
+    repo = pname;
+    rev = "eda83efe4e0044f880370ed5e92aa7e3fdbef971";
+    sha256 = "1p7ah3x850ajpq07xvxxd7fx2i67cf0n71ww085g32k9fwij4rd4";
+  };
+
+  installPhase = ''
+    install -D -m 0444 liquidprompt $out/bin/liquidprompt
+    install -D -m 0444 liquidpromptrc-dist $out/share/doc/liquidprompt/liquidpromptrc-dist
+    install -D -m 0444 liquid.theme $out/share/doc/liquidprompt/liquid.theme
+
+    install -D -m 0444 liquidprompt.plugin.zsh \
+      $out/share/zsh/plugins/liquidprompt/liquidprompt.plugin.zsh
+    install -D -m 0444 liquidprompt \
+      $out/share/zsh/plugins/liquidprompt/liquidprompt
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A full-featured & carefully designed adaptive prompt for Bash & Zsh";
+    homepage = https://github.com/nojhan/liquidprompt;
+    license = licenses.agpl3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ gerschtli ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7177,6 +7177,8 @@ in
 
   ksh = callPackage ../shells/ksh { };
 
+  liquidprompt = callPackage ../shells/liquidprompt { };
+
   mksh = callPackage ../shells/mksh { };
 
   oh = callPackage ../shells/oh { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add liquidprompt package at 2018-05-21. Unfortunately the last tag in the repo is a while back and missing features, so I took the rev of the most recent commit.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

