### PR TITLE
pythonPackages: update azure

### DIFF
--- a/pkgs/development/python-modules/azure-common/default.nix
+++ b/pkgs/development/python-modules/azure-common/default.nix
@@ -8,14 +8,14 @@
 }:
 
 buildPythonPackage rec {
-  version = "1.1.21";
+  version = "1.1.23";
   pname = "azure-common";
   disabled = isPyPy;
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "25d696d2affbf5fe9b13aebe66271fce545e673e7e1eeaaec2d73599ba639d63";
+    sha256 = "1qslpmwmy1bcgpf2xixidny82xwg4m4pi8bi1v63r510ixdikcak";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-storage-blob/default.nix
+++ b/pkgs/development/python-modules/azure-storage-blob/default.nix
@@ -9,20 +9,17 @@
 
 buildPythonPackage rec {
   pname = "azure-storage-blob";
-  version = "1.5.0";
+  version = "2.0.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "f187a878e7a191f4e098159904f72b4146cf70e1aabaf6484ab4ba72fc6f252c";
+    sha256 = "0ckhhx3x0xvqqzs36d368z02fr2k23waazx0v2fjn8hqbnzilf4k";
   };
 
   propagatedBuildInputs = [
     azure-common
     azure-storage-common
   ] ++ lib.optional (!isPy3k) futures;
-
-  # has no tests
-  doCheck = false;
 
   meta = with lib; {
     description = "Client library for Microsoft Azure Storage services containing the blob service APIs";

--- a/pkgs/development/python-modules/azure-storage-common/default.nix
+++ b/pkgs/development/python-modules/azure-storage-common/default.nix
@@ -11,11 +11,11 @@
 
 buildPythonPackage rec {
   pname = "azure-storage-common";
-  version = "1.4.2";
+  version = "2.0.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "4ec87c7537d457ec95252e0e46477e2c1ccf33774ffefd05d8544682cb0ae401";
+    sha256 = "0227pnbha1npw50p3498y621la8hl272am51ggrvy3xmdxgwv423";
   };
 
   propagatedBuildInputs = [
@@ -24,9 +24,6 @@ buildPythonPackage rec {
     python-dateutil
     requests
   ] ++ lib.optional (!isPy3k) azure-storage-nspkg;
-
-  # has no tests
-  doCheck = false;
 
   meta = with lib; {
     description = "Client library for Microsoft Azure Storage services containing common code shared by blob, file and queue";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Extracted from #64962.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @jonringer 
