### PR TITLE
amazon-init: run userdata as a script if it starts with #!

### DIFF
--- a/nixos/modules/virtualisation/amazon-init.nix
+++ b/nixos/modules/virtualisation/amazon-init.nix
@@ -14,12 +14,11 @@ let
 
     isScript() {
         local fn="$1"
-        local fd
-        local magic
+        local fd magic
         exec {fd}< "$fn"
         read -r -n 2 -u "$fd" magic
         exec {fd}<&-
-        if [[ "$magic" =~ \#! ]]; then return 0; else return 1; fi
+        [ "$magic" = \#! ]
     }
 
     if [ -s "$userData" ]; then
@@ -73,4 +72,3 @@ in {
     };
   };
 }
-


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I want to boot an ec2 instance with the nix configuration in a git repository. My userdata is a short script that looks like:

```
#!/usr/bin/env nix-shell
#!nix-shell -p git -i bash

git clone ...
nixos-rebuild switch
```

I don't see another "escape hatch" that lets me do this. I did consider making a Nix userdata that configures a systemd unit that causes a second reconfiguration, but that's much more verbose. Considering the way userdata finds its way into cloudformation templates and similar, I wanted to keep it as short as possible.

The implementation is `isScript` was lifted from patch-shebangs.sh.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
