### PR TITLE
nixos/doc: document that services defined with `systemd.users` aren't restarted by nixos-rebuild

### DIFF
--- a/nixos/doc/manual/installation/changing-config.xml
+++ b/nixos/doc/manual/installation/changing-config.xml
@@ -14,6 +14,13 @@
   to build the new configuration, make it the default configuration for
   booting, and try to realise the configuration in the running system (e.g., by
   restarting system services).
+  <warning>
+   <para>
+    This command doesn't start/stop <link linkend="opt-systemd.user.services">user
+    services</link> automatically. <command>nixos-rebuild</command> only runs a
+    <literal>daemon-reload</literal> for each user with running user services.
+   </para>
+  </warning>
  </para>
  <warning>
   <para>

--- a/nixos/doc/manual/man-nixos-rebuild.xml
+++ b/nixos/doc/manual/man-nixos-rebuild.xml
@@ -101,7 +101,8 @@
    NixOS module, you must run <command>nixos-rebuild</command> to make the
    changes take effect. It builds the new system in
    <filename>/nix/store</filename>, runs its activation script, and stop and
-   (re)starts any system services if needed.
+   (re)starts any system services if needed. Please note that user services need
+   to be started manually as they aren't detected by the activation script at the moment.
   </para>
   <para>
    This command has one required argument, which specifies the desired


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Issues like #66187 prove that most newcomers expect `nixos-rebuild` to properly start/restart/reload user services which isn't the case at the moment. This patch mentions that in the `nixos-rebuild` manpage and in an additional warning block in the NixOS manual.

cc @l0b0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
