### PR TITLE
Postgresql plugins fixes

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/cstore_fdw.nix
+++ b/pkgs/servers/sql/postgresql/ext/cstore_fdw.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   };
 
   installPhase = ''
-    mkdir -p $out/{lib,share/extension}
+    mkdir -p $out/{lib,share/postgresql/extension}
 
     cp *.so      $out/lib
     cp *.sql     $out/share/postgresql/extension

--- a/pkgs/servers/sql/postgresql/ext/pg_auto_failover.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_auto_failover.nix
@@ -1,8 +1,5 @@
 { stdenv, fetchFromGitHub, postgresql, openssl, zlib, readline }:
 
-if stdenv.lib.versionOlder postgresql.version "10"
-then throw "pg_auto_failover not supported for PostgreSQL ${postgresql.version}"
-else
 stdenv.mkDerivation rec {
   pname = "pg_auto_failover";
   version = "1.0.3";
@@ -29,5 +26,6 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.marsam ];
     platforms = postgresql.meta.platforms;
     license = licenses.postgresql;
+    broken = versionOlder postgresql.version "10";
   };
 }

--- a/pkgs/servers/sql/postgresql/ext/pg_bigm.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_bigm.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/bin    # For buildEnv to setup proper symlinks. See #22653
-    mkdir -p $out/{lib,share/extension}
+    mkdir -p $out/{lib,share/postgresql/extension}
 
     cp *.so      $out/lib
     cp *.sql     $out/share/postgresql/extension

--- a/pkgs/servers/sql/postgresql/ext/pg_cron.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_cron.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   };
 
   installPhase = ''
-    mkdir -p $out/{lib,share/extension}
+    mkdir -p $out/{lib,share/postgresql/extension}
 
     cp *.so      $out/lib
     cp *.sql     $out/share/postgresql/extension

--- a/pkgs/servers/sql/postgresql/ext/pg_hll.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_hll.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   };
 
   installPhase = ''
-    mkdir -p $out/{lib,share/extension}
+    mkdir -p $out/{lib,share/postgresql/extension}
 
     cp *.so      $out/lib
     cp *.sql     $out/share/postgresql/extension

--- a/pkgs/servers/sql/postgresql/ext/pg_partman.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_partman.nix
@@ -14,8 +14,7 @@ stdenv.mkDerivation rec {
   };
 
   installPhase = ''
