### PR TITLE
falkon: use qt5's mkDerivation

### DIFF
--- a/pkgs/applications/networking/browsers/falkon/default.nix
+++ b/pkgs/applications/networking/browsers/falkon/default.nix
@@ -1,12 +1,13 @@
-{ stdenv, lib, fetchFromGitHub, cmake, extra-cmake-modules, pkgconfig, qmake
+{ stdenv, mkDerivation, lib, fetchFromGitHub
+, cmake, extra-cmake-modules, pkgconfig, qmake
 , libpthreadstubs, libxcb, libXdmcp
 , qtsvg, qttools, qtwebengine, qtx11extras
 , qtwayland
 , kwallet
 }:
 
-stdenv.mkDerivation rec {
-  name = "falkon-${version}";
+mkDerivation rec {
+  pname = "falkon";
   version = "3.1.0";
 
   src = fetchFromGitHub {


### PR DESCRIPTION
###### Motivation for this change
See #65399

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change (none)
- [x] Tested execution of all binary files (runs inside `nix-shell --pure -p`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @ttuegel @peterhoeg 
