### PR TITLE
minikube: restore kvm2 plugin

### DIFF
--- a/pkgs/applications/networking/cluster/docker-machine/kvm2.nix
+++ b/pkgs/applications/networking/cluster/docker-machine/kvm2.nix
@@ -1,6 +1,6 @@
-{ stdenv, buildGoPackage, libvirt, pkgconfig, minikube }:
+{ stdenv, buildGoModule, libvirt, pkgconfig, minikube }:
 
-buildGoPackage rec {
+buildGoModule rec {
   pname = "docker-machine-kvm2";
   name = "${pname}-${version}";
   version = minikube.version;
@@ -10,6 +10,8 @@ buildGoPackage rec {
 
   src = minikube.src;
 
+  modSha256 = minikube.go-modules.outputHash;
+
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ libvirt ];
 
@@ -18,7 +20,7 @@ buildGoPackage rec {
   '';
 
   postInstall = ''
-    mv $bin/bin/kvm $bin/bin/docker-machine-driver-kvm2
+    mv $out/bin/kvm $out/bin/docker-machine-driver-kvm2
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/networking/cluster/minikube/default.nix
+++ b/pkgs/applications/networking/cluster/minikube/default.nix
@@ -49,6 +49,7 @@ in buildGoModule rec {
   '';
 
   postInstall = ''
+    wrapProgram $out/bin/${pname} --prefix PATH : $out/bin:${stdenv.lib.makeBinPath binPath}
     mkdir -p $out/share/bash-completion/completions/
     MINIKUBE_WANTUPDATENOTIFICATION=false MINIKUBE_WANTKUBECTLDOWNLOADMSG=false HOME=$PWD $out/bin/minikube completion bash > $out/share/bash-completion/completions/minikube
     mkdir -p $out/share/zsh/site-functions/


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Run minikube with kvm2 backend

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @ebzzry @copumpkin @vdemeester 
