### PR TITLE
[Do Not Merge [yet]] Update jupyterlab

### DIFF
--- a/pkgs/applications/editors/jupyterlab/default.nix
+++ b/pkgs/applications/editors/jupyterlab/default.nix
@@ -9,26 +9,18 @@
 
 buildPythonPackage rec {
   pname = "jupyterlab";
-  version = "0.35.6";
+  version = "1.0.9";
   disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "2ec845845d51221e39d0d753884a19342c953f39febf3148a68631bf57ecb774";
+    sha256 = "1hpqlgadswxivqvhnz7m3z000lgs4q11fbklzc8vzy1fpicg1dp8";
   };
 
   propagatedBuildInputs = [ jupyterlab_server notebook ];
 
   makeWrapperArgs = [
     "--set" "JUPYTERLAB_DIR" "$out/share/jupyter/lab"
-  ];
-
-  patches = [
-    (fetchpatch {
-      name = "bump-jupyterlab_server-version";
-      url = https://github.com/jupyterlab/jupyterlab/commit/3b8d451e6f9a4c609e60cde5fbb3cc84aae79951.patch;
-      sha256 = "08vv6rp1k5fbmvj4v9x1d9zb6ymm9pv8ml80j7p45r9fay34rndf";
-    })
   ];
 
   # Depends on npm

--- a/pkgs/development/python-modules/json5/default.nix
+++ b/pkgs/development/python-modules/json5/default.nix
@@ -1,0 +1,15 @@
+{ buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "json5";
+  version = "0.8.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1c3k5blbhq7g2lnbap26a846ag5x19ivisd3wfzz6bzdl46hyjqj";
+  };
+
+  # Necessary json5 test files aren't included in the download
+  doCheck = false;
+}
+

--- a/pkgs/development/python-modules/jsonschema3/default.nix
+++ b/pkgs/development/python-modules/jsonschema3/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, buildPythonPackage, fetchPypi, python
+, nose, mock, vcversioner, functools32, setuptools_scm, attrs, pyrsistent, twisted, perf }:
+
+buildPythonPackage rec {
+  pname = "jsonschema";
+  version = "3.0.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "03anb4ljl624lixrsaxfi7i1iwavw39sd8cfkhcy0dr2dixjnjld";
+  };
+
+  nativeBuildInputs = [ setuptools_scm ];
+  checkInputs = [ nose mock vcversioner twisted perf ];
+  propagatedBuildInputs = [ functools32 attrs pyrsistent ];
+
+  postPatch = ''
+    substituteInPlace jsonschema/tests/test_jsonschema_test_suite.py \
+      --replace "python" "${python.pythonForBuild.interpreter}"
+  '';
+
+  checkPhase = ''
+    nosetests
+  '';
+
+  /*
+  ERROR: jsonschema.tests.test_validators.test_Draft7Validator_date_ignores_non_strings
+  ----------------------------------------------------------------------
+  Traceback (most recent call last):
+    File "/nix/store/72gfj2iqmi6pb0b4xsxafmsjj2fnr2hg-python3.7-nose-1.3.7/lib/python3.7/site-packages/nose/case.py", line 197, in runTest
+      self.test(*self.arg)
+  TypeError: test() missing 1 required positional argument: 'self'
+  */
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/Julian/jsonschema;
+    description = "An implementation of JSON Schema validation for Python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ domenkozar ];
+  };
+}

--- a/pkgs/servers/jupyterlab/default.nix
+++ b/pkgs/servers/jupyterlab/default.nix
@@ -6,20 +6,21 @@
 , pythonOlder
 , requests
 , pytest
+, json5
 }:
 
 buildPythonPackage rec {
   pname = "jupyterlab_server";
-  version = "0.3.0";
+  version = "1.0.6";
   disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "13b728z5ls0g3p1gq5hvfqg7302clxna5grvgjfwbfzss0avlpjc";
+    sha256 = "1bax8iqwcc5p02h5ysdc48zvx7ll5jfzfsybhb3lfvyfpwkpb5yh";
   };
 
   checkInputs = [ requests pytest ];
-  propagatedBuildInputs = [ notebook jsonschema ];
+  propagatedBuildInputs = [ notebook jsonschema json5 ];
 
   # test_listing test fails
   # this is a new package and not all tests pass

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4117,6 +4117,13 @@ in
 
   jupyter-kernel = callPackage ../applications/editors/jupyter/kernel.nix { };
 
