### PR TITLE
nixos/prometheus2: replace alertmanagerURL with new alertmanagers option

### DIFF
--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -51,6 +51,10 @@ with lib;
     (mkRemovedOptionModule [ "services" "misc" "nzbget" "openFirewall" ] "The port used by nzbget is managed through the web interface so you should adjust your firewall rules accordingly.")
     (mkRemovedOptionModule [ "services" "prometheus" "alertmanager" "user" ] "The alertmanager service is now using systemd's DynamicUser mechanism which obviates a user setting.")
     (mkRemovedOptionModule [ "services" "prometheus" "alertmanager" "group" ] "The alertmanager service is now using systemd's DynamicUser mechanism which obviates a group setting.")
+    (mkRemovedOptionModule [ "services" "prometheus2" "alertmanagerURL" ] ''
+      Due to incompatibility, the alertmanagerURL option has been removed,
+      please use 'services.prometheus2.alertmanagers' instead.
+    '')
     (mkRenamedOptionModule [ "services" "tor" "relay" "portSpec" ] [ "services" "tor" "relay" "port" ])
     (mkRenamedOptionModule [ "services" "vmwareGuest" ] [ "virtualisation" "vmware" "guest" ])
     (mkRenamedOptionModule [ "jobs" ] [ "systemd" "services" ])

--- a/nixos/modules/services/monitoring/prometheus/default.nix
+++ b/nixos/modules/services/monitoring/prometheus/default.nix
@@ -79,12 +79,8 @@ let
       (pkgs.writeText "prometheus.rules" (concatStringsSep "\n" cfg2.rules))
     ]);
     scrape_configs = filterValidPrometheus cfg2.scrapeConfigs;
-    alerting = optionalAttrs (cfg2.alertmanagerURL != []) {
-      alertmanagers = [{
-        static_configs = [{
-          targets = cfg2.alertmanagerURL;
-        }];
-      }];
+    alerting = {
+      inherit (cfg2) alertmanagers;
     };
   };
 
@@ -738,11 +734,23 @@ in {
         '';
       };
 
-      alertmanagerURL = mkOption {
-        type = types.listOf types.str;
+      alertmanagers = mkOption {
+        type = types.listOf types.attrs;
+        example = literalExample ''
+          [ {
+            scheme = "https";
+            path_prefix = "/alertmanager";
+            static_configs = [ {
+              targets = [
+                "prometheus.domain.tld"
+              ];
+            } ];
+          } ]
+        '';
         default = [];
         description = ''
-          List of Alertmanager URLs to send notifications to.
+          A list of alertmanagers to send alerts to.
+          See <link xlink:href="https://prometheus.io/docs/prometheus/latest/configuration/configuration/#alertmanager_config">the official documentation</link> for more information.
         '';
       };
 


### PR DESCRIPTION
###### Motivation for this change
Prometheus2 does no longer support the command-line flag to specify
an alertmanager. Instead it now supports both service discovery and
configuration of alertmanagers in the alerting config section.

Simply mapping the previous option to an entry in the new alertmanagers
section is not enough to allow for complete configurations of an
alertmanager.

For example in a setup where an alertmanager runs under the same subdomain as prometheus but under a seperate path, this needs to be configured in the alerting section of the prometheus config and currently the module does not provide this functionality.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @basvandijk @andir @fpletz 