### PR TITLE
castxml: set correct -DCLANG_RESOURCE_DIR

### DIFF
--- a/pkgs/development/tools/castxml/default.nix
+++ b/pkgs/development/tools/castxml/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub
+{ lib, stdenv, fetchFromGitHub
 , pythonPackages
 , cmake
 , llvmPackages
@@ -19,8 +19,10 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ] ++ stdenv.lib.optionals withMan [ pythonPackages.sphinx ];
 
+  clangVersion = lib.getVersion llvmPackages.clang;
+
   cmakeFlags = [
-    "-DCLANG_RESOURCE_DIR=${llvmPackages.clang-unwrapped}"
+    "-DCLANG_RESOURCE_DIR=${llvmPackages.clang-unwrapped}/lib/clang/${clangVersion}/"
     "-DSPHINX_MAN=${if withMan then "ON" else "OFF"}"
   ];
 


### PR DESCRIPTION
This change fixes #66456

According to the comment in [CastXML CMakeLists.txt](https://github.com/CastXML/CastXML/blob/67e01959e94c8579e339c0d3f7acbed658950383/CMakeLists.txt#L165-L173) this variable should point to the directory that contains `include/stddef.h`. This change fixes the variable, so now built package contains the file.

```
$ nix-build -A castxml
/nix/store/ry5fhfvi7ixn47a7i9pripn1fq1kbxwr-CastXML-0.2.0
$ ls result/share/castxml/clang/include/stddef.h
result/share/castxml/clang/include/stddef.h
```