### PR TITLE
swiftformat: init at 0.44.0

### DIFF
--- a/pkgs/development/tools/swiftformat/default.nix
+++ b/pkgs/development/tools/swiftformat/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, lib, fetchFromGitHub, runCommand }:
+
+# This derivation is impure: it relies on an Xcode toolchain being installed
+# and available in the expected place. The values of sandboxProfile and
+# hydraPlatforms are copied pretty directly from the MacVim derivation, which
+# is also impure.
+
+stdenv.mkDerivation rec {
+  pname = "swiftformat";
+  version = "0.44.0";
+
+  src = fetchFromGitHub {
+    owner = "nicklockwood";
+    repo = "SwiftFormat";
+    rev = "${version}";
+    sha256 = "13s6syzpxklkv07s1dzdccnqz6p316rrhjpxg8y8dy19ynj5jzvg";
+  };
+
+  preConfigure = "LD=$CC";
+
+  buildPhase = ''
+    /usr/bin/xcodebuild -project SwiftFormat.xcodeproj \
+      -scheme "SwiftFormat (Command Line Tool)" \
+      CODE_SIGN_IDENTITY= SYMROOT=build OBJROOT=build
+  '';
+
+  installPhase = ''
+    install -D -m 0555 build/Release/swiftformat $out/bin/swiftformat
+  '';
+
+  sandboxProfile = ''
+    (allow file-read* file-write* process-exec mach-lookup)
+    ; block homebrew dependencies
+    (deny file-read* file-write* process-exec mach-lookup (subpath "/usr/local") (with no-log))
+  '';
+
+  meta = with lib; {
+    description = "A code formatting and linting tool for Swift";
+    homepage = "https://github.com/nicklockwood/SwiftFormat";
+    license = licenses.mit;
+    maintainers = [ maintainers.bdesham ];
+    platforms = platforms.darwin;
+    hydraPlatforms = [];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10676,6 +10676,8 @@ in
 
   swarm = callPackage ../development/tools/analysis/swarm { };
 
+  swiftformat = callPackage ../development/tools/swiftformat { };
+
   swig1 = callPackage ../development/tools/misc/swig { };
   swig2 = callPackage ../development/tools/misc/swig/2.x.nix { };
   swig3 = callPackage ../development/tools/misc/swig/3.x.nix { };


### PR DESCRIPTION
###### Motivation for this change

SwiftFormat is a code formatting and linting tool for Swift. I requested a derivation for it in #67221; it turned out to be pretty easy to package, with the caveat that it impurely uses the user’s Xcode toolchain. I would welcome an approach that doesn’t require such a hack.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).