### PR TITLE
emacs-irony: fix build

### DIFF
--- a/pkgs/applications/editors/emacs-modes/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/melpa-packages.nix
@@ -131,20 +131,20 @@ env NIXPKGS_ALLOW_BROKEN=1 nix-instantiate --show-trace ../../../../ -A emacsPac
         # upstream issue: missing file header
         initsplit = markBroken super.initsplit;
 
-        irony = super.irony.overrideAttrs(old: {
+        irony = super.irony.overrideAttrs (old: {
+          cmakeFlags = old.cmakeFlags or [] ++ [ "-DCMAKE_INSTALL_BINDIR=bin" ];
           preConfigure = ''
             cd server
           '';
           preBuild = ''
             make
+            install -D bin/irony-server $out/bin/irony-server
+            cd ..
           '';
-          postInstall = ''
-            mkdir -p $out
-            mv $out/share/emacs/site-lisp/elpa/*/server/bin $out
-            rm -rf $out/share/emacs/site-lisp/elpa/*/server
-          '';
-          preCheck = ''
+          checkPhase = ''
             cd source/server
+            make check
+            cd ../..
           '';
           dontUseCmakeBuildDir = true;
           doCheck = true;
@@ -395,13 +395,6 @@ env NIXPKGS_ALLOW_BROKEN=1 nix-instantiate --show-trace ../../../../ -A emacsPac
 
         # Expects bash to be at /bin/bash
         helm-rtags = markBroken super.helm-rtags;
-
-        # Fails with "package does not untar cleanly into ..."
-        irony = shared.irony.overrideAttrs(old: {
-          meta = old.meta // {
-            broken = true;
-          };
-        });
 
         orgit =
           (super.orgit.overrideAttrs (attrs: {

--- a/pkgs/applications/editors/emacs-modes/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/melpa-packages.nix
@@ -33,8 +33,6 @@ env NIXPKGS_ALLOW_BROKEN=1 nix-instantiate --show-trace ../../../../ -A emacsPac
     inherit (import ./libgenerated.nix lib self) melpaDerivation;
     super = lib.listToAttrs (map (melpaDerivation variant) (lib.importJSON archiveJson));
 
-    generic = import ./melpa-generic.nix;
-
     overrides = rec {
       shared = {
         # Expects bash to be at /bin/bash


### PR DESCRIPTION
Fixes #66556

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
