### PR TITLE
nixos/gnome3: fix default background setting

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -29,10 +29,10 @@ let
      chmod -R a+w $out/share/gsettings-schemas/nixos-gsettings-overrides
      cat - > $out/share/gsettings-schemas/nixos-gsettings-overrides/glib-2.0/schemas/nixos-defaults.gschema.override <<- EOF
        [org.gnome.desktop.background]
-       picture-uri='${pkgs.nixos-artwork.wallpapers.simple-dark-gray}/share/artwork/gnome/nix-wallpaper-simple-dark-gray.png'
+       picture-uri='file://${pkgs.nixos-artwork.wallpapers.simple-dark-gray}/share/artwork/gnome/nix-wallpaper-simple-dark-gray.png'
 
        [org.gnome.desktop.screensaver]
-       picture-uri='${pkgs.nixos-artwork.wallpapers.simple-dark-gray-bottom}/share/artwork/gnome/nix-wallpaper-simple-dark-gray_bottom.png'
+       picture-uri='file://${pkgs.nixos-artwork.wallpapers.simple-dark-gray-bottom}/share/artwork/gnome/nix-wallpaper-simple-dark-gray_bottom.png'
 
        [org.gnome.shell]
        favorite-apps=[ 'org.gnome.Epiphany.desktop', 'evolution.desktop', 'org.gnome.Music.desktop', 'org.gnome.Photos.desktop', 'org.gnome.Nautilus.desktop', 'org.gnome.Software.desktop' ]

--- a/pkgs/desktops/gnome-3/core/gnome-control-center/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-control-center/default.nix
@@ -24,6 +24,7 @@
 , gnome-settings-daemon
 , gnome3
 , grilo
+, grilo-plugins
 , gsettings-desktop-schemas
 , gsound
 , gtk3
@@ -100,6 +101,7 @@ stdenv.mkDerivation rec {
     gnome-online-accounts
     gnome-settings-daemon
     grilo
+    grilo-plugins # for setting wallpaper from Flickr
     gsettings-desktop-schemas
     gsound
     gtk3

--- a/pkgs/desktops/gnome-3/core/gnome-control-center/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-control-center/default.nix
@@ -1,15 +1,66 @@
-{ fetchurl, stdenv, substituteAll, meson, ninja, pkgconfig, gnome3, ibus, gettext, upower, wrapGAppsHook
-, libcanberra-gtk3, accountsservice, libpwquality, libpulseaudio
-, gdk-pixbuf, librsvg, libgudev, libsecret, gnome-color-manager
-, libxml2, polkit, libxslt, libgtop, libsoup, colord, colord-gtk
-, libkrb5, networkmanagerapplet, networkmanager, glibc
-, libwacom, samba, shared-mime-info, tzdata, libgnomekbd
-, docbook_xsl, modemmanager, clutter, clutter-gtk, cheese, gnome-session
-, fontconfig, sound-theme-freedesktop, grilo, python3
-, gtk3, glib, glib-networking, gsettings-desktop-schemas
-, gnome-desktop, gnome-settings-daemon, gnome-online-accounts
-, vino, gnome-bluetooth, tracker, adwaita-icon-theme
-, udisks2, gsound, libhandy, cups, mutter }:
+{ fetchurl
+, stdenv
+, substituteAll
+, accountsservice
+, adwaita-icon-theme
+, cheese
+, clutter
+, clutter-gtk
+, colord
+, colord-gtk
+, cups
+, docbook_xsl
+, fontconfig
+, gdk-pixbuf
+, gettext
+, glib
+, glib-networking
+, glibc
+, gnome-bluetooth
+, gnome-color-manager
+, gnome-desktop
+, gnome-online-accounts
+, gnome-session
+, gnome-settings-daemon
+, gnome3
+, grilo
+, gsettings-desktop-schemas
+, gsound
+, gtk3
+, ibus
+, libcanberra-gtk3
+, libgnomekbd
+, libgtop
+, libgudev
+, libhandy
+, libkrb5
+, libpulseaudio
+, libpwquality
+, librsvg
+, libsecret
+, libsoup
+, libwacom
+, libxml2
+, libxslt
+, meson
+, modemmanager
+, mutter
+, networkmanager
+, networkmanagerapplet
+, ninja
+, pkgconfig
+, polkit
+, python3
+, samba
+, shared-mime-info
+, sound-theme-freedesktop
+, tracker
+, tzdata
+, udisks2
+, upower
+, vino
+, wrapGAppsHook
+}:
 
 stdenv.mkDerivation rec {
   pname = "gnome-control-center";
@@ -21,20 +72,60 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    meson ninja pkgconfig gettext wrapGAppsHook libxslt docbook_xsl
-    shared-mime-info python3
+    docbook_xsl
+    gettext
+    libxslt
+    meson
+    ninja
+    pkgconfig
+    python3
+    shared-mime-info
+    wrapGAppsHook
   ];
 
   buildInputs = [
-    ibus gtk3 glib glib-networking upower gsettings-desktop-schemas
-    libxml2 gnome-desktop gnome-settings-daemon polkit libgtop
-    gnome-online-accounts libsoup colord libpulseaudio fontconfig colord-gtk
-    accountsservice libkrb5 networkmanagerapplet libwacom samba
-    grilo libpwquality vino libcanberra-gtk3 libgudev libsecret
-    gdk-pixbuf adwaita-icon-theme librsvg clutter clutter-gtk cheese
-    networkmanager modemmanager gnome-bluetooth tracker
-    udisks2 gsound libhandy
+    accountsservice
+    adwaita-icon-theme
+    cheese
+    clutter
+    clutter-gtk
+    colord
+    colord-gtk
+    fontconfig
+    gdk-pixbuf
+    glib
+    glib-networking
+    gnome-bluetooth
+    gnome-desktop
+    gnome-online-accounts
+    gnome-settings-daemon
+    grilo
+    gsettings-desktop-schemas
+    gsound
+    gtk3
+    ibus
+    libcanberra-gtk3
+    libgtop
+    libgudev
+    libhandy
+    libkrb5
+    libpulseaudio
+    libpwquality
+    librsvg
+    libsecret
+    libsoup
+    libwacom
+    libxml2
+    modemmanager
     mutter # schemas for the keybindings
+    networkmanager
+    networkmanagerapplet
+    polkit
+    samba
+    tracker
+    udisks2
+    upower
+    vino
   ];
 
   patches = [


### PR DESCRIPTION
Fix the following error when opening Background panel in GNOME Settings:

    URI '/nix/store/…-simple-dark-gray-2016-02-19/share/artwork/gnome/nix-wallpaper-simple-dark-gray.png' is invalid