### PR TITLE
sdrangel : init at 4.11.7

### DIFF
--- a/pkgs/applications/radio/sdrangel/default.nix
+++ b/pkgs/applications/radio/sdrangel/default.nix
@@ -1,0 +1,74 @@
+{
+boost,
+cm256cc,
+cmake,
+codec2,
+fetchFromGitHub,
+fftwFloat,
+glew,
+lib,
+libav,
+libiio,
+libopus,
+libpulseaudio,
+libusb,
+limesuite,
+mkDerivation,
+ocl-icd,
+opencv3,
+pkgconfig,
+qtbase,
+qtmultimedia,
+qtwebsockets,
+serialdv
+}:
+
+let
+
+  codec2' = codec2.overrideAttrs (old: {
+    src = fetchFromGitHub {
+      owner = "drowe67";
+      repo = "codec2";
+      rev = "567346818c0d4d697773cf66d925fdb031e15668";
+      sha256 = "0ngqlh2cw5grx2lg7xj8baz6p55gfhq4caggxkb4pxlg817pwbpa";
+    };
+  });
+
+in mkDerivation rec {
+  pname = "sdrangel";
+  version = "4.11.7";
+
+  src = fetchFromGitHub {
+    owner = "f4exb";
+    repo = "sdrangel";
+    rev = "v${version}";
+    sha256 = "0zbx0gklylk8npb3wnnmqpam0pdxl40f20i3wzwwh4gqrppxywzx";
+    fetchSubmodules = false;
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = [
+    glew opencv3 libusb boost libopus limesuite libav libiio libpulseaudio
+    qtbase qtwebsockets qtmultimedia
+    fftwFloat
+    codec2' cm256cc serialdv
+  ];
+  cmakeFlags = [
+    "-DLIBSERIALDV_INCLUDE_DIR:PATH=${serialdv}/include/serialdv"
+    "-DLIMESUITE_INCLUDE_DIR:PATH=${limesuite}/include"
+    "-DLIMESUITE_LIBRARY:FILEPATH=${limesuite}/lib/libLimeSuite.so"
+  ];
+
+  LD_LIBRARY_PATH = "${ocl-icd}/lib";
+
+  meta = with lib; {
+    description = "Software defined radio (SDR) software";
+    longDescription = ''
+        SDRangel is an Open Source Qt5 / OpenGL 3.0+ SDR and signal analyzer frontend to various hardware.
+    '';
+    homepage = "https://github.com/f4exb/sdrangel";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ alkeryn ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16330,6 +16330,8 @@ in
 
   sdparm = callPackage ../os-specific/linux/sdparm { };
 
+  sdrangel = libsForQt5.callPackage ../applications/radio/sdrangel {  };
+
   sepolgen = callPackage ../os-specific/linux/sepolgen { };
 
   setools = callPackage ../os-specific/linux/setools { };


### PR DESCRIPTION
###### Motivation for this change

Sdrangel was missing from nixpkgs

###### Things done

Added sdrangel derivation and myself to the maintainers list

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

@markuskowa 

This is my first PR / nixpkgs contribution so that list is a little overwhelming ^
