### PR TITLE
Enable work variant firewall with iptables-compat

### DIFF
--- a/nixos/modules/services/networking/firewall.nix
+++ b/nixos/modules/services/networking/firewall.nix
@@ -334,7 +334,8 @@ in
       package = mkOption {
         type = types.package;
         default = pkgs.iptables;
-        example = pkgs.iptables-compat;
+        defaultText = "pkgs.iptables";
+        example = literalExample "pkgs.iptables-nftables-compat";
         description =
           ''
             The iptables package to use for running the firewall service."

--- a/nixos/modules/services/networking/firewall.nix
+++ b/nixos/modules/services/networking/firewall.nix
@@ -331,6 +331,16 @@ in
           '';
       };
 
+      package = mkOption {
+        type = types.package;
+        default = pkgs.iptables;
+        example = pkgs.iptables-compat;
+        description =
+          ''
+            The iptables package to use for running the firewall service."
+          '';
+      };
+
       logRefusedConnections = mkOption {
         type = types.bool;
         default = true;
@@ -536,7 +546,7 @@ in
 
     networking.firewall.trustedInterfaces = [ "lo" ];
 
-    environment.systemPackages = [ pkgs.iptables ] ++ cfg.extraPackages;
+    environment.systemPackages = [ cfg.package ] ++ cfg.extraPackages;
 
     boot.kernelModules = (optional cfg.autoLoadConntrackHelpers "nf_conntrack")
       ++ map (x: "nf_conntrack_${x}") cfg.connectionTrackingModules;
@@ -555,7 +565,7 @@ in
       before = [ "network-pre.target" ];
       after = [ "systemd-modules-load.service" ];
 
-      path = [ pkgs.iptables ] ++ cfg.extraPackages;
+      path = [ cfg.package ] ++ cfg.extraPackages;
 
       # FIXME: this module may also try to load kernel modules, but
       # containers don't have CAP_SYS_MODULE.  So the host system had

--- a/pkgs/os-specific/linux/iptables/default.nix
+++ b/pkgs/os-specific/linux/iptables/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, pruneLibtoolFiles, flex, bison
 , libmnl, libnetfilter_conntrack, libnfnetlink, libnftnl, libpcap
-, modeCompat ? false
+, nftablesCompat ? false
 }:
 
 with stdenv.lib;
@@ -28,11 +28,11 @@ stdenv.mkDerivation rec {
     "--enable-libipq"
     "--enable-nfsynproxy"
     "--enable-shared"
-  ] ++ optional (!modeCompat) "--disable-nftables";
+  ] ++ optional (!nftablesCompat) "--disable-nftables";
 
   outputs = [ "out" "dev" ];
 
-  postInstall = optional modeCompat ''
+  postInstall = optional nftablesCompat ''
     rm $out/sbin/{iptables,iptables-restore,iptables-save,ip6tables,ip6tables-restore,ip6tables-save}
     ln -sv xtables-nft-multi $out/bin/iptables
     ln -sv xtables-nft-multi $out/bin/iptables-restore

--- a/pkgs/os-specific/linux/iptables/default.nix
+++ b/pkgs/os-specific/linux/iptables/default.nix
@@ -1,32 +1,48 @@
-{ stdenv, fetchurl, bison, flex, pkgconfig, pruneLibtoolFiles
-, libnetfilter_conntrack, libnftnl, libmnl, libpcap }:
+{ stdenv, fetchurl, pkgconfig, pruneLibtoolFiles, flex, bison
+, libmnl, libnetfilter_conntrack, libnfnetlink, libnftnl, libpcap
+, modeCompat ? false
+}:
+
+with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  pname = "iptables";
   version = "1.8.3";
+  pname = "iptables";
 
   src = fetchurl {
     url = "https://www.netfilter.org/projects/${pname}/files/${pname}-${version}.tar.bz2";
     sha256 = "106xkkg5crsscjlinxvqvprva23fwwqfgrzl8m2nn841841sqg52";
   };
 
-  nativeBuildInputs = [ bison flex pkgconfig pruneLibtoolFiles ];
+  nativeBuildInputs = [ pkgconfig pruneLibtoolFiles flex bison ];
 
-  buildInputs = [ libnetfilter_conntrack libnftnl libmnl libpcap ];
+  buildInputs = [ libmnl libnetfilter_conntrack libnfnetlink libnftnl libpcap ];
 
   preConfigure = ''
     export NIX_LDFLAGS="$NIX_LDFLAGS -lmnl -lnftnl"
   '';
 
   configureFlags = [
-    "--enable-devel"
-    "--enable-shared"
     "--enable-bpf-compiler"
-  ];
+    "--enable-devel"
+    "--enable-libipq"
+    "--enable-nfsynproxy"
+    "--enable-shared"
+  ] ++ optional (!modeCompat) "--disable-nftables";
 
   outputs = [ "out" "dev" ];
 
-  meta = with stdenv.lib; {
+  postInstall = optional modeCompat ''
+    rm $out/sbin/{iptables,iptables-restore,iptables-save,ip6tables,ip6tables-restore,ip6tables-save}
+    ln -sv xtables-nft-multi $out/bin/iptables
+    ln -sv xtables-nft-multi $out/bin/iptables-restore
+    ln -sv xtables-nft-multi $out/bin/iptables-save
+    ln -sv xtables-nft-multi $out/bin/ip6tables
+    ln -sv xtables-nft-multi $out/bin/ip6tables-restore
+    ln -sv xtables-nft-multi $out/bin/ip6tables-save
+  '';
+
+  meta = {
     description = "A program to configure the Linux IP packet filtering ruleset";
     homepage = https://www.netfilter.org/projects/iptables/index.html;
     platforms = platforms.linux;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15631,7 +15631,7 @@ in
 
   iptables = iptables-legacy;
   iptables-legacy = callPackage ../os-specific/linux/iptables { };
-  iptables-compat = callPackage ../os-specific/linux/iptables { modeCompat = true; };
+  iptables-nftables-compat = callPackage ../os-specific/linux/iptables { nftablesCompat = true; };
 
   iptstate = callPackage ../os-specific/linux/iptstate { } ;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15629,7 +15629,9 @@ in
 
   iputils = callPackage ../os-specific/linux/iputils { };
 
-  iptables = callPackage ../os-specific/linux/iptables { };
+  iptables = iptables-legacy;
+  iptables-legacy = callPackage ../os-specific/linux/iptables { };
+  iptables-compat = callPackage ../os-specific/linux/iptables { modeCompat = true; };
 
   iptstate = callPackage ../os-specific/linux/iptstate { } ;
 


### PR DESCRIPTION
###### Motivation for this change
Enable work variant firewall and fail2ban with iptables-compat - nftables compatibility.

Example configuration:
```
  services.fail2ban = {
    enable = true;
    packageFirewall = pkgs.iptables-compat;
    jails = {
      DEFAULT = ''
        enabled  = true
      '';
      ssh-iptables = ''
        enabled  = true
      '';
    };
  };

  networking.firewall.enable = true;
  networking.firewall.package = pkgs.iptables-compat;
```
Work tested in a virtual machine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
