### PR TITLE
wireshark-cli: remove Qt from build closure

### DIFF
--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, pcre, perl, flex, bison, gettext, libpcap, libnl, c-ares
 , gnutls, libgcrypt, libgpgerror, geoip, openssl, lua5, python3, libcap, glib
-, libssh, nghttp2, zlib, cmake, extra-cmake-modules, fetchpatch, makeWrapper
+, libssh, nghttp2, zlib, cmake, fetchpatch, makeWrapper
 , withQt ? true, qt5 ? null
 , ApplicationServices, SystemConfiguration, gmp
 }:
@@ -29,7 +29,7 @@ in stdenv.mkDerivation {
   ];
 
   nativeBuildInputs = [
-    bison cmake extra-cmake-modules flex pkgconfig
+    bison cmake flex pkgconfig
   ] ++ optional withQt qt5.wrapQtAppsHook;
 
   buildInputs = [


### PR DESCRIPTION
### Motivation

Not sure how it gets into extra-cmake-modules but I saw the following tree on my system:

+---/nix/store/s8abxisr8d5m6mgyqmas52msjzvdc0dn-wireshark-cli-3.0.3.drv
|   + [...]
|   +---/nix/store/izi9ma2lqz7kppswhqkrdh1b98a8a853-extra-cmake-modules-5.58.0.drv
|   |   +---[...]
|   |   +---/nix/store/scgsmlabpvm6r31kps8p7yflwh17q7ns-hook.drv
|   |       +---/nix/store/9krlzvny65gdc8s7kpb6lkx8cd02c25b-default-builder.sh [...]
|   |       +---/nix/store/0iwik51jw5r1a2ffk4q5fmlpbqziwkvi-bash-4.4-p23.drv [...]
|   |       +---/nix/store/8af1a7lnk062h46lfs762pkzbyam5sb3-wrap-qt-apps-hook.sh
|   |       +---/nix/store/lsd5v3xzsskl14fpi4n4a851d7h1g7i3-qtbase-5.12.0.drv
[...]

### Evaluation

Successfully built:
- [x] wireshark-cli
- [x] wireshark