### PR TITLE
gomplate: init at 3.5.0

### DIFF
--- a/pkgs/development/tools/gomplate/default.nix
+++ b/pkgs/development/tools/gomplate/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  pname = "gomplate";
+  version = "3.5.0";
+
+  # Git revision as defined here:
+  # https://github.com/hairyhenderson/gomplate/blob/eb2dbf65167e8bef7b62615c30431d75adc4e4b6/Makefile#L13
+  rev = "fd00d0ff";
+
+  src = fetchFromGitHub {
+     owner = "hairyhenderson";
+     repo = pname;
+     rev = "v${version}";
+     sha256 = "0q3fssgwn7p95pn4nh5qajssrc55jqf5gwq6cpirfim0c339pl95";
+   };
+
+  preBuild = ''
+    export buildFlagsArray+=(
+      "-ldflags=
+        -w -s
+        -X ${goPackagePath}/version.Version=${version}
+        -X ${goPackagePath}/version.GitCommit=${rev}")
+  '';
+
+  goPackagePath = "github.com/hairyhenderson/gomplate";
+  subPackages = [ "cmd/gomplate" ];
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "A flexible commandline tool for template rendering. Supports lots of local and remote datasources";
+    homepage = https://gomplate.ca/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ jlesquembre ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16177,6 +16177,8 @@ in
 
   gomodifytags = callPackage ../development/tools/gomodifytags { };
 
+  gomplate = callPackage ../development/tools/gomplate { };
+
   go-langserver = callPackage ../development/tools/go-langserver { };
 
   gotests = callPackage ../development/tools/gotests { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add [gomplate](https://docs.gomplate.ca)

I was able to build it locally. I also did some tests and the binary seems to work fine, but I don't have much experience with go packages, feedback about the nix expression would be appreciated. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).




