### PR TITLE
kolf: init at 19.08.0

### DIFF
--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -129,6 +129,7 @@ let
       kmix = callPackage ./kmix.nix {};
       kmplot = callPackage ./kmplot.nix {};
       knotes = callPackage ./knotes.nix {};
+      kolf = callPackage ./kolf.nix {};
       kolourpaint = callPackage ./kolourpaint.nix {};
       kompare = callPackage ./kompare.nix {};
       konsole = callPackage ./konsole.nix {};

--- a/pkgs/applications/kde/kolf.nix
+++ b/pkgs/applications/kde/kolf.nix
@@ -1,0 +1,16 @@
+{ lib
+, mkDerivation
+, extra-cmake-modules
+, kdoctools
+, libkdegames, kconfig, kio, ktextwidgets
+}:
+
+mkDerivation {
+  name = "kolf";
+  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+  buildInputs = [ libkdegames kio ktextwidgets ];
+  meta = {
+    license = with lib.licenses; [ gpl2 ];
+    maintainers = with lib.maintainers; [ peterhoeg ];
+  };
+}


### PR DESCRIPTION
##### Motivation for this change

This can go to staging with all the other kde changes. Nothing critical.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
