### PR TITLE
proxychains-ng: init at 4.14

### DIFF
--- a/pkgs/tools/networking/proxychains-ng/default.nix
+++ b/pkgs/tools/networking/proxychains-ng/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub }:
+
+let
+  proxychains-ng-src-4-14 = fetchFromGitHub {
+    owner = "rofl0r";
+    repo = "proxychains-ng";
+    rev = "e895fb713ac1c1e92ee0795645f220573181c6fb";
+    sha256 = "03wk2xpxwc7kwlq6z9jf9df1vlh6p0dn0kf826fh1k7nfaa8c4py";
+  };
+in
+stdenv.mkDerivation rec {
+  name = "proxychains-ng-${version}";
+  version = "4.14";
+
+  src = proxychains-ng-src-4-14;
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/rofl0r/proxychains-ng;
+    changelog = "https://github.com/rofl0r/proxychains-ng/tree/v${version}";
+    license = licenses.gpl2;
+    platforms = with platforms; linux ++ freebsd ++ netbsd ++ openbsd ++ darwin;
+    description = "Proxifier";
+  };
+}

--- a/pkgs/tools/networking/proxychains-ng/default.nix
+++ b/pkgs/tools/networking/proxychains-ng/default.nix
@@ -1,25 +1,22 @@
 { stdenv, fetchFromGitHub }:
 
-let
-  proxychains-ng-src-4-14 = fetchFromGitHub {
+stdenv.mkDerivation {
+  pname = "proxychains-ng";
+  version = "4.14";
+
+  src = fetchFromGitHub {
     owner = "rofl0r";
     repo = "proxychains-ng";
     rev = "e895fb713ac1c1e92ee0795645f220573181c6fb";
     sha256 = "03wk2xpxwc7kwlq6z9jf9df1vlh6p0dn0kf826fh1k7nfaa8c4py";
   };
-in
-stdenv.mkDerivation rec {
-  name = "proxychains-ng-${version}";
-  version = "4.14";
-
-  src = proxychains-ng-src-4-14;
   doCheck = true;
 
   meta = with stdenv.lib; {
     homepage = https://github.com/rofl0r/proxychains-ng;
     changelog = "https://github.com/rofl0r/proxychains-ng/tree/v${version}";
     license = licenses.gpl2;
-    platforms = with platforms; linux ++ freebsd ++ netbsd ++ openbsd ++ darwin;
+    platforms = platforms.unix;
     description = "Proxifier";
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add proxychains-ng which is more maintained than proxychains.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).