### PR TITLE
Androidenv fixes

### DIFF
--- a/doc/languages-frameworks/android.section.md
+++ b/doc/languages-frameworks/android.section.md
@@ -185,10 +185,9 @@ with import <nixpkgs> {};
 
 androidenv.emulateApp {
   name = "emulate-MyAndroidApp";
-  platformVersion = "24";
-  abiVersion = "armeabi-v7a"; # mips, x86 or x86_64
-  systemImageType = "default";
-  useGoogleAPIs = false;
+  platformVersion = "28";
+  abiVersion = "x86_64"; # armeabi-v7a, mips, x86
+  systemImageType = "google_apis_playstore";
 }
 ```
 
@@ -201,7 +200,7 @@ with import <nixpkgs> {};
 androidenv.emulateApp {
   name = "emulate-MyAndroidApp";
   platformVersion = "24";
-  abiVersion = "armeabi-v7a"; # mips, x86 or x86_64
+  abiVersion = "armeabi-v7a"; # mips, x86, x86_64
   systemImageType = "default";
   useGoogleAPIs = false;
   app = ./MyApp.apk;

--- a/pkgs/development/mobile/androidenv/build-app.nix
+++ b/pkgs/development/mobile/androidenv/build-app.nix
@@ -1,4 +1,4 @@
-{ composeAndroidPackages, stdenv, ant, jdk, gnumake, gawk }:
+{ composeAndroidPackages, stdenv, lib, ant, jdk, gnumake, gawk }:
 
 { name
 , release ? false, keyStore ? null, keyAlias ? null, keyStorePassword ? null, keyAliasPassword ? null
@@ -16,11 +16,11 @@ let
   extraArgs = removeAttrs args ([ "name" ] ++ builtins.attrNames androidSdkFormalArgs);
 in
 stdenv.mkDerivation ({
-  name = stdenv.lib.replaceChars [" "] [""] name; # Android APKs may contain white spaces in their names, but Nix store paths cannot
+  name = lib.replaceChars [" "] [""] name; # Android APKs may contain white spaces in their names, but Nix store paths cannot
   ANDROID_HOME = "${androidsdk}/libexec/android-sdk";
   buildInputs = [ jdk ant ];
   buildPhase = ''
-    ${stdenv.lib.optionalString release ''
+    ${lib.optionalString release ''
       # Provide key singing attributes
       ( echo "key.store=${keyStore}"
         echo "key.alias=${keyAlias}"
@@ -31,7 +31,7 @@ stdenv.mkDerivation ({
 
     export ANDROID_SDK_HOME=`pwd` # Key files cannot be stored in the user's home directory. This overrides it.
 
-    ${stdenv.lib.optionalString (args ? includeNDK && args.includeNDK) ''
+    ${lib.optionalString (args ? includeNDK && args.includeNDK) ''
       export GNUMAKE=${gnumake}/bin/make
       export NDK_HOST_AWK=${gawk}/bin/gawk
       ${androidsdk}/libexec/android-sdk/ndk-bundle/ndk-build

--- a/pkgs/development/mobile/androidenv/compose-android-packages.nix
+++ b/pkgs/development/mobile/androidenv/compose-android-packages.nix
@@ -21,7 +21,7 @@
 }:
 
 let
-  inherit (pkgs) stdenv fetchurl makeWrapper unzip;
+  inherit (pkgs) stdenv lib fetchurl makeWrapper unzip;
 
   # Determine the Android os identifier from Nix's system identifier
   os = if stdenv.system == "x86_64-linux" then "linux"
@@ -59,12 +59,12 @@ let
   };
 
   system-images-packages =
-    stdenv.lib.recursiveUpdate
+    lib.recursiveUpdate
       system-images-packages-android
-      (stdenv.lib.recursiveUpdate system-images-packages-android-tv
-        (stdenv.lib.recursiveUpdate system-images-packages-android-wear
-          (stdenv.lib.recursiveUpdate system-images-packages-android-wear-cn
-            (stdenv.lib.recursiveUpdate system-images-packages-google_apis system-images-packages-google_apis_playstore))));
+      (lib.recursiveUpdate system-images-packages-android-tv
+        (lib.recursiveUpdate system-images-packages-android-wear
+          (lib.recursiveUpdate system-images-packages-android-wear-cn
+            (lib.recursiveUpdate system-images-packages-google_apis system-images-packages-google_apis_playstore))));
 
   # Generated addons
   addons = import ./generated/addons.nix {
@@ -77,15 +77,13 @@ rec {
   };
 
   platform-tools = import ./platform-tools.nix {
-    inherit deployAndroidPackage os autoPatchelfHook pkgs;
-    inherit (stdenv) lib;
+    inherit deployAndroidPackage os autoPatchelfHook pkgs lib;
     package = packages.platform-tools."${platformToolsVersion}";
   };
 
   build-tools = map (version:
     import ./build-tools.nix {
-      inherit deployAndroidPackage os autoPatchelfHook makeWrapper pkgs pkgs_i686;
-      inherit (stdenv) lib;
+      inherit deployAndroidPackage os autoPatchelfHook makeWrapper pkgs pkgs_i686 lib;
       package = packages.build-tools."${version}";
     }
   ) buildToolsVersions;
@@ -96,8 +94,7 @@ rec {
   };
 
   emulator = import ./emulator.nix {
-    inherit deployAndroidPackage os autoPatchelfHook makeWrapper pkgs pkgs_i686;
-    inherit (stdenv) lib;
+    inherit deployAndroidPackage os autoPatchelfHook makeWrapper pkgs pkgs_i686 lib;
     package = packages.emulator."${emulatorVersion}"."${os}";
   };
 
@@ -115,7 +112,7 @@ rec {
     }
   ) platformVersions;
 
-  system-images = stdenv.lib.flatten (map (apiVersion:
+  system-images = lib.flatten (map (apiVersion:
     map (type:
       map (abiVersion:
         deployAndroidPackage {
@@ -124,7 +121,7 @@ rec {
           # Patch 'google_apis' system images so they're recognized by the sdk.
           # Without this, `android list targets` shows 'Tag/ABIs : no ABIs' instead
           # of 'Tag/ABIs : google_apis*/*' and the emulator fails with an ABI-related error.
-          patchInstructions = stdenv.lib.optionalString (stdenv.lib.hasPrefix "google_apis" type) ''
+          patchInstructions = lib.optionalString (lib.hasPrefix "google_apis" type) ''
             sed -i '/^Addon.Vendor/d' source.properties
           '';
         }
@@ -134,23 +131,20 @@ rec {
 
   lldb = map (version:
     import ./lldb.nix {
-      inherit deployAndroidPackage os autoPatchelfHook pkgs;
-      inherit (stdenv) lib;
+      inherit deployAndroidPackage os autoPatchelfHook pkgs lib;
       package = packages.lldb."${version}";
     }
   ) lldbVersions;
 
   cmake = map (version:
     import ./cmake.nix {
-      inherit deployAndroidPackage os autoPatchelfHook pkgs;
-      inherit (stdenv) lib;
+      inherit deployAndroidPackage os autoPatchelfHook pkgs lib;
       package = packages.cmake."${version}";
     }
   ) cmakeVersions;
 
   ndk-bundle = import ./ndk-bundle {
-    inherit deployAndroidPackage os autoPatchelfHook makeWrapper pkgs platform-tools;
-    inherit (stdenv) lib;
+    inherit deployAndroidPackage os autoPatchelfHook makeWrapper pkgs lib platform-tools;
     package = packages.ndk-bundle."${ndkVersion}";
   };
 
@@ -170,24 +164,24 @@ rec {
 
   # Function that automatically links all plugins for which multiple versions can coexist
   linkPlugins = {name, plugins}:
-    stdenv.lib.optionalString (plugins != []) ''
+    lib.optionalString (plugins != []) ''
       mkdir -p ${name}
-      ${stdenv.lib.concatMapStrings (plugin: ''
+      ${lib.concatMapStrings (plugin: ''
         ln -s ${plugin}/libexec/android-sdk/${name}/* ${name}
       '') plugins}
     '';
 
   # Function that automatically links a plugin for which only one version exists
   linkPlugin = {name, plugin, check ? true}:
-    stdenv.lib.optionalString check ''
+    lib.optionalString check ''
       ln -s ${plugin}/libexec/android-sdk/* ${name}
     '';
 
   # Links all plugins related to a requested platform
   linkPlatformPlugins = {name, plugins, check}:
-    stdenv.lib.optionalString check ''
+    lib.optionalString check ''
       mkdir -p ${name}
-      ${stdenv.lib.concatMapStrings (plugin: ''
+      ${lib.concatMapStrings (plugin: ''
         ln -s ${plugin}/libexec/android-sdk/${name}/* ${name}
       '') plugins}
     ''; # */
@@ -200,8 +194,7 @@ rec {
     https://developer.android.com/studio/terms
     by setting nixpkgs config option 'android_sdk.accept_license = true;'
   '' else import ./tools.nix {
-    inherit deployAndroidPackage requireFile packages toolsVersion autoPatchelfHook makeWrapper os pkgs pkgs_i686;
-    inherit (stdenv) lib;
+    inherit deployAndroidPackage requireFile packages toolsVersion autoPatchelfHook makeWrapper os pkgs pkgs_i686 lib;
 
     postInstall = ''
       # Symlink all requested plugins
@@ -216,9 +209,9 @@ rec {
       ${linkPlugins { name = "cmake"; plugins = cmake; }}
       ${linkPlugin { name = "ndk-bundle"; plugin = ndk-bundle; check = includeNDK; }}
 
-      ${stdenv.lib.optionalString includeSystemImages ''
+      ${lib.optionalString includeSystemImages ''
         mkdir -p system-images
-        ${stdenv.lib.concatMapStrings (system-image: ''
+        ${lib.concatMapStrings (system-image: ''
           apiVersion=$(basename $(echo ${system-image}/libexec/android-sdk/system-images/*))
           type=$(basename $(echo ${system-image}/libexec/android-sdk/system-images/*/*))
           mkdir -p system-images/$apiVersion/$type
@@ -230,7 +223,7 @@ rec {
       ${linkPlatformPlugins { name = "add-ons"; plugins = google-apis; check = useGoogleTVAddOns; }}
 
       # Link extras
-      ${stdenv.lib.concatMapStrings (identifier:
+      ${lib.concatMapStrings (identifier:
         let
           path = addons.extras."${identifier}".path;
           addon = deployAndroidPackage {

--- a/pkgs/development/mobile/androidenv/compose-android-packages.nix
+++ b/pkgs/development/mobile/androidenv/compose-android-packages.nix
@@ -121,6 +121,12 @@ rec {
         deployAndroidPackage {
           inherit os;
           package = system-images-packages.${apiVersion}.${type}.${abiVersion};
+          # Patch 'google_apis' system images so they're recognized by the sdk.
+          # Without this, `android list targets` shows 'Tag/ABIs : no ABIs' instead
+          # of 'Tag/ABIs : google_apis*/*' and the emulator fails with an ABI-related error.
+          patchInstructions = stdenv.lib.optionalString (stdenv.lib.hasPrefix "google_apis" type) ''
+            sed -i '/^Addon.Vendor/d' source.properties
+          '';
         }
       ) abiVersions
     ) systemImageTypes

--- a/pkgs/development/mobile/androidenv/default.nix
+++ b/pkgs/development/mobile/androidenv/default.nix
@@ -10,12 +10,12 @@ rec {
   };
 
   buildApp = import ./build-app.nix {
-    inherit (pkgs) stdenv jdk ant gnumake gawk;
+    inherit (pkgs) stdenv lib jdk ant gnumake gawk;
     inherit composeAndroidPackages;
   };
 
   emulateApp = import ./emulate-app.nix {
-    inherit (pkgs) stdenv;
+    inherit (pkgs) stdenv lib;
     inherit composeAndroidPackages;
   };
 

--- a/pkgs/development/mobile/androidenv/emulate-app.nix
+++ b/pkgs/development/mobile/androidenv/emulate-app.nix
@@ -1,4 +1,4 @@
-{ composeAndroidPackages, stdenv }:
+{ composeAndroidPackages, stdenv, lib }:
 { name, app ? null
 , platformVersion ? "16", abiVersion ? "armeabi-v7a", systemImageType ? "default"
 , enableGPU ? false, extraAVDFiles ? []
@@ -74,12 +74,12 @@ stdenv.mkDerivation {
         # Create a virtual android device
         yes "" | ${sdk}/libexec/android-sdk/tools/android create avd -n device -t 1 --abi ${systemImageType}/${abiVersion} $NIX_ANDROID_AVD_FLAGS
 
-        ${stdenv.lib.optionalString enableGPU ''
+        ${lib.optionalString enableGPU ''
           # Enable GPU acceleration
           echo "hw.gpu.enabled=yes" >> $ANDROID_SDK_HOME/.android/avd/device.avd/config.ini
         ''}
 
-        ${stdenv.lib.concatMapStrings (extraAVDFile: ''
+        ${lib.concatMapStrings (extraAVDFile: ''
           ln -sf ${extraAVDFile} $ANDROID_SDK_HOME/.android/avd/device.avd
         '') extraAVDFiles}
     fi
@@ -110,7 +110,7 @@ stdenv.mkDerivation {
 
     echo "ready" >&2
 
-    ${stdenv.lib.optionalString (app != null) ''
+    ${lib.optionalString (app != null) ''
       # Install the App through the debugger, if it has not been installed yet
 
       if [ -z "${package}" ] || [ "$(${sdk}/libexec/android-sdk/platform-tools/adb -s emulator-$port shell pm list packages | grep package:${package})" = "" ]
@@ -126,7 +126,7 @@ stdenv.mkDerivation {
       fi
 
       # Start the application
-      ${stdenv.lib.optionalString (package != null && activity != null) ''
+      ${lib.optionalString (package != null && activity != null) ''
           ${sdk}/libexec/android-sdk/platform-tools/adb -s emulator-$port shell am start -a android.intent.action.MAIN -n ${package}/${activity}
       ''}
     ''}

--- a/pkgs/development/mobile/androidenv/emulate-app.nix
+++ b/pkgs/development/mobile/androidenv/emulate-app.nix
@@ -15,7 +15,7 @@ let
     abiVersions = [ abiVersion ];
   } // sdkExtraArgs;
 
-  androidsdkComposition = (composeAndroidPackages sdkArgs).androidsdk;
+  sdk = (composeAndroidPackages sdkArgs).androidsdk;
 in
 stdenv.mkDerivation {
   inherit name;
@@ -41,7 +41,7 @@ stdenv.mkDerivation {
     ''}
 
     # We need to specify the location of the Android SDK root folder
-    export ANDROID_SDK_ROOT=${androidsdkComposition}/libexec/android-sdk
+    export ANDROID_SDK_ROOT=${sdk}/libexec/android-sdk
 
     # We have to look for a free TCP port
 
@@ -49,7 +49,7 @@ stdenv.mkDerivation {
 
     for i in $(seq 5554 2 5584)
     do
-        if [ -z "$(${androidsdkComposition}/libexec/android-sdk/platform-tools/adb devices | grep emulator-$i)" ]
+        if [ -z "$(${sdk}/libexec/android-sdk/platform-tools/adb devices | grep emulator-$i)" ]
         then
             port=$i
             break
@@ -67,12 +67,12 @@ stdenv.mkDerivation {
     export ANDROID_SERIAL="emulator-$port"
 
     # Create a virtual android device for testing if it does not exists
-    ${androidsdkComposition}/libexec/android-sdk/tools/android list targets
+    ${sdk}/libexec/android-sdk/tools/android list targets
 
-    if [ "$(${androidsdkComposition}/libexec/android-sdk/tools/android list avd | grep 'Name: device')" = "" ]
+    if [ "$(${sdk}/libexec/android-sdk/tools/android list avd | grep 'Name: device')" = "" ]
     then
         # Create a virtual android device
-        yes "" | ${androidsdkComposition}/libexec/android-sdk/tools/android create avd -n device -t 1 --abi ${systemImageType}/${abiVersion} $NIX_ANDROID_AVD_FLAGS
+        yes "" | ${sdk}/libexec/android-sdk/tools/android create avd -n device -t 1 --abi ${systemImageType}/${abiVersion} $NIX_ANDROID_AVD_FLAGS
 
         ${stdenv.lib.optionalString enableGPU ''
           # Enable GPU acceleration
@@ -85,23 +85,23 @@ stdenv.mkDerivation {
     fi
 
     # Launch the emulator
-    ${androidsdkComposition}/libexec/android-sdk/emulator/emulator -avd device -no-boot-anim -port $port $NIX_ANDROID_EMULATOR_FLAGS &
+    ${sdk}/libexec/android-sdk/emulator/emulator -avd device -no-boot-anim -port $port $NIX_ANDROID_EMULATOR_FLAGS &
 
     # Wait until the device has completely booted
     echo "Waiting until the emulator has booted the device and the package manager is ready..." >&2
 
-    ${androidsdkComposition}/libexec/android-sdk/platform-tools/adb -s emulator-$port wait-for-device
+    ${sdk}/libexec/android-sdk/platform-tools/adb -s emulator-$port wait-for-device
 
     echo "Device state has been reached" >&2
 
-    while [ -z "$(${androidsdkComposition}/libexec/android-sdk/platform-tools/adb -s emulator-$port shell getprop dev.bootcomplete | grep 1)" ]
+    while [ -z "$(${sdk}/libexec/android-sdk/platform-tools/adb -s emulator-$port shell getprop dev.bootcomplete | grep 1)" ]
     do
         sleep 5
     done
 
     echo "dev.bootcomplete property is 1" >&2
 
-    #while [ -z "$(${androidsdkComposition}/libexec/android-sdk/platform-tools/adb -s emulator-$port shell getprop sys.boot_completed | grep 1)" ]
+    #while [ -z "$(${sdk}/libexec/android-sdk/platform-tools/adb -s emulator-$port shell getprop sys.boot_completed | grep 1)" ]
     #do
         #sleep 5
     #done
@@ -113,7 +113,7 @@ stdenv.mkDerivation {
     ${stdenv.lib.optionalString (app != null) ''
       # Install the App through the debugger, if it has not been installed yet
 
-      if [ -z "${package}" ] || [ "$(${androidsdkComposition}/libexec/android-sdk/platform-tools/adb -s emulator-$port shell pm list packages | grep package:${package})" = "" ]
+      if [ -z "${package}" ] || [ "$(${sdk}/libexec/android-sdk/platform-tools/adb -s emulator-$port shell pm list packages | grep package:${package})" = "" ]
       then
           if [ -d "${app}" ]
           then
@@ -122,12 +122,12 @@ stdenv.mkDerivation {
               appPath="${app}"
           fi
 
-          ${androidsdkComposition}/libexec/android-sdk/platform-tools/adb -s emulator-$port install "$appPath"
+          ${sdk}/libexec/android-sdk/platform-tools/adb -s emulator-$port install "$appPath"
       fi
 
       # Start the application
       ${stdenv.lib.optionalString (package != null && activity != null) ''
-          ${androidsdkComposition}/libexec/android-sdk/platform-tools/adb -s emulator-$port shell am start -a android.intent.action.MAIN -n ${package}/${activity}
+          ${sdk}/libexec/android-sdk/platform-tools/adb -s emulator-$port shell am start -a android.intent.action.MAIN -n ${package}/${activity}
       ''}
     ''}
     EOF

--- a/pkgs/development/mobile/androidenv/emulate-app.nix
+++ b/pkgs/development/mobile/androidenv/emulate-app.nix
@@ -1,24 +1,21 @@
 { composeAndroidPackages, stdenv }:
 { name, app ? null
-, platformVersion ? "16", abiVersion ? "armeabi-v7a", systemImageType ? "default", useGoogleAPIs ? false
+, platformVersion ? "16", abiVersion ? "armeabi-v7a", systemImageType ? "default"
 , enableGPU ? false, extraAVDFiles ? []
 , package ? null, activity ? null
-, avdHomeDir ? null
-}@args:
+, avdHomeDir ? null, sdkExtraArgs ? {}
+}:
 
 let
-  androidSdkArgNames = builtins.attrNames (builtins.functionArgs composeAndroidPackages);
-
-  # Extract the parameters meant for the Android SDK
-  androidParams = {
+  sdkArgs = {
     platformVersions = [ platformVersion ];
     includeEmulator = true;
     includeSystemImages = true;
     systemImageTypes = [ systemImageType ];
     abiVersions = [ abiVersion ];
-  };
+  } // sdkExtraArgs;
 
-  androidsdkComposition = (composeAndroidPackages androidParams).androidsdk;
+  androidsdkComposition = (composeAndroidPackages sdkArgs).androidsdk;
 in
 stdenv.mkDerivation {
   inherit name;


### PR DESCRIPTION
Please see the individual commit messages.

Use this to test commit `androidenv: Fix deployment of google_apis* system images`:
```bash
emu=$(nix-build --no-out-link - <<'EOF'
with (import /tmp/nixpkgs {});
androidenv.emulateApp {
  name = "google_apis_system";
  platformVersion = "28";
  abiVersion = "x86_64";
  systemImageType = "google_apis_playstore";
}
EOF
)
$emu/bin/run-test-emulator
```

cc @svanderburg

###### Things done
All of them.