### PR TITLE
parity: 2.5.5 -> 2.5.6, parity-beta: 2.6.0 -> 2.6.1

### DIFF
--- a/pkgs/applications/altcoins/parity/beta.nix
+++ b/pkgs/applications/altcoins/parity/beta.nix
@@ -1,6 +1,6 @@
 let
-  version     = "2.6.0";
-  sha256      = "1v0wc6l09nr42ljlq5lq1dgignm53hq3pmrgp2sld9zfxy3vdy0x";
-  cargoSha256 = "1bkcvziz0diy76nbcgykajpnp6akva0m7ka7q6w3s9k7awxjxkx3";
+  version     = "2.6.1";
+  sha256      = "0yvscs2ivy08zla3jhirxhwwaqsn9j5ml4sqbgx6h5rh19c941vh";
+  cargoSha256 = "1s3c44cggajrmc504klf4cyb1s4l5ny48yihs9c3fc0n8d064017";
 in
   import ./parity.nix { inherit version sha256 cargoSha256; }

--- a/pkgs/applications/altcoins/parity/default.nix
+++ b/pkgs/applications/altcoins/parity/default.nix
@@ -1,6 +1,6 @@
 let
-  version     = "2.5.5";
-  sha256      = "193fnrf1pr67wblyxd5gbrg1rgflphnfaxgm3kb4iawjh18br6c6";
-  cargoSha256 = "1w9p43v76igb62mbjk2rl7fynk13l4hpz25jd4f4hk5b2y2wf3r7";
+  version     = "2.5.6";
+  sha256      = "1qkrqkkgjvm27babd6bidhf1n6vdp8rac1zy5kf61nfzplxzr2dy";
+  cargoSha256 = "0aa0nkv3jr7cdzswbxghxxv0y65a59jgs1682ch8vrasi0x17m1x";
 in
   import ./parity.nix { inherit version sha256 cargoSha256; }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update `parity` and `parity-beta` to the latest releases.

- https://github.com/paritytech/parity-ethereum/releases/tag/v2.5.6
- https://github.com/paritytech/parity-ethereum/releases/tag/v2.6.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @akru 
