### PR TITLE
tclreadline: init at 2.3.8

### DIFF
--- a/pkgs/development/interpreters/tclreadline/default.nix
+++ b/pkgs/development/interpreters/tclreadline/default.nix
@@ -1,0 +1,68 @@
+{ stdenv
+, fetchFromGitHub
+, automake
+, autoconf
+, libtool
+, readline
+, tcl
+, tk
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tclreadline";
+  version = "2.3.8";
+
+  src = fetchFromGitHub {
+    owner = "flightaware";
+    repo = "tclreadline";
+    rev = "v${version}";
+    sha256 = "18jl56p0hwgynxpvr0v7b5mvvzc1m64fn61c0957bgb45mc250yq";
+  };
+
+  nativeBuildInputs = [
+    automake
+    autoconf
+    libtool
+  ];
+  buildInputs = [
+    readline
+    tcl
+    tk
+  ];
+
+  preConfigure = "NOCONFIGURE=1 ./autogen.sh";
+
+  configureFlags = [
+    "--enable-tclshrl"
+    "--enable-wishrl"
+    "--with-tcl=${tcl}/lib"
+    "--with-tk=${tk}/lib"
+    "--with-readline-includes=${readline.dev}/include/readline"
+    "--with-libtool=${libtool}"
+  ];
+
+  # The provided makefile leaves a wrong reference to /build/ in RPATH,
+  # so we fix it after checking that everything is also present in $out
+  preFixup = stdenv.lib.optionalString stdenv.isLinux ''
+    needed_libraries=$(ls .libs | grep '\.\(so\|la\)$')
+    for lib in $needed_libraries; do
+      if ! ls $out/lib | grep "$lib"; then
+        echo "$lib was not installed correctly"
+        exit 1
+      fi
+    done
+    for executable in $out/bin/{wishrl,tclshrl}; do
+      patchelf --set-rpath \
+        "$(patchelf --print-rpath "$executable" | sed "s@$builddir/.libs@$out/lib@")" \
+        "$executable"
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "GNU readline for interactive tcl shells";
+    homepage = "https://github.com/flightaware/tclreadline";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ fgaz ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10760,6 +10760,8 @@ in
   tcl-8_5 = callPackage ../development/interpreters/tcl/8.5.nix { };
   tcl-8_6 = callPackage ../development/interpreters/tcl/8.6.nix { };
 
+  tclreadline = callPackage ../development/interpreters/tclreadline { };
+
   wasm = ocamlPackages.wasm;
 
   proglodyte-wasm = callPackage ../development/interpreters/proglodyte-wasm { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

tcl is nice

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
