### PR TITLE
terraform-providers: bump versions

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/data.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/data.nix
@@ -4,15 +4,15 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-acme";
-      version = "1.3.4";
-      sha256  = "1kam9mwgqh31f1m8kn86bkdi4ccfj5h38f80g3frrla4p2zw9l55";
+      version = "1.3.5";
+      sha256  = "0xjxxz3vxq7vk7sv6b5p57z5x92dmrm44v6ksffcg76ngc40nrxk";
     };
   alicloud =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-alicloud";
-      version = "1.52.2";
-      sha256  = "1s127p6rm3kmrxjk9kr02rgjk58rs864c0b46i8lmaj7x5yznaz5";
+      version = "1.54.0";
+      sha256  = "01pmhwdnhfsk785ja11hxn5l5fmklnkiv12kv2pw2280cdljfcv4";
     };
   archive =
     {
@@ -39,8 +39,8 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-aws";
-      version = "2.21.0";
-      sha256  = "18aw0fz3pzd7wci3z19nain499rfr9npb3sm0k34nkajjjryqngc";
+      version = "2.23.0";
+      sha256  = "0yscy0qmdl07air0b16i6zd0w8y3z20pk5l53pwm78ssdxn3w6qc";
     };
   azuread =
     {
@@ -53,8 +53,8 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-azurerm";
-      version = "1.32.0";
-      sha256  = "01287yknd2bp2yqzyn2221mkv2hz4xd5dghps5pzrkdv0m1w4p35";
+      version = "1.32.1";
+      sha256  = "0ydzibmvz52i62pk0g96rl7vxhff5izrsgdwk6lgc56nw63w2l8g";
     };
   azurestack =
     {
@@ -109,8 +109,8 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-cloudflare";
-      version = "1.16.1";
-      sha256  = "0lxx7wkvmi6zpql7g33bg12gx67i4xm2v885j70b9vf8brj40h2j";
+      version = "1.17.1";
+      sha256  = "0kmkk5fhgsvjakqrfs7p92dcljn04asxq15af1r9n5csq54q7na3";
     };
   cloudscale =
     {
@@ -151,8 +151,8 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-digitalocean";
-      version = "1.5.0";
-      sha256  = "14kqyp4j4ld8gla8rn3an6wpjh942h5bn39d68nnf4y7nx3vvbfs";
+      version = "1.6.0";
+      sha256  = "06cxm3qcym8jwp4nl1bzk3p9fbaz26bvddqzn3p8l57c802qqds6";
     };
   dme =
     {
@@ -179,8 +179,8 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-docker";
-      version = "2.1.0";
-      sha256  = "183pkjf6x8xk84sij2w2v3sms8pjv7hzwricamd2sf3n0fkqvjiq";
+      version = "2.1.1";
+      sha256  = "0px3xj76ay5ixpmynas49z31xmk4zmpn0917y6a20kr2x2abi9zb";
     };
   dyn =
     {
@@ -200,8 +200,8 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-fastly";
-      version = "0.8.1";
-      sha256  = "1ghvf7nwj02r31zgnrnmhagqbbq696ll39b2wjzlimb6c3fw7ik0";
+      version = "0.9.0";
+      sha256  = "0g3rgi6s9hyb6vzl682n8zqz5virdxvxh04v88n9iy5r7hwrxxzg";
     };
   flexibleengine =
     {
@@ -228,15 +228,15 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-google";
-      version = "2.11.0";
-      sha256  = "16577pkp3m5pqqqhvxq1rvx99p1230pmqksm6wplh25ry5yp5v7w";
+      version = "2.12.0";
+      sha256  = "15fdpmdikm77hlfksdbcblysb82sd51vw4ninx60hzgddqp6ll4m";
     };
   google-beta =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-google-beta";
-      version = "2.11.0";
-      sha256  = "0hj2c17kb6k4zy1630fvmyniln5m1ncpyys4wl8v1j0arb8vg2wz";
+      version = "2.12.0";
+      sha256  = "11aky7jvm7i39pnj3ypy42d9yk9akqb3wjb03hyllzfddwhvay5q";
     };
   grafana =
     {
@@ -249,8 +249,8 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-hcloud";
-      version = "1.11.0";
-      sha256  = "037hbwp10h57cj74ja6c4wjgfrfggbpd4glbc81xpp22rxij40j9";
+      version = "1.12.0";
+      sha256  = "1r61s7chq636fcjv67g0vjlc35xx0ycy58hg6b5i5rdc9737v7hp";
     };
   hedvig =
     {
@@ -263,15 +263,15 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-helm";
-      version = "0.10.0";
-      sha256  = "09qxpgdljkfbyn1ihki2pp2m9wxmrxvp91d1myinml466jylxjar";
+      version = "0.10.2";
+      sha256  = "1xp8dx6ncskmfa9bjd54434f4a7pnjz5r3yvnh1hmv3i5ykfxzdn";
     };
   heroku =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-heroku";
