### PR TITLE
libreoffice-fresh: 6.2.4.2 -> 6.3.0.4

### DIFF
--- a/pkgs/applications/office/libreoffice/default-primary-src.nix
+++ b/pkgs/applications/office/libreoffice/default-primary-src.nix
@@ -2,9 +2,9 @@
 
 rec {
   major = "6";
-  minor = "2";
-  patch = "4";
-  tweak = "2";
+  minor = "3";
+  patch = "0";
+  tweak = "4";
 
   subdir = "${major}.${minor}.${patch}";
 
@@ -12,6 +12,6 @@ rec {
 
   src = fetchurl {
     url = "https://download.documentfoundation.org/libreoffice/src/${subdir}/libreoffice-${version}.tar.xz";
-    sha256 = "1drq59lc6p4s8mil2syz93l97phsbk9dcrd5gikqi2dwlzkli0gz";
+    sha256 = "1mxflzrcm04djkj8ifyy4rwgl8bxirrvzrn864w6rgvzn43h30w7";
   };
 }

--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -48,14 +48,14 @@ let
 
     translations = fetchSrc {
       name = "translations";
-      sha256 = "0ahyrkg1sa4a0igvvd98spjlm5k34cddpwpxl7qhir8ldgighk2c";
+      sha256 = "0730fw2kr00b2d56jkdzjdz49c4k4mxiz879c7ikw59c5zvrh009";
     };
 
     # TODO: dictionaries
 
     help = fetchSrc {
       name = "help";
-      sha256 = "0zrfm8kw6m60wz6mn4y5jhlng90ya045nxyh46sib9nl4nd4d98s";
+      sha256 = "1w9bqwzz75vvxxy9dgln0v6p6isf8mkqnkg1nzlaykvdgsn5sp4z";
     };
 
   };
