### PR TITLE
wavpack: CVE-2018-7253 and CVE-2018-7254

### DIFF
--- a/pkgs/development/libraries/wavpack/default.nix
+++ b/pkgs/development/libraries/wavpack/default.nix
@@ -69,6 +69,16 @@ stdenv.mkDerivation rec {
       name = "CVE-2019-1010319.patch";
       sha256 = "011sqdgpykilaj2c4ns298z7aad03yprpva0dqr39nx88ji6jnrb";
     })
+    (fetchpatch {
+      url = "https://github.com/dbry/WavPack/commit/36a24c7881427d2e1e4dc1cef58f19eee0d13aec.patch";
+      name = "CVE-2018-7253.patch";
+      sha256 = "130kvmlpaj6x1pm6qzdzrmf4xzhp0pj29qrardb76zcfinx5pk2n";
+    })
+    (fetchpatch {
+      url = "https://github.com/dbry/WavPack/commit/8e3fe45a7bac31d9a3b558ae0079e2d92a04799e.patch";
+      name = "CVE-2018-7254.patch";
+      sha256 = "06fdzw2cbdj8ajf171z1g53cl6bf1cdh2czswqldrqqvv3jkzk77";
+    })
   ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Fixes #67201

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).