### PR TITLE
nixos/misc: Fix nixpkgs.config merge function

### DIFF
--- a/nixos/modules/misc/nixpkgs.nix
+++ b/nixos/modules/misc/nixpkgs.nix
@@ -19,7 +19,7 @@ let
       lhs = optCall lhs_ { inherit pkgs; };
       rhs = optCall rhs_ { inherit pkgs; };
     in
-    lhs // rhs //
+    recursiveUpdate lhs rhs //
     optionalAttrs (lhs ? packageOverrides) {
       packageOverrides = pkgs:
         optCall lhs.packageOverrides pkgs //


### PR DESCRIPTION
###### Motivation for this change
Previously nested attrsets would override each other

With this module:
```nix
{ lib, ... }: {

  nixpkgs.config = lib.mkMerge [
    { foo.bar = true; }
    { foo.baz = true; }
  ];

}
```

Before it would evaluate to
```nix
{ foo = { baz = true; }; }
```

Now it evaluates to
```nix
{ foo = { bar = true; baz = true; }; }
```

Fixes a problem https://github.com/NixOS/nixpkgs/pull/66448 tries to workaround