### PR TITLE
nix-gitignore: update to addd0c9665ddb28e4dd2067dd50a7d4e135fbb29 version

### DIFF
--- a/pkgs/build-support/nix-gitignore/default.nix
+++ b/pkgs/build-support/nix-gitignore/default.nix
@@ -147,10 +147,10 @@ in rec {
         ' sh {} \; > $out
       '');
 
-  withGitignoreFile = patterns: root:
-    lib.toList patterns ++ [(root + "/.gitignore")];
+  withGitIgnoredFilesAndDirs = patterns: root:
+    lib.toList patterns ++ [(root + "/.gitignore") (".git")];
 
-  withRecursiveGitignoreFile = patterns: root:
+  withRecursiveGitIgnoredFilesAndDirs = patterns: root:
     lib.toList patterns ++ [(compileRecursiveGitignore root)];
 
   # filterSource derivatives
@@ -159,10 +159,10 @@ in rec {
     filterSource (gitignoreFilterPure filter patterns root) root;
 
   gitignoreFilterSource = filter: patterns: root:
-    gitignoreFilterSourcePure filter (withGitignoreFile patterns root) root;
+    gitignoreFilterSourcePure filter (withGitIgnoredFilesAndDirs patterns root) root;
 
   gitignoreFilterRecursiveSource = filter: patterns: root:
-    gitignoreFilterSourcePure filter (withRecursiveGitignoreFile patterns root) root;
+    gitignoreFilterSourcePure filter (withRecursiveGitIgnoredFilesAndDirs patterns root) root;
 
   # "Filter"-less alternatives
 
@@ -174,5 +174,5 @@ in rec {
       "use [] or \"\" if there are no additional patterns"
     else gitignoreFilterSource (_: _: true) patterns;
 
-  gitignoreRecursiveSource = gitignoreFilterSourcePure (_: _: true);
+  gitignoreRecursiveSource = gitignoreFilterRecursiveSource (_: _: true);
 }


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

https://github.com/siers/nix-gitignore/issues/22#event-2548254783

###### Things done

tested with https://github.com/siers/nix-gitignore/blob/master/test.sh

```
 ~/projects/nix-gitignore   master  ./test.sh
these derivations will be built:
  /nix/store/wkz7bmkrhjr36ci6i1gcw5bggy6rmr6y-test-tree.drv
building '/nix/store/wkz7bmkrhjr36ci6i1gcw5bggy6rmr6y-test-tree.drv'...
these derivations will be built:
  /nix/store/x6sddi1xvvm7di7cvg02nfsjv8jv6v1h-test-tree.drv
building '/nix/store/x6sddi1xvvm7di7cvg02nfsjv8jv6v1h-test-tree.drv'...
building '/nix/store/9hgd5c9p5wc625fhj2f4m06pzj7bg56q-test-tree-recursive-recursive-gitignore.drv'...
these derivations will be built:
  /nix/store/n6mzzil7c2wsyav793xan329c4xl1w9y-test-tree-git.drv
  /nix/store/sr7wspzlsclp9aqpfrl1027si6gdln58-test-tree-git.drv
  /nix/store/h9sy6d8kxcbdfzg0rdyrkf1nzw83nk1s-nix-gitignore-test.drv
building '/nix/store/n6mzzil7c2wsyav793xan329c4xl1w9y-test-tree-git.drv'...
building '/nix/store/sr7wspzlsclp9aqpfrl1027si6gdln58-test-tree-git.drv'...
building '/nix/store/h9sy6d8kxcbdfzg0rdyrkf1nzw83nk1s-nix-gitignore-test.drv'...
success
```

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Profpatsch
