### PR TITLE
wishbone-tool: init at 0.2.8

### DIFF
--- a/pkgs/development/tools/misc/wishbone-tool/default.nix
+++ b/pkgs/development/tools/misc/wishbone-tool/default.nix
@@ -1,0 +1,25 @@
+{ lib, fetchFromGitHub, rustPlatform, libusb }:
+let
+  version = "0.2.8";
+  src = fetchFromGitHub {
+    owner = "xobs";
+    repo = "wishbone-utils";
+    rev = "v${version}";
+    sha256 = "0v6s5yl0y6bd2snf12x6c77rwvqkg6ybi1sm4wr7qdgbwq563nxp";
+  };
+in
+rustPlatform.buildRustPackage {
+  pname = "wishbone-tool";
+  inherit version;
+  src = "${src}/wishbone-tool";
+  cargoSha256 = "0pj8kf6s1c666p4kc6q1hlvaqm0lm9aqnsx5r034g1y8sxnnyri2";
+  buildInputs = [ libusb ];
+
+  meta = with lib; {
+    description = "Manipulate a Wishbone device over some sort of bridge";
+    homepage = "https://github.com/xobs/wishbone-utils#wishbone-tool";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ edef ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24446,6 +24446,8 @@ in
     inherit (gnome3) zenity;
   };
 
+  wishbone-tool = callPackage ../development/tools/misc/wishbone-tool { };
+
   with-shell = callPackage ../applications/misc/with-shell { };
 
   wmutils-core = callPackage ../tools/X11/wmutils-core { };


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).