### PR TITLE
linux: 5.2-rc7 -> 5.3-rc8

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -145,7 +145,7 @@ let
       NF_TABLES_IPV4              = whenAtLeast "4.17" yes;
       NF_TABLES_ARP               = whenAtLeast "4.17" yes;
       NF_TABLES_IPV6              = whenAtLeast "4.17" yes;
-      NF_TABLES_BRIDGE            = whenAtLeast "4.17" yes;
+      NF_TABLES_BRIDGE            = whenBetween "4.17" "5.3" yes;
     };
 
     wireless = {
@@ -631,8 +631,8 @@ let
       IDLE_PAGE_TRACKING  = yes;
       IRDA_ULTRA          = whenOlder "4.17" yes; # Ultra (connectionless) protocol
 
-      JOYSTICK_IFORCE_232 = option yes; # I-Force Serial joysticks and wheels
-      JOYSTICK_IFORCE_USB = option yes; # I-Force USB joysticks and wheels
+      JOYSTICK_IFORCE_232 = { optional = true; tristate = whenOlder "5.3" "y"; }; # I-Force Serial joysticks and wheels
+      JOYSTICK_IFORCE_USB = { optional = true; tristate = whenOlder "5.3" "y"; }; # I-Force USB joysticks and wheels
       JOYSTICK_XPAD_FF    = option yes; # X-Box gamepad rumble support
       JOYSTICK_XPAD_LEDS  = option yes; # LED Support for Xbox360 controller 'BigX' LED
 

--- a/pkgs/os-specific/linux/kernel/linux-testing.nix
+++ b/pkgs/os-specific/linux/kernel/linux-testing.nix
@@ -3,7 +3,7 @@
 with stdenv.lib;
 
 buildLinux (args // rec {
-  version = "5.3-rc7";
+  version = "5.3-rc8";
   extraMeta.branch = "5.3";
 
   # modDirVersion needs to be x.y.z, will always add .0
@@ -11,7 +11,7 @@ buildLinux (args // rec {
 
   src = fetchurl {
     url = "https://git.kernel.org/torvalds/t/linux-${version}.tar.gz";
-    sha256 = "1cjiy4sd681k6c75kjwldp4h7nqr9if668h3lcg09qyd80cqbywp";
+    sha256 = "01pr8xb9akjzafl8zkpwwkmlsjxghv5bx0larkjqdakjfspqnhzj";
   };
 
   # Should the testing kernels ever be built on Hydra?

--- a/pkgs/os-specific/linux/kernel/linux-testing.nix
+++ b/pkgs/os-specific/linux/kernel/linux-testing.nix
@@ -3,15 +3,15 @@
 with stdenv.lib;
 
 buildLinux (args // rec {
-  version = "5.2-rc7";
-  extraMeta.branch = "5.2";
+  version = "5.3-rc5";
+  extraMeta.branch = "5.3";
 
   # modDirVersion needs to be x.y.z, will always add .0
   modDirVersion = if (modDirVersionArg == null) then builtins.replaceStrings ["-"] [".0-"] version else modDirVersionArg;
 
   src = fetchurl {
     url = "https://git.kernel.org/torvalds/t/linux-${version}.tar.gz";
-    sha256 = "1128jb1y4gia5icv614ycp3c5mkvrb2l2wn20765b3si256g68n4";
+    sha256 = "1hsmd53fn1irv7w0z84i3rqdi497p1hsazasjv4g3bj1s9qcqjbp";
   };
 
   # Should the testing kernels ever be built on Hydra?

--- a/pkgs/os-specific/linux/kernel/linux-testing.nix
+++ b/pkgs/os-specific/linux/kernel/linux-testing.nix
@@ -3,7 +3,7 @@
 with stdenv.lib;
 
 buildLinux (args // rec {
-  version = "5.3-rc5";
+  version = "5.3-rc6";
   extraMeta.branch = "5.3";
 
   # modDirVersion needs to be x.y.z, will always add .0
@@ -11,7 +11,7 @@ buildLinux (args // rec {
 
   src = fetchurl {
     url = "https://git.kernel.org/torvalds/t/linux-${version}.tar.gz";
-    sha256 = "1hsmd53fn1irv7w0z84i3rqdi497p1hsazasjv4g3bj1s9qcqjbp";
+    sha256 = "0q6h4hr42bi6cj8vi3g2v4yqj7x8rz8npz8sr2lxh0gy35akjdig";
   };
 
   # Should the testing kernels ever be built on Hydra?

--- a/pkgs/os-specific/linux/kernel/linux-testing.nix
+++ b/pkgs/os-specific/linux/kernel/linux-testing.nix
@@ -3,7 +3,7 @@
 with stdenv.lib;
 
 buildLinux (args // rec {
-  version = "5.3-rc6";
+  version = "5.3-rc7";
   extraMeta.branch = "5.3";
 
   # modDirVersion needs to be x.y.z, will always add .0
@@ -11,7 +11,7 @@ buildLinux (args // rec {
 
   src = fetchurl {
     url = "https://git.kernel.org/torvalds/t/linux-${version}.tar.gz";
-    sha256 = "0q6h4hr42bi6cj8vi3g2v4yqj7x8rz8npz8sr2lxh0gy35akjdig";
+    sha256 = "1cjiy4sd681k6c75kjwldp4h7nqr9if668h3lcg09qyd80cqbywp";
   };
 
   # Should the testing kernels ever be built on Hydra?

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -190,7 +190,6 @@ let
         # To save space, exclude a bunch of unneeded stuff when copying.
         (cd .. && rsync --archive --prune-empty-dirs \
             --exclude='/build/' \
-            --exclude='/Documentation/' \
             * $dev/lib/modules/${modDirVersion}/source/)
 
         cd $dev/lib/modules/${modDirVersion}/source

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15740,8 +15740,6 @@ in
   linux_testing = callPackage ../os-specific/linux/kernel/linux-testing.nix {
     kernelPatches = [
       kernelPatches.bridge_stp_helper
-      kernelPatches.modinst_arg_list_too_long
-      kernelPatches.export_kernel_fpu_functions
     ];
   };
 


### PR DESCRIPTION
###### Motivation for this change
Get ready for next mainstream kernel

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I had to remove the `--exclude='/Documentation/'` clause because I could not figure out how to make the build happy.
It will look for `Documentation/KConfig` and try to build that.
Somehow, I could not determine where it is actually told to look for that...

The fpu functions are now exported (under different names) and zfsonlinux/zfs@becdcec7b9cd6b8beaa2273495b97c06de24e9e5 picks them up from there