### PR TITLE
 minikube: 1.2.0 -> 1.6.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -710,6 +710,12 @@
     githubId = 55833;
     name = "Troels Henriksen";
   };
+  atkinschang = {
+    email = "atkinschang+nixpkgs@gmail.com";
+    github = "AtkinsChang";
+    githubId = 5193600;
+    name = "Atkins Chang";
+  };
   atnnn = {
     email = "etienne@atnnn.com";
     github = "atnnn";

--- a/pkgs/applications/networking/cluster/docker-machine/hyperkit.nix
+++ b/pkgs/applications/networking/cluster/docker-machine/hyperkit.nix
@@ -1,10 +1,11 @@
 { lib, buildGoModule, minikube }:
 
 buildGoModule rec {
-  inherit (minikube) version src nativeBuildInputs buildInputs goPackagePath postPatch preBuild;
+  inherit (minikube) version src nativeBuildInputs buildInputs goPackagePath preBuild;
 
   pname = "docker-machine-hyperkit";
   subPackages = [ "cmd/drivers/hyperkit" ];
+
   modSha256   = minikube.go-modules.outputHash;
 
   postInstall = ''

--- a/pkgs/applications/networking/cluster/docker-machine/hyperkit.nix
+++ b/pkgs/applications/networking/cluster/docker-machine/hyperkit.nix
@@ -1,0 +1,21 @@
+{ lib, buildGoModule, minikube }:
+
+buildGoModule rec {
+  inherit (minikube) version src nativeBuildInputs buildInputs goPackagePath postPatch preBuild;
+
+  pname = "docker-machine-hyperkit";
+  subPackages = [ "cmd/drivers/hyperkit" ];
+  modSha256   = minikube.go-modules.outputHash;
+
+  postInstall = ''
+    mv $out/bin/hyperkit $out/bin/docker-machine-driver-hyperkit
+  '';
+
+  meta = with lib; {
+    homepage = https://github.com/kubernetes/minikube/blob/master/docs/drivers.md;
+    description = "HyperKit driver for docker-machine.";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ atkinschang ];
+    platforms = platforms.darwin;
+  };
+}

--- a/pkgs/applications/networking/cluster/docker-machine/kvm2.nix
+++ b/pkgs/applications/networking/cluster/docker-machine/kvm2.nix
@@ -1,7 +1,7 @@
 { lib, buildGoModule, minikube }:
 
 buildGoModule rec {
-  inherit (minikube) version src nativeBuildInputs buildInputs goPackagePath postPatch preBuild;
+  inherit (minikube) version src nativeBuildInputs buildInputs goPackagePath preBuild;
 
   pname = "docker-machine-kvm2";
   subPackages = [ "cmd/drivers/kvm" ];

--- a/pkgs/applications/networking/cluster/docker-machine/kvm2.nix
+++ b/pkgs/applications/networking/cluster/docker-machine/kvm2.nix
@@ -1,32 +1,22 @@
-{ stdenv, buildGoModule, libvirt, pkgconfig, minikube }:
+{ lib, buildGoModule, minikube }:
 
 buildGoModule rec {
-  pname = "docker-machine-kvm2";
-  version = minikube.version;
+  inherit (minikube) version src nativeBuildInputs buildInputs goPackagePath postPatch preBuild;
 
-  goPackagePath = "k8s.io/minikube";
+  pname = "docker-machine-kvm2";
   subPackages = [ "cmd/drivers/kvm" ];
 
-  src = minikube.src;
-
-  modSha256 = minikube.go-modules.outputHash;
-
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ libvirt ];
-
-  preBuild = ''
-    export buildFlagsArray=(-ldflags="-X k8s.io/minikube/pkg/drivers/kvm/version.VERSION=v${version}")
-  '';
+  modSha256   = minikube.go-modules.outputHash;
 
   postInstall = ''
     mv $out/bin/kvm $out/bin/docker-machine-driver-kvm2
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://github.com/kubernetes/minikube/blob/master/docs/drivers.md;
     description = "KVM2 driver for docker-machine.";
     license = licenses.asl20;
-    maintainers = with maintainers; [ tadfisher ];
+    maintainers = with maintainers; [ tadfisher atkinschang ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/applications/networking/cluster/minikube/default.nix
+++ b/pkgs/applications/networking/cluster/minikube/default.nix
@@ -4,36 +4,30 @@
 , pkgconfig
 , makeWrapper
 , go-bindata
-, bash
 , libvirt
 , vmnet
 }:
 
 buildGoModule rec {
   pname   = "minikube";
-  version = "1.3.1";
+  version = "1.5.2";
   # for -ldflags
-  commit  = "ca60a424ce69a4d79f502650199ca2b52f29e631";
+  commit  = "792dbf92a1de583fcee76f8791cff12e0c9440ad";
 
   goPackagePath = "k8s.io/minikube";
   subPackages   = [ "cmd/minikube" ];
-  modSha256     = "0ajzkc3xs7ql0v5762d3rh6idk04nhglfph3ldl25mnafwb7qd9l";
+  modSha256     = "0nv7f1a1ag3r58i1hnk0nikrms0a22017rq55nl39bg9z58d4vk2";
 
   src = fetchFromGitHub {
     owner  = "kubernetes";
     repo   = "minikube";
     rev    = "v${version}";
-    sha256 = "0kfd7041y6fayz8jl7zlw2lccnrx4d9qramx99j8mcw5syc2mwsd";
+    sha256 = "1hahils630aajzrb0z82h3kpgibsyj0lwrknd9whdmvzi2yisr3w";
   };
 
   nativeBuildInputs = [ pkgconfig go-bindata makeWrapper ];
   buildInputs = stdenv.lib.optionals stdenv.isLinux [ libvirt ]
     ++ stdenv.lib.optionals stdenv.isDarwin [ vmnet ];
-
-  postPatch = ''
-    substituteInPlace pkg/minikube/command/exec_runner.go \
-      --replace "/bin/bash" ${bash}/bin/bash
-  '';
 
   preBuild = ''
     go-bindata -nomemcopy -o pkg/minikube/assets/assets.go -pkg assets deploy/addons/...

--- a/pkgs/applications/networking/cluster/minikube/default.nix
+++ b/pkgs/applications/networking/cluster/minikube/default.nix
@@ -10,19 +10,19 @@
 
 buildGoModule rec {
   pname   = "minikube";
-  version = "1.6.2";
+  version = "1.8.1";
   # for -ldflags
-  commit  = "54f28ac5d3a815d1196cd5d57d707439ee4bb392";
+  commit  = "cbda04cf6bbe65e987ae52bb393c10099ab62014";
 
   goPackagePath = "k8s.io/minikube";
   subPackages   = [ "cmd/minikube" ];
-  modSha256     = "0ix9z0kifjlj9yjrj2m6lk1qya5cqz4v3pkp61cj6xfp36m4z3l2";
+  modSha256     = "1wyz8aq291lx614ilqrcgzdc8rjxbd6v3rv1fy6r2m6snyysycfn";
 
   src = fetchFromGitHub {
     owner  = "kubernetes";
     repo   = "minikube";
     rev    = "v${version}";
-    sha256 = "1s18asq6bn94i33chyzl8r8hkpq3cf7pip7byadf2i05n59i9ha2";
+    sha256 = "1nf0n701rw3anp8j7k3f553ipqwpzzxci41zsi0il4l35dpln5g0";
   };
 
   nativeBuildInputs = [ pkgconfig go-bindata makeWrapper ];

--- a/pkgs/applications/networking/cluster/minikube/default.nix
+++ b/pkgs/applications/networking/cluster/minikube/default.nix
@@ -1,68 +1,73 @@
-{ stdenv, buildGoModule, fetchFromGitHub, go-bindata, libvirt, qemu
-, gpgme, makeWrapper, vmnet
-, docker-machine-kvm, docker-machine-kvm2
-, extraDrivers ? []
+{ stdenv
+, buildGoModule
+, fetchFromGitHub
+, pkgconfig
+, makeWrapper
+, go-bindata
+, bash
+, libvirt
+, vmnet
 }:
 
-let
-  drivers = stdenv.lib.filter (d: d != null) (extraDrivers
-            ++ stdenv.lib.optionals stdenv.isLinux [ docker-machine-kvm docker-machine-kvm2 ]);
-
-  binPath = drivers
-            ++ stdenv.lib.optionals stdenv.isLinux ([ libvirt qemu ]);
-
-in buildGoModule rec {
+buildGoModule rec {
   pname   = "minikube";
-  version = "1.2.0";
-
-  kubernetesVersion = "1.15.0";
+  version = "1.3.1";
+  # for -ldflags
+  commit  = "ca60a424ce69a4d79f502650199ca2b52f29e631";
 
   goPackagePath = "k8s.io/minikube";
+  subPackages   = [ "cmd/minikube" ];
+  modSha256     = "0ajzkc3xs7ql0v5762d3rh6idk04nhglfph3ldl25mnafwb7qd9l";
 
   src = fetchFromGitHub {
     owner  = "kubernetes";
     repo   = "minikube";
     rev    = "v${version}";
-    sha256 = "0l9znrp49877cp1bkwx84c8lv282ga5a946rjbxi8gznkf3kwaw7";
+    sha256 = "0kfd7041y6fayz8jl7zlw2lccnrx4d9qramx99j8mcw5syc2mwsd";
   };
 
-  modSha256 = "1cp63n0x2lgbqvvymx9byx48r42qw6w224x5x4iiarc2nryfdhn0";
+  nativeBuildInputs = [ pkgconfig go-bindata makeWrapper ];
+  buildInputs = stdenv.lib.optionals stdenv.isLinux [ libvirt ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ vmnet ];
 
-  buildInputs = [ go-bindata makeWrapper gpgme ] ++ stdenv.lib.optional stdenv.hostPlatform.isDarwin vmnet;
-  subPackages = [ "cmd/minikube" ] ++ stdenv.lib.optional stdenv.hostPlatform.isDarwin "cmd/drivers/hyperkit";
+  postPatch = ''
+    substituteInPlace pkg/minikube/command/exec_runner.go \
+      --replace "/bin/bash" ${bash}/bin/bash
+  '';
 
   preBuild = ''
     go-bindata -nomemcopy -o pkg/minikube/assets/assets.go -pkg assets deploy/addons/...
+    go-bindata -nomemcopy -o pkg/minikube/translate/translations.go -pkg translate translations/...
 
     VERSION_MAJOR=$(grep "^VERSION_MAJOR" Makefile | sed "s/^.*\s//")
     VERSION_MINOR=$(grep "^VERSION_MINOR" Makefile | sed "s/^.*\s//")
     ISO_VERSION=v$VERSION_MAJOR.$VERSION_MINOR.0
     ISO_BUCKET=$(grep "^ISO_BUCKET" Makefile | sed "s/^.*\s//")
-    KUBERNETES_VERSION=${kubernetesVersion}
 
     export buildFlagsArray="-ldflags=\
-      -X k8s.io/minikube/pkg/version.version=v${version} \
-      -X k8s.io/minikube/pkg/version.isoVersion=$ISO_VERSION \
-      -X k8s.io/minikube/pkg/version.isoPath=$ISO_BUCKET \
-      -X k8s.io/minikube/vendor/k8s.io/client-go/pkg/version.gitVersion=$KUBERNETES_VERSION \
-      -X k8s.io/minikube/vendor/k8s.io/kubernetes/pkg/version.gitVersion=$KUBERNETES_VERSION"
+      -X ${goPackagePath}/pkg/version.version=v${version} \
+      -X ${goPackagePath}/pkg/version.isoVersion=$ISO_VERSION \
+      -X ${goPackagePath}/pkg/version.isoPath=$ISO_BUCKET \
+      -X ${goPackagePath}/pkg/version.gitCommitID=${commit} \
+      -X ${goPackagePath}/pkg/drivers/kvm.version=v${version} \
+      -X ${goPackagePath}/pkg/drivers/kvm.gitCommitID=${commit} \
+      -X ${goPackagePath}/pkg/drivers/hyperkit.version=v${version} \
+      -X ${goPackagePath}/pkg/drivers/hyperkit.gitCommitID=${commit}"
   '';
 
   postInstall = ''
-    wrapProgram $out/bin/${pname} --prefix PATH : $out/bin:${stdenv.lib.makeBinPath binPath}
     mkdir -p $out/share/bash-completion/completions/
     MINIKUBE_WANTUPDATENOTIFICATION=false MINIKUBE_WANTKUBECTLDOWNLOADMSG=false HOME=$PWD $out/bin/minikube completion bash > $out/share/bash-completion/completions/minikube
+
     mkdir -p $out/share/zsh/site-functions/
     MINIKUBE_WANTUPDATENOTIFICATION=false MINIKUBE_WANTKUBECTLDOWNLOADMSG=false HOME=$PWD $out/bin/minikube completion zsh > $out/share/zsh/site-functions/_minikube
-  ''+ stdenv.lib.optionalString stdenv.hostPlatform.isDarwin ''
-    mv $out/bin/hyperkit $out/bin/docker-machine-driver-hyperkit
   '';
 
   meta = with stdenv.lib; {
     homepage    = https://github.com/kubernetes/minikube;
     description = "A tool that makes it easy to run Kubernetes locally";
     license     = licenses.asl20;
-    maintainers = with maintainers; [ ebzzry copumpkin vdemeester ];
+    maintainers = with maintainers; [ ebzzry copumpkin vdemeester atkinschang ];
     platforms   = with platforms; unix;
   };
 }

--- a/pkgs/applications/networking/cluster/minikube/default.nix
+++ b/pkgs/applications/networking/cluster/minikube/default.nix
@@ -10,19 +10,19 @@
 
 buildGoModule rec {
   pname   = "minikube";
-  version = "1.5.2";
+  version = "1.6.2";
   # for -ldflags
-  commit  = "792dbf92a1de583fcee76f8791cff12e0c9440ad";
+  commit  = "54f28ac5d3a815d1196cd5d57d707439ee4bb392";
 
   goPackagePath = "k8s.io/minikube";
   subPackages   = [ "cmd/minikube" ];
-  modSha256     = "0nv7f1a1ag3r58i1hnk0nikrms0a22017rq55nl39bg9z58d4vk2";
+  modSha256     = "0ix9z0kifjlj9yjrj2m6lk1qya5cqz4v3pkp61cj6xfp36m4z3l2";
 
   src = fetchFromGitHub {
     owner  = "kubernetes";
     repo   = "minikube";
     rev    = "v${version}";
-    sha256 = "1hahils630aajzrb0z82h3kpgibsyj0lwrknd9whdmvzi2yisr3w";
+    sha256 = "1s18asq6bn94i33chyzl8r8hkpq3cf7pip7byadf2i05n59i9ha2";
   };
 
   nativeBuildInputs = [ pkgconfig go-bindata makeWrapper ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18793,6 +18793,7 @@ in
   docker-gc = callPackage ../applications/virtualization/docker/gc.nix { };
 
   docker-machine = callPackage ../applications/networking/cluster/docker-machine { };
+  docker-machine-hyperkit = callPackage ../applications/networking/cluster/docker-machine/hyperkit.nix { };
   docker-machine-kvm = callPackage ../applications/networking/cluster/docker-machine/kvm.nix { };
   docker-machine-kvm2 = callPackage ../applications/networking/cluster/docker-machine/kvm2.nix { };
   docker-machine-xhyve = callPackage ../applications/networking/cluster/docker-machine/xhyve.nix {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Upgrade to [`v1.6.2`](https://github.com/kubernetes/minikube/releases/tag/v1.6.2) and fix bugs in previous version:
- fix building errors and use `buildGoModule` for `docker-machine-kvm2`
- fix `minikube` bugs running on `nixos` cause by `exec /bin/bash` command
- separate `docker-machine-hyperkit` from `minikube` like what `docker-machine-kvm2` did

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
