### PR TITLE
smartgithg: 18.2.9 -> 19.1.1

### DIFF
--- a/pkgs/applications/version-management/smartgithg/default.nix
+++ b/pkgs/applications/version-management/smartgithg/default.nix
@@ -13,11 +13,11 @@
 
 stdenv.mkDerivation rec {
   pname = "smartgithg";
-  version = "18.2.9";
+  version = "19.1.1";
 
   src = fetchurl {
     url = "https://www.syntevo.com/downloads/smartgit/smartgit-linux-${builtins.replaceStrings [ "." ] [ "_" ] version}.tar.gz";
-    sha256 = "0d08awb2s3w1w8n8048abw2x4wnqhfx96sls9kdsnxj0xrszgz67";
+    sha256 = "0i0dvyy9d63f4hk8czlyk83ai0ywhqp7wbdkq3s87l7irwgs42jy";
   };
 
   nativeBuildInputs = [ wrapGAppsHook ];


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken (bad sha) while reviewing another package.

bumped version while at it

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @jraygauthier 

```
[1 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/66692
1 package were build:
smartgithg
```