### PR TITLE
maintainers list: remove my gpg keys (super quick PR)

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -66,14 +66,6 @@
     email = "aaron@ajanse.me";
     github = "aaronjanse";
     name = "Aaron Janse";
-    keys = [
-      { longkeyid = "rsa2048/0x651BD4B37D75E234"; # Email only
-        fingerprint = "490F 5009 34E7 20BD 4C53  96C2 651B D4B3 7D75 E234";
-      }
-      { longkeyid = "rsa4096/0xBE6C92145BFF4A34"; # Git, etc
-        fingerprint = "CED9 6DF4 63D7 B86A 1C4B  1322 BE6C 9214 5BFF 4A34";
-      }
-    ];
   };
   aaronschif = {
     email = "aaronschif@gmail.com";


### PR DESCRIPTION
I removed my gpg keys because:
1. they have changed
2. nobody needs them anyway

I tested a rebuild with my commit and nothing broke.