+  inherit (
+    let pythonPkgs = python3.pkgs.overrideScope' (self: super: {
+      jsonschema = self.jsonschema3;
+    }); in {
+      jupyterlab_server = pythonPkgs.callPackage ../servers/jupyterlab { };
+    }) jupyterlab_server;
+
   jwhois = callPackage ../tools/networking/jwhois { };
 
   k2pdfopt = callPackage ../applications/misc/k2pdfopt { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4121,8 +4121,11 @@ in
     let pythonPkgs = python3.pkgs.overrideScope' (self: super: {
       jsonschema = self.jsonschema3;
     }); in {
+      jupyterlab = pythonPkgs.callPackage ../applications/editors/jupyterlab {
+        inherit jupyterlab_server;
+      };
       jupyterlab_server = pythonPkgs.callPackage ../servers/jupyterlab { };
-    }) jupyterlab_server;
+    }) jupyterlab jupyterlab_server;
 
   jwhois = callPackage ../tools/networking/jwhois { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2496,7 +2496,7 @@ in {
 
   jupyterlab_launcher = callPackage ../development/python-modules/jupyterlab_launcher { };
 
-  jupyterlab_server = callPackage ../development/python-modules/jupyterlab_server { };
+  jupyterlab_server = throw "pkgs.python3.pkgs.jupyterlab_server has moved to pkgs.jupyterlab_server";
 
   jupyterlab = callPackage ../development/python-modules/jupyterlab {};
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2498,7 +2498,7 @@ in {
 
   jupyterlab_server = throw "pkgs.python3.pkgs.jupyterlab_server has moved to pkgs.jupyterlab_server";
 
-  jupyterlab = callPackage ../development/python-modules/jupyterlab {};
+  jupyterlab = throw "python3.pkgs.jupyterlab has moved to pkgs.jupyterlab";
 
   jupytext = callPackage ../development/python-modules/jupytext { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14,13 +14,12 @@
 
 with pkgs.lib;
 
-let
-  packages = ( self:
+(makeScope pkgs.newScope ( self:
 
 let
   inherit (python.passthru) isPy27 isPy33 isPy34 isPy35 isPy36 isPy37 isPy38 isPy3k isPyPy pythonAtLeast pythonOlder;
 
-  callPackage = pkgs.newScope self;
+  callPackage = self.callPackage;
 
   namePrefix = python.libPrefix + "-";
 
@@ -105,7 +104,7 @@ in {
 
   inherit (python.passthru) isPy27 isPy33 isPy34 isPy35 isPy36 isPy37 isPy3k isPyPy pythonAtLeast pythonOlder;
   inherit python bootstrapped-pip buildPythonPackage buildPythonApplication;
-  inherit fetchPypi callPackage;
+  inherit fetchPypi;
   inherit hasPythonModule requiredPythonModules makePythonPath disabledIf;
   inherit toPythonModule toPythonApplication;
   inherit buildSetupcfg;
@@ -6194,6 +6193,4 @@ in {
   runway-python = callPackage ../development/python-modules/runway-python { };
 
   pyprof2calltree = callPackage ../development/python-modules/pyprof2calltree { };
-});
-
-in fix' (extends overrides packages)
+})).overrideScope' overrides

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3114,6 +3114,8 @@ in {
 
   jsonschema = callPackage ../development/python-modules/jsonschema { };
 
+  jsonschema3 = callPackage ../development/python-modules/jsonschema3 { };
+
   vcversioner = callPackage ../development/python-modules/vcversioner { };
 
   falcon = callPackage ../development/python-modules/falcon { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2453,6 +2453,8 @@ in {
 
   jsmin = callPackage ../development/python-modules/jsmin { };
 
+  json5 = callPackage ../development/python-modules/json5 { };
+
   jsonmerge = callPackage ../development/python-modules/jsonmerge { };
 
   jsonpatch = callPackage ../development/python-modules/jsonpatch { };


### PR DESCRIPTION
##### Motivation for this change

Do not merge yet, this is dependent on https://github.com/NixOS/nixpkgs/pull/67422

Closes https://github.com/NixOS/nixpkgs/issues/65625

This introduces `jsonschema3` in parallel to `jsonschema` (version 2), because apparently [a lot of python packages probably still depend on v2](https://github.com/NixOS/nixpkgs/pull/65824#issuecomment-517885153)

Ping @FRidh @JonathanReeve 

###### Things done

- [ ] Tested that the new version actually works. I'd like @JonathanReeve to do that because I'm not a jupyterlab user
- [x] Built using sandboxing
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
