### PR TITLE
nixos/ofono: various improvements

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -648,6 +648,7 @@
   ./services/networking/nullidentdmod.nix
   ./services/networking/nylon.nix
   ./services/networking/ocserv.nix
+  ./services/networking/ofono.nix
   ./services/networking/oidentd.nix
   ./services/networking/openfire.nix
   ./services/networking/openntpd.nix

--- a/nixos/modules/services/networking/ofono.nix
+++ b/nixos/modules/services/networking/ofono.nix
@@ -1,0 +1,20 @@
+# Ofono daemon.
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  ###### interface
+  options = {
+    services.ofono = {
+      enable = mkEnableOption "Ofono";
+    };
+  };
+
+  ###### implementation
+  config = mkIf config.services.ofono.enable {
+    services.dbus.packages = [ pkgs.ofono ];
+
+    systemd.packages = [ pkgs.ofono ];
+  };
+}

--- a/nixos/modules/services/networking/ofono.nix
+++ b/nixos/modules/services/networking/ofono.nix
@@ -3,18 +3,42 @@
 
 with lib;
 
+let
+
+  cfg = config.services.ofono;
+
+  plugin_path =
+    lib.concatMapStringsSep ":"
+      (plugin: "${plugin}/lib/ofono/plugins")
+      cfg.plugins
+    ;
+
+in
+
 {
   ###### interface
   options = {
     services.ofono = {
       enable = mkEnableOption "Ofono";
+
+      plugins = mkOption {
+        type = types.listOf types.package;
+        default = [];
+        example = literalExample "[ pkgs.modem-manager-gui ]";
+        description = ''
+          The list of plugins to install.
+        '';
+      };
     };
   };
 
   ###### implementation
-  config = mkIf config.services.ofono.enable {
+  config = mkIf cfg.enable {
     services.dbus.packages = [ pkgs.ofono ];
 
     systemd.packages = [ pkgs.ofono ];
+
+    systemd.services.ofono.environment.OFONO_PLUGIN_PATH = mkIf (cfg.plugins != []) plugin_path;
+
   };
 }

--- a/pkgs/applications/networking/modem-manager-gui/default.nix
+++ b/pkgs/applications/networking/modem-manager-gui/default.nix
@@ -1,7 +1,22 @@
-{ stdenv, pkgconfig, python3, fetchhg, gtk3, glib, gdbm, gtkspell3, ofono, itstool, libappindicator-gtk3, perlPackages, glibcLocales, meson, ninja }:
+{ stdenv
+, pkgconfig
+, python3
+, fetchhg
+, gtk3
+, glib
+, gdbm
+, gtkspell3
+, ofono
+, itstool
+, libappindicator-gtk3
+, perlPackages
+, glibcLocales
+, meson
+, ninja
+}:
 
 stdenv.mkDerivation rec {
-  name = "modem-manager-gui-${version}";
+  pname = "modem-manager-gui";
   version = "0.0.19.1";
 
   src = fetchhg {
@@ -10,14 +25,11 @@ stdenv.mkDerivation rec {
     sha256 = "11iibh36567814h2bz41sa1072b86p1l13xyj670pwkh9k8kw8fd";
   };
 
-  LC_ALL = "en_US.utf-8";
-
   nativeBuildInputs = [
     pkgconfig
     python3
     perlPackages.Po4a
     itstool
-    glibcLocales
     meson
     ninja
   ];

--- a/pkgs/applications/networking/modem-manager-gui/default.nix
+++ b/pkgs/applications/networking/modem-manager-gui/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, pkgconfig, python3, fetchhg, gtk3, glib, gdbm, gtkspell3, itstool, libappindicator-gtk3, perlPackages, glibcLocales, meson, ninja }:
+{ stdenv, pkgconfig, python3, fetchhg, gtk3, glib, gdbm, gtkspell3, ofono, itstool, libappindicator-gtk3, perlPackages, glibcLocales, meson, ninja }:
 
 stdenv.mkDerivation rec {
   name = "modem-manager-gui-${version}";
@@ -27,6 +27,7 @@ stdenv.mkDerivation rec {
     glib
     gdbm
     gtkspell3
+    ofono
     libappindicator-gtk3
   ];
 

--- a/pkgs/development/tools/ofono-phonesim/default.nix
+++ b/pkgs/development/tools/ofono-phonesim/default.nix
@@ -1,0 +1,47 @@
+{ stdenv
+, mkDerivation
+, fetchFromGitHub
+, autoreconfHook
+, pkgconfig
+, qtbase
+, qtscript
+}:
+
+mkDerivation rec {
+  pname = "ofono-phonesim";
+  version = "unstable-2014-04-22";
+
+  src = fetchFromGitHub {
+    owner = "jpakkane";
+    repo = "ofono-phonesim";
+    rev = "baa41f04e6a86c5289d7185cad8a6f08a5c3ed0a";
+    sha256 = "0ywalvvf3dfbn81ml21gji1n2hywh2nmakynakjzyyskcqjn2wiz";
+  };
+
+  patches = [
+    ./qt5-compat.patch
+  ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkgconfig
+  ];
+
+  buildInputs = [
+    qtbase
+    qtscript
+  ];
+
+  makeFlags = [
+    "MOC=${qtbase.dev}/bin/moc"
+    "UIC=${qtbase.dev}/bin/uic"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Phone Simulator for modem testing";
+    homepage = https://github.com/jpakkane/ofono-phonesim;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ jtojnar ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/tools/ofono-phonesim/qt5-compat.patch
+++ b/pkgs/development/tools/ofono-phonesim/qt5-compat.patch
@@ -1,0 +1,48 @@
+diff --git a/configure.ac b/configure.ac
+index 2436292..993df87 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -21,18 +21,18 @@ AC_ARG_ENABLE(optimization, AC_HELP_STRING([--disable-optimization],
+ 	fi
+ ])
+ 
+-PKG_CHECK_MODULES(QT, QtCore QtGui QtXml QtNetwork QtScript QtDBus, dummy=yes,
++PKG_CHECK_MODULES(QT, Qt5Core Qt5Gui Qt5Widgets Qt5Xml Qt5Network Qt5Script Qt5DBus, dummy=yes,
+ 						AC_MSG_ERROR(Qt is required))
+ AC_SUBST(QT_CFLAGS)
+ AC_SUBST(QT_LIBS)
+ 
+ AC_MSG_CHECKING(for moc)
+-MOC="`$PKG_CONFIG --variable=moc_location QtCore`"
++MOC="`$PKG_CONFIG --variable=moc_location Qt5Core`"
+ AC_SUBST(MOC)
+ AC_MSG_RESULT($MOC)
+ 
+ AC_MSG_CHECKING(for uic)
+-UIC="`$PKG_CONFIG --variable=uic_location QtCore`"
++UIC="`$PKG_CONFIG --variable=uic_location Qt5Core`"
+ AC_SUBST(UIC)
+ AC_MSG_RESULT($UIC)
+ 
+diff --git a/src/control.cpp b/src/control.cpp
+index e1838a6..880da68 100644
+--- a/src/control.cpp
++++ b/src/control.cpp
+@@ -22,7 +22,7 @@
+ #include <qslider.h>
+ #include <qcheckbox.h>
+ #include <qcombobox.h>
+-#include <QtGui/qmessagebox.h>
++#include <QMessageBox>
+ #include <qfiledialog.h>
+ #include <Qt>
+ #include <qbuffer.h>
+@@ -31,7 +31,7 @@
+ #include <QFileInfo>
+ #include <QFile>
+ #include <QDir>
+-#include <QtGui/QHeaderView>
++#include <QHeaderView>
+ 
+ #define TWO_BYTE_MAX 65535
+ #define FOUR_CHAR 4

--- a/pkgs/tools/networking/ofono/0001-Search-connectors-in-OFONO_PLUGIN_PATH.patch
+++ b/pkgs/tools/networking/ofono/0001-Search-connectors-in-OFONO_PLUGIN_PATH.patch
@@ -1,0 +1,120 @@
+From 0e0994c9716700c9484b3dccb25f98a9a59d1744 Mon Sep 17 00:00:00 2001
+From: Jan Tojnar <jtojnar@gmail.com>
+Date: Fri, 23 Aug 2019 18:42:51 +0200
+Subject: [PATCH] Search connectors in OFONO_PLUGIN_PATH
+
+Previously, the connectors would only be looked for in a single
+directory, specified during compilation. This patch allows to
+traverse a list of directories provided by an environment variable.
+---
+ src/plugin.c | 77 ++++++++++++++++++++++++++++++++++------------------
+ 1 file changed, 50 insertions(+), 27 deletions(-)
+
+diff --git a/src/plugin.c b/src/plugin.c
+index 924a45ec..f05055c3 100644
+--- a/src/plugin.c
++++ b/src/plugin.c
+@@ -99,35 +99,12 @@ static gboolean check_plugin(struct ofono_plugin_desc *desc,
+ 	return TRUE;
+ }
+ 
+-#include "builtin.h"
+-
+-int __ofono_plugin_init(const char *pattern, const char *exclude)
+-{
+-	gchar **patterns = NULL;
+-	gchar **excludes = NULL;
+-	GSList *list;
+-	GDir *dir;
++static handle_dir(const gchar *plugin_path, const gchar **patterns, const gchar **excludes) {
+ 	const gchar *file;
+ 	gchar *filename;
+-	unsigned int i;
+-
+-	DBG("");
+-
+-	if (pattern)
+-		patterns = g_strsplit_set(pattern, ":, ", -1);
+-
+-	if (exclude)
+-		excludes = g_strsplit_set(exclude, ":, ", -1);
+-
+-	for (i = 0; __ofono_builtin[i]; i++) {
+-		if (check_plugin(__ofono_builtin[i],
+-					patterns, excludes) == FALSE)
+-			continue;
+-
+-		add_plugin(NULL, __ofono_builtin[i]);
+-	}
++	GDir *dir;
+ 
+-	dir = g_dir_open(PLUGINDIR, 0, NULL);
++	dir = g_dir_open(plugin_path, 0, NULL);
+ 	if (dir != NULL) {
+ 		while ((file = g_dir_read_name(dir)) != NULL) {
+ 			void *handle;
+@@ -137,7 +114,7 @@ int __ofono_plugin_init(const char *pattern, const char *exclude)
+ 					g_str_has_suffix(file, ".so") == FALSE)
+ 				continue;
+ 
+-			filename = g_build_filename(PLUGINDIR, file, NULL);
++			filename = g_build_filename(plugin_path, file, NULL);
+ 
+ 			handle = dlopen(filename, RTLD_NOW);
+ 			if (handle == NULL) {
+@@ -168,6 +145,52 @@ int __ofono_plugin_init(const char *pattern, const char *exclude)
+ 
+ 		g_dir_close(dir);
+ 	}
++}
++
++#include "builtin.h"
++
++int __ofono_plugin_init(const char *pattern, const char *exclude)
++{
++	gchar **patterns = NULL;
++	gchar **excludes = NULL;
++	GSList *list;
++	unsigned int i;
++
++	DBG("");
++
++	if (pattern)
++		patterns = g_strsplit_set(pattern, ":, ", -1);
++
++	if (exclude)
++		excludes = g_strsplit_set(exclude, ":, ", -1);
++
++	for (i = 0; __ofono_builtin[i]; i++) {
++		if (check_plugin(__ofono_builtin[i],
++					patterns, excludes) == FALSE)
++			continue;
++
++		add_plugin(NULL, __ofono_builtin[i]);
++	}
++
++
++	const gchar *plugin_path;
++
++	plugin_path = g_getenv ("OFONO_PLUGIN_PATH");
++
++	if (!plugin_path) {
++		gchar **plugin_path_list;
++		gsize i;
++
++		plugin_path_list = g_strsplit (plugin_path, G_SEARCHPATH_SEPARATOR_S, 0);
++
++		for (i = 0; plugin_path_list[i]; i++) {
++			handle_dir(plugin_path_list, patterns, excludes);
++		}
++
++		g_strfreev(plugin_path_list);
++	}
++
++	handle_dir(PLUGINDIR, patterns, excludes);
+ 
+ 	for (list = plugins; list; list = list->next) {
+ 		struct ofono_plugin *plugin = list->data;
+-- 
+2.22.0
+

--- a/pkgs/tools/networking/ofono/default.nix
+++ b/pkgs/tools/networking/ofono/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   ];
 
   configureFlags = [
-    "--with-dbusconfdir=${placeholder ''out''}/etc/dbus-1/system.d"
+    "--with-dbusconfdir=${placeholder ''out''}/share"
     "--with-systemdunitdir=${placeholder ''out''}/lib/systemd/system"
     "--enable-external-ell"
   ];

--- a/pkgs/tools/networking/ofono/default.nix
+++ b/pkgs/tools/networking/ofono/default.nix
@@ -22,6 +22,10 @@ stdenv.mkDerivation rec {
     sha256 = "1qzysmzpgbh6zc3x9xh931wxcazka9wwx727c2k66z9gal2n6n66";
   };
 
+  patches = [
+    ./0001-Search-connectors-in-OFONO_PLUGIN_PATH.patch
+  ];
+
   nativeBuildInputs = [
     autoreconfHook
     pkgconfig

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5128,6 +5128,8 @@ in
 
   offlineimap = callPackage ../tools/networking/offlineimap { };
 
+  ofono-phonesim = libsForQt5.callPackage ../development/tools/ofono-phonesim/default.nix { };
+
   oh-my-zsh = callPackage ../shells/zsh/oh-my-zsh { };
 
   ola = callPackage ../applications/misc/ola { };


### PR DESCRIPTION
Continuation of https://github.com/NixOS/nixpkgs/pull/66565

Added support for ofono plug-ins:

```nix
{ pkgs, ... }: {
  services.ofono.enable = true;
  services.ofono.plugins = [ pkgs.modem-manager-gui ];
}
```