### PR TITLE
zanshin: 2017-11-25 -> 2019-07-28

### DIFF
--- a/pkgs/applications/office/zanshin/default.nix
+++ b/pkgs/applications/office/zanshin/default.nix
@@ -9,13 +9,13 @@
 
 mkDerivation rec {
   pname = "zanshin";
-  version = "2017-11-25";
+  version = "2019-07-28";
 
   src = fetchFromGitHub {
     owner = "KDE";
     repo = "zanshin";
-    rev = "3df91dd81682d2ccfe542c4582dc1d5f98537c89";
-    sha256 = "18wx7bdqzp81xmwi266gphh2lfbcp5s0fzyp654gki40yhkqph6m";
+    rev = "a8c223e745ed7e6aa3dd3cb0786a625a5c54e378";
+    sha256 = "0jglwh30x7qrl41n3dhawn4c25dmrzscpvcajhgb6fwcl4w8cgfm";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

General update - needed for recent KDE frameworks update in staging.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
