### PR TITLE
openblas: 0.3.6 -> 0.3.7

### DIFF
--- a/pkgs/development/libraries/science/math/openblas/default.nix
+++ b/pkgs/development/libraries/science/math/openblas/default.nix
@@ -87,12 +87,12 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "openblas";
-  version = "0.3.6";
+  version = "0.3.7";
   src = fetchFromGitHub {
     owner = "xianyi";
     repo = "OpenBLAS";
     rev = "v${version}";
-    sha256 = "12vg0g3s4m49fr8z04j15yrgscqnaaflnkckjbffqxnrf90fcav1";
+    sha256 = "0vs1dlzyla02wajpkfzz8x3lfpgmwiaaizq2nmdjbkzkb7jnxhhz";
   };
 
   inherit blas64;


### PR DESCRIPTION
###### Motivation for this change
Would be nice to have for 19.09. There seem to be some improvements regarding thread safety [Changelog](https://github.com/xianyi/OpenBLAS/releases).
This may solve https://github.com/NixOS/nixpkgs/issues/59901 (cc @gebner).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @ttuegel 
