### PR TITLE
scons: 3.1.0 -> 3.1.1

### DIFF
--- a/pkgs/development/tools/build-managers/scons/default.nix
+++ b/pkgs/development/tools/build-managers/scons/default.nix
@@ -8,7 +8,7 @@ in {
     sha256 = "0wzid419mlwqw9llrg8gsx4nkzhqy16m4m40r0xnh6cwscw5wir4";
   };
   scons_latest = mkScons {
-    version = "3.1.0";
-    sha256 = "0bqkrpk5j6wvlljpdsimazav44y43qkl9mzc4f8ig8nl73blixgk";
+    version = "3.1.1";
+    sha256 = "19a3j6x7xkmr2srk2yzxx3wv003h9cxx08vr81ps76blvmzl3sjc";
   };
 }


### PR DESCRIPTION
~~WIP, currently testing the rebuilds (but should most likely be fine).~~

Rebuilds look fine (the two failed packages require manual steps and are simply skipped):
```
2 package failed to build:
d1x-rebirth-full d2x-rebirth-full

90 package were build:
aj-snapshot alfred aspcud bombono cabal2nix carla chaps d1x_rebirth dep2nix digikam endless-sky faust2jack faust2jaqt fceux ffado gambatte gitAndTools.gitFull gitAndTools.gitSVN gitAndTools.svn-all-fast-export gitAndTools.svn2git giv godot goxel gpredict gpsd gringo gtk-recordmydesktop hammer hydra jack1 jack2 jackmix jackmix_jack1 kdeApplications.marble kexi libsForQt5.kreport libsForQt511.kreport lsp-plugins ltc-tools luppp lutris lutris-free lutris-unwrapped marathon mesos mixxx mongodb muse mypaint nix-prefetch-scripts nix-prefetch-svn nix-update-source nsis opam opam_1_2 perl528Packages.SVNSimple perl530Packages.SVNSimple pingus pulseeffects python27Packages.pysvn qlandkartegt qt-recordmydesktop rabbitvcs rapidsvn rhvoice rmlint scons serf shotcut sonic-pi spark subversion subversion19 subversionClient subversion_1_10 svnfs swift-im swiften tambura tdm tetraproc the-powder-toy urjtag vcstool vdrift vdrift-bin viking xboxdrv xsettingsd ydiff
```

Announcement:
https://scons.org/scons-311-is-available.html

Changelog:
https://raw.githubusercontent.com/SConsProject/scons/rel_3.1.1/src/CHANGES.txt

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
