### PR TITLE
linuxPackages/ixgbevf: 4.3.4 -> 4.6.1, unbreak

### DIFF
--- a/pkgs/os-specific/linux/ixgbevf/default.nix
+++ b/pkgs/os-specific/linux/ixgbevf/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "ixgbevf-${version}-${kernel.version}";
-  version = "4.3.4";
+  version = "4.6.1";
 
   src = fetchurl {
     url = "mirror://sourceforge/e1000/ixgbevf-${version}.tar.gz";
-    sha256 = "122zn9nd8f95bpidiiinc8xaizypkirqs8vlmsdy2iv3w65md9k3";
+    sha256 = "0h8a2g4hm38wmr13gvi2188r7nlv2c5rx6cal9gkf1nh6sla181c";
   };
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
@@ -17,15 +17,18 @@ stdenv.mkDerivation rec {
     cd src
     makeFlagsArray+=(KSRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build INSTALL_MOD_PATH=$out MANDIR=/share/man)
     substituteInPlace common.mk --replace /sbin/depmod ${kmod}/bin/depmod
+    # prevent host system kernel introspection
+    substituteInPlace common.mk --replace /boot/System.map /not-exists
   '';
 
   enableParallelBuilding = true;
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Intel 82599 Virtual Function Driver";
     homepage = https://sourceforge.net/projects/e1000/files/ixgbevf%20stable/;
-    license = stdenv.lib.licenses.gpl2;
+    license = licenses.gpl2;
     priority = 20;
-    broken = (stdenv.lib.versionOlder kernel.version "4.9");
+    # kernels ship ixgbevf driver for a long time already, maybe switch to a newest kernel?
+    broken = versionAtLeast kernel.version "5.2";
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update. Kernel ships it's own version of `ixgbevf` driver, so this out-of-tree driver should only be used with extremely old kernels.

I've marked it as `broken` for newer kernels, both because it is broken and no longer of much use.

Related https://github.com/NixOS/nixpkgs/pull/58956

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @peterhoeg 