### PR TITLE
warsow,warsow-engine: fix mirror URL

### DIFF
--- a/pkgs/games/warsow/default.nix
+++ b/pkgs/games/warsow/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "2.1.2";
 
   src = fetchurl {
-    url = "http://sebastian.network/warsow/${name}.tar.gz";
+    url = "http://slice.sh/warsow/${name}.tar.gz";
     sha256 = "07y2airw5qg3s1bf1c63a6snjj22riz0mqhk62jmfm9nrarhavrc";
   };
 

--- a/pkgs/games/warsow/engine.nix
+++ b/pkgs/games/warsow/engine.nix
@@ -48,5 +48,6 @@ in stdenv.mkDerivation (libs // rec {
     license = licenses.gpl2;
     maintainers = with maintainers; [ astsmtl abbradar ];
     platforms = platforms.linux;
+    broken = stdenv.isAarch64;
   };
 })

--- a/pkgs/games/warsow/engine.nix
+++ b/pkgs/games/warsow/engine.nix
@@ -13,7 +13,7 @@ in stdenv.mkDerivation (libs // rec {
   version = "2.1.0";
 
   src = fetchurl {
-    url = "http://sebastian.network/warsow/warsow_21_sdk.tar.gz";
+    url = "http://slice.sh/warsow/warsow_21_sdk.tar.gz";
     sha256 = "0fj5k7qpf6far8i1xhqxlpfjch10zj26xpilhp95aq2yiz08pj4r";
   };
 


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Current one does not resolve. New one is the one currently present on warsow.net. Hashes unchanged.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @astsmtl @abbradar 