### PR TITLE
fix firefox 60

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -10,7 +10,7 @@
 , yasm, libGLU_combined, sqlite, unzip, makeWrapper
 , hunspell, libXdamage, libevent, libstartup_notification, libvpx
 , icu, libpng, jemalloc, glib
-, autoconf213, which, gnused, cargo, rustc, llvmPackages
+, autoconf213, which, gnused, cargo, rustc, cargo_1_36, rustc_1_36, llvmPackages
 , rust-cbindgen, nodejs, nasm, fetchpatch
 , debugBuild ? false
 
@@ -169,7 +169,9 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs =
-    [ autoconf213 which gnused pkgconfig perl python2 cargo rustc ]
+    [ autoconf213 which gnused pkgconfig perl python2 ]
+    ++ (if (lib.versionAtLeast ffversion "67"/*somewhere betwween ESRs*/)
+          then [ cargo rustc ] else [ cargo_1_36 rustc_1_36 ])
     ++ lib.optional gtk3Support wrapGAppsHook
     ++ lib.optionals stdenv.isDarwin [ xcbuild rsync ]
     ++ lib.optional  (lib.versionAtLeast ffversion "61.0") [ python3 ]

--- a/pkgs/development/compilers/rust-1_36/binary.nix
+++ b/pkgs/development/compilers/rust-1_36/binary.nix
@@ -1,0 +1,102 @@
+{ stdenv, makeWrapper, bash, curl, darwin
+, version
+, src
+, platform
+, versionType
+}:
+
+let
+  inherit (stdenv.lib) optionalString;
+  inherit (darwin.apple_sdk.frameworks) Security;
+
+  bootstrapping = versionType == "bootstrap";
+
+  installComponents
+    = "rustc,rust-std-${platform}"
+    + (optionalString bootstrapping ",cargo")
+    ;
+in
+
+rec {
+  rustc = stdenv.mkDerivation rec {
+    name = "rustc-${versionType}-${version}";
+
+    inherit version;
+    inherit src;
+
+    meta = with stdenv.lib; {
+      homepage = http://www.rust-lang.org/;
+      description = "A safe, concurrent, practical language";
+      maintainers = with maintainers; [ qknight ];
+      license = [ licenses.mit licenses.asl20 ];
+    };
+
+    buildInputs = [ bash ]
+      ++ stdenv.lib.optional stdenv.isDarwin Security;
+
+    postPatch = ''
+      patchShebangs .
+    '';
+
+    installPhase = ''
+      ./install.sh --prefix=$out \
+        --components=${installComponents}
+
+      ${optionalString (stdenv.isLinux && bootstrapping) ''
+        patchelf \
+          --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+          "$out/bin/rustc"
+        patchelf \
+          --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+          "$out/bin/rustdoc"
+        patchelf \
+          --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+          "$out/bin/cargo"
+      ''}
+
+      # Do NOT, I repeat, DO NOT use `wrapProgram` on $out/bin/rustc
+      # (or similar) here. It causes strange effects where rustc loads
+      # the wrong libraries in a bootstrap-build causing failures that
+      # are very hard to track down. For details, see
+      # https://github.com/rust-lang/rust/issues/34722#issuecomment-232164943
+    '';
+
+    setupHooks = ./setup-hook.sh;
+  };
+
+  cargo = stdenv.mkDerivation rec {
+    name = "cargo-${versionType}-${version}";
+
+    inherit version;
+    inherit src;
+
+    meta = with stdenv.lib; {
+      homepage = http://www.rust-lang.org/;
+      description = "A safe, concurrent, practical language";
+      maintainers = with maintainers; [ qknight ];
+      license = [ licenses.mit licenses.asl20 ];
+    };
+
+    buildInputs = [ makeWrapper bash ]
+      ++ stdenv.lib.optional stdenv.isDarwin Security;
+
+    postPatch = ''
+      patchShebangs .
+    '';
+
+    installPhase = ''
+      patchShebangs ./install.sh
+      ./install.sh --prefix=$out \
+        --components=cargo
+
+      ${optionalString (stdenv.isLinux && bootstrapping) ''
+        patchelf \
+          --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+          "$out/bin/cargo"
+      ''}
+
+      wrapProgram "$out/bin/cargo" \
+        --suffix PATH : "${rustc}/bin"
+    '';
+  };
+}

