### PR TITLE
Revert "nixos/hardened: use graphene-hardened malloc by default"

### DIFF
--- a/nixos/modules/profiles/hardened.nix
+++ b/nixos/modules/profiles/hardened.nix
@@ -14,8 +14,6 @@ with lib;
 
   nix.allowedUsers = mkDefault [ "@users" ];
 
-  environment.memoryAllocator.provider = mkDefault "graphene-hardened";
-
   security.hideProcessInformation = mkDefault true;
 
   security.lockKernelModules = mkDefault true;


### PR DESCRIPTION
This reverts commit 48ff4f119735dc60c3e2794a71b00757b838d877.

Causes too much breakage to be enabled by default [1] [2].

[1]: https://github.com/NixOS/nixpkgs/issues/61489
[2]: https://github.com/NixOS/nixpkgs/issues/65000

I intend to merge this before the relase freeze, just leaving it here in case a better solution emerges in time.