### PR TITLE
clonehero: init at 0.23.2.2

### DIFF
--- a/pkgs/games/clonehero/default.nix
+++ b/pkgs/games/clonehero/default.nix
@@ -1,0 +1,73 @@
+{ lib
+, stdenv
+, fetchurl
+, autoPatchelfHook
+, alsaLib
+, gtk2
+, libXrandr
+, libXScrnSaver
+, udev
+, zlib
+}:
+
+let
+  name = "clonehero";
+in
+stdenv.mkDerivation rec {
+  pname = "${name}-unwrapped";
+  version = "0.23.2.2";
+
+  src = fetchurl {
+    url = "http://dl.clonehero.net/${name}-v${lib.removePrefix "0" version}/${name}-linux.tar.gz";
+    sha256 = "0k9jcnd55yhr42gj8cmysd18yldp4k3cpk4z884p2ww03fyfq7mi";
+  };
+
+  outputs = [ "out" "doc" ];
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  buildInputs = [
+    # Load-time libraries (loaded from DT_NEEDED section in ELF binary)
+    gtk2
+    stdenv.cc.cc.lib
+    zlib
+
+    # Run-time libraries (loaded with dlopen)
+    alsaLib # ALSA sound
+    libXrandr # X11 resolution detection
+    libXScrnSaver # X11 screensaver prevention
+    udev # udev input drivers
+  ];
+
+  installPhase = ''
+    mkdir -p "$out/bin" "$out/share"
+    install -Dm755 ${name} "$out/bin"
+    cp -r clonehero_Data "$out/share"
+
+    mkdir -p "$doc/share/${name}"
+    cp README.txt "$doc/share/${name}"
+  '';
+
+  # Patch required run-time libraries as load-time libraries
+  #
+  # Libraries found with:
+  # > strings clonehero | grep '\.so'
+  # and
+  # > strace clonehero 2>&1 | grep '\.so'
+  postFixup = ''
+    patchelf \
+      --add-needed libasound.so.2 \
+      --add-needed libudev.so.1 \
+      --add-needed libXrandr.so.2 \
+      --add-needed libXss.so.1 \
+      "$out/bin/${name}"
+  '';
+
+  meta = with lib; {
+    description = "Clone of Guitar Hero and Rockband-style games";
+    homepage = "https://clonehero.net";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ metadark ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/games/clonehero/fhs-wrapper.nix
+++ b/pkgs/games/clonehero/fhs-wrapper.nix
@@ -1,0 +1,39 @@
+{ clonehero-unwrapped
+, makeDesktopItem
+, buildFHSUserEnv
+, liberation_ttf
+, callPackage
+}:
+
+let
+  name = "clonehero";
+  desktopName = "Clone Hero";
+  desktopItem = makeDesktopItem {
+    inherit name desktopName;
+    comment = clonehero-unwrapped.meta.description;
+    exec = name;
+    icon = name;
+    categories = "Game;";
+  };
+in
+buildFHSUserEnv {
+  inherit name;
+  inherit (clonehero-unwrapped) meta;
+
+  # Clone Hero has /usr/share/fonts hard-coded in its binary for looking up fonts.
+  # This workaround is necessary for rendering text on the keybinding screen (and possibly elsewhere)
+  # If a better solution is found, the FHS environment can be removed.
+  extraBuildCommands = ''
+    chmod +w usr/share
+    mkdir -p usr/share/fonts/truetype
+    ln -s ${liberation_ttf}/share/fonts/truetype/* usr/share/fonts/truetype
+  '';
+
+  extraInstallCommands = ''
+    mkdir -p "$out/share/applications" "$out/share/pixmaps"
+    cp ${desktopItem}/share/applications/* "$out/share/applications"
+    ln -s ${clonehero-unwrapped}/share/clonehero_Data/Resources/UnityPlayer.png "$out/share/pixmaps/${name}.png"
+  '';
+
+  runScript = callPackage ./xdg-wrapper.nix { };
+}

--- a/pkgs/games/clonehero/xdg-wrapper.nix
+++ b/pkgs/games/clonehero/xdg-wrapper.nix
@@ -1,0 +1,21 @@
+{ stdenv, clonehero-unwrapped, writeScript }:
+
+# Clone Hero doesn't have an installer, so it just stores configuration & data relative to the binary.
+# This wrapper works around that limitation, storing game configuration & data in XDG_CONFIG_HOME.
+let
+  name = "clonehero";
+  desktopName = "Clone Hero";
+in
+writeScript "${name}-xdg-wrapper-${clonehero-unwrapped.version}" ''
+  #!${stdenv.shell} -e
+  configDir="''${XDG_CONFIG_HOME:-$HOME/.config}/unity3d/srylain Inc_/${desktopName}"
+  mkdir -p "$configDir"
+
+  # Force link shipped clonehero_Data, unless directory already exists (to allow modding)
+  if [ ! -d "$configDir/clonehero_Data" ] || [ -L "$configDir/clonehero_Data" ]; then
+    ln -snf ${clonehero-unwrapped}/share/clonehero_Data "$configDir"
+  fi
+
+  # Fake argv[0] to emulate running in the config directory
+  exec -a "$configDir/${name}" ${clonehero-unwrapped}/bin/${name} "$@"
+''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25245,6 +25245,10 @@ in
 
   chocolateDoom = callPackage ../games/chocolate-doom { };
 
+  clonehero-unwrapped = pkgs.callPackage ../games/clonehero { };
+
+  clonehero = pkgs.callPackage ../games/clonehero/fhs-wrapper.nix { };
+
   crispyDoom = callPackage ../games/crispy-doom { };
 
   cri-o = callPackage ../applications/virtualization/cri-o/wrapper.nix { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Adds Clone Hero to nixpkgs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
