### PR TITLE
pythonPackages.moderngl_window: init at 1.2.0

### DIFF
--- a/pkgs/development/python-modules/moderngl_window/default.nix
+++ b/pkgs/development/python-modules/moderngl_window/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, isPy3k
+, numpy
+, moderngl
+, pyglet
+, pillow
+, pyrr
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "moderngl_window";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "moderngl";
+    repo = pname;
+    rev = version;
+    sha256 = "054w77lyc2nc0dyx76zsrbq2b3xbywdijhb62b2qqm99ldr1k1x5";
+  };
+
+  propagatedBuildInputs = [ numpy moderngl pyglet pillow pyrr ];
+
+  disabled = !isPy3k;
+
+  # Tests need a display to run.
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/moderngl/moderngl_window";
+    description = "Cross platform helper library for ModernGL making window creation and resource loading simple";
+    license = licenses.mit;
+    platforms = platforms.linux; # should be mesaPlatforms, darwin build breaks.
+    maintainers = with maintainers; [ c0deaddict ];
+  };
+}

--- a/pkgs/development/python-modules/pyglet/default.nix
+++ b/pkgs/development/python-modules/pyglet/default.nix
@@ -43,6 +43,8 @@ buildPythonPackage rec {
                 path = '${gtk2-x11}/lib/libgdk-x11-2.0${ext}'
             elif name == 'gdk_pixbuf-2.0':
                 path = '${gdk-pixbuf}/lib/libgdk_pixbuf-2.0${ext}'
+            elif name == 'Xext':
+                path = '${xorg.libXext}/lib/libXext${ext}'
             if path is not None:
                 return ctypes.cdll.LoadLibrary(path)
         raise Exception("Could not load library {}".format(names))

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3893,6 +3893,8 @@ in {
 
   moderngl = callPackage ../development/python-modules/moderngl { };
 
+  moderngl-window = callPackage ../development/python-modules/moderngl_window { };
+
   modestmaps = callPackage ../development/python-modules/modestmaps { };
 
   # Needed here because moinmoin is loaded as a Python library.


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Examples of `pythonPackages.moderngl` use this package. When upgrading the package wanted to run the tests.

This PR also upgrades `pythonPackages.pyglet` to `1.4.2` because moderngl_window requires it.

Tested this package (and the changes to `pyglet`) indirectly with [examples of ModernGL](https://github.com/moderngl/moderngl/tree/master/examples).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
