### PR TITLE
dolphin-emu fixes and updates

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -576,6 +576,12 @@
     githubId = 816777;
     name = "Ashley Gillman";
   };
+  ashkitten = {
+    email = "ashlea@protonmail.com";
+    github = "ashkitten";
+    githubId = 9281956;
+    name = "ash lea";
+  };
   aske = {
     email = "aske@fmap.me";
     github = "aske";

--- a/pkgs/misc/emulators/dolphin-emu/default.nix
+++ b/pkgs/misc/emulators/dolphin-emu/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, pkgconfig, cmake, bluez, ffmpeg, libao, gtk2, glib, libGLU_combined
-, gettext, libpthreadstubs, libXrandr, libXext, readline, openal
-, libXdmcp, portaudio, fetchFromGitHub, libusb, libevdev
+{ stdenv, fetchpatch, pkgconfig, cmake, bluez, ffmpeg, libao, gtk2, glib
+, libGLU_combined , gettext, libpthreadstubs, libXrandr, libXext, readline
+, openal , libXdmcp, portaudio, fetchFromGitHub, libusb, libevdev
 , wxGTK30, soundtouch, miniupnpc, mbedtls, curl, lzo, sfml
 , libpulseaudio ? null }:
 
@@ -15,17 +15,26 @@ stdenv.mkDerivation rec {
     sha256 = "07mlfnh0hwvk6xarcg315x7z2j0qbg9g7cm040df9c8psiahc3g6";
   };
 
+  patches = [
+    # Fix build with soundtouch 2.1.2
+    (fetchpatch {
+      url = "https://src.fedoraproject.org/rpms/dolphin-emu/raw/a1b91fdf94981e12c8889a02cba0ec2267d0f303/f/dolphin-emu-5.0-soundtouch-exception-fix.patch";
+      name = "dolphin-emu-5.0-soundtouch-exception-fix.patch";
+      sha256 = "0yd3l46nja5qiknnl30ryad98f3v8911jwnr67hn61dzx2kwbbaw";
+    })
+  ];
+
   postPatch = ''
     substituteInPlace Source/Core/VideoBackends/OGL/RasterFont.cpp \
       --replace " CHAR_WIDTH " " CHARWIDTH "
   '';
 
-  cmakeFlags = ''
-    -DGTK2_GLIBCONFIG_INCLUDE_DIR=${glib.out}/lib/glib-2.0/include
-    -DGTK2_GDKCONFIG_INCLUDE_DIR=${gtk2.out}/lib/gtk-2.0/include
-    -DGTK2_INCLUDE_DIRS=${gtk2.dev}/include/gtk-2.0
-    -DENABLE_LTO=True
-  '';
+  cmakeFlags = [
+    "-DGTK2_GLIBCONFIG_INCLUDE_DIR=${glib.out}/lib/glib-2.0/include"
+    "-DGTK2_GDKCONFIG_INCLUDE_DIR=${gtk2.out}/lib/gtk-2.0/include"
+    "-DGTK2_INCLUDE_DIRS=${gtk2.dev}/include/gtk-2.0"
+    "-DENABLE_LTO=True"
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/misc/emulators/dolphin-emu/default.nix
+++ b/pkgs/misc/emulators/dolphin-emu/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchpatch, pkgconfig, cmake, bluez, ffmpeg, libao, gtk2, glib
+{ stdenv, lib, fetchpatch, pkgconfig, cmake, bluez, ffmpeg, libao, gtk2, glib
 , libGLU_combined , gettext, libpthreadstubs, libXrandr, libXext, readline
 , openal , libXdmcp, portaudio, fetchFromGitHub, libusb, libevdev
 , wxGTK30, soundtouch, miniupnpc, mbedtls, curl, lzo, sfml
@@ -45,11 +45,11 @@ stdenv.mkDerivation rec {
                   libevdev libXdmcp portaudio libusb libpulseaudio
                   wxGTK30 soundtouch miniupnpc mbedtls curl lzo sfml ];
 
-  meta = {
+  meta = with lib; {
     homepage = https://dolphin-emu.org/;
     description = "Gamecube/Wii/Triforce emulator for x86_64 and ARMv8";
-    license = stdenv.lib.licenses.gpl2Plus;
-    maintainers = with stdenv.lib.maintainers; [ MP2E ];
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ MP2E ashkitten ];
     # x86_32 is an unsupported platform.
     # Enable generic build if you really want a JIT-less binary.
     platforms = [ "x86_64-linux" ];

--- a/pkgs/misc/emulators/dolphin-emu/master.nix
+++ b/pkgs/misc/emulators/dolphin-emu/master.nix
@@ -21,13 +21,13 @@ let
   };
 in stdenv.mkDerivation rec {
   name = "dolphin-emu-${version}";
-  version = "5.0-10751";
+  version = "5.0-10879";
 
   src = fetchFromGitHub {
     owner = "dolphin-emu";
     repo = "dolphin";
-    rev = "64c0ff576c6d3ea2ee35e6b6d7ea8c814442d53f";
-    sha256 = "19351j3gys9kgxpdjv1dckaiv74dylcdh1kx0z9qz8llv9s1r0s3";
+    rev = "c7fc9126aaf447a014af4aed195b17aa593dd49b";
+    sha256 = "1pf4mxacxhrkvvh9j49ackm8hahl8x0ligmann1pafsb4lw0xbnj";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/misc/emulators/dolphin-emu/master.nix
+++ b/pkgs/misc/emulators/dolphin-emu/master.nix
@@ -77,7 +77,7 @@ in stdenv.mkDerivation rec {
     homepage = "https://dolphin-emu.org";
     description = "Gamecube/Wii/Triforce emulator for x86_64 and ARMv8";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ MP2E ];
+    maintainers = with maintainers; [ MP2E ashkitten ];
     branch = "master";
     # x86_32 is an unsupported platform.
     # Enable generic build if you really want a JIT-less binary.

--- a/pkgs/misc/emulators/dolphin-emu/master.nix
+++ b/pkgs/misc/emulators/dolphin-emu/master.nix
@@ -39,9 +39,9 @@ in stdenv.mkDerivation rec {
     libXrandr libXext libXxf86vm libXinerama libSM readline openal libXdmcp lzo
     portaudio libusb libpng hidapi miniupnpc enet mbedtls soundtouch sfml
     qtbase
-  ] ++ stdenv.lib.optionals stdenv.isLinux [
+  ] ++ lib.optionals stdenv.isLinux [
     bluez udev libevdev alsaLib vulkan-loader
-  ] ++ stdenv.lib.optionals stdenv.isDarwin [
+  ] ++ lib.optionals stdenv.isDarwin [
     CoreBluetooth OpenGL ForceFeedback IOKit
   ];
 
@@ -51,7 +51,7 @@ in stdenv.mkDerivation rec {
     "-DDOLPHIN_WC_REVISION=${src.rev}"
     "-DDOLPHIN_WC_DESCRIBE=${version}"
     "-DDOLPHIN_WC_BRANCH=master"
-  ] ++ stdenv.lib.optionals stdenv.isDarwin [
+  ] ++ lib.optionals stdenv.isDarwin [
     "-DOSX_USE_DEFAULT_SEARCH_PATH=True"
   ];
 
@@ -62,7 +62,7 @@ in stdenv.mkDerivation rec {
   # - Allow Dolphin to use nix-provided libraries instead of building them
   postPatch = ''
     sed -i -e 's,DISTRIBUTOR "None",DISTRIBUTOR "NixOS",g' CMakeLists.txt
-  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+  '' + lib.optionalString stdenv.isDarwin ''
     sed -i -e 's,if(NOT APPLE),if(true),g' CMakeLists.txt
     sed -i -e 's,if(LIBUSB_FOUND AND NOT APPLE),if(LIBUSB_FOUND),g' \
       CMakeLists.txt
@@ -73,7 +73,7 @@ in stdenv.mkDerivation rec {
     ln -sf $out/bin/dolphin-emu $out/bin/dolphin-emu-master
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "https://dolphin-emu.org";
     description = "Gamecube/Wii/Triforce emulator for x86_64 and ARMv8";
     license = licenses.gpl2Plus;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2661,7 +2661,7 @@ in
   dotnetfx40 = callPackage ../development/libraries/dotnetfx40 { };
 
   dolphinEmu = callPackage ../misc/emulators/dolphin-emu { };
-  dolphinEmuMaster = callPackage ../misc/emulators/dolphin-emu/master.nix {
+  dolphinEmuMaster = qt5.callPackage ../misc/emulators/dolphin-emu/master.nix {
     inherit (darwin.apple_sdk.frameworks) CoreBluetooth ForceFeedback IOKit OpenGL;
   };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

- `dolphinEmu` was broken, fixed building with `soundtouch-2.1.2`
- both `dolphinEmu` and `dolphinEmuMaster` were broken at runtime (see #65399)
- replaced instances of `stdenv.lib` with `lib` for readability
- added self as co-maintainer

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @MP2E