### PR TITLE
nftables: enable all features in kernel

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -99,8 +99,6 @@ let
     networking = {
       NET                = yes;
       IP_PNP             = no;
-      NETFILTER          = yes;
-      NETFILTER_ADVANCED = yes;
       IP_VS_PROTO_TCP    = yes;
       IP_VS_PROTO_UDP    = yes;
       IP_VS_PROTO_ESP    = yes;
@@ -145,12 +143,25 @@ let
       KEY_DH_OPERATIONS = whenAtLeast "4.7" yes;
 
       # needed for nftables
-      NF_TABLES_INET              = whenAtLeast "4.17" yes;
-      NF_TABLES_NETDEV            = whenAtLeast "4.17" yes;
-      NF_TABLES_IPV4              = whenAtLeast "4.17" yes;
-      NF_TABLES_ARP               = whenAtLeast "4.17" yes;
-      NF_TABLES_IPV6              = whenAtLeast "4.17" yes;
-      NF_TABLES_BRIDGE            = whenBetween "4.17" "5.3" yes;
+      # Networking Options
+      NETFILTER                   = yes;
+      NETFILTER_ADVANCED          = yes;
+      # Core Netfilter Configuration
+      NF_CONNTRACK_ZONES          = yes;
+      NF_CONNTRACK_EVENTS         = yes;
+      NF_CONNTRACK_TIMEOUT        = yes;
+      NF_CONNTRACK_TIMESTAMP      = yes;
+      NETFILTER_NETLINK_GLUE_CT   = yes;
+      NF_TABLES_INET              = whenAtLeast "4.19" yes;
+      NF_TABLES_NETDEV            = whenAtLeast "4.19" yes;
+      # IP: Netfilter Configuration
+      NF_TABLES_IPV4              = yes;
+      NF_TABLES_ARP               = whenAtLeast "4.19" yes;
+      # IPv6: Netfilter Configuration
+      NF_TABLES_IPV6              = yes;
+      # Bridge Netfilter Configuration
+      NF_TABLES_BRIDGE            = mkMerge [ (whenBetween "4.19" "5.3" yes)
+                                              (whenAtLeast "5.3" module) ];
 
       # needed for ss
       INET_DIAG         = yes;


### PR DESCRIPTION
###### Motivation for this change
Enable all nftables features in kernel 5.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nixos/nixpkgs/66841)
<!-- Reviewable:end -->
