### PR TITLE
vimplugin-unison-syntax: init at 1.0M1c

### DIFF
--- a/pkgs/misc/vim-plugins/overrides.nix
+++ b/pkgs/misc/vim-plugins/overrides.nix
@@ -260,6 +260,18 @@ self: super: {
       };
     });
 
+  unisonSyntax = buildVimPluginFrom2Nix {
+    pname = "unison-syntax";
+    version = "2019-08-21";
+    src = fetchFromGitHub {
+      owner = "unisonweb";
+      repo = "unison";
+      rev = "08effd4535d2f388d9548ed238755bb38d48175b";
+      sha256 = "0kbx5h41hsqzmfq6kb2c3p3a59z0xjvwg6ixyv4gs0kwkj7bvdfj";
+    };
+    preInstall = "cd editor-support/vim";
+    meta.maintainers = with stdenv.lib.maintainers; [ virusdave ];
+  };
 
   vimshell-vim = super.vimshell-vim.overrideAttrs(old: {
     dependencies = with super; [ vimproc-vim ];


### PR DESCRIPTION

###### Motivation for this change
Simple syntax highlighting plugin for unison language.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @worldofpeace 
