### PR TITLE
ocamlPackages.sedlex: 1.99.4 -> 1.99.5

### DIFF
--- a/pkgs/development/ocaml-modules/sedlex/default.nix
+++ b/pkgs/development/ocaml-modules/sedlex/default.nix
@@ -6,11 +6,11 @@ else
 
 stdenv.mkDerivation rec {
   name = "ocaml${ocaml.version}-sedlex-${version}";
-  version = "1.99.4";
+  version = "1.99.5";
 
   src = fetchzip {
-    url = "https://github.com/alainfrisch/sedlex/archive/v${version}.tar.gz";
-    sha256 = "1b7nqxyfcz8i7m4b8zil2rn6ygh2czy26f9v64xnxn8r0hy9sh1m";
+    url = "https://github.com/ocaml-community/sedlex/archive/fb84e1766fc4b29e79ec40029ffee5cdb37b392f.tar.gz";
+    sha256 = "0phnqyn6mpv5byr1kkphl24y9q9fb2k3xg9yb457h5816q6ya72n";
   };
 
   buildInputs = [ ocaml findlib ppx_tools_versioned ];
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   dontStrip = true;
 
   meta = {
-    homepage = https://github.com/alainfrisch/sedlex;
+    homepage = https://github.com/ocaml-community/sedlex;
     description = "An OCaml lexer generator for Unicode";
     license = stdenv.lib.licenses.mit;
     inherit (ocaml.meta) platforms;


### PR DESCRIPTION
###### Motivation for this change

Compatibility with recent ppx_tools_versioned.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
