### PR TITLE
paprefs: clean up dependencies

### DIFF
--- a/pkgs/applications/audio/paprefs/default.nix
+++ b/pkgs/applications/audio/paprefs/default.nix
@@ -1,4 +1,14 @@
-{ fetchurl, stdenv, meson, ninja, gettext, pkgconfig, pulseaudioFull, gtkmm3, dbus-glib, wrapGAppsHook }:
+{ fetchurl
+, stdenv
+, meson
+, ninja
+, gettext
+, pkgconfig
+, pulseaudioFull
+, glibmm
+, gtkmm3
+, wrapGAppsHook
+}:
 
 stdenv.mkDerivation rec {
   name = "paprefs-1.1";
@@ -8,9 +18,19 @@ stdenv.mkDerivation rec {
     sha256 = "189z5p20hk0xv9vwvym293503j4pwl03xqk9hl7cl6dwgv0l7wkf";
   };
 
-  nativeBuildInputs = [ meson ninja gettext pkgconfig wrapGAppsHook ];
+  nativeBuildInputs = [
+    meson
+    ninja
+    gettext
+    pkgconfig
+    wrapGAppsHook
+  ];
 
-  buildInputs = [ pulseaudioFull gtkmm3 dbus-glib ];
+  buildInputs = [
+    pulseaudioFull
+    glibmm
+    gtkmm3
+  ];
 
   meta = with stdenv.lib; {
     description = "PulseAudio Preferences";


### PR DESCRIPTION
Since 1.1, paprefs no longer depends on dbus-glib but the dependencies were not refreshed during an automated update.

* https://gitlab.freedesktop.org/pulseaudio/paprefs/commit/b8246d3f9b308770a49861cd2dea4d06cd88554e
* https://gitlab.freedesktop.org/pulseaudio/paprefs/commit/0a5e8a94392df3f1af80d79d8253638b4945078f

While at it, also format inputs for diff friendliness.