### PR TITLE
gscan2pdf: 2.3.0 -> 2.5.5

### DIFF
--- a/pkgs/applications/graphics/gscan2pdf/default.nix
+++ b/pkgs/applications/graphics/gscan2pdf/default.nix
@@ -1,17 +1,20 @@
 { stdenv, fetchurl, perlPackages, wrapGAppsHook,
+  # libs
   librsvg, sane-backends, sane-frontends,
-  imagemagick, libtiff, djvulibre, poppler_utils, ghostscript, unpaper,
-  xvfb_run, hicolor-icon-theme, liberation_ttf, file, pdftk }:
+  # runtime dependencies
+  imagemagick, libtiff, djvulibre, poppler_utils, ghostscript, unpaper, pdftk,
+  # test dependencies
+  xvfb_run, liberation_ttf, file, tesseract }:
 
 with stdenv.lib;
 
 perlPackages.buildPerlPackage rec {
   pname = "gscan2pdf";
-  version = "2.3.0";
+  version = "2.5.5";
 
   src = fetchurl {
     url = "mirror://sourceforge/gscan2pdf/${version}/${pname}-${version}.tar.xz";
-    sha256 = "0mcsmly0j9pmyzh6py8r6sfa30hc6gv300hqq3dxj4hv653vhkk9";
+    sha256 = "0gfhjmv768hx2l3jk2mjhh1snkgkaddgw70s14jq8kxhhzvhlmv8";
   };
 
   nativeBuildInputs = [ wrapGAppsHook ];
@@ -66,7 +69,8 @@ perlPackages.buildPerlPackage rec {
       --prefix PATH : "${djvulibre}/bin" \
       --prefix PATH : "${poppler_utils}/bin" \
       --prefix PATH : "${ghostscript}/bin" \
-      --prefix PATH : "${unpaper}/bin"
+      --prefix PATH : "${unpaper}/bin" \
+      --prefix PATH : "${pdftk}/bin"
   '';
 
   enableParallelBuilding = true;
@@ -76,16 +80,17 @@ perlPackages.buildPerlPackage rec {
   outputs = [ "out" "man" ];
 
   checkInputs = [
-    xvfb_run
-    hicolor-icon-theme
     imagemagick
     libtiff
     djvulibre
     poppler_utils
     ghostscript
-    file
-    pdftk
     unpaper
+    pdftk
+
+    xvfb_run
+    file
+    tesseract # tests are expecting tesseract 3.x precisely
   ];
 
   checkPhase = ''
@@ -97,7 +102,6 @@ perlPackages.buildPerlPackage rec {
     description = "A GUI to produce PDFs or DjVus from scanned documents";
     homepage = http://gscan2pdf.sourceforge.net/;
     license = licenses.gpl3;
-    maintainers = [ maintainers.pacien ];
+    maintainers = with maintainers; [ pacien ];
   };
 }
-


### PR DESCRIPTION
###### Motivation for this change

This PR updates gscan2pdf to the latest version.

- [x] builds succesfully
- [x] all tests are passing
- [x] could scan and save a test document manually

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc /
