### PR TITLE
xkbvalidate: Use $CC instead of hardcoded gcc

### DIFF
--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -714,7 +714,7 @@ in
       nativeBuildInputs = [ pkgs.xkbvalidate ];
       preferLocalBuild = true;
     } ''
-      validate "$xkbModel" "$layout" "$xkbVariant" "$xkbOptions"
+      xkbvalidate "$xkbModel" "$layout" "$xkbVariant" "$xkbOptions"
       touch "$out"
     '');
 

--- a/pkgs/tools/X11/xkbvalidate/default.nix
+++ b/pkgs/tools/X11/xkbvalidate/default.nix
@@ -11,5 +11,5 @@ runCommandCC "xkbvalidate" {
 } ''
   mkdir -p "$out/bin"
   $CC -std=c11 -Wall -pedantic -lxkbcommon ${./xkbvalidate.c} \
-    -o "$out/bin/validate"
+    -o "$out/bin/xkbvalidate"
 ''

--- a/pkgs/tools/X11/xkbvalidate/default.nix
+++ b/pkgs/tools/X11/xkbvalidate/default.nix
@@ -5,11 +5,11 @@ runCommandCC "xkbvalidate" {
   meta = {
     description = "NixOS tool to validate X keyboard configuration";
     license = lib.licenses.mit;
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
     maintainers = [ lib.maintainers.aszlig ];
   };
 } ''
   mkdir -p "$out/bin"
-  $CC -std=gnu11 -Wall -pedantic -lxkbcommon ${./xkbvalidate.c} \
+  $CC -std=c11 -Wall -pedantic -lxkbcommon ${./xkbvalidate.c} \
     -o "$out/bin/validate"
 ''

--- a/pkgs/tools/X11/xkbvalidate/default.nix
+++ b/pkgs/tools/X11/xkbvalidate/default.nix
@@ -10,6 +10,6 @@ runCommandCC "xkbvalidate" {
   };
 } ''
   mkdir -p "$out/bin"
-  gcc -std=gnu11 -Wall -pedantic -lxkbcommon ${./xkbvalidate.c} \
+  $CC -std=gnu11 -Wall -pedantic -lxkbcommon ${./xkbvalidate.c} \
     -o "$out/bin/validate"
 ''


### PR DESCRIPTION
I initially didn't use `$CC` because I thought this would be GCC specific, but it turns out that Clang actually accepts `-std=gnu11`.

So using `$CC` here might not work on compilers other than Clang or GCC, but at the moment those are the compilers we typically use in nixpkgs, so even if we'd use some other compiler it *might* even work there.

I've tested this by compiling against `clangStdenv` with both `$CC` and `clang` hardcoded and it works.

This was reported by @dkudriavtsev on IRC.