### PR TITLE
aws-sam-cli: avoid hard-coded requests version (use the nix package version)

### DIFF
--- a/pkgs/development/tools/aws-sam-cli/default.nix
+++ b/pkgs/development/tools/aws-sam-cli/default.nix
@@ -56,7 +56,7 @@ buildPythonApplication rec {
   ];
 
   postPatch = ''
-    substituteInPlace requirements/base.txt --replace "requests==2.20.1" "requests==2.22.0"
+    substituteInPlace requirements/base.txt --replace "requests==2.20.1" "requests==${requests.version}"
     substituteInPlace requirements/base.txt --replace "six~=1.11.0" "six~=1.12.0"
     substituteInPlace requirements/base.txt --replace "PyYAML~=3.12" "PyYAML~=5.1"
   '';


### PR DESCRIPTION
###### Motivation for this change

aws-sam-cli had a hard-coded number dependency on pythonModule.requests's version. This small PR makes it use `${requests.version}` instead (thanks to a pointer from @grahamc).

This package has been out of date several times for me (today is the first time I knew how to [fix it](https://github.com/NixOS/nixpkgs/pull/67267)); this should make it forward-compatible.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @andreabedini @dhl
