### PR TITLE
[19.03] terraform: 0.12.3 -> 0.12.6

### DIFF
--- a/pkgs/applications/networking/cluster/terraform/default.nix
+++ b/pkgs/applications/networking/cluster/terraform/default.nix
@@ -97,8 +97,8 @@ in rec {
   terraform_0_11-full = terraform_0_11.full;
 
   terraform_0_12 = pluggable (generic {
-    version = "0.12.3";
-    sha256 = "190bvd1q6h2hgi6s2ca6wnaib4k90rjq5g5l93vcbfjcczcgbv5q";
+    version = "0.12.4";
+    sha256 = "0hbrdnryfla6d3mjn2sf6qbi79slhd92s2xgcqk3bgvr1n6k0k7n";
     patches = [ ./provider-path.patch ];
     passthru = { inherit plugins; };
   });

--- a/pkgs/applications/networking/cluster/terraform/default.nix
+++ b/pkgs/applications/networking/cluster/terraform/default.nix
@@ -97,8 +97,8 @@ in rec {
   terraform_0_11-full = terraform_0_11.full;
 
   terraform_0_12 = pluggable (generic {
-    version = "0.12.5";
-    sha256 = "0p064rhaanwx4szs8hv6mdqad8d2bgfd94h2la11j58xbsxc7hap";
+    version = "0.12.6";
+    sha256 = "0vxvciv4amblxx50wivlm60fyj1ardfgdpj3l8cj9fhi79b3khxl";
     patches = [ ./provider-path.patch ];
     passthru = { inherit plugins; };
   });

--- a/pkgs/applications/networking/cluster/terraform/default.nix
+++ b/pkgs/applications/networking/cluster/terraform/default.nix
@@ -97,8 +97,8 @@ in rec {
   terraform_0_11-full = terraform_0_11.full;
 
   terraform_0_12 = pluggable (generic {
-    version = "0.12.4";
-    sha256 = "0hbrdnryfla6d3mjn2sf6qbi79slhd92s2xgcqk3bgvr1n6k0k7n";
+    version = "0.12.5";
+    sha256 = "0p064rhaanwx4szs8hv6mdqad8d2bgfd94h2la11j58xbsxc7hap";
     patches = [ ./provider-path.patch ];
     passthru = { inherit plugins; };
   });


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This brings up a lot of bug fixes, most notably for various crashes and `terraform fmt` which was a regression in the ways how code is formatted.

**NOTE** Still not ready for merging, as everything Go related fails to build on Darwin after 3590ff2d4c64711a194e3f18fc5c140e7dfa25df. Working on fixing that.

Fails with:
```
$ nix-build . -A pkgs.terraform_0_12 --argstr system "x86_64-darwin"
...
building '/nix/store/8i66967wln7z6nal6i4npkl4ks901nhv-swift-corefoundation.drv'...
building '/nix/store/gkgyss9s4hkxm3z2aly7mr4cg3jwrxg0-swift-corefoundation-private.drv'...
unpacking sources
unpacking sources
unpacking source archive /nix/store/q19wpy2aylv4a6z5c6p52ih8pi2kcbpq-source
unpacking source archive /nix/store/q19wpy2aylv4a6z5c6p52ih8pi2kcbpq-source
source root is source/CoreFoundation
source root is source/CoreFoundation
patching sources
patching sources
substituteStream(): WARNING: pattern '#if defined(__GNU__) ||' doesn't match anything in file 'Base.subproj/CFAsmMacros.h'
substituteStream(): WARNING: pattern '#if defined(__GNU__) ||' doesn't match anything in file 'Base.subproj/CFAsmMacros.h'
configuring
configuring
/nix/store/3iqn6s3xabswcqirr7302c3kn4dd7q4k-bootstrap-stage1-stdenv-darwin/setup: ../configure: /usr/bin/env: bad interpreter: Operation not permitted
/nix/store/3iqn6s3xabswcqirr7302c3kn4dd7q4k-bootstrap-stage1-stdenv-darwin/setup: ../configure: /usr/bin/env: bad interpreter: Operation not permitted
builder for '/nix/store/gkgyss9s4hkxm3z2aly7mr4cg3jwrxg0-swift-corefoundation-private.drv' failed with exit code 126
builder for '/nix/store/8i66967wln7z6nal6i4npkl4ks901nhv-swift-corefoundation.drv' failed with exit code 126
cannot build derivation '/nix/store/8x0ymrcaiamka8r3gk9l0wlzyx3lycn8-bootstrap-stage2-stdenv-darwin.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/qww9pydqjlp47g32bl8hrpgvzphn24p1-bootstrap-stage2-stdenv-darwin.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/vr6il6rllr2xg3vws55rnlc0idcrd12h-bootstrap-stage3-stdenv-darwin.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/ycx6ynnf1j14vgkac62skb22pd3y0jws-bootstrap-stage3-stdenv-darwin.drv': 1 dependencies couldn't be built
...
``` 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
