### PR TITLE
dynamic-colors: 0.2.2.1 -> 0.2.2.2

### DIFF
--- a/pkgs/tools/misc/dynamic-colors/default.nix
+++ b/pkgs/tools/misc/dynamic-colors/default.nix
@@ -1,38 +1,26 @@
 { stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  name = "dynamic-colors-${version}";
-  version = "0.2.2.1";
+  pname = "dynamic-colors";
+  version = "0.2.2.2";
 
   src = fetchFromGitHub {
     owner  = "peterhoeg";
     repo   = "dynamic-colors";
     rev    = "v${version}";
-    sha256 = "0qz76n5sspgpz6bz66jfkyr42da3skbpw9wbvxgm3ha343azfaiw";
+    sha256 = "0i63570z9aqbxa8ixh4ayb3akgjdnlqyl2sbf9d7x8f1pxhk5kd5";
   };
 
-  dontBuild = true;
-  dontStrip = true;
+  PREFIX = placeholder "out";
 
-  installPhase = ''
-    mkdir -p \
-      $out/bin \
-      $out/share/dynamic-colors/colorschemes \
-      $out/share/bash-completion/completions \
-      $out/share/zsh/site-packages
-
-    install -m755 bin/dynamic-colors              $out/bin/
-    install -m644 completions/dynamic-colors.bash $out/share/bash-completion/completions/dynamic-colors
-    install -m644 completions/dynamic-colors.zsh  $out/share/zsh/site-packages/_dynamic-colors
-    install -m644 colorschemes/*               -t $out/share/dynamic-colors/colorschemes
-
-    substituteInPlace $out/bin/dynamic-colors \
+  postPatch = ''
+    substituteInPlace bin/dynamic-colors \
       --replace /usr/share/dynamic-colors $out/share/dynamic-colors
   '';
 
   meta = with stdenv.lib; {
     description = "Change terminal colors on the fly";
-    homepage    = https://github.com/peterhoeg/dynamic-colors;
+    homepage    = "https://github.com/peterhoeg/dynamic-colors";
     license     = licenses.mit;
     maintainers = with maintainers; [ peterhoeg ];
     platforms   = platforms.unix;


### PR DESCRIPTION
###### Motivation for this change

Minor update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
