### PR TITLE
nixos/jormungandr: adding genesis tests

### DIFF
--- a/nixos/modules/services/networking/jormungandr.nix
+++ b/nixos/modules/services/networking/jormungandr.nix
@@ -13,7 +13,7 @@ let
   configSettings = {
     storage = dataDir;
     p2p = {
-      public_address = "/ip4/127.0.0.1/tcp/8606";
+      public_address = "/ip4/127.0.0.1/tcp/8299";
       messages = "high";
       blocks = "high";
     };

--- a/pkgs/applications/altcoins/jormungandr/default.nix
+++ b/pkgs/applications/altcoins/jormungandr/default.nix
@@ -24,6 +24,22 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [ pkgconfig protobuf ];
   buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Security ];
 
+  patchPhase = ''
+    sed -i "s~SCRIPTPATH=.*~SCRIPTPATH=$out/templates/~g" scripts/bootstrap
+  '';
+
+  installPhase = ''
+    install -d $out/bin $out/templates
+    install -m755 target/*/release/jormungandr $out/bin/
+    install -m755 target/*/release/jcli $out/bin/
+    install -m755 scripts/send-transaction $out/templates
+    install -m755 scripts/jcli-helpers $out/bin/
+    install -m755 scripts/bootstrap $out/bin/jormungandr-bootstrap
+    install -m644 scripts/faucet-send-money.shtempl $out/templates/
+    install -m644 scripts/create-account-and-delegate.shtempl $out/templates/
+    install -m644 scripts/faucet-send-certificate.shtempl $out/templates/
+  '';
+
   PROTOC = "${protobuf}/bin/protoc";
 
   # Disabling integration tests


### PR DESCRIPTION
###### Motivation for this change

Adding jormungandr tests for the genesis/praos blockchain.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).