### PR TITLE
buildPerlPackage: remove postFixup

### DIFF
--- a/pkgs/development/perl-modules/generic/builder.sh
+++ b/pkgs/development/perl-modules/generic/builder.sh
@@ -25,17 +25,6 @@ preConfigure() {
     perl Makefile.PL PREFIX=$out INSTALLDIRS=site $makeMakerFlags PERL=$(type -P perl) FULLPERL=\"$fullperl/bin/perl\"
 }
 
-
-postFixup() {
-    # If a user installs a Perl package, she probably also wants its
-    # dependencies in the user environment (since Perl modules don't
-    # have something like an RPATH, so the only way to find the
-    # dependencies is to have them in the PERL5LIB variable).
-    if test -e $out/nix-support/propagated-build-inputs; then
-        ln -s $out/nix-support/propagated-build-inputs $out/nix-support/propagated-user-env-packages
-    fi
-}
-
 if test -n "$perlPreHook"; then
     eval "$perlPreHook"
 fi


### PR DESCRIPTION
It has no effect since system-wide $PERL5LIB removed more than an year ago
