### PR TITLE
icedtea_web: 1.7.1 -> 1.7.2 (plus CVE patches)

### DIFF
--- a/pkgs/development/compilers/icedtea-web/default.nix
+++ b/pkgs/development/compilers/icedtea-web/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jdk, gtk2, xulrunner, zip, pkgconfig, perl, npapi_sdk, bash, bc, git }:
+{ stdenv, fetchurl, jdk, glib, xulrunner, zip, pkgconfig, perl, npapi_sdk, bash, bc, git }:
 let
 
 cveFixes = fetchurl {
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig bc perl ];
-  buildInputs = [ gtk2 xulrunner zip npapi_sdk ];
+  buildInputs = [ glib xulrunner zip npapi_sdk ];
 
   postPatch = ''
     # The patch includes binary blobs for tests so we must use `git apply`

--- a/pkgs/development/compilers/icedtea-web/default.nix
+++ b/pkgs/development/compilers/icedtea-web/default.nix
@@ -32,8 +32,13 @@ stdenv.mkDerivation rec {
     ${git}/bin/git apply --verbose --exclude=ChangeLog ${cveFixes}
   '';
 
+  postInstall = ''
+    mv $out/bin/itweb-settings{.sh,}
+    mv $out/bin/javaws{.sh,}
+    mv $out/bin/policyeditor{.sh,}
+  '';
+
   preConfigure = ''
-    #patchShebangs javac.in
     configureFlagsArray+=("BIN_BASH=${bash}/bin/bash")
   '';
 

--- a/pkgs/development/compilers/icedtea-web/default.nix
+++ b/pkgs/development/compilers/icedtea-web/default.nix
@@ -1,17 +1,36 @@
-{ stdenv, fetchurl, jdk, gtk2, xulrunner, zip, pkgconfig, perl, npapi_sdk, bash, bc }:
+{ stdenv, fetchurl, jdk, gtk2, xulrunner, zip, pkgconfig, perl, npapi_sdk, bash, bc, git }:
+let
+
+cveFixes = fetchurl {
+  # CVE-2019-10185: zip-slip attack during auto-extraction of a JAR file.
+  # CVE-2019-10181: executable code could be injected in a JAR file without
+  #                 compromising the signature verification.
+  # CVE-2019-10182: improper path sanitization from elements in JNLP
+  #                  files.
+  url = "https://patch-diff.githubusercontent.com/raw/AdoptOpenJDK/IcedTea-Web/pull/346.patch";
+  sha256 = "1lzwib5affz9nm3iyd0ij33km9k8ny9r6p9429zlgxfq4s6jdrqc";
+};
+
+in
 
 stdenv.mkDerivation rec {
   name = "icedtea-web-${version}";
 
-  version = "1.7.1";
+  version = "1.7.2";
 
   src = fetchurl {
     url = "http://icedtea.wildebeest.org/download/source/${name}.tar.gz";
-    sha256 = "1b9z0i9b1dsc2qpfdzbn2fi4vi3idrhm7ig45g1ny40ymvxcwwn9";
+    sha256 = "1gsgcf2h25kg12d4mzsw0kaf3i72bfqkr8vi70d0yq9lqinrfkl2";
   };
 
   nativeBuildInputs = [ pkgconfig bc perl ];
   buildInputs = [ gtk2 xulrunner zip npapi_sdk ];
+
+  postPatch = ''
+    # The patch includes binary blobs for tests so we must use `git apply`
+    # directly instead of relying on `git patch` from `patchPhase`
+    ${git}/bin/git apply --verbose --exclude=ChangeLog ${cveFixes}
+  '';
 
   preConfigure = ''
     #patchShebangs javac.in


### PR DESCRIPTION
On Wed, 31 Jul 2019 it was announced that IcedTea-Web was affected by the below
security vulnerabilities:

- CVE-2019-10185: zip-slip attack during auto-extraction of a JAR file.

- CVE-2019-10181: executable code could be injected in a JAR file without
  compromising the signature verification.

- CVE-2019-10182: improper path sanitization from elements in JNLP
  files.

Version 1.7 was patched, but no release was made. Moreover, the patches apply
cleanly only to 1.7.2, not the current 1.7.1.

Rather than marking 1.7.1 as insecure, update to 1.7.2 and apply the official
patches.

~Note that the patch file has been edited to remove the addition of binary
blobs (that cannot be applied).~

References:

https://www.openwall.com/lists/oss-security/2019/07/31/2
https://github.com/AdoptOpenJDK/IcedTea-Web/issues/327
https://github.com/AdoptOpenJDK/IcedTea-Web/pull/346

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Same manual testing as done in #66422 but using the shell launchers instead of the rust ones.

###### Notify maintainers

cc @grahamc (NixOS security team)
@worldofpeace (reviewer of related #66422)
