### PR TITLE
androidenv: android licenses

### DIFF
--- a/doc/languages-frameworks/android.section.md
+++ b/doc/languages-frameworks/android.section.md
@@ -85,6 +85,23 @@ For each requested system image we can specify the following options:
 * `abiVersions` specifies what kind of ABI version of each system image should
   be included. Defaults to: `armeabi-v7a`.
 
+* `licenses` specifies accepted licenses in a form of `<filename> = <license-hash>`.
+  
+  As of 2019, popular set is:
+  ```
+  {
+      android-googletv-license = "601085b94cd77f0b54ff86406957099ebe79c4d6";
+      android-sdk-license = "24333f8a63b6825ea9c5514f83c2829b004d1fee";
+      android-sdk-preview-license = "84831b9409646a918e30573bab4c9c91346d8abd";
+      google-gdk-license = "33b6a2b64607f11b759f320ef9dff4ae5c47d97a";
+      mips-android-sysimage-license = "e9acab5b5fbb560a72cfaecce8946896ff6aab9d";
+  }
+  ```
+
+  To accept other licenses, you may need to install SDK yourself, run
+  `sdkmanager --update`, accept licenses (if you wish) and then recover hashes
+  from `ANDROID_HOME/libexec/android-sdk/licenses` folder.
+
 Most of the function arguments have reasonable default settings.
 
 When building the above expression with:

--- a/pkgs/development/mobile/androidenv/compose-android-packages.nix
+++ b/pkgs/development/mobile/androidenv/compose-android-packages.nix
@@ -18,6 +18,7 @@
 , useGoogleAPIs ? false
 , useGoogleTVAddOns ? false
 , includeExtras ? []
+, licenses ? {}  # {<file-name>: <license-hash>}
 }:
 
 let
@@ -193,6 +194,8 @@ rec {
     You must accept the Android Software Development Kit License Agreement at
     https://developer.android.com/studio/terms
     by setting nixpkgs config option 'android_sdk.accept_license = true;'
+
+    Except that, you may need to provide accepted licenses to your android SDK composition.
   '' else import ./tools.nix {
     inherit deployAndroidPackage requireFile packages toolsVersion autoPatchelfHook makeWrapper os pkgs pkgs_i686;
     inherit (stdenv) lib;
@@ -254,6 +257,10 @@ rec {
       do
           ln -s $i $out/bin
       done
+
+      # create license files in top sdk path
+      mkdir $out/licenses
+      ${builtins.concatStringsSep "\n" (builtins.attrValues (builtins.mapAttrs (k: v: "echo -e '\n${v}' > $out/licenses/${k}") licenses))}
     '';
   };
 }


### PR DESCRIPTION
###### Motivation for this change 

Android SDK requires accepted licenses, those are save in specific location and looks like android tools construct paths based on their location, rather than env variables (which means they are looking in nix store and user is not able to add them setting environment variable [at least I didn't find how to do it]).

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @svanderburg 
