### PR TITLE
ttyd: 1.4.2_pre* -> 1.5.2

### DIFF
--- a/pkgs/servers/ttyd/default.nix
+++ b/pkgs/servers/ttyd/default.nix
@@ -5,21 +5,15 @@
 
 with builtins;
 
-let
-  # ttyd hasn't seen a release in quite a while. remove all this
-  # junk when a new one happens (eventually)
-  revCount = 174;
+stdenv.mkDerivation rec {
+  pname = "ttyd";
+  version = "1.5.2";
   src = fetchFromGitHub {
-    owner  = "tsl0922";
-    repo   = "ttyd";
-    rev    = "6df6ac3e03b705ddd46109c2ac43a1cba439c0df";
-    sha256 = "0g5jlfa7k6qd59ysdagczlhwgjfjspb3sfbd8b790hcil933qrxm";
+    owner = "tsl0922";
+    repo = pname;
+    rev = "refs/tags/${version}";
+    sha256 = "16nngc3dqrsgpapzvl34c0msgdd1fyp3k8r1jj1m9bch6z2p50bl";
   };
-
-in stdenv.mkDerivation rec {
-  name = "ttyd-${version}";
-  version = "1.4.2_pre${toString revCount}_${substring 0 8 src.rev}";
-  inherit src;
 
   nativeBuildInputs = [ pkgconfig cmake xxd ];
   buildInputs = [ openssl libwebsockets json_c libuv ];


### PR DESCRIPTION
###### Motivation for this change

https://github.com/tsl0922/ttyd/releases/tag/1.5.2
https://github.com/tsl0922/ttyd/releases/tag/1.5.1
https://github.com/tsl0922/ttyd/releases/tag/1.5.0
https://github.com/tsl0922/ttyd/releases/tag/1.4.3
https://github.com/tsl0922/ttyd/releases/tag/1.4.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @thoughtpolice