-      version = "2.1.0";
-      sha256  = "17gb8lpcp7fwgv6mv3sw5was571pa0pp00izrrkyhbcddw5p84mc";
+      version = "2.1.2";
+      sha256  = "0n8id5rw4hzsiic9yv4rzm709npagv9sfp6dd1ax6np5kai78b87";
     };
   http =
     {
@@ -284,8 +284,8 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-huaweicloud";
-      version = "1.6.0";
-      sha256  = "03f92mq4ydfwnxh0v4sm6brllxw6m7kh8j19md9aq0wxcwr5wp6q";
+      version = "1.7.0";
+      sha256  = "1yhyyh33hvzs74pryb383p1w0c0d4vn23pnm6snxi1cw49wgiiyf";
     };
   icinga2 =
     {
@@ -305,15 +305,15 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-influxdb";
-      version = "1.2.0";
-      sha256  = "1nldywbwg5lgzhlq8hmisv63riipd0aaa4p5ya6qvx5cnj5yhsx8";
+      version = "1.3.0";
+      sha256  = "19af40g8hgz2rdz6523v0fs71ww7qdlf2mh5j9vb7pfzriqwa5k9";
     };
   kubernetes =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-kubernetes";
       version = "1.8.1";
-      sha256  = "1c69p7rqijinzr0lqh4iwa0g89w2hjm2csadbxkfha0a8iqq73r1";
+      sha256  = "0jcc3i10x0qz7sj8l5yv98jc2g32a6yhdpc45sq33wmhcvp1fsn4";
     };
   librato =
     {
@@ -382,22 +382,22 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-nomad";
-      version = "1.4.0";
-      sha256  = "04dh7gas6viny6bkx89fkwmxrw101b8bmw14m2mzfkxn70cl2na4";
+      version = "1.4.1";
+      sha256  = "1v4wwinnb2qc71jgil4607kgdccjivssabqgb5l3yk8pwfidgdnr";
     };
   ns1 =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-ns1";
-      version = "1.4.1";
-      sha256  = "1zcl7yda0rqj76d9slm92kvj5ry3v5va48l8i5vlxa1znnf8d89d";
+      version = "1.5.0";
+      sha256  = "1m6f1hsx2gcb5b50sm8cj04hkmn71xlxji8qwlswasz2sg1sllrx";
     };
   nsxt =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-nsxt";
-      version = "1.1.0";
-      sha256  = "0y9n4acbrjf5n2v8j10qfnz8677gil60by5miz3wd2qpxwgmhhm8";
+      version = "1.1.1";
+      sha256  = "19bbycify25bshpyq65qjxnl72b6wmwwwdb7hxl94hhbgx2c9z29";
     };
   null =
     {
@@ -417,8 +417,8 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-oci";
-      version = "3.35.0-rc1";
-      sha256  = "1728zap32iabsa2a6762caf9h7fgspi1z8gnq03269qhy7jsknv8";
+      version = "3.37.0-rc1";
+      sha256  = "0ahqnh9qzixp434qn2ckj8p32kb9x26l1xz8yr84h6sqfrn58bcv";
     };
   oneandone =
     {
@@ -431,22 +431,22 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-opc";
-      version = "1.3.6";
-      sha256  = "1b11837j0d8s59pjkankbm3p5l87aw1s17mn2q7nvy65kgzalsra";
+      version = "1.3.7";
+      sha256  = "01g09w8mqfp1d8phplsdj0vz63q5bgq9fqwy2kp4vrnwb70dq52w";
     };
   openstack =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-openstack";
-      version = "1.20.0";
-      sha256  = "0hfcypz95aj1wwhybpkc74k8g2iqax724qdm11s2iyjmq5c7iz2z";
+      version = "1.21.1";
+      sha256  = "0nvhn2bnk11sz4i98yw7rpxi8b3c2y04qq37ybvqx2jyi3n9kj30";
     };
   opentelekomcloud =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-opentelekomcloud";
