### PR TITLE
iw: 5.0.1 -> 5.3

### DIFF
--- a/pkgs/os-specific/linux/iw/default.nix
+++ b/pkgs/os-specific/linux/iw/default.nix
@@ -1,12 +1,12 @@
-{stdenv, fetchurl, libnl, pkgconfig}:
+{ stdenv, fetchurl, pkgconfig, libnl }:
 
 stdenv.mkDerivation rec {
   pname = "iw";
-  version = "5.0.1";
+  version = "5.3";
 
   src = fetchurl {
     url = "https://www.kernel.org/pub/software/network/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "03awbfrr9i78vgwsa6z2c8g14mia9z8qzrvzxar2ad9299wylf0y";
+    sha256 = "1m85ap8hwzfs7xf9r0v5d55ra4mhw45f6vclc7j6gsldpibyibq4";
   };
 
   nativeBuildInputs = [ pkgconfig ];
@@ -16,9 +16,15 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Tool to use nl80211";
-    homepage = http://wireless.kernel.org/en/users/Documentation/iw;
+    longDescription = ''
+      iw is a new nl80211 based CLI configuration utility for wireless devices.
+      It supports all new drivers that have been added to the kernel recently.
+      The old tool iwconfig, which uses Wireless Extensions interface, is
+      deprecated and it's strongly recommended to switch to iw and nl80211.
+    '';
+    homepage = https://wireless.wiki.kernel.org/en/users/Documentation/iw;
     license = stdenv.lib.licenses.isc;
-    maintainers = with stdenv.lib.maintainers; [viric];
+    maintainers = with stdenv.lib.maintainers; [ viric primeos ];
     platforms = with stdenv.lib.platforms; linux;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @viric FYI: I've added myself as maintainer as your last `iw` commit is from 2013.
