### PR TITLE
ec2-utils: init at 0.5.1, include in amazon-image profile

### DIFF
--- a/nixos/modules/virtualisation/amazon-image.nix
+++ b/nixos/modules/virtualisation/amazon-image.nix
@@ -125,6 +125,9 @@ in
     services.openssh.enable = true;
     services.openssh.permitRootLogin = "prohibit-password";
 
+    # Creates symlinks for block device names.
+    services.udev.packages = [ pkgs.ec2-utils ];
+
     # Force getting the hostname from EC2.
     networking.hostName = mkDefault "";
 

--- a/pkgs/tools/virtualization/ec2-utils/default.nix
+++ b/pkgs/tools/virtualization/ec2-utils/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, lib, rpmextract, fetchurl, python2, tree }:
+
+stdenv.mkDerivation {
+  name = "ec2-utils";
+  version = "0.5.1";
+
+  # The url can be determined by booting an "Amazon Linux 2" and running:
+  # > yumdownloader --urls ec2-utils
+  src = fetchurl {
+    url = "http://amazonlinux.ap-northeast-1.amazonaws.com/blobstore/a3b4d2c35c2300518fe10381a05b3bd7936ff5cdd3d351143a11bf84073d9e00/ec2-utils-0.5-1.amzn2.0.1.noarch.rpm";
+    sha256 = "004y7l3q9gqi78a53lykrpsnz4yp7dds1083w67m2013bk1x5d53";
+  };
+
+  nativeBuildInputs = [ rpmextract ];
+
+  buildInputs = [ python2 ];
+
+  unpackPhase = ''
+    mkdir source
+    cd source
+    rpmextract "$src"
+  '';
+
+  installPhase = ''
+    mkdir $out
+
+    mv --target-directory $out \
+      etc sbin usr/bin usr/lib
+  '';
+
+  postFixup = ''
+    for i in $out/etc/udev/rules.d/*.rules; do
+      substituteInPlace "$i" \
+        --replace '/sbin' "$out/bin"
+    done
+
+    substituteInPlace "$out/etc/udev/rules.d/70-ec2-nvme-devices.rules" \
+      --replace 'ec2nvme-nsid' "$out/lib/udev/ec2nvme-nsid"
+  '';
+
+  meta = {
+    description = "A set of tools for running in EC2";
+    homepage = https://aws.amazon.com/amazon-linux-ami/;
+    license = lib.licenses.apsl20;
+    maintainers = with lib.maintainers; [ thefloweringash ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -689,6 +689,8 @@ in
 
   ec2_ami_tools = callPackage ../tools/virtualization/ec2-ami-tools { };
 
+  ec2-utils = callPackage ../tools/virtualization/ec2-utils { };
+
   altermime = callPackage ../tools/networking/altermime {};
 
   alttab = callPackage ../tools/X11/alttab { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Friendly device names on ec2 instances. This is the most "upstream" version I could find.

Note to reviewer: this package includes a handful of udev rules:
```
result/etc/udev/rules.d
├── 51-ec2-hvm-devices.rules
├── 52-ec2-vcpu.rules
├── 60-cdrom_id.rules
└── 70-ec2-nvme-devices.rules
```

I primarily want `70-ec2-nvme-devices.rules`, but haven't thought carefully about the consequences of including the rest.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).