### PR TITLE
blackmagic: 1.6.1 -> unstable-2019-08-13

### DIFF
--- a/pkgs/development/tools/misc/blackmagic/default.nix
+++ b/pkgs/development/tools/misc/blackmagic/default.nix
@@ -1,28 +1,30 @@
 { stdenv, lib, fetchFromGitHub
-, gcc-arm-embedded, binutils-arm-embedded, libftdi
+, gcc-arm-embedded, libftdi1
 , python, pythonPackages
 }:
 
 with lib;
 
 stdenv.mkDerivation rec {
-  name = "blackmagic-${version}";
-  version = "1.6.1";
+  pname = "blackmagic";
+  version = "unstable-2019-08-13";
+  # `git describe --always`
+  firmwareVersion = "v1.6.1-317-gc9c8b08";
 
   src = fetchFromGitHub {
     owner = "blacksphere";
     repo = "blackmagic";
-    rev = "29386aee140e5e99a958727358f60980418b4c88";
-    sha256 = "05x19y80mixk6blpnfpfngy5d41jpjvdqgjzkmhv1qc03bhyhc82";
+    rev = "c9c8b089f716c31433432f5ee54c5c206e4945cf";
+    sha256 = "0175plba7h3r1p584ygkjlvg2clvxa2m0xfdcb2v8jza2vzc8ywd";
     fetchSubmodules = true;
   };
 
   nativeBuildInputs = [
-    gcc-arm-embedded binutils-arm-embedded
+    gcc-arm-embedded
   ];
 
   buildInputs = [
-    libftdi
+    libftdi1
     python
     pythonPackages.intelhex
   ];
@@ -30,7 +32,7 @@ stdenv.mkDerivation rec {
   postPatch = ''
     # Prevent calling out to `git' to generate a version number:
     substituteInPlace src/Makefile \
-      --replace '`git describe --always --dirty`' '${version}'
+      --replace '$(shell git describe --always --dirty)' '${firmwareVersion}'
 
     # Fix scripts that generate headers:
     for f in $(find scripts libopencm3/scripts -type f); do
@@ -40,6 +42,8 @@ stdenv.mkDerivation rec {
 
   buildPhase = "${stdenv.shell} ${./helper.sh}";
   installPhase = ":"; # buildPhase does this.
+
+  enableParallelBuilding = true;
 
   meta = {
     description = "In-application debugger for ARM Cortex microcontrollers";
@@ -56,7 +60,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = https://github.com/blacksphere/blackmagic;
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ pjones ];
+    maintainers = with maintainers; [ pjones emily ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/tools/misc/blackmagic/helper.sh
+++ b/pkgs/development/tools/misc/blackmagic/helper.sh
@@ -10,6 +10,8 @@ out=${out:-/tmp}
 
 ################################################################################
 export CFLAGS=$NIX_CFLAGS_COMPILE
+export MAKEFLAGS="\
+  ${enableParallelBuilding:+-j${NIX_BUILD_CORES} -l${NIX_BUILD_CORES}}"
 
 ################################################################################
 PRODUCTS="blackmagic.bin blackmagic.hex blackmagic_dfu.bin blackmagic_dfu.hex"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9095,11 +9095,7 @@ in
   bison = bison3;
   yacc = bison; # TODO: move to aliases.nix
 
-  blackmagic = callPackage ../development/tools/misc/blackmagic {
-    stdenv = gcc6Stdenv;
-    gcc-arm-embedded = pkgsCross.arm-embedded.buildPackages.gcc;
-    binutils-arm-embedded = pkgsCross.arm-embedded.buildPackages.binutils;
-  };
+  blackmagic = callPackage ../development/tools/misc/blackmagic { };
 
   bloaty = callPackage ../development/tools/bloaty { };
 


### PR DESCRIPTION
I updated the version number to include the commit ID as upstream
apparently doesn't plan on making another stable release:

  https://github.com/blacksphere/blackmagic/issues/486

This is my first nixpkgs contribution, so apologies if I've messed
anything up! I had to switch to a newer `gcc-arm-embedded` to get it
to compile properly.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @pjones
