### PR TITLE
allegro: 5.2.4.0 -> 5.2.5.0

### DIFF
--- a/pkgs/development/libraries/allegro/5.nix
+++ b/pkgs/development/libraries/allegro/5.nix
@@ -8,14 +8,14 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "allegro-${version}";
-  version = "5.2.4.0";
+  pname = "allegro";
+  version = "5.2.5.0";
 
   src = fetchFromGitHub {
     owner = "liballeg";
     repo = "allegro5";
     rev = version;
-    sha256 = "01y3hirn5b08f188nnhb2cbqj4vzysr7l2qpz2208srv8arzmj2d";
+    sha256 = "1jrnizpwznyxz2c7zb75lfy7l51ww5jlqfaahcrycfj1xay9mpqp";
   };
 
   buildInputs = [
@@ -26,14 +26,6 @@ stdenv.mkDerivation rec {
     libXi libXfixes
     enet libtheora freetype physfs libopus pkgconfig gtk2 pcre libXdmcp
     libpulseaudio libpthreadstubs
-  ];
-
-  patches = [
-   # fix compilation with mesa 18.2.5
-   (fetchpatch {
-     url = "https://github.com/liballeg/allegro5/commit/a40d30e21802ecf5c9382cf34af9b01bd3781e47.patch";
-     sha256 = "1f1xlj5y2vr6wzmcz04s8kxn8cfdwrg9kjlnvpz9dix1z3qjnd4m";
-   })
   ];
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change
fixing @r-rytanm updates

ran dwarf-fortress, and it works.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[16 built, 25 copied (515.9 MiB), 360.0 MiB DL]
2 package were build:
allegro5 dwarf-fortress-packages.dwarf-fortress-full
```