### PR TITLE
onnxruntime: init at 0.5.0

### DIFF
--- a/pkgs/development/libraries/onnxruntime/default.nix
+++ b/pkgs/development/libraries/onnxruntime/default.nix
@@ -1,0 +1,62 @@
+{ stdenv, fetchFromGitHub, glibcLocales
+, cmake, python3
+}:
+
+stdenv.mkDerivation rec {
+  pname = "onnxruntime";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "onnxruntime";
+    rev = "v${version}";
+    sha256 = "0s8ylc5xr55490hbz7zn3hnp9dnyp92d320ln8xw5hqkw3mgyr3p";
+    # TODO: use nix-versions of grpc, onnx, eigen, googletest, etc.
+    # submodules increase src size and compile times significantly
+    # not currently feasible due to how integrated cmake build is with git
+    fetchSubmodules = true;
+  };
+
+  # TODO: build server, and move .so's to lib output
+  outputs = [ "out" "dev" ];
+
+  nativeBuildInputs = [
+    cmake
+    python3 # for shared-lib or server
+  ];
+
+  cmakeDir = "../cmake";
+
+  cmakeFlags = [
+    "-Donnxruntime_USE_OPENMP=ON"
+    "-Donnxruntime_BUILD_SHARED_LIB=ON"
+    "-Donnxruntime_ENABLE_LTO=ON"
+  ];
+
+  # ContribOpTest.StringNormalizerTest sets locale to en_US.UTF-8"
+  preCheck = stdenv.lib.optionalString stdenv.isLinux ''
+    export LOCALE_ARCHIVE="${glibcLocales}/lib/locale/locale-archive"
+  '';
+  doCheck = true;
+
+  postInstall = ''
+    rm -r $out/bin   # ctest runner
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Cross-platform, high performance scoring engine for ML models";
+    longDescription = ''
+      ONNX Runtime is a performance-focused complete scoring engine
+      for Open Neural Network Exchange (ONNX) models, with an open
+      extensible architecture to continually address the latest developments
+      in AI and Deep Learning. ONNX Runtime stays up to date with the ONNX
+      standard with complete implementation of all ONNX operators, and
+      supports all ONNX releases (1.2+) with both future and backwards
+      compatibility.
+    '';
+    homepage = "https://github.com/microsoft/onnxruntime";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1852,6 +1852,8 @@ in
 
   onboard = callPackage ../applications/misc/onboard { };
 
+  onnxruntime = callPackage ../development/libraries/onnxruntime { };
+
   xkbd = callPackage ../applications/misc/xkbd { };
 
   optar = callPackage ../tools/graphics/optar {};


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Onnxruntime is a scoring engine for ML models. Somewhat of a competitor against other scoring engines such as tensorflow.

This is just the initial starting point for cpu-enabled dynamically linked libraries. CUDA, MKL, and other refinements are due later. Not really feasible with how integrated their cmake + git-submodule layout is right now

cc @costrouc  because he's into ML stuff.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

closure size:
```
$ nix path-info -Sh ./result
/nix/store/pnq3kfg37cv6cxmhccwcpiqhw4gz95qv-onnxruntime-0.5.0     40.5M
```
just relies on gcc (for the time being):
```
$ nix-store -q --tree ./result
/nix/store/pnq3kfg37cv6cxmhccwcpiqhw4gz95qv-onnxruntime-0.5.0
+---/nix/store/iykxb0bmfjmi7s53kfg6pjbfpd8jmza6-glibc-2.27
|   +---/nix/store/iykxb0bmfjmi7s53kfg6pjbfpd8jmza6-glibc-2.27 [...]
+---/nix/store/pjx3f50x0qziyivs7rbg5s12p99nn2np-gcc-7.4.0-lib
    +---/nix/store/iykxb0bmfjmi7s53kfg6pjbfpd8jmza6-glibc-2.27 [...]
    +---/nix/store/pjx3f50x0qziyivs7rbg5s12p99nn2np-gcc-7.4.0-lib [...]
```
```
$ tree ./result/
./result/
└── lib
    ├── libonnxruntime.so -> libonnxruntime.so.0.5.0
    └── libonnxruntime.so.0.5.0
```
the result-dev/lib/cmake/protobuf is from onnxruntime doing a `add_subdirectory` on the entire protobuf codebase.
```
$ tree -L 3 ./result-dev
./result-dev
├── include
│   └── onnxruntime
│       └── core
├── lib
│   └── cmake
│       └── protobuf
└── nix-support
    └── propagated-build-inputs
```
