### PR TITLE
buildPerlPackage: deduplicate -I paths in shebangs

### DIFF
--- a/pkgs/development/perl-modules/generic/builder.sh
+++ b/pkgs/development/perl-modules/generic/builder.sh
@@ -4,7 +4,9 @@ PERL5LIB="$PERL5LIB${PERL5LIB:+:}$out/lib/perl5/site_perl"
 
 perlFlags=
 for i in $(IFS=:; echo $PERL5LIB); do
-    perlFlags="$perlFlags -I$i"
+    if [[ $perlFlags != *" -I$i"* ]]; then
+        perlFlags="$perlFlags -I$i"
+    fi
 done
 
 oldPreConfigure="$preConfigure"

--- a/pkgs/development/perl-modules/generic/builder.sh
+++ b/pkgs/development/perl-modules/generic/builder.sh
@@ -16,17 +16,18 @@ preConfigure() {
 
     eval "$oldPreConfigure"
 
-    find . | while read fn; do
-        if test -f "$fn"; then
-            first=$(dd if="$fn" count=2 bs=1 2> /dev/null)
-            if test "$first" = "#!"; then
-                echo "patching $fn..."
-                sed -i "$fn" -e "s|^#\!\(.*\bperl\b.*\)$|#\!\1$perlFlags|"
-            fi
+    find . -type f | while read fn; do
+        if [[ "$(dd if="$fn" count=2 bs=1 2> /dev/null)" == "#!" ]]; then
+            # on `fixupPhase`, `patchShebangsAuto` will replace $devperl/bin/perl with $hostperl/bin/perl
+            # for now, a perl working on build platform is required to run tests, etc
+            echo "patching shebang of $(pwd)/$fn:"
+            echo -n "- "; head -n1 "$fn"
+            sed -E "s|^#!.*\bperl\b.*$|#!$devperl/bin/perl$perlFlags|" -i "$fn"
+            echo -n "+ "; head -n1 "$fn"
         fi
     done
 
-    perl Makefile.PL PREFIX=$out INSTALLDIRS=site $makeMakerFlags PERL=$(type -P perl) FULLPERL=\"$fullperl/bin/perl\"
+    perl Makefile.PL PREFIX=$out INSTALLDIRS=site $makeMakerFlags PERL=$devperl/bin/perl FULLPERL=$fullperl/bin/perl
 }
 
 

--- a/pkgs/development/perl-modules/generic/builder.sh
+++ b/pkgs/development/perl-modules/generic/builder.sh
@@ -37,16 +37,6 @@ preConfigure() {
 }
 
 
-postFixup() {
-    # If a user installs a Perl package, she probably also wants its
-    # dependencies in the user environment (since Perl modules don't
-    # have something like an RPATH, so the only way to find the
-    # dependencies is to have them in the PERL5LIB variable).
-    if test -e $out/nix-support/propagated-build-inputs; then
-        ln -s $out/nix-support/propagated-build-inputs $out/nix-support/propagated-user-env-packages
-    fi
-}
-
 if test -n "$perlPreHook"; then
     eval "$perlPreHook"
 fi

