### PR TITLE
pythonPackages.urwid: 1.3.1 -> 2.0.1

### DIFF
--- a/pkgs/development/python-modules/urwid/default.nix
+++ b/pkgs/development/python-modules/urwid/default.nix
@@ -1,31 +1,13 @@
-{ stdenv, buildPythonPackage, fetchPypi, fetchpatch }:
+{ stdenv, buildPythonPackage, fetchPypi }:
 
-buildPythonPackage (rec {
+buildPythonPackage rec {
   pname = "urwid";
-  version = "1.3.1";
+  version = "2.0.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "18cnd1wdjcas08x5qwa5ayw6jsfcn33w4d9f7q3s29fy6qzc1kng";
+    sha256 = "1g6cpicybvbananpjikmjk8npmjk4xvak1wjzji62wc600wkwkb4";
   };
-
-  patches = [
-   # fix tests
-   (fetchpatch {
-     url = "https://github.com/urwid/urwid/commit/4b0ed8b6030450e6d99909a7c683e9642e546387.patch";
-     sha256 = "0azpn0ylbg8mfpr0y27n4lnq0ph75a4d4m9wdv3napnhf1vh9ahx";
-   })
-   # fix tests
-   (fetchpatch {
-     url = "https://github.com/floppym/urwid/commit/f68f2cf089cfd5ec45863baf59a91d5aeb0cf5c3.patch";
-     sha256 = "1b3vz7mrwz2bqvdwvbyv2j835f9lzapgw0j2km4sam76bxmgfpgq";
-   })
-  ];
-
-  postPatch = ''
-    # Several tests keep failing on Hydra
-    rm urwid/tests/test_vterm.py
-  '';
 
   meta = with stdenv.lib; {
     description = "A full-featured console (xterm et al.) user interface library";
@@ -34,4 +16,4 @@ buildPythonPackage (rec {
     license = licenses.lgpl21;
     maintainers = with maintainers; [ ];
   };
-})
+}


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

A new package I'd like to contribute depends on urwid>=2.0.0, from upstream's [changelog](http://urwid.org/changelog.html), it seems no breaking changes were done. I hope this is reliable enough and that this update won't break existing packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).