### PR TITLE
pythonPackages.nltk: 3.2.5 -> 3.4.5 (security fix - backport to release-19.03)

### DIFF
--- a/pkgs/development/python-modules/nltk/default.nix
+++ b/pkgs/development/python-modules/nltk/default.nix
@@ -1,17 +1,25 @@
-{ fetchurl, buildPythonPackage, lib, six, pythonAtLeast, pythonOlder }:
+{ fetchPypi, buildPythonPackage, lib, six, singledispatch, isPy3k, fetchpatch }:
 
 buildPythonPackage rec {
-  version = "3.2.5";
+  version = "3.4";
   pname = "nltk";
 
-  src = fetchurl {
-    url = "mirror://pypi/n/nltk/nltk-${version}.tar.gz";
-    sha256 = "2661f9971d983db314bbebd51ba770811a362c6597fd0f303bb1d3beadcb4834";
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
+    sha256 = "286f6797204ffdb52525a1d21ec0a221ec68b8e3fa4f2d25f412ac8e63c70e8d";
   };
 
-  propagatedBuildInputs = [ six ];
+  propagatedBuildInputs = [ six ] ++ lib.optional (!isPy3k) singledispatch;
 
-  disabled = pythonOlder "2.7" || pythonOlder "3.4" && (pythonAtLeast "3.0");
+  # TODO: remove patch during update to new version
+  patches = [
+    (fetchpatch {
+      url = https://github.com/nltk/nltk/commit/3966111cbf2f35fb86082b2f12acd90d75e9b8bb.patch;
+      includes = [ "setup.py" ];
+      sha256 = "1sxafnvf6nzv6d996xc1rys06x62s36swgpfqhsyh6l1lj7y38jw";
+    })
+  ];
 
   # Tests require some data, the downloading of which is impure. It would
   # probably make sense to make the data another derivation, but then feeding

--- a/pkgs/development/python-modules/nltk/default.nix
+++ b/pkgs/development/python-modules/nltk/default.nix
@@ -1,25 +1,16 @@
 { fetchPypi, buildPythonPackage, lib, six, singledispatch, isPy3k, fetchpatch }:
 
 buildPythonPackage rec {
-  version = "3.4";
+  version = "3.4.3";
   pname = "nltk";
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "286f6797204ffdb52525a1d21ec0a221ec68b8e3fa4f2d25f412ac8e63c70e8d";
+    sha256 = "1cjkv4jmmlr0w4qi399ncgb6lp41mb9i352934288wh9xad15mqj";
   };
 
   propagatedBuildInputs = [ six ] ++ lib.optional (!isPy3k) singledispatch;
-
-  # TODO: remove patch during update to new version
-  patches = [
-    (fetchpatch {
-      url = https://github.com/nltk/nltk/commit/3966111cbf2f35fb86082b2f12acd90d75e9b8bb.patch;
-      includes = [ "setup.py" ];
-      sha256 = "1sxafnvf6nzv6d996xc1rys06x62s36swgpfqhsyh6l1lj7y38jw";
-    })
-  ];
 
   # Tests require some data, the downloading of which is impure. It would
   # probably make sense to make the data another derivation, but then feeding

--- a/pkgs/development/python-modules/nltk/default.nix
+++ b/pkgs/development/python-modules/nltk/default.nix
@@ -1,13 +1,13 @@
 { fetchPypi, buildPythonPackage, lib, six, singledispatch, isPy3k, fetchpatch }:
 
 buildPythonPackage rec {
-  version = "3.4.3";
+  version = "3.4.4";
   pname = "nltk";
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "1cjkv4jmmlr0w4qi399ncgb6lp41mb9i352934288wh9xad15mqj";
+    sha256 = "1dbwwhsbsp31bvvksq7kyrfs6s27lp8wgwqs4qf6hajkz2jj0k3n";
   };
 
   propagatedBuildInputs = [ six ] ++ lib.optional (!isPy3k) singledispatch;

--- a/pkgs/development/python-modules/nltk/default.nix
+++ b/pkgs/development/python-modules/nltk/default.nix
@@ -1,13 +1,13 @@
 { fetchPypi, buildPythonPackage, lib, six, singledispatch, isPy3k, fetchpatch }:
 
 buildPythonPackage rec {
-  version = "3.4.4";
+  version = "3.4.5";
   pname = "nltk";
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "1dbwwhsbsp31bvvksq7kyrfs6s27lp8wgwqs4qf6hajkz2jj0k3n";
+    sha256 = "153x2clrnigs74jdgnn3qmljdjj4gprmvpdvh49i18ls4m8mbm5y";
   };
 
   propagatedBuildInputs = [ six ] ++ lib.optional (!isPy3k) singledispatch;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Port #67278 to release-19.93

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @dtzWill 
