### PR TITLE
directfb: fix build on ARM

### DIFF
--- a/pkgs/development/compilers/flux/default.nix
+++ b/pkgs/development/compilers/flux/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, lib, fetchFromGitHub, autoreconfHook, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  pname = "flux";
+  version = "2013-09-20";
+
+  src = fetchFromGitHub {
+    owner = "deniskropp";
+    repo = pname;
+    rev = "e45758aa9384b9740ff021ea952399fd113eb0e9";
+    sha256 = "11f3ypg0sdq5kj69zgz6kih1yrzgm48r16spyvzwvlswng147410";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+
+  meta = with lib; {
+    description = "An interface description language used by DirectFB";
+    homepage = "https://github.com/deniskropp/flux";
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/libraries/directfb/default.nix
+++ b/pkgs/development/libraries/directfb/default.nix
@@ -1,31 +1,29 @@
-{ stdenv, fetchurl, pkgconfig, perl, zlib, libjpeg, freetype, libpng, giflib
+{ stdenv, lib, fetchFromGitHub, autoreconfHook, perl, pkgconfig, flux, zlib
+, libjpeg, freetype, libpng, giflib
 , enableX11 ? true, xorg
 , enableSDL ? true, SDL }:
 
-let s = 
-rec {
-   version = "1.7.7";
-   name="directfb-${version}";
-   sha256 = "18r7h0pwbyyk8z3pgdv77nmma8lvr1si9gl1ghxgxf1ivhwcd1dp";
-   url="http://directfb.org/downloads/Core/DirectFB-1.7/DirectFB-${version}.tar.gz";
-}
-; in
-stdenv.mkDerivation {
-  inherit (s) name;
-  src = fetchurl {
-    inherit (s) url sha256;
+stdenv.mkDerivation rec {
+  pname = "directfb";
+  version = "1.7.7";
+
+  src = fetchFromGitHub {
+    owner = "deniskropp";
+    repo = "DirectFB";
+    rev = "DIRECTFB_${lib.replaceStrings ["."] ["_"] version}";
+    sha256 = "0bs3yzb7hy3mgydrj8ycg7pllrd2b6j0gxj596inyr7ihssr3i0y";
   };
 
-  nativeBuildInputs = [ perl pkgconfig ];
+  nativeBuildInputs = [ autoreconfHook perl pkgconfig flux ];
 
   buildInputs = [ zlib libjpeg freetype giflib libpng ]
-    ++ stdenv.lib.optional enableSDL SDL
-    ++ stdenv.lib.optionals enableX11 (with xorg; [
+    ++ lib.optional enableSDL SDL
+    ++ lib.optionals enableX11 (with xorg; [
       xorgproto libX11 libXext
       libXrender
     ]);
 
-  NIX_LDFLAGS="-lgcc_s";
+  NIX_LDFLAGS = "-lgcc_s";
 
   configureFlags = [
     "--enable-sdl"
@@ -35,14 +33,11 @@ stdenv.mkDerivation {
     "--enable-fbdev"
     "--enable-mmx"
     "--enable-sse"
-    #"--enable-sysfs" # not recognized
     "--with-software"
     "--with-smooth-scaling"
-    ] ++ stdenv.lib.optionals enableX11 [
-      "--enable-x11"
-    ];
+  ] ++ lib.optional enableX11 "--enable-x11";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Graphics and input library designed with embedded systems in mind";
     longDescription = ''
       DirectFB is a thin library that provides hardware graphics acceleration,
@@ -54,7 +49,7 @@ stdenv.mkDerivation {
       power to embedded systems and sets a new standard for graphics under
       Linux.
     '';
-    homepage = http://directfb.org/;
+    homepage = "https://github.com/deniskropp/DirectFB";
     license = licenses.lgpl21;
     platforms = platforms.linux;
     maintainers = [ maintainers.bjornfor ];

--- a/pkgs/development/libraries/directfb/default.upstream
+++ b/pkgs/development/libraries/directfb/default.upstream
@@ -1,3 +1,0 @@
-url 'http://directfb.org/index.php?path=Main%2FDownloads'
-version_link 'DirectFB-[0-9]'
-minimize_overwrite

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3054,6 +3054,8 @@ in
     stdenv = gccStdenv;
   };
 
+  flux = callPackage ../development/compilers/flux { };
+
   fierce = callPackage ../tools/security/fierce { };
 
   figlet = callPackage ../tools/misc/figlet { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

`directfb` does not currently build on ARM and its source URL is defunct.

###### Things done

I was initially going to apply the [patch that Debian uses](https://salsa.debian.org/debian/directfb/blob/master/debian/patches/0004-Add-missing-files-from-upstream.patch) to fix this issue, but I noticed that the source URL is not longer valid. `tarballs.nixos.org` has a copy, which prevented anyone from noticing that it disappeared. The `directfb.org` domain expired and was taken over by a squatter a couple of years ago.

The main author of the package created a [repository on GitHub](https://github.com/deniskropp/DirectFB), so I switched the package to use that instead. This required adding a package for the `flux` compiler, which was previously run when creating the tarball.

Switching to the GitHub source had the side effect of adding the file that was missing from the autotools created tarball, fixing the build on ARM.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @bjornfor
