### PR TITLE
kernel generate-config.pl: Allow whitespace in values

### DIFF
--- a/pkgs/os-specific/linux/kernel/generate-config.pl
+++ b/pkgs/os-specific/linux/kernel/generate-config.pl
@@ -28,7 +28,7 @@ open ANSWERS, "<$ENV{KERNEL_CONFIG}" or die "Could not open answer file";
 while (<ANSWERS>) {
     chomp;
     s/#.*//;
-    if (/^\s*([A-Za-z0-9_]+)(\?)?\s+(\S+)\s*$/) {
+    if (/^\s*([A-Za-z0-9_]+)(\?)?\s+(.*\S)\s*$/) {
         $answers{$1} = $3;
         $requiredAnswers{$1} = !(defined $2);
     } elsif (!/^\s*$/) {


### PR DESCRIPTION
###### Motivation for this change
In particular, this allows setting CONFIG_CMDLINE to a value with
multiple space-seperated parameters. Other variables also take free-form
strings and might similarly benefit.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @dezgeg
