### PR TITLE
mumble_overlay: fixing the library path

### DIFF
--- a/pkgs/applications/networking/mumble/overlay.nix
+++ b/pkgs/applications/networking/mumble/overlay.nix
@@ -12,10 +12,10 @@ in stdenv.mkDerivation {
 
   installPhase = ''
     mkdir -p $out/lib
-    ln -s ${mumble}/lib/libmumble.so.1.* $out/lib/libmumble.so.1
+    ln -s ${mumble}/lib/libmumble.so.1.2.* $out/lib/libmumble.so.1
     ${lib.optionalString (mumble_i686 != null) ''
       mkdir -p $out/lib32
-      ln -s ${mumble_i686}/lib/libmumble.so.1.* $out/lib32/libmumble.so.1
+      ln -s ${mumble_i686}/lib/libmumble.so.1.2.* $out/lib32/libmumble.so.1
     ''}
     install -Dm755 scripts/mumble-overlay $out/bin/mumble-overlay
     sed -i "s,/usr/lib,$out/lib,g" $out/bin/mumble-overlay


### PR DESCRIPTION
###### Motivation for this change

Fixes https://hydra.nixos.org/build/98761160

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
