### PR TITLE
pass-otp: 1.1.1 -> 1.2.0

### DIFF
--- a/pkgs/tools/security/pass/extensions/otp.nix
+++ b/pkgs/tools/security/pass/extensions/otp.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "pass-otp-${version}";
-  version = "1.1.1";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "tadfisher";
     repo = "pass-otp";
     rev = "v${version}";
-    sha256 = "0m8x5dqwcr9jim530685nsq4zn941hhl7ridmmd63b204z141rwa";
+    sha256 = "0cpqrf3939hcvwg7sd8055ghc8x964ilimlri16czzx188a9jx9v";
   };
 
   buildInputs = [ oathToolkit ];
@@ -19,13 +19,15 @@ stdenv.mkDerivation rec {
     sed -i -e 's|OATH=\$(which oathtool)|OATH=${oathToolkit}/bin/oathtool|' otp.bash
   '';
 
-  installFlags = [ "PREFIX=$(out)" ];
+  installFlags = [ "PREFIX=$(out)"
+                   "BASHCOMPDIR=$(out)/share/bash-completion/completions"
+                 ];
 
   meta = with stdenv.lib; {
     description = "A pass extension for managing one-time-password (OTP) tokens";
     homepage = https://github.com/tadfisher/pass-otp;
     license = licenses.gpl3;
-    maintainers = with maintainers; [ jwiegley tadfisher ];
+    maintainers = with maintainers; [ jwiegley tadfisher toonn ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
Had to specify `BASHCOMPDIR` in `$out` to keep things pure.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

`pass-otp` has been outdated since november 2018 apparently.

###### Things done

I bumped this because the build failed on my machine, a mac. It still fails so I haven't been able to test the changes. The previous version worked fine on another mac so I think the build failure is specific to my machine.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

EDIT: Managed to build it on another mac. And it generated an otp just fine.
P.s.: Should I add myself as a maintainer? If I'm using this anyway I don't mind keeping it up to date.