### PR TITLE
gcompris: use Qt mkDerivation

### DIFF
--- a/pkgs/games/gcompris/default.nix
+++ b/pkgs/games/gcompris/default.nix
@@ -1,37 +1,55 @@
-{stdenv, cmake, qtbase, fetchurl, qtdeclarative, qtmultimedia, qttools, qtsensors, qmlbox2d, gettext, qtquickcontrols, qtgraphicaleffects, qtxmlpatterns, makeWrapper,
-  gst_all_1, ninja
+{ mkDerivation
+, cmake
+, fetchurl
+, gettext
+, gst_all_1
+, lib
+, ninja
+, qmlbox2d
+, qtbase
+, qtdeclarative
+, qtgraphicaleffects
+, qtmultimedia
+, qtquickcontrols
+, qtsensors
+, qttools
+, qtxmlpatterns
 }:
-stdenv.mkDerivation rec {
+
+mkDerivation rec {
+  pname = "gcompris";
   version = "0.96";
-  name = "gcompris-${version}";
 
   src = fetchurl {
     url = "http://gcompris.net/download/qt/src/gcompris-qt-${version}.tar.xz";
     sha256 = "06483il59l46ny2w771sg45dgzjwv1ph7vidzzbj0wb8wbk2rg52";
   };
 
-  cmakeFlags = "-DQML_BOX2D_LIBRARY=${qmlbox2d}/${qtbase.qtQmlPrefix}/Box2D.2.0";
+  cmakeFlags = [
+    "-DQML_BOX2D_LIBRARY=${qmlbox2d}/${qtbase.qtQmlPrefix}/Box2D.2.0"
+  ];
 
-  nativeBuildInputs = [ cmake ninja makeWrapper ];
-  buildInputs = [ qtbase qtdeclarative qttools qtsensors qmlbox2d gettext qtquickcontrols qtmultimedia qtgraphicaleffects qtxmlpatterns] ++ soundPlugins;
-  soundPlugins = with gst_all_1; [gst-plugins-good gstreamer gst-plugins-base gst-plugins-bad];
+  nativeBuildInputs = [ cmake gettext ninja qttools ];
+
+  buildInputs = [
+    qmlbox2d qtbase qtdeclarative qtgraphicaleffects qtmultimedia qtquickcontrols qtsensors qtxmlpatterns
+  ] ++ (with gst_all_1; [
+    gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad
+  ]);
 
   postInstall = ''
-    # install .desktop and icon file
-    mkdir -p $out/share/applications/
-    mkdir -p $out/share/icons/hicolor/256x256/apps/
-    cp ../org.kde.gcompris.desktop $out/share/applications/gcompris.desktop
-    cp -r ../images/256-apps-gcompris-qt.png $out/share/icons/hicolor/256x256/apps/gcompris-qt.png
+    install -Dm444 ../org.kde.gcompris.desktop        $out/share/applications/gcompris.desktop
+    install -Dm444 ../images/256-apps-gcompris-qt.png $out/share/icons/hicolor/256x256/apps/gcompris-qt.png
+    install -Dm444 ../org.kde.gcompris.appdata.xml -t $out/share/metainfo
 
-    wrapProgram "$out/bin/gcompris-qt" \
-       --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0"
-    '';
+    qtWrapperArgs+=(--prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0")
+  '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A high quality educational software suite, including a large number of activities for children aged 2 to 10";
     homepage = "https://gcompris.net/";
-    maintainers = [ maintainers.guibou ];
-    platforms = [ "i686-linux" "x86_64-linux" ];
     license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ guibou ];
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
##### Motivation for this change

Part of the move to use Qt's mkDerivation.

Also ran nixpkgs-fmt on it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @guibou
