### PR TITLE
gopass: 1.8.6 -> unstable-2019-07-31

### DIFF
--- a/pkgs/tools/security/gopass/default.nix
+++ b/pkgs/tools/security/gopass/default.nix
@@ -1,40 +1,40 @@
-{ stdenv, buildGoPackage, fetchFromGitHub, git, gnupg, xclip, wl-clipboard, makeWrapper }:
+{ stdenv, buildGoModule, fetchFromGitHub
+, git, gnupg
+, wl-clipboard, xclip
+, makeWrapper }:
 
-buildGoPackage rec {
+buildGoModule rec {
   pname = "gopass";
-  version = "1.8.6";
+  version = "8c7b4a250052d401722b6cbf9308b23a3d3d5661";
+  src = fetchFromGitHub {
+    owner = "gopasspw";
+    repo = "gopass";
+    rev = version;
+    sha256 = "1n1xrswypl30vqppw85jsnl412cgpwch35npgsbakkm2lr4z8qja";
+  };
 
   goPackagePath = "github.com/gopasspw/gopass";
+  modSha256 = "0ijj5sc2q9fx94slxxzqnx97f833pk48a0jfvq9dk9y9biszf2q4";
 
   nativeBuildInputs = [ makeWrapper ];
 
-  src = fetchFromGitHub {
-    owner = "gopasspw";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "0v3sx9hb03bdn4rvsv2r0jzif6p1rx47hrkpsbnwva31k396mck2";
-  };
-
-  wrapperPath = stdenv.lib.makeBinPath ([
+  makeFlags = [
+    "PREFIX=${placeholder ''out''}"
+  ];
+  
+  wrapperPath = with stdenv.lib; makeBinPath ([
     git
     gnupg
     xclip
   ] ++ stdenv.lib.optional stdenv.isLinux wl-clipboard);
 
-  postInstall = ''
-    mkdir -p \
-      $bin/share/bash-completion/completions \
-      $bin/share/zsh/site-functions \
-      $bin/share/fish/vendor_completions.d
-    $bin/bin/gopass completion bash > $bin/share/bash-completion/completions/_gopass
-    $bin/bin/gopass completion zsh  > $bin/share/zsh/site-functions/_gopass
-    $bin/bin/gopass completion fish > $bin/share/fish/vendor_completions.d/gopass.fish
-  '';
-
   postFixup = ''
-    wrapProgram $bin/bin/gopass \
+    wrapProgram $out/bin/gopass \
       --prefix PATH : "${wrapperPath}"
   '';
+
+  # Use makefile installPhase for completions
+  installPhase = null;
 
   meta = with stdenv.lib; {
     description     = "The slightly more awesome Standard Unix Password Manager for Teams. Written in Go.";


### PR DESCRIPTION
###### Motivation for this change
Mostly just to get feedback on how to build the new version built with module support.

cc: @worldofpeace 

Here's the **failing** build log: https://gist.github.com/colemickens/e0f7be3c350a583bb9c69b6caa9b73f2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
