### PR TITLE
aws-sam-cli: update requests dependency to 2.22.0

### DIFF
--- a/pkgs/development/tools/aws-sam-cli/default.nix
+++ b/pkgs/development/tools/aws-sam-cli/default.nix
@@ -56,7 +56,7 @@ buildPythonApplication rec {
   ];
 
   postPatch = ''
-    substituteInPlace requirements/base.txt --replace "requests==2.20.1" "requests==2.21.0"
+    substituteInPlace requirements/base.txt --replace "requests==2.20.1" "requests==2.22.0"
     substituteInPlace requirements/base.txt --replace "six~=1.11.0" "six~=1.12.0"
     substituteInPlace requirements/base.txt --replace "PyYAML~=3.12" "PyYAML~=5.1"
   '';


### PR DESCRIPTION
#### Motivation for this change

[pythonPackages.requests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/python-modules/requests/default.nix) was [updated to v`2.22.0` on July 21](https://github.com/NixOS/nixpkgs/commit/abc9221996c8b619ddd8e9304431e6e549c1dbf6).

[aws-sam-cli](https://github.com/NixOS/nixpkgs/tree/master/pkgs/development/tools/aws-sam-cli) is [hard-coded to set the requests version](https://github.com/NixOS/nixpkgs/blob/b67b08518eb09571e838707e3ffad2b597d027a1/pkgs/development/tools/aws-sam-cli/default.nix#L59) to `2.21.0`, so `aws-sam-cli` currently fails to build.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @andreabedini @dhl
