### PR TITLE
graalvm8-ee: 19.1.1 -> 19.2.0

### DIFF
--- a/pkgs/development/compilers/graalvm/enterprise-edition.nix
+++ b/pkgs/development/compilers/graalvm/enterprise-edition.nix
@@ -3,26 +3,26 @@
 let
   graalvm8-ee = stdenv.mkDerivation rec {
     pname = "graalvm8-ee";
-    version = "19.1.1";
+    version = "19.2.0";
     srcs = [
       (requireFile {
          name   = "graalvm-ee-linux-amd64-${version}.tar.gz";
-         sha256 = "1ayg4chiw08jbrivmsylh6275sn0ygzc0iaic28fk7hhw5dc6r2f";
+         sha256 = "1j56lyids48zyjhxk8xl4niy8hk6qzi1aj7c55yfh62id8v6cpbw";
          url    = "https://www.oracle.com/technetwork/graalvm/downloads/index.html";
       })
       (requireFile {
          name   = "native-image-installable-svm-svmee-linux-amd64-${version}.jar";
-         sha256 = "1mvc4id193gl482fnjcgh4dz29ifqwigqq68ib0i1p3ks1nnj717";
+         sha256 = "07c25l27msxccqrbz4bknz0sxsl0z2k8990cdfkbrgxvhxspfnnm";
          url    = "https://www.oracle.com/technetwork/graalvm/downloads/index.html";
       })
       (requireFile {
          name   = "python-installable-svm-svmee-linux-amd64-${version}.jar";
-         sha256 = "0q7sggqk5myad053dsfw2i1n8v4wspahg1ac7zr3y3srqvdb0xfp";
+         sha256 = "1c7kpz56w9p418li97ymixdwywscr85vhn7jkzxq71bj7ia7pxwz";
          url    = "https://www.oracle.com/technetwork/graalvm/downloads/index.html";
       })
       (requireFile {
          name   = "ruby-installable-svm-svmee-linux-amd64-${version}.jar";
-         sha256 = "1xax1bg155d74jhv7h0qb7vbc95jy4wm4bvbpvr76ivzn7qaml6j";
+         sha256 = "13jfm5qpxqxz7f5n9yyvqrv1vwigifrjwk3hssp23maski2ssys1";
          url    = "https://www.oracle.com/technetwork/graalvm/downloads/index.html";
       })
     ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @hlolli @NeQuissimus 
