### PR TITLE
qarte: use qt5’s mkDerivation and an other fix

### DIFF
--- a/pkgs/applications/video/qarte/default.nix
+++ b/pkgs/applications/video/qarte/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchbzr, python3, rtmpdump, makeWrapper }:
+{ mkDerivation, lib, fetchbzr, python3, rtmpdump }:
 
 let
-  pythonEnv = python3.withPackages (ps: with ps; [ pyqt5 sip ]);
-in stdenv.mkDerivation {
+  pythonEnv = python3.withPackages (ps: with ps; [ pyqt5 ]);
+in mkDerivation {
   name = "qarte-4.6.0";
   src = fetchbzr {
     url = http://bazaar.launchpad.net/~vincent-vandevyvre/qarte/qarte-4;
@@ -10,28 +10,33 @@ in stdenv.mkDerivation {
     sha256 = "0v4zpj8w67ydvnmanxbl8pwvn0cfv70c0mlw36a1r4n0rvgxffcn";
   };
 
-  buildInputs = [ makeWrapper pythonEnv ];
+  buildInputs = [ pythonEnv ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     mv qarte $out/bin/
     substituteInPlace $out/bin/qarte \
       --replace '/usr/share' "$out/share"
-    wrapProgram $out/bin/qarte \
-      --prefix PATH : "${rtmpdump}/bin"
 
     mkdir -p $out/share/man/man1/
     mv qarte.1 $out/share/man/man1/
 
     mkdir -p $out/share/qarte
     mv * $out/share/qarte/
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    wrapQtApp $out/bin/qarte \
+      --prefix PATH : ${rtmpdump}/bin
   '';
 
   meta = {
     homepage = https://launchpad.net/qarte;
     description = "A recorder for Arte TV Guide and Arte Concert";
-    license = stdenv.lib.licenses.gpl3;
-    maintainers = with stdenv.lib.maintainers; [ vbgl ];
-    platforms = stdenv.lib.platforms.linux;
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ vbgl ];
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/applications/video/qarte/default.nix
+++ b/pkgs/applications/video/qarte/default.nix
@@ -1,7 +1,7 @@
 { mkDerivation, lib, fetchbzr, python3, rtmpdump }:
 
 let
-  pythonEnv = python3.withPackages (ps: with ps; [ pyqt5 ]);
+  pythonEnv = python3.withPackages (ps: with ps; [ pyqt5_with_qtmultimedia ]);
 in mkDerivation {
   name = "qarte-4.6.0";
   src = fetchbzr {

--- a/pkgs/development/python-modules/pyqt/5.x.nix
+++ b/pkgs/development/python-modules/pyqt/5.x.nix
@@ -6,6 +6,7 @@
 , qtdeclarative
 , qtwebchannel
 , withConnectivity ? false, qtconnectivity
+, withMultimedia ? false, qtmultimedia
 , withWebKit ? false, qtwebkit
 , withWebSockets ? false, qtwebsockets
 }:
@@ -50,6 +51,7 @@ in buildPythonPackage rec {
     qtwebchannel
   ]
     ++ lib.optional withConnectivity qtconnectivity
+    ++ lib.optional withMultimedia qtmultimedia
     ++ lib.optional withWebKit qtwebkit
     ++ lib.optional withWebSockets qtwebsockets
   ;
@@ -121,6 +123,7 @@ in buildPythonPackage rec {
     ]
     ++ lib.optional withWebSockets "PyQt5.QtWebSockets"
     ++ lib.optional withWebKit "PyQt5.QtWebKit"
+    ++ lib.optional withMultimedia "PyQt5.QtMultimedia"
     ++ lib.optional withConnectivity "PyQt5.QtConnectivity"
     ;
     imports = lib.concatMapStrings (module: "import ${module};") modules;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5689,7 +5689,7 @@ in
 
   openmodelica = callPackage ../applications/science/misc/openmodelica { };
 
-  qarte = callPackage ../applications/video/qarte { };
+  qarte = libsForQt5.callPackage ../applications/video/qarte { };
 
   qlcplus = libsForQt5.callPackage ../applications/misc/qlcplus { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -984,6 +984,8 @@ in {
   */
   pyqt5_with_qtwebkit = self.pyqt5.override { withWebKit = true; };
 
+  pyqt5_with_qtmultimedia = self.pyqt5.override { withMultimedia = true; };
+
   pyqtwebengine = pkgs.libsForQt5.callPackage ../development/python-modules/pyqtwebengine {
     pythonPackages = self;
   };


### PR DESCRIPTION
###### Motivation for this change

qarte fails to run (cc #65399).

Regarding QtMultimedia for pyqt, I made it opt-in as it seems to increase a lot the closure size of pyqt5 (257·10⁶ before, 313·10⁶ after) and would otherwise impact a lot of packages that I’d rather not touch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @svanderburg (pyqt5)
