### PR TITLE
avro-tools: properly installing the jar file

### DIFF
--- a/pkgs/development/tools/avro-tools/default.nix
+++ b/pkgs/development/tools/avro-tools/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, makeWrapper, jre, lib }:
 
 stdenv.mkDerivation rec {
+  pname = "avro-tools";
   version = "1.9.0";
-  name = "avro-tools-${version}";
 
   src = fetchurl {
     url =
-    "https://repo1.maven.org/maven2/org/apache/avro/avro-tools/${version}/${name}.jar";
+    "https://repo1.maven.org/maven2/org/apache/avro/avro-tools/${version}/${pname}-${version}.jar";
     sha256 = "164mcz7ljd2ikwsq9ba98galcjar4g4n6ag7kkh466nwrpbmd2zi";
   };
 
@@ -19,11 +19,10 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/bin
     mkdir -p $out/libexec/avro-tools
-    mv $src ${name}.jar
-    cp ${name}.jar $out/libexec/avro-tools
+    cp $src $out/libexec/avro-tools/${pname}.jar
 
     makeWrapper ${jre}/bin/java $out/bin/avro-tools \
-    --add-flags "-jar $out/libexec/avro-tools/${name}.jar"
+    --add-flags "-jar $out/libexec/avro-tools/${pname}.jar"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Fixing https://hydra.nixos.org/build/98448493

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @NeQuissimus 
