### PR TITLE
s3ql: clean up dependencies, build for release, fix tests, fix `--systemd` option, fix `umount.s3ql`

### DIFF
--- a/pkgs/tools/backup/s3ql/default.nix
+++ b/pkgs/tools/backup/s3ql/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, python3Packages, sqlite, which }:
+{ stdenv, fetchFromGitHub, python3Packages, psmisc, sqlite, utillinuxMinimal, which }:
 
 python3Packages.buildPythonApplication rec {
   pname = "s3ql";
@@ -11,25 +11,45 @@ python3Packages.buildPythonApplication rec {
     sha256 = "1x0xj8clfs8fdczn8skc2wag5i4z47bsvlczn22iaf20hll1bb2w";
   };
 
-  checkInputs = [ which ] ++ (with python3Packages; [ cython pytest ]);
+  nativeBuildInputs = with python3Packages; [
+    cython
+  ];
+  buildInputs = [
+    sqlite
+  ];
+  checkInputs = with python3Packages; [
+    pytest
+  ] ++ [
+    which
+  ];
   propagatedBuildInputs = with python3Packages; [
-    sqlite apsw pycrypto requests defusedxml dugong llfuse
-    cython pytest pytest-catchlog google_auth google-auth-oauthlib
+    apsw
+    cryptography
+    defusedxml
+    dugong
+    google-auth-oauthlib
+    google_auth
+    llfuse
+    requests
+    systemd
+  ] ++ [
+    psmisc # `umount.s3ql` requires `fuser`
+    utillinuxMinimal.bin # `umount.s3ql` requires `umount`
   ];
 
   preBuild = ''
+    # http://www.rath.org/s3ql-docs/installation.html#installing-s3ql
+    rm ./MANIFEST.in # Build for release
     ${python3Packages.python.interpreter} ./setup.py build_cython build_ext --inplace
   '';
 
   checkPhase = ''
-    # Removing integration tests
-    rm tests/t{4,5,6}_*
-    pytest tests
+    HOME=$TMPDIR pytest tests
   '';
 
   meta = with stdenv.lib; {
     description = "A full-featured file system for online data storage";
-    homepage = "https://github.com/s3ql/s3ql/";
+    homepage = "https://github.com/s3ql/s3ql";
     license = licenses.gpl3;
     maintainers = with maintainers; [ rushmorem ];
     platforms = platforms.linux;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Move dependencies to proper inputs. Build for release instead of development. Fix and enable all tests. Use the correct `crypography` library instead of `pycrypto`, as per [installation instructions](http://www.rath.org/s3ql-docs/installation.html#installing-s3ql).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of (most) binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @rushmorem
