### PR TITLE
[staging]bash-completion: 2.8 -> 2.9

### DIFF
--- a/pkgs/shells/bash/bash-completion/default.nix
+++ b/pkgs/shells/bash/bash-completion/default.nix
@@ -1,15 +1,36 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchFromGitHub
+, autoreconfHook
+, python3Packages
+, bashInteractive
+}:
 
 stdenv.mkDerivation rec {
   pname = "bash-completion";
-  version = "2.8";
+  version = "2.9";
 
-  src = fetchurl {
-    url = "https://github.com/scop/bash-completion/releases/download/${version}/${pname}-${version}.tar.xz";
-    sha256 = "0kgmflrr1ga9wfk770vmakna3nj46ylb5ky9ipd0v2k9ymq5a7y0";
+  src = fetchFromGitHub {
+    owner = "scop";
+    repo = "bash-completion";
+    rev = version;
+    sha256 = "1813r4jxfa2zgzm2ppjhrq62flfmxai8433pklxcrl4fp5wwx9yv";
   };
 
+  nativeBuildInputs = [ autoreconfHook ];
+
   doCheck = true;
+  checkInputs = [
+    python3Packages.pexpect
+    python3Packages.pytest
+    bashInteractive
+  ];
+
+  # ignore ip_addresses because it tries to touch network
+  # ignore test_ls because impure logic
+  checkPhase = ''
+    pytest . \
+      --ignore=test/t/unit/test_unit_ip_addresses.py \
+      --ignore=test/t/test_ls.py
+  '';
 
   prePatch = stdenv.lib.optionalString stdenv.isDarwin ''
     sed -i -e 's/readlink -f/readlink/g' bash_completion completions/*


### PR DESCRIPTION
###### Motivation for this change
update packages @r-ryantm  cannot.

Changelog located: https://github.com/scop/bash-completion/blob/master/CHANGES

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @peti 


not really sure how to test this

```
$ nix path-info -Sh ./result
/nix/store/r7zq02r87ixkv6lb0ip2014ydn6ii2dz-bash-completion-2.9  965.6K
$ nix path-info -Sh ./result
/nix/store/lrvfslpvawf7q54bgwbi1msskklmg7p6-bash-completion-2.8  913.1K
```