### PR TITLE
perl: Update detected platform version

### DIFF
--- a/pkgs/development/interpreters/perl/sw_vers.patch
+++ b/pkgs/development/interpreters/perl/sw_vers.patch
@@ -7,7 +7,7 @@ index afadf53..80b7533 100644
      # "ProductVersion:    10.10.5"   "10.10"
      # "ProductVersion:    10.11"     "10.11"
 -        prodvers=`sw_vers|awk '/^ProductVersion:/{print $2}'|awk -F. '{print $1"."$2}'`
-+        prodvers="10.10"
++        prodvers="${MACOSX_DEPLOYMENT_TARGET:-10.12}"
      case "$prodvers" in
      10.*)
        add_macosx_version_min ccflags $prodvers


### PR DESCRIPTION
###### Motivation for this change
Instead of hardcoding the version as 10.10, we should just detect it as being MACOSX_DEPLOYMENT_TARGET (which was updated in #64458 to 10.12).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @eelco

---

I haven't built this because I have no idea how to do so without rebuilding essentially the whole world.