### PR TITLE
slirp4netns: 0.3.0 -> 0.4.2

### DIFF
--- a/pkgs/tools/networking/slirp4netns/default.nix
+++ b/pkgs/tools/networking/slirp4netns/default.nix
@@ -1,19 +1,19 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, glib }:
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, glib, libcap, libseccomp }:
 
 stdenv.mkDerivation rec {
   pname = "slirp4netns";
-  version = "0.3.0";
+  version = "0.4.2";
 
   src = fetchFromGitHub {
     owner = "rootless-containers";
     repo = "slirp4netns";
     rev = "v${version}";
-    sha256 = "079m44l4l0p1c2sbkpzsy6zpv94glwmrc72ip2djcscnaq4b1763";
+    sha256 = "0i0rhb7n2i2nmbvdqdx83vi3kw4r17p7p099sr857cr3f3c221qx";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
 
-  buildInputs = [ glib ];
+  buildInputs = [ libcap libseccomp glib ];
 
   enableParallelBuilding = true;
 
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/rootless-containers/slirp4netns;
     description = "User-mode networking for unprivileged network namespaces";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ orivej ];
+    maintainers = with maintainers; [ orivej saschagrunert ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update the package to the latest version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @orivej
