### PR TITLE
include-what-you-use: 0.10 -> 0.12

### DIFF
--- a/pkgs/development/tools/analysis/include-what-you-use/default.nix
+++ b/pkgs/development/tools/analysis/include-what-you-use/default.nix
@@ -3,10 +3,10 @@
 stdenv.mkDerivation rec {
   name = "include-what-you-use-${version}";
   # Also bump llvmPackages in all-packages.nix to the supported version!
-  version = "0.10";
+  version = "0.12";
 
   src = fetchurl {
-    sha256 = "16alan9rwbhpyfxmlpc7gbfnbqd877wdqrkvgqrjb1jlqkzpg55s";
+    sha256 = "09b0h704fh7r4f5h92p5997cj3zk1v04bqp4jk1j1f6cmfq2z2d5";
     url = "${meta.homepage}/downloads/${name}.src.tar.gz";
   };
 
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     substituteInPlace $out/bin/iwyu_tool.py \
-      --replace "['include-what-you-use']" "['$out/bin/include-what-you-use']"
+      --replace "'include-what-you-use'" "'$out/bin/include-what-you-use'"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9352,7 +9352,7 @@ in
   };
 
   include-what-you-use = callPackage ../development/tools/analysis/include-what-you-use {
-    llvmPackages = llvmPackages_6;
+    llvmPackages = llvmPackages_8;
   };
 
   indent = callPackage ../development/tools/misc/indent { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Upgrade include-what-you-use to the latest released version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
