### PR TITLE
ocamlPackages.javalib: 3.0 -> 3.1.1

### DIFF
--- a/pkgs/development/ocaml-modules/javalib/default.nix
+++ b/pkgs/development/ocaml-modules/javalib/default.nix
@@ -1,24 +1,21 @@
-{ stdenv, fetchzip, which, ocaml, findlib, camlp4
-, camlzip, camomile, extlib
+{ stdenv, fetchzip, which, ocaml, findlib
+, camlzip, extlib
 }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4"
-then throw "javalib not supported for ocaml ${ocaml.version}"
+if !stdenv.lib.versionAtLeast ocaml.version "4.04"
+then throw "javalib is not available for OCaml ${ocaml.version}"
 else
 
-let
-  pname = "javalib";
-in
 stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-${pname}-${version}";
-  version = "3.0";
+  name = "ocaml${ocaml.version}-javalib-${version}";
+  version = "3.1.1";
 
   src = fetchzip {
     url = "https://github.com/javalib-team/javalib/archive/v${version}.tar.gz";
-    sha256 = "02zgn1z1wj3rbg9xqmbagys91bnsy27iwrngkivzhlykyaw9vf6n";
+    sha256 = "1myrf7kw7pi04pmp0bi4747nj4h4vfxlla05sz2hp4w8k76iscld";
   };
 
-  buildInputs = [ which ocaml findlib camlp4 ];
+  buildInputs = [ which ocaml findlib ];
 
   patches = [ ./configure.sh.patch ./Makefile.config.example.patch ];
 
@@ -29,13 +26,13 @@ stdenv.mkDerivation rec {
   configureScript = "./configure.sh";
   dontAddPrefix = "true";
 
-  propagatedBuildInputs = [ camlzip camomile extlib ];
+  propagatedBuildInputs = [ camlzip extlib ];
 
   meta = with stdenv.lib; {
     description = "A library that parses Java .class files into OCaml data structures";
     homepage = https://javalib-team.github.io/javalib/;
     license = licenses.lgpl3;
     maintainers = [ maintainers.vbgl ];
-    platforms = ocaml.meta.platforms or [];
+    inherit (ocaml.meta) platforms;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update; less dependencies.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
