### PR TITLE
dfeet: 0.3.14 -> 0.3.15

### DIFF
--- a/pkgs/development/tools/misc/d-feet/default.nix
+++ b/pkgs/development/tools/misc/d-feet/default.nix
@@ -1,22 +1,64 @@
-{ stdenv, pkgconfig, fetchurl, itstool, intltool, libxml2, glib, gtk3
-, python3Packages, wrapGAppsHook, gnome3, libwnck3, gobject-introspection }:
+{ stdenv
+, pkgconfig
+, fetchurl
+, meson
+, ninja
+, glib
+, gtk3
+, python3
+, wrapGAppsHook
+, gnome3
+, libwnck3
+, gobject-introspection
+, gettext
+, itstool
+}:
 
-let
+python3.pkgs.buildPythonApplication rec {
   pname = "d-feet";
-  version = "0.3.14";
-in python3Packages.buildPythonApplication rec {
-  name = "${pname}-${version}";
+  version = "0.3.15";
+
   format = "other";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/d-feet/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1m8lwiwl5jhi0x7y6x5zmd3hjplgvdjrb8a8jg74rvkygslj1p7f";
+    url = "mirror://gnome/sources/d-feet/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "1cgxgpj546jgpyns6z9nkm5k48lid8s36mvzj8ydkjqws2d19zqz";
   };
 
-  nativeBuildInputs = [ pkgconfig itstool intltool wrapGAppsHook libxml2 ];
-  buildInputs = [ glib gtk3 gnome3.adwaita-icon-theme libwnck3 gobject-introspection ];
+  nativeBuildInputs = [
+    gettext
+    gobject-introspection
+    itstool
+    meson
+    ninja
+    pkgconfig
+    python3
+    wrapGAppsHook
+  ];
 
-  propagatedBuildInputs = with python3Packages; [ pygobject3 pep8 ];
+  buildInputs = [
+    glib
+    gnome3.adwaita-icon-theme
+    gtk3
+    libwnck3
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    pygobject3
+  ];
+
+  mesonFlags = [
+    "-Dtests=false" # needs dbus
+  ];
+
+  # Temporary fix
+  # See https://github.com/NixOS/nixpkgs/issues/56943
+  strictDeps = false;
+
+  postPatch = ''
+    chmod +x meson_post_install.py
+    patchShebangs meson_post_install.py
+  '';
 
   passthru = {
     updateScript = gnome3.updateScript {
@@ -26,17 +68,15 @@ in python3Packages.buildPythonApplication rec {
     };
   };
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "D-Feet is an easy to use D-Bus debugger";
-
     longDescription = ''
       D-Feet can be used to inspect D-Bus interfaces of running programs
       and invoke methods on those interfaces.
     '';
-
     homepage = https://wiki.gnome.org/Apps/DFeet;
-    platforms = stdenv.lib.platforms.all;
-    license = stdenv.lib.licenses.gpl2;
-    maintainers = with stdenv.lib.maintainers; [ ktosiek ];
+    platforms = platforms.linux;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ ktosiek ];
   };
 }


### PR DESCRIPTION
Port to meson.

https://gitlab.gnome.org/GNOME/d-feet/blob/0.3.15/NEWS

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).