### PR TITLE
bdsync: 0.10.1 -> 0.11.1

### DIFF
--- a/pkgs/tools/backup/bdsync/default.nix
+++ b/pkgs/tools/backup/bdsync/default.nix
@@ -1,35 +1,33 @@
-{ stdenv, fetchFromGitHub, openssl, coreutils, which }:
+{ stdenv, fetchFromGitHub
+, openssl
+, pandoc
+, which
+}:
 
 stdenv.mkDerivation rec {
-
-  name = "${pname}-${version}";
   pname = "bdsync";
-  version = "0.10.1";
+  version = "0.11.1";
 
   src = fetchFromGitHub {
     owner = "TargetHolding";
     repo = pname;
     rev = "v${version}";
-    sha256 = "144hlbk3k29l7sja6piwhd2jsnzzsak13fcjbahd6m8yimxyb2nf";
+    sha256 = "11grdyc6fgw93jvj965awsycqw5qbzsdys7n8farqnmya8qv8gac";
   };
+
+  nativeBuildInputs = [ pandoc which ];
+  buildInputs = [ openssl ];
 
   postPatch = ''
     patchShebangs ./tests.sh
     patchShebangs ./tests/
   '';
 
-  buildInputs = [ openssl coreutils which ];
-
   doCheck = true;
-  checkPhase = ''
-    make test
-  '';
 
   installPhase = ''
-    mkdir -p $out/bin
-    mkdir -p $out/share/man/man1
-    cp bdsync $out/bin/
-    cp bdsync.1 $out/share/man/man1/
+    install -Dm755 bdsync -t $out/bin/
+    install -Dm644 bdsync.1 -t $out/share/man/man1/
   '';
 
   meta = with stdenv.lib; {
@@ -39,5 +37,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     maintainers = with maintainers; [ jluttine ];
   };
-
 }


### PR DESCRIPTION
###### Motivation for this change
fixing builds that @r-ryantm fails to update

cleaned up the expression a bit

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
$ nix path-info -Sh ./result
/nix/store/y1xw32lsdj159lkvqhjs838xai4lnmx7-bdsync-0.10.1         30.5M
$ nix path-info -Sh ./result
/nix/store/175gg3bmcfrbc98q6xza9lbjdlhh019p-bdsync-0.11.1         30.5M
```
```
[2 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/66590
1 package were build:
bdsync
```