### PR TITLE
vnote: fix by using qt's mkDerivation, 2.6 -> 2.7.2

### DIFF
--- a/pkgs/applications/office/vnote/default.nix
+++ b/pkgs/applications/office/vnote/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, fetchFromGitHub, qmake, qtbase, qtwebengine, hicolor-icon-theme, makeDesktopItem }:
+{ lib, mkDerivation, fetchFromGitHub, qmake, qtbase, qtwebengine, hicolor-icon-theme }:
 
 let
   description = "A note-taking application that knows programmers and Markdown better";
-in stdenv.mkDerivation rec {
-  version = "2.6";
+in mkDerivation rec {
+  version = "2.7.2";
   pname = "vnote";
 
   src = fetchFromGitHub {
@@ -11,13 +11,13 @@ in stdenv.mkDerivation rec {
     repo = "vnote";
     fetchSubmodules = true;
     rev = "v${version}";
-    sha256 = "10lnzzwz7fjj55kbn3j6gdl9yi6a85mdjis586p3zcc4830mlv91";
+    sha256 = "0mk1ingcyznpwq4bfkxa8nx9yx5y3kgsmr4qffriq7bh1cx9dwjy";
   };
 
   nativeBuildInputs = [ qmake ];
   buildInputs = [ qtbase qtwebengine hicolor-icon-theme ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     inherit description;
     homepage = "https://tamlok.github.io/vnote";
     license = licenses.mit;


### PR DESCRIPTION
###### Motivation for this change

https://github.com/tamlok/vnote/releases/tag/v2.7.2
https://github.com/tamlok/vnote/releases/tag/v2.7.1
https://github.com/tamlok/vnote/releases/tag/v2.7

cc #65399

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @kuznero