### PR TITLE
prometheus-blackbox-exporter: 0.12.0 -> 0.14.0, run tests and check config

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters/blackbox.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/blackbox.nix
@@ -4,6 +4,13 @@ with lib;
 
 let
   cfg = config.services.prometheus.exporters.blackbox;
+
+  checkConfig = file: pkgs.runCommand "checked-blackbox-exporter.conf" {
+    preferLocalBuild = true;
+    buildInputs = [ pkgs.buildPackages.prometheus-blackbox-exporter ]; } ''
+    ln -s ${file} $out
+    blackbox_exporter --config.check --config.file $out
+  '';
 in
 {
   port = 9115;
@@ -21,7 +28,7 @@ in
       ExecStart = ''
         ${pkgs.prometheus-blackbox-exporter}/bin/blackbox_exporter \
           --web.listen-address ${cfg.listenAddress}:${toString cfg.port} \
-          --config.file ${cfg.configFile} \
+          --config.file ${checkConfig cfg.configFile} \
           ${concatStringsSep " \\\n  " cfg.extraFlags}
       '';
       ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";

--- a/pkgs/servers/monitoring/prometheus/blackbox-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/blackbox-exporter.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "blackbox_exporter-${version}";
-  version = "0.12.0";
+  version = "0.14.0";
   rev = version;
 
   goPackagePath = "github.com/prometheus/blackbox_exporter";
@@ -11,14 +11,16 @@ buildGoPackage rec {
     rev = "v${version}";
     owner = "prometheus";
     repo = "blackbox_exporter";
-    sha256 = "0gd3vymk3qdfjnf0rx9kwc6v0jv7f8l30igvj2v7bljar2d6hzxf";
+    sha256 = "1v5n59p9jl6y1ka9mqp0ibx1kpcb3gbpl0i6bhqpbr154frmqm4x";
   };
+
+  doCheck = true;
 
   meta = with stdenv.lib; {
     description = "Blackbox probing of endpoints over HTTP, HTTPS, DNS, TCP and ICMP";
-    homepage = https://github.com/prometheus/blackbox_exporter;
+    homepage = "https://github.com/prometheus/blackbox_exporter";
     license = licenses.asl20;
-    maintainers = with maintainers; [ globin fpletz ];
+    maintainers = with maintainers; [ globin fpletz willibutz ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update to the latest release, which now supports checking the config file.

###### Things done

The tests are now run, the config file is checked during eval and I added myself as maintainer.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS (x86_64-linux)
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @globin  @fpletz
