### PR TITLE
pythonPackages.mixpanel: moving pytest and mock to checkInputs

### DIFF
--- a/pkgs/development/python-modules/mixpanel/default.nix
+++ b/pkgs/development/python-modules/mixpanel/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     sha256 = "0yq1bcsjzsz7yz4rp69izsdn47rvkld4wki2xmapp8gg2s9i8709";
   };
 
-  buildInputs = [ pytest mock ];
+  checkInputs = [ pytest mock ];
   propagatedBuildInputs = [ six ];
   checkPhase = "py.test tests.py";
 


### PR DESCRIPTION
###### Motivation for this change

Fixing https://hydra.nixos.org/build/98969420

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).