### PR TITLE
agdaIowaStdlib: 1.4.0 -> 1.5.0, also agdaPrelude update

### DIFF
--- a/pkgs/development/libraries/agda/agda-iowa-stdlib/default.nix
+++ b/pkgs/development/libraries/agda/agda-iowa-stdlib/default.nix
@@ -1,14 +1,14 @@
 { stdenv, agda, fetchFromGitHub }:
 
 agda.mkDerivation (self: rec {
-  version = "1.4.0";
+  version = "1.5.0";
   name = "agda-iowa-stdlib-${version}";
 
   src = fetchFromGitHub {
     owner = "cedille";
     repo  = "ial";
     rev = "v${version}";
-    sha256 = "1gwxpybxwdj5ipbb3gapm7r5hfl3g6sj9kp13954pdmx8d5b0gma";
+    sha256 = "0dlis6v6nzbscf713cmwlx8h9n2gxghci8y21qak3hp18gkxdp0g";
   };
 
   sourceDirectories = [ "./." ];

--- a/pkgs/development/libraries/agda/agda-prelude/default.nix
+++ b/pkgs/development/libraries/agda/agda-prelude/default.nix
@@ -1,13 +1,13 @@
 { stdenv, agda, fetchgit }:
 
 agda.mkDerivation (self: rec {
-  version = "0dca24a81d417db2ae8fc871eccb7776f7eae952";
+  version = "eacc961c2c312b7443109a7872f99d55557df317";
   name = "agda-prelude-${version}";
 
   src = fetchgit {
     url = "https://github.com/UlfNorell/agda-prelude.git";
     rev = version;
-    sha256 = "0gwfgvj96i1mx5v01bi46h567d1q1fbgvzv6z8zv91l2jhybwff5";
+    sha256 = "0iql67hb1q0fn8dwkcx07brkdkxqfqrsbwjy71ndir0k7qzw7qv2";
   };
 
   topSourceDirectories = [ "src" ];


### PR DESCRIPTION
agdaIowaStdlib: https://hydra.nixos.org/build/98831905
agdaPrelude: https://hydra.nixos.org/build/98865987

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Fuuzetsu @mpickering 
