### PR TITLE
ocamlPackages.ocplib-json-typed: 0.5 -> 0.7.1

### DIFF
--- a/pkgs/development/ocaml-modules/ocplib-json-typed/browser.nix
+++ b/pkgs/development/ocaml-modules/ocplib-json-typed/browser.nix
@@ -1,0 +1,14 @@
+{ buildDunePackage, ocplib-json-typed, js_of_ocaml }:
+
+buildDunePackage {
+  pname = "ocplib-json-typed-browser";
+  inherit (ocplib-json-typed) version src;
+
+  propagatedBuildInputs = [ ocplib-json-typed js_of_ocaml ];
+
+  meta = {
+    description = "A Json_repr interface over JavaScript's objects";
+    inherit (ocplib-json-typed.meta) homepage license maintainers;
+  };
+}
+

--- a/pkgs/development/ocaml-modules/ocplib-json-typed/bson.nix
+++ b/pkgs/development/ocaml-modules/ocplib-json-typed/bson.nix
@@ -1,0 +1,13 @@
+{ buildDunePackage, ocplib-json-typed, ocplib-endian }:
+
+buildDunePackage {
+  pname = "ocplib-json-typed-bson";
+  inherit (ocplib-json-typed) version src;
+
+  propagatedBuildInputs = [ ocplib-json-typed ocplib-endian ];
+
+  meta = {
+    description = "A Json_repr compatible implementation of the JSON compatible subset of BSON";
+    inherit (ocplib-json-typed.meta) homepage license maintainers;
+  };
+}

--- a/pkgs/development/ocaml-modules/ocplib-json-typed/default.nix
+++ b/pkgs/development/ocaml-modules/ocplib-json-typed/default.nix
@@ -1,25 +1,21 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, ocplib-endian, js_of_ocaml, uri }:
+{ lib, buildDunePackage, fetchFromGitHub, uri }:
 
-stdenv.mkDerivation rec {
-	name = "ocaml${ocaml.version}-ocplib-json-typed-${version}";
-	version = "0.5";
+buildDunePackage rec {
+	pname = "ocplib-json-typed";
+	version = "0.7.1";
 	src = fetchFromGitHub {
 		owner = "OCamlPro";
 		repo = "ocplib-json-typed";
 		rev = "v${version}";
-		sha256 = "02c600wm2wdpzb66pivxzwjhqa2dm7dqyfvw3mbvkv1g2jj7kn2q";
+		sha256 = "1gv0vqqy9lh7isaqg54b3lam2sh7nfjjazi6x7zn6bh5f77g1p5q";
 	};
 
-	buildInputs = [ ocaml findlib ocplib-endian js_of_ocaml ];
 	propagatedBuildInputs = [ uri ];
-
-	createFindlibDestdir = true;
 
 	meta = {
 		description = "A collection of type-aware JSON utilities for OCaml";
-		license = stdenv.lib.licenses.lgpl21;
-		maintainers = [ stdenv.lib.maintainers.vbgl ];
+		license = lib.licenses.lgpl21;
+		maintainers = [ lib.maintainers.vbgl ];
 		inherit (src.meta) homepage;
-		inherit (ocaml.meta) platforms;
 	};
 }

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -549,6 +549,10 @@ let
 
     ocplib-json-typed = callPackage ../development/ocaml-modules/ocplib-json-typed { };
 
+    ocplib-json-typed-browser = callPackage ../development/ocaml-modules/ocplib-json-typed/browser.nix { };
+
+    ocplib-json-typed-bson = callPackage ../development/ocaml-modules/ocplib-json-typed/bson.nix { };
+
     ocplib-simplex = callPackage ../development/ocaml-modules/ocplib-simplex { };
 
     ocsigen_server = callPackage ../development/ocaml-modules/ocsigen-server { };


### PR DESCRIPTION
###### Motivation for this change

Compatibility with recent js-of-ocaml.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

