### PR TITLE
pazi: 0.2.0 -> 0.3.0

### DIFF
--- a/pkgs/tools/misc/pazi/cargo-lock.patch
+++ b/pkgs/tools/misc/pazi/cargo-lock.patch
@@ -6,8 +6,8 @@ index 074b0ca..22f3bc5 100644
  
  [[package]]
  name = "pazi"
--version = "0.1.0"
-+version = "0.2.0"
+-version = "0.2.0"
++version = "0.3.0"
  dependencies = [
-  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
-  "crossbeam-channel 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/pkgs/tools/misc/pazi/default.nix
+++ b/pkgs/tools/misc/pazi/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, rustPlatform }:
+{ stdenv, fetchFromGitHub, rustPlatform, darwin }:
 
 rustPlatform.buildRustPackage rec {
   pname = "pazi";
@@ -10,6 +10,8 @@ rustPlatform.buildRustPackage rec {
     rev = "v${version}";
     sha256 = "1gnh6047hacavcb9bhps9d1zjns66rdbd158fw20kjp1lln5srrn";
   };
+
+  buildInputs = stdenv.lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Security ];
 
   cargoSha256 = "15s03vwgl6562n5h9r4d5kp2r168jakn5nwnyibmrs8r5q0idmjs";
 

--- a/pkgs/tools/misc/pazi/default.nix
+++ b/pkgs/tools/misc/pazi/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "pazi";
-  version = "0.2.0";
+  version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "euank";
     repo = pname;
     rev = "v${version}";
-    sha256 = "12z2vyzmyxfq1krbbrjar7c2gvyq1969v16pb2pm7f4g4k24g0c8";
+    sha256 = "1gnh6047hacavcb9bhps9d1zjns66rdbd158fw20kjp1lln5srrn";
   };
 
-  cargoSha256 = "1w97jvlamxlxkqpim5iyayhbsqvg3rqds2nxq1fk5imj4hbi3681";
+  cargoSha256 = "15s03vwgl6562n5h9r4d5kp2r168jakn5nwnyibmrs8r5q0idmjs";
 
   cargoPatches = [ ./cargo-lock.patch ];
 


### PR DESCRIPTION
###### Motivation for this change
fixing builds that @r-ryantm can't update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @bbigras 

```
$ nix path-info -Sh ./result
/nix/store/bl4jsq7xin3vbpdbvbx37qviharl4w37-pazi-0.2.0    28.7M
$ nix path-info -Sh ./result
/nix/store/kbr3c6gma7nzngn82g6x6c3zwlg88by1-pazi-0.3.0    28.6M
```
```
[1 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/66639
1 package were build:
pazi
```