### PR TITLE
Add `python3Packages.ckcc-protocol` package, and list it as a dependency for `electrum`.

### DIFF
--- a/pkgs/applications/misc/electrum/default.nix
+++ b/pkgs/applications/misc/electrum/default.nix
@@ -74,6 +74,7 @@ python3Packages.buildPythonApplication {
     tlslite-ng
 
     # plugins
+    ckcc-protocol
     keepkey
     trezor
     btchip

--- a/pkgs/development/python-modules/ckcc-protocol/default.nix
+++ b/pkgs/development/python-modules/ckcc-protocol/default.nix
@@ -1,0 +1,35 @@
+{ stdenv
+, buildPythonPackage
+, click
+, ecdsa
+, hidapi
+, lib
+, fetchPypi
+, pytest
+, pyaes
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "ckcc-protocol";
+  version = "0.8.0";
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1mbs9l8qycy50j5lq6az7l5d8i40nb0vmlyhcyax298qp6c1r1gh";
+  };
+
+  checkInputs = [
+    pytest
+  ];
+
+  propagatedBuildInputs = [ click ecdsa hidapi pyaes ];
+
+  meta = with stdenv.lib; {
+    description = "Communicate with your Coldcard using Python";
+    homepage = https://github.com/Coldcard/ckcc-protocol;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.hkjn ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6138,6 +6138,8 @@ in {
     inherit (pkgs) udev libusb1;
   };
 
+  ckcc-protocol = callPackage ../development/python-modules/ckcc-protocol { };
+
   mnemonic = callPackage ../development/python-modules/mnemonic { };
 
   keepkey = callPackage ../development/python-modules/keepkey { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The https://coldcardwallet.com/ is a hardware wallet for Bitcoin. This change adds the `python3Packages.ckcc-protocol` package, and lists it as a dependency for `electrum`.

Similar to `keepkey`, `trezor` and `btchip`, `ckcc-protocol` is a plugin,
allowing electrum to communicate with the https://coldcardwallet.com/.

Also ~add `hkjn` to maintainers, and~ list `hkjn` as initial maintainer for `ckcc-protocol`. (Would be happy to hand over to official Coldcard maintainers at any point, if they are willing.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

N/A
