### PR TITLE
pythonPackages.pydot_ng: fix build

### DIFF
--- a/pkgs/development/python-modules/pydot_ng/default.nix
+++ b/pkgs/development/python-modules/pydot_ng/default.nix
@@ -1,10 +1,9 @@
-{ stdenv
-, buildPythonPackage
-, fetchPypi
+{ lib, buildPythonPackage, fetchPypi, isPy27
+, graphviz
+, mock
 , pyparsing
 , pytest
 , unittest2
-, pkgs
 }:
 
 buildPythonPackage rec {
@@ -16,19 +15,22 @@ buildPythonPackage rec {
     sha256 = "8c8073b97aa7030c28118961e2c6c92f046e4cb57aeba7df87146f7baa6530c5";
   };
 
-  buildInputs = [ pytest unittest2 ];
-  propagatedBuildInputs = [ pkgs.graphviz pyparsing ];
+  propagatedBuildInputs = [ graphviz pyparsing ];
+
+  checkInputs = [
+    graphviz
+    mock
+    pytest
+  ] ++ lib.optionals isPy27 [ unittest2];
 
   checkPhase = ''
-    mkdir test/my_tests
-    py.test test
+    pytest
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "https://pypi.python.org/pypi/pydot-ng";
     description = "Python 3-compatible update of pydot, a Python interface to Graphviz's Dot";
     license = licenses.mit;
-    maintainers = [ maintainers.bcdarwin ];
+    maintainers = with maintainers; [ bcdarwin jonringer ];
   };
-
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4311,7 +4311,7 @@ in {
     inherit (pkgs) graphviz;
   };
 
-  pydot_ng = callPackage ../development/python-modules/pydot_ng { };
+  pydot_ng = callPackage ../development/python-modules/pydot_ng { graphviz = pkgs.graphviz; };
 
   pyelftools = callPackage ../development/python-modules/pyelftools { };
 


### PR DESCRIPTION
###### Motivation for this change
was helping out @mmahut  and decided to take over the package from  #66925

closes  #66925
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @bcdarwin 

```
[2 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/66966
2 package were build:
python27Packages.pydot_ng python37Packages.pydot_ng
```