### PR TITLE
SDL2: don't mix space-separated / lists in cmake config

### DIFF
--- a/pkgs/development/libraries/SDL2/find-headers.patch
+++ b/pkgs/development/libraries/SDL2/find-headers.patch
@@ -1,12 +1,13 @@
 diff -ru3 SDL2-2.0.4/sdl2-config.cmake.in SDL2-2.0.4-new/sdl2-config.cmake.in
 --- SDL2-2.0.4/sdl2-config.cmake.in	2016-01-02 22:56:31.000000000 +0300
 +++ SDL2-2.0.4-new/sdl2-config.cmake.in	2016-08-22 05:26:42.420397323 +0300
-@@ -6,5 +6,5 @@
+@@ -6,5 +6,6 @@
  set(SDL2_PREFIX "@prefix@")
  set(SDL2_EXEC_PREFIX "@prefix@")
  set(SDL2_LIBDIR "@libdir@")
 -set(SDL2_INCLUDE_DIRS "@includedir@/SDL2")
 +set(SDL2_INCLUDE_DIRS "@includedir@/SDL2" $ENV{SDL2_PATH})
++separate_arguments(SDL2_INCLUDE_DIRS)
  set(SDL2_LIBRARIES "-L${SDL2_LIBDIR} @SDL_RLD_FLAGS@ @SDL_LIBS@")
 diff -ru3 SDL2-2.0.4/sdl2-config.in SDL2-2.0.4-new/sdl2-config.in
 --- SDL2-2.0.4/sdl2-config.in	2016-01-02 22:56:31.000000000 +0300


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
The SDL2_PATH environment variable is space-separated. However, CMake
lists are semicolon separated, and doing set(list "a" ${var}) will end
up with list containing "a;b c d". This causes downstream users to fail
parsing the include dirs list.

Normalize the include dirs list to a normal CMake semicolon-separated
list using separate_arguments.

Tested with https://github.com/delroth/infra.delroth.net/commit/96208bddcc126e2a1f596f36353cd6eece3c70ec -- does not build without this patch, builds with this patch. (I'm planning to upstream that pkg once this patch is in.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @abbradar 
