### PR TITLE
apfs-fuse: init at 20190723

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1484,6 +1484,11 @@
     github = "eadwu";
     name = "Edmund Wu";
   };
+  ealasu = {
+    email = "emanuel.alasu@gmail.com";
+    github = "ealasu";
+    name = "Emanuel Alasu";
+  };
   eamsden = {
     email = "edward@blackriversoft.com";
     github = "eamsden";

--- a/pkgs/tools/filesystems/apfs-fuse/default.nix
+++ b/pkgs/tools/filesystems/apfs-fuse/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, fuse3, bzip2, zlib, attr, cmake }:
+
+stdenv.mkDerivation rec {
+  pname = "apfs-fuse-unstable";
+  version = "2019-07-23";
+
+  src = fetchFromGitHub {
+    owner  = "sgan81";
+    repo   = "apfs-fuse";
+    rev    = "309ecb030f38edac4c10fa741a004c5eb7a23e15";
+    sha256 = "0wq6rlqi00m5dp5gbzy65i1plm40j6nsm7938zvfgx5laal4wzr2";
+    fetchSubmodules = true;
+  };
+
+  buildInputs = [ fuse3 bzip2 zlib attr ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = with stdenv.lib; {
+    homepage    = "https://github.com/sgan81/apfs-fuse";
+    description = "FUSE driver for APFS (Apple File System)";
+    license     = licenses.gpl2;
+    maintainers = with maintainers; [ ealasu ];
+    platforms   = platforms.linux;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -560,6 +560,8 @@ in
 
   antora = callPackage ../development/tools/documentation/antora {};
 
+  apfs-fuse = callPackage ../tools/filesystems/apfs-fuse { };
+
   apktool = callPackage ../development/tools/apktool {
     inherit (androidenv.androidPkgs_9_0) build-tools;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add apfs-fuse.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
