### PR TITLE
processing: 3.4 -> 3.5.3

### DIFF
--- a/pkgs/applications/graphics/processing/default.nix
+++ b/pkgs/applications/graphics/processing/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, fetchurl, xmlstarlet, makeWrapper, ant, jdk, rsync, javaPackages, libXxf86vm, gsettings-desktop-schemas }:
 
 stdenv.mkDerivation rec {
-  version = "3.4";
-  name = "processing3-${version}";
+  pname = "processing";
+  version = "3.5.3";
 
   src = fetchFromGitHub {
     owner = "processing";
     repo = "processing";
-    rev = "processing-0265-${version}";
-    sha256 = "12wpxgn2wd5vbasx9584w5yb1s319smq1zh8m7dvp7gkqw9plwp4";
+    rev = "processing-0269-${version}";
+    sha256 = "0ajniy3a0i0rx7is46r85yh3ah4zm4ra1gbllmihw9pmnfjgfajn";
   };
 
   nativeBuildInputs = [ ant rsync makeWrapper ];
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     ${xmlstarlet}/bin/xmlstarlet ed --inplace -P -d '//get[@src="http://download.processing.org/reference.zip"]' build/build.xml
     install -D -m0444 ${fetchurl {
                           url    = http://download.processing.org/reference.zip;
-                          sha256 = "0ai0cr62gc7n6y22ki3qibyj1qnlaxv1miqxmmahfk3hpbyfqz9n";
+                          sha256 = "198bpk8mzns6w5h0zdf50wr6iv7sgdi6v7jznj5rbsnpgyilxz35";
                         }
                        } ./java/reference.zip
 
@@ -39,16 +39,16 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir $out
-    cp -dpR build/linux/work $out/${name}
+    cp -dpR build/linux/work $out/${pname}
 
-    rmdir $out/${name}/java
-    ln -s ${jdk} $out/${name}/java
+    rmdir $out/${pname}/java
+    ln -s ${jdk} $out/${pname}/java
 
-    makeWrapper $out/${name}/processing      $out/bin/processing \
+    makeWrapper $out/${pname}/processing      $out/bin/processing \
         --prefix XDG_DATA_DIRS : ${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name} \
         --prefix _JAVA_OPTIONS " " -Dawt.useSystemAAFontSettings=lcd \
         --prefix LD_LIBRARY_PATH : ${libXxf86vm}/lib
-    makeWrapper $out/${name}/processing-java $out/bin/processing-java \
+    makeWrapper $out/${pname}/processing-java $out/bin/processing-java \
         --prefix XDG_DATA_DIRS : ${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name} \
         --prefix _JAVA_OPTIONS " " -Dawt.useSystemAAFontSettings=lcd \
         --prefix LD_LIBRARY_PATH : ${libXxf86vm}/lib

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -274,6 +274,7 @@ mapAliases ({
   postgis = postgresqlPackages.postgis;
   # end
   ppl-address-book = throw "deprecated in 2019-05-02: abandoned by upstream.";
+  processing3 = processing; # added 2019-08-16
   procps-ng = procps; # added 2018-06-08
   pulseaudioLight = pulseaudio; # added 2018-04-25
   qca-qt5 = libsForQt5.qca-qt5;  # added 2015-12-19

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19919,8 +19919,7 @@ in
 
   qiv = callPackage ../applications/graphics/qiv { };
 
-  processing = processing3;
-  processing3 = callPackage ../applications/graphics/processing3 {
+  processing = callPackage ../applications/graphics/processing {
     jdk = oraclejdk8;
   };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Package was out-of-date and broken due to a change of an unversioned URL.

Fixes #66518.

###### Things done

Updates processing to the latest version and fixes the `reference.zip` hash. AFAIK, there is no versioned URL for this file.

Since Processing 3 is the only version included in nixpkgs now, I moved the `processing3` attribute to `aliases.nix`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @juliendehos Can you see if this works for you?
