### PR TITLE
liburing: bump to 0.1 tag + some extra patches

### DIFF
--- a/pkgs/development/libraries/liburing/default.nix
+++ b/pkgs/development/libraries/liburing/default.nix
@@ -1,15 +1,53 @@
 { stdenv, fetchgit
+, fetchpatch
 }:
 
 stdenv.mkDerivation rec {
   name = "liburing-${version}";
-  version = "1.0.0pre156_${builtins.substring 0 7 src.rev}";
+  version = "0.1";
 
   src = fetchgit {
     url    = "http://git.kernel.dk/liburing";
-    rev    = "c31c7ec4bcd7bb0d7b28897d730431c02b9d4ea1";
-    sha256 = "17d6s03fyajcrijca9d2d6llbf8cl8dyalpxnl39az3452p04s11";
+    rev    = "refs/tags/liburing-${version}";
+    sha256 = "038iqsbm9bdmlwvmb899bc6g1rw5dalr990azynbvgn8qs5adysh";
   };
+
+  patches = [
+
+    # This patch re-introduces support for aarch64-linux, by adding the
+    # necessary memory barrier primitives for it to work.
+    #
+    # Already upstream: remove when moving to the next version
+    (fetchpatch {
+      url    = "http://git.kernel.dk/cgit/liburing/patch/?id=0520db454c29f1d96cda6cf6cedeb93df65301e8";
+      sha256 = "1i8133sb1imzxpplmhlhnaxkffgplhj40vanivc6clbibvhgwpq6";
+    })
+
+    # This patch shuffles the name of the io_uring memory barrier primitives.
+    # They were using extremely common names by accident, which caused
+    # namespace conflicts with many other projects using the same names. Note:
+    # this does not change the user-visible API of liburing (liburing is
+    # designed exactly to hide the necessary memory barriers when using the
+    # io_uring syscall directly). It only changes the names of some internals.
+    # The only reason this caused problems at all is because memory barrier
+    # primitives are written as preprocessor defines, in a common header file,
+    # which get included unilaterally.
+    #
+    # Already upstream: remove when moving to the next version
+    (fetchpatch {
+      url    = "http://git.kernel.dk/cgit/liburing/patch/?id=552c6a08d04c74d20eeaa86f535bfd553b352370";
+      sha256 = "123d6jdqfy7b8aq9f6ax767n48hhbx6pln3nlrp623595i8zz3wf";
+    })
+
+    # Finally, this patch fixes the aarch64-linux support introduced by the
+    # first patch, but which was _broken_ by the second patch, in a horrid
+    # twist of fate: it neglected to change the names of the aarch64 barriers
+    # appropriately. (I assume the author did not attempt to compile for
+    # aarch64, hence this regression)
+    #
+    # Not yet upstream: TBD.
+    ./fix-aarch64-barrier-names.patch
+  ];
 
   separateDebugInfo = true;
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/liburing/fix-aarch64-barrier-names.patch
+++ b/pkgs/development/libraries/liburing/fix-aarch64-barrier-names.patch
@@ -1,0 +1,29 @@
+diff --git a/src/include/liburing/barrier.h b/src/include/liburing/barrier.h
+index 8efa6dd..051b20f 100644
+--- a/src/include/liburing/barrier.h
++++ b/src/include/liburing/barrier.h
+@@ -61,15 +61,15 @@ do {						\
+ 
+ #elif defined(__aarch64__)
+ /* Adapted from arch/arm64/include/asm/barrier.h */
+-#define dmb(opt)	asm volatile("dmb " #opt : : : "memory")
+-#define dsb(opt)	asm volatile("dsb " #opt : : : "memory")
+-
+-#define mb()		dsb(sy)
+-#define rmb()		dsb(ld)
+-#define wmb()		dsb(st)
+-#define smp_mb()	dmb(ish)
+-#define smp_rmb()	dmb(ishld)
+-#define smp_wmb()	dmb(ishst)
++#define io_uring_dmb(opt)	asm volatile("dmb " #opt : : : "memory")
++#define io_uring_dsb(opt)	asm volatile("dsb " #opt : : : "memory")
++
++#define io_uring_mb()		io_uring_dsb(sy)
++#define io_uring_rmb()		io_uring_dsb(ld)
++#define io_uring_wmb()		io_uring_dsb(st)
++#define io_uring_smp_mb()	io_uring_dmb(ish)
++#define io_uring_smp_rmb()	io_uring_dmb(ishld)
++#define io_uring_smp_wmb()	io_uring_dmb(ishst)
+ 
+ #else /* defined(__x86_64__) || defined(__i386__) || defined(__aarch64__) */
+ /*


### PR DESCRIPTION
Normally changing the version of the tag in this manner would be nasty
for users -- `nix-env -u` would not see this as an upgrade on the
channel, for instance, if you had a previous version installed. But
liburing is a *library* and does not really come included with any
useful end-user tools. Most cases will use it directly as a build
dependency, in which case, an appropriate rebuild will happen anyway.

This also re-introduces AArch64 builds, which was previously broken due
to some internal changes requiring memory barrier support. In a twist of
fate, however, this was later broken by another patch, which was written
to fix a *different* regression for users. So we simply apply both of
these patches, as well as a third patch that re-fixes AArch64 support,
which I will submit upstream to Jens. Life is never easy.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] other Linux distributions