### PR TITLE
ljsyscall: init at 20180515

### DIFF
--- a/maintainers/scripts/luarocks-packages.csv
+++ b/maintainers/scripts/luarocks-packages.csv
@@ -18,6 +18,7 @@ http,,,,,vcunat
 inspect,,,,,
 ldoc,,,,,
 lgi,,,,,
+ljsyscall,,,,lua5_1,lblasc
 lpeg,,,,,vyp
 lpeg_patterns,,,,,
 lpeglabel,,,,,

--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -412,6 +412,26 @@ lgi = buildLuarocksPackage {
     };
   };
 };
+ljsyscall = buildLuarocksPackage {
+  pname = "ljsyscall";
+  version = "0.12-1";
+
+  src = fetchurl {
+    url    = https://luarocks.org/ljsyscall-0.12-1.src.rock;
+    sha256 = "12gs81lnzpxi5d409lbrvjfflld5l2xsdkfhkz93xg7v65sfhh2j";
+  };
+  disabled = (lua.luaversion != "5.1");
+  propagatedBuildInputs = [ lua ];
+
+  meta = with stdenv.lib; {
+    homepage = "http://www.myriabit.com/ljsyscall/";
+    description = "LuaJIT Linux syscall FFI";
+    maintainers = with maintainers; [ lblasc ];
+    license = {
+      fullName = "MIT";
+    };
+  };
+};
 lpeg = buildLuarocksPackage {
   pname = "lpeg";
   version = "1.0.2-1";

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -80,6 +80,25 @@ with super;
     */
   });
 
+  ljsyscall = super.ljsyscall.override(rec {
+    version = "unstable-20180515";
+    # package hasn't seen any release for a long time
+    src = pkgs.fetchFromGitHub {
+      owner = "justincormack";
+      repo = "ljsyscall";
+      rev = "e587f8c55aad3955dddab3a4fa6c1968037b5c6e";
+      sha256 = "06v52agqyziwnbp2my3r7liv245ddmb217zmyqakh0ldjdsr8lz4";
+    };
+    knownRockspec = "rockspec/ljsyscall-scm-1.rockspec";
+    # actually library works fine with lua 5.2
+    preConfigure = ''
+      sed -i 's/lua == 5.1/lua >= 5.1, < 5.3/' ${knownRockspec}
+    '';
+    disabled = luaOlder "5.1" || luaAtLeast "5.3";
+
+    propagatedBuildInputs = with pkgs.lib; optional (!isLuaJIT) luaffi;
+  });
+
   lgi = super.lgi.override({
     nativeBuildInputs = [
       pkgs.pkgconfig


### PR DESCRIPTION
#### Motivation for this change

Add LuaJIT syscall library, sadly latest release is unusable.
It is possible to use this library with plain Lua 5.1 with help of `luaffi`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @teto 
