### PR TITLE
fortune: 2.6.2 -> 2.10.0, use official tarball

### DIFF
--- a/pkgs/tools/misc/fortune/default.nix
+++ b/pkgs/tools/misc/fortune/default.nix
@@ -1,37 +1,38 @@
 { stdenv, fetchurl, cmake, recode, perl }:
 
-let srcs = {
-      fortune = fetchurl {
-        url = "https://github.com/shlomif/fortune-mod/archive/fortune-mod-${version}.tar.gz";
-        sha256 = "89223bb649ea62b030527f181539182d6a17a1a43b0cc499a52732b839f7b691";
-      };
-      shlomifCommon = fetchurl {
-        url = https://bitbucket.org/shlomif/shlomif-cmake-modules/raw/default/shlomif-cmake-modules/Shlomif_Common.cmake;
-        sha256 = "62f188a9f1b7ab0e757eb0bc6540d9c0026d75edc7acc1c3cdf7438871d0a94f";
-      };
-    };
-    version = "2.6.2";
-in
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "fortune-mod";
-  inherit version;
+  version = "2.10.0";
 
-  src = srcs.fortune;
-
-  sourceRoot = "fortune-mod-fortune-mod-${version}/fortune-mod";
+  src = fetchurl {
+    url = "https://www.shlomifish.org/open-source/projects/fortune-mod/arcs/fortune-mod-${version}.tar.xz";
+    sha256 = "07g50hij87jb7m40pkvgd47qfvv4s805lwiz79jbqcxzd7zdyax7";
+  };
 
   nativeBuildInputs = [ cmake perl ];
 
   buildInputs = [ recode ];
 
-  preConfigure = ''
-    cp ${srcs.shlomifCommon} cmake/Shlomif_Common.cmake
-  '';
+  cmakeFlags = [
+    "-DLOCALDIR=${placeholder "out"}/share/fortunes"
+  ];
 
-  postInstall = ''
-    mv $out/games/fortune $out/bin/fortune
-    rm -r $out/games
-  '';
+  patches = [ (builtins.toFile "not-a-game.patch" ''
+    diff --git a/CMakeLists.txt b/CMakeLists.txt
+    index 865e855..5a59370 100644
+    --- a/CMakeLists.txt
+    +++ b/CMakeLists.txt
+    @@ -154,7 +154,7 @@ ENDMACRO()
+     my_exe(
+         "fortune"
+         "fortune/fortune.c"
+    -    "games"
+    +    "bin"
+     )
+
+     my_exe(
+    -- 
+  '') ];
 
   meta = with stdenv.lib; {
     description = "A program that displays a pseudorandom message from a database of quotations";


### PR DESCRIPTION
###### Motivation for this change

https://github.com/shlomif/fortune-mod/blob/fortune-mod-2.10.0/fortune-mod/ChangeLog

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).