### PR TITLE
libpinyin: 2.1.91 ->  2.3.0

### DIFF
--- a/pkgs/development/libraries/libpinyin/default.nix
+++ b/pkgs/development/libraries/libpinyin/default.nix
@@ -1,31 +1,36 @@
-{ stdenv, fetchurl, fetchFromGitHub, autoreconfHook, glib, db, pkgconfig }:
+{ stdenv, fetchurl, fetchFromGitHub
+, autoreconfHook
+, glib
+, db
+, pkgconfig
+}:
 
 let
   modelData = fetchurl {
-    url    = "mirror://sourceforge/libpinyin/models/model14.text.tar.gz";
-    sha256 = "0qqk30nflj07zjhs231c95ln4yj4ipzwxxiwrxazrg4hb8bhypqq";
+    url    = "mirror://sourceforge/libpinyin/models/model17.text.tar.gz";
+    sha256 = "1kb2nswpsqlk2qm5jr7vqcp97f2dx7nvpk24lxjs1g12n252f5z0";
   };
 in
 stdenv.mkDerivation rec {
   name = "libpinyin-${version}";
-  version = "2.1.91";
-
-  nativeBuildInputs = [ autoreconfHook glib db pkgconfig ];
-
-  postUnpack = ''
-    tar -xzf ${modelData} -C $sourceRoot/data
-  '';
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner  = "libpinyin";
     repo   = "libpinyin";
     rev    = version;
-    sha256 = "0jbvn65p3zh0573hh27aasd3qly5anyfi8jnps2dxi0my09wbrq3";
+    sha256 = "14fkpp16s5k0pbw5wwd24pqr0qbdjgbl90n9aqwx72m03n7an40l";
   };
+
+  postUnpack = ''
+    tar -xzf ${modelData} -C $sourceRoot/data
+  '';
+
+  nativeBuildInputs = [ autoreconfHook glib db pkgconfig ];
 
   meta = with stdenv.lib; {
     description = "Library for intelligent sentence-based Chinese pinyin input method";
-    homepage    = https://sourceforge.net/projects/libpinyin;
+    homepage    = "https://sourceforge.net/projects/libpinyin";
     license     = licenses.gpl2;
     maintainers = with maintainers; [ ericsagnes ];
     platforms   = platforms.linux;


### PR DESCRIPTION
###### Motivation for this change
fixing builds that @r-ryantm fails to update

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
3 package were build:
fcitx-engines.libpinyin ibus-engines.libpinyin libpinyin
```