### PR TITLE
pythonPackage.nixpart0: disable for python3

### DIFF
--- a/pkgs/tools/filesystems/nixpart/0.4/default.nix
+++ b/pkgs/tools/filesystems/nixpart/0.4/default.nix
@@ -54,11 +54,12 @@ let
   };
 
 in buildPythonApplication rec {
-  name = "nixpart-${version}";
+  pname = "nixpart";
   version = "0.4.1";
+  disabled = python.isPy3k;
 
   src = fetchurl {
-    url = "https://github.com/aszlig/nixpart/archive/v${version}.tar.gz";
+    url = "https://github.com/NixOS/nixpart/archive/v${version}.tar.gz";
     sha256 = "0avwd8p47xy9cydlbjxk8pj8q75zyl68gw2w6fnkk78dcb1a3swp";
   };
 
@@ -66,10 +67,11 @@ in buildPythonApplication rec {
 
   doCheck = false;
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "NixOS storage manager/partitioner";
-    license = stdenv.lib.licenses.gpl2Plus;
-    maintainers = [ stdenv.lib.maintainers.aszlig ];
-    platforms = stdenv.lib.platforms.linux;
+    homepage = "https://github.com/NixOS/nixpart";
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.aszlig ];
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
noticed it was failling to build when reviewing #67658

`python2Packages.nixpart0` still builds fine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @aszlig 
