### PR TITLE
gotestsum: Init at 0.3.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1822,6 +1822,12 @@
     githubId = 18535642;
     name = "Emily";
   };
+  endocrimes = {
+    email = "dani@builds.terrible.systems";
+    github = "endocrimes";
+    githubId = 1330683;
+    name = "Danielle Lancashire";
+  };
   ederoyd46 = {
     email = "matt@ederoyd.co.uk";
     github = "ederoyd46";

--- a/pkgs/development/tools/gotestsum/default.nix
+++ b/pkgs/development/tools/gotestsum/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, buildGoModule }:
+
+buildGoModule rec {
+  pname = "gotestsum";
+  version = "0.3.5";
+
+  src = fetchFromGitHub {
+    owner = "gotestyourself";
+    repo = "gotestsum";
+    rev = "v${version}";
+    sha256 = "1d4sbvk9wqzl3g3da8inqdkvd43rkwvmq969jlgl1k1agv5xjxqv";
+  };
+
+  modSha256 = "1dgs643pmcw68yc003zss52hbvsy6hxzwkrhr0qmsqkmzxryb3bn";
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/gotestyourself/gotestsum";
+    description = "A human friendly `go test` runner";
+    platforms = platforms.linux ++ platforms.darwin;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ endocrimes ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16198,6 +16198,8 @@ in
 
   gotests = callPackage ../development/tools/gotests { };
 
+  gotestsum = callPackage ../development/tools/gotestsum { };
+
   impl = callPackage ../development/tools/impl { };
 
   quicktemplate = callPackage ../development/tools/quicktemplate { };


### PR DESCRIPTION
###### Motivation for this change

Introduce a nix package for `gotestsum`, a golang test runner that provides both better human friendly output and also machine readable junit xml without having to run tests multiple times. It's fairly new but used heavily by go projects that I interact with.

I'm adding it here rather than keeping it in my personal package repository as it may provide value to others.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
