### PR TITLE
gitAndTools.qgit: 2.8 -> 2.9

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/qgit/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/qgit/default.nix
@@ -1,22 +1,21 @@
-{ stdenv, fetchFromGitHub, cmake, qtbase }:
+{ mkDerivation, lib, fetchFromGitHub, cmake, qtbase }:
 
-stdenv.mkDerivation rec {
-  name = "qgit-2.8";
+mkDerivation rec {
+  pname = "qgit";
+  version = "2.9";
 
   src = fetchFromGitHub {
     owner = "tibirna";
     repo = "qgit";
-    rev = name;
-    sha256 = "01l6mz2f333x3zbfr68mizwpsh6sdsnadcavpasidiych1m5ry8f";
+    rev = "${pname}-${version}";
+    sha256 = "0n4dq9gffm9yd7n5p5qcdfgrmg2kwnfd51hfx10adgj9ibxlnc3z";
   };
 
   buildInputs = [ qtbase ];
 
   nativeBuildInputs = [ cmake ];
 
-  enableParallelBuilding = true;
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     license = licenses.gpl2;
     homepage = https://github.com/tibirna/qgit;
     description = "Graphical front-end to Git";


### PR DESCRIPTION
###### Motivation for this change
Regular update



###### Things done
Cleanup/modernize:

* switch`name` -> `pname`
* qtApps compatibility: use Qt's `mkDerivation`


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @peterhoeg 
