### PR TITLE
python3Minimal: Add top-level for a minimal Python 3 build 

### DIFF
--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -22,6 +22,7 @@
 , passthruFun
 , bash
 , stripIdlelib ? false
+, stripTests ? false
 }:
 
 assert x11Support -> tcl != null
@@ -226,6 +227,9 @@ in with passthru; stdenv.mkDerivation {
     '' + optionalString stripIdlelib ''
     # Strip IDLE (and turtledemo, which uses it)
     rm -R $out/bin/idle* $out/lib/python*/{idlelib,turtledemo}
+    '' + optionalString stripTests ''
+    # Strip tests
+    rm -R $out/lib/python*/test $out/lib/python*/**/test{,s}
     '' + ''
     # Include a sitecustomize.py file
     cp ${../sitecustomize.py} $out/${sitePackages}/sitecustomize.py

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -24,6 +24,7 @@
 , stripConfig ? false
 , stripIdlelib ? false
 , stripTests ? false
+, stripTkinter ? false
 , rebuildBytecode ? true
 , stripBytecode ? false
 }:
@@ -232,6 +233,8 @@ in with passthru; stdenv.mkDerivation {
     '' + optionalString stripIdlelib ''
     # Strip IDLE (and turtledemo, which uses it)
     rm -R $out/bin/idle* $out/lib/python*/{idlelib,turtledemo}
+    '' + optionalString stripTkinter ''
+    rm -R $out/lib/python*/tkinter
     '' + optionalString stripTests ''
     # Strip tests
     rm -R $out/lib/python*/test $out/lib/python*/**/test{,s}

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -24,6 +24,7 @@
 , stripConfig ? false
 , stripIdlelib ? false
 , stripTests ? false
+, rebuildBytecode ? true
 }:
 
 assert x11Support -> tcl != null
