### PR TITLE
cbor-diag: 0.5.2 -> 0.5.6

### DIFF
--- a/pkgs/development/tools/cbor-diag/Gemfile.lock
+++ b/pkgs/development/tools/cbor-diag/Gemfile.lock
@@ -1,10 +1,12 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    cbor-diag (0.5.2)
+    cbor-diag (0.5.6)
       json
+      neatjson
       treetop (~> 1)
-    json (2.1.0)
+    json (2.2.0)
+    neatjson (0.9)
     polyglot (0.3.5)
     treetop (1.6.10)
       polyglot (~> 0.3)
@@ -16,4 +18,4 @@ DEPENDENCIES
   cbor-diag
 
 BUNDLED WITH
-   1.14.6
+   1.17.2

--- a/pkgs/development/tools/cbor-diag/gemset.nix
+++ b/pkgs/development/tools/cbor-diag/gemset.nix
@@ -1,22 +1,38 @@
 {
   cbor-diag = {
-    dependencies = ["json" "treetop"];
+    dependencies = ["json" "neatjson" "treetop"];
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1g4pxf1ag4pyb351m06l08ig1smnf8w27ynqfxkgmwak5mh1z7w1";
+      sha256 = "0pd0k4malg1l7w3ck5glh9w0hrsvknk8rp32vrir74yww1g6yplv";
       type = "gem";
     };
-    version = "0.5.2";
+    version = "0.5.6";
   };
   json = {
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "01v6jjpvh3gnq6sgllpfqahlgxzj50ailwhj9b3cd20hi2dx0vxp";
+      sha256 = "0sx97bm9by389rbzv8r1f43h06xcz8vwi3h5jv074gvparql7lcx";
       type = "gem";
     };
-    version = "2.1.0";
+    version = "2.2.0";
+  };
+  neatjson = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0fa2v7b6433j0iqh5iq9r71v7a5xabgjvqwsbl21vcsac7vf3ncw";
+      type = "gem";
+    };
+    version = "0.9";
   };
   polyglot = {
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1bqnxwyip623d8pr29rg6m8r0hdg08fpr2yb74f46rn1wgsnxmjr";
@@ -26,6 +42,8 @@
   };
   treetop = {
     dependencies = ["polyglot"];
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0g31pijhnv7z960sd09lckmw9h8rs3wmc8g4ihmppszxqm99zpv7";


### PR DESCRIPTION
###### Motivation for this change
Update cbor-tools to latest version.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @fdns 
cc @nicknovitski 

