### PR TITLE
nextcloud-client: clean up

### DIFF
--- a/pkgs/applications/networking/nextcloud-client/0001-Explicitly-copy-dbus-files-into-the-store-dir.patch
+++ b/pkgs/applications/networking/nextcloud-client/0001-Explicitly-copy-dbus-files-into-the-store-dir.patch
@@ -16,7 +16,7 @@ index 1f35335..7f76951 100644
  
  macro(dbus_add_activation_service _sources)
 -    PKGCONFIG_GETVAR(dbus-1 session_bus_services_dir _install_dir)
-+    set(_install_dir "${CMAKE_INSTALL_PREFIX}/etc/dbus-1/service")
++    set(_install_dir "${CMAKE_INSTALL_DATADIR}/dbus-1/service")
      foreach (_i ${_sources})
          get_filename_component(_service_file ${_i} ABSOLUTE)
          string(REGEX REPLACE "\\.service.*$" ".service" _output_file ${_i})

--- a/pkgs/applications/networking/nextcloud-client/default.nix
+++ b/pkgs/applications/networking/nextcloud-client/default.nix
@@ -1,17 +1,17 @@
-{ lib, mkDerivation, fetchgit, cmake, pkgconfig, qtbase, qtwebkit, qtkeychain, qttools, sqlite
+{ lib, mkDerivation, fetchFromGitHub, cmake, pkgconfig, qtbase, qtwebkit, qtkeychain, qttools, sqlite
 , inotify-tools, openssl, pcre, qtwebengine, libsecret
 , libcloudproviders
 }:
 
 mkDerivation rec {
-  name = "nextcloud-client-${version}";
+  pname = "nextcloud-client";
   version = "2.5.3";
 
-  src = fetchgit {
-    url = "git://github.com/nextcloud/desktop.git";
-    rev = "refs/tags/v${version}";
-    sha256 = "0fbw56bfbyk3cqv94iqfsxjf01dwy1ysjz89dri7qccs65rnjswj";
-    fetchSubmodules = true;
+  src = fetchFromGitHub {
+    owner = "nextcloud";
+    repo = "desktop";
+    rev = "v${version}";
+    sha256 = "1pzlq507fasf2ljf37gkw00qrig4w2r712rsy05zfwlncgcn7fnw";
   };
 
   patches = [
@@ -20,29 +20,15 @@ mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig cmake ];
 
-  buildInputs = [ qtbase qtwebkit qtkeychain qttools qtwebengine sqlite openssl.out pcre inotify-tools libcloudproviders ];
-
-  enableParallelBuilding = true;
-
-  NIX_LDFLAGS = "${openssl.out}/lib/libssl.so ${openssl.out}/lib/libcrypto.so";
-
-  cmakeFlags = [
-    "-UCMAKE_INSTALL_LIBDIR"
-    "-DCMAKE_BUILD_TYPE=Release"
-    "-DOPENSSL_LIBRARIES=${openssl.out}/lib"
-    "-DOPENSSL_INCLUDE_DIR=${openssl.dev}/include"
-    "-DINOTIFY_LIBRARY=${inotify-tools}/lib/libinotifytools.so"
-    "-DINOTIFY_INCLUDE_DIR=${inotify-tools}/include"
-  ];
+  buildInputs = [ qtbase qtwebkit qtkeychain qttools qtwebengine sqlite openssl pcre inotify-tools libcloudproviders ];
 
   qtWrapperArgs = [
     ''--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libsecret ]}''
   ];
 
-  postInstall = ''
-    sed -i 's/\(Icon.*\)=nextcloud/\1=Nextcloud/g' \
-    $out/share/applications/nextcloud.desktop
-  '';
+  cmakeFlags = [
+    "-DCMAKE_INSTALL_LIBDIR=lib" # expected to be prefix-relative by build code setting RPATH
+  ];
 
   meta = with lib; {
     description = "Nextcloud themed desktop client";

--- a/pkgs/applications/networking/nextcloud-client/default.nix
+++ b/pkgs/applications/networking/nextcloud-client/default.nix
@@ -1,6 +1,19 @@
-{ lib, mkDerivation, fetchFromGitHub, cmake, pkgconfig, qtbase, qtwebkit, qtkeychain, qttools, sqlite
-, inotify-tools, openssl, pcre, qtwebengine, libsecret
+{ lib
+, mkDerivation
+, fetchFromGitHub
+, cmake
+, inotify-tools
 , libcloudproviders
+, libsecret
+, openssl
+, pcre
+, pkgconfig
+, qtbase
+, qtkeychain
+, qttools
+, qtwebengine
+, qtwebkit
+, sqlite
 }:
 
 mkDerivation rec {
@@ -18,12 +31,26 @@ mkDerivation rec {
     ./0001-Explicitly-copy-dbus-files-into-the-store-dir.patch
   ];
 
-  nativeBuildInputs = [ pkgconfig cmake ];
+  nativeBuildInputs = [
+    pkgconfig
+    cmake
+  ];
 
-  buildInputs = [ qtbase qtwebkit qtkeychain qttools qtwebengine sqlite openssl pcre inotify-tools libcloudproviders ];
+  buildInputs = [
+    inotify-tools
+    libcloudproviders
+    openssl
+    pcre
+    qtbase
+    qtkeychain
+    qttools
+    qtwebengine
+    qtwebkit
+    sqlite
+  ];
 
   qtWrapperArgs = [
-    ''--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libsecret ]}''
+    "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libsecret ]}"
   ];
 
   cmakeFlags = [


### PR DESCRIPTION
Continuation of https://github.com/NixOS/nixpkgs/pull/67306

* Switched to non-deprecated dbus config path.
* Removed CMake flags for finding dependencies, the project can find them on its own.
* Properly fixed the RPATH issue from https://github.com/NixOS/nixpkgs/pull/15406 – ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}.
* Dropped changing Icon name in the desktop file as it was fixed upstream.
* Switched to fetchFromGitHub, as the submodules are only for Win, Mac & crash reporting.
* Dropped enableParallelBuilding = true, as it is on by default with CMake.
* Formatted the expression.

cc @Ma27 @worldofpeace