### PR TITLE
[WIP] environment.etc: loaOf -> attrsOf

### DIFF
--- a/nixos/modules/config/i18n.nix
+++ b/nixos/modules/config/i18n.nix
@@ -147,14 +147,9 @@ with lib;
     };
 
     # ‘/etc/locale.conf’ is used by systemd.
-    environment.etc = singleton
-      { target = "locale.conf";
-        source = pkgs.writeText "locale.conf"
-          ''
-            LANG=${config.i18n.defaultLocale}
-            ${concatStringsSep "\n" (mapAttrsToList (n: v: ''${n}=${v}'') config.i18n.extraLocaleSettings)}
-          '';
-      };
-
+    environment.etc."locale.conf".text = ''
+      LANG=${config.i18n.defaultLocale}
+      ${concatStringsSep "\n" (mapAttrsToList (n: v: ''${n}=${v}'') config.i18n.extraLocaleSettings)}
+    '';
   };
 }

--- a/nixos/modules/config/pulseaudio.nix
+++ b/nixos/modules/config/pulseaudio.nix
@@ -215,10 +215,7 @@ in {
 
   config = mkMerge [
     {
-      environment.etc = singleton {
-        target = "pulse/client.conf";
-        source = clientConf;
-      };
+      environment.etc."pulse/client.conf".source = clientConf;
 
       hardware.pulseaudio.configFile = mkDefault "${getBin overriddenPackage}/etc/pulse/default.pa";
     }
@@ -228,19 +225,12 @@ in {
 
       sound.enable = true;
 
-      environment.etc = [
-        { target = "asound.conf";
-          source = alsaConf; }
-
-        { target = "pulse/daemon.conf";
-          source = writeText "daemon.conf" (lib.generators.toKeyValue {} cfg.daemon.config); }
-
-        { target = "openal/alsoft.conf";
-          source = writeText "alsoft.conf" "drivers=pulse"; }
-
-        { target = "libao.conf";
-          source = writeText "libao.conf" "default_driver=pulse"; }
-      ];
+      environment.etc = {
+        "asound.conf".source = alsaConf;
+        "pulse/daemon.conf".text = lib.generators.toKeyValue {} cfg.daemon.config;
+        "openal/alsoft.conf".text = "drivers=pulse";
+        "libao.conf".text = "default_driver=pulse";
+      };
 
       # Disable flat volumes to enable relative ones
       hardware.pulseaudio.daemon.config.flat-volumes = mkDefault "no";
@@ -275,10 +265,8 @@ in {
     })
 
     (mkIf nonSystemWide {
-      environment.etc = singleton {
-        target = "pulse/default.pa";
-        source = myConfigFile;
-      };
+      environment.etc."pulse/default.pa".source = myConfigFile;
+
       systemd.user = {
         services.pulseaudio = {
           restartIfChanged = true;

--- a/nixos/modules/programs/dconf.nix
+++ b/nixos/modules/programs/dconf.nix
@@ -5,8 +5,7 @@ with lib;
 let
   cfg = config.programs.dconf;
 
-  mkDconfProfile = name: path:
-    { source = path; target = "dconf/profile/${name}"; };
+  mkDconfProfile = name: path: nameValuePair "dconf/profile/${name}" { source = path; };
 
 in
 {
@@ -29,8 +28,7 @@ in
   ###### implementation
 
   config = mkIf (cfg.profiles != {} || cfg.enable) {
-    environment.etc = optionals (cfg.profiles != {})
-      (mapAttrsToList mkDconfProfile cfg.profiles);
+    environment.etc = mapAttrs' mkDconfProfile cfg.profiles;
 
     services.dbus.packages = [ pkgs.gnome3.dconf ];
 

--- a/nixos/modules/programs/shadow.nix
+++ b/nixos/modules/programs/shadow.nix
@@ -65,23 +65,17 @@ in
       lib.optional (types.shellPackage.check config.users.defaultUserShell)
         config.users.defaultUserShell;
 
-    environment.etc =
-      [ { # /etc/login.defs: global configuration for pwdutils.  You
-          # cannot login without it!
-          source = pkgs.writeText "login.defs" loginDefs;
-          target = "login.defs";
-        }
-
-        { # /etc/default/useradd: configuration for useradd.
-          source = pkgs.writeText "useradd"
-            ''
-              GROUP=100
-              HOME=/home
-              SHELL=${utils.toShellPath config.users.defaultUserShell}
-            '';
-          target = "default/useradd";
-        }
-      ];
+    environment.etc = {
+      # /etc/login.defs: global configuration for pwdutils.  You
+      # cannot login without it!
+      "login.defs".text = loginDefs;
+      # /etc/default/useradd: configuration for useradd.
+      "default/useradd".text = ''
+        GROUP=100
+        HOME=/home
+        SHELL=${utils.toShellPath config.users.defaultUserShell}
+      '';
+    };
 
     security.pam.services =
       { chsh = { rootOK = true; };

--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -475,10 +475,9 @@ let
 
   motd = pkgs.writeText "motd" config.users.motd;
 
-  makePAMService = pamService:
-    { source = pkgs.writeText "${pamService.name}.pam" pamService.text;
-      target = "pam.d/${pamService.name}";
-    };
+  makePAMService = pamService: nameValuePair
+  "pam.d/${pamService.name}"
+  { source = pkgs.writeText "${pamService.name}.pam" pamService.text; };
 
 in
 
@@ -740,7 +739,7 @@ in
     };
 
     environment.etc =
-      mapAttrsToList (n: v: makePAMService v) config.security.pam.services;
+      mapAttrs' (n: v: makePAMService v) config.security.pam.services;
 
     systemd.tmpfiles.rules = optionals
       (any (s: s.updateWtmp) (attrValues config.security.pam.services))

--- a/nixos/modules/security/pam_mount.nix
+++ b/nixos/modules/security/pam_mount.nix
@@ -36,37 +36,34 @@ in
   config = mkIf (cfg.enable || anyPamMount) {
 
     environment.systemPackages = [ pkgs.pam_mount ];
-    environment.etc = [{
-      target = "security/pam_mount.conf.xml";
-      source =
-        let
-          extraUserVolumes = filterAttrs (n: u: u.cryptHomeLuks != null) config.users.users;
-          userVolumeEntry = user: "<volume user=\"${user.name}\" path=\"${user.cryptHomeLuks}\" mountpoint=\"${user.home}\" />\n";
-        in
-         pkgs.writeText "pam_mount.conf.xml" ''
-          <?xml version="1.0" encoding="utf-8" ?>
-          <!DOCTYPE pam_mount SYSTEM "pam_mount.conf.xml.dtd">
-          <!-- auto generated from Nixos: modules/config/users-groups.nix -->
-          <pam_mount>
-          <debug enable="0" />
+    environment.etc."security/pam_mount.conf.xml".source =
+      let
+        extraUserVolumes = filterAttrs (n: u: u.cryptHomeLuks != null) config.users.users;
+        userVolumeEntry = user: "<volume user=\"${user.name}\" path=\"${user.cryptHomeLuks}\" mountpoint=\"${user.home}\" />\n";
+      in
+      pkgs.writeText "pam_mount.conf.xml" ''
+        <?xml version="1.0" encoding="utf-8" ?>
+        <!DOCTYPE pam_mount SYSTEM "pam_mount.conf.xml.dtd">
+        <!-- auto generated from Nixos: modules/config/users-groups.nix -->
+        <pam_mount>
+        <debug enable="0" />
 
-          ${concatStrings (map userVolumeEntry (attrValues extraUserVolumes))}
-          ${concatStringsSep "\n" cfg.extraVolumes}
+        ${concatStrings (map userVolumeEntry (attrValues extraUserVolumes))}
+        ${concatStringsSep "\n" cfg.extraVolumes}
 
-          <!-- if activated, requires ofl from hxtools to be present -->
-          <logout wait="0" hup="no" term="no" kill="no" />
-          <!-- set PATH variable for pam_mount module -->
-          <path>${pkgs.utillinux}/bin</path>
-          <!-- create mount point if not present -->
-          <mkmountpoint enable="1" remove="true" />
+        <!-- if activated, requires ofl from hxtools to be present -->
+        <logout wait="0" hup="no" term="no" kill="no" />
+        <!-- set PATH variable for pam_mount module -->
+        <path>${pkgs.utillinux}/bin</path>
+        <!-- create mount point if not present -->
+        <mkmountpoint enable="1" remove="true" />
 
-          <!-- specify the binaries to be called -->
-          <cryptmount>${pkgs.pam_mount}/bin/mount.crypt %(VOLUME) %(MNTPT)</cryptmount>
-          <cryptumount>${pkgs.pam_mount}/bin/umount.crypt %(MNTPT)</cryptumount>
-          <pmvarrun>${pkgs.pam_mount}/bin/pmvarrun -u %(USER) -o %(OPERATION)</pmvarrun>
-          </pam_mount>
-          '';
-    }];
+        <!-- specify the binaries to be called -->
+        <cryptmount>${pkgs.pam_mount}/bin/mount.crypt %(VOLUME) %(MNTPT)</cryptmount>
+        <cryptumount>${pkgs.pam_mount}/bin/umount.crypt %(MNTPT)</cryptumount>
+        <pmvarrun>${pkgs.pam_mount}/bin/pmvarrun -u %(USER) -o %(OPERATION)</pmvarrun>
+        </pam_mount>
+      '';
 
   };
 }

--- a/nixos/modules/security/sudo.nix
+++ b/nixos/modules/security/sudo.nix
@@ -212,7 +212,7 @@ in
 
     security.pam.services.sudo = { sshAgentAuth = true; };
 
-    environment.etc = singleton
+    environment.etc."sudoers" =
       { source =
           pkgs.runCommand "sudoers"
           {
@@ -222,7 +222,6 @@ in
           # Make sure that the sudoers file is syntactically valid.
           # (currently disabled - NIXOS-66)
           "${pkgs.buildPackages.sudo}/sbin/visudo -f $src -c && cp $src $out";
-        target = "sudoers";
         mode = "0440";
       };
 

--- a/nixos/modules/services/audio/alsa.nix
+++ b/nixos/modules/services/audio/alsa.nix
@@ -87,12 +87,7 @@ in
 
     environment.systemPackages = [ alsaUtils ];
 
-    environment.etc = mkIf (!pulseaudioEnabled && config.sound.extraConfig != "")
-      [
-        { source = pkgs.writeText "asound.conf" config.sound.extraConfig;
-          target = "asound.conf";
-        }
-      ];
+    environment.etc."asound.conf".text = mkIf (!pulseaudioEnabled && config.sound.extraConfig != "") config.sound.extraConfig;
 
     # ALSA provides a udev rule for restoring volume settings.
     services.udev.packages = [ alsaUtils ];

--- a/nixos/modules/services/hardware/bluetooth.nix
+++ b/nixos/modules/services/hardware/bluetooth.nix
@@ -59,15 +59,12 @@ in {
 
     environment.systemPackages = [ bluez-bluetooth pkgs.openobex pkgs.obexftp ];
 
-    environment.etc = singleton {
-      source = pkgs.writeText "main.conf" ''
-        [Policy]
-        AutoEnable=${lib.boolToString cfg.powerOnBoot}
+    environment.etc."bluetooth/main.conf".source = pkgs.writeText "main.conf" ''
+      [Policy]
+      AutoEnable=${lib.boolToString cfg.powerOnBoot}
 
-        ${cfg.extraConfig}
-      '';
-      target = "bluetooth/main.conf";
-    };
+      ${cfg.extraConfig}
+    '';
 
     services.udev.packages = [ bluez-bluetooth ];
     services.dbus.packages = [ bluez-bluetooth ];

--- a/nixos/modules/services/hardware/sane_extra_backends/brscan4.nix
+++ b/nixos/modules/services/hardware/sane_extra_backends/brscan4.nix
@@ -67,11 +67,11 @@ in
 {
   options = {
 
-    hardware.sane.brscan4.enable = 
+    hardware.sane.brscan4.enable =
       mkEnableOption "Brother's brscan4 scan backend" // {
       description = ''
         When enabled, will automatically register the "brscan4" sane
-        backend and bring configuration files to their expected location. 
+        backend and bring configuration files to their expected location.
       '';
     };
 
@@ -95,14 +95,11 @@ in
       pkgs.brscan4
     ];
 
-    environment.etc = singleton {
-      target = "opt/brother/scanner/brscan4";
-      source = "${etcFiles}/etc/opt/brother/scanner/brscan4";
-    };
+    environment.etc."opt/brother/scanner/brscan4".source = "${etcFiles}/etc/opt/brother/scanner/brscan4";
 
     assertions = [
       { assertion = all (x: !(null != x.ip && null != x.nodename)) netDeviceList;
-          
+
         message = ''
           When describing a network device as part of the attribute list
           `hardware.sane.brscan4.netDevices`, only one of its `ip` or `nodename`

--- a/nixos/modules/services/hardware/tlp.nix
+++ b/nixos/modules/services/hardware/tlp.nix
@@ -103,13 +103,10 @@ in
 
     services.udev.packages = [ tlp ];
 
-    environment.etc = [{ source = confFile;
-                         target = "default/tlp";
-                       }
-                      ] ++ optional enableRDW {
-                        source = "${tlp}/etc/NetworkManager/dispatcher.d/99tlp-rdw-nm";
-                        target = "NetworkManager/dispatcher.d/99tlp-rdw-nm";
-                      };
+    environment.etc = {
+      "default/tlp".source = confFile;
+      "NetworkManager/dispatcher.d/99tlp-rdw-nm" = mkIf enableRDW "${tlp}/etc/NetworkManager/dispatcher.d/99tlp-rdw-nm";
+    };
 
     environment.systemPackages = [ tlp ];
 

--- a/nixos/modules/services/hardware/udev.nix
+++ b/nixos/modules/services/hardware/udev.nix
@@ -280,14 +280,10 @@ in
 
     boot.kernelParams = mkIf (!config.networking.usePredictableInterfaceNames) [ "net.ifnames=0" ];
 
-    environment.etc =
-      [ { source = udevRules;
-          target = "udev/rules.d";
-        }
-        { source = hwdbBin;
-          target = "udev/hwdb.bin";
-        }
-      ];
+    environment.etc = {
+      "udev/rules.d".source = udevRules;
+      "udev/hwdb.bin".source = hwdbBin;
+    };
 
     system.requiredKernelConfig = with config.lib.kernelConfig; [
       (isEnabled "UNIX")

--- a/nixos/modules/services/mail/postfix.nix
+++ b/nixos/modules/services/mail/postfix.nix
@@ -612,10 +612,7 @@ in
     {
 
       environment = {
-        etc = singleton
-          { source = "/var/lib/postfix/conf";
-            target = "postfix";
-          };
+        etc."postfix".source = "/var/lib/postfix/conf";
 
         # This makes it comfortable to run 'postqueue/postdrop' for example.
         systemPackages = [ pkgs.postfix ];

--- a/nixos/modules/services/mail/spamassassin.nix
+++ b/nixos/modules/services/mail/spamassassin.nix
@@ -124,7 +124,7 @@ in
     # Allow users to run 'spamc'.
 
     environment = {
-      etc = singleton { source = spamdEnv; target = "spamassassin"; };
+      etc."spamassassin".source = spamdEnv;
       systemPackages = [ pkgs.spamassassin ];
     };
 

--- a/nixos/modules/services/monitoring/nagios.nix
+++ b/nixos/modules/services/monitoring/nagios.nix
@@ -152,11 +152,7 @@ in
 
     # This isn't needed, it's just so that the user can type "nagiostats
     # -c /etc/nagios.cfg".
-    environment.etc = [
-      { source = cfg.mainConfigFile;
-        target = "nagios.cfg";
-      }
-    ];
+    environment.etc."nagios.cfg".source = cfg.mainConfigFile;
 
     environment.systemPackages = [ pkgs.nagios ];
     systemd.services.nagios = {

--- a/nixos/modules/services/monitoring/ups.nix
+++ b/nixos/modules/services/monitoring/ups.nix
@@ -214,40 +214,27 @@ in
       environment.NUT_STATEPATH = "/var/lib/nut/";
     };
 
-    environment.etc = [
-      { source = pkgs.writeText "nut.conf"
-        ''
-          MODE = ${cfg.mode}
-        '';
-        target = "nut/nut.conf";
-      }
-      { source = pkgs.writeText "ups.conf"
-        ''
-          maxstartdelay = ${toString cfg.maxStartDelay}
+    environment.etc = {
+      "nut/nut.conf".text = ''
+        MODE = ${cfg.mode}
+      '';
+      "nut/ups.conf".text = ''
+        maxstartdelay = ${toString cfg.maxStartDelay}
 
-          ${flip concatStringsSep (forEach (attrValues cfg.ups) (ups: ups.summary)) "
+        ${flip concatStringsSep (forEach (attrValues cfg.ups) (ups: ups.summary)) "
 
-          "}
-        '';
-        target = "nut/ups.conf";
-      }
-      { source = cfg.schedulerRules;
-        target = "nut/upssched.conf";
-      }
+        "}
+      '';
+      "nut/upssched.conf".source = cfg.schedulerRules;
+
       # These file are containing private informations and thus should not
       # be stored inside the Nix store.
       /*
-      { source = ;
-        target = "nut/upsd.conf";
-      }
-      { source = ;
-        target = "nut/upsd.users";
-      }
-      { source = ;
-        target = "nut/upsmon.conf;
-      }
+      "nut/upsd.conf".source = ;
+      "nut/upsd.users".source = ;
+      "nut/upsmon.conf".source = ;
       */
-    ];
+    };
 
     power.ups.schedulerRules = mkDefault "${pkgs.nut}/etc/upssched.conf.sample";
 

--- a/nixos/modules/services/network-filesystems/drbd.nix
+++ b/nixos/modules/services/network-filesystems/drbd.nix
@@ -47,10 +47,7 @@ let cfg = config.services.drbd; in
         options drbd usermode_helper=/run/current-system/sw/bin/drbdadm
       '';
 
-    environment.etc = singleton
-      { source = pkgs.writeText "drbd.conf" cfg.config;
-        target = "drbd.conf";
-      };
+    environment.etc."drbd.conf".text = cfg.config;
 
     systemd.services.drbd = {
       after = [ "systemd-udev.settle.service" "network.target" ];

--- a/nixos/modules/services/networking/dhcpcd.nix
+++ b/nixos/modules/services/networking/dhcpcd.nix
@@ -185,11 +185,7 @@ in
 
     environment.systemPackages = [ dhcpcd ];
 
-    environment.etc =
-      [ { source = exitHook;
-          target = "dhcpcd.exit-hook";
-        }
-      ];
+    environment.etc."dhcpcd.exit-hook".source = exitHook;
 
     powerManagement.resumeCommands = mkIf config.systemd.services.dhcpcd.enable
       ''

--- a/nixos/modules/services/scheduling/fcron.nix
+++ b/nixos/modules/services/scheduling/fcron.nix
@@ -21,11 +21,11 @@ let
     '';
 
   allowdeny = target: users:
-    { source = pkgs.writeText "fcron.${target}" (concatStringsSep "\n" users);
-      target = "fcron.${target}";
-      mode = "644";
-      gid = config.ids.gids.fcron;
-    };
+  {
+    source = pkgs.writeText "fcron.${target}" (concatStringsSep "\n" users);
+    mode = "644";
+    gid = config.ids.gids.fcron;
+  };
 
 in
 
@@ -86,33 +86,33 @@ in
 
     services.fcron.systab = systemCronJobs;
 
-    environment.etc =
-      [ (allowdeny "allow" (cfg.allow))
-        (allowdeny "deny" cfg.deny)
-        # see man 5 fcron.conf
-        { source =
-            let
-              isSendmailWrapped =
-                lib.hasAttr "sendmail" config.security.wrappers;
+    environment.etc = {
+      "fcron.allow" = allowdeny "allow" cfg.allow;
+      "fcron.deny" = allowdeny "deny" cfg.deny;
+      # see man 5 fcron.conf
+      "fcron.conf" = {
+        source =
+          let
+            isSendmailWrapped =
+              lib.hasAttr "sendmail" config.security.wrappers;
               sendmailPath =
                 if isSendmailWrapped then "/run/wrappers/bin/sendmail"
                 else "${config.system.path}/bin/sendmail";
-            in
-            pkgs.writeText "fcron.conf" ''
-              fcrontabs   =       /var/spool/fcron
-              pidfile     =       /run/fcron.pid
-              fifofile    =       /run/fcron.fifo
-              fcronallow  =       /etc/fcron.allow
-              fcrondeny   =       /etc/fcron.deny
-              shell       =       /bin/sh
-              sendmail    =       ${sendmailPath}
-              editor      =       ${pkgs.vim}/bin/vim
-            '';
-          target = "fcron.conf";
+          in
+          pkgs.writeText "fcron.conf" ''
+            fcrontabs   =       /var/spool/fcron
+            pidfile     =       /run/fcron.pid
+            fifofile    =       /run/fcron.fifo
+            fcronallow  =       /etc/fcron.allow
+            fcrondeny   =       /etc/fcron.deny
+            shell       =       /bin/sh
+            sendmail    =       ${sendmailPath}
+            editor      =       ${pkgs.vim}/bin/vim
+          '';
           gid = config.ids.gids.fcron;
           mode = "0644";
-        }
-      ];
+      };
+    };
 
     environment.systemPackages = [ pkgs.fcron ];
     users.users.fcron = {

--- a/nixos/modules/services/security/fprot.nix
+++ b/nixos/modules/services/security/fprot.nix
@@ -48,10 +48,7 @@ in {
     services.fprot.updater.licenseKeyfile = mkDefault "${pkgs.fprot}/opt/f-prot/license.key";
 
     environment.systemPackages = [ pkgs.fprot ];
-    environment.etc = singleton {
-      source = "${pkgs.fprot}/opt/f-prot/f-prot.conf";
-      target = "f-prot.conf";
-    };
+    environment.etc."f-prot.conf".source = "${pkgs.fprot}/opt/f-prot/f-prot.conf";
 
     users.users = singleton
       { name = fprotUser;

--- a/nixos/modules/services/security/torsocks.nix
+++ b/nixos/modules/services/security/torsocks.nix
@@ -112,10 +112,6 @@ in
   config = mkIf cfg.enable {
     environment.systemPackages = [ pkgs.torsocks (wrapTorsocks "torsocks-faster" cfg.fasterServer) ];
 
-    environment.etc =
-      [ { source = pkgs.writeText "torsocks.conf" (configFile cfg.server);
-          target = "tor/torsocks.conf";
-        }
-      ];
+    environment.etc."tor/torsocks.conf".text = configFile cfg.server;
   };
 }

--- a/nixos/modules/services/system/dbus.nix
+++ b/nixos/modules/services/system/dbus.nix
@@ -66,10 +66,7 @@ in
 
     environment.systemPackages = [ pkgs.dbus.daemon pkgs.dbus ];
 
-    environment.etc = singleton
-      { source = configDir;
-        target = "dbus-1";
-      };
+    environment.etc."dbus-1".source = configDir;
 
     users.users.messagebus = {
       uid = config.ids.uids.messagebus;

--- a/nixos/modules/services/ttys/agetty.nix
+++ b/nixos/modules/services/ttys/agetty.nix
@@ -102,16 +102,13 @@ in
         enable = mkDefault config.boot.isContainer;
       };
 
-    environment.etc = singleton
-      { # Friendly greeting on the virtual consoles.
-        source = pkgs.writeText "issue" ''
+    # Friendly greeting on the virtual consoles.
+    environment.etc."issue".text = ''
 
-          [1;32m${config.services.mingetty.greetingLine}[0m
-          ${config.services.mingetty.helpLine}
+      [1;32m${config.services.mingetty.greetingLine}[0m
+      ${config.services.mingetty.helpLine}
 
-        '';
-        target = "issue";
-      };
+    '';
 
   };
 

--- a/nixos/modules/services/x11/desktop-managers/enlightenment.nix
+++ b/nixos/modules/services/x11/desktop-managers/enlightenment.nix
@@ -68,10 +68,7 @@ in
 
     security.wrappers = (import "${e.enlightenment}/e-wrappers.nix").security.wrappers;
 
-    environment.etc = singleton
-      { source = xcfg.xkbDir;
-        target = "X11/xkb";
-      };
+    environment.etc."X11/xkb".source = xcfg.xkbDir;
 
     fonts.fonts = [ pkgs.dejavu_fonts pkgs.ubuntu_font_family ];
 

--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -190,10 +190,7 @@ in
         "/share"
       ];
 
-      environment.etc = singleton {
-        source = xcfg.xkbDir;
-        target = "X11/xkb";
-      };
+      environment.etc."X11/xkb".source = xcfg.xkbDir;
 
       # Enable GTK applications to load SVG icons
       services.xserver.gdk-pixbuf.modulePackages = [ pkgs.librsvg ];

--- a/nixos/modules/services/x11/hardware/libinput.nix
+++ b/nixos/modules/services/x11/hardware/libinput.nix
@@ -2,8 +2,9 @@
 
 with lib;
 
-let cfg = config.services.xserver.libinput;
-    xorgBool = v: if v then "on" else "off";
+let
+  cfg = config.services.xserver.libinput;
+  xorgBool = v: if v then "on" else "off";
 in {
 
   options = {
@@ -198,12 +199,7 @@ in {
 
     environment.systemPackages = [ pkgs.xorg.xf86inputlibinput ];
 
-    environment.etc = [
-      (let cfgPath = "X11/xorg.conf.d/40-libinput.conf"; in {
-        source = pkgs.xorg.xf86inputlibinput.out + "/share/" + cfgPath;
-        target = cfgPath;
-      })
-    ];
+    environment.etc."X11/xorg.conf.d/40-libinput.conf".source = pkgs.xorg.xf86inputlibinput.out + "/share/X11/xorg.conf.d/40-libinput.conf";
 
     services.udev.packages = [ pkgs.libinput.out ];
 

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -588,39 +588,25 @@ in
       })
     ];
 
-    environment.etc =
-      (optionals cfg.exportConfiguration
-        [ { source = "${configFile}";
-            target = "X11/xorg.conf";
-          }
-          # -xkbdir command line option does not seems to be passed to xkbcomp.
-          { source = "${cfg.xkbDir}";
-            target = "X11/xkb";
-          }
-        ])
+    environment.etc = {
       # localectl looks into 00-keyboard.conf
-      ++ [
-        {
-          text = ''
-            Section "InputClass"
-              Identifier "Keyboard catchall"
-              MatchIsKeyboard "on"
-              Option "XkbModel" "${cfg.xkbModel}"
-              Option "XkbLayout" "${cfg.layout}"
-              Option "XkbOptions" "${cfg.xkbOptions}"
-              Option "XkbVariant" "${cfg.xkbVariant}"
-            EndSection
-          '';
-          target = "X11/xorg.conf.d/00-keyboard.conf";
-        }
-      ]
+      "X11/xorg.conf.d/00-keyboard.conf".text = ''
+        Section "InputClass"
+        Identifier "Keyboard catchall"
+        MatchIsKeyboard "on"
+        Option "XkbModel" "${cfg.xkbModel}"
+        Option "XkbLayout" "${cfg.layout}"
+        Option "XkbOptions" "${cfg.xkbOptions}"
+        Option "XkbVariant" "${cfg.xkbVariant}"
+        EndSection
+      '';
       # Needed since 1.18; see https://bugs.freedesktop.org/show_bug.cgi?id=89023#c5
-      ++ (let cfgPath = "/X11/xorg.conf.d/10-evdev.conf"; in
-        [{
-          source = xorg.xf86inputevdev.out + "/share" + cfgPath;
-          target = cfgPath;
-        }]
-      );
+      "/X11/xorg.conf.d/10-evdev.conf".source = xorg.xf86inputevdev.out + "/share/X11/xorg.conf.d/10-evdev.conf";
+    } // optionalAttrs cfg.exportConfiguration {
+      "X11/xorg.conf".source = "${configFile}";
+      # -xkbdir command line option does not seems to be passed to xkbcomp.
+      "X11/xkb".source = "${cfg.xkbDir}";
+    };
 
     environment.systemPackages =
       [ xorg.xorgserver.out

--- a/nixos/modules/system/boot/kernel.nix
+++ b/nixos/modules/system/boot/kernel.nix
@@ -256,10 +256,7 @@ in
 
     # Create /etc/modules-load.d/nixos.conf, which is read by
     # systemd-modules-load.service to load required kernel modules.
-    environment.etc = singleton
-      { target = "modules-load.d/nixos.conf";
-        source = kernelModulesConf;
-      };
+    environment.etc."modules-load.d/nixos.conf".source = kernelModulesConf;
 
     systemd.services."systemd-modules-load" =
       { wantedBy = [ "multi-user.target" ];

--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -872,10 +872,10 @@ let
         '';
     };
 
-  unitFiles = map (name: {
-    target = "systemd/network/${name}";
-    source = "${cfg.units.${name}.unit}/${name}";
-  }) (attrNames cfg.units);
+  unitFiles = mapAttrs' (name: value: nameValuePair
+    "systemd/network/${name}"
+    { source = "${cfg.units.${name}.unit}/${name}";
+    }) cfg.units;
 in
 
 {
@@ -936,7 +936,7 @@ in
 
     systemd.services.systemd-networkd = {
       wantedBy = [ "multi-user.target" ];
-      restartTriggers = map (f: f.source) (unitFiles);
+      restartTriggers = map (f: f.source) (attrValues unitFiles);
       # prevent race condition with interface renaming (#39069)
       requires = [ "systemd-udev-settle.service" ];
       after = [ "systemd-udev-settle.service" ];

--- a/nixos/modules/system/etc/etc.nix
+++ b/nixos/modules/system/etc/etc.nix
@@ -46,7 +46,7 @@ in
         Set of files that have to be linked in <filename>/etc</filename>.
       '';
 
-      type = with types; loaOf (submodule (
+      type = with types; attrsOf (submodule (
         { name, config, ... }:
         { options = {
 

--- a/nixos/modules/virtualisation/xen-dom0.nix
+++ b/nixos/modules/virtualisation/xen-dom0.nix
@@ -227,27 +227,16 @@ in
       ];
 
 
-    environment.etc =
-      [ { source = "${cfg.package}/etc/xen/xl.conf";
-          target = "xen/xl.conf";
-        }
-        { source = "${cfg.package}/etc/xen/scripts";
-          target = "xen/scripts";
-        }
-        { text = ''
+    environment.etc = {
+      "xen/xl.conf".source = "${cfg.package}/etc/xen/xl.conf";
+      "xen/scripts".source = "${cfg.package}/etc/xen/scripts";
+      "default/xendomains".text = ''
             source ${cfg.package}/etc/default/xendomains
 
             ${cfg.domains.extraConfig}
           '';
-          target = "default/xendomains";
-        }
-      ]
-      ++ lib.optionals (builtins.compareVersions cfg.package.version "4.10" >= 0) [
-        # in V 4.10 oxenstored requires /etc/xen/oxenstored.conf to start
-        { source = "${cfg.package}/etc/xen/oxenstored.conf";
-          target = "xen/oxenstored.conf";
-        }
-      ];
+      "xen/oxenstored.conf".source = mkIf (builtins.compareVersions cfg.package.version "4.10" >= 0) "${cfg.package}/etc/xen/oxenstored.conf";  # in V 4.10 oxenstored requires /etc/xen/oxenstored.conf to start
+    };
 
     # Xen provides udev rules.
     services.udev.packages = [ cfg.package ];


### PR DESCRIPTION
###### Motivation for this change
Having `environment.etc` set using a list makes it very hard to override with `mkForce`
see: https://logs.nix.samueldr.com/nixos/2019-08-25#2523375;

###### Things done
Changed the type of `environment.etc` to `attrsOf` and changed every instance of it being set with a list in nixos

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @aanderse @cleverca22 

I'm sure there are a lot of mistakes in what I've done, especially with `mapAttrs'`. Is there any way to go about checking this automatically?
Also I expect my commit names aren't very good or maybe they should be squashed, I'm happy to rebase if someone suggests something better
