### PR TITLE
gnome3.vino: 3.22.0 -> 2019-07-08

### DIFF
--- a/pkgs/desktops/gnome-3/core/vino/default.nix
+++ b/pkgs/desktops/gnome-3/core/vino/default.nix
@@ -1,29 +1,85 @@
-{ stdenv, fetchurl, lib, wrapGAppsHook
-, pkgconfig, gnome3, gtk3, glib, intltool, libXtst, libnotify, libsoup
-, telepathySupport ? false, dbus-glib ? null, telepathy-glib ? null
-, libsecret, gnutls, libgcrypt, avahi, zlib, libjpeg, libXdamage, libXfixes, libXext
-, networkmanager }:
-
-with lib;
+{ stdenv
+, fetchFromGitLab
+, wrapGAppsHook
+, pkgconfig
+, gnome3
+, gtk3
+, glib
+, intltool
+, libXtst
+, libnotify
+, libsoup
+, libsecret
+, gnutls
+, libgcrypt
+, avahi
+, zlib
+, libjpeg
+, libXdamage
+, libXfixes
+, libXext
+, networkmanager
+, gnome-common
+, libtool
+, automake
+, autoconf
+, telepathySupport ? false
+, dbus-glib ? null
+, telepathy-glib ? null
+}:
 
 stdenv.mkDerivation rec {
-  name = "vino-${version}";
-  version = "3.22.0";
+  pname = "vino";
+  version = "unstable-2019-07-08";
 
-  src = fetchurl {
-    url = "mirror://gnome/sources/vino/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "2911c779b6a2c46e5bc8e5a0c94c2a4d5bd4a1ee7e35f2818702cb13d9d23bab";
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "GNOME";
+    repo = "vino";
+    rev = "aed81a798558c8127b765cd4fb4dc726d10f1e21";
+    sha256 = "16r4cj5nsygmd9v97nq6d1yhynzak9hdnaprcdbmwfhh0c9w8jv3";
   };
 
   doCheck = true;
 
-  nativeBuildInputs = [ intltool wrapGAppsHook pkgconfig ];
+  nativeBuildInputs = [
+    autoconf
+    automake
+    gnome-common
+    intltool
+    libtool
+    pkgconfig
+    wrapGAppsHook
+  ];
 
   buildInputs = [
-    gnome3.adwaita-icon-theme gtk3 glib libXtst libnotify libsoup
-    libsecret gnutls libgcrypt avahi zlib libjpeg
-    libXdamage libXfixes libXext networkmanager
-  ] ++ optionals telepathySupport [ dbus-glib telepathy-glib ];
+    avahi
+    glib
+    gnome3.adwaita-icon-theme
+    gnutls
+    gtk3
+    libXdamage
+    libXext
+    libXfixes
+    libXtst
+    libgcrypt
+    libjpeg
+    libnotify
+    libsecret
+    libsoup
+    networkmanager
+    zlib
+  ]
+  ++ stdenv.lib.optionals telepathySupport [ dbus-glib telepathy-glib ]
+  ;
+
+  preConfigure = ''
+    NOCONFIGURE=1 ./autogen.sh
+  '';
+
+  postInstall = stdenv.lib.optionalString (!telepathySupport) ''
+    rm -f $out/share/dbus-1/services/org.freedesktop.Telepathy.Client.Vino.service
+  '';
 
   passthru = {
     updateScript = gnome3.updateScript {
@@ -35,7 +91,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = https://wiki.gnome.org/Projects/Vino;
     description = "GNOME desktop sharing server";
-    maintainers = with maintainers; [ lethalman domenkozar ];
+    maintainers = gnome3.maintainers;
     license = licenses.gpl2;
     platforms = platforms.linux;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Noticed that the dbus service was failing to activate `org.freedesktop.Telepathy.Client.Vino.service`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
