### PR TITLE
gnome3.gnome-characters: correct entry point

### DIFF
--- a/pkgs/desktops/gnome-3/apps/gnome-characters/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-characters/default.nix
@@ -1,38 +1,58 @@
-{ stdenv, fetchurl, meson, ninja, pkgconfig, gettext, gnome3, glib, gtk3, pango, wrapGAppsHook, python3
-, gobject-introspection, gjs, libunistring, gsettings-desktop-schemas, adwaita-icon-theme, gnome-desktop }:
+{ stdenv
+, fetchurl
+, meson
+, ninja
+, pkgconfig
+, gettext
+, gnome3
+, glib
+, gtk3
+, pango
+, wrapGAppsHook
+, python3
+, gobject-introspection
+, gjs
+, libunistring
+, gsettings-desktop-schemas
+, adwaita-icon-theme
+, gnome-desktop
+}:
 
 stdenv.mkDerivation rec {
-  name = "gnome-characters-${version}";
+  pname = "gnome-characters";
   version = "3.32.1";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/gnome-characters/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
+    url = "mirror://gnome/sources/gnome-characters/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "1mpg125x9k879ryg8xgbm9w1amx6b3iq9sqv7xfii7kzaanjb4js";
   };
+
+  nativeBuildInputs = [
+    gettext
+    gobject-introspection
+    meson
+    ninja
+    pkgconfig
+    python3
+    wrapGAppsHook
+  ];
+
+
+  buildInputs = [
+    adwaita-icon-theme
+    gjs
+    glib
+    gnome-desktop # for typelib
+    gsettings-desktop-schemas
+    gtk3
+    libunistring
+    pango
+  ];
 
   postPatch = ''
     chmod +x meson_post_install.py # patchShebangs requires executable file
     patchShebangs meson_post_install.py
   '';
-
-  passthru = {
-    updateScript = gnome3.updateScript {
-      packageName = "gnome-characters";
-      attrPath = "gnome3.gnome-characters";
-    };
-  };
-
-  nativeBuildInputs = [ meson ninja pkgconfig gettext wrapGAppsHook python3 gobject-introspection ];
-  buildInputs = [
-    glib gtk3 gjs pango gsettings-desktop-schemas
-    adwaita-icon-theme libunistring
-    # typelib
-    gnome-desktop
-  ];
-
-  mesonFlags = [
-    "-Ddbus_service_dir=${placeholder "out"}/share/dbus-1/services"
-  ];
 
   dontWrapGApps = true;
 
@@ -47,6 +67,13 @@ stdenv.mkDerivation rec {
       wrapProgram $file "''${gappsWrapperArgs[@]}"
     done
   '';
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = pname;
+      attrPath = "gnome3.${pname}";
+    };
+  };
 
   meta = with stdenv.lib; {
     homepage = https://wiki.gnome.org/Design/Apps/CharacterMap;

--- a/pkgs/desktops/gnome-3/apps/gnome-characters/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-characters/default.nix
@@ -34,6 +34,20 @@ stdenv.mkDerivation rec {
     "-Ddbus_service_dir=${placeholder "out"}/share/dbus-1/services"
   ];
 
+  dontWrapGApps = true;
+
+  # Fixes https://github.com/NixOS/nixpkgs/issues/31168
+  postFixup = ''
+    for file in $out/share/org.gnome.Characters/org.gnome.Characters \
+       $out/share/org.gnome.Characters/org.gnome.Characters.BackgroundService
+    do
+      sed -e $"2iimports.package._findEffectiveEntryPointName = () => \'$(basename $file)\' " \
+        -i $file
+
+      wrapProgram $file "''${gappsWrapperArgs[@]}"
+    done
+  '';
+
   meta = with stdenv.lib; {
     homepage = https://wiki.gnome.org/Design/Apps/CharacterMap;
     description = "Simple utility application to find and insert unusual characters";


### PR DESCRIPTION
###### Motivation for this change
Fix #31168

@jtojnar Do you remember if this was an edge case or a general issue?
If in general, maybe we could have a setup-hook to do this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
