### PR TITLE
azpainter: init at 2.1.4

### DIFF
--- a/pkgs/applications/graphics/azpainter/default.nix
+++ b/pkgs/applications/graphics/azpainter/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, autoreconfHook
+, libX11, libXext, libXi
+, freetype, fontconfig
+, libpng, libjpeg
+, zlib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "azpainter";
+  version = "2.1.4";
+
+  src = fetchFromGitHub {
+    owner = "Symbian9";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    sha256 = "1hrr9lhsbjyzar3nxvli6cazr7zhyzh0p8hwpg4g9ga6njs8vi8m";
+  };
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  buildInputs = [
+    libX11 libXext libXi
+    freetype fontconfig
+    libpng libjpeg
+    zlib
+  ];
+
+  configureFlags = [
+    "--with-freetype-dir=${stdenv.lib.getDev freetype}/include/freetype2"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Full color painting software for illustration drawing";
+    homepage = "https://osdn.net/projects/azpainter";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17208,6 +17208,8 @@ in
 
   avocode = callPackage ../applications/graphics/avocode {};
 
+  azpainter = callPackage ../applications/graphics/azpainter { };
+
   cadence =  libsForQt5.callPackage ../applications/audio/cadence { };
 
   milkytracker = callPackage ../applications/audio/milkytracker { };


### PR DESCRIPTION
###### Motivation for this change

"Full color painting software for illustration drawing"

Saw mentioned on HN, wanted to check it out: https://news.ycombinator.com/item?id=20717413

Glad I did, try it yourself! :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).