### PR TITLE
erlang: Fix build error on darwin

### DIFF
--- a/pkgs/development/interpreters/erlang/R19.nix
+++ b/pkgs/development/interpreters/erlang/R19.nix
@@ -14,6 +14,6 @@ mkDerivation rec {
   ];
 
   prePatch = ''
-    substituteInPlace configure.in --replace '`sw_vers -productVersion`' '10.10'
+    substituteInPlace configure.in --replace '`sw_vers -productVersion`' "''${MACOSX_DEPLOYMENT_TARGET:-10.12}"
   '';
 }

--- a/pkgs/development/interpreters/erlang/R20.nix
+++ b/pkgs/development/interpreters/erlang/R20.nix
@@ -5,6 +5,6 @@ mkDerivation rec {
   sha256 = "0v2iiyzss8hiih98wvj0gi2qzdmmhh7bvc9p025wlfm4k7r1109a";
 
   prePatch = ''
-    substituteInPlace configure.in --replace '`sw_vers -productVersion`' '10.10'
+    substituteInPlace configure.in --replace '`sw_vers -productVersion`' "''${MACOSX_DEPLOYMENT_TARGET:-10.12}"
   '';
 }

--- a/pkgs/development/interpreters/erlang/R21.nix
+++ b/pkgs/development/interpreters/erlang/R21.nix
@@ -5,6 +5,6 @@ mkDerivation rec {
   sha256 = "1szybirrcpqsl2nmlmpbkxjqnm6i7l7bma87m5cpwi0kpvlxwmcw";
 
   prePatch = ''
-    substituteInPlace configure.in --replace '`sw_vers -productVersion`' '10.10'
+    substituteInPlace configure.in --replace '`sw_vers -productVersion`' "''${MACOSX_DEPLOYMENT_TARGET:-10.12}"
   '';
 }

--- a/pkgs/development/interpreters/erlang/R22.nix
+++ b/pkgs/development/interpreters/erlang/R22.nix
@@ -5,7 +5,7 @@ mkDerivation rec {
   sha256 = "1aqkhd6nwdn4xp5yz02zbymd4x8ij8fjw9ji8kh860n1a513k9ai";
 
   prePatch = ''
-    substituteInPlace make/configure.in --replace '`sw_vers -productVersion`' '10.10'
+    substituteInPlace make/configure.in --replace '`sw_vers -productVersion`' "''${MACOSX_DEPLOYMENT_TARGET:-10.12}"
     substituteInPlace erts/configure.in --replace '-Wl,-no_weak_imports' ""
   '';
 }


### PR DESCRIPTION
###### Motivation for this change
Erlang stopped building on Darwin as a result of https://github.com/NixOS/nixpkgs/pull/64458 (which bumped `MACOSX_DEPLOYMENT_TARGET`). This is because it was hardcoding 10.10 as the detected platform.

Fixes #66644

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @the-kenny @sjmackenzie @couchemar @gleber

---

Build succeeded. I don't have any good way to test erlang offhand, but I did run `result/bin/erl` and got a REPL. I haven't tested the other executables.