### PR TITLE
luarocks: Update detected platform version

### DIFF
--- a/pkgs/development/tools/misc/luarocks/darwin-3.0.x.patch
+++ b/pkgs/development/tools/misc/luarocks/darwin-3.0.x.patch
@@ -10,7 +10,7 @@ index f93e67a..2eb2db9 100644
 +      defaults.variables.STAT = "stat"
        defaults.variables.STATFLAG = "-f '%A'"
 -      local version = util.popen_read("sw_vers -productVersion")
-+      local version = "10.10"
++      local version = os.getenv("MACOSX_DEPLOYMENT_TARGET") or "10.12"
        version = tonumber(version and version:match("^[^.]+%.([^.]+)")) or 3
        if version >= 10 then
           version = 8

--- a/pkgs/development/tools/misc/luarocks/darwin-3.1.3.patch
+++ b/pkgs/development/tools/misc/luarocks/darwin-3.1.3.patch
@@ -7,7 +7,7 @@ index c5af5a2..1949fdc 100644
        defaults.arch = "macosx-"..target_cpu
        defaults.variables.LIBFLAG = "-bundle -undefined dynamic_lookup -all_load"
 -      local version = util.popen_read("sw_vers -productVersion")
-+      local version = "10.10"
++      local version = os.getenv("MACOSX_DEPLOYMENT_TARGET") or "10.12"
        version = tonumber(version and version:match("^[^.]+%.([^.]+)")) or 3
        if version >= 10 then
           version = 8


### PR DESCRIPTION
#### Motivation for this change
Now that our MACOSX_DEPLOYMENT_TARGET is set to 10.12 (see #64458), we shouldn't be hardcoding the platform at build time as 10.10. This change makes it inherit the MACOSX_DEPLOYMENT_TARGET value.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @raskin @teto