### PR TITLE
python3Packages.pytest-repeat: moving pytest to checkInputs

### DIFF
--- a/pkgs/development/python-modules/pytest-repeat/default.nix
+++ b/pkgs/development/python-modules/pytest-repeat/default.nix
@@ -24,7 +24,8 @@ buildPythonPackage rec {
     })
   ];
 
-  buildInputs = [ setuptools_scm pytest ];
+  buildInputs = [ setuptools_scm ];
+  checkInputs = [ pytest ];
 
   checkPhase = ''
     py.test


### PR DESCRIPTION
###### Motivation for this change

Fixing https://hydra.nixos.org/build/98965244

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @costrouc 
