### PR TITLE
freetype: Remove unnecessary `--disable-static`.

### DIFF
--- a/pkgs/development/libraries/freetype/default.nix
+++ b/pkgs/development/libraries/freetype/default.nix
@@ -50,7 +50,7 @@ in stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  configureFlags = [ "--disable-static" "--bindir=$(dev)/bin" "--enable-freetype-config" ];
+  configureFlags = [ "--bindir=$(dev)/bin" "--enable-freetype-config" ];
 
   # native compiler to generate building tool
   CC_BUILD = "${buildPackages.stdenv.cc}/bin/cc";


### PR DESCRIPTION
###### Motivation for this change

The true-by-default `dontDisableStatic` already takes care of it.

Fixes freetype not being overridable to have static libs.

This is the most pressing one of the fixes in #66759 (which is for `staging`, this is for `master`), because man GUI apps require `freetype` so it's a big blocker for statically linking them when `dontDisableStatic` doesn't work due to the hardcode.

Found via https://github.com/nh2/static-haskell-nix/issues/47.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @ttuegel 

cc @matthewbauer @dtzWill @Ericson2314 
