### PR TITLE
nftables: 0.9.0 -> 0.9.1

### DIFF
--- a/pkgs/os-specific/linux/nftables/default.nix
+++ b/pkgs/os-specific/linux/nftables/default.nix
@@ -1,28 +1,35 @@
-{ stdenv, fetchurl, pkgconfig, docbook2x, docbook_xml_dtd_45
-, flex, bison, libmnl, libnftnl, gmp, readline }:
+{ stdenv, fetchurl, pkgconfig, bison, flex
+, libmnl, libnftnl, libpcap
+, gmp, jansson, readline
+, withXtables ? false , iptables
+}:
+
+with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  version = "0.9.0";
+  version = "0.9.1";
   name = "nftables-${version}";
 
   src = fetchurl {
     url = "https://netfilter.org/projects/nftables/files/${name}.tar.bz2";
-    sha256 = "14bygs6vg2v448cw5r4pxqi8an29hw0m9vab8hpmgjmrzjsq30dd";
+    sha256 = "1kjg3dykf2aw76d76viz1hm0rav57nfbdwlngawgn2slxmlbplza";
   };
 
   configureFlags = [
-    "CONFIG_MAN=y"
-    "DB2MAN=docbook2man"
-  ];
+    "--disable-man-doc"
+    "--with-json"
+  ] ++ optional withXtables "--with-xtables";
 
-  XML_CATALOG_FILES = "${docbook_xml_dtd_45}/xml/dtd/docbook/catalog.xml";
+  nativeBuildInputs = [ pkgconfig bison flex ];
 
-  nativeBuildInputs = [ pkgconfig docbook2x flex bison ];
-  buildInputs = [ libmnl libnftnl gmp readline ];
+  buildInputs = [
+    libmnl libnftnl libpcap
+    gmp readline jansson
+  ] ++ optional withXtables iptables;
 
-  meta = with stdenv.lib; {
+  meta = {
     description = "The project that aims to replace the existing {ip,ip6,arp,eb}tables framework";
-    homepage = http://netfilter.org/projects/nftables;
+    homepage = "https://netfilter.org/projects/nftables/";
     license = licenses.gpl2;
     platforms = platforms.linux;
   };


### PR DESCRIPTION
###### Motivation for this change
Update nftables to version 0.9.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
