### PR TITLE
exim: add SPF support (+ init libspf2 at 1.2.10)

### DIFF
--- a/pkgs/development/libraries/libspf2/default.nix
+++ b/pkgs/development/libraries/libspf2/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchurl, autoreconfHook }:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  pname = "libspf2";
+  version = "1.2.10";
+
+  src = fetchurl {
+    url = "https://www.libspf2.org/spf/libspf2-${version}.tar.gz";
+    sha256 = "1j91p0qiipzf89qxq4m1wqhdf01hpn1h5xj4djbs51z23bl3s7nr";
+  };
+
+  patches = [
+    (fetchurl {
+      name = "0001-gcc-variadic-macros.patch";
+      url = "https://github.com/shevek/libspf2/commit/5852828582f556e73751076ad092f72acf7fc8b6.patch";
+      sha256 = "1v6ashqzpr0xidxq0vpkjd8wd66cj8df01kyzj678ljzcrax35hk";
+    })
+  ];
+
+  postPatch = ''
+    # disable static bins compilation
+    sed -i \
+      -e '/bin_PROGRAMS/s/spfquery_static//' src/spfquery/Makefile.am \
+      -e '/bin_PROGRAMS/s/spftest_static//' src/spftest/Makefile.am \
+      -e '/bin_PROGRAMS/s/spfd_static//' src/spfd/Makefile.am \
+      -e '/bin_PROGRAMS/s/spf_example_static//' src/spf_example/Makefile.am
+  '';
+
+  # autoreconf necessary because we modified automake files
+  nativeBuildInputs = [ autoreconfHook ];
+
+  doCheck = true;
+
+  meta = {
+    description = "Implementation of the Sender Policy Framework for SMTP authorization";
+    homepage = https://www.libspf2.org;
+    license = with licenses; [ lgpl21Plus bsd2 ];
+    maintainers = with maintainers; [ pacien ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/servers/mail/exim/default.nix
+++ b/pkgs/servers/mail/exim/default.nix
@@ -3,6 +3,7 @@
 , enableMySQL ? false, mysql, zlib
 , enableAuthDovecot ? false, dovecot
 , enablePAM ? false, pam
+, enableSPF ? true, libspf2
 }:
 
 stdenv.mkDerivation rec {
@@ -18,7 +19,8 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optional enableLDAP openldap
     ++ stdenv.lib.optionals enableMySQL [ mysql.connector-c zlib ]
     ++ stdenv.lib.optional enableAuthDovecot dovecot
-    ++ stdenv.lib.optional enablePAM pam;
+    ++ stdenv.lib.optional enablePAM pam
+    ++ stdenv.lib.optional enableSPF libspf2;
 
   preBuild = ''
     sed '
@@ -63,6 +65,10 @@ stdenv.mkDerivation rec {
         s:^# \(SUPPORT_PAM\)=.*:\1=yes:
         s:^\(EXTRALIBS_EXIM\)=\(.*\):\1=\2 -lpam:
         s:^# \(EXTRALIBS_EXIM\)=.*:\1=-lpam:
+      ''}
+      ${stdenv.lib.optionalString enableSPF ''
+        s:^# \(SUPPORT_SPF\)=.*:\1=yes:
+        s:^# \(LDFLAGS += -lspf2\):\1:
       ''}
       #/^\s*#.*/d
       #/^\s*$/d

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4498,6 +4498,8 @@ in
 
   libsidplayfp = callPackage ../development/libraries/libsidplayfp { };
 
+  libspf2 = callPackage ../development/libraries/libspf2 { };
+
   libsrs2 = callPackage ../development/libraries/libsrs2 { };
 
   libtermkey = callPackage ../development/libraries/libtermkey { };


### PR DESCRIPTION
###### Motivation for this change

This PR adds SPF support to the exim package and inits libspf2 at 1.2.10.

I'm not sure whether we should enable SPF by default, as it's quite common.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @4z3 (exim package maintainer)

@ofborg build libspf2
@ofborg build exim