### PR TITLE
starship: init at 0.10.1

### DIFF
--- a/pkgs/tools/misc/starship/default.nix
+++ b/pkgs/tools/misc/starship/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, rustPlatform, openssl, pkgconfig, libiconv, darwin }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "starship";
+  version = "0.10.1";
+
+  src = fetchFromGitHub {
+    owner = "starship";
+    repo = "starship";
+    rev = "v${version}";
+    sha256 = "045lq4nsrdssmqbcj0551f2c5qd2rcvhs8gr4p4iniv7s89yz1xl";
+  };
+
+  buildInputs = [ openssl ] ++ stdenv.lib.optionals stdenv.isDarwin [ libiconv darwin.apple_sdk.frameworks.Security ];
+  nativeBuildInputs = [ pkgconfig ];
+
+  cargoSha256 = "126y8q19qr37wrj6x4hqh0v7nqr9yfrycwqfgdlaw6i33gb0qam9";
+
+  meta = with stdenv.lib; {
+    description = "A minimal, blazing fast, and extremely customizable prompt for any shell";
+    homepage = "https://starship.rs";
+    license = licenses.isc;
+    maintainers = with maintainers; [ bbigras ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16904,6 +16904,8 @@ in
 
   stdmanpages = callPackage ../data/documentation/std-man-pages { };
 
+  starship = callPackage ../tools/misc/starship { };
+
   stix-otf = callPackage ../data/fonts/stix-otf { };
 
   stix-two = callPackage ../data/fonts/stix-two { };


### PR DESCRIPTION
###### Motivation for this change
Add the starship package. Which is a promising simple prompt.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).