### PR TITLE
ocamlPackages.ppx_deriving: 4.2.1 -> 4.4

### DIFF
--- a/pkgs/development/ocaml-modules/ppx_deriving/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving/default.nix
@@ -1,41 +1,22 @@
-{ stdenv, ocaml, findlib, ocamlbuild, fetchzip
-, cppo, ppx_tools, ppx_derivers, result, ounit, ocaml-migrate-parsetree
+{ lib, fetchzip, buildDunePackage
+, cppo, ppxfind, ppx_tools, ppx_derivers, result, ounit, ocaml-migrate-parsetree
 }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.02"
-then throw "ppx_deriving is not available for OCaml ${ocaml.version}"
-else
-
-let param =
-  if ocaml.version == "4.03.0"
-  then {
-    version = "4.1";
-    sha256 = "0cy9p8d8cbcxvqyyv8fz2z9ypi121zrgaamdlp4ld9f3jnwz7my9";
-    extraPropagatedBuildInputs = [];
-  } else {
-    version = "4.2.1";
-    sha256 = "1yhhjnncbbb7fsif7qplndh01s1xd72dqm8f3jkgx9y4ariqqvf9";
-    extraPropagatedBuildInputs = [ ocaml-migrate-parsetree ppx_derivers ];
-}; in
-
-stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-ppx_deriving-${version}";
-  inherit (param) version;
+buildDunePackage rec {
+  pname = "ppx_deriving";
+  version = "4.4";
 
   src = fetchzip {
     url = "https://github.com/ocaml-ppx/ppx_deriving/archive/v${version}.tar.gz";
-    inherit (param) sha256;
+    sha256 = "0b2gaxlh54pcz3b4891yd143nx852mwggcy0yhq8g85dl3iisxzq";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild cppo ounit ];
-  propagatedBuildInputs = param.extraPropagatedBuildInputs ++
-    [ ppx_tools result ];
+  buildInputs = [ ppxfind cppo ounit ];
+  propagatedBuildInputs = [ ocaml-migrate-parsetree ppx_derivers ppx_tools result ];
 
-  createFindlibDestdir = true;
+  doCheck = true;
 
-  installPhase = "OCAMLPATH=$OCAMLPATH:`ocamlfind printconf destdir` make install";
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "deriving is a library simplifying type-driven code generation on OCaml >=4.02.";
     maintainers = [ maintainers.maurer ];
     license = licenses.mit;

--- a/pkgs/development/ocaml-modules/ppx_tools/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_tools/default.nix
@@ -20,6 +20,9 @@ let param = {
   "4.07" = {
     version = "5.1+4.06.0";
     sha256 = "1ww4cspdpgjjsgiv71s0im5yjkr3544x96wsq1vpdacq7dr7zwiw"; };
+  "4.08" = {
+    version = "5.3+4.08.0";
+    sha256 = "0vdmhs3hpmh5iclx4lzgdpf362m4l35zprxs73r84z1yhr4jcr4m"; };
 }."${ocaml.meta.branch}";
 in
   stdenv.mkDerivation {

--- a/pkgs/development/ocaml-modules/ppxfind/default.nix
+++ b/pkgs/development/ocaml-modules/ppxfind/default.nix
@@ -1,6 +1,6 @@
-{ lib, buildDunePackage, fetchurl, ocaml-migrate-parsetree }:
+{ lib, buildDunePackage, fetchurl, ocaml, ocaml-migrate-parsetree }:
 
-buildDunePackage rec {
+buildDunePackage (rec {
 	pname = "ppxfind";
 	version = "1.3";
 	src = fetchurl {
@@ -18,4 +18,8 @@ buildDunePackage rec {
 		license = lib.licenses.bsd3;
 		maintainers = [ lib.maintainers.vbgl ];
 	};
-}
+} // (
+if lib.versions.majorMinor ocaml.version == "4.04" then {
+  dontStrip = true;
+} else {}
+))


### PR DESCRIPTION
##### Motivation for this change

Compatibility with OCaml 4.08.

Also enable a dependency (ppx_tools) on OCaml 4.08 and fix a dependency (ppxfind) on OCaml 4.04.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
