### PR TITLE
Lua: consolidate setup hooks

### DIFF
--- a/pkgs/applications/networking/browsers/luakit/default.nix
+++ b/pkgs/applications/networking/browsers/luakit/default.nix
@@ -31,8 +31,7 @@ stdenv.mkDerivation rec {
     # TODO: why is not this the default? The test runner adds
     # ';./lib/?.lua;./lib/?/init.lua' to package.path, but the build-utils
     # scripts don't add an equivalent
-    export LUA_PATH="$NIX_LUA_PATH;./?.lua;./?/init.lua"
-    export LUA_CPATH="$NIX_LUA_CPATH"
+    export LUA_PATH="$LUA_PATH;./?.lua;./?/init.lua"
   '';
 
   makeFlags = [
@@ -49,8 +48,8 @@ stdenv.mkDerivation rec {
   in ''
     gappsWrapperArgs+=(
       --prefix XDG_CONFIG_DIRS : "$out/etc/xdg"
-      --prefix LUA_PATH ';' "${luaKitPath};$NIX_LUA_PATH"
-      --prefix LUA_CPATH ';' "$NIX_LUA_CPATH"
+      --prefix LUA_PATH ';' "${luaKitPath};$LUA_PATH"
+      --prefix LUA_CPATH ';' "$LUA_CPATH"
     )
   '';
 

--- a/pkgs/development/interpreters/lua-5/setup-hook.sh
+++ b/pkgs/development/interpreters/lua-5/setup-hook.sh
@@ -1,47 +1,47 @@
 # set -e
 
 nix_print() {
-    if [ ${NIX_DEBUG:-0} -ge $1 ]; then
-        echo "$2"
-    fi
+  if [ ${NIX_DEBUG:-0} -ge $1 ]; then
+    echo "$2"
+  fi
 }
 
 nix_debug() {
-    nix_print 3 "$1"
+  nix_print 3 "$1"
 }
 
 addToLuaSearchPathWithCustomDelimiter() {
-    local varName="$1"
-    local absPattern="$2"
-    # delete longest match starting from the lua placeholder '?'
-    local topDir="${absPattern%%\?*}"
+  local varName="$1"
+  local absPattern="$2"
+  # delete longest match starting from the lua placeholder '?'
+  local topDir="${absPattern%%\?*}"
 
-    # export only if the folder exists else LUA_PATH grows too big
-    if  [ ! -d "$topDir" ]; then return; fi
+  # export only if the folder exists else LUA_PATH/LUA_CPATH grow too large
+  if [[ ! -d "$topDir" ]]; then return; fi
 
-    export "${varName}=${!varName:+${!varName};}${absPattern}"
+  # export only if we haven't already got this dir in the search path
+  if [[ ${!varName} == *"$absPattern"* ]]; then return; fi
+
+  export "${varName}=${!varName:+${!varName};}${absPattern}"
 }
 
 addToLuaPath() {
-    local dir="$1"
+  local dir="$1"
 
-    if [[ ! -d "$dir" ]]; then
-        nix_debug "$dir not a directory abort"
-        return 0
-    fi
-    cd "$dir"
-    for pattern in @luapathsearchpaths@;
-    do
-        addToLuaSearchPathWithCustomDelimiter NIX_LUA_PATH "$PWD/$pattern"
-    done
+  if [[ ! -d "$dir" ]]; then
+    nix_debug "$dir not a directory abort"
+    return 0
+  fi
+  cd "$dir"
+  for pattern in @luapathsearchpaths@; do
+    addToLuaSearchPathWithCustomDelimiter LUA_PATH "$PWD/$pattern"
+  done
 
-    # LUA_CPATH
-    for pattern in @luacpathsearchpaths@;
-    do
-        addToLuaSearchPathWithCustomDelimiter NIX_LUA_CPATH "$PWD/$pattern"
-    done
-    cd - >/dev/null
+  # LUA_CPATH
+  for pattern in @luacpathsearchpaths@; do
+    addToLuaSearchPathWithCustomDelimiter LUA_CPATH "$PWD/$pattern"
+  done
+  cd - >/dev/null
 }
 
 addEnvHooks "$hostOffset" addToLuaPath
-

--- a/pkgs/development/interpreters/lua-5/wrap.sh
+++ b/pkgs/development/interpreters/lua-5/wrap.sh
@@ -4,73 +4,72 @@
 set -e
 
 wrapLuaPrograms() {
-    wrapLuaProgramsIn "$out/bin" "$out $luaPath"
+  wrapLuaProgramsIn "$out/bin" "$out $luaPath"
 }
 
 # Builds environment variables like LUA_PATH and PATH walking through closure
 # of dependencies.
 buildLuaPath() {
-    local luaPath="$1"
-    local path
+  local luaPath="$1"
+  local path
 
-    # Create an empty table of paths (see doc on loadFromPropagatedInputs
-    # for how this is used). Build up the program_PATH and program_LUA_PATH
-    # variables.
-    declare -A luaPathsSeen=()
-    program_PATH=
-    luaPathsSeen["@lua@"]=1
-    addToSearchPath program_PATH @lua@/bin
-    for path in $luaPath; do
-        addToLuaPath "$path"
-    done
+  # Create an empty table of paths (see doc on loadFromPropagatedInputs
+  # for how this is used). Build up the program_PATH and program_LUA_PATH
+  # variables.
+  declare -A luaPathsSeen=()
+  program_PATH=
+  luaPathsSeen["@lua@"]=1
+  addToSearchPath program_PATH @lua@/bin
+  for path in $luaPath; do
+    addToLuaPath "$path"
+  done
 }
-
 
 # with an executable shell script which will set some environment variables
 # and then call into the original binary (which has been given a .wrapped suffix).
 # luaPath is a list of directories
 wrapLuaProgramsIn() {
-    local dir="$1"
-    local luaPath="$2"
-    local f
+  local dir="$1"
+  local luaPath="$2"
+  local f
 
-    buildLuaPath "$luaPath"
+  buildLuaPath "$luaPath"
 
-    if [ ! -d "$dir" ]; then
-        nix_debug "$dir not a directory"
-        return
+  if [ ! -d "$dir" ]; then
+    nix_debug "$dir not a directory"
+    return
+  fi
+
+  nix_debug "wrapping programs in [$dir]"
+
+  # Find all regular files in the output directory that are executable.
+  find "$dir" -type f -perm -0100 -print0 | while read -d "" f; do
+    # Rewrite "#! .../env lua" to "#! /nix/store/.../lua".
+    # Strip suffix, like "3" or "2.7m" -- we don't have any choice on which
+    # Lua to use besides one with this hook anyway.
+    if head -n1 "$f" | grep -q '#!.*/env.*\(lua\)'; then
+      sed -i "$f" -e "1 s^.*/env[ ]*\(lua\)[^ ]*^#! @executable@^"
     fi
 
-    nix_debug "wrapping programs in [$dir]"
+    # wrapProgram creates the executable shell script described
+    # above. The script will set LUA_(C)PATH and PATH variables!
+    # (see pkgs/build-support/setup-hooks/make-wrapper.sh)
+    local -a wrap_args=("$f"
+      --prefix PATH ':' "$program_PATH"
+      --prefix LUA_PATH ';' "$LUA_PATH"
+      --prefix LUA_CPATH ';' "$LUA_CPATH"
+    )
 
-    # Find all regular files in the output directory that are executable.
-    find "$dir" -type f -perm -0100 -print0 | while read -d "" f; do
-        # Rewrite "#! .../env lua" to "#! /nix/store/.../lua".
-        # Strip suffix, like "3" or "2.7m" -- we don't have any choice on which
-        # Lua to use besides one with this hook anyway.
-        if head -n1 "$f" | grep -q '#!.*/env.*\(lua\)'; then
-            sed -i "$f" -e "1 s^.*/env[ ]*\(lua\)[^ ]*^#! @executable@^"
-        fi
+    # Add any additional arguments provided by makeWrapperArgs
+    # argument to buildLuaPackage.
+    # makeWrapperArgs
+    local -a user_args="($makeWrapperArgs)"
+    local -a wrapProgramArgs=("${wrap_args[@]}" "${user_args[@]}")
 
-        # wrapProgram creates the executable shell script described
-        # above. The script will set LUA_(C)PATH and PATH variables!
-        # (see pkgs/build-support/setup-hooks/make-wrapper.sh)
-        local -a wrap_args=("$f"
-            --prefix PATH ':' "$program_PATH"
-            --prefix LUA_PATH ';' "$NIX_LUA_PATH"
-            --prefix LUA_CPATH ';' "$NIX_LUA_CPATH"
-        )
+    # see setup-hooks/make-wrapper.sh
+    wrapProgram "${wrapProgramArgs[@]}"
 
-        # Add any additional arguments provided by makeWrapperArgs
-        # argument to buildLuaPackage.
-        # makeWrapperArgs
-        local -a user_args="($makeWrapperArgs)"
-        local -a wrapProgramArgs=("${wrap_args[@]}" "${user_args[@]}")
-
-        # see setup-hooks/make-wrapper.sh
-        wrapProgram "${wrapProgramArgs[@]}"
-
-    done
+  done
 }
 
 # Adds the lib and bin directories to the LUA_PATH and PATH variables,
@@ -78,22 +77,22 @@ wrapLuaProgramsIn() {
 # `propagated-native-build-inputs`, while avoiding duplicating paths by
 # flagging the directories it has visited in `luaPathsSeen`.
 loadFromPropagatedInputs() {
-    local dir="$1"
-    # Stop if we've already visited here.
-    if [ -n "${luaPathsSeen[$dir]}" ]; then
-        return;
-    fi
-    luaPathsSeen[$dir]=1
+  local dir="$1"
+  # Stop if we've already visited here.
+  if [ -n "${luaPathsSeen[$dir]}" ]; then
+    return
+  fi
+  luaPathsSeen[$dir]=1
 
-    addToLuaPath "$dir"
-    addToSearchPath program_PATH $dir/bin
+  addToLuaPath "$dir"
+  addToSearchPath program_PATH $dir/bin
 
-    # Inspect the propagated inputs (if they exist) and recur on them.
-    local prop="$dir/nix-support/propagated-native-build-inputs"
-    if [ -e "$prop" ]; then
-        local new_path
-        for new_path in $(cat $prop); do
-            loadFromPropagatedInputs "$new_path"
-        done
-    fi
+  # Inspect the propagated inputs (if they exist) and recur on them.
+  local prop="$dir/nix-support/propagated-native-build-inputs"
+  if [ -e "$prop" ]; then
+    local new_path
+    for new_path in $(cat $prop); do
+      loadFromPropagatedInputs "$new_path"
+    done
+  fi
 }

--- a/pkgs/development/interpreters/lua-5/wrapper.nix
+++ b/pkgs/development/interpreters/lua-5/wrapper.nix
@@ -43,7 +43,7 @@ let
               rm -f "$out/bin/$prg"
               if [ -x "$prg" ]; then
                 nix_debug "Making wrapper $prg"
-                makeWrapper "$path/bin/$prg" "$out/bin/$prg" --suffix LUA_PATH ';' "$NIX_LUA_PATH"   --suffix LUA_CPATH ';' "$NIX_LUA_CPATH" ${stdenv.lib.concatStringsSep " " makeWrapperArgs}
+                makeWrapper "$path/bin/$prg" "$out/bin/$prg" --suffix LUA_PATH ';' "$LUA_PATH"   --suffix LUA_CPATH ';' "$LUA_CPATH" ${stdenv.lib.concatStringsSep " " makeWrapperArgs}
               fi
             fi
           done

--- a/pkgs/development/lua-modules/generic/default.nix
+++ b/pkgs/development/lua-modules/generic/default.nix
@@ -1,6 +1,6 @@
 { lua, writeText, toLuaModule }:
 
-{ buildInputs ? [], disabled ? false, ... } @ attrs:
+{ disabled ? false, ... } @ attrs:
 
 if disabled then
   throw "${attrs.name} not supported by interpreter lua-${lua.luaversion}"
@@ -18,37 +18,8 @@ else
     //
     {
       name = "lua${lua.luaversion}-" + attrs.name;
-      buildInputs = buildInputs ++ [ lua ];
-
-      setupHook = writeText "setup-hook.sh" ''
-        # check for lua/clua modules and don't add duplicates
-
-        addLuaLibPath() {
-          local package_path="$1/share/lua/${lua.luaversion}"
-          if [[ ! -d $package_path ]]; then return; fi
-          if [[ $LUA_PATH = *"$package_path"* ]]; then return; fi
-
-          if [[ -z $LUA_PATH ]]; then
-            export LUA_PATH="$package_path/?.lua;$package_path/?/init.lua"
-          else
-            export LUA_PATH="$LUA_PATH;$package_path/?.lua;$package_path/?/init.lua"
-          fi
-        }
-
-        addLuaLibCPath() {
-          local package_cpath="$1/lib/lua/${lua.luaversion}"
-          if [[ ! -d $package_cpath ]]; then return; fi
-          if [[ $LUA_CPATH = *"$package_cpath"* ]]; then return; fi
-
-          if [[ -z $LUA_CPATH ]]; then
-            export LUA_CPATH="$package_cpath/?.so"
-          else
-            export LUA_CPATH="$LUA_CPATH;$package_cpath/?.so"
-          fi
-        }
-
-        addEnvHooks "$hostOffset" addLuaLibPath
-        addEnvHooks "$hostOffset" addLuaLibCPath
-      '';
+      propagatedBuildInputs = [
+        lua # propagate it for its setup-hook
+      ];
     }
   ) )

--- a/pkgs/servers/xmpp/prosody/default.nix
+++ b/pkgs/servers/xmpp/prosody/default.nix
@@ -54,12 +54,12 @@ stdenv.mkDerivation rec {
         cp -r $communityModules/mod_${module} $out/lib/prosody/modules/
       '') (withCommunityModules ++ withOnlyInstalledCommunityModules)}
       wrapProgram $out/bin/prosody \
-        --prefix LUA_PATH ';' "$NIX_LUA_PATH" \
-        --prefix LUA_CPATH ';' "$NIX_LUA_CPATH"
+        --prefix LUA_PATH ';' "$LUA_PATH" \
+        --prefix LUA_CPATH ';' "$LUA_CPATH"
       wrapProgram $out/bin/prosodyctl \
         --add-flags '--config "/etc/prosody/prosody.cfg.lua"' \
-        --prefix LUA_PATH ';' "$NIX_LUA_PATH" \
-        --prefix LUA_CPATH ';' "$NIX_LUA_CPATH"
+        --prefix LUA_PATH ';' "$LUA_PATH" \
+        --prefix LUA_CPATH ';' "$LUA_CPATH"
     '';
 
   passthru.communityModules = withCommunityModules;

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -64,17 +64,18 @@ in
 with self; {
 
   getLuaPathList = majorVersion: [
-     "lib/lua/${majorVersion}/?.lua" "share/lua/${majorVersion}/?.lua"
-    "share/lua/${majorVersion}/?/init.lua" "lib/lua/${majorVersion}/?/init.lua"
+    "share/lua/${majorVersion}/?.lua"
+    "share/lua/${majorVersion}/?/init.lua"
   ];
   getLuaCPathList = majorVersion: [
-     "lib/lua/${majorVersion}/?.so" "share/lua/${majorVersion}/?.so" "share/lua/${majorVersion}/?/init.so"
+    "lib/lua/${majorVersion}/?.so"
   ];
 
   # helper functions for dealing with LUA_PATH and LUA_CPATH
-  getPath       = lib : type : "${lib}/lib/lua/${lua.luaversion}/?.${type};${lib}/share/lua/${lua.luaversion}/?.${type}";
-  getLuaPath    = lib : getPath lib "lua";
-  getLuaCPath   = lib : getPath lib "so";
+  getPath = drv: pathListForVersion:
+    lib.concatMapStringsSep ";" (path: "${drv}/${path}") (pathListForVersion lua.luaversion);
+  getLuaPath = drv: getPath drv getLuaPathList;
+  getLuaCPath = drv: getPath drv getLuaCPathList;
 
   #define build lua package function
   buildLuaPackage = callPackage ../development/lua-modules/generic {


### PR DESCRIPTION
###### Motivation for this change
- Means there are no longer two separate setup hooks for Lua packages, with partially-overlapping functionality.
- Fixes pre-existing issues that came to light [here](https://github.com/NixOS/nixpkgs/pull/63108#issuecomment-508670438).

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @teto @vcunat can one of you two poke ofborg for this? I know from last time it would take me a couple days to do a nix-review for all the builds >.>.

Both prosody tests pass, I've manually tested luakit, and I've tested a handful of `buildLuaPackage` and `buildLuarocksPackage` derivations, all have worked fine.
