### PR TITLE
ocamlPackages.ppx_tools_versioned: 5.1 -> 5.2.3

### DIFF
--- a/pkgs/development/ocaml-modules/logs/default.nix
+++ b/pkgs/development/ocaml-modules/logs/default.nix
@@ -5,7 +5,9 @@ let
   webpage = "https://erratique.ch/software/${pname}";
 in
 
-assert stdenv.lib.versionAtLeast ocaml.version "4.01.0";
+if !stdenv.lib.versionAtLeast ocaml.version "4.03"
+then throw "logs is not available for OCaml ${ocaml.version}"
+else
 
 stdenv.mkDerivation rec {
   name = "ocaml-${pname}-${version}";

--- a/pkgs/development/ocaml-modules/ppx_tools_versioned/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_tools_versioned/default.nix
@@ -1,23 +1,19 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, ocaml-migrate-parsetree }:
+{ lib, fetchFromGitHub, buildDunePackage, ocaml-migrate-parsetree }:
 
-stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-ppx_tools_versioned-${version}";
-  version = "5.1";
+buildDunePackage rec {
+  pname = "ppx_tools_versioned";
+  version = "5.2.3";
 
   src = fetchFromGitHub {
-    owner = "let-def";
-    repo = "ppx_tools_versioned";
+    owner = "ocaml-ppx";
+    repo = pname;
     rev = version;
-    sha256 = "1c7kvca67qpyr4hiy492yik5x31lmkhyhy5wpl0l0fbx7fr7l624";
+    sha256 = "1hcmpnw26zf70a71r3d2c2c0mn8q084gdn1r36ynng6fv9hq6j0y";
   };
-
-  buildInputs = [ ocaml findlib ];
 
   propagatedBuildInputs = [ ocaml-migrate-parsetree ];
 
-  createFindlibDestdir = true;
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://github.com/let-def/ppx_tools_versioned;
     description = "Tools for authors of syntactic tools (such as ppx rewriters)";
     license = licenses.gpl2;


### PR DESCRIPTION
###### Motivation for this change

Compatibility with OCaml 4.08.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @volth 