-    mkdir -p $out/bin    # For buildEnv to setup proper symlinks. See #22653
-    mkdir -p $out/{lib,share/extension}
+    mkdir -p $out/{lib,share/postgresql/extension}
 
     cp src/*.so      $out/lib
     cp updates/*     $out/share/postgresql/extension

--- a/pkgs/servers/sql/postgresql/ext/pg_topn.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_topn.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   };
 
   installPhase = ''
-    mkdir -p $out/{lib,share/extension}
+    mkdir -p $out/{lib,share/postgresql/extension}
 
     cp *.so      $out/lib
     cp *.sql     $out/share/postgresql/extension

--- a/pkgs/servers/sql/postgresql/ext/pipelinedb.nix
+++ b/pkgs/servers/sql/postgresql/ext/pipelinedb.nix
@@ -1,8 +1,5 @@
 { stdenv, fetchFromGitHub, postgresql, zeromq, openssl }:
 
-if stdenv.lib.versionOlder postgresql.version "10"
-then throw "PipelineDB not supported for PostgreSQL ${postgresql.version}"
-else
 stdenv.mkDerivation rec {
   pname = "pipelinedb";
   version = "1.0.0-13";
@@ -35,5 +32,6 @@ stdenv.mkDerivation rec {
     license = licenses.asl20;
     platforms = postgresql.meta.platforms;
     maintainers = [ maintainers.marsam ];
+    broken = versionOlder postgresql.version "10";
   };
 }

--- a/pkgs/servers/sql/postgresql/ext/tds_fdw.nix
+++ b/pkgs/servers/sql/postgresql/ext/tds_fdw.nix
@@ -25,5 +25,6 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.steve-chavez ];
     platforms   = postgresql.meta.platforms;
     license     = licenses.postgresql;
+    broken = versionAtLeast postgresql.version "11.0";
   };
 }

--- a/pkgs/servers/sql/postgresql/ext/temporal_tables.nix
+++ b/pkgs/servers/sql/postgresql/ext/temporal_tables.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   };
 
   installPhase = ''
-    mkdir -p $out/{bin,lib,share/extension}
+    mkdir -p $out/{lib,share/postgresql/extension}
 
     cp *.so      $out/lib
     cp *.sql     $out/share/postgresql/extension

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -7,6 +7,7 @@ let
   # If we're in hydra, we can dispense with the more verbose error
   # messages and make problems easier to spot.
   inHydra = config.inHydra or false;
+  getName = attrs: attrs.name or ("${attrs.pname or "«name-missing»"}-${attrs.version or "«version-missing»"}");
 
   # See discussion at https://github.com/NixOS/nixpkgs/pull/25304#issuecomment-298385426
   # for why this defaults to false, but I (@copumpkin) want to default it to true soon.
@@ -107,23 +108,23 @@ let
         You can install it anyway by whitelisting this package, using the
         following methods:
 
-        a) for `nixos-rebuild` you can add ‘${attrs.name or "«name-missing»"}’ to
+        a) for `nixos-rebuild` you can add ‘${getName attrs}’ to
            `nixpkgs.config.permittedInsecurePackages` in the configuration.nix,
            like so:
 
              {
                nixpkgs.config.permittedInsecurePackages = [
-                 "${attrs.name or "«name-missing»"}"
+                 "${getName attrs}"
                ];
              }
 
         b) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
-        ‘${attrs.name or "«name-missing»"}’ to `permittedInsecurePackages` in
+        ‘${getName attrs}’ to `permittedInsecurePackages` in
         ~/.config/nixpkgs/config.nix, like so:
 
              {
                permittedInsecurePackages = [
-                 "${attrs.name or "«name-missing»"}"
+                 "${getName attrs}"
                ];
              }
 
@@ -134,9 +135,9 @@ let
       actualOutputs = attrs.outputs or [ "out" ];
       missingOutputs = builtins.filter (output: ! builtins.elem output actualOutputs) expectedOutputs;
     in ''
-      The package ${attrs.name} has set meta.outputsToInstall to: ${builtins.concatStringsSep ", " expectedOutputs}
+      The package ${getName attrs} has set meta.outputsToInstall to: ${builtins.concatStringsSep ", " expectedOutputs}
 
-      however ${attrs.name} only has the outputs: ${builtins.concatStringsSep ", " actualOutputs}
+      however ${getName attrs} only has the outputs: ${builtins.concatStringsSep ", " actualOutputs}
 
       and is missing the following ouputs:
 
@@ -146,9 +147,9 @@ let
   handleEvalIssue = { meta, attrs }: { reason , errormsg ? "" }:
     let
       msg = if inHydra
-        then "Failed to evaluate ${attrs.name or "«name-missing»"}: «${reason}»: ${errormsg}"
+        then "Failed to evaluate ${getName attrs}: «${reason}»: ${errormsg}"
         else ''
-          Package ‘${attrs.name or "«name-missing»"}’ in ${pos_str meta} ${errormsg}, refusing to evaluate.
+          Package ‘${getName attrs}’ in ${pos_str meta} ${errormsg}, refusing to evaluate.
 
         '' + (builtins.getAttr reason remediation) attrs;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14844,6 +14844,7 @@ in
   ;
   postgresql = postgresql_9_6.override { this = postgresql; };
   postgresqlPackages = recurseIntoAttrs postgresql.pkgs;
+  postgresql11Packages = recurseIntoAttrs postgresql_11.pkgs;
 
   postgresql_jdbc = callPackage ../development/java-modules/postgresql_jdbc { };
 


### PR DESCRIPTION
Found some failures: https://hydra.nixos.org/eval/1536115?filter=postgresqlPackages&compare=1536056&full=1#tabs-still-fail

- fix extension target dir for some plugins (cc @matthewbauer @ehamberg )
- build PG11 plugins on Hydra
- mark `tds_fdw` broken for newer PGs (cc @steve-chavez )
- check-meta: teach about `${pname}-${version}`, because I've got "name-missing" in:
    ```
    error: Package ‘«name-missing»’ in /home/ubuntu/danylo/nixpkgs/pkgs/servers/sql/postgresql/ext/tds_fdw.nix:23 is marked as broken, refusing to evaluate.
    ```
(cc @copumpkin @Synthetica9 @FRidh )
- replace some `throw`s with `meta.broken`. This is debatable, because packages are broken only for specific PG versions, and users don't know about this from new error message. But I still think it is a better option than `throw` (cc @marsam , related https://github.com/NixOS/nixpkgs/issues/36229)

I've built all with
```
$ nix-build -E 'with import ./.{}; with lib; flip filterAttrs postgresqlPackages (n: v: !v.meta.broken or false)'
$ nix-build -E 'with import ./.{}; with lib; flip filterAttrs postgresql11Packages (n: v: !v.meta.broken or false)'
```