### PR TITLE
crystal: init at 0.30.1

### DIFF
--- a/pkgs/development/compilers/crystal/default.nix
+++ b/pkgs/development/compilers/crystal/default.nix
@@ -199,5 +199,12 @@ in rec {
     binary = binaryCrystal_0_29;
   };
 
-  crystal = crystal_0_29;
+  crystal_0_30 = generic {
+    version = "0.30.1";
+    sha256  = "0fbk784zjflsl3hys5a1xmn8mda8kb2z7ql58wpyfavivswxanbs";
+    doCheck = false; # 6 checks are failing now
+    binary = binaryCrystal_0_29;
+  };
+
+  crystal = crystal_0_30;
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7388,6 +7388,7 @@ in
     crystal_0_26
     crystal_0_27
     crystal_0_29
+    crystal_0_30
     crystal;
 
   icr = callPackage ../development/tools/icr {};


### PR DESCRIPTION

###### Motivation for this change

Latest crystal: https://crystal-lang.org/2019/08/12/crystal-0.30.1-released.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
