### PR TITLE
treewide: remove redundant quotes

### DIFF
--- a/nixos/modules/config/fonts/fontconfig.nix
+++ b/nixos/modules/config/fonts/fontconfig.nix
@@ -51,8 +51,8 @@ let
                   then "fontconfig"
                   else "fontconfig_${version}";
       makeCache = fontconfig: pkgs.makeFontsCache { inherit fontconfig; fontDirectories = config.fonts.fonts; };
-      cache     = makeCache pkgs."${fcPackage}";
-      cache32   = makeCache pkgs.pkgsi686Linux."${fcPackage}";
+      cache     = makeCache pkgs.${fcPackage};
+      cache32   = makeCache pkgs.pkgsi686Linux.${fcPackage};
     in
     pkgs.writeText "fc-00-nixos-cache.conf" ''
       <?xml version='1.0'?>

--- a/nixos/modules/hardware/printers.nix
+++ b/nixos/modules/hardware/printers.nix
@@ -94,8 +94,8 @@ in {
             ppdOptions = mkOption {
               type = types.attrsOf types.str;
               example = {
-                "PageSize" = "A4";
-                "Duplex" = "DuplexNoTumble";
+                PageSize = "A4";
+                Duplex = "DuplexNoTumble";
               };
               default = {};
               description = ''
@@ -110,7 +110,7 @@ in {
   };
 
   config = mkIf (cfg.ensurePrinters != [] && config.services.printing.enable) {
-    systemd.services."ensure-printers" = let
+    systemd.services.ensure-printers = let
       cupsUnit = if config.services.printing.startWhenNeeded then "cups.socket" else "cups.service";
     in {
       description = "Ensure NixOS-configured CUPS printers";

--- a/nixos/modules/programs/x2goserver.nix
+++ b/nixos/modules/programs/x2goserver.nix
@@ -6,7 +6,7 @@ let
   cfg = config.programs.x2goserver;
 
   defaults = {
-    superenicer = { "enable" = cfg.superenicer.enable; };
+    superenicer = { enable = cfg.superenicer.enable; };
   };
   confText = generators.toINI {} (recursiveUpdate defaults cfg.settings);
   x2goServerConf = pkgs.writeText "x2goserver.conf" confText;

--- a/nixos/modules/services/audio/roon-server.nix
+++ b/nixos/modules/services/audio/roon-server.nix
@@ -61,8 +61,8 @@ in {
     };
 
     
-    users.groups."${cfg.group}" = {};
-    users.users."${cfg.user}" =
+    users.groups.${cfg.group} = {};
+    users.users.${cfg.user} =
       if cfg.user == "roon-server" then {
         isSystemUser = true;
         description = "Roon Server user";

--- a/nixos/modules/services/cluster/kubernetes/flannel.nix
+++ b/nixos/modules/services/cluster/kubernetes/flannel.nix
@@ -47,7 +47,7 @@ in
       }];
     };
 
-    systemd.services."mk-docker-opts" = {
+    systemd.services.mk-docker-opts = {
       description = "Pre-Docker Actions";
       path = with pkgs; [ gawk gnugrep ];
       script = ''
@@ -57,7 +57,7 @@ in
       serviceConfig.Type = "oneshot";
     };
 
-    systemd.paths."flannel-subnet-env" = {
+    systemd.paths.flannel-subnet-env = {
       wantedBy = [ "flannel.service" ];
       pathConfig = {
         PathModified = "/run/flannel/subnet.env";

--- a/nixos/modules/services/network-filesystems/ceph.nix
+++ b/nixos/modules/services/network-filesystems/ceph.nix
@@ -390,7 +390,7 @@ in
 
     systemd.targets = let
       targets = [
-        { "ceph" = { description = "Ceph target allowing to start/stop all ceph service instances at once";
+        { ceph = { description = "Ceph target allowing to start/stop all ceph service instances at once";
                      wantedBy = [ "multi-user.target" ]; }; }
       ] ++ optional cfg.mon.enable (makeTarget "mon")
         ++ optional cfg.mds.enable (makeTarget "mds")

--- a/nixos/modules/services/networking/pdns-recursor.nix
+++ b/nixos/modules/services/networking/pdns-recursor.nix
@@ -168,7 +168,7 @@ in {
       disable-syslog = true;
     };
 
-    users.users."${username}" = {
+    users.users.${username} = {
       home = dataDir;
       createHome = true;
       uid = config.ids.uids.pdns-recursor;

--- a/nixos/modules/services/web-apps/icingaweb2/icingaweb2.nix
+++ b/nixos/modules/services/web-apps/icingaweb2/icingaweb2.nix
@@ -165,7 +165,7 @@ in {
 
   config = mkIf cfg.enable {
     services.phpfpm.pools = mkIf (cfg.pool == "${poolName}") {
-      "${poolName}" = {
+      ${poolName} = {
         user = "icingaweb2";
         phpOptions = ''
           extension = ${pkgs.phpPackages.imagick}/lib/php/extensions/imagick.so

--- a/nixos/modules/services/web-apps/moodle.nix
+++ b/nixos/modules/services/web-apps/moodle.nix
@@ -18,7 +18,7 @@ let
   global $CFG;
   $CFG = new stdClass();
 
-  $CFG->dbtype    = '${ { "mysql" = "mariadb"; "pgsql" = "pgsql"; }.${cfg.database.type} }';
+  $CFG->dbtype    = '${ { mysql = "mariadb"; pgsql = "pgsql"; }.${cfg.database.type} }';
   $CFG->dblibrary = 'native';
   $CFG->dbhost    = '${cfg.database.host}';
   $CFG->dbname    = '${cfg.database.name}';
@@ -92,8 +92,8 @@ in
         type = types.int;
         description = "Database host port.";
         default = {
-          "mysql" = 3306;
-          "pgsql" = 5432;
+          mysql = 3306;
+          pgsql = 5432;
         }.${cfg.database.type};
         defaultText = "3306";
       };
@@ -294,7 +294,7 @@ in
 
     systemd.services.httpd.after = optional mysqlLocal "mysql.service" ++ optional pgsqlLocal "postgresql.service";
 
-    users.users."${user}".group = group;
+    users.users.${user}.group = group;
 
   };
 }

--- a/nixos/modules/services/web-apps/restya-board.nix
+++ b/nixos/modules/services/web-apps/restya-board.nix
@@ -179,7 +179,7 @@ in
   config = mkIf cfg.enable {
 
     services.phpfpm.pools = {
-      "${poolName}" = {
+      ${poolName} = {
         inherit (cfg) user group;
 
         phpOptions = ''

--- a/nixos/modules/services/web-apps/selfoss.nix
+++ b/nixos/modules/services/web-apps/selfoss.nix
@@ -115,7 +115,7 @@ in
 
   config = mkIf cfg.enable {
     services.phpfpm.pools = mkIf (cfg.pool == "${poolName}") {
-      "${poolName}" = {
+      ${poolName} = {
         user = "nginx";
         settings = mapAttrs (name: mkDefault) {
           "listen.owner" = "nginx";

--- a/nixos/modules/services/web-apps/tt-rss.nix
+++ b/nixos/modules/services/web-apps/tt-rss.nix
@@ -520,7 +520,7 @@ let
     ];
 
     services.phpfpm.pools = mkIf (cfg.pool == "${poolName}") {
-      "${poolName}" = {
+      ${poolName} = {
         inherit (cfg) user;
         settings = mapAttrs (name: mkDefault) {
           "listen.owner" = "nginx";

--- a/nixos/modules/services/web-servers/phpfpm/default.nix
+++ b/nixos/modules/services/web-servers/phpfpm/default.nix
@@ -36,7 +36,7 @@ let
 
   poolOpts = { name, ... }:
     let
-      poolOpts = cfg.pools."${name}";
+      poolOpts = cfg.pools.${name};
     in
     {
       options = {

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -243,11 +243,11 @@ in
       services.geoclue2.enable = mkDefault true;
       services.geoclue2.enableDemoAgent = false; # GNOME has its own geoclue agent
 
-      services.geoclue2.appConfig."gnome-datetime-panel" = {
+      services.geoclue2.appConfig.gnome-datetime-panel = {
         isAllowed = true;
         isSystem = true;
       };
-      services.geoclue2.appConfig."gnome-color-panel" = {
+      services.geoclue2.appConfig.gnome-color-panel = {
         isAllowed = true;
         isSystem = true;
       };

--- a/pkgs/applications/audio/AMB-plugins/default.nix
+++ b/pkgs/applications/audio/AMB-plugins/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     longDescription = ''
       Mono and stereo to B-format panning, horizontal rotator, square, hexagon and cube decoders.
     '';
-    version = "${version}";
+    version = version;
     homepage = http://kokkinizita.linuxaudio.org/linuxaudio/ladspa/index.html;
     license = stdenv.lib.licenses.gpl2Plus;
     maintainers = [ stdenv.lib.maintainers.magnetophon ];

--- a/pkgs/applications/audio/FIL-plugins/default.nix
+++ b/pkgs/applications/audio/FIL-plugins/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
       All switches and controls are internally smoothed, so they can be used 'live' whithout any clicks or zipper noises.
       This should make this plugin a good candidate for use in systems that allow automation of plugin control ports, such as Ardour, or for stage use.
     '';
-    version = "${version}";
+    version = version;
     homepage = http://kokkinizita.linuxaudio.org/linuxaudio/ladspa/index.html;
     license = stdenv.lib.licenses.gpl2Plus;
     maintainers = [ stdenv.lib.maintainers.magnetophon ];

--- a/pkgs/applications/audio/axoloti/default.nix
+++ b/pkgs/applications/audio/axoloti/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "axoloti";
     repo = "axoloti";
-    rev = "${version}";
+    rev = version;
     sha256 = "1qffis277wshldr3i939b0r2x3a2mlr53samxqmr2nk1sfm2b4w9";
   };
 

--- a/pkgs/applications/audio/csound/csound-qt/default.nix
+++ b/pkgs/applications/audio/csound/csound-qt/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "CsoundQt";
     repo = "CsoundQt";
-    rev = "${version}";
+    rev = version;
     sha256 = "007jhkh0k6qk52r77i067999dwdiimazix6ggp2hvyc4pj6n5dip";
   };
 

--- a/pkgs/applications/audio/faust/faust2.nix
+++ b/pkgs/applications/audio/faust/faust2.nix
@@ -20,7 +20,7 @@ let
   src = fetchFromGitHub {
     owner = "grame-cncm";
     repo = "faust";
-    rev = "${version}";
+    rev = version;
     sha256 = "1pci8ac6sqrm3mb3yikmmr3iy35g3nj4iihazif1amqkbdz719rc";
     fetchSubmodules = true;
   };

--- a/pkgs/applications/audio/ir.lv2/default.nix
+++ b/pkgs/applications/audio/ir.lv2/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "tomszilagyi";
     repo = "ir.lv2";
-    rev = "${version}";
+    rev = version;
     sha256 = "1p6makmgr898fakdxzl4agh48qqwgv1k1kwm8cgq187n0mhiknp6";
   };
 

--- a/pkgs/applications/audio/lsp-plugins/default.nix
+++ b/pkgs/applications/audio/lsp-plugins/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "sadko4u";
-    repo = "${pname}";
+    repo = pname;
     rev = "${pname}-${version}";
     sha256 = "1dzpl7f354rwp37bkr9h2yyafykcdn6m1qqfshqg77fj0pcsw8r2";
   };

--- a/pkgs/applications/audio/musescore/darwin.nix
+++ b/pkgs/applications/audio/musescore/darwin.nix
@@ -9,7 +9,7 @@ with lib;
 
 stdenv.mkDerivation rec {
   pname = "musescore-darwin";
-  version = "${concatStringsSep "." versionComponents}";
+  version = concatStringsSep "." versionComponents;
 
   src = fetchurl {
     url =  "ftp://ftp.osuosl.org/pub/musescore/releases/MuseScore-${concatStringsSep "." (take 3 versionComponents)}/MuseScore-${version}.dmg";

--- a/pkgs/applications/audio/sooperlooper/default.nix
+++ b/pkgs/applications/audio/sooperlooper/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
       and the engine can be run standalone on a computer without a monitor.
     '';
 
-    version = "${version}";
+    version = version;
     homepage = http://essej.net/sooperlooper/index.html;
     license = stdenv.lib.licenses.gpl2;
     maintainers = [ stdenv.lib.maintainers.magnetophon ];

--- a/pkgs/applications/audio/spotifyd/default.nix
+++ b/pkgs/applications/audio/spotifyd/default.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "Spotifyd";
     repo = "spotifyd";
-    rev = "${version}";
+    rev = version;
     sha256 = "1iybk9xrrvhrcl2xl5r2xhyn1ydhrgwnnb8ldhsw5c16b32z03q1";
   };
 

--- a/pkgs/applications/audio/ssrc/default.nix
+++ b/pkgs/applications/audio/ssrc/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
       without audible degradation.
     '';
 
-    version = "${version}";
+    version = version;
     homepage = http://shibatch.sourceforge.net/;
     license = licenses.gpl2;
     maintainers = with maintainers; [ leenaars];

--- a/pkgs/applications/audio/tambura/default.nix
+++ b/pkgs/applications/audio/tambura/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "olilarkin";
-    repo = "${pname}";
+    repo = pname;
     rev = "v${version}";
     sha256 = "1w80cmiyzca1wirf5gypg3hcix1ky777id8wnd3k92mn1jf4a24y";
   };

--- a/pkgs/applications/audio/whipper/default.nix
+++ b/pkgs/applications/audio/whipper/default.nix
@@ -30,7 +30,7 @@ python2.pkgs.buildPythonApplication rec {
   ];
 
   makeWrapperArgs = [
-    "--prefix" "PATH" ":" "${stdenv.lib.makeBinPath [ accuraterip-checksum cdrdao utillinux flac sox ]}"
+    "--prefix" "PATH" ":" (stdenv.lib.makeBinPath [ accuraterip-checksum cdrdao utillinux flac sox ])
   ];
 
   # some tests require internet access

--- a/pkgs/applications/blockchains/nano-wallet/default.nix
+++ b/pkgs/applications/blockchains/nano-wallet/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = let
     options = {
-      BOOST_ROOT = "${boost}";
+      BOOST_ROOT = boost;
       Boost_USE_STATIC_LIBS = "OFF";
       RAIBLOCKS_GUI = "ON";
       RAIBLOCKS_TEST = "ON";

--- a/pkgs/applications/editors/emacs-modes/emacs2nix.nix
+++ b/pkgs/applications/editors/emacs-modes/emacs2nix.nix
@@ -14,7 +14,7 @@ in pkgs.mkShell {
     pkgs.bash
   ];
 
-  EMACS2NIX = "${src}";
+  EMACS2NIX = src;
 
   shellHook = ''
     export PATH=$PATH:${src}

--- a/pkgs/applications/editors/emacs-modes/manual-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/manual-packages.nix
@@ -6,7 +6,7 @@
     src = pkgs.fetchFromGitHub {
       owner = "skeeto";
       repo = "elisp-ffi";
-      rev = "${version}";
+      rev = version;
       sha256 = "0z2n3h5l5fj8wl8i1ilfzv11l3zba14sgph6gz7dx7q12cnp9j22";
     };
     buildInputs = [ external.libffi ];

--- a/pkgs/applications/editors/geany/with-vte.nix
+++ b/pkgs/applications/editors/geany/with-vte.nix
@@ -1,7 +1,7 @@
 { runCommand, makeWrapper, geany, gnome2 }:
 let name = builtins.replaceStrings ["geany-"] ["geany-with-vte-"] geany.name;
 in
-runCommand "${name}" { nativeBuildInputs = [ makeWrapper ]; inherit (geany.meta); } "
+runCommand name { nativeBuildInputs = [ makeWrapper ]; inherit (geany.meta); } "
    mkdir -p $out
    ln -s ${geany}/share $out
    makeWrapper ${geany}/bin/geany $out/bin/geany --prefix LD_LIBRARY_PATH : ${gnome2.vte}/lib

--- a/pkgs/applications/editors/jupyter/kernel.nix
+++ b/pkgs/applications/editors/jupyter/kernel.nix
@@ -8,7 +8,7 @@ let
     in {
       displayName = "Python 3";
       argv = [
-        "${env.interpreter}"
+        env.interpreter
         "-m"
         "ipykernel_launcher"
         "-f"

--- a/pkgs/applications/editors/retext/default.nix
+++ b/pkgs/applications/editors/retext/default.nix
@@ -35,7 +35,7 @@ in python.pkgs.buildPythonApplication {
   src = fetchFromGitHub {
     owner = "retext-project";
     repo = "retext";
-    rev = "${version}";
+    rev = version;
     sha256 = "1zcapywspc9v5zf5cxqkcy019np9n41gmryqixj66zsvd544c6si";
   };
 

--- a/pkgs/applications/editors/vscode/vscode.nix
+++ b/pkgs/applications/editors/vscode/vscode.nix
@@ -11,8 +11,8 @@ let
   archive_fmt = if system == "x86_64-darwin" then "zip" else "tar.gz";
 
   sha256 = {
-    "x86_64-linux" = "1iz36nhkg78346g5407df6jv4d1ydb22hhgs8hiaxql3hq5z7x3q";
-    "x86_64-darwin" = "1iijk0kx90rax39iradbbafyvd3vwnzsgvyb3s13asy42pbhhkky";
+    x86_64-linux = "1iz36nhkg78346g5407df6jv4d1ydb22hhgs8hiaxql3hq5z7x3q";
+    x86_64-darwin = "1iijk0kx90rax39iradbbafyvd3vwnzsgvyb3s13asy42pbhhkky";
   }.${system};
 in
   callPackage ./generic.nix rec {

--- a/pkgs/applications/editors/vscode/vscodium.nix
+++ b/pkgs/applications/editors/vscode/vscodium.nix
@@ -11,8 +11,8 @@ let
   archive_fmt = if system == "x86_64-darwin" then "zip" else "tar.gz";
 
   sha256 = {
-    "x86_64-linux" = "09rq5jx7aicwp3qqi5pcv6bmyyp1rm5cfa96hvy3f4grhq1fi132";
-    "x86_64-darwin" = "1y1lbb3q5myaz7jg21x5sl0in8wr46brqj9zyrg3f16zahsagzr4";
+    x86_64-linux = "09rq5jx7aicwp3qqi5pcv6bmyyp1rm5cfa96hvy3f4grhq1fi132";
+    x86_64-darwin = "1y1lbb3q5myaz7jg21x5sl0in8wr46brqj9zyrg3f16zahsagzr4";
   }.${system};
 in
   callPackage ./generic.nix rec {

--- a/pkgs/applications/graphics/ipe/default.nix
+++ b/pkgs/applications/graphics/ipe/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   sourceRoot = "${name}/src";
 
-  IPEPREFIX="${placeholder "out"}";
+  IPEPREFIX=placeholder "out";
   URWFONTDIR="${texlive}/texmf-dist/fonts/type1/urw/";
   LUA_PACKAGE = "lua";
 

--- a/pkgs/applications/graphics/runwayml/default.nix
+++ b/pkgs/applications/graphics/runwayml/default.nix
@@ -16,7 +16,7 @@ let
   };
 
   binary = appimageTools.wrapType2 {
-    name = "${pname}";
+    name = pname;
     inherit src;
   };
   # we only use this to extract the icon

--- a/pkgs/applications/misc/digitalbitbox/default.nix
+++ b/pkgs/applications/misc/digitalbitbox/default.nix
@@ -81,7 +81,7 @@ in stdenv.mkDerivation rec {
   LUPDATE="${qttools.dev}/bin/lupdate";
   LRELEASE="${qttools.dev}/bin/lrelease";
   MOC="${qtbase.dev}/bin/moc";
-  QTDIR="${qtbase.dev}";
+  QTDIR=qtbase.dev;
   RCC="${qtbase.dev}/bin/rcc";
   UIC="${qtbase.dev}/bin/uic";
 

--- a/pkgs/applications/misc/et/default.nix
+++ b/pkgs/applications/misc/et/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "geistesk";
     repo = "et";
-    rev = "${version}";
+    rev = version;
     sha256 = "167w9qwfpd63rgy0xmkkkh5krmd91q42c3ijy3j099krgdfbb9bc";
   };
 

--- a/pkgs/applications/misc/gosmore/default.nix
+++ b/pkgs/applications/misc/gosmore/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
   src = fetchsvn {
     url = http://svn.openstreetmap.org/applications/rendering/gosmore;
     sha256 = "0qsckpqx7i7f8gkqhkzdamr65250afk1rpnh3nbman35kdv3dsxi";
-    rev = "${version}";
+    rev = version;
     ignoreExternals = true;
   };
 

--- a/pkgs/applications/misc/gummi/default.nix
+++ b/pkgs/applications/misc/gummi/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   src = pkgs.fetchFromGitHub {
     owner = "alexandervdm";
     repo = "gummi";
-    rev = "${version}";
+    rev = version;
     sha256 = "1vw8rhv8qj82l6l22kpysgm9mxilnki2kjmvxsnajbqcagr6s7cn";
   };
 

--- a/pkgs/applications/misc/keepassx/community.nix
+++ b/pkgs/applications/misc/keepassx/community.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "keepassxreboot";
     repo = "keepassxc";
-    rev = "${version}";
+    rev = version;
     sha256 = "1r63bl0cam04rps1bjr107qvwsmay4254nv00gwhh9n45s6cslac";
   };
 

--- a/pkgs/applications/misc/memo/default.nix
+++ b/pkgs/applications/misc/memo/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner  = "mrVanDalo";
     repo   = "memo";
-    rev    = "${version}";
+    rev    = version;
     sha256 = "0azx2bx6y7j0637fg3m8zigcw09zfm2mw9wjfg218sx88cm1wdkp";
   };
 

--- a/pkgs/applications/misc/prusa-slicer/default.nix
+++ b/pkgs/applications/misc/prusa-slicer/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   # xs/src/libnest2d/cmake_modules/FindNLopt.cmake in the package source -
   # for finding the nlopt library, which doesn't pick up the package in the nix store.
   # We need to set the path via the NLOPT environment variable instead.
-  NLOPT = "${nlopt}";
+  NLOPT = nlopt;
 
   prePatch = ''
     # In nix ioctls.h isn't available from the standard kernel-headers package

--- a/pkgs/applications/misc/qdirstat/default.nix
+++ b/pkgs/applications/misc/qdirstat/default.nix
@@ -11,7 +11,7 @@ in mkDerivation rec {
   src = fetchFromGitHub {
     owner = "shundhammer";
     repo = "qdirstat";
-    rev = "${version}";
+    rev = version;
     sha256 = "0q4ccjmlbqifg251kyxwys8wspdskr8scqhacyfrs9cmnjxcjqan";
   };
 

--- a/pkgs/applications/misc/qsyncthingtray/default.nix
+++ b/pkgs/applications/misc/qsyncthingtray/default.nix
@@ -12,7 +12,7 @@ mkDerivation rec {
   src = fetchFromGitHub {
     owner  = "sieren";
     repo   = "QSyncthingTray";
-    rev    = "${version}";
+    rev    = version;
     sha256 = "1n9g4j7qznvg9zl6x163pi9f7wsc3x6q76i33psnm7x2v1i22x5w";
   };
 

--- a/pkgs/applications/misc/rxvt_unicode/default.nix
+++ b/pkgs/applications/misc/rxvt_unicode/default.nix
@@ -8,12 +8,12 @@ let
   description = "A clone of the well-known terminal emulator rxvt";
 
   desktopItem = makeDesktopItem {
-    name = "${pname}";
+    name = pname;
     exec = "urxvt";
     icon = "utilities-terminal";
     comment = description;
     desktopName = "URxvt";
-    genericName = "${pname}";
+    genericName = pname;
     categories = "System;TerminalEmulator;";
   };
 in

--- a/pkgs/applications/misc/spacefm/default.nix
+++ b/pkgs/applications/misc/spacefm/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "IgnorantGuru";
     repo = "spacefm";
-    rev = "${version}";
+    rev = version;
     sha256 = "089r6i40lxcwzp60553b18f130asspnzqldlpii53smz52kvpirx";
   };
 

--- a/pkgs/applications/misc/terminal-parrot/default.nix
+++ b/pkgs/applications/misc/terminal-parrot/default.nix
@@ -7,7 +7,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "jmhobbs";
     repo = "terminal-parrot";
-    rev = "${version}";
+    rev = version;
     sha256 = "1b4vr4s1zpkpf5kc1r2kdlp3hf88qp1f7h05g8kd62zf4sfbj722";
   };
 

--- a/pkgs/applications/misc/todolist/default.nix
+++ b/pkgs/applications/misc/todolist/default.nix
@@ -9,7 +9,7 @@ buildGoPackage rec {
   src = fetchFromGitHub {
     owner = "gammons";
     repo = "todolist";
-    rev = "${version}";
+    rev = version;
     sha256 = "0dazfymby5xm4482p9cyj23djmkz5q7g79cqm2d85mczvz7vks8p";
   };
 

--- a/pkgs/applications/misc/toot/default.nix
+++ b/pkgs/applications/misc/toot/default.nix
@@ -7,7 +7,7 @@ python3Packages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner  = "ihabunek";
     repo   = "toot";
-    rev    = "${version}";
+    rev    = version;
     sha256 = "11dgz082shxpbsxr4i41as040cfqinm5lbcg3bmsxqvc4hsz2nr5";
   };
 

--- a/pkgs/applications/misc/xiphos/default.nix
+++ b/pkgs/applications/misc/xiphos/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "crosswire";
     repo = "xiphos";
-    rev = "${version}";
+    rev = version;
     sha256 = "1vwf1ps6nrajxl1qbs6v1cgykmq5wn4j09j10gbcd3b2nvrprf3g";
   };
 

--- a/pkgs/applications/misc/xmr-stak/default.nix
+++ b/pkgs/applications/misc/xmr-stak/default.nix
@@ -17,7 +17,7 @@ stdenv'.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "fireice-uk";
     repo = "xmr-stak";
-    rev = "${version}";
+    rev = version;
     sha256 = "1p8hx8gwnv7a49pffq1xmzmrfi3gs6dyra9dn2xi7cl75yn9kfhm";
   };
 

--- a/pkgs/applications/networking/c14/default.nix
+++ b/pkgs/applications/networking/c14/default.nix
@@ -9,7 +9,7 @@ buildGoPackage rec {
   src = fetchFromGitHub {
     owner = "online-net";
     repo = "c14-cli";
-    rev = "${version}";
+    rev = version;
     sha256 = "0b1piviy6vvdbak8y8bc24rk3c1fi67vv3352pmnzvrhsar2r5yf";
   };
 

--- a/pkgs/applications/networking/cluster/hetzner-kube/default.nix
+++ b/pkgs/applications/networking/cluster/hetzner-kube/default.nix
@@ -7,7 +7,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "xetys";
     repo = "hetzner-kube";
-    rev = "${version}";
+    rev = version;
     sha256 = "11202i3340vaz8xh59gwj5x0djcgbzq9jfy2214lcpml71qc85f0";
   };
 

--- a/pkgs/applications/networking/cluster/kubernetes/default.nix
+++ b/pkgs/applications/networking/cluster/kubernetes/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     patchShebangs ./hack
   '';
 
-  WHAT="${concatStringsSep " " components}";
+  WHAT=concatStringsSep " " components;
 
   postBuild = ''
     ./hack/update-generated-docs.sh

--- a/pkgs/applications/networking/cluster/kubetail/default.nix
+++ b/pkgs/applications/networking/cluster/kubetail/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "johanhaleby";
     repo = "kubetail";
-    rev = "${version}";
+    rev = version;
     sha256 = "0mcv23p0h1ww9gvax8b4b4x5hmg02shrbgms0v0c72cmw0zf2phr";
   };
 

--- a/pkgs/applications/networking/cluster/sonobuoy/default.nix
+++ b/pkgs/applications/networking/cluster/sonobuoy/default.nix
@@ -10,7 +10,7 @@ buildGoPackage rec {
   goPackagePath = "github.com/heptio/sonobuoy";
 
   buildFlagsArray =
-    let t = "${goPackagePath}";
+    let t = goPackagePath;
     in ''
       -ldflags=
         -s -X ${t}/pkg/buildinfo.Version=${version}

--- a/pkgs/applications/networking/cluster/stern/default.nix
+++ b/pkgs/applications/networking/cluster/stern/default.nix
@@ -11,7 +11,7 @@ buildGoPackage rec {
   src = fetchFromGitHub {
     owner = "wercker";
     repo = "stern";
-    rev = "${version}";
+    rev = version;
     sha256 = "0xndlq0ks8flzx6rdd4lnkxpkbvdy9sj1jwys5yj7p989ls8by3n";
   };
 

--- a/pkgs/applications/networking/gdrive/default.nix
+++ b/pkgs/applications/networking/gdrive/default.nix
@@ -3,7 +3,7 @@
 buildGoPackage rec {
   pname = "gdrive";
   version = "2.1.0";
-  rev     = "${version}";
+  rev     = version;
 
   goPackagePath = "github.com/prasmussen/gdrive";
 

--- a/pkgs/applications/networking/instant-messengers/linphone/default.nix
+++ b/pkgs/applications/networking/instant-messengers/linphone/default.nix
@@ -14,8 +14,8 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "BelledonneCommunications";
-    repo = "${baseName}";
-    rev = "${version}";
+    repo = baseName;
+    rev = version;
     sha256 = "0az2ywrpx11sqfb4s4r2v726avcjf4k15bvrqj7xvhz7hdndmh0j";
   };
 

--- a/pkgs/applications/networking/instant-messengers/oysttyer/default.nix
+++ b/pkgs/applications/networking/instant-messengers/oysttyer/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner  = "oysttyer";
     repo   = "oysttyer";
-    rev    = "${version}";
+    rev    = version;
     sha256 = "0cm1hvi68iqgjsg15xdii271pklgzjn9j9afb1c460z71kgy3wz2";
   };
 

--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/pidgin-mra/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/pidgin-mra/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
 
   src = fetchgit {
     url = "https://github.com/dreadatour/pidgin-mra";
-    rev = "${version}";
+    rev = version;
     sha256 = "1adq57g11kw7bfpivyvfk3nlpjkc8raiw4bzn3gn4nx3m0wl99vw";
   };
 

--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-vk-plugin/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-vk-plugin/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
 
   src = fetchhg {
     url = "https://bitbucket.org/olegoandreev/purple-vk-plugin";
-    rev = "${version}";
+    rev = version;
     sha256 = "02p57fgx8ml00cbrb4f280ak2802svz80836dzk9f1zwm1bcr2qc";
   };
 

--- a/pkgs/applications/networking/instant-messengers/profanity/default.nix
+++ b/pkgs/applications/networking/instant-messengers/profanity/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "profanity-im";
     repo = "profanity";
-    rev = "${version}";
+    rev = version;
     sha256 = "15adg7ndjkzy04lizjmnvv0pf0snhzp6a8x74mndcm0zma0dia0z";
   };
 

--- a/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
+++ b/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "psi-plus";
     repo = "psi-plus-snapshots";
-    rev = "${version}";
+    rev = version;
     sha256 = "1nv1ynad2gcn7r8mm2w3kixmahaql7xax1lccsqyxqmj1r0klk8q";
   };
 

--- a/pkgs/applications/networking/instant-messengers/wire-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/wire-desktop/default.nix
@@ -18,13 +18,13 @@ let
   pname = "wire-desktop";
 
   version = {
-    "x86_64-linux" = "3.10.2904";
-    "x86_64-darwin" = "3.10.3133";
+    x86_64-linux = "3.10.2904";
+    x86_64-darwin = "3.10.3133";
   }.${system} or throwSystem;
 
   sha256 = {
-    "x86_64-linux" = "1vrz4568mlhylx17jw4z452f0vrd8yd8qkbpkcvnsbhs6k066xcn";
-    "x86_64-darwin" = "0d8g9fl3yciqp3aic374rzcywb5d5yipgni992khsfdfqhcvm3x9";
+    x86_64-linux = "1vrz4568mlhylx17jw4z452f0vrd8yd8qkbpkcvnsbhs6k066xcn";
+    x86_64-darwin = "0d8g9fl3yciqp3aic374rzcywb5d5yipgni992khsfdfqhcvm3x9";
   }.${system} or throwSystem;
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/networking/mailreaders/mailpile/default.nix
+++ b/pkgs/applications/networking/mailreaders/mailpile/default.nix
@@ -7,7 +7,7 @@ python2Packages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "mailpile";
     repo = "Mailpile";
-    rev = "${version}";
+    rev = version;
     sha256 = "1z5psh00fjr8gnl4yjcl4m9ywfj24y1ffa2rfb5q8hq4ksjblbdj";
   };
 

--- a/pkgs/applications/networking/ndppd/default.nix
+++ b/pkgs/applications/networking/ndppd/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "DanielAdolfsson";
     repo = "ndppd";
-    rev = "${version}";
+    rev = version;
     sha256 = "0niri5q9qyyyw5lmjpxk19pv3v4srjvmvyd5k6ks99mvqczjx9c0";
   };
 

--- a/pkgs/applications/networking/newsreaders/quiterss/default.nix
+++ b/pkgs/applications/networking/newsreaders/quiterss/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "QuiteRSS";
     repo = "quiterss";
-    rev = "${version}";
+    rev = version;
     sha256 = "0xav9qr8n6310636nfbgx4iix65fs3ya5rz2isxsf38bkjm7r3pa";
   };
 

--- a/pkgs/applications/networking/p2p/transmission-remote-gtk/default.nix
+++ b/pkgs/applications/networking/p2p/transmission-remote-gtk/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "transmission-remote-gtk";
     repo = "transmission-remote-gtk";
-    rev = "${version}";
+    rev = version;
     sha256 = "1pipc1f94jdppv597mqmcj2kw2rdvaqcbl512v7z8vir76p1a7gk";
   };
 

--- a/pkgs/applications/networking/ssb/patchwork/default.nix
+++ b/pkgs/applications/networking/ssb/patchwork/default.nix
@@ -11,7 +11,7 @@ let
   };
 
   binary = appimageTools.wrapType2 {
-    name = "${pname}";
+    name = pname;
     inherit src;
   };
   # we only use this to extract the icon

--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -279,7 +279,7 @@ in stdenv.mkDerivation rec {
   '';
 
   configureFlags = [
-    "${if withHelp then "" else "--without-help"}"
+    (if withHelp then "" else "--without-help")
     "--with-boost=${boost.dev}"
     "--with-boost-libdir=${boost.out}/lib"
     "--with-beanshell-jar=${bsh}"

--- a/pkgs/applications/office/libreoffice/still.nix
+++ b/pkgs/applications/office/libreoffice/still.nix
@@ -279,7 +279,7 @@ in stdenv.mkDerivation rec {
   '';
 
   configureFlags = [
-    "${if withHelp then "" else "--without-help"}"
+    (if withHelp then "" else "--without-help")
     "--with-boost=${boost.dev}"
     "--with-boost-libdir=${boost.out}/lib"
     "--with-beanshell-jar=${bsh}"

--- a/pkgs/applications/office/libreoffice/wrapper.nix
+++ b/pkgs/applications/office/libreoffice/wrapper.nix
@@ -2,7 +2,7 @@
 let
   jdk = libreoffice.jdk;
 in
-(runCommand "${libreoffice.name}" {
+(runCommand libreoffice.name {
   inherit dbus libreoffice jdk bash;
 } ''
   mkdir -p "$out/bin"

--- a/pkgs/applications/office/paperless/withConfig.nix
+++ b/pkgs/applications/office/paperless/withConfig.nix
@@ -39,7 +39,7 @@ let
     PAPERLESS_CONSUMPTION_DIR = "${dataDir}/consume";
     PAPERLESS_MEDIADIR = "${dataDir}/media";
     PAPERLESS_STATICDIR = "${dataDir}/static";
-    PAPERLESS_DBDIR = "${dataDir}";
+    PAPERLESS_DBDIR = dataDir;
   }) // config;
 
   envVarDefs = mapAttrsToList (n: v: ''export ${n}="${toString v}"'') envVars;

--- a/pkgs/applications/office/wordgrinder/default.nix
+++ b/pkgs/applications/office/wordgrinder/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     repo = "wordgrinder";
     owner = "davidgiven";
-    rev = "${version}";
+    rev = version;
     sha256 = "08lnq5wmspfqdjmqm15gizcq0xr7mg4h62qhvwj63v0sd6ks1cal";
   };
 

--- a/pkgs/applications/radio/dablin/default.nix
+++ b/pkgs/applications/radio/dablin/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "Opendigitalradio";
     repo = "dablin";
-    rev = "${version}";
+    rev = version;
     sha256 = "04ir7yg7psnnb48s1qfppvvx6lak4s8f6fqdg721y2kd9129jm82";
   };
 

--- a/pkgs/applications/radio/multimon-ng/default.nix
+++ b/pkgs/applications/radio/multimon-ng/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "EliasOenal";
     repo = "multimon-ng";
-    rev = "${version}";
+    rev = version;
     sha256 = "1973xfyvzl1viz19zr83cgqlx5laxbjrca35rqabn6dlb6xb5xk8";
   };
 

--- a/pkgs/applications/radio/qradiolink/default.nix
+++ b/pkgs/applications/radio/qradiolink/default.nix
@@ -14,7 +14,7 @@ in stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "kantooon";
     repo = "qradiolink";
-    rev = "${version}";
+    rev = version;
     sha256 = "0xhg5zhjznmls5m3rhpk1qx0dipxmca12s85w15d0i7qwva2f1gi";
   };
 

--- a/pkgs/applications/radio/uhd/default.nix
+++ b/pkgs/applications/radio/uhd/default.nix
@@ -27,7 +27,7 @@ in stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "EttusResearch";
     repo = "uhd";
-    rev = "${uhdVer}";
+    rev = uhdVer;
     sha256 = "0y1hff4vslfv36vxgvjqajg4862a11d4wgr0vcb0visgh1bi8qgy";
   };
 

--- a/pkgs/applications/science/biology/eggnog-mapper/default.nix
+++ b/pkgs/applications/science/biology/eggnog-mapper/default.nix
@@ -7,7 +7,7 @@ python27Packages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "eggnogdb";
     repo = "eggnog-mapper";
-    rev = "${version}";
+    rev = version;
     sha256 = "1aaaflppy84bhkh2hb5gnzm4xgrz0rz0cgfpadr9w8cva8p0sqdv";
   };
 

--- a/pkgs/applications/science/chemistry/pymol/default.nix
+++ b/pkgs/applications/science/chemistry/pymol/default.nix
@@ -13,8 +13,8 @@ let
   description = "A Python-enhanced molecular graphics tool";
 
   desktopItem = makeDesktopItem {
-    name = "${pname}";
-    exec = "${pname}";
+    name = pname;
+    exec = pname;
     desktopName = "PyMol Molecular Graphics System";
     genericName = "Molecular Modeler";
     comment = description;

--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -17,7 +17,7 @@ let
     src = fetchFromGitHub {
       owner = "KiCad";
       repo = "kicad-${name}";
-      rev = "${version}";
+      rev = version;
       inherit sha256 name;
     };
     nativeBuildInputs = [

--- a/pkgs/applications/science/math/sage/flask-oldsessions.nix
+++ b/pkgs/applications/science/math/sage/flask-oldsessions.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "mitsuhiko";
     repo = "flask-oldsessions";
-    rev = "${version}";
+    rev = version;
     sha256 = "04b5m8njjiwld9a0zw55iqwvyjgwcpdbhz1cic8nyhgcmypbicqn";
   };
 

--- a/pkgs/applications/science/math/sage/pybrial.nix
+++ b/pkgs/applications/science/math/sage/pybrial.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
     src = fetchFromGitHub {
       owner = "BRiAl";
       repo = "BRiAl";
-      rev = "${version}";
+      rev = version;
       sha256 = "0qy4cwy7qrk4zg151cmws5cglaa866z461cnj9wdnalabs7v7qbg";
     };
 

--- a/pkgs/applications/science/misc/simgrid/default.nix
+++ b/pkgs/applications/science/misc/simgrid/default.nix
@@ -13,7 +13,7 @@
 with stdenv.lib;
 
 let
-  optionOnOff = option: "${if option then "on" else "off"}";
+  optionOnOff = option: if option then "on" else "off";
 in
 
 stdenv.mkDerivation rec {

--- a/pkgs/applications/science/molecular-dynamics/lammps/default.nix
+++ b/pkgs/applications/science/molecular-dynamics/lammps/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "lammps";
     repo = "lammps";
-    rev = "${version}";
+    rev = version;
     sha256 = "1dlifm9wm1jcw2zwal3fnzzl41ng08c7v48w6hx2mz84zljg1nsj";
   };
 

--- a/pkgs/applications/science/robotics/apmplanner2/default.nix
+++ b/pkgs/applications/science/robotics/apmplanner2/default.nix
@@ -10,7 +10,7 @@ mkDerivation rec {
   src = fetchFromGitHub {
     owner = "ArduPilot";
     repo = "apm_planner";
-    rev = "${version}";
+    rev = version;
     sha256 = "1k0786mjzi49nb6yw4chh9l4dmkf9gybpxg9zqkr5yg019nyzcvd";
   };
 

--- a/pkgs/applications/version-management/git-and-tools/git-secrets/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-secrets/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = "git-secrets";
-    rev = "${version}";
+    rev = version;
     sha256 = "10lnxg0q855zi3d6804ivlrn6dc817kilzdh05mmz8a0ccvm2qc7";
   };
 

--- a/pkgs/applications/version-management/git-and-tools/gitweb/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/gitweb/default.nix
@@ -18,7 +18,7 @@ in buildEnv {
   name = "gitweb-${stdenv.lib.getVersion git}";
 
   ignoreCollisions = true;
-  paths = stdenv.lib.optional gitwebTheme "${gitwebThemeSrc}"
+  paths = stdenv.lib.optional gitwebTheme gitwebThemeSrc
        ++ [ "${git}/share/gitweb" ];
 
   meta = git.meta // {

--- a/pkgs/applications/version-management/git-and-tools/pass-git-helper/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/pass-git-helper/default.nix
@@ -7,7 +7,7 @@ buildPythonApplication rec {
   src = fetchFromGitHub {
     owner  = "languitar";
     repo   = "pass-git-helper";
-    rev    = "${version}";
+    rev    = version;
     sha256 = "1zccbmq5l6asl9qm1f90vg9467y3spmv3ayrw07qizrj43yfd9ap";
   };
 

--- a/pkgs/applications/version-management/git-review/default.nix
+++ b/pkgs/applications/version-management/git-review/default.nix
@@ -6,7 +6,7 @@ pythonPackages.buildPythonApplication rec {
 
   # Manually set version because prb wants to get it from the git
   # upstream repository (and we are installing from tarball instead)
-  PBR_VERSION = "${version}";
+  PBR_VERSION = version;
 
   src = fetchFromGitHub {
     owner = "openstack-infra";

--- a/pkgs/applications/version-management/gitlab/default.nix
+++ b/pkgs/applications/version-management/gitlab/default.nix
@@ -7,7 +7,7 @@ let
   rubyEnv = bundlerEnv rec {
     name = "gitlab-env-${version}";
     inherit ruby;
-    gemdir = ./rubyEnv- + "${if gitlabEnterprise then "ee" else "ce"}";
+    gemdir = ./rubyEnv- + (if gitlabEnterprise then "ee" else "ce");
     gemset =
       let x = import (gemdir + "/gemset.nix");
       in x // {

--- a/pkgs/applications/version-management/peru/default.nix
+++ b/pkgs/applications/version-management/peru/default.nix
@@ -9,7 +9,7 @@ python3Packages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "buildinspace";
     repo = "peru";
-    rev = "${version}";
+    rev = version;
     sha256 = "0p4j51m89glx12cd65lcnbwpvin0v49wkhrx06755skr7v37pm2a";
   };
 

--- a/pkgs/applications/version-management/yadm/default.nix
+++ b/pkgs/applications/version-management/yadm/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner  = "TheLocehiliosan";
     repo   = "yadm";
-    rev    = "${version}";
+    rev    = version;
     sha256 = "0873jgks7dpfkj5km1jchxdrhf7lia70p0f8zsrh9p4crj5f4pc6";
   };
 

--- a/pkgs/applications/video/kodi/plugins.nix
+++ b/pkgs/applications/video/kodi/plugins.nix
@@ -487,7 +487,7 @@ let self = rec {
     src = fetchFromGitHub {
       owner = "peak3d";
       repo = "inputstream.adaptive";
-      rev = "${version}";
+      rev = version;
       sha256 = "09d9b35mpaf3g5m51viyan9hv7d2i8ndvb9wm0j7rs5gwsf0k71z";
     };
 

--- a/pkgs/applications/video/obs-studio/default.nix
+++ b/pkgs/applications/video/obs-studio/default.nix
@@ -42,7 +42,7 @@ in mkDerivation rec {
   src = fetchFromGitHub {
     owner = "jp9000";
     repo = "obs-studio";
-    rev = "${version}";
+    rev = version;
     sha256 = "05brixq2z98mvn1q2rgdl27xj798509nv8yh6h0yzqyk9gly4anz";
   };
 

--- a/pkgs/applications/video/openshot-qt/libopenshot.nix
+++ b/pkgs/applications/video/openshot-qt/libopenshot.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   [ imagemagick ffmpeg swig python3 unittest-cpp
     cppzmq czmqpp qtbase qtmultimedia ];
 
-  LIBOPENSHOT_AUDIO_DIR = "${libopenshot-audio}";
+  LIBOPENSHOT_AUDIO_DIR = libopenshot-audio;
   "UNITTEST++_INCLUDE_DIR" = "${unittest-cpp}/include/UnitTest++";
 
   doCheck = false;

--- a/pkgs/applications/video/streamlink/default.nix
+++ b/pkgs/applications/video/streamlink/default.nix
@@ -7,7 +7,7 @@ pythonPackages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "streamlink";
     repo = "streamlink";
-    rev = "${version}";
+    rev = version;
     sha256 = "1vyf0pifdqygg98azdkfhy5fdckb0w2ca7c46mkrj452gkvmcq33";
   };
 

--- a/pkgs/applications/virtualization/virt-manager/qt.nix
+++ b/pkgs/applications/virtualization/virt-manager/qt.nix
@@ -11,7 +11,7 @@ mkDerivation rec {
   src = fetchFromGitHub {
     owner  = "F1ash";
     repo   = "qt-virt-manager";
-    rev    = "${version}";
+    rev    = version;
     sha256 = "1z2kq88lljvr24z1kizvg3h7ckf545h4kjhhrjggkr0w4wjjwr43";
   };
 

--- a/pkgs/applications/window-managers/leftwm/default.nix
+++ b/pkgs/applications/window-managers/leftwm/default.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
     src = fetchFromGitHub {
         owner = "leftwm";
         repo = "leftwm";
-        rev = "${version}";
+        rev = version;
         sha256 = "0ji7m2npkdg27gm33b19rxr50km0gm1h9czi1f425vxq65mlkl4y";
     };
 

--- a/pkgs/applications/window-managers/stumpwm/default.nix
+++ b/pkgs/applications/window-managers/stumpwm/default.nix
@@ -35,8 +35,8 @@ stdenv.mkDerivation {
 
   src = fetchgit {
     url = "https://github.com/stumpwm/stumpwm";
-    rev = "${versionSpec.rev}";
-    sha256 = "${versionSpec.sha256}";
+    rev = versionSpec.rev;
+    sha256 = versionSpec.sha256;
   };
 
   # NOTE: The patch needs an update for the next release.

--- a/pkgs/build-support/dhall-to-nix.nix
+++ b/pkgs/build-support/dhall-to-nix.nix
@@ -33,6 +33,6 @@ let
       };
 
     in
-      import "${drv}";
+      import drv;
 in
   dhallToNix

--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -52,7 +52,7 @@ else
 stdenvNoCC.mkDerivation {
   inherit name;
   builder = ./builder.sh;
-  fetcher = "${./nix-prefetch-git}";  # This must be a string to ensure it's called with bash.
+  fetcher = ./nix-prefetch-git;  # This must be a string to ensure it's called with bash.
   nativeBuildInputs = [git];
 
   outputHashAlgo = "sha256";

--- a/pkgs/build-support/fetchgit/private.nix
+++ b/pkgs/build-support/fetchgit/private.nix
@@ -4,7 +4,7 @@
     else null;
 
   GIT_SSH = let
-    config = ''${let
+    config = let
         sshConfigFile = if (builtins.tryEval <ssh-config-file>).success
           then <ssh-config-file>
           else builtins.trace ''
@@ -14,7 +14,7 @@
 
             You may need StrictHostKeyChecking=no in the config file. Since ssh will refuse to use a group-readable private key, if using build-users you will likely want to use something like IdentityFile /some/directory/%u/key and have a directory for each build user accessible to that user.
           '' "/var/lib/empty/config";
-      in builtins.toString sshConfigFile}'';
+      in builtins.toString sshConfigFile;
 
     ssh-wrapped = runCommand "fetchgit-ssh" {
       nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/build-support/vm/windows/default.nix
+++ b/pkgs/build-support/vm/windows/default.nix
@@ -25,7 +25,7 @@ in {
     bootstrap = bootstrapper attrs.windowsImage;
   in {
     requiredSystemFeatures = [ "kvm" ];
-    builder = "${pkgs.stdenv.shell}";
+    builder = pkgs.stdenv.shell;
     args = ["-e" (bootstrap.resumeAndRun builder)];
     windowsImage = bootstrap.suspendedVM;
     origArgs = attrs.args;

--- a/pkgs/build-support/writers/test.nix
+++ b/pkgs/build-support/writers/test.nix
@@ -159,8 +159,8 @@ in runCommand "test-writers" {
   meta.platforms = stdenv.lib.platforms.all;
 } ''
   ${lib.concatMapStringsSep "\n" (test: writeTest "success" "${test}/bin/test_writers") (lib.attrValues bin)}
-  ${lib.concatMapStringsSep "\n" (test: writeTest "success" "${test}") (lib.attrValues simple)}
-  ${lib.concatMapStringsSep "\n" (test: writeTest "success" "${test}") (lib.attrValues path)}
+  ${lib.concatMapStringsSep "\n" (test: writeTest "success" test) (lib.attrValues simple)}
+  ${lib.concatMapStringsSep "\n" (test: writeTest "success" test) (lib.attrValues path)}
 
   echo 'nix-writers successfully tested' >&2
   touch $out

--- a/pkgs/data/documentation/stdman/default.nix
+++ b/pkgs/data/documentation/stdman/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "jeaye";
     repo = "stdman";
-    rev = "${version}";
+    rev = version;
     sha256 = "1017vwhcwlwi5sa8h6pkhj048in826wxnhl6qarykmzksvidff3r";
   };
 

--- a/pkgs/desktops/gnome-3/core/dconf-editor/default.nix
+++ b/pkgs/desktops/gnome-3/core/dconf-editor/default.nix
@@ -27,7 +27,7 @@ in stdenv.mkDerivation rec {
 
   passthru = {
     updateScript = gnome3.updateScript {
-      packageName = "${pname}";
+      packageName = pname;
       attrPath = "gnome3.${pname}";
     };
   };

--- a/pkgs/desktops/gnome-3/core/gnome-screenshot/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-screenshot/default.nix
@@ -28,7 +28,7 @@ in stdenv.mkDerivation rec {
 
   passthru = {
     updateScript = gnome3.updateScript {
-      packageName = "${pname}";
+      packageName = pname;
       attrPath = "gnome3.${pname}";
     };
   };

--- a/pkgs/desktops/gnome-3/extensions/taskwhisperer/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/taskwhisperer/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     (substituteAll {
       src = ./fix-paths.patch;
       task = "${taskwarrior}/bin/task";
-      shell = "${runtimeShell}";
+      shell = runtimeShell;
     })
   ];
 

--- a/pkgs/desktops/gnome-3/games/gnome-klotski/default.nix
+++ b/pkgs/desktops/gnome-3/games/gnome-klotski/default.nix
@@ -28,7 +28,7 @@ in stdenv.mkDerivation rec {
 
   passthru = {
     updateScript = gnome3.updateScript {
-      packageName = "${pname}";
+      packageName = pname;
       attrPath = "gnome3.${pname}";
     };
   };

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/network/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/network/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
   patches = [
     (substituteAll {
       src = ./nma.patch;
-      networkmanagerapplet = "${networkmanagerapplet}";
+      networkmanagerapplet = networkmanagerapplet;
     })
   ];
 

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/power/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/power/default.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
   patches = [
     (substituteAll {
       src = ./dpms-helper-exec.patch;
-      elementary_dpms_helper = "${elementary-dpms-helper}";
+      elementary_dpms_helper = elementary-dpms-helper;
     })
     ./hardcode-gsettings.patch
   ];

--- a/pkgs/desktops/pantheon/desktop/elementary-session-settings/default.nix
+++ b/pkgs/desktops/pantheon/desktop/elementary-session-settings/default.nix
@@ -47,7 +47,7 @@ let
 
   dockitemAutostart = substituteAll {
     src = ./default-elementary-dockitems.desktop;
-    script = "${dockitems-script}";
+    script = dockitems-script;
   };
 
   executable = writeShellScriptBin "pantheon" ''

--- a/pkgs/desktops/pantheon/desktop/extra-elementary-contracts/default.nix
+++ b/pkgs/desktops/pantheon/desktop/extra-elementary-contracts/default.nix
@@ -19,8 +19,8 @@ stdenv.mkDerivation rec {
   patches = [
     (substituteAll {
       src = ./exec-path.patch;
-      file_roller = "${file-roller}";
-      gnome_bluetooth = "${gnome-bluetooth}";
+      file_roller = file-roller;
+      gnome_bluetooth = gnome-bluetooth;
     })
   ];
 

--- a/pkgs/development/arduino/arduino-core/default.nix
+++ b/pkgs/development/arduino/arduino-core/default.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "arduino";
     repo = "Arduino";
-    rev = "${version}";
+    rev = version;
     sha256 = "0kblq0bqap2zzkflrj6rmdi8dvqxa28fcwwrc3lfmbz2893ni3w4";
   };
 
@@ -72,22 +72,22 @@ stdenv.mkDerivation rec {
   teensyduino_src = fetchurl {
     url = "https://www.pjrc.com/teensy/td_${teensyduino_version}/TeensyduinoInstall.${teensy_architecture}";
     sha256 =
-      lib.optionalString ("${teensy_architecture}" == "linux64")
+      lib.optionalString (teensy_architecture == "linux64")
         "09ysanip5d2f5axzd81z2l74ayng60zqhjxmxs7xa5098fff46il"
-      + lib.optionalString ("${teensy_architecture}" == "linux32")
+      + lib.optionalString (teensy_architecture == "linux32")
         "1zw3cfv2p62dwg8838vh0gd1934b18cyx7c13azvwmrpj601l0xx"
-      + lib.optionalString ("${teensy_architecture}" == "linuxarm")
+      + lib.optionalString (teensy_architecture == "linuxarm")
         "12421z26ksx84aldw1pq0cakh8jhs33mwafgvfij0zfgn9x0i877";
     };
   # Used because teensyduino requires jars be a specific size
   arduino_dist_src = fetchurl {
     url = "http://downloads.arduino.cc/arduino-${version}-${teensy_architecture}.tar.xz";
     sha256 =
-      lib.optionalString ("${teensy_architecture}" == "linux64")
+      lib.optionalString (teensy_architecture == "linux64")
         "1lv4in9j0r8s0cis4zdvbk2637vlj12w69wdxgcxcrwvkcdahkpa"
-      + lib.optionalString ("${teensy_architecture}" == "linux32")
+      + lib.optionalString (teensy_architecture == "linux32")
         "0zla3a6gd9prclgrbbgsmhf8ds8zb221m65x21pvz0y1cwsdvjpm"
-      + lib.optionalString ("${teensy_architecture}" == "linuxarm")
+      + lib.optionalString (teensy_architecture == "linuxarm")
         "1w5m49wfd68zazli0lf3w4zykab8n7mzp3wnbjqfpx2vip80bqnz";
   };
 

--- a/pkgs/development/arduino/arduino-mk/default.nix
+++ b/pkgs/development/arduino/arduino-mk/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner  = "sudar";
     repo   = "Arduino-Makefile";
-    rev    = "${version}";
+    rev    = version;
     sha256 = "0flpl97d2231gp51n3y4qvf3y1l8xzafi1sgpwc305vwc2h4dl2x";
   };
 

--- a/pkgs/development/beam-modules/build-erlang-mk.nix
+++ b/pkgs/development/beam-modules/build-erlang-mk.nix
@@ -25,7 +25,7 @@ let
     };
 
   pkg = self: stdenv.mkDerivation ( attrs // {
-    app_name = "${name}";
+    app_name = name;
     name = "${name}-${version}";
     inherit version;
 

--- a/pkgs/development/compilers/swift/default.nix
+++ b/pkgs/development/compilers/swift/default.nix
@@ -35,7 +35,7 @@
 let
   v_base = "5.0.2";
   version = "${v_base}-RELEASE";
-  version_friendly = "${v_base}";
+  version_friendly = v_base;
 
   tag = "refs/tags/swift-${version}";
   fetch = { repo, sha256, fetchSubmodules ? false }:

--- a/pkgs/development/compilers/vlang/default.nix
+++ b/pkgs/development/compilers/vlang/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "vlang";
     repo = "v";
-    rev = "${version}";
+    rev = version;
     sha256 = "0js92v2r1h4vaaha3z1spgi7qynlmr9vls41gxp284w4yhnjzv15";
   };
 
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   vc = fetchFromGitHub {
     owner = "vlang";
     repo = "vc";
-    rev = "${version}";
+    rev = version;
     sha256 = "0qx1drs1hr94w7vaaq5w8mkq7j1d3biffnmxkyz63yv8573k03bj";
   };
 

--- a/pkgs/development/compilers/z88dk/default.nix
+++ b/pkgs/development/compilers/z88dk/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   #_FORTIFY_SOURCE requires compiling with optimization (-O)
   NIX_CFLAGS_COMPILE = "-O";
 
-  short_rev = "${builtins.substring 0 7 src.rev}";
+  short_rev = builtins.substring 0 7 src.rev;
   makeFlags = [
     "git_rev=${short_rev}"
     "version=${version}"

--- a/pkgs/development/compilers/zulu/8.nix
+++ b/pkgs/development/compilers/zulu/8.nix
@@ -65,7 +65,7 @@ in stdenv.mkDerivation {
   rpath = stdenv.lib.strings.makeLibraryPath libraries;
 
   passthru = {
-    home = "${zulu}";
+    home = zulu;
   };
 
   meta = with stdenv.lib; {

--- a/pkgs/development/compilers/zulu/default.nix
+++ b/pkgs/development/compilers/zulu/default.nix
@@ -62,7 +62,7 @@ in stdenv.mkDerivation {
   rpath = stdenv.lib.strings.makeLibraryPath libraries;
 
   passthru = {
-    home = "${zulu}";
+    home = zulu;
   };
 
   meta = with stdenv.lib; {

--- a/pkgs/development/coq-modules/contribs/default.nix
+++ b/pkgs/development/coq-modules/contribs/default.nix
@@ -3,13 +3,13 @@
 let mkContrib = repo: revs: param:
   stdenv.mkDerivation rec {
     name = "coq${coq.coq-version}-${repo}-${version}";
-    version = "${param.version}";
+    version = param.version;
 
     src = fetchFromGitHub {
       owner = "coq-contribs";
-      repo = "${repo}";
-      rev = "${param.rev}";
-      sha256 = "${param.sha256}";
+      repo = repo;
+      rev = param.rev;
+      sha256 = param.sha256;
     };
 
     buildInputs = with coq.ocamlPackages; [ ocaml camlp5 findlib coq ];

--- a/pkgs/development/coq-modules/equations/default.nix
+++ b/pkgs/development/coq-modules/equations/default.nix
@@ -38,13 +38,13 @@ in
 stdenv.mkDerivation rec {
 
   name = "coq${coq.coq-version}-equations-${version}";
-  version = "${param.version}";
+  version = param.version;
 
   src = fetchFromGitHub {
     owner = "mattam82";
     repo = "Coq-Equations";
-    rev = "${param.rev}";
-    sha256 = "${param.sha256}";
+    rev = param.rev;
+    sha256 = param.sha256;
   };
 
   buildInputs = with coq.ocamlPackages; [ ocaml camlp5 findlib coq ];

--- a/pkgs/development/interpreters/guile/2.0.nix
+++ b/pkgs/development/interpreters/guile/2.0.nix
@@ -122,6 +122,6 @@
 
 (stdenv.lib.optionalAttrs (!stdenv.isLinux) {
   # Work around <https://bugs.gnu.org/14201>.
-  SHELL = "${stdenv.shell}";
-  CONFIG_SHELL = "${stdenv.shell}";
+  SHELL = stdenv.shell;
+  CONFIG_SHELL = stdenv.shell;
 })

--- a/pkgs/development/interpreters/love/0.10.nix
+++ b/pkgs/development/interpreters/love/0.10.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
   src = fetchFromBitbucket {
     owner = "rude";
     repo = "love";
-    rev = "${version}";
+    rev = version;
     sha256 = "19yfmlcx6w8yi4ndm5lni8lrsvnn77bxw5py0dc293nzzlaqa9ym";
   };
 

--- a/pkgs/development/interpreters/love/11.1.nix
+++ b/pkgs/development/interpreters/love/11.1.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
   src = fetchFromBitbucket {
     owner = "rude";
     repo = "love";
-    rev = "${version}";
+    rev = version;
     sha256 = "0q1lsgc1621czrg49nmabq6am9sgxa9syxrwzlksqqr4dyzw4nmf";
   };
 

--- a/pkgs/development/interpreters/pixie/default.nix
+++ b/pkgs/development/interpreters/pixie/default.nix
@@ -36,7 +36,7 @@ let
     buildInputs = libs;
     PYTHON = if buildWithPypy
       then "${pypy}/pypy-c/pypy-c"
-      else "${python2.interpreter}";
+      else python2.interpreter;
     unpackPhase = ''
       cp -R ${pixie-src} pixie-src
       mkdir pypy-src

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -129,8 +129,8 @@ in with passthru; stdenv.mkDerivation {
     substituteInPlace "Lib/tkinter/tix.py" --replace "os.environ.get('TIX_LIBRARY')" "os.environ.get('TIX_LIBRARY') or '${tix}/lib'"
   '';
 
-  CPPFLAGS = "${concatStringsSep " " (map (p: "-I${getDev p}/include") buildInputs)}";
-  LDFLAGS = "${concatStringsSep " " (map (p: "-L${getLib p}/lib") buildInputs)}";
+  CPPFLAGS = concatStringsSep " " (map (p: "-I${getDev p}/include") buildInputs);
+  LDFLAGS = concatStringsSep " " (map (p: "-L${getLib p}/lib") buildInputs);
   LIBS = "${optionalString (!stdenv.isDarwin) "-lcrypt"} ${optionalString (ncurses != null) "-lncurses"}";
   NIX_LDFLAGS = optionalString stdenv.isLinux "-lgcc_s";
   # Determinism: We fix the hashes of str, bytes and datetime objects.

--- a/pkgs/development/interpreters/renpy/default.nix
+++ b/pkgs/development/interpreters/renpy/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
 
   pythonPath = [ pygame_sdl2 tkinter ];
 
-  RENPY_DEPS_INSTALL = stdenv.lib.concatStringsSep "::" (map (path: "${path}") [
+  RENPY_DEPS_INSTALL = stdenv.lib.concatStringsSep "::" (map (path: path) [
     SDL2 SDL2.dev libpng ffmpeg ffmpeg.out freetype glew.dev glew.out libGLU_combined fribidi zlib
   ]);
 

--- a/pkgs/development/libraries/abseil-cpp/default.nix
+++ b/pkgs/development/libraries/abseil-cpp/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "abseil";
     repo = "abseil-cpp";
-    rev = "${rev}";
+    rev = rev;
     sha256 = "1bpz44hxq5fpkv6jlgphzk7mxjiiah526jgb63ih5pd1hd2cfw1r";
   };
 

--- a/pkgs/development/libraries/alembic/default.nix
+++ b/pkgs/development/libraries/alembic/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec
   src = fetchFromGitHub {
     owner = "alembic";
     repo = "alembic";
-    rev = "${version}";
+    rev = version;
     sha256 = "1lalbqn4cwf0vp4hiq72gwpd7kq501j21rnjb380mv26pk7r2ivz";
   };
 

--- a/pkgs/development/libraries/arb/default.nix
+++ b/pkgs/development/libraries/arb/default.nix
@@ -4,8 +4,8 @@ stdenv.mkDerivation rec {
   version = "2.16.0";
   src = fetchFromGitHub {
     owner = "fredrik-johansson";
-    repo = "${pname}";
-    rev = "${version}";
+    repo = pname;
+    rev = version;
     sha256 = "0478671wfwy3gl26sbxh1jq1ih36z4k72waa8y2y2lvn649gb7cd";
   };
   buildInputs = [mpir gmp mpfr flint];

--- a/pkgs/development/libraries/audio/ntk/default.nix
+++ b/pkgs/development/libraries/audio/ntk/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Fork of FLTK 1.3.0 with additional functionality";
-    version = "${version}";
+    version = version;
     homepage = http://non.tuxfamily.org/;
     license = stdenv.lib.licenses.lgpl21;
     maintainers = with stdenv.lib.maintainers; [ magnetophon nico202 ];

--- a/pkgs/development/libraries/audio/rtaudio/default.nix
+++ b/pkgs/development/libraries/audio/rtaudio/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "thestk";
     repo = "rtaudio";
-    rev = "${version}";
+    rev = version;
     sha256 = "1pglnjz907ajlhnlnig3p0sx7hdkpggr8ss7b3wzf1lykzgv9l52";
   };
 

--- a/pkgs/development/libraries/audio/rtmidi/default.nix
+++ b/pkgs/development/libraries/audio/rtmidi/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "thestk";
     repo = "rtmidi";
-    rev = "${version}";
+    rev = version;
     sha256 = "1g31p6a96djlbk9jh5r4pjly3x76lhccva9hrw6xzdma8dsjzgyq";
   };
 

--- a/pkgs/development/libraries/audio/zita-alsa-pcmi/default.nix
+++ b/pkgs/development/libraries/audio/zita-alsa-pcmi/default.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "The successor of clalsadrv, provides easy access to ALSA PCM devices";
-    version = "${version}";
+    version = version;
     homepage = http://kokkinizita.linuxaudio.org/linuxaudio/downloads/index.html;
     license = stdenv.lib.licenses.gpl3;
     maintainers = [ stdenv.lib.maintainers.magnetophon ];

--- a/pkgs/development/libraries/audio/zita-convolver/default.nix
+++ b/pkgs/development/libraries/audio/zita-convolver/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Convolution library by Fons Adriaensen";
-    version = "${version}";
+    version = version;
     homepage = http://kokkinizita.linuxaudio.org/linuxaudio/downloads/index.html;
     license = stdenv.lib.licenses.gpl2;
     maintainers = [ stdenv.lib.maintainers.magnetophon ];

--- a/pkgs/development/libraries/audio/zita-resampler/default.nix
+++ b/pkgs/development/libraries/audio/zita-resampler/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Resample library by Fons Adriaensen";
-    version = "${version}";
+    version = version;
     homepage = http://kokkinizita.linuxaudio.org/linuxaudio/downloads/index.html;
     license = stdenv.lib.licenses.gpl2;
     maintainers = [ stdenv.lib.maintainers.magnetophon ];

--- a/pkgs/development/libraries/bctoolbox/default.nix
+++ b/pkgs/development/libraries/bctoolbox/default.nix
@@ -6,8 +6,8 @@ stdenv.mkDerivation rec {
   buildInputs = [cmake mbedtls bcunit srtp];
   src = fetchFromGitHub {
     owner = "BelledonneCommunications";
-    repo = "${baseName}";
-    rev = "${version}";
+    repo = baseName;
+    rev = version;
     sha256 = "1cxx243wyzkd4xnvpyqf97n0rjhfckpvw1vhwnbwshq3q6fra909";
   };
 

--- a/pkgs/development/libraries/belcard/default.nix
+++ b/pkgs/development/libraries/belcard/default.nix
@@ -7,8 +7,8 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "BelledonneCommunications";
-    repo = "${baseName}";
-    rev = "${version}";
+    repo = baseName;
+    rev = version;
     sha256 = "1pwji83vpsdrfma24rnj3rz1x0a0g6zk3v4xjnip7zf2ys3zcnlk";
   };
 

--- a/pkgs/development/libraries/belle-sip/default.nix
+++ b/pkgs/development/libraries/belle-sip/default.nix
@@ -9,8 +9,8 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "BelledonneCommunications";
-    repo = "${baseName}";
-    rev = "${version}";
+    repo = baseName;
+    rev = version;
     sha256 = "0q70db1klvhca1af29bm9paka3gyii5hfbzrj4178gclsg7cj8fk";
   };
 

--- a/pkgs/development/libraries/belr/default.nix
+++ b/pkgs/development/libraries/belr/default.nix
@@ -7,8 +7,8 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "BelledonneCommunications";
-    repo = "${baseName}";
-    rev = "${version}";
+    repo = baseName;
+    rev = version;
     sha256 = "0mf8lsyq1z3b5p47c00lnwc8n7v9nzs1fd2g9c9hnz6fjd2ka44w";
   };
 

--- a/pkgs/development/libraries/bzrtp/default.nix
+++ b/pkgs/development/libraries/bzrtp/default.nix
@@ -7,8 +7,8 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "BelledonneCommunications";
-    repo = "${baseName}";
-    rev = "${version}";
+    repo = baseName;
+    rev = version;
     sha256 = "0438zzxp82bj5fmvqnwlljkgrz9ab5qm5lgpwwgmg1cp78bp2l45";
   };
 

--- a/pkgs/development/libraries/caf/default.nix
+++ b/pkgs/development/libraries/caf/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "actor-framework";
     repo = "actor-framework";
-    rev = "${version}";
+    rev = version;
     sha256 = "10dcpmdsfq6r7hpvg413pqi1q3rjvgn7f87c17ghyz30x6rjhaic";
   };
 

--- a/pkgs/development/libraries/cddlib/default.nix
+++ b/pkgs/development/libraries/cddlib/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "cddlib";
     repo = "cddlib";
-    rev = "${version}";
+    rev = version;
     sha256 = "1z03ljy3rrr0qq5gq54vynnif6fn0xhn05g90nnv0dpyc3ps8lzp";
   };
   buildInputs = [gmp];

--- a/pkgs/development/libraries/curlcpp/default.nix
+++ b/pkgs/development/libraries/curlcpp/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "JosephP91";
     repo = "curlcpp";
-    rev = "${version}";
+    rev = version;
     sha256 = "025qg5hym73xrvyhalv3jgbf9jqnnzkdjs3zwsgbpqx58zyd5bg5";
   };
 

--- a/pkgs/development/libraries/eclib/default.nix
+++ b/pkgs/development/libraries/eclib/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   # ping @timokau for more info
   src = fetchFromGitHub {
     owner = "JohnCremona";
-    repo = "${pname}";
+    repo = pname;
     rev = "v${version}";
     sha256 = "1910np1xzyjzszay24xn4b81qhpsvhp5aix9vdpknplni2mq8kwb";
   };

--- a/pkgs/development/libraries/epoxy/default.nix
+++ b/pkgs/development/libraries/epoxy/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "anholt";
     repo = "libepoxy";
-    rev = "${version}";
+    rev = version;
     sha256 = "03nrmf161xyj3q9zsigr5qj5vx5dsfxxyjva73cm1mgqqc5d60px";
   };
 

--- a/pkgs/development/libraries/fflas-ffpack/default.nix
+++ b/pkgs/development/libraries/fflas-ffpack/default.nix
@@ -7,8 +7,8 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "linbox-team";
-    repo = "${pname}";
-    rev = "${version}";
+    repo = pname;
+    rev = version;
     sha256 = "1ynbjd72qrwp0b4kpn0p5d7gddpvj8dlb5fwdxajr5pvkvi3if74";
   };
 

--- a/pkgs/development/libraries/ffmpeg/3.4.nix
+++ b/pkgs/development/libraries/ffmpeg/3.4.nix
@@ -5,7 +5,7 @@
 }@args:
 
 callPackage ./generic.nix (args // rec {
-  version = "${branch}";
+  version = branch;
   branch = "3.4.6";
   sha256 = "1s20wzgxxrm56gckyb8cf1lh36hdnkdxvmmnnvdxvia4zb3grf1b";
   darwinFrameworks = [ Cocoa CoreMedia ];

--- a/pkgs/development/libraries/ffmpeg/4.nix
+++ b/pkgs/development/libraries/ffmpeg/4.nix
@@ -5,7 +5,7 @@
 }@args:
 
 callPackage ./generic.nix (args // rec {
-  version = "${branch}";
+  version = branch;
   branch = "4.2";
   sha256 = "1f3glany3p2j832a9wia5vj8ds9xpm0xxlyia91y17hy85gxwsrh";
   darwinFrameworks = [ Cocoa CoreMedia VideoToolbox ];

--- a/pkgs/development/libraries/fmt/default.nix
+++ b/pkgs/development/libraries/fmt/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "fmtlib";
     repo = "fmt";
-    rev = "${version}";
+    rev = version;
     sha256 = "1hl9s69a5ql5nckc0ifh2fzlgsgv1wsn6yhqkpnrhasqkhj0hgv4";
   };
 

--- a/pkgs/development/libraries/fplll/20160331.nix
+++ b/pkgs/development/libraries/fplll/20160331.nix
@@ -5,8 +5,8 @@ stdenv.mkDerivation rec {
   pname = "fplll";
   version = "20160331";
   src = fetchFromGitHub {
-    owner = "${pname}";
-    repo = "${pname}";
+    owner = pname;
+    repo = pname;
     rev = "11dea26c2f9396ffb7a7191aa371343f1f74c5c3";
     sha256 = "1clxch9hbr30w6s84m2mprxv58adhg5qw6sa2p3jr1cy4r7r59ib";
   };

--- a/pkgs/development/libraries/fplll/default.nix
+++ b/pkgs/development/libraries/fplll/default.nix
@@ -5,9 +5,9 @@ stdenv.mkDerivation rec {
   pname = "fplll";
   version = "5.2.1";
   src = fetchFromGitHub {
-    owner = "${pname}";
-    repo = "${pname}";
-    rev = "${version}";
+    owner = pname;
+    repo = pname;
+    rev = version;
     sha256 = "015qmrd7nfaysbv1hbwiprz9g6hnww1y1z1xw8f43ysb7k1b5nbg";
   };
   nativeBuildInputs = [autoconf automake libtool gettext autoreconfHook];

--- a/pkgs/development/libraries/gio-sharp/default.nix
+++ b/pkgs/development/libraries/gio-sharp/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     owner = "mono";
     repo = "gio-sharp";
 
-    rev = "${version}";
+    rev = version;
     sha256 = "13pc529pjabj7lq23dbndc26ssmg5wkhc7lfvwapm87j711m0zig";
   };
 

--- a/pkgs/development/libraries/givaro/default.nix
+++ b/pkgs/development/libraries/givaro/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   version = "4.1.1";
   src = fetchFromGitHub {
     owner = "linbox-team";
-    repo = "${pname}";
+    repo = pname;
     rev = "v${version}";
     sha256 = "11wz57q6ijsvfs5r82masxgr319as92syi78lnl9lgdblpc6xigk";
   };

--- a/pkgs/development/libraries/glfw/3.x.nix
+++ b/pkgs/development/libraries/glfw/3.x.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "glfw";
     repo = "GLFW";
-    rev = "${version}";
+    rev = version;
     sha256 = "0gq6ad38b3azk0w2yy298yz2vmg2jmf9g0ydidqbmiswpk25ills";
   };
 

--- a/pkgs/development/libraries/gnome-sharp/default.nix
+++ b/pkgs/development/libraries/gnome-sharp/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "mono";
     repo = "gnome-sharp";
-    rev = "${version}";
+    rev = version;
     sha256 = "15jsm6n0sih0nf3w8vmvik97q7l3imz4vkdzmp9k7bssiz4glj1z";
   };
 

--- a/pkgs/development/libraries/gtk-sharp-beans/default.nix
+++ b/pkgs/development/libraries/gtk-sharp-beans/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     owner = "mono";
     repo = "gtk-sharp-beans";
 
-    rev = "${version}";
+    rev = version;
     sha256 = "04sylwdllb6gazzs2m4jjfn14mil9l3cny2q0xf0zkhczzih6ah1";
   };
 

--- a/pkgs/development/libraries/hpx/default.nix
+++ b/pkgs/development/libraries/hpx/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "STEllAR-GROUP";
     repo = "hpx";
-    rev = "${version}";
+    rev = version;
     sha256 = "0yzxb8520qh9rvzsa190yzx21jn3d8rl8ac5v01767ygd0413hfk";
   };
 

--- a/pkgs/development/libraries/kerberos/krb5.nix
+++ b/pkgs/development/libraries/kerberos/krb5.nix
@@ -15,7 +15,7 @@ with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "${type}krb5-${version}";
   majorVersion = "1.17";
-  version = "${majorVersion}";
+  version = majorVersion;
 
   src = fetchurl {
     url = "https://kerberos.org/dist/krb5/${majorVersion}/krb5-${version}.tar.gz";

--- a/pkgs/development/libraries/libao/default.nix
+++ b/pkgs/development/libraries/libao/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner  = "xiph";
     repo   = "libao";
-    rev    = "${version}";
+    rev    = version;
     sha256 = "0svgk4sc9kdhcsfyvbvgm5vpbg3sfr6z5rliflrw49v3x2i4vxq5";
   };
 

--- a/pkgs/development/libraries/libaosd/default.nix
+++ b/pkgs/development/libraries/libaosd/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner  = "atheme-legacy";
     repo   = "libaosd";
-    rev    = "${version}";
+    rev    = version;
     sha256 = "1cn7k0n74p6jp25kxwcyblhmbdvgw3mikvj0m2jh4c6xccfrgb9a";
   };
 

--- a/pkgs/development/libraries/libgphoto2/default.nix
+++ b/pkgs/development/libraries/libgphoto2/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "gphoto";
     repo = "libgphoto2";
-    rev = "${meta.tag}";
+    rev = meta.tag;
     sha256 = "1sc2ycx11khf0qzp1cqxxx1qymv6bjfbkx3vvbwz6wnbyvsigxz2";
   };
 

--- a/pkgs/development/libraries/libgroove/default.nix
+++ b/pkgs/development/libraries/libgroove/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "andrewrk";
     repo = "libgroove";
-    rev = "${version}";
+    rev = version;
     sha256 = "1la9d9kig50mc74bxvhx6hzqv0nrci9aqdm4k2j4q0s1nlfgxipd";
   };
 

--- a/pkgs/development/libraries/liblangtag/default.nix
+++ b/pkgs/development/libraries/liblangtag/default.nix
@@ -8,8 +8,8 @@ stdenv.mkDerivation rec {
 
   src = fetchFromBitbucket {
     owner = "tagoh";
-    repo = "${pname}";
-    rev = "${version}";
+    repo = pname;
+    rev = version;
     sha256 = "19dk2qsg7f3ig9xz8d73jvikmf5kvrwi008wrz2psxinbdml442g";
   };
 

--- a/pkgs/development/libraries/liblaxjson/default.nix
+++ b/pkgs/development/libraries/liblaxjson/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "andrewrk";
     repo = "liblaxjson";
-    rev = "${version}";
+    rev = version;
     sha256 = "01iqbpbhnqfifhv82m6hi8190w5sdim4qyrkss7z1zyv3gpchc5s";
   };
 

--- a/pkgs/development/libraries/librime/default.nix
+++ b/pkgs/development/libraries/librime/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "rime";
     repo = "librime";
-    rev = "${version}";
+    rev = version;
     sha256 = "0xskhdhk7dgpc71r39pfzxi5vrlzy90aqj1gzv8nnapq91p2awhv";
   };
 

--- a/pkgs/development/libraries/libsoundio/default.nix
+++ b/pkgs/development/libraries/libsoundio/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "andrewrk";
     repo = "libsoundio";
-    rev = "${version}";
+    rev = version;
     sha256 = "12l4rvaypv87vigdrmjz48d4d6sq4gfxf5asvnc4adyabxb73i4x";
   };
 

--- a/pkgs/development/libraries/linbox/default.nix
+++ b/pkgs/development/libraries/linbox/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "linbox-team";
-    repo = "${pname}";
+    repo = pname;
     rev = "v${version}";
     sha256 = "10j6dspbsq7d2l4q3y0c1l1xwmaqqba2fxg59q5bhgk9h5d7q571";
   };

--- a/pkgs/development/libraries/lmdbxx/default.nix
+++ b/pkgs/development/libraries/lmdbxx/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "drycpp";
     repo = "lmdbxx";
-    rev = "${version}";
+    rev = version;
     sha256 = "1jmb9wg2iqag6ps3z71bh72ymbcjrb6clwlkgrqf1sy80qwvlsn6";
   };
 

--- a/pkgs/development/libraries/mediastreamer/default.nix
+++ b/pkgs/development/libraries/mediastreamer/default.nix
@@ -11,8 +11,8 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "BelledonneCommunications";
-    repo = "${baseName}";
-    rev = "${version}";
+    repo = baseName;
+    rev = version;
     sha256 = "02745bzl2r1jqvdqzyv94fjd4w92zr976la4c4nfvsy52waqah7j";
   };
 

--- a/pkgs/development/libraries/msgpuck/default.nix
+++ b/pkgs/development/libraries/msgpuck/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "rtsisyk";
     repo = "msgpuck";
-    rev = "${version}";
+    rev = version;
     sha256 = "0cjq86kncn3lv65vig9cqkqqv2p296ymcjjbviw0j1s85cfflps0";
   };
 

--- a/pkgs/development/libraries/ndpi/default.nix
+++ b/pkgs/development/libraries/ndpi/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "ntop";
     repo = "nDPI";
-    rev = "${version}";
+    rev = version;
     sha256 = "0lc4vga89pm954vf92g9fa6xwsjkb13jd6wrcc35zy5j04nf9rzf";
   };
 

--- a/pkgs/development/libraries/notify-sharp/default.nix
+++ b/pkgs/development/libraries/notify-sharp/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     owner = "GNOME";
     repo = "notify-sharp";
 
-    rev = "${version}";
+    rev = version;
     sha256 = "1vm7mnmxdwrgy4mr07lfva8sa6a32f2ah5x7w8yzcmahaks3sj5m";
   };
 

--- a/pkgs/development/libraries/openbsm/default.nix
+++ b/pkgs/development/libraries/openbsm/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
-    rev = "${lib.toUpper (builtins.replaceStrings ["." "-"] ["_" "_"] "${pname}-${version}")}";
+    rev = lib.toUpper (builtins.replaceStrings ["." "-"] ["_" "_"] "${pname}-${version}");
     sha256 = "0b98359hd8mm585sh145ss828pg2y8vgz38lqrb7nypapiyqdnd1";
   };
 

--- a/pkgs/development/libraries/opendht/default.nix
+++ b/pkgs/development/libraries/opendht/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "savoirfairelinux";
     repo = "opendht";
-    rev = "${version}";
+    rev = version;
     sha256 = "1mj3zsywxphh9wcazyqsldwwn14r77xv9cjsmc0nmcybsl2bwnpl";
   };
 

--- a/pkgs/development/libraries/oracle-instantclient/default.nix
+++ b/pkgs/development/libraries/oracle-instantclient/default.nix
@@ -22,32 +22,32 @@ let
 
   # determine the version number, there might be different ones per architecture
   version = {
-    "x86_64-linux" = "19.3.0.0.0";
-    "x86_64-darwin" = "18.1.0.0.0";
-  }."${stdenv.hostPlatform.system}" or throwSystem;
+    x86_64-linux = "19.3.0.0.0";
+    x86_64-darwin = "18.1.0.0.0";
+  }.${stdenv.hostPlatform.system} or throwSystem;
 
   # hashes per component and architecture
   hashes = {
-    "x86_64-linux" = {
-      "basic"   = "1yk4ng3a9ka1mzgfph9br6rwclagbgfvmg6kja11nl5dapxdzaxy";
-      "sdk"     = "115v1gqr0czy7dcf2idwxhc6ja5b0nind0mf1rn8iawgrw560l99";
-      "sqlplus" = "0zj5h84ypv4n4678kfix6jih9yakb277l9hc0819iddc0a5slbi5";
-      "odbc"    = "1g1z6pdn76dp440fh49pm8ijfgjazx4cvxdi665fsr62h62xkvch";
+    x86_64-linux = {
+      basic   = "1yk4ng3a9ka1mzgfph9br6rwclagbgfvmg6kja11nl5dapxdzaxy";
+      sdk     = "115v1gqr0czy7dcf2idwxhc6ja5b0nind0mf1rn8iawgrw560l99";
+      sqlplus = "0zj5h84ypv4n4678kfix6jih9yakb277l9hc0819iddc0a5slbi5";
+      odbc    = "1g1z6pdn76dp440fh49pm8ijfgjazx4cvxdi665fsr62h62xkvch";
     };
-    "x86_64-darwin" = {
-      "basic"   = "fac3cdaaee7526f6c50ff167edb4ba7ab68efb763de24f65f63fb48cc1ba44c0";
-      "sdk"     = "98e6d797f1ce11e59b042b232f62380cec29ec7d5387b88a9e074b741c13e63a";
-      "sqlplus" = "02e66dc52398fced75e7efcb6b4372afcf617f7d88344fb7f0f4bb2bed371f3b";
-      "odbc"    = "5d0cdd7f9dd2e27affbc9b36ef9fc48e329713ecd36905fdd089366e365ae8a2";
+    x86_64-darwin = {
+      basic   = "fac3cdaaee7526f6c50ff167edb4ba7ab68efb763de24f65f63fb48cc1ba44c0";
+      sdk     = "98e6d797f1ce11e59b042b232f62380cec29ec7d5387b88a9e074b741c13e63a";
+      sqlplus = "02e66dc52398fced75e7efcb6b4372afcf617f7d88344fb7f0f4bb2bed371f3b";
+      odbc    = "5d0cdd7f9dd2e27affbc9b36ef9fc48e329713ecd36905fdd089366e365ae8a2";
     };
-  }."${stdenv.hostPlatform.system}" or throwSystem;
+  }.${stdenv.hostPlatform.system} or throwSystem;
 
   # rels per component and architecture, optional
   rels = {
-    "x86_64-darwin" = {
-      "sdk" = "2";
+    x86_64-darwin = {
+      sdk = "2";
     };
-  }."${stdenv.hostPlatform.system}" or {};
+  }.${stdenv.hostPlatform.system} or {};
 
   # convert platform to oracle architecture names
   arch = {
@@ -80,7 +80,7 @@ let
 
   # assemble srcs
   srcs = map (component:
-    (fetcher (srcFilename component arch version rels."${component}" or "") hashes."${component}" or ""))
+    (fetcher (srcFilename component arch version rels.${component} or "") hashes.${component} or ""))
   components;
 
   pname = "oracle-instantclient";

--- a/pkgs/development/libraries/ortp/default.nix
+++ b/pkgs/development/libraries/ortp/default.nix
@@ -7,8 +7,8 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "BelledonneCommunications";
-    repo = "${baseName}";
-    rev = "${version}";
+    repo = baseName;
+    rev = version;
     sha256 = "12cwv593bsdnxs0zfcp07vwyk7ghlz2wv7vdbs1ksv293w3vj2rv";
   };
 

--- a/pkgs/development/libraries/qjson/default.nix
+++ b/pkgs/development/libraries/qjson/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "flavio";
     repo = "qjson";
-    rev = "${version}";
+    rev = version;
     sha256 = "1f4wnxzx0qdmxzc7hqk28m0sva7z9p9xmxm6aifvjlp0ha6pmfxs";
   };
 

--- a/pkgs/development/libraries/science/math/magma/default.nix
+++ b/pkgs/development/libraries/science/math/magma/default.nix
@@ -22,7 +22,7 @@ in stdenv.mkDerivation {
 
   doCheck = false;
 
-  MKLROOT = optionalString mklSupport "${mkl}";
+  MKLROOT = optionalString mklSupport mkl;
 
   enableParallelBuilding=true;
   buildFlags = [ "magma" "magma_sparse" ];

--- a/pkgs/development/libraries/science/math/zn_poly/default.nix
+++ b/pkgs/development/libraries/science/math/zn_poly/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
 
   # name of library file ("libzn_poly.so")
   libbasename = "libzn_poly";
-  libext = "${stdenv.targetPlatform.extensions.sharedLibrary}";
+  libext = stdenv.targetPlatform.extensions.sharedLibrary;
 
   makeFlags = [ "CC=cc" ];
 

--- a/pkgs/development/libraries/smarty3-i18n/default.nix
+++ b/pkgs/development/libraries/smarty3-i18n/default.nix
@@ -5,7 +5,7 @@
   src = fetchFromGitHub {
     owner = "kikimosha";
     repo = "smarty3-i18n";
-    rev = "${version}";
+    rev = version;
     sha256 = "0rjxq4wka73ayna3hb5dxc5pgc8bw8p5fy507yc6cv2pl4h4nji2";
   };
 

--- a/pkgs/development/libraries/snappy/default.nix
+++ b/pkgs/development/libraries/snappy/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "google";
     repo = "snappy";
-    rev = "${version}";
+    rev = version;
     sha256 = "1x7r8sjmdqlqjz0xfiwdyrqpgaj5yrvrgb28ivgpvnxgar5qv6m2";
   };
 

--- a/pkgs/development/libraries/tachyon/default.nix
+++ b/pkgs/development/libraries/tachyon/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
          if stdenv.hostPlatform.system == "x86_64-freebsd" then "bsd"           else
          if stdenv.hostPlatform.system == "x686-freebsd"   then "bsd"           else
          throw "Don't know what arch to select for tachyon build";
-  makeFlags = "${arch}";
+  makeFlags = arch;
   patches = [
     # Remove absolute paths in Make-config (and unset variables so they can be set in preBuild)
     ./no-absolute-paths.patch

--- a/pkgs/development/libraries/v8/3.14.nix
+++ b/pkgs/development/libraries/v8/3.14.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "v8";
     repo = "v8";
-    rev = "${version}";
+    rev = version;
     inherit sha256;
   };
   patchPhase = ''

--- a/pkgs/development/libraries/xavs/default.nix
+++ b/pkgs/development/libraries/xavs/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
 
   src = fetchsvn {
     url = "https://svn.code.sf.net/p/xavs/code/trunk";
-    rev = "${version}";
+    rev = version;
     sha256 = "0drw16wm95dqszpl7j33y4gckz0w0107lnz6wkzb66f0dlbv48cf";
   };
 

--- a/pkgs/development/misc/google-clasp/google-clasp.nix
+++ b/pkgs/development/misc/google-clasp/google-clasp.nix
@@ -2,7 +2,7 @@
 
 {pkgs ? import <nixpkgs> {
     inherit system;
-  }, system ? builtins.currentSystem, nodejs ? pkgs."nodejs-10_x"}:
+  }, system ? builtins.currentSystem, nodejs ? pkgs.nodejs-10_x}:
 
 let
   nodeEnv = import ../../node-packages/node-env.nix {

--- a/pkgs/development/mobile/androidenv/compose-android-packages.nix
+++ b/pkgs/development/mobile/androidenv/compose-android-packages.nix
@@ -78,13 +78,13 @@ rec {
 
   platform-tools = import ./platform-tools.nix {
     inherit deployAndroidPackage os autoPatchelfHook pkgs lib;
-    package = packages.platform-tools."${platformToolsVersion}";
+    package = packages.platform-tools.${platformToolsVersion};
   };
 
   build-tools = map (version:
     import ./build-tools.nix {
       inherit deployAndroidPackage os autoPatchelfHook makeWrapper pkgs pkgs_i686 lib;
-      package = packages.build-tools."${version}";
+      package = packages.build-tools.${version};
     }
   ) buildToolsVersions;
 
@@ -95,7 +95,7 @@ rec {
 
   emulator = import ./emulator.nix {
     inherit deployAndroidPackage os autoPatchelfHook makeWrapper pkgs pkgs_i686 lib;
-    package = packages.emulator."${emulatorVersion}"."${os}";
+    package = packages.emulator.${emulatorVersion}.${os};
   };
 
   platforms = map (version:
@@ -132,20 +132,20 @@ rec {
   lldb = map (version:
     import ./lldb.nix {
       inherit deployAndroidPackage os autoPatchelfHook pkgs lib;
-      package = packages.lldb."${version}";
+      package = packages.lldb.${version};
     }
   ) lldbVersions;
 
   cmake = map (version:
     import ./cmake.nix {
       inherit deployAndroidPackage os autoPatchelfHook pkgs lib;
-      package = packages.cmake."${version}";
+      package = packages.cmake.${version};
     }
   ) cmakeVersions;
 
   ndk-bundle = import ./ndk-bundle {
     inherit deployAndroidPackage os autoPatchelfHook makeWrapper pkgs lib platform-tools;
-    package = packages.ndk-bundle."${ndkVersion}";
+    package = packages.ndk-bundle.${ndkVersion};
   };
 
   google-apis = map (version:

--- a/pkgs/development/mobile/genymotion/default.nix
+++ b/pkgs/development/mobile/genymotion/default.nix
@@ -7,7 +7,7 @@ let
   packages = [
     stdenv.cc.cc zlib glib xorg.libX11 libxkbcommon libXmu libXi libXext libGL
   ];
-  libPath = "${stdenv.lib.makeLibraryPath packages}";
+  libPath = stdenv.lib.makeLibraryPath packages;
 in
 stdenv.mkDerivation rec {
   pname = "genymotion";

--- a/pkgs/development/ocaml-modules/biniou/1.0.nix
+++ b/pkgs/development/ocaml-modules/biniou/1.0.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A binary data format designed for speed, safety, ease of use and backward compatibility as protocols evolve";
-    homepage = "${webpage}";
+    homepage = webpage;
     license = licenses.bsd3;
     maintainers = [ maintainers.vbgl ];
     platforms = ocaml.meta.platforms or [];

--- a/pkgs/development/ocaml-modules/containers/default.nix
+++ b/pkgs/development/ocaml-modules/containers/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "c-cube";
     repo = "ocaml-containers";
-    rev = "${version}";
+    rev = version;
     sha256 = "1wbarxphdrxvy7qsdp4p837h1zrv0z83pgs5lbz2h3kdnyvz2f1i";
   };
 

--- a/pkgs/development/ocaml-modules/elina/default.nix
+++ b/pkgs/development/ocaml-modules/elina/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--use-apron"
     "--use-opam"
-    "--apron-prefix" "${apron}"
+    "--apron-prefix" apron
   ]
   ++ stdenv.lib.optional stdenv.isDarwin "--absolute-dylibs"
   ;

--- a/pkgs/development/ocaml-modules/gen/default.nix
+++ b/pkgs/development/ocaml-modules/gen/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "c-cube";
     repo = "gen";
-    rev = "${version}";
+    rev = version;
     sha256 = "14b8vg914nb0yp1hgxzm29bg692m0gqncjj43b599s98s1cwl92h";
   };
 

--- a/pkgs/development/ocaml-modules/gg/default.nix
+++ b/pkgs/development/ocaml-modules/gg/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation {
       matrices, quaternions, axis aligned boxes, colors, color spaces, and
       raster data.
     '';
-    homepage = "${webpage}";
+    homepage = webpage;
     platforms = ocaml.meta.platforms or [];
     license = licenses.bsd3;
     maintainers = [ maintainers.jirkamarsik ];

--- a/pkgs/development/ocaml-modules/lacaml/default.nix
+++ b/pkgs/development/ocaml-modules/lacaml/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "mmottl";
     repo = "lacaml";
-    rev = "${version}";
+    rev = version;
     sha256 = "1aflg07cc9ak9mg1cr0qr368c9s141glwlarl5nhalf6hhq7ibcb";
   };
 

--- a/pkgs/development/ocaml-modules/logs/default.nix
+++ b/pkgs/development/ocaml-modules/logs/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Logging infrastructure for OCaml";
-    homepage = "${webpage}";
+    homepage = webpage;
     inherit (ocaml.meta) platforms;
     maintainers = [ maintainers.sternenseemann ];
     license = licenses.isc;

--- a/pkgs/development/ocaml-modules/ocaml-result/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-result/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "janestreet";
     repo = "result";
-    rev = "${version}";
+    rev = version;
     sha256 = "1jwzpcmxwgkfsbjz9zl59v12hf1vv4r9kiifancn9p8gm206g3g0";
   };
 

--- a/pkgs/development/ocaml-modules/opam-file-format/default.nix
+++ b/pkgs/development/ocaml-modules/opam-file-format/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "ocaml";
     repo = "opam-file-format";
-    rev = "${version}";
+    rev = version;
     sha256 = "0fqb99asnair0043hhc8r158d6krv5nzvymd0xwycr5y72yrp0hv";
   };
 

--- a/pkgs/development/ocaml-modules/otfm/default.nix
+++ b/pkgs/development/ocaml-modules/otfm/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation {
       provides low-level access to font tables and functions to decode some
       of them.
     '';
-    homepage = "${webpage}";
+    homepage = webpage;
     platforms = ocaml.meta.platforms or [];
     license = licenses.bsd3;
     maintainers = [ maintainers.jirkamarsik ];

--- a/pkgs/development/ocaml-modules/otr/default.nix
+++ b/pkgs/development/ocaml-modules/otr/default.nix
@@ -9,7 +9,7 @@ buildDunePackage rec {
   src = fetchFromGitHub {
     owner  = "hannesm";
     repo   = "ocaml-otr";
-    rev    = "${version}";
+    rev    = version;
     sha256 = "0iz6p85a0jxng9aq9blqsky173zaqfr6wlc5j48ad55lgwzlbih5";
   };
 

--- a/pkgs/development/ocaml-modules/ppx_tools/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_tools/default.nix
@@ -23,7 +23,7 @@ let param = {
   "4.08" = {
     version = "5.3+4.08.0";
     sha256 = "0vdmhs3hpmh5iclx4lzgdpf362m4l35zprxs73r84z1yhr4jcr4m"; };
-}."${ocaml.meta.branch}";
+}.${ocaml.meta.branch};
 in
   stdenv.mkDerivation {
     name = "ocaml${ocaml.version}-ppx_tools-${param.version}";

--- a/pkgs/development/ocaml-modules/sawja/default.nix
+++ b/pkgs/development/ocaml-modules/sawja/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     description = "A library written in OCaml, relying on Javalib to provide a high level representation of Java bytecode programs";
-    homepage = "${webpage}";
+    homepage = webpage;
     license = licenses.gpl3Plus;
     maintainers = [ maintainers.vbgl ];
     platforms = ocaml.meta.platforms or [];

--- a/pkgs/development/ocaml-modules/tls/default.nix
+++ b/pkgs/development/ocaml-modules/tls/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner  = "mirleft";
     repo   = "ocaml-tls";
-    rev    = "${version}";
+    rev    = version;
     sha256 = "02wv4lia583imn3sfci4nqv6ac5nzig5j3yfdnlqa0q8bp9rfc6g";
   };
 

--- a/pkgs/development/ocaml-modules/tsdl/default.nix
+++ b/pkgs/development/ocaml-modules/tsdl/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation {
   inherit (topkg) buildPhase installPhase;
 
   meta = with stdenv.lib; {
-    homepage = "${webpage}";
+    homepage = webpage;
     description = "Thin bindings to the cross-platform SDL library";
     license = licenses.bsd3;
     platforms = ocaml.meta.platforms or [];

--- a/pkgs/development/ocaml-modules/uucd/default.nix
+++ b/pkgs/development/ocaml-modules/uucd/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "An OCaml module to decode the data of the Unicode character database from its XML representation";
-    homepage = "${webpage}";
+    homepage = webpage;
     platforms = ocaml.meta.platforms or [];
     maintainers = [ maintainers.vbgl ];
     license = licenses.bsd3;

--- a/pkgs/development/ocaml-modules/uucp/default.nix
+++ b/pkgs/development/ocaml-modules/uucp/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     description = "An OCaml library providing efficient access to a selection of character properties of the Unicode character database";
-    homepage = "${webpage}";
+    homepage = webpage;
     platforms = ocaml.meta.platforms or [];
     license = licenses.bsd3;
     maintainers = [ maintainers.vbgl ];

--- a/pkgs/development/ocaml-modules/uunf/default.nix
+++ b/pkgs/development/ocaml-modules/uunf/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "An OCaml module for normalizing Unicode text";
-    homepage = "${webpage}";
+    homepage = webpage;
     platforms = ocaml.meta.platforms or [];
     license = licenses.bsd3;
     maintainers = [ maintainers.vbgl ];

--- a/pkgs/development/ocaml-modules/uuseg/default.nix
+++ b/pkgs/development/ocaml-modules/uuseg/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "An OCaml library for segmenting Unicode text";
-    homepage = "${webpage}";
+    homepage = webpage;
     platforms = ocaml.meta.platforms or [];
     license = licenses.bsd3;
     maintainers = [ maintainers.vbgl ];

--- a/pkgs/development/ocaml-modules/uutf/default.nix
+++ b/pkgs/development/ocaml-modules/uutf/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Non-blocking streaming Unicode codec for OCaml";
-    homepage = "${webpage}";
+    homepage = webpage;
     platforms = ocaml.meta.platforms or [];
     license = licenses.bsd3;
     maintainers = [ maintainers.vbgl ];

--- a/pkgs/development/ocaml-modules/vg/default.nix
+++ b/pkgs/development/ocaml-modules/vg/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation {
     Renderers for PDF, SVG and the HTML canvas are distributed with the
     module. An API allows to implement new renderers.
     '';
-    homepage = "${webpage}";
+    homepage = webpage;
     inherit (ocaml.meta) platforms;
     license = licenses.isc;
     maintainers = [ maintainers.jirkamarsik ];

--- a/pkgs/development/ocaml-modules/xmlm/default.nix
+++ b/pkgs/development/ocaml-modules/xmlm/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "An OCaml streaming codec to decode and encode the XML data format";
-    homepage = "${webpage}";
+    homepage = webpage;
     platforms = ocaml.meta.platforms or [];
     maintainers = [ maintainers.vbgl ];
     license = licenses.bsd3;

--- a/pkgs/development/pharo/launcher/default.nix
+++ b/pkgs/development/pharo/launcher/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   desktopItem = makeDesktopItem {
     name = "Pharo";
-    exec = "${executable-name}";
+    exec = executable-name;
     icon = "pharo";
     comment = "Launcher for Pharo distributions";
     desktopName = "Pharo";

--- a/pkgs/development/python-modules/alot/default.nix
+++ b/pkgs/development/python-modules/alot/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "pazz";
     repo = "alot";
-    rev = "${version}";
+    rev = version;
     sha256 = "1isn0p0i2a7dlbrdk5ib01xa1wgi6bi9ka4xl4vj8iw1q4i5fqv9";
   };
 

--- a/pkgs/development/python-modules/ansible-kernel/default.nix
+++ b/pkgs/development/python-modules/ansible-kernel/default.nix
@@ -16,7 +16,7 @@
 
 let
   kernelSpecFile = writeText "kernel.json" (builtins.toJSON {
-    argv = [ "${python.interpreter}" "-m" "ansible_kernel" "-f" "{connection_file}" ];
+    argv = [ python.interpreter "-m" "ansible_kernel" "-f" "{connection_file}" ];
     codemirror_mode = "yaml";
     display_name = "Ansible";
     language = "ansible";

--- a/pkgs/development/python-modules/bap/default.nix
+++ b/pkgs/development/python-modules/bap/default.nix
@@ -6,7 +6,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "BinaryAnalysisPlatform";
     repo = "bap-python";
-    rev = "${version}";
+    rev = version;
     sha256 = "1ahkrmcn7qaivps1gar8wd9mq2qqyx6zzvznf5r9rr05h17x5lbp";
   };
 

--- a/pkgs/development/python-modules/beaker/default.nix
+++ b/pkgs/development/python-modules/beaker/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "bbangert";
     repo = "beaker";
-    rev = "${version}";
+    rev = version;
     sha256 = "0xrvg503xmi28w0hllr4s7fkap0p09fgw2wax3p1s2r6b3xjvbz7";
   };
 

--- a/pkgs/development/python-modules/hocr-tools/default.nix
+++ b/pkgs/development/python-modules/hocr-tools/default.nix
@@ -11,7 +11,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "tmbdev";
-    repo = "${pname}";
+    repo = pname;
     rev = "v${version}";
     sha256 = "14f9hkp7pr677085w8iidwd0la9cjzy3pyj3rdg9b03nz9pc0w6p";
   };

--- a/pkgs/development/python-modules/locustio/default.nix
+++ b/pkgs/development/python-modules/locustio/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "locustio";
     repo = "locust";
-    rev = "${version}";
+    rev = version;
     sha256 = "1645d63ig4ymw716b6h53bhmjqqc13p9r95k1xfx66ck6vdqnisd";
   };
 

--- a/pkgs/development/python-modules/ludios_wpull/default.nix
+++ b/pkgs/development/python-modules/ludios_wpull/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   disabled = !isPy3k;
 
   src = fetchFromGitHub {
-    rev = "${version}";
+    rev = version;
     owner = "ludios";
     repo = "wpull";
     sha256 = "1j96avm0ynbazypzp766wh26n4qc73y7wgsiqfrdfl6x7rx20wgf";

--- a/pkgs/development/python-modules/magic/default.nix
+++ b/pkgs/development/python-modules/magic/default.nix
@@ -4,7 +4,7 @@
 }:
 
 buildPythonPackage {
-  name = "${pkgs.file.name}";
+  name = pkgs.file.name;
 
   src = pkgs.file.src;
 

--- a/pkgs/development/python-modules/netcdf4/default.nix
+++ b/pkgs/development/python-modules/netcdf4/default.nix
@@ -37,10 +37,10 @@ buildPythonPackage rec {
 
   # Variables used to configure the build process
   USE_NCCONFIG="0";
-  HDF5_DIR="${hdf5}";
-  NETCDF4_DIR="${netcdf}";
-  CURL_DIR="${curl.dev}";
-  JPEG_DIR="${libjpeg.dev}";
+  HDF5_DIR=hdf5;
+  NETCDF4_DIR=netcdf;
+  CURL_DIR=curl.dev;
+  JPEG_DIR=libjpeg.dev;
 
   meta = with stdenv.lib; {
     description = "Interface to netCDF library (versions 3 and 4)";

--- a/pkgs/development/python-modules/nmigen/default.nix
+++ b/pkgs/development/python-modules/nmigen/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
 
   postPatch = let
     tool = pkg: name:
-      if pkg == null then {} else { "${name}" = "${pkg}/bin/${name}"; };
+      if pkg == null then {} else { ${name} = "${pkg}/bin/${name}"; };
 
     # Only FOSS toolchain supported out of the box, sorry!
     toolchainOverrides =

--- a/pkgs/development/python-modules/pdfminer_six/default.nix
+++ b/pkgs/development/python-modules/pdfminer_six/default.nix
@@ -7,7 +7,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "pdfminer";
     repo = "pdfminer.six";
-    rev = "${version}";
+    rev = version;
     sha256 = "1v8pcx43fgidv1g54s92k85anvcss08blkhm4yi1hn1ybl0mmw6c";
   };
 

--- a/pkgs/development/python-modules/pybluez/default.nix
+++ b/pkgs/development/python-modules/pybluez/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "karulis";
-    repo = "${pname}";
+    repo = pname;
     rev = "a0b226a61b166e170d48539778525b31e47a4731";
     sha256 = "104dm5ngfhqisv1aszdlr3szcav2g3bhsgzmg4qfs09b3i5zj047";
   };

--- a/pkgs/development/python-modules/pytesseract/default.nix
+++ b/pkgs/development/python-modules/pytesseract/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
   patches = [
     (substituteAll {
       src = ./tesseract-binary.patch;
-      drv = "${tesseract}";
+      drv = tesseract;
     })
   ];
 

--- a/pkgs/development/python-modules/pytest-helpers-namespace/default.nix
+++ b/pkgs/development/python-modules/pytest-helpers-namespace/default.nix
@@ -10,7 +10,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "saltstack";
-    repo = "${pname}";
+    repo = pname;
     rev = "v${version}";
     sha256 = "0z9f25d2wpf3lnqzmmnrlvl5b1f7kqwjjf4nzs9x2bpf91s5zny1";
   };

--- a/pkgs/development/python-modules/ruffus/default.nix
+++ b/pkgs/development/python-modules/ruffus/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "cgat-developers";
-    repo = "${pname}";
+    repo = pname;
     rev = "v${version}";
     sha256 = "1gyabqafq4s2sy0prh3k1m8859shzjmfxr7fimx10liflvki96a9";
   };

--- a/pkgs/development/python-modules/shiboken2/default.nix
+++ b/pkgs/development/python-modules/shiboken2/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
     cd sources/shiboken2
   '';
 
-  CLANG_INSTALL_DIR = "${llvmPackages.libclang.out}";
+  CLANG_INSTALL_DIR = llvmPackages.libclang.out;
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ llvmPackages.libclang python qt5.qtbase qt5.qtxmlpatterns ];

--- a/pkgs/development/python-modules/sklearn-deap/default.nix
+++ b/pkgs/development/python-modules/sklearn-deap/default.nix
@@ -8,7 +8,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "rsteca";
     repo = pname;
-    rev = "${version}";
+    rev = version;
     sha256 = "1yqnmy8h08i2y6bb2s0a5nx9cwvyg45293whqh420c195gpzg1x3";
   };
 

--- a/pkgs/development/python-modules/slackclient/default.nix
+++ b/pkgs/development/python-modules/slackclient/default.nix
@@ -7,7 +7,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner  = "slackapi";
     repo   = pname;
-    rev    = "${version}";
+    rev    = version;
     sha256 = "073fwf6fm2sqdp5ms3vm1v3ljh0pldi69k048404rp6iy3cfwkp0";
   };
 

--- a/pkgs/development/python-modules/sqlalchemy-imageattach/default.nix
+++ b/pkgs/development/python-modules/sqlalchemy-imageattach/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   src = pkgs.fetchFromGitHub {
     repo = "sqlalchemy-imageattach";
     owner = "dahlia";
-    rev = "${version}";
+    rev = version;
     sha256 = "0ba97pn5dh00qvxyjbr0mr3pilxqw5kb3a6jd4wwbsfcv6nngqig";
   };
 

--- a/pkgs/development/python-modules/tensorflow/bin.nix
+++ b/pkgs/development/python-modules/tensorflow/bin.nix
@@ -51,7 +51,7 @@ in buildPythonPackage {
   format = "wheel";
 
   src = let
-    pyVerNoDot = lib.strings.stringAsChars (x: if x == "." then "" else x) "${python.pythonVersion}";
+    pyVerNoDot = lib.strings.stringAsChars (x: if x == "." then "" else x) python.pythonVersion;
     pyver = if stdenv.isDarwin then builtins.substring 0 1 pyVerNoDot else pyVerNoDot;
     platform = if stdenv.isDarwin then "mac" else "linux";
     unit = if cudaSupport then "gpu" else "cpu";

--- a/pkgs/development/python-modules/unicorn/default.nix
+++ b/pkgs/development/python-modules/unicorn/default.nix
@@ -10,7 +10,7 @@ buildPythonPackage rec {
   };
 
   # needs python2 at build time
-  PYTHON="${buildPackages.python2.interpreter}";
+  PYTHON=buildPackages.python2.interpreter;
 
   setupPyBuildFlags = [ "--plat-name" "linux" ];
 

--- a/pkgs/development/python-modules/urwidtrees/default.nix
+++ b/pkgs/development/python-modules/urwidtrees/default.nix
@@ -11,7 +11,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "pazz";
     repo = "urwidtrees";
-    rev = "${version}";
+    rev = version;
     sha256 = "1n1kpidvkdnsqyb82vlvk78gmly96kh8351lqxn2pzgwwns6fml2";
   };
 

--- a/pkgs/development/python-modules/vultr/default.nix
+++ b/pkgs/development/python-modules/vultr/default.nix
@@ -11,7 +11,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
       owner = "spry-group";
       repo = "python-vultr";
-      rev = "${version}";
+      rev = version;
       sha256 = "1qjvvr2v9gfnwskdl0ayazpcmiyw9zlgnijnhgq9mcri5gq9jw5h";
   };
 

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -806,11 +806,11 @@ let
 
     RAppArmor = old.RAppArmor.overrideDerivation (attrs: {
       patches = [ ./patches/RAppArmor.patch ];
-      LIBAPPARMOR_HOME = "${pkgs.libapparmor}";
+      LIBAPPARMOR_HOME = pkgs.libapparmor;
     });
 
     RMySQL = old.RMySQL.overrideDerivation (attrs: {
-      MYSQL_DIR="${pkgs.mysql.connector-c}";
+      MYSQL_DIR=pkgs.mysql.connector-c;
       preConfigure = ''
         patchShebangs configure
       '';

--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -501,7 +501,7 @@ in
   sassc = attrs: {
     nativeBuildInputs = [ rake ];
     dontBuild = false;
-    SASS_LIBSASS_PATH = "${libsass}";
+    SASS_LIBSASS_PATH = libsass;
     postPatch = ''
       substituteInPlace lib/sassc/native.rb \
         --replace 'gem_root = spec.gem_dir' 'gem_root = File.join(__dir__, "../../")'

--- a/pkgs/development/ruby-modules/with-packages/test.nix
+++ b/pkgs/development/ruby-modules/with-packages/test.nix
@@ -21,14 +21,14 @@ let
     lib.mapAttrs (name: gem:
       let
         test =
-          if builtins.isList gemTests."${name}"
+          if builtins.isList gemTests.${name}
           then pkgs.writeText "${name}.rb" ''
                 puts "${name} GEM_HOME: #{ENV['GEM_HOME']}"
-                ${lib.concatStringsSep "\n" (map (n: "require '${n}'") gemTests."${name}")}
+                ${lib.concatStringsSep "\n" (map (n: "require '${n}'") gemTests.${name})}
               ''
-          else pkgs.writeText "${name}.rb" gemTests."${name}";
+          else pkgs.writeText "${name}.rb" gemTests.${name};
 
-        deps = ruby.withPackages (g: [ g."${name}" ]);
+        deps = ruby.withPackages (g: [ g.${name} ]);
       in stdenv.mkDerivation {
         name = "test-gem-${ruby.name}-${name}";
         buildInputs = [ deps ];

--- a/pkgs/development/tools/alloy/default.nix
+++ b/pkgs/development/tools/alloy/default.nix
@@ -7,7 +7,7 @@ let generic = { major, version, src }:
     nameMajor = "alloy${major}";
 
     desktopItem = makeDesktopItem rec {
-      name = "${nameMajor}";
+      name = nameMajor;
       exec = name;
       icon = name;
       desktopName = "Alloy ${major}";

--- a/pkgs/development/tools/build-managers/arpa2cm/default.nix
+++ b/pkgs/development/tools/build-managers/arpa2cm/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     sha256 = "093h7njj8d8iiwnw5byfxkkzlbny60fwv1w57j8f1lsd4yn6rih4";
     rev = "version-${version}";
-    repo = "${pname}";
+    repo = pname;
     owner = "arpa2";
   };
 

--- a/pkgs/development/tools/doctl/default.nix
+++ b/pkgs/development/tools/doctl/default.nix
@@ -9,7 +9,7 @@ buildGoPackage rec {
   goPackagePath = "github.com/digitalocean/doctl";
 
   excludedPackages = ''\(doctl-gen-doc\|install-doctl\|release-doctl\)'';
-  buildFlagsArray = let t = "${goPackagePath}"; in ''
+  buildFlagsArray = let t = goPackagePath; in ''
      -ldflags=
         -X ${t}.Major=${major}
         -X ${t}.Minor=${minor}

--- a/pkgs/development/tools/git-quick-stats/default.nix
+++ b/pkgs/development/tools/git-quick-stats/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     repo = "git-quick-stats";
     owner = "arzzen";
-    rev = "${version}";
+    rev = version;
     sha256 = "1px1sk7b6mjnbclsr1jn33m9k4wd8wqyw4d6w1rgj0ii29lhzmqi";
   };
   PREFIX = builtins.placeholder "out";

--- a/pkgs/development/tools/global-platform-pro/default.nix
+++ b/pkgs/development/tools/global-platform-pro/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "martinpaljak";
     repo = "GlobalPlatformPro";
-    rev = "${version}";
+    rev = version;
     sha256 = "1vws6cbgm3mrwc2xz9j1y262vw21x3hjc9m7rqc4hn3m7gjpwsvg";
   };
 

--- a/pkgs/development/tools/goconvey/default.nix
+++ b/pkgs/development/tools/goconvey/default.nix
@@ -12,7 +12,7 @@ buildGoPackage rec {
   src = fetchFromGitHub {
     owner = "smartystreets";
     repo = "goconvey";
-    rev = "${version}";
+    rev = version;
     sha256 = "1ph18rkl3ns3fgin5i4j54w5a69grrmf3apcsmnpdn1wlrbs3dxh";
   };
 

--- a/pkgs/development/tools/gosec/default.nix
+++ b/pkgs/development/tools/gosec/default.nix
@@ -13,7 +13,7 @@ buildGoPackage rec {
   src = fetchFromGitHub {
     owner = "securego";
     repo = "gosec";
-    rev = "${version}";
+    rev = version;
     sha256 = "1420yl4cjp4v4xv0l0wbahgl6bjhz77lx5va9hqa6abddmqvx1hg";
   };
 

--- a/pkgs/development/tools/jid/default.nix
+++ b/pkgs/development/tools/jid/default.nix
@@ -9,7 +9,7 @@ buildGoPackage rec {
   src = fetchFromGitHub {
     owner = "simeji";
     repo = "jid";
-    rev = "${version}";
+    rev = version;
     sha256 = "0p4srp85ilcafrn9d36rzpzg5k5jd7is93p68hamgxqyiiw6a8fi";
   };
 

--- a/pkgs/development/tools/jmespath/default.nix
+++ b/pkgs/development/tools/jmespath/default.nix
@@ -3,7 +3,7 @@
 buildGoPackage rec {
   pname = "jmespath";
   version = "0.2.2";
-  rev = "${version}";
+  rev = version;
 
   goPackagePath = "github.com/jmespath/go-jmespath";
 

--- a/pkgs/development/tools/jp/default.nix
+++ b/pkgs/development/tools/jp/default.nix
@@ -3,7 +3,7 @@
 buildGoPackage rec {
   pname = "jp";
   version = "0.1.2";
-  rev = "${version}";
+  rev = version;
 
   goPackagePath = "github.com/jmespath/jp";
 

--- a/pkgs/development/tools/jsduck/default.nix
+++ b/pkgs/development/tools/jsduck/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = (import ./gemset.nix).jsduck.version;
 
   env = bundlerEnv {
-    name = "${pname}";
+    name = pname;
     gemfile = ./Gemfile;
     lockfile = ./Gemfile.lock;
     gemset = ./gemset.nix;

--- a/pkgs/development/tools/kafkacat/default.nix
+++ b/pkgs/development/tools/kafkacat/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "edenhill";
     repo = "kafkacat";
-    rev = "${version}";
+    rev = version;
     sha256 = "0zs2nmf3ghm9iar7phc0ncqsb9nhipav94v6qmpxkfwxd2ljkpds";
   };
 

--- a/pkgs/development/tools/makerpm/default.nix
+++ b/pkgs/development/tools/makerpm/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "ivan-tkatchev";
     repo = "makerpm";
-    rev = "${version}";
+    rev = version;
     sha256 = "089dkbh5705ppyi920rd0ksjc0143xmvnhm8qrx93rsgwc1ggi1y";
   };
 

--- a/pkgs/development/tools/misc/kibana/6.x.nix
+++ b/pkgs/development/tools/misc/kibana/6.x.nix
@@ -18,12 +18,12 @@ let
   shas =
     if enableUnfree
     then {
-      "x86_64-linux"  = "1xwklhqxk5rmdrgy2simwvijzq29kyq5w2w3hy53xh2i1zlnyvq3";
-      "x86_64-darwin" = "1qpdn28mrpggd55khzqqld6r89l0hb870rigxcw2i8p2yx3jv106";
+      x86_64-linux  = "1xwklhqxk5rmdrgy2simwvijzq29kyq5w2w3hy53xh2i1zlnyvq3";
+      x86_64-darwin = "1qpdn28mrpggd55khzqqld6r89l0hb870rigxcw2i8p2yx3jv106";
     }
     else {
-      "x86_64-linux"  = "1wpnwal2rq5v2bsp5qil9j6dplif7ql5394sy4ia5ghp2fzifxmf";
-      "x86_64-darwin" = "12z8i0wbw10c097glbpdy350p0h3957433f51qfx2p0ghgkzkhzv";
+      x86_64-linux  = "1wpnwal2rq5v2bsp5qil9j6dplif7ql5394sy4ia5ghp2fzifxmf";
+      x86_64-darwin = "12z8i0wbw10c097glbpdy350p0h3957433f51qfx2p0ghgkzkhzv";
     };
 
 in stdenv.mkDerivation rec {

--- a/pkgs/development/tools/misc/kibana/7.x.nix
+++ b/pkgs/development/tools/misc/kibana/7.x.nix
@@ -18,12 +18,12 @@ let
   shas =
     if enableUnfree
     then {
-      "x86_64-linux"  = "0sc5709k3z7lb8qcjpj49s6vfv69ds2wc8319ag9x776nyz1pqxi";
-      "x86_64-darwin" = "0zh4q46vfdwaihs838ck8fap92i3b4x10wbpmx8mcwyfk5v0fkch";
+      x86_64-linux  = "0sc5709k3z7lb8qcjpj49s6vfv69ds2wc8319ag9x776nyz1pqxi";
+      x86_64-darwin = "0zh4q46vfdwaihs838ck8fap92i3b4x10wbpmx8mcwyfk5v0fkch";
     }
     else {
-      "x86_64-linux"  = "1pq17fasryharvw4byybvmcf5172hcmy6cp0m8bxhkxagwilprba";
-      "x86_64-darwin" = "11crpx2qs2nzkzv6fvs1gqn9v4zalxkzsc5br0fy1y02lzm26zbm";
+      x86_64-linux  = "1pq17fasryharvw4byybvmcf5172hcmy6cp0m8bxhkxagwilprba";
+      x86_64-darwin = "11crpx2qs2nzkzv6fvs1gqn9v4zalxkzsc5br0fy1y02lzm26zbm";
     };
 
 in stdenv.mkDerivation rec {
@@ -32,7 +32,7 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://artifacts.elastic.co/downloads/kibana/${name}-${plat}-${arch}.tar.gz";
-    sha256 = shas."${stdenv.hostPlatform.system}" or (throw "Unknown architecture");
+    sha256 = shas.${stdenv.hostPlatform.system} or (throw "Unknown architecture");
   };
 
   patches = [

--- a/pkgs/development/tools/misc/lsof/default.nix
+++ b/pkgs/development/tools/misc/lsof/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "lsof-org";
     repo = "lsof";
-    rev = "${version}";
+    rev = version;
     sha256 = "1gd6r0nv8xz76pmvk52dgmfl0xjvkxl0s51b4jk4a0lphw3393yv";
   };
 

--- a/pkgs/development/tools/misc/trv/default.nix
+++ b/pkgs/development/tools/misc/trv/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "afiniate";
     repo = "trv";
-    rev = "${version}";
+    rev = version;
     sha256 = "0fv0zh76djqhkzfzwv6k60rnky50pw9gn01lwhijrggrcxrrphz1";
   };
 

--- a/pkgs/development/tools/misc/xc3sprog/default.nix
+++ b/pkgs/development/tools/misc/xc3sprog/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   src = fetchsvn {
     url = "https://svn.code.sf.net/p/xc3sprog/code/trunk";
     sha256 = "1rfhms3i7375kdlg0sdg5k52ix3xv5llj2dr30vamyg7pk74y8rx";
-    rev = "${version}";
+    rev = version;
   };
 
   buildInputs = [ cmake libusb libftdi ];

--- a/pkgs/development/tools/ocaml/camlidl/default.nix
+++ b/pkgs/development/tools/ocaml/camlidl/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A stub code generator and COM binding for Objective Caml";
-    homepage = "${webpage}";
+    homepage = webpage;
     license = "LGPL";
     maintainers = [ stdenv.lib.maintainers.roconnor ];
   };

--- a/pkgs/development/tools/ocaml/cppo/default.nix
+++ b/pkgs/development/tools/ocaml/cppo/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation ({
     longDescription = ''
       Cppo is an equivalent of the C preprocessor targeted at the OCaml language and its variants.
     '';
-    homepage = "${webpage}";
+    homepage = webpage;
     maintainers = [ maintainers.vbgl ];
     license = licenses.bsd3;
   };

--- a/pkgs/development/tools/ocaml/omake/0.9.8.6-rc1.nix
+++ b/pkgs/development/tools/ocaml/omake/0.9.8.6-rc1.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Omake build system";
-    homepage = "${webpage}";
+    homepage = webpage;
     license = "GPL";
     platforms = ocaml.meta.platforms or [];
   };

--- a/pkgs/development/tools/rucksack/default.nix
+++ b/pkgs/development/tools/rucksack/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "andrewrk";
     repo = "rucksack";
-    rev = "${version}";
+    rev = version;
     sha256 = "0bcm20hqxqnq1j0zghb9i7z9frri6bbf7rmrv5g8dd626sq07vyv";
   };
 

--- a/pkgs/development/tools/slimerjs/default.nix
+++ b/pkgs/development/tools/slimerjs/default.nix
@@ -6,9 +6,9 @@ let
     version="1.0.0";
     name="${baseName}-${version}";
     owner = "laurentj";
-    repo = "${baseName}";
+    repo = baseName;
     sha256="1w4sfrv520isbs7r1rlzl5y3idrpad7znw9fc92yz40jlwz7sxs4";
-    rev = "${version}";
+    rev = version;
   };
   buildInputs = [
     unzip zip

--- a/pkgs/development/tools/toluapp/default.nix
+++ b/pkgs/development/tools/toluapp/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "LuaDist";
     repo  = "toluapp";
-    rev   = "${version}";
+    rev   = version;
     sha256 = "0zd55bc8smmgk9j4cf0jpibb03lgsvl0knpwhplxbv93mcdnw7s0";
   };
 

--- a/pkgs/development/tools/vagrant/default.nix
+++ b/pkgs/development/tools/vagrant/default.nix
@@ -55,7 +55,7 @@ in buildRubyGem rec {
   postInstall =
     let
       pathAdditions = lib.makeSearchPath "bin"
-        (map (x: "${lib.getBin x}") ([
+        (map (x: lib.getBin x) ([
           libarchive
         ] ++ lib.optionals withLibvirt [
           libguestfs

--- a/pkgs/development/tools/vcstool/default.nix
+++ b/pkgs/development/tools/vcstool/default.nix
@@ -14,7 +14,7 @@ buildPythonApplication rec {
 
   propagatedBuildInputs = [ pyyaml ];
 
-  makeWrapperArgs = ["--prefix" "PATH" ":" "${stdenv.lib.makeBinPath [ git bazaar subversion ]}"];
+  makeWrapperArgs = ["--prefix" "PATH" ":" (stdenv.lib.makeBinPath [ git bazaar subversion ])];
 
   doCheck = false; # requires network
 

--- a/pkgs/development/tools/vultr/default.nix
+++ b/pkgs/development/tools/vultr/default.nix
@@ -8,7 +8,7 @@ buildGoPackage rec {
   src = fetchFromGitHub {
     owner = "JamesClonk";
     repo = "vultr";
-    rev = "${version}";
+    rev = version;
     sha256 = "1bx2x17aa6wfn4qy9lxk8sh7shs3x5ppz2z49s0xm8qq0rs1qi92";
   };
 

--- a/pkgs/games/90secondportraits/default.nix
+++ b/pkgs/games/90secondportraits/default.nix
@@ -11,8 +11,8 @@ let
 
   desktopItem = makeDesktopItem {
     name = "90secondportraits";
-    exec = "${pname}";
-    icon = "${icon}";
+    exec = pname;
+    icon = icon;
     comment = "A silly speed painting game";
     desktopName = "90 Second Portraits";
     genericName = "90secondportraits";

--- a/pkgs/games/assaultcube/default.nix
+++ b/pkgs/games/assaultcube/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ file zlib ] ++ optionals client [ openal SDL SDL_image libogg libvorbis ];
 
   targets = (optionalString server "server") + (optionalString client " client");
-  makeFlags = [ "-C source/src" "CXX=c++" "${targets}" ];
+  makeFlags = [ "-C source/src" "CXX=c++" targets ];
 
   desktop = makeDesktopItem {
     name = "AssaultCube";
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     genericName = "First-person shooter";
     categories = "Application;Game;ActionGame;Shooter";
     icon = "assaultcube.png";
-    exec = "${pname}";
+    exec = pname;
   };
 
   gamedatadir = "/share/games/${pname}";

--- a/pkgs/games/cataclysm-dda/default.nix
+++ b/pkgs/games/cataclysm-dda/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (common // rec {
   name = "cataclysm-dda-${version}";
 
   src = fetchFromCleverRaven {
-    rev = "${version}";
+    rev = version;
     sha256 = "00zzhx1mh1qjq668cga5nbrxp2qk6b82j5ak65skhgnlr6ii4ysc";
   };
 

--- a/pkgs/games/duckmarines/default.nix
+++ b/pkgs/games/duckmarines/default.nix
@@ -11,8 +11,8 @@ let
 
   desktopItem = makeDesktopItem {
     name = "duckmarines";
-    exec = "${pname}";
-    icon = "${icon}";
+    exec = pname;
+    icon = icon;
     comment = "Duck-themed action puzzle video game";
     desktopName = "Duck Marines";
     genericName = "duckmarines";

--- a/pkgs/games/eternity-engine/default.nix
+++ b/pkgs/games/eternity-engine/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "team-eternity";
     repo = "eternity";
-    rev = "${version}";
+    rev = version;
     sha256 = "00kpq4k23hjmzjaymw3sdda7mqk8fjq6dzf7fmdal9fm7lfmj41k";
   };
 

--- a/pkgs/games/flightgear/default.nix
+++ b/pkgs/games/flightgear/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
   desktopItem = makeDesktopItem {
     name = "flightgear";
     exec = "fgfs";
-    icon = "${iconsrc}";
+    icon = iconsrc;
     comment = "FlightGear Flight Simulator";
     desktopName = "FlightGear";
     genericName = "Flight simulator";

--- a/pkgs/games/megaglest/default.nix
+++ b/pkgs/games/megaglest/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "MegaGlest";
     repo = "megaglest-source";
-    rev = "${version}";
+    rev = version;
     fetchSubmodules = true;
     sha256 = "0fb58a706nic14ss89zrigphvdiwy5s9dwvhscvvgrfvjpahpcws";
   };

--- a/pkgs/games/mrrescue/default.nix
+++ b/pkgs/games/mrrescue/default.nix
@@ -11,8 +11,8 @@ let
 
   desktopItem = makeDesktopItem {
     name = "mrrescue";
-    exec = "${pname}";
-    icon = "${icon}";
+    exec = pname;
+    icon = icon;
     comment = "Arcade-style fire fighting game"; 
     desktopName = "Mr. Rescue";
     genericName = "mrrescue";

--- a/pkgs/games/nexuiz/default.nix
+++ b/pkgs/games/nexuiz/default.nix
@@ -11,7 +11,7 @@
 let
   version = "2.5.2";
 
-  version_short = stdenv.lib.replaceChars [ "." ] [ "" ] "${version}";
+  version_short = stdenv.lib.replaceChars [ "." ] [ "" ] version;
 in stdenv.mkDerivation {
   pname = "nexuiz";
   inherit version;

--- a/pkgs/games/orthorobot/default.nix
+++ b/pkgs/games/orthorobot/default.nix
@@ -11,8 +11,8 @@ let
 
   desktopItem = makeDesktopItem {
     name = "orthorobot";
-    exec = "${pname}";
-    icon = "${icon}";
+    exec = pname;
+    icon = icon;
     comment = "Robot game";
     desktopName = "Orthorobot";
     genericName = "orthorobot";

--- a/pkgs/games/rimshot/default.nix
+++ b/pkgs/games/rimshot/default.nix
@@ -11,8 +11,8 @@ let
 
   desktopItem = makeDesktopItem {
     name = "rimshot";
-    exec = "${pname}";
-    icon = "${icon}";
+    exec = pname;
+    icon = icon;
     comment = "Create your own music";
     desktopName = "Rimshot";
     genericName = "rimshot";

--- a/pkgs/games/runelite/default.nix
+++ b/pkgs/games/runelite/default.nix
@@ -18,7 +18,7 @@
     name = "RuneLite";
     type = "Application";
     exec = "runelite";
-    icon = "${icon}";
+    icon = icon;
     comment = "Open source Old School RuneScape client";
     terminal = "false";
     desktopName = "RuneLite";

--- a/pkgs/games/sienna/default.nix
+++ b/pkgs/games/sienna/default.nix
@@ -11,8 +11,8 @@ let
 
   desktopItem = makeDesktopItem {
     name = "sienna";
-    exec = "${pname}";
-    icon = "${icon}";
+    exec = pname;
+    icon = icon;
     comment = "Fast-paced one button platformer"; 
     desktopName = "Sienna";
     genericName = "sienna";

--- a/pkgs/games/tdm/default.nix
+++ b/pkgs/games/tdm/default.nix
@@ -10,7 +10,7 @@ let
     desktopName = pname;
     name = pname;
     exec = "@out@/bin/${pname}";
-    icon = "${pname}";
+    icon = pname;
     terminal = "False";
     comment = "The Dark Mod - stealth FPS inspired by the Thief series";
     type = "Application";

--- a/pkgs/games/tome4/default.nix
+++ b/pkgs/games/tome4/default.nix
@@ -8,7 +8,7 @@ let
     desktopName = pname;
     name = pname;
     exec = "@out@/bin/${pname}";
-    icon = "${pname}";
+    icon = pname;
     terminal = "False";
     comment = "An open-source, single-player, role-playing roguelike game set in the world of Eyal.";
     type = "Application";

--- a/pkgs/games/vapor/default.nix
+++ b/pkgs/games/vapor/default.nix
@@ -12,8 +12,8 @@ let
 
   desktopItem = makeDesktopItem {
     name = "Vapor";
-    exec = "${pname}";
-    icon = "${icon}";
+    exec = pname;
+    icon = icon;
     comment = "LÖVE Distribution Client"; 
     desktopName = "Vapor";
     genericName = "vapor";

--- a/pkgs/misc/brightnessctl/default.nix
+++ b/pkgs/misc/brightnessctl/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "Hummer12007";
     repo = "brightnessctl";
-    rev = "${version}";
+    rev = version;
     sha256 = "1n1gb8ldgqv3vs565yhk1w4jfvrviczp94r8wqlkv5q6ab43c8w9";
   };
 

--- a/pkgs/misc/emulators/ccemux/default.nix
+++ b/pkgs/misc/emulators/ccemux/default.nix
@@ -25,7 +25,7 @@ let
   desktopItem =  makeDesktopItem {
     name = "CCEmuX";
     exec = "ccemux";
-    icon = "${desktopIcon}";
+    icon = desktopIcon;
     comment = "A modular ComputerCraft emulator";
     desktopName = "CCEmuX";
     genericName = "ComputerCraft Emulator";

--- a/pkgs/misc/emulators/nestopia/default.nix
+++ b/pkgs/misc/emulators/nestopia/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "rdanbrook";
     repo = "nestopia";
-    rev = "${version}";
+    rev = version;
     sha256 = "0frr0gvjh5mxzdhj0ii3sh671slgnzlm8naqlc4h87rx4p4sz2y2";
   };
 

--- a/pkgs/misc/lightspark/default.nix
+++ b/pkgs/misc/lightspark/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "lightspark";
     repo = "lightspark";
-    rev = "${version}";
+    rev = version;
     sha256 = "0chydd516wfi73n8dvivk6nwxb9kjimdfghyv9sffmqmza0mv13s";
   };
 

--- a/pkgs/misc/sailsd/default.nix
+++ b/pkgs/misc/sailsd/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "sails-simulator";
     repo = "sailsd";
-    rev = "${version}";
+    rev = version;
     sha256 = "147cr4aw1kw4gv3bhn0cska855kmyah8m70vdw1q2lwz56lbf4mb";
   };
 

--- a/pkgs/misc/scream-receivers/default.nix
+++ b/pkgs/misc/scream-receivers/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "duncanthrax";
     repo = "scream";
-    rev = "${version}";
+    rev = version;
     sha256 = "1iqhs7m0fv3vfld7h288j5j0jc5xdihaghd0jd9qrk68mj2g6g9w";
   };
 

--- a/pkgs/misc/themes/blackbird/default.nix
+++ b/pkgs/misc/themes/blackbird/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "2017-12-13";
 
   src = fetchFromGitHub {
-    repo = "${pname}";
+    repo = pname;
     owner = "shimmerproject";
     rev = "a1c5674c0ec38b4cc8ba41d2c0e6187987ae7eb4";
     sha256 = "0xskcw36ci2ykra5gir5pkrawh2qkcv18p4fp2kxivssbd20d4jw";

--- a/pkgs/misc/vim-plugins/vim-utils.nix
+++ b/pkgs/misc/vim-plugins/vim-utils.nix
@@ -253,7 +253,7 @@ let
         # TODO: proper quoting
         toNix = x:
           if (builtins.isString x) then "'${x}'"
-          else if builtins.isAttrs x && builtins ? out then toNix "${x}" # a derivation
+          else if builtins.isAttrs x && builtins ? out then toNix x # a derivation
           else if builtins.isAttrs x then "{${lib.concatStringsSep ", " (lib.mapAttrsToList (n: v: "${toNix n}: ${toNix v}") x)}}"
           else if builtins.isList x then "[${lib.concatMapStringsSep ", " toNix x}]"
           else throw "turning ${lib.generators.toPretty {} x} into a VimL thing not implemented yet";

--- a/pkgs/os-specific/linux/bolt/default.nix
+++ b/pkgs/os-specific/linux/bolt/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     domain = "gitlab.freedesktop.org";
     owner = "bolt";
     repo = "bolt";
-    rev = "${version}";
+    rev = version;
     sha256 = "1qamls0fll0qc27lqavf56hv1yj6v6n4ry90g7bcnwpvccmd82yd";
   };
 

--- a/pkgs/os-specific/linux/klibc/shrunk.nix
+++ b/pkgs/os-specific/linux/klibc/shrunk.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation {
   # name due to the sed hackery below.  Once patchelf 0.4 is in the
   # tree, we can do this properly.
   #name = "${klibc.name}-shrunk";
-  name = "${klibc.name}";
+  name = klibc.name;
   buildCommand = ''
     mkdir -p $out/lib
     cp -prd ${klibc.out}/lib/klibc/bin $out/

--- a/pkgs/os-specific/linux/ofp/default.nix
+++ b/pkgs/os-specific/linux/ofp/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "OpenFastPath";
     repo = "ofp";
-    rev = "${version}";
+    rev = version;
     sha256 = "05902593fycgkwzk5g7wzgk0k40nrrgybplkdka3rqnlj6aydhqf";
   };
 

--- a/pkgs/os-specific/linux/pcm/default.nix
+++ b/pkgs/os-specific/linux/pcm/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "opcm";
     repo = "pcm";
-    rev = "${version}";
+    rev = version;
     sha256 = "15kh5ry2w1zj2mbg98hlayw8g53jy79q2ixj2wm48g8vagamv77z";
   };
 

--- a/pkgs/os-specific/linux/pps-tools/default.nix
+++ b/pkgs/os-specific/linux/pps-tools/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "redlab-i";
-    repo = "${baseName}";
+    repo = baseName;
     rev = "v${version}";
     sha256 = "1yh9g0l59dkq4ci0wbb03qin3c3cizfngmn9jy1vwm5zm6axlxhf";
   };

--- a/pkgs/os-specific/linux/service-wrapper/default.nix
+++ b/pkgs/os-specific/linux/service-wrapper/default.nix
@@ -4,7 +4,7 @@ let
   name = "service-wrapper-${version}";
   version = "19.04"; # Akin to Ubuntu Release
 in
-runCommand "${name}" {
+runCommand name {
   script = substituteAll {
     src = ./service-wrapper.sh;
     isExecutable = true;

--- a/pkgs/os-specific/linux/shadow/default.nix
+++ b/pkgs/os-specific/linux/shadow/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "shadow-maint";
     repo = "shadow";
-    rev = "${version}";
+    rev = version;
     sha256 = "1llcv77lvpc4h3rgww9ms736kbdisiylcr2z02863f41afxbwl82";
   };
 

--- a/pkgs/os-specific/linux/tbs/default.nix
+++ b/pkgs/os-specific/linux/tbs/default.nix
@@ -21,7 +21,7 @@ in stdenv.mkDerivation {
   name = "tbs-2018.04.18-${kernel.version}";
 
   srcs = [ media build ];
-  sourceRoot = "${build.name}";
+  sourceRoot = build.name;
 
   preConfigure = ''
     make dir DIR=../${media.name}

--- a/pkgs/os-specific/linux/undervolt/default.nix
+++ b/pkgs/os-specific/linux/undervolt/default.nix
@@ -7,7 +7,7 @@ python3Packages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "georgewhewell";
     repo = "undervolt";
-    rev = "${version}";
+    rev = version;
     sha256 = "1d934lp8yczrfslmwff6fxzd4arja2vg00s5kwdr949bxpa6w59c";
   };
 

--- a/pkgs/servers/coturn/default.nix
+++ b/pkgs/servers/coturn/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "coturn";
     repo = "coturn";
-    rev = "${version}";
+    rev = version;
     sha256 = "12x604lgva1d3g4wvl3f66rdj6lkjk5cqr0l3xas33xgzgm13pwr";
   };
 

--- a/pkgs/servers/http/unit/default.nix
+++ b/pkgs/servers/http/unit/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "nginx";
     repo = "unit";
-    rev = "${version}";
+    rev = version;
     sha256 = "00y7hc6bzn38f9mcqxnzddnwwsiba4ss9vwd9vgc95sj0yvv885a";
   };
 

--- a/pkgs/servers/monitoring/facette/default.nix
+++ b/pkgs/servers/monitoring/facette/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "facette";
     repo = "facette";
-    rev = "${version}";
+    rev = version;
     sha256 = "0p28s2vn18cqg8p7bzhb38wky0m98d5xv3wvf1nmg1kmwhwim6mi";
   };
   nativeBuildInputs = [ go pkgconfig nodejs nodePackages.npm pandoc ];

--- a/pkgs/servers/monitoring/plugins/esxi.nix
+++ b/pkgs/servers/monitoring/plugins/esxi.nix
@@ -2,7 +2,7 @@
 
 let
   bName = "check_esxi_hardware";
-  pName = stdenv.lib.replaceStrings [ "_" ] [ "-" ] "${bName}";
+  pName = stdenv.lib.replaceStrings [ "_" ] [ "-" ] bName;
 
 in python2Packages.buildPythonApplication rec {
   name = "${pName}-${version}";

--- a/pkgs/servers/monitoring/plugins/labs_consol_de.nix
+++ b/pkgs/servers/monitoring/plugins/labs_consol_de.nix
@@ -11,7 +11,7 @@ let
 
   generic = { pname, version, sha256, description, buildInputs, ... }:
   let
-    name' = "${stdenv.lib.replaceStrings [ "-" ] [ "_" ] "${pname}"}-${version}";
+    name' = "${stdenv.lib.replaceStrings [ "-" ] [ "_" ] pname}-${version}";
   in stdenv.mkDerivation {
     name = "${pname}-${version}";
 

--- a/pkgs/servers/monitoring/prometheus/prom2json.nix
+++ b/pkgs/servers/monitoring/prometheus/prom2json.nix
@@ -3,7 +3,7 @@
 buildGoPackage rec {
   pname = "prom2json";
   version = "0.1.0";
-  rev = "${version}";
+  rev = version;
 
   goPackagePath = "github.com/prometheus/prom2json";
 

--- a/pkgs/servers/monitoring/telegraf/default.nix
+++ b/pkgs/servers/monitoring/telegraf/default.nix
@@ -13,7 +13,7 @@ buildGoPackage rec {
   src = fetchFromGitHub {
     owner = "influxdata";
     repo = "telegraf";
-    rev = "${version}";
+    rev = version;
     sha256 = "0g27yczb49xf8nbhkzx7lv8378613afq9qx1gr5yhlpfrl4sgb69";
   };
 

--- a/pkgs/servers/monitoring/uchiwa/default.nix
+++ b/pkgs/servers/monitoring/uchiwa/default.nix
@@ -7,7 +7,7 @@ let
 
   src = fetchFromGitHub {
     inherit owner repo sha256;
-    rev    = "${version}";
+    rev    = version;
   };
 
   backend = buildGoPackage {

--- a/pkgs/servers/samba/4.x.nix
+++ b/pkgs/servers/samba/4.x.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
     [ "--with-static-modules=NONE"
       "--with-shared-modules=ALL"
       "--with-system-mitkrb5"
-      "--with-system-mitkdc" "${krb5Full}"
+      "--with-system-mitkdc" krb5Full
       "--enable-fhs"
       "--sysconfdir=/etc"
       "--localstatedir=/var"

--- a/pkgs/servers/search/elasticsearch/7.x.nix
+++ b/pkgs/servers/search/elasticsearch/7.x.nix
@@ -17,12 +17,12 @@ let
   shas =
     if enableUnfree
     then {
-      "x86_64-linux"  = "0x1ws6iqflvzphg2srvdrn4xrr5wd5fnykkc9h006mj9rb5lp1k9";
-      "x86_64-darwin" = "0yjzgsbsgwa6gbp270fqfm1klm6f8n4s2xmay62gdgvnsj543cxz";
+      x86_64-linux  = "0x1ws6iqflvzphg2srvdrn4xrr5wd5fnykkc9h006mj9rb5lp1k9";
+      x86_64-darwin = "0yjzgsbsgwa6gbp270fqfm1klm6f8n4s2xmay62gdgvnsj543cxz";
     }
     else {
-      "x86_64-linux"  = "1nl6yic1j422l2c7mf8wv0ylfx6marrwm7d181z9nzdswq509kpg";
-      "x86_64-darwin" = "1sy4an9d1faifr3n2y45kalrd22yb68dnpjhi9h8q73c21gp8pzf";
+      x86_64-linux  = "1nl6yic1j422l2c7mf8wv0ylfx6marrwm7d181z9nzdswq509kpg";
+      x86_64-darwin = "1sy4an9d1faifr3n2y45kalrd22yb68dnpjhi9h8q73c21gp8pzf";
     };
 in
 stdenv.mkDerivation (rec {
@@ -31,7 +31,7 @@ stdenv.mkDerivation (rec {
 
   src = fetchurl {
     url = "https://artifacts.elastic.co/downloads/elasticsearch/${name}-${plat}-${arch}.tar.gz";
-    sha256 = shas."${stdenv.hostPlatform.system}" or (throw "Unknown architecture");
+    sha256 = shas.${stdenv.hostPlatform.system} or (throw "Unknown architecture");
   };
 
   patches = [ ./es-home-6.x.patch ];

--- a/pkgs/servers/sickbeard/sickrage.nix
+++ b/pkgs/servers/sickbeard/sickrage.nix
@@ -7,7 +7,7 @@ python2.pkgs.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "SickRage";
     repo = "SickRage";
-    rev = "${version}"; 
+    rev = version; 
     sha256 = "0lzklpsxqrb73inbv8almnhbnb681pmi44gzc8i4sjwmdksiiif9";
   };
 

--- a/pkgs/servers/sks/default.nix
+++ b/pkgs/servers/sks/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromBitbucket {
     owner = "skskeyserver";
     repo = "sks-keyserver";
-    rev = "${version}";
+    rev = version;
     sha256 = "00q5ma5rvl10rkc6cdw8d69bddgrmvy0ckqj3hbisy65l4idj2zm";
   };
 

--- a/pkgs/servers/skydns/default.nix
+++ b/pkgs/servers/skydns/default.nix
@@ -3,7 +3,7 @@
 buildGoPackage rec {
   pname = "skydns";
   version = "2.5.3a";
-  rev = "${version}";
+  rev = version;
   
   goPackagePath = "github.com/skynetservices/skydns";
 

--- a/pkgs/servers/web-apps/cryptpad/node-packages.nix
+++ b/pkgs/servers/web-apps/cryptpad/node-packages.nix
@@ -2,7 +2,7 @@
 
 {pkgs ? import <nixpkgs> {
     inherit system;
-  }, system ? builtins.currentSystem, nodejs ? pkgs."nodejs-6_x"}:
+  }, system ? builtins.currentSystem, nodejs ? pkgs.nodejs-6_x}:
 
 let
   nodeEnv = import ../../../development/node-packages/node-env.nix {

--- a/pkgs/servers/x11/xquartz/default.nix
+++ b/pkgs/servers/x11/xquartz/default.nix
@@ -137,7 +137,7 @@ in stdenv.mkDerivation {
     ruby ${./patch_plist.rb} \
       ${stdenv.lib.escapeShellArg (builtins.toXML {
         XQUARTZ_DEFAULT_CLIENT = "${xterm}/bin/xterm";
-        XQUARTZ_DEFAULT_SHELL  = "${shell}";
+        XQUARTZ_DEFAULT_SHELL  = shell;
         XQUARTZ_DEFAULT_STARTX = "@STARTX@";
         FONTCONFIG_FILE        = "@FONTCONFIG_FILE@";
       })} \

--- a/pkgs/shells/zsh/nix-zsh-completions/default.nix
+++ b/pkgs/shells/zsh/nix-zsh-completions/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "spwhitt";
     repo = "nix-zsh-completions";
-    rev = "${version}";
+    rev = version;
     sha256 = "0fq1zlnsj1bb7byli7mwlz7nm2yszwmyx43ccczcv51mjjfivyp3";
   };
 

--- a/pkgs/shells/zsh/zsh-completions/default.nix
+++ b/pkgs/shells/zsh/zsh-completions/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "zsh-users";
     repo = "zsh-completions";
-    rev = "${version}";
+    rev = version;
     sha256 = "1yf4rz99acdsiy0y1v3bm65xvs2m0sl92ysz0rnnrlbd5amn283l";
   };
 

--- a/pkgs/tools/X11/ffcast/default.nix
+++ b/pkgs/tools/X11/ffcast/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "lolilolicon";
     repo = "FFcast";
-    rev = "${version}";
+    rev = version;
     sha256 = "047y32bixhc8ksr98vwpgd0k1xxgsv2vs0n3kc2xdac4krc9454h";
   };
 

--- a/pkgs/tools/X11/xbanish/default.nix
+++ b/pkgs/tools/X11/xbanish/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "jcs";
-    repo = "${pname}";
+    repo = pname;
     rev = "v${version}";
     sha256 = "0vp8ja68hpmqkl61zyjar3czhmny1hbm74m8f393incfz1ymr3i8";
   };

--- a/pkgs/tools/X11/xrectsel/default.nix
+++ b/pkgs/tools/X11/xrectsel/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "lolilolicon";
     repo = "xrectsel";
-    rev = "${version}";
+    rev = version;
     sha256 = "0prl4ky3xzch6xcb673mcixk998d40ngim5dqc5374b1ls2r6n7l";
   };
 

--- a/pkgs/tools/admin/awslogs/default.nix
+++ b/pkgs/tools/admin/awslogs/default.nix
@@ -7,7 +7,7 @@ python3Packages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "jorgebastida";
     repo = "awslogs";
-    rev = "${version}";
+    rev = version;
     sha256 = "0vdpld7r7y78x1lcd5z3qsx047dwichxb8f3447yzl75fnsm75dc";
   };
 

--- a/pkgs/tools/archivers/xarchiver/default.nix
+++ b/pkgs/tools/archivers/xarchiver/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "ib";
     repo = "xarchiver";
-    rev = "${version}";
+    rev = version;
     sha256 = "1iklwgykgymrwcc5p1cdbh91v0ih1m58s3w9ndl5kyd44bwlb7px";
   };
 

--- a/pkgs/tools/audio/glyr/default.nix
+++ b/pkgs/tools/audio/glyr/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "sahib";
     repo = "glyr";
-    rev = "${version}";
+    rev = version;
     sha256 = "1miwbqzkhg0v3zysrwh60pj9sv6ci4lzq2vq2hhc6pc6hdyh8xyr";
   };
 

--- a/pkgs/tools/backup/grab-site/default.nix
+++ b/pkgs/tools/backup/grab-site/default.nix
@@ -5,7 +5,7 @@ python3Packages.buildPythonApplication rec {
   name = "grab-site-${version}";
 
   src = fetchFromGitHub {
-    rev = "${version}";
+    rev = version;
     owner = "ArchiveTeam";
     repo = "grab-site";
     sha256 = "01n3mi9q593sd2bbmbbp5pn2c3pkwj7iqmy02zbh8ciqskraja4z";

--- a/pkgs/tools/filesystems/cryfs/default.nix
+++ b/pkgs/tools/filesystems/cryfs/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner  = "cryfs";
     repo   = "cryfs";
-    rev    = "${version}";
+    rev    = version;
     sha256 = "04yqpad8x0hiiwpykcn3swi0py6sg9xid6g15ny2qs4j3llin5ry";
   };
 

--- a/pkgs/tools/filesystems/simg2img/default.nix
+++ b/pkgs/tools/filesystems/simg2img/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "anestisb";
     repo = "android-simg2img";
-    rev = "${version}";
+    rev = version;
     sha256 = "119gl9i61g2wr07hzv6mi1ihql6yd6pwq94ki2pgcpfbamv8f6si";
   };
 

--- a/pkgs/tools/filesystems/squashfuse/default.nix
+++ b/pkgs/tools/filesystems/squashfuse/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "vasi";
-    repo  = "${pname}";
+    repo  = pname;
     rev = "540204955134eee44201d50132a5f66a246bcfaf";
     sha256 = "062s77y32p80vc24a79z31g90b9wxzvws1xvicgx5fn1pd0xa0q6";
   };

--- a/pkgs/tools/filesystems/udftools/default.nix
+++ b/pkgs/tools/filesystems/udftools/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "pali";
     repo = "udftools";
-    rev = "${version}";
+    rev = version;
     sha256 = "0mz04h3rki6ljwfs15z83gf4vv816w7xgz923waiqgmfj9xpvx87";
   };
 

--- a/pkgs/tools/graphics/flam3/default.nix
+++ b/pkgs/tools/graphics/flam3/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     inherit rev;
     owner = "scottdraves";
-    repo = "${pname}";
+    repo = pname;
     sha256 = "18iyj16k0sn3fs52fj23lj31xi4avlddhbib6kk309576nlxp17w";
   };
 

--- a/pkgs/tools/graphics/gromit-mpx/default.nix
+++ b/pkgs/tools/graphics/gromit-mpx/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "bk138";
     repo = "gromit-mpx";
-    rev = "${version}";
+    rev = version;
     sha256 = "1dkmp5rhzp56sz9cfxill2pkdz2anwb8kkxkypvk2xhqi64cvkrs";
   };
 

--- a/pkgs/tools/misc/antimicro/default.nix
+++ b/pkgs/tools/misc/antimicro/default.nix
@@ -7,7 +7,7 @@ mkDerivation rec {
   src = fetchFromGitHub {
     owner = "AntiMicro";
     repo = "antimicro";
-    rev = "${version}";
+    rev = version;
     sha256 = "1q40ayxwwyq85lc89cnj1cm2nar625h4vhh8dvmb2qcxczaggf4v";
   };
 

--- a/pkgs/tools/misc/autorandr/default.nix
+++ b/pkgs/tools/misc/autorandr/default.nix
@@ -48,7 +48,7 @@ in
     src = fetchFromGitHub {
       owner = "phillipberndt";
       repo = "autorandr";
-      rev = "${version}";
+      rev = version;
       sha256 = "1bp1cqkrpg77rjyh4lq1agc719fmxn92jkiicf6nbhfl8kf3l3vy";
     };
 

--- a/pkgs/tools/misc/bcunit/default.nix
+++ b/pkgs/tools/misc/bcunit/default.nix
@@ -6,8 +6,8 @@ stdenv.mkDerivation rec {
   buildInputs = [cmake];
   src = fetchFromGitHub {
     owner = "BelledonneCommunications";
-    repo = "${baseName}";
-    rev = "${version}";
+    repo = baseName;
+    rev = version;
     sha256 = "063yl7kxkix76r49qrj0h1qpz2p538d1yw8aih0x4i47g35k00y7";
   };
 

--- a/pkgs/tools/misc/bonfire/default.nix
+++ b/pkgs/tools/misc/bonfire/default.nix
@@ -11,7 +11,7 @@ buildPythonApplication rec {
   # https://github.com/blue-yonder/bonfire/pull/18
   src = fetchFromGitHub {
     owner = "blue-yonder";
-    repo = "${pname}";
+    repo = pname;
     rev = "d0af9ca10394f366cfa3c60f0741f1f0918011c2";
     sha256 = "193zcvzbhxwwkwbgmnlihhhazwkajycxf4r71jz1m12w301sjhq5";
   };

--- a/pkgs/tools/misc/clipster/default.nix
+++ b/pkgs/tools/misc/clipster/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation  rec {
   src = fetchFromGitHub {
     owner = "mrichar1";
     repo = "clipster";
-    rev = "${version}";
+    rev = version;
     sha256 = "0582r8840dk4k4jj1zq6kmyh7z9drcng099bj7f4wvr468nb9z1p";
   };
 

--- a/pkgs/tools/misc/diskscan/default.nix
+++ b/pkgs/tools/misc/diskscan/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner  = "baruch";
     repo   = "diskscan";
-    rev    = "${version}";
+    rev    = version;
     sha256 = "1s2df082yrnr3gqnapdsqz0yd0ld75bin37g0rms83ymzkh4ysgv";
   };
 

--- a/pkgs/tools/misc/duc/default.nix
+++ b/pkgs/tools/misc/duc/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "zevv";
     repo = "duc";
-    rev = "${version}";
+    rev = version;
     sha256 = "1i7ry25xzy027g6ysv6qlf09ax04q4vy0kikl8h0aq5jbxsl9q52";
   };
 

--- a/pkgs/tools/misc/fasd/default.nix
+++ b/pkgs/tools/misc/fasd/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "clvv";
-    repo = "${pname}";
+    repo = pname;
     rev = "90b531a5daaa545c74c7d98974b54cbdb92659fc";
     sha256 = "0i22qmhq3indpvwbxz7c472rdyp8grag55x7iyjz8gmyn8gxjc11";
   };

--- a/pkgs/tools/misc/fltrdr/default.nix
+++ b/pkgs/tools/misc/fltrdr/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     repo   = "fltrdr";
     owner  = "octobanana";
-    rev    = "${version}";
+    rev    = version;
     sha256 = "1vpci7vqzcpdd21zgigyz38k77r9fc81dmiwsvfr8w7gad5sg6sj";
   };
 

--- a/pkgs/tools/misc/fsmon/default.nix
+++ b/pkgs/tools/misc/fsmon/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "nowsecure";
     repo = "fsmon";
-    rev = "${version}";
+    rev = version;
     sha256 = "1b99cd5k2zh30sagp3f55jvj1r48scxibv7aqqc2sp82sci59npg";
   };
 

--- a/pkgs/tools/misc/keychain/default.nix
+++ b/pkgs/tools/misc/keychain/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "funtoo";
     repo = "keychain";
-    rev = "${version}";
+    rev = version;
     sha256 = "1bkjlg0a2bbdjhwp37ci1rwikvrl4s3xlbf2jq2z4azc96dr83mj";
   };
 

--- a/pkgs/tools/misc/mcfly/default.nix
+++ b/pkgs/tools/misc/mcfly/default.nix
@@ -3,7 +3,7 @@
 rustPlatform.buildRustPackage rec {
   pname = "mcfly";
   version = "v0.3.1";
-  rev = "${version}";
+  rev = version;
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/tools/misc/pspg/default.nix
+++ b/pkgs/tools/misc/pspg/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "okbob";
     repo = "pspg";
-    rev = "${version}";
+    rev = version;
     sha256 = "1lwzyimn28a7q8k2c8z7and4qhrdil0za8lixh96z6x4lcb0rz5q";
   };
 

--- a/pkgs/tools/misc/riemann-c-client/default.nix
+++ b/pkgs/tools/misc/riemann-c-client/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "algernon";
     repo = "riemann-c-client";
-    rev = "${name}";
+    rev = name;
     sha256 = "01gzqxqm1xvki2vd78c7my2kgp4fyhkcf5j5fmy8z0l93lgj82rr";
   };
 

--- a/pkgs/tools/misc/thefuck/default.nix
+++ b/pkgs/tools/misc/thefuck/default.nix
@@ -9,7 +9,7 @@ buildPythonApplication rec {
 
   src = fetchFromGitHub {
     owner = "nvbn";
-    repo = "${pname}";
+    repo = pname;
     rev = version;
     sha256 = "1qhxwjjgrzpqrqjv7l2847ywpln76lyd6j8bl9gz2r6kl0fx2fqs";
   };

--- a/pkgs/tools/misc/trash-cli/default.nix
+++ b/pkgs/tools/misc/trash-cli/default.nix
@@ -9,7 +9,7 @@ python3Packages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "andreafrancia";
     repo = "trash-cli";
-    rev = "${version}";
+    rev = version;
     sha256 = "1bqazna223ibqjwbc1wfvfnspfyrvjy8347qlrgv4cpng72n7gfi";
   };
 

--- a/pkgs/tools/misc/txtw/default.nix
+++ b/pkgs/tools/misc/txtw/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "baskerville";
     repo = "txtw";
-    rev = "${version}";
+    rev = version;
     sha256 = "17yjdgdd080fsf5r1wzgk6vvzwsa15gcwc9z64v7x588jm1ryy3k";
   };
 

--- a/pkgs/tools/misc/vimpager/build.nix
+++ b/pkgs/tools/misc/vimpager/build.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
 
     owner  = "rkitover";
     repo   = "vimpager";
-    rev    = "${version}";
+    rev    = version;
   };
 
   buildInputs = [ coreutils sharutils ]; # for uuencode

--- a/pkgs/tools/misc/void/default.nix
+++ b/pkgs/tools/misc/void/default.nix
@@ -7,7 +7,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "spacejam";
     repo = "void";
-    rev = "${version}";
+    rev = version;
     sha256 = "08vazw4rszqscjz988k89z28skyj3grm81bm5iwknxxagmrb20fz";
   };
 

--- a/pkgs/tools/misc/xv/default.nix
+++ b/pkgs/tools/misc/xv/default.nix
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner  = "chrisvest";
     repo   = pname;
-    rev    = "${version}";
+    rev    = version;
     sha256 = "0x2yd21sr4wik3z22rknkx1fgb64j119ynjls919za8gd83zk81g";
   };
 

--- a/pkgs/tools/networking/brook/default.nix
+++ b/pkgs/tools/networking/brook/default.nix
@@ -8,7 +8,7 @@ buildGoPackage rec {
 
   src = fetchFromGitHub {
     owner = "txthinking";
-    repo = "${pname}";
+    repo = pname;
     rev = "v${version}";
     sha256 = "04gx1p447wabw3d18s9sm8ynlvj2bp8ac9dsgs08kd1dyrsjlljk";
   };

--- a/pkgs/tools/networking/dd-agent/datadog-agent.nix
+++ b/pkgs/tools/networking/dd-agent/datadog-agent.nix
@@ -13,7 +13,7 @@ in buildGoPackage rec {
 
   src = fetchFromGitHub {
     inherit owner repo;
-    rev    = "${version}";
+    rev    = version;
     sha256 = "1dwdiaf357l9c6b2cps5mdyfma3c1mp96zzxg1826fvz3x8ix68z";
   };
 

--- a/pkgs/tools/networking/dd-agent/datadog-process-agent.nix
+++ b/pkgs/tools/networking/dd-agent/datadog-process-agent.nix
@@ -8,7 +8,7 @@ buildGoPackage rec {
 
   src = fetchFromGitHub {
     inherit owner repo;
-    rev    = "${version}";
+    rev    = version;
     sha256 = "0fc2flm0pa44mjxvn4fan0mkvg9yyg27w68xdgrnpdifj99kxxjf";
   };
 

--- a/pkgs/tools/networking/gmrender-resurrect/default.nix
+++ b/pkgs/tools/networking/gmrender-resurrect/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "hzeller";
     repo = "gmrender-resurrect";
-    rev = "${version}";
+    rev = version;
     sha256 = "1dmdhyz27bh74qmvncfd3kw7zqwnd05bhxcfjjav98z5qrxdygj4";
   };
 

--- a/pkgs/tools/networking/httpstat/default.nix
+++ b/pkgs/tools/networking/httpstat/default.nix
@@ -6,7 +6,7 @@ pythonPackages.buildPythonApplication rec {
     src = fetchFromGitHub {
       owner = "reorx";
       repo = pname;
-      rev = "${version}";
+      rev = version;
       sha256 = "1vriibcsq4j1hvm5yigbbmmv21dc40y5c9gvd31dg9qkaz26hml6";
     };
     doCheck = false; # No tests

--- a/pkgs/tools/networking/megatools/default.nix
+++ b/pkgs/tools/networking/megatools/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "megous";
     repo = "megatools";
-    rev = "${version}";
+    rev = version;
     sha256 = "001hw8j36ld03wwaphq3xdaazf2dpl36h84k8xmk524x8vlia8lk";
   };
 

--- a/pkgs/tools/networking/network-manager/l2tp/default.nix
+++ b/pkgs/tools/networking/network-manager/l2tp/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "nm-l2tp";
     repo = "network-manager-l2tp";
-    rev = "${version}";
+    rev = version;
     sha256 = "0cq07kvlm98s8a7l4a3zmqnif8x3307kv7n645zx3f1r7x72b8m4";
   };
 

--- a/pkgs/tools/networking/ngrok-1/default.nix
+++ b/pkgs/tools/networking/ngrok-1/default.nix
@@ -3,7 +3,7 @@
 buildGoPackage rec {
   pname = "ngrok";
   version = "1.7.1";
-  rev = "${version}";
+  rev = version;
 
   goPackagePath = "ngrok";
 

--- a/pkgs/tools/networking/ngrok-2/default.nix
+++ b/pkgs/tools/networking/ngrok-2/default.nix
@@ -17,7 +17,7 @@ let versions = builtins.fromJSON (builtins.readFile ./versions.json);
 in
 stdenv.mkDerivation {
   name = "ngrok-${version}";
-  version = "${version}";
+  version = version;
 
   # run ./update
   src = fetchurl { inherit sha256 url; };

--- a/pkgs/tools/networking/opensm/default.nix
+++ b/pkgs/tools/networking/opensm/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "linux-rdma";
     repo = "opensm";
-    rev = "${version}";
+    rev = version;
     sha256 = "1nb6zl93ffbgb8z8728j0dxrmvk3pm0i6a1sn7mpn8ki1vkf2y0j";
   };
 

--- a/pkgs/tools/networking/persepolis/default.nix
+++ b/pkgs/tools/networking/persepolis/default.nix
@@ -17,7 +17,7 @@ buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "persepolisdm";
     repo = "persepolis";
-    rev = "${version}";
+    rev = version;
     sha256 = "0xngk8wgj5k27mh3bcrf2wwzqr8a3g0d4pc5i5vcavnnaj03j44m";
   };
 

--- a/pkgs/tools/networking/tinyproxy/default.nix
+++ b/pkgs/tools/networking/tinyproxy/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec{
 
   src = fetchFromGitHub {
     sha256 = "0gzapnllzyc005l3rs6iarjk1p5fc8mf9ysbck1mbzbd8xg6w35s";
-    rev = "${version}";
+    rev = version;
     repo = "tinyproxy";
     owner = "tinyproxy";
   };

--- a/pkgs/tools/networking/wolfebin/default.nix
+++ b/pkgs/tools/networking/wolfebin/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "thejoshwolfe";
     repo = "wolfebin";
-    rev = "${version}";
+    rev = version;
     sha256 = "16xj6zz30sn9q05p211bmmsl0i6fknfxf8dssn6knm6nkiym8088";
   };
 

--- a/pkgs/tools/networking/yrd/default.nix
+++ b/pkgs/tools/networking/yrd/default.nix
@@ -10,7 +10,7 @@ in pythonPackages.buildPythonApplication {
 
   src = fetchFromGitHub {
     owner = "kpcyrd";
-    repo = "${pname}";
+    repo = pname;
     rev = "v${version}";
     inherit sha256;
   };

--- a/pkgs/tools/networking/zap/default.nix
+++ b/pkgs/tools/networking/zap/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "zaproxy";
     repo = "zaproxy";
-    rev ="${version}";
+    rev =version;
     sha256 = "1bz4pgq66v6kxmgj99llacm1d85vj8z78jlgc2z9hv0ha5i57y32";
   };
 

--- a/pkgs/tools/package-management/cargo-release/default.nix
+++ b/pkgs/tools/package-management/cargo-release/default.nix
@@ -7,7 +7,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "sunng87";
     repo = "cargo-release";
-    rev = "${version}";
+    rev = version;
     sha256 = "14l5znr1nl69v2v3mdrlas85krq9jn280ssflmd0dz7i4fxiaflc";
   };
 

--- a/pkgs/tools/package-management/nix-review/default.nix
+++ b/pkgs/tools/package-management/nix-review/default.nix
@@ -18,7 +18,7 @@ python3.pkgs.buildPythonApplication rec {
   };
 
   makeWrapperArgs = [
-    "--prefix" "PATH" ":" "${lib.makeBinPath [ nix git ]}"
+    "--prefix" "PATH" ":" (lib.makeBinPath [ nix git ])
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/security/hash-slinger/default.nix
+++ b/pkgs/tools/security/hash-slinger/default.nix
@@ -8,8 +8,8 @@ in stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "letoams";
-    repo = "${pname}";
-    rev = "${version}";
+    repo = pname;
+    rev = version;
     sha256 = "05wn744ydclpnpyah6yfjqlfjlasrrhzj48lqmm5a91nyps5yqyn";
   };
 

--- a/pkgs/tools/security/lynis/default.nix
+++ b/pkgs/tools/security/lynis/default.nix
@@ -6,8 +6,8 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "CISOfy";
-    repo = "${pname}";
-    rev = "${version}";
+    repo = pname;
+    rev = version;
     sha256 = "1lkkbvxm0rgrrlx0szaxmf8ghc3d26wal96sgqk84m37mvs1f7p0";
   };
 

--- a/pkgs/tools/security/masscan/default.nix
+++ b/pkgs/tools/security/masscan/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner  = "robertdavidgraham";
     repo   = "masscan";
-    rev    = "${version}";
+    rev    = version;
     sha256 = "0q0c7bsf0pbl8napry1qyg0gl4pd8wn872h4mz9b56dx4rx90vqg";
   };
 

--- a/pkgs/tools/security/munge/default.nix
+++ b/pkgs/tools/security/munge/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "dun";
     repo = "munge";
-    rev = "${name}";
+    rev = name;
     sha256 = "1c4ff3d8ad3inbliszr4slym3b4cn19bn6mxm13mzy20jyi2rm70";
   };
 

--- a/pkgs/tools/security/pass/extensions/genphrase.nix
+++ b/pkgs/tools/security/pass/extensions/genphrase.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "congma";
     repo = "pass-genphrase";
-    rev = "${version}";
+    rev = version;
     sha256 = "0vcg3b79n1r949qfn8ns85bq2mfsmbf4jw2dlzif8425n8ppfsgd";
   };
 

--- a/pkgs/tools/security/shc/default.nix
+++ b/pkgs/tools/security/shc/default.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation rec {
   pname = "shc";
   version = "4.0.3";
-  rev = "${version}";
+  rev = version;
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/tools/system/clinfo/default.nix
+++ b/pkgs/tools/system/clinfo/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
     src = fetchFromGitHub {
       owner = "Oblomov";
       repo = "clinfo";
-      rev = "${version}";
+      rev = version;
       sha256 = "0y2q0lz5yzxy970b7w7340vp4fl25vndahsyvvrywcrn51ipgplx";
     };
 

--- a/pkgs/tools/system/hwinfo/default.nix
+++ b/pkgs/tools/system/hwinfo/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "opensuse";
     repo = "hwinfo";
-    rev = "${version}";
+    rev = version;
     sha256 = "1fvlrqx1wgl79a9j3xhhhdihj4lkpbrchfsc27il0p52fynn4dji";
   };
 

--- a/pkgs/tools/system/lshw/default.nix
+++ b/pkgs/tools/system/lshw/default.nix
@@ -6,7 +6,7 @@ let numVersion = "02.18"; # :(
 in
 stdenv.mkDerivation rec {
   name = "lshw-${numVersion}b";
-  version = "${numVersion}";
+  version = numVersion;
 
   src = fetchurl {
     url = "https://ezix.org/software/files/lshw-B.${version}.tar.gz";

--- a/pkgs/tools/system/ps_mem/default.nix
+++ b/pkgs/tools/system/ps_mem/default.nix
@@ -8,7 +8,7 @@ in pythonPackages.buildPythonApplication {
 
   src = fetchFromGitHub {
     owner = "pixelb";
-    repo = "${pname}";
+    repo = pname;
     rev = "v${version}";
     sha256 = "0kcxlmfisbwf24p2k72njfyfp22fjr9p9zalg9b4w0yhnlzk24ph";
   };

--- a/pkgs/tools/system/vboot_reference/default.nix
+++ b/pkgs/tools/system/vboot_reference/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
 
   src = fetchgit {
     url = https://chromium.googlesource.com/chromiumos/platform/vboot_reference;
-    rev = "${checkout}";
+    rev = checkout;
     sha256 = "1zja4ma6flch08h5j2l1hqnxmw2xwylidnddxxd5y2x05dai9ddj";
   };
 

--- a/pkgs/tools/text/invoice2data/default.nix
+++ b/pkgs/tools/text/invoice2data/default.nix
@@ -9,7 +9,7 @@ python3Packages.buildPythonPackage rec {
     sha256 = "1phz0a8jxg074k0im7shrrdfvdps7bn1fa4zwcf8q3sa2iig26l4";
   };
 
-  makeWrapperArgs = ["--prefix" "PATH" ":" "${stdenv.lib.makeBinPath [ imagemagick xpdf tesseract ]}" ];
+  makeWrapperArgs = ["--prefix" "PATH" ":" (stdenv.lib.makeBinPath [ imagemagick xpdf tesseract ]) ];
 
   propagatedBuildInputs = with python3Packages; [ unidecode dateparser pyyaml pillow chardet pdfminer ];
 

--- a/pkgs/tools/text/silver-searcher/default.nix
+++ b/pkgs/tools/text/silver-searcher/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "ggreer";
     repo = "the_silver_searcher";
-    rev = "${version}";
+    rev = version;
     sha256 = "0cyazh7a66pgcabijd27xnk1alhsccywivv6yihw378dqxb22i1p";
   };
 

--- a/pkgs/tools/text/xml/basex/default.nix
+++ b/pkgs/tools/text/xml/basex/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   desktopItem = makeDesktopItem {
     name = "basex";
     exec = "basexgui %f";
-    icon = "${./basex.svg}"; # icon copied from Ubuntu basex package
+    icon = ./basex.svg; # icon copied from Ubuntu basex package
     comment = "Visually query and analyse your XML data";
     desktopName = "BaseX XML Database";
     genericName = "XML database tool";

--- a/pkgs/tools/typesetting/sshlatex/default.nix
+++ b/pkgs/tools/typesetting/sshlatex/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "iblech";
     repo = "sshlatex";
-    rev = "${version}";
+    rev = version;
     sha256 = "0kaah8is74zba9373xccmsxmnnn6kh0isr4qpg21x3qhdzhlxl7q";
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16616,7 +16616,7 @@ in
 
   # solve collision for nix-env before https://github.com/NixOS/nix/pull/815
   dejavu_fontsEnv = buildEnv {
-    name = "${dejavu_fonts.name}";
+    name = dejavu_fonts.name;
     paths = [ dejavu_fonts.out ];
   };
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -219,7 +219,7 @@ let
     };
 
     buildInputs = [ ArchiveExtract ];
-    TIDYP_DIR = "${pkgs.tidyp}";
+    TIDYP_DIR = pkgs.tidyp;
     propagatedBuildInputs = [ FileShareDir ];
   };
 


### PR DESCRIPTION
remove redundant quotes

I suspect it might require to adjust option's type somewhere (`types.str` -> `types.package`) but I did not hit the issue.