### PR TITLE
dockerTools: document extraCommands, increase layers

### DIFF
--- a/doc/functions/dockertools.xml
+++ b/doc/functions/dockertools.xml
@@ -325,7 +325,7 @@ hello        latest   de2bf4786de6   About a minute ago   25.2MB
     </term>
     <listitem>
      <para>
-       Commands to run while building the final layer, without access
+       Shell commands to run while building the final layer, without access
        to most of the layer contents. Changes to this layer are "on top"
        of all the other layers, so can create additional directories
        and files.

--- a/doc/functions/dockertools.xml
+++ b/doc/functions/dockertools.xml
@@ -312,7 +312,10 @@ hello        latest   de2bf4786de6   About a minute ago   25.2MB
       Maximum number of layers to create.
      </para>
      <para>
-      <emphasis>Default:</emphasis> <literal>24</literal>
+      <emphasis>Default:</emphasis> <literal>100</literal>
+     </para>
+     <para>
+      <emphasis>Maximum:</emphasis> <literal>125</literal>
      </para>
     </listitem>
    </varlistentry>

--- a/doc/functions/dockertools.xml
+++ b/doc/functions/dockertools.xml
@@ -316,6 +316,19 @@ hello        latest   de2bf4786de6   About a minute ago   25.2MB
      </para>
     </listitem>
    </varlistentry>
+   <varlistentry>
+    <term>
+     <varname>extraCommands</varname> <emphasis>optional</emphasis>
+    </term>
+    <listitem>
+     <para>
+       Commands to run while building the final layer, without access
+       to most of the layer contents. Changes to this layer are "on top"
+       of all the other layers, so can create additional directories
+       and files.
+     </para>
+    </listitem>
+   </varlistentry>
   </variablelist>
 
   <section xml:id="dockerTools-buildLayeredImage-arg-contents">

--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -291,9 +291,10 @@ rec {
     # Files to add to the layer.
     closure,
     configJson,
-    # Docker has a 42-layer maximum, we pick 24 to ensure there is plenty
-    # of room for extension
-    maxLayers ? 24
+    # Docker has a 125-layer maximum, we pick 100 to ensure there is
+    # plenty of room for extension.
+    # https://github.com/moby/moby/blob/b3e9f7b13b0f0c414fa6253e1f17a86b2cff68b5/layer/layer_store.go#L23-L26
+    maxLayers ? 100
   }:
     let
       storePathToLayer = substituteAll


### PR DESCRIPTION
##### Motivation for this change

Document extraCommands for buildLayeredImage, and raise the layer count since it is a much higher limit in reality.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
