### PR TITLE
dnsmasq: Make unexpected resolvconf integration separately opt-in

### DIFF
--- a/nixos/modules/services/networking/dnsmasq.nix
+++ b/nixos/modules/services/networking/dnsmasq.nix
@@ -62,6 +62,15 @@ in
         '';
       };
 
+      useResolvConfUpstreams = mkOption {
+        type = types.bool;
+        default = false;
+        description = lib.mdDoc ''
+          Whether dnsmasq should include as upstream servers the DNS servers
+          provided by resolvconf (which are typically determined via DHCP).
+        '';
+      };
+
       alwaysKeepRunning = mkOption {
         type = types.bool;
         default = false;
@@ -129,8 +138,8 @@ in
 
     services.dnsmasq.settings = {
       dhcp-leasefile = mkDefault "${stateDir}/dnsmasq.leases";
-      conf-file = mkDefault (optional cfg.resolveLocalQueries "/etc/dnsmasq-conf.conf");
-      resolv-file = mkDefault (optional cfg.resolveLocalQueries "/etc/dnsmasq-resolv.conf");
+      conf-file = mkDefault (optional cfg.useResolvConfUpstreams "/etc/dnsmasq-conf.conf");
+      resolv-file = mkDefault (optional cfg.useResolvConfUpstreams "/etc/dnsmasq-resolv.conf");
     };
 
     networking.nameservers =
@@ -145,10 +154,10 @@ in
     };
     users.groups.dnsmasq = {};
 
-    networking.resolvconf = mkIf cfg.resolveLocalQueries {
-      useLocalResolver = mkDefault true;
+    networking.resolvconf = {
+      useLocalResolver = mkIf cfg.resolveLocalQueries (mkDefault true);
 
-      extraConfig = ''
+      extraConfig = mkIf cfg.useResolvConfUpstreams ''
         dnsmasq_conf=/etc/dnsmasq-conf.conf
         dnsmasq_resolv=/etc/dnsmasq-resolv.conf
       '';


### PR DESCRIPTION
###### Motivation for this change
Currently, if you set `services.dnsmasq.resolveLocalQueries = true;` (the default), then dnsmasq will not only resolve DNS queries for the local system, but it will also make it so that any resolvconf-provided DNS servers are injected into dnsmasq's list of upstream DNS servers.

This behaviour was introduced way back in #3745, but is problematic on several fronts:
- It isn't documented by the option description, at all.
- It probably should not be enabled by default (while potentially useful, using dnsmasq with DHCP-supplied upstreams is not *that* common a use-case).
- It can't be separately configured -- while the user can disable use of the `resolv-file` directive by adding `no-resolv` to `extraConfig`, there is no way to disable reading of the resolvconf-produced `/etc/dnsmasq-conf.conf` file. On my system at least, this file configures dnsmasq to resolve queries for my system's search domain using the DHCP-supplied server.

This PR migrates the functionality to its own, documented, opt-in configuration option. The only downside to this is that it will change the behaviour on existing systems.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] ~macOS~
   - [ ] ~other Linux distributions~
- [ ] ~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~
- [ ] ~Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`~
- [ ] ~Tested execution of all binary files (usually in `./result/bin/`)~
- [ ] ~Determined the impact on package closure size (by running `nix path-info -S` before and after)~
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
