### PR TITLE
pythonPackages.itypes: init at 1.1.0

### DIFF
--- a/pkgs/development/python-modules/itypes/default.nix
+++ b/pkgs/development/python-modules/itypes/default.nix
@@ -1,0 +1,23 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+}:
+
+buildPythonPackage rec {
+  pname = "itypes";
+  version = "1.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "c6e77bb9fd68a4bfeb9d958fea421802282451a25bac4913ec94db82a899c073";
+  };
+
+  # Pypi does not provide test files
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Basic immutable container types for Python.";
+    license = licenses.bsd3;
+    homepage = "https://github.com/tomchristie/itypes";
+  };
+}

--- a/pkgs/development/python-modules/itypes/default.nix
+++ b/pkgs/development/python-modules/itypes/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with lib; {
-    description = "Basic immutable container types for Python.";
+    description = "Basic immutable container types for Python";
     license = licenses.bsd3;
     homepage = "https://github.com/tomchristie/itypes";
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -673,6 +673,8 @@ in {
 
   inquirer = callPackage ../development/python-modules/inquirer { };
 
+  itypes = callPackage ../development/python-modules/itypes { };
+
   jira = callPackage ../development/python-modules/jira { };
 
   jwcrypto = callPackage ../development/python-modules/jwcrypto { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
I'm enjoying my experience as a developer with NixOS so far, and I want to make nixpkgs friendlier to other Python developers. itypes is a dependency to many projects I currently work at.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
