### PR TITLE
pythonPackages: Switch to lib.makeScope for `overrideScope` support

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14,13 +14,12 @@
 
 with pkgs.lib;
 
-let
-  packages = ( self:
+(makeScope pkgs.newScope ( self:
 
 let
   inherit (python.passthru) isPy27 isPy33 isPy34 isPy35 isPy36 isPy37 isPy38 isPy3k isPyPy pythonAtLeast pythonOlder;
 
-  callPackage = pkgs.newScope self;
+  callPackage = self.callPackage;
 
   namePrefix = python.libPrefix + "-";
 
@@ -105,7 +104,7 @@ in {
 
   inherit (python.passthru) isPy27 isPy33 isPy34 isPy35 isPy36 isPy37 isPy3k isPyPy pythonAtLeast pythonOlder;
   inherit python bootstrapped-pip buildPythonPackage buildPythonApplication;
-  inherit fetchPypi callPackage;
+  inherit fetchPypi;
   inherit hasPythonModule requiredPythonModules makePythonPath disabledIf;
   inherit toPythonModule toPythonApplication;
   inherit buildSetupcfg;
@@ -6194,6 +6193,4 @@ in {
   runway-python = callPackage ../development/python-modules/runway-python { };
 
   pyprof2calltree = callPackage ../development/python-modules/pyprof2calltree { };
-});
-
-in fix' (extends overrides packages)
+})).overrideScope' overrides


### PR DESCRIPTION
###### Motivation for this change

This change allows previously ~final package sets to be overridden with
overlays , e.g. you can do `pkgs.python.pkgs.overrideScope' (self: super: { ... })`
whereas previously only `pkgs.python.override { packageOverrides =
(self: super: { ... })` was possible.

This therefore also allows packages definitions to transitively override
dependencies. So e.g. if jupyterlab_server requires jsonschema >= 3, but
the rest of the packages should still use jsonschema == 2, you can
define it as such:

```nix
jupyterlab_server = (self.overrideScope' (self: super: {
  jsonschema = self.jsonschema3;
})).callPackage ../development/python-modules/jupyterlab_server { };
```

This applies the overlay to the whole dependency closure, whereas

```nix
jupyterlab_server = callPackage ../development/python-modules/jupyterlab_server {
  jsonschema = self.jsonschema3;
};
```

would only make it apply to jupyterlab_server itself, but not its
dependencies, resulting in build-time errors. To get the desired effect without
this change, this would be needed for this specific case:

```nix
jupyterlab_server = callPackage ../development/python-modules/jupyterlab_server {
  jsonschema = self.jsonschema3;
  notebook = self.notebook.override {
    nbformat = self.nbformat.override {
      jsonschema = self.jsonschema3;
    };
    nbconvert = self.nbconvert.override {
      nbformat = self.nbformat.override {
        jsonschema = self.jsonschema3;
      };
    };
  };
};
```

Ping @FRidh @JonathanReeve @jonringer @veprbl 

###### Things done

- [ ] Tested that all python override strategies still work
