### PR TITLE
ocamlPackage.cohttp: 2.0.0 -> 2.1.3

### DIFF
--- a/pkgs/development/ocaml-modules/cohttp/default.nix
+++ b/pkgs/development/ocaml-modules/cohttp/default.nix
@@ -1,22 +1,22 @@
 { lib, fetchFromGitHub, buildDunePackage
 , ppx_fields_conv, ppx_sexp_conv
-, base64, fieldslib, jsonm, re, stringext, uri
+, base64, fieldslib, jsonm, re, stringext, uri-sexp
 }:
 
 buildDunePackage rec {
   pname = "cohttp";
-	version = "2.0.0";
+	version = "2.1.3";
 
 	src = fetchFromGitHub {
 		owner = "mirage";
 		repo = "ocaml-cohttp";
 		rev = "v${version}";
-		sha256 = "0nz9y7l5s9a2rq5sb1m5705h99wvf4dk3fhcgragwhy5nwwzcya8";
+		sha256 = "16k4ldmz6ljryhr139adlma130frb5wh13qswkrwc5gxx6d2wh8d";
 	};
 
 	buildInputs = [ jsonm ppx_fields_conv ppx_sexp_conv ];
 
-	propagatedBuildInputs = [ base64 fieldslib re stringext uri ];
+	propagatedBuildInputs = [ base64 fieldslib re stringext uri-sexp ];
 
 	meta = {
 		description = "HTTP(S) library for Lwt, Async and Mirage";

--- a/pkgs/development/ocaml-modules/uri/default.nix
+++ b/pkgs/development/ocaml-modules/uri/default.nix
@@ -1,5 +1,5 @@
-{ lib, fetchurl, buildDunePackage, ppx_sexp_conv, ounit
-, re, sexplib0, stringext
+{ lib, fetchurl, buildDunePackage, ounit
+, re, stringext
 }:
 
 buildDunePackage rec {
@@ -12,7 +12,7 @@ buildDunePackage rec {
   };
 
   buildInputs = [ ounit ];
-  propagatedBuildInputs = [ ppx_sexp_conv re sexplib0 stringext ];
+  propagatedBuildInputs = [ re stringext ];
   doCheck = true;
 
   meta = {

--- a/pkgs/development/ocaml-modules/uri/sexp.nix
+++ b/pkgs/development/ocaml-modules/uri/sexp.nix
@@ -1,0 +1,13 @@
+{ lib, ocaml, buildDunePackage, uri, ounit, ppx_sexp_conv, sexplib0 }:
+
+if !lib.versionAtLeast ocaml.version "4.04"
+then throw "uri-sexp is not available for OCaml ${ocaml.version}"
+else
+
+buildDunePackage {
+  pname = "uri-sexp";
+  inherit (uri) version src doCheck meta;
+
+  buildInputs = [ ounit ];
+  propagatedBuildInputs = [ ppx_sexp_conv sexplib0 uri ];
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -768,6 +768,8 @@ let
       then callPackage ../development/ocaml-modules/uri { }
       else callPackage ../development/ocaml-modules/uri/legacy.nix { };
 
+    uri-sexp = callPackage ../development/ocaml-modules/uri/sexp.nix { };
+
     uri_p4 = callPackage ../development/ocaml-modules/uri/legacy.nix {
       legacyVersion = true;
     };


### PR DESCRIPTION
###### Motivation for this change

cohttp has been broken by #67008 This update fixes it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

