### PR TITLE
chipsec: 1.3.7 -> 1.4.0

### DIFF
--- a/pkgs/tools/security/chipsec/default.nix
+++ b/pkgs/tools/security/chipsec/default.nix
@@ -1,14 +1,14 @@
-{ stdenv, lib, fetchFromGitHub, python27Packages, nasm, libelf
+{ stdenv, lib, fetchFromGitHub, pythonPackages, nasm, libelf
 , kernel ? null, withDriver ? false }:
-python27Packages.buildPythonApplication rec {
+pythonPackages.buildPythonApplication rec {
   name = "chipsec-${version}";
-  version = "1.3.7";
+  version = "1.4.0";
 
   src = fetchFromGitHub {
     owner = "chipsec";
     repo = "chipsec";
     rev = version;
-    sha256 = "00hwhi5f24y429zazhm77l1pp31q7fmx7ks3sfm6d16v89zbcp9a";
+    sha256 = "09ipr0vls1l2wln4z3dc9vx0zp63ps3dxkwlpm9rqqbpg7qq6lrp";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
https://github.com/chipsec/chipsec/releases/tag/1.4.0

Runs fine on NixOS x64 with `linuxPackages_latest`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @ myself
