### PR TITLE
bees: Try all findmnt modes in service wrapper

### DIFF
--- a/pkgs/tools/filesystems/bees/bees-service-wrapper
+++ b/pkgs/tools/filesystems/bees/bees-service-wrapper
@@ -140,7 +140,11 @@ _setup() {
 
   [[ $bees_uuid ]] || {
     # if bees_uuid is not in our .conf file, look it up with findmnt
-    read -r bees_uuid fstype < <(findmnt -n -o uuid,fstype "$bees_fsSpec") && [[ $fstype ]] || exit
+    for findmnt_mode in --kernel --mtab --fstab; do
+      read -r bees_uuid fstype < <(findmnt "$findmnt_mode" -n -o uuid,fstype "$bees_fsSpec") ||:
+      [[ $bees_uuid && $fstype ]] && break
+    done
+    [[ $bees_uuid ]] || die "Unable to identify a device matching $bees_fsSpec with findmnt"
     [[ $fstype = btrfs ]] || die "Device type is $fstype, not btrfs"
   }
 


### PR DESCRIPTION
###### Motivation for this change

As reported by @Evils-Devils in Zygo/bees#123, the bees service wrapper
can fail on account of `findmnt` not being able to identify a mounted
filesystem using the default (kernel-introspection) mechanism.

Fall back to mtab and fstab-based inspection in turn should this fail.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`) *(yes, via NixOS tests)*
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

