### PR TITLE
gnome3.evolution-data-server: Hardcode more GSettings schemas

### DIFF
--- a/pkgs/desktops/gnome-3/core/evolution-data-server/default.nix
+++ b/pkgs/desktops/gnome-3/core/evolution-data-server/default.nix
@@ -2,7 +2,7 @@
 , intltool, libsoup, libxml2, libsecret, icu, sqlite, tzdata, libcanberra-gtk3, gcr
 , p11-kit, db, nspr, nss, libical, gperf, wrapGAppsHook, glib-networking, pcre
 , vala, cmake, ninja, kerberos, openldap, webkitgtk, libaccounts-glib, json-glib
-, glib, gtk3, gnome-online-accounts, libgweather, libgdata }:
+, glib, gtk3, gnome-online-accounts, libgweather, libgdata, gsettings-desktop-schemas }:
 
 stdenv.mkDerivation rec {
   name = "evolution-data-server-${version}";
@@ -20,8 +20,13 @@ stdenv.mkDerivation rec {
       src = ./fix-paths.patch;
       inherit tzdata;
     })
-    ./hardcode-gsettings.patch
   ];
+
+  prePatch = ''
+    substitute ${./hardcode-gsettings.patch} hardcode-gsettings.patch --subst-var-by ESD_GSETTINGS_PATH $out/share/gsettings-schemas/${name}/glib-2.0/schemas \
+      --subst-var-by GDS_GSETTINGS_PATH "${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}/glib-2.0/schemas"
+    patches="$patches $PWD/hardcode-gsettings.patch"
+  '';
 
   nativeBuildInputs = [
     cmake ninja pkgconfig intltool python3 gperf wrapGAppsHook gobject-introspection vala
@@ -42,11 +47,6 @@ stdenv.mkDerivation rec {
     "-DCMAKE_SKIP_BUILD_RPATH=OFF"
     "-DINCLUDE_INSTALL_DIR=${placeholder "dev"}/include"
   ];
-
-  postPatch = ''
-    substituteInPlace src/libedataserver/e-source-registry.c --subst-var-by ESD_GSETTINGS_PATH $out/share/gsettings-schemas/${name}/glib-2.0/schemas
-  '';
-
 
   passthru = {
     updateScript = gnome3.updateScript {

--- a/pkgs/desktops/gnome-3/core/evolution-data-server/hardcode-gsettings.patch
+++ b/pkgs/desktops/gnome-3/core/evolution-data-server/hardcode-gsettings.patch
@@ -1,36 +1,526 @@
-diff --git a/src/libedataserver/e-source-registry.c b/src/libedataserver/e-source-registry.c
-index 9c166dbaf..ef368f8d4 100644
---- a/src/libedataserver/e-source-registry.c
-+++ b/src/libedataserver/e-source-registry.c
-@@ -116,6 +116,8 @@ struct _ESourceRegistryPrivate {
- 	GHashTable *sources;
- 	GMutex sources_lock;
+diff --git a/src/addressbook/libebook/e-book-client.c b/src/addressbook/libebook/e-book-client.c
+index 2c0557c3c..5955aa55e 100644
+--- a/src/addressbook/libebook/e-book-client.c
++++ b/src/addressbook/libebook/e-book-client.c
+@@ -1989,7 +1989,20 @@ e_book_client_get_self (ESourceRegistry *registry,
  
-+	GSettingsSchemaSource *schema_source;
-+	GSettingsSchema *schema;
- 	GSettings *settings;
+ 	*out_client = book_client;
  
- 	gboolean initialized;
-@@ -1339,7 +1341,11 @@ source_registry_dispose (GObject *object)
- 	if (priv->settings != NULL) {
- 		g_signal_handlers_disconnect_by_data (priv->settings, object);
- 		g_object_unref (priv->settings);
-+		g_settings_schema_unref (priv->schema);
-+		g_settings_schema_source_unref (priv->schema_source);
- 		priv->settings = NULL;
-+		priv->schema = NULL;
-+		priv->schema_source = NULL;
+-	settings = g_settings_new (SELF_UID_PATH_ID);
++	{
++		GSettingsSchemaSource *schema_source;
++		GSettingsSchema *schema;
++		schema_source = g_settings_schema_source_new_from_directory("@ESD_GSETTINGS_PATH@",
++									    g_settings_schema_source_get_default(),
++									    TRUE,
++									    NULL);
++		schema = g_settings_schema_source_lookup(schema_source,
++							 SELF_UID_PATH_ID,
++							 FALSE);
++		settings = g_settings_new_full(schema, NULL, NULL);
++		g_settings_schema_source_unref(schema_source);
++		g_settings_schema_unref(schema);
++	}
+ 	uid = g_settings_get_string (settings, SELF_UID_KEY);
+ 	g_object_unref (settings);
+ 
+@@ -2057,7 +2070,20 @@ e_book_client_set_self (EBookClient *client,
+ 	g_return_val_if_fail (
+ 		e_contact_get_const (contact, E_CONTACT_UID) != NULL, FALSE);
+ 
+-	settings = g_settings_new (SELF_UID_PATH_ID);
++	{
++		GSettingsSchemaSource *schema_source;
++		GSettingsSchema *schema;
++		schema_source = g_settings_schema_source_new_from_directory("@ESD_GSETTINGS_PATH@",
++									    g_settings_schema_source_get_default(),
++									    TRUE,
++									    NULL);
++		schema = g_settings_schema_source_lookup(schema_source,
++							 SELF_UID_PATH_ID,
++							 FALSE);
++		settings = g_settings_new_full(schema, NULL, NULL);
++		g_settings_schema_source_unref(schema_source);
++		g_settings_schema_unref(schema);
++	}
+ 	g_settings_set_string (
+ 		settings, SELF_UID_KEY,
+ 		e_contact_get_const (contact, E_CONTACT_UID));
+@@ -2093,8 +2119,20 @@ e_book_client_is_self (EContact *contact)
+ 	 * unfortunately the API doesn't allow that.
+ 	 */
+ 	g_mutex_lock (&mutex);
+-	if (!settings)
+-		settings = g_settings_new (SELF_UID_PATH_ID);
++	if (!settings) {
++		GSettingsSchemaSource *schema_source;
++		GSettingsSchema *schema;
++		schema_source = g_settings_schema_source_new_from_directory("@ESD_GSETTINGS_PATH@",
++									    g_settings_schema_source_get_default(),
++									    TRUE,
++									    NULL);
++		schema = g_settings_schema_source_lookup(schema_source,
++							 SELF_UID_PATH_ID,
++							 FALSE);
++		settings = g_settings_new_full(schema, NULL, NULL);
++		g_settings_schema_source_unref(schema_source);
++		g_settings_schema_unref(schema);
++	}
+ 	uid = g_settings_get_string (settings, SELF_UID_KEY);
+ 	g_mutex_unlock (&mutex);
+ 
+diff --git a/src/addressbook/libebook/e-book.c b/src/addressbook/libebook/e-book.c
+index 3396b57c0..ac6420b2e 100644
+--- a/src/addressbook/libebook/e-book.c
++++ b/src/addressbook/libebook/e-book.c
+@@ -2594,7 +2594,20 @@ e_book_get_self (ESourceRegistry *registry,
+ 		return FALSE;
  	}
  
- 	/* Chain up to parent's finalize() method. */
-@@ -1743,7 +1749,9 @@ e_source_registry_init (ESourceRegistry *registry)
+-	settings = g_settings_new (SELF_UID_PATH_ID);
++	{
++		GSettingsSchemaSource *schema_source;
++		GSettingsSchema *schema;
++		schema_source = g_settings_schema_source_new_from_directory("@ESD_GSETTINGS_PATH@",
++									    g_settings_schema_source_get_default(),
++									    TRUE,
++									    NULL);
++		schema = g_settings_schema_source_lookup(schema_source,
++							 SELF_UID_PATH_ID,
++							 FALSE);
++		settings = g_settings_new_full(schema, NULL, NULL);
++		g_settings_schema_source_unref(schema_source);
++		g_settings_schema_unref(schema);
++	}
+ 	uid = g_settings_get_string (settings, SELF_UID_KEY);
+ 	g_object_unref (settings);
+ 
+@@ -2649,7 +2662,20 @@ e_book_set_self (EBook *book,
+ 	g_return_val_if_fail (E_IS_BOOK (book), FALSE);
+ 	g_return_val_if_fail (E_IS_CONTACT (contact), FALSE);
+ 
+-	settings = g_settings_new (SELF_UID_PATH_ID);
++	{
++		GSettingsSchemaSource *schema_source;
++		GSettingsSchema *schema;
++		schema_source = g_settings_schema_source_new_from_directory("@ESD_GSETTINGS_PATH@",
++									    g_settings_schema_source_get_default(),
++									    TRUE,
++									    NULL);
++		schema = g_settings_schema_source_lookup(schema_source,
++							 SELF_UID_PATH_ID,
++							 FALSE);
++		settings = g_settings_new_full(schema, NULL, NULL);
++		g_settings_schema_source_unref(schema_source);
++		g_settings_schema_unref(schema);
++	}
+ 	g_settings_set_string (
+ 		settings, SELF_UID_KEY,
+ 		e_contact_get_const (contact, E_CONTACT_UID));
+@@ -2677,7 +2703,20 @@ e_book_is_self (EContact *contact)
+ 
+ 	g_return_val_if_fail (E_IS_CONTACT (contact), FALSE);
+ 
+-	settings = g_settings_new (SELF_UID_PATH_ID);
++	{
++		GSettingsSchemaSource *schema_source;
++		GSettingsSchema *schema;
++		schema_source = g_settings_schema_source_new_from_directory("@ESD_GSETTINGS_PATH@",
++									    g_settings_schema_source_get_default(),
++									    TRUE,
++									    NULL);
++		schema = g_settings_schema_source_lookup(schema_source,
++							 SELF_UID_PATH_ID,
++							 FALSE);
++		settings = g_settings_new_full(schema, NULL, NULL);
++		g_settings_schema_source_unref(schema_source);
++		g_settings_schema_unref(schema);
++	}
+ 	uid = g_settings_get_string (settings, SELF_UID_KEY);
+ 	g_object_unref (settings);
+ 
+diff --git a/src/calendar/backends/contacts/e-cal-backend-contacts.c b/src/calendar/backends/contacts/e-cal-backend-contacts.c
+index de1716941..e83b104f1 100644
+--- a/src/calendar/backends/contacts/e-cal-backend-contacts.c
++++ b/src/calendar/backends/contacts/e-cal-backend-contacts.c
+@@ -1397,7 +1397,20 @@ e_cal_backend_contacts_init (ECalBackendContacts *cbc)
+ 		(GDestroyNotify) g_free,
+ 		(GDestroyNotify) contact_record_free);
+ 
+-	cbc->priv->settings = g_settings_new ("org.gnome.evolution-data-server.calendar");
++	{
++		GSettingsSchemaSource *schema_source;
++		GSettingsSchema *schema;
++		schema_source = g_settings_schema_source_new_from_directory("@ESD_GSETTINGS_PATH@",
++									    g_settings_schema_source_get_default(),
++									    TRUE,
++									    NULL);
++		schema = g_settings_schema_source_lookup(schema_source,
++							 "org.gnome.evolution-data-server.calendar",
++							 FALSE);
++		cbc->priv->settings = g_settings_new_full(schema, NULL, NULL);
++		g_settings_schema_source_unref(schema_source);
++		g_settings_schema_unref(schema);
++	}
+ 	cbc->priv->notifyid = 0;
+ 	cbc->priv->update_alarms_id = 0;
+ 	cbc->priv->alarm_enabled = FALSE;
+diff --git a/src/calendar/libecal/e-reminder-watcher.c b/src/calendar/libecal/e-reminder-watcher.c
+index b08a7f301..a49fe39c5 100644
+--- a/src/calendar/libecal/e-reminder-watcher.c
++++ b/src/calendar/libecal/e-reminder-watcher.c
+@@ -2202,7 +2202,21 @@ e_reminder_watcher_init (EReminderWatcher *watcher)
+ 
+ 	watcher->priv = G_TYPE_INSTANCE_GET_PRIVATE (watcher, E_TYPE_REMINDER_WATCHER, EReminderWatcherPrivate);
+ 	watcher->priv->cancellable = g_cancellable_new ();
+-	watcher->priv->settings = g_settings_new ("org.gnome.evolution-data-server.calendar");
++	{
++		GSettingsSchemaSource *schema_source;
++		GSettingsSchema *schema;
++		schema_source = g_settings_schema_source_new_from_directory("@ESD_GSETTINGS_PATH@",
++									    g_settings_schema_source_get_default(),
++									    TRUE,
++									    NULL);
++		schema = g_settings_schema_source_lookup(schema_source,
++							 "org.gnome.evolution-data-server.calendar",
++							 FALSE);
++		watcher->priv->settings = g_settings_new_full(schema, NULL,
++							      NULL);
++		g_settings_schema_source_unref(schema_source);
++		g_settings_schema_unref(schema);
++	}
+ 	watcher->priv->scheduled = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, e_reminder_watcher_free_rd_slist);
+ 	watcher->priv->default_zone = icaltimezone_copy (zone);
+ 	watcher->priv->timers_enabled = TRUE;
+diff --git a/src/camel/camel-cipher-context.c b/src/camel/camel-cipher-context.c
+index dcdc3eed0..fd2e428c2 100644
+--- a/src/camel/camel-cipher-context.c
++++ b/src/camel/camel-cipher-context.c
+@@ -1635,7 +1635,20 @@ camel_cipher_can_load_photos (void)
+ 	GSettings *settings;
+ 	gboolean load_photos;
+ 
+-	settings = g_settings_new ("org.gnome.evolution-data-server");
++	{
++		GSettingsSchemaSource *schema_source;
++		GSettingsSchema *schema;
++		schema_source = g_settings_schema_source_new_from_directory("@ESD_GSETTINGS_PATH@",
++									    g_settings_schema_source_get_default(),
++									    TRUE,
++									    NULL);
++		schema = g_settings_schema_source_lookup(schema_source,
++							 "org.gnome.evolution-data-server",
++							 FALSE);
++		settings = g_settings_new_full(schema, NULL, NULL);
++		g_settings_schema_source_unref(schema_source);
++		g_settings_schema_unref(schema);
++	}
+ 	load_photos = g_settings_get_boolean (settings, "camel-cipher-load-photos");
+ 	g_clear_object (&settings);
+ 
+diff --git a/src/camel/camel-gpg-context.c b/src/camel/camel-gpg-context.c
+index 1b3362886..f0811b292 100644
+--- a/src/camel/camel-gpg-context.c
++++ b/src/camel/camel-gpg-context.c
+@@ -573,7 +573,20 @@ gpg_ctx_get_executable_name (void)
+ 		GSettings *settings;
+ 		gchar *path;
+ 
+-		settings = g_settings_new ("org.gnome.evolution-data-server");
++		{
++			GSettingsSchemaSource *schema_source;
++			GSettingsSchema *schema;
++			schema_source = g_settings_schema_source_new_from_directory("@ESD_GSETTINGS_PATH@",
++										    g_settings_schema_source_get_default(),
++										    TRUE,
++										    NULL);
++			schema = g_settings_schema_source_lookup(schema_source,
++								 "org.gnome.evolution-data-server",
++								 FALSE);
++			settings = g_settings_new_full(schema, NULL, NULL);
++			g_settings_schema_source_unref(schema_source);
++			g_settings_schema_unref(schema);
++		}
+ 		path = g_settings_get_string (settings, "camel-gpg-binary");
+ 		g_clear_object (&settings);
+ 
+diff --git a/src/libedataserver/e-network-monitor.c b/src/libedataserver/e-network-monitor.c
+index e0d8b87d6..3a4d5a359 100644
+--- a/src/libedataserver/e-network-monitor.c
++++ b/src/libedataserver/e-network-monitor.c
+@@ -255,7 +255,20 @@ e_network_monitor_constructed (GObject *object)
+ 	/* Chain up to parent's method. */
+ 	G_OBJECT_CLASS (e_network_monitor_parent_class)->constructed (object);
+ 
+-	settings = g_settings_new ("org.gnome.evolution-data-server");
++	{
++		GSettingsSchemaSource *schema_source;
++		GSettingsSchema *schema;
++		schema_source = g_settings_schema_source_new_from_directory("@ESD_GSETTINGS_PATH@",
++									    g_settings_schema_source_get_default(),
++									    TRUE,
++									    NULL);
++		schema = g_settings_schema_source_lookup(schema_source,
++							 "org.gnome.evolution-data-server",
++							 FALSE);
++		settings = g_settings_new_full(schema, NULL, NULL);
++		g_settings_schema_source_unref(schema_source);
++		g_settings_schema_unref(schema);
++	}
+ 	g_settings_bind (
+ 		settings, "network-monitor-gio-name",
+ 		object, "gio-name",
+diff --git a/src/libedataserver/e-oauth2-service-google.c b/src/libedataserver/e-oauth2-service-google.c
+index f0c6f2cbf..0053e3ce6 100644
+--- a/src/libedataserver/e-oauth2-service-google.c
++++ b/src/libedataserver/e-oauth2-service-google.c
+@@ -69,7 +69,20 @@ eos_google_read_settings (EOAuth2Service *service,
+ 	if (!value) {
+ 		GSettings *settings;
+ 
+-		settings = g_settings_new ("org.gnome.evolution-data-server");
++		{
++			GSettingsSchemaSource *schema_source;
++			GSettingsSchema *schema;
++			schema_source = g_settings_schema_source_new_from_directory("@ESD_GSETTINGS_PATH@",
++										    g_settings_schema_source_get_default(),
++										    TRUE,
++										    NULL);
++			schema = g_settings_schema_source_lookup(schema_source,
++								 "org.gnome.evolution-data-server",
++								 FALSE);
++			settings = g_settings_new_full(schema, NULL, NULL);
++			g_settings_schema_source_unref(schema_source);
++			g_settings_schema_unref(schema);
++		}
+ 		value = g_settings_get_string (settings, key_name);
+ 		g_object_unref (settings);
+ 
+diff --git a/src/libedataserver/e-oauth2-service-outlook.c b/src/libedataserver/e-oauth2-service-outlook.c
+index 687c10d3b..684583c35 100644
+--- a/src/libedataserver/e-oauth2-service-outlook.c
++++ b/src/libedataserver/e-oauth2-service-outlook.c
+@@ -70,7 +70,20 @@ eos_outlook_read_settings (EOAuth2Service *service,
+ 	if (!value) {
+ 		GSettings *settings;
+ 
+-		settings = g_settings_new ("org.gnome.evolution-data-server");
++		{
++			GSettingsSchemaSource *schema_source;
++			GSettingsSchema *schema;
++			schema_source = g_settings_schema_source_new_from_directory("@ESD_GSETTINGS_PATH@",
++										    g_settings_schema_source_get_default(),
++										    TRUE,
++										    NULL);
++			schema = g_settings_schema_source_lookup(schema_source,
++								 "org.gnome.evolution-data-server",
++								 FALSE);
++			settings = g_settings_new_full(schema, NULL, NULL);
++			g_settings_schema_source_unref(schema_source);
++			g_settings_schema_unref(schema);
++		}
+ 		value = g_settings_get_string (settings, key_name);
+ 		g_object_unref (settings);
+ 
+diff --git a/src/libedataserver/e-oauth2-service.c b/src/libedataserver/e-oauth2-service.c
+index 682673c16..436f52d5f 100644
+--- a/src/libedataserver/e-oauth2-service.c
++++ b/src/libedataserver/e-oauth2-service.c
+@@ -95,7 +95,20 @@ eos_default_guess_can_process (EOAuth2Service *service,
+ 	name_len = strlen (name);
+ 	hostname_len = strlen (hostname);
+ 
+-	settings = g_settings_new ("org.gnome.evolution-data-server");
++	{
++		GSettingsSchemaSource *schema_source;
++		GSettingsSchema *schema;
++		schema_source = g_settings_schema_source_new_from_directory("@ESD_GSETTINGS_PATH@",
++									    g_settings_schema_source_get_default(),
++									    TRUE,
++									    NULL);
++		schema = g_settings_schema_source_lookup(schema_source,
++							 "org.gnome.evolution-data-server",
++							 FALSE);
++		settings = g_settings_new_full(schema, NULL, NULL);
++		g_settings_schema_source_unref(schema_source);
++		g_settings_schema_unref(schema);
++	}
+ 	values = g_settings_get_strv (settings, "oauth2-services-hint");
+ 	g_object_unref (settings);
+ 
+diff --git a/src/libedataserver/e-proxy.c b/src/libedataserver/e-proxy.c
+index 883379a60..989353494 100644
+--- a/src/libedataserver/e-proxy.c
++++ b/src/libedataserver/e-proxy.c
+@@ -969,8 +969,37 @@ e_proxy_init (EProxy *proxy)
+ 
+ 	proxy->priv->type = PROXY_TYPE_SYSTEM;
+ 
+-	proxy->priv->evolution_proxy_settings = g_settings_new ("org.gnome.evolution.shell.network-config");
+-	proxy->priv->proxy_settings = g_settings_new ("org.gnome.system.proxy");
++	{
++		GSettingsSchemaSource *schema_source;
++		GSettingsSchema *schema;
++		schema_source = g_settings_schema_source_new_from_directory("@ESD_GSETTINGS_PATH@",
++									    g_settings_schema_source_get_default(),
++									    TRUE,
++									    NULL);
++		schema = g_settings_schema_source_lookup(schema_source,
++							 "org.gnome.evolution.shell.network-config",
++							 FALSE);
++		proxy->priv->evolution_proxy_settings = g_settings_new_full(schema,
++									    NULL,
++									    NULL);
++		g_settings_schema_source_unref(schema_source);
++		g_settings_schema_unref(schema);
++	}
++	{
++		GSettingsSchemaSource *schema_source;
++		GSettingsSchema *schema;
++		schema_source = g_settings_schema_source_new_from_directory("@ESD_GSETTINGS_PATH@",
++									    g_settings_schema_source_get_default(),
++									    TRUE,
++									    NULL);
++		schema = g_settings_schema_source_lookup(schema_source,
++							 "org.gnome.system.proxy",
++							 FALSE);
++		proxy->priv->proxy_settings = g_settings_new_full(schema,
++								  NULL, NULL);
++		g_settings_schema_source_unref(schema_source);
++		g_settings_schema_unref(schema);
++	}
+ 	proxy->priv->proxy_http_settings = g_settings_get_child (proxy->priv->proxy_settings, "http");
+ 	proxy->priv->proxy_https_settings = g_settings_get_child (proxy->priv->proxy_settings, "https");
+ 	proxy->priv->proxy_socks_settings = g_settings_get_child (proxy->priv->proxy_settings, "socks");
+diff --git a/src/libedataserver/e-source-registry.c b/src/libedataserver/e-source-registry.c
+index a5a30a3e1..5fbdf8190 100644
+--- a/src/libedataserver/e-source-registry.c
++++ b/src/libedataserver/e-source-registry.c
+@@ -1749,7 +1749,21 @@ e_source_registry_init (ESourceRegistry *registry)
  
  	g_mutex_init (&registry->priv->sources_lock);
  
 -	registry->priv->settings = g_settings_new (GSETTINGS_SCHEMA);
-+	GSettingsSchemaSource *schema_source = registry->priv->schema_source = g_settings_schema_source_new_from_directory ("@ESD_GSETTINGS_PATH@",  g_settings_schema_source_get_default (), TRUE, NULL);
-+	registry->priv->schema = g_settings_schema_source_lookup (schema_source, GSETTINGS_SCHEMA, FALSE);
-+	registry->priv->settings = g_settings_new_full (registry->priv->schema, NULL, NULL);
++	{
++		GSettingsSchemaSource *schema_source;
++		GSettingsSchema *schema;
++		schema_source = g_settings_schema_source_new_from_directory("@ESD_GSETTINGS_PATH@",
++									    g_settings_schema_source_get_default(),
++									    TRUE,
++									    NULL);
++		schema = g_settings_schema_source_lookup(schema_source,
++							 GSETTINGS_SCHEMA,
++							 FALSE);
++		registry->priv->settings = g_settings_new_full(schema, NULL,
++							       NULL);
++		g_settings_schema_source_unref(schema_source);
++		g_settings_schema_unref(schema);
++	}
  
  	g_signal_connect (
  		registry->priv->settings, "changed",
+diff --git a/src/libedataserverui/e-reminders-widget.c b/src/libedataserverui/e-reminders-widget.c
+index f89cd4a5c..06cca9b5f 100644
+--- a/src/libedataserverui/e-reminders-widget.c
++++ b/src/libedataserverui/e-reminders-widget.c
+@@ -1642,7 +1642,21 @@ static void
+ e_reminders_widget_init (ERemindersWidget *reminders)
+ {
+ 	reminders->priv = G_TYPE_INSTANCE_GET_PRIVATE (reminders, E_TYPE_REMINDERS_WIDGET, ERemindersWidgetPrivate);
+-	reminders->priv->settings = g_settings_new ("org.gnome.evolution-data-server.calendar");
++	{
++		GSettingsSchemaSource *schema_source;
++		GSettingsSchema *schema;
++		schema_source = g_settings_schema_source_new_from_directory("@ESD_GSETTINGS_PATH@",
++									    g_settings_schema_source_get_default(),
++									    TRUE,
++									    NULL);
++		schema = g_settings_schema_source_lookup(schema_source,
++							 "org.gnome.evolution-data-server.calendar",
++							 FALSE);
++		reminders->priv->settings = g_settings_new_full(schema, NULL,
++								NULL);
++		g_settings_schema_source_unref(schema_source);
++		g_settings_schema_unref(schema);
++	}
+ 	reminders->priv->cancellable = g_cancellable_new ();
+ 	reminders->priv->is_empty = TRUE;
+ 	reminders->priv->is_mapped = FALSE;
+diff --git a/src/services/evolution-source-registry/evolution-source-registry-autoconfig.c b/src/services/evolution-source-registry/evolution-source-registry-autoconfig.c
+index 6f03053d6..dffc186c7 100644
+--- a/src/services/evolution-source-registry/evolution-source-registry-autoconfig.c
++++ b/src/services/evolution-source-registry/evolution-source-registry-autoconfig.c
+@@ -706,7 +706,20 @@ evolution_source_registry_merge_autoconfig_sources (ESourceRegistryServer *serve
+ 	gchar *autoconfig_directory;
+ 	gint ii;
+ 
+-	settings = g_settings_new ("org.gnome.evolution-data-server");
++	{
++		GSettingsSchemaSource *schema_source;
++		GSettingsSchema *schema;
++		schema_source = g_settings_schema_source_new_from_directory("@ESD_GSETTINGS_PATH@",
++									    g_settings_schema_source_get_default(),
++									    TRUE,
++									    NULL);
++		schema = g_settings_schema_source_lookup(schema_source,
++							 "org.gnome.evolution-data-server",
++							 FALSE);
++		settings = g_settings_new_full(schema, NULL, NULL);
++		g_settings_schema_source_unref(schema_source);
++		g_settings_schema_unref(schema);
++	}
+ 
+ 	autoconfig_sources = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, e_autoconfig_free_merge_source_data);
+ 
+diff --git a/src/services/evolution-source-registry/evolution-source-registry-migrate-proxies.c b/src/services/evolution-source-registry/evolution-source-registry-migrate-proxies.c
+index d531cb9e2..c5b1c761c 100644
+--- a/src/services/evolution-source-registry/evolution-source-registry-migrate-proxies.c
++++ b/src/services/evolution-source-registry/evolution-source-registry-migrate-proxies.c
+@@ -61,7 +61,20 @@ evolution_source_registry_migrate_proxies (ESourceRegistryServer *server)
+ 	extension_name = E_SOURCE_EXTENSION_PROXY;
+ 	extension = e_source_get_extension (source, extension_name);
+ 
+-	settings = g_settings_new (NETWORK_CONFIG_SCHEMA_ID);
++	{
++		GSettingsSchemaSource *schema_source;
++		GSettingsSchema *schema;
++		schema_source = g_settings_schema_source_new_from_directory("@ESD_GSETTINGS_PATH@",
++									    g_settings_schema_source_get_default(),
++									    TRUE,
++									    NULL);
++			schema = g_settings_schema_source_lookup(schema_source,
++								 NETWORK_CONFIG_SCHEMA_ID,
++								 FALSE);
++			settings = g_settings_new_full(schema, NULL, NULL);
++			g_settings_schema_source_unref(schema_source);
++			g_settings_schema_unref(schema);
++	}
+ 
+ 	switch (g_settings_get_int (settings, "proxy-type")) {
+ 		case 1:
+diff --git a/src/services/evolution-source-registry/evolution-source-registry.c b/src/services/evolution-source-registry/evolution-source-registry.c
+index 1c0a11382..3e144845e 100644
+--- a/src/services/evolution-source-registry/evolution-source-registry.c
++++ b/src/services/evolution-source-registry/evolution-source-registry.c
+@@ -181,7 +181,20 @@ main (gint argc,
+ 
+ reload:
+ 
+-	settings = g_settings_new ("org.gnome.evolution-data-server");
++	{
++		GSettingsSchemaSource *schema_source;
++		GSettingsSchema *schema;
++		schema_source = g_settings_schema_source_new_from_directory("@ESD_GSETTINGS_PATH@",
++									    g_settings_schema_source_get_default(),
++									    TRUE,
++									    NULL);
++		schema = g_settings_schema_source_lookup(schema_source,
++							 "org.gnome.evolution-data-server",
++							 FALSE);
++		settings = g_settings_new_full(schema, NULL, NULL);
++		g_settings_schema_source_unref(schema_source);
++		g_settings_schema_unref(schema);
++	}
+ 
+ 	if (!opt_disable_migration && !g_settings_get_boolean (settings, "migrated")) {
+ 		g_settings_set_boolean (settings, "migrated", TRUE);

--- a/pkgs/desktops/gnome-3/core/evolution-data-server/hardcode-gsettings.patch
+++ b/pkgs/desktops/gnome-3/core/evolution-data-server/hardcode-gsettings.patch
@@ -377,7 +377,7 @@ index 883379a60..989353494 100644
 +	{
 +		GSettingsSchemaSource *schema_source;
 +		GSettingsSchema *schema;
-+		schema_source = g_settings_schema_source_new_from_directory("@ESD_GSETTINGS_PATH@",
++		schema_source = g_settings_schema_source_new_from_directory("@GDS_GSETTINGS_PATH@",
 +									    g_settings_schema_source_get_default(),
 +									    TRUE,
 +									    NULL);


### PR DESCRIPTION
Geary crashes for me with

```
![???] 11:06:53 1.424732 GLib-GIO: Settings schema 'org.gnome.evolution-data-server.addressbook' is not installed
fish: “geary” terminated by signal SIGTRAP (Trace or breakpoint trap)
```

I used [Coccinelle](http://coccinelle.lip6.fr/) to create a base patch:

`spatch --sp-file hardcode-gsettings.cocci --dir src/ --in-place`

```cocci
@@
expression GSETTINGS_SCHEMA;
expression settings;
@@
- settings = g_settings_new (GSETTINGS_SCHEMA);
+ GSettingsSchemaSource *schema_source;
+ schema_source = g_settings_schema_source_new_from_directory ("@ESD_GSETTINGS_PATH@",  g_settings_schema_source_get_default (), TRUE, NULL);
+ GSettingsSchema *schema;
+ schema = g_settings_schema_source_lookup (schema_source, GSETTINGS_SCHEMA, FALSE);
+ settings = g_settings_new_full (schema, NULL, NULL);
+ g_settings_schema_source_unref (schema_source);
+ g_settings_schema_unref (schema);
```

and then manually fixed the conflict & gsettings-desktop-schemas path.