### PR TITLE
libversion: 2.8.1 -> 2.9.0

### DIFF
--- a/pkgs/development/libraries/libversion/default.nix
+++ b/pkgs/development/libraries/libversion/default.nix
@@ -1,10 +1,8 @@
 { stdenv, fetchFromGitHub, cmake }:
 
-let
-  version = "2.8.1";
-in
-stdenv.mkDerivation {
-  name = "libversion-${version}";
+stdenv.mkDerivation rec {
+  pname = "libversion";
+  version = "2.9.0";
 
   src = fetchFromGitHub {
     owner = "repology";


### PR DESCRIPTION
###### Motivation for this change
fixing package bumps that @r-ryantm seems to fail on.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[2 built, 1 copied, 0.0 MiB DL]
2 package were build:
libversion python37Packages.libversion
```