### PR TITLE
ec2-instance-connect-cli: init at 1.0.0

### DIFF
--- a/pkgs/tools/security/ec2-instance-connect-cli/default.nix
+++ b/pkgs/tools/security/ec2-instance-connect-cli/default.nix
@@ -1,0 +1,25 @@
+{ buildPythonPackage, fetchPypi, lib, botocore }:
+
+buildPythonPackage rec {
+  pname = "ec2-instance-connect-cli";
+  version = "1.0.0";
+
+  src = fetchPypi {
+    pname = "ec2instanceconnectcli";
+    inherit version;
+    sha256 = "1s4xya5ddlv9vbbn62lhcspl4g1fjqhh5nq2snbmliqssmw8r0fw";
+  };
+
+  propagatedBuildInputs = [ botocore ];
+
+  postInstall = ''
+    rm -v $out/bin/*.cmd
+  '';
+
+  meta = {
+    homepage = https://aws.amazon.com/cli/;
+    description = "An all-in-one client for EC2 Instance Connect that handles key brokerage and establishing connection to EC2 Instances";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ thefloweringash ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -808,6 +808,8 @@ in
 
   dpt-rp1-py = callPackage ../tools/misc/dpt-rp1-py { };
 
+  ec2-instance-connect-cli = python3Packages.callPackage ../tools/security/ec2-instance-connect-cli { };
+
   ecdsautils = callPackage ../tools/security/ecdsautils { };
 
   sedutil = callPackage ../tools/security/sedutil { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Tool for using #66463. Requires updated botocore (in #66465).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
