### PR TITLE
docui: 1.0.3 -> 2.0.0

### DIFF
--- a/pkgs/tools/misc/docui/default.nix
+++ b/pkgs/tools/misc/docui/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   name = "docui-${version}";
-  version = "1.0.3";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "skanehira";
     repo = "docui";
     rev = version;
-    sha256 = "1kbap36hccwlj273is98cvgf5z5cl2c3s6p46nh6bnykz3zqzs71";
+    sha256 = "0rizl4rxmb3brzvqxw5llbgvq3rncix3h60pgq50djdf0jjnn5hs";
   };
 
-  modSha256 = "1qma9bnd4k594cr5dcv74xns53mhfyl4jsm01chf85dxywjjd9vd";
+  modSha256 = "0asqz9nnx80g2wi7dzxrfmppcraywrwdqi9vzr66vaihwpfpfnwz";
 
   meta = with stdenv.lib; {
     description = "TUI Client for Docker";

--- a/pkgs/tools/misc/docui/default.nix
+++ b/pkgs/tools/misc/docui/default.nix
@@ -18,5 +18,6 @@ buildGoModule rec {
     homepage = https://github.com/skanehira/docui;
     license = licenses.mit;
     platforms = platforms.linux ++ platforms.darwin;
+    maintainers = with maintainers; [ aethelz ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

https://github.com/skanehira/docui/releases/tag/2.0.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @