### PR TITLE
libv4l: disable building qt

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12346,6 +12346,7 @@ in
   };
 
   libv4l = lowPrio (v4l-utils.override {
+    withGUI = false;
     withUtils = false;
   });
 


### PR DESCRIPTION
fda2590abb81 ported v4l-utils to Qt5. Unfortunately, they included it into libv4l variant, increasing the closure size for sane-backends among other things. This removes the GUI support from the library.