### PR TITLE
Revert "gitlab-runner: don't bundle prebuilt docker images"

### DIFF
--- a/pkgs/development/tools/continuous-integration/gitlab-runner/default.nix
+++ b/pkgs/development/tools/continuous-integration/gitlab-runner/default.nix
@@ -2,6 +2,16 @@
 
 let
   version = "12.1.0";
+  # Gitlab runner embeds some docker images these are prebuilt for arm and x86_64
+  docker_x86_64 = fetchurl {
+    url = "https://gitlab-runner-downloads.s3.amazonaws.com/v${version}/helper-images/prebuilt-x86_64.tar.xz";
+    sha256 = "1yx530h5rz7wmd012962f9dfj0hvj1m7zab5vchndna4svzzycch";
+  };
+
+  docker_arm = fetchurl {
+    url = "https://gitlab-runner-downloads.s3.amazonaws.com/v${version}/helper-images/prebuilt-arm.tar.xz";
+    sha256 = "0zsin76qiq46w675wdkaz3ng1i9szad3hzmk5dngdnr59gq5mqhk";
+  };
 in
 buildGoPackage rec {
   inherit version;
@@ -23,6 +33,13 @@ buildGoPackage rec {
   };
 
   patches = [ ./fix-shell-path.patch ];
+
+  postInstall = ''
+    touch $bin/bin/hello
+    install -d $bin/bin/helper-images
+    ln -sf ${docker_x86_64} $bin/bin/helper-images/prebuilt-x86_64.tar.xz
+    ln -sf ${docker_arm} $bin/bin/helper-images/prebuilt-arm.tar.xz
+  '';
 
   meta = with lib; {
     description = "GitLab Runner the continuous integration executor of GitLab";


### PR DESCRIPTION
Reverts NixOS/nixpkgs#66225

As we don't have the git hash in our runner, the runner can't fetch the images until https://gitlab.com/gitlab-org/gitlab-runner/issues/4509 is fixed.

@zimbatm I think it's best to revert this. Sorry for the trouble.

