### PR TITLE
autogen: reduce closure size

### DIFF
--- a/pkgs/development/tools/misc/autogen/default.nix
+++ b/pkgs/development/tools/misc/autogen/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, buildPackages, fetchurl, which, pkgconfig, perl, guile, libxml2 }:
+{ stdenv, buildPackages, fetchurl, which, pkgconfig, perl, guile, libxml2
+, removeReferencesTo }:
 
 stdenv.mkDerivation rec {
   name = "autogen-${version}";
@@ -11,7 +12,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "bin" "dev" "lib" "out" "man" "info" ];
 
-  nativeBuildInputs = [ which pkgconfig perl ]
+  nativeBuildInputs = [ which pkgconfig perl removeReferencesTo ]
     # autogen needs a build autogen when cross-compiling
     ++ stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
       buildPackages.buildPackages.autogen buildPackages.texinfo ];
@@ -43,7 +44,10 @@ stdenv.mkDerivation rec {
       sed -e "s|$dev/include|/no-such-autogen-include-path|" -i $f
       sed -e "s|$bin/bin|/no-such-autogen-bin-path|" -i $f
       sed -e "s|$lib/lib|/no-such-autogen-lib-path|" -i $f
+      sed -e "s|$out|/no-such-autogen-lib-path|" -i $f
     done
+
+    remove-references-to -t $out $lib/lib/lib*
   '';
 
   #doCheck = true; # 2 tests fail because of missing /dev/tty

--- a/pkgs/development/tools/misc/autogen/default.nix
+++ b/pkgs/development/tools/misc/autogen/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
     remove-references-to -t $out $lib/lib/lib*
   '';
 
-  #doCheck = true; # 2 tests fail because of missing /dev/tty
+  doCheck = true;
 
   meta = with stdenv.lib; {
     description = "Automated text and program generation tool";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
