### PR TITLE
libressl: build libcrypto with noexecstack

### DIFF
--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -25,7 +25,10 @@ let
 
     # Ensure that the output libraries do not require an executable stack.
     # Without this, libcrypto would be built with the executable stack flag set.
-    NIX_LDFLAGS = ["-z" "noexecstack"];
+    # For Clang, the flag is '--noexecstack', for GCC it is '-z noexecstack'.
+    NIX_LDFLAGS = if stdenv.isDarwin
+      then ["--noexecstack"]
+      else ["-z" "noexecstack"];
 
     enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -13,7 +13,15 @@ let
 
     nativeBuildInputs = [ cmake ];
 
-    cmakeFlags = [ "-DENABLE_NC=ON" "-DBUILD_SHARED_LIBS=ON" ];
+    cmakeFlags = [
+      "-DENABLE_NC=ON"
+      "-DBUILD_SHARED_LIBS=ON"
+      # Ensure that the output libraries do not require an executable stack.
+      # Without this define, assembly files in libcrypto do not include a
+      # .note.GNU-stack section, and if that section is missing from any object,
+      # the linker will make the stack executable.
+      "-DCMAKE_C_FLAGS=-DHAVE_GNU_STACK"
+    ];
 
     # The autoconf build is broken as of 2.9.1, resulting in the following error:
     # libressl-2.9.1/tls/.libs/libtls.a', needed by 'handshake_table'.
@@ -22,15 +30,6 @@ let
     preConfigure = ''
       rm configure
     '';
-
-    # Ensure that the output libraries do not require an executable stack.
-    # Without this, libcrypto would be built with the executable stack flag set.
-    # For GCC the flag is '-z noexecstack'. Clang, which is used on Darwin,
-    # expects '--noexecstack'. Execstack is an ELF thing, so it is not needed
-    # on Darwin.
-    NIX_LDFLAGS = if stdenv.isDarwin
-      then []
-      else ["-z" "noexecstack"];
 
     enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -25,9 +25,11 @@ let
 
     # Ensure that the output libraries do not require an executable stack.
     # Without this, libcrypto would be built with the executable stack flag set.
-    # For Clang, the flag is '--noexecstack', for GCC it is '-z noexecstack'.
+    # For GCC the flag is '-z noexecstack'. Clang, which is used on Darwin,
+    # expects '--noexecstack'. Execstack is an ELF thing, so it is not needed
+    # on Darwin.
     NIX_LDFLAGS = if stdenv.isDarwin
-      then ["--noexecstack"]
+      then []
       else ["-z" "noexecstack"];
 
     enableParallelBuilding = true;

--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -23,6 +23,10 @@ let
       rm configure
     '';
 
+    # Ensure that the output libraries do not require an executable stack.
+    # Without this, libcrypto would be built with the executable stack flag set.
+    NIX_LDFLAGS = ["-z" "noexecstack"];
+
     enableParallelBuilding = true;
 
     outputs = [ "bin" "dev" "out" "man" "nc" ];


### PR DESCRIPTION
For some reason, libcrypto would be built with the executable stack flag set. I found out about this when Nginx failed to load the shared library, because I was running it with `MemoryDenyWriteExecute=true` which does not permit executable stacks.

I am not sure why the stack ends up executable; the other shared libraries which are part of LibreSSL do not have this flag set. You can verify this with `execstack -q`. Non-executable stacks should be the
default, and from checking some other files, that does appear to be the case. The LibreSSL sources do not contain the string "execstack", so I am not sure what causes the default to be overridden.

Adding `-z noexecstack` to the linker flags makes the linker unset the flag. Now my Nginx can load the library, and so far I have not run into other issues.

I would like to understand where the shared stack requirement came from though. Without knowing where it originates from, it is hard to say what the impact of disabling it is. I did find these threads, which suggest that it is safe to use `noexecstack`:

* http://openssl.6102.n7.nabble.com/PATCH-libcrypto-without-executable-stack-td30772.html
* https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=430583

###### Motivation for this change

Nginx built against LibreSSL cannot use `MemoryDenyWriteExecute=true` at the moment, because `libcrypto.so.45` requires an executable stack. This is a weird requirement, especially for a crypto library.

Still, I would like to understand where the requirement came from before merging this.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`). Also tested Nginx built against this LibreSSL.
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @thoughtpolice @fpletz @globin