### PR TITLE
cargo-make: 0.22.0 -> 0.22.1

### DIFF
--- a/pkgs/development/tools/rust/cargo-make/default.nix
+++ b/pkgs/development/tools/rust/cargo-make/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-make";
-  version = "0.22.0";
+  version = "0.22.1";
 
   src =
     let
@@ -10,11 +10,11 @@ rustPlatform.buildRustPackage rec {
         owner = "sagiegurari";
         repo = pname;
         rev = version;
-        sha256 = "13nl370immbhjarc0vfzrsflml3alh2f2zrh4znbks4yc3yp790z";
+        sha256 = "1wsams41zl56mkb8671n5fqkkchs68jd9nvfzry8axxiv7n175gc";
       };
       cargo-lock = fetchurl {
-        url = "https://gist.githubusercontent.com/xrelkd/e4c9c7738b21f284d97cb7b1d181317d/raw/d31cfb3598d0a2886abd4d2ed43a02d493c8de8c/cargo-make-Cargo.lock";
-        sha256 = "08fzl98d277n9xn3hrg9jahkqwdjfi5saajsppwzdbb3l7xw4jh2";
+        url = "https://gist.githubusercontent.com/xrelkd/e4c9c7738b21f284d97cb7b1d181317d/raw/850e9830f4ab4bc65da6eb5cd8b0911970a7739f/cargo-make-Cargo.lock";
+        sha256 = "0knmzplxmh8vksmpg56l2p1a10hpqbr9hmbk3hv0aj63125rhhqy";
       };
     in
     runCommand "cargo-make-src" {} ''
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = stdenv.lib.optionals stdenv.isDarwin [ Security ];
 
-  cargoSha256 = "0gj4a15slxnp31mlfgh57h3cwv0lnw5gdmkrmmj79migi96i5i6y";
+  cargoSha256 = "18j0nflf997z4nwdxifxp1ji1rbwqbg6zm2256j21am4ak45krsy";
 
   # Some tests fail because they need network access.
   # However, Travis ensures a proper build.


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update `cargo-make` to the latest release.
- https://github.com/sagiegurari/cargo-make/releases/tag/0.22.1

**Note**: `doCheck` is set as `false`.
Some tests fail because they need network access. However, Travis-CI ensures a proper build.
- https://travis-ci.org/sagiegurari/cargo-make/jobs/574290697
- https://travis-ci.org/sagiegurari/cargo-make/jobs/574290698
- https://travis-ci.org/sagiegurari/cargo-make/jobs/574290700

`cargo-make` is a subcommand for `cargo`. You need to invoke `cargo-make` via `cargo` command.
To test the binary files in `./result/bin`, consider the following commands:
```
[john@nixos:~/result/bin] PATH=.:$PATH cargo make --version
cargo-make 0.22.1
[john@nixos:~/result/bin] PATH=.:$PATH ./makers --version
makers 0.22.1
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
