### PR TITLE
ix: init at 20190815

### DIFF
--- a/pkgs/tools/misc/ix/default.nix
+++ b/pkgs/tools/misc/ix/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl, makeWrapper, curl }:
+
+stdenv.mkDerivation rec {
+  pname = "ix";
+  version = "20190815";
+
+  src = fetchurl {
+    url = "http://ix.io/client";
+    sha256 =  "0xc2s4s1aq143zz8lgkq5k25dpf049dw253qxiav5k7d7qvzzy57";
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  phases = [ "installPhase" "fixupPhase" ];
+
+  installPhase = ''
+    install -Dm +x $src $out/bin/ix
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/ix --prefix PATH : "${stdenv.lib.makeBinPath [ curl ]}"
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "http://ix.io";
+    description = "Command line pastebin";
+    maintainers = with maintainers; [ asymmetric ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3970,6 +3970,8 @@ in
 
   isync = callPackage ../tools/networking/isync { };
 
+  ix = callPackage ../tools/misc/ix { };
+
   jaaa = callPackage ../applications/audio/jaaa { };
 
   jackett = callPackage ../servers/jackett { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Adds cli client for http://ix.io.

Was not able to find a license.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
