### PR TITLE
varnish5: fix build

### DIFF
--- a/pkgs/servers/varnish/default.nix
+++ b/pkgs/servers/varnish/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchurl, pcre, libxslt, groff, ncurses, pkgconfig, readline, libedit
-, python3, makeWrapper }:
+, python2, python3, makeWrapper }:
 
 let
-  common = { version, sha256, extraBuildInputs ? [] }:
+  common = { version, sha256, python, extraNativeBuildInputs ? [] }:
     stdenv.mkDerivation rec {
       name = "varnish-${version}";
 
@@ -11,11 +11,10 @@ let
         inherit sha256;
       };
 
-      nativeBuildInputs = [ pkgconfig ];
+      nativeBuildInputs = with python.pkgs; [ pkgconfig docutils ] ++ extraNativeBuildInputs;
       buildInputs = [
-        pcre libxslt groff ncurses readline python3 libedit
-        python3.pkgs.docutils makeWrapper
-      ] ++ extraBuildInputs;
+        pcre libxslt groff ncurses readline libedit makeWrapper python
+      ];
 
       buildFlags = "localstatedir=/var/spool";
 
@@ -41,14 +40,17 @@ in
   varnish4 = common {
     version = "4.1.10";
     sha256 = "08kwx0il6cqxsx3897042plh1yxjaanbaqjbspfl0xgvyvxk6j1n";
+    python = python2;
   };
   varnish5 = common {
     version = "5.2.1";
     sha256 = "1cqlj12m426c1lak1hr1fx5zcfsjjvka3hfirz47hvy1g2fjqidq";
+    python = python2;
   };
   varnish6 = common {
     version = "6.2.0";
     sha256 = "0lwfk2gq99c653h5f51fs3j37r0gh2pf0p4w5z986nm2mi9z6yn3";
-    extraBuildInputs = [ python3.pkgs.sphinx ];
+    python = python3;
+    extraNativeBuildInputs = [ python3.pkgs.sphinx ];
   };
 }

--- a/pkgs/servers/varnish/default.nix
+++ b/pkgs/servers/varnish/default.nix
@@ -11,6 +11,8 @@ let
         inherit sha256;
       };
 
+      passthru.python = python;
+
       nativeBuildInputs = with python.pkgs; [ pkgconfig docutils ] ++ extraNativeBuildInputs;
       buildInputs = [
         pcre libxslt groff ncurses readline libedit makeWrapper python

--- a/pkgs/servers/varnish/dynamic.nix
+++ b/pkgs/servers/varnish/dynamic.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, varnish, python, docutils }:
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, varnish, docutils }:
 
 stdenv.mkDerivation rec {
   version = "0.3";
@@ -11,8 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "12a42lbv0vf6fn3qnvngw893kmbd006f8pgab4ir7irc8855xjgf";
   };
 
-  nativeBuildInputs = [ pkgconfig docutils autoreconfHook ];
-  buildInputs = [ varnish python ];
+  nativeBuildInputs = [ pkgconfig docutils autoreconfHook varnish.python ];
+  buildInputs = [ varnish ];
   postPatch = ''
     substituteInPlace Makefile.am --replace "''${LIBVARNISHAPI_DATAROOTDIR}/aclocal" "${varnish.dev}/share/aclocal"
   '';

--- a/pkgs/servers/varnish/modules.nix
+++ b/pkgs/servers/varnish/modules.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, varnish, python, docutils, removeReferencesTo }:
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, varnish, docutils, removeReferencesTo }:
 
 stdenv.mkDerivation rec {
   version = "0.14.0";
@@ -11,8 +11,15 @@ stdenv.mkDerivation rec {
     sha256 = "17fkbr4i70qgdqsrx1x28ag20xkfyz1v3q3d3ywmv409aczqhm40";
   };
 
-  nativeBuildInputs = [ pkgconfig autoreconfHook docutils removeReferencesTo ];
-  buildInputs = [ varnish python ];
+  nativeBuildInputs = [
+    autoreconfHook
+    docutils
+    pkgconfig
+    removeReferencesTo
+    varnish.python  # use same python version as varnish server
+  ];
+
+  buildInputs = [ varnish ];
 
   postPatch = ''
     substituteInPlace bootstrap   --replace "''${dataroot}/aclocal"                  "${varnish.dev}/share/aclocal"

--- a/pkgs/servers/varnish/rtstatus.nix
+++ b/pkgs/servers/varnish/rtstatus.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, varnish, python, docutils }:
+{ stdenv, fetchurl, pkgconfig, varnish, docutils }:
 
 stdenv.mkDerivation rec {
   version = "1.2.0";
@@ -9,8 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "0hll1aspgpv1daw5sdbn5w1d6birchxgapzb6zi1nhahjlimy4ly";
   };
 
-  nativeBuildInputs = [ pkgconfig docutils ];
-  buildInputs = [ varnish python ];
+  nativeBuildInputs = [ pkgconfig docutils varnish.python ];
+  buildInputs = [ varnish ];
   configureFlags = [ "VMOD_DIR=$(out)/lib/varnish/vmods" ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
fixing some regression from #66559

varnish5 isn't ready for the upgrade to python3, but varnish 6 requires it, so i parameterized it in the generic builder.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @fpletz  @mmahut 

before:
```
[1 built (1 failed), 21 copied (28.5 MiB), 19.5 MiB DL]
error: build of '/nix/store/zjv7yyzyjbj4f0zf9kzwc9ifj9m42mc0-env.drv' failed
https://github.com/NixOS/nixpkgs/pull/66559
4 package failed to build:
collectd collectd-data prometheus-varnish-exporter varnish
```
after:
```
[1 built, 6 copied (15.8 MiB), 4.0 MiB DL]
5 package were build:
collectd collectd-data prometheus-varnish-exporter varnish varnish4
```