### PR TITLE
nixos/modules/services/x11/hardware/: add cmt module 

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3181,6 +3181,12 @@
     githubId = 1047859;
     name = "Kaz Wesley";
   };
+  kcalvinalvin = {
+    email = "calvin@kcalvinalvin.info";
+    github = "kcalvinalvin";
+    githubId = 37185887;
+    name = "Calvin Kim";
+  };
   kentjames = {
     email = "jameschristopherkent@gmail.com";
     github = "kentjames";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -842,6 +842,7 @@
   ./services/x11/hardware/multitouch.nix
   ./services/x11/hardware/synaptics.nix
   ./services/x11/hardware/wacom.nix
+  ./services/x11/hardware/cmt.nix
   ./services/x11/gdk-pixbuf.nix
   ./services/x11/redshift.nix
   ./services/x11/urxvtd.nix

--- a/nixos/modules/services/x11/hardware/cmt.nix
+++ b/nixos/modules/services/x11/hardware/cmt.nix
@@ -1,0 +1,54 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+cfg = config.services.xserver.cmt;
+etcPath = "X11/xorg.conf.d";
+
+in {
+
+  options = {
+
+    services.xserver.cmt = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Enable chrome multitouch input (cmt). Touchpad drivers that are configured for chromebooks.";
+      };
+      models = mkOption {
+        type = types.enum [ "atlas" "banjo" "candy" "caroline" "cave" "celes" "clapper" "cyan" "daisy" "elan" "elm" "enguarde" "eve" "expresso" "falco" "gandof" "glimmer" "gnawty" "heli" "kevin" "kip" "leon" "lulu" "orco" "pbody" "peppy" "pi" "pit" "puppy" "quawks" "rambi" "samus" "snappy" "spring" "squawks" "swanky" "winky" "wolf" "auron_paine" "auron_yuna" "daisy_skate" "nyan_big" "nyan_blaze" "veyron_jaq" "veyron_jerry" "veyron_mighty" "veyron_minnie" "veyron_speedy" ];
+        example = "banjo";
+        description = ''
+          Which models to enable cmt for. Enter the Code Name for your Chromebook.
+          Code Name can be found at <link xlink:href="https://www.chromium.org/chromium-os/developer-information-for-chrome-os-devices" />.
+        '';
+      };
+    }; #closes services
+  }; #closes options
+
+  config = mkIf cfg.enable {
+
+    services.xserver.modules = [ pkgs.xf86_input_cmt ];
+
+    environment.etc = {
+      "${etcPath}/40-touchpad-cmt.conf" = {
+        source = "${pkgs.chromium-xorg-conf}/40-touchpad-cmt.conf";
+      };
+      "${etcPath}/50-touchpad-cmt-${cfg.models}.conf" = {
+        source = "${pkgs.chromium-xorg-conf}/50-touchpad-cmt-${cfg.models}.conf";
+      };
+      "${etcPath}/60-touchpad-cmt-${cfg.models}.conf" = {
+        source = "${pkgs.chromium-xorg-conf}/60-touchpad-cmt-${cfg.models}.conf";
+      };
+    };
+
+    assertions = [
+      {
+        assertion = !config.services.xserver.libinput.enable;
+        message = "cmt and libinput are incompatible, you cannot enable both (in services.xserver).";
+      }
+    ];
+  };
+}

--- a/pkgs/os-specific/linux/chromium-xorg-conf/default.nix
+++ b/pkgs/os-specific/linux/chromium-xorg-conf/default.nix
@@ -1,0 +1,8 @@
+{fetchgit }:
+
+fetchgit {
+  name = "chromium-xorg-conf";
+  url = "https://chromium.googlesource.com/chromiumos/platform/xorg-conf";
+  rev = "26fb9d57e195c7e467616b35b17e2b5d279c1514";
+  sha256 = "0643y3l3hjk4mv4lm3h9z56h990q6k11hcr10lcqppgsii0d3zcf";
+}

--- a/pkgs/os-specific/linux/libevdevc/default.nix
+++ b/pkgs/os-specific/linux/libevdevc/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, coreutils, pkgconfig, glib, jsoncpp }:
+
+stdenv.mkDerivation rec {
+  name = "libevdevc";
+  version = "2.0.1";
+  src = fetchFromGitHub {
+    owner = "hugegreenbug";
+    repo = "libevdevc";
+    rev = "v${version}";
+    sha256 = "0ry30krfizh87yckmmv8n082ad91mqhhbbynx1lfidqzb6gdy2dd";
+  };
+
+  postPatch = ''
+    substituteInPlace common.mk \
+      --replace /bin/echo ${coreutils}/bin/echo
+    substituteInPlace include/module.mk \
+      --replace /usr/include /include
+  '';
+
+  makeFlags = [ "DESTDIR=$(out)" "LIBDIR=/lib" ];
+
+  meta = with stdenv.lib; {
+    description = "ChromiumOS libevdev. Renamed to avoid conflicts with the standard libevdev found in Linux distros.";
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+    homepage = "https://chromium.googlesource.com/chromiumos/platform/libevdev/";
+    maintainers = with maintainers; [ kcalvinalvin ];
+  };
+}

