### PR TITLE
pythonPackage.pyown: fix builds

### DIFF
--- a/pkgs/development/python-modules/pyowm/default.nix
+++ b/pkgs/development/python-modules/pyowm/default.nix
@@ -16,8 +16,7 @@ buildPythonPackage rec {
   # This may actually break the package.
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "requests>=2.18.2,<2.19" "requests"  \
-      --replace "geojson>=2.3.0,<2.4" "geojson<2.5,>=2.3.0"
+      --replace "requests>=2.18.2,<2.19" "requests"
   '';
 
   # No tests in archive

--- a/pkgs/development/python-modules/pyowm/default.nix
+++ b/pkgs/development/python-modules/pyowm/default.nix
@@ -1,8 +1,10 @@
-{ lib, buildPythonPackage, fetchPypi, requests, geojson }:
+{ lib, buildPythonPackage, fetchPypi, pythonOlder, requests, geojson }:
 
 buildPythonPackage rec {
   pname = "pyowm";
   version = "2.10.0";
+
+  disabled = pythonOlder "3.3";
 
   src = fetchPypi {
     inherit pname version;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

- Version 2.10 relaxed the requirement for geojson from `geojson>=2.3.0,<2.4` to `geojson>=2.3.0,<3`. Remove the postPatch hook that adjusted this requirement when it broke in nixpkgs.
- Python2 support has been deprecated in 2.9 (https://github.com/csparpa/pyowm/releases/tag/2.9.0)
- Python-3.3 support dropped in 2.10 (https://github.com/csparpa/pyowm/releases/tag/2.10)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
