### PR TITLE
ocamlPackages.lablgtk: 2.18.6 -> 2.18.8

### DIFF
--- a/pkgs/development/ocaml-modules/lablgtk/default.nix
+++ b/pkgs/development/ocaml-modules/lablgtk/default.nix
@@ -3,9 +3,9 @@
 let param =
   let check = stdenv.lib.versionAtLeast ocaml.version; in
   if check "4.06" then {
-    version = "2.18.6";
-    url = https://forge.ocamlcore.org/frs/download.php/1726/lablgtk-2.18.6.tar.gz;
-    sha256 = "1y38fdvswy6hmppm65qvgdk4pb3ghhnvz7n4ialf46340r1s5p2d";
+    version = "2.18.8";
+    url = "https://github.com/garrigue/lablgtk/releases/download/lablgtk2188/lablgtk-2.18.8.tar.gz";
+    sha256 = "1qsd9nv96fxddc8zayqiqxw9hcyf29axckqg100fm2brs2prpxci";
   } else if check "3.12" then {
     version = "2.18.5";
     url = https://forge.ocamlcore.org/frs/download.php/1627/lablgtk-2.18.5.tar.gz;


### PR DESCRIPTION
###### Motivation for this change

Ensures compatibility with OCaml 4.08.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @maggesi @roconnor 