--- a/pkgs/development/compilers/rust-1_36/bootstrap.nix
+++ b/pkgs/development/compilers/rust-1_36/bootstrap.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchurl, callPackage }:
+
+let
+  # Note: the version MUST be one version prior to the version we're
+  # building
+  version = "1.36.0";
+
+  # fetch hashes by running `print-hashes.sh 1.36.0`
+  hashes = {
+    i686-unknown-linux-gnu = "9f95c3e96622a792858c8a1c9274fa63e6992370493b27c1ac7299a3bec5156d";
+    x86_64-unknown-linux-gnu = "15e592ec52f14a0586dcebc87a957e472c4544e07359314f6354e2b8bd284c55";
+    armv7-unknown-linux-gnueabihf = "798181a728017068f9eddfa665771805d97846cd87bddcd67e0fe27c8d082ceb";
+    aarch64-unknown-linux-gnu = "db78c24d93756f9fe232f081dbc4a46d38f8eec98353a9e78b9b164f9628042d";
+    i686-apple-darwin = "3dbc34fdea8bc030badf9c8b2572c09fd3f5369b59ac099fc521064b390b9e60";
+    x86_64-apple-darwin = "91f151ec7e24f5b0645948d439fc25172ec4012f0584dd16c3fb1acb709aa325";
+  };
+
+  platform =
+    if stdenv.hostPlatform.system == "i686-linux"
+    then "i686-unknown-linux-gnu"
+    else if stdenv.hostPlatform.system == "x86_64-linux"
+    then "x86_64-unknown-linux-gnu"
+    else if stdenv.hostPlatform.system == "armv7l-linux"
+    then "armv7-unknown-linux-gnueabihf"
+    else if stdenv.hostPlatform.system == "aarch64-linux"
+    then "aarch64-unknown-linux-gnu"
+    else if stdenv.hostPlatform.system == "i686-darwin"
+    then "i686-apple-darwin"
+    else if stdenv.hostPlatform.system == "x86_64-darwin"
+    then "x86_64-apple-darwin"
+    else throw "missing bootstrap url for platform ${stdenv.hostPlatform.system}";
+
+  src = fetchurl {
+     url = "https://static.rust-lang.org/dist/rust-${version}-${platform}.tar.gz";
+     sha256 = hashes."${platform}";
+  };
+
+in callPackage ./binary.nix
+  { inherit version src platform;
+    versionType = "bootstrap";
+  }

