### PR TITLE
qtpass: 1.2.3 -> 1.3.0

### DIFF
--- a/pkgs/applications/misc/qtpass/default.nix
+++ b/pkgs/applications/misc/qtpass/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, mkDerivation, fetchFromGitHub, git, gnupg, pass, qtbase, qtsvg, qttools, qmake, makeWrapper }:
+{ stdenv, mkDerivation, fetchFromGitHub, fetchpatch
+, git, gnupg, pass, qtbase, qtsvg, qttools, qmake, makeWrapper
+}:
 
 mkDerivation rec {
   pname = "qtpass";
@@ -14,6 +16,15 @@ mkDerivation rec {
   buildInputs = [ git gnupg pass qtbase qtsvg qttools ];
 
   nativeBuildInputs = [ makeWrapper qmake ];
+
+  # Fix missing app icon on Wayland. Has been upstreamed and should be safe to
+  # remove in versions > 1.3.0
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/IJHack/QtPass/commit/aba8c4180f0ab3d66c44f88b21f137b19d17bde8.patch";
+      sha256 = "009bcq0d75khmaligzd7736xdzy6a8s1m9dgqybn70h801h92fcr";
+    })
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/applications/misc/qtpass/default.nix
+++ b/pkgs/applications/misc/qtpass/default.nix
@@ -1,21 +1,21 @@
-{ stdenv, mkDerivation, fetchFromGitHub, fetchpatch
-, git, gnupg, pass, qtbase, qtsvg, qttools, qmake, makeWrapper
+{ stdenv, lib, mkDerivation, fetchFromGitHub, fetchpatch
+, git, gnupg, pass, qtbase, qtsvg, qttools, qmake
 }:
 
 mkDerivation rec {
   pname = "qtpass";
-  version = "1.2.3";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner  = "IJHack";
     repo   = "QtPass";
     rev    = "v${version}";
-    sha256 = "1vfhfyccrxq9snyvayqfzm5rqik8ny2gysyv7nipc91kvhq3bhky";
+    sha256 = "0v3ca4fdjk6l24vc9wlc0i7r6fdj85kjmnb7jvicd3f8xi9mvhnv";
   };
 
   buildInputs = [ git gnupg pass qtbase qtsvg qttools ];
 
-  nativeBuildInputs = [ makeWrapper qmake ];
+  nativeBuildInputs = [ qmake ];
 
   # Fix missing app icon on Wayland. Has been upstreamed and should be safe to
   # remove in versions > 1.3.0
@@ -29,9 +29,7 @@ mkDerivation rec {
   enableParallelBuilding = true;
 
   qtWrapperArgs = [
-    "--suffix PATH : ${git}/bin"
-    "--suffix PATH : ${gnupg}/bin"
-    "--suffix PATH : ${pass}/bin"
+    "--suffix PATH : ${lib.makeBinPath [ git gnupg pass ]}"
   ];
 
   postInstall = ''


### PR DESCRIPTION
##### Motivation for this change

Updating to latest version. Also includes a patch to fix the missing app icon under Wayland (see https://github.com/IJHack/QtPass/pull/468)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @hrdinka 
