### PR TITLE
Variant Ant themes: init at 1.3.0

### DIFF
--- a/pkgs/data/themes/ant-theme/ant-bloody.nix
+++ b/pkgs/data/themes/ant-theme/ant-bloody.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchurl, gtk-engine-murrine }:
+
+let
+  themeName = "Ant-Bloody";
+in
+stdenv.mkDerivation rec {
+  pname = "ant-bloody-theme";
+  version = "1.3.0";
+
+  src = fetchurl {
+    url = "https://github.com/EliverLara/${themeName}/releases/download/v${version}/${themeName}.tar";
+    sha256 = "0rrz50kmzjmqj17hvrw67pbaclwxv85i5m08s7842iky6dnn5z8s";
+  };
+
+  propagatedUserEnvPkgs = [
+    gtk-engine-murrine
+  ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/themes/${themeName}
+    cp -a * $out/share/themes/${themeName}
+    rm -r $out/share/themes/${themeName}/{Art,LICENSE,README.md,gtk-2.0/render-assets.sh}
+    runHook postInstall
+  '';
+
+  outputHashAlgo = "sha256";
+  outputHashMode = "recursive";
+  outputHash = "0v5pdhysa2460sh400cpq11smcfsi9g1lbfzx8nj1w5a21d811cz";
+
+  meta = with stdenv.lib; {
+    description = "Bloody variant of the Ant theme";
+    homepage = "https://github.com/EliverLara/${themeName}";
+    license = licenses.gpl3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ alexarice ];
+  };
+}

--- a/pkgs/data/themes/ant-theme/ant-dracula.nix
+++ b/pkgs/data/themes/ant-theme/ant-dracula.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchurl, gtk-engine-murrine }:
+
+let
+  themeName = "Ant-Dracula";
+in
+stdenv.mkDerivation rec {
+  pname = "ant-dracula-theme";
+  version = "1.3.0";
+
+  src = fetchurl {
+    url = "https://github.com/EliverLara/${themeName}/releases/download/v${version}/${themeName}.tar";
+    sha256 = "00b8w69xapqy8kc7zqwlfz1xpld6hibbh35djvhcnd905gzzymkd";
+  };
+
+  propagatedUserEnvPkgs = [
+    gtk-engine-murrine
+  ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/themes/${themeName}
+    cp -a * $out/share/themes/${themeName}
+    rm -r $out/share/themes/${themeName}/{Art,LICENSE,README.md,gtk-2.0/render-assets.sh}
+    runHook postInstall
+  '';
+
+  outputHashAlgo = "sha256";
+  outputHashMode = "recursive";
+  outputHash = "1a9mkxfb0zixx8s05h15lhnnzygh2qzc8k2q10i0khx90bf72x14";
+
+  meta = with stdenv.lib; {
+    description = "Dracula variant of the Ant theme";
+    homepage = "https://github.com/EliverLara/${themeName}";
+    license = licenses.gpl3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ alexarice ];
+  };
+}

--- a/pkgs/data/themes/ant-theme/ant-nebula.nix
+++ b/pkgs/data/themes/ant-theme/ant-nebula.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchurl, gtk-engine-murrine }:
+
+let
+  themeName = "Ant-Nebula";
+in
+stdenv.mkDerivation rec {
+  pname = "ant-nebula-theme";
+  version = "1.3.0";
+
+  src = fetchurl {
+    url = "https://github.com/EliverLara/${themeName}/releases/download/v${version}/${themeName}.tar";
+    sha256 = "1xpgw577nmgjk547mg2vvv0gdai60srgncykm5pb1w8dnlk69jbz";
+  };
+
+  propagatedUserEnvPkgs = [
+    gtk-engine-murrine
+  ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/themes/${themeName}
+    cp -a * $out/share/themes/${themeName}
+    rm -r $out/share/themes/${themeName}/{Art,LICENSE,README.md,gtk-2.0/render-assets.sh}
+    runHook postInstall
+  '';
+
+  outputHashAlgo = "sha256";
+  outputHashMode = "recursive";
+  outputHash = "1lmlc4fvjnp05gshc0arfysh8r1xxzpzdv3j0bk40mjf3d59814c";
+
+  meta = with stdenv.lib; {
+    description = "Nebula variant of the Ant theme";
+    homepage = "https://github.com/EliverLara/${themeName}";
+    license = licenses.gpl3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ alexarice ];
+  };
+}

--- a/pkgs/data/themes/ant-theme/ant.nix
+++ b/pkgs/data/themes/ant-theme/ant.nix
@@ -1,11 +1,14 @@
 { stdenv, fetchurl, gtk-engine-murrine }:
 
+let
+  themeName = "Ant";
+in
 stdenv.mkDerivation rec {
   pname = "ant-theme";
   version = "1.3.0";
 
   src = fetchurl {
-    url = "https://github.com/EliverLara/Ant/releases/download/v${version}/Ant.tar";
+    url = "https://github.com/EliverLara/${themeName}/releases/download/v${version}/${themeName}.tar";
     sha256 = "1r795v96ywzcb4dq08q2fdbmfia32g36cc512mhy41s8fb1a47dz";
   };
 
@@ -17,21 +20,21 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     runHook preInstall
-    mkdir -p $out/share/themes/Ant
-    cp -a * $out/share/themes/Ant
-    rm -r $out/share/themes/Ant/{Art,LICENSE,README.md,gtk-2.0/render-assets.sh}
+    mkdir -p $out/share/themes/${themeName}
+    cp -a * $out/share/themes/${themeName}
+    rm -r $out/share/themes/${themeName}/{Art,LICENSE,README.md,gtk-2.0/render-assets.sh}
     runHook postInstall
   '';
 
   outputHashAlgo = "sha256";
   outputHashMode = "recursive";
-  outputHash = "1gpacrmi5y87shp39jgy78n0ca2xdpvbqfh0mgldlxx99ca9rvvy";
+  outputHash = "07iv4jangqnzrvjr749vl3x31z7dxds51bq1bhz5acbjbwf25wjf";
 
   meta = with stdenv.lib; {
     description = "A flat and light theme with a modern look";
-    homepage = https://github.com/EliverLara/Ant;
+    homepage = "https://github.com/EliverLara/${themeName}";
     license = licenses.gpl3;
     platforms = platforms.all;
-    maintainers = [ ];
+    maintainers = with maintainers; [ alexarice ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17370,7 +17370,13 @@ in
 
   anonymousPro = callPackage ../data/fonts/anonymous-pro { };
 
-  ant-theme = callPackage ../data/themes/ant-theme { };
+  ant-theme = callPackage ../data/themes/ant-theme/ant.nix { };
+
+  ant-bloody-theme = callPackage ../data/themes/ant-theme/ant-bloody.nix { };
+
+  ant-dracula-theme = callPackage ../data/themes/ant-theme/ant-dracula.nix { };
+
+  ant-nebula-theme = callPackage ../data/themes/ant-theme/ant-nebula.nix { };
 
   arc-icon-theme = callPackage ../data/icons/arc-icon-theme { };
 


### PR DESCRIPTION
###### Things done 

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc
