### PR TITLE
alsa: allow 'sound.mediaKeys.enable' to work even when 'hardware.pulseaudio.enable' is used

### DIFF
--- a/nixos/modules/services/hardware/actkbd.nix
+++ b/nixos/modules/services/hardware/actkbd.nix
@@ -6,17 +6,46 @@ let
 
   cfg = config.services.actkbd;
 
-  configFile = pkgs.writeText "actkbd.conf" ''
+  isUserBindings = bool:
+    builtins.filter (a: a.userMode == bool) cfg.bindings;
+
+  mkConfigFile = isUser:
+    pkgs.writeText "actkbd.conf" ''
     ${concatMapStringsSep "\n"
       ({ keys, events, attributes, command, ... }:
         ''${concatMapStringsSep "+" toString keys}:${concatStringsSep "," events}:${concatStringsSep "," attributes}:${command}''
       )
-      cfg.bindings}
-    ${cfg.extraConfig}
-  '';
+      ( isUserBindings isUser )}
+      ${cfg.extraConfig}'';
+
+  mkSystemdService = config:
+  {
+    enable = true;
+    restartIfChanged = true;
+    unitConfig = {
+      Description = "actkbd on %I";
+      ConditionPathExists = "%I";
+    };
+    serviceConfig = {
+      Type = "forking";
+      ExecStart = "${pkgs.actkbd}/bin/actkbd -D -c ${config} -d %I";
+    };
+  };
 
   bindingCfg = { ... }: {
     options = {
+
+      userMode = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          whether to deploy this binding as a systemd user service; useful for
+          some programs which require user privileges. This is rarely needed and
+          should only be enabled if it is absolutely required.
+
+          E.g. <option>sound.mediaKeys</option> enables this when <option>hardware.pulseaudio.enable</option> is set.
+          '';
+      };
 
       keys = mkOption {
         type = types.listOf types.int;
@@ -107,21 +136,36 @@ in
     services.udev.packages = lib.singleton (pkgs.writeTextFile {
       name = "actkbd-udev-rules";
       destination = "/etc/udev/rules.d/61-actkbd.rules";
-      text = ''
-        ACTION=="add", SUBSYSTEM=="input", KERNEL=="event[0-9]*", ENV{ID_INPUT_KEY}=="1", TAG+="systemd", ENV{SYSTEMD_WANTS}+="actkbd@$env{DEVNAME}.service"
+      text = let actkbdVar = "actkbd@$env{DEVNAME}.service";
+      in ''
+        ACTION=="add" \
+        , SUBSYSTEM=="input" \
+        , KERNEL=="event[0-9]*" \
+        , ENV{ID_INPUT_KEY}=="1" \
+        , TAG+="systemd" \
+        , ENV{SYSTEMD_WANTS}+="${actkbdVar}" \
+        , ENV{SYSTEMD_USER_WANTS}+="${actkbdVar}"
       '';
     });
 
-    systemd.services."actkbd@" = {
-      enable = true;
-      restartIfChanged = true;
-      unitConfig = {
-        Description = "actkbd on %I";
-        ConditionPathExists = "%I";
-      };
-      serviceConfig = {
-        Type = "forking";
-        ExecStart = "${pkgs.actkbd}/bin/actkbd -D -c ${configFile} -d %I";
+    systemd.services = mkIf ( isUserBindings false != [] )
+    { "actkbd@" = ( mkSystemdService (mkConfigFile false) );
+    };
+
+    systemd.user = mkIf ( isUserBindings true != [] )
+    { services."actkbd@" = mkSystemdService (mkConfigFile true);
+
+      # this is needed because input devices initialize at boot and systemd
+      # only starts device dependant services on their initialization
+      services."start-actkbd" =
+      { enable = true;
+        unitConfig =
+        { Description = "user instances of actkbd";
+          Type = "idle";
+        };
+        script =
+          "${pkgs.systemd}/bin/systemctl --user start 'actkbd@*.service' --all";
+        wantedBy = [ "default.target" ];
       };
     };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
This resolves #66854 by adding new functionality to actkbd, allowing it to selectively deploy a systemd user service when a special 'userMode' toggle is set in the bindings attribute set. This does not work globally, but per binding so you can still have system-wide bindings for those that work fine that way, and user session bindings for any program which requires user permissions. I have split the config files for each instance so that the same binding will not be called by both services.

Additionally, I have modified 'sound.mediaKeys.enable' to take advantage of this new feature so that bindings for volume control will still work even when 'hardware.pulseaudio.enable' is set.

I imagine many users of NixOS are advanced users that use a lightweight window manager and not a full DE, so this should benefit anybody in that situation to have volume keys that 'just work' even when using a Wayland session or no graphical session at all.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
