### PR TITLE
stm32loader: init at 0.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1518,6 +1518,11 @@
     github = "liclac";
     name = "embr";
   };
+  emily = {
+    email = "nixpkgs@emily.moe";
+    github = "emilazy";
+    name = "Emily";
+  };
   ederoyd46 = {
     email = "matt@ederoyd.co.uk";
     github = "ederoyd46";

--- a/pkgs/development/python-modules/stm32loader/default.nix
+++ b/pkgs/development/python-modules/stm32loader/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildPythonPackage
+, isPy27
+, fetchPypi
+, progress
+, pyserial
+, pytest
+, mock
+}:
+
+buildPythonPackage rec {
+  pname = "stm32loader";
+  version = "0.5.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1w6jg4dcyz6si6dcyx727sxi75wnl0j89xkiwqmsw286s1y8ijjw";
+  };
+
+  propagatedBuildInputs = [ progress pyserial ];
+
+  checkInputs = [ pytest ] ++ lib.optional isPy27 mock;
+
+  checkPhase = ''
+    pytest --strict tests/unit
+  '';
+
+  meta = with lib; {
+    description = "Flash firmware to STM32 microcontrollers in Python";
+    homepage = https://github.com/florisla/stm32loader;
+    changelog = "https://github.com/florisla/stm32loader/blob/v${version}/CHANGELOG.md";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ emily ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6104,6 +6104,8 @@ in
 
   stdman = callPackage ../data/documentation/stdman { };
 
+  stm32loader = with python3Packages; toPythonApplication stm32loader;
+
   storebrowse = callPackage ../tools/system/storebrowse { };
 
   stubby = callPackage ../tools/networking/stubby { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1160,6 +1160,8 @@ in {
 
   statistics = callPackage ../development/python-modules/statistics { };
 
+  stm32loader = callPackage ../development/python-modules/stm32loader { };
+
   stumpy = callPackage ../development/python-modules/stumpy { };
 
   sumo = callPackage ../development/python-modules/sumo { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).