### PR TITLE
kakounePlugins: Add 5 kakoune plugins

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4578,6 +4578,12 @@
     githubId = 9939720;
     name = "Philippe Nguyen";
   };
+  nrdxp = {
+    email = "tim.deh@pm.me";
+    github = "nrdxp";
+    githubId = 34083928;
+    name = "Tim DeHerrera";
+  };
   nshalman = {
     email = "nahamu@gmail.com";
     github = "nshalman";

--- a/pkgs/applications/editors/kakoune/plugins.nix
+++ b/pkgs/applications/editors/kakoune/plugins.nix
@@ -1,5 +1,0 @@
-{ parinfer-rust }:
-
-{
-  inherit parinfer-rust;
-}

--- a/pkgs/applications/editors/kakoune/plugins/default.nix
+++ b/pkgs/applications/editors/kakoune/plugins/default.nix
@@ -1,0 +1,10 @@
+{ pkgs, parinfer-rust }:
+
+{
+  inherit parinfer-rust;
+  kak-fzf = pkgs.callPackage ./kak-fzf.nix { };
+  kak-powerline = pkgs.callPackage ./kak-powerline.nix { };
+  kak-auto-pairs = pkgs.callPackage ./kak-auto-pairs.nix { };
+  kak-vertical-selection = pkgs.callPackage ./kak-vertical-selection.nix { };
+  kak-buffers = pkgs.callPackage ./kak-buffers.nix { };
+}

--- a/pkgs/applications/editors/kakoune/plugins/default.nix
+++ b/pkgs/applications/editors/kakoune/plugins/default.nix
@@ -2,9 +2,10 @@
 
 {
   inherit parinfer-rust;
+
+  kak-auto-pairs = pkgs.callPackage ./kak-auto-pairs.nix { };
+  kak-buffers = pkgs.callPackage ./kak-buffers.nix { };
   kak-fzf = pkgs.callPackage ./kak-fzf.nix { };
   kak-powerline = pkgs.callPackage ./kak-powerline.nix { };
-  kak-auto-pairs = pkgs.callPackage ./kak-auto-pairs.nix { };
   kak-vertical-selection = pkgs.callPackage ./kak-vertical-selection.nix { };
-  kak-buffers = pkgs.callPackage ./kak-buffers.nix { };
 }

--- a/pkgs/applications/editors/kakoune/plugins/kak-auto-pairs.nix
+++ b/pkgs/applications/editors/kakoune/plugins/kak-auto-pairs.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub }:
+stdenv.mkDerivation {
+  name = "kak-auto-pairs";
+  version = "2019-07-27";
+  src = fetchFromGitHub {
+    owner = "alexherbo2";
+    repo = "auto-pairs.kak";
+    rev = "886449b1a04d43e5deb2f0ef4b1aead6084c7a5f";
+    sha256 = "0knfhdvslzw1f1r1k16733yhkczrg3yijjz6n2qwira84iv3239j";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/kak/autoload/plugins
+    cp -r rc $out/share/kak/autoload/plugins/auto-pairs
+  '';
+
+  meta = with stdenv.lib;
+  { description = "Kakoune extension to enable automatic closing of pairs";
+    homepage = "https://github.com/alexherbo2/auto-pairs.kak";
+    license = licenses.publicDoman;
+    maintainers = with maintainers; [ nrdxp ];
+    platform = platforms.all;
+  };
+}

--- a/pkgs/applications/editors/kakoune/plugins/kak-buffers.nix
+++ b/pkgs/applications/editors/kakoune/plugins/kak-buffers.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub }:
+stdenv.mkDerivation {
+  name = "kak-buffers";
+  version = "2019-04-03";
+  src = fetchFromGitHub {
+    owner = "Delapouite";
+    repo = "kakoune-buffers";
+    rev = "3b35b23ac2be661a37c085d34dd04d066450f757";
+    sha256 = "0f3g0v1sjinii3ig9753jjj35v2km4h9bcfw9xgzwz8b10d75bax";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/kak/autoload/plugins
+    cp -r buffers.kak $out/share/kak/autoload/plugins
+  '';
+
+  meta = with stdenv.lib;
+  { description = "Ease navigation between opened buffers in Kakoune";
+    homepage = "https://github.com/Delapouite/kakoune-buffers";
+    license = licenses.publicDoman;
+    maintainers = with maintainers; [ nrdxp ];
+    platform = platforms.all;
+  };
+}

--- a/pkgs/applications/editors/kakoune/plugins/kak-fzf.nix
+++ b/pkgs/applications/editors/kakoune/plugins/kak-fzf.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub }:
+stdenv.mkDerivation {
+  name = "kak-fzf";
+  version = "2019-07-16";
+  src = fetchFromGitHub {
+    owner = "andreyorst";
+    repo = "fzf.kak";
+    rev = "ede90d3e02bceb714f997adfcbab8260b42e0a19";
+    sha256 = "18w90j3fpk2ddn68497s33n66aap8phw5636y1r7pqsa641zdxcv";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/kak/autoload/plugins
+    cp -r rc $out/share/kak/autoload/plugins/fzf
+  '';
+
+  meta = with stdenv.lib;
+  { description = "Kakoune plugin that brings integration with fzf";
+    homepage = "https://github.com/andreyorst/fzf.kak";
+    license = licenses.publicDoman;
+    maintainers = with maintainers; [ nrdxp ];
+    platform = platforms.all;
+  };
+}

--- a/pkgs/applications/editors/kakoune/plugins/kak-fzf.nix
+++ b/pkgs/applications/editors/kakoune/plugins/kak-fzf.nix
@@ -1,4 +1,7 @@
-{ stdenv, fetchFromGitHub }:
+{ stdenv, fetchFromGitHub, fzf }:
+
+assert stdenv.lib.asserts.assertOneOf "fzf" fzf.pname [ "fzf" "skim" ];
+
 stdenv.mkDerivation {
   name = "kak-fzf";
   version = "2019-07-16";
@@ -8,6 +11,17 @@ stdenv.mkDerivation {
     rev = "ede90d3e02bceb714f997adfcbab8260b42e0a19";
     sha256 = "18w90j3fpk2ddn68497s33n66aap8phw5636y1r7pqsa641zdxcv";
   };
+
+  configurePhase = ''
+    if [[ -x "${fzf}/bin/fzf" ]]; then
+      fzfImpl='${fzf}/bin/fzf'
+    else
+      fzfImpl='${fzf}/bin/sk'
+    fi
+
+    substituteInPlace rc/fzf.kak \
+      --replace \'fzf\' \'"$fzfImpl"\'
+  '';
 
   installPhase = ''
     mkdir -p $out/share/kak/autoload/plugins

--- a/pkgs/applications/editors/kakoune/plugins/kak-powerline.nix
+++ b/pkgs/applications/editors/kakoune/plugins/kak-powerline.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub }:
+stdenv.mkDerivation {
+  name = "kak-powerline";
+  version = "2019-07-23";
+  src = fetchFromGitHub {
+    owner = "andreyorst";
+    repo = "powerline.kak";
+    rev = "82b01eb6c97c7380b7da253db1fd484a5de13ea4";
+    sha256 = "1480wp2jc7c84z1wqmpf09lzny6kbnbhiiym2ffaddxrd4ns9i6z";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/kak/autoload/plugins
+    cp -r rc $out/share/kak/autoload/plugins/powerline
+  '';
+
+  meta = with stdenv.lib;
+  { description = "Kakoune modeline, but with passion";
+    homepage = "https://github.com/andreyorst/powerline.kak";
+    license = licenses.publicDoman;
+    maintainers = with maintainers; [ nrdxp ];
+    platform = platforms.all;
+  };
+}

--- a/pkgs/applications/editors/kakoune/plugins/kak-powerline.nix
+++ b/pkgs/applications/editors/kakoune/plugins/kak-powerline.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub }:
+{ stdenv, git, fetchFromGitHub }:
 stdenv.mkDerivation {
   name = "kak-powerline";
   version = "2019-07-23";
@@ -8,6 +8,11 @@ stdenv.mkDerivation {
     rev = "82b01eb6c97c7380b7da253db1fd484a5de13ea4";
     sha256 = "1480wp2jc7c84z1wqmpf09lzny6kbnbhiiym2ffaddxrd4ns9i6z";
   };
+
+  configurePhase = ''
+    substituteInPlace rc/modules/git.kak \
+      --replace \'git\' \'${git}/bin/git\'
+  '';
 
   installPhase = ''
     mkdir -p $out/share/kak/autoload/plugins

--- a/pkgs/applications/editors/kakoune/plugins/kak-vertical-selection.nix
+++ b/pkgs/applications/editors/kakoune/plugins/kak-vertical-selection.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub }:
+stdenv.mkDerivation {
+  name = "kak-vertical-selection";
+  version = "2019-04-11";
+  src = fetchFromGitHub {
+    owner = "occivink";
+    repo = "kakoune-vertical-selection";
+    rev = "c420f8b867ce47375fac303886e31623669a42b7";
+    sha256 = "13jdyd2j45wvgqvxdzw9zww14ly93bqjb6700zzxj7mkbiff6wsb";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/kak/autoload/plugins
+    cp -r vertical-selection.kak $out/share/kak/autoload/plugins
+  '';
+
+  meta = with stdenv.lib;
+  { description = "Select up and down lines that match the same pattern in Kakoune";
+    homepage = "https://github.com/occivink/kakoune-vertical-selection";
+    license = licenses.publicDoman;
+    maintainers = with maintainers; [ nrdxp ];
+    platform = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4138,7 +4138,7 @@ in
   kalibrate-hackrf = callPackage ../applications/radio/kalibrate-hackrf { };
 
   wrapKakoune = callPackage ../applications/editors/kakoune/wrapper.nix { };
-  kakounePlugins = callPackage ../applications/editors/kakoune/plugins.nix { };
+  kakounePlugins = callPackage ../applications/editors/kakoune/plugins { };
   kakoune-unwrapped = callPackage ../applications/editors/kakoune { };
   kakoune = wrapKakoune kakoune-unwrapped { };
 


### PR DESCRIPTION
Should be compatible with
https://github.com/NixOS/nixpkgs/pull/64310

* kak-auto-pairs: for automatic closing of pairs
* kak-buffers: for easier buffer management
* kak-fzf: for fzf integration
* kak-powerline: for a prettier modeline
* kak-vertical-selection: for easy vertical selections

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @eraserhd @vrthra
