### PR TITLE
system-syzygy: init at 1.0.1

### DIFF
--- a/pkgs/games/system-syzygy/default.nix
+++ b/pkgs/games/system-syzygy/default.nix
@@ -1,0 +1,43 @@
+{lib, rustPlatform, fetchFromGitHub, fetchurl, SDL2, makeWrapper, makeDesktopItem}:
+
+let
+  desktopFile = makeDesktopItem {
+    name = "system-syzygy";
+    exec = "%out%/bin/syzygy";
+    comment = "A puzzle game";
+    desktopName = "System Syzygy";
+    categories = "Game;";
+  };
+in
+rustPlatform.buildRustPackage rec {
+  pname = "system-syzygy";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "mdsteele";
+    repo = "syzygy";
+    rev = "5ba148fed7aae14bf35108d7303e4194e8ffe5e8";
+    sha256 = "07mzwx8ql33q865snnw4gm3dgf0mnm60lnq1f5fgas2yjy9g9vwa";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ SDL2 ];
+
+  cargoSha256 = "03724z33dqxbbrzpvz172qh45qrgnyb801algjdcm32v8xsx81qg";
+
+  postInstall = ''
+    mkdir -p $out/share/syzygy/
+    cp -r ${src}/data/* $out/share/syzygy/
+    wrapProgram $out/bin/syzygy --set SYZYGY_DATA_DIR $out/share/syzygy
+    mkdir -p $out/share/applications
+    substituteAll ${desktopFile}/share/applications/system-syzygy.desktop $out/share/applications/system-syzygy.desktop
+  '';
+
+
+  meta = with lib; {
+    description = "A story and a puzzle game, where you solve a variety of puzzle";
+    homepage = "https://mdsteele.games/syzygy";
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.marius851000 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22372,6 +22372,8 @@ in
 
   synthv1 = callPackage ../applications/audio/synthv1 { };
 
+  system-syzygy = callPackage ../games/system-syzygy { };
+
   t4kcommon = callPackage ../games/t4kcommon { };
 
   tcl2048 = callPackage ../games/tcl2048 { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Wanted to add this game.

###### Things done
Not sure this will work on macos, but the game is compatible. I don't have a macOS device to test this.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
