### PR TITLE
nixosTests.systemd: remove duplicate copypasta

### DIFF
--- a/nixos/tests/systemd.nix
+++ b/nixos/tests/systemd.nix
@@ -78,15 +78,6 @@ import ./make-test.nix ({ pkgs, ... }: {
       $machine->fail('dumpe2fs /dev/vdb | grep -q "^Last mount time: *n/a"');
     };
 
-    # Regression test for https://github.com/NixOS/nixpkgs/issues/35268
-    subtest "file system with x-initrd.mount is not unmounted", sub {
-      $machine->shutdown;
-      $machine->waitForUnit('multi-user.target');
-      # If the file system was unmounted during the shutdown the file system
-      # has a last mount time, because the file system wasn't checked.
-      $machine->fail('dumpe2fs /dev/vdb | grep -q "^Last mount time: *n/a"');
-    };
-
     subtest "systemd-shutdown works", sub {
       $machine->shutdown;
       $machine->waitForUnit('multi-user.target');


### PR DESCRIPTION
It seems the regression test for #35268 sneaked in twice.
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @abbradar 