-      version = "1.10.0";
-      sha256  = "12c7qjlmvsxd4nv0k2vsvlnl1iq2k0b8xx29q5a6h98dnhrnpfic";
+      version = "1.11.0";
+      sha256  = "175j2bbw3bdbjq1b7b1kwsr8iay9aafz165d0brfpb8gf096y7xa";
     };
   opsgenie =
     {
@@ -473,15 +473,15 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-packet";
-      version = "2.2.1";
-      sha256  = "05zhrpynn2yrimlg553f0567b284x51g5yafz29g647vvsqd1rpn";
+      version = "2.3.0";
+      sha256  = "1v2758wjhrn7rhwdx658w3sf1q5lp4cawl6llbv4p16c5fyzwwc2";
     };
   pagerduty =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-pagerduty";
-      version = "1.3.0";
-      sha256  = "1l3rk7c31qafadpg2b0mzvfx7lwwk82vcn489fr35rvmv99zfkh8";
+      version = "1.3.1";
+      sha256  = "1x29ya0xcjj2b3x2q2q7iyqric8vswf18a5bwhwv2017c1g4n299";
     };
   panos =
     {
@@ -501,8 +501,8 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-powerdns";
-      version = "0.1.0";
-      sha256  = "1k9xjx2smk6478dsrcnqk1k6r2pddpa9n8aghq5d1a5yhfsq5zzz";
+      version = "1.0.0";
+      sha256  = "1qh4z69b0sqxwjjgc8xis165gdszav9yc85ba6pgyl3wbymkld30";
     };
   profitbricks =
     {
@@ -522,15 +522,15 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-rancher";
-      version = "1.3.0";
-      sha256  = "0b62hhb87xqmc1izl5lyk2kvkrkgrjil5z1xwprfdl6yz4fnin0w";
+      version = "1.4.0";
+      sha256  = "106arszmdjmgrz4iv01bbf72jarn7zjqvmc43b6n1s3lzd7jnfpc";
     };
   random =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-random";
-      version = "2.1.2";
-      sha256  = "102bgd8s9yhm2ny2akv04mhwf5mphqhsxx9vxjbg7ygqnz9ka5nw";
+      version = "2.2.0";
+      sha256  = "0vg33jbvyxvg4dwcwjb2p57jjkq7qj50d356r4a1f2ysl2axwwjw";
     };
   rightscale =
     {
@@ -543,8 +543,8 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-rundeck";
-      version = "0.3.0";
-      sha256  = "10xhj3xxdhbdxq14linqabn8cm0gnnswfwr0r20s1yp7pn36lgkj";
+      version = "0.4.0";
+      sha256  = "1x131djsny8w84yf7w2il33wlc3ysy3k399dziii2lmq4h8sgrpr";
     };
   runscope =
     {
@@ -613,8 +613,8 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-tencentcloud";
-      version = "1.13.0";
-      sha256  = "0mdgpkzv1gfyvpndvv195f6nxmvpv4wvssxlqvmccf8vvmb32nyn";
+      version = "1.15.0";
+      sha256  = "1ics91fxsl1z1wqd961wdn2s22ck25yphp341qlbs8ln2dcwk8r7";
     };
   terraform =
     {
@@ -662,15 +662,15 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-vault";
-      version = "2.1.0";
-      sha256  = "1nbiz2mnknaimfvh1zmmsp1crrhcpy4q6maaakqybqzabkn9wibr";
+      version = "2.2.0";
+      sha256  = "0k9frx29pjrrx67cwzsrnj0x90ff5k99l5yzfgb58sajkz1j8nln";
     };
   vcd =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-vcd";
-      version = "2.3.0";
-      sha256  = "1x9ydp6kscgj0m7vkf4ly0y80016qcfbshgmlydrvq7dbw44qlr9";
+      version = "2.4.0";
+      sha256  = "020wmdl5cbma9r7sv3bx6v8b59w5nwkzgwj4xm7a2s6kn8jygr2x";
     };
   vsphere =
     {
@@ -683,8 +683,8 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-yandex";
-      version = "0.8.2";
-      sha256  = "07p88asjcjndpv36dhvfazb440k2f2v4j7rpvqqmfccwyyqkwwjr";
+      version = "0.9.0";
+      sha256  = "0x3l0pbpdsm43jsx42xzc46r9j40l7szkcf851q16wsxf70lchqr";
     };
   matchbox =
     {


### PR DESCRIPTION
###### Motivation for this change
Keep terraform-providers up-to-date.

###### Things done
I ran ./update-all.sh to get changes in data.nix.
I ran locally nix-shell on macOS to verify a new AWS provider (2.23) with terraform 0.11 and 0.12.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
