### PR TITLE
nixos: zsh: setopt prompt_sp to workaround a zsh bug

### DIFF
--- a/nixos/modules/programs/zsh/zsh.nix
+++ b/nixos/modules/programs/zsh/zsh.nix
@@ -70,7 +70,7 @@ in
       promptInit = mkOption {
         default = ''
           if [ "$TERM" != dumb ]; then
-              autoload -U promptinit && promptinit && prompt walters
+              autoload -U promptinit && promptinit && prompt walters && setopt prompt_sp
           fi
         '';
         description = ''


### PR DESCRIPTION
# What? Why?

See #38535. I took the fix by @Mic92 and tested it in all the ttys and ptys I ever use. It seems to work.

Closes #38535.

# `git log`

- nixos: zsh: setopt prompt_sp to workaround a zsh bug

  See #38535, properly fixing the prompt seems complicated, and this seems
  to work in all the ttys I checked.

  Suggested by @Mic92.

# `nix-instantiate` environment

- Host OS: Linux 4.9, SLNOS 19.09
- Nix: nix-env (Nix) 2.2.2
- Multi-user: yes
- Sandbox: yes
- NIXPKGS_CONFIG:

```nix
{
  checkMeta = true;
  doCheckByDefault = true;
}
```

# `nix-env -qaP` diffs

- On x86_64-linux: noop
- On aarch64-linux: noop
- On x86_64-darwin: noop

/cc @dtzWill