### PR TITLE
strawberry: init at 0.6.3

### DIFF
--- a/pkgs/applications/audio/strawberry/default.nix
+++ b/pkgs/applications/audio/strawberry/default.nix
@@ -1,0 +1,91 @@
+{ mkDerivation
+, stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, pkgconfig
+, alsaLib
+, boost
+, chromaprint
+, fftw
+, gnutls
+, libcdio
+, libmtp
+, libpthreadstubs
+, libtasn1
+, libXdmcp
+, pcre
+, protobuf
+, sqlite
+, taglib
+, libpulseaudio ? null
+, libselinux ? null
+, libsepol ? null
+, p11_kit ? null
+, utillinux ? null
+, qtbase
+, qtx11extras
+, qttools
+, withGstreamer ? true
+, gst_all_1 ? null
+, withVlc ? true
+, vlc ? null
+}:
+
+mkDerivation rec {
+  pname = "strawberry";
+  version = "0.6.3";
+
+  src = fetchFromGitHub {
+    owner = "jonaski";
+    repo = pname;
+    rev = version;
+    sha256 = "01j5jzzicy895kg9sjy46lbcm5kvf3642d3q5wwb2fyvyq1fbcv0";
+  };
+
+  buildInputs = [
+    alsaLib
+    boost
+    chromaprint
+    fftw
+    gnutls
+    libcdio
+    libmtp
+    libpthreadstubs
+    libtasn1
+    libXdmcp
+    pcre
+    protobuf
+    sqlite
+    taglib
+    qtbase
+    qtx11extras
+  ]
+  ++ lib.optionals stdenv.isLinux [
+    libpulseaudio
+    libselinux
+    libsepol
+    p11_kit
+    utillinux
+  ]
+  ++ lib.optionals withGstreamer (with gst_all_1; [
+    gstreamer
+    gst-plugins-base
+    gst-plugins-good
+  ])
+  ++ lib.optional withVlc vlc;
+
+  nativeBuildInputs = [ cmake pkgconfig qttools ];
+
+  cmakeFlags = [
+    "-DUSE_SYSTEM_TAGLIB=ON"
+  ];
+
+  meta = with lib; {
+    description = "Music player and music collection organizer";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ peterhoeg ];
+    # upstream says darwin should work but they lack maintainers as of 0.6.3
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2783,6 +2783,8 @@ in
 
   sonobuoy = callPackage ../applications/networking/cluster/sonobuoy { };
 
+  strawberry = libsForQt5.callPackage ../applications/audio/strawberry { };
+
   tealdeer = callPackage ../tools/misc/tealdeer { };
 
   teamocil = callPackage ../tools/misc/teamocil { };


### PR DESCRIPTION
##### Motivation for this change

strawberry is a *maintained* fork of clementine. Can highly recommend it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @ttuegel as clementine maintainer
