### PR TITLE
sdrangel: add airpsy, hackrf, rtlsdr support

### DIFF
--- a/pkgs/applications/radio/sdrangel/default.nix
+++ b/pkgs/applications/radio/sdrangel/default.nix
@@ -1,4 +1,5 @@
 {
+airspy,
 boost,
 cm256cc,
 cmake,
@@ -6,6 +7,7 @@ codec2,
 fetchFromGitHub,
 fftwFloat,
 glew,
+hackrf,
 lib,
 libav,
 libiio,
@@ -20,6 +22,7 @@ pkgconfig,
 qtbase,
 qtmultimedia,
 qtwebsockets,
+rtl-sdr,
 serialdv
 }:
 
@@ -49,9 +52,8 @@ in mkDerivation rec {
   nativeBuildInputs = [ cmake pkgconfig ];
   buildInputs = [
     glew opencv3 libusb boost libopus limesuite libav libiio libpulseaudio
-    qtbase qtwebsockets qtmultimedia
-    fftwFloat
-    codec2' cm256cc serialdv
+    qtbase qtwebsockets qtmultimedia rtl-sdr airspy hackrf
+    fftwFloat codec2' cm256cc serialdv
   ];
   cmakeFlags = [
     "-DLIBSERIALDV_INCLUDE_DIR:PATH=${serialdv}/include/serialdv"


### PR DESCRIPTION
###### Motivation for this change
Add support for more SDR devices

###### Things done
Tested with hardware
* RTL-SDR
* AirSpy 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Alkeryn 
