### PR TITLE
rustPackages.clippy: init at rust-1.36.0

### DIFF
--- a/pkgs/development/compilers/rust/clippy.nix
+++ b/pkgs/development/compilers/rust/clippy.nix
@@ -1,0 +1,35 @@
+{ stdenv, lib, rustPlatform, rustc, Security, patchelf }:
+rustPlatform.buildRustPackage rec {
+  name = "clippy-${rustc.version}";
+  inherit (rustc) version src;
+
+  # the rust source tarball already has all the dependencies vendored, no need to fetch them again
+  cargoVendorDir = "vendor";
+  preBuild = "pushd src/tools/clippy";
+  postBuild = "popd";
+
+  # changes hash of vendor directory otherwise
+  dontUpdateAutotoolsGnuConfigScripts = true;
+
+  buildInputs = [ rustc ] ++ stdenv.lib.optionals stdenv.isDarwin [ Security ];
+
+  # fixes: error: the option `Z` is only accepted on the nightly compiler
+  RUSTC_BOOTSTRAP = 1;
+
+  # Without disabling the test the build fails with:
+  # error: failed to run custom build command for `rustc_llvm v0.0.0
+  #   (/private/tmp/nix-build-clippy-1.36.0.drv-0/rustc-1.36.0-src/src/librustc_llvm)
+  doCheck = false;
+
+  preFixup = stdenv.lib.optionalString stdenv.isDarwin ''
+    install_name_tool -add_rpath "${rustc}/lib" $out/bin/clippy-driver
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://rust-lang.github.io/rust-clippy/;
+    description = "A bunch of lints to catch common mistakes and improve your Rust code";
+    maintainers = with maintainers; [ basvandijk ];
+    license = with licenses; [ mit asl20 ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/compilers/rust/default.nix
+++ b/pkgs/development/compilers/rust/default.nix
@@ -64,6 +64,7 @@
         rustPlatform = bootRustPlatform;
         inherit CoreFoundation Security;
       };
+      clippy = self.callPackage ./clippy.nix { inherit Security; };
     });
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This packages [rust-clippy](https://github.com/rust-lang/rust-clippy) at the version specified by the git submodule at: 
https://github.com/rust-lang/rust/tree/1.36.0/src/tools

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).