### PR TITLE
pythonPackages.imgaug: 0.3.0-patch

### DIFF
--- a/pkgs/development/python-modules/imgaug/default.nix
+++ b/pkgs/development/python-modules/imgaug/default.nix
@@ -1,30 +1,55 @@
-{ stdenv, buildPythonPackage, fetchPypi, numpy, scipy, scikitimage, opencv3, six }:
+{ buildPythonPackage
+, fetchurl
+, imageio
+, numpy
+, opencv3
+, pytest
+, scikitimage
+, scipy
+, shapely
+, six
+, stdenv
+}:
 
 buildPythonPackage rec {
   pname = "imgaug";
   version = "0.3.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "e1354d41921f1b306b50c5141b4870f17e81b531cae2f5c3093da9dc4dcb3cf4";
+  src = fetchurl {
+    url = "https://github.com/aleju/imgaug/archive/c3d99a420efc45652a1264920dc20378a54b1325.zip";
+    sha256 = "sha256:174nvhyhdn3vz0i34rqmkn26840j3mnfr55cvv5bdf9l4y9bbjq2";
   };
 
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace "opencv-python-headless" ""
+    substituteInPlace setup.py \
+      --replace "opencv-python-headless" "" 
+    substituteInPlace pytest.ini \
+      --replace "--xdoctest --xdoctest-global-exec=\"import imgaug as ia\nfrom imgaug import augmenters as iaa\"" ""
+  '';
+
   propagatedBuildInputs = [
+    imageio
     numpy
-    scipy
-    scikitimage
     opencv3
+    scikitimage
+    scipy
+    shapely
     six
   ];
 
-  # disable tests when there are no tests in the PyPI archive
-  doCheck = false;
+  checkPhase = ''
+     pytest ./test
+  '';
+
+  checkInputs = [ opencv3 pytest ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/aleju/imgaug;
     description = "Image augmentation for machine learning experiments";
     license = licenses.mit;
-    maintainers = with maintainers; [ cmcdragonkai ];
-    broken = true; # opencv-python bindings aren't available yet, and look non-trivial
+    maintainers = with maintainers; [ cmcdragonkai rakesh4g ];
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
Added patch to bypass opencv-python dependency from imgaug

@CMCDragonkai

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @CMCDragonkai @FRidh 
