### PR TITLE
ocamlPackages.otr: 0.3.4 -> 0.3.6

### DIFF
--- a/pkgs/development/ocaml-modules/otr/default.nix
+++ b/pkgs/development/ocaml-modules/otr/default.nix
@@ -1,35 +1,22 @@
-{ stdenv, fetchFromGitHub, ocaml, ocamlbuild, findlib, topkg
-, ppx_tools, ppx_sexp_conv, cstruct, ppx_cstruct, sexplib, rresult, nocrypto
-, astring
+{ lib, fetchFromGitHub, buildDunePackage
+, cstruct, sexplib0, rresult, nocrypto, astring
 }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.03"
-then throw "otr is not available for OCaml ${ocaml.version}"
-else
-
-stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-otr-${version}";
-  version = "0.3.4";
+buildDunePackage rec {
+  pname = "otr";
+  version = "0.3.6";
 
   src = fetchFromGitHub {
     owner  = "hannesm";
     repo   = "ocaml-otr";
     rev    = "${version}";
-    sha256 = "0ixf0jvccmcbhk5mhzqakfzimvz200wkdkq3z2d0bdzyggslbdl4";
+    sha256 = "0iz6p85a0jxng9aq9blqsky173zaqfr6wlc5j48ad55lgwzlbih5";
   };
 
-  buildInputs = [ ocaml ocamlbuild findlib topkg ppx_tools ppx_sexp_conv ppx_cstruct ];
-  propagatedBuildInputs = [ cstruct sexplib rresult nocrypto astring ];
-
-  buildPhase = "${topkg.run} build --tests true";
-
-  inherit (topkg) installPhase;
+  propagatedBuildInputs = [ cstruct sexplib0 rresult nocrypto astring ];
 
   doCheck = true;
-  checkPhase = "${topkg.run} test";
-
-  meta = with stdenv.lib; {
-    inherit (ocaml.meta) platforms;
+  meta = with lib; {
     homepage = https://github.com/hannesm/ocaml-otr;
     description = "Off-the-record messaging protocol, purely in OCaml";
     license = licenses.bsd2;


### PR DESCRIPTION
###### Motivation for this change

Compatibility with recent versions of the cstruct library.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

