### PR TITLE
stdenv: add isELFExec, isELFDyn, fix wrappers

### DIFF
--- a/pkgs/development/libraries/qt-5/hooks/wrap-qt-apps-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/wrap-qt-apps-hook.sh
@@ -82,7 +82,7 @@ wrapQtAppsHook() {
 
         find "$targetDir" -executable -print0 | while IFS= read -r -d '' file
         do
-            isELF "$file" || continue
+            isELFExec "$file" || continue
 
             if [ -f "$file" ]
             then

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -212,6 +212,18 @@ isELF() {
     if [ "$magic" = $'\177ELF' ]; then return 0; else return 1; fi
 }
 
+# Return success if the specified file is an ELF object
+# and its e_type is ET_EXEC (executable file)
+isELFExec() {
+    grep -ao -P '^\177ELF.{11}\x00\x02' "$1" >/dev/null
+}
+
+# Return success if the specified file is an ELF object
+# and its e_type is ET_DYN (shared object file)
+isELFDyn() {
+    grep -ao -P '^\177ELF.{11}\x00\x03' "$1" >/dev/null
+}
+
 # Return success if the specified file is a script (i.e. starts with
 # "#!").
 isScript() {


### PR DESCRIPTION
###### Motivation for this change
`wrapQtAppsHook` uses `isELF` from `pkgs/stdenv/generic/setup.sh` to determine whether to wrap a program or not.
This can accidentially wrap `.so` files (and other non-executables), so I added `isELFExec` and `isELFDyn` to be able to distinguish.
Afterwards, `wrapQtAppsHook` is changed to use `isELFExec` instead of just `isELF`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).