### PR TITLE
Bump libosinfo packages

### DIFF
--- a/pkgs/data/misc/osinfo-db/default.nix
+++ b/pkgs/data/misc/osinfo-db/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "osinfo-db";
-  version = "20190726";
+  version = "20190805";
 
   src = fetchurl {
     url = "https://releases.pagure.org/libosinfo/${pname}-${version}.tar.xz";
-    sha256 = "0kcdq8g324a368bqvki718ms5kdcc3dzfmpgzyxwl0mkxbmhmirr";
+    sha256 = "1la80kmh58nrra8aa4grv31gc7xbqbybl8q1m4yv0byb11slg93x";
   };
 
   nativeBuildInputs = [ osinfo-db-tools intltool libxml2 ];

--- a/pkgs/development/libraries/libosinfo/default.nix
+++ b/pkgs/development/libraries/libosinfo/default.nix
@@ -1,43 +1,31 @@
-{ stdenv, fetchurl, fetchpatch, pkgconfig, intltool, gobject-introspection, gtk-doc, docbook_xsl
-, glib, libsoup, libxml2, libxslt, check, curl, perl, hwdata, osinfo-db, vala ? null
+{ stdenv, fetchurl, fetchpatch, pkgconfig, gettext, gobject-introspection, gtk-doc, docbook_xsl
+, glib, libsoup, libxml2, libxslt, check, curl, perl, hwdata, osinfo-db, substituteAll
+, vala ? null
 }:
 
 stdenv.mkDerivation rec {
   pname = "libosinfo";
-  version = "1.5.0";
+  version = "1.6.0";
 
   src = fetchurl {
     url = "https://releases.pagure.org/${pname}/${pname}-${version}.tar.gz";
-    sha256 = "12b0xj9fz9q91d1pz9xm6aqap5k1ip0m9m3qvqmwjy1lk1kjasdz";
+    sha256 = "1iwh35mahch1ls3sgq7wz8kamxrxisrff5ciqzyh2qxlrqf5qf1w";
   };
 
   outputs = [ "out" "dev" "devdoc" ];
 
   nativeBuildInputs = [
-    pkgconfig vala intltool gobject-introspection gtk-doc docbook_xsl
+    pkgconfig vala gettext gobject-introspection gtk-doc docbook_xsl
   ];
   buildInputs = [ glib libsoup libxml2 libxslt ];
   checkInputs = [ check curl perl ];
 
   patches = [
-    ./osinfo-db-data-dir.patch
-    # https://nvd.nist.gov/vuln/detail/CVE-2019-13313
-    (fetchpatch {
-      url = "https://gitlab.com/libosinfo/libosinfo/commit/3654abee6ead9f11f8bb9ba8fc71efd6fa4dabbc.patch";
-      name = "CVE-2019-13313-1.patch";
-      sha256 = "1lybywfj6b41zfjk33ap90bab5l84lf5y3kif7vd2b6wq5r91rcn";
-    })
-    (fetchpatch {
-      url = "https://gitlab.com/libosinfo/libosinfo/commit/08fb8316b4ac42fe74c1fa5ca0ac593222cdf81a.patch";
-      name = "CVE-2019-13313-2.patch";
-      sha256 = "1f6rhkrgy3j8nmidk97wnz6p35zs1dsd63d3np76q7qs7ra74w9z";
+    (substituteAll {
+      src = ./osinfo-db-data-dir.patch;
+      osinfo_db_data_dir = "${osinfo-db}/share";
     })
   ];
-
-  postPatch = ''
-    patchShebangs .
-    substituteInPlace osinfo/osinfo_loader.c --subst-var-by OSINFO_DB_DATA_DIR "${osinfo-db}/share"
-  '';
 
   configureFlags = [
     "--with-usb-ids-path=${hwdata}/share/hwdata/usb.ids"

--- a/pkgs/development/libraries/libosinfo/osinfo-db-data-dir.patch
+++ b/pkgs/development/libraries/libosinfo/osinfo-db-data-dir.patch
@@ -5,7 +5,7 @@
          path = g_getenv("OSINFO_SYSTEM_DIR");
          if (!path)
 -            path = DATA_DIR "/osinfo";
-+            path = "@OSINFO_DB_DATA_DIR@/osinfo";
++            path = "@osinfo_db_data_dir@/osinfo";
  
          file = g_file_new_for_path(path);
      }

--- a/pkgs/tools/misc/osinfo-db-tools/default.nix
+++ b/pkgs/tools/misc/osinfo-db-tools/default.nix
@@ -1,18 +1,18 @@
-{ stdenv, fetchurl, pkgconfig, intltool, glib, libxml2
-, libxslt, libarchive, bzip2, lzma, json-glib
+{ stdenv, fetchurl, pkgconfig, gettext, glib, libxml2, perl
+, libxslt, libarchive, bzip2, lzma, json-glib, libsoup
 }:
 
 stdenv.mkDerivation rec {
   pname = "osinfo-db-tools";
-  version = "1.5.0";
+  version = "1.6.0";
 
   src = fetchurl {
     url = "https://releases.pagure.org/libosinfo/${pname}-${version}.tar.gz";
-    sha256 = "1pihjwajmahldxi3isnq6wcsbwj0hsnq8z5kp3w4j615ygrn0cgl";
+    sha256 = "0x155d4hqz7mabgqvgydqjm9d8aabc78vr0v0pnsp9vkdlcv3mfh";
   };
 
-  nativeBuildInputs = [ pkgconfig intltool ];
-  buildInputs = [ glib json-glib libxml2 libxslt libarchive bzip2 lzma ];
+  nativeBuildInputs = [ pkgconfig gettext perl ];
+  buildInputs = [ glib json-glib libxml2 libxslt libarchive bzip2 lzma libsoup ];
 
   meta = with stdenv.lib; {
     description = "Tools for managing the osinfo database";


### PR DESCRIPTION
###### Motivation for this change
noticed osinfo-db-tools wasn't able to be updated by @r-ryantm 

Edit:
closes #67004
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @bjornfor 
