### PR TITLE
gevent-websocket: enable python3

### DIFF
--- a/pkgs/development/python-modules/gevent-websocket/default.nix
+++ b/pkgs/development/python-modules/gevent-websocket/default.nix
@@ -3,20 +3,19 @@
 , fetchPypi
 , isPy3k
 , gevent
+, gunicorn
 }:
 
 buildPythonPackage rec {
   pname = "gevent-websocket";
   version = "0.10.1";
-  # SyntaxError in tests.
-  disabled = isPy3k;
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "1c2zv2rahp1gil3cj66hfsqgy0n35hz9fny3ywhr2319d0lz7bky";
   };
 
-  propagatedBuildInputs = [ gevent ];
+  propagatedBuildInputs = [ gevent gunicorn ];
 
   meta = with stdenv.lib; {
     homepage = https://www.gitlab.com/noppo/gevent-websocket;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Enable building for python3

###### Things done
Extend build inputs to include gunicorn and enable building for python3

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

None specified.
