### PR TITLE
s3ql: 2.26 -> 3.2

### DIFF
--- a/pkgs/tools/backup/s3ql/default.nix
+++ b/pkgs/tools/backup/s3ql/default.nix
@@ -1,33 +1,35 @@
-{ stdenv, fetchurl, python3Packages, sqlite, which }:
+{ stdenv, fetchFromGitHub, python3Packages, sqlite, which }:
 
 python3Packages.buildPythonApplication rec {
-  name = "${pname}-${version}";
   pname = "s3ql";
-  version = "2.26";
+  version = "3.2";
 
-  src = fetchurl {
-    url = "https://bitbucket.org/nikratio/${pname}/downloads/${name}.tar.bz2";
-    sha256 = "0xs1jbak51zwjrd6jmd96xl3a3jpw0p1s05f7sw5wipvvg0xnmfn";
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "release-${version}";
+    sha256 = "01ky0jc1s3w9dry5siz9b69jf2maiargz99axgxvyihap0d7qs52";
   };
 
-  buildInputs = [ which ]; # tests will fail without which
+  checkInputs = [ which ] ++ (with python3Packages; [ cython pytest ]);
   propagatedBuildInputs = with python3Packages; [
     sqlite apsw pycrypto requests defusedxml dugong llfuse
-    cython pytest pytest-catchlog
+    cython pytest pytest-catchlog google_auth google-auth-oauthlib
   ];
 
   preBuild = ''
-    # https://bitbucket.org/nikratio/s3ql/issues/118/no-module-named-s3qldeltadump-running#comment-16951851
     ${python3Packages.python.interpreter} ./setup.py build_cython build_ext --inplace
   '';
 
   checkPhase = ''
+    # Removing integration tests
+    rm tests/t{4,5,6}_*
     pytest tests
   '';
 
   meta = with stdenv.lib; {
     description = "A full-featured file system for online data storage";
-    homepage = https://bitbucket.org/nikratio/s3ql;
+    homepage = "https://github.com/s3ql/s3ql/";
     license = licenses.gpl3;
     maintainers = with maintainers; [ rushmorem ];
     platforms = platforms.linux;


### PR DESCRIPTION
#### Motivation for this change

Updating the package and fixing the build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @rushmorem 
