### PR TITLE
nixos/systemd: enable systemd cgroup accounting by default

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1909.xml
+++ b/nixos/doc/manual/release-notes/rl-1909.xml
@@ -506,12 +506,20 @@
     been removed.
    </para>
   </listitem>
-   <listitem>
-    <para>
-      The <literal>rmilter</literal> package was removed with associated module and options due deprecation by upstream developer.
-      Use <literal>rspamd</literal> in proxy mode instead.
-    </para>
-   </listitem>
+  <listitem>
+   <para>
+    The <literal>rmilter</literal> package was removed with associated module and options due deprecation by upstream developer.
+    Use <literal>rspamd</literal> in proxy mode instead.
+   </para>
+  </listitem>
+  <listitem>
+   <para>
+     systemd cgroup accounting via the
+     <link linkend="opt-systemd.enableCgroupAccounting">systemd.enableCgroupAccounting</link>
+     option is now enabled by default. It now also enables the more recent Block IO and IP accounting
+     features.
+   </para>
+  </listitem>
   </itemizedlist>
  </section>
 </section>

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -806,8 +806,6 @@ in
           DefaultCPUAccounting=yes
           DefaultIOAccounting=yes
           DefaultBlockIOAccounting=yes
-          DefaultMemoryAccounting=yes
-          DefaultTasksAccounting=yes
         ''}
         DefaultLimitCORE=infinity
         ${config.systemd.extraConfig}

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -537,7 +537,7 @@ in
     };
 
     systemd.enableCgroupAccounting = mkOption {
-      default = false;
+      default = true;
       type = types.bool;
       description = ''
         Whether to enable cgroup accounting.

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -804,8 +804,10 @@ in
         [Manager]
         ${optionalString config.systemd.enableCgroupAccounting ''
           DefaultCPUAccounting=yes
+          DefaultBlockIOAccounting=yes
           DefaultIOAccounting=yes
           DefaultBlockIOAccounting=yes
+          DefaultIPAccounting=yes
         ''}
         DefaultLimitCORE=infinity
         ${config.systemd.extraConfig}

--- a/nixos/tests/systemd.nix
+++ b/nixos/tests/systemd.nix
@@ -89,5 +89,12 @@ import ./make-test.nix ({ pkgs, ... }: {
      $machine->waitForUnit('multi-user.target');
      $machine->succeed('sysctl net.core.default_qdisc | grep -q "fq_codel"');
    };
+
+   # Test cgroup accounting is enabled
+   subtest "systemd cgroup accounting is enabled", sub {
+     $machine->waitForUnit('multi-user.target');
+     $machine->succeed('systemctl show testservice1.service -p IOAccounting | grep -q "yes"');
+     $machine->succeed('systemctl status testservice1.service | grep -q "CPU:"');
+   };
   '';
 })


### PR DESCRIPTION
###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/29095#issuecomment-522623775

fixes #29095.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @davidak @arianvp 
