### PR TITLE
axel: 2.17.3 -> 2.17.5

### DIFF
--- a/pkgs/tools/networking/axel/default.nix
+++ b/pkgs/tools/networking/axel/default.nix
@@ -1,22 +1,22 @@
 { stdenv, fetchFromGitHub, autoreconfHook, autoconf-archive
-, pkgconfig, gettext, libssl }:
+, pkgconfig, gettext, libssl, txt2man }:
 
 stdenv.mkDerivation rec {
   pname = "axel";
-  version = "2.17.3";
+  version = "2.17.5";
 
   src = fetchFromGitHub {
     owner = "axel-download-accelerator";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0kdd2y92plv240ba2j3xrm0f8xygvm1ijghnric4whsnxvmgym7h";
+    sha256 = "0kwfbwh9g2227icgykgwa057vll5rkgac3df0pby530bivqzzzlw";
   };
 
-  nativeBuildInputs = [ autoreconfHook pkgconfig autoconf-archive ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig autoconf-archive txt2man ];
 
   buildInputs = [ gettext libssl ];
 
-  installFlags = [ "ETCDIR=$(out)/etc" ];
+  installFlags = [ "ETCDIR=${placeholder "out"}/etc" ];
 
   meta = with stdenv.lib; {
     description = "Console downloading program with some features for parallel connections for faster downloading";


### PR DESCRIPTION
###### Motivation for this change
Fixing updates that @r-ryantm is unable to.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @pSub 

```
$ nix path-info -Sh ./result
/nix/store/jwsny62kmkmr5rnayfpsdjxc4wmwhrfq-axel-2.17.3   30.5M
$ nix path-info -Sh ./result
/nix/store/5cm5a09vfn894fx9alswq338d4yj2477-axel-2.17.5   30.6M
```
```
[1 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/66602
1 package were build:
axel
```