### PR TITLE
prometheus-cups-exporter: init at unstable-2019-03-17

### DIFF
--- a/pkgs/servers/monitoring/prometheus/cups-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/cups-exporter.nix
@@ -1,0 +1,36 @@
+{ lib, fetchFromGitHub, python3Packages }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "prometheus-cups-exporter-unstable";
+  version = "2019-03-17";
+
+  format = "other";
+
+  src = fetchFromGitHub {
+    owner = "ThoreKr";
+    repo = "cups_exporter";
+    rev = "8fd1c2517e9878b7b7c73a450e5e546f437954a9";
+    sha256 = "1cwk2gbw2svqjlzgwv5wqzhq7fxwrwsrr0kkbnqn4mfb0kq6pa8m";
+  };
+
+  propagatedBuildInputs = with python3Packages; [ prometheus_client pycups ];
+
+  installPhase = ''
+    mkdir -p $out/share/
+    cp cups_exporter.py $out/share/
+  '';
+
+  fixupPhase = ''
+    makeWrapper "${python3Packages.python.interpreter}" "$out/bin/prometheus-cups-exporter" \
+          --set PYTHONPATH "$PYTHONPATH" \
+          --add-flags "$out/share/cups_exporter.py"
+  '';
+
+  meta = with lib; {
+    description = "A simple prometheus exporter for cups implemented in python";
+    homepage = "https://github.com/ThoreKr/cups_exporter";
+    license = licenses.unfree;
+    maintainers = [ maintainers.mmahut ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15011,6 +15011,7 @@ in
   prometheus-bind-exporter = callPackage ../servers/monitoring/prometheus/bind-exporter.nix { };
   prometheus-blackbox-exporter = callPackage ../servers/monitoring/prometheus/blackbox-exporter.nix { };
   prometheus-collectd-exporter = callPackage ../servers/monitoring/prometheus/collectd-exporter.nix { };
+  prometheus-cups-exporter = callPackage ../servers/monitoring/prometheus/cups-exporter.nix { };
   prometheus-consul-exporter = callPackage ../servers/monitoring/prometheus/consul-exporter.nix { };
   prometheus-dnsmasq-exporter = callPackage ../servers/monitoring/prometheus/dnsmasq-exporter.nix { };
   prometheus-dovecot-exporter = callPackage ../servers/monitoring/prometheus/dovecot-exporter.nix { };


### PR DESCRIPTION
###### Motivation for this change

init at unstable-2019-03-17


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).