### PR TITLE
qt5ct: fix missing app icon and name when running under Wayland

### DIFF
--- a/pkgs/tools/misc/qt5ct/default.nix
+++ b/pkgs/tools/misc/qt5ct/default.nix
@@ -15,6 +15,11 @@ mkDerivation rec {
 
   buildInputs = [ qtbase ];
 
+  # Wayland needs to know the desktop file name in order to show the app name and icon.
+  # Patch has been upstreamed and can be removed in the future.
+  # See: https://sourceforge.net/p/qt5ct/code/549/
+  patches = [ ./wayland.patch ];
+
   qmakeFlags = [
     "LRELEASE_EXECUTABLE=${getDev qttools}/bin/lrelease"
   ];

--- a/pkgs/tools/misc/qt5ct/wayland.patch
+++ b/pkgs/tools/misc/qt5ct/wayland.patch
@@ -1,0 +1,22 @@
+--- a/src/qt5ct/main.cpp
++++ b/src/qt5ct/main.cpp
+@@ -29,14 +29,18 @@
+ #include <QApplication>
+ #include <QLibraryInfo>
+ #include <QLocale>
+-#include "qt5ct.h"
++#include <QtGlobal>
+ #include <QTranslator>
+ #include <QtDebug>
++#include "qt5ct.h"
+ #include "mainwindow.h"
+ 
+ int main(int argc, char **argv)
+ {
+     QApplication app(argc, argv);
++#if (QT_VERSION >= QT_VERSION_CHECK(5, 7, 0))
++    QGuiApplication::setDesktopFileName("qt5ct.desktop");
++#endif
+     QTranslator translator;
+     QString locale = Qt5CT::systemLanguageID();
+     translator.load(QString(":/qt5ct_") + locale);


### PR DESCRIPTION
###### Motivation for this change

The app icon and name were missing when running under Wayland (`QT_QPA_PLATFORM=wayland`). Xorg/XWayland (`QT_QPA_PLATFORM=xcb`) were unaffected.

The patch has been upstreamed and can be removed once a new release is available.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Ralith 
