### PR TITLE
pamixer: 1.3.1 -> 1.4

### DIFF
--- a/pkgs/applications/audio/pamixer/default.nix
+++ b/pkgs/applications/audio/pamixer/default.nix
@@ -1,27 +1,20 @@
 { stdenv, fetchFromGitHub, fetchpatch, boost, libpulseaudio }:
 
 stdenv.mkDerivation rec {
-  name = "pamixer-${version}";
-  version = "1.3.1";
+  pname = "pamixer";
+  version = "1.4";
 
   src = fetchFromGitHub {
     owner = "cdemoulins";
     repo = "pamixer";
     rev = version;
-    sha256 = "15zs2x4hnrpxphqn542b6qqm4ymvhkvbcfyffy69d6cki51chzzw";
+    sha256 = "1i14550n8paijwwnhksv5izgfqm3s5q2773bdfp6vyqybkll55f7";
   };
-
-  # Remove after https://github.com/cdemoulins/pamixer/pull/16 gets fixed
-  patches = [(fetchpatch {
-    url = "https://github.com/oxij/pamixer/commit/dea1cd967aa837940e5c0b04ef7ebc47a7a93d63.patch";
-    sha256 = "0s77xmsiwywyyp6f4bjxg1sqdgms1k5fiy7na6ws0aswshfnzfjb";
-  })];
 
   buildInputs = [ boost libpulseaudio ];
 
   installPhase = ''
-    mkdir -p $out/bin
-    cp pamixer $out/bin
+    install -Dm755 pamixer -t $out/bin
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
fixing updates @r-ryantm has trouble doing.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[2 built, 0.0 MiB DL]
1 package were build:
pamixer
```