### PR TITLE
verifpal: init at 0.2

### DIFF
--- a/pkgs/development/tools/pigeon/default.nix
+++ b/pkgs/development/tools/pigeon/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildGoPackage, fetchFromGitHub }:
+buildGoPackage {
+  pname = "pigeon";
+  version = "20190810-f3db42a662";
+
+  goPackagePath = "github.com/mna/pigeon";
+  goDeps = ./deps.nix;
+
+  src = fetchFromGitHub {
+    owner = "mna";
+    repo = "pigeon";
+    rev = "f3db42a662eded7550fc7cd11605d05311dfa30f";
+    sha256 = "1n0zqidwbqqfslrirpbqw14ylgiry6ggcp9ll4h8rf1chqwk6dhv";
+  };
+
+  meta = {
+    homepage = "https://github.com/mna/pigeon";
+    description = "A PEG parser generator for Go";
+    maintainers = with lib.maintainers; [ zimbatm ];
+    license = with lib.licenses; [ bsd3 ];
+  };
+}

--- a/pkgs/development/tools/pigeon/deps.nix
+++ b/pkgs/development/tools/pigeon/deps.nix
@@ -1,0 +1,66 @@
+# file generated from go.mod using vgo2nix (https://github.com/adisbladis/vgo2nix)
+[
+  {
+    goPackagePath = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev = "c2843e01d9a2";
+      sha256 = "01xgxbj5r79nmisdvpq48zfy8pzaaj90bn6ngd4nf33j9ar1dp8r";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev = "3b0461eec859";
+      sha256 = "0l00c8l0a8xnv6qdpwfzxxsr58jggacgzdrwiprrfx2xqm37b6d5";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sync";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sync";
+      rev = "112230192c58";
+      sha256 = "05i2k43j2d0llq768hg5pf3hb2yhfzp9la1w5wp0rsnnzblr0lfn";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev = "d0b11bdaac8a";
+      sha256 = "18yfsmw622l7gc5sqriv5qmck6903vvhivpzp8i3xfy3z33dybdl";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/text";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/text";
+      rev = "v0.3.0";
+      sha256 = "0r6x6zjzhr8ksqlpiwm5gdd7s209kwk5p4lw54xjvz10cs3qlq19";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/tools";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/tools";
+      rev = "b29f5f60c37a";
+      sha256 = "118rvb59hc1fykbmif4008rbxw1p0dblc8dxkq96yaapd6p0vbpn";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/xerrors";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/xerrors";
+      rev = "a985d3407aa7";
+      sha256 = "00wzr5w8aadipgc3rkk8f11i41znskfj9ix5nhhaxyg7isrslgcj";
+    };
+  }
+]

--- a/pkgs/tools/security/verifpal/default.nix
+++ b/pkgs/tools/security/verifpal/default.nix
@@ -1,0 +1,38 @@
+{ lib, fetchFromGitHub, buildGoPackage, pigeon }:
+buildGoPackage rec {
+  pname = "verifpal";
+  version = "0.2";
+
+  goPackagePath = "github.com/SymbolicSoft/verifpal";
+  goDeps = ./deps.nix;
+
+  src = fetchFromGitHub {
+    owner = "SymbolicSoft";
+    repo = pname;
+    rev = version;
+    sha256 = "08a0xvgg94k6vq91ylvgi97kpkjbw0rw172v2dzwl2rfpzkigk1r";
+  };
+
+  postPatch = ''
+    sed -e 's|/bin/echo |echo |g' -i Makefile
+  '';
+
+  buildInputs = [ pigeon ];
+
+  buildPhase = ''
+    make -C go/src/$goPackagePath parser linux
+  '';
+
+  installPhase = ''
+    mkdir -p $bin/bin
+    cp go/src/$goPackagePath/build/bin/linux/verifpal $bin/bin/
+  '';
+
+  meta = {
+    homepage = "https://verifpal.com/";
+    description = "Cryptographic protocol analysis for students and engineers";
+    maintainers = with lib.maintainers; [ zimbatm ];
+    license = with lib.licenses; [ gpl3 ];
+    platforms = ["x86_64-linux"];
+  };
+}

--- a/pkgs/tools/security/verifpal/deps.nix
+++ b/pkgs/tools/security/verifpal/deps.nix
@@ -1,0 +1,12 @@
+# file generated from go.mod using vgo2nix (https://github.com/adisbladis/vgo2nix)
+[
+  {
+    goPackagePath = "github.com/logrusorgru/aurora";
+    fetch = {
+      type = "git";
+      url = "https://github.com/logrusorgru/aurora";
+      rev = "94edacc10f9b";
+      sha256 = "0bhwy3rrd8mwb8xjwf44nj6vmxaj5hdvayvszr1rskkmz08l5v01";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24891,4 +24891,6 @@ in
 
   pigeon = callPackage ../development/tools/pigeon {};
 
+  verifpal = callPackage ../tools/security/verifpal {};
+
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24888,4 +24888,7 @@ in
   uhubctl = callPackage ../tools/misc/uhubctl {};
 
   kodelife = callPackage ../applications/graphics/kodelife {};
+
+  pigeon = callPackage ../development/tools/pigeon {};
+
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Done for the NLNet PET program

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
