### PR TITLE
redis: Try to fix cross-compilation

### DIFF
--- a/pkgs/servers/nosql/redis/default.nix
+++ b/pkgs/servers/nosql/redis/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, lua }:
+{ stdenv, fetchurl, lua, jemalloc }:
 
 stdenv.mkDerivation rec {
   version = "5.0.5";
@@ -9,8 +9,21 @@ stdenv.mkDerivation rec {
     sha256 = "0xd3ak527cnkz2cn422l2ag9nsa6mhv7y2y49zwqy7fjk6bh0f91";
   };
 
+  # Cross-compiling fixes
+  configurePhase = ''
+    ${stdenv.lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+      # This fixes hiredis, which has the AR awkwardly coded.
+      # Probably a good candidate for a patch upstream.
+      makeFlagsArray+=('STLIB_MAKE_CMD=${stdenv.cc.targetPrefix}ar rcs $(STLIBNAME)')
+    ''}
+  '';
+
   buildInputs = [ lua ];
-  makeFlags = "PREFIX=$(out)";
+  # More cross-compiling fixes.
+  # Note: this enables libc malloc as a temporary fix for cross-compiling.
+  # Due to hardcoded configure flags in jemalloc, we can't cross-compile vendored jemalloc properly, and so we're forced to use libc allocator.
+  # It's weird that the build isn't failing because of failure to compile dependencies, it's from failure to link them!
+  makeFlags = "PREFIX=$(out)" + stdenv.lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) " AR=${stdenv.cc.targetPrefix}ar RANLIB=${stdenv.cc.targetPrefix}ranlib MALLOC=libc";
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
**Note**: This makes redis use libc malloc when cross-compiling to ARM. This may or may not degrade performance.

The reason for this is vendored jemalloc with Redis' patches. The makefile for deps has hardcoded configure flags for jemalloc, and as a result, it is unable to cross-compile it.

This may be ugly, and may be rejected. There is an alternative, which is fixing the vendored jemalloc build and sending patches upstream, but I'm proposing this as a temporary fix.

The build for this is available at https://glovebox.fireburn.ru/job/nixos-armv7l/nixos-unstable/redis-libc-malloc, built against latest nixos-unstable channel.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Redis won't cross-compile, particularly for ARM. I'm trying to fix it here.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers
cc @globin @berdario 