### PR TITLE
wtfutil: init at 0.19.1

### DIFF
--- a/pkgs/tools/misc/wtfutil/default.nix
+++ b/pkgs/tools/misc/wtfutil/default.nix
@@ -1,0 +1,33 @@
+{ buildGoModule, fetchFromGitHub, stdenv } :
+
+buildGoModule rec {
+  pname = "wtfutil";
+  version = "0.19.1";
+
+  src = fetchFromGitHub {
+    owner = "wtfutil";
+    repo = "wtf";
+    rev = "v${version}";
+    sha256 = "19qzg5blqm5p7rrnaqh4f9aj53i743mawjnd1h9lfahbgmil1d24";
+  };
+
+  modSha256 = "1q21pc4yyiq4dihsb9n7261ssj52nnik8dq6fg4gvlnnpgcjp570";
+
+  # As per https://github.com/wtfutil/wtf/issues/501, one of the
+  # dependencies can't be fetched, so vendored dependencies should
+  # be used instead
+  modBuildPhase = ''
+    runHook preBuild
+    make build -mod=vendor
+    runHook postBuild
+  '';
+
+  meta = with stdenv.lib; {
+    description = "The personal information dashboard for your terminal.";
+    homepage = https://wtfutil.com;
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ yrashk ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24401,6 +24401,8 @@ in
 
   wraith = callPackage ../applications/networking/irc/wraith { };
 
+  wtfutil = callPackage ../tools/misc/wtfutil { };
+
   wxmupen64plus = callPackage ../misc/emulators/wxmupen64plus { };
 
   wxsqlite3 = callPackage ../development/libraries/wxsqlite3 {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


