### PR TITLE
cage: init at 0.1.1

### DIFF
--- a/pkgs/applications/window-managers/cage/default.nix
+++ b/pkgs/applications/window-managers/cage/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchFromGitHub
+, meson, ninja, pkgconfig, makeWrapper
+, wlroots, wayland, wayland-protocols, pixman, libxkbcommon
+, systemd, mesa, libX11
+, xwayland ? null
+}:
+
+stdenv.mkDerivation rec {
+  pname = "cage";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "Hjdskes";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1vp4mfkflrjmlgyx5mkbzdi3iq58m76q7l9dfrsk85xn0642d6q1";
+  };
+
+  nativeBuildInputs = [ meson ninja pkgconfig makeWrapper ];
+
+  buildInputs = [
+    wlroots wayland wayland-protocols pixman libxkbcommon
+    # TODO: Not specified but required:
+    systemd mesa libX11
+  ];
+
+  enableParallelBuilding = true;
+
+  mesonFlags = [ "-Dxwayland=${stdenv.lib.boolToString (xwayland != null)}" ];
+
+  postFixup = stdenv.lib.optionalString (xwayland != null) ''
+    wrapProgram $out/bin/cage --prefix PATH : "${xwayland}/bin"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A Wayland kiosk";
+    homepage    = https://www.hjdskes.nl/projects/cage/;
+    license     = licenses.mit;
+    platforms   = platforms.linux;
+    maintainers = with maintainers; [ primeos ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17535,6 +17535,8 @@ in
 
   bviplus = callPackage ../applications/editors/bviplus { };
 
+  cage = callPackage ../applications/window-managers/cage { };
+
   calf = callPackage ../applications/audio/calf {
       inherit (gnome2) libglade;
       stdenv = gcc5Stdenv;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add a useful tool for Wayland based kiosks (0.1.1 is still a pre-release but for my use-case it worked well so far).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
