### PR TITLE
buildRustPackage: set HOME

### DIFF
--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -79,6 +79,10 @@ in stdenv.mkDerivation (args // {
 
   configurePhase = args.configurePhase or ''
     runHook preConfigure
+
+    # https://github.com/NixOS/nixpkgs/issues/61618
+    export HOME=$(mktemp -d)
+
     mkdir -p .cargo
     cat >> .cargo/config <<'EOF'
     [target."${stdenv.buildPlatform.config}"]


### PR DESCRIPTION
###### Motivation for this change

Set $HOME for `buildRustPackage`, fixes https://github.com/NixOS/nixpkgs/issues/61618. 


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @layus @Mic92