### PR TITLE
jameica: 2.8.2 -> 2.8.4

### DIFF
--- a/pkgs/applications/office/jameica/default.nix
+++ b/pkgs/applications/office/jameica/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, makeDesktopItem, makeWrapper, ant, jdk, jre, gtk2, glib, xorg, Cocoa }:
 
 let
-  _version = "2.8.2";
-  _build = "450";
+  _version = "2.8.4";
+  _build = "453";
   version = "${_version}-${_build}";
   name = "jameica-${version}";
 
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     owner = "willuhn";
     repo = "jameica";
     rev = "V_${builtins.replaceStrings ["."] ["_"] _version}_BUILD_${_build}";
-    sha256 = "197n35lvx51k6cbp3fhndvfb38sikl4mjqcd42fgvn2khy2sij68";
+    sha256 = "1imm3wpdrgh2sr2wh9vgaf2mp1ixs845vgzk5ib82mak7lg9m1zl";
   };
 
   # there is also a build.gradle, but it only seems to be used to vendor 3rd party libraries


### PR DESCRIPTION
###### Motivation for this change
2.8.3 switches to the gtk backend by default and corrects some minor graphic glitches
2.8.4 fixed a bug in the plugin manager

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
