### PR TITLE
uwimap: Fixed cross-compilation

### DIFF
--- a/pkgs/tools/networking/uwimap/default.nix
+++ b/pkgs/tools/networking/uwimap/default.nix
@@ -1,6 +1,6 @@
 {stdenv, fetchurl, pam, openssl}:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation ({
   name = "uw-imap-2007f";
 
   src = fetchurl {
@@ -12,7 +12,8 @@ stdenv.mkDerivation {
     then "osx"
     else "lnp" # Linux with PAM modules;
     # -fPIC is required to compile php with imap on x86_64 systems
-    + stdenv.lib.optionalString stdenv.isx86_64 " EXTRACFLAGS=-fPIC";
+    + stdenv.lib.optionalString stdenv.isx86_64 " EXTRACFLAGS=-fPIC"
+    + stdenv.lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) " CC=${stdenv.hostPlatform.config}-gcc RANLIB=${stdenv.hostPlatform.config}-ranlib";
 
   hardeningDisable = [ "format" ];
 
@@ -46,4 +47,11 @@ stdenv.mkDerivation {
   passthru = {
     withSSL = true;
   };
-}
+} // stdenv.lib.optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) {
+  # This is set here to prevent rebuilds on native compilation.
+  # Configure phase is a no-op there, because this package doesn't use ./configure scripts.
+  configurePhase = ''
+    echo "Cross-compilation, injecting make flags"
+    makeFlagsArray+=("ARRC=${stdenv.hostPlatform.config}-ar rc")
+  '';
+})


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
This is my second cross-compilation fix, discovered when building PHP. The build system, as with Lua, couldn't find cc, ar and ranlib - I helped it a little.

Note: this PR shouldn't cause any rebuilds of native packages!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers
This package doesn't seem to have a maintainer, sorry!