### PR TITLE
at-spi2-core: wrap at-spi-bus-launcher

### DIFF
--- a/pkgs/development/libraries/at-spi2-core/default.nix
+++ b/pkgs/development/libraries/at-spi2-core/default.nix
@@ -5,6 +5,8 @@
 , ninja
 , pkgconfig
 , gobject-introspection
+, gsettings-desktop-schemas
+, makeWrapper
 
 , dbus
 , glib
@@ -27,7 +29,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  nativeBuildInputs = [ meson ninja pkgconfig gobject-introspection ]
+  nativeBuildInputs = [ meson ninja pkgconfig gobject-introspection makeWrapper ]
     # Fixup rpaths because of meson, remove with meson-0.47
     ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;
   buildInputs = [ dbus glib libX11 libXtst libXi ];
@@ -45,6 +47,13 @@ stdenv.mkDerivation rec {
       packageName = pname;
     };
   };
+
+  postFixup = ''
+    # Cannot use wrapGAppsHook'due to a dependency cycle
+    wrapProgram $out/libexec/at-spi-bus-launcher \
+      --prefix GIO_EXTRA_MODULES : "${stdenv.lib.getLib gnome3.dconf}/lib/gio/modules" \
+      --prefix XDG_DATA_DIRS : ${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}
+  '';
 
   meta = with stdenv.lib; {
     description = "Assistive Technology Service Provider Interface protocol definitions and daemon for D-Bus";


### PR DESCRIPTION
Currently the following warnings and errors are logged on GNOME startup:

	Aug 22 19:34:16 kaiser dbus-daemon[1229]: [session uid=132 pid=1229] Activating via systemd: service name='org.a11y.Bus' unit='at-spi-dbus-bus.service' requested by ':1.8' (uid=132 pid=1246 comm="/nix/store/5anz
	kdq6src76c4lm4m98w2a8f3j2cc4-gnome-" label="kernel")
	Aug 22 19:34:16 kaiser systemd[1223]: Starting Accessibility services bus...
	Aug 22 19:34:16 kaiser at-spi-bus-laun[1341]: Using the 'memory' GSettings backend.  Your settings will not be saved or shared with other applications.
	Aug 22 19:34:16 kaiser dbus-daemon[1229]: [session uid=132 pid=1229] Successfully activated service 'org.a11y.Bus'
	Aug 22 19:34:16 kaiser systemd[1223]: Started Accessibility services bus.
	Aug 22 19:34:16 kaiser at-spi-bus-launcher[1341]: dbus-daemon[1345]: Activating service name='org.a11y.atspi.Registry' requested by ':1.0' (uid=132 pid=1246 comm="/nix/store/5anzkdq6src76c4lm4m98w2a8f3j2cc4-gnom
	e-" label="kernel")
	Aug 22 19:34:16 kaiser at-spi-bus-launcher[1341]: dbus-daemon[1345]: Successfully activated service 'org.a11y.atspi.Registry'
	Aug 22 19:34:16 kaiser at-spi-bus-launcher[1341]: SpiRegistry daemon is running with well-known name - org.a11y.atspi.Registry
	[…]
	Aug 22 19:34:26 kaiser dbus-daemon[1775]: [session uid=1000 pid=1775] Activating via systemd: service name='org.a11y.Bus' unit='at-spi-dbus-bus.service' requested by ':1.10' (uid=1000 pid=1852 comm="/nix/store/0k7r7imgs4zw3c9csldq7clmcyn4cy6k-gnome-" label="kernel")
	Aug 22 19:34:26 kaiser systemd[1769]: Starting Accessibility services bus...
	Aug 22 19:34:26 kaiser at-spi-bus-laun[1858]: g_settings_schema_source_lookup: assertion 'source != NULL' failed
	Aug 22 19:34:26 kaiser at-spi-bus-laun[1858]: g_settings_schema_source_lookup: assertion 'source != NULL' failed
	Aug 22 19:34:26 kaiser dbus-daemon[1775]: [session uid=1000 pid=1775] Successfully activated service 'org.a11y.Bus'
	Aug 22 19:34:26 kaiser systemd[1769]: Started Accessibility services bus.
	Aug 22 19:34:26 kaiser at-spi-bus-launcher[1858]: dbus-daemon[1862]: Activating service name='org.a11y.atspi.Registry' requested by ':1.0' (uid=1000 pid=1852 comm="/nix/store/0k7r7imgs4zw3c9csldq7clmcyn4cy6k-gnome-" label="kernel")
	Aug 22 19:34:26 kaiser at-spi-bus-launcher[1858]: dbus-daemon[1862]: Successfully activated service 'org.a11y.atspi.Registry'
	Aug 22 19:34:26 kaiser at-spi-bus-launcher[1858]: SpiRegistry daemon is running with well-known name - org.a11y.atspi.Registry

This patch starts wrapping the binary, fixing one of the stragglers from https://github.com/NixOS/nixpkgs/issues/14120.

Unfortunately, we could not use wrapGAppsHook due to dependency cycle.

cc @worldofpeace