### PR TITLE
weechat-autojoin: init at 0.3.1; weechat-text-item: init at 0.9

### DIFF
--- a/pkgs/applications/networking/irc/weechat/scripts/autojoin/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/autojoin/default.nix
@@ -1,0 +1,18 @@
+{ lib, callPackage }:
+
+callPackage ../mk-weechat-script.nix {} {
+  pname = "autojoin";
+  version = "0.3.1";
+
+  filename = "autojoin.py";
+
+  repoRev = "e19ddd3558ac74f695bacf420a6efddc5e3c54bd";
+  repoSha256 = "044zciaf81bi4y69ayji34i9ncqbxk9drijsiz2qa8lxxmp7qqac";
+
+  meta = with lib; {
+    homepage = "https://weechat.org/scripts/source/autojoin.py.html/";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ bdesham ];
+    description = "A WeeChat script to automatically rejoin the current channels";
+  };
+}

--- a/pkgs/applications/networking/irc/weechat/scripts/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/default.nix
@@ -1,15 +1,15 @@
 { callPackage, luaPackages, python3Packages }:
 
 {
-  weechat-matrix-bridge = callPackage ./weechat-matrix-bridge {
-    inherit (luaPackages) cjson luaffi;
-  };
-
-  weechat-matrix = python3Packages.callPackage ./weechat-matrix { };
-
   wee-slack = callPackage ./wee-slack { };
 
   weechat-autosort = callPackage ./weechat-autosort { };
+
+  weechat-matrix = python3Packages.callPackage ./weechat-matrix { };
+
+  weechat-matrix-bridge = callPackage ./weechat-matrix-bridge {
+    inherit (luaPackages) cjson luaffi;
+  };
 
   weechat-otr = callPackage ./weechat-otr { };
 }

--- a/pkgs/applications/networking/irc/weechat/scripts/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/default.nix
@@ -1,6 +1,8 @@
 { callPackage, luaPackages, python3Packages }:
 
 {
+  autojoin = callPackage ./autojoin { };
+
   wee-slack = callPackage ./wee-slack { };
 
   weechat-autosort = callPackage ./weechat-autosort { };

--- a/pkgs/applications/networking/irc/weechat/scripts/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/default.nix
@@ -3,6 +3,8 @@
 {
   autojoin = callPackage ./autojoin { };
 
+  text-item = callPackage ./text-item { };
+
   wee-slack = callPackage ./wee-slack { };
 
   weechat-autosort = callPackage ./weechat-autosort { };

--- a/pkgs/applications/networking/irc/weechat/scripts/mk-weechat-script.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/mk-weechat-script.nix
@@ -1,0 +1,53 @@
+{ stdenv, fetchFromGitHub }:
+
+# This is a variant of mkDerivation to make derivations for the scripts on the
+# Weechat Scripts site (https://weechat.org/scripts/). These scripts are stored
+# in a Git repository at https://github.com/weechat/scripts. To build a script,
+# this function downloads a particular revision of that repository and extracts
+# a particular file. (All of the scripts on that site are interpreted, so no
+# build phase is needed.)
+
+# The name of the derivation to be produced.
+{ pname
+# The version of the derivation.
+, version
+# The filename (including extension) of the script.
+, filename
+# The subfolder within the Git repo in which this script can be found. This
+# value can be inferred from the value of "filename"; it shouldn't be necessary
+# to set it explicitly.
+, subfolder ? if stdenv.lib.strings.hasSuffix ".scm" filename then "guile"
+         else if stdenv.lib.strings.hasSuffix ".js"  filename then "javascript"
+         else if stdenv.lib.strings.hasSuffix ".lua" filename then "lua"
+         else if stdenv.lib.strings.hasSuffix ".pl"  filename then "perl"
+         else if stdenv.lib.strings.hasSuffix ".py"  filename then "python"
+         else if stdenv.lib.strings.hasSuffix ".tcl" filename then "tcl"
+         else throw "The value of the \"filename\" attribute has an unrecognized suffix"
+# The revision of the scripts repo.
+, repoRev
+# The checksum of this revision of the repo.
+, repoSha256
+# The usual derivation metadata (description, license, etc.).
+, meta
+} @ attrs:
+
+stdenv.mkDerivation rec {
+  inherit (pname version meta);
+
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "weechat";
+    repo = "scripts";
+    rev = repoRev;
+    sha256 = repoSha256;
+  };
+
+  passthru.scripts = [ filename ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    install -D -m 0644 ${subfolder}/${filename} $out/share/${filename}
+  '';
+}

--- a/pkgs/applications/networking/irc/weechat/scripts/text-item/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/text-item/default.nix
@@ -1,0 +1,18 @@
+{ lib, callPackage }:
+
+callPackage ../mk-weechat-script.nix {} {
+  pname = "text-item";
+  version = "0.9";
+
+  filename = "text_item.py";
+
+  repoRev = "5a87f03a37764cb1d87ab09463b4986cb1b82d8b";
+  repoSha256 = "1yqbf59q8fxd44v5hv519si4kr3y3hhd5nvrsay7ljfjqm0rpwp4";
+
+  meta = with lib; {
+    homepage = "https://weechat.org/scripts/source/text_item.py.html/";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ bdesham ];
+    description = "A WeeChat script to add plain-text bar items";
+  };
+}


### PR DESCRIPTION
#### Motivation for this change

Adds two scripts to be used with the Weechat chat client:

- weechat-autojoin: When quitting Weechat, automatically saves the list of current IRC channels so that they can be joined next time Weechat is launched.
- weechat-text-item: Allows pieces of static text to be included in Weechat’s various status bars.

~~These scripts come from the Weechat scripts site, which doesn’t seem to offer a way to download a specific version of a script—only the latest version. Therefore, I included the two scripts directly within Nixpkgs. They’re 6,703 bytes and 10,764 bytes. If anyone knows of a way to get specific versions from the Weechat site that would obviously be preferable. (The text_item script says that development is hosted at https://github.com/weechatter/weechat-scripts, but the Weechat site has a more recent version of the script than that repo does.)~~ This problem is now fixed; the derivations just use `fetchFromGitHub` like you’d expect.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @lovek323 @the-kenny @lheckemann @Ma27 (the maintainers of Weechat itself)