### PR TITLE
nvidia_x11_beta: stable -> 435.17

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -19,7 +19,12 @@ rec {
   stable = if stdenv.hostPlatform.system == "x86_64-linux" then stable_430 else legacy_390;
 
   # No active beta right now
-  beta = stable;
+  beta = generic {
+    version = "435.17";
+    sha256_64bit = "19p9v5km1kfw45ghqmzgawa2fdq559jj6h1dkbnkbbzhp2syq757";
+    settingsSha256 = "1i3bmsrgzwpahsgxyffly2hipxbparnr63c1xvb63wmivbad3fg9";
+    persistencedSha256 = "0pifk6nzbyr08hs6229v91jnawg0dgfcqyv1n4yl2fbaqcrw1bfq";
+  };
 
   stable_430 = generic {
     version = "430.40";


### PR DESCRIPTION
Could probably be merged just as is but it's quite a nice update.
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
http://download.nvidia.com/XFree86/Linux-x86_64/435.17/README/primerenderoffload.html
All there is to say.
Though the implementation will probably have to take place in another PR if I don't manage to get it done soon.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

Those who might be interested, sorry for pinging if you aren't.
cc @ambrop72 
