### PR TITLE
 ansible: 2.8.2 -> 2.8.4 

### DIFF
--- a/pkgs/development/python-modules/ansible/default.nix
+++ b/pkgs/development/python-modules/ansible/default.nix
@@ -1,5 +1,5 @@
 { lib
-, fetchurl
+, fetchFromGitHub
 , buildPythonPackage
 , pycrypto
 , paramiko
@@ -18,11 +18,13 @@
 
 buildPythonPackage rec {
   pname = "ansible";
-  version = "2.8.2";
+  version = "2.8.4";
 
-  src = fetchurl {
-    url = "https://releases.ansible.com/ansible/${pname}-${version}.tar.gz";
-    sha256 = "1e5ba829ca0602c55b33da399b06f99b135a34014b661d1c36d8892a1e2d3730";
+  src = fetchFromGitHub {
+    owner = "ansible";
+    repo = "ansible";
+    rev = "v${version}";
+    sha256 = "1fp7zz8awfv70nn8i6x0ggx4472377hm7787x16qv2kz4nb069ki";
   };
 
   prePatch = ''

--- a/pkgs/development/python-modules/pytest-ansible/default.nix
+++ b/pkgs/development/python-modules/pytest-ansible/default.nix
@@ -1,6 +1,6 @@
 { stdenv
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , ansible
 , pytest
 , mock
@@ -8,11 +8,13 @@
 
 buildPythonPackage rec {
   pname = "pytest-ansible";
-  version = "2.0.2";
+  version = "2.1.1";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "d69d89cbcf29e587cbe6ec4b229346edbf027d3c04944dd7bcbf3d7bba46348f";
+  src = fetchFromGitHub {
+    owner = "ansible";
+    repo = "pytest-ansible";
+    rev = "v${version}";
+    sha256 = "0v97sqk3q2vkmwnjlnncz8ss8086x9jg3cz0g2nzlngs4ql1gdb0";
   };
 
   patchPhase = ''
@@ -24,11 +26,11 @@ buildPythonPackage rec {
   checkInputs =  [ mock ];
   propagatedBuildInputs = [ ansible pytest ];
 
-  # tests not included with release
+  # tests not included with release, even on github
   doCheck = false;
 
   checkPhase = ''
-    pytest
+    HOME=$TMPDIR pytest tests/
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
fixing @r-ryantm updates

###### Things done


- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @costrouc 
