### PR TITLE
owl-lisp: 0.1.16 -> 0.1.19

### DIFF
--- a/pkgs/development/compilers/owl-lisp/default.nix
+++ b/pkgs/development/compilers/owl-lisp/default.nix
@@ -1,33 +1,31 @@
-{ stdenv, fetchFromGitHub, coreutils, which }:
+{ stdenv, fetchFromGitLab, coreutils, which }:
 
 stdenv.mkDerivation rec {
-  name    = "owl-lisp-${version}";
-  version = "0.1.16";
+  pname = "owl-lisp";
+  version = "0.1.19";
 
-  src = fetchFromGitHub {
-    owner  = "aoh";
-    repo   = "owl-lisp";
+  src = fetchFromGitLab {
+    owner  = "owl-lisp";
+    repo   = "owl";
     rev    = "v${version}";
-    sha256 = "1qp6p48bmlyn83rqi6k3d098dg4cribavg5rd4x17z37i181vxvj";
+    sha256 = "1bgjd2gkr5risfcc401rlr5fc82gwm4r2gpp9gzkg9h64acivkjx";
   };
 
   nativeBuildInputs = [ which ];
 
   prePatch = ''
-    substituteInPlace Makefile --replace /usr $out
-
-    for f in tests/run tests/exec.sh ; do
-      substituteInPlace $f --replace /bin/echo ${coreutils}/bin/echo
-    done
+    substituteInPlace Makefile \
+      --replace /usr $out
   '';
 
   # tests are run as part of the compilation process
   doCheck = false;
 
   meta = with stdenv.lib; {
-    description = "A functional lisp";
-    homepage    = https://github.com/aoh/owl-lisp;
+    description = "A functional Scheme for world domination";
+    homepage    = "https://gitlab.com/owl-lisp/owl";
     license     = licenses.mit;
     maintainers = with maintainers; [ peterhoeg ];
+    platforms   = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Regular update - new upstream as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
