### PR TITLE
botan2: 2.7 -> 2.11

### DIFF
--- a/pkgs/development/libraries/botan/2.0.nix
+++ b/pkgs/development/libraries/botan/2.0.nix
@@ -1,9 +1,9 @@
 { callPackage, ... } @ args:
 
 callPackage ./generic.nix (args // {
-  baseVersion = "2.7";
+  baseVersion = "2.11";
   revision = "0";
-  sha256 = "142aqabwc266jxn8wrp0f1ffrmcvdxwvyh8frb38hx9iaqazjbg4";
+  sha256 = "0bwndamxfn34f7igkpmc8zs7xf52qwsjbykjm53583wxnff9cyra";
   postPatch = ''
     sed -e 's@lang_flags "@&--std=c++11 @' -i src/build-data/cc/{gcc,clang}.txt
   '';

--- a/pkgs/development/libraries/botan/2.0.nix
+++ b/pkgs/development/libraries/botan/2.0.nix
@@ -1,9 +1,8 @@
 { callPackage, ... } @ args:
 
 callPackage ./generic.nix (args // {
-  baseVersion = "2.11";
-  revision = "0";
-  sha256 = "0bwndamxfn34f7igkpmc8zs7xf52qwsjbykjm53583wxnff9cyra";
+  version = "2.11.0";
+  sha256 = "19pqpxbdrjyglbx9c0z8m98vj4bbidn66pkysjabyqx71596r2ah";
   postPatch = ''
     sed -e 's@lang_flags "@&--std=c++11 @' -i src/build-data/cc/{gcc,clang}.txt
   '';

--- a/pkgs/development/libraries/botan/default.nix
+++ b/pkgs/development/libraries/botan/default.nix
@@ -1,9 +1,8 @@
 { callPackage, ... } @ args:
 
 callPackage ./generic.nix (args // {
-  baseVersion = "1.10";
-  revision = "17";
-  sha256 = "04rnha712dd3sdb2q7k2yw45sf405jyigk7yrjfr6bwd9fvgyiv8";
+  version = "1.10.17";
+  sha256 = "10807mx31vl1ql2bjq8j9mffx7yrh1rppy9k6nbhnc3b0z7nhwgm";
   extraConfigureFlags = "--with-gnump";
   postPatch = ''
     sed -e 's@lang_flags "@&--std=c++11 @' -i src/build-data/cc/{gcc,clang}.txt

--- a/pkgs/development/libraries/botan/generic.nix
+++ b/pkgs/development/libraries/botan/generic.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, python, bzip2, zlib, gmp, openssl, boost
+{ stdenv, fetchFromGitHub, python, bzip2, zlib, gmp, openssl, boost
 # Passed by version specific builders
-, baseVersion, revision, sha256
+, version, sha256
 , extraConfigureFlags ? ""
 , postPatch ? null
 , darwin
@@ -9,17 +9,15 @@
 
 stdenv.mkDerivation rec {
   pname = "botan";
-  version = "${baseVersion}.${revision}";
+  inherit version;
 
-  src = fetchurl {
-    name = "Botan-${version}.tgz";
-    urls = [
-       "http://files.randombit.net/botan/v${baseVersion}/Botan-${version}.tgz"
-       "http://botan.randombit.net/releases/Botan-${version}.tgz"
-       "https://github.com/randombit/botan/archive/${version}.tar.gz"
-    ];
+  src = fetchFromGitHub {
+    owner = "randombit";
+    repo = "botan";
+    rev = version;
     inherit sha256;
   };
+
   inherit postPatch;
 
   buildInputs = [ python bzip2 zlib gmp openssl boost ]
@@ -49,5 +47,4 @@ stdenv.mkDerivation rec {
     platforms = ["x86_64-linux" "i686-linux" "x86_64-darwin"];
     license = licenses.bsd2;
   };
-  passthru.updateInfo.downloadPage = "http://files.randombit.net/botan/";
 }

--- a/pkgs/development/libraries/botan/generic.nix
+++ b/pkgs/development/libraries/botan/generic.nix
@@ -16,6 +16,7 @@ stdenv.mkDerivation rec {
     urls = [
        "http://files.randombit.net/botan/v${baseVersion}/Botan-${version}.tgz"
        "http://botan.randombit.net/releases/Botan-${version}.tgz"
+       "https://github.com/randombit/botan/archive/${version}.tar.gz"
     ];
     inherit sha256;
   };


### PR DESCRIPTION
###### Motivation for this change
fixing @r-ryantm updates

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

powerdns is broken on master:
```
[3 built (1 failed), 88 copied (2618.7 MiB), 240.2 MiB DL]
error: build of '/nix/store/w9yyvmc9a6vpcqr9c5vi37c518b0f1wg-env.drv' failed
1 package failed to build:
powerdns

4 package were build:
biboumi botan2 kea neopg
```