### PR TITLE
jormungandr: removing rustup

### DIFF
--- a/pkgs/applications/altcoins/jormungandr/default.nix
+++ b/pkgs/applications/altcoins/jormungandr/default.nix
@@ -5,7 +5,6 @@
 , openssl
 , pkgconfig
 , protobuf
-, rustup
 , darwin
 }:
 
@@ -22,7 +21,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "13zcbhhdf4xakp37r920xzcb0prdk58jlph9f3hwlp8npmcws52p";
 
-  nativeBuildInputs = [ pkgconfig protobuf rustup ];
+  nativeBuildInputs = [ pkgconfig protobuf ];
   buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Security ];
 
   PROTOC = "${protobuf}/bin/protoc";


### PR DESCRIPTION
###### Motivation for this change

We do not require rustup anymore, therefore it won't be trying to create the .rustup.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
