### PR TITLE
nixos-generate-config: Add system.copySystemConfiguration = true

### DIFF
--- a/nixos/modules/installer/tools/tools.nix
+++ b/nixos/modules/installer/tools/tools.nix
@@ -157,6 +157,12 @@ in
         #   extraGroups = [ "wheel" ]; # Enable ‘sudo’ for the user.
         # };
 
+        # With this option enabled, if you accidentally remove this file you can
+        # still recover it from
+        # - /run/current-system/configuration.nix (last one)
+        # - /nix/var/nix/profiles/system-*/configuration.nix (old versions)
+        system.copySystemConfiguration = true;
+
         # This value determines the NixOS release with which your system is to be
         # compatible, in order to avoid breaking some software such as database
         # servers. You should change this only after NixOS release notes say you


### PR DESCRIPTION
#### Motivation for this change

This will be useful for the many people who accidentally delete their
configuration.nix file.

The alternative of changing the default of this option to true won't
work well because for some NixOS build, we can't assume for the
configuration file to be at the standard location. E.g. in nixops,
<nixos-config> will point to something completely different than what
the nixops evaluation thinks, therefore leaking the nixops deploy users
config into the deployment machines. See also https://github.com/NixOS/nixpkgs/pull/16922

This continues https://github.com/NixOS/nixpkgs/pull/24707

In the future we might want to add an option like `system.copySystemConfigurationDir = ./.` which would copy the whole directory the configuration is in.

Ping @danbst @techhazard @bobvanderlinden @ryantrinkle @vcunat 

#### Things done

- [x] Tested that it works with
```diff
diff --git a/nixos/tests/installer.nix b/nixos/tests/installer.nix
index a136678c6ef..4599d01e1ef 100644
--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -754,4 +754,13 @@ in {
     '';
   };
 
+  copySystemConfig = makeInstallerTest "copySystemConfig" (simple-test-config // {
+    extraConfig = ''
+      system.copySystemConfiguration = true;
+    '';
+    preBootCommands = ''
+      $machine->succeed("test -e /run/current-system/configuration.nix");
+    '';
+  });
+
 }
```

I don't think it's worth including this as another NixOS test though