### PR TITLE
docker-compose: add zsh completion

### DIFF
--- a/pkgs/applications/virtualization/docker-compose/default.nix
+++ b/pkgs/applications/virtualization/docker-compose/default.nix
@@ -5,6 +5,7 @@
 , six, texttable, websocket_client, cached-property
 , enum34, functools32, paramiko
 }:
+
 buildPythonApplication rec {
   version = "1.24.1";
   pname = "docker-compose";
@@ -32,15 +33,17 @@ buildPythonApplication rec {
   '';
 
   postInstall = ''
-    mkdir -p $out/share/bash-completion/completions/
-    cp contrib/completion/bash/docker-compose $out/share/bash-completion/completions/docker-compose
+    install -D -m 0444 contrib/completion/bash/docker-compose \
+      $out/share/bash-completion/completions/docker-compose
+
+    install -D -m 0444 contrib/completion/zsh/_docker-compose \
+      $out/share/zsh-completion/zsh/site-functions/_docker-compose
   '';
 
   meta = with stdenv.lib; {
     homepage = https://docs.docker.com/compose/;
     description = "Multi-container orchestration for Docker";
     license = licenses.asl20;
-    maintainers = with maintainers; [
-    ];
+    maintainers = [ ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add zsh completion script in docker-compose package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
