### PR TITLE
git-up: 1.4.2 -> 1.6.1

### DIFF
--- a/pkgs/applications/version-management/git-up/default.nix
+++ b/pkgs/applications/version-management/git-up/default.nix
@@ -1,17 +1,18 @@
-{ stdenv, fetchurl, python2Packages, git }:
+{ stdenv, fetchurl, pythonPackages, git }:
 
-python2Packages.buildPythonApplication rec {
-  version = "1.4.2";
+pythonPackages.buildPythonApplication rec {
   pname = "git-up";
+  version = "1.6.1";
 
-  src = fetchurl {
-    url = "mirror://pypi/g/git-up/${pname}-${version}.zip";
-    sha256 = "121ia5gyjy7js6fbsx9z98j2qpq7rzwpsj8gnfvsbz2d69g0vl7q";
+  src = pythonPackages.fetchPypi {
+    inherit pname version;
+    sha256 = "0gs791yb0cndg9879vayvcj329jwhzpk6wrf9ri12l5hg8g490za";
   };
 
-  buildInputs = [ git ] ++ (with python2Packages; [ nose ]);
-  propagatedBuildInputs = with python2Packages; [ click colorama docopt GitPython six termcolor ];
+  # git should be on path for tool to work correctly
+  propagatedBuildInputs = [ git ] ++ (with pythonPackages; [ click colorama docopt GitPython six termcolor ]);
 
+  checkInputs = [ git pythonPackages.nose ]; # git needs to be on path
   # 1. git fails to run as it cannot detect the email address, so we set it
   # 2. $HOME is by default not a valid dir, so we have to set that too
   # https://github.com/NixOS/nixpkgs/issues/12591
@@ -22,7 +23,7 @@ python2Packages.buildPythonApplication rec {
     '';
 
   postInstall = ''
-    rm -r $out/${python2Packages.python.sitePackages}/PyGitUp/tests
+    rm -r $out/${pythonPackages.python.sitePackages}/PyGitUp/tests
   '';
 
   meta = with stdenv.lib; {
@@ -31,6 +32,5 @@ python2Packages.buildPythonApplication rec {
     license = licenses.mit;
     maintainers = with maintainers; [ peterhoeg ];
     platforms = platforms.all;
-    broken = true; # Incompatible with Git 2.15 object store.
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3374,7 +3374,9 @@ in
 
   git-sizer = callPackage ../applications/version-management/git-sizer { };
 
-  git-up = callPackage ../applications/version-management/git-up { };
+  git-up = callPackage ../applications/version-management/git-up {
+    pythonPackages = python3Packages;
+  };
 
   gitfs = callPackage ../tools/filesystems/gitfs { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
fixing @r-ryantm update failures.

bumped python2 to python3
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @peterhoeg 
