### PR TITLE
fmit: 1.1.14 -> 1.2.6

### DIFF
--- a/pkgs/applications/audio/fmit/default.nix
+++ b/pkgs/applications/audio/fmit/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, fftw, qtbase, qtmultimedia, qmake
+{ stdenv, mkDerivation, fetchFromGitHub, fftw, qtbase, qtmultimedia, qmake, itstool, wrapQtAppsHook
 , alsaSupport ? true, alsaLib ? null
 , jackSupport ? false, libjack2 ? null
 , portaudioSupport ? false, portaudio ? null }:
@@ -9,18 +9,18 @@ assert portaudioSupport -> portaudio != null;
 
 with stdenv.lib;
 
-stdenv.mkDerivation rec {
-  name = "fmit-${version}";
-  version = "1.1.14";
+mkDerivation rec {
+  pname = "fmit";
+  version = "1.2.6";
 
   src = fetchFromGitHub {
-    sha256 = "18gvl8smcnigzldy1acs5h8rscf287b39xi4y2cl5armqbj0y38x";
-    rev = "v${version}";
-    repo = "fmit";
     owner = "gillesdegottex";
+    repo = "fmit";
+    rev = "v${version}";
+    sha256 = "03nzkig5mw2rqwhwmg0qvc5cnk9bwh2wp13jh0mdrr935w0587mz";
   };
 
-  nativeBuildInputs = [ qmake ];
+  nativeBuildInputs = [ qmake itstool wrapQtAppsHook ];
   buildInputs = [ fftw qtbase qtmultimedia ]
     ++ optionals alsaSupport [ alsaLib ]
     ++ optionals jackSupport [ libjack2 ]


### PR DESCRIPTION
###### Motivation for this change
fixing updates @r-ryantm  cannot

also, fixed executable about wrapping Qt

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[1 built, 0.0 MiB DL]
1 package were build:
fmit
```
The large increase is because Qt is now properly included in the closure.
```
$ nix path-info -Sh ./result
/nix/store/98vv44jpnymqmbx5b6galwg117dvg3l3-fmit-1.2.6   406.5M
$ nix path-info -Sh ./result
/nix/store/pg3f03yh62xrpz3zqz8q8l41n872j3x3-fmit-1.1.14  207.1M
```

previous execution error:
```
$ ./result/bin/fmit
Free Music Instrument Tuner (Version 1.1.14-)
qt.qpa.plugin: Could not find the Qt platform plugin "xcb" in ""
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
```