### PR TITLE
xen: 4.8.3 -> 4.8.5, unbreak

### DIFF
--- a/pkgs/applications/virtualization/xen/4.8.nix
+++ b/pkgs/applications/virtualization/xen/4.8.nix
@@ -68,7 +68,7 @@ callPackage (import ./generic.nix (rec {
       src = fetchgit {
         url = https://xenbits.xen.org/git-http/qemu-xen.git;
         rev = "refs/tags/qemu-xen-${version}";
-        sha256 = "090ibcgs3xwmavk9yg2vaqr3xp9hirnfd3r40ccvrl49c5x58w3g";
+        sha256 = "0lb7zd5nvr6znx47z93nbq4gj8xfb3622s8r2cvmpqmwnmlc3nd4";
       };
       patches = [
         qemuMemfdBuildFix

--- a/pkgs/applications/virtualization/xen/4.8.nix
+++ b/pkgs/applications/virtualization/xen/4.8.nix
@@ -43,6 +43,11 @@ let
     sha256 = "0gaz93kb33qc0jx6iphvny0yrd17i8zhcl3a9ky5ylc2idz0wiwa";
   };
 
+  # Ported from
+  #"https://xenbits.xen.org/gitweb/?p=qemu-xen.git;a=patch;h=e014dbe74e0484188164c61ff6843f8a04a8cb9d";
+  #"https://xenbits.xen.org/gitweb/?p=qemu-xen.git;a=patch;h=0e3b891fefacc0e49f3c8ffa3a753b69eb7214d2";
+  qemuGlusterfs6Fix = ./qemu-gluster-6-compat.diff;
+
   qemuDeps = [
     udev pciutils xorg.libX11 SDL pixman acl glusterfs spice-protocol usbredir
     alsaLib
@@ -50,11 +55,11 @@ let
 in
 
 callPackage (import ./generic.nix (rec {
-  version = "4.8.3";
+  version = "4.8.5";
 
   src = fetchurl {
     url = "https://downloads.xenproject.org/release/xen/${version}/xen-${version}.tar.gz";
-    sha256 = "0vhkpyy5x7kc36hnav95fn194ngsmc3m2xcc78vccs00gdf6m8q9";
+    sha256 = "04xcf01jad1lpqnmjblzhnjzp0bss9fjd9awgcycjx679arbaxqz";
   };
 
   # Sources needed to build tools and firmwares.
@@ -63,10 +68,11 @@ callPackage (import ./generic.nix (rec {
       src = fetchgit {
         url = https://xenbits.xen.org/git-http/qemu-xen.git;
         rev = "refs/tags/qemu-xen-${version}";
-        sha256 = "0lb7zd5nvr6znx47z93nbq4gj8xfb3622s8r2cvmpqmwnmlc3nd4";
+        sha256 = "090ibcgs3xwmavk9yg2vaqr3xp9hirnfd3r40ccvrl49c5x58w3g";
       };
       patches = [
         qemuMemfdBuildFix
+        qemuGlusterfs6Fix
       ];
       buildInputs = qemuDeps;
       meta.description = "Xen's fork of upstream Qemu";
@@ -155,13 +161,8 @@ callPackage (import ./generic.nix (rec {
     ++ optional (withInternalOVMF) "--enable-ovmf";
 
   patches = with xsa; flatten [
-    # XSA_231 to XSA-251 are fixed in 4.8.3 (verified with git log)
-    XSA_252_49
     # 253: 4.8 not affected
     # 254: no patch supplied by xen project (Meltdown/Spectre)
-    XSA_255_49_1
-    XSA_255_49_2
-    XSA_256_48
     xenlockprofpatch
     xenpmdpatch
   ];
@@ -176,10 +177,8 @@ callPackage (import ./generic.nix (rec {
       -i tools/libxl/libxl_device.c
   '';
 
-  passthru = {
-    qemu-system-i386 = if withInternalQemu
+  passthru.qemu-system-i386 = if withInternalQemu
       then "lib/xen/bin/qemu-system-i386"
       else throw "this xen has no qemu builtin";
-  };
 
 })) ({ ocamlPackages = ocaml-ng.ocamlPackages_4_05; } // args)

--- a/pkgs/applications/virtualization/xen/generic.nix
+++ b/pkgs/applications/virtualization/xen/generic.nix
@@ -121,8 +121,8 @@ stdenv.mkDerivation (rec {
 
   patches = [ ./0000-fix-ipxe-src.patch
               ./0000-fix-install-python.patch
-              ./acpica-utils-20180427.patch]
-         ++ (config.patches or []);
+            ] ++ optional (versionOlder version "4.8.5") ./acpica-utils-20180427.patch
+            ++ (config.patches or []);
 
   postPatch = ''
     ### Hacks

--- a/pkgs/applications/virtualization/xen/qemu-gluster-6-compat.diff
+++ b/pkgs/applications/virtualization/xen/qemu-gluster-6-compat.diff
@@ -1,0 +1,95 @@
+diff --git a/block/gluster.c b/block/gluster.c
+index 01b479fbb9..29552e1186 100644
+--- a/block/gluster.c
++++ b/block/gluster.c
+@@ -15,6 +15,10 @@
+ #include "qemu/uri.h"
+ #include "qemu/error-report.h"
+ 
++#ifdef CONFIG_GLUSTERFS_FTRUNCATE_HAS_STAT
++# define glfs_ftruncate(fd, offset) glfs_ftruncate(fd, offset, NULL, NULL)
++#endif
++
+ #define GLUSTER_OPT_FILENAME        "filename"
+ #define GLUSTER_OPT_VOLUME          "volume"
+ #define GLUSTER_OPT_PATH            "path"
+@@ -613,7 +617,11 @@ static void qemu_gluster_complete_aio(void *opaque)
+ /*
+  * AIO callback routine called from GlusterFS thread.
+  */
+-static void gluster_finish_aiocb(struct glfs_fd *fd, ssize_t ret, void *arg)
++static void gluster_finish_aiocb(struct glfs_fd *fd, ssize_t ret,
++#ifdef CONFIG_GLUSTERFS_IOCB_HAS_STAT
++                                 struct glfs_stat *pre, struct glfs_stat *post,
++#endif
++                                 void *arg)
+ {
+     GlusterAIOCB *acb = (GlusterAIOCB *)arg;
+ 
+diff --git a/configure b/configure
+index 4b808f9d17..89fb27fd0d 100755
+--- a/configure
++++ b/configure
+@@ -301,6 +301,8 @@ glusterfs=""
+ glusterfs_xlator_opt="no"
+ glusterfs_discard="no"
+ glusterfs_zerofill="no"
++glusterfs_ftruncate_has_stat="no"
++glusterfs_iocb_has_stat="no"
+ archipelago="no"
+ gtk=""
+ gtkabi=""
+@@ -3444,6 +3446,38 @@ if test "$glusterfs" != "no" ; then
+     if $pkg_config --atleast-version=6 glusterfs-api; then
+       glusterfs_zerofill="yes"
+     fi
++    cat > $TMPC << EOF
++#include <glusterfs/api/glfs.h>
++
++int
++main(void)
++{
++	/* new glfs_ftruncate() passes two additional args */
++	return glfs_ftruncate(NULL, 0, NULL, NULL);
++}
++EOF
++    if compile_prog "$glusterfs_cflags" "$glusterfs_libs" ; then
++      glusterfs_ftruncate_has_stat="yes"
++    fi
++    cat > $TMPC << EOF
++#include <glusterfs/api/glfs.h>
++
++/* new glfs_io_cbk() passes two additional glfs_stat structs */
++static void
++glusterfs_iocb(glfs_fd_t *fd, ssize_t ret, struct glfs_stat *prestat, struct glfs_stat *poststat, void *data)
++{}
++
++int
++main(void)
++{
++	glfs_io_cbk iocb = &glusterfs_iocb;
++	iocb(NULL, 0 , NULL, NULL, NULL);
++	return 0;
++}
++EOF
++    if compile_prog "$glusterfs_cflags" "$glusterfs_libs" ; then
++      glusterfs_iocb_has_stat="yes"
++    fi
+   else
+     if test "$glusterfs" = "yes" ; then
+       feature_not_found "GlusterFS backend support" \
+@@ -5415,6 +5449,14 @@ if test "$archipelago" = "yes" ; then
+   echo "ARCHIPELAGO_LIBS=$archipelago_libs" >> $config_host_mak
+ fi
+ 
++if test "$glusterfs_ftruncate_has_stat" = "yes" ; then
++  echo "CONFIG_GLUSTERFS_FTRUNCATE_HAS_STAT=y" >> $config_host_mak
++fi
++
++if test "$glusterfs_iocb_has_stat" = "yes" ; then
++  echo "CONFIG_GLUSTERFS_IOCB_HAS_STAT=y" >> $config_host_mak
++fi
++
+ if test "$libssh2" = "yes" ; then
+   echo "CONFIG_LIBSSH2=m" >> $config_host_mak
+   echo "LIBSSH2_CFLAGS=$libssh2_cflags" >> $config_host_mak


### PR DESCRIPTION
It was broken during GlusterFs upgrade: https://github.com/NixOS/nixpkgs/pull/66736

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @oxij @Shados 
