### PR TITLE
libetpan: 1.8 -> 1.9.3

### DIFF
--- a/pkgs/development/libraries/libetpan/default.nix
+++ b/pkgs/development/libraries/libetpan/default.nix
@@ -1,17 +1,24 @@
-{ autoconf, automake, fetchgit, libtool, stdenv, openssl }:
+{ stdenv, fetchFromGitHub
+, autoconf
+, automake
+, libtool
+, openssl
+}:
 
-let version = "1.8"; in
+stdenv.mkDerivation rec {
+  pname = "libetpan";
+  version = "1.9.3";
 
-stdenv.mkDerivation {
-  name = "libetpan-${version}";
-
-  src = fetchgit {
-    url = "git://github.com/dinhviethoa/libetpan";
-    rev = "refs/tags/" + version;
-    sha256 = "09xqy1n18qn63x7idfrpwm59lfkvb1p5vxkyksywvy4f6mn4pyxk";
+  src = fetchFromGitHub {
+    owner = "dinhviethoa";
+    repo = "libetpan";
+    rev = version;
+    sha256 = "19g4qskg71jv7sxfxsdkjmrxk9mk5kf9b6fhw06g6wvm3205n95f";
   };
 
-  buildInputs = [ autoconf automake libtool openssl ];
+  nativeBuildInputs = [ libtool autoconf automake ];
+
+  buildInputs = [ openssl ];
 
   configureScript = "./autogen.sh";
 


### PR DESCRIPTION
###### Motivation for this change
fixing @r-ryantm packages that fail to auto-update

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[3 built, 9 copied (71.8 MiB), 22.9 MiB DL]
3 package were build:
clawsMail libetpan mailcore2
```
```
$ nix path-info -Sh ./results/libetpan
/nix/store/4s3mnh9mz3hjrlrs3kph5zxih685ybdr-libetpan-1.9.3        40.4M
```
```
$ nix path-info -Sh ./result
/nix/store/yfnm97lnpk244x0g3jkfly5c50f8k36n-libetpan-1.8          40.4M
```