### PR TITLE
autogen: fix build reproducibility issues

### DIFF
--- a/pkgs/development/tools/misc/autogen/default.nix
+++ b/pkgs/development/tools/misc/autogen/default.nix
@@ -8,6 +8,7 @@ stdenv.mkDerivation rec {
     url = "mirror://gnu/autogen/rel${version}/autogen-${version}.tar.xz";
     sha256 = "1n5zq4872sakvz9c7ncsdcfp0z8rsybsxvbmhkpbd19ii0pacfxy";
   };
+  patches = [ ./libopts-r13y.patch ];
 
   outputs = [ "bin" "dev" "lib" "out" "man" "info" ];
 
@@ -19,7 +20,13 @@ stdenv.mkDerivation rec {
     guile libxml2
   ];
 
-  configureFlags = stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  configureFlags = [
+    # For build reproducibility: autogen's ./configure measures how long it
+    # takes to run some part of the configure script, and uses that as a
+    # timeout for command execution within its final binary. Hardcode it to 10s
+    # instead.
+    "--enable-timeout=10"
+  ] ++ stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "--with-libxml2=${libxml2.dev}"
     "--with-libxml2-cflags=-I${libxml2.dev}/include/libxml2"
     # the configure check for regcomp wants to run a host program

--- a/pkgs/development/tools/misc/autogen/libopts-r13y.patch
+++ b/pkgs/development/tools/misc/autogen/libopts-r13y.patch
@@ -1,0 +1,13 @@
+--- a/pkg/libopts/mklibsrc.sh     2019-08-13 06:43:38.670875866 +0200
++++ b/pkg/libopts/mklibsrc.sh     2019-08-13 06:42:08.046283976 +0200
+@@ -113,7 +113,8 @@
+ cd ..
+ echo ! cd `pwd`
+ echo ! tar cvf ${tag}.${sfx} ${tag}
+-tar cvf - ${tag} | $gz > ${top_builddir}/autoopts/${tag}.${sfx}
++tar --sort=name --mtime=0 cvf - ${tag} \
++  | $gz > ${top_builddir}/autoopts/${tag}.${sfx}
+ rm -rf ${tag}
+ 
+ ## Local Variables:
+


### PR DESCRIPTION
###### Motivation for this change
https://r13y.com/diff/2d1d9ebcbadce93e8dc711b4519442c992003b68ab1ad8445a425ea7dd7bf1e2-dd2c04513f0896c22e745c5368ff35cf0bdd607c121e9821958676305d59617a.html

Note: patch not sent upstream -- I see "GNU", I don't bother. I have no interest in signing the GNU CLA or figuring out the most likely convoluted process involved in submitting a 2 lines patch ¯\\\_(ツ)\_/¯ @brkorb fyi

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @grahamc (let me know if you'd rather not be cc'd on these -- since you maintain r13y.com I assume you have an interest in these changes)
