### PR TITLE
apmplanner2: fix build against qt 5.12

### DIFF
--- a/pkgs/applications/science/robotics/apmplanner2/default.nix
+++ b/pkgs/applications/science/robotics/apmplanner2/default.nix
@@ -1,12 +1,12 @@
-{ stdenv, fetchFromGitHub, qmake
+{ lib, mkDerivation, fetchFromGitHub, fetchpatch, qmake
 , qtbase, qtscript, qtwebkit, qtserialport, qtsvg, qtdeclarative, qtquickcontrols2
 , alsaLib, libsndfile, flite, openssl, udev, SDL2
 }:
 
-stdenv.mkDerivation rec {
-  name = "apmplanner2-${version}";
-  # TODO revert Qt511 to Qt5 in pkgs/top-level/all-packages.nix on next release
+mkDerivation rec {
+  pname = "apmplanner2";
   version = "2.0.27-rc1";
+
   src = fetchFromGitHub {
     owner = "ArduPilot";
     repo = "apm_planner";
@@ -14,11 +14,19 @@ stdenv.mkDerivation rec {
     sha256 = "1k0786mjzi49nb6yw4chh9l4dmkf9gybpxg9zqkr5yg019nyzcvd";
   };
 
-  qtInputs = [
+  patches = [
+    # can be dropped after 2.0.27-rc1
+    (fetchpatch {
+      url = "https://github.com/ArduPilot/apm_planner/commit/299ff23b5e9910de04edfc06b6893bb06b47a57b.patch";
+      sha256 = "16rc81iwqp2i46g6bm9lbvcjfsk83999r9h8w1pz0mys7rsilvqy";
+    })
+  ];
+
+  buildInputs = [
+    alsaLib libsndfile flite openssl udev SDL2
     qtbase qtscript qtwebkit qtserialport qtsvg qtdeclarative qtquickcontrols2
   ];
 
-  buildInputs = [ alsaLib libsndfile flite openssl udev SDL2 ] ++ qtInputs;
   nativeBuildInputs = [ qmake ];
 
   qmakeFlags = [ "apm_planner.pro" ];
@@ -29,7 +37,7 @@ stdenv.mkDerivation rec {
     substituteInPlace $out/share/applications/apmplanner2.desktop \
                       --replace /usr $out
   '';
-  
+
   enableParallelBuilding = true;
 
   meta = {
@@ -39,7 +47,7 @@ stdenv.mkDerivation rec {
       Includes support for the APM and PX4 based controllers.
     '';
     homepage = http://ardupilot.org/planner2/;
-    license = stdenv.lib.licenses.gpl3;
-    maintainers = [ stdenv.lib.maintainers.wucke13 ];
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ wucke13 ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23455,7 +23455,7 @@ in
 
   ### SCIENCE/ROBOTICS
 
-  apmplanner2 = libsForQt511.callPackage ../applications/science/robotics/apmplanner2 { };
+  apmplanner2 = libsForQt5.callPackage ../applications/science/robotics/apmplanner2 { };
 
   betaflight-configurator = callPackage ../applications/science/robotics/betaflight-configurator { };
 


### PR DESCRIPTION
##### Motivation for this change

Couple of things:
1. Apply a patch to make it compile with Qt 5.12
2. stdenv.mkDerivation -> mkDerivation
3. name -> pname, version

I don't actually use this application - it was part of a cleanup for a new KDE version that touched Qt which prompted this PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @wucke13 
