### PR TITLE
ocsigen-start: 1.5.0 -> 1.8.0; ocsigen-toolkit: 2.0.0 -> 2.2.0

### DIFF
--- a/pkgs/development/ocaml-modules/ocsigen-start/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-start/default.nix
@@ -1,14 +1,13 @@
-{ stdenv, fetchFromGitHub, buildOcaml, ocsigen-toolkit, eliom, ocaml_pcre, pgocaml, macaque, safepass, yojson, ocsigen_deriving, ocsigen_server
+{ stdenv, fetchFromGitHub, ocaml, findlib, ocsigen-toolkit, eliom, ocaml_pcre, pgocaml, macaque, safepass, yojson, ocsigen_deriving, ocsigen_server
 , js_of_ocaml-camlp4
 , resource-pooling
 }:
 
-buildOcaml rec
-{
-  name = "ocsigen-start";
-  version = "1.5.0";
+stdenv.mkDerivation rec {
+  name = "ocaml${ocaml.version}-ocsigen-start-${version}";
+  version = "1.8.0";
 
-  buildInputs = [ eliom js_of_ocaml-camlp4 ];
+  buildInputs = [ ocaml findlib eliom js_of_ocaml-camlp4 ];
   propagatedBuildInputs = [ pgocaml macaque safepass ocaml_pcre ocsigen-toolkit yojson ocsigen_deriving ocsigen_server resource-pooling ];
 
   patches = [ ./templates-dir.patch ];
@@ -16,12 +15,14 @@ buildOcaml rec
   postPatch = ''
   substituteInPlace "src/os_db.ml" --replace "citext" "text"
   '';
+
+  createFindlibDestdir = true;
   
   src = fetchFromGitHub {
     owner = "ocsigen";
-    repo = name;
+    repo = "ocsigen-start";
     rev = version;
-    sha256 = "07478hz5jhxb242hfr808516k81vdbzj4j6cycvls3b9lzbyszha";
+    sha256 = "0h5gp06vxy6jpppz1x840gyf9viiy7lic7spx7fxldpy2jpv058s";
   };
 
   meta = {
@@ -31,6 +32,7 @@ buildOcaml rec
      An Eliom application skeleton, ready to use to build your own application with users, (pre)registration, notifications, etc.
       '';
     license = stdenv.lib.licenses.lgpl21;
+    inherit (ocaml.meta) platforms;
     maintainers = [ stdenv.lib.maintainers.gal_bolle ];
   };
 

--- a/pkgs/development/ocaml-modules/ocsigen-toolkit/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-toolkit/default.nix
@@ -5,7 +5,7 @@
 stdenv.mkDerivation rec {
  pname = "ocsigen-toolkit";
  name = "ocaml${ocaml.version}-${pname}-${version}";
- version = "2.0.0";
+ version = "2.2.0";
 
  propagatedBuildInputs = [ calendar eliom js_of_ocaml-ppx_deriving_json ];
  buildInputs = [ ocaml findlib opaline ];
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     owner = "ocsigen";
     repo = pname;
     rev = version;
-    sha256 = "0gkiqw3xi31l9q9h89fnr5gfmxi9w9lg9rlv16h4ssjgrgq3y5cw";
+    sha256 = "0qy6501jf81qcmkbicgrb1x4pxsjkhr40plwdn09w37d8vx9va3s";
   };
 
   createFindlibDestdir = true;


### PR DESCRIPTION
###### Motivation for this change

Compatibility with recent js-of-ocaml

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @FlorentBecker
