### PR TITLE
tinyprog: init at 1.0.24.dev99+ga77f828

### DIFF
--- a/pkgs/development/python-modules/jsonmerge/default.nix
+++ b/pkgs/development/python-modules/jsonmerge/default.nix
@@ -1,0 +1,25 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, jsonschema
+}:
+
+buildPythonPackage rec {
+  pname = "jsonmerge";
+  version = "1.6.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "03l2j1lrcwcp7af4x8agxnkib0ndybfrbhn2gi7mnk6gbxfw1aw3";
+  };
+
+  propagatedBuildInputs = [ jsonschema ];
+
+  meta = with lib; {
+    description = "Merge a series of JSON documents";
+    homepage = https://github.com/avian2/jsonmerge;
+    changelog = "https://github.com/avian2/jsonmerge/blob/jsonmerge-${version}/ChangeLog";
+    license = licenses.mit;
+    maintainers = with maintainers; [ emily ];
+  };
+}

--- a/pkgs/development/tools/misc/tinyprog/default.nix
+++ b/pkgs/development/tools/misc/tinyprog/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, python3Packages
+, fetchFromGitHub
+}:
+
+with python3Packages; buildPythonApplication rec {
+  pname = "tinyprog";
+  # `python setup.py --version` from repo checkout
+  version = "1.0.24.dev99+ga77f828";
+
+  src = fetchFromGitHub {
+    owner = "tinyfpga";
+    repo = "TinyFPGA-Bootloader";
+    rev = "a77f828d3d6ae077e323ec96fc3925efab5aa9d7";
+    sha256 = "0jg47q0n1qkdrzri2q6n9a7czicj0qk58asz0xhzkajx1k9z3g5q";
+  };
+
+  sourceRoot = "source/programmer";
+
+  propagatedBuildInputs = [
+    pyserial
+    jsonmerge
+    intelhex
+    tqdm
+    six
+    packaging
+    pyusb
+  ];
+
+  nativeBuildInputs = [ setuptools_scm ];
+
+  preBuild = ''
+    export SETUPTOOLS_SCM_PRETEND_VERSION="${version}"
+  '';
+
+  meta = with lib; {
+    homepage = https://github.com/tinyfpga/TinyFPGA-Bootloader/tree/master/programmer;
+    description = "Programmer for FPGA boards using the TinyFPGA USB Bootloader";
+    maintainers = with maintainers; [ emily ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6368,6 +6368,8 @@ in
 
   tinyemu = callPackage ../applications/virtualization/tinyemu { };
 
+  tinyprog = callPackage ../development/tools/misc/tinyprog { };
+
   tinyproxy = callPackage ../tools/networking/tinyproxy {};
 
   tio = callPackage ../tools/misc/tio { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2428,6 +2428,8 @@ in {
 
   jsmin = callPackage ../development/python-modules/jsmin { };
 
+  jsonmerge = callPackage ../development/python-modules/jsonmerge { };
+
   jsonpatch = callPackage ../development/python-modules/jsonpatch { };
 
   jsonpickle = callPackage ../development/python-modules/jsonpickle { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This is the programmer used for USB [TinyFPGA](https://tinyfpga.com/) devices. A previous pull request to add it, https://github.com/NixOS/nixpkgs/pull/52878, stalled out. I've used the git version because there's no source tarball on PyPI and there have been a substantial number of changes since the last release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @thoughtpolice as potentially interested going by the `yosys`/`icestorm` maintainers? :)

Sorry for the minor deluge of new packages!