### PR TITLE
ariang: init at 1.1.3

### DIFF
--- a/pkgs/servers/web-apps/ariang/default.nix
+++ b/pkgs/servers/web-apps/ariang/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchurl, unzip }:
+
+stdenv.mkDerivation rec {
+  pname = "ariang";
+  version = "1.1.3";
+
+  src = fetchurl {
+    url = "https://github.com/mayswind/AriaNg/releases/download/${version}/AriaNg-${version}.zip";
+    sha256 = "1hc6hz6a4l4qc8hgq08ihdcba8dkjki4cxc2kx22fy6dd67997f9";
+  };
+  sourceRoot = ".";
+  buildInputs = [ unzip ];
+
+  installPhase = ''
+    mkdir $out
+    cp -ra * $out/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Modern web frontend making aria2 easier to use";
+    license = licenses.mit;
+    homepage = "http://ariang.mayswind.net/";
+    maintainers = with maintainers; [ dawidsowa ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14480,6 +14480,8 @@ in
 
   archiveopteryx = callPackage ../servers/mail/archiveopteryx { };
 
+  ariang = callPackage ../servers/web-apps/ariang { };
+
   atlassian-confluence = callPackage ../servers/atlassian/confluence.nix { };
   atlassian-crowd = callPackage ../servers/atlassian/crowd.nix { };
   atlassian-jira = callPackage ../servers/atlassian/jira.nix { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Added [AriaNG](http://ariang.mayswind.net/) web app.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
