### PR TITLE
vdirsyncer: fix build with openssl 1.1

### DIFF
--- a/pkgs/tools/misc/vdirsyncer/default.nix
+++ b/pkgs/tools/misc/vdirsyncer/default.nix
@@ -8,17 +8,18 @@ python3Packages.buildPythonApplication rec {
   name = "${pname}-${version}";
 
   src = fetchFromGitHub {
-    owner = "pimutils";
+    owner = "spk";
     repo = pname;
-    rev = "ac45cf144b0ceb72cc2a9f454808688f3ac9ba4f";
-    sha256 = "0hqsjdpgvm7d34q5b2hzmrzfxk43ald1bx22mvgg559kw1ck54s9";
+    # fix-build-style branch, see https://github.com/pimutils/vdirsyncer/pull/798
+    rev = "2c62d03bd73f8b44a47c2e769ade046697896ae9";
+    sha256 = "1q6xvzz5rf5sqdaj3mdvhpgwy5b16isavgg7vardgjwqwv1yal28";
   };
 
   native = rustPlatform.buildRustPackage {
     name = "${name}-native";
     inherit src;
     sourceRoot = "source/rust";
-    cargoSha256 = "1qziwlf6nlkpxb1hamb7qsipqg9ibp871rimgpwil38vqmyd570s";
+    cargoSha256 = "1n1dxq3klsry5mmbfff2jv7ih8mr5zvpncrdgba6qs93wi77qi0y";
     buildInputs = [ pkgconfig openssl ] ++ stdenv.lib.optional stdenv.isDarwin Security;
   };
 
@@ -35,18 +36,6 @@ python3Packages.buildPythonApplication rec {
   nativeBuildInputs = with python3Packages; [ setuptools_scm ];
 
   checkInputs = with python3Packages; [ hypothesis pytest pytest-localserver pytest-subtesthack ];
-
-  patches = [
-    # Fixes for hypothesis: https://github.com/pimutils/vdirsyncer/pull/779
-    (fetchpatch {
-      url = https://github.com/pimutils/vdirsyncer/commit/22ad88a6b18b0979c5d1f1d610c1d2f8f87f4b89.patch;
-      sha256 = "0dbzj6jlxhdidnm3i21a758z83sdiwzhpd45pbkhycfhgmqmhjpl";
-    })
-    (fetchpatch {
-      url = https://github.com/pimutils/vdirsyncer/commit/29417235321c249c65904bc7948b066ef5683aee.patch;
-      sha256 = "0zvr0y88gm3vprjcdzs4m151laa9qhkyi61rvrfdjmf42fwhbm80";
-    })
-  ];
 
   postPatch = ''
     # Invalid argument: 'perform_health_check' is not a valid setting
@@ -74,7 +63,7 @@ python3Packages.buildPythonApplication rec {
   meta = with stdenv.lib; {
     homepage = https://github.com/pimutils/vdirsyncer;
     description = "Synchronize calendars and contacts";
-    maintainers = with maintainers; [ matthiasbeyer ];
+    maintainers = with maintainers; [ matthiasbeyer gebner ];
     license = licenses.mit;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Build failed after #22357.

The upstream maintenance situation for vdirsyncer is a bit dire at the moment (see https://github.com/pimutils/vdirsyncer/issues/790 for details).  Therefore we now use @spk's [`fix-build-style` branch](https://github.com/pimutils/vdirsyncer/pull/798), which seems to be best currently maintained version of vdirsyncer.  This branch also includes the two patches from https://github.com/pimutils/vdirsyncer/pull/779, that we used to apply.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @matthiasbeyer 
