### PR TITLE
hydra-cli: init at 0.2.0

### DIFF
--- a/pkgs/development/tools/misc/hydra-cli/default.nix
+++ b/pkgs/development/tools/misc/hydra-cli/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, lib, pkgconfig, openssl, fetchFromGitHub, rustPlatform, darwin }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "hydra-cli";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "nlewo";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1jdlmc45hwblcxs6hvy3gi2dr7qyzs1sg5zr26jrpxrbvqqzrdhc";
+  };
+
+  cargoSha256 = "0dqj2pdqfbgg8r3h2s07p3m9zgl9xl4vislbqs6a0f1ahrczlda5";
+
+  buildInputs = lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Security ];
+
+  nativeBuildInputs = [
+    pkgconfig
+    openssl
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A client for the Hydra CI";
+    homepage = "https://github.com/nlewo/hydra-cli";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ gilligan lewo ];
+    platforms = platforms.all;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11299,6 +11299,8 @@ in
 
   hydra = callPackage ../development/tools/misc/hydra { };
 
+  hydra-cli = callPackage ../development/tools/misc/hydra-cli { };
+
   hydraAntLogger = callPackage ../development/libraries/java/hydra-ant-logger { };
 
   hyena = callPackage ../development/libraries/hyena { };


### PR DESCRIPTION
Adding [hydra-cli](https://github.com/nlewo/hydra-cli) 

-----

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).