### PR TITLE
pyprof2calltree: move to python-packages

### DIFF
--- a/pkgs/development/python-modules/pyprof2calltree/default.nix
+++ b/pkgs/development/python-modules/pyprof2calltree/default.nix
@@ -1,6 +1,6 @@
-{ lib, buildPythonApplication, fetchFromGitHub }:
+{ lib, buildPythonPackage, fetchFromGitHub }:
 
-buildPythonApplication rec {
+buildPythonPackage rec {
   pname = "pyprof2calltree";
   version = "1.4.4";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9780,7 +9780,7 @@ in
 
   pprof = callPackage ../development/tools/profiling/pprof { };
 
-  pyprof2calltree = pythonPackages.callPackage ../development/tools/profiling/pyprof2calltree { };
+  pyprof2calltree = with python3Packages; toPythonApplication pyprof2calltree;
 
   prelink = callPackage ../development/tools/misc/prelink { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6158,6 +6158,8 @@ in {
   wget = callPackage ../development/python-modules/wget { };
 
   runway-python = callPackage ../development/python-modules/runway-python { };
+
+  pyprof2calltree = callPackage ../development/python-modules/pyprof2calltree { };
 });
 
 in fix' (extends overrides packages)


### PR DESCRIPTION
###### Motivation for this change

pyprof2calltree is hard-coded to pythonPackages and fails for Python 3 profile results. See #66511.
Since it can also be used as a library it makes sense to move it into pythonPackages.

Note: I've not been keeping up-to-date with Nix developments lately, so any corrections are welcome.

In particular, is there a better way to deprecate the old expression in `all-packages.nix`? We could also keep it as-is (only change the path to `default.nix` to its new location in python-modules), or change it to be built using `python3Packages`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
