### PR TITLE
coursier: 1.1.0-M14-6 -> 2.0.0-RC3-3

### DIFF
--- a/pkgs/development/tools/coursier/default.nix
+++ b/pkgs/development/tools/coursier/default.nix
@@ -1,12 +1,18 @@
 { stdenv, fetchurl, makeWrapper, jre }:
 
+let
+  zshCompletion = version: fetchurl {
+    url = "https://raw.githubusercontent.com/coursier/coursier/v${version}/modules/cli/src/main/resources/completions/zsh";
+    sha256 = "0gfr1q66crh6si4682xbxnj41igws83qj710npgm2bvq90xa8m49";
+  };
+in
 stdenv.mkDerivation rec {
   name = "coursier-${version}";
-  version = "1.1.0-M14-6";
+  version = "2.0.0-RC3-3";
 
   src = fetchurl {
     url = "https://github.com/coursier/coursier/releases/download/v${version}/coursier";
-    sha256 = "01q0gz4qnwvnd7mprcm5aj77hrxyr6ax8jp4d9jkqfkg272znaj7";
+    sha256 = "1qrybajwk46h6d1yp6n4zxdvrfl19lqhjsqxbm48vk3wbvj31vyl";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -15,6 +21,9 @@ stdenv.mkDerivation rec {
     install -Dm555 $src $out/bin/coursier
     patchShebangs $out/bin/coursier
     wrapProgram $out/bin/coursier --prefix PATH ":" ${jre}/bin
+
+    # copy zsh completion
+    install -Dm755 ${zshCompletion version} $out/share/zsh/site-functions/_coursier
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
Update coursier (https://github.com/coursier/coursier/) to 2.0.0-RC3-3 and also install the zsh completion.  The fetching of the completion is not **that** nice, so please suggest alternatives if there are any better ways to do this.  (Note I can't build the whole coursier from src because it's a Scala Project)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @adelbertc @NeQuissimus 
