### PR TITLE
pythonPackages.pykalman: init at 0.9.5

### DIFF
--- a/pkgs/development/python-modules/pykalman/default.nix
+++ b/pkgs/development/python-modules/pykalman/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, numpy
+, scipy
+, nose
+, fetchpatch
+}:
+
+buildPythonPackage rec {
+  pname = "pykalman";
+  version = "0.9.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0f7v0y71wx514b1r65nr11d1c8cc5jg4p9vg073a896r41vz8sl1";
+  };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/everling/pykalman/commit/644c85c3fbd9f957f6fef862a77dfb672b20b46a.patch";
+      sha256 = "052qq2lbz9fk7zq689chniv1c5j6rx9d6s6dy7sqw78bj5z0mkgd";
+    })
+  ];
+
+  propagatedBuildInputs = [ numpy scipy ];
+  checkInputs = [ nose ];
+
+  meta = with lib; {
+    description = "An implementation of the Kalman Filter, Kalman Smoother, and EM algorithm in Python";
+    homepage = "https://pykalman.github.io/";
+    license = licenses.bsd0;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -918,6 +918,8 @@ in {
 
   pyjwkest = callPackage ../development/python-modules/pyjwkest { };
 
+  pykalman = callPackage ../development/python-modules/pykalman { };
+
   pykde4 = callPackage ../development/python-modules/pykde4 {
     inherit (self) pyqt4;
     callPackage = pkgs.callPackage;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
