### PR TITLE
sampler: init at 1.0.3

### DIFF
--- a/pkgs/applications/misc/sampler/default.nix
+++ b/pkgs/applications/misc/sampler/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildGoModule, fetchFromGitHub, alsaLib }:
+
+buildGoModule rec {
+  pname = "sampler";
+  version = "1.0.3";
+
+  src = fetchFromGitHub {
+    owner = "sqshq";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "129vifb1y57vyqj9p23gq778jschndh2y2ingwvjz0a6lrm45vpf";
+  };
+
+  modSha256 = "0wgwnn50lrg6ix5ll2jdwi421wgqgsv4y9xd5hfj81kya3dxcbw0";
+
+  subPackages = [ "." ];
+
+  buildInputs = [ alsaLib ];
+
+  meta = with lib; {
+    description = "Tool for shell commands execution, visualization and alerting";
+    homepage = "https://sampler.dev";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ uvnikita ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15058,6 +15058,8 @@ in
 
   sambaFull = samba4Full;
 
+  sampler = callPackage ../applications/misc/sampler { };
+
   shairplay = callPackage ../servers/shairplay { avahi = avahi-compat; };
 
   shairport-sync = callPackage ../servers/shairport-sync { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Sampler is a tool for a simple monitoring and alerting in console with ASCII graphics.
See https://github.com/sqshq/sampler.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
