### PR TITLE
Backport to 19.03: oraclejdk: use working mirror for download

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
@@ -89,8 +89,9 @@ let result = stdenv.mkDerivation rec {
       armv7l-linux  = "linux-arm32-vfp-hflt";
       aarch64-linux = "linux-arm64-vfp-hflt";
     }.${stdenv.hostPlatform.system};
+    javadlPlatformName = "linux-i586";
   in fetchurl {
-   url = "http://download.oracle.com/otn-pub/java/jdk/${productVersion}u${patchVersion}-b${buildVersion}/${releaseToken}/jdk-${productVersion}u${patchVersion}-${platformName}.tar.gz";
+   url = "http://javadl.oracle.com/webapps/download/GetFile/1.${productVersion}.0_${patchVersion}-b${buildVersion}/${releaseToken}/${javadlPlatformName}/jdk-${productVersion}u${patchVersion}-${platformName}.tar.gz";
    curlOpts = "-b oraclelicense=a";
    sha256 = sha256.${stdenv.hostPlatform.system};
   };


### PR DESCRIPTION
backport #59947 to 19.03
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @FRidh 
