### PR TITLE
yubikey-personalization-gui: install man, desktop files and icons

### DIFF
--- a/pkgs/tools/misc/yubikey-personalization-gui/default.nix
+++ b/pkgs/tools/misc/yubikey-personalization-gui/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchurl, mkDerivation, pkgconfig, yubikey-personalization, qtbase, qmake, libyubikey }:
+{ stdenv, fetchurl, mkDerivation, pkgconfig, qtbase, qmake, imagemagick
+, libyubikey, yubikey-personalization }:
 
 mkDerivation rec {
   name = "yubikey-personalization-gui-3.1.25";
@@ -8,12 +9,27 @@ mkDerivation rec {
     sha256 = "1knyv5yss8lhzaff6jpfqv12fjf1b8b21mfxzx3qi0hw4nl8n2v8";
   };
 
-  nativeBuildInputs = [ pkgconfig qmake ];
+  nativeBuildInputs = [ pkgconfig qmake imagemagick ];
   buildInputs = [ yubikey-personalization qtbase libyubikey ];
 
   installPhase = ''
-    mkdir -p $out/bin
-    cp build/release/yubikey-personalization-gui $out/bin
+    install -D -m0755 build/release/yubikey-personalization-gui "$out/bin/yubikey-personalization-gui"
+    install -D -m0644 resources/lin/yubikey-personalization-gui.1 "$out/share/man/man1/yubikey-personalization-gui.1"
+
+    # Desktop files
+    install -D -m0644 resources/lin/yubikey-personalization-gui.desktop "$out/share/applications/yubikey-personalization-gui.desktop"
+    install -D -m0644 resources/lin/yubikey-personalization-gui.desktop "$out/share/pixmaps/yubikey-personalization-gui.xpm"
+
+    # Icons
+    install -D -m0644 resources/lin/yubikey-personalization-gui.png "$out/share/icons/hicolor/128x128/apps/yubikey-personalization-gui.png"
+    for SIZE in 16 24 32 48 64 96; do
+      # set modify/create for reproducible builds
+      convert -scale ''${SIZE} +set date:create +set date:modify \
+        resources/lin/yubikey-personalization-gui.png \
+        yubikey-personalization-gui.png
+
+      install -D -m0644 yubikey-personalization-gui.png "$out/share/icons/hicolor/''${SIZE}x''${SIZE}/apps/yubikey-personalization-gui.png"
+    done
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Nices integration with desktop environments

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
