### PR TITLE
ssb-patchwork: 3.14.1 -> 3.16.2

### DIFF
--- a/pkgs/applications/networking/ssb/patchwork/default.nix
+++ b/pkgs/applications/networking/ssb/patchwork/default.nix
@@ -1,13 +1,13 @@
 { appimageTools, symlinkJoin, lib, fetchurl, makeDesktopItem }:
 
 let
-  pname = "patchwork";
-  version = "3.14.1";
+  pname = "ssb-patchwork";
+  version = "3.16.2";
   name = "${pname}-${version}";
 
   src = fetchurl {
-    url = "https://github.com/ssbc/patchwork/releases/download/v${version}/ssb-${pname}-${version}-x86_64.AppImage";
-    sha256 = "01vsldabv9nmbx8kzlgw275zykm72s1dxglnaq4jz5vbysbyn0qd";
+    url = "https://github.com/ssbc/patchwork/releases/download/v${version}/${pname}-${version}-x86_64.AppImage";
+    sha256 = "0hi9ysmwhiiww82a3mqdd2b1anj7qa41b46f6zb3q9d0b8nmvlz4";
   };
 
   binary = appimageTools.wrapType2 {
@@ -20,8 +20,8 @@ let
   };
 
   desktopItem = makeDesktopItem {
-    name = "patchwork";
-    exec = "${binary}/bin/patchwork";
+    name = "ssb-patchwork";
+    exec = "${binary}/bin/ssb-patchwork";
     icon = "ssb-patchwork.png";
     comment = "Decentralized messaging and sharing app";
     desktopName = "Patchwork";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6266,6 +6266,8 @@ in
 
   svgcleaner = callPackage ../tools/graphics/svgcleaner { };
 
+  ssb-patchwork = callPackage ../applications/networking/ssb/patchwork { };
+
   ssdeep = callPackage ../tools/security/ssdeep { };
 
   ssh-ident = callPackage ../tools/networking/ssh-ident { };
@@ -13361,8 +13363,6 @@ in
   lv2Unstable = callPackage ../development/libraries/audio/lv2/unstable.nix { };
 
   lvtk = callPackage ../development/libraries/audio/lvtk { };
-
-  patchwork = callPackage ../applications/networking/ssb/patchwork { };
 
   qradiolink = callPackage ../applications/radio/qradiolink { };
 


### PR DESCRIPTION
###### Motivation for this change

- Updating patchwork to 3.16.2.
- Renaming the binary to `ssb-patchwork` to prevent naming collision
  with graphviz's `patchwork`.

Note: I renamed the package binary to prevent a naming collision with graphviz. This is a pretty standard thing to do. As a matter of fact, both the [archlinux AUR package](https://aur.archlinux.org/packages/ssb-patchwork/) and the [debian official .deb release](https://github.com/ssbc/patchwork/releases/download/v3.16.2/ssb-patchwork_3.16.2_amd64.deb) are doing that.

I missed that during my last review, my bad @flokli :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @thedavidmeister @flokli 
