### PR TITLE
Revert "fwupd: 1.2.8 -> 1.2.10"

### DIFF
--- a/pkgs/os-specific/linux/firmware/fwupd/default.nix
+++ b/pkgs/os-specific/linux/firmware/fwupd/default.nix
@@ -31,11 +31,11 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "fwupd";
-  version = "1.2.10";
+  version = "1.2.8";
 
   src = fetchurl {
     url = "https://people.freedesktop.org/~hughsient/releases/fwupd-${version}.tar.xz";
-    sha256 = "0inngs7i48akm9c7fmdsf9zjif595rkaba69rl76jfwfv8r21vjb";
+    sha256 = "0qbvq52c0scn1h99i1rf2la6rrhckin6gb02k7l0v3g07mxs20wc";
   };
 
   outputs = [ "out" "lib" "dev" "devdoc" "man" "installedTests" ];


### PR DESCRIPTION
Reverts NixOS/nixpkgs#66886

Tests were failing like
```
Getting the list of remotes...
PolicyKit files are missing, see https://github.com/hughsie/fwupd/wiki/PolicyKit-files-are-missing
FAIL: fwupd/fwupdmgr.test (Child process exited with code 1)
(9.95 seconds)
error: command `gnome-desktop-testing-runner' did not succeed (exit code 2)
(9.95 seconds)
command `gnome-desktop-testing-runner' did not succeed (exit code 2)
cleaning up
```

and this needs to manually updated pretty much always.