### PR TITLE
kde: multiple staging fixes

### DIFF
--- a/pkgs/applications/kde/ktouch.nix
+++ b/pkgs/applications/kde/ktouch.nix
@@ -3,7 +3,8 @@
 , kconfig, kconfigwidgets, kcoreaddons, kdeclarative, ki18n
 , kitemviews, kcmutils, kio, knewstuff, ktexteditor, kwidgetsaddons
 , kwindowsystem, kxmlgui, qtscript, qtdeclarative, kqtquickcharts
-, qtx11extras, qtgraphicaleffects, qtxmlpatterns, xorg
+, qtx11extras, qtgraphicaleffects, qtxmlpatterns, qtquickcontrols2
+, xorg
 }:
 
 
@@ -19,7 +20,7 @@
       kconfig kconfigwidgets kcoreaddons kdeclarative ki18n
       kitemviews kcmutils kio knewstuff ktexteditor kwidgetsaddons
       kwindowsystem kxmlgui qtscript qtdeclarative kqtquickcharts
-      qtx11extras qtgraphicaleffects qtxmlpatterns
+      qtx11extras qtgraphicaleffects qtxmlpatterns qtquickcontrols2
       xorg.libxkbfile xorg.libxcb
     ];
 

--- a/pkgs/development/libraries/grantlee/5/default.nix
+++ b/pkgs/development/libraries/grantlee/5/default.nix
@@ -3,8 +3,7 @@
 mkDerivation rec {
   pname = "grantlee";
   version = "5.1.0";
-  grantleeCompatVersion = "5.1";
-  grantleePluginPrefix = "lib/grantlee/${grantleeCompatVersion}";
+  grantleePluginPrefix = "lib/grantlee/${lib.versions.majorMinor version}";
 
   src = fetchurl {
     url = "https://github.com/steveire/grantlee/archive/v${version}.tar.gz";

--- a/pkgs/development/libraries/grantlee/5/grantlee-cxx11.patch
+++ b/pkgs/development/libraries/grantlee/5/grantlee-cxx11.patch
@@ -1,0 +1,24 @@
+From 3a5fc7662da3261be6496611900c095844e56ab1 Mon Sep 17 00:00:00 2001
+From: Albert Astals Cid <aacid@kde.org>
+Date: Sat, 20 Jul 2019 17:35:30 +0200
+Subject: [PATCH] Fix compile with newer Qt/cmake combination
+
+Without this i get huge errors about Qt needing C++11 support
+---
+ CMakeLists.txt | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6d51110..0859788 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -11,6 +11,9 @@ endif()
+ 
+ project(Grantlee)
+ 
++set (CMAKE_CXX_STANDARD 11)
++set (CMAKE_CXX_EXTENSIONS OFF)
++
+ # Workaround for http://public.kitware.com/Bug/view.php?id=12301
+ if (MINGW)
+   if(NOT CMAKE_BUILD_TYPE)

--- a/pkgs/development/libraries/grantlee/5/series
+++ b/pkgs/development/libraries/grantlee/5/series
@@ -1,2 +1,3 @@
 grantlee-nix-profiles.patch
 grantlee-no-canonicalize-filepath.patch
+grantlee-cxx11.patch

--- a/pkgs/development/libraries/kde-frameworks/kdewebkit.nix
+++ b/pkgs/development/libraries/kde-frameworks/kdewebkit.nix
@@ -8,4 +8,7 @@ mkDerivation {
   buildInputs = [ kconfig kcoreaddons kio kparts ];
   propagatedBuildInputs = [ qtwebkit ];
   outputs = [ "out" "dev" ];
+  cmakeFlags = [
+    "-DBUILD_DESIGNERPLUGIN=OFF"
+  ];
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Some KDE applications are not building currently in the staging-next branch

The patch is coming from here : https://github.com/tsdgeos/grantlee/commits/fix_compilation
I didn't backport the upstream patch because the current master is to far away from the latest tag to apply such big patch cleanly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @ttuegel 
