### PR TITLE
wayback_machine_downloader: init at 2.2.1

### DIFF
--- a/pkgs/applications/networking/wayback_machine_downloader/Gemfile
+++ b/pkgs/applications/networking/wayback_machine_downloader/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org' do
+  gem 'wayback_machine_downloader'
+end

--- a/pkgs/applications/networking/wayback_machine_downloader/Gemfile.lock
+++ b/pkgs/applications/networking/wayback_machine_downloader/Gemfile.lock
@@ -1,0 +1,13 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    wayback_machine_downloader (2.2.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  wayback_machine_downloader!
+
+BUNDLED WITH
+   1.17.2

--- a/pkgs/applications/networking/wayback_machine_downloader/default.nix
+++ b/pkgs/applications/networking/wayback_machine_downloader/default.nix
@@ -1,0 +1,17 @@
+{ lib, bundlerApp, bundlerUpdateScript }:
+bundlerApp {
+  pname = "wayback_machine_downloader";
+  exes = [ "wayback_machine_downloader" ];
+  gemdir = ./.;
+
+  passthru.updateScript = bundlerUpdateScript "wayback_machine_downloader";
+
+  meta = with lib; {
+    description =
+      "Download an entire website from the Internet Archive Wayback Machine.";
+    homepage = "https://github.com/hartator/wayback-machine-downloader";
+    license = licenses.mit;
+    maintainers = [ maintainers.manveru ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/applications/networking/wayback_machine_downloader/default.nix
+++ b/pkgs/applications/networking/wayback_machine_downloader/default.nix
@@ -7,8 +7,7 @@ bundlerApp {
   passthru.updateScript = bundlerUpdateScript "wayback_machine_downloader";
 
   meta = with lib; {
-    description =
-      "Download an entire website from the Internet Archive Wayback Machine.";
+    description = "Download websites from the Internet Archive Wayback Machine";
     homepage = "https://github.com/hartator/wayback-machine-downloader";
     license = licenses.mit;
     maintainers = [ maintainers.manveru ];

--- a/pkgs/applications/networking/wayback_machine_downloader/gemset.nix
+++ b/pkgs/applications/networking/wayback_machine_downloader/gemset.nix
@@ -1,0 +1,12 @@
+{
+  wayback_machine_downloader = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "12kb1qmvmmsaihqab1prn6cmynkn6cgb4vf41mgv22wkcgv5wgk2";
+      type = "gem";
+    };
+    version = "2.2.1";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5734,6 +5734,8 @@ in
 
   qview = libsForQt5.callPackage ../applications/graphics/qview {};
 
+  wayback_machine_downloader = callPackage ../applications/networking/wayback_machine_downloader { };
+
   wiggle = callPackage ../development/tools/wiggle { };
 
   radamsa = callPackage ../tools/security/radamsa { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Just used it myself

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).