### PR TITLE
go: 1.12.7 -> 1.12.8, 1.11.12 -> 1.11.13

### DIFF
--- a/pkgs/development/compilers/go/1.11.nix
+++ b/pkgs/development/compilers/go/1.11.nix
@@ -30,11 +30,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "go";
-  version = "1.11.12";
+  version = "1.11.13";
 
   src = fetchurl {
     url = "https://dl.google.com/go/go${version}.src.tar.gz";
-    sha256 = "09k9zmq7hhgg0bf1y7rwa0kn7q1vkkr94cmg2iv9lq3najh5nykd";
+    sha256 = "0vr95zb2rky42wfh1jd4fvbm9wcq1mnii0742pfx7j8h7kk83462";
   };
 
   # perl is used for testing go vet

--- a/pkgs/development/compilers/go/1.12.nix
+++ b/pkgs/development/compilers/go/1.12.nix
@@ -30,11 +30,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "go";
-  version = "1.12.7";
+  version = "1.12.8";
 
   src = fetchurl {
     url = "https://dl.google.com/go/go${version}.src.tar.gz";
-    sha256 = "04rvwj69gmw3bz8pw5pf10r21ar0pgpnswp15nkddf04dxyl9s4m";
+    sha256 = "1wamgb1kk379ys6v9vr60lnvrbnr2vvdshx2ahhpc86yzix2yl79";
   };
 
   # perl is used for testing go vet


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Upstream update (this is a security update that affects http2)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @rvolosatovs

----------------------------------

First time contributing here so  a few notes, this is who I got the sha256, but note how the one I got for the 1.12.7 doesn't match what is on master right now:

```
$ nix-prefetch-url --unpack https://dl.google.com/go/go1.12.7.src.tar.gz
unpacking...
[21.0 MiB DL]
path is '/nix/store/mz292x2airgwp2mh0v9nmj0wavw7aj56-go1.12.7.src.tar.gz'
16zf3jxrji01rxn318hqmm6yhp5qjgg2k11ypadm1x2w7rdpr39j
$ nix-prefetch-url --unpack https://dl.google.com/go/go1.12.8.src.tar.gz
unpacking...
[21.0 MiB DL]
path is '/nix/store/ypyn3m33zbr60h9vqk9j5i6lzxprgn1k-go1.12.8.src.tar.gz'
1wamgb1kk379ys6v9vr60lnvrbnr2vvdshx2ahhpc86yzix2yl79
$ nix-prefetch-url --unpack https://dl.google.com/go/go1.11.13.src.tar.gz
unpacking...
[20.1 MiB DL]
path is '/nix/store/rf6wll3sajsl0xhzs2lm649vfmq2z54q-go1.11.13.src.tar.gz'
0vr95zb2rky42wfh1jd4fvbm9wcq1mnii0742pfx7j8h7kk83462

```

Then, I tried to follow [docs about submitting changes](https://nixos.org/nixpkgs/manual/#chap-submitting-changes), but this part:

```
nix-env -i pkg-name -f <path to your local nixpkgs folder>
```

gives me:

```
$ nix-env -i go -f pkgs/
warning: name collision in input Nix expressions, skipping '/home/diego/work/ascendant/nixpkgs/pkgs/applications/editors/vscode/generic.nix'
warning: name collision in input Nix expressions, skipping '/home/diego/work/ascendant/nixpkgs/pkgs/applications/editors/yi/wrapper.nix'
error: too many Nix expressions in directory '/home/diego/work/ascendant/nixpkgs/pkgs/applications/misc'

```

I also tried passing a closer path to the go compiler nix file:

```
$ nix-env -i go -f pkgs/development/compilers
warning: name collision in input Nix expressions, skipping '/home/diego/work/ascendant/nixpkgs/pkgs/development/compilers/gcc/5'
warning: name collision in input Nix expressions, skipping '/home/diego/work/ascendant/nixpkgs/pkgs/development/compilers/llvm/4'
warning: name collision in input Nix expressions, skipping '/home/diego/work/ascendant/nixpkgs/pkgs/development/compilers/llvm/5'
warning: name collision in input Nix expressions, skipping '/home/diego/work/ascendant/nixpkgs/pkgs/development/compilers/llvm/6'
warning: name collision in input Nix expressions, skipping '/home/diego/work/ascendant/nixpkgs/pkgs/development/compilers/llvm/7'
warning: name collision in input Nix expressions, skipping '/home/diego/work/ascendant/nixpkgs/pkgs/development/compilers/llvm/8'
warning: name collision in input Nix expressions, skipping '/home/diego/work/ascendant/nixpkgs/pkgs/development/compilers/mono/4.nix'
warning: name collision in input Nix expressions, skipping '/home/diego/work/ascendant/nixpkgs/pkgs/development/compilers/mono/5.nix'
warning: name collision in input Nix expressions, skipping '/home/diego/work/ascendant/nixpkgs/pkgs/development/compilers/mozart/binary.nix'
warning: name collision in input Nix expressions, skipping '/home/diego/work/ascendant/nixpkgs/pkgs/development/compilers/ocaml/generic.nix'
warning: name collision in input Nix expressions, skipping '/home/diego/work/ascendant/nixpkgs/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix'
error: cannot auto-call a function that has an argument without a default value ('stdenv')
```

If you can spell it out for me, I can run any testing I need to.

For reference, this update comes with some pretty big security fixes [https://groups.google.com/d/topic/golang-nuts/fCQWxqxP8aA/discussion](https://groups.google.com/d/topic/golang-nuts/fCQWxqxP8aA/discussion)