### PR TITLE
nbstripout: moving buildInputs to checkInputs

### DIFF
--- a/pkgs/applications/version-management/nbstripout/default.nix
+++ b/pkgs/applications/version-management/nbstripout/default.nix
@@ -9,7 +9,8 @@ buildPythonApplication rec {
   # Mercurial should be added as a build input but because it's a Python
   # application, it would mess up the Python environment. Thus, don't add it
   # here, instead add it to PATH when running unit tests
-  buildInputs = [ pytest pytest-flake8 pytest-cram git pytestrunner ];
+  checkInputs = [ pytest pytest-flake8 pytest-cram git ];
+  nativeBuildInputs = [ pytestrunner ];
   propagatedBuildInputs = [ ipython nbformat ];
 
   # PyPI source is currently missing tests. Thus, use GitHub instead.


### PR DESCRIPTION
###### Motivation for this change

Fixes https://hydra.nixos.org/build/98602011

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @jluttine 
