### PR TITLE
buildRustPackage: fix cross-compilation to aarch64-unknown-linux-musl

### DIFF
--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -86,6 +86,10 @@ in stdenv.mkDerivation (args // {
     ${stdenv.lib.optionalString (stdenv.buildPlatform.config != stdenv.hostPlatform.config) ''
     [target."${stdenv.hostPlatform.config}"]
     "linker" = "${ccForHost}"
+    ${# https://github.com/rust-lang/rust/issues/46651#issuecomment-433611633
+      stdenv.lib.optionalString (stdenv.hostPlatform.isMusl && stdenv.hostPlatform.isAarch64) ''
+    "rustflags" = [ "-C", "target-feature=+crt-static", "-C", "link-arg=-lgcc" ]
+    ''}
     ''}
     EOF
     cat .cargo/config


### PR DESCRIPTION
###### Motivation for this change

See: https://github.com/rust-lang/rust/issues/46651

musl libc for aarch64 doesn't have `__addtf3`, `__subtf3`, `__multf3` symbols that Rust expects. This change allows to use statically linked in GCC for these symbols, allowing to build statically linked Rust binaries using Nixpkgs (Rust assumes that musl targets always want static linking).

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Ericson2314 @matthewbauer @Mic92
