### PR TITLE
gengetopt: 2.22.6 -> 2.23

### DIFF
--- a/pkgs/development/tools/misc/gengetopt/default.nix
+++ b/pkgs/development/tools/misc/gengetopt/default.nix
@@ -1,17 +1,25 @@
-{ fetchurl, stdenv }:
+{ fetchurl, stdenv, texinfo, help2man }:
 
 stdenv.mkDerivation rec {
-  name = "gengetopt-2.22.6";
+  pname = "gengetopt";
+  version = "2.23";
 
   src = fetchurl {
-    url = "mirror://gnu/gengetopt/${name}.tar.gz";
-    sha256 = "1xq1kcfs6hri101ss4dhym0jn96z4v6jdvx288mfywadc245mc1h";
+    url = "mirror://gnu/${pname}/${pname}-${version}.tar.xz";
+    sha256 = "1b44fn0apsgawyqa4alx2qj5hls334mhbszxsy6rfr0q074swhdr";
   };
 
   doCheck = true;
 
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [ texinfo help2man ];
+
+  #Fix, see #28255
   postPatch = ''
-    sed -e 's/set -o posix/set +o posix/' -i configure
+    substituteInPlace configure --replace \
+      'set -o posix' \
+      'set +o posix'
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

https://www.gnu.org/software/gengetopt/NEWS

* deps, parallel build

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers