### PR TITLE
libvisio: 0.1.6 -> 0.1.7

### DIFF
--- a/pkgs/development/libraries/libvisio/default.nix
+++ b/pkgs/development/libraries/libvisio/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   name = "libvisio-${version}";
-  version = "0.1.6";
+  version = "0.1.7";
 
   outputs = [ "out" "bin" "dev" "doc" ];
 
   src = fetchurl {
     url = "https://dev-www.libreoffice.org/src/libvisio/${name}.tar.xz";
-    sha256 = "1yahpfl13qk6178irv8jn5ppxdn7isafqisyqsdw0lqxcz9h447y";
+    sha256 = "0k7adcbbf27l7n453cca1m6s9yj6qvb5j6bsg2db09ybf3w8vbwg";
   };
 
   nativeBuildInputs = [ pkgconfig cppunit doxygen ];


### PR DESCRIPTION
###### Motivation for this change

https://gerrit.libreoffice.org/plugins/gitiles/libvisio/+/libvisio-0.1.7/NEWS

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers