### PR TITLE
pythonPackages.django_silk: 3.0.2 -> 3.0.3

### DIFF
--- a/pkgs/development/python-modules/django_silk/default.nix
+++ b/pkgs/development/python-modules/django_silk/default.nix
@@ -23,14 +23,14 @@
 
 buildPythonPackage rec {
   pname = "django-silk";
-  version = "3.0.2";
+  version = "3.0.3";
 
   # pypi tarball doesn't include test project
   src = fetchFromGitHub {
     owner = "jazzband";
     repo = "django-silk";
     rev = version;
-    sha256 = "1fbaafc2gx01gscdalp6hj6bz4b0cmq59lgmvsydw7jkds4mps7c";
+    sha256 = "0j1r88zv7fvmlnrzr2h65czzdcpvl7n847ra1pfc52bfa4lf8b9j";
   };
   # "test_time_taken" tests aren't suitable for reproducible execution, but django's
   # test runner doesn't have an easy way to ignore tests - so instead prevent it from picking


### PR DESCRIPTION
###### Motivation for this change
Minor release. https://github.com/jazzband/django-silk/blob/master/CHANGELOG.md#303-2019-08-12 for those interested.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
