### PR TITLE
pulseview: use mkDerivation

### DIFF
--- a/pkgs/applications/science/electronics/pulseview/default.nix
+++ b/pkgs/applications/science/electronics/pulseview/default.nix
@@ -1,13 +1,14 @@
-{ stdenv, fetchurl, pkgconfig, cmake, glib, boost, libsigrok
+{ mkDerivation, lib, fetchurl, pkgconfig, cmake, glib, boost, libsigrok
 , libsigrokdecode, libserialport, libzip, udev, libusb1, libftdi1, glibmm
 , pcre, librevisa, python3, qtbase, qtsvg
 }:
 
-stdenv.mkDerivation rec {
-  name = "pulseview-0.4.1";
+mkDerivation rec {
+  pname = "pulseview";
+  version = "0.4.1";
 
   src = fetchurl {
-    url = "https://sigrok.org/download/source/pulseview/${name}.tar.gz";
+    url = "https://sigrok.org/download/source/pulseview/${pname}-${version}.tar.gz";
     sha256 = "0bvgmkgz37n2bi9niskpl05hf7rsj1lj972fbrgnlz25s4ywxrwy";
   };
 
@@ -15,16 +16,15 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     glib boost libsigrok libsigrokdecode libserialport libzip udev libusb1 libftdi1 glibmm
-    pcre librevisa python3 qtbase qtsvg
+    pcre librevisa python3
+    qtbase qtsvg
   ];
 
-  enableParallelBuilding = true;
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Qt-based LA/scope/MSO GUI for sigrok (a signal analysis software suite)";
     homepage = https://sigrok.org/;
     license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ bjornfor ];
     platforms = platforms.linux;
-    maintainers = [ maintainers.bjornfor ];
   };
 }


### PR DESCRIPTION
##### Motivation for this change

```stdenv.mkDerivation``` -> the Qt specific version of ```mkDerivation```.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @bjornfor 
