### PR TITLE
hidapi: 0.8.0-RC1 -> 0.9.0

### DIFF
--- a/pkgs/development/libraries/hidapi/default.nix
+++ b/pkgs/development/libraries/hidapi/default.nix
@@ -1,25 +1,29 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, udev, libusb
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, systemd, libusb
 , darwin }:
 
 stdenv.mkDerivation rec {
-  name = "hidapi-0.8.0-rc1";
+  pname = "hidapi";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
-    owner = "signal11";
+    owner = "libusb";
     repo = "hidapi";
-    rev = name;
-    sha256 = "13d5jkmh9nh4c2kjch8k8amslnxapa9vkqzrk1z6rqmw8qgvzbkj";
+    rev = "${pname}-${version}";
+    sha256 = "1p4g8lgwj4rki6lbn5l6rvwj0xlbn1xfh4d255bg5pvgczmwmc4i";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
+
   buildInputs = [ ]
-    ++ stdenv.lib.optionals stdenv.isLinux [ udev libusb ];
+    ++ stdenv.lib.optionals stdenv.isLinux [ libusb systemd ];
+
+  enableParallelBuilding = true;
 
   propagatedBuildInputs = stdenv.lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ IOKit Cocoa ]);
 
   meta = with stdenv.lib; {
-    homepage = https://github.com/signal11/hidapi;
     description = "Library for communicating with USB and Bluetooth HID devices";
+    homepage = "https://github.com/libusb/hidapi";
     # Actually, you can chose between GPLv3, BSD or HIDAPI license (more liberal)
     license = licenses.bsd3;
     platforms = platforms.unix;


### PR DESCRIPTION
###### Motivation for this change

There is now a proper, maintained upstream. Need to run nix-review on this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
