### PR TITLE
[19.03] dovecot apply CVE-2019-11500 patches

### DIFF
--- a/pkgs/servers/mail/dovecot/default.nix
+++ b/pkgs/servers/mail/dovecot/default.nix
@@ -55,6 +55,18 @@ stdenv.mkDerivation rec {
       sha256 = "1di6adkd8f6gjkpf8aiqxzwvscsq188qqah6b7r23q9j3zlv47mv";
     })
 
+    (fetchpatch {
+      name = "CVE-2019-11500-1.patch";
+      url = https://github.com/dovecot/core/commit/85fcb895ca7f0bcb8ee72047fe0e1e78532ff90b.patch;
+      sha256 = "0cn0sk5giaf2z26zp53cj9h0xcbj347ad6zgp2k377fphn9yjcc5";
+    })
+
+    (fetchpatch {
+      name = "CVE-2019-11500-2.patch";
+      url = https://github.com/dovecot/core/commit/f904cbdfec25582bc5e2a7435bf82ff769f2526a.patch;
+      sha256 = "1dcp8axbpcib837n2x54xxylyglbh2zh9bf0y3vpvmapya162s1a";
+    })
+
   ];
 
   configureFlags = [

--- a/pkgs/servers/mail/dovecot/plugins/pigeonhole/default.nix
+++ b/pkgs/servers/mail/dovecot/plugins/pigeonhole/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, dovecot, openssl }:
+{ stdenv, fetchurl, dovecot, openssl, fetchpatch }:
 
 stdenv.mkDerivation rec {
   name = "dovecot-pigeonhole-${version}";
@@ -10,6 +10,19 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ dovecot openssl ];
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2019-11500-1.patch";
+      url = https://github.com/dovecot/pigeonhole/commit/7ce9990a5e6ba59e89b7fe1c07f574279aed922c.patch;
+      sha256 = "07l4m2wkqn910zb8d477q6asryfqzhbhxl4fl0w89s763maiam9v";
+    })
+    (fetchpatch {
+      name = "CVE-2019-11500-2.patch";
+      url = https://github.com/dovecot/pigeonhole/commit/4a299840cdb51f61f8d1ebc0210b19c40dfbc1cc.patch;
+      sha256 = "1p7jl3fcxr63yrgj5m11sbmbfnibrx5v9aifscn1wq858jnn8myf";
+    })
+  ];
 
   preConfigure = ''
     substituteInPlace src/managesieve/managesieve-settings.c --replace \


### PR DESCRIPTION

###### Motivation for this change

Follow-up on #67623 & #67637 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @tokudan @rickynils 
