### PR TITLE
rivalcfg: init at 3.6.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3947,6 +3947,10 @@
     github = "orivej";
     name = "Orivej Desh";
   };
+  ornxka = {
+    email = "ornx@protonmail.com";
+    name = "ornxka";
+  };
   osener = {
     email = "ozan@ozansener.com";
     github = "osener";

--- a/pkgs/misc/rivalcfg/default.nix
+++ b/pkgs/misc/rivalcfg/default.nix
@@ -1,0 +1,30 @@
+{ lib, fetchFromGitHub, python3Packages }:
+
+with python3Packages; buildPythonPackage rec {
+  pname = "rivalcfg";
+  version = "3.6.0";
+
+  src = fetchFromGitHub {
+    owner = "flozz";
+    repo = "rivalcfg";
+    rev = "v${version}";
+    sha256 = "1xfaxc2qhbgi46m8ihhcgk9xfgkrvaqk0fhfav13378cihhdwwpn";
+  };
+
+  propagatedBuildInputs = [ hidapi ];
+
+  checkInputs = [ pytest ];
+  checkPhase = "pytest";
+
+  postInstall = ''
+    mkdir -p $out/etc/udev/rules.d
+    substitute $src/rivalcfg/data/99-steelseries-rival.rules $out/etc/udev/rules.d/99-steelseries-rival.rules --replace MODE=\"0666\" "MODE=\"0664\", GROUP=\"users\""
+  '';
+
+  meta = with lib; {
+    description = "Small CLI utility program that allows you to configure SteelSeries Rival gaming mice";
+    homepage = "https://github.com/flozz/rivalcfg";
+    license     = licenses.wtfpl;
+    maintainers = with maintainers; [ ornxka ];
+  };
+}


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
added the rivalcfg package for configuring steelseries mice

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
