### PR TITLE
libcbor: 2019-02-23 -> 2019-07-25

### DIFF
--- a/pkgs/development/libraries/libcbor/default.nix
+++ b/pkgs/development/libraries/libcbor/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libcbor";
-  version = "2019-02-23";
+  version = "2019-07-25";
 
   src = fetchFromGitHub {
     owner = "PJK";
     repo = pname;
-    rev = "87f977e732ca216682a8583a0e43803eb6b9c028";
-    sha256 = "17p1ahdcpf5d4r472lhciscaqjq4pyxy9xjhqqx8mv646xmyripm";
+    rev = "82512d851205fbc7f65d96a0b4a8e1bad2e4f3c6";
+    sha256 = "01hy7n21gxz4gp3gdwm2ywz822p415bj2k9ccxgwz3plvncs4xa1";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/libcbor/default.nix
+++ b/pkgs/development/libraries/libcbor/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "libcbor";
-  version = "2019-07-25";
+  version = "unstable-2019-07-25";
 
   src = fetchFromGitHub {
     owner = "PJK";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

git bump, including removal of stray printf

printf was causing issues (via libfido2)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @