### PR TITLE
kcc: init at 5.5.1

### DIFF
--- a/pkgs/applications/graphics/kcc/default.nix
+++ b/pkgs/applications/graphics/kcc/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, mkDerivationWith
+, python3Packages
+, p7zip
+, archiveSupport ? true
+}:
+
+mkDerivationWith python3Packages.buildPythonApplication rec {
+  pname = "kcc";
+  version = "5.5.1";
+
+  src = python3Packages.fetchPypi {
+    inherit version;
+    pname = "KindleComicConverter";
+    sha256 = "5dbee5dc5ee06a07316ae5ebaf21ffa1970094dbae5985ad735e2807ef112644";
+  };
+  
+  propagatedBuildInputs = with python3Packages ; [
+    pillow
+    pyqt5
+    psutil
+    python-slugify
+    raven
+  ];
+
+  qtWrapperArgs = lib.optional archiveSupport [ "--prefix" "PATH" ":" "${ lib.makeBinPath [ p7zip ] }" ];
+
+  postFixup =  ''
+    wrapProgram $out/bin/kcc "''${qtWrapperArgs[@]}"
+  '';
+
+  meta = with lib; {
+    description = "Python app to convert comic/manga files or folders to EPUB, Panel View MOBI or E-Ink optimized CBZ";
+    homepage = "https://kcc.iosphe.re";
+    license = licenses.isc;
+    maintainers = with maintainers; [ dawidsowa ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9692,6 +9692,8 @@ in
 
   kati = callPackage ../development/tools/build-managers/kati { };
 
+  kcc = libsForQt5.callPackage ../applications/graphics/kcc { };
+
   kconfig-frontends = callPackage ../development/tools/misc/kconfig-frontends {
     gperf = gperf_3_0;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Added [Kindle Comic Converter](https://kcc.iosphe.re/)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
