### PR TITLE
dotnet-sdk: Get dotnet tool install working

### DIFF
--- a/pkgs/development/compilers/dotnet/sdk/default.nix
+++ b/pkgs/development/compilers/dotnet/sdk/default.nix
@@ -29,6 +29,11 @@ in
       patchelf --set-interpreter "${stdenv.cc.bintools.dynamicLinker}" ./dotnet
       patchelf --set-rpath "${rpath}" ./dotnet
       find -type f -name "*.so" -exec patchelf --set-rpath '$ORIGIN:${rpath}' {} \;
+
+      # apphost used by `dotnet tool install`
+      patchelf --set-interpreter "${stdenv.cc.bintools.dynamicLinker}" sdk/*/AppHostTemplate/apphost
+      patchelf --set-rpath "${rpath}" sdk/*/AppHostTemplate/apphost
+
       echo -n "dotnet-sdk version: "
       ./dotnet --version
       runHook postBuild


### PR DESCRIPTION
######  Motivation for this change

Some dotnet packages have to be installed as tools, which does not work in the current state:
```
$ dotnet tool install  -g dotnetsay
    
Failed to create shell shim for tool 'dotnetsay': Failed to create tool shim for command 'dotnetsay': Access to the path '/home/bara/.dotnet/tools/dotnetsay' is denied.
Tool 'dotnetsay' failed to install.
```

There are multiple problems:

* [x] library path not set for `apphost` binary also fixed in 6bc3acd3b9088cd58761da9b1703b17901cca9b9
* [ ] `DOTNET_ROOT` defaults to `/user/share/dotnet`  https://github.com/dotnet/cli/issues/9114 https://github.com/dotnet/core-setup/issues/8570
       It might be possible to overwrite the string in the binary, since strings folowing it are not important, this is hacky
* [x] `apphost` must be writable, because file permissions are copied https://github.com/dotnet/cli/issues/12234 might be fixed in 3.1 by https://github.com/dotnet/core-setup/pull/8644


###### Notify maintainers

(not yet for the draft)
cc 
