### PR TITLE
pythonPackages.elpy: 1.28.0 -> 1.29.1 add tests

### DIFF
--- a/pkgs/development/python-modules/elpy/default.nix
+++ b/pkgs/development/python-modules/elpy/default.nix
@@ -1,32 +1,43 @@
 { stdenv
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , rope
 , flake8
 , autopep8
 , jedi
 , importmagic
-, isPy27
+, black
+, mock
+, nose
+, yapf
+, isPy3k
 }:
 
 buildPythonPackage rec {
   pname = "elpy";
-  version = "1.28.0";
+  version = "1.29.1";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "0lx6bf6ajx6wmnns03gva5sh1mmmxahjaqrn735cgwn6j4ikyqfs";
+  src = fetchFromGitHub {
+    owner = "jorgenschaefer";
+    repo = pname;
+    rev = version;
+    sha256 = "19sd5p03rkp5yibq1ilwisq8jlma02ks2kdc3swy6r27n4hy90xf";
   };
 
-  propagatedBuildInputs = [ flake8 autopep8 jedi importmagic ]
-    ++ stdenv.lib.optionals isPy27 [ rope ];
+  propagatedBuildInputs = [ flake8 autopep8 jedi importmagic rope yapf ]
+    ++ stdenv.lib.optionals isPy3k [ black ];
 
-  doCheck = false; # there are no tests
+  checkInputs = [ mock nose ];
+
+  checkPhase = ''
+    HOME=$(mktemp -d) nosetests -e "test_should_complete_top_level_modules_for_import"
+  '';
 
   meta = with stdenv.lib; {
     description = "Backend for the elpy Emacs mode";
     homepage = "https://github.com/jorgenschaefer/elpy";
     license = licenses.gpl3;
+    maintainers = [ maintainers.costrouc ];
   };
 
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Latest version of elpy works with black

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
