### PR TITLE
vistafonts-cht: init

### DIFF
--- a/pkgs/data/fonts/vista-fonts-cht/default.nix
+++ b/pkgs/data/fonts/vista-fonts-cht/default.nix
@@ -1,0 +1,41 @@
+{ lib, stdenvNoCC, fetchurl, cabextract }:
+
+stdenvNoCC.mkDerivation {
+  pname = "vista-fonts-cht";
+  version = "1";
+
+  src = fetchurl {
+    url = https://download.microsoft.com/download/7/6/b/76bd7a77-be02-47f3-8472-fa1de7eda62f/VistaFont_CHT.EXE;
+    sha256 = "sha256-fSnbbxlMPzbhFSQyKxQaS5paiWji8njK7tS8Eppsj6g=";
+  };
+
+  nativeBuildInputs = [ cabextract ];
+
+  unpackPhase = ''
+    cabextract --lowercase --filter '*.TTF' $src
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/truetype
+    cp *.ttf $out/share/fonts/truetype
+
+    # Set up no-op font configs to override any aliases set up by
+    # other packages.
+    mkdir -p $out/etc/fonts/conf.d
+    substitute ${./no-op.conf} $out/etc/fonts/conf.d/30-msjhenghei.conf \
+      --subst-var-by fontname "Microsoft JhengHei"
+  '';
+
+
+  meta = with lib; {
+    description = "TrueType fonts from Microsoft Windows Vista For Traditional Chinese (Microsoft JhengHei)";
+    homepage = "https://www.microsoft.com/typography/fonts/family.aspx";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ atkinschang ];
+
+    # Set a non-zero priority to allow easy overriding of the
+    # fontconfig configuration files.
+    priority = 5;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/data/fonts/vista-fonts-cht/no-op.conf
+++ b/pkgs/data/fonts/vista-fonts-cht/no-op.conf
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
+<fontconfig>
+  <!-- This configuation is intentionally left empty in order to
+       override any other font package that may wish to set up an
+       alias for the Microsoft @fontname@ font. If you actually do
+       want to have the alias then please change the priority of that
+       package; see the Nix manual page for nix-env for details. -->
+</fontconfig>

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23120,6 +23120,8 @@ in
 
   vistafonts-chs = callPackage ../data/fonts/vista-fonts-chs { };
 
+  vistafonts-cht = callPackage ../data/fonts/vista-fonts-cht { };
+
   vollkorn = callPackage ../data/fonts/vollkorn { };
 
   weather-icons = callPackage ../data/fonts/weather-icons { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
`vistafonts-cht`, font from vista for CJK characters.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).