### PR TITLE
treewide: name -> pname

### DIFF
--- a/pkgs/applications/blockchains/ethabi.nix
+++ b/pkgs/applications/blockchains/ethabi.nix
@@ -3,7 +3,7 @@
 with rustPlatform;
 
 buildRustPackage rec {
-  name = "ethabi-${version}";
+  pname = "ethabi";
   version = "7.0.0";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/blockchains/polkadot/default.nix
+++ b/pkgs/applications/blockchains/polkadot/default.nix
@@ -6,7 +6,7 @@
 }:
 
 rustPlatform.buildRustPackage rec {
-  name = "polkadot-${version}";
+  pname = "polkadot";
   version = "0.2.17";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/blockchains/zcash/librustzcash/default.nix
+++ b/pkgs/applications/blockchains/zcash/librustzcash/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, rustPlatform }:
 
 rustPlatform.buildRustPackage rec {
-  name = "librustzcash-unstable-${version}";
+  pname = "librustzcash-unstable";
   version = "2017-03-17";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/gis/whitebox-tools/default.nix
+++ b/pkgs/applications/gis/whitebox-tools/default.nix
@@ -1,6 +1,6 @@
 { stdenv, rustPlatform , fetchFromGitHub, Security }:
 rustPlatform.buildRustPackage rec {
-  name = "whitebox_tools-${version}";
+  pname = "whitebox_tools";
   version = "0.9.0";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/misc/electrum/dash.nix
+++ b/pkgs/applications/misc/electrum/dash.nix
@@ -2,7 +2,7 @@
 
 python2Packages.buildPythonApplication rec {
   version = "2.9.3.1";
-  name = "electrum-dash-${version}";
+  pname = "electrum-dash";
 
   src = fetchurl {
     url = "https://github.com/akhavr/electrum-dash/releases/download/${version}/Electrum-DASH-${version}.tar.gz";

--- a/pkgs/applications/misc/moolticute/default.nix
+++ b/pkgs/applications/misc/moolticute/default.nix
@@ -3,7 +3,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "moolticute-${version}";
+  pname = "moolticute";
   version = "0.30.8";
 
   src = fetchurl {

--- a/pkgs/applications/misc/todiff/default.nix
+++ b/pkgs/applications/misc/todiff/default.nix
@@ -1,7 +1,7 @@
 { stdenv, rustPlatform, fetchFromGitHub }:
 
 rustPlatform.buildRustPackage rec {
-  name = "todiff-${version}";
+  pname = "todiff";
   version = "0.6.1";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/networking/cluster/click/default.nix
+++ b/pkgs/applications/networking/cluster/click/default.nix
@@ -3,7 +3,7 @@
 with rustPlatform;
 
 buildRustPackage rec {
-  name = "click-${version}";
+  pname = "click";
   version = "0.4.2";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/networking/cluster/habitat/default.nix
+++ b/pkgs/applications/networking/cluster/habitat/default.nix
@@ -4,7 +4,7 @@
 with rustPlatform;
 
 buildRustPackage rec {
-  name = "habitat-${version}";
+  pname = "habitat";
   version = "0.30.2";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/networking/dyndns/cfdyndns/default.nix
+++ b/pkgs/applications/networking/dyndns/cfdyndns/default.nix
@@ -3,7 +3,7 @@
 with rustPlatform;
 
 buildRustPackage rec {
-  name = "cfdyndns-${version}";
+  pname = "cfdyndns";
   version = "0.0.1";
   src = fetchFromGitHub {
     owner = "colemickens";

--- a/pkgs/applications/networking/feedreaders/newsboat/default.nix
+++ b/pkgs/applications/networking/feedreaders/newsboat/default.nix
@@ -2,11 +2,11 @@
 , asciidoc, docbook_xml_dtd_45, libxslt, docbook_xsl, libiconv, Security, makeWrapper }:
 
 rustPlatform.buildRustPackage rec {
-  name = "newsboat-${version}";
+  pname = "newsboat";
   version = "2.16.1";
 
   src = fetchurl {
-    url = "https://newsboat.org/releases/${version}/${name}.tar.xz";
+    url = "https://newsboat.org/releases/${version}/${pname}-${version}.tar.xz";
     sha256 = "0lxdsfcwa4byhfnn0gv34w3rr531f4nfqgi8j4qqmh3gncbwh8s0";
   };
 

--- a/pkgs/applications/networking/feedreaders/rawdog/default.nix
+++ b/pkgs/applications/networking/feedreaders/rawdog/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, python2Packages }:
 
 python2Packages.buildPythonApplication rec {
-  name = "rawdog-${version}";
+  pname = "rawdog";
   version = "2.23";
 
   src = fetchurl {
-    url = "https://offog.org/files/${name}.tar.gz";
+    url = "https://offog.org/files/${pname}-${version}.tar.gz";
     sha256 = "18nyg19mwxyqdnykplkqmzb4n27vvrhvp639zai8f81gg9vdbsjp";
   };
 

--- a/pkgs/applications/networking/mailreaders/mailpile/default.nix
+++ b/pkgs/applications/networking/mailreaders/mailpile/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, python2Packages, gnupg1orig, openssl, git }:
 
 python2Packages.buildPythonApplication rec {
-  name = "mailpile-${version}";
+  pname = "mailpile";
   version = "1.0.0rc2";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/science/logic/elan/default.nix
+++ b/pkgs/applications/science/logic/elan/default.nix
@@ -1,7 +1,7 @@
 { stdenv, pkgconfig, curl, openssl, zlib, fetchFromGitHub, rustPlatform }:
 
 rustPlatform.buildRustPackage rec {
-  name = "elan-${version}";
+  pname = "elan";
   version = "0.7.5";
 
   cargoSha256 = "0lc320m3vw76d6pa5wp6c9jblac6lmyf9qqnxmsnkn4ixdhnghsd";

--- a/pkgs/applications/science/machine-learning/labelimg/default.nix
+++ b/pkgs/applications/science/machine-learning/labelimg/default.nix
@@ -1,6 +1,6 @@
 { stdenv, python2Packages, fetchurl }:
   python2Packages.buildPythonApplication rec {
-    name = "labelImg-${version}";
+    pname = "labelImg";
     version = "1.6.0";
     src = fetchurl {
       url = "https://github.com/tzutalin/labelImg/archive/v${version}.tar.gz";

--- a/pkgs/applications/science/misc/rink/default.nix
+++ b/pkgs/applications/science/misc/rink/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage rec {
   version = "0.4.4";
-  name = "rink-${version}";
+  pname = "rink";
 
   src = fetchFromGitHub {
     owner = "tiffany352";

--- a/pkgs/applications/version-management/bazaar/tools.nix
+++ b/pkgs/applications/version-management/bazaar/tools.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, python2Packages }:
 
 python2Packages.buildPythonApplication rec {
-  name = "bzr-tools-${version}";
+  pname = "bzr-tools";
   version = "2.6.0";
 
   src = fetchurl {

--- a/pkgs/applications/version-management/cvs2svn/default.nix
+++ b/pkgs/applications/version-management/cvs2svn/default.nix
@@ -4,11 +4,11 @@
 }:
 
 python2Packages.buildPythonApplication  rec {
-  name = "cvs2svn-${version}";
+  pname = "cvs2svn";
   version = "2.5.0";
 
   src = fetchurl {
-    url = "http://cvs2svn.tigris.org/files/documents/1462/49543/${name}.tar.gz";
+    url = "http://cvs2svn.tigris.org/files/documents/1462/49543/${pname}-${version}.tar.gz";
     sha256 = "1ska0z15sjhyfi860rjazz9ya1gxbf5c0h8dfqwz88h7fccd22b4";
   };
 

--- a/pkgs/applications/version-management/git-and-tools/git-big-picture/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-big-picture/default.nix
@@ -4,8 +4,6 @@ python2Packages.buildPythonApplication rec {
   pname = "git-big-picture";
   version = "0.10.1";
 
-  name = "${pname}-${version}";
-
   src = fetchFromGitHub {
     owner = "esc";
     repo = pname;

--- a/pkgs/applications/version-management/git-and-tools/git-codeowners/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-codeowners/default.nix
@@ -1,6 +1,6 @@
 { lib, rustPlatform, fetchFromGitHub }:
 rustPlatform.buildRustPackage rec {
-  name = "git-codeowners-${version}";
+  pname = "git-codeowners";
   version = "0.1.2";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/version-management/git-and-tools/git-dit/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-dit/default.nix
@@ -16,7 +16,7 @@
 with rustPlatform;
 
 buildRustPackage rec {
-  name = "git-dit-${version}";
+  pname = "git-dit";
   version = "0.4.0";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/version-management/git-up/default.nix
+++ b/pkgs/applications/version-management/git-up/default.nix
@@ -2,10 +2,10 @@
 
 python2Packages.buildPythonApplication rec {
   version = "1.4.2";
-  name = "git-up-${version}";
+  pname = "git-up";
 
   src = fetchurl {
-    url = "mirror://pypi/g/git-up/${name}.zip";
+    url = "mirror://pypi/g/git-up/${pname}-${version}.zip";
     sha256 = "121ia5gyjy7js6fbsx9z98j2qpq7rzwpsj8gnfvsbz2d69g0vl7q";
   };
 

--- a/pkgs/applications/version-management/gitinspector/default.nix
+++ b/pkgs/applications/version-management/gitinspector/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchzip, python2Packages}:
 
 python2Packages.buildPythonApplication rec {
-  name = "gitinspector-${version}";
+  pname = "gitinspector";
   version = "0.4.4";
   namePrefix = "";
 
   src = fetchzip {
     url = "https://github.com/ejwa/gitinspector/archive/v${version}.tar.gz";
     sha256 = "1pfsw6xldm6jigs3nhysvqaxk8a0zf8zczgfkrp920as9sya3c7m";
-    name = name + "-src";
+    name = "${pname}-${version}" + "-src";
   };
 
   checkInputs = with python2Packages; [

--- a/pkgs/applications/version-management/pijul/default.nix
+++ b/pkgs/applications/version-management/pijul/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, rustPlatform, darwin, openssl, libsodium, nettle, clang, libclang, pkgconfig }:
 
 rustPlatform.buildRustPackage rec {
-  name = "pijul-${version}";
+  pname = "pijul";
   version = "0.12.0";
 
   src = fetchurl {
-    url = "https://pijul.org/releases/${name}.tar.gz";
+    url = "https://pijul.org/releases/${pname}-${version}.tar.gz";
     sha256 = "1rm787kkh3ya8ix0rjvj7sbrg9armm0rnpkga6gjmsbg5bx20y4q";
   };
 

--- a/pkgs/applications/version-management/rabbitvcs/default.nix
+++ b/pkgs/applications/version-management/rabbitvcs/default.nix
@@ -1,6 +1,6 @@
 { fetchFromGitHub, lib, python2Packages, meld, subversion, gvfs, xdg_utils }:
 python2Packages.buildPythonApplication rec {
-  name = "rabbitvcs-${version}";
+  pname = "rabbitvcs";
   version = "0.17.1";
   namePrefix = "";
 

--- a/pkgs/applications/version-management/sit/default.nix
+++ b/pkgs/applications/version-management/sit/default.nix
@@ -3,7 +3,7 @@
   libiconv, CoreFoundation, Security }:
 
 rustPlatform.buildRustPackage rec {
-  name = "sit-${version}";
+  pname = "sit";
   version = "0.4.1";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/version-management/tailor/default.nix
+++ b/pkgs/applications/version-management/tailor/default.nix
@@ -1,7 +1,7 @@
 { fetchurl, python2Packages }:
 
 python2Packages.buildPythonApplication rec {
-  name = "tailor-${version}";
+  pname = "tailor";
   version = "0.9.35";
 
   src = fetchurl {

--- a/pkgs/applications/virtualization/cntr/default.nix
+++ b/pkgs/applications/virtualization/cntr/default.nix
@@ -1,7 +1,7 @@
 { stdenv, rustPlatform, fetchFromGitHub }:
 
 rustPlatform.buildRustPackage rec {
-  name = "cntr-${version}";
+  pname = "cntr";
   version = "1.2.0";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/virtualization/railcar/default.nix
+++ b/pkgs/applications/virtualization/railcar/default.nix
@@ -1,7 +1,7 @@
 { lib, fetchFromGitHub, rustPlatform, libseccomp }:
 
 rustPlatform.buildRustPackage rec {
-  name = "railcar-${version}";
+  pname = "railcar";
   version = "1.0.4";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/window-managers/dwm/dwm-status.nix
+++ b/pkgs/applications/window-managers/dwm/dwm-status.nix
@@ -8,7 +8,7 @@ let
 in
 
 rustPlatform.buildRustPackage rec {
-  name = "dwm-status-${version}";
+  pname = "dwm-status";
   version = "1.6.2";
 
   src = fetchFromGitHub {

--- a/pkgs/data/machine-learning/mnist/default.nix
+++ b/pkgs/data/machine-learning/mnist/default.nix
@@ -20,7 +20,7 @@ let
   };
 in
   stdenvNoCC.mkDerivation rec {
-    name = "mnist-${version}";
+    pname = "mnist";
     version = "2018-11-16";
     installPhase = ''
       mkdir -p $out

--- a/pkgs/development/compilers/fasm/bin.nix
+++ b/pkgs/development/compilers/fasm/bin.nix
@@ -1,7 +1,7 @@
 { stdenvNoCC, lib, fetchurl }:
 
 stdenvNoCC.mkDerivation rec {
-  name = "fasm-bin-${version}";
+  pname = "fasm-bin";
 
   version = "1.73.16";
 

--- a/pkgs/development/compilers/rust/rustfmt.nix
+++ b/pkgs/development/compilers/rust/rustfmt.nix
@@ -1,7 +1,7 @@
 { stdenv, rustPlatform, Security }:
 
 rustPlatform.buildRustPackage rec {
-  name = "rustfmt-${version}";
+  pname = "rustfmt";
   inherit (rustPlatform.rust.rustc) version src;
 
   # the rust source tarball already has all the dependencies vendored, no need to fetch them again

--- a/pkgs/development/interpreters/pyrex/0.9.5.nix
+++ b/pkgs/development/interpreters/pyrex/0.9.5.nix
@@ -3,7 +3,8 @@
 let version = "0.9.5.1.1"; in
 
 python2Packages.buildPythonPackage {
-  name = "pyrex-${version}";
+  pname = "pyrex";
+  inherit version;
 
   src = fetchurl {
     url = "https://www.cosc.canterbury.ac.nz/greg.ewing/python/Pyrex/oldtar/Pyrex-${version}.tar.gz";

--- a/pkgs/development/interpreters/pyrex/0.9.6.nix
+++ b/pkgs/development/interpreters/pyrex/0.9.6.nix
@@ -3,7 +3,8 @@
 let version = "0.9.6.4"; in
 
 python2Packages.buildPythonPackage {
-  name = "pyrex-${version}";
+  pname = "pyrex";
+  inherit version;
 
   src = fetchurl {
     url = "https://www.cosc.canterbury.ac.nz/greg.ewing/python/Pyrex/oldtar/Pyrex-${version}.tar.gz";

--- a/pkgs/development/interpreters/wasm-gc/default.nix
+++ b/pkgs/development/interpreters/wasm-gc/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, rustPlatform }:
 
 rustPlatform.buildRustPackage rec {
-  name = "wasm-gc-${version}";
+  pname = "wasm-gc";
   version = "0.1.6";
 
   src = fetchFromGitHub {

--- a/pkgs/development/misc/loc/default.nix
+++ b/pkgs/development/misc/loc/default.nix
@@ -4,7 +4,7 @@ with rustPlatform;
 
 buildRustPackage rec {
   version = "0.4.1";
-  name = "loc-${version}";
+  pname = "loc";
 
   src = fetchFromGitHub {
     owner = "cgag";

--- a/pkgs/development/tools/analysis/panopticon/default.nix
+++ b/pkgs/development/tools/analysis/panopticon/default.nix
@@ -4,7 +4,6 @@
 rustPlatform.buildRustPackage rec {
   pname = "panopticon";
   version = "unstable-20171202";
-  name = "${pname}-${version}";
 
   src = fetchFromGitHub {
     owner = "das-labor";

--- a/pkgs/development/tools/clog-cli/default.nix
+++ b/pkgs/development/tools/clog-cli/default.nix
@@ -3,7 +3,7 @@
 with rustPlatform;
 
 buildRustPackage rec {
-  name = "clog-cli-${version}";
+  pname = "clog-cli";
   version = "0.9.3";
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/documentation/mdsh/default.nix
+++ b/pkgs/development/tools/documentation/mdsh/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, rustPlatform }:
 
 rustPlatform.buildRustPackage rec {
-  name = "mdsh-${version}";
+  pname = "mdsh";
   version = "0.1.4";
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/geckodriver/default.nix
+++ b/pkgs/development/tools/geckodriver/default.nix
@@ -9,7 +9,7 @@ with rustPlatform;
 
 buildRustPackage rec {
   version = "0.22.0";
-  name = "geckodriver-${version}";
+  pname = "geckodriver";
 
   src = fetchFromGitHub {
     owner = "mozilla";

--- a/pkgs/development/tools/git-series/default.nix
+++ b/pkgs/development/tools/git-series/default.nix
@@ -4,7 +4,7 @@ with rustPlatform;
 
 buildRustPackage rec {
   version = "0.9.1";
-  name = "git-series-${version}";
+  pname = "git-series";
 
   src = fetchFromGitHub {
     owner = "git-series";

--- a/pkgs/development/tools/misc/sccache/default.nix
+++ b/pkgs/development/tools/misc/sccache/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage rec {
   version = "0.2.10";
-  name = "sccache-${version}";
+  pname = "sccache";
 
   src = fetchFromGitHub {
     owner = "mozilla";

--- a/pkgs/development/tools/parinfer-rust/default.nix
+++ b/pkgs/development/tools/parinfer-rust/default.nix
@@ -1,7 +1,7 @@
 { stdenv, rustPlatform, fetchFromGitHub }:
 
 rustPlatform.buildRustPackage rec {
-  name = "parinfer-rust-${version}";
+  pname = "parinfer-rust";
   version = "0.3.1";
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/pax-rs/default.nix
+++ b/pkgs/development/tools/pax-rs/default.nix
@@ -2,7 +2,7 @@
 with rustPlatform;
 
 buildRustPackage rec {
-  name = "pax-rs-${version}";
+  pname = "pax-rs";
   version = "0.4.0";
 
   meta = with stdenv.lib; {

--- a/pkgs/development/tools/rq/default.nix
+++ b/pkgs/development/tools/rq/default.nix
@@ -3,7 +3,7 @@
 with rustPlatform;
 
 buildRustPackage rec {
-  name = "rq-${version}";
+  pname = "rq";
   version = "0.10.4";
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/rust/cargo-asm/default.nix
+++ b/pkgs/development/tools/rust/cargo-asm/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, rustPlatform, Security }:
 
 rustPlatform.buildRustPackage rec {
-  name = "cargo-asm-${version}";
+  pname = "cargo-asm";
   version = "0.1.17";
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/rust/cargo-fuzz/default.nix
+++ b/pkgs/development/tools/rust/cargo-fuzz/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, fetchurl, runCommand, rustPlatform }:
 
 rustPlatform.buildRustPackage rec {
-  name = "cargo-fuzz-${version}";
+  pname = "cargo-fuzz";
   version = "0.5.3"; # Note to self: on 0.5.4, remove the hand-added Cargo.lock
 
   src =

--- a/pkgs/development/tools/rust/cargo-generate/default.nix
+++ b/pkgs/development/tools/rust/cargo-generate/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, rustPlatform, Security, openssl, pkgconfig, libiconv, curl }:
 
 rustPlatform.buildRustPackage rec {
-  name = "cargo-generate-${version}";
+  pname = "cargo-generate";
   version = "0.3.0";
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/rust/cbindgen/default.nix
+++ b/pkgs/development/tools/rust/cbindgen/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, rustPlatform, Security }:
 
 rustPlatform.buildRustPackage rec {
-  name = "rust-cbindgen-${version}";
+  pname = "rust-cbindgen";
   version = "0.8.7";
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/rust/racer/default.nix
+++ b/pkgs/development/tools/rust/racer/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, rustPlatform, makeWrapper, substituteAll, Security }:
 
 rustPlatform.buildRustPackage rec {
-  name = "racer-${version}";
+  pname = "racer";
   version = "2.1.22";
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/rust/racerd/default.nix
+++ b/pkgs/development/tools/rust/racerd/default.nix
@@ -3,7 +3,7 @@
 with rustPlatform;
 
 buildRustPackage rec {
-  name = "racerd-${version}";
+  pname = "racerd";
   version = "2019-03-20";
   src = fetchFromGitHub {
     owner = "jwilm";

--- a/pkgs/development/tools/rust/rainicorn/default.nix
+++ b/pkgs/development/tools/rust/rainicorn/default.nix
@@ -3,7 +3,7 @@
 with rustPlatform;
 
 buildRustPackage rec {
-  name = "rainicorn-${version}";
+  pname = "rainicorn";
   version = "1.0.0";
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/rust/svd2rust/default.nix
+++ b/pkgs/development/tools/rust/svd2rust/default.nix
@@ -3,7 +3,7 @@
 with rustPlatform;
 
 buildRustPackage rec {
-  name = "svd2rust-${version}";
+  pname = "svd2rust";
   version = "0.14.0";
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/wasm-pack/default.nix
+++ b/pkgs/development/tools/wasm-pack/default.nix
@@ -8,7 +8,7 @@
 }:
 
 rustPlatform.buildRustPackage rec {
-  name = "wasm-pack-${version}";
+  pname = "wasm-pack";
   version = "0.8.1";
 
   src = fetchFromGitHub {

--- a/pkgs/games/dwarf-fortress/twbt/default.nix
+++ b/pkgs/games/dwarf-fortress/twbt/default.nix
@@ -44,7 +44,7 @@ let
 in
 
 stdenvNoCC.mkDerivation rec {
-  name = "twbt-${version}";
+  pname = "twbt";
   version = release.twbtRelease;
 
   src = fetchurl {

--- a/pkgs/os-specific/linux/dstat/default.nix
+++ b/pkgs/os-specific/linux/dstat/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, python2Packages }:
 
 python2Packages.buildPythonApplication rec {
-  name = "dstat-${version}";
+  pname = "dstat";
   format = "other";
   version = "0.7.3";
 

--- a/pkgs/os-specific/linux/kernel-headers/default.nix
+++ b/pkgs/os-specific/linux/kernel-headers/default.nix
@@ -7,7 +7,8 @@ let
   makeLinuxHeaders = { src, version, patches ? [] }: stdenvNoCC.mkDerivation {
     inherit src;
 
-    name = "linux-headers-${version}";
+    pname = "linux-headers";
+    inherit version;
 
     ARCH = stdenvNoCC.hostPlatform.platform.kernelArch or stdenvNoCC.hostPlatform.kernelArch;
 

--- a/pkgs/servers/webmetro/default.nix
+++ b/pkgs/servers/webmetro/default.nix
@@ -2,7 +2,6 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "webmetro";
-  name = "${pname}-${version}";
   version = "unstable-20180426";
 
   src = fetchFromGitHub {

--- a/pkgs/shells/ion/default.nix
+++ b/pkgs/shells/ion/default.nix
@@ -3,7 +3,7 @@
 with rustPlatform;
 
 buildRustPackage rec {
-  name = "ion-${version}";
+  pname = "ion";
   version = "1.0.5";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/X11/xidlehook/default.nix
+++ b/pkgs/tools/X11/xidlehook/default.nix
@@ -2,7 +2,7 @@
 , xlibsWrapper, xorg, libpulseaudio, pkgconfig, patchelf, Security }:
 
 rustPlatform.buildRustPackage rec {
-  name = "xidlehook-${version}";
+  pname = "xidlehook";
   version = "0.7.0";
 
   doCheck = false;

--- a/pkgs/tools/admin/intecture/agent.nix
+++ b/pkgs/tools/admin/intecture/agent.nix
@@ -4,7 +4,7 @@
 with rustPlatform;
 
 buildRustPackage rec {
-  name = "intecture-agent-${version}";
+  pname = "intecture-agent";
   version = "0.3.1";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/admin/intecture/auth.nix
+++ b/pkgs/tools/admin/intecture/auth.nix
@@ -4,7 +4,7 @@
 with rustPlatform;
 
 buildRustPackage rec {
-  name = "intecture-auth-${version}";
+  pname = "intecture-auth";
   version = "0.1.2";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/admin/intecture/cli.nix
+++ b/pkgs/tools/admin/intecture/cli.nix
@@ -4,7 +4,7 @@
 with rustPlatform;
 
 buildRustPackage rec {
-  name = "intecture-cli-${version}";
+  pname = "intecture-cli";
   version = "0.3.4";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/backup/amazon-glacier-cmd-interface/default.nix
+++ b/pkgs/tools/backup/amazon-glacier-cmd-interface/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, python2Packages  }:
 
 python2Packages.buildPythonApplication rec {
-  name     = "amazon-glacier-cmd-interface-${version}";
+  pname = "amazon-glacier-cmd-interface";
   version  = "2016-09-01";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/backup/duplicity/default.nix
+++ b/pkgs/tools/backup/duplicity/default.nix
@@ -5,11 +5,11 @@
 , rsync, makeWrapper }:
 
 python2Packages.buildPythonApplication rec {
-  name = "duplicity-${version}";
+  pname = "duplicity";
   version = "0.7.19";
 
   src = fetchurl {
-    url = "https://code.launchpad.net/duplicity/${stdenv.lib.versions.majorMinor version}-series/${version}/+download/${name}.tar.gz";
+    url = "https://code.launchpad.net/duplicity/${stdenv.lib.versions.majorMinor version}-series/${version}/+download/${pname}-${version}.tar.gz";
     sha256 = "0ag9dknslxlasslwfjhqgcqbkb1mvzzx93ry7lch2lfzcdd91am6";
   };
   patches = [

--- a/pkgs/tools/backup/rdedup/default.nix
+++ b/pkgs/tools/backup/rdedup/default.nix
@@ -3,7 +3,7 @@
 , Security }:
 
 rustPlatform.buildRustPackage rec {
-  name = "rdedup-${version}";
+  pname = "rdedup";
   version = "3.1.1";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/filesystems/btrfs-dedupe/default.nix
+++ b/pkgs/tools/filesystems/btrfs-dedupe/default.nix
@@ -3,7 +3,7 @@
 with rustPlatform;
 
 buildRustPackage rec {
-  name = "btrfs-dedupe-${version}";
+  pname = "btrfs-dedupe";
   version = "1.1.0";
 
 

--- a/pkgs/tools/filesystems/gitfs/default.nix
+++ b/pkgs/tools/filesystems/gitfs/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, python2Packages }:
 
 python2Packages.buildPythonApplication rec {
-  name = "gitfs-${version}";
+  pname = "gitfs";
   version = "0.4.5.1";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/graphics/gifski/default.nix
+++ b/pkgs/tools/graphics/gifski/default.nix
@@ -1,7 +1,7 @@
 { stdenv, rustPlatform, fetchFromGitHub, pkgconfig }:
 
 rustPlatform.buildRustPackage rec {
-  name = "gifski-${version}";
+  pname = "gifski";
   version = "0.8.7";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/graphics/svgcleaner/default.nix
+++ b/pkgs/tools/graphics/svgcleaner/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, rustPlatform }:
 
 rustPlatform.buildRustPackage rec {
-  name = "svgcleaner-${version}";
+  pname = "svgcleaner";
   version = "0.9.2";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/misc/bmap-tools/default.nix
+++ b/pkgs/tools/misc/bmap-tools/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, python2Packages }:
 
 python2Packages.buildPythonApplication rec {
-  name = "bmap-tools-${version}";
+  pname = "bmap-tools";
   version = "3.4";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/misc/crudini/default.nix
+++ b/pkgs/tools/misc/crudini/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, python2Packages, help2man }:
 
 python2Packages.buildPythonApplication rec {
-  name = "crudini-${version}";
+  pname = "crudini";
   version = "0.9";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/misc/diskus/default.nix
+++ b/pkgs/tools/misc/diskus/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, rustPlatform, Security }:
 
 rustPlatform.buildRustPackage rec {
-  name = "diskus-${version}";
+  pname = "diskus";
   version = "0.5.0";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/misc/dust/default.nix
+++ b/pkgs/tools/misc/dust/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, rustPlatform }:
 
 rustPlatform.buildRustPackage rec {
-  name = "dust-${version}";
+  pname = "dust";
   version = "0.2.3";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/misc/exa/default.nix
+++ b/pkgs/tools/misc/exa/default.nix
@@ -5,7 +5,7 @@
 with rustPlatform;
 
 buildRustPackage rec {
-  name = "exa-${version}";
+  pname = "exa";
   version = "0.9.0";
 
   cargoSha256 = "1hgjp23rjd90wyf0nq6d5akjxdfjlaps54dv23zgwjvkhw24fidf";

--- a/pkgs/tools/misc/fd/default.nix
+++ b/pkgs/tools/misc/fd/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, rustPlatform }:
 
 rustPlatform.buildRustPackage rec {
-  name = "fd-${version}";
+  pname = "fd";
   version = "7.3.0";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/misc/heatseeker/default.nix
+++ b/pkgs/tools/misc/heatseeker/default.nix
@@ -3,7 +3,7 @@
 with rustPlatform;
 
 buildRustPackage rec {
-  name = "heatseeker-${version}";
+  pname = "heatseeker";
   version = "1.5.1";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/misc/journaldriver/default.nix
+++ b/pkgs/tools/misc/journaldriver/default.nix
@@ -1,7 +1,7 @@
 { lib, fetchFromGitHub, rustPlatform, pkgconfig, openssl, systemd }:
 
 rustPlatform.buildRustPackage rec {
-  name        = "journaldriver-${version}";
+  pname = "journaldriver";
   version     = "1.1.0";
   cargoSha256 = "0wmr0r54ar7gvhvhv76a49ap74lx8hl79bf73vc4f4xlj7hj303g";
 

--- a/pkgs/tools/misc/kargo/default.nix
+++ b/pkgs/tools/misc/kargo/default.nix
@@ -2,10 +2,10 @@
 
 python2Packages.buildPythonApplication rec {
   version = "0.4.6";
-  name = "kargo-${version}";
+  pname = "kargo";
 
   src = fetchurl {
-    url = "mirror://pypi/k/kargo/${name}.tar.gz";
+    url = "mirror://pypi/k/kargo/${pname}-${version}.tar.gz";
     sha256 = "1sm721c3d4scpc1gj2j3qwssr6jjvw6aq3p7ipvhbd9ywmm9dd7b";
   };
 

--- a/pkgs/tools/misc/mcfly/default.nix
+++ b/pkgs/tools/misc/mcfly/default.nix
@@ -1,7 +1,7 @@
 { stdenv, rustPlatform, fetchFromGitHub }:
 
 rustPlatform.buildRustPackage rec {
-  name = "mcfly-${version}";
+  pname = "mcfly";
   version = "v0.3.1";
   rev = "${version}";
 

--- a/pkgs/tools/misc/miniserve/default.nix
+++ b/pkgs/tools/misc/miniserve/default.nix
@@ -1,7 +1,7 @@
 { stdenv, rustPlatform, fetchFromGitHub, cmake, pkgconfig, zlib }:
 
 rustPlatform.buildRustPackage rec {
-  name    = "miniserve-${version}";
+  pname = "miniserve";
   version = "0.2.1";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/misc/parallel-rust/default.nix
+++ b/pkgs/tools/misc/parallel-rust/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, rustPlatform }:
 
 rustPlatform.buildRustPackage rec {
-  name = "parallel-rust-${version}";
+  pname = "parallel-rust";
   version = "0.11.3";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/misc/powerline-rs/default.nix
+++ b/pkgs/tools/misc/powerline-rs/default.nix
@@ -1,7 +1,6 @@
 { stdenv, lib, rustPlatform, fetchFromGitLab, pkgconfig, file, perl, curl, cmake, openssl, libssh2, libgit2, libzip, Security }:
 rustPlatform.buildRustPackage rec {
   pname = "powerline-rs";
-  name = "${pname}-${version}";
   version = "0.1.9";
 
   src = fetchFromGitLab {

--- a/pkgs/tools/misc/tealdeer/default.nix
+++ b/pkgs/tools/misc/tealdeer/default.nix
@@ -1,7 +1,7 @@
 { stdenv, rustPlatform, fetchFromGitHub, pkgconfig, openssl, cacert, curl }:
 
 rustPlatform.buildRustPackage rec {
-  name = "tealdeer-${version}";
+  pname = "tealdeer";
   version = "1.1.0";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/misc/termplay/default.nix
+++ b/pkgs/tools/misc/termplay/default.nix
@@ -1,6 +1,6 @@
 { rustPlatform, fetchFromGitHub, lib, makeWrapper, gst_all_1, libsixel }:
 rustPlatform.buildRustPackage rec {
-  name = "termplay-${version}";
+  pname = "termplay";
   version = "2.0.4";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/misc/vivid/default.nix
+++ b/pkgs/tools/misc/vivid/default.nix
@@ -1,7 +1,6 @@
 { stdenv, fetchFromGitHub, rustPlatform }:
 
 rustPlatform.buildRustPackage rec {
-  name = "${pname}-${version}";
   pname = "vivid";
   version = "0.4.0";
 

--- a/pkgs/tools/misc/void/default.nix
+++ b/pkgs/tools/misc/void/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, rustPlatform }:
 
 rustPlatform.buildRustPackage rec {
-  name = "void-${version}";
+  pname = "void";
   version = "1.1.5";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/misc/websocat/default.nix
+++ b/pkgs/tools/misc/websocat/default.nix
@@ -2,7 +2,7 @@
 }:
 
 rustPlatform.buildRustPackage rec {
-  name = "websocat-${version}";
+  pname = "websocat";
   version = "1.3.0";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/networking/bukubrow/default.nix
+++ b/pkgs/tools/networking/bukubrow/default.nix
@@ -1,7 +1,7 @@
 { stdenv, rustPlatform, fetchFromGitHub, sqlite }:
 
 rustPlatform.buildRustPackage rec {
-  name = "bukubrow-${version}";
+  pname = "bukubrow";
   version = "2.4.0";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/networking/gnirehtet/default.nix
+++ b/pkgs/tools/networking/gnirehtet/default.nix
@@ -15,7 +15,8 @@ apk = stdenv.mkDerivation {
 };
 in
 rustPlatform.buildRustPackage {
-  name = "gnirehtet-${version}";
+  pname = "gnirehtet";
+  inherit version;
 
   src = fetchFromGitHub {
       owner = "Genymobile";

--- a/pkgs/tools/networking/s3cmd/default.nix
+++ b/pkgs/tools/networking/s3cmd/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, python2Packages }:
 
 python2Packages.buildPythonApplication rec {
-  name = "s3cmd-${version}";
+  pname = "s3cmd";
   version = "2.0.2";
   
   src = fetchFromGitHub {

--- a/pkgs/tools/networking/ssh-agents/default.nix
+++ b/pkgs/tools/networking/ssh-agents/default.nix
@@ -4,7 +4,7 @@
 }:
 
 stdenvNoCC.mkDerivation rec {
-  name = "ssh-agents-${version}";
+  pname = "ssh-agents";
   version = "1.0.1";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/networking/tox-node/default.nix
+++ b/pkgs/tools/networking/tox-node/default.nix
@@ -6,7 +6,7 @@
 with rustPlatform;
 
 buildRustPackage rec {
-  name = "tox-node-${version}";
+  pname = "tox-node";
   version = "0.0.8";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/nix/nixdoc/default.nix
+++ b/pkgs/tools/nix/nixdoc/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, rustPlatform, darwin }:
 
 rustPlatform.buildRustPackage rec {
-  name    = "nixdoc-${version}";
+  pname = "nixdoc";
   version = "1.0.1";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/package-management/cargo-graph/default.nix
+++ b/pkgs/tools/package-management/cargo-graph/default.nix
@@ -1,6 +1,6 @@
 { lib, rustPlatform, fetchFromGitHub }:
 rustPlatform.buildRustPackage rec {
-  name = "cargo-graph-${version}";
+  pname = "cargo-graph";
   version = "0.2.0-d895af1";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/package-management/cargo-license/default.nix
+++ b/pkgs/tools/package-management/cargo-license/default.nix
@@ -1,6 +1,6 @@
 { lib, rustPlatform, fetchFromGitHub }:
 rustPlatform.buildRustPackage rec {
-  name = "cargo-license-${version}";
+  pname = "cargo-license";
   version = "0.2.0";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/package-management/cargo-release/default.nix
+++ b/pkgs/tools/package-management/cargo-release/default.nix
@@ -1,7 +1,7 @@
 { stdenv, rustPlatform, fetchFromGitHub, Security }:
 
 rustPlatform.buildRustPackage rec {
-  name = "cargo-release-${version}";
+  pname = "cargo-release";
   version = "0.10.5";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/package-management/cargo-tree/default.nix
+++ b/pkgs/tools/package-management/cargo-tree/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, rustPlatform, fetchFromGitHub, pkgconfig, cmake, curl, libiconv, darwin }:
 rustPlatform.buildRustPackage rec {
-  name = "cargo-tree-${version}";
+  pname = "cargo-tree";
   version = "0.26.0";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/package-management/nix-du/default.nix
+++ b/pkgs/tools/package-management/nix-du/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, rustPlatform, nix, boost, graphviz, darwin }:
 rustPlatform.buildRustPackage rec {
-  name = "nix-du-${version}";
+  pname = "nix-du";
   version = "0.3.0";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/package-management/nix-index/default.nix
+++ b/pkgs/tools/package-management/nix-index/default.nix
@@ -3,7 +3,7 @@
 }:
 
 rustPlatform.buildRustPackage rec {
-  name = "nix-index-${version}";
+  pname = "nix-index";
   version = "0.1.2";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/system/mq-cli/default.nix
+++ b/pkgs/tools/system/mq-cli/default.nix
@@ -1,7 +1,7 @@
 { fetchFromGitHub, lib, rustPlatform }:
 
 rustPlatform.buildRustPackage rec {
-  name    = "mq-cli-${version}";
+  pname = "mq-cli";
   version = "1.0.0";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/text/coloursum/default.nix
+++ b/pkgs/tools/text/coloursum/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, rustPlatform }:
 
 rustPlatform.buildRustPackage rec {
-  name = "coloursum-${version}";
+  pname = "coloursum";
   version = "0.1.0";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/text/mdbook/default.nix
+++ b/pkgs/tools/text/mdbook/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, rustPlatform, CoreServices, darwin }:
 
 rustPlatform.buildRustPackage rec {
-  name = "mdbook-${version}";
+  pname = "mdbook";
   version = "0.3.1";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/text/staccato/default.nix
+++ b/pkgs/tools/text/staccato/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, rustPlatform }:
 
 rustPlatform.buildRustPackage rec {
-  name = "staccato-${version}";
+  pname = "staccato";
   version = "0.1.6";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/text/xsv/default.nix
+++ b/pkgs/tools/text/xsv/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, rustPlatform, Security }:
 
 rustPlatform.buildRustPackage rec {
-  name = "xsv-${version}";
+  pname = "xsv";
   version = "0.13.0";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/typesetting/tectonic/default.nix
+++ b/pkgs/tools/typesetting/tectonic/default.nix
@@ -2,7 +2,7 @@
 , darwin, fontconfig, harfbuzz, openssl, pkgconfig }:
 
 rustPlatform.buildRustPackage rec {
-  name = "tectonic-${version}";
+  pname = "tectonic";
   version = "0.1.11";
 
   src = fetchFromGitHub {


### PR DESCRIPTION
###### Motivation for this change

continuation of https://github.com/NixOS/nixpkgs/pull/66585 and https://github.com/NixOS/nixpkgs/pull/66751
name->pname replacement in `buildRustPackage` and `python2Packages.buildPythonApplication`
