### PR TITLE
nixos/containers: add unprivileged option

### DIFF
--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -139,6 +139,7 @@ let
         --bind="/nix/var/nix/profiles/per-container/$INSTANCE:/nix/var/nix/profiles" \
         --bind="/nix/var/nix/gcroots/per-container/$INSTANCE:/nix/var/nix/gcroots" \
         ${optionalString (!cfg.ephemeral) "--link-journal=try-guest"} \
+        ${optionalString (cfg.unprivileged) "-U"} \
         --setenv PRIVATE_NETWORK="$PRIVATE_NETWORK" \
         --setenv HOST_BRIDGE="$HOST_BRIDGE" \
         --setenv HOST_ADDRESS="$HOST_ADDRESS" \
@@ -238,8 +239,8 @@ let
     ExecReload = pkgs.writeScript "reload-container"
       ''
         #! ${pkgs.runtimeShell} -e
-        ${pkgs.nixos-container}/bin/nixos-container run "$INSTANCE" -- \
-          bash --login -c "''${SYSTEM_PATH:-/nix/var/nix/profiles/system}/bin/switch-to-configuration test"
+        ${pkgs.systemd}/bin/machinectl shell "$INSTANCE" \
+          ''${SYSTEM_PATH:-/nix/var/nix/profiles/system}/bin/switch-to-configuration test
       '';
 
     SyslogIdentifier = "container %i";
@@ -423,6 +424,7 @@ let
       extraVeths = {};
       additionalCapabilities = [];
       ephemeral = false;
+      unprivileged = false;
       allowedDevices = [];
       hostAddress = null;
       hostAddress6 = null;
@@ -513,6 +515,16 @@ in
                 Grant additional capabilities to the container.  See the
                 capabilities(7) and systemd-nspawn(1) man pages for more
                 information.
+              '';
+            };
+
+            unprivileged = mkOption {
+              type = types.bool;
+              default = false;
+              description = ''
+                Run container in unprivileged mode using private users feature of <command>systemd-nspawn</command>.
+                This option is eqvivalent of adding -U parameter to <command>systemd-nspawn</command> command.
+                See <literal>systemd-nspawn(1)</literal> man page for more information.
               '';
             };
 

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -48,6 +48,7 @@ in
   colord = handleTest ./colord.nix {};
   containers-bridge = handleTest ./containers-bridge.nix {};
   containers-ephemeral = handleTest ./containers-ephemeral.nix {};
+  containers-unprivileged = handleTest ./containers-unprivileged.nix {};
   containers-extra_veth = handleTest ./containers-extra_veth.nix {};
   containers-hosts = handleTest ./containers-hosts.nix {};
   containers-imperative = handleTest ./containers-imperative.nix {};

--- a/nixos/tests/containers-unprivileged.nix
+++ b/nixos/tests/containers-unprivileged.nix
@@ -1,0 +1,56 @@
+# Test for NixOS' container support.
+
+import ./make-test.nix ({ pkgs, ...} : {
+  name = "containers-unprivileged";
+
+  machine = { pkgs, ... }: {
+    virtualisation.memorySize = 768;
+    virtualisation.writableStore = true;
+
+    containers.webserver = {
+      unprivileged = true;
+      privateNetwork = true;
+      hostAddress = "10.231.136.1";
+      localAddress = "10.231.136.2";
+      config = {
+        services.nginx = {
+          enable = true;
+          virtualHosts.localhost = {
+            root = (pkgs.runCommand "localhost" {} ''
+              mkdir "$out"
+              echo hello world > "$out/index.html"
+            '');
+          };
+        };
+        networking.firewall.allowedTCPPorts = [ 80 ];
+      };
+    };
+  };
+
+  testScript = ''
+    $machine->succeed("nixos-container list") =~ /webserver/ or die;
+
+    # Start the webserver container.
+    $machine->succeed("nixos-container start webserver");
+
+    my $ip = $machine->succeed("nixos-container show-ip webserver");
+    chomp $ip;
+    $machine->succeed("ping -n -c1 $ip");
+
+    # Check that container root folder is owned by a new private user
+    $machine->succeed('test $(stat -c "%U" /var/lib/containers/webserver) == "vu-webserver-0"');
+
+    # Check that webserver is working before reload
+    $machine->succeed("curl --fail http://$ip/ > /dev/null");
+
+    # Reload container
+    $machine->succeed('systemctl reload container@webserver');
+
+    # Check that webserver is working after reload
+    $machine->succeed("curl --fail http://$ip/ > /dev/null");
+
+    # Stop the container.
+    $machine->succeed("nixos-container stop webserver");
+    $machine->fail("curl --fail --connect-timeout 2 http://$ip/ > /dev/null");
+  '';
+})


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
There are two parts of this commit:
- the switch from `nixos-container run` to `machinectl shell` in reload command which fixes #57083
- the new `unprivileged` option that adds `-U` to `systemd-nspawn` command

As described in #57083, the first change is necessary since `nixos-container` command fails to enter container namespace when userns is enabled due to missing `-u` argument to nsenter call. Otherwise, to my best knowledge, `machinectl shell` should be a drop-in replacement for `nixos-container run` in this context.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @grahamc @danbst @flokli @arianvp @mmahut 
