### PR TITLE
glm: 0.9.8.5 -> 0.9.9.5

### DIFF
--- a/pkgs/development/libraries/glm/default.nix
+++ b/pkgs/development/libraries/glm/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, fetchzip, cmake }:
 
 stdenv.mkDerivation rec {
-  version = "0.9.8.5";
+  version = "0.9.9.5";
   name = "glm-${version}";
 
   src = fetchzip {
     url = "https://github.com/g-truc/glm/releases/download/${version}/${name}.zip";
-    sha256 = "0dkfj4hin3am9fxgcvwr5gj0h9y52x7wa03lfwb3q0bvaj1rsly2";
+    sha256 = "1rn875y5fqqr350w05bbvd5cbhzq90nbqlv1bcrm9664pih2glm5";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -16,15 +16,10 @@ stdenv.mkDerivation rec {
   cmakeConfigureFlags = [ "-DGLM_INSTALL_ENABLE=off" ];
 
   # fetch newer version of platform.h which correctly supports gcc 7.3
-  gcc7PlatformPatch = fetchurl {
-    url = "https://raw.githubusercontent.com/g-truc/glm/384dab02e45a8ad3c1a3fa0906e0d5682c5b27b9/glm/simd/platform.h";
-    sha256 = "0ym0sgwznxhfyi014xs55x3ql7r65fjs34sqb5jiaffkdhkqgzia";
-  };
 
   postPatch = ''
     substituteInPlace CMakeLists.txt \
       --replace '"''${CMAKE_CURRENT_BINARY_DIR}/''${GLM_INSTALL_CONFIGDIR}' '"''${GLM_INSTALL_CONFIGDIR}'
-    cp ${gcc7PlatformPatch} glm/simd/platform.h
   '';
 
   NIX_CFLAGS_COMPILE = stdenv.lib.optionals stdenv.isDarwin [


### PR DESCRIPTION
Update glm package to latest version

Builds; not tested in action

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Motivation for this change
Package version update to the latest. API has changed lately, and 0.9.8 does not work with new applications.
Removed GCC7 platform patch, ported from newer glm - commit `384dab02e45a8` (from which the patch is ported) is already a part of 0.9.9.5 release, and available from 0.9.9.0.
###### Things done


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions (Fedora 29)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers
Calling last file updater - cc @globin
