### PR TITLE
gitAndTools.topgit: 0.9 -> 0.19.12

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/topgit/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/topgit/default.nix
@@ -1,26 +1,30 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchFromGitHub, git, perl }:
 
 stdenv.mkDerivation rec {
-  name = "topgit-0.9";
+  pname = "topgit";
+  version = "0.19.12";
 
-  src = fetchurl {
-    url = "https://github.com/greenrd/topgit/archive/${name}.tar.gz";
-    sha256 = "1z9x42a0cmn8n2n961qcfl522nd6j9a3dpx1jbqfp24ddrk5zd94";
+  src = fetchFromGitHub {
+    owner = "mackyle";
+    repo = "topgit";
+    rev = "${pname}-${version}";
+    sha256 = "1wvf8hmwwl7a2fr17cfs3pbxjccdsjw9ngzivxlgja0gvfz4hjd5";
   };
 
-  configurePhase = "makeFlags=prefix=$out";
+  makeFlags = [ "prefix=${placeholder "out"}" ];
+
+  nativeBuildInputs = [ perl git ];
 
   postInstall = ''
-    mkdir -p "$out/share/doc/${name}" "$out/etc/bash_completion.d/"
-    mv README "$out/share/doc/${name}/"
-    mv contrib/tg-completion.bash "$out/etc/bash_completion.d/"
+    install -Dm644 README -t"$out/share/doc/${pname}-${version}/"
+    install -Dm755 contrib/tg-completion.bash -t "$out/etc/bash_completion.d/"
   '';
 
-  meta = {
-    homepage = https://github.com/greenrd/topgit;
+  meta = with stdenv.lib; {
     description = "TopGit manages large amount of interdependent topic branches";
-    license = stdenv.lib.licenses.gpl2;
-    platforms = stdenv.lib.platforms.unix;
-    maintainers = with stdenv.lib.maintainers; [ marcweber ];
+    homepage = "https://github.com/mackyle/topgit";
+    license = licenses.gpl2;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ marcweber ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
fixing builds that @r-ryantm  fails to upgrade

maintained repo was moved to  https://github.com/mackyle/topgit
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @MarcWeber 

```
$ nix path-info -Sh ./result
/nix/store/5710xlh2v4cvql50mvifswl2jicglz3k-topgit-0.19.12        30.9M
$ nix path-info -Sh ./result
/nix/store/j1k5a52id2n24n0dln55c0xswzfkcps0-topgit-0.9    28.2M
```
```
[1 built, 0.0 MiB DL]
1 package were build:
gitAndTools.topGit
```