### PR TITLE
ffmpeg_4: Enable support for AV1 decoding via dav1d by default

### DIFF
--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, pkgconfig, perl, texinfo, yasm
 , alsaLib, bzip2, fontconfig, freetype, gnutls, libiconv, lame, libass, libogg
 , libssh, libtheora, libva, libdrm, libvorbis, libvpx, lzma, libpulseaudio, soxr
-, x264, x265, xvidcore, zlib, libopus, speex, nv-codec-headers
+, x264, x265, xvidcore, zlib, libopus, speex, nv-codec-headers, dav1d
 , openglSupport ? false, libGLU_combined ? null
 # Build options
 , runtimeCpuDetectBuild ? true # Detect CPU capabilities at runtime
@@ -145,6 +145,7 @@ stdenv.mkDerivation rec {
       (ifMinVer "2.8" "--enable-libopus")
       "--enable-libspeex"
       (ifMinVer "2.8" "--enable-libx265")
+      (ifMinVer "4.2" (enableFeature (dav1d != null) "libdav1d"))
     # Developer flags
       (enableFeature debugDeveloper "debug")
       (enableFeature optimizationsDeveloper "optimizations")
@@ -170,7 +171,8 @@ stdenv.mkDerivation rec {
     ++ optional isLinux alsaLib
     ++ optionals isDarwin darwinFrameworks
     ++ optional vdpauSupport libvdpau
-    ++ optional sdlSupport (if reqMin "3.2" then SDL2 else SDL);
+    ++ optional sdlSupport (if reqMin "3.2" then SDL2 else SDL)
+    ++ optional (reqMin "4.2") dav1d;
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
This is e.g. required for mpv (depends on ffmpeg_4) to play AV1 videos.
Fixes #54990.

But since dav1d is only a AV1 decoder this doesn't support AV1 encoding
as well (that would require an additional dependency on libaom).

TODOs for review:
- [x] should we rename the option to `av1DecodingSupport` (or add `libaom` as well)?
  - Removed the option entirely but made it possible to set `dav1d` to `null`.
- [x] is AV1 decoding relevant enough to enable it by default? The file contains the following note:
```
 * THIS IS A MINIMAL BUILD OF FFMPEG, do not include dependencies unless
 * a build that depends on ffmpeg requires them to be compiled into ffmpeg,
 * see `ffmpeg-full' for an ffmpeg build with all features included.
```
  - Seems to be relevant enough, the AV1 adoption should proceed "rapidly" (hopefully :D).
- [ ] test how well (performance) this works on different platforms. E.g. on my laptop this works pretty well (smooth 1080p playback), but on my older AMD Phenom II X6 1100T CPU this didn't work that well (too many frames dropped and high CPU usage for 1080p, depending on the Video - IIRC it worked better with more frame and tile threads).
  - High bitrate test files can e.g. be found here: http://download.opencontent.netflix.com/?prefix=AV1/Chimera/, I e.g. used:
    - Chimera-AV1-10bit-1920x1080-6191kbps.mp4
    - Chimera-AV1-8bit-1920x1080-6736kbps.mp4
  - [YouTube AV1 Beta Launch Playlist](https://www.youtube.com/playlist?list=PLyqf6gJt7KuHBmeVzZteZUlNUQAVLwrZS)

TODOs:
- [x] created this commit yesterday and forgot that it doesn't only affect `ffmpeg_4` which causes the many rebuilds (IIRC ~2.5k), ~~that might be avoidable (I'll take a look later).~~ -> It affects the other versions because `ifMinVer` evaluates to `null` and therefore changes the list (could avoid this but that wouldn't match the existing file/code structure).
  - Decided to base this on staging.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
