### PR TITLE
vault: 1.0.2 -> 1.2.2

### DIFF
--- a/nixos/modules/services/security/vault.nix
+++ b/nixos/modules/services/security/vault.nix
@@ -70,7 +70,7 @@ in
       };
 
       storageBackend = mkOption {
-        type = types.enum [ "inmem" "file" "consul" "zookeeper" "s3" "azure" "dynamodb" "etcd" "mssql" "mysql" "postgresql" "swift" "gcs" ];
+        type = types.enum [ "inmem" "file" "consul" "zookeeper" "s3" "azure" "dynamodb" "etcd" "mssql" "mysql" "postgresql" "swift" "gcs" "raft" ];
         default = "inmem";
         description = "The name of the type of storage backend";
       };

--- a/pkgs/tools/security/vault/default.nix
+++ b/pkgs/tools/security/vault/default.nix
@@ -1,36 +1,25 @@
-{ stdenv, fetchFromGitHub, go, gox, removeReferencesTo }:
+{ stdenv, fetchFromGitHub, buildGoModule }:
 
-stdenv.mkDerivation rec {
+buildGoModule rec {
   name = "vault-${version}";
-  version = "1.1.3";
+  version = "1.2.2";
 
   src = fetchFromGitHub {
     owner = "hashicorp";
     repo = "vault";
     rev = "v${version}";
-    sha256 = "0dylwvs95crvn1p7pbyzib979rxzp4ivzvi5k4f5ivp4ygnp597s";
+    sha256 = "1xljm7xmb4ldg3wx8s9kw1spffg4ywk4r1jqfa743czd2xxmqavl";
   };
 
-  nativeBuildInputs = [ go gox removeReferencesTo ];
+  modSha256 = "13pr3piv6hrsc562qagpn1h5wckiziyfqraj13172hdglz3n2i7q";
 
-  preBuild = ''
-    patchShebangs ./
-    substituteInPlace scripts/build.sh --replace 'git rev-parse HEAD' 'echo ${src.rev}'
-    sed -i s/'^GIT_DIRTY=.*'/'GIT_DIRTY="+NixOS"'/ scripts/build.sh
+  buildFlagsArray = [
+    "-tags='vault'"
+    "-ldflags=\"-X github.com/hashicorp/vault/sdk/version.GitCommit='v${version}'\""
+  ];
 
-    mkdir -p .git/hooks src/github.com/hashicorp
-    ln -s $(pwd) src/github.com/hashicorp/vault
-
-    export GOPATH=$(pwd)
-    export GOCACHE="$TMPDIR/go-cache"
-  '';
-
-  installPhase = ''
-    mkdir -p $out/bin $out/share/bash-completion/completions
-
-    cp pkg/*/* $out/bin/
-    find $out/bin -type f -exec remove-references-to -t ${go} '{}' +
-
+  postInstall = ''
+    mkdir -p $out/share/bash-completion/completions
     echo "complete -C $out/bin/vault vault" > $out/share/bash-completion/completions/vault
   '';
 


### PR DESCRIPTION
This upgrades Vault to version 1.2.2. To accomplish this, we migrate to using the `buildGoModule` helper, as since the previous nixpkgs release the Vault build process migrated to modules, and does not vendor its dependencies.

We also stop using the vault build script, and gox, as it only really provides value for local development, where it configures GOOS/GOARCH and installs into some convenient dev locations.

###### Motivation for this change
Using newer vault features in my development environment..

It also introduces the new `raft` storage backend to the service definition.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @rushmorem @lnl7 @offline @pradeepchhetri
