### PR TITLE
nixos/system-config-printer: init 

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1909.xml
+++ b/nixos/doc/manual/release-notes/rl-1909.xml
@@ -144,6 +144,32 @@
      but will make sure that the given printers are configured as declared.
     </para>
    </listitem>
+   <listitem>
+    <para>
+     There is a new <xref linkend="opt-services.system-config-printer.enable"/> and <xref linkend="opt-programs.system-config-printer.enable"/> module
+     for the program of the same name. If you previously had <literal>system-config-printer</literal> enabled through some other
+     means you should migrate to using one of these modules.
+    </para>
+    <itemizedlist>
+     <para>If you're a user of the following desktopManager modules no action is needed:</para>
+     <listitem>
+      <para><option>services.xserver.desktopManager.plasma5</option></para>
+     </listitem>
+     <listitem>
+      <para><option>services.xserver.desktopManager.gnome3</option></para>
+     </listitem>
+     <listitem>
+      <para><option>services.xserver.desktopManager.pantheon</option></para>
+     </listitem>
+     <listitem>
+      <para><option>services.xserver.desktopManager.mate</option></para>
+      <para>
+       Note Mate uses <literal>programs.system-config-printer</literal> as it doesn't
+       use it as a service, but its graphical interface directly.
+      </para>
+     </listitem>
+    </itemizedlist>
+   </listitem>
   </itemizedlist>
 
  </section>

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -151,6 +151,7 @@
   ./programs/sysdig.nix
   ./programs/systemtap.nix
   ./programs/sway.nix
+  ./programs/system-config-printer.nix
   ./programs/thefuck.nix
   ./programs/tmux.nix
   ./programs/tsm-client.nix
@@ -309,6 +310,7 @@
   ./services/desktops/gnome3/tracker.nix
   ./services/desktops/gnome3/tracker-miners.nix
   ./services/desktops/profile-sync-daemon.nix
+  ./services/desktops/system-config-printer.nix
   ./services/desktops/telepathy.nix
   ./services/desktops/tumbler.nix
   ./services/desktops/zeitgeist.nix

--- a/nixos/modules/programs/system-config-printer.nix
+++ b/nixos/modules/programs/system-config-printer.nix
@@ -1,0 +1,32 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+{
+
+  ###### interface
+
+  options = {
+
+    programs.system-config-printer = {
+
+      enable = mkEnableOption "system-config-printer, a Graphical user interface for CUPS administration";
+
+    };
+
+  };
+
+
+  ###### implementation
+
+  config = mkIf config.programs.system-config-printer.enable {
+
+    environment.systemPackages = [
+      pkgs.system-config-printer
+    ];
+
+    services.system-config-printer.enable = true;
+
+  };
+
+}

--- a/nixos/modules/services/desktops/system-config-printer.nix
+++ b/nixos/modules/services/desktops/system-config-printer.nix
@@ -1,0 +1,38 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+{
+
+  ###### interface
+
+  options = {
+
+    services.system-config-printer = {
+
+      enable = mkEnableOption "system-config-printer, a service for CUPS administration used by printing interfaces";
+
+    };
+
+  };
+
+
+  ###### implementation
+
+  config = mkIf config.services.system-config-printer.enable {
+
+    services.dbus.packages = [
+      pkgs.system-config-printer
+    ];
+
+    systemd.packages = [
+      pkgs.system-config-printer
+    ];
+
+    services.udev.packages = [
+      pkgs.system-config-printer
+    ];
+
+  };
+
+}

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -233,10 +233,9 @@ in
       services.gnome3.gnome-user-share.enable = mkDefault true;
       services.gnome3.rygel.enable = mkDefault true;
       services.gvfs.enable = true;
+      services.system-config-printer.enable = (mkIf config.services.printing.enable (mkDefault true));
       services.telepathy.enable = mkDefault true;
       systemd.packages = [ pkgs.gnome3.vino ];
