### PR TITLE
texi2html: 1.82 -> 5.0

### DIFF
--- a/pkgs/development/tools/misc/texi2html/default.nix
+++ b/pkgs/development/tools/misc/texi2html/default.nix
@@ -1,20 +1,27 @@
-{ stdenv, fetchurl, perl }:
+{ stdenv, fetchurl, perl, gettext }:
 
 stdenv.mkDerivation rec {
-  name = "texi2html-1.82";
+  pname = "texi2html";
+  version = "5.0";
 
   src = fetchurl {
-    url = "mirror://savannah/texi2html/${name}.tar.bz2";
-    sha256 = "1wdli2szkgm3l0vx8rf6lylw0b0m47dlz9iy004n928nqkzix76n";
+    url = "mirror://savannah/texi2html/${pname}-${version}.tar.bz2";
+    sha256 = "1yprv64vrlcbksqv25asplnjg07mbq38lfclp1m5lj8cw878pag8";
   };
 
-  buildInputs = [perl];
+  nativeBuildInputs = [ gettext ];
+  buildInputs = [ perl ];
 
-  meta = { 
+  preBuild = ''
+    substituteInPlace separated_to_hash.pl \
+      --replace "/usr/bin/perl" "${perl}/bin/perl"
+  '';
+
+  meta = with stdenv.lib; {
     description = "Perl script which converts Texinfo source files to HTML output";
     homepage = https://www.nongnu.org/texi2html/;
-    license = stdenv.lib.licenses.gpl2;
-    maintainers = [stdenv.lib.maintainers.marcweber];
-    platforms = stdenv.lib.platforms.unix;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.marcweber ];
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
fixing broken @r-ryantm updates

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @MarcWeber 

```
[295 built, 594 copied (1482.8 MiB), 469.4 MiB DL]
https://github.com/NixOS/nixpkgs/pull/67531
12 package were build:
asciidocFull asciidoc-full-with-plugins btrbk denemo disorderfs frescobaldi lilypond lilypond-unstable lilypond-with-fonts solfege texi2html udiskie
```