### PR TITLE
ripasso-cursive: init unstable at 2019-08-27

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5656,6 +5656,12 @@
     githubId = 918365;
     name = "Stefan Frijters";
   };
+  sgo = {
+    email = "stig@stig.io";
+    github = "stigtsp";
+    githubId = 75371;
+    name = "Stig Palmquist";
+  };
   sgraf = {
     email = "sgraf1337@gmail.com";
     github = "sgraf812";

--- a/pkgs/tools/security/ripasso/cursive.nix
+++ b/pkgs/tools/security/ripasso/cursive.nix
@@ -1,0 +1,30 @@
+{ stdenv, lib, rustPlatform, fetchFromGitHub, pkgconfig, ncurses, python3, openssl, libgpgerror, gpgme, xorg }:
+
+with rustPlatform;
+buildRustPackage rec {
+  version = "unstable-2019-08-27";
+  pname = "ripasso-cursive";
+
+  src = fetchFromGitHub {
+    owner = "cortex";
+    repo = "ripasso";
+    rev  = "1b5ef4ae19f95f1422ba5cb09e9e689880599c40";
+    sha256 = "1lh1in8knpqz4vbsmdyd4hh8y4bfhxjciysfbq3qzdpdpihgj0nn";
+  };
+
+  cargoSha256 = "0dwaa106vj7jbgshhqpjabsr0zmkg1a5syzky7jcaasvc7r7njwl";
+  cargoBuildFlags = [ "-p ripasso-cursive" ];
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [
+    ncurses python3 openssl libgpgerror gpgme xorg.libxcb
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A simple password manager written in Rust";
+    homepage = "https://github.com/cortex/ripasso";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ sgo ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1924,6 +1924,8 @@ in
     conf = config.riot-web.conf or null;
   };
 
+  ripasso-cursive = callPackage ../tools/security/ripasso/cursive.nix {};
+
   roundcube = callPackage ../servers/roundcube { };
 
   roundcubePlugins = dontRecurseIntoAttrs (callPackage ../servers/roundcube/plugins { });


### PR DESCRIPTION
###### Motivation for this change

Ripasso is a simple password manager written in Rust, compatible with password-store repos. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @adisbladis 
