### PR TITLE
Allow changing xdg-user-dirs with environment.etc

### DIFF
--- a/nixos/modules/programs/environment.nix
+++ b/nixos/modules/programs/environment.nix
@@ -21,6 +21,7 @@ in
         PAGER = mkDefault "less -R";
         EDITOR = mkDefault "nano";
         XCURSOR_PATH = [ "$HOME/.icons" ];
+        XDG_CONFIG_DIRS = [ "/etc/xdg" ]; # needs to be before profile-relative paths to allow changes through environment.etc
       };
 
     environment.profiles = mkAfter

--- a/pkgs/tools/X11/xdg-user-dirs/default.nix
+++ b/pkgs/tools/X11/xdg-user-dirs/default.nix
@@ -11,8 +11,9 @@ stdenv.mkDerivation rec {
   buildInputs = [ libxslt docbook_xsl makeWrapper ];
 
   preFixup = ''
+    # fallback values need to be last
     wrapProgram "$out/bin/xdg-user-dirs-update" \
-      --prefix XDG_CONFIG_DIRS : "$out/etc/xdg"
+      --suffix XDG_CONFIG_DIRS : "$out/etc/xdg"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
### Motivation
Now you will be able to include the following to your `configuration.nix` to change the default directories:

```nix
{
  environment.etc."xdg/user-dirs.defaults".text = ''
    DESKTOP=system/desktop
    DOWNLOAD=downloads
    TEMPLATES=system/templates
    PUBLICSHARE=system/public
    DOCUMENTS=documents
    MUSIC=media/music
    PICTURES=media/photos
    VIDEOS=media/video
  '';
}
```

Closes https://github.com/NixOS/nixpkgs/issues/33282

### Elaboration

See https://github.com/NixOS/nixpkgs/issues/33282#issuecomment-524550842 for evolution
