### PR TITLE
treewide: Remove unnecessary `--disable-static`

### DIFF
--- a/pkgs/applications/display-managers/lightdm/default.nix
+++ b/pkgs/applications/display-managers/lightdm/default.nix
@@ -61,7 +61,6 @@ stdenv.mkDerivation rec {
     "--localstatedir=/var"
     "--sysconfdir=/etc"
     "--disable-tests"
-    "--disable-static"
     "--disable-dmrc"
   ] ++ optional withQt4 "--enable-liblightdm-qt"
     ++ optional withQt5 "--enable-liblightdm-qt5";

--- a/pkgs/applications/misc/kiwix/default.nix
+++ b/pkgs/applications/misc/kiwix/default.nix
@@ -82,7 +82,6 @@ stdenv.mkDerivation rec {
   '';
 
   configureFlags = [
-    "--disable-static"
     "--disable-staticbins"
   ];
 

--- a/pkgs/applications/science/electronics/alliance/default.nix
+++ b/pkgs/applications/science/electronics/alliance/default.nix
@@ -20,7 +20,6 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--prefix=$(out)"
-    "--disable-static"
   ];
 
   preConfigure = ''

--- a/pkgs/desktops/gnome-3/core/mutter/3.28.nix
+++ b/pkgs/desktops/gnome-3/core/mutter/3.28.nix
@@ -58,7 +58,6 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--with-x"
-    "--disable-static"
     "--enable-shape"
     "--enable-sm"
     "--enable-startup-notification"

