### PR TITLE
freetalk: fixed cross-compilation

### DIFF
--- a/pkgs/applications/networking/instant-messengers/freetalk/default.nix
+++ b/pkgs/applications/networking/instant-messengers/freetalk/default.nix
@@ -1,9 +1,7 @@
 { stdenv, fetchFromGitHub
 , guile, pkgconfig, glib, loudmouth, gmp, libidn, readline, libtool
 , libunwind, ncurses, curl, jansson, texinfo
-, automake, autoconf
-}:
-
+, automake, autoconf }:
 stdenv.mkDerivation rec {
   name = "freetalk-${version}";
   version = "4.1";
@@ -19,11 +17,10 @@ stdenv.mkDerivation rec {
     ./autogen.sh
   '';
 
- nativeBuildInputs = [ pkgconfig ];
- buildInputs = [
+  nativeBuildInputs = [ pkgconfig texinfo autoconf automake ];
+  buildInputs = [
     guile glib loudmouth gmp libidn readline libtool
-    libunwind ncurses curl jansson texinfo
-    autoconf automake
+    libunwind ncurses curl jansson
   ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Some build-time and run-time dependencies were mixed. I put them in a right place!

(I hope texinfo isn't really required at runtime, but moving it to a build-time dependency seemed to work, so it doesn't link to it.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @7c6f434c 
