### PR TITLE
Ensure blas produces pkg config files

### DIFF
--- a/pkgs/development/libraries/science/math/blas/default.nix
+++ b/pkgs/development/libraries/science/math/blas/default.nix
@@ -44,19 +44,16 @@ stdenv.mkDerivation rec {
     install ${dashD} -m755 libblas.so.${version} "$out/lib/libblas.so.${version}"
     ln -s libblas.so.${version} "$out/lib/libblas.so.3"
     ln -s libblas.so.${version} "$out/lib/libblas.so"
-    # Write pkgconfig aliases. Upstream report:
-    # https://github.com/xianyi/OpenBLAS/issues/1740
-    # This is a copy from openblas/default.nix
+    # Write pkgconfig alias.
+    # See also openblas/default.nix
     mkdir $out/lib/pkgconfig
-    for alias in blas cblas lapack; do
-      cat <<EOF > $out/lib/pkgconfig/$alias.pc
-Name: $alias
+    cat <<EOF > $out/lib/pkgconfig/blas.pc
+Name: blas
 Version: ${version}
-Description: $alias provided by the BLAS package.
+Description: blas provided by the BLAS package.
 Cflags: -I$out/include
 Libs: -L$out/lib -lblas
 EOF
-    done
   '';
 
   preFixup = stdenv.lib.optionalString stdenv.isDarwin ''

--- a/pkgs/development/libraries/science/math/blas/default.nix
+++ b/pkgs/development/libraries/science/math/blas/default.nix
@@ -44,6 +44,19 @@ stdenv.mkDerivation rec {
     install ${dashD} -m755 libblas.so.${version} "$out/lib/libblas.so.${version}"
     ln -s libblas.so.${version} "$out/lib/libblas.so.3"
     ln -s libblas.so.${version} "$out/lib/libblas.so"
+    # Write pkgconfig aliases. Upstream report:
+    # https://github.com/xianyi/OpenBLAS/issues/1740
+    # This is a copy from openblas/default.nix
+    mkdir $out/lib/pkgconfig
+    for alias in blas cblas lapack; do
+      cat <<EOF > $out/lib/pkgconfig/$alias.pc
+Name: $alias
+Version: ${version}
+Description: $alias provided by the BLAS package.
+Cflags: -I$out/include
+Libs: -L$out/lib -lblas
+EOF
+    done
   '';
 
   preFixup = stdenv.lib.optionalString stdenv.isDarwin ''

--- a/pkgs/development/libraries/science/math/blas/default.nix
+++ b/pkgs/development/libraries/science/math/blas/default.nix
@@ -51,7 +51,6 @@ stdenv.mkDerivation rec {
 Name: blas
 Version: ${version}
 Description: blas provided by the BLAS package.
-Cflags: -I$out/include
 Libs: -L$out/lib -lblas
 EOF
   '';


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Some Haskell packages use `PkgConfig-Depends: blas` and currently the `blas` package doesn't produce these.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`

I tried to use this but

```
nix-shell -I nixpkgs=~/nixpkgs -p nix-review --run "nix-review wip"
...
Has to be execute from nixpkgs repository
```

and

```
nix-shell -p nix-review --run "nix-review wip"
error: file 'nixpkgs' was not found in the Nix search path (add it using $NIX_PATH or -I), at (string):1:13
```

- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

There doesn't seem to be a maintainer (at least I couldn't find one in the `default.nix`)
