### PR TITLE
anki: use wrapQtAppsHook to fix execution

### DIFF
--- a/pkgs/development/python-modules/pyqtwebengine/default.nix
+++ b/pkgs/development/python-modules/pyqtwebengine/default.nix
@@ -1,5 +1,6 @@
 { lib, fetchurl, pythonPackages, pkgconfig
 , qmake, qtbase, qtsvg, qtwebengine
+, wrapQtAppsHook
 }:
 
 let
@@ -77,8 +78,11 @@ in buildPythonPackage rec {
 
   doCheck = true;
 
-
   enableParallelBuilding = true;
+
+  passthru = {
+    inherit wrapQtAppsHook;
+  };
 
   meta = with lib; {
     description = "Python bindings for Qt5";

--- a/pkgs/games/anki/default.nix
+++ b/pkgs/games/anki/default.nix
@@ -191,6 +191,6 @@ buildPythonApplication rec {
       license = licenses.agpl3Plus;
       broken = stdenv.hostPlatform.isAarch64;
       platforms = platforms.mesaPlatforms;
-      maintainers = with maintainers; [ the-kenny Profpatsch enzime ];
+      maintainers = with maintainers; [ oxij the-kenny Profpatsch enzime ];
     };
 }

--- a/pkgs/games/anki/default.nix
+++ b/pkgs/games/anki/default.nix
@@ -95,10 +95,6 @@ buildPythonApplication rec {
     nativeBuildInputs = [ pyqtwebengine.wrapQtAppsHook ];
     buildInputs = [ lame mplayer libpulseaudio  ];
 
-    makeWrapperArgs = [
-        ''--prefix PATH ':' "${lame}/bin:${mplayer}/bin"''
-    ];
-
     patches = [
       # Disable updated version check.
       ./no-version-check.patch
@@ -132,8 +128,6 @@ buildPythonApplication rec {
       env HOME=$TMP pytest --ignore tests/test_sync.py
     '';
 
-    dontWrapQtApps = true;
-
     installPhase = ''
       pp=$out/lib/${python.libPrefix}/site-packages
 
@@ -160,14 +154,17 @@ buildPythonApplication rec {
       cp -rv locale $out/share/
       cp -rv anki aqt web $pp/
 
-      wrapPythonPrograms
-      for program in $out/bin/*; do
-        wrapQtApp "$program"
-      done
-
       # copy the manual into $doc
       cp -r ${manual}/share/doc/anki/html $doc/share/doc/anki
     '';
+
+    dontWrapQtApps = true;
+    makeWrapperArgs = [
+        ''--prefix PATH ':' "${lame}/bin:${mplayer}/bin"''
+        "\${qtWrapperArgs[@]}"
+    ];
+
+    # now wrapPythonPrograms from postFixup will add both python and qt env variables
 
     passthru = {
       inherit manual;

--- a/pkgs/games/anki/default.nix
+++ b/pkgs/games/anki/default.nix
@@ -92,6 +92,7 @@ buildPythonApplication rec {
 
     checkInputs = [ pytest glibcLocales nose ];
 
+    nativeBuildInputs = [ pyqtwebengine.wrapQtAppsHook ];
     buildInputs = [ lame mplayer libpulseaudio  ];
 
     makeWrapperArgs = [
@@ -131,6 +132,8 @@ buildPythonApplication rec {
       env HOME=$TMP pytest --ignore tests/test_sync.py
     '';
 
+    dontWrapQtApps = true;
+
     installPhase = ''
       pp=$out/lib/${python.libPrefix}/site-packages
 
@@ -158,6 +161,9 @@ buildPythonApplication rec {
       cp -rv anki aqt web $pp/
 
       wrapPythonPrograms
+      for program in $out/bin/*; do
+        wrapQtApp "$program"
+      done
 
       # copy the manual into $doc
       cp -r ${manual}/share/doc/anki/html $doc/share/doc/anki
@@ -167,7 +173,7 @@ buildPythonApplication rec {
       inherit manual;
     };
 
-    meta = with stdenv.lib; {
+    meta = with lib; {
       homepage = "https://apps.ankiweb.net/";
       description = "Spaced repetition flashcard program";
       longDescription = ''


### PR DESCRIPTION
# What?

At the moment running `anki` fails with

```
qt: Could not find the Qt platform plugin "xcb" in ""
qt: This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
```

This PR fixes it, properly, by inheriting the hook from the `pyqtwebengine` so that QT versions match.

# Why?

The use of `wrapQtAppsHook` is now required for Qt apps. See #65399 for more info.

# `git log`

- pyqtwebengine: passthru wrapQtAppsHook

- anki: use wrapQtAppsHook from pyqtwebengine

- anki: add myself as a maintainer

  (Adding to the front of the list because it was I who added this expression to
  nixpkgs in e00c03101f8d052473fee17e5f7a6a975dc5edb4 7 years ago. :])

# `nix-instantiate` environment

- Host OS: Linux 4.9, SLNOS 19.09
- Nix: nix-env (Nix) 2.2.2
- Multi-user: yes
- Sandbox: yes
- NIXPKGS_CONFIG:

```nix
{
  checkMeta = true;
  doCheckByDefault = true;
}
```

# `nix-env -qaP` diffs

- On x86_64-linux:
  - Updated (1):
    - anki
- On aarch64-linux: noop
- On x86_64-darwin:
  - Updated (1):
    - anki

/cc @Profpatsch @asymmetric @ttuegel