### PR TITLE
stig: init at 0.10.1a0

### DIFF
--- a/pkgs/applications/networking/p2p/stig/default.nix
+++ b/pkgs/applications/networking/p2p/stig/default.nix
@@ -1,9 +1,9 @@
 { lib
 , fetchFromGitHub
-, python
+, python3
 }:
 
-python.pkgs.buildPythonApplication rec {
+python3.pkgs.buildPythonApplication rec {
   pname = "stig";
   # This project has a different concept for pre release / alpha,
   # Read the project's README for details: https://github.com/rndusr/stig#stig
@@ -26,7 +26,7 @@ python.pkgs.buildPythonApplication rec {
       --replace "urwidtrees>=1.0.3dev0" "urwidtrees"
   '';
 
-  buildInputs = with python.pkgs; [
+  buildInputs = with python3.pkgs; [
     urwid
     urwidtrees
     aiohttp
@@ -38,7 +38,7 @@ python.pkgs.buildPythonApplication rec {
     setproctitle
   ];
 
-  checkInputs = with python.pkgs; [
+  checkInputs = with python3.pkgs; [
     asynctest
     pytest
   ];

--- a/pkgs/applications/networking/p2p/stig/default.nix
+++ b/pkgs/applications/networking/p2p/stig/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, lib, pkgs, python3 }:
+
+with python3.pkgs; buildPythonApplication rec {
+  pname = "stig";
+  version = "0.10.1a0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1xi87kmnyfvdwwx6g6hdgzb6c0jwl98fpvhrg62py80x3j5qlc4a";
+  };
+  postUnpack = ''
+    substituteInPlace stig-${version}/setup.py \
+    --replace "urwidtrees>=1.0.3dev0" "urwidtrees"
+  '';
+
+  propagatedBuildInputs = [
+    urwid
+    urwidtrees
+    aiohttp
+    async-timeout
+    pyxdg
+    blinker
+    natsort
+    maxminddb
+    setproctitle
+  ];
+  # Currently, tests fail with:
+  # ```
+  # TypeError: don't know how to make test from: <stig.client.geoip.GeoIP object at 0x7ffff6594290>
+  # ```
+  # checkInputs = [
+    # asynctest
+  # ];
+  doCheck = false;
+
+  meta = with lib; {
+    description = "TUI and CLI for the BitTorrent client Transmission";
+    homepage = "https://github.com/rndusr/stig";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ doronbehar ];
+  };
+}
+

--- a/pkgs/applications/networking/p2p/stig/default.nix
+++ b/pkgs/applications/networking/p2p/stig/default.nix
@@ -39,7 +39,7 @@ python.pkgs.buildPythonApplication rec {
   ];
 
   checkPhase = ''
-    pytest --exitfirst tests
+    pytest tests
   '';
 
   meta = with lib; {

--- a/pkgs/applications/networking/p2p/stig/default.nix
+++ b/pkgs/applications/networking/p2p/stig/default.nix
@@ -1,16 +1,19 @@
-{ stdenv, lib, pkgs, python3 }:
+{ lib, fetchFromGitHub, python }:
 
-with python3.pkgs; buildPythonApplication rec {
+with python.pkgs; buildPythonApplication rec {
   pname = "stig";
-  version = "0.10.1a0";
+  version = "0.10.1a";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "1xi87kmnyfvdwwx6g6hdgzb6c0jwl98fpvhrg62py80x3j5qlc4a";
+  src = fetchFromGitHub {
+    owner = "rndusr";
+    repo = "stig";
+    rev = "v${version}";
+    sha256 = "076rlial6h1nhwdxf1mx5nf2zld5ci43cadj9wf8xms7zn8s6c8v";
   };
-  postUnpack = ''
-    substituteInPlace stig-${version}/setup.py \
-    --replace "urwidtrees>=1.0.3dev0" "urwidtrees"
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "urwidtrees>=1.0.3dev0" "urwidtrees"
   '';
 
   propagatedBuildInputs = [
@@ -24,14 +27,15 @@ with python3.pkgs; buildPythonApplication rec {
     maxminddb
     setproctitle
   ];
-  # Currently, tests fail with:
-  # ```
-  # TypeError: don't know how to make test from: <stig.client.geoip.GeoIP object at 0x7ffff6594290>
-  # ```
-  # checkInputs = [
-    # asynctest
-  # ];
-  doCheck = false;
+
+  checkInputs = [
+    asynctest
+    pytest
+  ];
+
+  checkPhase = ''
+    pytest --exitfirst tests
+  '';
 
   meta = with lib; {
     description = "TUI and CLI for the BitTorrent client Transmission";
@@ -40,4 +44,3 @@ with python3.pkgs; buildPythonApplication rec {
     maintainers = with maintainers; [ doronbehar ];
   };
 }
-

--- a/pkgs/applications/networking/p2p/stig/default.nix
+++ b/pkgs/applications/networking/p2p/stig/default.nix
@@ -1,4 +1,7 @@
-{ lib, fetchFromGitHub, python }:
+{ lib
+, fetchFromGitHub
+, python
+}:
 
 with python.pkgs; buildPythonApplication rec {
   pname = "stig";

--- a/pkgs/applications/networking/p2p/stig/default.nix
+++ b/pkgs/applications/networking/p2p/stig/default.nix
@@ -5,6 +5,8 @@
 
 python.pkgs.buildPythonApplication rec {
   pname = "stig";
+  # This project has a different concept for pre release / alpha,
+  # Read the project's README for details: https://github.com/rndusr/stig#stig
   version = "0.10.1a";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/networking/p2p/stig/default.nix
+++ b/pkgs/applications/networking/p2p/stig/default.nix
@@ -3,7 +3,7 @@
 , python
 }:
 
-with python.pkgs; buildPythonApplication rec {
+python.pkgs.buildPythonApplication rec {
   pname = "stig";
   version = "0.10.1a";
 
@@ -19,7 +19,7 @@ with python.pkgs; buildPythonApplication rec {
       --replace "urwidtrees>=1.0.3dev0" "urwidtrees"
   '';
 
-  propagatedBuildInputs = [
+  with python3.pkgs; propagatedBuildInputs = [
     urwid
     urwidtrees
     aiohttp

--- a/pkgs/applications/networking/p2p/stig/default.nix
+++ b/pkgs/applications/networking/p2p/stig/default.nix
@@ -21,7 +21,7 @@ python.pkgs.buildPythonApplication rec {
       --replace "urwidtrees>=1.0.3dev0" "urwidtrees"
   '';
 
-  with python3.pkgs; buildInputs = [
+  buildInputs = with python.pkgs; [
     urwid
     urwidtrees
     aiohttp
@@ -33,7 +33,7 @@ python.pkgs.buildPythonApplication rec {
     setproctitle
   ];
 
-  checkInputs = [
+  checkInputs = with python.pkgs; [
     asynctest
     pytest
   ];

--- a/pkgs/applications/networking/p2p/stig/default.nix
+++ b/pkgs/applications/networking/p2p/stig/default.nix
@@ -16,6 +16,11 @@ python.pkgs.buildPythonApplication rec {
     sha256 = "076rlial6h1nhwdxf1mx5nf2zld5ci43cadj9wf8xms7zn8s6c8v";
   };
 
+  # urwidtrees 1.0.3 is requested by the developer because 1.0.2 (which is packaged
+  # in nixpkgs) is not uploaded to pypi and 1.0.1 has a problematic `setup.py`.
+  # As long as we don't have any problems installing it, no special features / specific bugs
+  # were fixed in 1.0.3 that aren't available in 1.0.2 are used by stig.
+  # See https://github.com/rndusr/stig/issues/120
   postPatch = ''
     substituteInPlace setup.py \
       --replace "urwidtrees>=1.0.3dev0" "urwidtrees"

--- a/pkgs/applications/networking/p2p/stig/default.nix
+++ b/pkgs/applications/networking/p2p/stig/default.nix
@@ -21,7 +21,7 @@ python.pkgs.buildPythonApplication rec {
       --replace "urwidtrees>=1.0.3dev0" "urwidtrees"
   '';
 
-  with python3.pkgs; propagatedBuildInputs = [
+  with python3.pkgs; buildInputs = [
     urwid
     urwidtrees
     aiohttp

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16951,6 +16951,8 @@ in
 
   starship = callPackage ../tools/misc/starship { };
 
+  stig = callPackage ../applications/networking/p2p/stig { };
+
   stix-otf = callPackage ../data/fonts/stix-otf { };
 
   stix-two = callPackage ../data/fonts/stix-two { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16951,7 +16951,7 @@ in
 
   starship = callPackage ../tools/misc/starship { };
 
-  stig = callPackage ../applications/networking/p2p/stig { python = python3; };
+  stig = callPackage ../applications/networking/p2p/stig { };
 
   stix-otf = callPackage ../data/fonts/stix-otf { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16951,7 +16951,7 @@ in
 
   starship = callPackage ../tools/misc/starship { };
 
-  stig = callPackage ../applications/networking/p2p/stig { };
+  stig = callPackage ../applications/networking/p2p/stig { python = python3; };
 
   stix-otf = callPackage ../data/fonts/stix-otf { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers