### PR TITLE
[19.03] kea: 1.5.0 -> 1.5.0-P1 (security)

### DIFF
--- a/pkgs/tools/networking/kea/default.nix
+++ b/pkgs/tools/networking/kea/default.nix
@@ -4,11 +4,11 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "kea";
-  version = "1.5.0";
+  version = "1.5.0-P1";
 
   src = fetchurl {
     url = "https://ftp.isc.org/isc/${pname}/${version}/${name}.tar.gz";
-    sha256 = "1v5a3prgrplw6dp9124f9gpy0kz0jrjwhnvzrw3zcynad2mlzkpd";
+    sha256 = "0bqxzp3f7cmraa5davj2az1hx1gbbchqzlz3ai26c802agzafyhz";
   };
 
   patches = [ ./dont-create-var.patch ];


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Backport of #67672 

Fixes:

* CVE-2019-6472 affects the Kea DHCPv6 server, which can exit
  with an assertion failure if the DHCPv6 server process receives
  a request containing DUID value which is too large.
  (https://kb.isc.org/docs/cve-2019-6474)

* CVE-2019-6473 affects the Kea DHCPv4 server, which can exit with
  an assertion failure if it receives a packed containing a malformed
  option.  (https://kb.isc.org/docs/cve-2019-6473)

* CVE-2019-6474 can cause a condition where the server cannot be
  restarted without manual operator intervention to correct a problem
  that can be deliberately introduced into the stored leases.
  CVE-2019-6474 can only affect servers which are using memfile
  for lease storage.  (https://kb.isc.org/docs/cve-2019-6474)

Annoucement: https://www.openwall.com/lists/oss-security/2019/08/29/1
(cherry picked from commit e6e3270bd44ddc7d94df6b054a1e4e543055ca05)



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @fpletz
