### PR TITLE
buildPerlPackage: phase out "name"

### DIFF
--- a/pkgs/development/perl-modules/generic/default.nix
+++ b/pkgs/development/perl-modules/generic/default.nix
@@ -1,14 +1,11 @@
 { lib, stdenv, perl, buildPerl, toPerlModule }:
 
-{ buildInputs ? [], nativeBuildInputs ? [], ... } @ attrs:
+{ pname, version, buildInputs ? [], nativeBuildInputs ? [], ... } @ attrs:
 
-assert attrs?pname -> attrs?version;
-assert attrs?pname -> !(attrs?name);
 
-(if attrs ? name then
-  lib.trivial.warn "builtPerlPackage: `name' (\"${attrs.name}\") is deprecated, use `pname' and `version' instead"
- else
-  (x: x))
+if attrs ? name then
+  throw "builtPerlPackage: `name' (\"${attrs.name}\") is deprecated, use `pname' and `version' instead"
+else
 toPerlModule(stdenv.mkDerivation (
   (
   lib.recursiveUpdate
@@ -34,15 +31,15 @@ toPerlModule(stdenv.mkDerivation (
     # https://metacpan.org/pod/release/XSAWYERX/perl-5.26.0/pod/perldelta.pod#Removal-of-the-current-directory-%28%22.%22%29-from-@INC
     PERL_USE_UNSAFE_INC = "1";
 
-    meta.homepage = "https://metacpan.org/release/${attrs.pname or (builtins.parseDrvName attrs.name).name}"; # TODO: phase-out `attrs.name`
+    meta.homepage = "https://metacpan.org/release/${pname}";
     meta.platforms = perl.meta.platforms;
   }
   attrs
   )
   //
   {
-    pname = "perl${perl.version}-${attrs.pname or (builtins.parseDrvName attrs.name).name}"; # TODO: phase-out `attrs.name`
-    version = attrs.version or (builtins.parseDrvName attrs.name).version;                   # TODO: phase-out `attrs.name`
+    pname = "perl${perl.version}-${pname}";
+    inherit version;
     builder = ./builder.sh;
     buildInputs = buildInputs ++ [ perl ];
     nativeBuildInputs = nativeBuildInputs ++ [ (perl.dev or perl) ];

--- a/pkgs/development/perl-modules/generic/default.nix
+++ b/pkgs/development/perl-modules/generic/default.nix
@@ -41,7 +41,7 @@ toPerlModule(stdenv.mkDerivation (
     pname = "perl${perl.version}-${pname}";
     inherit version;
     builder = ./builder.sh;
-    buildInputs = buildInputs ++ [ perl ]; # the only reason for host platform's `perl` here is to support authomatic `patchShebang` of programs which may be in `$out/bin`
+    buildInputs = buildInputs ++ [ perl ]; # the only reason for host platform's `perl` here is to support automatic `patchShebang` of programs which may be in `$out/bin`
     nativeBuildInputs = nativeBuildInputs ++ [ (perl.dev or perl) ];
     fullperl = buildPerl;
   }

--- a/pkgs/development/perl-modules/generic/default.nix
+++ b/pkgs/development/perl-modules/generic/default.nix
@@ -41,7 +41,7 @@ toPerlModule(stdenv.mkDerivation (
     pname = "perl${perl.version}-${pname}";
     inherit version;
     builder = ./builder.sh;
-    buildInputs = buildInputs ++ [ perl ];
+    buildInputs = buildInputs ++ [ perl ]; # the only reason for host platform's `perl` here is to support authomatic `patchShebang` of programs which may be in `$out/bin`
     nativeBuildInputs = nativeBuildInputs ++ [ (perl.dev or perl) ];
     fullperl = buildPerl;
   }


### PR DESCRIPTION
Some time ago `perlPackages.*` have been refactored to use `buildPerlPackage` with `pname` and `version` instead of `name`
and a warning was printed when it was used with `name` to prompt users fix their code.
As time passed, now the warning is being replaced with a fatal error and the support for `name` is removed.

PS. rebuild is not expected