### PR TITLE
twitter-color-emoji: init at 12.1.2

### DIFF
--- a/pkgs/data/fonts/noto-fonts/tools.nix
+++ b/pkgs/data/fonts/noto-fonts/tools.nix
@@ -1,14 +1,14 @@
 { fetchFromGitHub, pythonPackages, lib }:
 
 pythonPackages.buildPythonPackage rec {
-  version = "2017-09-25";
+  version = "unstable-2019-03-20";
   name = "nototools-${version}";
 
   src = fetchFromGitHub {
-    owner = "googlei18n";
+    owner = "googlefonts";
     repo = "nototools";
-    rev = "v2017-09-25-tooling-for-phase3-update";
-    sha256 = "03nzvcvwmrhfrcjhg218q2f3hfrm3vlivp4rk19sc397kh3hisiz";
+    rev = "9c4375f07c9adc00c700c5d252df6a25d7425870";
+    sha256 = "0z9i23vl6xar4kvbqbc8nznq3s690mqc5zfv280l1c02l5n41smc";
   };
 
   propagatedBuildInputs = with pythonPackages; [ fonttools numpy ];
@@ -26,6 +26,6 @@ pythonPackages.buildPythonPackage rec {
   meta = {
     description = "Noto fonts support tools and scripts plus web site generation";
     license = lib.licenses.asl20;
-    homepage = https://github.com/googlei18n/nototools;
+    homepage = https://github.com/googlefonts/nototools;
   };
 }

--- a/pkgs/data/fonts/twitter-color-emoji/default.nix
+++ b/pkgs/data/fonts/twitter-color-emoji/default.nix
@@ -1,0 +1,122 @@
+# Based upon https://src.fedoraproject.org/rpms/twitter-twemoji-fonts/tree/454acad50ba584d9602ccd4238fc5e585abc15c9
+# The main difference is that we use “Twitter Color Emoji” name (which is recognized by upstream fontconfig)
+
+{ stdenv
+, fetchFromGitHub
+, cairo
+, imagemagick
+, pkg-config
+, pngquant
+, python2
+, which
+, zopfli
+}:
+
+let
+  version = "12.1.2";
+
+  # Cannot use noto-fonts-emoji.src since it is too old
+  # and still tries to use vendored pngquant.
+  notoSrc = fetchFromGitHub {
+    name = "noto";
+    owner = "googlefonts";
+    repo = "noto-emoji";
+    rev = "833a43d03246a9325e748a2d783006454d76ff66";
+    sha256 = "1g6ikzk8banm3ihqm9g27ggjq2mn1b1hq3zhpl13lxid6mp60s4a";
+  };
+
+  twemojiSrc = fetchFromGitHub {
+    name = "twemoji";
+    owner = "twitter";
+    repo = "twemoji";
+    rev = "v${version}";
+    sha256 = "0vzmlp83vnk4njcfkn03jcc1vkg2rf12zf5kj3p3a373xr4ds1zn";
+  };
+
+  python = python2.withPackages (pp: with pp; [
+    nototools
+  ]);
+in
+stdenv.mkDerivation rec {
+  pname = "twitter-color-emoji";
+  inherit version;
+
+  srcs = [
+    notoSrc
+    twemojiSrc
+  ];
+
+  sourceRoot = notoSrc.name;
+
+  postUnpack = ''
+    chmod -R +w ${twemojiSrc.name}
+    mv ${twemojiSrc.name} ${notoSrc.name}
+  '';
+
+  nativeBuildInputs = [
+    cairo
+    imagemagick
+    pkg-config
+    pngquant
+    python
+    which
+    zopfli
+  ];
+
+  postPatch = let
+    templateSubstitutions = stdenv.lib.concatStringsSep "; " [
+      ''s#Noto Color Emoji#Twitter Color Emoji#''
+      ''s#NotoColorEmoji#TwitterColorEmoji#''
+      ''s#Copyright .* Google Inc\.#Twitter, Inc and other contributors.#''
+      ''s# Version .*# ${version}#''
+      ''s#.*is a trademark.*##''
+      ''s#Google, Inc\.#Twitter, Inc and other contributors#''
+      ''s#http://www.google.com/get/noto/#https://twemoji.twitter.com/#''
+      ''s#.*is licensed under.*#      Creative Commons Attribution 4.0 International#''
+      ''s#http://scripts.sil.org/OFL#http://creativecommons.org/licenses/by/4.0/#''
+    ];
+  in ''
+    patchShebangs ./flag_glyph_name.py
+
+    sed '${templateSubstitutions}' NotoColorEmoji.tmpl.ttx.tmpl > TwitterColorEmoji.tmpl.ttx.tmpl
+    pushd ${twemojiSrc.name}/assets/72x72/
+    for png in *.png; do
+        mv $png emoji_u''${png//-/_}
+    done
+    popd
+  '';
+
+  makeFlags = [
+    "EMOJI=TwitterColorEmoji"
+    "EMOJI_SRC_DIR=${twemojiSrc.name}/assets/72x72"
+    "BODY_DIMENSIONS=76x72"
+  ];
+
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    install -Dm644 TwitterColorEmoji.ttf $out/share/fonts/truetype/TwitterColorEmoji.ttf
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Color emoji font with a flat visual style, designed and used by Twitter";
+    longDescription = ''
+      A bitmap color emoji font built from the Twitter Emoji for
+      Everyone artwork with support for ZWJ, skin tone diversity and country
+      flags.
+
+      This font uses Google’s CBDT format making it work on Android and Linux graphical stack.
+    '';
+    homepage = "https://twemoji.twitter.com/";
+    # In noto-emoji-fonts source
+    ## noto-emoji code is in ASL 2.0 license
+    ## Emoji fonts are under OFL license
+    ### third_party color-emoji code is in ASL 2.0 license
+    ### third_party region-flags code is in Public Domain license
+    # In twemoji source
+    ## Artwork is Creative Commons Attribution 4.0 International
+    ## Non-artwork is MIT
+    license = with licenses; [ asl20 ofl cc-by-40 mit ];
+    maintainers = with maintainers; [ jtojnar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17137,6 +17137,8 @@ in
     inherit (nodePackages) svgo;
   };
 
+  twitter-color-emoji = callPackage ../data/fonts/twitter-color-emoji { };
+
   tzdata = callPackage ../data/misc/tzdata { };
 
   ubuntu_font_family = callPackage ../data/fonts/ubuntu-font-family { };


### PR DESCRIPTION
I needed some free color emoji font for testing https://github.com/NixOS/nixpkgs/pull/67667. We only had Noto Color Emoji in nixpkgs – other fonts were either non-free (JoyPixels), or used fontconfig-incompatible SVG-in-OpenType format (Emoji One and TwEmoji).

- [x] Tested that this font renders properly
- Successfully built:
  - [x] python2Packages.nototools
  - [x] twitter-color-emoji (~30 min)
  - [x] noto-emoji-fonts (~10 min)