### PR TITLE
cargo-web: 0.6.25 -> 0.6.26

### DIFF
--- a/pkgs/development/tools/cargo-web/default.nix
+++ b/pkgs/development/tools/cargo-web/default.nix
@@ -4,16 +4,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-web";
-  version = "0.6.25";
+  version = "0.6.26";
 
   src = fetchFromGitHub {
     owner = "koute";
     repo = pname;
     rev = version;
-    sha256 = "0q77bryc7ap8gb4rzp9xk8ngqwxh106qn7899g30lwxycnyii0mf";
+    sha256 = "1dl5brj5fnmxmwl130v36lvy4j64igdpdvjwmxw3jgg2c6r6b7cd";
   };
 
-  cargoSha256 = "1f4sj260q4rlzbajwimya1yhh90hmmbhr47yfg9i8xcv5cg0cqjn";
+  cargoSha256 = "1cbyy9rc33f69hbs0ff00v0v3p92f3lqq8ma5aqid5dm6d8l2dx5";
 
   nativeBuildInputs = [ openssl perl pkgconfig ];
   buildInputs = stdenv.lib.optionals stdenv.isDarwin [ CoreServices Security ];
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage rec {
     description = "A Cargo subcommand for the client-side Web";
     homepage = https://github.com/koute/cargo-web;
     license = with licenses; [ asl20 /* or */ mit ];
-    maintainers = [ maintainers.kevincox ];
+    maintainers = with maintainers; [ kevincox ];
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update `cargo-web` to the latest release.
- https://github.com/koute/cargo-web/releases/tag/0.6.26
- https://github.com/koute/cargo-web#changelog

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @kevincox
