### PR TITLE
buildRustPackage: add verifyCargoDeps option

### DIFF
--- a/doc/languages-frameworks/rust.section.md
+++ b/doc/languages-frameworks/rust.section.md
@@ -43,6 +43,7 @@ rustPlatform.buildRustPackage rec {
   };
 
   cargoSha256 = "0q68qyl2h6i0qsz82z840myxlnjay8p1w5z7hfyr8fqp7wgwa9cx";
+  verifyCargoDeps = true;
 
   meta = with stdenv.lib; {
     description = "A fast line-oriented regex search tool, similar to ag and ack";
@@ -63,6 +64,9 @@ When the `Cargo.lock`, provided by upstream, is not in sync with the
 `Cargo.toml`, it is possible to use `cargoPatches` to update it. All patches
 added in `cargoPatches` will also be prepended to the patches in `patches` at
 build-time.
+
+When `verifyCargoDeps` is set to `true`, the build will also verify that the
+`cargoSha256` is not out of date by comparing the `Cargo.lock` file in both the `cargoDeps` and `src`. Note that this option changes the value of `cargoSha256` since it also copies the `Cargo.lock` in it. To avoid breaking backward-compatibility this option is not enabled by default but hopefully will be in the future.
 
 ## Compiling Rust crates using Nix instead of Cargo
 

--- a/pkgs/build-support/rust/fetchcargo.nix
+++ b/pkgs/build-support/rust/fetchcargo.nix
@@ -17,7 +17,16 @@ let cargo-vendor-normalise = stdenv.mkDerivation {
   preferLocalBuild = true;
 };
 in
-{ name ? "cargo-deps", src, srcs, patches, sourceRoot, sha256, cargoUpdateHook ? "" }:
+{ name ? "cargo-deps"
+, src
+, srcs
+, patches
+, sourceRoot
+, sha256
+, cargoUpdateHook ? ""
+, # whenever to also include the Cargo.lock in the output
+  copyLockfile ? false
+}:
 stdenv.mkDerivation {
   name = "${name}-vendor";
   nativeBuildInputs = [ cacert git cargo-vendor-normalise cargo ];
@@ -37,6 +46,9 @@ stdenv.mkDerivation {
         exit 1
     fi
 
+    # Keep the original around for copyLockfile
+    cp Cargo.lock Cargo.lock.orig
+
     export CARGO_HOME=$(mktemp -d cargo-home.XXX)
     CARGO_CONFIG=$(mktemp cargo-config.XXXX)
 
@@ -52,6 +64,10 @@ stdenv.mkDerivation {
     if ! cmp $CARGO_CONFIG ${./fetchcargo-default-config.toml} > /dev/null; then
       install -D $CARGO_CONFIG $out/.cargo/config;
     fi;
+
+  '' + stdenv.lib.optionalString copyLockfile ''
+    # add the Cargo.lock to allow hash invalidation
+    cp Cargo.lock.orig $out/Cargo.lock
   '';
 
   outputHashAlgo = "sha256";

--- a/pkgs/development/tools/documentation/mdsh/default.nix
+++ b/pkgs/development/tools/documentation/mdsh/default.nix
@@ -11,7 +11,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "0m3f5mrdmnmkfsy7mc6x3jf4ainmq0z42mv935ikcdbjwwjbd5gq";
   };
 
-  cargoSha256 = "11kzl0ns84xhdacn0k7nilgzgpwazmaaqdjf2kcarxf2h01b0rjv";
+  cargoSha256 = "0adc525hbs7j7zasvcdxy7k6pf145hs711hjbzgwf72k514ypyrl";
+  verifyCargoDeps = true;
 
   meta = with stdenv.lib; {
     description = "Markdown shell pre-processor";


### PR DESCRIPTION
When enabled, it allows to check whenever the cargoSha256 needs updating
or not. This technique depends on IFD and is not allowed inside of
nixpkgs but it's handy to have available. Eg:

    let
      pkg = buildRustPackage { ... };
      srcContent = builtins.readFile "${pkg.src}/Cargo.lock";
      depsContent = builtins.readFile "${pkgs.cargoDeps}/Cargo.lock";
    in
      # this will fail when the cargoSha256 gets out of sync
      assert (srcContent == depsContent);
      pkg

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
