### PR TITLE
vde2: build with `--disable-python` by default

### DIFF
--- a/pkgs/tools/networking/vde2/default.nix
+++ b/pkgs/tools/networking/vde2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, openssl, libpcap, python2 }:
+{ stdenv, fetchurl, fetchpatch, openssl, libpcap, python2, withPython ? false }:
 
 stdenv.mkDerivation rec {
   name = "vde2-2.3.2";
@@ -15,8 +15,10 @@ stdenv.mkDerivation rec {
     }
   );
 
+  configureFlags = stdenv.lib.optional (!withPython) [ "--disable-python" ];
 
-  buildInputs = [ openssl libpcap python2 ];
+  buildInputs = [ openssl libpcap ]
+    ++ stdenv.lib.optional withPython python2;
 
   hardeningDisable = [ "format" ];
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This package explicitly depends on `python2` which will be EOLed at the
end of the year[1]. This package provides python bindings for `python2`,
however the latest release (also used by other distros) is from 2011[2]
and doesn't support v3. For instance, debian ships `vde2` without
`python2` support since Debian Jessie[3].

KVM and QEMU appear to build fine, also NixOS tests and ISO builds are
still functional.

By running `nix-review` against this change, only `xen` packages failed,
but those were already broken on master[4].

Finally it's also worth mentioning that the closure size of `vde2` drops
from 99.5M to 33.5M without `python2` according to `nix path-info -S -h`.

[1] https://pythonclock.org/
[2] https://github.com/virtualsquare/vde-2/releases/tag/vde-2
    (vde.sourceforge.net redirects to this github page)
[3] https://packages.debian.org/en/jessie/vde2
[4] https://hydra.nixos.org/build/99185451, https://hydra.nixos.org/build/99187262


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