--- a/pkgs/development/compilers/rust-1_36/cargo.nix
+++ b/pkgs/development/compilers/rust-1_36/cargo.nix
@@ -1,0 +1,56 @@
+{ stdenv, file, curl, pkgconfig, python, openssl, cmake, zlib
+, makeWrapper, libiconv, cacert, rustPlatform, rustc, libgit2
+, CoreFoundation, Security
+}:
+
+rustPlatform.buildRustPackage rec {
+  name = "cargo-${rustc.version}";
+  inherit (rustc) version src;
+
+  # the rust source tarball already has all the dependencies vendored, no need to fetch them again
+  cargoVendorDir = "vendor";
+  preBuild = "pushd src/tools/cargo";
+  postBuild = "popd";
+
+  passthru.rustc = rustc;
+
+  # changes hash of vendor directory otherwise
+  dontUpdateAutotoolsGnuConfigScripts = true;
+
+  nativeBuildInputs = [ pkgconfig cmake makeWrapper ];
+  buildInputs = [ cacert file curl python openssl zlib libgit2 ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ CoreFoundation Security libiconv ];
+
+  LIBGIT2_SYS_USE_PKG_CONFIG = 1;
+
+  # fixes: the cargo feature `edition` requires a nightly version of Cargo, but this is the `stable` channel
+  RUSTC_BOOTSTRAP = 1;
+
+  postInstall = ''
+    # NOTE: We override the `http.cainfo` option usually specified in
+    # `.cargo/config`. This is an issue when users want to specify
+    # their own certificate chain as environment variables take
+    # precedence
+    wrapProgram "$out/bin/cargo" \
+      --suffix PATH : "${rustc}/bin" \
+      --set CARGO_HTTP_CAINFO "${cacert}/etc/ssl/certs/ca-bundle.crt" \
+      --set SSL_CERT_FILE "${cacert}/etc/ssl/certs/ca-bundle.crt"
+  '';
+
+  checkPhase = ''
+    # Disable cross compilation tests
+    export CFG_DISABLE_CROSS_TESTS=1
+    cargo test
+  '';
+
+  # Disable check phase as there are failures (4 tests fail)
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://crates.io;
+    description = "Downloads your Rust project's dependencies and builds your project";
+    maintainers = with maintainers; [ wizeman retrry ];
+    license = [ licenses.mit licenses.asl20 ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/compilers/rust-1_36/clippy.nix
+++ b/pkgs/development/compilers/rust-1_36/clippy.nix
@@ -1,0 +1,35 @@
+{ stdenv, lib, rustPlatform, rustc, Security, patchelf }:
+rustPlatform.buildRustPackage rec {
+  name = "clippy-${rustc.version}";
+  inherit (rustc) version src;
+
+  # the rust source tarball already has all the dependencies vendored, no need to fetch them again
+  cargoVendorDir = "vendor";
+  preBuild = "pushd src/tools/clippy";
+  postBuild = "popd";
+
+  # changes hash of vendor directory otherwise
+  dontUpdateAutotoolsGnuConfigScripts = true;
+
+  buildInputs = [ rustc ] ++ stdenv.lib.optionals stdenv.isDarwin [ Security ];
+
+  # fixes: error: the option `Z` is only accepted on the nightly compiler
+  RUSTC_BOOTSTRAP = 1;
+
+  # Without disabling the test the build fails with:
+  # error: failed to run custom build command for `rustc_llvm v0.0.0
+  #   (/private/tmp/nix-build-clippy-1.36.0.drv-0/rustc-1.36.0-src/src/librustc_llvm)
+  doCheck = false;
+
+  preFixup = stdenv.lib.optionalString stdenv.isDarwin ''
+    install_name_tool -add_rpath "${rustc}/lib" $out/bin/clippy-driver
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://rust-lang.github.io/rust-clippy/;
+    description = "A bunch of lints to catch common mistakes and improve your Rust code";
+    maintainers = with maintainers; [ basvandijk ];
+    license = with licenses; [ mit asl20 ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/compilers/rust-1_36/default.nix
+++ b/pkgs/development/compilers/rust-1_36/default.nix
@@ -1,0 +1,72 @@
+{ stdenv, lib
+, buildPackages
+, newScope, callPackage
+, CoreFoundation, Security
+, llvmPackages_5
+, pkgsBuildTarget, pkgsBuildBuild
+}: rec {
+  makeRustPlatform = { rustc, cargo, ... }: {
+    rust = {
+      inherit rustc cargo;
+    };
+
+    buildRustPackage = callPackage ../../../build-support/rust {
+      inherit rustc cargo;
+
+      fetchcargo = buildPackages.callPackage ../../../build-support/rust/fetchcargo.nix {
+        inherit cargo;
+      };
+    };
+
+    rustcSrc = callPackage ./rust-src.nix {
+      inherit rustc;
+    };
+  };
+
+  # This just contains tools for now. But it would conceivably contain
+  # libraries too, say if we picked some default/recommended versions from
+  # `cratesIO` to build by Hydra and/or try to prefer/bias in Cargo.lock for
+  # all vendored Carnix-generated nix.
+  #
+  # In the end game, rustc, the rust standard library (`core`, `std`, etc.),
+  # and cargo would themselves be built with `buildRustCreate` like
+  # everything else. Tools and `build.rs` and procedural macro dependencies
+  # would be taken from `buildRustPackages` (and `bootstrapRustPackages` for
+  # anything provided prebuilt or their build-time dependencies to break
+  # cycles / purify builds). In this way, nixpkgs would be in control of all
+  # bootstrapping.
+  packages = {
+    prebuilt = callPackage ./bootstrap.nix {};
+    stable = lib.makeScope newScope (self: let
+      # Like `buildRustPackages`, but may also contain prebuilt binaries to
+      # break cycle. Just like `bootstrapTools` for nixpkgs as a whole,
+      # nothing in the final package set should refer to this.
+      bootstrapRustPackages = self.buildRustPackages.overrideScope' (_: _:
+        lib.optionalAttrs (stdenv.buildPlatform == stdenv.hostPlatform)
+          buildPackages.rust.packages.prebuilt);
+      bootRustPlatform = makeRustPlatform bootstrapRustPackages;
+    in {
+      # Packages suitable for build-time, e.g. `build.rs`-type stuff.
+      buildRustPackages = buildPackages.rust.packages.stable;
+      # Analogous to stdenv
+      rustPlatform = makeRustPlatform self.buildRustPackages;
+      rustc = self.callPackage ./rustc.nix ({
+        # Use boot package set to break cycle
+        rustPlatform = bootRustPlatform;
+      } // lib.optionalAttrs (stdenv.cc.isClang && stdenv.hostPlatform == stdenv.buildPlatform) {
+        stdenv = llvmPackages_5.stdenv;
+        pkgsBuildBuild = pkgsBuildBuild // { targetPackages.stdenv = llvmPackages_5.stdenv; };
+        pkgsBuildHost = pkgsBuildBuild // { targetPackages.stdenv = llvmPackages_5.stdenv; };
+        pkgsBuildTarget = pkgsBuildTarget // { targetPackages.stdenv = llvmPackages_5.stdenv; };
+      });
+      rustfmt = self.callPackage ./rustfmt.nix { inherit Security; };
+      cargo = self.callPackage ./cargo.nix {
+        # Use boot package set to break cycle
+        rustPlatform = bootRustPlatform;
+        inherit CoreFoundation Security;
+      };
+      clippy = self.callPackage ./clippy.nix { inherit Security; };
+      rls = self.callPackage ./rls { inherit CoreFoundation Security; };
+    });
+  };
+}

--- a/pkgs/development/compilers/rust-1_36/patches/net-tcp-disable-tests.patch
+++ b/pkgs/development/compilers/rust-1_36/patches/net-tcp-disable-tests.patch
@@ -1,0 +1,92 @@
+diff -ru rustc-1.36.0-src-orig/src/libstd/net/tcp.rs rustc-1.36.0-src/src/libstd/net/tcp.rs
+--- rustc-1.36.0-src-orig/src/libstd/net/tcp.rs	2019-07-03 10:00:00.000000000 +0200
++++ rustc-1.36.0-src/src/libstd/net/tcp.rs	2019-07-07 11:33:35.378130207 +0200
+@@ -973,6 +973,7 @@
+         }
+     }
+ 
++    #[cfg_attr(target_os = "macos", ignore)]
+     #[test]
+     fn listen_localhost() {
+         let socket_addr = next_test_ip4();
+@@ -1031,6 +1032,7 @@
+         })
+     }
+ 
++    #[cfg_attr(target_os = "macos", ignore)]
+     #[test]
+     fn read_eof() {
+         each_ip(&mut |addr| {
+@@ -1050,6 +1052,7 @@
+         })
+     }
+ 
++    #[cfg_attr(target_os = "macos", ignore)]
+     #[test]
+     fn write_close() {
+         each_ip(&mut |addr| {
+@@ -1076,6 +1079,7 @@
+         })
+     }
+ 
++    #[cfg_attr(target_os = "macos", ignore)]
+     #[test]
+     fn multiple_connect_serial() {
+         each_ip(&mut |addr| {
+@@ -1098,6 +1102,7 @@
+         })
+     }
+ 
++    #[cfg_attr(target_os = "macos", ignore)]
+     #[test]
+     fn multiple_connect_interleaved_greedy_schedule() {
+         const MAX: usize = 10;
+@@ -1134,6 +1139,7 @@
+     }
+ 
+     #[test]
++    #[cfg_attr(target_os = "macos", ignore)]
+     fn multiple_connect_interleaved_lazy_schedule() {
+         const MAX: usize = 10;
+         each_ip(&mut |addr| {
+@@ -1467,6 +1473,7 @@
+     }
+ 
+     #[test]
++    #[cfg_attr(target_os = "macos", ignore)]
+     fn clone_while_reading() {
+         each_ip(&mut |addr| {
+             let accept = t!(TcpListener::bind(&addr));
+@@ -1597,7 +1604,7 @@
+ 
+     // FIXME: re-enabled openbsd tests once their socket timeout code
+     //        no longer has rounding errors.
+-    #[cfg_attr(any(target_os = "netbsd", target_os = "openbsd"), ignore)]
++    #[cfg_attr(any(target_os = "netbsd", target_os = "openbsd", target_os = "macos"), ignore)]
+     #[cfg_attr(target_env = "sgx", ignore)] // FIXME: https://github.com/fortanix/rust-sgx/issues/31
+     #[test]
+     fn timeouts() {
+@@ -1643,6 +1650,7 @@
+         drop(listener);
+     }
+ 
++    #[cfg_attr(target_os = "macos", ignore)]
+     #[test]
+     #[cfg_attr(target_env = "sgx", ignore)] // FIXME: https://github.com/fortanix/rust-sgx/issues/31
+     fn test_read_with_timeout() {
+@@ -1687,6 +1695,7 @@
+         drop(listener);
+     }
+ 
++    #[cfg_attr(target_os = "macos", ignore)]
+     #[test]
+     #[cfg_attr(target_env = "sgx", ignore)]
+     fn nodelay() {
+@@ -1719,6 +1728,7 @@
+         assert_eq!(ttl, t!(stream.ttl()));
+     }
+ 
++    #[cfg_attr(target_os = "macos", ignore)]
+     #[test]
+     #[cfg_attr(target_env = "sgx", ignore)]
+     fn set_nonblocking() {

--- a/pkgs/development/compilers/rust-1_36/patches/stdsimd-disable-doctest.patch
+++ b/pkgs/development/compilers/rust-1_36/patches/stdsimd-disable-doctest.patch
@@ -1,0 +1,20 @@
+diff --git a/src/stdsimd/coresimd/x86/mod.rs b/src/stdsimd/coresimd/x86/mod.rs
+index 32915c332..7cb54f31e 100644
+--- a/src/stdsimd/coresimd/x86/mod.rs
++++ b/src/stdsimd/coresimd/x86/mod.rs
+@@ -279,7 +279,6 @@ types! {
+     ///
+     /// # Examples
+     ///
+-    /// ```
+     /// # #![feature(cfg_target_feature, target_feature, stdsimd)]
+     /// # #![cfg_attr(not(dox), no_std)]
+     /// # #[cfg(not(dox))]
+@@ -301,7 +300,6 @@ types! {
+     /// # }
+     /// # if is_x86_feature_detected!("sse") { unsafe { foo() } }
+     /// # }
+-    /// ```
+     pub struct __m256(f32, f32, f32, f32, f32, f32, f32, f32);
+ 
+     /// 256-bit wide set of four `f64` types, x86-specific

--- a/pkgs/development/compilers/rust-1_36/print-hashes.sh
+++ b/pkgs/development/compilers/rust-1_36/print-hashes.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# All rust-related downloads can be found at
+# https://static.rust-lang.org/dist/index.html.  To find the date on
+# which a particular thing was last updated, look for the *-date.txt
+# file, e.g.
+# https://static.rust-lang.org/dist/channel-rust-beta-date.txt
+
+PLATFORMS=(
+  i686-unknown-linux-gnu
+  x86_64-unknown-linux-gnu
+  armv7-unknown-linux-gnueabihf
+  aarch64-unknown-linux-gnu
+  i686-apple-darwin
+  x86_64-apple-darwin
+)
+BASEURL=https://static.rust-lang.org/dist
+VERSION=${1:-}
+DATE=${2:-}
+
+if [[ -z $VERSION ]]
+then
+    echo "No version supplied"
+    exit -1
+fi
+
+if [[ -n $DATE ]]
+then
+    BASEURL=$BASEURL/$DATE
+fi
+
+for PLATFORM in "${PLATFORMS[@]}"
+do
+    URL="$BASEURL/rust-$VERSION-$PLATFORM.tar.gz.sha256"
+    SHA256=$(curl -sSfL $URL | cut -d ' ' -f 1)
+    echo "$PLATFORM = \"$SHA256\";"
+done

--- a/pkgs/development/compilers/rust-1_36/rls/default.nix
+++ b/pkgs/development/compilers/rust-1_36/rls/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchFromGitHub, rustPlatform
+, openssh, openssl, pkgconfig, cmake, zlib, curl, libiconv
+, CoreFoundation, Security }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "rls";
+  inherit (rustPlatform.rust.rustc) src version;
+
+  # changes hash of vendor directory otherwise
+  dontUpdateAutotoolsGnuConfigScripts = true;
+
+  cargoVendorDir = "vendor";
+  preBuild = ''
+    pushd src/tools/rls
+    # client tests are flaky
+    rm tests/client.rs
+  '';
+
+  # a nightly compiler is required unless we use this cheat code.
+  RUSTC_BOOTSTRAP=1;
+
+  # rls-rustc links to rustc_private crates
+  CARGO_BUILD_RUSTFLAGS = if stdenv.isDarwin then "-C rpath" else null;
+
+  nativeBuildInputs = [ pkgconfig cmake ];
+  buildInputs = [ openssh openssl curl zlib libiconv ]
+    ++ (stdenv.lib.optionals stdenv.isDarwin [ CoreFoundation Security ]);
+
+  doCheck = true;
+
+  preInstall = "popd";
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/rls --version
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Rust Language Server - provides information about Rust programs to IDEs and other tools";
+    homepage = https://github.com/rust-lang/rls/;
+    license = with licenses; [ asl20 /* or */ mit ];
+    maintainers = with maintainers; [ symphorien ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/compilers/rust-1_36/rust-src.nix
+++ b/pkgs/development/compilers/rust-1_36/rust-src.nix
@@ -1,0 +1,11 @@
+{ stdenv, rustc }:
+
+stdenv.mkDerivation {
+  name = "rust-src";
+  src = rustc.src;
+  phases = [ "unpackPhase" "installPhase" ];
+  installPhase = ''
+    mv src $out
+    rm -rf $out/{ci,doc,driver,etc,grammar,llvm,rt,rtstartup,rustllvm,test,tools,vendor}
+  '';
+}

--- a/pkgs/development/compilers/rust-1_36/rustc.nix
+++ b/pkgs/development/compilers/rust-1_36/rustc.nix
@@ -1,0 +1,225 @@
+{ stdenv, removeReferencesTo, pkgsBuildBuild, pkgsBuildHost, pkgsBuildTarget
+, fetchurl, file, python2, tzdata, ps
+, llvmPackages_7, darwin, git, cmake, rustPlatform
+, which, libffi, gdb
+, withBundledLLVM ? false
+}:
+
+let
+  inherit (stdenv.lib) optional optionalString;
+  inherit (darwin.apple_sdk.frameworks) Security;
+
+  llvmPackages = llvmPackages_7;
+
+  llvmSharedForBuild = pkgsBuildBuild.llvmPackages.llvm.override { enableSharedLibraries = true; };
+  llvmSharedForHost = pkgsBuildHost.llvmPackages.llvm.override { enableSharedLibraries = true; };
+  llvmSharedForTarget = pkgsBuildTarget.llvmPackages.llvm.override { enableSharedLibraries = true; };
+
+  # For use at runtime
+  llvmShared = llvmPackages.llvm.override { enableSharedLibraries = true; };
+in
+
+stdenv.mkDerivation rec {
+  pname = "rustc";
+  version = "1.36.0";
+
+  src = fetchurl {
+    url = "https://static.rust-lang.org/dist/rustc-${version}-src.tar.gz";
+    sha256 = "06xv2p6zq03lidr0yaf029ii8wnjjqa894nkmrm6s0rx47by9i04";
+  };
+
+  # Provide the compiler-rt sources needed for profiling.
+  preConfigure = ''
+    mkdir src/llvm-project/compiler-rt
+    tar xf ${llvmPackages.compiler-rt.src} -C src/llvm-project/compiler-rt --strip-components=1
+  '';
+
+  __darwinAllowLocalNetworking = true;
+
+  # rustc complains about modified source files otherwise
+  dontUpdateAutotoolsGnuConfigScripts = true;
+
+  # Running the default `strip -S` command on Darwin corrupts the
+  # .rlib files in "lib/".
+  #
+  # See https://github.com/NixOS/nixpkgs/pull/34227
+  #
+  # Running `strip -S` when cross compiling can harm the cross rlibs.
+  # See: https://github.com/NixOS/nixpkgs/pull/56540#issuecomment-471624656
+  stripDebugList = [ "bin" ];
+
+  NIX_LDFLAGS =
+       # when linking stage1 libstd: cc: undefined reference to `__cxa_begin_catch'
+       optional (stdenv.isLinux && !withBundledLLVM) "--push-state --as-needed -lstdc++ --pop-state"
+    ++ optional (stdenv.isDarwin && !withBundledLLVM) "-lc++"
+    ++ optional stdenv.isDarwin "-rpath ${llvmSharedForHost}/lib";
+
+  # Increase codegen units to introduce parallelism within the compiler.
+  RUSTFLAGS = "-Ccodegen-units=10";
+
+  # We need rust to build rust. If we don't provide it, configure will try to download it.
+  # Reference: https://github.com/rust-lang/rust/blob/master/src/bootstrap/configure.py
+  configureFlags = let
+    setBuild  = "--set=target.${stdenv.buildPlatform.config}";
+    setHost   = "--set=target.${stdenv.hostPlatform.config}";
+    setTarget = "--set=target.${stdenv.targetPlatform.config}";
+    ccForBuild  = "${pkgsBuildBuild.targetPackages.stdenv.cc}/bin/${pkgsBuildBuild.targetPackages.stdenv.cc.targetPrefix}cc";
+    cxxForBuild = "${pkgsBuildBuild.targetPackages.stdenv.cc}/bin/${pkgsBuildBuild.targetPackages.stdenv.cc.targetPrefix}c++";
+    ccForHost  = "${pkgsBuildHost.targetPackages.stdenv.cc}/bin/${pkgsBuildHost.targetPackages.stdenv.cc.targetPrefix}cc";
+    cxxForHost = "${pkgsBuildHost.targetPackages.stdenv.cc}/bin/${pkgsBuildHost.targetPackages.stdenv.cc.targetPrefix}c++";
+    ccForTarget  = "${pkgsBuildTarget.targetPackages.stdenv.cc}/bin/${pkgsBuildTarget.targetPackages.stdenv.cc.targetPrefix}cc";
+    cxxForTarget = "${pkgsBuildTarget.targetPackages.stdenv.cc}/bin/${pkgsBuildTarget.targetPackages.stdenv.cc.targetPrefix}c++";
+  in [
+    "--release-channel=stable"
+    "--set=build.rustc=${rustPlatform.rust.rustc}/bin/rustc"
+    "--set=build.cargo=${rustPlatform.rust.cargo}/bin/cargo"
+    "--enable-rpath"
+    "--enable-vendor"
+    "--build=${stdenv.buildPlatform.config}"
+    "--host=${stdenv.hostPlatform.config}"
+    "--target=${stdenv.targetPlatform.config}"
+
+    "${setBuild}.cc=${ccForBuild}"
+    "${setHost}.cc=${ccForHost}"
+    "${setTarget}.cc=${ccForTarget}"
+
+    "${setBuild}.linker=${ccForBuild}"
+    "${setHost}.linker=${ccForHost}"
+    "${setTarget}.linker=${ccForTarget}"
+
+    "${setBuild}.cxx=${cxxForBuild}"
+    "${setHost}.cxx=${cxxForHost}"
+    "${setTarget}.cxx=${cxxForTarget}"
+  ] ++ optional (!withBundledLLVM) [
+    "--enable-llvm-link-shared"
+    "${setBuild}.llvm-config=${llvmSharedForBuild}/bin/llvm-config"
+    "${setHost}.llvm-config=${llvmSharedForHost}/bin/llvm-config"
+    "${setTarget}.llvm-config=${llvmSharedForTarget}/bin/llvm-config"
+  ] ++ optional stdenv.isLinux [
+    "--enable-profiler" # build libprofiler_builtins
+  ];
+
+  # The bootstrap.py will generated a Makefile that then executes the build.
+  # The BOOTSTRAP_ARGS used by this Makefile must include all flags to pass
+  # to the bootstrap builder.
+  postConfigure = ''
+    substituteInPlace Makefile \
+      --replace 'BOOTSTRAP_ARGS :=' 'BOOTSTRAP_ARGS := --jobs $(NIX_BUILD_CORES)'
+  '';
+
+  patches = [
+    ./patches/net-tcp-disable-tests.patch
+
+    # Re-evaluate if this we need to disable this one
+    #./patches/stdsimd-disable-doctest.patch
+
+    # Fails on hydra - not locally; the exact reason is unknown.
+    # Comments in the test suggest that some non-reproducible environment
+    # variables such $RANDOM can make it fail.
+    # ./patches/disable-test-inherit-env.patch
+  ];
+
+  # the rust build system complains that nix alters the checksums
+  dontFixLibtool = true;
+
+  postPatch = ''
+    patchShebangs src/etc
+
+    ${optionalString (!withBundledLLVM) ''rm -rf src/llvm''}
+
+    # Fix the configure script to not require curl as we won't use it
+    sed -i configure \
+      -e '/probe_need CFG_CURL curl/d'
+
+    # On Hydra: `TcpListener::bind(&addr)`: Address already in use (os error 98)'
+    sed '/^ *fn fast_rebind()/i#[ignore]' -i src/libstd/net/tcp.rs
+
+    # https://github.com/rust-lang/rust/issues/39522
+    echo removing gdb-version-sensitive tests...
+    find src/test/debuginfo -type f -execdir grep -q ignore-gdb-version '{}' \; -print -delete
+    rm src/test/debuginfo/{borrowed-c-style-enum.rs,c-style-enum-in-composite.rs,gdb-pretty-struct-and-enums.rs,generic-enum-with-different-disr-sizes.rs}
+
+    # Useful debugging parameter
+    # export VERBOSE=1
+  '' + optionalString stdenv.isDarwin ''
+    # Disable all lldb tests.
+    # error: Can't run LLDB test because LLDB's python path is not set
+    rm -vr src/test/debuginfo/*
+    rm -v src/test/run-pass/backtrace-debuginfo.rs || true
+
+    # error: No such file or directory
+    rm -v src/test/ui/run-pass/issues/issue-45731.rs || true
+
+    # Disable tests that fail when sandboxing is enabled.
+    substituteInPlace src/libstd/sys/unix/ext/net.rs \
+        --replace '#[test]' '#[test] #[ignore]'
+    substituteInPlace src/test/run-pass/env-home-dir.rs \
+        --replace 'home_dir().is_some()' true
+    rm -v src/test/run-pass/fds-are-cloexec.rs || true  # FIXME: pipes?
+    rm -v src/test/ui/run-pass/threads-sendsync/sync-send-in-std.rs || true  # FIXME: ???
+  '';
+
+  # rustc unfortunately needs cmake to compile llvm-rt but doesn't
+  # use it for the normal build. This disables cmake in Nix.
+  dontUseCmakeConfigure = true;
+
+  # ps is needed for one of the test cases
+  nativeBuildInputs = [
+    file python2 ps rustPlatform.rust.rustc git cmake
+    which libffi removeReferencesTo
+  ] # Only needed for the debuginfo tests
+    ++ optional (!stdenv.isDarwin) gdb;
+
+  buildInputs = optional stdenv.isDarwin Security
+    ++ optional (!withBundledLLVM) llvmShared;
+
+  outputs = [ "out" "man" "doc" ];
+  setOutputFlags = false;
+
+  # Disable codegen units and hardening for the tests.
+  preCheck = ''
+    export RUSTFLAGS=
+    export TZDIR=${tzdata}/share/zoneinfo
+    export hardeningDisable=all
+  '' +
+  # Ensure TMPDIR is set, and disable a test that removing the HOME
+  # variable from the environment falls back to another home
+  # directory.
+  optionalString stdenv.isDarwin ''
+    export TMPDIR=/tmp
+    sed -i '28s/home_dir().is_some()/true/' ./src/test/run-pass/env-home-dir.rs
+  '';
+
+  # 1. Upstream is not running tests on aarch64:
+  # see https://github.com/rust-lang/rust/issues/49807#issuecomment-380860567
+  # So we do the same.
+  # 2. Tests run out of memory for i686
+  #doCheck = !stdenv.isAarch64 && !stdenv.isi686;
+
+  # Disabled for now; see https://github.com/NixOS/nixpkgs/pull/42348#issuecomment-402115598.
+  doCheck = false;
+
+  # remove references to llvm-config in lib/rustlib/x86_64-unknown-linux-gnu/codegen-backends/librustc_codegen_llvm-llvm.so
+  # and thus a transitive dependency on ncurses
+  postInstall = ''
+    find $out/lib -name "*.so" -type f -exec remove-references-to -t ${llvmShared} '{}' '+'
+  '';
+
+  configurePlatforms = [];
+
+  # https://github.com/NixOS/nixpkgs/pull/21742#issuecomment-272305764
+  # https://github.com/rust-lang/rust/issues/30181
+  # enableParallelBuilding = false;
+
+  setupHooks = ./setup-hook.sh;
+
+  requiredSystemFeatures = [ "big-parallel" ];
+
+  meta = with stdenv.lib; {
+    homepage = https://www.rust-lang.org/;
+    description = "A safe, concurrent, practical language";
+    maintainers = with maintainers; [ madjar cstrahan wizeman globin havvy ];
+    license = [ licenses.mit licenses.asl20 ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/development/compilers/rust-1_36/rustfmt.nix
+++ b/pkgs/development/compilers/rust-1_36/rustfmt.nix
@@ -1,0 +1,33 @@
+{ stdenv, rustPlatform, Security }:
+
+rustPlatform.buildRustPackage rec {
+  name = "rustfmt-${version}";
+  inherit (rustPlatform.rust.rustc) version src;
+
+  # the rust source tarball already has all the dependencies vendored, no need to fetch them again
+  cargoVendorDir = "vendor";
+  preBuild = "pushd src/tools/rustfmt";
+  preInstall = "popd";
+
+  # changes hash of vendor directory otherwise
+  dontUpdateAutotoolsGnuConfigScripts = true;
+
+  buildInputs = stdenv.lib.optional stdenv.isDarwin Security;
+
+  # As of 1.0.0 and rustc 1.30 rustfmt requires a nightly compiler
+  RUSTC_BOOTSTRAP = 1;
+
+  # we run tests in debug mode so tests look for a debug build of
+  # rustfmt. Anyway this adds nearly no compilation time.
+  preCheck = ''
+    cargo build
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A tool for formatting Rust code according to style guidelines";
+    homepage = https://github.com/rust-lang-nursery/rustfmt;
+    license = with licenses; [ mit asl20 ];
+    maintainers = with maintainers; [ globin basvandijk ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/compilers/rust-1_36/setup-hook.sh
+++ b/pkgs/development/compilers/rust-1_36/setup-hook.sh
@@ -1,0 +1,4 @@
+# Fix 'failed to open: /homeless-shelter/.cargo/.package-cache' in rust 1.36.
+if [[ -z $IN_NIX_SHELL && -z $CARGO_HOME ]]; then
+    export CARGO_HOME=$TMPDIR
+fi

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8282,6 +8282,12 @@ in
   inherit (rustPackages) cargo rustc rustPlatform;
   inherit (rust) makeRustPlatform;
 
+  rust_1_36 = callPackage ../development/compilers/rust-1_36 {
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
+  };
+  rustc_1_36 = rust_1_36.packages.stable.rustc;
+  cargo_1_36 = rust_1_36.packages.stable.cargo;
+
   buildRustCrate = callPackage ../build-support/rust/build-rust-crate { };
   buildRustCrateHelpers = callPackage ../build-support/rust/build-rust-crate/helpers.nix { };
   buildRustCrateTests = recurseIntoAttrs (callPackage ../build-support/rust/build-rust-crate/test { }).tests;


### PR DESCRIPTION
Since a rust update #66686, browsers based on Firefox 60 ESR [didn't build anymore](https://hydra.nixos.org/build/99246893):
> error: trait objects without an explicit `dyn` are deprecated

- [x] verify the `firefox-esr-60` build (at least)