### PR TITLE
yle-dl: 2.31 -> 20190614 

### DIFF
--- a/pkgs/development/python-modules/mini-amf/default.nix
+++ b/pkgs/development/python-modules/mini-amf/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildPythonPackage, fetchFromGitHub
+, six
+, defusedxml
+}:
+
+buildPythonPackage rec {
+  pname = "mini-amf";
+  version = "0.9.1";
+
+  src = fetchFromGitHub {
+    owner = "zackw";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1jirg4wnwx8yr65adhbiig0laspiqvplqd180dgpnabj89c72p0m";
+  };
+
+  propagatedBuildInputs = [ defusedxml six ];
+
+  meta = with lib; {
+    description = "Minimal AMF encoder and decoder for Python";
+    homepage = "https://github.com/zackw/mini-amf";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/development/python-modules/pyamf/default.nix
+++ b/pkgs/development/python-modules/pyamf/default.nix
@@ -4,8 +4,8 @@ buildPythonPackage rec {
   pname = "PyAMF";
   version = "0.8.0";
 
-  # according to setup.py
-  disabled = isPy3k;
+  # doesn't support py2 according to setup.py, endian tests seem to fail on arm
+  disabled = isPy3k || stdenv.isAarch32 || stdenv.isAarch64;
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/pyamf/py3amf.nix
+++ b/pkgs/development/python-modules/pyamf/py3amf.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchPypi, buildPythonPackage, isPy27, defusedxml, pytest }:
+
+buildPythonPackage rec {
+  pname = "Py3AMF";
+  version = "0.8.9";
+
+  # according to setup.py
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1pmh6p7mqdjmy2yj4mv6s1vnf7l9sn326dr6465mxhd6qz6mmgzi";
+  };
+
+  propagatedBuildInputs = [ defusedxml ];
+
+  checkInputs = [ pytest ];
+  # test_wsgi: attempts network access
+  # test_remoting: obsolete usage of assertRaises
+  checkPhase = ''
+    pytest pyamf/tests \
+      --ignore=pyamf/tests/gateway/test_wsgi.py \
+      --ignore=pyamf/tests/test_remoting.py
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Py3AMF is fork of PyAMF to support Python3";
+    homepage = https://github.com/StdCarrot/Py3AMF;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/tools/misc/yle-dl/default.nix
+++ b/pkgs/tools/misc/yle-dl/default.nix
@@ -1,6 +1,6 @@
-{ lib, fetchFromGitHub, rtmpdump, php, pythonPackages, ffmpeg }:
+{ lib, fetchFromGitHub, rtmpdump, php, python3Packages, ffmpeg }:
 
-pythonPackages.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "yle-dl";
   version = "20190614";
 
@@ -11,7 +11,7 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "1995528c4h7gr1zxs3f2ja1vaw16gbvbig4ra81x78270s5025l9";
   };
 
-  propagatedBuildInputs = with pythonPackages; [
+  propagatedBuildInputs = with python3Packages; [
     attrs
     ConfigArgParse
     ffmpeg
@@ -27,7 +27,7 @@ pythonPackages.buildPythonApplication rec {
   pythonPath = [ rtmpdump php ];
 
   doCheck = false; # tests require network access
-  checkInputs = with pythonPackages; [ pytest pytestrunner ];
+  checkInputs = with python3Packages; [ pytest pytestrunner ];
 
   meta = with lib; {
     description = "Downloads videos from Yle (Finnish Broadcasting Company) servers";

--- a/pkgs/tools/misc/yle-dl/default.nix
+++ b/pkgs/tools/misc/yle-dl/default.nix
@@ -1,23 +1,35 @@
-{ stdenv, fetchFromGitHub, rtmpdump, php, pythonPackages, ffmpeg }:
+{ lib, fetchFromGitHub, rtmpdump, php, pythonPackages, ffmpeg }:
 
 pythonPackages.buildPythonApplication rec {
-  name = "yle-dl-${version}";
-  version = "2.31";
+  pname = "yle-dl";
+  version = "20190614";
 
   src = fetchFromGitHub {
     owner = "aajanki";
     repo = "yle-dl";
     rev = version;
-    sha256 = "0k93p9csyjm0w33diwl5s22kzs3g78jl3n9k8nxxpqrybfjl912f";
+    sha256 = "1995528c4h7gr1zxs3f2ja1vaw16gbvbig4ra81x78270s5025l9";
   };
 
-  propagatedBuildInputs = with pythonPackages; [ lxml pyamf pycrypto requests future ffmpeg ];
+  propagatedBuildInputs = with pythonPackages; [
+    attrs
+    ConfigArgParse
+    ffmpeg
+    future
+    lxml
+    mini-amf
+    pyamf
+    pycrypto
+    pycryptodomex
+    requests
+  ];
+
   pythonPath = [ rtmpdump php ];
 
   doCheck = false; # tests require network access
   checkInputs = with pythonPackages; [ pytest pytestrunner ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Downloads videos from Yle (Finnish Broadcasting Company) servers";
     homepage = https://aajanki.github.io/yle-dl/;
     license = licenses.gpl3;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -849,7 +849,10 @@ in {
 
   pyairvisual = callPackage ../development/python-modules/pyairvisual { };
 
-  pyamf = callPackage ../development/python-modules/pyamf { };
+  pyamf = if isPy27 then
+            callPackage ../development/python-modules/pyamf { }
+          else
+            callPackage ../development/python-modules/pyamf/py3amf.nix { };
 
   pyarrow = callPackage ../development/python-modules/pyarrow {
     inherit (pkgs) arrow-cpp cmake pkgconfig;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -723,6 +723,8 @@ in {
 
   maxminddb = callPackage ../development/python-modules/maxminddb { };
 
+  mini-amf = callPackage ../development/python-modules/mini-amf { };
+
   mininet-python = (toPythonModule (pkgs.mininet.override{ inherit python; })).py;
 
   mkl-service = callPackage ../development/python-modules/mkl-service { };


### PR DESCRIPTION
###### Motivation for this change
fixing @r-ryantm failed updates.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @dezgeg 

closure mostly due to ffmpeg + python + php
```
$ nix path-info -Sh ./result
/nix/store/3dnbdkxvnb46f9p4zv71xjzvj1326imw-yle-dl-20190614      413.9M
```
```
[2 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/67656
3 package were build:
python27Packages.mini-amf python37Packages.mini-amf yle-dl
```