### PR TITLE
pythonPackages.robotframework-databaselibrary: init at 1.2.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6117,6 +6117,12 @@
     githubId = 870673;
     name = "Takuo Yonezawa";
   };
+  talkara = {
+    email = "taito.horiuchi@relexsolutions.com";
+    github = "talkara";
+    githubId = 51232929;
+    name = "Taito Horiuchi";
+  };
   talyz = {
     email = "kim.lindberger@gmail.com";
     github = "talyz";

--- a/pkgs/development/python-modules/robotframework-databaselibrary/default.nix
+++ b/pkgs/development/python-modules/robotframework-databaselibrary/default.nix
@@ -1,0 +1,27 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, robotframework
+}:
+
+buildPythonPackage rec {
+  version = "1.2.4";
+  pname = "robotframework-databaselibrary";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "627d872b3dda6a308a650ac9e676dadedf9c294e4ef70ad207cbb86b78eb8847";
+  };
+
+  # unit tests are impure
+  doCheck = false;
+
+  propagatedBuildInputs = [ robotframework ];
+
+  meta = with stdenv.lib; {
+    description = "Database Library contains utilities meant for Robot Framework";
+    homepage = https://github.com/franz-see/Robotframework-Database-Library;
+    license = licenses.asl20;
+  };
+
+}

--- a/pkgs/development/python-modules/robotframework-databaselibrary/default.nix
+++ b/pkgs/development/python-modules/robotframework-databaselibrary/default.nix
@@ -22,6 +22,7 @@ buildPythonPackage rec {
     description = "Database Library contains utilities meant for Robot Framework";
     homepage = https://github.com/franz-see/Robotframework-Database-Library;
     license = licenses.asl20;
+    maintainers = with maintainers; [ talkara ];
   };
 
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4691,6 +4691,8 @@ in {
 
   robotframework = callPackage ../development/python-modules/robotframework { };
 
+  robotframework-databaselibrary = callPackage ../development/python-modules/robotframework-databaselibrary { };
+
   robotframework-requests = callPackage ../development/python-modules/robotframework-requests { };
 
   robotframework-ride = callPackage ../development/python-modules/robotframework-ride { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
