### PR TITLE
EC2 instance connect support

### DIFF
--- a/nixos/modules/virtualisation/amazon-image.nix
+++ b/nixos/modules/virtualisation/amazon-image.nix
@@ -17,7 +17,12 @@ let
 in
 
 {
-  imports = [ ../profiles/headless.nix ./ec2-data.nix ./amazon-init.nix ];
+  imports = [
+    ../profiles/headless.nix
+    ./amazon-init.nix
+    ./ec2-data.nix
+    ./ec2-instance-connect.nix
+  ];
 
   config = {
 

--- a/nixos/modules/virtualisation/ec2-instance-connect.nix
+++ b/nixos/modules/virtualisation/ec2-instance-connect.nix
@@ -1,0 +1,47 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.ec2.instance-connect;
+in
+{
+  options = {
+    ec2.instance-connect.enable = lib.mkEnableOption "EC2 Instance Connect";
+  };
+
+  config = lib.mkIf cfg.enable {
+    users.users.ec2-instance-connect = {
+      isSystemUser = true;
+    };
+
+    systemd.services.ec2-intance-connect = {
+      description = "EC2 Instance Connect Host Key Harvesting";
+      after = [ "ssh.service" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        ExecStart = "${pkgs.ec2-instance-connect}/bin/eic_harvest_hostkeys";
+        Type = "oneshot";
+        RemainAfterExit = true;
+      };
+    };
+
+    services.openssh.extraConfig = ''
+      AuthorizedKeysCommand /etc/ssh/authorized_keys_command_eic_run_authorized_keys %u %f
+      AuthorizedKeysCommandUser ec2-instance-connect
+    '';
+
+    # Ugly: sshd refuses to start if a store path is given because
+    # /nix/store is group-writable.  So indirect by a symlink.
+    # Another instance of this is found in the Google OS Login module
+    environment.etc."ssh/authorized_keys_command_eic_run_authorized_keys" = {
+      mode = "0755";
+      text = ''
+        #!/bin/sh
+        exec ${pkgs.ec2-instance-connect}/bin/eic_run_authorized_keys "$@"
+      '';
+    };
+  };
+
+  meta = {
+    maintainers = with lib.maintainers; [ thefloweringash ];
+  };
+}

--- a/pkgs/tools/security/ec2-instance-connect/default.nix
+++ b/pkgs/tools/security/ec2-instance-connect/default.nix
@@ -1,0 +1,54 @@
+{ stdenv, fetchFromGitHub, lib, makeWrapper, which
+, bash, coreutils, gnugrep, gnused, gawk, curl, findutils
+, utillinux, openssl, openssh, cacert }:
+
+stdenv.mkDerivation rec {
+  pname = "ec2-instance-connect";
+  version = "1.0-9";
+
+  src = fetchFromGitHub {
+    owner = "aws";
+    repo = "aws-ec2-instance-connect-config";
+    rev = version;
+    sha256 = "1gw4shjpsp7pzmc76mynr6vfhay88gdn9dsmqg258225lwjwigrh";
+  };
+
+  installPhase = ''
+    mkdir $out
+    cp -r src/bin $out
+  '';
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [
+    bash coreutils gnugrep gnused gawk curl findutils
+    utillinux openssl openssh
+  ];
+
+  fixupPhase = ''
+    # Most tools are called as /bin/$tool or /usr/bin/tool. This
+    # script replaces all such references with their versions from
+    # buildInputs.
+
+    $SHELL ${./fixup-bin-paths.sh} \
+      $out/bin \
+      ${which}/bin/which \
+      ${lib.escapeShellArg (lib.makeBinPath buildInputs)}
+
+    substituteInPlace $out/bin/eic_curl_authorized_keys \
+      --replace 'ca_path=/etc/ssl/certs' 'ca_path=/etc/ssl/certs/ca-bundle.crt'
+
+    # Some tools from coreutils (wc, rm, dirname) are referenced without
+    # an absolute path.
+    for script in $out/bin/*; do
+      wrapProgram "$script" --prefix PATH : ${lib.makeBinPath [ coreutils ]}
+    done
+  '';
+
+  meta = {
+    homepage = https://github.com/aws/aws-ec2-instance-connect-config;
+    description = "EC2 instance scripting to enable EC2 Instance Connect";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ thefloweringash ];
+  };
+}

--- a/pkgs/tools/security/ec2-instance-connect/fixup-bin-paths.sh
+++ b/pkgs/tools/security/ec2-instance-connect/fixup-bin-paths.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$1
+which=$2
+search_path=$3
+
+
+find_absolute_paths() {
+    grep -Ehr --only-matching '(/usr)?/bin/\w+' "$1" | sort | uniq
+}
+
+resolve_path() {
+    local search_path=$1
+    local bin=$2
+    local base resolved
+    base=$(basename "$bin")
+    # Use explicit which tool here to force shell builtins to be
+    # resolved via the search path. This matches upstream behaviour.
+    resolved=$(PATH="$search_path" $which "$base" 2>/dev/null || true)
+    if [ "$resolved" ]; then
+        echo "Resolved $base -> $resolved" >&2
+        echo "$resolved"
+    else
+        echo "Unable to find $base" >&2
+        exit 1
+    fi
+}
+
+mapfile -t replacements < <(
+    find_absolute_paths "$script_dir" | while read -r from; do
+        to=$(resolve_path "$search_path" "$from")
+        [ -z "$to" ] && exit 1
+        printf "%s\n" -e
+        echo "s^${from}\b^${to}^g"
+    done
+)
+
+mapfile -t targets < <(find "$script_dir" -type f)
+
+set -x
+sed -i "${replacements[@]}" "${targets[@]}"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -773,6 +773,8 @@ in
 
   dpt-rp1-py = callPackage ../tools/misc/dpt-rp1-py { };
 
+  ec2-instance-connect = callPackage ../tools/security/ec2-instance-connect { };
+
   ecdsautils = callPackage ../tools/security/ecdsautils { };
 
   sedutil = callPackage ../tools/security/sedutil { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Amazon released [EC2 Instance Connect] that allows SSH authentication to be attached to Amazon's authentication system (IAM). They provide packages for Ubuntu and their first party linux. This is an implementation for NixOS.

A note about the implementation: it's a lot of shell scripting, where the scripts are written in a style where the majority (but not all!) of external commands are written with absolute paths. To make this work, these need to be rewritten somehow. I elected to replace the call sites with their resolved path by looking up the path in a constructed `lib.makeBinPath`. For the few that aren't absolute, I also added coreutils to the PATH in the wrapper.

[EC2 Instance Connect]: https://aws.amazon.com/about-aws/whats-new/2019/06/introducing-amazon-ec2-instance-connect/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
