### PR TITLE
oracle-instantclient: 12.2.0.1.0 -> 19.3.0.0.0

### DIFF
--- a/pkgs/development/libraries/odpic/default.nix
+++ b/pkgs/development/libraries/odpic/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   postFixup = ''
     ${stdenv.lib.optionalString (stdenv.isLinux) ''
-      patchelf --set-rpath "${libPath}" $out/lib/libodpic${stdenv.hostPlatform.extensions.sharedLibrary}
+      patchelf --set-rpath "${libPath}:$(patchelf --print-rpath $out/lib/libodpic${stdenv.hostPlatform.extensions.sharedLibrary})" $out/lib/libodpic${stdenv.hostPlatform.extensions.sharedLibrary}
     ''}
     ${stdenv.lib.optionalString (stdenv.isDarwin) ''
       install_name_tool -add_rpath "${libPath}" $out/lib/libodpic${stdenv.hostPlatform.extensions.sharedLibrary}

--- a/pkgs/development/libraries/odpic/default.nix
+++ b/pkgs/development/libraries/odpic/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optionals stdenv.isLinux [ libaio ];
 
   libPath = stdenv.lib.makeLibraryPath
-    [ oracle-instantclient ];
+    [ oracle-instantclient.lib ];
 
   dontPatchELF = true;
   makeFlags = [ "PREFIX=$(out)" "CC=cc" "LD=cc"];

--- a/pkgs/development/libraries/odpic/default.nix
+++ b/pkgs/development/libraries/odpic/default.nix
@@ -1,21 +1,25 @@
-{ stdenv, fetchurl, fixDarwinDylibNames, oracle-instantclient, libaio }:
+{ stdenv, fetchFromGitHub, fixDarwinDylibNames, oracle-instantclient, libaio }:
 
-stdenv.mkDerivation rec {
-  name = "odpic-${version}";
-  version = "3.1.0";
+let
+  version = "3.2.1";
+  libPath = stdenv.lib.makeLibraryPath [ oracle-instantclient.lib ];
 
-  src = fetchurl {
-    url = "https://github.com/oracle/odpi/archive/v${version}.tar.gz";
-    sha256 = "0m6g7lbvfir4amf2cnap9wz9fmqrihqpihd84igrd7fp076894c0";
+in stdenv.mkDerivation {
+  inherit version;
+
+  pname = "odpic";
+
+  src = fetchFromGitHub {
+    owner = "oracle";
+    repo = "odpi";
+    rev = "v${version}";
+    sha256 = "1f9gznc7h73cgx32p55rkhzla6l7l9dg53ilwh6zdgdqlp7n018i";
   };
 
   nativeBuildInputs = stdenv.lib.optional stdenv.isDarwin [ fixDarwinDylibNames ];
 
   buildInputs = [ oracle-instantclient ]
     ++ stdenv.lib.optionals stdenv.isLinux [ libaio ];
-
-  libPath = stdenv.lib.makeLibraryPath
-    [ oracle-instantclient.lib ];
 
   dontPatchELF = true;
   makeFlags = [ "PREFIX=$(out)" "CC=cc" "LD=cc"];

--- a/pkgs/development/libraries/oracle-instantclient/default.nix
+++ b/pkgs/development/libraries/oracle-instantclient/default.nix
@@ -103,7 +103,10 @@ in stdenv.mkDerivation {
   installPhase = ''
     mkdir -p "$out/"{bin,include,lib,"share/java","share/${pname}-${version}/demo/"} $lib/lib
     install -Dm755 {adrci,genezi,uidrvci,sqlplus} $out/bin
-    install -Dm644 *${extLib}* $lib/lib
+
+    # cp to preserve symlinks
+    cp -P *${extLib}* $lib/lib
+
     install -Dm644 *.jar $out/share/java
     install -Dm644 sdk/include/* $out/include
     install -Dm644 sdk/demo/* $out/share/${pname}-${version}/demo

--- a/pkgs/development/libraries/oracle-instantclient/default.nix
+++ b/pkgs/development/libraries/oracle-instantclient/default.nix
@@ -1,46 +1,95 @@
-{ stdenv, requireFile, autoPatchelfHook, fixDarwinDylibNames, unzip, libaio, makeWrapper, odbcSupport ? false, unixODBC }:
+{ stdenv
+, fetchurl
+, requireFile
+, autoPatchelfHook
+, fixDarwinDylibNames
+, unzip
+, libaio
+, makeWrapper
+, odbcSupport ? true
+, unixODBC
+}:
 
 assert odbcSupport -> unixODBC != null;
 
 let
   inherit (stdenv.lib) optional optionals optionalString;
 
-  baseVersion = "12.2";
-  version = "${baseVersion}.0.1.0";
-
-  requireSource = component: arch: version: rel: hash: (requireFile rec {
-    name = "instantclient-${component}-${arch}-${version}" + (optionalString (rel != "") "-${rel}") + ".zip";
-    url = "http://www.oracle.com/technetwork/database/database-technologies/instant-client/downloads/index.html";
-    sha256 = hash;
-  });
-
   throwSystem = throw "Unsupported system: ${stdenv.hostPlatform.system}";
 
+  # assemble list of components
+  components = [ "basic" "sdk" "sqlplus" ] ++ optional odbcSupport "odbc";
+
+  # determine the version number, there might be different ones per architecture
+  version = {
+    "x86_64-linux" = "19.3.0.0.0";
+    "x86_64-darwin" = "18.1.0.0.0";
+  }."${stdenv.hostPlatform.system}" or throwSystem;
+
+  # hashes per component and architecture
+  hashes = {
+    "x86_64-linux" = {
+      "basic"   = "1yk4ng3a9ka1mzgfph9br6rwclagbgfvmg6kja11nl5dapxdzaxy";
+      "sdk"     = "115v1gqr0czy7dcf2idwxhc6ja5b0nind0mf1rn8iawgrw560l99";
+      "sqlplus" = "0zj5h84ypv4n4678kfix6jih9yakb277l9hc0819iddc0a5slbi5";
+      "odbc"    = "1g1z6pdn76dp440fh49pm8ijfgjazx4cvxdi665fsr62h62xkvch";
+    };
+    "x86_64-darwin" = {
+      "basic"   = "fac3cdaaee7526f6c50ff167edb4ba7ab68efb763de24f65f63fb48cc1ba44c0";
+      "sdk"     = "98e6d797f1ce11e59b042b232f62380cec29ec7d5387b88a9e074b741c13e63a";
+      "sqlplus" = "02e66dc52398fced75e7efcb6b4372afcf617f7d88344fb7f0f4bb2bed371f3b";
+      "odbc"    = "5d0cdd7f9dd2e27affbc9b36ef9fc48e329713ecd36905fdd089366e365ae8a2";
+    };
+  }."${stdenv.hostPlatform.system}" or throwSystem;
+
+  # rels per component and architecture, optional
+  rels = {
+    "x86_64-darwin" = {
+      "sdk" = "2";
+    };
+  }."${stdenv.hostPlatform.system}" or {};
+
+  # convert platform to oracle architecture names
   arch = {
     "x86_64-linux" = "linux.x64";
     "x86_64-darwin" = "macos.x64";
   }."${stdenv.hostPlatform.system}" or throwSystem;
 
-  srcs = {
-    "x86_64-linux" = [
-      (requireSource "basic" arch version "" "5015e3c9fba84e009f7519893f798a1622c37d1ae2c55104ff502c52a0fe5194")
-      (requireSource "sdk" arch version "" "7f404c3573c062ce487a51ac4cfe650c878d7edf8e73b364ec852645ed1098cb")
-      (requireSource "sqlplus" arch version "" "d49b2bd97376591ca07e7a836278933c3f251875c215044feac73ba9f451dfc2") ]
-      ++ optional odbcSupport (requireSource "odbc" arch version "2" "365a4ae32c7062d9fbc3fb41add748e7881f774484a175a4b41a2c294ce9095d");
-    "x86_64-darwin" = [
-      (requireSource "basic" arch version "2" "3ed3102e5a24f0da638694191edb34933309fb472eb1df21ad5c86eedac3ebb9")
-      (requireSource "sdk" arch version "2" "e0befca9c4e71ebc9f444957ffa70f01aeeec5976ea27c40406471b04c34848b")
-      (requireSource "sqlplus" arch version "2" "d147cbb5b2a954fdcb4b642df4f0bd1153fd56e0f56e7fa301601b4f7e2abe0e") ]
-      ++ optional odbcSupport (requireSource "odbc" arch version "2" "1805c1ab6c8c5e8df7bdcc35d7f2b94c329ecf4dff9bde55d5f9b159ecd8b64e");
-  }."${stdenv.hostPlatform.system}" or throwSystem;
+  # calculate the filename of a single zip file
+  srcFilename = component: arch: version: rel:
+    "instantclient-${component}-${arch}-${version}" +
+    (optionalString (rel != "") "-${rel}") +
+    (optionalString (arch == "linux.x64") "dbru") + # ¯\_(ツ)_/¯
+    ".zip";
 
+  # fetcher for the clickthrough artifacts (requiring manual download)
+  fetchClickThrough =  srcFilename: hash: (requireFile {
+    name = srcFilename;
+    url = "https://www.oracle.com/database/technologies/instant-client/downloads.html";
+    sha256 = hash;
+  });
+
+  # fetcher for the non clickthrough artifacts
+  fetchSimple = srcFilename: hash: fetchurl {
+    url = "https://download.oracle.com/otn_software/linux/instantclient/193000/${srcFilename}";
+    sha256 = hash;
+  };
+
+  # pick the appropriate fetcher depending on the platform
+  fetcher = if stdenv.hostPlatform.system == "x86_64-linux" then fetchSimple else fetchClickThrough;
+
+  # assemble srcs
+  srcs = map (component:
+    (fetcher (srcFilename component arch version rels."${component}" or "") hashes."${component}" or ""))
+  components;
+
+  pname = "oracle-instantclient";
   extLib = stdenv.hostPlatform.extensions.sharedLibrary;
-in stdenv.mkDerivation rec {
-  inherit version srcs;
-  name = "oracle-instantclient-${version}";
+in stdenv.mkDerivation {
+  inherit pname version srcs;
 
   buildInputs = [ stdenv.cc.cc.lib ]
-    ++ optionals (stdenv.isLinux) [ libaio ]
+    ++ optional stdenv.isLinux libaio
     ++ optional odbcSupport unixODBC;
 
   nativeBuildInputs = [ makeWrapper unzip ]
@@ -52,20 +101,22 @@ in stdenv.mkDerivation rec {
   unpackCmd = "unzip $curSrc";
 
   installPhase = ''
-    mkdir -p "$out/"{bin,include,"share/java","share/${name}/demo/"} $lib/lib
+    mkdir -p "$out/"{bin,include,lib,"share/java","share/${pname}-${version}/demo/"} $lib/lib
     install -Dm755 {adrci,genezi,uidrvci,sqlplus} $out/bin
     install -Dm644 *${extLib}* $lib/lib
-
     install -Dm644 *.jar $out/share/java
     install -Dm644 sdk/include/* $out/include
-    install -Dm644 sdk/demo/* $out/share/${name}/demo
+    install -Dm644 sdk/demo/* $out/share/${pname}-${version}/demo
 
+    # provide alias
+    ln -sfn $out/bin/sqlplus $out/bin/sqlplus64
+  '';
+
+  postFixup = ''
     # PECL::oci8 will not build without this
     # this symlink only exists in dist zipfiles for some platforms
     ln -sfn $out/lib/libclntsh${extLib}.12.1 $out/lib/libclntsh${extLib}
-  '';
-
-  postFixup = optionalString stdenv.isDarwin ''
+  '' + optionalString stdenv.isDarwin ''
     for exe in "$out/bin/"* ; do
       if [ ! -L "$exe" ]; then
         install_name_tool -add_rpath "$lib/lib" "$exe"

--- a/pkgs/development/libraries/oracle-instantclient/default.nix
+++ b/pkgs/development/libraries/oracle-instantclient/default.nix
@@ -112,18 +112,13 @@ in stdenv.mkDerivation {
     ln -sfn $out/bin/sqlplus $out/bin/sqlplus64
   '';
 
-  postFixup = ''
-    # PECL::oci8 will not build without this
-    # this symlink only exists in dist zipfiles for some platforms
-    ln -sfn $out/lib/libclntsh${extLib}.12.1 $out/lib/libclntsh${extLib}
-  '' + optionalString stdenv.isDarwin ''
+  postFixup = optionalString stdenv.isDarwin ''
     for exe in "$out/bin/"* ; do
       if [ ! -L "$exe" ]; then
         install_name_tool -add_rpath "$lib/lib" "$exe"
       fi
     done
   '';
-
 
   meta = with stdenv.lib; {
     description = "Oracle instant client libraries and sqlplus CLI";

--- a/pkgs/development/perl-modules/DBD-Oracle/default.nix
+++ b/pkgs/development/perl-modules/DBD-Oracle/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, buildPerlPackage, DBI, TestNoWarnings, oracle-instantclient }:
+{ stdenv, fetchurl, buildPerlPackage, DBI, TestNoWarnings, oracle-instantclient }:
 
 buildPerlPackage {
   pname = "DBD-Oracle";
@@ -13,4 +13,8 @@ buildPerlPackage {
 
   buildInputs = [ TestNoWarnings oracle-instantclient ] ;
   propagatedBuildInputs = [ DBI ];
+
+  postBuild = stdenv.lib.optionalString stdenv.isDarwin ''
+    install_name_tool -add_rpath "${oracle-instantclient.lib}/lib" blib/arch/auto/DBD/Oracle/Oracle.bundle
+  '';
 }

--- a/pkgs/development/perl-modules/DBD-Oracle/default.nix
+++ b/pkgs/development/perl-modules/DBD-Oracle/default.nix
@@ -9,7 +9,7 @@ buildPerlPackage {
     sha256 = "b6db7f43c6252179274cfe99c1950b93e248f8f0fe35b07e50388c85d814d5f3";
   };
 
-  ORACLE_HOME = "${oracle-instantclient}/lib";
+  ORACLE_HOME = "${oracle-instantclient.lib}/lib";
 
   buildInputs = [ TestNoWarnings oracle-instantclient ] ;
   propagatedBuildInputs = [ DBI ];

--- a/pkgs/development/perl-modules/DBD-Oracle/default.nix
+++ b/pkgs/development/perl-modules/DBD-Oracle/default.nix
@@ -2,11 +2,11 @@
 
 buildPerlPackage {
   pname = "DBD-Oracle";
-  version = "1.76";
+  version = "1.80";
 
   src = fetchurl {
     url = mirror://cpan/authors/id/Z/ZA/ZARQUON/DBD-Oracle-1.76.tar.gz;
-    sha256 = "b6db7f43c6252179274cfe99c1950b93e248f8f0fe35b07e50388c85d814d5f3";
+    sha256 = "1wym2kc8b31qa1zb0dgyy3w4iqlk1faw36gy9hkpj895qr1pznxn";
   };
 
   ORACLE_HOME = "${oracle-instantclient.lib}/lib";

--- a/pkgs/development/python-modules/cx_oracle/default.nix
+++ b/pkgs/development/python-modules/cx_oracle/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonPackage rec {
   pname = "cx_Oracle";
-  version = "7.1.3";
+  version = "7.2.2";
 
   buildInputs = [ odpic ];
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "4f26b7418e2796112f8b36338a2f9a7c07dd08df53d857e3478bb53f61dd52e4";
+    sha256 = "1kp6fgyln0jkdbjm20h6rhybsmvqjj847frhsndyfvkf38m32ss0";
   };
 
   preConfigure = ''

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -237,9 +237,12 @@ let
     pname = "oci8";
 
     sha256 = "0jhivxj1nkkza4h23z33y7xhffii60d7dr51h1czjk10qywl7pyd";
-
     buildInputs = [ pkgs.oracle-instantclient ];
-    configureFlags = [ "--with-oci8=shared,instantclient,${pkgs.oracle-instantclient}/lib" ];
+    configureFlags = [ "--with-oci8=shared,instantclient,${pkgs.oracle-instantclient.lib}/lib" ];
+
+    postPatch = ''
+      sed -i -e 's|OCISDKMANINC=`.*$|OCISDKMANINC="${pkgs.oracle-instantclient.dev}/include"|' config.m4
+    '';
   };
 
   pcs = buildPecl rec {


### PR DESCRIPTION
##### Motivation for this change
It's now possible to download Oracle Instant Client without having to
click a checkbox to agree to the license, and then log in with an Oracle
account to start the download, at least on Linux (for now).

Darwin still seems to be at 18.1 (and needs manual fetching).
Version numbers haven't been that aligned recently, so I refactored the derivation to support different version numbers and fetchers per platform.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Repro:

```sh
$(nix-build -E "with import /path/to/checkout {};python3.withPackages (p: [p.cx_oracle p.ptpython])")/bin/ptpython
```
```py
import cx_Oracle
connection = cx_Oracle.connect("MAIN_USER/MAIN_PASSWORD@localhost/orclpdb1")
```
