### PR TITLE
quaternion: use qt specific mkDerivation

### DIFF
--- a/pkgs/applications/networking/instant-messengers/quaternion/default.nix
+++ b/pkgs/applications/networking/instant-messengers/quaternion/default.nix
@@ -1,10 +1,11 @@
-{ stdenv, lib, fetchFromGitHub, cmake
+{ mkDerivation, stdenv, lib, fetchFromGitHub, cmake
 , qtbase, qtquickcontrols, qtkeychain, qtmultimedia, qttools
 , libqmatrixclient_0_5 }:
 
 let
-  generic = version: sha256: prefix: library: stdenv.mkDerivation rec {
-    name = "quaternion-${version}";
+  generic = version: sha256: prefix: library: mkDerivation rec {
+    pname = "quaternion";
+    inherit version;
 
     src = fetchFromGitHub {
       owner = "QMatrixClient";
@@ -13,9 +14,9 @@ let
       inherit sha256;
     };
 
-    buildInputs = [ qtbase qtmultimedia qtquickcontrols qtkeychain qttools library ];
+    buildInputs = [ qtbase qtmultimedia qtquickcontrols qtkeychain library ];
 
-    nativeBuildInputs = [ cmake ];
+    nativeBuildInputs = [ cmake qttools ];
 
     postInstall = if stdenv.isDarwin then ''
       mkdir -p $out/Applications
@@ -28,7 +29,7 @@ let
 
     meta = with lib; {
       description = "Cross-platform desktop IM client for the Matrix protocol";
-      homepage    = https://matrix.org/docs/projects/client/quaternion.html;
+      homepage    = "https://matrix.org/docs/projects/client/quaternion.html";
       license     = licenses.gpl3;
       maintainers = with maintainers; [ peterhoeg ];
       inherit (qtbase.meta) platforms;


### PR DESCRIPTION
###### Motivation for this change

Use the proper qt5 mkDerivation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
