### PR TITLE
i2p: 0.9.41 -> 0.9.42

### DIFF
--- a/pkgs/tools/networking/i2p/default.nix
+++ b/pkgs/tools/networking/i2p/default.nix
@@ -1,13 +1,16 @@
 { stdenv, ps, coreutils, fetchurl, jdk, jre, ant, gettext, which }:
 
 let wrapper = stdenv.mkDerivation rec {
-  name = "wrapper-${version}";
+  pname = "wrapper";
   version = "3.5.35";
+
   src = fetchurl {
     url = "https://wrapper.tanukisoftware.com/download/${version}/wrapper_${version}_src.tar.gz";
     sha256 = "0mjyw9ays9v6lnj21pmfd3qdvd9b6rwxfmw3pg6z0kyf2jadixw2";
   };
+
   buildInputs = [ jdk ];
+
   buildPhase = ''
     export ANT_HOME=${ant}
     export JAVA_HOME=${jdk}/lib/openjdk/jre/
@@ -16,6 +19,7 @@ let wrapper = stdenv.mkDerivation rec {
     sed 's/ testsuite$//' -i src/c/Makefile-linux-x86-64.make
     ${if stdenv.isi686 then "./build32.sh" else "./build64.sh"}
   '';
+
   installPhase = ''
     mkdir -p $out/{bin,lib}
     cp bin/wrapper $out/bin/wrapper
@@ -27,17 +31,22 @@ let wrapper = stdenv.mkDerivation rec {
 in
 
 stdenv.mkDerivation rec {
-  name = "i2p-0.9.41";
+  pname = "i2p";
+  version = "0.9.42";
+
   src = fetchurl {
-    url = "https://github.com/i2p/i2p.i2p/archive/${name}.tar.gz";
-    sha256 = "0adrj56i3pcc9ainj22akjrrvy73carz5jk29qa1h2b9q03di73b";
+    url = "https://download.i2p2.de/releases/${version}/i2psource_${version}.tar.bz2";
+    sha256 = "04y71hzkdpjzbac569rhyg1zfx37j0alggbl9gnkaqfbprb2nj1h";
   };
+
   buildInputs = [ jdk ant gettext which ];
   patches = [ ./i2p.patch ];
+
   buildPhase = ''
     export JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
     ant preppkg-linux-only
-    '';
+  '';
+
   installPhase = ''
     set -B
     mkdir -p $out/{bin,share}
@@ -61,13 +70,13 @@ stdenv.mkDerivation rec {
     mv $out/man $out/share/
     chmod +x $out/bin/* $out/i2psvc
     rm $out/{osid,postinstall.sh,INSTALL-headless.txt}
-    '';
+  '';
 
   meta = with stdenv.lib; {
-    homepage = https://geti2p.net;
     description = "Applications and router for I2P, anonymity over the Internet";
-    maintainers = [ maintainers.joelmo ];
+    homepage = "https://geti2p.net";
     license = licenses.gpl2;
     platforms = [ "x86_64-linux" "i686-linux" ];
+    maintainers = [ maintainers.joelmo ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @joelmo
