### PR TITLE
python3Packages.boltztrap2: moving cmake to nativeBuildInputs

### DIFF
--- a/pkgs/development/python-modules/boltztrap2/default.nix
+++ b/pkgs/development/python-modules/boltztrap2/default.nix
@@ -7,7 +7,6 @@
 , matplotlib
 , ase
 , netcdf4
-, pytest
 , pythonOlder
 , cython
 , cmake
@@ -23,16 +22,11 @@ buildPythonPackage rec {
     sha256 = "81e8a5ef8240c6a2205463fa7bc643b8033125237927f5492dab0b5d1aadb35a";
   };
 
-  buildInputs = [ cython cmake ];
-  checkInputs = [ pytest ];
   propagatedBuildInputs = [ spglib numpy scipy matplotlib ase netcdf4 ];
+  nativeBuildInputs = [ cmake cython ];
 
   # pypi release does no include files for tests
   doCheck = false;
-
-  checkPhase = ''
-    py.test
-  '';
 
   meta = with stdenv.lib; {
     homepage = https://www.boltztrap.org/;


### PR DESCRIPTION
#### Motivation for this change

Fixing https://hydra.nixos.org/build/98969449

Moving cmake to nativeBuildInputs, cleaning up test dependencies.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @costrouc 
