### PR TITLE
python.pkgs.python-unshare: init at 0.2

### DIFF
--- a/pkgs/development/python-modules/python-unshare/default.nix
+++ b/pkgs/development/python-modules/python-unshare/default.nix
@@ -1,0 +1,27 @@
+{ stdenv
+, buildPythonPackage
+, fetchFromGitHub
+}:
+
+buildPythonPackage rec {
+  pname = "python-unshare";
+  # pypi version doesn't support Python 3 and the package didn't update for a long time:
+  # https://github.com/TheTincho/python-unshare/pull/8
+  version = "2018-05-20";
+
+  src = fetchFromGitHub {
+    owner = "TheTincho";
+    repo = "python-unshare";
+    rev = "4e98c177bdeb24c5dcfcd66c457845a776bbb75c";
+    sha256 = "1h9biinhy5m7r2cj4abhvsg2hb6xjny3n2dxnj1336zpa082ys3h";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Python bindings for the Linux unshare() syscall";
+    homepage    = "https://github.com/thetincho/python-unshare";
+    license     = licenses.gpl2;
+    platforms   = platforms.linux;
+    maintainers = with maintainers; [ abbradar ];
+  };
+
+}

--- a/pkgs/development/python-modules/python-unshare/default.nix
+++ b/pkgs/development/python-modules/python-unshare/default.nix
@@ -7,7 +7,7 @@ buildPythonPackage rec {
   pname = "python-unshare";
   # pypi version doesn't support Python 3 and the package didn't update for a long time:
   # https://github.com/TheTincho/python-unshare/pull/8
-  version = "2018-05-20";
+  version = "unstable-2018-05-20";
 
   src = fetchFromGitHub {
     owner = "TheTincho";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3528,6 +3528,8 @@ in {
 
   python-Levenshtein = callPackage ../development/python-modules/python-levenshtein { };
 
+  python-unshare = callPackage ../development/python-modules/python-unshare { };
+
   fs = callPackage ../development/python-modules/fs { };
 
   fs-s3fs = callPackage ../development/python-modules/fs-s3fs { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add a package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I'll merge it when tests pass.