### PR TITLE
amarok: 2.9.0-20180618 -> 2.9.0-20190731

### DIFF
--- a/pkgs/applications/audio/amarok/default.nix
+++ b/pkgs/applications/audio/amarok/default.nix
@@ -6,21 +6,18 @@
 , curl, ffmpeg, gdk-pixbuf, libaio, libmtp, loudmouth, lzo, lz4, mysql57, pcre, snappy, taglib, taglib_extras
 }:
 
-let
+mkDerivation {
   pname = "amarok";
-  version = "2.9.0-20180618";
-
-in mkDerivation {
-  name = "${pname}-${version}";
+  version = "2.9.0-20190731";
 
   src = fetchgit {
     # master has the Qt5 version as of April 2018 but a formal release has not
     # yet been made so change this back to the proper upstream when such a
     # release is out
     url    = git://anongit.kde.org/amarok.git;
-    # url = "mirror://kde/stable/${pname}/${version}/src/${name}.tar.xz";
-    rev    = "5d43efa454b6a6c9c833a6f3d7f8ff3cae738c96";
-    sha256 = "0fyrbgldg4wbb2darm4aav5fpzbacxzfjrdqwkhv9xr13j7zsvm3";
+    # url = "mirror://kde/stable/${pname}/${version}/src/${name}.tar.CZ";
+    rev    = "783da6d8e93737f5e41a3bc017906dc1f94bb94f";
+    sha256 = "08bypxk5kaay98hbwz9pj3hwgiyk3qmn9qw99bnjkkkw9wzsxiy6";
   };
 
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];


### PR DESCRIPTION
###### Motivation for this change

Getting closer to a proper qt5 release.

Let's send it to staging due to the large number of kde changes there.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
