### PR TITLE
nixos/utils: use removePrefix in escapeSystemdPath

### DIFF
--- a/nixos/lib/utils.nix
+++ b/nixos/lib/utils.nix
@@ -14,7 +14,7 @@ rec {
   # becomes dev-xyzzy.  FIXME: slow.
   escapeSystemdPath = s:
    replaceChars ["/" "-" " "] ["-" "\\x2d" "\\x20"]
-    (if hasPrefix "/" s then substring 1 (stringLength s) s else s);
+   (removePrefix "/" s);
 
   # Returns a system path for a given shell package
   toShellPath = shell:


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
I was in the process of creating my own escaping function, when I discovered that something like this was already in master. While I'm not sure whether half-handingly reimplement removePrefix has any performance benefits that were forgotten to document, it seems to make more sense to implement it that way.

###### Things done

Only tested using nix-repl. Are there tests for this hidden somewhere?

For my own function, knowing about the incompleteness of the replacement table, I used the following assertion function taken from [here](https://github.com/systemd/systemd/blob/ad16158c10dfc3258831a9ff2f1a988214f51653/src/basic/unit-name.c#L19)

```
isValidUnitName = name: (builtins.match "[a-zA-Z0-9:_.\\-]+" name) == [];
```

Something like this would allow to check if a user gives input that is incorrectly escaped and return with a proper error message saying that the escaping function has to be improved, but I have no idea how to validate that globally and with an acceptable performance.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers
Could not find a maintainer, so
cc @wkennington as the last one who touched that part.
