### PR TITLE
Pass hoogle-local's buildCommand as a file.

### DIFF
--- a/pkgs/development/haskell-modules/hoogle.nix
+++ b/pkgs/development/haskell-modules/hoogle.nix
@@ -57,11 +57,11 @@ stdenv.mkDerivation {
   name = "hoogle-local-0.1";
   buildInputs = [ghc hoogle];
 
-  phases = [ "buildPhase" ];
-
   inherit docPackages;
 
-  buildPhase = ''
+  passAsFile = ["buildCommand"];
+
+  buildCommand = ''
     ${lib.optionalString (packages != [] -> docPackages == [])
        ("echo WARNING: localHoogle package list empty, even though"
        + " the following were specified: "


### PR DESCRIPTION
This is necessary when a very large number of packages are included in the
package database. Without this change, setting up the build environment will
fail, since the environment will be too large.

This simply applies the technique mentioned in https://github.com/NixOS/nixpkgs/issues/25057 to solve this problem.