### PR TITLE
btanks: fix building with lua 5.2

### DIFF
--- a/pkgs/games/btanks/default.nix
+++ b/pkgs/games/btanks/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, fetchpatch, sconsPackages, pkgconfig, SDL, libGLU_combined, zlib, smpeg
-, SDL_image, libvorbis, expat, zip, lua5_1 }:
+{ stdenv, fetchurl, fetchpatch, sconsPackages, pkgconfig, SDL, libGL, zlib, smpeg
+, SDL_image, libvorbis, expat, zip, lua }:
 
 stdenv.mkDerivation rec {
   pname = "btanks";
@@ -11,16 +11,19 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ sconsPackages.scons_3_0_1 pkgconfig ];
-  buildInputs = [ SDL libGLU_combined zlib smpeg SDL_image libvorbis expat zip lua5_1 ];
+
+  buildInputs = [ SDL libGL zlib smpeg SDL_image libvorbis expat zip lua ];
+
+  enableParallelBuilding = true;
 
   NIX_CFLAGS_COMPILE = "-I${SDL_image}/include/SDL";
 
-  prePatch = ''
-    substituteInPlace ./engine/SConscript --replace "lua5.1" "lua" \
-          --replace "lua5.0" "lua"
-  '';
-
   patches = [
+    (fetchpatch {
+      url = "https://aur.archlinux.org/cgit/aur.git/plain/lua52.patch?h=btanks";
+      sha256 = "0ip563kz6lhwiims5djrxq3mvb7jx9yzkpsqxxhbi9n6qzz7y2az";
+      name = "lua52.patch";
+    })
     (fetchpatch {
       url = "https://salsa.debian.org/games-team/btanks/raw/master/debian/patches/gcc-4.7.patch";
       sha256 = "1dxlk1xh69gj10sqcsyckiakb8an3h41206wby4z44mpmvxc7pi4";
@@ -32,8 +35,8 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with stdenv.lib; {
-    homepage = "https://sourceforge.net/projects/btanks/";
     description = "Fast 2d tank arcade game";
+    homepage = "https://sourceforge.net/projects/btanks/";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
   };


### PR DESCRIPTION
###### Motivation for this change

Make it build with lua 5.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