--- a/pkgs/development/perl-modules/generic/builder.sh
+++ b/pkgs/development/perl-modules/generic/builder.sh
@@ -28,7 +28,7 @@ preConfigure() {
             # for now, a perl working on build platform is required to run tests, etc
             echo "patching shebang of $(pwd)/$fn:"
             echo -n "- "; head -n1 "$fn"
-            sed -E "s|^#!.*\bperl\b.*$|#!$devperl/bin/perl$perlFlags|" -i "$fn"
+            sed -E "s|^#!\s*(/usr/bin/env\s+)?\S*\bperl\b\S*(.*)$|#!$devperl/bin/perl\2$perlFlags|" -i "$fn"
             echo -n "+ "; head -n1 "$fn"
         fi
     done

--- a/pkgs/development/perl-modules/generic/builder.sh
+++ b/pkgs/development/perl-modules/generic/builder.sh
@@ -4,7 +4,9 @@ PERL5LIB="$PERL5LIB${PERL5LIB:+:}$out/lib/perl5/site_perl"
 
 perlFlags=
 for i in $(IFS=:; echo $PERL5LIB); do
-    if [[ $perlFlags != *" -I$i"* ]]; then
+    # exclude paths pointing to perl derivation (like /nix/store/abcdfghijklmnpqrsvwxyz0123456789-perl-5.28.2/lib/perl5/site_perl)
+    # they are needless pointing to correct perl, and source of subtle bugs pointing to another perl
+    if [[ ! $i =~ /[0123456789abcdfghijklmnpqrsvwxyz]{32}-perl-[0-9.]+/lib/perl5/site_perl$ ]] && [[ $perlFlags != *" -I$i"* ]]; then
         perlFlags="$perlFlags -I$i"
     fi
 done

--- a/pkgs/development/perl-modules/generic/builder.sh
+++ b/pkgs/development/perl-modules/generic/builder.sh
@@ -33,7 +33,7 @@ preConfigure() {
         fi
     done
 
-    perl Makefile.PL PREFIX=$out INSTALLDIRS=site $makeMakerFlags PERL=$devperl/bin/perl FULLPERL=$fullperl/bin/perl
+    perl Makefile.PL PREFIX=$out INSTALLDIRS=site $makeMakerFlags PERL=$devperl/bin/perl FULLPERL=\"$fullperl/bin/perl\"
 }
 
 

--- a/pkgs/development/perl-modules/generic/default.nix
+++ b/pkgs/development/perl-modules/generic/default.nix
@@ -46,6 +46,9 @@ toPerlModule(stdenv.mkDerivation (
     builder = ./builder.sh;
     buildInputs = buildInputs ++ [ perl ];
     nativeBuildInputs = nativeBuildInputs ++ [ (perl.dev or perl) ];
+    
+    # environment variables passed to ./builder.sh
+    hostperl = perl;
     fullperl = buildPerl;
   }
 ))

--- a/pkgs/development/perl-modules/generic/default.nix
+++ b/pkgs/development/perl-modules/generic/default.nix
@@ -49,6 +49,7 @@ toPerlModule(stdenv.mkDerivation (
     
     # environment variables passed to ./builder.sh
     hostperl = perl;
+    devperl = perl.dev or perl;
     fullperl = buildPerl;
   }
 ))

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -14324,6 +14324,10 @@ let
       sha256 = "be9fb8910b108e5d1a66f002b659ad22576e88d779b703dff9d15122c3f80834";
     };
     propagatedBuildInputs = [ MixinLinewise ];
+    # restore data files used in tests which are corrupted by patching shebangs
+    preCheck = ''
+      tar xf $src */xt --strip-components=1
+    '';
     meta = {
       description = "Read a POD document as a series of trivial events";
       license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
@@ -16685,6 +16689,10 @@ let
       sha256 = "7853b44a9819eb3e6003260eedf904a1ad80035ea5254296ce014f96084b65d4";
     };
     propagatedBuildInputs = [ UNIVERSALrequire ];
+    # restore data files used in tests which are corrupted by patching shebangs
+    preCheck = ''
+      tar xf $src */t --strip-components=1
+    '';
     meta = {
       description = "Check whether Perl files compile correctly";
       license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -5630,9 +5630,6 @@ let
     };
     buildInputs = [ CaptureTiny ];
     propagatedBuildInputs = [ EmailAbstract EmailAddress MooXTypesMooseLike SubExporter Throwable TryTiny ];
-    postPatch = ''
-      patchShebangs --build util
-    '';
     meta = {
       homepage = https://github.com/rjbs/Email-Sender;
       description = "A library for sending email";


### PR DESCRIPTION
It makes [shebangs lines 3 times shorter](https://github.com/NixOS/nixpkgs/pull/55786#issuecomment-463842415)

It is not big an improvement, but [sometimes it is critical](https://github.com/NixOS/nixpkgs/pull/66446#issuecomment-520181977), for example on Darwin with its 512-byte limit