### PR TITLE
 virt-viewer: remove unused packages

### DIFF
--- a/pkgs/applications/virtualization/virt-viewer/default.nix
+++ b/pkgs/applications/virtualization/virt-viewer/default.nix
@@ -1,10 +1,7 @@
-{ stdenv, fetchurl, pkgconfig, intltool, glib, libxml2, gtk3, gtk-vnc, gmp
-, libgcrypt, gnupg, cyrus_sasl, shared-mime-info, libvirt, yajl
-, gsettings-desktop-schemas, wrapGAppsHook, libvirt-glib, libcap_ng, numactl
-, libapparmor, gst_all_1
+{ stdenv, fetchurl, pkgconfig, intltool, shared-mime-info, wrapGAppsHook
+, glib, gsettings-desktop-schemas, gtk-vnc, gtk3, libvirt, libvirt-glib, libxml2, vte
 , spiceSupport ? true
 , spice-gtk ? null, spice-protocol ? null, libcap ? null, gdbm ? null
-, xenSupport ? false, xen ? null
 }:
 
 assert spiceSupport ->
@@ -22,19 +19,18 @@ stdenv.mkDerivation rec {
     sha256 = "1vdnjmhrva7r1n9nv09j8gc12hy0j9j5l4rka4hh0jbsbpnmiwyw";
   };
 
-  nativeBuildInputs = [ pkgconfig intltool wrapGAppsHook ];
+  nativeBuildInputs = [ pkgconfig intltool shared-mime-info wrapGAppsHook glib ];
   buildInputs = [
-    glib libxml2 gtk3 gtk-vnc gmp libgcrypt gnupg cyrus_sasl shared-mime-info
-    libvirt yajl gsettings-desktop-schemas libvirt-glib
-    libcap_ng numactl libapparmor
-  ] ++ optionals xenSupport [
-    xen
+    glib gsettings-desktop-schemas gtk-vnc gtk3 libvirt libvirt-glib libxml2 vte
   ] ++ optionals spiceSupport [
     spice-gtk spice-protocol libcap gdbm
   ];
 
   # Required for USB redirection PolicyKit rules file
   propagatedUserEnvPkgs = optional spiceSupport spice-gtk;
+
+  strictDeps = true;
+  enableParallelBuilding = true;
 
   meta = {
     description = "A viewer for remote virtual machines";

--- a/pkgs/development/libraries/libvirt-glib/default.nix
+++ b/pkgs/development/libraries/libvirt-glib/default.nix
@@ -1,12 +1,8 @@
-{ stdenv, fetchurl, pkgconfig, libvirt, glib, libxml2, intltool, libtool, yajl
-, nettle, libgcrypt, pythonPackages, gobject-introspection, libcap_ng, numactl
-, libapparmor, vala
-, xenSupport ? false, xen ? null
+{ stdenv, fetchurl, pkgconfig, gobject-introspection, intltool, vala
+, libcap_ng, libvirt, libxml2
 }:
 
-let
-  inherit (pythonPackages) python pygobject2;
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   name = "libvirt-glib-2.0.0";
 
   outputs = [ "out" "dev" ];
@@ -16,15 +12,11 @@ in stdenv.mkDerivation rec {
     sha256 = "0six9ckmvlwwyavyjkgc262qkpvfqgi8rjij7cyk00bmqq8c9s4l";
   };
 
-  nativeBuildInputs = [ pkgconfig vala ];
-  buildInputs = [
-    libvirt glib libxml2 intltool libtool yajl nettle libgcrypt
-    python pygobject2 gobject-introspection libcap_ng numactl libapparmor
-  ] ++ stdenv.lib.optionals xenSupport [
-    xen
-  ];
+  nativeBuildInputs = [ pkgconfig intltool vala gobject-introspection ];
+  buildInputs = [ libcap_ng libvirt libxml2 gobject-introspection ];
 
   enableParallelBuilding = true;
+  strictDeps = true;
 
   meta = with stdenv.lib; {
     description = "Library for working with virtual machines";
@@ -36,7 +28,7 @@ in stdenv.mkDerivation rec {
       - libvirt-gconfig - GObjects for manipulating libvirt XML documents
       - libvirt-gobject - GObjects for managing libvirt objects
     '';
-    homepage = http://libvirt.org/;
+    homepage = https://libvirt.org/;
     license = licenses.lgpl2Plus;
     platforms = platforms.linux;
   };


### PR DESCRIPTION
###### Motivation for this change
Smaller closure and remove unused packages.
Checked on the home server - virt-viewer worked. Libvirt builded with xen support. 
There is no way to check connect to the xen server

@jtojnar 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
