### PR TITLE
postgresqlPackages.plv8: 2.3.12 -> 2.3.13

### DIFF
--- a/pkgs/development/libraries/v8/plv8_6_x.nix
+++ b/pkgs/development/libraries/v8/plv8_6_x.nix
@@ -1,6 +1,8 @@
 # NOTE: this expression is NOT exported from the top-level of all-packages.nix,
-# it is exclusively used by the 'plv8' PostgreSQL extension, which requires a
-# very exact version.
+# it is exclusively used by the 'plv8' PostgreSQL extension.
+# Since plv8 2.3.2, plv8 no longer requires this specific version, but as of
+# 2019-08-29, nixpkgs does not have v8 6.x, and v8_5 is bumped to 5.4.232, which
+# is a bit outdated.  plv8 3.x is planned to support v8 7.x
 
 { stdenv, lib, fetchgit, fetchFromGitHub, gn, ninja, python, glib, pkgconfig
 , doCheck ? false

--- a/pkgs/servers/sql/postgresql/ext/plv8.nix
+++ b/pkgs/servers/sql/postgresql/ext/plv8.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "plv8";
-  version = "2.3.12";
+  version = "2.3.13";
 
   nativeBuildInputs = [ perl ];
   buildInputs = [ v8 postgresql ];
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     owner = "plv8";
     repo = "plv8";
     rev = "v${version}";
-    sha256 = "1yi1ibiibvd0x4z5dm698w32ljrj3yr4j25jm1zkgkwd4ii8y644";
+    sha256 = "12xpcc1ylzyy75wi1m4vijknzv2gxab05w9z90jb03faq18cnlql";
   };
 
   makefile = "Makefile.shared";

--- a/pkgs/servers/sql/postgresql/ext/plv8.nix
+++ b/pkgs/servers/sql/postgresql/ext/plv8.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     description = "V8 Engine Javascript Procedural Language add-on for PostgreSQL";
     homepage = "https://plv8.github.io/";
     maintainers = with maintainers; [ volth ];
-    platforms = platforms.linux;
+    platforms = [ "x86_64-linux" ];
     license = licenses.postgresql;
   };
 }

--- a/pkgs/servers/sql/postgresql/ext/plv8.nix
+++ b/pkgs/servers/sql/postgresql/ext/plv8.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "V8 Engine Javascript Procedural Language add-on for PostgreSQL";
     homepage = "https://plv8.github.io/";
-    maintainers = with maintainers; [ volth ];
+    maintainers = with maintainers; [ volth marsam ];
     platforms = [ "x86_64-linux" ];
     license = licenses.postgresql;
   };


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Changes: https://github.com/plv8/plv8/compare/v2.3.12...v2.3.13

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
