### PR TITLE
[19.03] nginx: apply patches from 1.16.1 for HTTP/2 vulnerabilities

### DIFF
--- a/pkgs/servers/http/nginx/generic.nix
+++ b/pkgs/servers/http/nginx/generic.nix
@@ -64,7 +64,23 @@ stdenv.mkDerivation {
 
   preConfigure = (concatMapStringsSep "\n" (mod: mod.preConfigure or "") modules);
 
-  patches = stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  patches = [
+    # HTTP/2: reject zero length headers with PROTOCOL_ERROR (from 1.16.1)
+      (fetchpatch {
+        url = https://github.com/nginx/nginx/commit/dbdd9ffea81d9db46fb88b5eba828f2ad080d388.patch;
+        sha256 = "a481901729be3ada3ac86f200772f326ef655b3ed0f55a0b1355e16fd4698adc";
+      })
+      # HTTP/2: limited number of DATA frames (from 1.16.1)
+      (fetchpatch {
+        url = https://github.com/nginx/nginx/commit/94c5eb142e58a86f81eb1369fa6fcb96c2f23d6b.patch;
+        sha256 = "af591ae3c711fc7c58f53ad493899f986dd5dabf3a154f9f597f3059e752c601";
+      })
+      #  HTTP/2: limited number of PRIORITY frames (from 1.16.1)
+      (fetchpatch {
+          url = https://github.com/nginx/nginx/commit/39bb3b9d4a33bd03c8ae0134dedc8a7700ae7b2b.patch;
+        sha256 = "1ad8fecdb343d40224de0f63724a21a691c141f52274439d13eca6d53f0a9128";
+      })
+  ] ++ stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     (fetchpatch {
       url = "https://raw.githubusercontent.com/openwrt/packages/master/net/nginx/patches/102-sizeof_test_fix.patch";
       sha256 = "0i2k30ac8d7inj9l6bl0684kjglam2f68z8lf3xggcc2i5wzhh8a";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fixing CVE-2019-9511, CVE-2019-9513, CVE-2019-9516 affecting HTTP/2 protocol in nginx 1.14.2 and 1.15.10.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I am running a patched 1.14.2 on my web servers (low traffic) without any issue. 1.15.10 was only tested to compile correctly. I have based this PR on `release-19.03`, should I base it on staging instead?

###### Notify maintainers

cc @thoughtpolice @fpletz 
