### PR TITLE
btrbk: 0.28.0 -> 0.28.3

### DIFF
--- a/pkgs/tools/backup/btrbk/default.nix
+++ b/pkgs/tools/backup/btrbk/default.nix
@@ -1,16 +1,16 @@
 { stdenv, fetchurl, coreutils, bash, btrfs-progs, openssh, perl, perlPackages
-, utillinux, asciidoc, makeWrapper }:
+, utillinux, asciidoc, asciidoctor, makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "btrbk-${version}";
-  version = "0.28.0";
+  version = "0.28.3";
 
   src = fetchurl {
     url = "https://digint.ch/download/btrbk/releases/${name}.tar.xz";
-    sha256 = "1bqgcbkdd5s3l3ba1ifa9l523r8cr5y3arjdy9f6rmm840kn7xzf";
+    sha256 = "0s69pcjkjxg77cgyjahwyg2w81ckgzwz1ds4ifjw7z0zhjxy7miz";
   };
 
-  nativeBuildInputs = [ asciidoc makeWrapper ];
+  nativeBuildInputs = [ asciidoc asciidoctor makeWrapper ];
 
   buildInputs = with perlPackages; [ perl DateCalc ];
 


### PR DESCRIPTION
###### Motivation for this change
fixing updates @r-ryantm  cannot.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @the-kenny 

```
$ nix path-info -Sh ./result
/nix/store/jsv5rvjmj8b3pma6kdnwzq0gvq1155y2-btrbk-0.28.3         157.2M
$ nix path-info -Sh ./result
/nix/store/g6l7dcycr9ssdgca2y9qsnnbiqh4586p-btrbk-0.28.0         157.2M
```
```
[1 built, 0.0 MiB DL]
1 package were build:
btrbk
```