### PR TITLE
mkgmap: init at 4289

### DIFF
--- a/pkgs/applications/misc/mkgmap/build.xml.patch
+++ b/pkgs/applications/misc/mkgmap/build.xml.patch
@@ -1,0 +1,11 @@
+--- a/build.xml	2019-08-26 23:22:55.104829846 +0300
++++ b/build.xml	2019-08-27 00:11:07.366257594 +0300
+@@ -227,7 +227,7 @@
+ 	</target>
+ 
+ 	<!-- Compile the product itself (no tests). -->
+-	<target name="compile" depends="prepare, resolve-compile"
++	<target name="compile" depends="prepare"
+ 					description="main compilation">
+ 
+ 		<javac srcdir="${src}" destdir="${build.classes}" encoding="utf-8" debug="true" includeantruntime="false">

--- a/pkgs/applications/misc/mkgmap/default.nix
+++ b/pkgs/applications/misc/mkgmap/default.nix
@@ -1,0 +1,57 @@
+{ stdenv, fetchurl, fetchsvn, jdk, jre, ant, makeWrapper }:
+
+let
+  fastutil = fetchurl {
+    url = "http://ivy.mkgmap.org.uk/repo/it.unimi.dsi/fastutil/6.5.15-mkg.1b/jars/fastutil.jar";
+    sha256 = "0d88m0rpi69wgxhnj5zh924q4zsvxq8m4ybk7m9mr3gz1hx0yx8c";
+  };
+  osmpbf = fetchurl {
+    url = "http://ivy.mkgmap.org.uk/repo/crosby/osmpbf/1.3.3/jars/osmpbf.jar";
+    sha256 = "0zb4pqkwly5z30ww66qhhasdhdrzwmrw00347yrbgyk2ii4wjad3";
+  };
+  protobuf = fetchurl {
+    url = "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/2.5.0/protobuf-java-2.5.0.jar";
+    sha256 = "0x6c4pbsizvk3lm6nxcgi1g2iqgrxcna1ip74lbn01f0fm2wdhg0";
+  };
+in
+
+stdenv.mkDerivation rec {
+  pname = "mkgmap";
+  version = "4289";
+
+  src = fetchsvn {
+    url = "https://svn.mkgmap.org.uk/mkgmap/mkgmap/trunk";
+    rev = version;
+    sha256 = "1sm1pw71q7z0jrxm8bcgm6xjl2mcidyibcf0a3m8fv2andidxrb4";
+  };
+
+  # This patch removes from the build process
+  # the automatic download of dependencies (see configurePhase)
+  patches = [ ./build.xml.patch ];
+
+  nativeBuildInputs = [ jdk ant makeWrapper ];
+
+  configurePhase = ''
+    mkdir -p lib/compile
+    cp ${fastutil} ${osmpbf} ${protobuf} lib/compile/
+  '';
+
+  buildPhase = "ant";
+
+  installPhase = ''
+    cd dist
+    install -Dm644 mkgmap.jar $out/share/java/mkgmap/mkgmap.jar
+    install -Dm644 doc/mkgmap.1 $out/share/man/man1/mkgmap.1
+    cp -r lib/ $out/share/java/mkgmap/
+    makeWrapper ${jre}/bin/java $out/bin/mkgmap \
+      --add-flags "-jar $out/share/java/mkgmap/mkgmap.jar"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Create maps for Garmin GPS devices from OpenStreetMap (OSM) data";
+    homepage = "http://www.mkgmap.org.uk";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5027,6 +5027,8 @@ in
 
   milu = callPackage ../applications/misc/milu { };
 
+  mkgmap = callPackage ../applications/misc/mkgmap { };
+
   mpack = callPackage ../tools/networking/mpack { };
 
   mtm = callPackage ../tools/misc/mtm { };


### PR DESCRIPTION
###### Motivation for this change

> The mkgmap program takes OpenStreetMap data and generates a map in the Garmin .img file format so that it can be loaded onto compatible GPS units.
http://www.mkgmap.org.uk/

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```bash
$ nix path-info -Sh ./result
/nix/store/2ww7c5qlh1kcl4rl2phh2ifsdmjcsdl6-mkgmap-r4289	 386.7M
$ tree result/
result/
├── bin
│   └── mkgmap
└── share
    ├── java
    │   └── mkgmap
    │       ├── lib
    │       │   ├── 0fi30jxc65ny98vqns4rgdghg9z0l904-osmpbf.jar
    │       │   ├── aq2zp403ym0v91i7hdf6mk7nd9d7g61z-protobuf-java-2.5.0.jar
    │       │   └── qanpvgsz9d5ykvfjsanrhhmcpyc1zxhr-fastutil.jar
    │       └── mkgmap.jar
    └── man
        └── man1
            └── mkgmap.1.gz

7 directories, 6 files
```