### PR TITLE
nixos/oxidized: Use symlinks for config files

### DIFF
--- a/nixos/modules/services/admin/oxidized.nix
+++ b/nixos/modules/services/admin/oxidized.nix
@@ -97,8 +97,8 @@ in
 
       preStart = ''
         mkdir -p ${cfg.dataDir}/.config/oxidized
-        cp -v ${cfg.routerDB} ${cfg.dataDir}/.config/oxidized/router.db
-        cp -v ${cfg.configFile} ${cfg.dataDir}/.config/oxidized/config
+        ln -f -s ${cfg.routerDB} ${cfg.dataDir}/.config/oxidized/router.db
+        ln -f -s ${cfg.configFile} ${cfg.dataDir}/.config/oxidized/config
       '';
 
       serviceConfig = {


### PR DESCRIPTION
The old `cp` suffers from a permission issue on the 2nd start of the service.
The files were copied from the read-only nix store. On the 2nd start of the service the `cp` failed.
The new version force creates a symlink which does not suffer from this.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
The oxidized service did only start for the first time. All other startup attempts failed:

```
-- Unit oxidized.service has begun starting up.
Aug 14 08:44:40 omniIT-pg02 krg794lqb6z8sbvg5waj2ck1yk5cpr25-unit-script-oxidized-pre-start[1172]: '/nix/store/52knh7571lwsil8j3knyk6wk2dv1fkg4-oxidized-router.db' -> '/var/lib/oxidized/.config/oxidized/router.db'
Aug 14 08:44:40 omniIT-pg02 krg794lqb6z8sbvg5waj2ck1yk5cpr25-unit-script-oxidized-pre-start[1172]: cp: cannot create regular file '/var/lib/oxidized/.config/oxidized/router.db': Permission denied
Aug 14 08:44:40 omniIT-pg02 systemd[1]: oxidized.service: Control process exited, code=exited, status=1/FAILURE
Aug 14 08:44:40 omniIT-pg02 systemd[1]: oxidized.service: Failed with result 'exit-code'.
Aug 14 08:44:40 omniIT-pg02 systemd[1]: Failed to start oxidized.service.
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @WilliButz 
