### PR TITLE
python3Packages.wsproto: 0.14.1 -> 0.15.0

### DIFF
--- a/pkgs/development/python-modules/wsproto/0.14.nix
+++ b/pkgs/development/python-modules/wsproto/0.14.nix
@@ -1,0 +1,25 @@
+{ lib, buildPythonPackage, fetchPypi, h11, enum34, pytest }:
+
+buildPythonPackage rec {
+  pname = "wsproto";
+  version = "0.14.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "051s127qb5dladxa14n9nqajwq7xki1dz1was5r5v9df5a0jq8pd";
+  };
+
+  propagatedBuildInputs = [ h11 enum34 ];
+
+  checkInputs = [ pytest ];
+
+  checkPhase = ''
+    py.test
+  '';
+
+  meta = with lib; {
+    description = "Pure Python, pure state-machine WebSocket implementation";
+    homepage = https://github.com/python-hyper/wsproto/;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/wsproto/default.nix
+++ b/pkgs/development/python-modules/wsproto/default.nix
@@ -1,15 +1,20 @@
-{ lib, buildPythonPackage, fetchPypi, h11, enum34, pytest }:
+{ lib, buildPythonPackage, fetchPypi, pythonOlder, isPy36
+, dataclasses
+, h11
+, pytest
+}:
 
 buildPythonPackage rec {
   pname = "wsproto";
-  version = "0.14.1";
+  version = "0.15.0";
+  disabled = pythonOlder "3.6"; # python versions <3.6
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "051s127qb5dladxa14n9nqajwq7xki1dz1was5r5v9df5a0jq8pd";
+    sha256 = "17gsxlli4w8am1wwwl3k90hpdfa213ax40ycbbvb7hjx1v1rhiv1";
   };
 
-  propagatedBuildInputs = [ h11 enum34 ];
+  propagatedBuildInputs = [ h11 ] ++ lib.optional isPy36 dataclasses;
 
   checkInputs = [ pytest ];
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6073,7 +6073,10 @@ in {
 
   us = callPackage ../development/python-modules/us { };
 
-  wsproto = callPackage ../development/python-modules/wsproto { };
+  wsproto = if (pythonAtLeast "3.6") then
+      callPackage ../development/python-modules/wsproto { }
+    else
+      callPackage ../development/python-modules/wsproto/0.14.nix { };
 
   h11 = callPackage ../development/python-modules/h11 { };
 


### PR DESCRIPTION
###### Motivation for this change
closes #67124

keep python2 version building for the ~10 people that still use it :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

```
https://github.com/NixOS/nixpkgs/pull/67303
5 package were build:
mitmproxy python37Packages.fastapi python37Packages.starlette python37Packages.uvicorn python37Packages.wsproto
```