### PR TITLE
mirrors: Add centos mirror

### DIFF
--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -169,6 +169,20 @@ rec {
     http://backpan.perl.org/  # for old releases
   ];
 
+  # CentOS.
+  centos = [
+    http://mirror.centos.org/centos/
+    # For old releases
+    http://vault.centos.org/
+    https://archive.kernel.org/centos-vault/
+    http://ftp.jaist.ac.jp/pub/Linux/CentOS-vault/
+    http://mirrors.aliyun.com/centos-vault/
+    https://mirror.chpc.utah.edu/pub/vault.centos.org/
+    https://mirror.its.sfu.ca/mirror/CentOS-vault/
+    https://mirror.math.princeton.edu/pub/centos-vault/
+    https://mirrors.tripadvisor.com/centos-vault/
+  ];
+
   # Debian.
   debian = [
     http://httpredir.debian.org/debian/

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -774,9 +774,7 @@ rec {
       in rec {
         name = "centos-${version}-i386";
         fullName = "CentOS ${version} (i386)";
-        # N.B. Switch to vault.centos.org when the next release comes out
-        # urlPrefix = "http://vault.centos.org/${version}/os/i386";
-        urlPrefix = "http://mirror.centos.org/centos-6/${version}/os/i386";
+        urlPrefix = "mirror://centos/${version}/os/i386";
         packagesList = fetchurl rec {
           url = "${urlPrefix}/repodata/${sha256}-primary.xml.gz";
           sha256 = "b826a45082ef68340325c0855f3d2e5d5a4d0f77d28ba3b871791d6f14a97aeb";
@@ -790,9 +788,7 @@ rec {
       in rec {
         name = "centos-${version}-x86_64";
         fullName = "CentOS ${version} (x86_64)";
-        # N.B. Switch to vault.centos.org when the next release comes out
-        # urlPrefix = "http://vault.centos.org/${version}/os/x86_64";
-        urlPrefix = "http://mirror.centos.org/centos-6/${version}/os/x86_64";
+        urlPrefix = "mirror://centos/${version}/os/x86_64";
         packagesList = fetchurl rec {
           url = "${urlPrefix}/repodata/${sha256}-primary.xml.gz";
           sha256 = "ed2b2d4ac98d774d4cd3e91467e1532f7e8b0275cfc91a0d214b532dcaf1e979";
@@ -807,9 +803,7 @@ rec {
       in rec {
         name = "centos-${version}-x86_64";
         fullName = "CentOS ${version} (x86_64)";
-        # N.B. Switch to vault.centos.org when the next release comes out
-        # urlPrefix = "http://vault.centos.org/${version}/os/x86_64";
-        urlPrefix = "http://mirror.centos.org/centos-7/${version}/os/x86_64";
+        urlPrefix = "mirror://centos/${version}/os/x86_64";
         packagesList = fetchurl rec {
           url = "${urlPrefix}/repodata/${sha256}-primary.xml.gz";
           sha256 = "b686d3a0f337323e656d9387b9a76ce6808b26255fc3a138b1a87d3b1cb95ed5";


### PR DESCRIPTION
###### Motivation for this change
This should remove the need to rename links from mirror.centos.org to vault.centos.org as the removed comment mentions.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


