### PR TITLE
nixos/xserver: refactor/fix xml tags for keyboard layout overrides

### DIFF
--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -468,7 +468,7 @@ self: super:
         <model>
           <configItem>
             <name>${name}</name>
-            <_description>${layout.description}</_description>
+            <description>${layout.description}</description>
             <vendor>${layout.description}</vendor>
           </configItem>
         </model>
@@ -484,8 +484,8 @@ self: super:
         <layout>
           <configItem>
             <name>${name}</name>
-            <_shortDescription>${name}</_shortDescription>
-            <_description>${layout.description}</_description>
+            <shortDescription>${name}</shortDescription>
+            <description>${layout.description}</description>
             <languageList>
               ${concatMapStrings (lang: "<iso639Id>${lang}</iso639Id>\n") layout.languages}
             </languageList>


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

With the current XML tags there is an issue when building with a custom keyboard.
As described here: https://github.com/NixOS/nixpkgs/pull/47764#issuecomment-521997293 the description of the new keyboard layout will be missing in the built file: xkeyboard-config-2.27/share/X11/xkb/rules/evdev.lst

@rnhmjoj explains that this broke when xkb dropped intltool ... https://github.com/NixOS/nixpkgs/pull/47764#issuecomment-523237183

###### Things done

I built with `https://github.com/NixOS/nixpkgs/pull/47764#issuecomment-523237183` and checked the output in xkeyboard-config-2.27/share/X11/xkb/rules/evdev.lst

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @rnhmjoj 
