### PR TITLE
Update Gambit and Gerbil from upstream

### DIFF
--- a/pkgs/development/compilers/gambit/unstable.nix
+++ b/pkgs/development/compilers/gambit/unstable.nix
@@ -1,13 +1,13 @@
 { stdenv, callPackage, fetchFromGitHub }:
 
 callPackage ./build.nix {
-  version = "unstable-2019-02-05";
-# git-version = "4.9.3";
+  version = "unstable-2019-07-21";
+# git-version = "4.9.3-109-g3b5f74fa";
   src = fetchFromGitHub {
     owner = "feeley";
     repo = "gambit";
-    rev = "baf7de67f6d800821412fe83a8d9e9e09faeb490";
-    sha256 = "0ygm5y8fvq6dbb8mwq52v8rc8pdnwm4qpmxlnx5m9hzzbm1kzxxv";
+    rev = "3b5f74fae74b2159e3bf6923f29a18b31cc15dcc";
+    sha256 = "07cb0d8754dqhxawkp5dp4y0bsa9kfald4dkj60j5yfnsp81y5mi";
   };
   inherit stdenv;
 }

--- a/pkgs/development/compilers/gerbil/unstable.nix
+++ b/pkgs/development/compilers/gerbil/unstable.nix
@@ -1,14 +1,14 @@
 { stdenv, callPackage, fetchFromGitHub, gambit-unstable }:
 
 callPackage ./build.nix {
-  version = "unstable-2019-02-09";
-  git-version = "0.16-DEV-15-gafc20fc2";
+  version = "unstable-2019-08-11";
+  git-version = "0.16-DEV-132-gcb58f9a3";
   gambit = gambit-unstable;
   src = fetchFromGitHub {
     owner = "vyzo";
     repo = "gerbil";
-    rev = "afc20fc21030e8445b46b8267cc4c52cfd662aad";
-    sha256 = "02v16zya9zryjs4wallibp1kvnpba60aw15y4k7zhddc71qjfbhw";
+    rev = "cb58f9a30630a6f3e85a55f2c1dcc654f517ffed";
+    sha256 = "18jh64v1gi6z3pks9zf19f2wcjpv21cs270dnaq617kgwp53vysh";
   };
   inherit stdenv;
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Catch up with upstream

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @7c6f434c
