### PR TITLE
iotop: use python3

### DIFF
--- a/pkgs/os-specific/linux/iotop/default.nix
+++ b/pkgs/os-specific/linux/iotop/default.nix
@@ -1,12 +1,19 @@
-{ stdenv, fetchurl, python2Packages }:
+{ stdenv, fetchurl, python3Packages, fetchpatch }:
 
-python2Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   name = "iotop-0.6";
 
   src = fetchurl {
     url = "http://guichaz.free.fr/iotop/files/${name}.tar.bz2";
     sha256 = "0nzprs6zqax0cwq8h7hnszdl3d2m4c2d4vjfxfxbnjfs9sia5pis";
   };
+
+  patches = [
+    (fetchpatch {
+      url = https://repo.or.cz/iotop.git/patch/99c8d7cedce81f17b851954d94bfa73787300599;
+      sha256 = "0rdgz6xpmbx77lkr1ixklliy1aavdsjmfdqvzwrjylbv0xh5wc8z";
+    })
+  ];
 
   doCheck = false;
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The support of python2 will be dropped by the end of 2019, so python3
should be used by default here. In fact, this package supports both
python v2 and v3, however the installation with python3 broke because of a
bug in setup.py which is only fixed in the upstream's master[1].

Additionally, distros like debian already use iotop along with python3[2],
so this should be a sensible thing to do.

[1] https://repo.or.cz/iotop.git?a=commit;h=99c8d7cedce81f17b851954d94bfa73787300599
[2] https://packages.debian.org/de/buster/iotop


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
