### PR TITLE
Update FOSS EDA tools again

### DIFF
--- a/pkgs/applications/science/logic/symbiyosys/default.nix
+++ b/pkgs/applications/science/logic/symbiyosys/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     description = "Tooling for Yosys-based verification flows";
     homepage    = https://symbiyosys.readthedocs.io/;
     license     = stdenv.lib.licenses.isc;
-    maintainers = with stdenv.lib.maintainers; [ thoughtpolice ];
-    platforms   = stdenv.lib.platforms.unix;
+    maintainers = with stdenv.lib.maintainers; [ thoughtpolice emily ];
+    platforms   = stdenv.lib.platforms.all;
   };
 }

--- a/pkgs/development/compilers/nextpnr/default.nix
+++ b/pkgs/development/compilers/nextpnr/default.nix
@@ -11,19 +11,6 @@
 
 let
   boostPython = boost.override { python = python3; enablePython = true; };
-
-  # This is a massive hack. For now, Trellis doesn't really support
-  # installation through an already-built package; you have to build it once to
-  # get the tools, then reuse the build directory to build nextpnr -- the
-  # 'install' phase doesn't install everything it needs.  This will be fixed in
-  # the future but for now we can do this horrific thing.
-  trellisRoot = trellis.overrideAttrs (_: {
-    installPhase = ''
-      mkdir -p $out
-      cp *.so ..
-      cd ../../.. && cp -R trellis database $out/
-    '';
-  });
 in
 stdenv.mkDerivation rec {
   pname = "nextpnr";
@@ -47,7 +34,8 @@ stdenv.mkDerivation rec {
   cmakeFlags =
     [ "-DARCH=generic;ice40;ecp5"
       "-DICEBOX_ROOT=${icestorm}/share/icebox"
-      "-DTRELLIS_ROOT=${trellisRoot}/trellis"
+      "-DTRELLIS_ROOT=${trellis}/share/trellis"
+      "-DPYTRELLIS_LIBDIR=${trellis}/lib/trellis"
       "-DUSE_OPENMP=ON"
       # warning: high RAM usage
       "-DSERIALIZE_CHIPDB=OFF"

--- a/pkgs/development/compilers/nextpnr/default.nix
+++ b/pkgs/development/compilers/nextpnr/default.nix
@@ -27,13 +27,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "nextpnr";
-  version = "2019.08.10";
+  version = "2019.08.21";
 
   src = fetchFromGitHub {
     owner  = "yosyshq";
     repo   = "nextpnr";
-    rev    = "3f26cf50767143e48d29ae691b2a0052c359eb15";
-    sha256 = "1gv84svw56ass9idbzh17h3yxkk9ydr40ijf9w72gf72rbixszdr";
+    rev    = "c192ba261d77ad7f0a744fb90b01e4a5b63938c4";
+    sha256 = "0g2ar1z89b31qw5vgqj2rrcv9rzncs94184dgcsrz19p866654mf";
   };
 
   nativeBuildInputs
@@ -66,8 +66,8 @@ stdenv.mkDerivation rec {
     description = "Place and route tool for FPGAs";
     homepage    = https://github.com/yosyshq/nextpnr;
     license     = licenses.isc;
-    platforms   = platforms.linux;
-    maintainers = with maintainers; [ thoughtpolice ];
+    platforms   = platforms.all;
+    maintainers = with maintainers; [ thoughtpolice emily ];
 
     broken = enableGui;
   };

--- a/pkgs/development/compilers/yosys/default.nix
+++ b/pkgs/development/compilers/yosys/default.nix
@@ -40,10 +40,14 @@ stdenv.mkDerivation rec {
 
   patchPhase = ''
     substituteInPlace ../yosys-abc/Makefile \
-      --replace 'CC   := gcc' ""
+      --replace 'CC   := gcc' "" \
+      --replace 'CXX  := g++' ""
     substituteInPlace ./Makefile \
       --replace 'CXX = clang' "" \
-      --replace 'ABCMKARGS = CC="$(CXX)"' 'ABCMKARGS =' \
+      --replace 'LD = clang++' 'LD = $(CXX)' \
+      --replace 'CXX = gcc' "" \
+      --replace 'LD = gcc' 'LD = $(CXX)' \
+      --replace 'ABCMKARGS = CC="$(CXX)" CXX="$(CXX)"' 'ABCMKARGS =' \
       --replace 'echo UNKNOWN' 'echo ${substring 0 10 (elemAt srcs 0).rev}'
   '';
 

--- a/pkgs/development/compilers/yosys/default.nix
+++ b/pkgs/development/compilers/yosys/default.nix
@@ -8,14 +8,14 @@ with builtins;
 
 stdenv.mkDerivation rec {
   pname = "yosys";
-  version = "2019.08.13";
+  version = "2019.08.21";
 
   srcs = [
     (fetchFromGitHub {
       owner  = "yosyshq";
       repo   = "yosys";
-      rev    = "19d6b8846f55b4c7be705619f753bec86deadac8";
-      sha256 = "185sbkxajx3k9j03n0cxq2qvzwfwdbcxp19h8vnk7ghd5y9gp602";
+      rev    = "fe1b2337fd7950e1d563be5b8ccbaa81688261e4";
+      sha256 = "0z7sngc2z081yyhzh8c2kchg48sp2333hn1wa94q5vsgnyzlqrdw";
       name   = "yosys";
     })
 
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
     '';
     homepage    = http://www.clifford.at/yosys/;
     license     = stdenv.lib.licenses.isc;
-    maintainers = with stdenv.lib.maintainers; [ shell thoughtpolice ];
-    platforms   = stdenv.lib.platforms.unix;
+    maintainers = with stdenv.lib.maintainers; [ shell thoughtpolice emily ];
+    platforms   = stdenv.lib.platforms.all;
   };
 }

--- a/pkgs/development/libraries/libftdi/default.nix
+++ b/pkgs/development/libraries/libftdi/default.nix
@@ -1,6 +1,6 @@
 {stdenv, fetchurl, libusb}:
 
-stdenv.mkDerivation rec {
+with stdenv; mkDerivation rec {
   name = "libftdi-0.20";
 
   src = fetchurl {
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   # Hack to avoid TMPDIR in RPATHs.
   preFixup = ''rm -rf "$(pwd)" '';
-  configureFlags = [ "--with-async-mode" ];
+  configureFlags = lib.optional (!isDarwin) [ "--with-async-mode" ];
 
   # allow async mode. from ubuntu. see:
   #   https://bazaar.launchpad.net/~ubuntu-branches/ubuntu/trusty/libftdi/trusty/view/head:/debian/patches/04_async_mode.diff
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "A library to talk to FTDI chips using libusb";
     homepage = https://www.intra2net.com/en/developer/libftdi/;
-    license = stdenv.lib.licenses.lgpl21;
-    platforms = stdenv.lib.platforms.linux;
+    license = lib.licenses.lgpl21;
+    platforms = lib.platforms.all;
   };
 }

--- a/pkgs/development/tools/icestorm/default.nix
+++ b/pkgs/development/tools/icestorm/default.nix
@@ -6,12 +6,12 @@
 # and IceStorm isn't intended to be used as a library other than by the
 # nextpnr build process (which is also sped up by using PyPy), so we
 # use it by default. See 18839e1 for more details.
-, usePyPy ? stdenv.isx86_64 /* pypy3 seems broken on i686 */
+, usePyPy ? stdenv.hostPlatform.system == "x86_64-linux"
 }:
 
 stdenv.mkDerivation rec {
   pname = "icestorm";
-  version = "2019.08.08";
+  version = "2019.08.15";
 
   pythonPkg = if usePyPy then pypy3 else python3;
   pythonInterp = pythonPkg.interpreter;
@@ -19,8 +19,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner  = "cliffordwolf";
     repo   = "icestorm";
-    rev    = "2ccae0d3864fd7268118287a85963c0116745cff";
-    sha256 = "1vlk5k7x6c1bjp19niyl0shljj8il94q2brjmda1rwhqxz81g9s7";
+    rev    = "95949315364f8d9b0c693386aefadf44b28e2cf6";
+    sha256 = "05q1vxlf9l5z9mam8jbv58jqj7nsd8v7ssy753sharpgzzgdc8a2";
   };
 
   nativeBuildInputs = [ pkgconfig ];
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
     '';
     homepage    = http://www.clifford.at/icestorm/;
     license     = stdenv.lib.licenses.isc;
-    maintainers = with stdenv.lib.maintainers; [ shell thoughtpolice ];
-    platforms   = stdenv.lib.platforms.linux;
+    maintainers = with stdenv.lib.maintainers; [ shell thoughtpolice emily ];
+    platforms   = stdenv.lib.platforms.all;
   };
 }

--- a/pkgs/development/tools/trellis/default.nix
+++ b/pkgs/development/tools/trellis/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
     '';
     homepage    = https://github.com/symbiflow/prjtrellis;
     license     = stdenv.lib.licenses.isc;
-    maintainers = with maintainers; [ q3k thoughtpolice ];
-    platforms   = stdenv.lib.platforms.linux;
+    maintainers = with maintainers; [ q3k thoughtpolice emily ];
+    platforms   = stdenv.lib.platforms.all;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8155,11 +8155,7 @@ in
 
   neko = callPackage ../development/compilers/neko { };
 
-  nextpnr = libsForQt5.callPackage ../development/compilers/nextpnr {
-    # QT 5.12 has a weird regression involving the floorplanning window having
-    # a 'blank' or 'transparent' background, so fall back to 5.11 for now.
-    qtbase = qt511.qtbase;
-  };
+  nextpnr = libsForQt5.callPackage ../development/compilers/nextpnr { };
 
   nasm = callPackage ../development/compilers/nasm { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

nextpnr was broken due to the SHA-256 of an incorrect commit being used, oops; so I took the opportunity to bump versions again, fix a few issues, and add myself to maintainers. (It was working without errors for me locally because of `fetchFromGitHub` using a fixed-output derivation and having the other commit cached; is there any way to proactively debug these issues?)

I also extended the platforms to `platforms.all` because all of these tools should work fine on Darwin/macOS as far as I know (in fact, they all run on Windows). Let me know if this is incorrect.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @thoughtpolice; I'm pretty sure the reason the nextpnr GUI was broken was overriding `qtbase` rather than using `libsForQt511`, but I can't reproduce the issue with Qt 5.12 locally anyway so I bumped it back. It looks like it might be related to YosysHQ/nextpnr#240 / YosysHQ/nextpnr#278; YosysHQ/nextpnr#169 might have fixed it?

cc @worldofpeace for the Qt nixpkgs infra changes in 993c02afd472de0741cb5defa9e81440438c76c1