### PR TITLE
wsjtx: Fix qt errors

### DIFF
--- a/pkgs/applications/radio/wsjtx/default.nix
+++ b/pkgs/applications/radio/wsjtx/default.nix
@@ -1,9 +1,9 @@
 { stdenv, fetchurl, asciidoc, asciidoctor, autoconf, automake, cmake,
   docbook_xsl, fftw, fftwFloat, gfortran, libtool, libusb1, qtbase,
-  qtmultimedia, qtserialport, qttools, texinfo }:
+  qtmultimedia, qtserialport, qttools, texinfo, wrapQtAppsHook }:
 
 stdenv.mkDerivation rec {
-  name = "wsjtx-${version}";
+  pname = "wsjtx";
   version = "2.1.0";
 
   # This is a "superbuild" tarball containing both wsjtx and a hamlib fork
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   # Omitting pkgconfig because it causes issues locating the built hamlib
   nativeBuildInputs = [
     asciidoc asciidoctor autoconf automake cmake docbook_xsl gfortran libtool
-    qttools texinfo
+    qttools texinfo wrapQtAppsHook
   ];
   buildInputs = [ fftw fftwFloat libusb1 qtbase qtmultimedia qtserialport ];
 
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
       These modes were all designed for making reliable, confirmed ham radio
       contacts under extreme weak-signal conditions.
     '';
-    homepage = http://physics.princeton.edu/pulsar/k1jt/wsjtx.html;
+    homepage = "https://physics.princeton.edu/pulsar/k1jt/wsjtx.html";
     # Older licenses are for the statically-linked hamlib
     license = with licenses; [ gpl3Plus gpl2Plus lgpl21Plus ];
     platforms = platforms.linux;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Also do minor fixes of the derivation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @lasandell @adisbladis 
