### PR TITLE
lightspark: init at 0.8.1

### DIFF
--- a/pkgs/misc/lightspark/default.nix
+++ b/pkgs/misc/lightspark/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub, pkgconfig, cmake, curl, zlib, ffmpeg, glew, pcre
+, rtmpdump, cairo, boost, SDL2, SDL2_mixer, libjpeg, gnome2, lzma, nasm
+, llvm_39, glibmm
+}:
+
+stdenv.mkDerivation rec {
+  pname = "lightspark";
+  version = "0.8.1";
+
+  src = fetchFromGitHub {
+    owner = "lightspark";
+    repo = "lightspark";
+    rev = "${version}";
+    sha256 = "0chydd516wfi73n8dvivk6nwxb9kjimdfghyv9sffmqmza0mv13s";
+  };
+
+  patchPhase = ''
+    sed -i 's/SET(ETCDIR "\/etc")/SET(ETCDIR "etc")/g' CMakeLists.txt
+  '';
+
+  nativeBuildInputs = [ pkgconfig cmake ];
+
+  buildInputs = [
+    curl zlib ffmpeg glew pcre rtmpdump cairo boost SDL2 SDL2_mixer libjpeg
+    gnome2.pango lzma nasm llvm_39 glibmm
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Open source Flash Player implementation";
+    homepage = "https://lightspark.github.io/";
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ jchw ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12541,6 +12541,8 @@ in
 
   lightlocker = callPackage ../misc/screensavers/light-locker { };
 
+  lightspark = callPackage ../misc/lightspark { };
+
   lightstep-tracer-cpp = callPackage ../development/libraries/lightstep-tracer-cpp { };
 
   linenoise = callPackage ../development/libraries/linenoise { };


### PR DESCRIPTION
###### Motivation for this change
Lightspark is an open source Flash Player implementation.

I put this in misc because Gnash is also in misc. If there is a better place please advise.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).