### PR TITLE
qemu: 4.0.0 -> 4.1.0

### DIFF
--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -35,7 +35,7 @@ let
 in
 
 stdenv.mkDerivation rec {
-  version = "4.0.0";
+  version = "4.1.0";
   name = "qemu-"
     + stdenv.lib.optionalString xenSupport "xen-"
     + stdenv.lib.optionalString hostCpuOnly "host-cpu-only-"
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://wiki.qemu.org/download/qemu-${version}.tar.bz2";
-    sha256 = "085g6f75si8hbn94mnnjn1r7ysixn5bqj4bhqwvadj00fhzp2zvd";
+    sha256 = "1bpl6hwiw1jdxk4xmqp10qgki0dji0l2rzr10dyhyk8d85vxxw29";
   };
 
   nativeBuildInputs = [ python python.pkgs.sphinx pkgconfig flex bison ];
@@ -78,11 +78,6 @@ stdenv.mkDerivation rec {
     ./no-etc-install.patch
     ./fix-qemu-ga.patch
     ./9p-ignore-noatime.patch
-    (fetchpatch {
-      url = "https://git.qemu.org/?p=qemu.git;a=patch;h=d52680fc932efb8a2f334cc6993e705ed1e31e99";
-      name = "CVE-2019-12155.patch";
-      sha256 = "0h2q71mcz3gvlrbfkqcgla74jdg73hvzcrwr4max2ckpxx8x9207";
-    })
   ] ++ optional nixosTestRunner ./force-uid0-on-9p.patch
     ++ optionals stdenv.hostPlatform.isMusl [
     (fetchpatch {

--- a/pkgs/applications/virtualization/qemu/no-etc-install.patch
+++ b/pkgs/applications/virtualization/qemu/no-etc-install.patch
@@ -1,25 +1,13 @@
-From 98b3e5993bbdb0013b6cc1814e0ad9555290c3af Mon Sep 17 00:00:00 2001
-From: Will Dietz <w@wdtz.org>
-Date: Tue, 23 Apr 2019 21:31:45 -0500
-Subject: [PATCH] no install localstatedir
-
----
- Makefile | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
 diff --git a/Makefile b/Makefile
-index 04a0d45050..5dc82d0eb7 100644
+index 85862fb8..ed52c5ec 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -786,7 +786,7 @@ endif
+@@ -841,7 +841,7 @@ endif
  
  ICON_SIZES=16x16 24x24 32x32 48x48 64x64 128x128 256x256 512x512
  
--install: all $(if $(BUILD_DOCS),install-doc) install-datadir install-localstatedir
-+install: all $(if $(BUILD_DOCS),install-doc) install-datadir
+-install: all $(if $(BUILD_DOCS),install-doc) install-datadir install-localstatedir \
++install: all $(if $(BUILD_DOCS),install-doc) install-datadir \
+ 	$(if $(INSTALL_BLOBS),$(edk2-decompressed)) \
+ 	recurse-install
  ifneq ($(TOOLS),)
- 	$(call install-prog,$(subst qemu-ga,qemu-ga$(EXESUF),$(TOOLS)),$(DESTDIR)$(bindir))
- endif
--- 
-2.21.GIT
-


### PR DESCRIPTION
###### Motivation for this change
Update qemu to version 4.1.0
Changelog - https://wiki.qemu.org/ChangeLog/4.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
