### PR TITLE
cm256cc: init at 1.0.5

### DIFF
--- a/pkgs/development/libraries/cm256cc/default.nix
+++ b/pkgs/development/libraries/cm256cc/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, cmake, boost } :
+
+stdenv.mkDerivation rec {
+  pname = "cm256cc";
+  version = "1.0.5";
+
+  src = fetchFromGitHub {
+    owner = "f4exb";
+    repo = "cm256cc";
+    rev = "v${version}";
+    sha256 = "0d16y3lhdwr644am4sxqpshpbc3qik6dgr1w2c39vy75w9ff61a0";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ boost ];
+
+  meta = with stdenv.lib; {
+    description = "Fast GF(256) Cauchy MDS Block Erasure Codec in C++";
+    homepage = "https://github.com/f4exb/cm256cc";
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ alkeryn ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -157,6 +157,8 @@ in
 
   cmark = callPackage ../development/libraries/cmark { };
 
+  cm256cc = callPackage ../development/libraries/cm256cc {  };
+
   conftest = callPackage ../development/tools/conftest {};
 
   corgi = callPackage ../development/tools/corgi { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

@markuskowa this one is one of the deps of sdrangel, i'm doing them in separate PR ^