### PR TITLE
haskell: get cabal-install 3.0.0.0 building on ghc-8.6.5 and ghc-8.8.1

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1059,9 +1059,11 @@ self: super: {
       dontCheck super.dhall
   );
 
+  # Missing test files in source distribution, fixed once 1.4.0 is bumped
+  # https://github.com/dhall-lang/dhall-haskell/pull/997
   dhall-json =
     generateOptparseApplicativeCompletions ["dhall-to-json" "dhall-to-yaml"] (
-      super.dhall-json
+      dontCheck super.dhall-json
   );
 
   dhall-nix =

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1008,6 +1008,7 @@ self: super: {
 
   # https://github.com/haskell-hvr/resolv/issues/1
   resolv = dontCheck super.resolv;
+  resolv_0_1_1_2 = dontCheck super.resolv_0_1_1_2;
 
   # spdx 0.2.2.0 needs older tasty
   # was fixed in spdx master (4288df6e4b7840eb94d825dcd446b42fef25ef56)

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -32,8 +32,11 @@ self: super: {
   # compiled on Linux. We provide the name to avoid evaluation errors.
   unbuildable = throw "package depends on meta package 'unbuildable'";
 
-  # Use the latest version of the Cabal library.
-  cabal-install = super.cabal-install.overrideScope (self: super: { Cabal = self.Cabal_2_4_1_0; });
+  cabal-install =
+    super.cabal-install.overrideScope (self: super: {
+      # Use the latest version of the Cabal library.
+      Cabal = self.Cabal_3_0_0_0;
+    });
 
   # The test suite depends on old versions of tasty and QuickCheck.
   hackage-security = dontCheck super.hackage-security;

--- a/pkgs/development/haskell-modules/configuration-ghc-8.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.6.x.nix
@@ -41,6 +41,11 @@ self: super: {
   unix = null;
   xhtml = null;
 
+  cabal-install = super.cabal-install.override {
+    # resolv-0.1.1.3 requires base-4.13 (GHC-8.8.1).
+    resolv = self.resolv_0_1_1_2;
+  };
+
   # https://github.com/tibbe/unordered-containers/issues/214
   unordered-containers = dontCheck super.unordered-containers;
 

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2486,6 +2486,7 @@ extra-packages:
   - dbus <1                             # for xmonad-0.26
   - deepseq == 1.3.0.1                  # required to build Cabal with GHC 6.12.3
   - generic-deriving == 1.10.5.*        # new versions don't compile with GHC 7.10.x
+  - ghc-lib-parser == 8.8.0.20190723    # required by hlint-2.2.2
   - gloss < 1.9.3                       # new versions don't compile with GHC 7.8.x
   - haddock < 2.17                      # required on GHC 7.10.x
   - haddock == 2.17.*                   # required on GHC 8.0.x

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -43,7 +43,7 @@ core-packages:
   - ghcjs-base-0
 
 default-package-overrides:
-  # LTS Haskell 14.2
+  # LTS Haskell 14.3
   - abstract-deque ==0.3
   - abstract-deque-tests ==0.3
   - abstract-par ==0.3.3
@@ -70,7 +70,7 @@ default-package-overrides:
   - aeson-utils ==0.3.0.2
   - aeson-yak ==0.1.1.3
   - al ==0.1.4.2
-  - alarmclock ==0.7.0.1
+  - alarmclock ==0.7.0.2
   - alerts ==0.1.2.0
   - alex ==3.2.4
   - alg ==0.2.10.0
@@ -91,7 +91,7 @@ default-package-overrides:
   - ANum ==0.2.0.2
   - aos-signature ==0.1.1
   - apecs ==0.8.1
-  - apecs-gloss ==0.2.2
+  - apecs-gloss ==0.2.3
   - apecs-physics ==0.4.2
   - api-field-json-th ==0.1.0.2
   - appar ==0.1.8
@@ -144,7 +144,7 @@ default-package-overrides:
   - aws-cloudfront-signed-cookies ==0.2.0.1
   - aws-lambda-haskell-runtime ==2.0.1
   - backprop ==0.2.6.3
-  - bank-holidays-england ==0.2.0.1
+  - bank-holidays-england ==0.2.0.2
   - barbies ==1.1.3.0
   - barrier ==0.1.1
   - base16-bytestring ==0.1.1.6
@@ -639,7 +639,7 @@ default-package-overrides:
   - explicit-exception ==0.1.10
   - exp-pairs ==0.2.0.0
   - extensible-exceptions ==0.1.1.4
-  - extra ==1.6.17
+  - extra ==1.6.18
   - extractable-singleton ==0.0.1
   - extrapolate ==0.3.3
   - fail ==4.9.0.0
@@ -774,7 +774,7 @@ default-package-overrides:
   - ghc-lib ==8.8.0.20190424
   - ghc-lib-parser ==8.8.0.20190424
   - ghc-parser ==0.2.0.3
-  - ghc-paths ==0.1.0.9
+  - ghc-paths ==0.1.0.12
   - ghc-prof ==1.4.1.5
   - ghc-syntax-highlighter ==0.0.4.0
   - ghc-tcplugins-extra ==0.3
@@ -963,7 +963,7 @@ default-package-overrides:
   - hsinstall ==2.2
   - HSlippyMap ==3.0.1
   - hslogger ==1.2.12
-  - hslua ==1.0.3.1
+  - hslua ==1.0.3.2
   - hslua-aeson ==1.0.0
   - hslua-module-system ==0.2.1
   - hslua-module-text ==0.2.1
@@ -1258,7 +1258,7 @@ default-package-overrides:
   - loopbreaker ==0.1.1.0
   - lrucache ==1.2.0.1
   - lrucaching ==0.3.3
-  - lsp-test ==0.6.0.0
+  - lsp-test ==0.6.1.0
   - lucid ==2.9.11
   - lucid-extras ==0.2.2
   - lxd-client-config ==0.1.0.1
@@ -1415,6 +1415,7 @@ default-package-overrides:
   - netlib-comfort-array ==0.0.0.1
   - netlib-ffi ==0.1.1
   - netpbm ==1.0.3
+  - netrc ==0.2.0.0
   - nettle ==0.3.0
   - netwire ==5.0.3
   - netwire-input ==0.0.7
@@ -1510,7 +1511,7 @@ default-package-overrides:
   - pandoc-csv2table ==1.0.7
   - pandoc-markdown-ghci-filter ==0.1.0.0
   - pandoc-pyplot ==2.1.5.1
-  - pandoc-types ==1.17.5.4
+  - pandoc-types ==1.17.6
   - pantry ==0.1.1.1
   - parallel ==3.2.2.0
   - parallel-io ==0.3.3
@@ -1808,9 +1809,9 @@ default-package-overrides:
   - safe-json ==0.1.0
   - safe-money ==0.9
   - SafeSemaphore ==0.10.1
-  - salak ==0.3.4.1
-  - salak-toml ==0.3.4.1
-  - salak-yaml ==0.3.4.1
+  - salak ==0.3.5.1
+  - salak-toml ==0.3.5.1
+  - salak-yaml ==0.3.5.1
   - saltine ==0.1.0.2
   - salve ==1.0.6
   - sample-frame ==0.0.3
@@ -1824,7 +1825,7 @@ default-package-overrides:
   - scalpel-core ==0.6.0
   - scanf ==0.1.0.0
   - scanner ==0.3
-  - scheduler ==1.4.1
+  - scheduler ==1.4.2
   - scientific ==0.3.6.2
   - scotty ==0.11.4
   - scrypt ==0.5.0
@@ -1957,6 +1958,7 @@ default-package-overrides:
   - sox ==0.2.3.1
   - soxlib ==0.0.3.1
   - sparse-linear-algebra ==0.3.1
+  - sparse-tensor ==0.2.1
   - spatial-math ==0.5.0.1
   - special-values ==0.1.0.0
   - speculate ==0.3.5
@@ -2418,7 +2420,7 @@ default-package-overrides:
   - xmonad-extras ==0.15.1
   - xss-sanitize ==0.3.6
   - xxhash-ffi ==0.2.0.0
-  - yaml ==0.11.1.0
+  - yaml ==0.11.1.1
   - yeshql ==4.1.0.1
   - yeshql-core ==4.1.0.2
   - yeshql-hdbc ==4.1.0.2

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -4283,7 +4283,6 @@ broken-packages:
   - dgim
   - dgs
   - dhall-check
-  - dhall-json
   - dhall-lsp-server
   - dhall-nix
   - dhall-to-cabal

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2519,6 +2519,7 @@ extra-packages:
   - proto-lens-protobuf-types == 0.2.*  # required for tensorflow-proto-0.1.x on GHC 8.2.x
   - proto-lens-protoc == 0.2.*          # required for tensorflow-proto-0.1.x on GHC 8.2.x
   - QuickCheck < 2                      # required by test-framework-quickcheck and its users
+  - resolv < 0.1.1.3                    # resolv-0.1.1.3 requires GHC 8.8.1.  cabal-install-3 uses resolv.
   - resourcet ==1.1.*                   # pre-lts-11.x versions neeed by git-annex 6.20180227
   - seqid < 0.2                         # newer versions depend on transformers 0.4.x which we cannot provide in GHC 7.8.x
   - seqid-streams < 0.2                 # newer versions depend on transformers 0.4.x which we cannot provide in GHC 7.8.x

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -3525,6 +3525,7 @@ broken-packages:
   - bv-sized
   - bytable
   - byteslice
+  - bytesmith
   - bytestring-builder-varword
   - bytestring-class
   - bytestring-csv
@@ -7617,6 +7618,7 @@ broken-packages:
   - notcpp
   - notmuch-haskell
   - notmuch-web
+  - now-haskell
   - np-linear
   - nptools
   - ntha

--- a/pkgs/development/haskell-modules/non-hackage-packages.nix
+++ b/pkgs/development/haskell-modules/non-hackage-packages.nix
@@ -12,44 +12,4 @@ self: super: {
 
   # https://github.com/channable/vaultenv/issues/1
   vaultenv = self.callPackage ../tools/haskell/vaultenv { };
-
-  cabal-install-3 = (self.callPackage
-    ({ mkDerivation, array, async, base, base16-bytestring, binary
-     , bytestring, Cabal, containers, cryptohash-sha256, deepseq
-     , directory, echo, edit-distance, filepath, hackage-security
-     , hashable, HTTP, mtl, network, network-uri, parsec, pretty
-     , process, random, resolv, stdenv, stm, tar, text, time, unix, zlib
-     , fetchFromGitHub
-     }:
-     mkDerivation {
-       pname = "cabal-install";
-       version = "3.0.0.0";
-       src = fetchFromGitHub {
-         owner = "haskell";
-         repo = "cabal";
-         rev = "b0e52fa173573705e861b129d9675e59de891e46";
-         sha256 = "1fbph6crsn9ji8ps1k8dsxvgqn38rp4ffvv6nia1y7rbrdv90ass";
-       };
-       postUnpack = "sourceRoot+=/cabal-install";
-       isLibrary = false;
-       isExecutable = true;
-       setupHaskellDepends = [ base Cabal filepath process ];
-       executableHaskellDepends = [
-         array async base base16-bytestring binary bytestring Cabal
-         containers cryptohash-sha256 deepseq directory echo edit-distance
-         filepath hackage-security hashable HTTP mtl network network-uri
-         parsec pretty process random resolv stm tar text time unix zlib
-       ];
-       doCheck = false;
-       postInstall = ''
-         mkdir $out/etc
-         mv bash-completion $out/etc/bash_completion.d
-       '';
-       homepage = "http://www.haskell.org/cabal/";
-       description = "The command-line interface for Cabal and Hackage";
-       license = stdenv.lib.licenses.bsd3;
-     }) {}).overrideScope (self: super: {
-       Cabal = self.Cabal_3_0_0_0;
-     });
-
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Taking a look at hdyra, it appears that `cabal-install` has recently been updated to 3.0.0.0, but it is failing to build on both GHC-8.6.5 and GHC-8.8.1:

- job: https://hydra.nixos.org/eval/1539239
- GHC-8.8.1: https://hydra.nixos.org/build/99351396
- GHC-8.6.5: https://hydra.nixos.org/build/99458404

This PR tries to fix cabal-install-3.0.0.0 so it builds on both GHC-8.6.5 and GHC-8.8.1.

Here's a summary of why cabal-install-3.0.0.0 doesn't work on both GHCs, and the changes I made in this PR:

- GHC-8.6.5:

    - cabal-install requires the [resolv](http://hackage.haskell.org/package/resolv) package.  However, the most recent version of `resolv` (0.1.1.3) requires base-4.13 (GHC-8.8.1).  So this PR makes sure a `resolve_0_1_1_2` is generated, and then uses that to build `cabal-install`.  (Although, I haven't actually generated `hackage-packages.nix`, so this code shouldn't work until `hackage-packages.nix` is regenerated).

- GHC-8.8.1:

    - cabal-install has an unnecessary dependency on `base <= 4.13`, so it has been jailbroken.

    - the `regex-base` package needs to be jailbroken (and patched) to work with `base-4.13` (GHC-8.8.1), however the build-depend is in a conditional, which it appears jailbreak-cabal can't deal with.  So I've had to do this by hand.

I also removed the `cabal-install-3` derivation, since it isn't needed anymore.

With these changes, I am now able to build `cabal-install`:

```console
$ nix-build -A haskell.packages.ghc865.cabal-install
/nix/store/91gdifa89jp99123kkklxakkyl234jxb-cabal-install-3.0.0.0
$ nix-build -A haskell.packages.ghc881.cabal-install
/nix/store/ggz9mffjm73kryx517xyja1xx6hakvv1-cabal-install-3.0.0.0
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @peti @Infinisil 
