### PR TITLE
libyamlcpp: Disable build & install of Google Test

### DIFF
--- a/pkgs/development/libraries/libyaml-cpp/default.nix
+++ b/pkgs/development/libraries/libyaml-cpp/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  cmakeFlags = "-DBUILD_SHARED_LIBS=ON";
+  cmakeFlags = "-DBUILD_SHARED_LIBS=ON -DYAML_CPP_BUILD_TESTS=OFF";
 
   meta = with stdenv.lib; {
     inherit (src.meta) homepage;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
The source repo includes a copy of Google Test which is build and installed by default, which then may lead to the wrong Google Test being used by packages using yaml-cpp (I just ran into this issue where headers came from the gtest Nix package and libraries from libyamlcpp).

Since no tests are executed for this package I've not thought about how change this impacts the ability to build & run unit tests in the future.

Before:
```
$ /nix/store/lbmc9yif9jjwm67vxqyzcp28nagfdv0b-libyaml-cpp-0.6.2/
└── lib
    ├── libgmock_main.so
    ├── libgmock.so
    ├── libgtest_main.so
    ├── libgtest.so
    ├── libyaml-cpp.so -> libyaml-cpp.so.0.6
    ├── libyaml-cpp.so.0.6 -> libyaml-cpp.so.0.6.2
    └── libyaml-cpp.so.0.6.2
```
After this commit:
```
$ tree /nix/store/gymr0ml4rmznz3m8b4k5a57c474cn3kg-libyaml-cpp-0.6.2
/nix/store/gymr0ml4rmznz3m8b4k5a57c474cn3kg-libyaml-cpp-0.6.2
└── lib
    ├── libyaml-cpp.so -> libyaml-cpp.so.0.6
    ├── libyaml-cpp.so.0.6 -> libyaml-cpp.so.0.6.2
    └── libyaml-cpp.so.0.6.2
```
Size:
```
# Before
$ nix path-info -Sh /nix/store/lbmc9yif9jjwm67vxqyzcp28nagfdv0b-libyaml-cpp-0.6.2
/nix/store/lbmc9yif9jjwm67vxqyzcp28nagfdv0b-libyaml-cpp-0.6.2     34.3M
$ nix path-info -Sh  /nix/store/sg9qvaf7px4qmy9zpf1w9bqsqgifa8kl-libyaml-cpp-0.6.2-dev
/nix/store/sg9qvaf7px4qmy9zpf1w9bqsqgifa8kl-libyaml-cpp-0.6.2-dev         35.9M

# After
$ nix path-info -Sh /nix/store/gymr0ml4rmznz3m8b4k5a57c474cn3kg-libyaml-cpp-0.6.2
/nix/store/gymr0ml4rmznz3m8b4k5a57c474cn3kg-libyaml-cpp-0.6.2     32.8M
$ nix path-info -Sh /nix/store/2x0gd7kwcx10b88k96a64k44wcgmkk7i-libyaml-cpp-0.6.2-dev
/nix/store/2x0gd7kwcx10b88k96a64k44wcgmkk7i-libyaml-cpp-0.6.2-dev         32.9M
```

Nix-review packages built: brise calamares dcm2niix facter fcitx-engines.rime interception-tools ip2unix librime libyamlcpp libyamlcpp_0_3 mongodb openxcom osm2xmap powerdns

scylladb is broken on master for me so it also failed with this change.

###### Things done
Disabled Google Test with option `-DYAML_CPP_BUILD_TESTS=OFF`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


###### Notify maintainers

cc @andir
