### PR TITLE
antlr4: 4.7.1 -> 4.7.2

### DIFF
--- a/pkgs/applications/misc/mysql-workbench/default.nix
+++ b/pkgs/applications/misc/mysql-workbench/default.nix
@@ -37,6 +37,12 @@ in stdenv.mkDerivation rec {
     })
   ];
 
+  # have it look for 4.7.2 instead of 4.7.1
+  preConfigure = ''
+    substituteInPlace CMakeLists.txt \
+      --replace "antlr-4.7.1-complete.jar" "antlr-4.7.2-complete.jar"
+  '';
+
   nativeBuildInputs = [
     cmake ninja pkgconfig jre swig wrapGAppsHook
   ];

--- a/pkgs/development/python-modules/antlr4-python2-runtime/default.nix
+++ b/pkgs/development/python-modules/antlr4-python2-runtime/default.nix
@@ -1,18 +1,21 @@
-{ stdenv, fetchPypi, buildPythonPackage, isPy3k }:
+{ lib, buildPythonPackage, isPy3k, python
+, antlr4
+}:
 
 buildPythonPackage rec {
   pname = "antlr4-python2-runtime";
-  version = "4.7.2";
+  inherit (antlr4.runtime.cpp) version src;
   disabled = isPy3k;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "04ljic5wnqpizln8q3c78pqrckz6q5nb433if00j1mlyv2yja22q";
-  };
+  sourceRoot = "source/runtime/Python2";
 
-  meta = {
+  checkPhase = ''
+    ${python.interpreter} tests/TestTokenStreamRewriter.py
+  '';
+
+  meta = with lib; {
     description = "Runtime for ANTLR";
     homepage = "https://www.antlr.org/";
-    license = stdenv.lib.licenses.bsd3;
+    license = licenses.bsd3;
   };
 }

--- a/pkgs/development/python-modules/antlr4-python3-runtime/default.nix
+++ b/pkgs/development/python-modules/antlr4-python3-runtime/default.nix
@@ -1,18 +1,22 @@
-{ stdenv, fetchPypi, buildPythonPackage, isPy3k }:
+{ lib, buildPythonPackage, isPy3k, python
+, antlr4
+}:
 
 buildPythonPackage rec {
   pname = "antlr4-python3-runtime";
-  version = "4.7.2";
+  inherit (antlr4.runtime.cpp) version src;
   disabled = !isPy3k;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "02xm7ccsf51vh4xsnhlg6pvchm1x3ckgv9kwm222w5drizndr30n";
-  };
+  sourceRoot = "source/runtime/Python3";
 
-  meta = {
+  checkPhase = ''
+    cd test
+    ${python.interpreter} ctest.py
+  '';
+
+  meta = with lib; {
     description = "Runtime for ANTLR";
     homepage = "https://www.antlr.org/";
-    license = stdenv.lib.licenses.bsd3;
+    license = licenses.bsd3;
   };
 }

--- a/pkgs/development/tools/parsing/antlr/4.7.nix
+++ b/pkgs/development/tools/parsing/antlr/4.7.nix
@@ -2,12 +2,12 @@
 , fetchFromGitHub, cmake, ninja, pkgconfig, libuuid, darwin }:
 
 let
-  version = "4.7.1";
+  version = "4.7.2";
   source = fetchFromGitHub {
     owner = "antlr";
     repo = "antlr4";
     rev = version;
-    sha256 = "1xb4d9bd4hw406v85s64gg8gwcrrsrw171vhga1gz4xj6pzfwxz7";
+    sha256 = "1pl0zs6c6wx9nmq30s7ccpc3dl72az55i8vfp574fw9sywmvxmlj";
   };
 
   runtime = {
@@ -38,9 +38,10 @@ let
   antlr = stdenv.mkDerivation {
     pname = "antlr";
     inherit version;
+
     src = fetchurl {
       url ="https://www.antlr.org/download/antlr-${version}-complete.jar";
-      sha256 = "1236gwnzchama92apb2swmklnypj01m7bdwwfvwvl8ym85scw7gl";
+      sha256 = "1d40nfkq3ws8g4ksx4gj6l6m2l9j4b605q6sf68z5vvmg5nkhlk8";
     };
 
     dontUnpack = true;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1379,9 +1379,9 @@ in {
 
   amqplib = callPackage ../development/python-modules/amqplib {};
 
-  antlr4-python2-runtime = callPackage ../development/python-modules/antlr4-python2-runtime {};
+  antlr4-python2-runtime = callPackage ../development/python-modules/antlr4-python2-runtime { antlr4 = pkgs.antlr4; };
 
-  antlr4-python3-runtime = callPackage ../development/python-modules/antlr4-python3-runtime {};
+  antlr4-python3-runtime = callPackage ../development/python-modules/antlr4-python3-runtime { antlr4 = pkgs.antlr4; };
 
   apipkg = callPackage ../development/python-modules/apipkg {};
 


### PR DESCRIPTION
###### Motivation for this change
fixing updates @r-ryantm cannot.

patched mysqlWorkbench so it looked for the new version as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
$ nix path-info -Sh ./result
/nix/store/hh7mfax21dkp0cb6fr4hjc9cax558mlm-antlr-4.7.2  380.1M
$ nix path-info -Sh ./result
/nix/store/f1pwavzhbi3xlk1468syaykw8aqq2x5l-antlr-4.7.1  380.2M
```
