### PR TITLE
emacs-packages: Make elpa & org package sets overrideable

### DIFF
--- a/pkgs/applications/editors/emacs-modes/elpa-generated.nix
+++ b/pkgs/applications/editors/emacs-modes/elpa-generated.nix
@@ -30,21 +30,21 @@
           license = lib.licenses.free;
         };
       }) {};
-    ada-mode = callPackage ({ cl-lib ? null
-                            , elpaBuild
+    ada-mode = callPackage ({ elpaBuild
                             , emacs
                             , fetchurl
                             , lib
+                            , uniquify-files
                             , wisi }:
       elpaBuild {
         pname = "ada-mode";
         ename = "ada-mode";
-        version = "6.1.1";
+        version = "6.2.1";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/ada-mode-6.1.1.tar";
-          sha256 = "090zyspc32fmfqwr0qpzi6qclsaarvb5484b0lq0cdyzgjhimdla";
+          url = "https://elpa.gnu.org/packages/ada-mode-6.2.1.tar";
+          sha256 = "0lg2y28qs8ls70d43ikhy5zcwadh5ddfw4k59p7sqb79w0y3lbnq";
         };
-        packageRequires = [ cl-lib emacs wisi ];
+        packageRequires = [ emacs uniquify-files wisi ];
         meta = {
           homepage = "https://elpa.gnu.org/packages/ada-mode.html";
           license = lib.licenses.free;
@@ -930,10 +930,10 @@
       elpaBuild {
         pname = "ebdb";
         ename = "ebdb";
-        version = "0.6.10";
+        version = "0.6.11";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/ebdb-0.6.10.tar";
-          sha256 = "0z0q7kcwczvdh0ddd775vv233j74sjlllv8pjm446bmy9cy6pg8j";
+          url = "https://elpa.gnu.org/packages/ebdb-0.6.11.tar";
+          sha256 = "1ljcp4vy8z5xbcrlf33xgi63a2px4fhx6928qhwr7sy7jwil2s6n";
         };
         packageRequires = [ cl-lib emacs seq ];
         meta = {
@@ -960,10 +960,10 @@
       elpaBuild {
         pname = "ebdb-i18n-chn";
         ename = "ebdb-i18n-chn";
-        version = "1.2";
+        version = "1.3";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/ebdb-i18n-chn-1.2.el";
-          sha256 = "1qgrlk625mhfd6n1mc0kqfzbisnb61kx3vrrl3bzlz4viq3kcc10";
+          url = "https://elpa.gnu.org/packages/ebdb-i18n-chn-1.3.el";
+          sha256 = "1w7xgagscyjxrw4xl8bz6wf7skvdvk5qdcp5p7kxl4r9nhjffj20";
         };
         packageRequires = [ ebdb pyim ];
         meta = {
@@ -1297,10 +1297,10 @@
       elpaBuild {
         pname = "gited";
         ename = "gited";
-        version = "0.5.3";
+        version = "0.5.4";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/gited-0.5.3.tar";
-          sha256 = "1bayfclczdzrmay8swszs8lliz5p4nnmjzzz2gh68rc16isjgh2z";
+          url = "https://elpa.gnu.org/packages/gited-0.5.4.tar";
+          sha256 = "07ckknggkqd733bnps21r46bacgyhd0v9wc0spid22hn0dnrfp12";
         };
         packageRequires = [ cl-lib emacs ];
         meta = {
@@ -2415,10 +2415,10 @@
       elpaBuild {
         pname = "phps-mode";
         ename = "phps-mode";
-        version = "0.2.3";
+        version = "0.2.4";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/phps-mode-0.2.3.tar";
-          sha256 = "1wp04d5mi97287qwhic239kkf4r69839gl0hsn5m8qr3dbkhqxy5";
+          url = "https://elpa.gnu.org/packages/phps-mode-0.2.4.tar";
+          sha256 = "0n6gj22w0llns3kx5hd69imhlrnlxx74zvhz7qikfx60669c5n20";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -2755,10 +2755,10 @@
       elpaBuild {
         pname = "relint";
         ename = "relint";
-        version = "1.9";
+        version = "1.10";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/relint-1.9.el";
-          sha256 = "0y386kch263199mwl93ambwib948s2vrw466kf0ly9cxv7xpv6hr";
+          url = "https://elpa.gnu.org/packages/relint-1.10.el";
+          sha256 = "1l0lh4pkksw7brmhhbaikwzs4zkgd2962ks1zy7m262dvkhxjfv8";
         };
         packageRequires = [ xr ];
         meta = {
@@ -3271,10 +3271,10 @@
       elpaBuild {
         pname = "uniquify-files";
         ename = "uniquify-files";
-        version = "1.0";
+        version = "1.0.1";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/uniquify-files-1.0.tar";
-          sha256 = "1n1r3pmnh9b8zb7pyv158pzmvha4gqqrfrapvpjdcrcnnd2dynkm";
+          url = "https://elpa.gnu.org/packages/uniquify-files-1.0.1.tar";
+          sha256 = "0c4lf25503z71wz9f0v6ag5lmqfxz94lmq65xvzvhmqvkxvsgpm5";
         };
         packageRequires = [ emacs ];
         meta = {
@@ -3551,18 +3551,38 @@
           license = lib.licenses.free;
         };
       }) {};
-    wisi = callPackage ({ cl-lib ? null, elpaBuild, emacs, fetchurl, lib, seq }:
+    wisi = callPackage ({ elpaBuild, emacs, fetchurl, lib, seq }:
       elpaBuild {
         pname = "wisi";
         ename = "wisi";
-        version = "2.1.1";
+        version = "2.2.1";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/wisi-2.1.1.tar";
-          sha256 = "0j7pnjik07j2ipj3xavhayngnmk5jdglq78azrjvwni88m12920n";
+          url = "https://elpa.gnu.org/packages/wisi-2.2.1.tar";
+          sha256 = "1qvhx8bpms7gri7y6wniwqd6nmqxj4lip5l3sphbq2kjf4zq4qd4";
         };
-        packageRequires = [ cl-lib emacs seq ];
+        packageRequires = [ emacs seq ];
         meta = {
           homepage = "https://elpa.gnu.org/packages/wisi.html";
+          license = lib.licenses.free;
+        };
+      }) {};
+    wisitoken-grammar-mode = callPackage ({ elpaBuild
+                                          , emacs
+                                          , fetchurl
+                                          , lib
+                                          , mmm-mode
+                                          , wisi }:
+      elpaBuild {
+        pname = "wisitoken-grammar-mode";
+        ename = "wisitoken-grammar-mode";
+        version = "1.0.2";
+        src = fetchurl {
+          url = "https://elpa.gnu.org/packages/wisitoken-grammar-mode-1.0.2.tar";
+          sha256 = "09rpjl3z6xzap0lbrjs9hf2nspwc5avvx75ah3aimgvizrf2kyp0";
+        };
+        packageRequires = [ emacs mmm-mode wisi ];
+        meta = {
+          homepage = "https://elpa.gnu.org/packages/wisitoken-grammar-mode.html";
           license = lib.licenses.free;
         };
       }) {};

--- a/pkgs/applications/editors/emacs-modes/elpa-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/elpa-packages.nix
@@ -4,11 +4,9 @@
 
 To update the list of packages from MELPA,
 
-1. Clone https://github.com/ttuegel/emacs2nix.
-2. Run `./elpa-packages.sh` from emacs2nix.
-3. Copy the new `elpa-generated.nix` file into Nixpkgs.
-4. Check for evaluation errors: `nix-instantiate ./. -A emacsPackagesNg.elpaPackages`.
-5. `git add pkgs/applications/editors/emacs-modes/elpa-generated.nix && git commit -m "elpa-packages $(date -Idate)"`
+1. Run `./update-elpa`.
+2. Check for evaluation errors: `nix-instantiate ../../../.. -A emacsPackagesNg.elpaPackages`.
+3. `git commit -m "elpa-packages $(date -Idate) -- elpa-generated.nix"`
 
 */
 

--- a/pkgs/applications/editors/emacs-modes/emacs2nix.nix
+++ b/pkgs/applications/editors/emacs-modes/emacs2nix.nix
@@ -1,0 +1,23 @@
+let
+  pkgs = import ../../../.. { };
+
+  src = pkgs.fetchgit {
+    url = "https://github.com/ttuegel/emacs2nix.git";
+    fetchSubmodules = true;
+    rev = "752fe1bd891425cb7a4a53cd7b98c194c1fe4518";
+    sha256 = "0asfdswh8sbnapbqhbz539zzxmv72f1iviha95iys34sgnd5k1nk";
+  };
+
+in pkgs.mkShell {
+
+  buildInputs = [
+    pkgs.bash
+  ];
+
+  EMACS2NIX = "${src}";
+
+  shellHook = ''
+    export PATH=$PATH:${src}
+  '';
+
+}

--- a/pkgs/applications/editors/emacs-modes/org-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/org-packages.nix
@@ -2,22 +2,23 @@
 
 # Updating
 
-To update the list of packages from ELPA,
+To update the list of packages from Org (ELPA),
 
-1. Clone https://github.com/ttuegel/emacs2nix
-2. Run `./org-packages.sh` from emacs2nix
-3. Copy the new org-packages.json file into Nixpkgs
-4. `git commit -m "org-packages $(date -Idate)"`
+1. Run `./update-org`.
+2. Check for evaluation errors: `nix-instantiate ../../../.. -A emacsPackagesNg.orgPackages`.
+3. `git commit -m "org-packages $(date -Idate)" -- org-generated.nix`
 
 */
 
-{ }:
+{ lib }:
 
-self:
+self: let
 
-  let
+  generateOrg = lib.makeOverridable ({
+    generated ? ./org-generated.nix
+  }: let
 
-    imported = import ./org-generated.nix {
+    imported = import generated {
       inherit (self) callPackage;
     };
 
@@ -26,6 +27,6 @@ self:
     overrides = {
     };
 
-    orgPackages = super // overrides;
+  in super // overrides);
 
-  in orgPackages
+in generateOrg { }

--- a/pkgs/applications/editors/emacs-modes/update-elpa
+++ b/pkgs/applications/editors/emacs-modes/update-elpa
@@ -1,0 +1,4 @@
+#! /usr/bin/env nix-shell
+#! nix-shell --show-trace ./emacs2nix.nix -i bash
+
+exec elpa-packages.sh --names $EMACS2NIX/names.nix -o elpa-generated.nix

--- a/pkgs/applications/editors/emacs-modes/update-org
+++ b/pkgs/applications/editors/emacs-modes/update-org
@@ -1,0 +1,4 @@
+#! /usr/bin/env nix-shell
+#! nix-shell --show-trace ./emacs2nix.nix -i bash
+
+exec org-packages.sh --names $EMACS2NIX/names.nix -o org-generated.nix

--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -55,7 +55,9 @@ let
   mkMelpaStablePackages = melpaGeneric "stable";
   mkMelpaPackages = melpaGeneric "unstable";
 
-  mkOrgPackages = import ../applications/editors/emacs-modes/org-packages.nix { };
+  mkOrgPackages = import ../applications/editors/emacs-modes/org-packages.nix {
+    inherit lib;
+  };
 
   emacsWithPackages = import ../build-support/emacs/wrapper.nix {
     inherit lib lndir makeWrapper stdenv runCommand;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
This is a follow up to https://github.com/NixOS/nixpkgs/pull/65874 implementing the same override mechanism for the rest of the emacs package sets.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
