### PR TITLE
haskell.buildStackProject: Pass nativeBuildInputs

### DIFF
--- a/pkgs/development/haskell-modules/generic-stack-builder.nix
+++ b/pkgs/development/haskell-modules/generic-stack-builder.nix
@@ -2,6 +2,7 @@
 , cacert, stack, makeSetupHook, lib }@depArgs:
 
 { buildInputs ? []
+, nativeBuildInputs ? []
 , extraArgs ? []
 , LD_LIBRARY_PATH ? []
 , ghc ? depArgs.ghc
@@ -22,7 +23,8 @@ in stdenv.mkDerivation (args // {
   buildInputs = buildInputs
     ++ lib.optional (stdenv.hostPlatform.libc == "glibc") glibcLocales;
 
-  nativeBuildInputs = [ ghc pkgconfig stack stackHook ];
+  nativeBuildInputs = nativeBuildInputs
+    ++ [ ghc pkgconfig stack stackHook ];
 
   STACK_PLATFORM_VARIANT = "nix";
   STACK_IN_NIX_SHELL = 1;


### PR DESCRIPTION
###### Motivation for this change

I don’t know if anyone else has this problem, but some of my stack shell files add `naitveBuildInputs` and this was broken in #53618.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @matthewbauer