### PR TITLE
osslsigncode: init at unstable-2019-07-25

### DIFF
--- a/pkgs/development/tools/osslsigncode/default.nix
+++ b/pkgs/development/tools/osslsigncode/default.nix
@@ -1,0 +1,31 @@
+{ stdenv
+, fetchFromGitHub
+, autoreconfHook
+, libgsf
+, pkgconfig
+, openssl_1_1
+, curl
+}:
+
+stdenv.mkDerivation rec {
+  pname = "osslsigncode";
+  version = "unstable-2019-07-25";
+
+  src = fetchFromGitHub {
+    owner = "mtrojnar";
+    repo = pname;
+    rev = "18810b7e0bb1d8e0d25b6c2565a065cf66bce5d7";
+    sha256 = "02jnbr3xdsb5dpll3k65080ryrfr7agawmjavwxd0v40w0an5yq8";
+  };
+
+  nativeBuildInputs = [ autoreconfHook libgsf pkgconfig openssl_1_1 curl ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/mtrojnar/osslsigncode";
+    description = "OpenSSL based Authenticode signing for PE/MSI/Java CAB files";
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.mmahut ];
+    platforms = platforms.all;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5240,6 +5240,8 @@ in
 
   ossec = callPackage ../tools/security/ossec {};
 
+  osslsigncode = callPackage ../development/tools/osslsigncode {};
+
   ostree = callPackage ../tools/misc/ostree { };
 
   otfcc = callPackage ../tools/misc/otfcc { };


### PR DESCRIPTION
###### Motivation for this change

 init at unstable-2019-07-25

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