@@ -144,6 +144,8 @@ in stdenv.mkDerivation rec {
       sed -e '/CPPUNIT_ASSERT_EQUAL(11148L, pOleObj->GetLogicRect().getWidth());/d ' -i sc/qa/unit/subsequent_filters-test.cxx
       # tilde expansion in path processing checks the existence of $HOME
       sed -e 's@OString sSysPath("~/tmp");@& return ; @' -i sal/qa/osl/file/osl_File.cxx
+      # fails on systems using ZFS, see https://github.com/NixOS/nixpkgs/issues/19071
+      sed -e '/CPPUNIT_TEST(getSystemPathFromFileURL_005);/d' -i './sal/qa/osl/file/osl_File.cxx'
       # rendering-dependent: on my computer the test table actually doesn't fit…
       # interesting fact: test disabled on macOS by upstream
       sed -re '/DECLARE_WW8EXPORT_TEST[(]testTableKeep, "tdf91083.odt"[)]/,+5d' -i ./sw/qa/extras/ww8export/ww8export.cxx
@@ -305,6 +307,9 @@ in stdenv.mkDerivation rec {
 
     # Without these, configure does not finish
     "--without-junit"
+
+    # Schema files for validation are not included in the source tarball
+    "--without-export-validation"
 
     "--disable-libnumbertext" # system-libnumbertext"
 

--- a/pkgs/applications/office/libreoffice/libreoffice-srcs.nix
+++ b/pkgs/applications/office/libreoffice/libreoffice-srcs.nix
@@ -28,11 +28,11 @@
     md5name = "976a12a59bc286d634a21d7be0841cc74289ea9077aa1af46be19d1a6e844c19-apr-util-1.5.4.tar.gz";
   }
   {
-    name = "boost_1_66_0.tar.bz2";
-    url = "http://dev-www.libreoffice.org/src/boost_1_66_0.tar.bz2";
-    sha256 = "5721818253e6a0989583192f96782c4a98eb6204965316df9f5ad75819225ca9";
+    name = "boost_1_69_0.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/boost_1_69_0.tar.bz2";
+    sha256 = "8f32d4617390d1c2d16f26a27ab60d97807b35440d45891fa340fc2648b04406";
     md5 = "";
-    md5name = "5721818253e6a0989583192f96782c4a98eb6204965316df9f5ad75819225ca9-boost_1_66_0.tar.bz2";
+    md5name = "8f32d4617390d1c2d16f26a27ab60d97807b35440d45891fa340fc2648b04406-boost_1_69_0.tar.bz2";
   }
   {
     name = "breakpad.zip";
@@ -105,11 +105,11 @@
     md5name = "1f467e5bb703f12cbbb09d5cf67ecf4a-converttexttonumber-1-5-0.oxt";
   }
   {
-    name = "curl-7.64.0.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/curl-7.64.0.tar.gz";
-    sha256 = "cb90d2eb74d4e358c1ed1489f8e3af96b50ea4374ad71f143fa4595e998d81b5";
+    name = "curl-7.65.0.tar.xz";
+    url = "http://dev-www.libreoffice.org/src/curl-7.65.0.tar.xz";
+    sha256 = "7766d263929404f693905b5e5222aa0f2bdf8c66ab4b8758f0c0820a42b966cd";
     md5 = "";
-    md5name = "cb90d2eb74d4e358c1ed1489f8e3af96b50ea4374ad71f143fa4595e998d81b5-curl-7.64.0.tar.gz";
+    md5name = "7766d263929404f693905b5e5222aa0f2bdf8c66ab4b8758f0c0820a42b966cd-curl-7.65.0.tar.xz";
   }
   {
     name = "libe-book-0.1.3.tar.xz";
@@ -231,11 +231,11 @@
     md5name = "edc4d741888bc0d38e32dbaa17149596-source-sans-pro-2.010R-ro-1.065R-it.tar.gz";
   }
   {
-    name = "source-serif-font-2.007R.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/source-serif-font-2.007R.tar.gz";
-    sha256 = "10b2bbb357d52bf0f516d3e0ac0a09b5f7901470fbf649b69dad9ccc2d29f7cb";
+    name = "source-serif-pro-3.000R.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/source-serif-pro-3.000R.tar.gz";
+    sha256 = "826a2b784d5cdb4c2bbc7830eb62871528360a61a52689c102a101623f1928e3";
     md5 = "";
-    md5name = "10b2bbb357d52bf0f516d3e0ac0a09b5f7901470fbf649b69dad9ccc2d29f7cb-source-serif-font-2.007R.tar.gz";
+    md5name = "826a2b784d5cdb4c2bbc7830eb62871528360a61a52689c102a101623f1928e3-source-serif-pro-3.000R.tar.gz";
   }
   {
     name = "EmojiOneColor-SVGinOT-1.3.tar.gz";
@@ -308,11 +308,11 @@
     md5name = "0e422d1564a6dbf22a9af598535425271e583514c0f7ba7d9091676420de34ac-libfreehand-0.1.2.tar.xz";
   }
   {
-    name = "freetype-2.8.1.tar.bz2";
-    url = "http://dev-www.libreoffice.org/src/freetype-2.8.1.tar.bz2";
-    sha256 = "e5435f02e02d2b87bb8e4efdcaa14b1f78c9cf3ab1ed80f94b6382fb6acc7d78";
+    name = "freetype-2.9.1.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/freetype-2.9.1.tar.bz2";
+    sha256 = "db8d87ea720ea9d5edc5388fc7a0497bb11ba9fe972245e0f7f4c7e8b1e1e84d";
     md5 = "";
-    md5name = "e5435f02e02d2b87bb8e4efdcaa14b1f78c9cf3ab1ed80f94b6382fb6acc7d78-freetype-2.8.1.tar.bz2";
+    md5name = "db8d87ea720ea9d5edc5388fc7a0497bb11ba9fe972245e0f7f4c7e8b1e1e84d-freetype-2.9.1.tar.bz2";
   }
   {
     name = "glm-0.9.4.6-libreoffice.zip";
@@ -329,18 +329,18 @@
     md5name = "1b29fedb8bfad775e70eafac5b0590621683b2d9869db994568e6401f4034ceb-gpgme-1.9.0.tar.bz2";
   }
   {
-    name = "graphite2-minimal-1.3.10.tgz";
-    url = "http://dev-www.libreoffice.org/src/graphite2-minimal-1.3.10.tgz";
-    sha256 = "aa5e58356cd084000609ebbd93fef456a1bc0ab9e46fea20e81552fb286232a9";
+    name = "graphite2-minimal-1.3.13.tgz";
+    url = "http://dev-www.libreoffice.org/src/graphite2-minimal-1.3.13.tgz";
+    sha256 = "d47d387161db7f7ebade1920aa7cbdc797e79772597d8b55e80b58d1071bcc36";
     md5 = "";
-    md5name = "aa5e58356cd084000609ebbd93fef456a1bc0ab9e46fea20e81552fb286232a9-graphite2-minimal-1.3.10.tgz";
+    md5name = "d47d387161db7f7ebade1920aa7cbdc797e79772597d8b55e80b58d1071bcc36-graphite2-minimal-1.3.13.tgz";
   }
   {
-    name = "harfbuzz-1.8.4.tar.bz2";
-    url = "http://dev-www.libreoffice.org/src/harfbuzz-1.8.4.tar.bz2";
-    sha256 = "3c592f86fa0da69e2e0e98cae9f5d5b61def3bb7948aa00ca45748f27fa545fd";
+    name = "harfbuzz-2.3.1.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/harfbuzz-2.3.1.tar.bz2";
+    sha256 = "f205699d5b91374008d6f8e36c59e419ae2d9a7bb8c5d9f34041b9a5abcae468";
     md5 = "";
-    md5name = "3c592f86fa0da69e2e0e98cae9f5d5b61def3bb7948aa00ca45748f27fa545fd-harfbuzz-1.8.4.tar.bz2";
+    md5name = "f205699d5b91374008d6f8e36c59e419ae2d9a7bb8c5d9f34041b9a5abcae468-harfbuzz-2.3.1.tar.bz2";
   }
   {
     name = "hsqldb_1_8_0.zip";
@@ -539,11 +539,11 @@
     md5name = "083daa92d8ee6f4af96a6143b12d7fc8fe1a547e14f862304f7281f8f7347483-ltm-1.0.zip";
   }
   {
-    name = "xmlsec1-1.2.27.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/xmlsec1-1.2.27.tar.gz";
-    sha256 = "97d756bad8e92588e6997d2227797eaa900d05e34a426829b149f65d87118eb6";
+    name = "xmlsec1-1.2.28.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/xmlsec1-1.2.28.tar.gz";
+    sha256 = "13eec4811ea30e3f0e16a734d1dbf7f9d246a71d540b48d143a07b489f6222d4";
     md5 = "";
-    md5name = "97d756bad8e92588e6997d2227797eaa900d05e34a426829b149f65d87118eb6-xmlsec1-1.2.27.tar.gz";
+    md5name = "13eec4811ea30e3f0e16a734d1dbf7f9d246a71d540b48d143a07b489f6222d4-xmlsec1-1.2.28.tar.gz";
   }
   {
     name = "libxml2-2.9.9.tar.gz";
@@ -602,11 +602,11 @@
     md5name = "ef36c1a1aabb2ba3b0bedaaafe717bf4480be2ba8de6f3894be5fd3702b013ba-libmspub-0.1.4.tar.xz";
   }
   {
-    name = "libmwaw-0.3.14.tar.xz";
-    url = "http://dev-www.libreoffice.org/src/libmwaw-0.3.14.tar.xz";
-    sha256 = "aca8bf1ce55ed83adbea82c70d4c8bebe8139f334b3481bf5a6e407f91f33ce9";
+    name = "libmwaw-0.3.15.tar.xz";
+    url = "http://dev-www.libreoffice.org/src/libmwaw-0.3.15.tar.xz";
+    sha256 = "0440bb09f05e3419423d8dfa36ee847056ebfd837f9cbc091fdb5b057daab0b1";
     md5 = "";
-    md5name = "aca8bf1ce55ed83adbea82c70d4c8bebe8139f334b3481bf5a6e407f91f33ce9-libmwaw-0.3.14.tar.xz";
+    md5name = "0440bb09f05e3419423d8dfa36ee847056ebfd837f9cbc091fdb5b057daab0b1-libmwaw-0.3.15.tar.xz";
   }
   {
     name = "mythes-1.2.4.tar.gz";
@@ -623,11 +623,11 @@
     md5name = "db0bd8cdec329b48f53a6f00199c92d5ba40b0f015b153718d1b15d3d967fbca-neon-0.30.2.tar.gz";
   }
   {
-    name = "nss-3.38-with-nspr-4.19.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/nss-3.38-with-nspr-4.19.tar.gz";
-    sha256 = "f271ec73291fa3e4bd4b59109f8035cc3a192fc33886f40ed4f9ee4b31c746e9";
+    name = "nss-3.45-with-nspr-4.21.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/nss-3.45-with-nspr-4.21.tar.gz";
+    sha256 = "fae11751100510d26f16a245f0db9a5b3d638ab28ce0bccd50d4314f7e526ba1";
     md5 = "";
-    md5name = "f271ec73291fa3e4bd4b59109f8035cc3a192fc33886f40ed4f9ee4b31c746e9-nss-3.38-with-nspr-4.19.tar.gz";
+    md5name = "fae11751100510d26f16a245f0db9a5b3d638ab28ce0bccd50d4314f7e526ba1-nss-3.45-with-nspr-4.21.tar.gz";
   }
   {
     name = "libodfgen-0.1.6.tar.bz2";
@@ -686,11 +686,11 @@
     md5name = "66adacd705a7d19895e08eac46d1e851332adf2e736c566bef1164e7a442519d-libpagemaker-0.0.4.tar.xz";
   }
   {
-    name = "pdfium-3550.tar.bz2";
-    url = "http://dev-www.libreoffice.org/src/pdfium-3550.tar.bz2";
-    sha256 = "572460f7f9e2f86d022a9c6a82f1e2ded6c3c29ba352d4b9fac60b87e2159679";
+    name = "pdfium-3794.tar.bz2";
+    url = "http://dev-www.libreoffice.org/src/pdfium-3794.tar.bz2";
+    sha256 = "e3faddcf741336c64ca2e6f72b23e9e60979969b2cf67c878c9a5bc38328cfc4";
     md5 = "";
-    md5name = "572460f7f9e2f86d022a9c6a82f1e2ded6c3c29ba352d4b9fac60b87e2159679-pdfium-3550.tar.bz2";
+    md5name = "e3faddcf741336c64ca2e6f72b23e9e60979969b2cf67c878c9a5bc38328cfc4-pdfium-3794.tar.bz2";
   }
   {
     name = "pixman-0.34.0.tar.gz";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Two changes besides the usual update:
- The disabled test is due to #19071.
- The export validation flag would ideally be a backport of LibreOffice/core@80805539f6bd9b5f6229682aa187de705cb83de9, but it turns out the test on that patch is wrong – the `schema` directory is present, it's the schema files that are missing.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @7c6f434c 

---

Should this be backported to 19.03 as well?
