### PR TITLE
uhubctl: init at unstable-2019-07-31

### DIFF
--- a/pkgs/tools/misc/uhubctl/default.nix
+++ b/pkgs/tools/misc/uhubctl/default.nix
@@ -1,0 +1,28 @@
+{ stdenv
+, fetchFromGitHub
+, libusb
+}:
+
+stdenv.mkDerivation rec {
+  pname = "uhubctl";
+  version = "unstable-2019-07-31";
+
+  src = fetchFromGitHub {
+    owner = "mvp";
+    repo = "uhubctl";
+    rev = "1961aa02e9924a54a6219d16c61a0beb0d626e46";
+    sha256 = "15mvqp1xh079nqp0mynh3l1wmw4maa320pn4jr8bz7nh3knmk0n1";
+  };
+
+  buildInputs = [ libusb ];
+
+  installFlags = [ "prefix=$(out)" ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/mvp/uhubctl";
+    description = "Utility to control USB power per-port on smart USB hubs";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ prusnak ];
+    platforms = with platforms; linux ++ darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24768,4 +24768,6 @@ in
   zfs-replicate = python3Packages.callPackage ../tools/backup/zfs-replicate { };
 
   runwayml = callPackage ../applications/graphics/runwayml {};
+
+  uhubctl = callPackage ../tools/misc/uhubctl {};
 }


### PR DESCRIPTION
#### Motivation for this change

This PR adds `uhubctl` utility to control USB power per-port on smart USB hubs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
