### PR TITLE
astyle: use cmake to avoid having to manually manage the build

### DIFF
--- a/pkgs/development/tools/misc/astyle/default.nix
+++ b/pkgs/development/tools/misc/astyle/default.nix
@@ -1,32 +1,26 @@
-{ stdenv, fetchurl }:
+{ stdenv, lib, fetchurl, cmake }:
 
-let
-  name = "astyle";
+stdenv.mkDerivation rec {
+  pname = "astyle";
   version = "3.1";
-in
-stdenv.mkDerivation {
-  name = "${name}-${version}";
 
   src = fetchurl {
-    url = "mirror://sourceforge/${name}/${name}_${version}_linux.tar.gz";
+    url = "mirror://sourceforge/${pname}/${pname}_${version}_linux.tar.gz";
     sha256 = "1ms54wcs7hg1bsywqwf2lhdfizgbk7qxc9ghasxk8i99jvwlrk6b";
   };
 
-  sourceRoot = if stdenv.cc.isClang
-    then "astyle/build/clang"
-    else "astyle/build/gcc";
+  # lots of hardcoded references to /usr
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace ' /usr/' " $out/"
+  '';
 
-  # -s option is obsolete on Darwin and breaks build
-  postPatch = if stdenv.isDarwin then ''
-    substituteInPlace Makefile --replace "LDFLAGSr   = -s" "LDFLAGSr ="
-  '' else null;
+  nativeBuildInputs = [ cmake ];
 
-  installFlags = "INSTALL=install prefix=$$out";
-
-  meta = {
-    homepage = http://astyle.sourceforge.net/;
+  meta = with lib; {
     description = "Source code indenter, formatter, and beautifier for C, C++, C# and Java";
-    license = stdenv.lib.licenses.lgpl3;
-    platforms = stdenv.lib.platforms.unix;
+    homepage = "https://astyle.sourceforge.net/";
+    license = licenses.lgpl3;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
##### Motivation for this change

upstream supports ```cmake``` so use that in order to no longer have special logic for clang/gcc and linux/darwin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).