-      services.dbus.packages =
-        optional config.services.printing.enable pkgs.system-config-printer;
 
       services.avahi.enable = mkDefault true;
 

--- a/nixos/modules/services/x11/desktop-managers/mate.nix
+++ b/nixos/modules/services/x11/desktop-managers/mate.nix
@@ -98,6 +98,9 @@ in
     programs.bash.vteIntegration = mkDefault true;
     programs.zsh.vteIntegration = mkDefault true;
 
+    # Mate uses this for printing
+    programs.system-config-printer.enable = (mkIf config.services.printing.enable (mkDefault true));
+
     services.gnome3.at-spi2-core.enable = true;
     services.gnome3.gnome-keyring.enable = true;
     services.gnome3.gnome-settings-daemon.enable = true;

--- a/nixos/modules/services/x11/desktop-managers/pantheon.nix
+++ b/nixos/modules/services/x11/desktop-managers/pantheon.nix
@@ -113,9 +113,9 @@ in
     services.colord.enable = mkDefault true;
     services.pantheon.files.enable = mkDefault true;
     services.tumbler.enable = mkDefault true;
-    services.dbus.packages = mkMerge [
-      ([ pkgs.pantheon.switchboard-plug-power ])
-      (mkIf config.services.printing.enable  ([pkgs.system-config-printer]) )
+    services.system-config-printer.enable = (mkIf config.services.printing.enable (mkDefault true));
+    services.dbus.packages = [
+      pkgs.pantheon.switchboard-plug-power
     ];
     services.pantheon.contractor.enable = mkDefault true;
     services.gnome3.at-spi2-core.enable = true;

--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -210,8 +210,7 @@ in
       # Enable helpful DBus services.
       services.udisks2.enable = true;
       services.upower.enable = config.powerManagement.enable;
-      services.dbus.packages =
-        mkIf config.services.printing.enable [ pkgs.system-config-printer ];
+      services.system-config-printer.enable = (mkIf config.services.printing.enable (mkDefault true));
 
       # Extra UDEV rules used by Solid
       services.udev.packages = [

--- a/nixos/modules/services/x11/desktop-managers/xfce4-14.nix
+++ b/nixos/modules/services/x11/desktop-managers/xfce4-14.nix
@@ -137,8 +137,7 @@ in
     services.gvfs.enable = true;
     services.gvfs.package = pkgs.xfce.gvfs;
     services.tumbler.enable = true;
-    services.dbus.packages =
-      optional config.services.printing.enable pkgs.system-config-printer;
+    services.system-config-printer.enable = (mkIf config.services.printing.enable (mkDefault true));
     services.xserver.libinput.enable = mkDefault true; # used in xfce4-settings-manager
 
     # Enable default programs

--- a/pkgs/tools/misc/system-config-printer/default.nix
+++ b/pkgs/tools/misc/system-config-printer/default.nix
@@ -61,6 +61,9 @@ stdenv.mkDerivation rec {
       # Manually expand literal "$(out)", which have failed to expand
       sed -e "s|ExecStart=\$(out)|ExecStart=$out|" \
           -i "$out/etc/systemd/system/configure-printer@.service"
+
+      substituteInPlace $out/etc/udev/rules.d/70-printers.rules \
+        --replace "udev-configure-printer" "$out/etc/udev/udev-configure-printer"
     '';
 
   meta = {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
I noticed that `system-config-printer` had a systemd service and udev rules that probably need to be added for appropriate function. ~I haven't switched gnome3 to use it yet because it would cause conflicts with other work.~(merged)

~Currently haven't tested this with a printer.~
I've tested printing in GNOME 3 and Pantheon.


###### Release note
![Screenshot from 2019-08-27 16 12 44](https://user-images.githubusercontent.com/28888242/63804619-94248c80-c8e5-11e9-87a4-aa38acf7f21d.png)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @matthewbauer (cups maintainer)
