### PR TITLE
gnurl: 7.64.0 -> 7.65.0

### DIFF
--- a/pkgs/applications/networking/p2p/gnunet/default.nix
+++ b/pkgs/applications/networking/p2p/gnunet/default.nix
@@ -1,20 +1,24 @@
 { stdenv, fetchurl, adns, curl, gettext, gmp, gnutls, libextractor
 , libgcrypt, libgnurl, libidn, libmicrohttpd, libtool, libunistring
 , makeWrapper, ncurses, pkgconfig, libxml2, sqlite, zlib
-, libpulseaudio, libopus, libogg }:
+, libpulseaudio, libopus, libogg, jansson }:
 
 stdenv.mkDerivation rec {
-  name = "gnunet-0.11.0";
+  pname = "gnunet";
+  version = "0.11.6";
 
   src = fetchurl {
-    url = "mirror://gnu/gnunet/${name}.tar.gz";
-    sha256 = "16kydkrjlf2vxflgls46bwaf9kjczf621p456q0qlphd7cy7lixp";
+    url = "mirror://gnu/gnunet/${pname}-${version}.tar.gz";
+    sha256 = "1gspr1lh885sb9r2anh7bi4zan3zjqx33lpyhq9hm2g0n5ip187q";
   };
 
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [ pkgconfig libtool makeWrapper ];
   buildInputs = [
-    adns curl gettext gmp gnutls libextractor libgcrypt libgnurl libidn
-    libmicrohttpd libtool libunistring libxml2 makeWrapper ncurses
-    pkgconfig sqlite zlib libpulseaudio libopus libogg
+    adns curl gmp gnutls libextractor libgcrypt libgnurl libidn
+    libmicrohttpd libunistring libxml2 ncurses gettext
+    sqlite zlib libpulseaudio libopus libogg jansson
   ];
 
   preConfigure = ''
@@ -29,26 +33,18 @@ stdenv.mkDerivation rec {
     find . \( -iname \*test\*.c -or -name \*.conf \) | \
       xargs sed -ie "s|/tmp|$TMPDIR|g"
 
-    # Ensure NSS installation works fine
-    configureFlags="$configureFlags --with-nssdir=$out/lib"
-    patchShebangs src/gns/nss/install-nss-plugin.sh
-
     sed -ie 's|@LDFLAGS@|@LDFLAGS@ $(Z_LIBS)|g' \
       src/regex/Makefile.in \
       src/fs/Makefile.in
   '';
 
+  # unfortunately, there's still a few failures with impure tests
   doCheck = false;
-
-  /* FIXME: Tests must be run this way, but there are still a couple of
-     failures.
-
-  postInstall =
-    '' export GNUNET_PREFIX="$out"
-       export PATH="$out/bin:$PATH"
-       make -k check
-    '';
-  */
+  checkPhase = ''
+    export GNUNET_PREFIX="$out"
+    export PATH="$out/bin:$PATH"
+    make -k check
+  '';
 
   meta = with stdenv.lib; {
     description = "GNU's decentralized anonymous and censorship-resistant P2P framework";
@@ -69,9 +65,7 @@ stdenv.mkDerivation rec {
     '';
 
     homepage = https://gnunet.org/;
-
     license = licenses.gpl2Plus;
-
     maintainers = with maintainers; [ vrthra ];
     platforms = platforms.gnu ++ platforms.linux;
   };

--- a/pkgs/development/libraries/libgnurl/default.nix
+++ b/pkgs/development/libraries/libgnurl/default.nix
@@ -2,23 +2,38 @@
   libidn2, libunistring, nghttp2 }:
 
 stdenv.mkDerivation rec {
-  version = "7.64.0";
-
-  name = "libgnurl-${version}";
+  pname = "libgnurl";
+  version = "7.65.3";
 
   src = fetchurl {
     url = "mirror://gnu/gnunet/gnurl-${version}.tar.gz";
-    sha256 = "0pvmbi32lixcpk10prplmwrmi4wzp3bc1aiyhr552kx0wqdqmdk8";
+    sha256 = "19l7jw3x83qk7yay5968pc39vzvxl55mhn1nmjh51miyda405qa9";
   };
 
   nativeBuildInputs = [ libtool groff perl pkgconfig python2 ];
-    
+
   buildInputs = [ gnutls zlib libidn2 libunistring nghttp2 ];
 
   configureFlags = [
     "--disable-ntlm-wb"
     "--without-ca-bundle"
     "--with-ca-fallback"
+    # below options will cause errors if enabled
+    "--disable-ftp"
+    "--disable-tftp"
+    "--disable-file"
+    "--disable-ldap"
+    "--disable-dict"
+    "--disable-rtsp"
+    "--disable-telnet"
+    "--disable-pop3"
+    "--disable-imap"
+    "--disable-smb"
+    "--disable-smtp"
+    "--disable-gopher"
+    "--without-ssl" # disables only openssl, not ssl in general
+    "--without-libpsl"
+    "--without-librtmp"
   ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
fixing @r-ryantm failed updates

insight into disabling a bunch of protocols located here: https://gnunet.org/en/gnurl.html

bumped gnunet as well:
- no longer supports nss
- did a little expression clean-up

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @falsifian @vrthra 

still features ssl, (just only gnutls, by design):
```
$ ./result/bin/gnurl --version
curl 7.65.3 (x86_64-pc-linux-gnu) libcurl/7.65.3 GnuTLS/3.6.9 zlib/1.2.11 libidn2/2.2.0
Release-Date: 2019-08-15
Protocols: http https
Features: AsynchDNS HTTPS-proxy IDN IPv6 Largefile libz NTLM SSL TLS-SRP UnixSockets
```

```
[4 built, 177 copied (713.0 MiB), 167.3 MiB DL]
https://github.com/NixOS/nixpkgs/pull/67520
2 package were build:
gnunet libgnurl
```