### PR TITLE
tiledb: init at 1.6.3

### DIFF
--- a/pkgs/development/libraries/tiledb/default.nix
+++ b/pkgs/development/libraries/tiledb/default.nix
@@ -1,0 +1,53 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, zlib
+, lz4
+, bzip2
+, zstd
+, spdlog_0
+, tbb
+, openssl
+, boost
+, libpqxx
+, clang-tools
+, catch2
+, python
+, gtest
+}:
+
+stdenv.mkDerivation rec {
+  name = "tiledb";
+  version = "1.6.3";
+
+  src = fetchFromGitHub {
+    owner = "TileDB-Inc";
+    repo = "TileDB";
+    rev = version;
+    sha256 = "sha256:0dgvz34v1w1sd9zrxpf0is6m4k4b0nzllmwyrdbwsiclkaxqa0ha";
+  };
+
+  nativeBuildInputs = [ clang-tools cmake gtest ];
+
+  buildInputs = [ catch2 zlib lz4 bzip2 zstd spdlog_0 tbb openssl boost libpqxx python ];
+
+  # emulate the process of pulling catch down
+  postPatch = ''
+    mkdir -p build/externals/src/ep_catch
+    ln -sf ${catch2}/include/catch2 build/externals/src/ep_catch/single_include
+  '';
+
+  doCheck = false;
+
+  installTargets = "install-tiledb";
+
+  meta = with lib; {
+    description = "TileDB allows you to manage the massive dense and sparse multi-dimensional array data";
+    homepage = https://github.com/TileDB-Inc/TileDB;
+    license = licenses.mit;
+    platforms = [ "x86_64-linux"];
+    maintainers = with maintainers; [ rakesh4g ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6620,6 +6620,8 @@ in
   thin-provisioning-tools = callPackage ../tools/misc/thin-provisioning-tools {  };
 
   tiled = libsForQt5.callPackage ../applications/editors/tiled { };
+  
+  tiledb = callPackage ../development/libraries/tiledb { };
 
   timemachine = callPackage ../applications/audio/timemachine { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @CMCDragonkai 
