### PR TITLE
btanks: patching away wrong lua library

### DIFF
--- a/pkgs/games/btanks/default.nix
+++ b/pkgs/games/btanks/default.nix
@@ -2,10 +2,11 @@
 , SDL_image, libvorbis, expat, zip, lua5_1 }:
 
 stdenv.mkDerivation rec {
-  name = "battle-tanks-0.9.8083";
+  pname = "btanks";
+  version = "0.9.8083";
 
   src = fetchurl {
-    url = mirror://sourceforge/btanks/btanks-0.9.8083.tar.bz2;
+    url = "mirror://sourceforge/${pname}/${pname}-${version}.tar.bz2";
     sha256 = "0ha35kxc8xlbg74wsrbapfgxvcrwy6psjkqi7c6adxs55dmcxliz";
   };
 
@@ -14,21 +15,26 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = "-I${SDL_image}/include/SDL";
 
+  prePatch = ''
+    substituteInPlace ./engine/SConscript --replace "lua5.1" "lua" \
+          --replace "lua5.0" "lua"
+  '';
+
   patches = [
     (fetchpatch {
-      url = "https://sources.debian.org/data/main/b/btanks/0.9.8083-7/debian/patches/gcc-4.7.patch";
+      url = "https://salsa.debian.org/games-team/btanks/raw/master/debian/patches/gcc-4.7.patch";
       sha256 = "1dxlk1xh69gj10sqcsyckiakb8an3h41206wby4z44mpmvxc7pi4";
     })
     (fetchpatch {
-      url = "https://sources.debian.org/data/main/b/btanks/0.9.8083-7/debian/patches/pow10f.patch";
+      url = "https://salsa.debian.org/games-team/btanks/raw/master/debian/patches/pow10f.patch";
       sha256 = "1h45790v2dpdbccfn6lwfgl8782q54i14cz9gpipkaghcka4y0g9";
     })
   ];
 
   meta = with stdenv.lib; {
-    homepage = https://sourceforge.net/projects/btanks/;
+    homepage = "https://sourceforge.net/projects/btanks/";
     description = "Fast 2d tank arcade game";
     license = licenses.gpl2Plus;
-    platforms = platforms.unix;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Fixing long failing build https://hydra.nixos.org/build/98444634

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
