### PR TITLE
Bazel test shebangs

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -5,7 +5,7 @@
 , lr, xe, zip, unzip, bash, writeCBin, coreutils
 , which, gawk, gnused, gnutar, gnugrep, gzip, findutils
 # updater
-, python3, writeScript
+, python27, python3, writeScript
 # Apple dependencies
 , cctools, libcxx, CoreFoundation, CoreServices, Foundation
 # Allow to independently override the jdks used to build and run respectively
@@ -328,10 +328,11 @@ stdenv.mkDerivation rec {
     '';
 
     genericPatches = ''
-      # Substitute python's stub shebang to plain python path. (see TODO add pr URL)
+      # Substitute j2objc and objc wrapper's python shebang to plain python path.
       # See also `postFixup` where python is added to $out/nix-support
-      substituteInPlace src/main/java/com/google/devtools/build/lib/bazel/rules/python/python_stub_template.txt \
-          --replace "#!/usr/bin/env python" "#!${python3}/bin/python"
+      substituteInPlace tools/j2objc/j2objc_header_map.py --replace "$!/usr/bin/python2.7" "#!${python27}/bin/python"
+      substituteInPlace tools/j2objc/j2objc_wrapper.py --replace "$!/usr/bin/python2.7" "#!${python27}/bin/python"
+      substituteInPlace tools/objc/j2objc_dead_code_pruner.py --replace "$!/usr/bin/python2.7" "#!${python27}/bin/python"
 
       # md5sum is part of coreutils
       sed -i 's|/sbin/md5|md5sum|' \
@@ -343,6 +344,8 @@ stdenv.mkDerivation rec {
         # Only files containing /bin are taken into account.
         substituteInPlace "$path" \
           --replace /bin/bash ${customBash}/bin/bash \
+          --replace "/usr/bin/env bash" ${customBash}/bin/bash \
+          --replace "/usr/bin/env python" ${python3}/bin/python \
           --replace /usr/bin/env ${coreutils}/bin/env \
           --replace /bin/true ${coreutils}/bin/true
       done

--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -329,7 +329,8 @@ stdenv.mkDerivation rec {
 
     genericPatches = ''
       # Substitute j2objc and objc wrapper's python shebang to plain python path.
-      # See also `postFixup` where python is added to $out/nix-support
+      # These scripts explicitly depend on Python 2.7, hence we use python27.
+      # See also `postFixup` where python27 is added to $out/nix-support
       substituteInPlace tools/j2objc/j2objc_header_map.py --replace "$!/usr/bin/python2.7" "#!${python27}/bin/python"
       substituteInPlace tools/j2objc/j2objc_wrapper.py --replace "$!/usr/bin/python2.7" "#!${python27}/bin/python"
       substituteInPlace tools/objc/j2objc_dead_code_pruner.py --replace "$!/usr/bin/python2.7" "#!${python27}/bin/python"
@@ -342,6 +343,8 @@ stdenv.mkDerivation rec {
       grep -rlZ /bin src/main/java/com/google/devtools | while IFS="" read -r -d "" path; do
         # If you add more replacements here, you must change the grep above!
         # Only files containing /bin are taken into account.
+        # We default to python3 where possible. See also `postFixup` where
+        # python3 is added to $out/nix-support
         substituteInPlace "$path" \
           --replace /bin/bash ${customBash}/bin/bash \
           --replace "/usr/bin/env bash" ${customBash}/bin/bash \
@@ -521,6 +524,10 @@ stdenv.mkDerivation rec {
     echo "${customBash} ${defaultShellPath}" >> $out/nix-support/depends
     # The templates get tar’d up into a .jar,
     # so nix can’t detect python is needed in the runtime closure
+    # Some of the scripts explicitly depend on Python 2.7. Otherwise, we
+    # default to using python3. Therefore, both python27 and python3 are
+    # runtime dependencies.
+    echo "${python27}" >> $out/nix-support/depends
     echo "${python3}" >> $out/nix-support/depends
   '' + lib.optionalString stdenv.isDarwin ''
     echo "${cctools}" >> $out/nix-support/depends

--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -208,6 +208,7 @@ stdenv.mkDerivation rec {
             # about why to create a subdir for the workspace.
             cp -r ${workspaceDir} wd && chmod u+w wd && cd wd
 
+            BAZEL_EXTRACTED=${be.install_dir}
             ${bazelScript}
 
             touch $out
@@ -223,6 +224,7 @@ stdenv.mkDerivation rec {
       };
 
     in {
+      shebang = callPackage ./shebang-test.nix { inherit runLocal bazelTest distDir; };
       bashTools = callPackage ./bash-tools-test.nix { inherit runLocal bazelTest distDir; };
       cpp = callPackage ./cpp-test.nix { inherit runLocal bazelTest bazel-examples distDir; };
       java = callPackage ./java-test.nix { inherit runLocal bazelTest bazel-examples distDir; };

--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -208,7 +208,6 @@ stdenv.mkDerivation rec {
             # about why to create a subdir for the workspace.
             cp -r ${workspaceDir} wd && chmod u+w wd && cd wd
 
-            BAZEL_EXTRACTED=${be.install_dir}
             ${bazelScript}
 
             touch $out
@@ -224,7 +223,7 @@ stdenv.mkDerivation rec {
       };
 
     in {
-      shebang = callPackage ./shebang-test.nix { inherit runLocal bazelTest distDir; };
+      shebang = callPackage ./shebang-test.nix { inherit runLocal extracted bazelTest distDir; };
       bashTools = callPackage ./bash-tools-test.nix { inherit runLocal bazelTest distDir; };
       cpp = callPackage ./cpp-test.nix { inherit runLocal bazelTest bazel-examples distDir; };
       java = callPackage ./java-test.nix { inherit runLocal bazelTest bazel-examples distDir; };

--- a/pkgs/development/tools/build-managers/bazel/shebang-test.nix
+++ b/pkgs/development/tools/build-managers/bazel/shebang-test.nix
@@ -25,7 +25,7 @@ let
       check_shebangs() {
         local dir="$1"
         { grep -Re '#!/usr/bin' $dir && FAIL=1; } || true
-        { grep -Re '#![^[:space:]]*/bin/env python' $dir && FAIL=1; } || true
+        { grep -Re '#![^[:space:]]*/bin/env' $dir && FAIL=1; } || true
       }
       BAZEL_EXTRACTED=${extracted bazel}/install
       check_shebangs $BAZEL_EXTRACTED

--- a/pkgs/development/tools/build-managers/bazel/shebang-test.nix
+++ b/pkgs/development/tools/build-managers/bazel/shebang-test.nix
@@ -1,0 +1,47 @@
+{
+  bazel
+, bazelTest
+, distDir
+, runLocal
+, unzip
+}:
+
+# Tests that all shebangs are patched appropriately.
+# #!/usr/bin/... should be replaced by Nix store references.
+# #!.../bin/env python should be replaced by Nix store reference to the python interpreter.
+
+let
+
+  workspaceDir = runLocal "our_workspace" {} "mkdir $out";
+
+  testBazel = bazelTest {
+    name = "bazel-test-shebangs";
+    inherit workspaceDir;
+    bazelPkg = bazel;
+    bazelScript = ''
+      set -ueo pipefail
+      FAIL=
+      check_shebangs() {
+        local dir="$1"
+        { grep -Re '#!/usr/bin' $dir && FAIL=1; } || true
+        { grep -Re '#![^[:space:]]*/bin/env python' $dir && FAIL=1; } || true
+      }
+      check_shebangs $BAZEL_EXTRACTED
+      while IFS= read -r -d "" zip; do
+        unzipped="./$zip/UNPACKED"
+        mkdir -p "$unzipped"
+        unzip -qq $zip -d "$unzipped"
+        check_shebangs "$unzipped"
+        rm -rf unzipped
+      done < <(find $BAZEL_EXTRACTED -type f -name '*.zip' -or -name '*.jar' -print0)
+      if [[ $FAIL = 1 ]]; then
+        echo "Found files in the bazel distribution with illegal shebangs." >&2
+        echo "Replace those by explicit Nix store paths." >&2
+        echo "Python scripts should not use \`bin/env python' but the Python interpreter's store path." >&2
+        exit 1
+      fi
+    '';
+    buildInputs = [ unzip ];
+  };
+
+in testBazel

--- a/pkgs/development/tools/build-managers/bazel/shebang-test.nix
+++ b/pkgs/development/tools/build-managers/bazel/shebang-test.nix
@@ -2,6 +2,7 @@
   bazel
 , bazelTest
 , distDir
+, extracted
 , runLocal
 , unzip
 }:
@@ -26,6 +27,7 @@ let
         { grep -Re '#!/usr/bin' $dir && FAIL=1; } || true
         { grep -Re '#![^[:space:]]*/bin/env python' $dir && FAIL=1; } || true
       }
+      BAZEL_EXTRACTED=${extracted bazel}/install
       check_shebangs $BAZEL_EXTRACTED
       while IFS= read -r -d "" zip; do
         unzipped="./$zip/UNPACKED"


### PR DESCRIPTION
As suggested by @Profpatsch  in https://github.com/NixOS/nixpkgs/pull/66718#issuecomment-522021975 this PR adds a test to Bazel checking that shebangs have been patched appropriately. 

This test flagged a few more instances of invalid python shebangs which are also fixed by this PR.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

See https://github.com/NixOS/nixpkgs/pull/66718#issuecomment-522021975

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Profpatsch 
