### PR TITLE
kubernetes: add generic builder and kops stable versions

### DIFF
--- a/pkgs/applications/networking/cluster/kubernetes/default.nix
+++ b/pkgs/applications/networking/cluster/kubernetes/default.nix
@@ -1,79 +1,118 @@
-{ stdenv, lib, fetchFromGitHub, removeReferencesTo, which, go, go-bindata, makeWrapper, rsync
+{ stdenv, lib, fetchFromGitHub, removeReferencesTo, makeWrapper
+, which, go, go-bindata, rsync
 , components ? [
-    "cmd/kubeadm"
-    "cmd/kubectl"
-    "cmd/kubelet"
-    "cmd/kube-apiserver"
-    "cmd/kube-controller-manager"
-    "cmd/kube-proxy"
-    "cmd/kube-scheduler"
-    "test/e2e/e2e.test"
-  ]
-}:
+  "cmd/kubeadm"
+  "cmd/kubectl"
+  "cmd/kubelet"
+  "cmd/kube-apiserver"
+  "cmd/kube-controller-manager"
+  "cmd/kube-proxy"
+  "cmd/kube-scheduler"
+  "test/e2e/e2e.test"
+]}:
 
 with lib;
 
-stdenv.mkDerivation rec {
-  pname = "kubernetes";
-  version = "1.15.3";
+let
+  versions = builtins.fromJSON (builtins.readFile ./versions.json);
 
-  src = fetchFromGitHub {
-    owner = "kubernetes";
-    repo = "kubernetes";
-    rev = "v${version}";
-    sha256 = "0vamr7m8i5svmvb0z01cngv3sffdfjj0bky2zalm7cfnapib8vz1";
+  generic = { version, sha256 }: stdenv.mkDerivation {
+    pname = "kubernetes";
+    inherit version;
+
+    src = fetchFromGitHub {
+      owner = "kubernetes";
+      repo = "kubernetes";
+      rev = "v${version}";
+      inherit sha256;
+    };
+
+    buildInputs = [ removeReferencesTo makeWrapper which go rsync go-bindata ];
+
+    outputs = ["out" "man" "pause"];
+
+    binaries = [
+      "kubectl"
+      "kubeadm"
+      "kube-apiserver"
+      "kube-controller-manager"
+      "kube-scheduler"
+      "kubelet"
+      "kubemark"
+      "hyperkube"
+      "kube-proxy"
+      "cloud-controller-manager"
+      "e2e.test"
+    ];
+
+    WHAT = concatStringsSep " " components;
+
+    preBuild = "export HOME=$PWD";
+
+    postPatch = ''
+      # go env breaks the sandbox
+      substituteInPlace "hack/lib/golang.sh" \
+        --replace 'echo "$(go env GOHOSTOS)/$(go env GOHOSTARCH)"' 'echo "${go.GOOS}/${go.GOARCH}"'
+
+      substituteInPlace "hack/update-generated-docs.sh" --replace "make" "make SHELL=${stdenv.shell}"
+      # hack/update-munge-docs.sh only performs some tests on the documentation.
+      # They broke building k8s; disabled for now.
+      echo "true" > "hack/update-munge-docs.sh"
+
+      patchShebangs ./hack
+    '';
+
+    postBuild = ''
+      ./hack/update-generated-docs.sh
+      (cd build/pause && cc pause.c -o pause)
+    '';
+
+    installPhase = ''
+      mkdir -p "$out/bin" "$out/share/bash-completion/completions" "$out/share/zsh/site-functions" "$man/share/man" "$pause/bin"
+
+      for binary in $binaries; do
+        if [ -f "_output/local/go/bin/$binary" ]; then
+          cp "_output/local/go/bin/$binary" "$out/bin/"
+        fi
+      done
+
+      cp build/pause/pause "$pause/bin/pause"
+      cp -R docs/man/man1 "$man/share/man"
+
+      ${optionalString ((builtins.compareVersions version "1.15") < 0) ''
+      cp cluster/addons/addon-manager/namespace.yaml $out/share
+      cp cluster/addons/addon-manager/kube-addons.sh $out/bin/kube-addons
+      cp ${./mk-docker-opts.sh} $out/bin/mk-docker-opts.sh
+      patchShebangs $out/bin/kube-addons
+      substituteInPlace $out/bin/kube-addons \
+        --replace /opt/namespace.yaml $out/share/namespace.yaml
+      '' + optionalString (elem "cmd/kubectl" components) ''
+      wrapProgram $out/bin/kube-addons --set "KUBECTL_BIN" "$out/bin/kubectl"
+      ''}
+
+      ${optionalString (elem "cmd/kubectl" components) ''
+      $out/bin/kubectl completion bash > $out/share/bash-completion/completions/kubectl
+      $out/bin/kubectl completion zsh > $out/share/zsh/site-functions/_kubectl
+      ''}
+    '';
+
+    preFixup = ''
+      find $out/bin $pause/bin -type f -exec remove-references-to -t ${go} '{}' +
+    '';
+
+    meta = {
+      description = "Production-Grade Container Scheduling and Management";
+      license = licenses.asl20;
+      homepage = https://kubernetes.io;
+      maintainers = with maintainers; [johanot offline];
+      platforms = platforms.unix;
+    };
   };
 
-  buildInputs = [ removeReferencesTo makeWrapper which go rsync go-bindata ];
+  minorVersion = version: concatStringsSep "_" (take 2 (builtins.splitVersion version));
 
-  outputs = ["out" "man" "pause"];
+  mkName = version: "kubernetes_${minorVersion version}";
 
-  postPatch = ''
-    # go env breaks the sandbox
-    substituteInPlace "hack/lib/golang.sh" \
-      --replace 'echo "$(go env GOHOSTOS)/$(go env GOHOSTARCH)"' 'echo "${go.GOOS}/${go.GOARCH}"'
+  mkVersion = version: nameValuePair (mkName version.version) (generic version);
 
-    substituteInPlace "hack/update-generated-docs.sh" --replace "make" "make SHELL=${stdenv.shell}"
-    # hack/update-munge-docs.sh only performs some tests on the documentation.
-    # They broke building k8s; disabled for now.
-    echo "true" > "hack/update-munge-docs.sh"
-
-    patchShebangs ./hack
-  '';
-
-  WHAT=concatStringsSep " " components;
-
-  postBuild = ''
-    ./hack/update-generated-docs.sh
-    (cd build/pause && cc pause.c -o pause)
-  '';
-
-  installPhase = ''
-    mkdir -p "$out/bin" "$out/share/bash-completion/completions" "$out/share/zsh/site-functions" "$man/share/man" "$pause/bin"
-
-    cp _output/local/go/bin/* "$out/bin/"
-    cp build/pause/pause "$pause/bin/pause"
-    cp -R docs/man/man1 "$man/share/man"
-
-    cp cluster/addons/addon-manager/kube-addons.sh $out/bin/kube-addons
-    patchShebangs $out/bin/kube-addons
-    wrapProgram $out/bin/kube-addons --set "KUBECTL_BIN" "$out/bin/kubectl"
-
-    cp ${./mk-docker-opts.sh} $out/bin/mk-docker-opts.sh
-
-    $out/bin/kubectl completion bash > $out/share/bash-completion/completions/kubectl
-    $out/bin/kubectl completion zsh > $out/share/zsh/site-functions/_kubectl
-  '';
-
-  preFixup = ''
-    find $out/bin $pause/bin -type f -exec remove-references-to -t ${go} '{}' +
-  '';
-
-  meta = {
-    description = "Production-Grade Container Scheduling and Management";
-    license = licenses.asl20;
-    homepage = https://kubernetes.io;
-    maintainers = with maintainers; [johanot offline];
-    platforms = platforms.unix;
-  };
-}
+in lib.listToAttrs (map mkVersion versions)

--- a/pkgs/applications/networking/cluster/kubernetes/mkversions.sh
+++ b/pkgs/applications/networking/cluster/kubernetes/mkversions.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -p httpie yq moreutils
+#!nix-shell -i bash
+
+set -eufxo pipefail
+
+echo '[]' >versions.json
+
+kops_recommended_versions() {
+    http https://raw.githubusercontent.com/kubernetes/kops/master/channels/stable \
+        | yq -r '.spec.kubernetesVersions[:5] | .[] | .recommendedVersion'
+}
+
+for version in $(kops_recommended_versions); do
+    jq \
+        --arg version "$version" \
+        --arg sha256 "$(nix-prefetch-url --unpack "https://github.com/kubernetes/kubernetes/tarball/v${version}")" \
+        '. + [{version: $version, sha256: $sha256}]' \
+        versions.json \
+        | sponge versions.json
+done

--- a/pkgs/applications/networking/cluster/kubernetes/versions.json
+++ b/pkgs/applications/networking/cluster/kubernetes/versions.json
@@ -1,15 +1,15 @@
 [
   {
-    "version": "1.15.2",
-    "sha256": "05sixqs3wj10yzxhrh8qn7q6pabhvnkgdhwq8vvkd4h758pnr1hh"
+    "version": "1.15.3",
+    "sha256": "0vamr7m8i5svmvb0z01cngv3sffdfjj0bky2zalm7cfnapib8vz1"
   },
   {
-    "version": "1.14.5",
-    "sha256": "1a0ab7fm02yci6fd72z888c01695jsj2k5vxk4pywxrd8xhszvzy"
+    "version": "1.14.6",
+    "sha256": "09ahcp4qmc44ydccf5x3g5v1dxcrm4h74p6r5vjl6r2vqb8d837f"
   },
   {
-    "version": "1.13.9",
-    "sha256": "0dnwxd38ixl5czv2g1qix3gfxmyh2ig0zbalgvc3lq9c57wd0yg8"
+    "version": "1.13.10",
+    "sha256": "0x9blsc0pn77aiaaws45r1531jl29psgljq0l67kpw0bgppg5y7w"
   },
   {
     "version": "1.12.10",

--- a/pkgs/applications/networking/cluster/kubernetes/versions.json
+++ b/pkgs/applications/networking/cluster/kubernetes/versions.json
@@ -1,0 +1,22 @@
+[
+  {
+    "version": "1.15.2",
+    "sha256": "05sixqs3wj10yzxhrh8qn7q6pabhvnkgdhwq8vvkd4h758pnr1hh"
+  },
+  {
+    "version": "1.14.5",
+    "sha256": "1a0ab7fm02yci6fd72z888c01695jsj2k5vxk4pywxrd8xhszvzy"
+  },
+  {
+    "version": "1.13.9",
+    "sha256": "0dnwxd38ixl5czv2g1qix3gfxmyh2ig0zbalgvc3lq9c57wd0yg8"
+  },
+  {
+    "version": "1.12.10",
+    "sha256": "18923qqblx0y3g6mk5lzkm2hbb3a09bxbnppabdb6svwqppazzjh"
+  },
+  {
+    "version": "1.11.10",
+    "sha256": "0gjh2sqdxm4yxcg22135368sk57dcdgcs5lfnhhv5g5ipsw0g9sc"
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19044,7 +19044,14 @@ in
 
   kubeval = callPackage ../applications/networking/cluster/kubeval { };
 
-  kubernetes = callPackage ../applications/networking/cluster/kubernetes { };
+  inherit (callPackages ../applications/networking/cluster/kubernetes {})
+    kubernetes_1_11
+    kubernetes_1_12
+    kubernetes_1_13
+    kubernetes_1_14
+    kubernetes_1_15;
+
+  kubernetes = kubernetes_1_15;
 
   kubectl = callPackage ../applications/networking/cluster/kubectl { };
 


### PR DESCRIPTION
###### Motivation for this change
Add generic builder for Kubernetes, and expressions for versions considered stable by [kops](https://github.com/kubernetes/kops).

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).