### PR TITLE
arping: 2.19 -> 2.20

### DIFF
--- a/pkgs/tools/networking/arping/default.nix
+++ b/pkgs/tools/networking/arping/default.nix
@@ -1,16 +1,16 @@
 { stdenv, fetchFromGitHub, autoreconfHook, libnet, libpcap }:
 
 stdenv.mkDerivation rec {
-  version = "2.19";
-  name = "arping-${version}";
+  version = "2.20";
+  pname = "arping";
 
   buildInputs = [ libnet libpcap ];
 
   src = fetchFromGitHub {
     owner = "ThomasHabets";
-    repo = "arping";
-    rev = "arping-${version}";
-    sha256 = "10gpil6ic17x8v628vhz9s98rnw1k8ci2xs56i52pr103irirczw";
+    repo = pname;
+    rev = "${pname}-${version}";
+    sha256 = "0gmyip552k6mq7013cvy5yc4akn2rz28s3g4x4vdq35vnxf66cyk";
   };
 
   nativeBuildInputs = [ autoreconfHook ];


### PR DESCRIPTION
###### Motivation for this change

https://github.com/ThomasHabets/arping/releases/tag/arping-2.20

Not sure when this might be used (vs variant in iputils),
but we have it and first update in long time, let's do this!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @