### PR TITLE
nixos/samba: add option reloadIfchanged

### DIFF
--- a/nixos/modules/services/network-filesystems/samba.nix
+++ b/nixos/modules/services/network-filesystems/samba.nix
@@ -63,6 +63,7 @@ let
       };
 
       restartTriggers = [ configFile ];
+      reloadIfChanged = cfg.reloadIfChanged;
     };
 
 in
@@ -198,6 +199,15 @@ in
               comment = "Public samba share.";
             };
           };
+      };
+
+      reloadIfChanged = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether samba's systemd units should be reloaded during a NixOS configuration switch if their definition has changed.
+          This prevents clients from being disconnected because samba is restarted during the configuration switch.
+        '';
       };
 
     };


### PR DESCRIPTION
This helps prevent client disconnects during configuration update.

###### Motivation for this change
Enable updating the samba configuration while the service is in use.

###### Things done

Manually tested the reloadIfChanged option.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

