### PR TITLE
[19.03] dovecot: 2.3.5.7 -> 2.3.7.2, pigeonhole: 0.5.5 -> 0.5.7.2

### DIFF
--- a/pkgs/servers/mail/dovecot/2.2.x-module_dir.patch
+++ b/pkgs/servers/mail/dovecot/2.2.x-module_dir.patch
@@ -1,8 +1,8 @@
 diff --git a/src/auth/main.c b/src/auth/main.c
-index 5a87c57..74bff52 100644
+index 2dbf9e1..b1e778a 100644
 --- a/src/auth/main.c
 +++ b/src/auth/main.c
-@@ -194,7 +194,7 @@ static void main_preinit(void)
+@@ -192,7 +192,7 @@ static void main_preinit(void)
  	mod_set.debug = global_auth_settings->debug;
  	mod_set.filter_callback = auth_module_filter;
  
@@ -11,7 +11,7 @@ index 5a87c57..74bff52 100644
  	module_dir_init(modules);
  
  	if (!worker)
-@@ -225,7 +225,7 @@ void auth_module_load(const char *names)
+@@ -223,7 +223,7 @@ void auth_module_load(const char *names)
  	mod_set.debug = global_auth_settings->debug;
  	mod_set.ignore_missing = TRUE;
  
@@ -21,19 +21,19 @@ index 5a87c57..74bff52 100644
  	module_dir_init(modules);
  }
 diff --git a/src/config/all-settings.c b/src/config/all-settings.c
-index de223a5..2df2d21 100644
+index 4a2ab53..5057d63 100644
 --- a/src/config/all-settings.c
 +++ b/src/config/all-settings.c
