### PR TITLE
gnome3.gnome-control-center: build with optimization

### DIFF
--- a/pkgs/desktops/gnome-3/core/gnome-control-center/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-control-center/default.nix
@@ -56,6 +56,11 @@ stdenv.mkDerivation rec {
     "-Dgnome_session_libexecdir=${gnome-session}/libexec"
   ];
 
+  # Build with optimization
+  # Must be done manually for plain buildtype
+  # https://gitlab.gnome.org/GNOME/gnome-control-center/blob/3.32.2/meson.build#L67
+  NIX_CFLAGS_COMPILE = "-Wp,-D_FORTIFY_SOURCE=2";
+
   preFixup = ''
     gappsWrapperArgs+=(
       --prefix XDG_DATA_DIRS : "${sound-theme-freedesktop}/share"


### PR DESCRIPTION
See https://gitlab.gnome.org/GNOME/gnome-control-center/blob/3.32.2/meson.build#L69

Must be done manually with plain buildtype.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
