### PR TITLE
kodelife: init at 0.8.3.93

### DIFF
--- a/pkgs/applications/graphics/kodelife/default.nix
+++ b/pkgs/applications/graphics/kodelife/default.nix
@@ -1,0 +1,53 @@
+{ stdenv
+, fetchzip
+, alsaLib
+, glib
+, gst_all_1
+, libGLU_combined
+, xorg
+}:
+
+stdenv.mkDerivation rec {
+  pname = "kodelife";
+  version = "0.8.3.93";
+
+  src = fetchzip {
+    url = "https://hexler.net/pub/${pname}/${pname}-${version}-linux-x86_64.zip";
+    sha256 = "1gidh0745g5mc8h5ypm2wamv1paymnrq3nh3yx1j70jwjg8v2v7g";
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+  dontStrip = true;
+  dontPatchELF = true;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mv KodeLife $out/bin
+  '';
+
+  preFixup = let
+    libPath = stdenv.lib.makeLibraryPath [
+      stdenv.cc.cc.lib
+      alsaLib
+      glib
+      gst_all_1.gstreamer
+      gst_all_1.gst-plugins-base
+      libGLU_combined
+      xorg.libX11
+    ];
+  in ''
+    patchelf \
+      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --set-rpath "${libPath}" \
+      $out/bin/KodeLife
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://hexler.net/products/kodelife";
+    description = "Real-time GPU shader editor";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ prusnak ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24770,4 +24770,6 @@ in
   runwayml = callPackage ../applications/graphics/runwayml {};
 
   uhubctl = callPackage ../tools/misc/uhubctl {};
+
+  kodelife = callPackage ../applications/graphics/kodelife {};
 }


### PR DESCRIPTION
###### Motivation for this change

This adds KodeLife - Real-time GPU shader editor.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
