### PR TITLE
ec2/create-amis.sh: register root device as /dev/xvda

### DIFF
--- a/nixos/maintainers/scripts/ec2/create-amis.sh
+++ b/nixos/maintainers/scripts/ec2/create-amis.sh
@@ -211,11 +211,11 @@ upload_image() {
         log "Registering snapshot $snapshot_id as AMI"
 
         local block_device_mappings=(
-            "DeviceName=/dev/sda1,Ebs={SnapshotId=$snapshot_id,VolumeSize=$image_logical_gigabytes,DeleteOnTermination=true,VolumeType=gp2}"
+            "DeviceName=/dev/xvda,Ebs={SnapshotId=$snapshot_id,VolumeSize=$image_logical_gigabytes,DeleteOnTermination=true,VolumeType=gp2}"
         )
 
         local extra_flags=(
-            --root-device-name /dev/sda1
+            --root-device-name /dev/xvda
             --sriov-net-support simple
             --ena-support
             --virtualization-type hvm


### PR DESCRIPTION
For the case of blkfront drives, there appears to be no difference
between /dev/sda1 and /dev/xvda: the drive always appears as the
kernel device /dev/xvda.

For the case of nvme drives, the root device typically appears as
/dev/nvme0n1.  Amazon provides the 'ec2-utils' package for their first
party linux ("Amazon Linux"), which configures udev to create symlinks
from the provided name to the nvme device name. This name is
communicated through nvme "Identify Controller" response, which can be
inspected with:

  nvme id-ctrl --raw-binary /dev/nvme0n1 | cut -c3073-3104 | hexdump -C

On Amazon Linux, where the device is attached as "/dev/xvda", this
creates:

- /dev/xvda  -> nvme0n1
- /dev/xvda1 -> nvme0n1p1

On NixOS where the device is attach as "/dev/sda1", this creates:

- /dev/sda1  -> nvme0n1
- /dev/sda11 -> nvme0n1p1

This is odd, but not inherently a problem.

NixOS unconditionally configures grub to install to `/dev/xvda`, which
fails on an instance using nvme storage. With the root device name set
to xvda, both blkfront and nvme drives are accessible as /dev/xvda,
either directly or by symlink.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Bootloader installation fails on ec2 instances using nvme drives.

```
$ sudo env NIXOS_INSTALL_BOOTLOADER=1 nixos-rebuild boot
building Nix...
building the system configuration...
updating GRUB 2 menu...
installing the GRUB 2 boot loader on /dev/xvda...
Installing for i386-pc platform.
/nix/store/dw6gx658kl755nfpwhf1fpy8pqmg6n8w-grub-2.02/sbin/grub-install: error: cannot find a GRUB drive for /dev/xvda.  Check your device.map.
/nix/store/b1nwca04xfngbb8w7swn8g4x6g90qxa5-install-grub.pl: installation of GRUB on /dev/xvda failed
warning: error(s) occurred while switching to the new configuration
```

The root drive on this istance is /dev/nvme0n1.

Depends on #67347 to provide the /dev/xvda symlink.

**Results:**

```
[root@ip-172-31-18-196:~]# ls -lh /dev/nvme0* /dev/xvda*
crw------- 1 root root 249, 0 Nov  1 20:47 /dev/nvme0
brw-rw---- 1 root disk 259, 0 Nov  1 20:47 /dev/nvme0n1
brw-rw---- 1 root disk 259, 2 Nov  1 20:47 /dev/nvme0n1p1
lrwxrwxrwx 1 root root      7 Nov  1 20:47 /dev/xvda -> nvme0n1
lrwxrwxrwx 1 root root      9 Nov  1 20:47 /dev/xvda1 -> nvme0n1p1

[root@ip-172-31-18-196:~]# NIXOS_INSTALL_BOOTLOADER=1 /run/current-system/bin/switch-to-configuration boot
updating GRUB 2 menu...
installing the GRUB 2 boot loader on /dev/xvda...
Installing for i386-pc platform.
Installation finished. No error reported.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
