### PR TITLE
prow: init unstable at 2019-08-14

### DIFF
--- a/pkgs/applications/networking/cluster/prow/13918-fix-go-sum.patch
+++ b/pkgs/applications/networking/cluster/prow/13918-fix-go-sum.patch
@@ -1,0 +1,22 @@
+From b0ab95b9664916618ebf5fe637b1bc4de4ba9a6e Mon Sep 17 00:00:00 2001
+From: "Wael M. Nasreddine" <wael.nasreddine@gmail.com>
+Date: Wed, 14 Aug 2019 23:07:51 -0700
+Subject: [PATCH] fix the hash of gomodules.xyz/jsonpatch/v2
+
+---
+ go.sum | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/go.sum b/go.sum
+index 6bb130b4d9b..b3f48a85d4a 100644
+--- a/go.sum
++++ b/go.sum
+@@ -452,7 +452,7 @@ golang.org/x/tools v0.0.0-20190312170243-e65039ee4138 h1:H3uGjxCR/6Ds0Mjgyp7LMK8
+ golang.org/x/tools v0.0.0-20190312170243-e65039ee4138/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
+ golang.org/x/tools v0.0.0-20190404132500-923d25813098 h1:MtqjsZmyGRgMmLUgxnmMJ6RYdvd2ib8ipiayHhqSxs4=
+ golang.org/x/tools v0.0.0-20190404132500-923d25813098/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
+-gomodules.xyz/jsonpatch/v2 v2.0.0 h1:lHNQverf0+Gm1TbSbVIDWVXOhZ2FpZopxRqpr2uIjs4=
++gomodules.xyz/jsonpatch/v2 v2.0.0 h1:OyHbl+7IOECpPKfVK42oFr6N7+Y2dR+Jsb/IiDV3hOo=
+ gomodules.xyz/jsonpatch/v2 v2.0.0/go.mod h1:IhYNNY4jnS53ZnfE4PAmpKtDpTCj1JFXc+3mwe7XcUU=
+ google.golang.org/api v0.0.0-20180910000450-7ca32eb868bf/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
+ google.golang.org/api v0.0.0-20181021000519-a2651947f503/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=

--- a/pkgs/applications/networking/cluster/prow/default.nix
+++ b/pkgs/applications/networking/cluster/prow/default.nix
@@ -1,0 +1,71 @@
+{ buildGoModule, fetchFromGitHub, lib }:
+
+buildGoModule rec {
+  pname = "prow-unstable";
+  version = "2019-08-14";
+  rev = "35a7744f5737bbc1c4e1256a9c9c5ad135c650e4";
+
+  src = fetchFromGitHub {
+    inherit rev;
+
+    owner = "kubernetes";
+    repo = "test-infra";
+    sha256 = "07kdlzrj59xyaa73vlx4s50fpg0brrkb0h0cyjgx81a0hsc7s03k";
+  };
+
+  patches = [
+    # https://github.com/kubernetes/test-infra/pull/13918
+    ./13918-fix-go-sum.patch
+  ];
+
+  modSha256 = "06q1zvhm78k64aj475k1xl38h7nk83mysd0bja0wknja048ymgsq";
+
+  subPackages = [
+    "./prow/cmd/admission"
+    "./prow/cmd/artifact-uploader"
+    "./prow/cmd/branchprotector"
+    "./prow/cmd/build"
+    "./prow/cmd/checkconfig"
+    "./prow/cmd/clonerefs"
+    "./prow/cmd/config-bootstrapper"
+    "./prow/cmd/crier"
+    "./prow/cmd/deck"
+    "./prow/cmd/entrypoint"
+    "./prow/cmd/gcsupload"
+    "./prow/cmd/gerrit"
+    "./prow/cmd/hook"
+    "./prow/cmd/horologium"
+    "./prow/cmd/initupload"
+    "./prow/cmd/jenkins-operator"
+    "./prow/cmd/mkbuild-cluster"
+    "./prow/cmd/mkpj"
+    "./prow/cmd/mkpod"
+    "./prow/cmd/peribolos"
+    "./prow/cmd/phaino"
+    "./prow/cmd/phony"
+    "./prow/cmd/pipeline"
+    "./prow/cmd/plank"
+    "./prow/cmd/sidecar"
+    "./prow/cmd/sinker"
+    "./prow/cmd/status-reconciler"
+    "./prow/cmd/sub"
+    "./prow/cmd/tackle"
+    "./prow/cmd/tide"
+    "./prow/cmd/tot"
+  ];
+
+  meta = with lib; {
+    description = "Prow is a Kubernetes based CI/CD system";
+    longDescription = ''
+      Prow is a Kubernetes based CI/CD system. Jobs can be triggered by various
+      types of events and report their status to many different services. In
+      addition to job execution, Prow provides GitHub automation in the form of
+      policy enforcement, chat-ops via /foo style commands, and automatic PR
+      merging.
+    '';
+    homepage = "https://github.com/kubernetes/test-infra/tree/master/prow";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ kalbasit ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24233,6 +24233,8 @@ in
 
   jx = callPackage ../applications/networking/cluster/jx {};
 
+  prow = callPackage ../applications/networking/cluster/prow {};
+
   inherit (callPackage ../applications/networking/cluster/terraform {})
     terraform_0_11
     terraform_0_11-full


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Packaging up https://github.com/kubernetes/test-infra/tree/master/prow.

The included patch is also filed [upstream](https://github.com/kubernetes/test-infra/pull/13918).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).