### PR TITLE
ocamlPackages.cstruct: 3.1.1 -> 4.0.0 and related updates

### DIFF
--- a/pkgs/applications/networking/instant-messengers/jackline/default.nix
+++ b/pkgs/applications/networking/instant-messengers/jackline/default.nix
@@ -3,14 +3,14 @@
 assert stdenv.lib.versionAtLeast ocamlPackages.ocaml.version "4.02.2";
 
 stdenv.mkDerivation rec {
-  version = "2018-05-11";
+  version = "2019-08-08";
   name = "jackline-${version}";
 
   src = fetchFromGitHub {
     owner  = "hannesm";
     repo   = "jackline";
-    rev    = "bc36b1c8b80fee6baba4f91011cd01b82a06e8eb";
-    sha256 = "1xx2yx8a95m84sa1bkxi3rlx7pd39zkqwk3znj0zzz3cni6apfrz";
+    rev    = "b934594010a563ded9c0f436e3fab8f1cae29856";
+    sha256 = "076h03jd970xlii90ax6kvgyq67g81gs30yvdzps366n7zzy3yfc";
   };
 
   buildInputs = with ocamlPackages; [

--- a/pkgs/development/ocaml-modules/bigarray-compat/default.nix
+++ b/pkgs/development/ocaml-modules/bigarray-compat/default.nix
@@ -1,0 +1,20 @@
+{ lib, buildDunePackage, fetchFromGitHub }:
+
+buildDunePackage rec {
+  pname = "bigarray-compat";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "mirage";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "06j1dwlpisxshdd0nab4n4x266gg1s1n8na16lpgw3fvcznwnimz";
+  };
+
+  meta = {
+    description = "Compatibility library to use Stdlib.Bigarray when possible";
+    inherit (src.meta) homepage;
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/development/ocaml-modules/cstruct/default.nix
+++ b/pkgs/development/ocaml-modules/cstruct/default.nix
@@ -1,20 +1,18 @@
-{ stdenv, fetchurl, buildDunePackage, sexplib, ocplib-endian }:
+{ lib, fetchurl, buildDunePackage }:
 
 buildDunePackage rec {
   pname = "cstruct";
-  version = "3.1.1";
+  version = "4.0.0";
 
   src = fetchurl {
-    url = "https://github.com/mirage/ocaml-cstruct/releases/download/v${version}/cstruct-${version}.tbz";
-    sha256 = "1x4jxsvd1lrfibnjdjrkfl7hqsc48rljnwbap6faanj9qhwwa6v2";
+    url = "https://github.com/mirage/ocaml-cstruct/releases/download/v${version}/cstruct-v${version}.tbz";
+    sha256 = "1q4fsc2m6d96yf42g3wb3gcnhpnxw800df5mh3yr25pprj8y4m1a";
   };
-
-  propagatedBuildInputs = [ sexplib ocplib-endian ];
 
   meta = {
     description = "Access C-like structures directly from OCaml";
-    license = stdenv.lib.licenses.isc;
+    license = lib.licenses.isc;
     homepage = "https://github.com/mirage/ocaml-cstruct";
-    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    maintainers = [ lib.maintainers.vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/cstruct/ppx.nix
+++ b/pkgs/development/ocaml-modules/cstruct/ppx.nix
@@ -1,4 +1,4 @@
-{ lib, buildDunePackage, cstruct, ppx_tools_versioned }:
+{ lib, buildDunePackage, cstruct, sexplib, ppx_tools_versioned }:
 
 if !lib.versionAtLeast (cstruct.version or "1") "3"
 then cstruct
@@ -8,8 +8,8 @@ buildDunePackage {
 	pname = "ppx_cstruct";
 	inherit (cstruct) version src meta;
 
-  minimumOCamlVersion = "4.02";
+	minimumOCamlVersion = "4.03";
 
-	buildInputs = [ ppx_tools_versioned ];
+	buildInputs = [ sexplib ppx_tools_versioned ];
 	propagatedBuildInputs = [ cstruct ];
 }

--- a/pkgs/development/ocaml-modules/cstruct/sexp.nix
+++ b/pkgs/development/ocaml-modules/cstruct/sexp.nix
@@ -1,0 +1,16 @@
+{ lib, buildDunePackage, alcotest, cstruct, sexplib }:
+
+if !lib.versionAtLeast (cstruct.version or "1") "3"
+then cstruct
+else
+
+buildDunePackage {
+	pname = "cstruct-sexp";
+	inherit (cstruct) version src meta;
+
+	doCheck = true;
+	buildInputs = [ alcotest ];
+
+	propagatedBuildInputs = [ cstruct sexplib ];
+}
+

--- a/pkgs/development/ocaml-modules/cstruct/unix.nix
+++ b/pkgs/development/ocaml-modules/cstruct/unix.nix
@@ -8,7 +8,7 @@ buildDunePackage {
 	pname = "cstruct-unix";
 	inherit (cstruct) version src meta;
 
-  minimumOCamlVersion = "4.02";
+	minimumOCamlVersion = "4.06";
 
 	propagatedBuildInputs = [ cstruct ];
 }

--- a/pkgs/development/ocaml-modules/domain-name/default.nix
+++ b/pkgs/development/ocaml-modules/domain-name/default.nix
@@ -1,0 +1,29 @@
+{ lib, buildDunePackage, fetchurl
+, alcotest
+, astring, fmt
+}:
+
+buildDunePackage rec {
+  pname = "domain-name";
+  version = "0.3.0";
+
+  src = fetchurl {
+    url = "https://github.com/hannesm/domain-name/releases/download/v${version}/domain-name-v${version}.tbz";
+    sha256 = "12kc9p2a2fi1ipc2hyhbzivxpph3npglxwdgvhd6v20rqqdyvnad";
+  };
+
+  minimumOCamlVersion = "4.03";
+
+  buildInputs = [ alcotest ];
+
+  propagatedBuildInputs = [ astring fmt ];
+
+  doCheck = true;
+
+  meta = {
+    homepage = "https://github.com/hannesm/domain-name";
+    description = "RFC 1035 Internet domain names";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/development/ocaml-modules/git/default.nix
+++ b/pkgs/development/ocaml-modules/git/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, buildDunePackage
-, astring, decompress, fmt, hex, logs, mstruct, ocaml_lwt, ocamlgraph, uri
+, astring, decompress, fmt, hex, logs, mstruct, ocaml_lwt, ocamlgraph, ocplib-endian, uri
 , alcotest, mtime, nocrypto
 }:
 
@@ -15,7 +15,7 @@ buildDunePackage rec {
 	};
 
 	buildInputs = [ alcotest mtime nocrypto ];
-	propagatedBuildInputs = [ astring decompress fmt hex logs mstruct ocaml_lwt ocamlgraph uri ];
+	propagatedBuildInputs = [ astring decompress fmt hex logs mstruct ocaml_lwt ocamlgraph ocplib-endian uri ];
 	doCheck = true;
 
 	meta = {

--- a/pkgs/development/ocaml-modules/gmap/default.nix
+++ b/pkgs/development/ocaml-modules/gmap/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildDunePackage, fetchurl, alcotest }:
+
+buildDunePackage rec {
+  pname = "gmap";
+  version = "0.3.0";
+
+  src = fetchurl {
+    url = "https://github.com/hannesm/gmap/releases/download/${version}/gmap-${version}.tbz";
+    sha256 = "073wa0lrb0jj706j87cwzf1a8d1ff14100mnrjs8z3xc4ri9xp84";
+  };
+
+  minimumOCamlVersion = "4.03";
+
+  buildInputs = [ alcotest ];
+
+  doCheck = true;
+
+  meta = {
+    description = "Heterogenous maps over a GADT";
+    homepage = "https://github.com/hannesm/gmap";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/development/ocaml-modules/nocrypto/default.nix
+++ b/pkgs/development/ocaml-modules/nocrypto/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchpatch, ocaml, findlib, ocamlbuild, topkg
-, cpuid, ocb-stubblr
+, cpuid, ocb-stubblr, sexplib
 , cstruct, zarith, ppx_sexp_conv
 , cstruct-lwt ? null
 }:
@@ -33,10 +33,18 @@ stdenv.mkDerivation rec {
       url = "https://raw.githubusercontent.com/ocaml/opam-repository/master/packages/nocrypto/nocrypto.0.5.4-1/files/0004-pack-package-workaround-ocamlbuild-272.patch";
       sha256 = "16k0w78plvqhl17qiqq1mckxhhcdysqgs94l54a1bn0l6fx3rvb9";
     })
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/ocaml/opam-repository/master/packages/nocrypto/nocrypto.0.5.4-1/files/0005-use-modern-cstruct-findlib.patch";
+      sha256 = "021k38zbdidw6g7j4vjxlnbsrnzq07bnavxzdjq23nbwlifs2nq9";
+    })
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/ocaml/opam-repository/master/packages/nocrypto/nocrypto.0.5.4-1/files/0006-explicit-dependency-on-sexplib.patch";
+      sha256 = "15kd0qgi96yxr3qkmaqny591l0s6qmwpprxd5xdx9qwv72hq813z";
+    })
   ];
 
   buildInputs = [ ocaml findlib ocamlbuild topkg cpuid ocb-stubblr ];
-  propagatedBuildInputs = [ cstruct ppx_sexp_conv zarith ] ++ optional withLwt cstruct-lwt;
+  propagatedBuildInputs = [ cstruct ppx_sexp_conv sexplib zarith ] ++ optional withLwt cstruct-lwt;
 
   buildPhase = "${topkg.buildPhase} --with-lwt ${boolToString withLwt}";
   inherit (topkg) installPhase;

--- a/pkgs/development/ocaml-modules/tls/default.nix
+++ b/pkgs/development/ocaml-modules/tls/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, ocaml, findlib, ocamlbuild, topkg
-, ppx_sexp_conv, result, x509, nocrypto, cstruct, ppx_cstruct, cstruct-unix, ounit
+, ppx_sexp_conv, result, x509, nocrypto, cstruct-sexp, ppx_cstruct, cstruct-unix, ounit
 , lwt     ? null}:
 
 with stdenv.lib;
@@ -11,23 +11,24 @@ then throw "tls is not available for OCaml ${ocaml.version}"
 else
 
 stdenv.mkDerivation rec {
-  version = "0.9.0";
+  version = "0.10.4";
   name = "ocaml${ocaml.version}-tls-${version}";
 
   src = fetchFromGitHub {
     owner  = "mirleft";
     repo   = "ocaml-tls";
     rev    = "${version}";
-    sha256 = "0qgw8lq8pk9hss7b5i6fr08pi711i0zqx7yyjgcil47ipjig6c31";
+    sha256 = "02wv4lia583imn3sfci4nqv6ac5nzig5j3yfdnlqa0q8bp9rfc6g";
   };
 
-  buildInputs = [ ocaml ocamlbuild findlib topkg ppx_sexp_conv ounit ppx_cstruct cstruct-unix ];
-  propagatedBuildInputs = [ cstruct nocrypto result x509 ] ++
+  buildInputs = [ ocaml ocamlbuild findlib topkg ppx_sexp_conv ppx_cstruct ]
+  ++ optionals doCheck [ ounit cstruct-unix ];
+  propagatedBuildInputs = [ cstruct-sexp nocrypto result x509 ] ++
                           optional withLwt lwt;
 
-  buildPhase = "${topkg.run} build --tests true --with-mirage false --with-lwt ${if withLwt then "true" else "false"}";
+  buildPhase = "${topkg.run} build --tests ${boolToString doCheck} --with-mirage false --with-lwt ${boolToString withLwt}";
 
-  doCheck = true;
+  doCheck = versionAtLeast ocaml.version "4.06";
   checkPhase = "${topkg.run} test";
 
   inherit (topkg) installPhase;

--- a/pkgs/development/ocaml-modules/x509/default.nix
+++ b/pkgs/development/ocaml-modules/x509/default.nix
@@ -1,28 +1,23 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, topkg
-, asn1-combinators, astring, nocrypto, ppx_sexp_conv
-, ounit, cstruct-unix
+{ lib, fetchurl, buildDunePackage, ocaml
+, alcotest, cstruct-unix
+, asn1-combinators, domain-name, fmt, gmap, nocrypto, rresult
 }:
 
-stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-x509-${version}";
-  version = "0.6.1";
+buildDunePackage rec {
+  pname = "x509";
+  version = "0.7.1";
 
   src = fetchurl {
-    url = "https://github.com/mirleft/ocaml-x509/releases/download/${version}/x509-${version}.tbz";
-    sha256 = "1c62mw9rnzq0rs3ihbhfs18nv4mdzwag7893hlqgji3wmaai70pk";
+    url = "https://github.com/mirleft/ocaml-x509/releases/download/v${version}/x509-v${version}.tbz";
+    sha256 = "0hnklgdm1fwwqi0nfvpdbp7ddqvrh9h8697mr99bxqdfhg6sxh1w";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild topkg ppx_sexp_conv ounit cstruct-unix ];
-  propagatedBuildInputs = [ asn1-combinators astring nocrypto ];
+  buildInputs = lib.optionals doCheck [ alcotest cstruct-unix ];
+  propagatedBuildInputs = [ asn1-combinators domain-name fmt gmap nocrypto rresult ];
 
-  buildPhase = "${topkg.run} build --tests true";
+  doCheck = lib.versionAtLeast ocaml.version "4.06";
 
-  doCheck = true;
-  checkPhase = "${topkg.run} test";
-
-  inherit (topkg) installPhase;
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://github.com/mirleft/ocaml-x509;
     description = "X509 (RFC5280) handling in OCaml";
     license = licenses.bsd2;

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -273,6 +273,8 @@ let
 
     gen = callPackage ../development/ocaml-modules/gen { };
 
+    gmap = callPackage ../development/ocaml-modules/gmap { };
+
     herelib = callPackage ../development/ocaml-modules/herelib { };
 
     higlo = callPackage ../development/ocaml-modules/higlo { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -61,6 +61,8 @@ let
 
     batteries = callPackage ../development/ocaml-modules/batteries { };
 
+    bigarray-compat = callPackage ../development/ocaml-modules/bigarray-compat { };
+
     bigstringaf = callPackage ../development/ocaml-modules/bigstringaf { };
 
     bistro = callPackage ../development/ocaml-modules/bistro { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -215,6 +215,8 @@ let
 
     dolog = callPackage ../development/ocaml-modules/dolog { };
 
+    domain-name = callPackage ../development/ocaml-modules/domain-name { };
+
     dtoa = callPackage ../development/ocaml-modules/dtoa { };
 
     dune = callPackage ../development/tools/ocaml/dune { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -188,6 +188,8 @@ let
       lwt = ocaml_lwt;
     };
 
+    cstruct-sexp = callPackage ../development/ocaml-modules/cstruct/sexp.nix {};
+
     cstruct-unix = callPackage ../development/ocaml-modules/cstruct/unix.nix {};
 
     csv =


### PR DESCRIPTION
###### Motivation for this change

Compatibility with OCaml 4.08 (cstruct-unix…).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @sternenseemann (jackline, tls)
