### PR TITLE
[WIP] autoPatchelfHook: search a valid interpreter, or fail

### DIFF
--- a/pkgs/applications/audio/bitwig-studio/bitwig-studio1.nix
+++ b/pkgs/applications/audio/bitwig-studio/bitwig-studio1.nix
@@ -55,6 +55,10 @@ stdenv.mkDerivation rec {
     substitute usr/share/applications/bitwig-studio.desktop \
       $out/share/applications/bitwig-studio.desktop \
       --replace /usr/bin/bitwig-studio $out/bin/bitwig-studio
+
+    # We only support x86_64-linux anyway,
+    # and these files cannot be correctly autoPatchelfHooked
+    rm -r $out/libexec/bin32
   '';
 
   postFixup = ''

--- a/pkgs/build-support/setup-hooks/auto-patchelf.sh
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.sh
@@ -114,7 +114,7 @@ patchElfInterpreter() {
     )
 
     echo "searching an '$(getSoArch "$toPatch")' interpreter for $toPatch" >&2
-    for f in "${paths[@]}"; do
+    for f in "${linkers[@]}"; do
         [ -f "$f" -a -r "$f" ] || continue
         local interpreter=$(< "$f")
 

--- a/pkgs/build-support/setup-hooks/auto-patchelf.sh
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.sh
@@ -103,15 +103,16 @@ autoPatchelfFile() {
 
     if isExecutable "$toPatch"; then
         # Find a suitable interpreter
-        echo "searching an interpreted for $toPatch"
+        echo "searching an interpreter for $toPatch"
         local interpreter="$(< "$NIX_CC/nix-support/dynamic-linker")"
         if [ "$(getSoArch "$toPatch")" != $(getSoArch "$interpreter") ]; then
             # try to find another interpreter
             local interpreter32="$(< "$NIX_CC/nix-support/dynamic-linker-m32")"
-            if [ -n $interpreter32 -a "$(getSoArch "$toPatch")" = $(getSoArch "$interpreter32") ]; then
+            if [ -n "$interpreter32" ]
+            && [ "$(getSoArch "$toPatch")" = "$(getSoArch "$interpreter32")" ]; then
                 interpreter=${interpreter32}
             else
-                echo "No interpreter found for arch $(getSoArch "$toPatch") needed by '$dep'" >&2
+                echo "No interpreter found for arch $(getSoArch "$toPatch") needed by '$toPatch'" >&2
                 false
             fi
         fi

--- a/pkgs/development/mobile/androidenv/build-tools.nix
+++ b/pkgs/development/mobile/androidenv/build-tools.nix
@@ -6,6 +6,8 @@ deployAndroidPackage {
     lib.optional (os == "linux") [ pkgs.glibc pkgs.zlib pkgs.ncurses5 pkgs_i686.glibc pkgs_i686.zlib pkgs_i686.ncurses5 ];
   patchInstructions = ''
     ${lib.optionalString (os == "linux") ''
+      rm -r $packageBaseDir/{i686,aarch64,mipsel,arm}-linux*
+
       addAutoPatchelfSearchPath $packageBaseDir/lib
       addAutoPatchelfSearchPath $packageBaseDir/lib64
       autoPatchelf --no-recurse $packageBaseDir/lib64


### PR DESCRIPTION
###### Motivation for this change

`autoPachelfHook` patches everything with the same interpreter
(`$NIX_CC/nix-support/dynamic-linker`) even on incompatible binaries.
This happens in particular when building with `multiStdenv`.

See https://discourse.nixos.org/t/binary-still-not-working-even-when-properly-patchelfed/1570/3?u=layus for details.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @tadfisher