### PR TITLE
postman: 7.0.7 -> 7.6.0

### DIFF
--- a/pkgs/development/web/postman/default.nix
+++ b/pkgs/development/web/postman/default.nix
@@ -96,6 +96,6 @@ stdenv.mkDerivation rec {
     description = "API Development Environment";
     license = licenses.postman;
     platforms = [ "x86_64-linux" ];
-    maintainers = with maintainers; [ xurei ];
+    maintainers = with maintainers; [ xurei evanjs ];
   };
 }

--- a/pkgs/development/web/postman/default.nix
+++ b/pkgs/development/web/postman/default.nix
@@ -1,20 +1,22 @@
-{ stdenv, lib, gnome2, fetchurl, pkgs, xorg, makeWrapper, makeDesktopItem }:
+{ stdenv, fetchurl, makeDesktopItem, wrapGAppsHook
+, atk, at-spi2-atk, alsaLib, cairo, cups, dbus, expat, gdk-pixbuf, glib, gtk3
+, freetype, fontconfig, nss, nspr, pango, udev, libX11, libxcb, libXi
+, libXcursor, libXdamage, libXrandr, libXcomposite, libXext, libXfixes
+, libXrender, libXtst, libXScrnSaver
+}:
 
 stdenv.mkDerivation rec {
   pname = "postman";
-  version = "7.0.7";
+  version = "7.6.0";
 
   src = fetchurl {
     url = "https://dl.pstmn.io/download/version/${version}/linux64";
-    sha256 = "47be1b955759520f3a2c7dcdecb85b4c52c38df717da294ba184f46f2058014a";
-    name = "${pname}-${version}.tar.gz";
+    sha256 = "sha256:03y82ydkj46l7dn35y944gnghbrrhc75y3yxdyidbh8fl3xvmlfv";
+    name = "${pname}.tar.gz";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
-
-  dontPatchELF = true;
-
-  buildPhase = ":";   # nothing to build
+  dontBuild = true; # nothing to build
+  dontConfigure = true;
 
   desktopItem = makeDesktopItem {
     name = "postman";
@@ -26,12 +28,48 @@ stdenv.mkDerivation rec {
     categories = "Application;Development;";
   };
 
+  buildInputs = [
+    stdenv.cc.cc.lib
+    atk
+    at-spi2-atk
+    alsaLib
+    cairo
+    cups
+    dbus
+    expat
+    gdk-pixbuf
+    glib
+    gtk3
+    freetype
+    fontconfig
+    nss
+    nspr
+    pango
+    udev
+    libX11
+    libxcb
+    libXi
+    libXcursor
+    libXdamage
+    libXrandr
+    libXcomposite
+    libXext
+    libXfixes
+    libXrender
+    libXtst
+    libXScrnSaver
+  ];
+
+  nativeBuildInputs = [ wrapGAppsHook ];
+
+
   installPhase = ''
     mkdir -p $out/share/postman
     cp -R app/* $out/share/postman
+    rm $out/share/postman/Postman
 
     mkdir -p $out/bin
-    ln -s $out/share/postman/Postman $out/bin/postman
+    ln -s $out/share/postman/_Postman $out/bin/postman
 
     mkdir -p $out/share/applications
     ln -s ${desktopItem}/share/applications/* $out/share/applications/
@@ -43,54 +81,20 @@ stdenv.mkDerivation rec {
     ln -s $out/share/postman/resources/app/assets/icon.png $iconSizeDir/postman.png
   '';
 
-  preFixup = let
-    libPath = lib.makeLibraryPath [
-      stdenv.cc.cc.lib
-      gnome2.pango
-      gnome2.GConf
-      pkgs.atk
-      pkgs.alsaLib
-      pkgs.cairo
-      pkgs.cups
-      pkgs.dbus.daemon.lib
-      pkgs.expat
-      pkgs.gdk-pixbuf
-      pkgs.glib
-      pkgs.gtk2-x11
-      pkgs.freetype
-      pkgs.fontconfig
-      pkgs.nss
-      pkgs.nspr
-      pkgs.udev.lib
-      xorg.libX11
-      xorg.libxcb
-      xorg.libXi
-      xorg.libXcursor
-      xorg.libXdamage
-      xorg.libXrandr
-      xorg.libXcomposite
-      xorg.libXext
-      xorg.libXfixes
-      xorg.libXrender
-      xorg.libX11
-      xorg.libXtst
-      xorg.libXScrnSaver
-    ];
-  in ''
-    patchelf \
-      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-      --set-rpath "${libPath}:$out/share/postman" \
-      $out/share/postman/Postman
-    patchelf --set-rpath "${libPath}" $out/share/postman/libnode.so
-    patchelf --set-rpath "${libPath}" $out/share/postman/libffmpeg.so
-
-    wrapProgram $out/share/postman/Postman --prefix LD_LIBRARY_PATH : ${libPath}
+  postFixup = ''
+    pushd $out/share/postman
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" _Postman
+    for file in $(find . -type f \( -name \*.node -o -name _Postman -o -name \*.so\* \) ); do
+      ORIGIN=$(patchelf --print-rpath $file); \
+      patchelf --set-rpath "${stdenv.lib.makeLibraryPath buildInputs}:$ORIGIN" $file
+    done
+    popd
   '';
 
   meta = with stdenv.lib; {
     homepage = https://www.getpostman.com;
     description = "API Development Environment";
-    license = stdenv.lib.licenses.postman;
+    license = licenses.postman;
     platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ xurei ];
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
https://www.getpostman.com/downloads/release-notes#changelog-linux-app-7.6.0

###### Things done
##### Major refactor
- This was primarily based on the GitKraken [expression](https://github.com/NixOS/nixpkgs/blob/7bc147a4966cfef5a27401c26ad1e8caddb9fc74/pkgs/applications/version-management/gitkraken/default.nix)
___
- Remove gnome2 (#39976)
  - Use pango instead of gnome2.pango
  - Remove gnome2.GConf
  - Remove gtk2-x11
- Add at-spi2-atk dependency
- Explicitly import packages rather than just pkgs or xorg
- Refactor patchelf to be more generic
- Use wrapGAppsHook
- Move libPath definition out of preFixup
- Remove dontPatchELF
- Remove unnecessary Postman binary, only use _Postman
___
###### Testing
- Open app
- Sent GET and POST requests and received responses
- Changed some settings
- Created a new collection
- Created a new request

Not experiencing any issues from the little I've tested so far.
___
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @xurei 