--- a/pkgs/development/libraries/blitz/default.nix
+++ b/pkgs/development/libraries/blitz/default.nix
@@ -37,7 +37,6 @@ stdenv.mkDerivation rec {
 
   configureFlags =
     [ "--enable-shared"
-      "--disable-static"
       "--enable-fortran"
       "--enable-optimize"
       "--with-pic=yes"

--- a/pkgs/development/libraries/ffmpeg-full/default.nix
+++ b/pkgs/development/libraries/ffmpeg-full/default.nix
@@ -271,7 +271,7 @@ stdenv.mkDerivation rec {
      *  Build flags
      */
     # On some ARM platforms --enable-thumb
-    "--enable-shared --disable-static"
+    "--enable-shared"
     (enableFeature true "pic")
     (if stdenv.cc.isClang then "--cc=clang" else null)
     (enableFeature smallBuild "small")

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -89,7 +89,6 @@ stdenv.mkDerivation rec {
       "--enable-version3"
     # Build flags
       "--enable-shared"
-      "--disable-static"
       (ifMinVer "0.6" "--enable-pic")
       (enableFeature runtimeCpuDetectBuild "runtime-cpudetect")
       "--enable-hardcoded-tables"

--- a/pkgs/development/libraries/fftw/default.nix
+++ b/pkgs/development/libraries/fftw/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   outputBin = "dev"; # fftw-wisdom
 
   configureFlags =
-    [ "--enable-shared" "--disable-static"
+    [ "--enable-shared"
       "--enable-threads"
     ]
     ++ optional (precision != "double") "--enable-${precision}"

--- a/pkgs/development/libraries/freetype/default.nix
+++ b/pkgs/development/libraries/freetype/default.nix
@@ -50,7 +50,7 @@ in stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  configureFlags = [ "--disable-static" "--bindir=$(dev)/bin" "--enable-freetype-config" ];
+  configureFlags = [ "--bindir=$(dev)/bin" "--enable-freetype-config" ];
 
   # native compiler to generate building tool
   CC_BUILD = "${buildPackages.stdenv.cc}/bin/cc";

--- a/pkgs/development/libraries/ijs/default.nix
+++ b/pkgs/development/libraries/ijs/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ autoreconfHook ];
 
-  configureFlags = [ "--disable-static" "--enable-shared" ];
+  configureFlags = [ "--enable-shared" ];
 
   meta = with stdenv.lib; {
     homepage = https://www.openprinting.org/download/ijs/;

--- a/pkgs/development/libraries/libpsl/default.nix
+++ b/pkgs/development/libraries/libpsl/default.nix
@@ -25,7 +25,6 @@ stdenv.mkDerivation rec {
   '';
 
   configureFlags = [
-    "--disable-static"
 #    "--enable-gtk-doc"
     "--enable-man"
     "--enable-valgrind-tests"

--- a/pkgs/development/libraries/librep/default.nix
+++ b/pkgs/development/libraries/librep/default.nix
@@ -19,10 +19,6 @@ stdenv.mkDerivation rec {
   buildInputs = [ readline texinfo ];
   propagatedBuildInputs = [ gdbm gmp libffi ];
 
-  configureFlags = [
-    "--disable-static"
-  ];
-
   setupHook = ./setup-hook.sh;
 
   meta = {

--- a/pkgs/development/libraries/libunity/default.nix
+++ b/pkgs/development/libraries/libunity/default.nix
@@ -48,7 +48,6 @@ stdenv.mkDerivation rec {
   '';
 
   configureFlags = [
-    "--disable-static"
     "--with-pygi-overrides-dir=${placeholder ''py''}/${python3.sitePackages}/gi/overrides"
   ];
 

--- a/pkgs/development/libraries/libvpx/default.nix
+++ b/pkgs/development/libraries/libvpx/default.nix
@@ -114,7 +114,7 @@ stdenv.mkDerivation rec {
     (if isDarwin || isCygwin then
        "--enable-static --disable-shared"
      else
-       "--disable-static --enable-shared")
+       "--enable-shared")
     (enableFeature smallSupport "small")
     (enableFeature postprocVisualizerSupport "postproc-visualizer")
     (enableFeature unitTestsSupport "unit-tests")

--- a/pkgs/development/libraries/vapoursynth/default.nix
+++ b/pkgs/development/libraries/vapoursynth/default.nix
@@ -30,7 +30,6 @@ stdenv.mkDerivation rec {
     ++ optional imwriSupport imagemagick7;
 
   configureFlags = [
-    "--disable-static"
     (optionalString (!ocrSupport)   "--disable-ocr")
     (optionalString (!imwriSupport) "--disable-imwri")
   ];

--- a/pkgs/development/libraries/xml-security-c/default.nix
+++ b/pkgs/development/libraries/xml-security-c/default.nix
@@ -20,7 +20,6 @@ stdenv.mkDerivation rec {
     "--with-openssl"
     "--with-xerces"
     "--with-xalan"
-    "--disable-static"
   ];
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/misc/drivers/epkowa/default.nix
+++ b/pkgs/misc/drivers/epkowa/default.nix
@@ -243,7 +243,7 @@ stdenv.mkDerivation rec {
     ];
   patchFlags = "-p0";
 
-  configureFlags = [ "--disable-static" "--enable-dependency-reduction" "--disable-frontend"];
+  configureFlags = [ "--enable-dependency-reduction" "--disable-frontend"];
 
   postConfigure = ''
     echo '#define NIX_ESCI_PREFIX "'${fwdir}'"' >> config.h

--- a/pkgs/servers/firebird/default.nix
+++ b/pkgs/servers/firebird/default.nix
@@ -51,7 +51,6 @@ stdenv.mkDerivation rec {
   configureFlags =
     [ "--with-serivec-port=${builtins.toString port}"
       "--with-service-name=${serviceName}"
-      # "--disable-static"
       "--with-system-editline"
       "--with-fblog=/var/log/firebird"
       "--with-fbconf=/etc/firebird"

--- a/pkgs/tools/filesystems/avfs/default.nix
+++ b/pkgs/tools/filesystems/avfs/default.nix
@@ -15,7 +15,6 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--enable-library"
     "--enable-fuse"
-    "--disable-static"
   ];
 
   meta = {

--- a/pkgs/tools/networking/webalizer/default.nix
+++ b/pkgs/tools/networking/webalizer/default.nix
@@ -19,7 +19,6 @@ stdenv.mkDerivation {
   configureFlags = [
     "--enable-dns"
     "--enable-geoip"
-    "--disable-static"
     "--enable-shared"
   ];
 


### PR DESCRIPTION
###### Motivation for this change

Removes unnecessary `--disable-static` for most of the few packages that still give it explicitly.

The true-by-default `dontDisableStatic` already takes care of it.
    
Fixes these packages not being overridable to have static libs.

###### Grepping

**Before:**

<details>

```
% git grep 'disable-static' HEAD~~ 
HEAD~~:doc/stdenv.xml:       <option>--disable-static</option> is added to the configure flags.
HEAD~~:pkgs/applications/display-managers/lightdm/default.nix:    "--disable-static"
HEAD~~:pkgs/applications/misc/kiwix/default.nix:    "--disable-static"
HEAD~~:pkgs/applications/misc/kiwix/default.nix:    "--disable-staticbins"
HEAD~~:pkgs/applications/networking/ids/snort/default.nix:    "--disable-static-daq"
HEAD~~:pkgs/applications/science/electronics/alliance/default.nix:    "--disable-static"
HEAD~~:pkgs/applications/science/logic/verit/default.nix:  # --disable-static actually enables static linking here...
HEAD~~:pkgs/applications/video/mkvtoolnix/default.nix:    "--disable-static-qt"
HEAD~~:pkgs/applications/video/mpv/default.nix:    "--disable-static-build"
HEAD~~:pkgs/desktops/gnome-3/core/mutter/3.28.nix:    "--disable-static"
HEAD~~:pkgs/development/libraries/blitz/default.nix:      "--disable-static"
HEAD~~:pkgs/development/libraries/boehm-gc/7.6.6.nix:    ++ lib.optional (stdenv.hostPlatform.libc == "musl") "--disable-static";
HEAD~~:pkgs/development/libraries/boehm-gc/default.nix:    ++ lib.optional (stdenv.hostPlatform.libc == "musl") "--disable-static";
HEAD~~:pkgs/development/libraries/concurrencykit/default.nix:  #Deleting this line causes "Unknown option --disable-static"
HEAD~~:pkgs/development/libraries/ffmpeg-full/default.nix:    "--enable-shared --disable-static"
HEAD~~:pkgs/development/libraries/ffmpeg/generic.nix:      "--disable-static"
HEAD~~:pkgs/development/libraries/fftw/default.nix:    [ "--enable-shared" "--disable-static"
HEAD~~:pkgs/development/libraries/freetype/default.nix:  configureFlags = [ "--disable-static" "--bindir=$(dev)/bin" "--enable-freetype-config" ];
HEAD~~:pkgs/development/libraries/ijs/default.nix:  configureFlags = [ "--disable-static" "--enable-shared" ];
HEAD~~:pkgs/development/libraries/libpsl/default.nix:    "--disable-static"
HEAD~~:pkgs/development/libraries/librep/default.nix:    "--disable-static"
HEAD~~:pkgs/development/libraries/libunity/default.nix:    "--disable-static"
HEAD~~:pkgs/development/libraries/libvpx/default.nix:       "--disable-static --enable-shared")
HEAD~~:pkgs/development/libraries/stlport/default.nix:  # fix hardcoded /usr/bin; not recognizing the standard --disable-static flag
HEAD~~:pkgs/development/libraries/vapoursynth/default.nix:    "--disable-static"
HEAD~~:pkgs/development/libraries/xml-security-c/default.nix:    "--disable-static"
HEAD~~:pkgs/development/tools/misc/binutils/default.nix:    (if enableShared then [ "--enable-shared" "--disable-static" ]
HEAD~~:pkgs/misc/drivers/epkowa/default.nix:  configureFlags = [ "--disable-static" "--enable-dependency-reduction" "--disable-frontend"];
HEAD~~:pkgs/misc/drivers/gutenprint/default.nix:    "--disable-static-genppd" # should be harmless on NixOS
HEAD~~:pkgs/servers/firebird/default.nix:      # "--disable-static"
HEAD~~:pkgs/stdenv/generic/setup.sh:            configureFlags="--disable-static $configureFlags"
HEAD~~:pkgs/tools/admin/tigervnc/default.nix:        --disable-xorgcfg --disable-xprint --disable-static \
HEAD~~:pkgs/tools/filesystems/avfs/default.nix:    "--disable-static"
HEAD~~:pkgs/tools/networking/tcptraceroute/default.nix:   # for reasons unknown --disable-static configure flag doesn't disable static
HEAD~~:pkgs/tools/networking/webalizer/default.nix:    "--disable-static"
```

</details>

**After:**

<details>

```
% git grep 'disable-static'
doc/stdenv.xml:       <option>--disable-static</option> is added to the configure flags.
pkgs/applications/misc/kiwix/default.nix:    "--disable-staticbins"
pkgs/applications/networking/ids/snort/default.nix:    "--disable-static-daq"
pkgs/applications/science/logic/verit/default.nix:  # --disable-static actually enables static linking here...
pkgs/applications/video/mkvtoolnix/default.nix:    "--disable-static-qt"
pkgs/applications/video/mpv/default.nix:    "--disable-static-build"
pkgs/development/libraries/boehm-gc/7.6.6.nix:    ++ lib.optional (stdenv.hostPlatform.libc == "musl") "--disable-static";
pkgs/development/libraries/boehm-gc/default.nix:    ++ lib.optional (stdenv.hostPlatform.libc == "musl") "--disable-static";
pkgs/development/libraries/concurrencykit/default.nix:  #Deleting this line causes "Unknown option --disable-static"
pkgs/development/libraries/stlport/default.nix:  # fix hardcoded /usr/bin; not recognizing the standard --disable-static flag
pkgs/development/tools/misc/binutils/default.nix:    (if enableShared then [ "--enable-shared" "--disable-static" ]
pkgs/misc/drivers/gutenprint/default.nix:    "--disable-static-genppd" # should be harmless on NixOS
pkgs/stdenv/generic/setup.sh:            configureFlags="--disable-static $configureFlags"
pkgs/tools/admin/tigervnc/default.nix:        --disable-xorgcfg --disable-xprint --disable-static \
pkgs/tools/networking/tcptraceroute/default.nix:   # for reasons unknown --disable-static configure flag doesn't disable static
```

</details>

For `boehm-gc` I wasn't sure, see https://github.com/NixOS/nixpkgs/pull/34645/files/bd11ffd2677081870971e583b3ed69d3e2b468b9#diff-fb963edb2daf02292a13632110f8bbf3 (CC @dtzWill)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @dtzWill @matthewbauer @Ericson2314 
