### PR TITLE
google-cloud-cpp: init at 0.11.0

### DIFF
--- a/pkgs/development/libraries/crc32c/default.nix
+++ b/pkgs/development/libraries/crc32c/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, cmake, gflags }:
+stdenv.mkDerivation rec {
+  pname = "crc32c";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "crc32c";
+    rev = version;
+    sha256 = "1sazkis9rzbrklfrvk7jn1mqywnq4yghmzg94mxd153h8b1sb149";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ gflags ];
+  NIX_CFLAGS_COMPILE = stdenv.lib.optional stdenv.isAarch64 "-march=armv8-a+crc";
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/google/crc32c;
+    description = "CRC32C implementation with support for CPU-specific acceleration instructions";
+    license = with licenses; [ bsd3 ];
+    maintainers = with maintainers; [ andir ];
+  };
+}

--- a/pkgs/development/libraries/google-cloud-cpp/default.nix
+++ b/pkgs/development/libraries/google-cloud-cpp/default.nix
@@ -1,0 +1,65 @@
+{ stdenv, grpc, curl, cmake, pkgconfig, fetchFromGitHub, doxygen, protobuf, crc32c, c-ares, nlohmann_json, fetchurl }:
+let
+  googleapis_rev = "a8ee1416f4c588f2ab92da72e7c1f588c784d3e6";
+  googleapis = fetchurl {
+    name = "${googleapis_rev}.tar.gz";
+    url = "https://github.com/googleapis/googleapis/archive/${googleapis_rev}.tar.gz";
+    sha256 = "1kxi27r034p7jfldhvgpbn6rqqqddycnja47m6jyjxj4rcmrp2kb";
+  };
+in stdenv.mkDerivation rec {
+  pname = "google-cloud-cpp";
+  version = "0.11.0";
+
+  src = fetchFromGitHub {
+    owner = "googleapis";
+    repo = "google-cloud-cpp";
+    rev = "v${version}";
+    sha256 = "1w942gzyv01ym1cv2a417x92zxra9s2v3xz5crcv84j919f616f8";
+  };
+
+  buildInputs = [ curl grpc protobuf nlohmann_json crc32c c-ares c-ares.cmake-config ];
+  nativeBuildInputs = [ cmake pkgconfig doxygen ];
+
+  outputs = [ "out" "dev" ];
+
+  postPatch = ''
+    NLOHMANN_SHA256=$(sha256sum ${nlohmann_json}/include/nlohmann/json.hpp | cut -f1 -d' ')
+    sed -e 's,https://github.com/nlohmann/json/releases/download/.*,file://${nlohmann_json}/include/nlohmann/json.hpp"),' \
+        -e "s,JSON_SHA256 .*,JSON_SHA256 ''${NLOHMANN_SHA256}," \
+        -i cmake/DownloadNlohmannJson.cmake
+
+    sed -e 's,https://github.com/googleapis/googleapis/archive/${googleapis_rev}.tar.gz,file://${googleapis},' \
+        -i cmake/external/googleapis.cmake
+
+    # Fixup the library path. It would build a path like /build/external//nix/store/…-foo/lib/foo.so for each library instead of /build/external/lib64/foo.so
+    sed -e 's,''${CMAKE_INSTALL_LIBDIR},lib64,g' \
+        -e 's,;lib64,lib,g' \
+        -i cmake/ExternalProjectHelper.cmake
+  '';
+
+  preFixup = ''
+    mv --no-clobber $out/lib64/cmake/* $out/lib/cmake
+    mv --no-clobber $out/lib64/pkgconfig/* $out/lib/pkgconfig
+    rmdir $out/lib64/cmake $out/lib64/pkgconfig
+    find $out/lib64
+
+    for file in $out/lib/pkgconfig/*; do
+      sed -e 's,\''${prefix}//,/,g' -i $file
+    done
+  '';
+
+  cmakeFlags = [
+    "-DGOOGLE_CLOUD_CPP_BIGTABLE_ENABLE_INSTALL=no"
+    "-DGOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER=package"
+    "-DGOOGLE_CLOUD_CPP_GOOGLEAPIS_PROVIDER=external"
+    "-DBUILD_SHARED_LIBS:BOOL=ON"
+    "-DGOOGLE_CLOUD_CPP_INSTALL_RPATH=$(out)/lib"
+  ];
+
+  meta = with stdenv.lib; {
+    license = with licenses; [ asl20 ];
+    homepage = https://github.com/googleapis/google-cloud-cpp;
+    description = "C++ Idiomatic Clients for Google Cloud Platform services";
+    maintainers = with maintainers; [ andir ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -755,6 +755,8 @@ in
 
   crumbs = callPackage ../applications/misc/crumbs { };
 
+  crc32c = callPackage ../development/libraries/crc32c { };
+
   cue = callPackage ../development/tools/cue { };
 
   deskew = callPackage ../applications/graphics/deskew { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3446,6 +3446,8 @@ in
 
   google-music-scripts = callPackage ../tools/audio/google-music-scripts { };
 
+  google-cloud-cpp = callPackage ../development/libraries/google-cloud-cpp { };
+
   gopro = callPackage ../tools/video/gopro { };
 
   gource = callPackage ../applications/version-management/gource { };


### PR DESCRIPTION
###### Motivation for this change

I started working on adding GCS support to Nix and needed a few dependencies for that.
See https://github.com/NixOS/nix/pull/3021.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @edolstra
