### PR TITLE
wev: init at 2019-08-11

### DIFF
--- a/pkgs/tools/misc/wev/default.nix
+++ b/pkgs/tools/misc/wev/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchurl
+, pkg-config, scdoc
+, wayland, wayland-protocols, libxkbcommon
+}:
+
+let
+  version = "2019-08-11";
+  commit = "47d17393473be152cf601272faf5704fff1c3f92";
+in stdenv.mkDerivation {
+  pname = "wev-unstable";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://git.sr.ht/~sircmpwn/wev/archive/${commit}.tar.gz";
+    sha256 = "0a5kvrviz77bf7357gqs2iy7a1bvb3izgkmiv1rdxzzmihd563ga";
+  };
+
+  nativeBuildInputs = [ pkg-config scdoc ];
+  buildInputs = [ wayland wayland-protocols libxkbcommon ];
+
+  installFlags = [ "PREFIX=$(out)" ];
+
+  meta = with stdenv.lib; {
+    description = "Wayland event viewer";
+    longDescription = ''
+      This is a tool for debugging events on a Wayland window, analagous to the
+      X11 tool xev.
+    '';
+    homepage = https://git.sr.ht/~sircmpwn/wev;
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ primeos ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2804,6 +2804,8 @@ in
 
   wallutils = callPackage ../tools/graphics/wallutils { };
 
+  wev = callPackage ../tools/misc/wev { };
+
   wl-clipboard = callPackage ../tools/misc/wl-clipboard { };
 
   z-lua = callPackage ../tools/misc/z-lua { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add a useful tool to debug events on Wayland (hesitated a bit as there is no release yet, but IMO it makes sense to have a Wayland equivalent to exv).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
