### PR TITLE
lib: introduce binPath

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -470,6 +470,28 @@ rec {
   getLib = getOutput "lib";
   getDev = getOutput "dev";
 
+  /* Returns the path to the binary in the package.
+     Useful for packages that only have one binary.
+
+     By default the package binary will be "$out/bin/$pname".
+     The default can be overridden by setting the `meta.binPath` attributte to
+     an absolute path within the package. Eg: "/bin/foo".
+
+     NOTE: this function is only building the path to the binary. The binary
+           is not guaranteed to exist.
+
+     Example:
+       binPath pkgs.bash
+       => "/nix/store/vwcxfvl2p0rnw2w6lqa2ax0wbcahlsss-bash-interactive-4.4-p23/bin/bash"
+  */
+  binPath = pkg:
+    let
+      out = getBin pkg;
+      pname = pkg.pname or ((builtins.parseDrvName pkg.name).name);
+      binPath = pkg.meta.binPath or "/bin/${pname}";
+    in
+      "${out}${binPath}";
+
   /* Pick the outputs of packages to place in buildInputs */
   chooseDevOutputs = drvs: builtins.map getDev drvs;
 

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -70,7 +70,7 @@ let
       genAttrs isDerivation toDerivation optionalAttrs
       zipAttrsWithNames zipAttrsWith zipAttrs recursiveUpdateUntil
       recursiveUpdate matchAttrs overrideExisting getOutput getBin
-      getLib getDev chooseDevOutputs zipWithNames zip;
+      getLib getDev binPath chooseDevOutputs zipWithNames zip;
     inherit (lists) singleton forEach foldr fold foldl foldl' imap0 imap1
       concatMap flatten remove findSingle findFirst any all count
       optional optionals toList range partition zipListsWith zipLists

--- a/pkgs/applications/editors/vscode/vscode.nix
+++ b/pkgs/applications/editors/vscode/vscode.nix
@@ -51,5 +51,6 @@ in
       license = licenses.unfree;
       maintainers = with maintainers; [ eadwu synthetica ];
       platforms = [ "x86_64-linux" "x86_64-darwin" ];
+      binPath = "/bin/code";
     };
   }

--- a/pkgs/applications/misc/timewarrior/default.nix
+++ b/pkgs/applications/misc/timewarrior/default.nix
@@ -22,6 +22,7 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     maintainers = with maintainers; [ matthiasbeyer mrVanDalo ];
     platforms = platforms.linux ++ platforms.darwin;
+    binPath = "/bin/timew";
   };
 }
 

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -84,6 +84,9 @@ rec {
         # Pointless to do this on a remote machine.
         preferLocalBuild = true;
         allowSubstitutes = false;
+        meta = {
+          binPath = destination;
+        };
       }
       ''
         n=$out${destination}

--- a/pkgs/development/libraries/ldns/default.nix
+++ b/pkgs/development/libraries/ldns/default.nix
@@ -46,5 +46,6 @@ stdenv.mkDerivation rec {
     homepage = http://www.nlnetlabs.nl/projects/ldns/;
     platforms = platforms.unix;
     maintainers = with maintainers; [ dtzWill ];
+    binPath = "/bin/ldns";
   };
 }

--- a/pkgs/servers/http/webfs/default.nix
+++ b/pkgs/servers/http/webfs/default.nix
@@ -30,5 +30,6 @@ stdenv.mkDerivation rec {
     license     = licenses.gpl2;
     platforms   = platforms.all;
     maintainers = with maintainers; [ zimbatm ];
+    binPath     = "/bin/webfsd";
   };
 }

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -203,6 +203,9 @@ let
     isIbusEngine = bool;
     isGutenprint = bool;
     badPlatforms = platforms;
+    # Set binPath to define the main executable of the derivation. See
+    # lib.binPath .
+    binPath = str;
   };
 
   checkMetaAttr = k: v:

--- a/pkgs/tools/text/ripgrep/default.nix
+++ b/pkgs/tools/text/ripgrep/default.nix
@@ -38,5 +38,6 @@ rustPlatform.buildRustPackage rec {
     license = with licenses; [ unlicense /* or */ mit ];
     maintainers = with maintainers; [ tailhook globin ma27 ];
     platforms = platforms.all;
+    binPath = "/bin/rg";
   };
 }


### PR DESCRIPTION
A lot of derivations have a *main* executable. For example pkgs.curl has
bin/curl, pkgs.bash has bin/bash. Writing those can be repetitive:
    
    "${lib.getBin pkgs.bash}/bin/bash"
    
Introduce a new `lib.binPath` function that can be used to infer a
default binary path for all packages.
    
    "${lib.binPath pkgs.bash}"
    
By default the binary is at $out/bin/$pname. For the package where that
doesn't match it's possible to provide a `meta.binPath` attribute that
contains the relative path to the binary.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
