### PR TITLE
Add large hunspell dicts

### DIFF
--- a/pkgs/development/libraries/hunspell/dictionaries.nix
+++ b/pkgs/development/libraries/hunspell/dictionaries.nix
@@ -141,11 +141,12 @@ let
     };
 
   mkDictFromWordlist =
-    { shortName, shortDescription, dictFileName, src }:
+    { shortName, shortDescription, srcFileName, dictFileName, src }:
     mkDict rec {
-      inherit src dictFileName;
+      inherit src srcFileName dictFileName;
       version = "2018.04.16";
       name = "hunspell-dict-${shortName}-wordlist-${version}";
+      srcReadmeFile = "README_" + srcFileName + ".txt";
       readmeFile = "README_" + dictFileName + ".txt";
       meta = with stdenv.lib; {
         description = "Hunspell dictionary for ${shortDescription} from Wordlist";
@@ -158,7 +159,12 @@ let
       phases = "unpackPhase installPhase";
       sourceRoot = ".";
       unpackCmd = ''
-        unzip $src ${dictFileName}.dic ${dictFileName}.aff ${readmeFile}
+        unzip $src ${srcFileName}.dic ${srcFileName}.aff ${srcReadmeFile}
+      '';
+      postUnpack = ''
+        mv ${srcFileName}.dic ${dictFileName}.dic || true
+        mv ${srcFileName}.aff ${dictFileName}.aff || true
+        mv ${srcReadmeFile} ${readmeFile}         || true
       '';
     };
 
@@ -294,6 +300,7 @@ in rec {
   en-us = mkDictFromWordlist {
     shortName = "en-us";
     shortDescription = "English (United States)";
+    srcFileName = "en_US";
     dictFileName = "en_US";
     src = fetchurl {
       url = mirror://sourceforge/wordlist/speller/2018.04.16/hunspell-en_US-2018.04.16.zip;
@@ -301,10 +308,23 @@ in rec {
     };
   };
 
+  en_US-large = en-us-large;
+  en-us-large = mkDictFromWordlist {
+    shortName = "en-us-large";
+    shortDescription = "English (United States) Large";
+    srcFileName = "en_US-large";
+    dictFileName = "en_US";
+    src = fetchurl {
+      url = mirror://sourceforge/wordlist/speller/2018.04.16/hunspell-en_US-large-2018.04.16.zip;
+      sha256 = "1xm9jgqbivp5cb78ykjxg47vzq1yqj82l7r4q5cjpivrv99s49qc";
+    };
+  };
+
   en_CA = en-ca;
   en-ca = mkDictFromWordlist {
     shortName = "en-ca";
     shortDescription = "English (Canada)";
+    srcFileName = "en_CA";
     dictFileName = "en_CA";
     src = fetchurl {
       url = mirror://sourceforge/wordlist/speller/2018.04.16/hunspell-en_CA-2018.04.16.zip;
@@ -312,10 +332,23 @@ in rec {
     };
   };
 
+  en_CA-large = en-ca-large;
+  en-ca-large = mkDictFromWordlist {
+    shortName = "en-ca-large";
+    shortDescription = "English (Canada) Large";
+    srcFileName = "en_CA-large";
+    dictFileName = "en_CA";
+    src = fetchurl {
+      url = mirror://sourceforge/wordlist/speller/2018.04.16/hunspell-en_CA-large-2018.04.16.zip;
+      sha256 = "1200xxyvv6ni8nk52v3059c367817vnrkm0cdh38rhiigb5flfha";
+    };
+  };
+
   en_AU = en-au;
   en-au = mkDictFromWordlist {
     shortName = "en-au";
     shortDescription = "English (Australia)";
+    srcFileName = "en_AU";
     dictFileName = "en_AU";
     src = fetchurl {
       url = mirror://sourceforge/wordlist/speller/2018.04.16/hunspell-en_AU-2018.04.16.zip;
@@ -323,13 +356,26 @@ in rec {
     };
   };
 
+  en_AU-large = en-au-large;
+  en-au-large = mkDictFromWordlist {
+    shortName = "en-au-large";
+    shortDescription = "English (Australia) Large";
+    srcFileName = "en_AU-large";
+    dictFileName = "en_AU";
+    src = fetchurl {
+      url = mirror://sourceforge/wordlist/speller/2018.04.16/hunspell-en_AU-large-2018.04.16.zip;
+      sha256 = "14l1w4dpk0k1js2wwq5ilfil89ni8cigph95n1rh6xi4lzxj7h6g";
+    };
+  };
+
   en_GB-ise = en-gb-ise;
   en-gb-ise = mkDictFromWordlist {
     shortName = "en-gb-ise";
     shortDescription = "English (United Kingdom, 'ise' ending)";
-    dictFileName = "en_GB-ise";
+    srcFileName = "en_GB-ise";
+    dictFileName = "en_GB";
     src = fetchurl {
-      url = mirror://sourceforge/wordlist/speller//hunspell-en_GB-ise-2018.04.16.zip;
+      url = mirror://sourceforge/wordlist/speller/2018.04.16/hunspell-en_GB-ise-2018.04.16.zip;
       sha256 = "0ylg1zvfvsawamymcc9ivrqcb9qhlpgpnizm076xc56jz554xc2l";
     };
   };
@@ -338,10 +384,23 @@ in rec {
   en-gb-ize = mkDictFromWordlist {
     shortName = "en-gb-ize";
     shortDescription = "English (United Kingdom, 'ize' ending)";
-    dictFileName = "en_GB-ize";
+    srcFileName = "en_GB-ize";
+    dictFileName = "en_GB";
     src = fetchurl {
-      url = mirror://sourceforge/wordlist/speller//hunspell-en_GB-ize-2018.04.16.zip;
+      url = mirror://sourceforge/wordlist/speller/2018.04.16/hunspell-en_GB-ize-2018.04.16.zip;
       sha256 = "1rmwy6sxmd400cwjf58az6g14sq28p18f5mlq8ybg8y33q9m42ps";
+    };
+  };
+
+  en_GB-large = en-gb-large;
+  en-gb-large = mkDictFromWordlist {
+    shortName = "en-gb-large";
+    shortDescription = "English (United Kingdom) Large";
+    srcFileName = "en_GB-large";
+    dictFileName = "en_GB";
+    src = fetchurl {
+      url = mirror://sourceforge/wordlist/speller/2018.04.16/hunspell-en_GB-large-2018.04.16.zip;
+      sha256 = "1y4d7x5vvi1qh1s3i09m0vvqrpdzzqhsdngr8nsh7hc5bnlm37mi";
     };
   };
 

--- a/pkgs/development/libraries/hunspell/dictionaries.nix
+++ b/pkgs/development/libraries/hunspell/dictionaries.nix
@@ -312,6 +312,7 @@ in rec {
     };
   };
 
+  en_AU = en-au;
   en-au = mkDictFromWordlist {
     shortName = "en-au";
     shortDescription = "English (Australia)";
@@ -321,7 +322,6 @@ in rec {
       sha256 = "1kp06npl1kd05mm9r52cg2iwc13x02zwqgpibdw15b6x43agg6f5";
     };
   };
-  en_AU = en-au;
 
   en_GB-ise = en-gb-ise;
   en-gb-ise = mkDictFromWordlist {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Larger dictionary options for American, Canadian and Australian English

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
