### PR TITLE
nixos/fontconfig: Allow setting default emoji font

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1909.xml
+++ b/nixos/doc/manual/release-notes/rl-1909.xml
@@ -600,6 +600,26 @@
       removed from nixpkgs due to lack of maintainer.
     </para>
    </listitem>
+   <listitem>
+    <para>
+     Using <option>fonts.enableDefaultFonts</option> adds a default emoji font <literal>noto-fonts-emoji</literal>.
+     <itemizedlist>
+      <para>Users of the following options will have this enabled by default:</para>
+      <listitem>
+       <para><option>services.xserver.enable</option></para>
+      </listitem>
+      <listitem>
+       <para><option>programs.sway.enable</option></para>
+      </listitem>
+      <listitem>
+       <para><option>programs.way-cooler.enable</option></para>
+      </listitem>
+      <listitem>
+       <para><option>services.xrdp.enable</option></para>
+      </listitem>
+     </itemizedlist>
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 </section>

--- a/nixos/modules/config/fonts/fontconfig.nix
+++ b/nixos/modules/config/fonts/fontconfig.nix
@@ -116,7 +116,7 @@ let
   defaultFontsConf =
     let genDefault = fonts: name:
       optionalString (fonts != []) ''
-        <alias>
+        <alias binding="same">
           <family>${name}</family>
           <prefer>
           ${concatStringsSep ""
@@ -138,6 +138,8 @@ let
       ${genDefault cfg.defaultFonts.serif     "serif"}
 
       ${genDefault cfg.defaultFonts.monospace "monospace"}
+
+      ${genDefault cfg.defaultFonts.emoji "emoji"}
 
     </fontconfig>
   '';
@@ -342,6 +344,21 @@ in
             description = ''
               System-wide default serif font(s). Multiple fonts may be listed
               in case multiple languages must be supported.
+            '';
+          };
+
+          emoji = mkOption {
+            type = types.listOf types.str;
+            default = ["Noto Color Emoji"];
+            description = ''
+              System-wide default emoji font(s). Multiple fonts may be listed
+              in case a font does not support all emoji.
+
+              Note that fontconfig matches color emoji fonts preferentially,
+              so if you want to use a black and white font while having
+              a color font installed (eg. Noto Color Emoji installed alongside
+              Noto Emoji), fontconfig will still choose the color font even
+              when it is later in the list.
             '';
           };
         };

--- a/nixos/modules/config/fonts/fonts.nix
+++ b/nixos/modules/config/fonts/fonts.nix
@@ -43,6 +43,7 @@ with lib;
         pkgs.xorg.fontmiscmisc
         pkgs.xorg.fontcursormisc
         pkgs.unifont
+        pkgs.noto-fonts-emoji
       ];
 
   };

--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -68,6 +68,7 @@ in rec {
         nixos.tests.chromium.x86_64-linux or []
         (all nixos.tests.firefox)
         (all nixos.tests.firewall)
+        (all nixos.tests.fontconfig-default-fonts)
         (all nixos.tests.gnome3-xorg)
         (all nixos.tests.gnome3)
         (all nixos.tests.pantheon)

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -87,6 +87,7 @@ in
   flatpak = handleTest ./flatpak.nix {};
   flatpak-builder = handleTest ./flatpak-builder.nix {};
   fluentd = handleTest ./fluentd.nix {};
+  fontconfig-default-fonts = handleTest ./fontconfig-default-fonts.nix {};
   fsck = handleTest ./fsck.nix {};
   fwupd = handleTestOn ["x86_64-linux"] ./fwupd.nix {}; # libsmbios is unsupported on aarch64
   gdk-pixbuf = handleTest ./gdk-pixbuf.nix {};

--- a/nixos/tests/fontconfig-default-fonts.nix
+++ b/nixos/tests/fontconfig-default-fonts.nix
@@ -1,0 +1,28 @@
+import ./make-test.nix ({ lib, ... }:
+{
+  name = "fontconfig-default-fonts";
+
+  machine = { config, pkgs, ... }: {
+    fonts.enableDefaultFonts = true; # Background fonts
+    fonts.fonts = with pkgs; [
+      noto-fonts-emoji
+      cantarell-fonts
+      twitter-color-emoji
+      source-code-pro
+      gentium
+    ];
+    fonts.fontconfig.defaultFonts = {
+      serif = [ "Gentium Plus" ];
+      sansSerif = [ "Cantarell" ];
+      monospace = [ "Source Code Pro" ];
+      emoji = [ "Twitter Color Emoji" ];
+    };
+  };
+
+  testScript = ''
+    $machine->succeed("fc-match serif | grep '\"Gentium Plus\"'");
+    $machine->succeed("fc-match sans-serif | grep '\"Cantarell\"'");
+    $machine->succeed("fc-match monospace | grep '\"Source Code Pro\"'");
+    $machine->succeed("fc-match emoji | grep '\"Twitter Color Emoji\"'");
+  '';
+})


### PR DESCRIPTION
In fontconfig’s `60-generic.conf`, order of preference is established for emoji font family. Because fontconfig parses the config files in lexicographic order, appending each `<prefer>` from `<alias>` element to the family’s prefer list (to be prepended before the family) [1], our font family defaults stored in `52-nixos-default-fonts.conf` will take precedence. That is, of course, unless the default `weak` binding [2] is used. Emoji family binds strongly [3], so we need to set binding to `same` for our `<alias>`es to be considered before the ones from `60-generic.conf`.

By default, we will set the option to all emoji fonts supported by fontconfig, so that emoji works for user if they have at least one emoji font installed. If they have multiple emoji fonts installed, we will use the fontconfig’s order of preference [4].

[1]: https://github.com/bohoomil/fontconfig-ultimate/issues/51#issuecomment-64678322
[2]: https://www.freedesktop.org/software/fontconfig/fontconfig-user.html#AEN25
[3]: https://gitlab.freedesktop.org/fontconfig/fontconfig/commit/cc8442dec85e9d416436d19eeae1783f2d3008f0
[4]: https://gitlab.freedesktop.org/fontconfig/fontconfig/commit/c41c9220181b203d1cf1f6435f6e3735cb7c84ac

#### Blocking PRs
- [x]  #67529 disable fontconfig-penultimate by default
- [x]  #67701 font needed for test

#### Related PRs
- #67663 add joypixels support to fontconfig
