### PR TITLE
nixos/x11: provide selected session to custom session

### DIFF
--- a/nixos/modules/services/x11/display-managers/default.nix
+++ b/nixos/modules/services/x11/display-managers/default.nix
@@ -109,7 +109,7 @@ let
 
       # Allow the user to setup a custom session type.
       if test -x ~/.xsession; then
-          exec ~/.xsession
+          eval exec ~/.xsession "$@"
       fi
 
       if test "$1"; then


### PR DESCRIPTION
The custom session script is always executed (when it exists). This provides the selected session script to the custom session script so that it can defer to it based on the value of xterm.

###### Motivation for this change

Currently, if the `.Xsession` file exists, it is always used, by calling it without arguments. It is normal behaviour, but it means that any session choice made by the user in the display manager will be ignored. By providing the selected session script and session name to the user's custom session script, we allows this script to make its own choice (for example, based on the session name) and either launch the user-configured (for example, in home-manager) session or the user selected session (for example, in LightDM).

###### Things done

Made the `xsessionWrapper` script forward its argument to the `.Xsession` script.

I tested this change with other DMs and home-manager. 

###### Notes

I had a quick look at existing custom `.Xsession` scripts to see if any would break when passed arguments, but didn't find anything, since most of these scripts don't expect any arguments (and so they never use them).

I've also read existing discussions on this repository about the rationale for `xsessionWrapper` always calling `.Xsession` whatever the user choosed in the DM (which is sound, as it allows more control). It was suggested that the script and session name should be available in the environment, but it doesn't seem to be the case (as it is never exported), and so made this change so that the `.Xsession` script can decide what to do (using the forwarded arguments).

If it's better to handle this with the environment, I can submit another PR that uses the environment instead of arguments.

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS _(not applicable)_
   - [ ] other Linux distributions _(not sure if applicable)_
- [ ] Tested via one or more NixOS test(s) _(didn't find any applicable test)_
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)  _(no binary file change)_
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date _(did not found any relevant documentation)_
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @edolstra 