@@ -236,6 +237,7 @@ in with passthru; stdenv.mkDerivation {
     '' + ''
     # Include a sitecustomize.py file
     cp ${../sitecustomize.py} $out/${sitePackages}/sitecustomize.py
+    '' + optionalString rebuildBytecode ''
 
     # Determinism: rebuild all bytecode
     # We exclude lib2to3 because that's Python 2 code which fails

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -134,6 +134,7 @@ in with passthru; stdenv.mkDerivation {
     "--without-ensurepip"
     "--with-system-expat"
     "--with-system-ffi"
+  ] ++ optionals (openssl != null) [
     "--with-openssl=${openssl.dev}"
   ] ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "ac_cv_buggy_getaddrinfo=no"
@@ -241,9 +242,9 @@ in with passthru; stdenv.mkDerivation {
 
   # Enforce that we don't have references to the OpenSSL -dev package, which we
   # explicitly specify in our configure flags above.
-  disallowedReferences = [
-    openssl.dev
-  ] ++ stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  disallowedReferences =
+    stdenv.lib.optionals (openssl != null) [ openssl.dev ]
+    ++ stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     # Ensure we don't have references to build-time packages.
     # These typically end up in shebangs.
     pythonForBuild buildPackages.bash

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -21,6 +21,7 @@
 , sha256
 , passthruFun
 , bash
+, stripConfig ? false
 , stripIdlelib ? false
 , stripTests ? false
 }:
@@ -224,6 +225,8 @@ in with passthru; stdenv.mkDerivation {
     find $out/lib/python*/config-* -type f -print -exec nuke-refs -e $out '{}' +
     find $out/lib -name '_sysconfigdata*.py*' -print -exec nuke-refs -e $out '{}' +
 
+    '' + optionalString stripConfig ''
+    rm -R $out/bin/python*-config $out/lib/python*/config-*
     '' + optionalString stripIdlelib ''
     # Strip IDLE (and turtledemo, which uses it)
     rm -R $out/bin/idle* $out/lib/python*/{idlelib,turtledemo}

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -25,6 +25,7 @@
 , stripIdlelib ? false
 , stripTests ? false
 , rebuildBytecode ? true
+, stripBytecode ? false
 }:
 
 assert x11Support -> tcl != null
@@ -247,6 +248,8 @@ in with passthru; stdenv.mkDerivation {
     find $out -name "*.py" | ${pythonForBuildInterpreter}     -m compileall -q -f -x "lib2to3" -i -
     find $out -name "*.py" | ${pythonForBuildInterpreter} -O  -m compileall -q -f -x "lib2to3" -i -
     find $out -name "*.py" | ${pythonForBuildInterpreter} -OO -m compileall -q -f -x "lib2to3" -i -
+    '' + optionalString stripBytecode ''
+    find $out -type d -name __pycache__ -print0 | xargs -0 -I {} rm -rf "{}"
   '';
 
   preFixup = stdenv.lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -21,6 +21,7 @@
 , sha256
 , passthruFun
 , bash
+, stripIdlelib ? false
 }:
 
 assert x11Support -> tcl != null
@@ -222,6 +223,10 @@ in with passthru; stdenv.mkDerivation {
     find $out/lib/python*/config-* -type f -print -exec nuke-refs -e $out '{}' +
     find $out/lib -name '_sysconfigdata*.py*' -print -exec nuke-refs -e $out '{}' +
 
+    '' + optionalString stripIdlelib ''
+    # Strip IDLE (and turtledemo, which uses it)
+    rm -R $out/bin/idle* $out/lib/python*/{idlelib,turtledemo}
+    '' + ''
     # Include a sitecustomize.py file
     cp ${../sitecustomize.py} $out/${sitePackages}/sitecustomize.py
 

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -111,6 +111,38 @@ in {
     inherit passthruFun;
   };
 
+  # Minimal versions of Python (built without optional dependencies)
+  python3Minimal = (callPackage ./cpython {
+    self = python3Minimal;
+    sourceVersion = {
+      major = "3";
+      minor = "7";
+      patch = "4";
+      suffix = "";
+    };
+    sha256 = "0gxiv5617zd7dnqm5k9r4q2188lk327nf9jznwq9j6b8p0s92ygv";
+    inherit (darwin) CF configd;
+    inherit passthruFun;
+
+    # strip down that python version as much as possible
+    openssl = null;
+    readline = null;
+    ncurses = null;
+    gdbm = null;
+    sqlite = null;
+    stripConfig = true;
+    stripIdlelib = true;
+    stripTests = true;
+    stripTkinter = true;
+    rebuildBytecode = false;
+    stripBytecode = true;
+  }).overrideAttrs(old: {
+    pname = "python3-minimal";
+    meta = old.meta // {
+      maintainers = [];
+    };
+  });
+
   pypy27 = callPackage ./pypy {
     self = pypy27;
     sourceVersion = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8754,7 +8754,7 @@ in
   python3Packages = python3.pkgs;
 
   pythonInterpreters = callPackage ./../development/interpreters/python {};
-  inherit (pythonInterpreters) python27 python35 python36 python37 python38 pypy27 pypy36;
+  inherit (pythonInterpreters) python27 python35 python36 python37 python38 python3Minimal pypy27 pypy36;
 
   # Python package sets.
   python27Packages = lib.hiPrioSet (recurseIntoAttrs python27.pkgs);


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
The regular `python3` closure is pretty big, especially for non-interactive scripts.

Before:
```
$  du -sch (nix-store -qR (nix-build '<nixpkgs>' --no-out-link -A python3)) | sort -h
56K	/nix/store/mppjwxsqh2jfzsy06zqwpwra1dcn66f2-libffi-3.2.1
80K	/nix/store/g8al6vdf21mgfi5774qx6r6cil1j7zr8-bzip2-1.0.6.0.1
132K	/nix/store/w3wqang215is14xqajycbxmd52b44qkw-zlib-1.2.11
260K	/nix/store/lflh9l7j6v456xvk4sq8ax51pycz5l21-expat-2.2.7
344K	/nix/store/ji9kpgmbddkv2l2szzjfqinhja2322k0-xz-5.2.4
392K	/nix/store/f00sh4p25dcg3ywcr2hzj0wyb01hgyrn-readline-6.3p08
696K	/nix/store/1g2vh6nqpx630fz7dbgwds11b6q70wxk-gdbm-1.18.1
1.2M	/nix/store/ph2lq28vn677rs9ibxcffwgyd8rb0w04-sqlite-3.28.0
1.3M	/nix/store/xfghy8ixrhz3kyy6p724iv3cxji088dx-bash-4.4-p23
3.6M	/nix/store/rngzs8bxnajzpwnkk4896gy9d5s525ic-openssl-1.0.2s
7.8M	/nix/store/2fxvx0vh4h6j6z09ihd2ifcpqsy7lw68-ncurses-6.1-20190112
29M	/nix/store/iykxb0bmfjmi7s53kfg6pjbfpd8jmza6-glibc-2.27
57M	/nix/store/w7gsq8v86hni4ynaqgwwlnlny115ylng-python3-3.7.4
101M	total
```

After:
```
$ du -sch (nix-store -qR (nix-build '<nixpkgs>' --no-out-link -A python3Minimal)) | sort -h
56K	/nix/store/mppjwxsqh2jfzsy06zqwpwra1dcn66f2-libffi-3.2.1
80K	/nix/store/g8al6vdf21mgfi5774qx6r6cil1j7zr8-bzip2-1.0.6.0.1
132K	/nix/store/w3wqang215is14xqajycbxmd52b44qkw-zlib-1.2.11
260K	/nix/store/lflh9l7j6v456xvk4sq8ax51pycz5l21-expat-2.2.7
344K	/nix/store/ji9kpgmbddkv2l2szzjfqinhja2322k0-xz-5.2.4
1.3M	/nix/store/xfghy8ixrhz3kyy6p724iv3cxji088dx-bash-4.4-p23
29M	/nix/store/iykxb0bmfjmi7s53kfg6pjbfpd8jmza6-glibc-2.27
56M	/nix/store/f3gzz8iqb4g07qxbcrg4sw14xpxindb4-python3-3.7.4
87M	total
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
