### PR TITLE
libical: 3.0.4 → 3.0.5

### DIFF
--- a/pkgs/development/libraries/libical/default.nix
+++ b/pkgs/development/libraries/libical/default.nix
@@ -1,34 +1,64 @@
-{ stdenv, fetchFromGitHub, perl, pkgconfig, cmake, ninja, vala, gobject-introspection
-, python3, tzdata, glib, libxml2, icu }:
+{ stdenv
+, fetchFromGitHub
+, cmake
+, glib
+, gobject-introspection
+, icu
+, libxml2
+, ninja
+, perl
+, pkgconfig
+, python3
+, tzdata
+, vala
+}:
 
 stdenv.mkDerivation rec {
   pname = "libical";
-  version = "3.0.4";
+  version = "3.0.5";
 
-  outputs = [ "out" "dev" ]; #"devdoc" ];
+  outputs = [ "out" "dev" ]; # "devdoc" ];
 
   src = fetchFromGitHub {
     owner = "libical";
     repo = "libical";
     rev = "v${version}";
-    sha256 = "1qgpbdjd6jsivw87v5w52268kqp0rv780kli8cgb3ndlv592wlbm";
+    sha256 = "03kjc4s1svmzkmzkr0irgczq37aslhj4bxnvjqav0jwa2zrynhra";
   };
 
   nativeBuildInputs = [
-    perl pkgconfig cmake ninja vala gobject-introspection
-    (python3.withPackages (pkgs: with pkgs; [ pygobject3 ])) # running libical-glib tests
-# Docs building fails: https://github.com/NixOS/nixpkgs/pull/61657#issuecomment-495579489
-#    gtk-doc docbook_xsl docbook_xml_dtd_43 # docs
+    cmake
+    gobject-introspection
+    ninja
+    perl
+    pkgconfig
+    vala
+    # Docs building fails:
+    # https://github.com/NixOS/nixpkgs/pull/67204
+    # previously with https://github.com/NixOS/nixpkgs/pull/61657#issuecomment-495579489
+    # gtk-doc docbook_xsl docbook_xml_dtd_43 # for docs
   ];
-  buildInputs = [ glib libxml2 icu ];
+  installCheckInputs = [
+    # running libical-glib tests
+    (python3.withPackages (pkgs: with pkgs; [
+      pygobject3
+    ]))
+  ];
+
+  buildInputs = [
+    glib
+    libxml2
+    icu
+  ];
 
   cmakeFlags = [
     "-DGOBJECT_INTROSPECTION=True"
+    "-DENABLE_GTK_DOC=False"
     "-DICAL_GLIB_VAPI=True"
   ];
 
   patches = [
-    # TODO: upstream this patch
+    # Will appear in 3.1.0
     # https://github.com/libical/libical/issues/350
     ./respect-env-tzdir.patch
   ];


### PR DESCRIPTION
https://github.com/libical/libical/releases/tag/v3.0.5

Docs now fail with a different issue so I had to keep them disabled:

```
FAILED: doc/reference/libical-glib/html/index.html
cd /build/source/build/doc/reference/libical-glib && /nix/store/0x1ylx8kxb4aivvj3m4yh64bnw85vkrx-gtk-doc-1.30/bin/gtkdoc-scan --module=libical-glib --deprecated-guards="LIBICAL_GLIB_DISABLE_DEPRECATED" --ignore-headers="libical-glib-private.h" --rebuild-sections --rebuild-types --source-dir="/build/source/build/src/libical-glib" && /nix/store/rlp98mmbvp008720p25k73w2khzs9rzn-cmake-3.14.5/bin/cmake -E chdir /build/source/build/doc/reference/libical-glib /nix/store/rlp98mmbvp008720p25k73w2khzs9rzn-cmake-3.14.5/bin/cmake -E env LD_LIBRARY_PATH=":/build/source/build/lib:/build/source/build/lib:/nix/store/vvj5xbcqjq3wcnaz0ca9a5q74vsgxghc-libical-3.0.5/lib:" /nix/store/0x1ylx8kxb4aivvj3m4yh64bnw85vkrx-gtk-doc-1.30/bin/gtkdoc-scangobj --module=libical-glib --cflags=\ -I/nix/store/90y20imp7c9rykrwj9xsavpmi4gpllr8-glib-2.60.4-dev/include\ -I/nix/store/90y20imp7c9rykrwj9xsavpmi4gpllr8-glib-2.60.4-dev/include/glib-2.0\ -I/nix/store/vl5a1s7i5bqjjbgs5x821avx3ddcx8a4-glib-2.60.4/lib/glib-2.0/include\ -I/nix/store/hnd5m3l1cysr5wpim0h0khvsycgr7577-libical-3.0.5-dev/include --ldflags=-L/build/source/build/lib\ -lical-glib\ -lglib-2.0\ -lgobject-2.0\ -L/nix/store/vl5a1s7i5bqjjbgs5x821avx3ddcx8a4-glib-2.60.4/lib\ -L/build/source/build/lib\ -lical\ -L/nix/store/vvj5xbcqjq3wcnaz0ca9a5q74vsgxghc-libical-3.0.5/lib && /nix/store/0x1ylx8kxb4aivvj3m4yh64bnw85vkrx-gtk-doc-1.30/bin/gtkdoc-mkdb --module=libical-glib --name-space=libical-glib --main-sgml-file="/build/source/build/doc/reference/libical-glib/libical-glib-docs.sgml" --sgml-mode --output-format=xml --source-dir="/build/source/build/src/libical-glib" && /nix/store/rlp98mmbvp008720p25k73w2khzs9rzn-cmake-3.14.5/bin/cmake -E make_directory /build/source/build/doc/reference/libical-glib/html && /nix/store/rlp98mmbvp008720p25k73w2khzs9rzn-cmake-3.14.5/bin/cmake -E chdir /build/source/build/doc/reference/libical-glib/html /nix/store/0x1ylx8kxb4aivvj3m4yh64bnw85vkrx-gtk-doc-1.30/bin/gtkdoc-mkhtml --path=.. libical-glib ../libical-glib-docs.sgml && /nix/store/0x1ylx8kxb4aivvj3m4yh64bnw85vkrx-gtk-doc-1.30/bin/gtkdoc-fixxref --module=libical-glib --module-dir=html --extra-dir=.. --html-dir="share/gtk-doc/html/libical-glib"
/nix/store/mgdjnsrkqgmxqjaqaxgqyqm7fwyi96fk-binutils-2.31.1/bin/ld: libical-glib-scan.o: undefined reference to symbol '__errno_location@@GLIBC_2.2.5'
/nix/store/mgdjnsrkqgmxqjaqaxgqyqm7fwyi96fk-binutils-2.31.1/bin/ld: /nix/store/iykxb0bmfjmi7s53kfg6pjbfpd8jmza6-glibc-2.27/lib/libpthread.so.0: error adding symbols: DSO missing from command line
2019-08-21 14:05:13,671:scangobj.py:execute_command:1198:WARNING:Linking scanner failed: 1, command: ld libical-glib-scan.o -L/build/source/build/lib -lical-glib -lglib-2.0 -lgobject-2.0 -L/nix/store/vl5a1s7i5bqjjbgs5x821avx3ddcx8a4-glib-2.60.4/lib -L/build/source/build/lib -lical -L/nix/store/vvj5xbcqjq3wcnaz0ca9a5q74vsgxghc-libical-3.0.5/lib -o libical-glib-scan
[169/227] Building C object src/libical-glib/CMakeFiles/ical-glib-static.dir/i-cal-derived-property.c.o
ninja: build stopped: subcommand failed.
```