### PR TITLE
irccloud: init at 0.13.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3514,6 +3514,11 @@
     githubId = 307589;
     name = "Nathaniel Baxter";
   };
+  lightbulbjim = {
+    email = "chris@killred.net";
+    github = "lightbulbjim";
+    name = "Chris Rendle-Short";
+  };
   lightdiscord = {
     email = "root@arnaud.sh";
     github = "lightdiscord";

--- a/pkgs/applications/networking/irc/irccloud/default.nix
+++ b/pkgs/applications/networking/irc/irccloud/default.nix
@@ -1,0 +1,38 @@
+{ appimageTools, fetchurl, lib }:
+
+let
+  pname = "irccloud";
+  version = "0.13.0";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/irccloud/irccloud-desktop/releases/download/v${version}/IRCCloud-${version}-linux-x86_64.AppImage";
+    sha256 = "0ff69m5jav2c90918avsr5wvik2gds3klij3dzhkb352fgrd1s0l";
+  };
+
+  appimageContents = appimageTools.extractType2 {
+    inherit name src;
+  };
+
+in appimageTools.wrapType2 rec {
+  inherit name src;
+
+  extraPkgs = pkgs: with pkgs; [ at-spi2-core ];
+
+  extraInstallCommands = ''
+    mv $out/bin/${name} $out/bin/${pname}
+    install -m 444 -D ${appimageContents}/irccloud.desktop $out/share/applications/irccloud.desktop
+    install -m 444 -D ${appimageContents}/usr/share/icons/hicolor/512x512/apps/irccloud.png \
+      $out/share/icons/hicolor/512x512/apps/irccloud.png
+    substituteInPlace $out/share/applications/irccloud.desktop \
+      --replace 'Exec=AppRun' 'Exec=${pname}'
+  '';
+
+  meta = with lib; {
+    description = "A desktop client for IRCCloud";
+    homepage = "https://www.irccloud.com";
+    license = licenses.asl20;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ lightbulbjim ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18970,6 +18970,8 @@ in
 
   iptraf-ng = callPackage ../applications/networking/iptraf-ng { };
 
+  irccloud = callPackage ../applications/networking/irc/irccloud { };
+
   irssi = callPackage ../applications/networking/irc/irssi { };
 
   irssi_fish = callPackage ../applications/networking/irc/irssi/fish { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Adding the IRCCloud desktop client.

It's an Electron app, so the source build is pretty messy with a lot of Node deps downloaded at build time. Consequently it won't build in sandbox mode.

Fortunately an official AppImage is provided (and is the preferred version as far as I can tell) so I'm using that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
