### PR TITLE
pythonPackages.iapws: init at 1.4

### DIFF
--- a/pkgs/development/python-modules/iapws/default.nix
+++ b/pkgs/development/python-modules/iapws/default.nix
@@ -1,0 +1,20 @@
+{ lib, buildPythonPackage, fetchPypi, scipy }:
+
+buildPythonPackage rec {
+  pname = "iapws";
+  version = "1.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "3d7a7a17343157dacd3f654b7f82d1974492209756c4de99332d4f6b375227e6";
+  };
+
+  propagatedBuildInputs = [ scipy ];
+
+  meta = with lib; {
+    description = "Python implementation of standard from IAPWS";
+    homepage = "https://github.com/jjgomera/iapws";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ dawidsowa ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3383,6 +3383,8 @@ in {
 
   httpretty = callPackage ../development/python-modules/httpretty { };
 
+  iapws = callPackage ../development/python-modules/iapws { };
+
   icalendar = callPackage ../development/python-modules/icalendar { };
 
   ifaddr = callPackage ../development/python-modules/ifaddr { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Added [iapws](https://github.com/jjgomera/iapws)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
