### PR TITLE
tree-wide: fix malformed meta.maintainers

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5907,6 +5907,12 @@
     githubId = 231788;
     name = "Stephen Weinberg";
   };
+  sterfield = {
+    email = "sterfield@gmail.com";
+    github = "sterfield";
+    githubId = 5747061;
+    name = "Guillaume Loetscher";
+  };
   sternenseemann = {
     email = "post@lukasepple.de";
     github = "sternenseemann";

--- a/pkgs/development/libraries/at-spi2-atk/default.nix
+++ b/pkgs/development/libraries/at-spi2-atk/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
     description = "D-Bus bridge for Assistive Technology Service Provider Interface (AT-SPI) and Accessibility Toolkit (ATK)";
     homepage = https://gitlab.gnome.org/GNOME/at-spi2-atk;
     license = licenses.lgpl2Plus; # NOTE: 2018-06-06: Please check the license when upstream sorts-out licensing: https://gitlab.gnome.org/GNOME/at-spi2-atk/issues/2
-    maintainers = with maintainers; [ jtojnar gnome3.maintainers ];
+    maintainers = gnome3.maintainers;
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/at-spi2-core/default.nix
+++ b/pkgs/development/libraries/at-spi2-core/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
     description = "Assistive Technology Service Provider Interface protocol definitions and daemon for D-Bus";
     homepage = https://gitlab.gnome.org/GNOME/at-spi2-core;
     license = licenses.lgpl2Plus; # NOTE: 2018-06-06: Please check the license when upstream sorts-out licensing: https://gitlab.gnome.org/GNOME/at-spi2-core/issues/2
-    maintainers = with maintainers; [ jtojnar gnome3.maintainers ];
+    maintainers = gnome3.maintainers;
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/python-modules/shamir-mnemonic/default.nix
+++ b/pkgs/development/python-modules/shamir-mnemonic/default.nix
@@ -13,10 +13,10 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ click colorama ];
 
-  meta = {
+  meta = with lib; {
     description = "Reference implementation of SLIP-0039";
     homepage = "https://github.com/trezor/python-shamir-mnemonic";
-    license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ "1000101" ];
+    license = licenses.mit;
+    maintainers = [ maintainers."1000101" ];
   };
 }

--- a/pkgs/development/python-modules/trezor/default.nix
+++ b/pkgs/development/python-modules/trezor/default.nix
@@ -40,10 +40,10 @@ buildPythonPackage rec {
     runHook postCheck
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Python library for communicating with TREZOR Bitcoin Hardware Wallet";
     homepage = "https://github.com/trezor/trezor-firmware/tree/master/python";
-    license = lib.licenses.gpl3;
-    maintainers = with lib.maintainers; [ np prusnak mmahut "1000101" ];
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ np prusnak mmahut maintainers."1000101" ];
   };
 }

--- a/pkgs/misc/acpilight/default.nix
+++ b/pkgs/misc/acpilight/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     homepage = "https://gitlab.com/wavexx/acpilight";
     description = "ACPI backlight control";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ "smakarov" ];
+    maintainers = with maintainers; [ smakarov ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/servers/sickbeard/sickrage.nix
+++ b/pkgs/servers/sickbeard/sickrage.nix
@@ -29,6 +29,6 @@ python2.pkgs.buildPythonApplication rec {
     longDescription = "It watches for new episodes of your favorite shows, and when they are posted it does its magic.";
     license     = licenses.gpl3;
     homepage    = https://sickrage.github.io;
-    maintainers = [ "sterfield@gmail.com" ];
+    maintainers = with maintainers; [ sterfield ];
   };
 }

--- a/pkgs/servers/trezord/default.nix
+++ b/pkgs/servers/trezord/default.nix
@@ -20,7 +20,7 @@ buildGoPackage rec {
     description = "TREZOR Communication Daemon aka TREZOR Bridge";
     homepage = "https://trezor.io";
     license = licenses.lgpl3;
-    maintainers = with maintainers; [ canndrew jb55 "1000101" prusnak mmahut ];
+    maintainers = with maintainers; [ canndrew jb55 prusnak mmahut maintainers."1000101" ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

These packages stood out while processing packages.json.gz,
where the maintainers field of some packages wasn't the expected list of sets,
but a nested list, or a string.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Notify maintainers

cc @sterfield @1000101 
