### PR TITLE
gnome2.libglade: make python2 build optional

### DIFF
--- a/pkgs/desktops/gnome-2/platform/libglade/default.nix
+++ b/pkgs/desktops/gnome-2/platform/libglade/default.nix
@@ -1,4 +1,6 @@
-{stdenv, fetchurl, pkgconfig, gtk2, libxml2, python, gettext}:
+{ stdenv, fetchurl, pkgconfig, gtk2, libxml2, python2 ? null, withLibgladeConvert ? false, gettext }:
+
+assert withLibgladeConvert -> python2 != null;
 
 stdenv.mkDerivation {
   name = "libglade-2.6.4";
@@ -11,7 +13,8 @@ stdenv.mkDerivation {
   outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ gtk2 python gettext ];
+  buildInputs = [ gtk2 gettext ]
+    ++ stdenv.lib.optional withLibgladeConvert python2;
 
   NIX_LDFLAGS = "-lgmodule-2.0";
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Python2 is only needed for `libglade-convert`[1] which is a simple
script that converts old glade files into new glade files and for tests
and docs which we currently don't generate.

As Python2 is about to get EOLed and this is mostly a tool to migrate
old data, it shouldn't be built by default. With this change,
`xscreensaver` and `xsecurelock` don't depend on Python2 anymore.

[1] https://manpages.ubuntu.com/manpages/trusty/man1/libglade-convert.1.html


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
