### PR TITLE
octopus: 9.0 -> 9.1

### DIFF
--- a/pkgs/applications/science/chemistry/octopus/default.nix
+++ b/pkgs/applications/science/chemistry/octopus/default.nix
@@ -1,27 +1,26 @@
-{ stdenv, fetchurl, symlinkJoin, gfortran, perl, procps
-, libyaml, libxc, fftw, openblas, gsl, netcdf, arpack
+{ stdenv, fetchFromGitLab, symlinkJoin, gfortran, perl, procps
+, libyaml, libxc, fftw, openblas, gsl, netcdf, arpack, autoreconfHook
 }:
 
-let
-  version = "9.0";
-  fftwAll = symlinkJoin { name ="ftw-dev-out"; paths = [ fftw.dev fftw.out ]; };
+stdenv.mkDerivation rec {
+  pname = "octopus";
+  version = "9.1";
 
-in stdenv.mkDerivation {
-  name = "octopus-${version}";
-
-  src = fetchurl {
-    url = "http://www.tddft.org/programs/octopus/down.php?file=${version}/octopus-${version}.tar.gz";
-    sha256 = "0p1gjykjnzm4m93mgjsmnxd0n2j381jk5kn3a7gkzxanixp60ilm";
+  src = fetchFromGitLab {
+    owner = "octopus-code";
+    repo = "octopus";
+    rev = version;
+    sha256 = "1l5fqgllk7rij16q7a3la7qq6isy8a5n37vk400qcscw1v32s90h";
   };
 
-  nativeBuildInputs = [ perl procps fftw.dev ];
-  buildInputs = [ libyaml gfortran libxc openblas gsl fftw.out netcdf arpack ];
+  nativeBuildInputs = [ perl procps autoreconfHook ];
+  buildInputs = [ libyaml gfortran libxc openblas gsl fftw netcdf arpack ];
 
   configureFlags = [
     "--with-yaml-prefix=${libyaml}"
     "--with-blas=-lopenblas"
     "--with-lapack=-lopenblas"
-    "--with-fftw-prefix=${fftwAll}"
+    "--with-fftw-prefix=${fftw.dev}"
     "--with-gsl-prefix=${gsl}"
     "--with-libxc-prefix=${libxc}"
   ];


### PR DESCRIPTION

###### Motivation for this change
Regular update

###### Things done
Cleanup of the derivation:
* switch to GitLab download
* cleanup fftw dependence

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

