### PR TITLE
tora: 3.1 -> 3.2.176

### DIFF
--- a/pkgs/development/tools/tora/default.nix
+++ b/pkgs/development/tools/tora/default.nix
@@ -1,41 +1,37 @@
 { mkDerivation, lib, fetchFromGitHub, cmake, extra-cmake-modules, makeWrapper
-, boost, doxygen, openssl, mysql, postgresql, graphviz, loki, qscintilla, qtbase }:
+, boost, doxygen, openssl, mysql, postgresql, graphviz, loki
+, qscintilla, qtbase, qttools }:
 
-let
-  qscintillaLib = (qscintilla.override { withQt5 = true; });
-
-in mkDerivation rec {
+mkDerivation rec {
   pname = "tora";
-  version = "3.1";
+  version = "3.2.176";
 
   src = fetchFromGitHub {
     owner  = "tora-tool";
     repo   = "tora";
-    rev    = "v${version}";
-    sha256 = "0wninl10bcgiljf6wnhn2rv8kmzryw78x5qvbw8s2zfjlnxjsbn7";
+    rev    = "39bf2837779bf458fc72a9f0e49271152e57829f";
+    sha256 = "0fr9b542i8r6shgnz33lc3cz333fnxgmac033yxfrdjfglzk0j2k";
   };
 
-  nativeBuildInputs = [ cmake extra-cmake-modules makeWrapper ];
+  nativeBuildInputs = [ cmake extra-cmake-modules makeWrapper qttools ];
+
   buildInputs = [
-    boost doxygen graphviz loki mysql.connector-c openssl postgresql qscintillaLib qtbase
+    boost doxygen graphviz loki mysql.connector-c openssl postgresql qscintilla qtbase
   ];
 
   preConfigure = ''
-    sed -i \
-      's|defaultGvHome = "/usr/bin"|defaultGvHome = "${lib.getBin graphviz}/bin"|' \
-      src/widgets/toglobalsetting.cpp
-
-    sed -i \
-      's|/usr/bin/dot|${lib.getBin graphviz}/bin/dot|' \
-      extlibs/libermodel/dotgraph.cpp
+    substituteInPlace src/widgets/toglobalsetting.cpp \
+      --replace 'defaultGvHome = "/usr/bin"' 'defaultGvHome = "${lib.getBin graphviz}/bin"'
+    substituteInPlace extlibs/libermodel/dotgraph.cpp \
+      --replace /usr/bin/dot ${lib.getBin graphviz}/bin/dot
   '';
 
   cmakeFlags = [
     "-DWANT_INTERNAL_LOKI=0"
     "-DWANT_INTERNAL_QSCINTILLA=0"
     # cmake/modules/FindQScintilla.cmake looks in qtbase and for the wrong library name
-    "-DQSCINTILLA_INCLUDE_DIR=${qscintillaLib}/include"
-    "-DQSCINTILLA_LIBRARY=${qscintillaLib}/lib/libqscintilla2.so"
+    "-DQSCINTILLA_INCLUDE_DIR=${qscintilla}/include"
+    "-DQSCINTILLA_LIBRARY=${qscintilla}/lib/libqscintilla2.so"
     "-DENABLE_DB2=0"
     "-DENABLE_ORACLE=0"
     "-DENABLE_TERADATA=0"


### PR DESCRIPTION
###### Motivation for this change

3.1 -> 3.2.176

3.2.176 is the latest stable release although it isn't tagged as such.

Not urgent, so merge into staging for the new qt.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
