### PR TITLE
prometheus-nginx-exporter: 0.4.1 -> 0.4.2, run tests

### DIFF
--- a/pkgs/servers/monitoring/prometheus/nginx-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/nginx-exporter.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "nginx_exporter-${version}";
-  version = "0.4.1";
+  version = "0.4.2";
 
   goPackagePath = "github.com/nginxinc/nginx-prometheus-exporter";
 
@@ -14,8 +14,10 @@ buildGoPackage rec {
     rev = "v${version}";
     owner = "nginxinc";
     repo = "nginx-prometheus-exporter";
-    sha256 = "0c5bxl9xrd4gh2w5wyrzghmbcy9k1khydzml5cm0rsyqhwsvs8m5";
+    sha256 = "023nl83w0fic7sj0yxxgj7jchyafqnmv6dq35amzz37ikx92mdcj";
   };
+
+  doCheck = true;
 
   meta = with stdenv.lib; {
     description = "NGINX Prometheus Exporter for NGINX and NGINX Plus";


### PR DESCRIPTION
###### Motivation for this change
Update to [latest release](https://github.com/nginxinc/nginx-prometheus-exporter/releases/tag/v0.4.2).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS (x86_64-linux & aarch64-linux)
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