--- a/pkgs/os-specific/linux/libgestures/default.nix
+++ b/pkgs/os-specific/linux/libgestures/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, pkgconfig, glib, jsoncpp }:
+
+stdenv.mkDerivation rec {
+  name = "libgestures-${version}";
+  version = "2.0.1";
+  src = fetchFromGitHub {
+    owner = "hugegreenbug";
+    repo = "libgestures";
+    rev = "v${version}";
+    sha256 = "0dfvads2adzx4k8cqc1rbwrk1jm2wn9wl2jk51m26xxpmh1g0zab";
+  };
+  patches = [ ./include-fix.patch ];
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace -Werror -Wno-error \
+      --replace '$(DESTDIR)/usr/include' '$(DESTDIR)/include'
+  '';
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ glib jsoncpp ];
+
+
+  makeFlags = [ "DESTDIR=$(out)" "LIBDIR=/lib" ];
+
+  meta = with stdenv.lib; {
+    description = "ChromiumOS libgestures modified to compile for Linux.";
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+    homepage = "https://chromium.googlesource.com/chromiumos/platform/gestures";
+    maintainers = with maintainers; [ kcalvinalvin ];
+  };
+}

--- a/pkgs/os-specific/linux/libgestures/include-fix.patch
+++ b/pkgs/os-specific/linux/libgestures/include-fix.patch
@@ -1,0 +1,12 @@
+diff -ur a/include/gestures/include/finger_metrics.h b/include/gestures/include/finger_metrics.h
+--- a/include/gestures/include/finger_metrics.h    1970-01-01 09:00:01.000000000 +0900
++++ b/include/gestures/include/finger_metrics.h    2018-12-01 16:58:51.590718511 +0900
+@@ -5,6 +5,8 @@
+ #ifndef GESTURES_FINGER_METRICS_H_
+ #define GESTURES_FINGER_METRICS_H_
+ 
++#include <math.h>
++
+ #include "gestures/include/gestures.h"
+ #include "gestures/include/prop_registry.h"
+#include "gestures/include/vector.h"

--- a/pkgs/os-specific/linux/xf86-input-cmt/default.nix
+++ b/pkgs/os-specific/linux/xf86-input-cmt/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, pkgconfig, xorgserver, xorgproto,
+  utilmacros, libgestures, libevdevc }:
+
+stdenv.mkDerivation rec {
+  name = "xf86-input-cmt-${version}";
+  version = "2.0.2";
+  src = fetchFromGitHub {
+    owner = "hugegreenbug";
+    repo = "xf86-input-cmt";
+    rev = "v${version}";
+    sha256 = "1cnwf518nc0ybc1r3rsgc1gcql1k3785khffv0i4v3akrm9wdw98";
+  };
+
+  postPatch = ''
+    patchShebangs ./apply_patches.sh
+    ./apply_patches.sh
+  '';
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [
+    xorgserver xorgproto utilmacros
+    libgestures libevdevc
+  ];
+
+  configureFlags = [
+    "--with-sdkdir=${placeholder "out"}"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Chromebook touchpad driver.";
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+    homepage = "www.github.com/hugegreenbug/xf86-input-cmt";
+    maintainers = with maintainers; [ kcalvinalvin ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9223,6 +9223,8 @@ in
 
   chromedriver = callPackage ../development/tools/selenium/chromedriver { gconf = gnome2.GConf; };
 
+  chromium-xorg-conf = callPackage ../os-specific/linux/chromium-xorg-conf { };
+
   chrpath = callPackage ../development/tools/misc/chrpath { };
 
   chruby = callPackage ../development/tools/misc/chruby { rubies = null; };
@@ -16435,6 +16437,8 @@ in
 
   wpa_supplicant_gui = libsForQt5.callPackage ../os-specific/linux/wpa_supplicant/gui.nix { };
 
+  xf86_input_cmt = callPackage ../os-specific/linux/xf86-input-cmt { };
+
   xf86_input_mtrack = callPackage ../os-specific/linux/xf86-input-mtrack { };
 
   xf86_input_multitouch = callPackage ../os-specific/linux/xf86-input-multitouch { };
@@ -16732,6 +16736,10 @@ in
   liberation_ttf = liberation_ttf_v2;
 
   liberation-sans-narrow = callPackage ../data/fonts/liberation-sans-narrow { };
+
+  libevdevc = callPackage ../os-specific/linux/libevdevc { };
+
+  libgestures = callPackage ../os-specific/linux/libgestures { };
 
   liberastika = callPackage ../data/fonts/liberastika { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
To add support for cmt (Chrome Multitouch), custom built drivers for Chromebooks.

Known issues: Can't control such things as acceleration through the desktop environment's GUI. Places an empty 50 or 60 .conf file in the /etc/X11/xorg.conf.d/

###### Things done
Fixes applied for the changes requested for #66195 (git commit cleanup and various changes)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Infinisil 