### PR TITLE
pythonPackages.jenkinsapi: fixing tests

### DIFF
--- a/pkgs/development/python-modules/jenkinsapi/default.nix
+++ b/pkgs/development/python-modules/jenkinsapi/default.nix
@@ -7,6 +7,14 @@
 , mock
 , nose
 , unittest2
+, requests-kerberos
+, codecov
+, tox
+, pylint
+, pycodestyle
+, pytest
+, pytestcov
+, pytest-mock
 }:
 
 buildPythonPackage rec {
@@ -18,8 +26,29 @@ buildPythonPackage rec {
     sha256 = "bf35b208fe05e65508f3b8bbb0f91d164b007632e27ebe5f54041174b681b696";
   };
 
+  patchPhase = ''
+    # Removing unpure tests
+    rm -fr jenkinsapi_tests/systests/conftest.py jenkinsapi_tests/unittests
+    substituteInPlace test-requirements.txt \
+      --replace "pytest==3.7.0" "pytest"
+  '';
+
+
   propagatedBuildInputs = [ pytz requests ];
-  buildInputs = [ coverage mock nose unittest2 ];
+  checkInputs = [
+    requests-kerberos
+    codecov
+    tox
+    pylint
+    pycodestyle
+    coverage
+    mock
+    nose
+    unittest2
+    pytest
+    pytestcov
+    pytest-mock
+  ];
 
   meta = with stdenv.lib; {
     description = "A Python API for accessing resources on a Jenkins continuous-integration server";


### PR DESCRIPTION
###### Motivation for this change

Fixing https://hydra.nixos.org/build/98959263

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @drets 