-@@ -836,7 +836,7 @@ static const struct mail_user_settings mail_user_default_settings = {
+@@ -1079,7 +1079,7 @@ static const struct mail_user_settings mail_user_default_settings = {
  	.last_valid_gid = 0,
  
  	.mail_plugins = "",
 -	.mail_plugin_dir = MODULEDIR,
 +	.mail_plugin_dir = "/etc/dovecot/modules",
  
- 	.mail_log_prefix = "%s(%u): ",
+ 	.mail_log_prefix = "%s(%u)<%{pid}><%{session}>: ",
  
-@@ -3545,7 +3545,7 @@ const struct doveadm_settings doveadm_default_settings = {
+@@ -4723,7 +4723,7 @@ const struct doveadm_settings doveadm_default_settings = {
  	.base_dir = PKG_RUNDIR,
  	.libexec_dir = PKG_LIBEXECDIR,
  	.mail_plugins = "",
@@ -43,12 +43,12 @@ index de223a5..2df2d21 100644
  	.auth_socket_path = "auth-userdb",
  	.doveadm_socket_path = "doveadm-server",
 diff --git a/src/config/config-parser.c b/src/config/config-parser.c
-index 2a5009a..134f92b 100644
+index 6894123..07e9fec 100644
 --- a/src/config/config-parser.c
 +++ b/src/config/config-parser.c
-@@ -1047,7 +1047,7 @@ void config_parse_load_modules(void)
+@@ -1077,7 +1077,7 @@ void config_parse_load_modules(void)
  
- 	memset(&mod_set, 0, sizeof(mod_set));
+ 	i_zero(&mod_set);
  	mod_set.abi_version = DOVECOT_ABI_VERSION;
 -	modules = module_dir_load(CONFIG_MODULE_DIR, NULL, &mod_set);
 +	modules = module_dir_load("/etc/dovecot/modules/settings", NULL, &mod_set);
@@ -56,10 +56,10 @@ index 2a5009a..134f92b 100644
  
  	i_array_init(&new_roots, 64);
 diff --git a/src/dict/main.c b/src/dict/main.c
-index e6c945e..06ad6c5 100644
+index 722ed02..4ed12ae 100644
 --- a/src/dict/main.c
 +++ b/src/dict/main.c
-@@ -62,7 +62,7 @@ static void main_init(void)
+@@ -104,7 +104,7 @@ static void main_init(void)
  	mod_set.abi_version = DOVECOT_ABI_VERSION;
  	mod_set.require_init_funcs = TRUE;
  
@@ -69,10 +69,10 @@ index e6c945e..06ad6c5 100644
  
  	/* Register only after loading modules. They may contain SQL drivers,
 diff --git a/src/doveadm/doveadm-settings.c b/src/doveadm/doveadm-settings.c
-index df12284..19c18da 100644
+index 88da40c..141ed05 100644
 --- a/src/doveadm/doveadm-settings.c
 +++ b/src/doveadm/doveadm-settings.c
-@@ -81,7 +81,7 @@ const struct doveadm_settings doveadm_default_settings = {
+@@ -86,7 +86,7 @@ const struct doveadm_settings doveadm_default_settings = {
  	.base_dir = PKG_RUNDIR,
  	.libexec_dir = PKG_LIBEXECDIR,
  	.mail_plugins = "",
@@ -82,7 +82,7 @@ index df12284..19c18da 100644
  	.auth_socket_path = "auth-userdb",
  	.doveadm_socket_path = "doveadm-server",
 diff --git a/src/lib-fs/fs-api.c b/src/lib-fs/fs-api.c
-index b50fbe0..ace3aff 100644
+index a939f61..846cf86 100644
 --- a/src/lib-fs/fs-api.c
 +++ b/src/lib-fs/fs-api.c
 @@ -114,7 +114,7 @@ static void fs_class_try_load_plugin(const char *driver)
@@ -95,10 +95,10 @@ index b50fbe0..ace3aff 100644
  	module_dir_init(fs_modules);
  
 diff --git a/src/lib-ssl-iostream/iostream-ssl.c b/src/lib-ssl-iostream/iostream-ssl.c
-index a0659ab..dba3729 100644
+index f857ec9..0d1023b 100644
 --- a/src/lib-ssl-iostream/iostream-ssl.c
 +++ b/src/lib-ssl-iostream/iostream-ssl.c
-@@ -34,7 +34,7 @@ static int ssl_module_load(const char **error_r)
+@@ -53,7 +53,7 @@ int ssl_module_load(const char **error_r)
  	mod_set.abi_version = DOVECOT_ABI_VERSION;
  	mod_set.setting_name = "<built-in lib-ssl-iostream lookup>";
  	mod_set.require_init_funcs = TRUE;
@@ -108,15 +108,28 @@ index a0659ab..dba3729 100644
  					&mod_set, error_r) < 0)
  		return -1;
 diff --git a/src/lib-storage/mail-storage-settings.c b/src/lib-storage/mail-storage-settings.c
-index e2233bf..bbf981e 100644
+index b314b52..7055094 100644
 --- a/src/lib-storage/mail-storage-settings.c
 +++ b/src/lib-storage/mail-storage-settings.c
-@@ -274,7 +274,7 @@ static const struct mail_user_settings mail_user_default_settings = {
+@@ -337,7 +337,7 @@ static const struct mail_user_settings mail_user_default_settings = {
  	.last_valid_gid = 0,
  
  	.mail_plugins = "",
 -	.mail_plugin_dir = MODULEDIR,
 +	.mail_plugin_dir = "/etc/dovecot/modules",
  
- 	.mail_log_prefix = "%s(%u): ",
+ 	.mail_log_prefix = "%s(%u)<%{pid}><%{session}>: ",
  
+diff --git a/src/lmtp/lmtp-settings.c b/src/lmtp/lmtp-settings.c
+index 1666ec9..8a27200 100644
+--- a/src/lmtp/lmtp-settings.c
++++ b/src/lmtp/lmtp-settings.c
+@@ -89,7 +89,7 @@ static const struct lmtp_settings lmtp_default_settings = {
+ 	.login_trusted_networks = "",
+ 
+ 	.mail_plugins = "",
+-	.mail_plugin_dir = MODULEDIR,
++	.mail_plugin_dir = "/etc/dovecot/modules",
+ };
+ 
+ static const struct setting_parser_info *lmtp_setting_dependencies[] = {

--- a/pkgs/servers/mail/dovecot/default.nix
+++ b/pkgs/servers/mail/dovecot/default.nix
@@ -9,7 +9,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "dovecot-2.3.5.2";
+  name = "dovecot-2.3.6";
 
   nativeBuildInputs = [ perl pkgconfig ];
   buildInputs =
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://dovecot.org/releases/2.3/${name}.tar.gz";
-    sha256 = "1whvyg087sjhkd8r0xnk4ij105j135acnfxq6n58c6nqxwdf855s";
+    sha256 = "1irnalplb47nlc26dn7zzdi95zhrxxi3miza7p3wdsgapv0qs7gd";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/servers/mail/dovecot/default.nix
+++ b/pkgs/servers/mail/dovecot/default.nix
@@ -9,7 +9,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "dovecot-2.3.6";
+  name = "dovecot-2.3.7";
 
   nativeBuildInputs = [ perl pkgconfig ];
   buildInputs =
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://dovecot.org/releases/2.3/${name}.tar.gz";
-    sha256 = "1irnalplb47nlc26dn7zzdi95zhrxxi3miza7p3wdsgapv0qs7gd";
+    sha256 = "1al382ykm94if5agasb9h2442a8s7wn43hlwh292ir1rhnp5dq8i";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/servers/mail/dovecot/default.nix
+++ b/pkgs/servers/mail/dovecot/default.nix
@@ -9,7 +9,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "dovecot-2.3.7.1";
+  name = "dovecot-2.3.7.2";
 
   nativeBuildInputs = [ perl pkgconfig ];
   buildInputs =
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://dovecot.org/releases/2.3/${name}.tar.gz";
-    sha256 = "1hq333vj4px4xa9djl8c1v3c8rac98v2mrb9vx1wisg6frpiv9f5";
+    sha256 = "0q0jgcv3ni2znkgyhc966ffphj1wk73y76wssh0yciqafs2f0v36";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/servers/mail/dovecot/default.nix
+++ b/pkgs/servers/mail/dovecot/default.nix
@@ -9,7 +9,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "dovecot-2.3.7";
+  name = "dovecot-2.3.7.1";
 
   nativeBuildInputs = [ perl pkgconfig ];
   buildInputs =
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://dovecot.org/releases/2.3/${name}.tar.gz";
-    sha256 = "1al382ykm94if5agasb9h2442a8s7wn43hlwh292ir1rhnp5dq8i";
+    sha256 = "1hq333vj4px4xa9djl8c1v3c8rac98v2mrb9vx1wisg6frpiv9f5";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/servers/mail/dovecot/default.nix
+++ b/pkgs/servers/mail/dovecot/default.nix
@@ -43,30 +43,6 @@ stdenv.mkDerivation rec {
     # so we can symlink plugins from several packages there.
     # The symlinking needs to be done in NixOS.
     ./2.2.x-module_dir.patch
-
-    (fetchpatch {
-      name = "CVE-2019-11494.patch";
-      url = https://github.com/dovecot/core/commit/f79745dae4a9a5fca33320e03a4fc9064b88d01e.patch;
-      sha256 = "0qyhcw8xsnjhk7s29mhsqa46m28r2bcjz7bxbjr48d7wl9r3v3fm";
-    })
-    (fetchpatch {
-      name = "CVE-2019-11499.patch";
-      url = https://github.com/dovecot/core/commit/e9d60648abb9bbceff89882a5309cb9532e702e9.patch;
-      sha256 = "1di6adkd8f6gjkpf8aiqxzwvscsq188qqah6b7r23q9j3zlv47mv";
-    })
-
-    (fetchpatch {
-      name = "CVE-2019-11500-1.patch";
-      url = https://github.com/dovecot/core/commit/85fcb895ca7f0bcb8ee72047fe0e1e78532ff90b.patch;
-      sha256 = "0cn0sk5giaf2z26zp53cj9h0xcbj347ad6zgp2k377fphn9yjcc5";
-    })
-
-    (fetchpatch {
-      name = "CVE-2019-11500-2.patch";
-      url = https://github.com/dovecot/core/commit/f904cbdfec25582bc5e2a7435bf82ff769f2526a.patch;
-      sha256 = "1dcp8axbpcib837n2x54xxylyglbh2zh9bf0y3vpvmapya162s1a";
-    })
-
   ];
 
   configureFlags = [

--- a/pkgs/servers/mail/dovecot/plugins/pigeonhole/default.nix
+++ b/pkgs/servers/mail/dovecot/plugins/pigeonhole/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "dovecot-pigeonhole-${version}";
-  version = "0.5.5";
+  version = "0.5.6";
 
   src = fetchurl {
     url = "https://pigeonhole.dovecot.org/releases/2.3/dovecot-2.3-pigeonhole-${version}.tar.gz";
-    sha256 = "19a9a6rdvdlrm00k2npprj6lrikjhngnmpgg412848rb3ip11anb";
+    sha256 = "1f7m2213w4hvqr3lvr03bv4lh92k35gxl01c2x8q8akk7viffbvw";
   };
 
   buildInputs = [ dovecot openssl ];

--- a/pkgs/servers/mail/dovecot/plugins/pigeonhole/default.nix
+++ b/pkgs/servers/mail/dovecot/plugins/pigeonhole/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "dovecot-pigeonhole-${version}";
-  version = "0.5.6";
+  version = "0.5.7.1";
 
   src = fetchurl {
     url = "https://pigeonhole.dovecot.org/releases/2.3/dovecot-2.3-pigeonhole-${version}.tar.gz";
-    sha256 = "1f7m2213w4hvqr3lvr03bv4lh92k35gxl01c2x8q8akk7viffbvw";
+    sha256 = "0a10mam68pmdh3fw8fnv5jff6xj1k770hvadym2c39vm3x6b4w1j";
   };
 
   buildInputs = [ dovecot openssl ];

--- a/pkgs/servers/mail/dovecot/plugins/pigeonhole/default.nix
+++ b/pkgs/servers/mail/dovecot/plugins/pigeonhole/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "dovecot-pigeonhole-${version}";
-  version = "0.5.7.1";
+  version = "0.5.7.2";
 
   src = fetchurl {
     url = "https://pigeonhole.dovecot.org/releases/2.3/dovecot-2.3-pigeonhole-${version}.tar.gz";
-    sha256 = "0a10mam68pmdh3fw8fnv5jff6xj1k770hvadym2c39vm3x6b4w1j";
+    sha256 = "1c0ijjmdskxydmvfk8ixxgg8ndnxx1smvycbp7jjd895a9f0r7fm";
   };
 
   buildInputs = [ dovecot openssl ];

--- a/pkgs/servers/mail/dovecot/plugins/pigeonhole/default.nix
+++ b/pkgs/servers/mail/dovecot/plugins/pigeonhole/default.nix
@@ -12,16 +12,6 @@ stdenv.mkDerivation rec {
   buildInputs = [ dovecot openssl ];
 
   patches = [
-    (fetchpatch {
-      name = "CVE-2019-11500-1.patch";
-      url = https://github.com/dovecot/pigeonhole/commit/7ce9990a5e6ba59e89b7fe1c07f574279aed922c.patch;
-      sha256 = "07l4m2wkqn910zb8d477q6asryfqzhbhxl4fl0w89s763maiam9v";
-    })
-    (fetchpatch {
-      name = "CVE-2019-11500-2.patch";
-      url = https://github.com/dovecot/pigeonhole/commit/4a299840cdb51f61f8d1ebc0210b19c40dfbc1cc.patch;
-      sha256 = "1p7jl3fcxr63yrgj5m11sbmbfnibrx5v9aifscn1wq858jnn8myf";
-    })
   ];
 
   preConfigure = ''


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Dovecot minor versions should be upgradeable without any incompatibilities, so picking just the security patches risks missing some commits that are by themselves not security fixes, but are required for later security fixes. Moving to the current supported version also eases support.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers
cc @andir @peti @rickynils @fpletz