### PR TITLE
poco, cctz: enable for darwin

### DIFF
--- a/pkgs/development/libraries/cctz/default.nix
+++ b/pkgs/development/libraries/cctz/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub }:
+{ stdenv, fetchFromGitHub, darwin }:
 
 stdenv.mkDerivation rec {
   name = "cctz-${version}";
@@ -13,7 +13,13 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "PREFIX=$(out)" ];
 
+  buildInputs = stdenv.lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Foundation;
+
   installTargets = [ "install_hdrs" "install_shared_lib" ];
+
+  postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
+    install_name_tool -id $out/lib/libcctz.so $out/lib/libcctz.so
+  '';
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/poco/default.nix
+++ b/pkgs/development/libraries/poco/default.nix
@@ -28,6 +28,5 @@ stdenv.mkDerivation rec {
     description = "Cross-platform C++ libraries with a network/internet focus";
     license = licenses.boost;
     maintainers = with maintainers; [ orivej ];
-    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
These were originally part of #62843, but that looks like it's on hold while `clickhouse` fix their darwin build upstream.

Tested on macos 10.13
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
