### PR TITLE
pythonPackage.Fabric: 2.4.0 -> 2.5.0

### DIFF
--- a/pkgs/development/python-modules/Fabric/default.nix
+++ b/pkgs/development/python-modules/Fabric/default.nix
@@ -1,33 +1,29 @@
-{ pkgs
-, buildPythonPackage
-, fetchPypi
-, invoke
-, paramiko
+{ lib, buildPythonPackage, fetchPypi
 , cryptography
-, pytest
+, invoke
 , mock
+, paramiko
+, pytest
 , pytest-relaxed
 }:
 
 buildPythonPackage rec {
   pname = "fabric";
-  version = "2.4.0";
+  version = "2.5.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "93684ceaac92e0b78faae551297e29c48370cede12ff0f853cdebf67d4b87068";
+    sha256 = "19nzdibjfndzcwvby20p59igqwyzw7skrb45v2mxqsjma5yjv114";
   };
 
   propagatedBuildInputs = [ invoke paramiko cryptography ];
   checkInputs = [ pytest mock pytest-relaxed ];
 
-  # ignore subprocess main errors (1) due to hardcoded /bin/bash
   checkPhase = ''
-    rm tests/main.py
     pytest tests
   '';
 
-  meta = with pkgs.lib; {
+  meta = with lib; {
     description = "Pythonic remote execution";
     homepage    = https://www.fabfile.org/;
     license     = licenses.bsd2;

--- a/pkgs/development/python-modules/invoke/default.nix
+++ b/pkgs/development/python-modules/invoke/default.nix
@@ -6,11 +6,11 @@
 
 buildPythonPackage rec {
   pname = "invoke";
-  version = "1.2.0";
+  version = "1.3.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1dr1a5qbb9z5hyns4zk086zm0iqbms33zv0s1296wx502y7jyjfw";
+    sha256 = "1nn7gad0rvy492acpyhkrp01zsk86acf34qhsvq4xmm6x39788n5";
   };
 
   patchPhase = ''


### PR DESCRIPTION
###### Motivation for this change
noticed it was acting weird while reviewing #67063

decided to bump it.

closes #67063

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @costrouc 

```
[1 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/67140
5 package were build:
Fabric pipenv python27Packages.invoke python37Packages.Fabric python37Packages.invoke
```