### PR TITLE
[WIP] android-file-transfer: get working for darwin

### DIFF
--- a/pkgs/tools/filesystems/android-file-transfer/default.nix
+++ b/pkgs/tools/filesystems/android-file-transfer/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, mkDerivation, fetchFromGitHub, cmake, fuse, readline, pkgconfig, qtbase }:
+{ stdenv, mkDerivation, fetchFromGitHub, cmake, fuse, readline, pkgconfig, osxfuse, qt5, qtbase }:
 
 mkDerivation rec {
   pname = "android-file-transfer";
@@ -11,14 +11,32 @@ mkDerivation rec {
     sha256 = "1pwayyd5xrmngfrmv2vwr8ns2wi199xkxf7dks8fl9zmlpizg3c3";
   };
 
-  nativeBuildInputs = [ cmake readline pkgconfig ];
-  buildInputs = [ fuse qtbase ];
+  nativeBuildInputs = [ cmake readline pkgconfig ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ qt5.wrapQtAppsHook ]
+  ;
+  buildInputs = [ qtbase ]
+    ++ stdenv.lib.optionals stdenv.isLinux [ fuse ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ osxfuse ]
+  ;
+
+  postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
+    sed -i"" -e '1i cmake_policy(SET CMP0025 NEW)' CMakeLists.txt
+  '';
+
+  postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
+    mkdir -p $out/Applications
+    mv $out/android-file-transfer.app $out/Applications
+
+    # Fixes "This application failed to start because it could not find or load the Qt
+    # platform plugin "cocoa"."
+    wrapQtApp $out/Applications/android-file-transfer.app/Contents/MacOS/android-file-transfer
+  '';
 
   meta = with stdenv.lib; {
     description = "Reliable MTP client with minimalistic UI";
     homepage = https://whoozle.github.io/android-file-transfer-linux/;
     license = licenses.lgpl21;
     maintainers = [ maintainers.xaverdh ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

- For tracking, this build runs into the cmake problem (not detecting features for "clang") 
 when building on Darwin #54606

Unfortunately this is a work-in-progress: the files under `bin` seem to work fine, but the qt `Application` doesn't open yet:  
```bash
$ open result/Applications/android-file-transfer.app
LSOpenURLsWithRole() failed with error -10810 for the file result/Applications/android-file-transfer.app.

$ ./result/Applications/android-file-transfer.app/Contents/MacOS/android-file-transfer
objc[32001]: Class QMacAutoReleasePoolTracker is implemented in both /nix/store/frk8i1qi24vx554fq0iiwd9p93dl0jdf-qtbase-5.12.0/lib/libQt5Core.5.dylib (0x103ec9768) and /nix/store/l08dykbz30jph236w6qqn0hgs9916kh6-qtbase-5.11.3/lib/libQt5Core.5.dylib (0x109ba6708). One of the two will be used. Which one is undefined.
objc[32001]: Class QT_ROOT_LEVEL_POOL__THESE_OBJECTS_WILL_BE_RELEASED_WHEN_QAPP_GOES_OUT_OF_SCOPE is implemented in both /nix/store/frk8i1qi24vx554fq0iiwd9p93dl0jdf-qtbase-5.12.0/lib/libQt5Core.5.dylib (0x103ec97e0) and /nix/store/l08dykbz30jph236w6qqn0hgs9916kh6-qtbase-5.11.3/lib/libQt5Core.5.dylib (0x109ba6780). One of the two will be used. Which one is undefined.
objc[32001]: Class RunLoopModeTracker is implemented in both /nix/store/frk8i1qi24vx554fq0iiwd9p93dl0jdf-qtbase-5.12.0/lib/libQt5Core.5.dylib (0x103ec9808) and /nix/store/l08dykbz30jph236w6qqn0hgs9916kh6-qtbase-5.11.3/lib/libQt5Core.5.dylib (0x109ba67a8). One of the two will be used. Which one is undefined.
QObject::moveToThread: Current thread (0x7fef5c7002a0) is not the object's thread (0x7fef5c41d180).
Cannot move to target thread (0x7fef5c7002a0)

You might be loading two sets of Qt binaries into the same process. Check that all plugins are compiled against the right Qt binaries. Export DYLD_PRINT_LIBRARIES=1 and check that only one set of binaries are being loaded.
qt.qpa.plugin: Could not load the Qt platform plugin "cocoa" in "" even though it was found.
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

Available platform plugins are: cocoa, minimal, offscreen.

[1]    32001 abort 
```

Not sure how to properly add the cocoa lib that qt needs? I tried adding `qtmacextras` to build inputs but that didn't work either. 

When complete, will close #60495
