### PR TITLE
ocamlPackages.charInfo_width: init at 1.1.0

### DIFF
--- a/pkgs/development/ocaml-modules/charInfo_width/default.nix
+++ b/pkgs/development/ocaml-modules/charInfo_width/default.nix
@@ -1,0 +1,19 @@
+{ lib, fetchzip, buildDunePackage, camomile, result }:
+
+buildDunePackage rec {
+  pname = "charInfo_width";
+  version = "1.1.0";
+  src = fetchzip {
+    url = "https://bitbucket.org/zandoye/charinfo_width/get/${version}.tar.bz2";
+    sha256 = "19mnq9a1yr16srqs8n6hddahr4f9d2gbpmld62pvlw1ps7nfrp9w";
+  };
+
+  propagatedBuildInputs = [ camomile result ];
+
+  meta = {
+    homepage = "https://bitbucket.org/zandoye/charinfo_width/";
+    description = "Determine column width for a character";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -128,6 +128,8 @@ let
 
     cairo2 = callPackage ../development/ocaml-modules/cairo2 { };
 
+    charInfo_width = callPackage ../development/ocaml-modules/charInfo_width { };
+
     checkseum = callPackage ../development/ocaml-modules/checkseum { };
 
     cil = callPackage ../development/ocaml-modules/cil { };


### PR DESCRIPTION
###### Motivation for this change

This  package is needed by recent versions of the zed library.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

