### PR TITLE
boost171: init at 1.71.0

### DIFF
--- a/pkgs/development/libraries/boost/1.71.nix
+++ b/pkgs/development/libraries/boost/1.71.nix
@@ -4,7 +4,8 @@ callPackage ./generic.nix (args // rec {
   version = "1.71.0";
 
   src = fetchurl {
-    url = "mirror://sourceforge/boost/boost_1_71_0.tar.bz2";
+    #url = "mirror://sourceforge/boost/boost_1_71_0.tar.bz2";
+    url = "https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.bz2";
     # SHA256 from http://www.boost.org/users/history/version_1_71_0.html
     sha256 = "d73a8da01e8bf8c7eda40b4c84915071a8c8a0df4a6734537ddde4a8580524ee";
   };

--- a/pkgs/development/libraries/boost/1.71.nix
+++ b/pkgs/development/libraries/boost/1.71.nix
@@ -1,0 +1,11 @@
+{ stdenv, callPackage, fetchurl, fetchpatch, ... } @ args:
+
+callPackage ./generic.nix (args // rec {
+  version = "1.71.0";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/boost/boost_1_71_0.tar.bz2";
+    # SHA256 from http://www.boost.org/users/history/version_1_71_0.html
+    sha256 = "d73a8da01e8bf8c7eda40b4c84915071a8c8a0df4a6734537ddde4a8580524ee";
+  };
+})

--- a/pkgs/development/libraries/boost/1.71.nix
+++ b/pkgs/development/libraries/boost/1.71.nix
@@ -5,7 +5,10 @@ callPackage ./generic.nix (args // rec {
 
   src = fetchurl {
     #url = "mirror://sourceforge/boost/boost_1_71_0.tar.bz2";
-    url = "https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.bz2";
+    urls = [ 
+      "mirror://sourceforge/boost/boost_1_71_0.tar.bz2"
+      "https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.bz2"
+    ];
     # SHA256 from http://www.boost.org/users/history/version_1_71_0.html
     sha256 = "d73a8da01e8bf8c7eda40b4c84915071a8c8a0df4a6734537ddde4a8580524ee";
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10287,7 +10287,8 @@ in
   boost169 = callPackage ../development/libraries/boost/1.69.nix { };
   boost16x = boost167;
   boost170 = callPackage ../development/libraries/boost/1.70.nix { };
-  boost17x = boost170;
+  boost171 = callPackage ../development/libraries/boost/1.71.nix { };
+  boost17x = boost171;
   boost = boost16x;
 
   boost_process = callPackage ../development/libraries/boost-process { };


### PR DESCRIPTION
###### Motivation for this change

https://www.boost.org/users/history/version_1_71_0.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

FWIW, using this as my default boost so LGTM :).