### PR TITLE
nodePackages.makam: init at 0.7.17

### DIFF
--- a/pkgs/development/node-packages/default-v12.nix
+++ b/pkgs/development/node-packages/default-v12.nix
@@ -7,6 +7,14 @@ let
   };
 in
 nodePackages // {
+  makam =  nodePackages.makam.override {
+    buildInputs = [ pkgs.nodejs pkgs.makeWrapper ];
+    postFixup = ''
+      wrapProgram "$out/bin/makam" --prefix PATH : ${stdenv.lib.makeBinPath [ pkgs.nodejs ]}
+      patchelf --set-interpreter ${stdenv.glibc}/lib/ld-linux-x86-64.so.2 "$out/lib/node_modules/makam/makam-bin-linux64"
+    '';
+  };
+
   node2nix = nodePackages.node2nix.override {
     buildInputs = [ pkgs.makeWrapper ];
     postInstall = ''

--- a/pkgs/development/node-packages/node-packages-v10.nix
+++ b/pkgs/development/node-packages/node-packages-v10.nix
@@ -13,67 +13,67 @@ let
         sha512 = "t4WmWoGV9gyzypwG3y3JlcK2t8fKLtvzBA7xEoFTj9SMPvOuLsf13uh4ikK0RRaaa9RPPWLgFUdOyIRaQvCpwQ==";
       };
     };
-    "@angular-devkit/architect-0.802.0" = {
+    "@angular-devkit/architect-0.803.2" = {
       name = "_at_angular-devkit_slash_architect";
       packageName = "@angular-devkit/architect";
-      version = "0.802.0";
+      version = "0.803.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.802.0.tgz";
-        sha512 = "Zd/ao7uE8ctV4n6drKl35cK5xrRsmgva7lsiBRc4J09vDWaRrCsxTKr6nw1gkFBDuSGZc9OmvtEFFPg2I/YHwQ==";
+        url = "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.803.2.tgz";
+        sha512 = "1HFuZzMOFhVmbfoNwbYDLU3hhYMFmtB0eve/dB4KEvCFq6AEoFPVc5xt4tWpeN41wISfiCgxf5kHE3y07g0Yag==";
       };
     };
-    "@angular-devkit/core-8.2.0" = {
+    "@angular-devkit/core-8.3.2" = {
       name = "_at_angular-devkit_slash_core";
       packageName = "@angular-devkit/core";
-      version = "8.2.0";
+      version = "8.3.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@angular-devkit/core/-/core-8.2.0.tgz";
-        sha512 = "jZQn5hQ84++00+yuD/Ak303/Q06keFVyd+QbSfVrpHTFyOwPeNNSPLbN6A0S7X3bKOuoZhUHg+eQBa5BljVC2g==";
+        url = "https://registry.npmjs.org/@angular-devkit/core/-/core-8.3.2.tgz";
+        sha512 = "jFrBGPJBhy4D4foH9YHDrlbqGmb+ZivTKtHnR4yV241VUd3W53+KABrvPyHeS5xk/aHTRsm76rx6l+UREEEUkw==";
       };
     };
-    "@angular-devkit/schematics-8.2.0" = {
+    "@angular-devkit/schematics-8.3.2" = {
       name = "_at_angular-devkit_slash_schematics";
       packageName = "@angular-devkit/schematics";
-      version = "8.2.0";
+      version = "8.3.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-8.2.0.tgz";
-        sha512 = "/XUWJijLXzhtWdjoQ5ioLo5r5V5+sJ0SSnSP0N8MQyLOgTd1FDGtBMsAMJ3n2/uwUl2/O9WTlV1xNLlg7neYVQ==";
+        url = "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-8.3.2.tgz";
+        sha512 = "WwiHtDeW7+Gw5pukdjyuwQ+Ino7AFnoKUqqYrsTwPnNky+p8JVT4tY6jTxwenOLOVsLSDz5oVn9jk5u70HLX4Q==";
       };
     };
-    "@antora/asciidoc-loader-2.0.0" = {
+    "@antora/asciidoc-loader-2.1.0" = {
       name = "_at_antora_slash_asciidoc-loader";
       packageName = "@antora/asciidoc-loader";
-      version = "2.0.0";
+      version = "2.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@antora/asciidoc-loader/-/asciidoc-loader-2.0.0.tgz";
-        sha512 = "kbpSBMM618Do5dXtG5mC5kk8VEXYDsciJ0orw7vrYeFzRBbR4Y4qpzbsQeuQNB4r2iLoztxErvg04SBb5CsGdQ==";
+        url = "https://registry.npmjs.org/@antora/asciidoc-loader/-/asciidoc-loader-2.1.0.tgz";
+        sha512 = "7fI/aunFYeXAaBHQi+Blzh2QwVXw/uJd/HWWdvPhG7Det/munIVeZFfmpxPkiWDrjyjImVNt9RSnhcRt4e5Ymg==";
       };
     };
-    "@antora/content-aggregator-2.0.0" = {
+    "@antora/content-aggregator-2.1.0" = {
       name = "_at_antora_slash_content-aggregator";
       packageName = "@antora/content-aggregator";
-      version = "2.0.0";
+      version = "2.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@antora/content-aggregator/-/content-aggregator-2.0.0.tgz";
-        sha512 = "24JQSDQZ609yJHs7abIqF5FikNg0EWvFwBYck1Kbl5vRikmDTpSMBhhPKJhAVe4lREm6/FVYO7t9CEmjp69prA==";
+        url = "https://registry.npmjs.org/@antora/content-aggregator/-/content-aggregator-2.1.0.tgz";
+        sha512 = "b/bWoP7WfAVUms6Rfz26vufeDjAiIdaU91WR69jaQS8OL4DF5hOdtYKpdW2mHj+uBvhoLmb+6yoPDsp5wqHHmg==";
       };
     };
-    "@antora/content-classifier-2.0.0" = {
+    "@antora/content-classifier-2.1.0" = {
       name = "_at_antora_slash_content-classifier";
       packageName = "@antora/content-classifier";
-      version = "2.0.0";
+      version = "2.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@antora/content-classifier/-/content-classifier-2.0.0.tgz";
-        sha512 = "d1MB57X3AaXy30rw+dudxbJ2cdw/Uk1U4JxHbWIkdrEJKty2fbnBu3xjyb70qAv5G0ayovJpqZOaR+YwS0ibbQ==";
+        url = "https://registry.npmjs.org/@antora/content-classifier/-/content-classifier-2.1.0.tgz";
+        sha512 = "ip4QvgQFtyFLrFX+stjnonNDpejT1PjC5xVCTqqjjYb7DnT1UiAzUw8I/VW+MCgIwLFRq6baNrKjN2DblwJU2w==";
       };
     };
-    "@antora/document-converter-2.0.0" = {
+    "@antora/document-converter-2.1.0" = {
       name = "_at_antora_slash_document-converter";
       packageName = "@antora/document-converter";
-      version = "2.0.0";
+      version = "2.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@antora/document-converter/-/document-converter-2.0.0.tgz";
-        sha512 = "8slnLdeMxI4kU64fMsNp58HjpFYZ7chrl5tCYr1/4Jr00fVHwn8vx2YS1cKyowcrmb9uG6YI/pMNt9F3kjTtYA==";
+        url = "https://registry.npmjs.org/@antora/document-converter/-/document-converter-2.1.0.tgz";
+        sha512 = "T/fCg0vCRgFb/H1jlC4dryrMOfW9K7c2OGCWRmJ6kKkp52jx4zj1xbWPNiqzJ09COdak8y+t+9NCQoCxbdI8zw==";
       };
     };
     "@antora/expand-path-helper-1.0.0" = {
@@ -85,67 +85,67 @@ let
         sha512 = "hg3y6M3OvRTb7jtLAnwwloYDxafbyKYttcf16kGCXvP7Wqosh7c+Ag+ltaZ7VSebpzpphO/umb/BXdpU7rxapw==";
       };
     };
-    "@antora/navigation-builder-2.0.0" = {
+    "@antora/navigation-builder-2.1.0" = {
       name = "_at_antora_slash_navigation-builder";
       packageName = "@antora/navigation-builder";
-      version = "2.0.0";
+      version = "2.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@antora/navigation-builder/-/navigation-builder-2.0.0.tgz";
-        sha512 = "tuI2dNDy9sqgkHoiqn52M0lWrxxOafrEUIPSskjyGf0MjFP3pBPKnHiBmAl2r+NhXCAfcIb5khe4rSS18bfiVA==";
+        url = "https://registry.npmjs.org/@antora/navigation-builder/-/navigation-builder-2.1.0.tgz";
+        sha512 = "57ZPdc/EMeGrQp6TilBclbvblUtyTTaQ2ufS+fIj0L3WKxTsXSLdg3ff7efq8V4JJfsxTTW8oEUI+u/rx/Wn1A==";
       };
     };
-    "@antora/page-composer-2.0.0" = {
+    "@antora/page-composer-2.1.0" = {
       name = "_at_antora_slash_page-composer";
       packageName = "@antora/page-composer";
-      version = "2.0.0";
+      version = "2.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@antora/page-composer/-/page-composer-2.0.0.tgz";
-        sha512 = "1I0vhO6UCyNJRLYICTU+jCTEmkHeJ13tao0nfOOAiSyamDkyX7vM935qfzGBjwZdur8Clq4jpiCuvFTmXMtIfQ==";
+        url = "https://registry.npmjs.org/@antora/page-composer/-/page-composer-2.1.0.tgz";
+        sha512 = "ElluPYhzuhaM/vOY0GWq6M3anhDMroNBKu20MzXVFV+Iubs8bGDZlcryCfeKsKHZPbgGWyqLOgt+CCj4v2KNDQ==";
       };
     };
-    "@antora/playbook-builder-2.0.0" = {
+    "@antora/playbook-builder-2.1.0" = {
       name = "_at_antora_slash_playbook-builder";
       packageName = "@antora/playbook-builder";
-      version = "2.0.0";
+      version = "2.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@antora/playbook-builder/-/playbook-builder-2.0.0.tgz";
-        sha512 = "uLU4+rpIRZiMit8s1lkbiz5L5V8cPL40RJMRHFb4B7k2PXbvNiZZAMHZBeFgVwfJIKmKAIeUCDgOHgiBIlFc+A==";
+        url = "https://registry.npmjs.org/@antora/playbook-builder/-/playbook-builder-2.1.0.tgz";
+        sha512 = "2+AFGNc6lVxpTxHM/mkRVkc/5sJc0ORe3VdT2HazEd43Ir6t7V3Nxcd9sUHBUxd3YXrR1IgE/xmE0fQEeRptYA==";
       };
     };
-    "@antora/redirect-producer-2.0.0" = {
+    "@antora/redirect-producer-2.1.0" = {
       name = "_at_antora_slash_redirect-producer";
       packageName = "@antora/redirect-producer";
-      version = "2.0.0";
+      version = "2.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@antora/redirect-producer/-/redirect-producer-2.0.0.tgz";
-        sha512 = "qlRPGNAhtbIOWK9XHEdH4Iiaz1/8SBvm5rK46R4YinjZqMibMehOfFoIdRf2qsE9mfOsYKwKUSF8Jnv/emXuJw==";
+        url = "https://registry.npmjs.org/@antora/redirect-producer/-/redirect-producer-2.1.0.tgz";
+        sha512 = "4HBcrGV5SQSKAhh1MLFs/3ewknmGD4Cu+pJtiwMbN5rXDSCcKtJ1ADjE5Llw+Dy1jTbujGNheGGyU2Up+FQeBA==";
       };
     };
-    "@antora/site-mapper-2.0.0" = {
+    "@antora/site-mapper-2.1.0" = {
       name = "_at_antora_slash_site-mapper";
       packageName = "@antora/site-mapper";
-      version = "2.0.0";
+      version = "2.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@antora/site-mapper/-/site-mapper-2.0.0.tgz";
-        sha512 = "rPpDLuJbM7c0fNpzf95qrxsjzNAXuyACXE+FXUOwmFp3SYIFGEWATLk1MMNes7SfLAchMMVwjEr1Uii3D5+/Mw==";
+        url = "https://registry.npmjs.org/@antora/site-mapper/-/site-mapper-2.1.0.tgz";
+        sha512 = "Bo/lQfNYa3EdrfGGp9s6+1oDM9F7rjBl3HllzpSIcZatb22bA6cRNGzETuhjyOuGndCD57BKFq5wGOhU+32pkQ==";
       };
     };
-    "@antora/site-publisher-2.0.0" = {
+    "@antora/site-publisher-2.1.0" = {
       name = "_at_antora_slash_site-publisher";
       packageName = "@antora/site-publisher";
-      version = "2.0.0";
+      version = "2.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@antora/site-publisher/-/site-publisher-2.0.0.tgz";
-        sha512 = "kjKfQSEpcLiw653h9IzCG+L9sYm/v9GXAcbzXN1IYoNPO1Od0EPQ2RXGviqeQNYcWJLyRq48cQpNx7o2/KqVag==";
+        url = "https://registry.npmjs.org/@antora/site-publisher/-/site-publisher-2.1.0.tgz";
+        sha512 = "k6Fg+krmAPTzPUl6MgqOOxsx8ggkHcPkVi5R28vCUegs2N9iWuFOBBJz+1YpfSoE/7TWOisBvw3xj+T0XzbvFA==";
       };
     };
-    "@antora/ui-loader-2.0.0" = {
+    "@antora/ui-loader-2.1.0" = {
       name = "_at_antora_slash_ui-loader";
       packageName = "@antora/ui-loader";
-      version = "2.0.0";
+      version = "2.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@antora/ui-loader/-/ui-loader-2.0.0.tgz";
-        sha512 = "CaD+Dp13G7EZhEr6Jg6OEvPHjJZ2FROXwdaY4XP+vBrKmI+QZwS3V+uG0NYbCRxhR1W8N8CYm5hc1UTvGH19cA==";
+        url = "https://registry.npmjs.org/@antora/ui-loader/-/ui-loader-2.1.0.tgz";
+        sha512 = "AteE7BfrzCQOj4k7FZODbM3E5H4VLUArcM4WXxHA4de86zfaQ6ILpwFfaX0Tm2WOFnX9UJDGdrpS/Y4mZROc5g==";
       };
     };
     "@apollographql/apollo-tools-0.4.0" = {
@@ -1246,13 +1246,13 @@ let
         sha512 = "k1WGfKRQyhJpIr+P17O5vLIo2ko1PFLKwoetatdduUSt/aQ4J2sJrJwwatdI5Z3SiYk/mRH9S3JpdmMFd/IK4g==";
       };
     };
-    "@evocateur/pacote-9.6.3" = {
+    "@evocateur/pacote-9.6.5" = {
       name = "_at_evocateur_slash_pacote";
       packageName = "@evocateur/pacote";
-      version = "9.6.3";
+      version = "9.6.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@evocateur/pacote/-/pacote-9.6.3.tgz";
-        sha512 = "ExqNqcbdHQprEgKnY/uQz7WRtyHRbQxRl4JnVkSkmtF8qffRrF9K+piZKNLNSkRMOT/3H0e3IP44QVCHaXMWOQ==";
+        url = "https://registry.npmjs.org/@evocateur/pacote/-/pacote-9.6.5.tgz";
+        sha512 = "EI552lf0aG2nOV8NnZpTxNo2PcXKPmDbF9K8eCBFQdIZwHNGN/mi815fxtmUMa2wTa1yndotICIDt/V0vpEx2w==";
       };
     };
     "@gulp-sourcemaps/identity-map-1.0.2" = {
@@ -1282,49 +1282,40 @@ let
         sha512 = "mV6T0IYqb0xL1UALPFplXYQmR0twnXG0M6jUswpquqT2sD12BOiCiLy3EvMp/Fy7s3DZElC4/aPjEjo2jeZpvw==";
       };
     };
-    "@hapi/hoek-6.2.4" = {
-      name = "_at_hapi_slash_hoek";
-      packageName = "@hapi/hoek";
-      version = "6.2.4";
+    "@hapi/bourne-1.3.2" = {
+      name = "_at_hapi_slash_bourne";
+      packageName = "@hapi/bourne";
+      version = "1.3.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz";
-        sha512 = "HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==";
+        url = "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz";
+        sha512 = "1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==";
       };
     };
-    "@hapi/hoek-8.1.0" = {
+    "@hapi/hoek-8.2.1" = {
       name = "_at_hapi_slash_hoek";
       packageName = "@hapi/hoek";
-      version = "8.1.0";
+      version = "8.2.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.1.0.tgz";
-        sha512 = "b1J4jxYnW+n6lC91V6Pqg9imP9BZq0HNCeM+3sbXg05rQsE9cGYrKFpZjyztVesGmNRE6R+QaEoWGATeIiUVjA==";
+        url = "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.2.1.tgz";
+        sha512 = "JPiBy+oSmsq3St7XlipfN5pNA6bDJ1kpa73PrK/zR29CVClDVqy04AanM/M/qx5bSF+I61DdCfAvRrujau+zRg==";
       };
     };
-    "@hapi/joi-15.1.0" = {
+    "@hapi/joi-15.1.1" = {
       name = "_at_hapi_slash_joi";
       packageName = "@hapi/joi";
-      version = "15.1.0";
+      version = "15.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.0.tgz";
-        sha512 = "n6kaRQO8S+kepUTbXL9O/UOL788Odqs38/VOfoCrATDtTvyfiO3fgjlSRaNkHabpTLgM7qru9ifqXlXbXk8SeQ==";
+        url = "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz";
+        sha512 = "entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==";
       };
     };
-    "@hapi/marker-1.0.0" = {
-      name = "_at_hapi_slash_marker";
-      packageName = "@hapi/marker";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@hapi/marker/-/marker-1.0.0.tgz";
-        sha512 = "JOfdekTXnJexfE8PyhZFyHvHjt81rBFSAbTIRAhF2vv/2Y1JzoKsGqxH/GpZJoF7aEfYok8JVcAHmSz1gkBieA==";
-      };
-    };
-    "@hapi/topo-3.1.2" = {
+    "@hapi/topo-3.1.3" = {
       name = "_at_hapi_slash_topo";
       packageName = "@hapi/topo";
-      version = "3.1.2";
+      version = "3.1.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.2.tgz";
-        sha512 = "r+aumOqJ5QbD6aLPJWqVjMAPsx5pZKz+F5yPqXZ/WWG9JTtHbQqlzrJoknJ0iJxLj9vlXtmpSdjlkszseeG8OA==";
+        url = "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.3.tgz";
+        sha512 = "JmS9/vQK6dcUYn7wc2YZTqzIKubAQcJKu2KCKAru6es482U5RT5fP1EXCPtlXpiK7PR0On/kpQKI4fRKkzpZBQ==";
       };
     };
     "@iarna/toml-2.2.3" = {
@@ -1336,94 +1327,94 @@ let
         sha512 = "FmuxfCuolpLl0AnQ2NHSzoUKWEJDFl63qXjzdoWBVyFCXzMGm1spBzk7LeHNoVCiWCF7mRVms9e6jEV9+MoPbg==";
       };
     };
-    "@ionic/cli-framework-2.1.2" = {
+    "@ionic/cli-framework-2.1.6" = {
       name = "_at_ionic_slash_cli-framework";
       packageName = "@ionic/cli-framework";
-      version = "2.1.2";
+      version = "2.1.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ionic/cli-framework/-/cli-framework-2.1.2.tgz";
-        sha512 = "PQZ5+T2ccVHTA3tnuGOarQhjB6lkeU9SaVzbkgyUHzBxadfenLFffEyLz7WHaLVQfR2po19NIJ2Hy8dIFKepig==";
+        url = "https://registry.npmjs.org/@ionic/cli-framework/-/cli-framework-2.1.6.tgz";
+        sha512 = "V0jkrOXfPes0N1ECmiWDgcRZSaWq7PUFCctMNNqe4xwbQ61aDNypEIQCvVdgIk16zVBKrMI4EP94Qplvi6CYGw==";
       };
     };
-    "@ionic/discover-2.0.2" = {
+    "@ionic/discover-2.0.5" = {
       name = "_at_ionic_slash_discover";
       packageName = "@ionic/discover";
-      version = "2.0.2";
+      version = "2.0.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ionic/discover/-/discover-2.0.2.tgz";
-        sha512 = "W4AMv6bmJzKtAz92m7XA+6rCkvO/9Q6+BJzrO9KD3qIt4rIH//CZP05yFK79XlqI3Vt4Ke0GsqBDuEfgBXaN/Q==";
+        url = "https://registry.npmjs.org/@ionic/discover/-/discover-2.0.5.tgz";
+        sha512 = "4gVq4UvCHzgQtE0Sffc6MZiwDE9XjWhYsKm81h85dz/iVT4sx0c5fFvJzGXg7OFHCsVN2PhmlIwdgmYetqB5Ow==";
       };
     };
-    "@ionic/utils-array-1.0.1" = {
+    "@ionic/utils-array-1.2.0" = {
       name = "_at_ionic_slash_utils-array";
       packageName = "@ionic/utils-array";
-      version = "1.0.1";
+      version = "1.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ionic/utils-array/-/utils-array-1.0.1.tgz";
-        sha512 = "XqGhwcGS5XwXpQbGi1K97UY1bBZLYlj/DQ5HVE6551C6QF6PRM8WAlpKs4m4Y1MZ5FRLbZOSykcx6q4mlFF5FA==";
+        url = "https://registry.npmjs.org/@ionic/utils-array/-/utils-array-1.2.0.tgz";
+        sha512 = "wJfshi287FRjZM43+w3OkMl4n7hDTmK/9Jxm9Ot5hBDgeLP6Fw/OBb6tt+nGjhRBJbk1oOi7ksJgyBw/+1ldzg==";
       };
     };
-    "@ionic/utils-fs-2.0.3" = {
+    "@ionic/utils-fs-2.0.6" = {
       name = "_at_ionic_slash_utils-fs";
       packageName = "@ionic/utils-fs";
-      version = "2.0.3";
+      version = "2.0.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ionic/utils-fs/-/utils-fs-2.0.3.tgz";
-        sha512 = "vTZ7ckBWAPyhOQ/EQKtQK2WdTaNdOJHtHLebOoFLy0Bl/fWlqNAaaLfc9IXkp+eGwYBmpa9t48bHjiHtF1IT5Q==";
+        url = "https://registry.npmjs.org/@ionic/utils-fs/-/utils-fs-2.0.6.tgz";
+        sha512 = "iU1UwU5NW2nlLvNNE3QoeH6I+wN3a4ypHFcS6Bp7qUDENeI+oTxHzVHKHM6qt7T/24TFLNcHVxcq/pGIt7vgOA==";
       };
     };
-    "@ionic/utils-network-1.0.1" = {
+    "@ionic/utils-network-1.0.4" = {
       name = "_at_ionic_slash_utils-network";
       packageName = "@ionic/utils-network";
-      version = "1.0.1";
+      version = "1.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ionic/utils-network/-/utils-network-1.0.1.tgz";
-        sha512 = "3fqq+2SzlWRpf4029Cry86D/Vb/hTc2zO90GtFlCU+3az2IpGQOzGeVrZ8az9pgzROY/hDfdL6VUsvwF4MF20g==";
+        url = "https://registry.npmjs.org/@ionic/utils-network/-/utils-network-1.0.4.tgz";
+        sha512 = "VDWlschcLc6t71AAk54ywycVwahRv2qK82DOxdiN02YwurqXclcT2wmZCjnzAgBOPEepqmxj0mKozPA9YYWcbg==";
       };
     };
-    "@ionic/utils-object-1.0.1" = {
+    "@ionic/utils-object-1.0.4" = {
       name = "_at_ionic_slash_utils-object";
       packageName = "@ionic/utils-object";
-      version = "1.0.1";
+      version = "1.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ionic/utils-object/-/utils-object-1.0.1.tgz";
-        sha512 = "SIc8bqsCJA8+zsIPS34TmgTJg0WyqkJzcSEZTdfpMPS+qPq/Sm2yaeDGRhlXGRnfDckulRiCK3mhW2dfNPTGhQ==";
+        url = "https://registry.npmjs.org/@ionic/utils-object/-/utils-object-1.0.4.tgz";
+        sha512 = "B05kWS+Uj0rGrvG1RvAzDBuggstmWM0X4OUb3p9GhZJJQsNK2/0W03VfPOkNuaDi15NF/WFwLS7/yp7kM25mTw==";
       };
     };
-    "@ionic/utils-process-1.0.1" = {
+    "@ionic/utils-process-1.0.4" = {
       name = "_at_ionic_slash_utils-process";
       packageName = "@ionic/utils-process";
-      version = "1.0.1";
+      version = "1.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ionic/utils-process/-/utils-process-1.0.1.tgz";
-        sha512 = "kEAte96A5xBA0wJX35ykHERgc4KkYS4Xiq7XsSMo3inBbN2rNUkRIzC+aFM3IFeNKtCqgNgh7t9LczvLDEzdiQ==";
+        url = "https://registry.npmjs.org/@ionic/utils-process/-/utils-process-1.0.4.tgz";
+        sha512 = "F70r4Dup0yz03lDVCiRva2Qz7+VXNtUnfx7pfIFaDQv54sUem7ozG6zl4db5EE3a4RAJUCbM5YQFsAojnEUc+g==";
       };
     };
-    "@ionic/utils-stream-2.0.0" = {
+    "@ionic/utils-stream-2.0.3" = {
       name = "_at_ionic_slash_utils-stream";
       packageName = "@ionic/utils-stream";
-      version = "2.0.0";
+      version = "2.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ionic/utils-stream/-/utils-stream-2.0.0.tgz";
-        sha512 = "xUMsvW6/5R3NpWJD6wkT/324PQ2RU9if9b4SjBgrSBrgKWEiwXopz6JihjRwh1Xq2qn5MiV+2eXSgpq5jnhX0w==";
+        url = "https://registry.npmjs.org/@ionic/utils-stream/-/utils-stream-2.0.3.tgz";
+        sha512 = "Y1OAcJwP8uNCYQiRxywfo85jdOVbfdvRwjuvFVupFrLQet6kOBKh9wHHnivoS9du+Wlq4VjuFh03LmmAaHwenA==";
       };
     };
-    "@ionic/utils-subprocess-1.0.3" = {
+    "@ionic/utils-subprocess-1.0.7" = {
       name = "_at_ionic_slash_utils-subprocess";
       packageName = "@ionic/utils-subprocess";
-      version = "1.0.3";
+      version = "1.0.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ionic/utils-subprocess/-/utils-subprocess-1.0.3.tgz";
-        sha512 = "JX65/RBWM/25k0Cum61aFalpcWCymX0uDf7B3rBT7ptzuEdawOrA2ho0t3J4wXgCqmHy+Pq0woaAqwg8rccDKw==";
+        url = "https://registry.npmjs.org/@ionic/utils-subprocess/-/utils-subprocess-1.0.7.tgz";
+        sha512 = "QXCqdwSSGiyxgs36faSbxiVIRCUBI6ckmCSWSLRGZAo4EZ7MuPQUqU+oVILkTWTOPAMWNcJtS67zJNMTccsSUg==";
       };
     };
-    "@ionic/utils-terminal-1.0.1" = {
+    "@ionic/utils-terminal-1.0.4" = {
       name = "_at_ionic_slash_utils-terminal";
       packageName = "@ionic/utils-terminal";
-      version = "1.0.1";
+      version = "1.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ionic/utils-terminal/-/utils-terminal-1.0.1.tgz";
-        sha512 = "y/mEpPNPW2oYfFGtFTCRbZAmp0Go17S7uNUFGKThV397lmHm3yiPiu0M5cDV9v/UDuOZ7nmz3LqwhtIaPPeK9g==";
+        url = "https://registry.npmjs.org/@ionic/utils-terminal/-/utils-terminal-1.0.4.tgz";
+        sha512 = "+iJbFff7mnJ6ROE465+/DG8eweFmINVy69Bdw9fr8Vcf8WhJWxMw0vd59J/gaUSsHuxoufZYftVXVoWUd8RfWA==";
       };
     };
     "@kbrandwijk/swagger-to-graphql-2.4.3" = {
@@ -2218,31 +2209,31 @@ let
         sha1 = "a777360b5b39a1a2e5106f8e858f2fd2d060c570";
       };
     };
-    "@sailshq/lodash-3.10.3" = {
+    "@sailshq/lodash-3.10.4" = {
       name = "_at_sailshq_slash_lodash";
       packageName = "@sailshq/lodash";
-      version = "3.10.3";
+      version = "3.10.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@sailshq/lodash/-/lodash-3.10.3.tgz";
-        sha512 = "XTF5BtsTSiSpTnfqrCGS5Q8FvSHWCywA0oRxFAZo8E1a8k1MMFUvk3VlRk3q/SusEYwy7gvVdyt9vvNlTa2VuA==";
+        url = "https://registry.npmjs.org/@sailshq/lodash/-/lodash-3.10.4.tgz";
+        sha512 = "YXJqp9gdHcZKAmBY/WnwFpPtNQp2huD/ME2YMurH2YHJvxrVzYsmpKw/pb7yINArRpp8E++fwbQd3ajYXGA45Q==";
       };
     };
-    "@schematics/angular-8.2.0" = {
+    "@schematics/angular-8.3.2" = {
       name = "_at_schematics_slash_angular";
       packageName = "@schematics/angular";
-      version = "8.2.0";
+      version = "8.3.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@schematics/angular/-/angular-8.2.0.tgz";
-        sha512 = "DOo2wtk9fk0kHCDA/I+/mRrGKirgeqVhDbgOV4d2gbYSAiTl0s1Gb4eFAkJeovQTlARfaL2PIqDDkNeYjc7xpw==";
+        url = "https://registry.npmjs.org/@schematics/angular/-/angular-8.3.2.tgz";
+        sha512 = "kDT5lhr488NpqS4OKn8B9VUwl5AUNqRkLLqWgNHvxQcV1OtLhVJVw4ih1vhrH7wlUd39EwnRqtBX+53cg2PDmA==";
       };
     };
-    "@schematics/update-0.802.0" = {
+    "@schematics/update-0.803.2" = {
       name = "_at_schematics_slash_update";
       packageName = "@schematics/update";
-      version = "0.802.0";
+      version = "0.803.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@schematics/update/-/update-0.802.0.tgz";
-        sha512 = "vMcFLTuw9jSlWQq6nNgMQi2fT/wGyaucvjkxFAs7pC+lyRwYws3IkOukbET7WeJ3ix0ZBEhMbPJ8EibUNDITjw==";
+        url = "https://registry.npmjs.org/@schematics/update/-/update-0.803.2.tgz";
+        sha512 = "UX01kuGEXMEnV19Dd7/lNzFnokZ05an9o0yEoRp50e7HH2mUOCPcxlnwGOq1obUJdyXkvItNrwWsIp2krXt4wQ==";
       };
     };
     "@sindresorhus/is-0.14.0" = {
@@ -2270,6 +2261,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/@slack/client/-/client-3.16.0.tgz";
         sha512 = "CWr7a3rTVrN5Vs8GYReRAvTourbXHOqB1zglcskj05ICH4GZL5BOAza2ARai+qc3Nz0nY08Bozi1x0014KOqlg==";
+      };
+    };
+    "@snyk/cli-interface-2.0.3" = {
+      name = "_at_snyk_slash_cli-interface";
+      packageName = "@snyk/cli-interface";
+      version = "2.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@snyk/cli-interface/-/cli-interface-2.0.3.tgz";
+        sha512 = "tQxCCEdX8+r71fYoOZB4jaPYUxrhWsdPAuQkbbsge9Vd22Gzy6iCVpLX2Ai0JKkqZ0tLU3cgNB7gulzce6fdAg==";
       };
     };
     "@snyk/composer-lockfile-parser-1.0.3" = {
@@ -2560,13 +2560,22 @@ let
         sha512 = "6BmYWSBea18+tSjjSC3QIyV93ZKAeNWGM7R6aYt1ryTZXrlHF+QLV0G2yV0viEGVyRkyQsWfMoJ0k/YghBX5sQ==";
       };
     };
-    "@types/body-parser-1.17.0" = {
+    "@types/body-parser-1.17.1" = {
       name = "_at_types_slash_body-parser";
       packageName = "@types/body-parser";
-      version = "1.17.0";
+      version = "1.17.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.0.tgz";
-        sha512 = "a2+YeUjPkztKJu5aIF2yArYFQQp8d51wZ7DavSHjFuY1mqVgidGyzEQ41JIVNy82fXj8yPgy2vJmfIywgESW6w==";
+        url = "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.1.tgz";
+        sha512 = "RoX2EZjMiFMjZh9lmYrwgoP9RTpAjSHiJxdp4oidAQVO02T7HER3xj9UKue5534ULWeqVEkujhWcyvUce+d68w==";
+      };
+    };
+    "@types/bunyan-1.8.6" = {
+      name = "_at_types_slash_bunyan";
+      packageName = "@types/bunyan";
+      version = "1.8.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@types/bunyan/-/bunyan-1.8.6.tgz";
+        sha512 = "YiozPOOsS6bIuz31ilYqR5SlLif4TBWsousN2aCWLi5233nZSX19tFbcQUPdR7xJ8ypPyxkCGNxg0CIV5n9qxQ==";
       };
     };
     "@types/connect-3.4.32" = {
@@ -2596,22 +2605,22 @@ let
         sha512 = "jnihWgshWystcJKrz8C9hV+Ot9lqOUyAh2RF+o3BEo6K6AS2l4zYCb9GYaBuZ3C6Il59uIGqpE3HvCun4KKeJA==";
       };
     };
-    "@types/cors-2.8.5" = {
+    "@types/cors-2.8.6" = {
       name = "_at_types_slash_cors";
       packageName = "@types/cors";
-      version = "2.8.5";
+      version = "2.8.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/cors/-/cors-2.8.5.tgz";
-        sha512 = "GmK8AKu8i+s+EChK/uZ5IbrXPcPaQKWaNSGevDT/7o3gFObwSUQwqb1jMqxuo+YPvj0ckGzINI+EO7EHcmJjKg==";
+        url = "https://registry.npmjs.org/@types/cors/-/cors-2.8.6.tgz";
+        sha512 = "invOmosX0DqbpA+cE2yoHGUlF/blyf7nB0OGYBBiH27crcVm5NmFaZkLP4Ta1hGaesckCi5lVLlydNJCxkTOSg==";
       };
     };
-    "@types/debug-4.1.4" = {
+    "@types/debug-4.1.5" = {
       name = "_at_types_slash_debug";
       packageName = "@types/debug";
-      version = "4.1.4";
+      version = "4.1.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/debug/-/debug-4.1.4.tgz";
-        sha512 = "D9MyoQFI7iP5VdpEyPZyjjqIJ8Y8EDNQFIFVLOmeg1rI1xiHOChyUPMPRUVfqFCerxfE+yS3vMyj37F6IdtOoQ==";
+        url = "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz";
+        sha512 = "Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==";
       };
     };
     "@types/estree-0.0.39" = {
@@ -2632,22 +2641,31 @@ let
         sha512 = "EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==";
       };
     };
-    "@types/express-4.17.0" = {
+    "@types/express-4.17.1" = {
       name = "_at_types_slash_express";
       packageName = "@types/express";
-      version = "4.17.0";
+      version = "4.17.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/express/-/express-4.17.0.tgz";
-        sha512 = "CjaMu57cjgjuZbh9DpkloeGxV45CnMGlVd+XpG7Gm9QgVrd7KFq+X4HY0vM+2v0bczS48Wg7bvnMY5TN+Xmcfw==";
+        url = "https://registry.npmjs.org/@types/express/-/express-4.17.1.tgz";
+        sha512 = "VfH/XCP0QbQk5B5puLqTLEeFgR8lfCJHZJKkInZ9mkYd+u8byX0kztXEQxEk4wZXJs8HI+7km2ALXjn4YKcX9w==";
       };
     };
-    "@types/express-serve-static-core-4.16.7" = {
+    "@types/express-serve-static-core-4.16.9" = {
       name = "_at_types_slash_express-serve-static-core";
       packageName = "@types/express-serve-static-core";
-      version = "4.16.7";
+      version = "4.16.9";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.7.tgz";
-        sha512 = "847KvL8Q1y3TtFLRTXcVakErLJQgdpFSaq+k043xefz9raEf0C7HalpSY7OW5PyjCnY8P7bPW5t/Co9qqp+USg==";
+        url = "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.9.tgz";
+        sha512 = "GqpaVWR0DM8FnRUJYKlWgyARoBUAVfRIeVDZQKOttLFp5SmhhF9YFIYeTPwMd/AXfxlP7xVO2dj1fGu0Q+krKQ==";
+      };
+    };
+    "@types/fs-capacitor-2.0.0" = {
+      name = "_at_types_slash_fs-capacitor";
+      packageName = "@types/fs-capacitor";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@types/fs-capacitor/-/fs-capacitor-2.0.0.tgz";
+        sha512 = "FKVPOCFbhCvZxpVAMhdBdTfVfXUpsh15wFHgqOKxh9N9vzWZVuWCSijZ5T4U34XYNnuj2oduh6xcs1i+LPI+BQ==";
       };
     };
     "@types/glob-7.1.1" = {
@@ -2659,31 +2677,22 @@ let
         sha512 = "1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==";
       };
     };
-    "@types/graphql-14.2.3" = {
-      name = "_at_types_slash_graphql";
-      packageName = "@types/graphql";
-      version = "14.2.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@types/graphql/-/graphql-14.2.3.tgz";
-        sha512 = "UoCovaxbJIxagCvVfalfK7YaNhmxj3BQFRQ2RHQKLiu+9wNXhJnlbspsLHt/YQM99IaLUUFJNzCwzc6W0ypMeQ==";
-      };
-    };
-    "@types/graphql-upload-8.0.0" = {
+    "@types/graphql-upload-8.0.3" = {
       name = "_at_types_slash_graphql-upload";
       packageName = "@types/graphql-upload";
-      version = "8.0.0";
+      version = "8.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/graphql-upload/-/graphql-upload-8.0.0.tgz";
-        sha512 = "xeDYfZb0SeRpCRuivN9TXLEVsbG0F4inFtx03yadZeaTXr1kC224/ZvlV6NKqQ//HNvUxneYcEoUB5ugJc8dnA==";
+        url = "https://registry.npmjs.org/@types/graphql-upload/-/graphql-upload-8.0.3.tgz";
+        sha512 = "hmLg9pCU/GmxBscg8GCr1vmSoEmbItNNxdD5YH2TJkXm//8atjwuprB+xJBK714JG1dkxbbhp5RHX+Pz1KsCMA==";
       };
     };
-    "@types/http-assert-1.5.0" = {
+    "@types/http-assert-1.5.1" = {
       name = "_at_types_slash_http-assert";
       packageName = "@types/http-assert";
-      version = "1.5.0";
+      version = "1.5.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.5.0.tgz";
-        sha512 = "8CBLG8RmxSvoY07FE6M/QpvJ7J5KzeKqF8eWN7Dq6Ks+lBTQae8Roc2G81lUu2Kw5Ju1gymOuvgyUsussbjAaA==";
+        url = "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.5.1.tgz";
+        sha512 = "PGAK759pxyfXE78NbKxyfRcWYA/KwW17X290cNev/qAsn9eQIxkH4shoNBafH37wewhDG/0p1cHPbK6+SzZjWQ==";
       };
     };
     "@types/keygrip-1.0.1" = {
@@ -2740,22 +2749,22 @@ let
         sha512 = "tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==";
       };
     };
-    "@types/node-10.14.14" = {
+    "@types/node-10.14.17" = {
       name = "_at_types_slash_node";
       packageName = "@types/node";
-      version = "10.14.14";
+      version = "10.14.17";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/node/-/node-10.14.14.tgz";
-        sha512 = "xXD08vZsvpv4xptQXj1+ky22f7ZoKu5ZNI/4l+/BXG3X+XaeZsmaFbbTKuhSE3NjjvRuZFxFf9sQBMXIcZNFMQ==";
+        url = "https://registry.npmjs.org/@types/node/-/node-10.14.17.tgz";
+        sha512 = "p/sGgiPaathCfOtqu2fx5Mu1bcjuP8ALFg4xpGgNkcin7LwRyzUKniEHBKdcE1RPsenq5JVPIpMTJSygLboygQ==";
       };
     };
-    "@types/node-12.6.9" = {
+    "@types/node-12.7.3" = {
       name = "_at_types_slash_node";
       packageName = "@types/node";
-      version = "12.6.9";
+      version = "12.7.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/node/-/node-12.6.9.tgz";
-        sha512 = "+YB9FtyxXGyD54p8rXwWaN1EWEyar5L58GlGWgtH2I9rGmLGBQcw63+0jw+ujqVavNuO47S1ByAjm9zdHMnskw==";
+        url = "https://registry.npmjs.org/@types/node/-/node-12.7.3.tgz";
+        sha512 = "3SiLAIBkDWDg6vFo0+5YJyHPWU9uwu40Qe+v+0MH8wRKYBimHvvAOyk3EzMrD/TrIlLYfXrqDqrg913PynrMJQ==";
       };
     };
     "@types/node-6.14.7" = {
@@ -2767,13 +2776,13 @@ let
         sha512 = "YbPXbaynBTe0pVExPhL76TsWnxSPeFAvImIsmylpBWn/yfw+lHy+Q68aawvZHsgskT44ZAoeE67GM5f+Brekew==";
       };
     };
-    "@types/node-8.10.51" = {
+    "@types/node-8.10.53" = {
       name = "_at_types_slash_node";
       packageName = "@types/node";
-      version = "8.10.51";
+      version = "8.10.53";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/node/-/node-8.10.51.tgz";
-        sha512 = "cArrlJp3Yv6IyFT/DYe+rlO8o3SIHraALbBW/+CcCYW/a9QucpLI+n2p4sRxAvl2O35TiecpX2heSZtJjvEO+Q==";
+        url = "https://registry.npmjs.org/@types/node/-/node-8.10.53.tgz";
+        sha512 = "aOmXdv1a1/vYUn1OT1CED8ftbkmmYbKhKGSyMDeJiidLvKRKvZUQOdXwG/wcNY7T1Qb0XTlVdiYjIq00U7pLrQ==";
       };
     };
     "@types/q-1.5.2" = {
@@ -2794,13 +2803,31 @@ let
         sha512 = "ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==";
       };
     };
-    "@types/serve-static-1.13.2" = {
+    "@types/restify-4.3.6" = {
+      name = "_at_types_slash_restify";
+      packageName = "@types/restify";
+      version = "4.3.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@types/restify/-/restify-4.3.6.tgz";
+        sha512 = "4l4f0EXnleXQttlhRCXtTuJ8UelsKiAKIK2AAEd2epBHu41aEbM0U2z6E5tUrNwlbxz7qaNBISduGMeg+G3PaA==";
+      };
+    };
+    "@types/semver-5.5.0" = {
+      name = "_at_types_slash_semver";
+      packageName = "@types/semver";
+      version = "5.5.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@types/semver/-/semver-5.5.0.tgz";
+        sha512 = "41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ==";
+      };
+    };
+    "@types/serve-static-1.13.3" = {
       name = "_at_types_slash_serve-static";
       packageName = "@types/serve-static";
-      version = "1.13.2";
+      version = "1.13.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.2.tgz";
-        sha512 = "/BZ4QRLpH/bNYgZgwhKEh+5AsboDBcUdlBYgzoLX0fpj3Y2gp6EApyOlM3bK53wQS/OE1SrdSYBAbux2D1528Q==";
+        url = "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.3.tgz";
+        sha512 = "oprSwp094zOglVrXdlo/4bAHtKTAxX6VT8FOZlBKrmyLbNvE1zxZyJ6yikMVtHIvwP45+ZQGJn+FdXGKTozq0g==";
       };
     };
     "@types/superagent-3.8.2" = {
@@ -2839,13 +2866,22 @@ let
         sha512 = "mlGER3Aqmq7bqR1tTTIVHq8KSAFFRyGbrxuM8C/H82g6k7r2fS+IMEkIu3D7JHzG10NvPdR8DNx0jr0pwpp4dA==";
       };
     };
-    "@types/ws-6.0.2" = {
+    "@types/ws-6.0.3" = {
       name = "_at_types_slash_ws";
       packageName = "@types/ws";
-      version = "6.0.2";
+      version = "6.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/ws/-/ws-6.0.2.tgz";
-        sha512 = "22XiR1ox9LftTaAtn/c5JCninwc7moaqbkJfaDUb7PkaUitcf5vbTZHdq9dxSMviCm9C3W85rzB8e6yNR70apQ==";
+        url = "https://registry.npmjs.org/@types/ws/-/ws-6.0.3.tgz";
+        sha512 = "yBTM0P05Tx9iXGq00BbJPo37ox68R5vaGTXivs6RGh/BQ6QP5zqZDGWdAO6JbRE/iR1l80xeGAwCQS2nMV9S/w==";
+      };
+    };
+    "@types/xml2js-0.4.3" = {
+      name = "_at_types_slash_xml2js";
+      packageName = "@types/xml2js";
+      version = "0.4.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.3.tgz";
+        sha512 = "Pv2HGRE4gWLs31In7nsyXEH4uVVsd0HNV9i2dyASvtDIlOtSTr1eczPLDpdEuyv5LWH5LT20GIXwPjkshKWI1g==";
       };
     };
     "@types/zen-observable-0.8.0" = {
@@ -2857,40 +2893,40 @@ let
         sha512 = "te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg==";
       };
     };
-    "@vue/cli-shared-utils-3.10.0" = {
+    "@vue/cli-shared-utils-3.11.0" = {
       name = "_at_vue_slash_cli-shared-utils";
       packageName = "@vue/cli-shared-utils";
-      version = "3.10.0";
+      version = "3.11.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@vue/cli-shared-utils/-/cli-shared-utils-3.10.0.tgz";
-        sha512 = "i96XBUtLdWeKFCC/ot12ngqnVikN/dXpelGdyxvNZczCkX7Je0FUdrZkiw0+uTYTu1RmuYWpLs+vb/YQerjiWg==";
+        url = "https://registry.npmjs.org/@vue/cli-shared-utils/-/cli-shared-utils-3.11.0.tgz";
+        sha512 = "D7pst/4v9H1DD66fLxlZOwRR09R03MV0ROdKxBHmh3FmnApCA/RiaolFA/8w+B3CnevYMlV3SJ5fOAgedbswbA==";
       };
     };
-    "@vue/cli-ui-3.10.0" = {
+    "@vue/cli-ui-3.11.0" = {
       name = "_at_vue_slash_cli-ui";
       packageName = "@vue/cli-ui";
-      version = "3.10.0";
+      version = "3.11.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@vue/cli-ui/-/cli-ui-3.10.0.tgz";
-        sha512 = "Tekgh54ClA+x3ey3H1td/RVhGt9MG02/z/OtG+q2Dcy9j47bscDDiTv3OJgw64WrH5tqz1aKEA/SibxL9ehS+Q==";
+        url = "https://registry.npmjs.org/@vue/cli-ui/-/cli-ui-3.11.0.tgz";
+        sha512 = "mbCUUOJSPGLQ+wxPTX+NE6HsiCpt3wpv56AuUlCv14mUEkm98p+4xzkgPQ1neYxG7fg5Vn8fExiFvge73Lvzdg==";
       };
     };
-    "@vue/cli-ui-addon-webpack-3.10.0" = {
+    "@vue/cli-ui-addon-webpack-3.11.0" = {
       name = "_at_vue_slash_cli-ui-addon-webpack";
       packageName = "@vue/cli-ui-addon-webpack";
-      version = "3.10.0";
+      version = "3.11.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@vue/cli-ui-addon-webpack/-/cli-ui-addon-webpack-3.10.0.tgz";
-        sha512 = "c930BWpeFu1H+mbUZT4VSLngD95yaOAg9qr21Kq1KMZ3CW7gakbttwpgXjn8edwdkvUl65IpSkdh/n/XyYyXxg==";
+        url = "https://registry.npmjs.org/@vue/cli-ui-addon-webpack/-/cli-ui-addon-webpack-3.11.0.tgz";
+        sha512 = "q0kELq8c6nPAM74J2NELxn9NdaQ0bqYS9l8EsvLbqfTd/GM7leWytkdO6GYClu1VJ3Ohm3xQsKjpDHCcKSW7tw==";
       };
     };
-    "@vue/cli-ui-addon-widgets-3.10.0" = {
+    "@vue/cli-ui-addon-widgets-3.11.0" = {
       name = "_at_vue_slash_cli-ui-addon-widgets";
       packageName = "@vue/cli-ui-addon-widgets";
-      version = "3.10.0";
+      version = "3.11.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@vue/cli-ui-addon-widgets/-/cli-ui-addon-widgets-3.10.0.tgz";
-        sha512 = "FvPB05n8Gp0TbvWPXnlwcQPSLZIwEY+Mzwh0pMDTN9yoxnf+/xhIt2PwRmFtecIBqyBZAIyYI50wmCxs9c2Hbw==";
+        url = "https://registry.npmjs.org/@vue/cli-ui-addon-widgets/-/cli-ui-addon-widgets-3.11.0.tgz";
+        sha512 = "iEKaaWyGafYmHJKDd2rISSqMw61L3XX9E9Vo/sVWK0uVITTsSyBmNwZeTcaaEB6YVbZeCHRJtq2Q/JRjvD9SPA==";
       };
     };
     "@webassemblyjs/ast-1.8.1" = {
@@ -3370,13 +3406,13 @@ let
         sha1 = "5faad9c2c07f60dd76770f71cf025b62a63cfd4e";
       };
     };
-    "abab-2.0.0" = {
+    "abab-2.0.1" = {
       name = "abab";
       packageName = "abab";
-      version = "2.0.0";
+      version = "2.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz";
-        sha512 = "sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w==";
+        url = "https://registry.npmjs.org/abab/-/abab-2.0.1.tgz";
+        sha512 = "1zSbbCuoIjafKZ3mblY5ikvAb0ODUbqBnFuUb7f6uLeQhhGJ0vEV4ntmtxKLT2WgXCO94E07BjunsIw1jOMPZw==";
       };
     };
     "abbrev-1.1.1" = {
@@ -3514,22 +3550,22 @@ let
         sha512 = "T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==";
       };
     };
-    "acorn-6.2.1" = {
+    "acorn-6.3.0" = {
       name = "acorn";
       packageName = "acorn";
-      version = "6.2.1";
+      version = "6.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz";
-        sha512 = "JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==";
+        url = "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz";
+        sha512 = "/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==";
       };
     };
-    "acorn-dynamic-import-4.0.0" = {
-      name = "acorn-dynamic-import";
-      packageName = "acorn-dynamic-import";
-      version = "4.0.0";
+    "acorn-7.0.0" = {
+      name = "acorn";
+      packageName = "acorn";
+      version = "7.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz";
-        sha512 = "d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw==";
+        url = "https://registry.npmjs.org/acorn/-/acorn-7.0.0.tgz";
+        sha512 = "PaF/MduxijYYt7unVGRuds1vBC9bFxbNf+VWqhOClfdgy7RlVkQqt610ig1/yxTgsDIfW1cWDel5EBbOy3jdtQ==";
       };
     };
     "acorn-globals-1.0.9" = {
@@ -3568,13 +3604,13 @@ let
         sha1 = "afdf9488fb1ecefc8348f6fb22f464e32a58b36b";
       };
     };
-    "acorn-jsx-5.0.1" = {
+    "acorn-jsx-5.0.2" = {
       name = "acorn-jsx";
       packageName = "acorn-jsx";
-      version = "5.0.1";
+      version = "5.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz";
-        sha512 = "HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==";
+        url = "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.2.tgz";
+        sha512 = "tiNTrP1MP0QrChmD2DdupCr6HWSFeKVw5d/dHTu4Y7rkAkRhU/Dt7dphAfIUyxtHpl/eBVip5uTNSpQJHylpAw==";
       };
     };
     "acorn-loose-6.1.0" = {
@@ -3586,13 +3622,13 @@ let
         sha512 = "FHhXoiF0Uch3IqsrnPpWwCtiv5PYvipTpT1k9lDMgQVVYc9iDuSl5zdJV358aI8twfHCYMFBRVYvAVki9wC/ng==";
       };
     };
-    "acorn-node-1.7.0" = {
+    "acorn-node-1.8.2" = {
       name = "acorn-node";
       packageName = "acorn-node";
-      version = "1.7.0";
+      version = "1.8.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/acorn-node/-/acorn-node-1.7.0.tgz";
-        sha512 = "XhahLSsCB6X6CJbe+uNu3Mn9sJBNFxtBN9NLgAOQovfS6Kh0lDUtmlclhjn9CvEK7A7YyRU13PXlNcpSiLI9Yw==";
+        url = "https://registry.npmjs.org/acorn-node/-/acorn-node-1.8.2.tgz";
+        sha512 = "8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==";
       };
     };
     "acorn-walk-6.2.0" = {
@@ -3602,6 +3638,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz";
         sha512 = "7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==";
+      };
+    };
+    "acorn-walk-7.0.0" = {
+      name = "acorn-walk";
+      packageName = "acorn-walk";
+      version = "7.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.0.0.tgz";
+        sha512 = "7Bv1We7ZGuU79zZbb6rRqcpxo3OY+zrdtloZWoyD8fmGX+FeXRjE+iuGkZjSXLVovLzrsvMGMy0EkwA0E0umxg==";
       };
     };
     "adal-node-0.1.28" = {
@@ -4180,13 +4225,13 @@ let
         sha512 = "VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==";
       };
     };
-    "ansi-styles-4.0.0" = {
+    "ansi-styles-4.1.0" = {
       name = "ansi-styles";
       packageName = "ansi-styles";
-      version = "4.0.0";
+      version = "4.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.0.0.tgz";
-        sha512 = "8zjUtFJ3db/QoPXuuEMloS2AUf79/yeyttJ7Abr3hteopJu9HK8vsgGviGUMq+zyA6cZZO6gAyZoMTF6TgaEjA==";
+        url = "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.1.0.tgz";
+        sha512 = "Qts4KCLKG+waHc9C4m07weIY8qyeixoS0h6RnbsNVD6Fw+pEZGW3vTyObL3WXpE09Mq4Oi7/lBEyLmOiLtlYWQ==";
       };
     };
     "ansi-term-0.0.2" = {
@@ -4261,13 +4306,13 @@ let
         sha512 = "5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==";
       };
     };
-    "anymatch-3.0.3" = {
+    "anymatch-3.1.0" = {
       name = "anymatch";
       packageName = "anymatch";
-      version = "3.0.3";
+      version = "3.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/anymatch/-/anymatch-3.0.3.tgz";
-        sha512 = "c6IvoeBECQlMVuYUjSwimnhmztImpErfxJzWZhIQinIvQWoGOnB0dLIgifbPHQt5heS6mNlaZG16f06H3C8t1g==";
+        url = "https://registry.npmjs.org/anymatch/-/anymatch-3.1.0.tgz";
+        sha512 = "Ozz7l4ixzI7Oxj2+cw+p0tVUt27BpaJ+1+q1TCeANWxHpvyn2+Un+YamBdfKu0uh8xLodGhoa1v7595NhKDAuA==";
       };
     };
     "ap-0.1.0" = {
@@ -4306,31 +4351,31 @@ let
         sha512 = "+KA685AV5ETEJfjZuviRTEImGA11uNBp/MJGnaCvkgr+BYRrGLruVKBv6WvyFod27WEB2sp7SsG8cNBKANhGLg==";
       };
     };
-    "apollo-cache-control-0.8.1" = {
+    "apollo-cache-control-0.8.2" = {
       name = "apollo-cache-control";
       packageName = "apollo-cache-control";
-      version = "0.8.1";
+      version = "0.8.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.8.1.tgz";
-        sha512 = "yQy5KB/OuX90PsdztWc4vfc4R//ZmW/AxNgXKWga0xW5OzEsysdJWHAsTzb40/rkJ9VNeQ+0N5wGikiS+jSCzg==";
+        url = "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.8.2.tgz";
+        sha512 = "rvx4DdoAAbWhm3L0IoWrxN+Zq2Xk4uAYbaiZk0Nhuc/y4AQUww3JV/z4EfCp3O5cy5/lNMW/tPOozcqi941awA==";
       };
     };
-    "apollo-cache-inmemory-1.6.2" = {
+    "apollo-cache-inmemory-1.6.3" = {
       name = "apollo-cache-inmemory";
       packageName = "apollo-cache-inmemory";
-      version = "1.6.2";
+      version = "1.6.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-cache-inmemory/-/apollo-cache-inmemory-1.6.2.tgz";
-        sha512 = "AyCl3PGFv5Qv1w4N9vlg63GBPHXgMCekZy5mhlS042ji0GW84uTySX+r3F61ZX3+KM1vA4m9hQyctrEGiv5XjQ==";
+        url = "https://registry.npmjs.org/apollo-cache-inmemory/-/apollo-cache-inmemory-1.6.3.tgz";
+        sha512 = "S4B/zQNSuYc0M/1Wq8dJDTIO9yRgU0ZwDGnmlqxGGmFombOZb9mLjylewSfQKmjNpciZ7iUIBbJ0mHlPJTzdXg==";
       };
     };
-    "apollo-client-2.6.3" = {
+    "apollo-client-2.6.4" = {
       name = "apollo-client";
       packageName = "apollo-client";
-      version = "2.6.3";
+      version = "2.6.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-client/-/apollo-client-2.6.3.tgz";
-        sha512 = "DS8pmF5CGiiJ658dG+mDn8pmCMMQIljKJSTeMNHnFuDLV0uAPZoeaAwVFiAmB408Ujqt92oIZ/8yJJAwSIhd4A==";
+        url = "https://registry.npmjs.org/apollo-client/-/apollo-client-2.6.4.tgz";
+        sha512 = "oWOwEOxQ9neHHVZrQhHDbI6bIibp9SHgxaLRVPoGvOFy7OH5XUykZE7hBQAVxq99tQjBzgytaZffQkeWo1B4VQ==";
       };
     };
     "apollo-codegen-0.20.2" = {
@@ -4405,22 +4450,22 @@ let
         sha512 = "0/h5hce2FIGn6Y4+EHMeMINQxFwcgjw1vU+xV3KGaaEgyEAEQ3/n9pyz43M8mOm/JVgg8Eb4CtM1AtCkRQuFGw==";
       };
     };
-    "apollo-datasource-0.6.1" = {
+    "apollo-datasource-0.6.2" = {
       name = "apollo-datasource";
       packageName = "apollo-datasource";
-      version = "0.6.1";
+      version = "0.6.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-0.6.1.tgz";
-        sha512 = "oy7c+9Up8PSZwJ1qTK9Idh1acDpIocvw+C0zcHg14ycvNz7qWHSwLUSaAjuQMd9SYFzB3sxfyEhyfyhIogT2+Q==";
+        url = "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-0.6.2.tgz";
+        sha512 = "GlqTfLjKFxNYxGGACDjDXUpm/vPfvXhUI/Qc/YdkY4ess/wn7EFdrmbZGIY56RJtXD5M7qjsQIH15t132KoPmQ==";
       };
     };
-    "apollo-engine-reporting-1.4.3" = {
+    "apollo-engine-reporting-1.4.4" = {
       name = "apollo-engine-reporting";
       packageName = "apollo-engine-reporting";
-      version = "1.4.3";
+      version = "1.4.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-engine-reporting/-/apollo-engine-reporting-1.4.3.tgz";
-        sha512 = "xv27qfc9dhi1yaWOhNQRmfF+SoLy74hl+M42arpIWdkoDe22fVTmTIqxqGwo4TFR3Z2OkAV5tNzuuOI/icd0Rg==";
+        url = "https://registry.npmjs.org/apollo-engine-reporting/-/apollo-engine-reporting-1.4.4.tgz";
+        sha512 = "FOk/HooLMesoKHo/TGOPYZuc2t4q9YwoeM+z0AGRUY70hL2o5Ie3x0XiMb+I5IVibR+jBIRRKP2ngmSFJ+LqSg==";
       };
     };
     "apollo-engine-reporting-protobuf-0.4.0" = {
@@ -4513,67 +4558,67 @@ let
         sha512 = "l7ieNCGxUaUAVAAp600HjbUJxVaxjJygtPV0tPTe1Q3HkPy6LEWoY6mNHV7T268g1hxtPTxcdRu7WLsJrg7ufw==";
       };
     };
-    "apollo-server-core-2.8.1" = {
+    "apollo-server-core-2.9.1" = {
       name = "apollo-server-core";
       packageName = "apollo-server-core";
-      version = "2.8.1";
+      version = "2.9.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.8.1.tgz";
-        sha512 = "BpvhKdycTI1v5n8biJ5c/DVF7MCbTL3JtB9llHGkqYgHaTH1gXguh2qD8Vcki+rpUNO5P1lcj5V6oVXoSUFXlA==";
+        url = "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.9.1.tgz";
+        sha512 = "ZWPGNdZv/SiPjfEU7Wwut9N9oAucGlbVT+XCnpUl93agvkg3fbeTCLYBbjAdSA0Q6opq0tvWVGzwXPLpx6jZcQ==";
       };
     };
-    "apollo-server-env-2.4.1" = {
+    "apollo-server-env-2.4.2" = {
       name = "apollo-server-env";
       packageName = "apollo-server-env";
-      version = "2.4.1";
+      version = "2.4.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-2.4.1.tgz";
-        sha512 = "J4G1Q6qyb7KjjqvQdVM5HUH3QDb52VK1Rv+MWL0rHcstJx9Fh/NK0sS+nujrMfKw57NVUs2d4KuYtl/EnW/txg==";
+        url = "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-2.4.2.tgz";
+        sha512 = "Qyi8fP8CWsBRAKs0fawMFauJj03I6N3ncWcGaVTuDppYluo4zjV6LqHfZ+YPWOx6apBihFNZap19RAhSnSwJLg==";
       };
     };
-    "apollo-server-errors-2.3.1" = {
+    "apollo-server-errors-2.3.2" = {
       name = "apollo-server-errors";
       packageName = "apollo-server-errors";
-      version = "2.3.1";
+      version = "2.3.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.3.1.tgz";
-        sha512 = "errZvnh0vUQChecT7M4A/h94dnBSRL213dNxpM5ueMypaLYgnp4hiCTWIEaooo9E4yMGd1qA6WaNbLDG2+bjcg==";
+        url = "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.3.2.tgz";
+        sha512 = "twVCP8tNHFzxOzU3jf84ppBFSvjvisZVWlgF82vwG+qEEUaAE5h5DVpeJbcI1vRW4VQPuFV+B+FIsnlweFKqtQ==";
       };
     };
-    "apollo-server-express-2.8.1" = {
+    "apollo-server-express-2.9.1" = {
       name = "apollo-server-express";
       packageName = "apollo-server-express";
-      version = "2.8.1";
+      version = "2.9.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.8.1.tgz";
-        sha512 = "XoWqSuNQkL8ivBq5LXJW6wV0/Ef+m8w4fAK/7PBspLHVfDAbHRyRr6zraotim2Kl7NOnzcqHtb6sB9yozjL0hA==";
+        url = "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.9.1.tgz";
+        sha512 = "3mmuojt9s9Gyqdf8fbdKtbw23UFYrtVQtTNASgVW8zCabZqs2WjYnijMRf1aL4u9VSl+BFMOZUPMYaeBX+u38w==";
       };
     };
-    "apollo-server-plugin-base-0.6.1" = {
+    "apollo-server-plugin-base-0.6.2" = {
       name = "apollo-server-plugin-base";
       packageName = "apollo-server-plugin-base";
-      version = "0.6.1";
+      version = "0.6.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.6.1.tgz";
-        sha512 = "gLLF0kz4QOOyczDGWuR2ZNDfa1nHfyFNG76ue8Es0/0ujnMT9KoSokXkx1hDh0X7FFTMj/MelYYoNEqgTH88zw==";
+        url = "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.6.2.tgz";
+        sha512 = "f7grbfoI5fPxGJDmrvG0ulWq8vFHwvJSUrcEChhiUCSMFZlpBil/1TSaxJRESiQqnoZ9s5WrVhzuwejxODGMYw==";
       };
     };
-    "apollo-server-types-0.2.1" = {
+    "apollo-server-types-0.2.2" = {
       name = "apollo-server-types";
       packageName = "apollo-server-types";
-      version = "0.2.1";
+      version = "0.2.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.2.1.tgz";
-        sha512 = "ls26d6jjY7x91ctLWtbpQHGW0lcFR1LcOpDvBQUC2aCwQzuW/6yV7F3hfcEdLR9pjIxcA4yAtFQcKf5olDWVkA==";
+        url = "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.2.2.tgz";
+        sha512 = "/G4yXUF4Kc6PVCIF12r+oB8AXkE4UVnJoyZHeHiPeDpXklrjwIAtov2WM2mTcSZuZe1EuEkeDci4+tj5zFD39Q==";
       };
     };
-    "apollo-tracing-0.8.1" = {
+    "apollo-tracing-0.8.2" = {
       name = "apollo-tracing";
       packageName = "apollo-tracing";
-      version = "0.8.1";
+      version = "0.8.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.8.1.tgz";
-        sha512 = "zhVNC7N6hg9IJEeSEXFDxcnXD5GJQAbHxaoKVBKEolcIIsz6EGd700ORdagJgFKLReVp9O65HPrZJCg66sVx7g==";
+        url = "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.8.2.tgz";
+        sha512 = "4SVxHZkKZX/7E6/4hAvEJXdHm+1BjQqtgEkv3ywyiVXoaKn0YNJL8BVIOI4GAt0qoc3KzT9MDJ1nf+SurUFjLQ==";
       };
     };
     "apollo-upload-client-10.0.1" = {
@@ -5719,13 +5764,13 @@ let
         sha1 = "00f35b2d27ac91b1f0d3ef2084c98cf1d1f0adc3";
       };
     };
-    "aws-sdk-2.504.0" = {
+    "aws-sdk-2.520.0" = {
       name = "aws-sdk";
       packageName = "aws-sdk";
-      version = "2.504.0";
+      version = "2.520.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.504.0.tgz";
-        sha512 = "azOX54oovJv0zWzO23fBgIprwsvx8KUuMR+cAUAOx23D8LJ5S+sl3UYS9Q1X4qF/blBTa4+ZNawZDV0N1HiQmw==";
+        url = "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.520.0.tgz";
+        sha512 = "I0BnCLyoqJ17bW48LYMpBcyhSpMW+c+H0GPnFoB7T8Xi2uype3sNV+4qzmHMVhVYv+2Xba9CMenyiH6qeYSwvQ==";
       };
     };
     "aws-sign2-0.6.0" = {
@@ -6322,13 +6367,13 @@ let
         sha512 = "Vj97CTn/lE9hR1D+jKUeHfNy+m1baNiJ1wJvoGyOBUx7F7kJqDZxr9nCHjO/Ad+irbR3HzR6jABpSSA29QsrXQ==";
       };
     };
-    "babel-plugin-minify-dead-code-elimination-0.5.0" = {
+    "babel-plugin-minify-dead-code-elimination-0.5.1" = {
       name = "babel-plugin-minify-dead-code-elimination";
       packageName = "babel-plugin-minify-dead-code-elimination";
-      version = "0.5.0";
+      version = "0.5.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.5.0.tgz";
-        sha512 = "XQteBGXlgEoAKc/BhO6oafUdT4LBa7ARi55mxoyhLHNuA+RlzRmeMAfc31pb/UqU01wBzRc36YqHQzopnkd/6Q==";
+        url = "https://registry.npmjs.org/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.5.1.tgz";
+        sha512 = "x8OJOZIrRmQBcSqxBcLbMIK8uPmTvNWPXH2bh5MDCW1latEqYiRMuUkPImKcfpo59pTUB2FT7HfcgtG8ZlR5Qg==";
       };
     };
     "babel-plugin-minify-flip-comparisons-0.4.3" = {
@@ -6340,13 +6385,13 @@ let
         sha1 = "00ca870cb8f13b45c038b3c1ebc0f227293c965a";
       };
     };
-    "babel-plugin-minify-guarded-expressions-0.4.3" = {
+    "babel-plugin-minify-guarded-expressions-0.4.4" = {
       name = "babel-plugin-minify-guarded-expressions";
       packageName = "babel-plugin-minify-guarded-expressions";
-      version = "0.4.3";
+      version = "0.4.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/babel-plugin-minify-guarded-expressions/-/babel-plugin-minify-guarded-expressions-0.4.3.tgz";
-        sha1 = "cc709b4453fd21b1f302877444c89f88427ce397";
+        url = "https://registry.npmjs.org/babel-plugin-minify-guarded-expressions/-/babel-plugin-minify-guarded-expressions-0.4.4.tgz";
+        sha512 = "RMv0tM72YuPPfLT9QLr3ix9nwUIq+sHT6z8Iu3sLbqldzC1Dls8DPCywzUIzkTx9Zh1hWX4q/m9BPoPed9GOfA==";
       };
     };
     "babel-plugin-minify-infinity-0.4.3" = {
@@ -6385,13 +6430,13 @@ let
         sha512 = "aXZiaqWDNUbyNNNpWs/8NyST+oU7QTpK7J9zFEFSA0eOmtUNMU3fczlTTTlnCxHmq/jYNFEmkkSG3DDBtW3Y4Q==";
       };
     };
-    "babel-plugin-minify-simplify-0.5.0" = {
+    "babel-plugin-minify-simplify-0.5.1" = {
       name = "babel-plugin-minify-simplify";
       packageName = "babel-plugin-minify-simplify";
-      version = "0.5.0";
+      version = "0.5.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/babel-plugin-minify-simplify/-/babel-plugin-minify-simplify-0.5.0.tgz";
-        sha512 = "TM01J/YcKZ8XIQd1Z3nF2AdWHoDsarjtZ5fWPDksYZNsoOjQ2UO2EWm824Ym6sp127m44gPlLFiO5KFxU8pA5Q==";
+        url = "https://registry.npmjs.org/babel-plugin-minify-simplify/-/babel-plugin-minify-simplify-0.5.1.tgz";
+        sha512 = "OSYDSnoCxP2cYDMk9gxNAed6uJDiDz65zgL6h8d3tm8qXIagWGMLWhqysT6DY3Vs7Fgq7YUDcjOomhVUb+xX6A==";
       };
     };
     "babel-plugin-minify-type-constructors-0.4.3" = {
@@ -6583,13 +6628,13 @@ let
         sha1 = "8ec7a03a138f001a1a8fb1e8113652bf1a55da46";
       };
     };
-    "babel-preset-minify-0.5.0" = {
+    "babel-preset-minify-0.5.1" = {
       name = "babel-preset-minify";
       packageName = "babel-preset-minify";
-      version = "0.5.0";
+      version = "0.5.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/babel-preset-minify/-/babel-preset-minify-0.5.0.tgz";
-        sha512 = "xj1s9Mon+RFubH569vrGCayA9Fm2GMsCgDRm1Jb8SgctOB7KFcrVc2o8K3YHUyMz+SWP8aea75BoS8YfsXXuiA==";
+        url = "https://registry.npmjs.org/babel-preset-minify/-/babel-preset-minify-0.5.1.tgz";
+        sha512 = "1IajDumYOAPYImkHbrKeiN5AKKP9iOmRoO2IPbIuVp0j2iuCcj0n7P260z38siKMZZ+85d3mJZdtW8IgOv+Tzg==";
       };
     };
     "babel-register-6.26.0" = {
@@ -7177,13 +7222,13 @@ let
         sha512 = "fvb6M58Ceiv/S94nu6zeaiMoJvUYOeIqRbgaClm+kJTzCAqJPtAR/31pXNYB5iEReOoKqQB5zY33gY0W6ZRWQQ==";
       };
     };
-    "bittorrent-dht-9.0.1" = {
+    "bittorrent-dht-9.0.2" = {
       name = "bittorrent-dht";
       packageName = "bittorrent-dht";
-      version = "9.0.1";
+      version = "9.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/bittorrent-dht/-/bittorrent-dht-9.0.1.tgz";
-        sha512 = "DgymMDZyv5y0pyys73pFa3rImRliqxkiDvVwJ35e+co6MHQJ30M5ZvTstwJ38CtdMlF36RoLnL2z14ICl7pv/A==";
+        url = "https://registry.npmjs.org/bittorrent-dht/-/bittorrent-dht-9.0.2.tgz";
+        sha512 = "w8JOhuJsdmRc1tlQpwXOmhBy4VwcFr/FDePo97mp0fiBbXQ8CFSemssBL0lSxB1+7sX3vQyZh31YJERNFyPJtA==";
       };
     };
     "bittorrent-peerid-1.3.0" = {
@@ -7213,13 +7258,13 @@ let
         sha1 = "ffd2eabc141d36ed5c1817df7e992f91fd7fc65c";
       };
     };
-    "bittorrent-tracker-9.12.1" = {
+    "bittorrent-tracker-9.14.4" = {
       name = "bittorrent-tracker";
       packageName = "bittorrent-tracker";
-      version = "9.12.1";
+      version = "9.14.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/bittorrent-tracker/-/bittorrent-tracker-9.12.1.tgz";
-        sha512 = "5gjqHG3xV3eEy3UOOn4kkB09sl66t+fYzBGFMI83lRC/+33xmgpDYnu2lOnjYdRPAKWv0nBJT5XR/l9JkQ341A==";
+        url = "https://registry.npmjs.org/bittorrent-tracker/-/bittorrent-tracker-9.14.4.tgz";
+        sha512 = "2Y/MNRjYhysD6t4r38z7l1WTT7g23IAqRWZRsj7xnnpciFn4xE4qiKmyFwA4gtbFGAZ14K3DdaqZbiQsC3PEfQ==";
       };
     };
     "bl-0.8.2" = {
@@ -7247,15 +7292,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz";
         sha512 = "e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==";
-      };
-    };
-    "bl-2.2.0" = {
-      name = "bl";
-      packageName = "bl";
-      version = "2.2.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/bl/-/bl-2.2.0.tgz";
-        sha512 = "wbgvOpqopSr7uq6fJrLH8EsvYMJf9gzfo2jCsL2eTy75qXPukA4pCgHamOQkZtY5vmfVtjB+P3LNlMHW5CEZXA==";
       };
     };
     "bl-3.0.0" = {
@@ -7780,13 +7816,13 @@ let
         sha512 = "qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==";
       };
     };
-    "browserify-16.3.0" = {
+    "browserify-16.5.0" = {
       name = "browserify";
       packageName = "browserify";
-      version = "16.3.0";
+      version = "16.5.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/browserify/-/browserify-16.3.0.tgz";
-        sha512 = "BWaaD7alyGZVEBBwSTYx4iJF5DswIGzK17o8ai9w4iKRbYpk3EOiprRHMRRA8DCZFmFeOdx7A385w2XdFvxWmg==";
+        url = "https://registry.npmjs.org/browserify/-/browserify-16.5.0.tgz";
+        sha512 = "6bfI3cl76YLAnCZ75AGu/XPOsqUhRyc0F/olGIJeCxtfxF2HvPKEcmjU9M8oAPxl4uBY1U7Nry33Q6koV3f2iw==";
       };
     };
     "browserify-aes-1.2.0" = {
@@ -7933,13 +7969,13 @@ let
         sha1 = "6d1bb601b07a4efced97094132093027c95bc298";
       };
     };
-    "buffer-5.2.1" = {
+    "buffer-5.4.2" = {
       name = "buffer";
       packageName = "buffer";
-      version = "5.2.1";
+      version = "5.4.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz";
-        sha512 = "c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==";
+        url = "https://registry.npmjs.org/buffer/-/buffer-5.4.2.tgz";
+        sha512 = "iy9koArjAFCzGnx3ZvNA6Z0clIbbFgbdWQ0mKD3hO0krOrZh8UgA6qMKcZvwLJxS+D6iVR76+5/pV56yMNYTag==";
       };
     };
     "buffer-alloc-1.2.0" = {
@@ -8122,13 +8158,22 @@ let
         sha1 = "7afd74a45f937fa422a1d338c08bbfdc76cd725d";
       };
     };
-    "bufrw-1.2.1" = {
+    "bufrw-1.3.0" = {
       name = "bufrw";
       packageName = "bufrw";
-      version = "1.2.1";
+      version = "1.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/bufrw/-/bufrw-1.2.1.tgz";
-        sha1 = "93f222229b4f5f5e2cd559236891407f9853663b";
+        url = "https://registry.npmjs.org/bufrw/-/bufrw-1.3.0.tgz";
+        sha512 = "jzQnSbdJqhIltU9O5KUiTtljP9ccw2u5ix59McQy4pV2xGhVLhRZIndY8GIrgh5HjXa6+QJ9AQhOd2QWQizJFQ==";
+      };
+    };
+    "builtin-modules-1.1.1" = {
+      name = "builtin-modules";
+      packageName = "builtin-modules";
+      version = "1.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz";
+        sha1 = "270f076c5a72c02f5b65a47df94c5fe3a278892f";
       };
     };
     "builtin-modules-2.0.0" = {
@@ -8311,13 +8356,13 @@ let
         sha1 = "3fb410c7e91558eb1ab22a82834577aa6bd61d42";
       };
     };
-    "cacache-12.0.2" = {
+    "cacache-12.0.3" = {
       name = "cacache";
       packageName = "cacache";
-      version = "12.0.2";
+      version = "12.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/cacache/-/cacache-12.0.2.tgz";
-        sha512 = "ifKgxH2CKhJEg6tNdAwziu6Q33EvuG26tYcda6PT3WKisZcYDXsnEdnRv67Po3yCzFfaSoMjGZzJyD2c3DT1dg==";
+        url = "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz";
+        sha512 = "kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==";
       };
     };
     "cache-base-1.0.1" = {
@@ -8536,13 +8581,13 @@ let
         sha1 = "a2aa5fb1af688758259c32c141426d78923b9b77";
       };
     };
-    "camelcase-keys-5.2.0" = {
+    "camelcase-keys-6.0.1" = {
       name = "camelcase-keys";
       packageName = "camelcase-keys";
-      version = "5.2.0";
+      version = "6.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-5.2.0.tgz";
-        sha512 = "mSM/OQKD1HS5Ll2AXxeaHSdqCGC/QQ8IrgTbKYA/rxnC36thBKysfIr9+OVBWuW17jyZF4swHkjtglawgBmVFg==";
+        url = "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.0.1.tgz";
+        sha512 = "Pet+fVo99HMVy183qJuyTiQECQlb0dCXg89qhixcud88j4BSns+gzhSrjRT0ustEYSWJqKMO42arm1cS1VG5FA==";
       };
     };
     "caniuse-api-3.0.0" = {
@@ -8968,13 +9013,13 @@ let
         sha1 = "798e689778151c8076b4b360e5edd28cda2bb468";
       };
     };
-    "chokidar-2.1.6" = {
+    "chokidar-2.1.8" = {
       name = "chokidar";
       packageName = "chokidar";
-      version = "2.1.6";
+      version = "2.1.8";
       src = fetchurl {
-        url = "https://registry.npmjs.org/chokidar/-/chokidar-2.1.6.tgz";
-        sha512 = "V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==";
+        url = "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz";
+        sha512 = "ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==";
       };
     };
     "chokidar-3.0.0" = {
@@ -9013,13 +9058,40 @@ let
         sha512 = "GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A==";
       };
     };
-    "chroma-js-2.0.4" = {
+    "chroma-js-2.0.6" = {
       name = "chroma-js";
       packageName = "chroma-js";
-      version = "2.0.4";
+      version = "2.0.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/chroma-js/-/chroma-js-2.0.4.tgz";
-        sha512 = "gk71qOrSdBTLbsd0DIUO3QjZL8tTvMwpG1EoXYScy7rI4rcO4EyYH6zGuvCgUDumKumqg0pt6Ua+vWnMJsTYhw==";
+        url = "https://registry.npmjs.org/chroma-js/-/chroma-js-2.0.6.tgz";
+        sha512 = "IiiClbBRkRwuXNl6impq5ssEhUGpmWvc5zzImZbDUWLWcFbj6ZbtsdZEx6sIXMKes7azgYaUpnmsY1T8BL6PqQ==";
+      };
+    };
+    "chrome-dgram-3.0.2" = {
+      name = "chrome-dgram";
+      packageName = "chrome-dgram";
+      version = "3.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/chrome-dgram/-/chrome-dgram-3.0.2.tgz";
+        sha512 = "Ay741EHF/Ib18un+LUtBNK43NrabD6GOuwVaka7uUbV0gFRLEPULm2Q05YSzRNBtSrbaO4eErmDdniiy/u8Lig==";
+      };
+    };
+    "chrome-dns-1.0.1" = {
+      name = "chrome-dns";
+      packageName = "chrome-dns";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/chrome-dns/-/chrome-dns-1.0.1.tgz";
+        sha512 = "HqsYJgIc8ljJJOqOzLphjAs79EUuWSX3nzZi2LNkzlw3GIzAeZbaSektC8iT/tKvLqZq8yl1GJu5o6doA4TRbg==";
+      };
+    };
+    "chrome-net-3.3.3" = {
+      name = "chrome-net";
+      packageName = "chrome-net";
+      version = "3.3.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/chrome-net/-/chrome-net-3.3.3.tgz";
+        sha512 = "11jL8+Ogna8M5TEdyalE8IG6cpaFEU3YcaxAj3YjZKjRM/PeT70pZbrUY+xoGwqiEJZwJE4Td2CvGxUvS9ytKQ==";
       };
     };
     "chrome-remote-interface-0.26.1" = {
@@ -9254,6 +9326,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz";
         sha1 = "b35dac376479facc3e94747d41d0d0f5238ffcb5";
+      };
+    };
+    "cli-cursor-3.1.0" = {
+      name = "cli-cursor";
+      packageName = "cli-cursor";
+      version = "3.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz";
+        sha512 = "I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==";
       };
     };
     "cli-list-0.2.0" = {
@@ -9562,22 +9643,13 @@ let
         sha512 = "FXDYw4TjR8wgPZYui2LeTqWh1BLpfQ8lB6upMtlpDF6WlOOxghmTTxWyngdKTgozqBgKnHbTVwTE+hOHqAykuQ==";
       };
     };
-    "closest-to-2.0.0" = {
-      name = "closest-to";
-      packageName = "closest-to";
-      version = "2.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/closest-to/-/closest-to-2.0.0.tgz";
-        sha1 = "bb2a860edb7769b62d04821748ae50da24dbefaa";
-      };
-    };
-    "cmd-shim-2.0.2" = {
+    "cmd-shim-2.1.0" = {
       name = "cmd-shim";
       packageName = "cmd-shim";
-      version = "2.0.2";
+      version = "2.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz";
-        sha1 = "6fcbda99483a8fd15d7d30a196ca69d688a2efdb";
+        url = "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.1.0.tgz";
+        sha512 = "A5C0Cyf2H8sKsHqX0tvIWRXw5/PK++3Dc0lDbsugr90nOECLLuSPahVQBG8pgmgiXgm/TzBWMqI2rWdZwHduAw==";
       };
     };
     "cmdln-3.2.1" = {
@@ -9769,13 +9841,13 @@ let
         sha512 = "QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==";
       };
     };
-    "color-convert-2.0.0" = {
+    "color-convert-2.0.1" = {
       name = "color-convert";
       packageName = "color-convert";
-      version = "2.0.0";
+      version = "2.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/color-convert/-/color-convert-2.0.0.tgz";
-        sha512 = "hzTicsCJIHdxih9+2aLR1tNGZX5qSJGRHDPVwSY26tVrEf55XNajLOBWz2UuWSIergszA09/bqnOiHyqx9fxQg==";
+        url = "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz";
+        sha512 = "RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==";
       };
     };
     "color-name-1.1.3" = {
@@ -10100,6 +10172,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz";
         sha1 = "9c99094176e12240cb22d6c5146098400fe0f7d4";
+      };
+    };
+    "commander-3.0.0" = {
+      name = "commander";
+      packageName = "commander";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/commander/-/commander-3.0.0.tgz";
+        sha512 = "pl3QrGOBa9RZaslQiqnnKX2J068wcQw7j9AIaBQ9/JEp5RY6je4jKTImg0Bd+rpoONSe7GUFSgkxLeo17m3Pow==";
       };
     };
     "commist-1.1.0" = {
@@ -10705,13 +10786,13 @@ let
         sha1 = "f67a4938c5233443564250479c67014bac878499";
       };
     };
-    "convict-4.4.1" = {
+    "convict-5.1.0" = {
       name = "convict";
       packageName = "convict";
-      version = "4.4.1";
+      version = "5.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/convict/-/convict-4.4.1.tgz";
-        sha512 = "celpR4hOWWwb/S8azhzgQwDon6muAJlNe2LTLeOGyoSgH390TsaqoieAe9BLbAv7+9wNfG7DTA2q3IfFp2viKw==";
+        url = "https://registry.npmjs.org/convict/-/convict-5.1.0.tgz";
+        sha512 = "0+Rf3wUfEpz+UuwksNgjREf+81eRDsiQ64ZAs3Gh2rZeXIjiI5m0pxwybRZUebpSKEfOFxN5oUthIUpnqIMh6w==";
       };
     };
     "cookie-0.0.4" = {
@@ -10939,15 +11020,6 @@ let
         sha512 = "h479g/5a0PXn//yiFuMrD5MDEbB+mtihNkWcE6uD/aCh/6z0FRZ9sWH3NfZbHDB+Bp1yGLYsjbH8LZBL8KOQ0w==";
       };
     };
-    "core-js-2.5.7" = {
-      name = "core-js";
-      packageName = "core-js";
-      version = "2.5.7";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz";
-        sha512 = "RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==";
-      };
-    };
     "core-js-2.6.9" = {
       name = "core-js";
       packageName = "core-js";
@@ -10957,31 +11029,22 @@ let
         sha512 = "HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==";
       };
     };
-    "core-js-3.1.4" = {
+    "core-js-3.2.1" = {
       name = "core-js";
       packageName = "core-js";
-      version = "3.1.4";
+      version = "3.2.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/core-js/-/core-js-3.1.4.tgz";
-        sha512 = "YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ==";
+        url = "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz";
+        sha512 = "Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw==";
       };
     };
-    "core-js-compat-3.1.4" = {
+    "core-js-compat-3.2.1" = {
       name = "core-js-compat";
       packageName = "core-js-compat";
-      version = "3.1.4";
+      version = "3.2.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.1.4.tgz";
-        sha512 = "Z5zbO9f1d0YrJdoaQhphVAnKPimX92D6z8lCGphH89MNRxlL1prI9ExJPqVwP0/kgkQCv8c4GJGT8X16yUncOg==";
-      };
-    };
-    "core-js-pure-3.1.4" = {
-      name = "core-js-pure";
-      packageName = "core-js-pure";
-      version = "3.1.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.1.4.tgz";
-        sha512 = "uJ4Z7iPNwiu1foygbcZYJsJs1jiXrTTCvxfLDXNhI/I+NHbSIEyr548y4fcsCEyWY0XgfAG/qqaunJ1SThHenA==";
+        url = "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.2.1.tgz";
+        sha512 = "MwPZle5CF9dEaMYdDeWm73ao/IflDH+FjeJCWEADcEgFSE9TLimFKwJsfmkwzI8eC0Aj0mgvMDjeQjrElkz4/A==";
       };
     };
     "core-util-is-1.0.2" = {
@@ -11173,13 +11236,13 @@ let
         sha512 = "MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==";
       };
     };
-    "create-torrent-4.2.1" = {
+    "create-torrent-4.3.0" = {
       name = "create-torrent";
       packageName = "create-torrent";
-      version = "4.2.1";
+      version = "4.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/create-torrent/-/create-torrent-4.2.1.tgz";
-        sha512 = "IlKF2B3vrAGVzcgYVVgfsekp4p2N9BqkGeVqckTljajs+qIQ5oAwAzELJtb6sZ14UQBT7ZQNOOyvxgIL98VpZg==";
+        url = "https://registry.npmjs.org/create-torrent/-/create-torrent-4.3.0.tgz";
+        sha512 = "zcKfxN61zvaiKBrREZSx6K7mu1JsFPT7uzP2JThlpd0JwXtlmMcM4zpCh7mVF/OYkK6sxLLSNWqWSQ3YTd42Ng==";
       };
     };
     "creato-1.0.5" = {
@@ -11389,13 +11452,13 @@ let
         sha1 = "5908668294a1becd261ae0a4ce21b0b551f21d16";
       };
     };
-    "css-parse-1.7.0" = {
+    "css-parse-2.0.0" = {
       name = "css-parse";
       packageName = "css-parse";
-      version = "1.7.0";
+      version = "2.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/css-parse/-/css-parse-1.7.0.tgz";
-        sha1 = "321f6cf73782a6ff751111390fc05e2c657d8c9b";
+        url = "https://registry.npmjs.org/css-parse/-/css-parse-2.0.0.tgz";
+        sha1 = "a468ee667c16d81ccf05c58c38d2a97c780dbfd4";
       };
     };
     "css-select-1.2.0" = {
@@ -12343,6 +12406,15 @@ let
         sha1 = "f5d260292b660e084eff4cdbc9f08ad3247448b5";
       };
     };
+    "deep-equal-1.1.0" = {
+      name = "deep-equal";
+      packageName = "deep-equal";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.0.tgz";
+        sha512 = "ZbfWJq/wN1Z273o7mUSjILYqehAktR2NVoSrOukDkU9kg2v/Uv89yU4Cvz8seJeAmtN5oqiefKq8FPuXOboqLw==";
+      };
+    };
     "deep-extend-0.2.11" = {
       name = "deep-extend";
       packageName = "deep-extend";
@@ -12370,13 +12442,13 @@ let
         sha512 = "LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==";
       };
     };
-    "deep-freeze-0.0.1" = {
-      name = "deep-freeze";
-      packageName = "deep-freeze";
-      version = "0.0.1";
+    "deep-freeze-node-1.1.3" = {
+      name = "deep-freeze-node";
+      packageName = "deep-freeze-node";
+      version = "1.1.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/deep-freeze/-/deep-freeze-0.0.1.tgz";
-        sha1 = "3a0b0005de18672819dfd38cd31f91179c893e84";
+        url = "https://registry.npmjs.org/deep-freeze-node/-/deep-freeze-node-1.1.3.tgz";
+        sha512 = "CrA+1BVGfs9ZrGFMYtHfFHncWivh9XPb+6g8bLOzYPJmW8FmUs1dXLjALzU1SMqOMdoD5pQJARXtzxfeLqE9HQ==";
       };
     };
     "deep-is-0.1.2" = {
@@ -12595,6 +12667,15 @@ let
         sha1 = "fcf490a37ece266464d9cc431ab98c5819ced095";
       };
     };
+    "delay-4.3.0" = {
+      name = "delay";
+      packageName = "delay";
+      version = "4.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/delay/-/delay-4.3.0.tgz";
+        sha512 = "Lwaf3zVFDMBop1yDuFZ19F9WyGcZcGacsbdlZtWjQmM50tOcMntm1njF/Nb/Vjij3KaSvCF+sEYGKrrjObu2NA==";
+      };
+    };
     "delayed-stream-0.0.5" = {
       name = "delayed-stream";
       packageName = "delayed-stream";
@@ -12809,6 +12890,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz";
         sha1 = "f41f1c10be4b00e87b5f13da680759f2c5bfd3e2";
+      };
+    };
+    "detect-node-2.0.4" = {
+      name = "detect-node";
+      packageName = "detect-node";
+      version = "2.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz";
+        sha512 = "ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==";
       };
     };
     "detective-4.7.1" = {
@@ -13252,15 +13342,6 @@ let
         sha1 = "672226dc74c8f799ad35307df936aba11acd6018";
       };
     };
-    "dom4-2.1.3" = {
-      name = "dom4";
-      packageName = "dom4";
-      version = "2.1.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/dom4/-/dom4-2.1.3.tgz";
-        sha512 = "begvh4z5GV0kyxx+YgJZ7sIo/jsELx/v7MQxoLZpOvT5yFo18X8dfgtUmKAwdGuyMeugncylarLHlO4gIK6YNw==";
-      };
-    };
     "domain-browser-1.2.0" = {
       name = "domain-browser";
       packageName = "domain-browser";
@@ -13423,6 +13504,15 @@ let
         sha1 = "def1f1ca5d6059d24a766e587942c21106ce1275";
       };
     };
+    "dotnet-deps-parser-4.5.0" = {
+      name = "dotnet-deps-parser";
+      packageName = "dotnet-deps-parser";
+      version = "4.5.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/dotnet-deps-parser/-/dotnet-deps-parser-4.5.0.tgz";
+        sha512 = "t6rBxcWVZSDNhhWdsbq9ozaCzfPXV79FiyES1JLNEoA7nYF+zDC2VZvFZSnH8ilU3bghJXxZPH+EcKYvfw8g/g==";
+      };
+    };
     "downgrade-root-1.2.2" = {
       name = "downgrade-root";
       packageName = "downgrade-root";
@@ -13513,13 +13603,13 @@ let
         sha1 = "0b078d5517937d873101452d9146737557b75e51";
       };
     };
-    "dtrace-provider-0.8.7" = {
+    "dtrace-provider-0.8.8" = {
       name = "dtrace-provider";
       packageName = "dtrace-provider";
-      version = "0.8.7";
+      version = "0.8.8";
       src = fetchurl {
-        url = "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.7.tgz";
-        sha1 = "dc939b4d3e0620cfe0c1cd803d0d2d7ed04ffd04";
+        url = "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.8.tgz";
+        sha512 = "b7Z7cNtHPhH9EJhNNbbeqTcXB8LGFFZhq1PGgEvpeHlzd36bhbdTWoE/Ba/YguqpBSlAPKnARWhVlhunCMwfxg==";
       };
     };
     "duplexer-0.1.1" = {
@@ -13756,13 +13846,13 @@ let
         sha512 = "PcW2a0tyTuPHz3tWyYqtK6r1fZ3gp+3Sop8Ph+ZYN81Ob5rwmbHEzaqs10N3BEsaGTkh/ooniXK+WwszGlc2+Q==";
       };
     };
-    "electron-to-chromium-1.3.215" = {
+    "electron-to-chromium-1.3.245" = {
       name = "electron-to-chromium";
       packageName = "electron-to-chromium";
-      version = "1.3.215";
+      version = "1.3.245";
       src = fetchurl {
-        url = "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.215.tgz";
-        sha512 = "ZV3OnwF0FlIygwxAG2H92yt7WGjWBpawyFAFu8e9k7xJatY+BPowID0D0Bs3PMACYAJATEejw/I9cawO27ZvTg==";
+        url = "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.245.tgz";
+        sha512 = "W1Tjm8VhabzYmiqLUD/sT/KTKkvZ8QpSkbTfLELBrFdnrolfkCgcbxFE3NXAxL5xedWXF74wWn0j6oVrgBdemw==";
       };
     };
     "elegant-spinner-1.0.1" = {
@@ -13774,13 +13864,13 @@ let
         sha1 = "db043521c95d7e303fd8f345bedc3349cfb0729e";
       };
     };
-    "element-helper-json-2.0.5" = {
+    "element-helper-json-2.0.6" = {
       name = "element-helper-json";
       packageName = "element-helper-json";
-      version = "2.0.5";
+      version = "2.0.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/element-helper-json/-/element-helper-json-2.0.5.tgz";
-        sha512 = "XBFDNA4aAygKLqt3S7jhwWivUJInO9Yw2zlJjayPDSNDsg9OMIHbi/UE3JfJq7kw9BHDn6CchnSRVIcWG1AuzA==";
+        url = "https://registry.npmjs.org/element-helper-json/-/element-helper-json-2.0.6.tgz";
+        sha512 = "AzJvyAAYwFvv4zesXVQbB8zNBMJl/6HjDulY2NfxHdOEhsjq1knIoYOI+Ln20OlYX431sxSBO/5ji+aaQr/VoQ==";
       };
     };
     "elementtree-0.1.7" = {
@@ -14198,15 +14288,6 @@ let
         sha1 = "85675afba237c43f98de2d46adc0e532a4dcf48b";
       };
     };
-    "envinfo-7.1.0" = {
-      name = "envinfo";
-      packageName = "envinfo";
-      version = "7.1.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/envinfo/-/envinfo-7.1.0.tgz";
-        sha512 = "38LJhrmyQafVInoYlaEDxomIfjtK+HUtp1JsInWdKtpxk0MlTU60fqYHg0LrKgxxJuq6H89ddw4IkxfQejZ77g==";
-      };
-    };
     "envinfo-7.3.1" = {
       name = "envinfo";
       packageName = "envinfo";
@@ -14423,6 +14504,15 @@ let
         sha512 = "J3ZkwbEnnO+fGAKrjVpeUAnZshAdfZvbhQpqfIH9kSAspReRC4nJnu8ewm55b4y9ElyeuhCTzJD0XiH8Tsbhlw==";
       };
     };
+    "es6-promisify-6.0.2" = {
+      name = "es6-promisify";
+      packageName = "es6-promisify";
+      version = "6.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.0.2.tgz";
+        sha512 = "eO6vFm0JvqGzjWIQA6QVKjxpmELfhWbDUWHm1rPfIbn55mhKPiAa5xpLmQWJrNa629ZIeQ8ZvMAi13kvrjK6Mg==";
+      };
+    };
     "es6-set-0.1.5" = {
       name = "es6-set";
       packageName = "es6-set";
@@ -14522,13 +14612,13 @@ let
         sha512 = "UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==";
       };
     };
-    "escodegen-1.11.1" = {
+    "escodegen-1.12.0" = {
       name = "escodegen";
       packageName = "escodegen";
-      version = "1.11.1";
+      version = "1.12.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz";
-        sha512 = "JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==";
+        url = "https://registry.npmjs.org/escodegen/-/escodegen-1.12.0.tgz";
+        sha512 = "TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==";
       };
     };
     "escodegen-1.9.1" = {
@@ -14576,13 +14666,13 @@ let
         sha512 = "S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==";
       };
     };
-    "eslint-6.1.0" = {
+    "eslint-6.2.2" = {
       name = "eslint";
       packageName = "eslint";
-      version = "6.1.0";
+      version = "6.2.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/eslint/-/eslint-6.1.0.tgz";
-        sha512 = "QhrbdRD7ofuV09IuE2ySWBz0FyXCq0rriLTZXZqaWSI79CVtHVRdkFuFTViiqzZhkCgfOh9USpriuGN2gIpZDQ==";
+        url = "https://registry.npmjs.org/eslint/-/eslint-6.2.2.tgz";
+        sha512 = "mf0elOkxHbdyGX1IJEUsNBzCDdyoUgljF3rRlgfyYh0pwGnreLc0jjD6ZuleOibjmnUWZLY2eXwSooeOgGJ2jw==";
       };
     };
     "eslint-plugin-no-unsafe-innerhtml-1.0.16" = {
@@ -14639,13 +14729,13 @@ let
         sha512 = "oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==";
       };
     };
-    "eslint-utils-1.4.0" = {
+    "eslint-utils-1.4.2" = {
       name = "eslint-utils";
       packageName = "eslint-utils";
-      version = "1.4.0";
+      version = "1.4.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.0.tgz";
-        sha512 = "7ehnzPaP5IIEh1r1tkjuIrxqhNkzUJa9z3R92tLJdZIVdWaczEhr3EbhGtsMrVxi1KeR8qA7Off6SWc5WNQqyQ==";
+        url = "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz";
+        sha512 = "eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==";
       };
     };
     "eslint-visitor-keys-1.0.0" = {
@@ -14655,6 +14745,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz";
         sha512 = "qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==";
+      };
+    };
+    "eslint-visitor-keys-1.1.0" = {
+      name = "eslint-visitor-keys";
+      packageName = "eslint-visitor-keys";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz";
+        sha512 = "8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==";
       };
     };
     "esm-3.2.25" = {
@@ -14693,13 +14792,13 @@ let
         sha512 = "qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==";
       };
     };
-    "espree-6.0.0" = {
+    "espree-6.1.1" = {
       name = "espree";
       packageName = "espree";
-      version = "6.0.0";
+      version = "6.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/espree/-/espree-6.0.0.tgz";
-        sha512 = "lJvCS6YbCn3ImT3yKkPe0+tJ+mH6ljhGNjHQH9mRtiO6gjhVAOhVXW1yjnwqGwTkK3bGbye+hb00nFNmu0l/1Q==";
+        url = "https://registry.npmjs.org/espree/-/espree-6.1.1.tgz";
+        sha512 = "EYbr8XZUhWbYCqQRW0duU5LxzL5bETN6AjKBGy1302qqzPaCH10QbRg3Wvco79Z8x9WbiE8HYB4e75xl6qUYvQ==";
       };
     };
     "esprima-2.0.0" = {
@@ -14765,13 +14864,13 @@ let
         sha512 = "64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==";
       };
     };
-    "estraverse-4.2.0" = {
+    "estraverse-4.3.0" = {
       name = "estraverse";
       packageName = "estraverse";
-      version = "4.2.0";
+      version = "4.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz";
-        sha1 = "0dee3fed31fcd469618ce7342099fc1afa0bdb13";
+        url = "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz";
+        sha512 = "39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==";
       };
     };
     "estree-walker-0.5.2" = {
@@ -14979,6 +15078,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz";
         sha512 = "tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==";
+      };
+    };
+    "eventemitter3-4.0.0" = {
+      name = "eventemitter3";
+      packageName = "eventemitter3";
+      version = "4.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz";
+        sha512 = "qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg==";
       };
     };
     "events-1.1.1" = {
@@ -15629,13 +15737,13 @@ let
         sha1 = "66e4028e381eaa002edeb280d10238f3a46c3402";
       };
     };
-    "fast-json-patch-2.2.0" = {
+    "fast-json-patch-2.2.1" = {
       name = "fast-json-patch";
       packageName = "fast-json-patch";
-      version = "2.2.0";
+      version = "2.2.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-2.2.0.tgz";
-        sha512 = "LdR6I9Cukps4lPUbSwrk81EHYo2XKsMnbiJJDQyBGGX7oTGovqBFxSVqQ+gOVoMxWfI1ua0vlHcXGpIggxtEFA==";
+        url = "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-2.2.1.tgz";
+        sha512 = "4j5uBaTnsYAV5ebkidvxiLUYOwjQ+JSFljeqfTxCrH9bDmlCQaOJFS84oDJ2rAXZq2yskmk3ORfoP9DCwqFNig==";
       };
     };
     "fast-json-stable-stringify-2.0.0" = {
@@ -15836,6 +15944,15 @@ let
         sha1 = "3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962";
       };
     };
+    "figures-3.0.0" = {
+      name = "figures";
+      packageName = "figures";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/figures/-/figures-3.0.0.tgz";
+        sha512 = "HKri+WoWoUgr83pehn/SIgLOMZ9nAWC6dcGj26RY2R4F50u4+RTUz0RCrUlOV3nKRAICW1UGzyb+kcX2qK1S/g==";
+      };
+    };
     "file-entry-cache-2.0.0" = {
       name = "file-entry-cache";
       packageName = "file-entry-cache";
@@ -15863,13 +15980,13 @@ let
         sha512 = "uzk64HRpUZyTGZtVuvrjP0FYxzQrBf4rojot6J65YMEbwBLB0CWm0CLojVpwpmFmxcE/lkvYICgfcGozbBq6rw==";
       };
     };
-    "file-type-12.0.1" = {
+    "file-type-12.1.0" = {
       name = "file-type";
       packageName = "file-type";
-      version = "12.0.1";
+      version = "12.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/file-type/-/file-type-12.0.1.tgz";
-        sha512 = "YIs1E51cmqcmgF38ODjy0+M/l5DyfIIy3vngTOujQr/lXqkaSskfBniaZoZ1HVIpa5FTf5e7hCXS4TzxfNGMRQ==";
+        url = "https://registry.npmjs.org/file-type/-/file-type-12.1.0.tgz";
+        sha512 = "aZkf42yWGiH+vSOpbVgvbnoRuX4JiitMX9pHYqTHemNQ3lrx64iHi33YGAP7TSJSno56kxQY1lHmw8S6ujlFUg==";
       };
     };
     "file-type-3.9.0" = {
@@ -16331,13 +16448,13 @@ let
         sha512 = "ougBA2q6Rn9sZrjZQ9r5pTFxCotlGouySpD2yRIuq5AYwwfIT8HHhVMeSwrN5qJayjHINLJyrnsSkkPCZyfMrQ==";
       };
     };
-    "flow-parser-0.104.0" = {
+    "flow-parser-0.106.3" = {
       name = "flow-parser";
       packageName = "flow-parser";
-      version = "0.104.0";
+      version = "0.106.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/flow-parser/-/flow-parser-0.104.0.tgz";
-        sha512 = "S2VGfM/qU4g9NUf2hA5qH/QmQsZIflxFO7victnYN1LR5SoOUsn3JtMhXLKHm2QlnZwwJKIdLt/uYyPr4LiQAA==";
+        url = "https://registry.npmjs.org/flow-parser/-/flow-parser-0.106.3.tgz";
+        sha512 = "V4K3tNmawjup+HySlIW5g3M0pywnTXvb32LeVxRHpQi4e3z2zCZIi+4JqnZWq/19JfYexEAquAbD95sORdOILQ==";
       };
     };
     "fluent-ffmpeg-2.1.2" = {
@@ -16457,13 +16574,13 @@ let
         sha1 = "5214d7537a4d06a4a301c0cc262feb84188002e7";
       };
     };
-    "follow-redirects-1.7.0" = {
+    "follow-redirects-1.8.1" = {
       name = "follow-redirects";
       packageName = "follow-redirects";
-      version = "1.7.0";
+      version = "1.8.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz";
-        sha512 = "m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==";
+        url = "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.8.1.tgz";
+        sha512 = "micCIbldHioIegeKs41DoH0KS3AXfFzgS30qVkM6z/XOE/GJgvmsoc839NUqa1B9udYe9dQxgv7KFwng6+p/dw==";
       };
     };
     "for-each-0.3.3" = {
@@ -16610,13 +16727,13 @@ let
         sha512 = "1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==";
       };
     };
-    "form-data-2.5.0" = {
+    "form-data-2.5.1" = {
       name = "form-data";
       packageName = "form-data";
-      version = "2.5.0";
+      version = "2.5.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/form-data/-/form-data-2.5.0.tgz";
-        sha512 = "WXieX3G/8side6VIqx44ablyULoGruSde5PNTxoUyo5CeyAMX6nVWUd0rgist/EuX655cjhUhTo1Fo3tRYqbcA==";
+        url = "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz";
+        sha512 = "m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==";
       };
     };
     "format-0.2.2" = {
@@ -16689,6 +16806,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz";
         sha1 = "4290fad27f13e89be7f33799c6bc5a0abfff0d19";
+      };
+    };
+    "freelist-1.0.3" = {
+      name = "freelist";
+      packageName = "freelist";
+      version = "1.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/freelist/-/freelist-1.0.3.tgz";
+        sha1 = "006775509f3935701784d3ed2fc9f12c9df1bab2";
       };
     };
     "fresh-0.1.0" = {
@@ -16770,6 +16896,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/fs-chunk-store/-/fs-chunk-store-1.7.0.tgz";
         sha512 = "KhjJmZAs2eqfhCb6PdPx4RcZtheGTz86tpTC5JTvqBn/xda+Nb+0C7dCyjOSN7T76H6a56LvH0SVXQMchLXDRw==";
+      };
+    };
+    "fs-chunk-store-2.0.1" = {
+      name = "fs-chunk-store";
+      packageName = "fs-chunk-store";
+      version = "2.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/fs-chunk-store/-/fs-chunk-store-2.0.1.tgz";
+        sha512 = "V9PXz33rhq6E9lFmvmElmLyvEvnSeryU/TzfHnCEIpEU6Y/2Fyc4xEeeneV/pUgKG1mRAKSU+DBtHyO2GQ2EBA==";
       };
     };
     "fs-constants-1.0.0" = {
@@ -17564,15 +17699,6 @@ let
         sha1 = "3b44afa0943bdc31b2037b934791e2e084bcb7f6";
       };
     };
-    "glob-7.0.6" = {
-      name = "glob";
-      packageName = "glob";
-      version = "7.0.6";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz";
-        sha1 = "211bafaf49e525b8cd93260d14ab136152b3f57a";
-      };
-    };
     "glob-7.1.2" = {
       name = "glob";
       packageName = "glob";
@@ -17699,13 +17825,13 @@ let
         sha1 = "e76989268a6c74c38908b1305b10fc0e394e9d0f";
       };
     };
-    "global-agent-2.0.1" = {
+    "global-agent-2.0.2" = {
       name = "global-agent";
       packageName = "global-agent";
-      version = "2.0.1";
+      version = "2.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/global-agent/-/global-agent-2.0.1.tgz";
-        sha512 = "2iGb96/51XxsekctZR4IiP7SoWuGEkmFpsyySasq3RFmvIwDCQJzatB2NqK0sk7h2hVYQdRphL52lrO5grF/jg==";
+        url = "https://registry.npmjs.org/global-agent/-/global-agent-2.0.2.tgz";
+        sha512 = "mQLICTW+QGJPuEI8WvEjdyPCcEnx5OqmJH2ADGtv9NknBfUsTnUsV9NeKfrjkwauT2zrSGQqDrS49f86kvnXoA==";
       };
     };
     "global-dirs-0.1.1" = {
@@ -17815,6 +17941,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz";
         sha512 = "S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==";
+      };
+    };
+    "globalthis-1.0.0" = {
+      name = "globalthis";
+      packageName = "globalthis";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/globalthis/-/globalthis-1.0.0.tgz";
+        sha512 = "vcCAZTJ3r5Qcu5l8/2oyVdoFwxKgfYnMTR2vwWeux/NAVZK3PwcMaWkdUIn4GJbmKuRK7xcvDsLuK+CKcXyodg==";
       };
     };
     "globalyzer-0.1.4" = {
@@ -17988,13 +18123,13 @@ let
         sha1 = "7cd2cdb228a4a3f36e95efa6cc142de7d1a136d0";
       };
     };
-    "graceful-fs-3.0.11" = {
+    "graceful-fs-3.0.12" = {
       name = "graceful-fs";
       packageName = "graceful-fs";
-      version = "3.0.11";
+      version = "3.0.12";
       src = fetchurl {
-        url = "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz";
-        sha1 = "7613c778a1afea62f25c630a086d7f3acbbdd818";
+        url = "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.12.tgz";
+        sha512 = "J55gaCS4iTTJfTXIxSVw3EMQckcqkpdRv3IR7gu6sq0+tbC363Zx6KH/SEwXASK9JRbhyZmVjJEVJIOxYsB3Qg==";
       };
     };
     "graceful-fs-4.1.11" = {
@@ -18006,13 +18141,13 @@ let
         sha1 = "0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658";
       };
     };
-    "graceful-fs-4.2.1" = {
+    "graceful-fs-4.2.2" = {
       name = "graceful-fs";
       packageName = "graceful-fs";
-      version = "4.2.1";
+      version = "4.2.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.1.tgz";
-        sha512 = "b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw==";
+        url = "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz";
+        sha512 = "IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==";
       };
     };
     "graceful-readlink-1.0.1" = {
@@ -18078,13 +18213,13 @@ let
         sha512 = "QZ5BL8ZO/B20VA8APauGBg3GyEgZ19eduvpLWoq5x7gMmWnHoy8rlQWPLmWgFvo1yNgjSEFMesmS4R6pPr7xog==";
       };
     };
-    "graphql-14.4.2" = {
+    "graphql-14.5.4" = {
       name = "graphql";
       packageName = "graphql";
-      version = "14.4.2";
+      version = "14.5.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/graphql/-/graphql-14.4.2.tgz";
-        sha512 = "6uQadiRgnpnSS56hdZUSvFrVcQ6OF9y6wkxJfKquFtHlnl7+KSuWwSJsdwiK1vybm1HgcdbpGkCpvhvsVQ0UZQ==";
+        url = "https://registry.npmjs.org/graphql/-/graphql-14.5.4.tgz";
+        sha512 = "dPLvHoxy5m9FrkqWczPPRnH0X80CyvRE6e7Fa5AWEqEAzg9LpxHvKh24po/482E6VWHigOkAmb4xCp6P9yT9gw==";
       };
     };
     "graphql-anywhere-4.2.4" = {
@@ -18132,22 +18267,13 @@ let
         sha512 = "bOufkkog0cSfHJ9gVD3Wy+KHmkSTHWcFfPaV/NVpIvfJx15gU0/CzuC6lcTjioWmn+UGzYdoqmP7OrJAWT57sw==";
       };
     };
-    "graphql-extensions-0.8.1" = {
+    "graphql-extensions-0.10.1" = {
       name = "graphql-extensions";
       packageName = "graphql-extensions";
-      version = "0.8.1";
+      version = "0.10.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.8.1.tgz";
-        sha512 = "d/L4x7/PPWhviJqi7jIWOVJPzfzagYgPizSQUpa+3hozbWhwpWEnfxwgL5/If5MnPUikBnqlkOLCyjHMNdipYA==";
-      };
-    };
-    "graphql-extensions-0.9.1" = {
-      name = "graphql-extensions";
-      packageName = "graphql-extensions";
-      version = "0.9.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.9.1.tgz";
-        sha512 = "JR/KStdwALd48B/xSG/Mi85zamuJd8THvVlzGM5juznPDN0wTYG5SARGzzvoqHxgxuUHYdzpvESwMAisORJdCQ==";
+        url = "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.10.1.tgz";
+        sha512 = "RIlC/jgBKZ/qyrb+cAu7oJVYLC0dJh6al35tNy8dnqE9JImNucy/gFWVOPW7q3fAaXqCHzbBEtdb+ws1L43LgQ==";
       };
     };
     "graphql-import-0.4.5" = {
@@ -18915,6 +19041,15 @@ let
         sha512 = "l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==";
       };
     };
+    "hexer-1.5.0" = {
+      name = "hexer";
+      packageName = "hexer";
+      version = "1.5.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/hexer/-/hexer-1.5.0.tgz";
+        sha1 = "b86ce808598e8a9d1892c571f3cedd86fc9f0653";
+      };
+    };
     "highlight.js-8.2.0" = {
       name = "highlight.js";
       packageName = "highlight.js";
@@ -18933,13 +19068,13 @@ let
         sha1 = "e6d9dbe57cbefe60751f02af336195870c90c01e";
       };
     };
-    "highlight.js-9.15.9" = {
+    "highlight.js-9.15.10" = {
       name = "highlight.js";
       packageName = "highlight.js";
-      version = "9.15.9";
+      version = "9.15.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.9.tgz";
-        sha512 = "M0zZvfLr5p0keDMCAhNBp03XJbKBxUx5AfyfufMdFMEP4N/Xj6dh0IqC75ys7BAzceR34NgcvXjupRVaHBPPVQ==";
+        url = "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.10.tgz";
+        sha512 = "RoV7OkQm0T3os3Dd2VHLNMoaoDVx77Wygln3n9l5YV172XonWG6rgQD3XnF/BuFFZw9A0TJgmMSO8FEWQgvcXw==";
       };
     };
     "hipchatter-0.3.2" = {
@@ -19014,13 +19149,13 @@ let
         sha1 = "08a74d9272a9cc83ae8e6bbe0303f0ee76432094";
       };
     };
-    "hosted-git-info-2.8.2" = {
+    "hosted-git-info-2.8.4" = {
       name = "hosted-git-info";
       packageName = "hosted-git-info";
-      version = "2.8.2";
+      version = "2.8.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.2.tgz";
-        sha512 = "CyjlXII6LMsPMyUzxpTt8fzh5QwzGqPmQXgY/Jyf4Zfp27t/FvfhwoE/8laaMUcMy816CkWF20I7NeQhwwY88w==";
+        url = "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz";
+        sha512 = "pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==";
       };
     };
     "hsl-regex-1.0.0" = {
@@ -19257,6 +19392,16 @@ let
         sha1 = "29691b6fc58f4f7e81a3605dca82682b068e4430";
       };
     };
+    "http-node-git://github.com/feross/http-node#cddd2872f0020ecf5016f326cf5e58c965eef52a" = {
+      name = "http-node";
+      packageName = "http-node";
+      version = "1.2.0";
+      src = fetchgit {
+        url = "git://github.com/feross/http-node";
+        rev = "cddd2872f0020ecf5016f326cf5e58c965eef52a";
+        sha256 = "30a26f49481223d63078ceff290f2a62c850be48ff278f0d8dd8d60abced2be2";
+      };
+    };
     "http-parser-js-0.4.10" = {
       name = "http-parser-js";
       packageName = "http-parser-js";
@@ -19264,6 +19409,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.10.tgz";
         sha1 = "92c9c1374c35085f75db359ec56cc257cbb93fa4";
+      };
+    };
+    "http-parser-js-0.4.13" = {
+      name = "http-parser-js";
+      packageName = "http-parser-js";
+      version = "0.4.13";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.13.tgz";
+        sha1 = "3bd6d6fde6e3172c9334c3b33b6c193d80fe1137";
       };
     };
     "http-proxy-1.17.0" = {
@@ -19410,13 +19564,13 @@ let
         sha512 = "PH5GBkXqFxw5+4eKaKRIkD23y6vRd/IXSl7IldyJxEXpDH9SEIXRORkBtkGni/ae2P7RVOw6Wxypd2tGXhha1w==";
       };
     };
-    "hypercore-7.5.1" = {
+    "hypercore-7.6.1" = {
       name = "hypercore";
       packageName = "hypercore";
-      version = "7.5.1";
+      version = "7.6.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/hypercore/-/hypercore-7.5.1.tgz";
-        sha512 = "tgololYj3O6Y0Mg6PK7EJntRu+auKSYuER2a8pVetPqnDSJ1RfAVlyVr3VmuS5W9hS0PwH4OXl4R/uVfkuNNoQ==";
+        url = "https://registry.npmjs.org/hypercore/-/hypercore-7.6.1.tgz";
+        sha512 = "ZQ1HdFXa9D5cSwXiu6vldYSE5ro6OBtyWdnFr8L/U3PFDCEpIyhyLvoRTscmP+7U2U9ZYSV3NoNHjWlNPIA8Gw==";
       };
     };
     "hypercore-crypto-1.0.0" = {
@@ -19428,13 +19582,13 @@ let
         sha512 = "xFwOnNlOt8L+SovC7dTNchKaNYJb5l8rKZZwpWQnCme1r7CU4Hlhp1RDqPES6b0OpS7DkTo9iU0GltQGkpsjMw==";
       };
     };
-    "hypercore-protocol-6.11.1" = {
+    "hypercore-protocol-6.12.0" = {
       name = "hypercore-protocol";
       packageName = "hypercore-protocol";
-      version = "6.11.1";
+      version = "6.12.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/hypercore-protocol/-/hypercore-protocol-6.11.1.tgz";
-        sha512 = "4vyYGzSTRCfpIPnpYO/WN0VeS2oGeIrzCCwIXfz5TL2dyyHu7wF5xiigNuUfTn9n3cTOwwbH+EKsygTNsO2yfw==";
+        url = "https://registry.npmjs.org/hypercore-protocol/-/hypercore-protocol-6.12.0.tgz";
+        sha512 = "T3oy9/7QFejqJX2RGcCUU1944e5/eKbLlSz9JPTNN1QbYFJgat/r7eTyOO8SMSLUimUmQx6YBMKhgYbdKzp7Bw==";
       };
     };
     "hyperdrive-9.16.0" = {
@@ -19608,13 +19762,13 @@ let
         sha512 = "cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==";
       };
     };
-    "ignore-5.1.2" = {
+    "ignore-5.1.4" = {
       name = "ignore";
       packageName = "ignore";
-      version = "5.1.2";
+      version = "5.1.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ignore/-/ignore-5.1.2.tgz";
-        sha512 = "vdqWBp7MyzdmHkkRWV5nY+PfGRbYbahfuvsBCh277tq+w9zyNi7h5CYJCK0kmzti9kU+O/cB7sE8HvKv6aXAKQ==";
+        url = "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz";
+        sha512 = "MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==";
       };
     };
     "ignore-by-default-1.0.1" = {
@@ -20031,15 +20185,6 @@ let
         sha512 = "QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==";
       };
     };
-    "inquirer-6.2.2" = {
-      name = "inquirer";
-      packageName = "inquirer";
-      version = "6.2.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/inquirer/-/inquirer-6.2.2.tgz";
-        sha512 = "Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==";
-      };
-    };
     "inquirer-6.5.0" = {
       name = "inquirer";
       packageName = "inquirer";
@@ -20047,6 +20192,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/inquirer/-/inquirer-6.5.0.tgz";
         sha512 = "scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==";
+      };
+    };
+    "inquirer-6.5.1" = {
+      name = "inquirer";
+      packageName = "inquirer";
+      version = "6.5.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/inquirer/-/inquirer-6.5.1.tgz";
+        sha512 = "uxNHBeQhRXIoHWTSNYUFhQVrHYFThIt6IVo2fFmSe8aBwdR3/w6b58hJpiL/fMukFkvGzjg+hSxFtwvVmKZmXw==";
+      };
+    };
+    "inquirer-6.5.2" = {
+      name = "inquirer";
+      packageName = "inquirer";
+      version = "6.5.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz";
+        sha512 = "cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==";
       };
     };
     "inquirer-autocomplete-prompt-1.0.1" = {
@@ -20418,13 +20581,13 @@ let
         sha1 = "50530dfb84fcc9aa7dbe7852e83a37b93b9f2aa6";
       };
     };
-    "is-absolute-url-3.0.0" = {
+    "is-absolute-url-3.0.1" = {
       name = "is-absolute-url";
       packageName = "is-absolute-url";
-      version = "3.0.0";
+      version = "3.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.0.tgz";
-        sha512 = "3OkP8XrM2Xq4/IxsJnClfMp3OaM3TAatLPLKPeWcxLBTrpe6hihwtX+XZfJTcXg/FTRi4qjy0y/C5qiyNxY24g==";
+        url = "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.1.tgz";
+        sha512 = "c2QjUwuMxLsld90sj3xYzpFYWJtuxkIn1f5ua9RTEYJt/vV2IsM+Py00/6qjV7qExgifUvt7qfyBGBBKm+2iBg==";
       };
     };
     "is-accessor-descriptor-0.1.6" = {
@@ -20461,6 +20624,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.3.tgz";
         sha512 = "A1IGAPO5AW9vSh7omxIlOGwIqEvpW/TA+DksVOPM5ODuxKlZS09+TEM1E3275lJqO2oJ38vDpeAL3DCIiHE6eA==";
+      };
+    };
+    "is-arguments-1.0.4" = {
+      name = "is-arguments";
+      packageName = "is-arguments";
+      version = "1.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz";
+        sha512 = "xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==";
       };
     };
     "is-arrayish-0.2.1" = {
@@ -21372,15 +21544,6 @@ let
         sha1 = "1f16e4aa22b04d1336b66188a66af3c600c3a66d";
       };
     };
-    "is-wsl-2.1.0" = {
-      name = "is-wsl";
-      packageName = "is-wsl";
-      version = "2.1.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/is-wsl/-/is-wsl-2.1.0.tgz";
-        sha512 = "pFTjpv/x5HRj8kbZ/Msxi9VrvtOMRBqaDi3OIcbwPI3OuH+r3lLxVWukLITBaOGJIbA/w2+M1eVmVa4XNQlAmQ==";
-      };
-    };
     "is-yarn-global-0.3.0" = {
       name = "is-yarn-global";
       packageName = "is-yarn-global";
@@ -21732,13 +21895,13 @@ let
         sha512 = "M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw==";
       };
     };
-    "js-beautify-1.10.1" = {
+    "js-beautify-1.10.2" = {
       name = "js-beautify";
       packageName = "js-beautify";
-      version = "1.10.1";
+      version = "1.10.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/js-beautify/-/js-beautify-1.10.1.tgz";
-        sha512 = "4y8SHOIRC+/YQ2gs3zJEKBUraQerq49FJYyXRpdzUGYQzCq8q9xtIh0YXial1S5KmonVui4aiUb6XaGyjE51XA==";
+        url = "https://registry.npmjs.org/js-beautify/-/js-beautify-1.10.2.tgz";
+        sha512 = "ZtBYyNUYJIsBWERnQP0rPN9KjkrDfJcMjuVGcvXOUJrD1zmOGwhRwQ4msG+HJ+Ni/FA7+sRQEMYVzdTQDvnzvQ==";
       };
     };
     "js-levenshtein-1.1.6" = {
@@ -21885,13 +22048,13 @@ let
         sha512 = "y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==";
       };
     };
-    "jsdom-15.1.1" = {
+    "jsdom-14.1.0" = {
       name = "jsdom";
       packageName = "jsdom";
-      version = "15.1.1";
+      version = "14.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/jsdom/-/jsdom-15.1.1.tgz";
-        sha512 = "cQZRBB33arrDAeCrAEWn1U3SvrvC8XysBua9Oqg1yWrsY/gYcusloJC3RZJXuY5eehSCmws8f2YeliCqGSkrtQ==";
+        url = "https://registry.npmjs.org/jsdom/-/jsdom-14.1.0.tgz";
+        sha512 = "O901mfJSuTdwU2w3Sn+74T+RnDVP+FuV5fH8tcPWyqrseRAb0s5xOtPgCFiPOtLcyK7CLIJwPyD83ZqQWvA5ng==";
       };
     };
     "jsdom-7.2.2" = {
@@ -22525,22 +22688,22 @@ let
         sha512 = "mgAJZeFYbpP0xzJzmS0TQTYoFI0sjy3GnKFhg8wyboL+KvWg2WLaA2Oy9PthLPx2Rxz4WeBMk4y3MSOrDJ95FA==";
       };
     };
-    "k-rpc-5.0.0" = {
+    "k-rpc-5.1.0" = {
       name = "k-rpc";
       packageName = "k-rpc";
-      version = "5.0.0";
+      version = "5.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/k-rpc/-/k-rpc-5.0.0.tgz";
-        sha512 = "vCH2rQdfMOS+MlUuTSuar1pS2EMrltURf9LmAR9xR6Jik0XPlMX3vEixgqMn17wKmFVCublJqSJ4hJIP7oKZ3Q==";
+        url = "https://registry.npmjs.org/k-rpc/-/k-rpc-5.1.0.tgz";
+        sha512 = "FGc+n70Hcjoa/X2JTwP+jMIOpBz+pkRffHnSl9yrYiwUxg3FIgD50+u1ePfJUOnRCnx6pbjmVk5aAeB1wIijuQ==";
       };
     };
-    "k-rpc-socket-1.8.0" = {
+    "k-rpc-socket-1.11.1" = {
       name = "k-rpc-socket";
       packageName = "k-rpc-socket";
-      version = "1.8.0";
+      version = "1.11.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/k-rpc-socket/-/k-rpc-socket-1.8.0.tgz";
-        sha512 = "f/9TynsO8YYjZ6JjNNtSSH7CJcIHcio1buy3zqByGxb/GX8AWLdL6FZEWTrN8V3/J7W4/E0ZTQQ+Jt2rVq7ELg==";
+        url = "https://registry.npmjs.org/k-rpc-socket/-/k-rpc-socket-1.11.1.tgz";
+        sha512 = "8xtA8oqbZ6v1Niryp2/g4GxW16EQh5MvrUylQoOG+zcrDff5CKttON2XUXvMwlIHq4/2zfPVFiinAccJ+WhxoA==";
       };
     };
     "keep-alive-agent-0.0.1" = {
@@ -22912,13 +23075,13 @@ let
         sha512 = "XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==";
       };
     };
-    "length-prefixed-message-3.0.3" = {
+    "length-prefixed-message-3.0.4" = {
       name = "length-prefixed-message";
       packageName = "length-prefixed-message";
-      version = "3.0.3";
+      version = "3.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/length-prefixed-message/-/length-prefixed-message-3.0.3.tgz";
-        sha1 = "245474d69abc0614dca368dc35aa8074982a23ac";
+        url = "https://registry.npmjs.org/length-prefixed-message/-/length-prefixed-message-3.0.4.tgz";
+        sha512 = "Tqyx4nggb9nkLD6p4hyIz7UiVNg5u3OnCP2h0hS/HXpheH88rsoNEgNB8xTnpPMw6zWXGZ7Cpg1zhWPlsJ0/TQ==";
       };
     };
     "less-2.7.3" = {
@@ -23387,15 +23550,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/lodash/-/lodash-4.16.6.tgz";
         sha1 = "d22c9ac660288f3843e16ba7d2b5d06cca27d777";
-      };
-    };
-    "lodash-4.17.14" = {
-      name = "lodash";
-      packageName = "lodash";
-      version = "4.17.14";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz";
-        sha512 = "mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==";
       };
     };
     "lodash-4.17.15" = {
@@ -25036,13 +25190,13 @@ let
         sha1 = "a65cd29087a92598b8791257a523e021222ac1f9";
       };
     };
-    "map-obj-3.1.0" = {
+    "map-obj-4.1.0" = {
       name = "map-obj";
       packageName = "map-obj";
-      version = "3.1.0";
+      version = "4.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/map-obj/-/map-obj-3.1.0.tgz";
-        sha512 = "Xg1iyYz/+iIW6YoMldux47H/e5QZyDSB41Kb0ev+YYHh3FJnyyzY0vTk/WbVeWcCvdXd70cOriUBmhP8alUFBA==";
+        url = "https://registry.npmjs.org/map-obj/-/map-obj-4.1.0.tgz";
+        sha512 = "glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==";
       };
     };
     "map-stream-0.0.7" = {
@@ -25223,15 +25377,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/matchdep/-/matchdep-2.0.0.tgz";
         sha1 = "c6f34834a0d8dbc3b37c27ee8bbcb27c7775582e";
-      };
-    };
-    "matcher-1.1.1" = {
-      name = "matcher";
-      packageName = "matcher";
-      version = "1.1.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/matcher/-/matcher-1.1.1.tgz";
-        sha512 = "+BmqxWIubKTRKNWx/ahnCkk3mG8m7OturVlqq6HiojGJTd5hVYbgZm6WzcYPCoB+KBT4Vd6R7WSRG2OADNaCjg==";
       };
     };
     "matcher-2.0.0" = {
@@ -26026,13 +26171,13 @@ let
         sha512 = "oP88Dw3LK/pdrKyMdlbmg3W50969UNr4ctISzJfPl+YPYHTAOrS+dihXnsgRNKSRIzDsrnV3eE2CCVlZbpOKdQ==";
       };
     };
-    "minipass-2.3.5" = {
+    "minipass-2.5.0" = {
       name = "minipass";
       packageName = "minipass";
-      version = "2.3.5";
+      version = "2.5.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz";
-        sha512 = "Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==";
+        url = "https://registry.npmjs.org/minipass/-/minipass-2.5.0.tgz";
+        sha512 = "9FwMVYhn6ERvMR8XFdOavRz4QK/VJV8elU1x50vYexf9lslDcWe/f4HBRxCPd185ekRSjU6CfYyJCECa/CQy7Q==";
       };
     };
     "minitouch-prebuilt-1.2.0" = {
@@ -26296,22 +26441,22 @@ let
         sha1 = "be2c005fda32e0b29af1f05d7c4b33214c701f92";
       };
     };
-    "mp4-box-encoding-1.3.0" = {
+    "mp4-box-encoding-1.4.1" = {
       name = "mp4-box-encoding";
       packageName = "mp4-box-encoding";
-      version = "1.3.0";
+      version = "1.4.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/mp4-box-encoding/-/mp4-box-encoding-1.3.0.tgz";
-        sha512 = "U4pMLpjT/UzB8d36dxj6Mf1bG9xypEvgbuRIa1fztRXNKKTCAtRxsnFZhNOd7YDFOKtjBgssYGvo4H/Q3ZY1MA==";
+        url = "https://registry.npmjs.org/mp4-box-encoding/-/mp4-box-encoding-1.4.1.tgz";
+        sha512 = "2/PRtGGiqPc/VEhbm7xAQ+gbb7yzHjjMAv6MpAifr5pCpbh3fQUdj93uNgwPiTppAGu8HFKe3PeU+OdRyAxStA==";
       };
     };
-    "mp4-stream-3.0.0" = {
+    "mp4-stream-3.1.0" = {
       name = "mp4-stream";
       packageName = "mp4-stream";
-      version = "3.0.0";
+      version = "3.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/mp4-stream/-/mp4-stream-3.0.0.tgz";
-        sha512 = "UCvsZaEP2b+Tl2mJOmb+TXdA2f24ggNUadgQkpgvaNDZQNGs6/O8ivFcj9ogf4Bj4R6dbqv18VXUdp16BhXk/A==";
+        url = "https://registry.npmjs.org/mp4-stream/-/mp4-stream-3.1.0.tgz";
+        sha512 = "ZQQjf0VEiqPucwRvmT3e0pfZfMSE3nc5ngGUiN1+2VMxCtrInrlAjZ2K6jpNmxSZ/roiQne/ovYJYTeOvZDXPw==";
       };
     };
     "mpath-0.2.1" = {
@@ -26647,13 +26792,13 @@ let
         sha512 = "xasv76hl6nr1dEy3lPvy7Ej7K/Lx3O/FCvwge8PeVJpciPPoNCbaANcNiBug3IpdvTveZUcAV0DJzdnUDMesNQ==";
       };
     };
-    "multistream-3.1.0" = {
+    "multistream-4.0.0" = {
       name = "multistream";
       packageName = "multistream";
-      version = "3.1.0";
+      version = "4.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/multistream/-/multistream-3.1.0.tgz";
-        sha512 = "zBgD3kn8izQAN/TaL1PCMv15vYpf+Vcrsfub06njuYVYlzUldzpopTlrEZ53pZVEbfn3Shtv7vRFoOv6LOV87Q==";
+        url = "https://registry.npmjs.org/multistream/-/multistream-4.0.0.tgz";
+        sha512 = "t0C8MAtH/d3Y+5nooEtUMWli92lVw9Jhx4uOhRl5GAwS5vc+YTmp/VXNJNsCBAMeEyK/6zhbk6x9JE3AiCvo4g==";
       };
     };
     "mustache-2.3.2" = {
@@ -26881,13 +27026,13 @@ let
         sha512 = "Hv9USGyH8EsPy0o8pPWE7x3YRIfuZDgMBirzjU6XLebhiSK2g53JlfqgolD0c39ne6wXAfaBNcIAvYe22Bav+Q==";
       };
     };
-    "nanoid-2.0.3" = {
+    "nanoid-2.0.4" = {
       name = "nanoid";
       packageName = "nanoid";
-      version = "2.0.3";
+      version = "2.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/nanoid/-/nanoid-2.0.3.tgz";
-        sha512 = "NbaoqdhIYmY6FXDRB4eYtDVC9Z9eCbn8TyaiC16LNKtpPv/aqa0tOPD8y6gNE4yUNnaZ7LLhYtXOev/6+cBtfw==";
+        url = "https://registry.npmjs.org/nanoid/-/nanoid-2.0.4.tgz";
+        sha512 = "sOJnBmY3TJQBVIBqKHoifuwygrocXg3NjS9rZSMnVl05XWSHK7Qxb177AIZQyMDjP86bz+yneozj/h9qsPLcCA==";
       };
     };
     "nanolru-1.0.0" = {
@@ -27425,13 +27570,13 @@ let
         sha512 = "iEOqDAOFl6uN5jZGRj39Jdo8qALzf2HPXtpFso8+BMaDylDrUMYMwhFbfYGgxdnMlsRnxYTwv68kaXEpsHIapg==";
       };
     };
-    "node-abi-2.10.0" = {
+    "node-abi-2.11.0" = {
       name = "node-abi";
       packageName = "node-abi";
-      version = "2.10.0";
+      version = "2.11.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/node-abi/-/node-abi-2.10.0.tgz";
-        sha512 = "OT0WepUvYHXdki6DU8LWhEkuo3M44i2paWBYtH9qXtPb9YiKlYEKa5WUII20XEcOv7UJPzfB0kZfPZdW46zdkw==";
+        url = "https://registry.npmjs.org/node-abi/-/node-abi-2.11.0.tgz";
+        sha512 = "kuy/aEg75u40v378WRllQ4ZexaXJiCvB68D2scDXclp/I4cRq6togpbOoKhmN07tns9Zldu51NNERo0wehfX9g==";
       };
     };
     "node-addon-api-1.7.1" = {
@@ -27669,13 +27814,13 @@ let
         sha512 = "SUDEb+o71XR5lXSTyivXd9J7fCloE3SyP4lSgt3lU2oSANiox+SxlNRGPjDKrwU1YN3ix2KN/VGGCg0t01rttQ==";
       };
     };
-    "node-notifier-5.4.2" = {
+    "node-notifier-5.4.3" = {
       name = "node-notifier";
       packageName = "node-notifier";
-      version = "5.4.2";
+      version = "5.4.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.2.tgz";
-        sha512 = "85nkTziazE2dR4pyoLxMwz0b9MmxFQPVXYs/WlWI7CPtBkARJOV+89khdNjpbclXIJDECQYnTvh1xuZV3WHkCA==";
+        url = "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.3.tgz";
+        sha512 = "M4UBGcs4jeOK9CjTsYwkvH6/MzuUmGCyTW+kCY7uO+1ZVr0+FHGdPdIf5CCLqAaxnRrWidyoQlNkMIIVwbKB8Q==";
       };
     };
     "node-persist-2.1.0" = {
@@ -27732,13 +27877,13 @@ let
         sha512 = "OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==";
       };
     };
-    "node-red-node-email-1.6.2" = {
+    "node-red-node-email-1.6.3" = {
       name = "node-red-node-email";
       packageName = "node-red-node-email";
-      version = "1.6.2";
+      version = "1.6.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/node-red-node-email/-/node-red-node-email-1.6.2.tgz";
-        sha512 = "px5xvIE649aEAh08hAqnFV/IyqN1EQ9nHsTp8OWvVdNZqfAEcT0O6jjMONN/ur5Az1Uyrc7cA3c+iYmc2yzGMg==";
+        url = "https://registry.npmjs.org/node-red-node-email/-/node-red-node-email-1.6.3.tgz";
+        sha512 = "78O7CASdGAP2wmMJvqsMYdNrCHI54lSE97hWpbNQPG2QC2d15TEUQU+E8KgNzquPtJn0Pjh/cvzt+kQwKjkaUg==";
       };
     };
     "node-red-node-feedparser-0.1.14" = {
@@ -27750,13 +27895,13 @@ let
         sha512 = "Bb9M5bFrOqoFxBVxfstBM/g+VPaV4EPQptXQBMrlsCd3P40CXcGL0mDylXU+3cekWNd5hLHfqTHvXJdkowHGDw==";
       };
     };
-    "node-red-node-rbe-0.2.4" = {
+    "node-red-node-rbe-0.2.5" = {
       name = "node-red-node-rbe";
       packageName = "node-red-node-rbe";
-      version = "0.2.4";
+      version = "0.2.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/node-red-node-rbe/-/node-red-node-rbe-0.2.4.tgz";
-        sha512 = "ft/8/dTRGzGQ9vCnAzuBxzR+aDv4Yun/vuSKi/eI5Qj2/ZBal28L9HpWziSTWlLrMhZns8CRz7s2p84P2ee/vA==";
+        url = "https://registry.npmjs.org/node-red-node-rbe/-/node-red-node-rbe-0.2.5.tgz";
+        sha512 = "WPwIOZIdDprgfqOe8bEun47wkFFc+5Uw/1w3O/kZn/kS2IpI1q+wijUDK+Hw8q4d8KgA58B30wh+10UvXzsPDA==";
       };
     };
     "node-red-node-sentiment-0.1.4" = {
@@ -27786,13 +27931,13 @@ let
         sha512 = "8V4tLL0nM1DOUgEtTOBSTZcLbtZ4Gg4CPFVHiPmLCo2QYTMQ0JdBIYj4pg95LbJbYkV721fqsw1RDsitBfYuCQ==";
       };
     };
-    "node-releases-1.1.26" = {
+    "node-releases-1.1.28" = {
       name = "node-releases";
       packageName = "node-releases";
-      version = "1.1.26";
+      version = "1.1.28";
       src = fetchurl {
-        url = "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz";
-        sha512 = "fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==";
+        url = "https://registry.npmjs.org/node-releases/-/node-releases-1.1.28.tgz";
+        sha512 = "AQw4emh6iSXnCpDiFe0phYcThiccmkNWMZnFZ+lDJjAP8J0m2fVd59duvUUyuTirQOhIAajTFkzG6FHCLBO59g==";
       };
     };
     "node-request-by-swagger-1.1.4" = {
@@ -28119,13 +28264,13 @@ let
         sha1 = "99b85aec29fcb388d2dd351f0013bf5268787e67";
       };
     };
-    "npm-lifecycle-3.1.2" = {
+    "npm-lifecycle-3.1.3" = {
       name = "npm-lifecycle";
       packageName = "npm-lifecycle";
-      version = "3.1.2";
+      version = "3.1.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/npm-lifecycle/-/npm-lifecycle-3.1.2.tgz";
-        sha512 = "nhfOcoTHrW1lJJlM2o77vTE2RWR4YOVyj7YzmY0y5itsMjEuoJHteio/ez0BliENEPsNxIUQgwhyEW9dShj3Ww==";
+        url = "https://registry.npmjs.org/npm-lifecycle/-/npm-lifecycle-3.1.3.tgz";
+        sha512 = "M0QmmqbEHBXxDrmc6X3+eKjW9+F7Edg1ENau92WkYw1sox6wojHzEZJIRm1ItljEiaigZlKL8mXni/4ylAy1Dg==";
       };
     };
     "npm-package-arg-6.1.0" = {
@@ -28135,6 +28280,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.0.tgz";
         sha512 = "zYbhP2k9DbJhA0Z3HKUePUgdB1x7MfIfKssC+WLPFMKTBZKpZh5m13PgexJjCq6KW7j17r0jHWcCpxEqnnncSA==";
+      };
+    };
+    "npm-package-arg-6.1.1" = {
+      name = "npm-package-arg";
+      packageName = "npm-package-arg";
+      version = "6.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.1.tgz";
+        sha512 = "qBpssaL3IOZWi5vEKUKW0cO7kzLeT+EQO9W8RsLOZf76KF9E/K9+wH0C7t06HXPpaH8WH5xF1MExLuCwbTqRUg==";
       };
     };
     "npm-packlist-1.4.4" = {
@@ -28171,6 +28325,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-2.2.3.tgz";
         sha512 = "+IluBC5K201+gRU85vFlUwX3PFShZAbAgDNp2ewJdWMVSppdo/Zih0ul2Ecky/X7b51J7LrrUAP+XOmOCvYZqA==";
+      };
+    };
+    "npm-pick-manifest-3.0.1" = {
+      name = "npm-pick-manifest";
+      packageName = "npm-pick-manifest";
+      version = "3.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-3.0.1.tgz";
+        sha512 = "QsJY1LuN6vuGg2BDnteeWGYODOYWZZwbW/YyCKHK4tt9uE+k2d70eg+Kr1CSLbX157Nu8UtY/Afdv884RnJSrQ==";
       };
     };
     "npm-prefix-1.2.0" = {
@@ -28507,6 +28670,15 @@ let
         sha512 = "GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==";
       };
     };
+    "object-is-1.0.1" = {
+      name = "object-is";
+      packageName = "object-is";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz";
+        sha1 = "0aa60ec9989a0b3ed795cf4d06f62cf1ad6539b6";
+      };
+    };
     "object-keys-0.4.0" = {
       name = "object-keys";
       packageName = "object-keys";
@@ -28822,6 +28994,15 @@ let
         sha1 = "067428230fd67443b2794b22bba528b6867962d4";
       };
     };
+    "onetime-5.1.0" = {
+      name = "onetime";
+      packageName = "onetime";
+      version = "5.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz";
+        sha512 = "5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==";
+      };
+    };
     "ono-4.0.11" = {
       name = "ono";
       packageName = "ono";
@@ -28957,13 +29138,13 @@ let
         sha512 = "I9PKfIZC+e4RXZ/qr1RhgyCnGgYX0UEIlXgWnCOVACIvFgaC9rz6Won7xbdhoHrd8IIhV7YEpHjreNUNkqCGkQ==";
       };
     };
-    "optimism-0.9.6" = {
+    "optimism-0.10.2" = {
       name = "optimism";
       packageName = "optimism";
-      version = "0.9.6";
+      version = "0.10.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/optimism/-/optimism-0.9.6.tgz";
-        sha512 = "bWr/ZP32UgFCQAoSkz33XctHwpq2via2sBvGvO5JIlrU8gaiM0LvoKj3QMle9LWdSKlzKik8XGSerzsdfYLNxA==";
+        url = "https://registry.npmjs.org/optimism/-/optimism-0.10.2.tgz";
+        sha512 = "zPfBIxFFWMmQboM9+Z4MSJqc1PXp82v1PFq/GfQaufI69mHKlup7ykGNnfuGIGssXJQkmhSodQ/k9EWwjd8O8A==";
       };
     };
     "optimist-0.2.8" = {
@@ -29290,13 +29471,13 @@ let
         sha512 = "vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==";
       };
     };
-    "p-limit-2.2.0" = {
+    "p-limit-2.2.1" = {
       name = "p-limit";
       packageName = "p-limit";
-      version = "2.2.0";
+      version = "2.2.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz";
-        sha512 = "pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==";
+        url = "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz";
+        sha512 = "85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==";
       };
     };
     "p-locate-2.0.0" = {
@@ -29362,6 +29543,15 @@ let
         sha512 = "3cRXXn3/O0o3+eVmUroJPSj/esxoEFIm0ZOno/T+NzG/VZgPOqQ8WKmlNqubSEpZmCIngEy34unkHGg83ZIBmg==";
       };
     };
+    "p-queue-6.1.1" = {
+      name = "p-queue";
+      packageName = "p-queue";
+      version = "6.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/p-queue/-/p-queue-6.1.1.tgz";
+        sha512 = "R9gq36Th88xZ+rWAptN5IXLwqkwA1gagCQhT6ZXQ6RxEfmjb9ZW+UBzRVqv9sm5TQmbbI/TsKgGLbOaA61xR5w==";
+      };
+    };
     "p-reduce-1.0.0" = {
       name = "p-reduce";
       packageName = "p-reduce";
@@ -29396,6 +29586,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz";
         sha512 = "88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==";
+      };
+    };
+    "p-timeout-3.1.0" = {
+      name = "p-timeout";
+      packageName = "p-timeout";
+      version = "3.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/p-timeout/-/p-timeout-3.1.0.tgz";
+        sha512 = "C27DYI+tCroT8J8cTEyySGydl2B7FlxrGNF5/wmMbl1V+jeehUCzEE/BVgzRebdm2K3ZitKOKx8YbdFumDyYmw==";
       };
     };
     "p-try-1.0.0" = {
@@ -29461,15 +29660,6 @@ let
         sha512 = "EeHQFFTlEmLrkIQoxbE9w0FuAWHoc1XpthDqnZ/i9keOt701cteyXwAxQFLpVqVjj3feh2TodkihjLaRUtIgLg==";
       };
     };
-    "package-json-6.4.0" = {
-      name = "package-json";
-      packageName = "package-json";
-      version = "6.4.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/package-json/-/package-json-6.4.0.tgz";
-        sha512 = "bd1T8OBG7hcvMd9c/udgv6u5v9wISP3Oyl9Cm7Weop8EFwrtcQDnS2sb6zhwqus2WslSr5wSTIPiTTpxxmPm7Q==";
-      };
-    };
     "package-json-6.5.0" = {
       name = "package-json";
       packageName = "package-json";
@@ -29506,13 +29696,22 @@ let
         sha1 = "79b302fc144cdfbb4ab6feba7040e6a5d99c79c7";
       };
     };
-    "pacote-9.5.4" = {
+    "pacote-9.5.5" = {
       name = "pacote";
       packageName = "pacote";
-      version = "9.5.4";
+      version = "9.5.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/pacote/-/pacote-9.5.4.tgz";
-        sha512 = "nWr0ari6E+apbdoN0hToTKZElO5h4y8DGFa2pyNA5GQIdcP0imC96bA0bbPw1gpeguVIiUgHHaAlq/6xfPp8Qw==";
+        url = "https://registry.npmjs.org/pacote/-/pacote-9.5.5.tgz";
+        sha512 = "jAEP+Nqj4kyMWyNpfTU/Whx1jA7jEc5cCOlurm0/0oL+v8TAp1QSsK83N7bYe+2bEdFzMAtPG5TBebjzzGV0cA==";
+      };
+    };
+    "pacote-9.5.8" = {
+      name = "pacote";
+      packageName = "pacote";
+      version = "9.5.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pacote/-/pacote-9.5.8.tgz";
+        sha512 = "0Tl8Oi/K0Lo4MZmH0/6IsT3gpGf9eEAznLXEQPKgPq7FscnbUOyopnVpwXlnQdIbCUaojWy1Wd7VMyqfVsRrIw==";
       };
     };
     "pad-0.0.5" = {
@@ -30397,13 +30596,13 @@ let
         sha512 = "OlE82n3yMOE5dY9RMOwxhoWefeMlxwk5IVxoj0sSzSFIlmvhN4obzTvO3s/d/b5JhcgXikjaspsy/HuUDTqbBg==";
       };
     };
-    "piece-length-1.0.0" = {
+    "piece-length-2.0.1" = {
       name = "piece-length";
       packageName = "piece-length";
-      version = "1.0.0";
+      version = "2.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/piece-length/-/piece-length-1.0.0.tgz";
-        sha1 = "4db7167157fd69fef14caf7262cd39f189b24508";
+        url = "https://registry.npmjs.org/piece-length/-/piece-length-2.0.1.tgz";
+        sha512 = "dBILiDmm43y0JPISWEmVGKBETQjwJe6mSU9GND+P9KW0SJGUwoU/odyH1nbalOP9i8WSYuqf1lQnaj92Bhw+Ug==";
       };
     };
     "pify-2.3.0" = {
@@ -30586,13 +30785,13 @@ let
         sha1 = "9a99433f3789d1e2757c04e3803395b6fa55a348";
       };
     };
-    "please-upgrade-node-3.1.1" = {
+    "please-upgrade-node-3.2.0" = {
       name = "please-upgrade-node";
       packageName = "please-upgrade-node";
-      version = "3.1.1";
+      version = "3.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.1.1.tgz";
-        sha512 = "KY1uHnQ2NlQHqIJQpnh/i54rKkuxCEBx+voJIS/Mvb+L2iYd2NMotwduhKTMjfC1uKoX3VXOxLjIYG66dfJTVQ==";
+        url = "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz";
+        sha512 = "gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==";
       };
     };
     "plist-1.2.0" = {
@@ -30721,13 +30920,13 @@ let
         sha1 = "2f4b58b5592972350cd97f482aba68f8e05574bc";
       };
     };
-    "portfinder-1.0.21" = {
+    "portfinder-1.0.23" = {
       name = "portfinder";
       packageName = "portfinder";
-      version = "1.0.21";
+      version = "1.0.23";
       src = fetchurl {
-        url = "https://registry.npmjs.org/portfinder/-/portfinder-1.0.21.tgz";
-        sha512 = "ESabpDCzmBS3ekHbmpAIiESq3udRsCBGiBZLsC+HgBKv2ezb0R4oG+7RnYEVZ/ZCfhel5Tx3UzdNWA0Lox2QCA==";
+        url = "https://registry.npmjs.org/portfinder/-/portfinder-1.0.23.tgz";
+        sha512 = "B729mL/uLklxtxuiJKfQ84WPxNw5a7Yhx3geQZdcA4GjNjZSTSSMMWyoennMVnTWSmAR0lMdzWYN0JLnHrg1KQ==";
       };
     };
     "posix-character-classes-0.1.1" = {
@@ -31100,13 +31299,13 @@ let
         sha512 = "pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==";
       };
     };
-    "posthtml-0.11.4" = {
+    "posthtml-0.11.6" = {
       name = "posthtml";
       packageName = "posthtml";
-      version = "0.11.4";
+      version = "0.11.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/posthtml/-/posthtml-0.11.4.tgz";
-        sha512 = "ezlzBkoPoRgh0jkmT1dsM8eT+lr2azyZ546kbda8oHnVnzvyaB3Ywo6UxUz8wPSOkFAAflCxZJhvvpQH1F6qcA==";
+        url = "https://registry.npmjs.org/posthtml/-/posthtml-0.11.6.tgz";
+        sha512 = "C2hrAPzmRdpuL3iH0TDdQ6XCc9M7Dcc3zEW5BLerY65G4tWWszwv6nG/ksi6ul5i2mx22ubdljgktXCtNkydkw==";
       };
     };
     "posthtml-parser-0.4.1" = {
@@ -31215,6 +31414,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/prettier-eslint/-/prettier-eslint-8.8.2.tgz";
         sha512 = "2UzApPuxi2yRoyMlXMazgR6UcH9DKJhNgCviIwY3ixZ9THWSSrUww5vkiZ3C48WvpFl1M1y/oU63deSy1puWEA==";
+      };
+    };
+    "prettier-tslint-0.4.2" = {
+      name = "prettier-tslint";
+      packageName = "prettier-tslint";
+      version = "0.4.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/prettier-tslint/-/prettier-tslint-0.4.2.tgz";
+        sha512 = "urhX7U/F+fu8sztEs/Z7CxNS8PdEytEwGKhQaH5fxxCdRmHGT45FoClyDlcZrMk9cK/8JpX/asFmTOHtSGJfLg==";
       };
     };
     "pretty-format-23.6.0" = {
@@ -31332,6 +31540,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/probe-image-size/-/probe-image-size-4.0.0.tgz";
         sha512 = "nm7RvWUxps+2+jZKNLkd04mNapXNariS6G5WIEVzvAqjx7EUuKcY1Dp3e6oUK7GLwzJ+3gbSbPLFAASHFQrPcQ==";
+      };
+    };
+    "process-0.10.1" = {
+      name = "process";
+      packageName = "process";
+      version = "0.10.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/process/-/process-0.10.1.tgz";
+        sha1 = "842457cc51cfed72dc775afeeafb8c6034372725";
       };
     };
     "process-0.11.10" = {
@@ -32270,13 +32487,13 @@ let
         sha1 = "1ee5b6f76fd3b3a49a5afb6ded5c0320acb3cfc7";
       };
     };
-    "pull-stream-3.6.13" = {
+    "pull-stream-3.6.14" = {
       name = "pull-stream";
       packageName = "pull-stream";
-      version = "3.6.13";
+      version = "3.6.14";
       src = fetchurl {
-        url = "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.13.tgz";
-        sha512 = "enbnbnO+czsPuCq9s9HTTzDzzVQD5TSe60aO3nBioeJ9mevh8RzE4Hxbujo9TReg1fJlmNEL8uyQTUgn8+rSHg==";
+        url = "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.14.tgz";
+        sha512 = "KIqdvpqHHaTUA2mCYcLG1ibEbu/LCKoJZsBWyv9lSYtPkJPBq8m3Hxa103xHi6D2thj5YXa0TqK3L3GUkwgnew==";
       };
     };
     "pull-through-1.0.18" = {
@@ -32594,6 +32811,15 @@ let
         sha512 = "VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==";
       };
     };
+    "qs-6.8.0" = {
+      name = "qs";
+      packageName = "qs";
+      version = "6.8.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/qs/-/qs-6.8.0.tgz";
+        sha512 = "tPSkj8y92PfZVbinY1n84i1Qdx75lZjMQYx9WZhnkofyxzw2r7Ho39G3/aEvSUdebxpnnM4LZJCtvE/Aq3+s9w==";
+      };
+    };
     "query-string-1.0.1" = {
       name = "query-string";
       packageName = "query-string";
@@ -32673,6 +32899,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz";
         sha1 = "4360b17c61136ad38078397ff11416e186dcfbb8";
+      };
+    };
+    "quick-lru-4.0.1" = {
+      name = "quick-lru";
+      packageName = "quick-lru";
+      version = "4.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz";
+        sha512 = "ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==";
       };
     };
     "quicktask-1.1.0" = {
@@ -32963,13 +33198,13 @@ let
         sha512 = "C0SIXdXDSus2yqqvV7qifnb4NoWP7mEBXJq3axci301mXHCZb8Djwm4hrEZo4UeXRaEnfjH98uQ8EBppk2oNWA==";
       };
     };
-    "react-is-16.8.6" = {
+    "react-is-16.9.0" = {
       name = "react-is";
       packageName = "react-is";
-      version = "16.8.6";
+      version = "16.9.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz";
-        sha512 = "aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==";
+        url = "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz";
+        sha512 = "tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==";
       };
     };
     "read-1.0.7" = {
@@ -32999,13 +33234,13 @@ let
         sha512 = "CEjy9LCzhmD7nUpJ1oVOE6s/hBkejlcJEgLQHVnQznOSilOPb+kpKktlLfFDK3/WP43+F80xkUTM2VOkYoSYvQ==";
       };
     };
-    "read-cmd-shim-1.0.1" = {
+    "read-cmd-shim-1.0.4" = {
       name = "read-cmd-shim";
       packageName = "read-cmd-shim";
-      version = "1.0.1";
+      version = "1.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz";
-        sha1 = "2d5d157786a37c055d22077c32c53f8329e91c7b";
+        url = "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.4.tgz";
+        sha512 = "Pqpl3qJ/QdOIjRYA0q5DND/gLvGOfpIz/fYVDGYpOXfW/lFrIttmLsBnd6IkyK10+JHU9zhsaudfvrQTBB9YFQ==";
       };
     };
     "read-metadata-1.0.0" = {
@@ -33026,13 +33261,13 @@ let
         sha1 = "2724fd6a8113d73764ac288d4386270c1dbf17f0";
       };
     };
-    "read-package-json-2.0.13" = {
+    "read-package-json-2.1.0" = {
       name = "read-package-json";
       packageName = "read-package-json";
-      version = "2.0.13";
+      version = "2.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.13.tgz";
-        sha512 = "/1dZ7TRZvGrYqE0UAfN6qQb5GYBsNcqS1C0tNK601CFOJmtHI7NIGXwetEPU/OtoFHZL3hDxm4rolFFVE9Bnmg==";
+        url = "https://registry.npmjs.org/read-package-json/-/read-package-json-2.1.0.tgz";
+        sha512 = "KLhu8M1ZZNkMcrq1+0UJbR8Dii8KZUqB0Sha4mOx/bknfKI/fyrQVrG/YIt2UOtG667sD8+ee4EXMM91W9dC+A==";
       };
     };
     "read-package-tree-5.3.1" = {
@@ -33197,13 +33432,13 @@ let
         sha512 = "1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==";
       };
     };
-    "readdirp-3.1.1" = {
+    "readdirp-3.1.2" = {
       name = "readdirp";
       packageName = "readdirp";
-      version = "3.1.1";
+      version = "3.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/readdirp/-/readdirp-3.1.1.tgz";
-        sha512 = "XXdSXZrQuvqoETj50+JAitxz1UPdt5dupjT6T5nVB+WvjMv2XKYj+s7hPeAVCXvmJrL36O4YYyWlIC3an2ePiQ==";
+        url = "https://registry.npmjs.org/readdirp/-/readdirp-3.1.2.tgz";
+        sha512 = "8rhl0xs2cxfVsqzreYCvs8EwBfn/DhVdqtoLmw19uI3SC5avYX9teCurlErfpPXGmYtMHReGaP2RsLnFvz/lnw==";
       };
     };
     "readline2-0.1.1" = {
@@ -33440,13 +33675,13 @@ let
         sha512 = "J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==";
       };
     };
-    "regexp-tree-0.1.11" = {
+    "regexp-tree-0.1.12" = {
       name = "regexp-tree";
       packageName = "regexp-tree";
-      version = "0.1.11";
+      version = "0.1.12";
       src = fetchurl {
-        url = "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.11.tgz";
-        sha512 = "7/l/DgapVVDzZobwMCCgMlqiqyLFJ0cduo/j+3BcDJIB+yJdsYCfKuI3l/04NV+H/rfNRdPIDbXNZHM9XvQatg==";
+        url = "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.12.tgz";
+        sha512 = "TsXZ8+cv2uxMEkLfgwO0E068gsNMLfuYwMMhiUxf0Kw2Vcgzq93vgl6wIlIYuPmfMqMjfQ9zAporiozqCnwLuQ==";
       };
     };
     "regexp.prototype.flags-1.2.0" = {
@@ -33485,13 +33720,13 @@ let
         sha1 = "86a763f58ee4d7c2f6b102e4764050de7ed90c6b";
       };
     };
-    "regexpu-core-4.5.4" = {
+    "regexpu-core-4.5.5" = {
       name = "regexpu-core";
       packageName = "regexpu-core";
-      version = "4.5.4";
+      version = "4.5.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.4.tgz";
-        sha512 = "BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==";
+        url = "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.5.tgz";
+        sha512 = "FpI67+ky9J+cDizQUJlIlNZFKual/lUkFr1AG6zOCpwZ9cLrg8UUVakyUQJD7fCDIe9Z2nwTQJNPyonatNmDFQ==";
       };
     };
     "registry-auth-token-3.3.2" = {
@@ -33755,13 +33990,13 @@ let
         sha1 = "c24bce2a283adad5bc3f58e0d48249b92379d8ef";
       };
     };
-    "render-media-3.3.0" = {
+    "render-media-3.3.1" = {
       name = "render-media";
       packageName = "render-media";
-      version = "3.3.0";
+      version = "3.3.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/render-media/-/render-media-3.3.0.tgz";
-        sha512 = "IWz+3KbUxFaxke8v/TJE0nZlhoNTTqSYS3hh284R+6rgqwahR4hA+5dAAyb0A1t4M4oLwePaGlHllfQiS2ItWQ==";
+        url = "https://registry.npmjs.org/render-media/-/render-media-3.3.1.tgz";
+        sha512 = "kabvYrlpPmQtraUAPjBI5hyK3vM/TJah+wnlKJPc27bo0POMU3x26db/zDuMqha6JXz8lLu/pI+ORDlwJmJtFQ==";
       };
     };
     "repeat-element-1.1.3" = {
@@ -34232,6 +34467,15 @@ let
         sha1 = "9f7ee287f82fd326d4fd162923d62129eee0dfaf";
       };
     };
+    "restore-cursor-3.1.0" = {
+      name = "restore-cursor";
+      packageName = "restore-cursor";
+      version = "3.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz";
+        sha512 = "l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==";
+      };
+    };
     "resumer-0.0.0" = {
       name = "resumer";
       packageName = "resumer";
@@ -34448,6 +34692,24 @@ let
         sha512 = "mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==";
       };
     };
+    "rimraf-2.7.1" = {
+      name = "rimraf";
+      packageName = "rimraf";
+      version = "2.7.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz";
+        sha512 = "uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==";
+      };
+    };
+    "rimraf-3.0.0" = {
+      name = "rimraf";
+      packageName = "rimraf";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/rimraf/-/rimraf-3.0.0.tgz";
+        sha512 = "NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==";
+      };
+    };
     "ripemd160-2.0.2" = {
       name = "ripemd160";
       packageName = "ripemd160";
@@ -34475,13 +34737,13 @@ let
         sha1 = "df43e80d9bc82ad4430bcfef03f49c717e8b2e8c";
       };
     };
-    "roarr-2.13.3" = {
+    "roarr-2.14.1" = {
       name = "roarr";
       packageName = "roarr";
-      version = "2.13.3";
+      version = "2.14.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/roarr/-/roarr-2.13.3.tgz";
-        sha512 = "f75w2kr46yWvV7tdnAFRzXiggNBaPrPAwai0Disa5NovRP5DtACrMrhr72Vot1ZNCDmMJ1hF7ix2Q5F+NJZwoA==";
+        url = "https://registry.npmjs.org/roarr/-/roarr-2.14.1.tgz";
+        sha512 = "Fhm9shQ8JhpjFnOT7bgxKR7Xcg1Tq+0/Tdy+bloB4sUxxAib4MZDMJ6AjUBRE+798l2MnhhF2JTqbqx1+/kRyQ==";
       };
     };
     "rollup-0.67.0" = {
@@ -34871,13 +35133,13 @@ let
         sha512 = "jLYV0DORrzY3xaz/S9ydJL6Iz7essZeAfnAavsJ+zsJGZ1MOnsS52yRjU3uF3pJa/lla7+wisp//fxOwOH8SKQ==";
       };
     };
-    "sanitize-filename-1.6.2" = {
+    "sanitize-filename-1.6.3" = {
       name = "sanitize-filename";
       packageName = "sanitize-filename";
-      version = "1.6.2";
+      version = "1.6.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.2.tgz";
-        sha512 = "cmTzND7RMxUB+f7gI+4+KAVHWEg0lfXvQJdko+FXDP5bNbGIdx4KMP5pX6lv5jfT9jSf6OBbjyxjFtZQwYA/ig==";
+        url = "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz";
+        sha512 = "y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==";
       };
     };
     "sax-0.5.8" = {
@@ -35114,13 +35376,13 @@ let
         sha512 = "RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==";
       };
     };
-    "semver-5.7.0" = {
+    "semver-5.7.1" = {
       name = "semver";
       packageName = "semver";
-      version = "5.7.0";
+      version = "5.7.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz";
-        sha512 = "Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==";
+        url = "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz";
+        sha512 = "sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==";
       };
     };
     "semver-6.0.0" = {
@@ -35357,13 +35619,13 @@ let
         sha512 = "5j9GgyGsP9vV9Uj1S0lDCvlsd+gc2LEPVK7HHHte7IyPwOD4lVQFeaX143gx3U5AnoCi+wbcb3mvaxVysjpxEw==";
       };
     };
-    "serialize-javascript-1.7.0" = {
+    "serialize-javascript-1.9.0" = {
       name = "serialize-javascript";
       packageName = "serialize-javascript";
-      version = "1.7.0";
+      version = "1.9.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.7.0.tgz";
-        sha512 = "ke8UG8ulpFOxO8f8gRYabHQe/ZntKlcig2Mp+8+URDP1D8vJZ0KUt7LYo07q25Z/+JVSgpr/cui9PIp5H6/+nA==";
+        url = "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.0.tgz";
+        sha512 = "UkGlcYMtw4d9w7YfCtJFgdRTps8N4L0A48R+SmcGL57ki1+yHwJXnalk5bjgrw+ljv6SfzjzPjhohod2qllg/Q==";
       };
     };
     "serialize-to-js-1.2.2" = {
@@ -35537,13 +35799,13 @@ let
         sha512 = "JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==";
       };
     };
-    "seventh-0.7.27" = {
+    "seventh-0.7.28" = {
       name = "seventh";
       packageName = "seventh";
-      version = "0.7.27";
+      version = "0.7.28";
       src = fetchurl {
-        url = "https://registry.npmjs.org/seventh/-/seventh-0.7.27.tgz";
-        sha512 = "vId7EbEQ7xr+wjBBFQBChtLzbqIQWe0cNtZMGtOVBig5p1XrsjVXvkBhdVcJRJdDh6pnn/5h5ai+208fDldXXA==";
+        url = "https://registry.npmjs.org/seventh/-/seventh-0.7.28.tgz";
+        sha512 = "WitJqSwsjLWbCP9cciaozByx4csddLQyNoaPBqOpYFMNE6iD6FK/pM8J2yqtpauSxJUUo7Wfv5KF5w1jbVov7A==";
       };
     };
     "sha.js-2.4.11" = {
@@ -35625,6 +35887,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz";
         sha1 = "f4781949cce402697127430ea3b3c5476f481767";
+      };
+    };
+    "shell-quote-1.7.1" = {
+      name = "shell-quote";
+      packageName = "shell-quote";
+      version = "1.7.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.1.tgz";
+        sha512 = "2kUqeAGnMAu6YrTPX4E3LfxacH9gKljzVjlkUeSqY0soGwK4KLl7TURXCem712tkhBCeeaFP9QK4dKn88s3Icg==";
       };
     };
     "shelljs-0.3.0" = {
@@ -35834,13 +36105,13 @@ let
         sha1 = "5d3d5751bb39aeba2f710d8eec78768df821f38d";
       };
     };
-    "simple-websocket-8.0.0" = {
+    "simple-websocket-8.0.1" = {
       name = "simple-websocket";
       packageName = "simple-websocket";
-      version = "8.0.0";
+      version = "8.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/simple-websocket/-/simple-websocket-8.0.0.tgz";
-        sha512 = "DwBEoqOq8gvnblarMPkhZD6AWituWbVfTil/UflowYm/Bu5SK23BDKGxrVwgQXGKydzxlSiYva7LC3/hXSRLIw==";
+        url = "https://registry.npmjs.org/simple-websocket/-/simple-websocket-8.0.1.tgz";
+        sha512 = "2QKSRjf+tqFXLVmOQjf95gHeKhuyx2k1ouDjtnE0uKCYw84HfN85HsXo+GmPH+2PIh5BQql++g2AIbHgGAZU4w==";
       };
     };
     "single-line-log-0.4.1" = {
@@ -36086,13 +36357,13 @@ let
         sha1 = "6541184cc90aeea6c6e7b35e2659082443c66198";
       };
     };
-    "snyk-1.210.0" = {
+    "snyk-1.221.1" = {
       name = "snyk";
       packageName = "snyk";
-      version = "1.210.0";
+      version = "1.221.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk/-/snyk-1.210.0.tgz";
-        sha512 = "k6/EIX1Dc4Qk8omcKQDm13RRywkKqXoQ0IMz5Nyk1y8sdmg1S78QSWnfTaEPe+OQE1olrtjInrDX3Yu20CnMzg==";
+        url = "https://registry.npmjs.org/snyk/-/snyk-1.221.1.tgz";
+        sha512 = "2NpAeh/r/74dZL8HM/I2OlH/AieTJGKyvF0Ux2YADI/7hSHSLgvrUamH6f53KzwEqDbVdewxzoIc3p9rUMG1Ew==";
       };
     };
     "snyk-config-2.2.3" = {
@@ -36104,13 +36375,13 @@ let
         sha512 = "9NjxHVMd1U1LFw66Lya4LXgrsFUiuRiL4opxfTFo0LmMNzUoU5Bk/p0zDdg3FE5Wg61r4fP2D8w+QTl6M8CGiw==";
       };
     };
-    "snyk-docker-plugin-1.25.1" = {
+    "snyk-docker-plugin-1.29.1" = {
       name = "snyk-docker-plugin";
       packageName = "snyk-docker-plugin";
-      version = "1.25.1";
+      version = "1.29.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-1.25.1.tgz";
-        sha512 = "n/LfA7VXjPEcSz2ZfZonT/DPSC89Zs1/HD0inPFN4RLQT3WiQnjqJUXct+D0nWwEVfhLWNc+Y7PLcTjpnZ9R3Q==";
+        url = "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-1.29.1.tgz";
+        sha512 = "Mucc1rZ7l0U8Dykr5m6HPjau8b2H8JVtVaXGbKSZD6e/47JDJhudkgrWjsS5Yt/Zdp1weE3+4SguftFiVR971A==";
       };
     };
     "snyk-go-parser-1.3.1" = {
@@ -36131,13 +36402,13 @@ let
         sha512 = "9hsGgloioGuey5hbZfv+MkFEslxXHyzUlaAazcR0NsY7VLyG/b2g3f88f/ZwCwlWaKL9LMv/ERIiey3oWAB/qg==";
       };
     };
-    "snyk-gradle-plugin-2.12.5" = {
+    "snyk-gradle-plugin-3.0.2" = {
       name = "snyk-gradle-plugin";
       packageName = "snyk-gradle-plugin";
-      version = "2.12.5";
+      version = "3.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-2.12.5.tgz";
-        sha512 = "AmiQQUL0nlY3SjWUSMSmmbp273ETJzsqvk1E8jf+G/Q3mRl9xZ6BkPMebweD/y5d/smoQmr6rKL57OG+OXoi3w==";
+        url = "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.0.2.tgz";
+        sha512 = "9nyR03kHmePqBGaQiUeo3RD1YJ4qE5/V4tOmDQ8LNjHTQ54Xr8OXFC5xlJMV8FCtXrRXY0/WX8RMUPEUAm4c9g==";
       };
     };
     "snyk-module-1.9.1" = {
@@ -36149,13 +36420,13 @@ let
         sha512 = "A+CCyBSa4IKok5uEhqT+hV/35RO6APFNLqk9DRRHg7xW2/j//nPX8wTSZUPF8QeRNEk/sX+6df7M1y6PBHGSHA==";
       };
     };
-    "snyk-mvn-plugin-2.3.3" = {
+    "snyk-mvn-plugin-2.4.0" = {
       name = "snyk-mvn-plugin";
       packageName = "snyk-mvn-plugin";
-      version = "2.3.3";
+      version = "2.4.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-2.3.3.tgz";
-        sha512 = "NYFL+jtHfAJk+Jdyme4I8pTvg/wfoHgkOs1g1nFUEPTcpBb5mfqy7Q9hDJWvnfXY8M6P9aEqvO+bmCVgTQvySg==";
+        url = "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-2.4.0.tgz";
+        sha512 = "Fmt6Mjx6zZz+4q6PnBkhuNGhEX++q/pKMI26ls4p3JPkx4KxBz89oncpkmf7P8YCkoaka8oHhtDEv/R4Z9LleQ==";
       };
     };
     "snyk-nodejs-lockfile-parser-1.16.0" = {
@@ -36167,13 +36438,13 @@ let
         sha512 = "cf3uozRXEG88nsjOQlo+SfOJPpcLs45qpnuk2vhBBZ577IMnV+fTOJQsP2YRiikLUbdgkVlduviwUO6OVn1PhA==";
       };
     };
-    "snyk-nuget-plugin-1.11.3" = {
+    "snyk-nuget-plugin-1.12.1" = {
       name = "snyk-nuget-plugin";
       packageName = "snyk-nuget-plugin";
-      version = "1.11.3";
+      version = "1.12.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-1.11.3.tgz";
-        sha512 = "UgLTMr7Vz0qZoL15SkFAUfMb4Vw/qFxf6lBoL2v8xA+Mqdvn2Yu9x/yW659ElFVSUjniqKTFyloKq9/XSv+c+A==";
+        url = "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-1.12.1.tgz";
+        sha512 = "QuANQxBjTGj3hEf2YpEQ0WuI4Yq/93boqWUs4eoSTfDyBRFgIkUP6fLkzNldrkL8fQbcagqQ2Xz8M9IEKRQtMg==";
       };
     };
     "snyk-paket-parser-1.5.0" = {
@@ -36203,13 +36474,13 @@ let
         sha512 = "KI6GHt+Oj4fYKiCp7duhseUj5YhyL/zJOrrJg0u6r59Ux9w8gmkUYT92FHW27ihwuT6IPzdGNEuy06Yv2C9WaQ==";
       };
     };
-    "snyk-python-plugin-1.10.2" = {
+    "snyk-python-plugin-1.13.2" = {
       name = "snyk-python-plugin";
       packageName = "snyk-python-plugin";
-      version = "1.10.2";
+      version = "1.13.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.10.2.tgz";
-        sha512 = "dLswHfVI9Ax8+Ia/onhv1p9S5y+Ie/oELOfpfNApbb0BPTJ5k1c2CQ7WcgQ5/nDRMUOgoKn4VTObaAGmD5or9A==";
+        url = "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.13.2.tgz";
+        sha512 = "G9R1cYHw0E/VSx9tFa5nZp+653FIMXheteidrF3hjUe71jRdJELEUV/z5jxqYEWEFemcwGhMfW87De91GChVIQ==";
       };
     };
     "snyk-resolve-1.0.1" = {
@@ -36221,22 +36492,22 @@ let
         sha512 = "7+i+LLhtBo1Pkth01xv+RYJU8a67zmJ8WFFPvSxyCjdlKIcsps4hPQFebhz+0gC5rMemlaeIV6cqwqUf9PEDpw==";
       };
     };
-    "snyk-resolve-deps-4.0.3" = {
+    "snyk-resolve-deps-4.4.0" = {
       name = "snyk-resolve-deps";
       packageName = "snyk-resolve-deps";
-      version = "4.0.3";
+      version = "4.4.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-resolve-deps/-/snyk-resolve-deps-4.0.3.tgz";
-        sha512 = "GP3VBrkz1iDDw2q8ftTqppHqzIAxmsUIoXR+FRWDKcipkKHXHJyUmtEo11QVT5fNRV0D0RCsssk2S5CTxTCu6A==";
+        url = "https://registry.npmjs.org/snyk-resolve-deps/-/snyk-resolve-deps-4.4.0.tgz";
+        sha512 = "aFPtN8WLqIk4E1ulMyzvV5reY1Iksz+3oPnUVib1jKdyTHymmOIYF7z8QZ4UUr52UsgmrD9EA/dq7jpytwFoOQ==";
       };
     };
-    "snyk-sbt-plugin-2.6.1" = {
+    "snyk-sbt-plugin-2.7.0" = {
       name = "snyk-sbt-plugin";
       packageName = "snyk-sbt-plugin";
-      version = "2.6.1";
+      version = "2.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-sbt-plugin/-/snyk-sbt-plugin-2.6.1.tgz";
-        sha512 = "zWU14cm+cpamJ0CJdekTfgmv6ifdgVcapO6d27KTJThqRuR0arCqGPPyZa/Zl+jzhcK0dtRS4Ihk7g+d36SWIg==";
+        url = "https://registry.npmjs.org/snyk-sbt-plugin/-/snyk-sbt-plugin-2.7.0.tgz";
+        sha512 = "qQSPkiyd/WNfo0z8MDK+87iIIT2wCn+k6tl9mx0VoNJo/z5jJLAoIc41zkGt/K8TjxA7VF1PV5B3tHqBp1xAVA==";
       };
     };
     "snyk-tree-1.0.0" = {
@@ -36491,13 +36762,13 @@ let
         sha512 = "UMmCHovws/sxIBZsIRhIl8uRPou/RFDD0vVop81T1hG106NLLgqajKKuHAOtAP6hflnZ0UrVA2VFwddTd/NQyA==";
       };
     };
-    "sodium-native-2.4.5" = {
+    "sodium-native-2.4.6" = {
       name = "sodium-native";
       packageName = "sodium-native";
-      version = "2.4.5";
+      version = "2.4.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/sodium-native/-/sodium-native-2.4.5.tgz";
-        sha512 = "G1uhd4l1OexzUC/6eHIbAvoivCs9T7ncDlEWodZglPZVUOXi6jtSe7tCi25aYB06zRoOjVfE4SL+hZ4EfkyZgw==";
+        url = "https://registry.npmjs.org/sodium-native/-/sodium-native-2.4.6.tgz";
+        sha512 = "Ro9lhTjot8M01nwKLXiqLSmjR7B8o+Wg4HmJUjEShw/q6XPlNMzjPkA1VJKaMH8SO8fJ/sggAKVwreTaFszS2Q==";
       };
     };
     "sodium-universal-2.0.0" = {
@@ -37002,6 +37273,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/sqlite3/-/sqlite3-4.0.9.tgz";
         sha512 = "IkvzjmsWQl9BuBiM4xKpl5X8WCR4w0AeJHRdobCdXZ8dT/lNc1XS6WqvY35N6+YzIIgzSBeY5prdFObID9F9tA==";
+      };
+    };
+    "sqlite3-4.1.0" = {
+      name = "sqlite3";
+      packageName = "sqlite3";
+      version = "4.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/sqlite3/-/sqlite3-4.1.0.tgz";
+        sha512 = "RvqoKxq+8pDHsJo7aXxsFR18i+dU2Wp5o12qAJOV5LNcDt+fgJsc2QKKg3sIRfXrN9ZjzY1T7SNe/DFVqAXjaw==";
       };
     };
     "srt2vtt-1.3.1" = {
@@ -37697,6 +37977,15 @@ let
         sha512 = "+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==";
       };
     };
+    "stream-http-3.1.0" = {
+      name = "stream-http";
+      packageName = "stream-http";
+      version = "3.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/stream-http/-/stream-http-3.1.0.tgz";
+        sha512 = "cuB6RgO7BqC4FBYzmnvhob5Do3wIdIsXAgGycHJnW+981gHqoYcYz9lqjJrk8WXRddbwPuqPYRl+bag6mYv4lw==";
+      };
+    };
     "stream-parser-0.3.1" = {
       name = "stream-parser";
       packageName = "stream-parser";
@@ -37742,15 +38031,6 @@ let
         sha1 = "bbf6b39f5f43ec30bc71babcb37557acecf34353";
       };
     };
-    "stream-to-blob-1.0.2" = {
-      name = "stream-to-blob";
-      packageName = "stream-to-blob";
-      version = "1.0.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/stream-to-blob/-/stream-to-blob-1.0.2.tgz";
-        sha512 = "ryeEu3DGMt/095uTShIYGzLbbhZ+tHQtgp5HWEhXALSoc4U1iLSvpReZUdysahnJ3tki80wBBgryqqBzFZ0KaA==";
-      };
-    };
     "stream-to-blob-2.0.0" = {
       name = "stream-to-blob";
       packageName = "stream-to-blob";
@@ -37760,13 +38040,13 @@ let
         sha512 = "E+YitTtIHo7RQ4Cmgl+EzlMpqvLroTynRgt4t0pI4y5oz/piqlBQB8NFXLIWcjGOsKw+THnImrdpWcOCVxK25Q==";
       };
     };
-    "stream-to-blob-url-2.1.2" = {
+    "stream-to-blob-url-3.0.0" = {
       name = "stream-to-blob-url";
       packageName = "stream-to-blob-url";
-      version = "2.1.2";
+      version = "3.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/stream-to-blob-url/-/stream-to-blob-url-2.1.2.tgz";
-        sha512 = "dpfeYUYNodazv7rU+B9DOBj8u+dueXKOWqCy1lzPBxqeVIqq93jVTn68DZoBPLiYXSdsY9AW8D1l1BuxvghqEA==";
+        url = "https://registry.npmjs.org/stream-to-blob-url/-/stream-to-blob-url-3.0.0.tgz";
+        sha512 = "Mu1iPvbBkzdUPCZ+J+XBr/oagjOBfj4vpErHRIe08QzWeILSDtF5LXo6v44HeQFpx7dfqcBKjGUbSNCJ+38zqQ==";
       };
     };
     "stream-to-promise-2.2.0" = {
@@ -38048,13 +38328,13 @@ let
         sha512 = "n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==";
       };
     };
-    "string_decoder-1.2.0" = {
+    "string_decoder-1.3.0" = {
       name = "string_decoder";
       packageName = "string_decoder";
-      version = "1.2.0";
+      version = "1.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz";
-        sha512 = "6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==";
+        url = "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz";
+        sha512 = "hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==";
       };
     };
     "stringify-entities-1.3.2" = {
@@ -38345,13 +38625,13 @@ let
         sha1 = "29f4dc129fa1ca22150cd867223cee2bed5ff6a2";
       };
     };
-    "stylus-0.54.5" = {
+    "stylus-0.54.7" = {
       name = "stylus";
       packageName = "stylus";
-      version = "0.54.5";
+      version = "0.54.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/stylus/-/stylus-0.54.5.tgz";
-        sha1 = "42b9560931ca7090ce8515a798ba9e6aa3d6dc79";
+        url = "https://registry.npmjs.org/stylus/-/stylus-0.54.7.tgz";
+        sha512 = "Yw3WMTzVwevT6ZTrLCYNHAFmanMxdylelL3hkWNgPMeTCpMwpV3nXjpOHuBXtFv7aiO2xRuQS6OoAdgkNcSNug==";
       };
     };
     "stylus-supremacy-2.12.7" = {
@@ -38741,13 +39021,13 @@ let
         sha512 = "YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==";
       };
     };
-    "systeminformation-4.14.4" = {
+    "systeminformation-4.14.8" = {
       name = "systeminformation";
       packageName = "systeminformation";
-      version = "4.14.4";
+      version = "4.14.8";
       src = fetchurl {
-        url = "https://registry.npmjs.org/systeminformation/-/systeminformation-4.14.4.tgz";
-        sha512 = "ib2dodksiiaGOW4rcKvFr5naHkODI9GwQPugLb6FLKppkIsE7rj2dfY2UdMBr7oX0/iZP981hoxmbk2e6zl99Q==";
+        url = "https://registry.npmjs.org/systeminformation/-/systeminformation-4.14.8.tgz";
+        sha512 = "05wW1YaMBI6LlVtvw2wXQGr0thpX8E0IImYcpbqUiNanfmq8e+V89pDW2L5V/mN8kU37W0VtVySftQ0PwMIXKw==";
       };
     };
     "syswide-cas-5.3.0" = {
@@ -38777,13 +39057,13 @@ let
         sha512 = "UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==";
       };
     };
-    "table-5.4.5" = {
+    "table-5.4.6" = {
       name = "table";
       packageName = "table";
-      version = "5.4.5";
+      version = "5.4.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/table/-/table-5.4.5.tgz";
-        sha512 = "oGa2Hl7CQjfoaogtrOHEJroOcYILTx7BZWLGsJIlzoWmB2zmguhNfPJZsWPKYek/MgCxfco54gEi31d1uN2hFA==";
+        url = "https://registry.npmjs.org/table/-/table-5.4.6.tgz";
+        sha512 = "wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==";
       };
     };
     "table-layout-0.4.5" = {
@@ -38832,13 +39112,13 @@ let
         sha1 = "7cbcb64b5a141b6a2efc2c5d2c67b4e150b2a268";
       };
     };
-    "tail-2.0.2" = {
+    "tail-2.0.3" = {
       name = "tail";
       packageName = "tail";
-      version = "2.0.2";
+      version = "2.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/tail/-/tail-2.0.2.tgz";
-        sha512 = "raFipiKWdGKEzxbvZwnhUGqjvsv0gpa/1A479rL//NOxnNwYZDN4MPk6xJJdUFs8P2Xrff3nbH5fcyYRLU4UHQ==";
+        url = "https://registry.npmjs.org/tail/-/tail-2.0.3.tgz";
+        sha512 = "s9NOGkLqqiDEtBttQZI7acLS8ycYK5sTlDwNjGnpXG9c8AWj0cfAtwEIzo/hVRMMiC5EYz+bXaJWC1u1u0GPpQ==";
       };
     };
     "taketalk-1.0.0" = {
@@ -39084,13 +39364,13 @@ let
         sha1 = "458b83887f288fc56d6fffbfad262e26638efa69";
       };
     };
-    "terminal-kit-1.29.3" = {
+    "terminal-kit-1.31.1" = {
       name = "terminal-kit";
       packageName = "terminal-kit";
-      version = "1.29.3";
+      version = "1.31.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/terminal-kit/-/terminal-kit-1.29.3.tgz";
-        sha512 = "RngmihiCinQ0CT3Q7l2R4aiV50czaB0gmGZ2rOZXhX5vWAkUAsnRVcv4JG068KQP1FbQNhm88CU/nBCZQmMPUQ==";
+        url = "https://registry.npmjs.org/terminal-kit/-/terminal-kit-1.31.1.tgz";
+        sha512 = "mKPPkvRgUAuerK/bcZze6GLl8Y8C/agPncFsgR9zwIcz/2xPydcng9hbB48tYz6jrY3IXumi6WkaEYYYyzYtWQ==";
       };
     };
     "terser-3.17.0" = {
@@ -39102,13 +39382,13 @@ let
         sha512 = "/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==";
       };
     };
-    "terser-4.1.3" = {
+    "terser-4.2.1" = {
       name = "terser";
       packageName = "terser";
-      version = "4.1.3";
+      version = "4.2.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/terser/-/terser-4.1.3.tgz";
-        sha512 = "on13d+cnpn5bMouZu+J8tPYQecsdRJCJuxFJ+FVoPBoLJgk5bCBkp+Uen2hWyi0KIUm6eDarnlAlH+KgIx/PuQ==";
+        url = "https://registry.npmjs.org/terser/-/terser-4.2.1.tgz";
+        sha512 = "cGbc5utAcX4a9+2GGVX4DsenG6v0x3glnDi5hx8816X1McEAwPlPgRtXPJzSBsbpILxZ8MQMT0KvArLuE0HP5A==";
       };
     };
     "terser-webpack-plugin-1.4.1" = {
@@ -39444,13 +39724,13 @@ let
         sha1 = "c9c58b575be8407375cb5e2462dacee74359f41d";
       };
     };
-    "timers-browserify-2.0.10" = {
+    "timers-browserify-2.0.11" = {
       name = "timers-browserify";
       packageName = "timers-browserify";
-      version = "2.0.10";
+      version = "2.0.11";
       src = fetchurl {
-        url = "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz";
-        sha512 = "YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==";
+        url = "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz";
+        sha512 = "60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==";
       };
     };
     "timers-ext-0.1.7" = {
@@ -39858,13 +40138,13 @@ let
         sha1 = "2d17d82cf669ada7f9dfe75db4b31f7034b71e29";
       };
     };
-    "torrent-discovery-9.1.2" = {
+    "torrent-discovery-9.2.1" = {
       name = "torrent-discovery";
       packageName = "torrent-discovery";
-      version = "9.1.2";
+      version = "9.2.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/torrent-discovery/-/torrent-discovery-9.1.2.tgz";
-        sha512 = "LW5CZEWwmlnK0iDwiV8glDI9jWQ1OhL1hGnyn5/ystOSa2+cZO1d2xcKemghf1tlG0C3ytmLE4rnM5yXR5eN3A==";
+        url = "https://registry.npmjs.org/torrent-discovery/-/torrent-discovery-9.2.1.tgz";
+        sha512 = "bjKkbTEkcoZTXF8nhcRu6UWqbkpUsehd/6umoZqjgj/dM8nD3O7wNkPZrmls+vVf+2LT9ejZMlNUvZCqSe8cqg==";
       };
     };
     "torrent-piece-1.1.2" = {
@@ -40218,6 +40498,15 @@ let
         sha512 = "4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==";
       };
     };
+    "tslint-5.19.0" = {
+      name = "tslint";
+      packageName = "tslint";
+      version = "5.19.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/tslint/-/tslint-5.19.0.tgz";
+        sha512 = "1LwwtBxfRJZnUvoS9c0uj8XQtAnyhWr9KlNvDIdB+oXyT+VpsOAaEhEgKi1HrZ8rq0ki/AAnbGSv4KM6/AfVZw==";
+      };
+    };
     "tsscmp-1.0.5" = {
       name = "tsscmp";
       packageName = "tsscmp";
@@ -40234,6 +40523,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz";
         sha512 = "LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==";
+      };
+    };
+    "tsutils-2.29.0" = {
+      name = "tsutils";
+      packageName = "tsutils";
+      version = "2.29.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz";
+        sha512 = "g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==";
       };
     };
     "ttl-1.3.1" = {
@@ -40488,6 +40786,15 @@ let
         sha512 = "ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==";
       };
     };
+    "typescript-3.6.2" = {
+      name = "typescript";
+      packageName = "typescript";
+      version = "3.6.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/typescript/-/typescript-3.6.2.tgz";
+        sha512 = "lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==";
+      };
+    };
     "typescript-eslint-parser-16.0.1" = {
       name = "typescript-eslint-parser";
       packageName = "typescript-eslint-parser";
@@ -40731,13 +41038,13 @@ let
         sha1 = "e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa";
       };
     };
-    "uncss-0.17.0" = {
+    "uncss-0.17.2" = {
       name = "uncss";
       packageName = "uncss";
-      version = "0.17.0";
+      version = "0.17.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/uncss/-/uncss-0.17.0.tgz";
-        sha512 = "ZFFHCpAUEC0kJkuJelLYjrr0/bHBlgrN8XRDQN+wt9VVqap8Avj4fxt2WDJJZi0aSzYVaWCQoX19ZM+JZ5lqnw==";
+        url = "https://registry.npmjs.org/uncss/-/uncss-0.17.2.tgz";
+        sha512 = "hu2HquwDItuGDem4YsJROdAD8SknmWtM24zwhQax6J1se8tPjV1cnwPKhtjodzBaUhaL8Zb3hlGdZ2WAUpbAOg==";
       };
     };
     "undeclared-identifiers-1.1.3" = {
@@ -41640,13 +41947,13 @@ let
         sha512 = "/Igrr2rPD0NH/dNx493alpHxGBF/XREu68bZU4zigrYiQMQpYL68sKbNo9ND5DcmbMp0lNppw4mOhSSONgUYKw==";
       };
     };
-    "ut_pex-1.2.1" = {
+    "ut_pex-2.0.0" = {
       name = "ut_pex";
       packageName = "ut_pex";
-      version = "1.2.1";
+      version = "2.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ut_pex/-/ut_pex-1.2.1.tgz";
-        sha512 = "ZrxMCbffYtxQDqvREN9kBXK2CB9tPnd5PylHoqQX9ai+3HV9/S39FnA5JnhLOC82dxIQQg0nTN2wmhtAdGNtOA==";
+        url = "https://registry.npmjs.org/ut_pex/-/ut_pex-2.0.0.tgz";
+        sha512 = "Uc0IxXGlES1DfeG+ITUISAvCF4Uldj7tt/n7s3TBt0KyXqDViOO26X5WfwXtUpEwn8fyZyerzf/YOK4rIZ2S3Q==";
       };
     };
     "utf-8-validate-1.2.2" = {
@@ -41856,6 +42163,15 @@ let
         sha512 = "yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==";
       };
     };
+    "uuid-3.3.3" = {
+      name = "uuid";
+      packageName = "uuid";
+      version = "3.3.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz";
+        sha512 = "pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==";
+      };
+    };
     "v8-compile-cache-2.0.3" = {
       name = "v8-compile-cache";
       packageName = "v8-compile-cache";
@@ -41953,15 +42269,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/validator/-/validator-10.11.0.tgz";
         sha512 = "X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw==";
-      };
-    };
-    "validator-10.8.0" = {
-      name = "validator";
-      packageName = "validator";
-      version = "10.8.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/validator/-/validator-10.8.0.tgz";
-        sha512 = "mXqMxfCh5NLsVgYVKl9WvnHNDPCcbNppHSPPowu0VjtSsGWVY+z8hJF44edLR1nbLNzi3jYoYsIl8KZpioIk6g==";
       };
     };
     "validator-5.2.0" = {
@@ -42396,13 +42703,13 @@ let
         sha1 = "ab6549d61d172c2b1b87be5c508d239c8ef87705";
       };
     };
-    "vlc-command-1.1.2" = {
+    "vlc-command-1.2.0" = {
       name = "vlc-command";
       packageName = "vlc-command";
-      version = "1.1.2";
+      version = "1.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vlc-command/-/vlc-command-1.1.2.tgz";
-        sha512 = "KZ15RTHz96OEiQDA8oNFn1edYDWyKJIWI4gF74Am9woZo5XmVYryk5RYXSwOMvsaAgL5ejICEGCl0suQyDBu+Q==";
+        url = "https://registry.npmjs.org/vlc-command/-/vlc-command-1.2.0.tgz";
+        sha512 = "YTr1w5KmxRN5CBCvplKOD6g/OjwCl5iz+SIjDbq8gWTkByYZun5duHm+OLUkBlbJrCGvMyFyNhTMQxV4Ny0v8g==";
       };
     };
     "vlq-0.2.3" = {
@@ -42495,13 +42802,13 @@ let
         sha512 = "perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg==";
       };
     };
-    "vscode-jsonrpc-4.1.0-next.2" = {
+    "vscode-jsonrpc-4.1.0-next.3" = {
       name = "vscode-jsonrpc";
       packageName = "vscode-jsonrpc";
-      version = "4.1.0-next.2";
+      version = "4.1.0-next.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-4.1.0-next.2.tgz";
-        sha512 = "GsBLjP9DxQ42yl1mW9GEIlnSc0+R8mfzhaebwmmTPEJjezD5SPoAo3DFrIAFZha9yvQ1nzZfZlhtVpGQmgxtXg==";
+        url = "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-4.1.0-next.3.tgz";
+        sha512 = "Z6oxBiMks2+UADV1QHXVooSakjyhI+eHTnXzDyVvVMmegvSfkXk2w6mPEdSkaNHFBdtWW7n20H1yw2nA3A17mg==";
       };
     };
     "vscode-languageclient-4.0.1" = {
@@ -42540,13 +42847,13 @@ let
         sha512 = "GuayqdKZqAwwaCUjDvMTAVRPJOp/SLON3mJ07eGsx/Iq9HjRymhKWztX41rISqDKhHVVyFM+IywICyZDla6U3A==";
       };
     };
-    "vscode-languageserver-5.3.0-next.8" = {
+    "vscode-languageserver-5.3.0-next.10" = {
       name = "vscode-languageserver";
       packageName = "vscode-languageserver";
-      version = "5.3.0-next.8";
+      version = "5.3.0-next.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-5.3.0-next.8.tgz";
-        sha512 = "6vUb96wsRfrFqndril3gct/FBCSc24OxFZ2iz7kuEuXvLaIcEVOcSZIqQK8oFN7PdbAIaa9nnIpKSy4Yd15cIw==";
+        url = "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-5.3.0-next.10.tgz";
+        sha512 = "QL7Fe1FT6PdLtVzwJeZ78pTic4eZbzLRy7yAQgPb9xalqqgZESR0+yDZPwJrM3E7PzOmwHBceYcJR54eQZ7Kng==";
       };
     };
     "vscode-languageserver-protocol-3.14.1" = {
@@ -42558,13 +42865,13 @@ let
         sha512 = "IL66BLb2g20uIKog5Y2dQ0IiigW0XKrvmWiOvc0yXw80z3tMEzEnHjaGAb3ENuU7MnQqgnYJ1Cl2l9RvNgDi4g==";
       };
     };
-    "vscode-languageserver-protocol-3.15.0-next.6" = {
+    "vscode-languageserver-protocol-3.15.0-next.8" = {
       name = "vscode-languageserver-protocol";
       packageName = "vscode-languageserver-protocol";
-      version = "3.15.0-next.6";
+      version = "3.15.0-next.8";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.0-next.6.tgz";
-        sha512 = "/yDpYlWyNs26mM23mT73xmOFsh1iRfgZfBdHmfAxwDKwpQKLoOSqVidtYfxlK/pD3IEKGcAVnT4WXTsguxxAMQ==";
+        url = "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.0-next.8.tgz";
+        sha512 = "9FigDhuYTUqX73IGKgJeyLmfXQJv9p3t22RF3peT+HM33uFiTZE3MUgHj4I9m/dKCDvuJt0yvbI27ut4hDoGRQ==";
       };
     };
     "vscode-languageserver-protocol-3.6.0" = {
@@ -42594,13 +42901,13 @@ let
         sha512 = "lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A==";
       };
     };
-    "vscode-languageserver-types-3.15.0-next.2" = {
+    "vscode-languageserver-types-3.15.0-next.4" = {
       name = "vscode-languageserver-types";
       packageName = "vscode-languageserver-types";
-      version = "3.15.0-next.2";
+      version = "3.15.0-next.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.15.0-next.2.tgz";
-        sha512 = "2JkrMWWUi2rlVLSo9OFR2PIGUzdiowEM8NgNYiwLKnXTjpwpjjIrJbNNxDik7Rv4oo9KtikcFQZKXbrKilL/MQ==";
+        url = "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.15.0-next.4.tgz";
+        sha512 = "IKIWTdUPBnOtwznIrhxKnjVZ7hYxEzwZ3M2xmDi7OjjexuOM6LnGtoo1Dv4wYSik4epK4STEib6e8da2GxUsJA==";
       };
     };
     "vscode-nls-3.2.5" = {
@@ -42729,15 +43036,6 @@ let
         sha512 = "jVZkw4/I/HT5ZMvRnhv78okGusqe0+qH2A0Em0Cp8aq78+NK9TII263CDVz2QXZsIT+yyV/gZc/j/vlwa+Epyg==";
       };
     };
-    "vuetify-helper-json-1.0.0" = {
-      name = "vuetify-helper-json";
-      packageName = "vuetify-helper-json";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/vuetify-helper-json/-/vuetify-helper-json-1.0.0.tgz";
-        sha512 = "JNjc77FJbWEOk+Y9uzPr8u3cogRivjUE1Ha9DhPruBJutRO1Lf4ZVff44/N37vwC9e9JJGjj7y4JtT2kY7exrw==";
-      };
-    };
     "w3c-hr-time-1.0.1" = {
       name = "w3c-hr-time";
       packageName = "w3c-hr-time";
@@ -42855,22 +43153,22 @@ let
         sha512 = "YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==";
       };
     };
-    "webpack-4.39.1" = {
+    "webpack-4.39.3" = {
       name = "webpack";
       packageName = "webpack";
-      version = "4.39.1";
+      version = "4.39.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/webpack/-/webpack-4.39.1.tgz";
-        sha512 = "/LAb2TJ2z+eVwisldp3dqTEoNhzp/TLCZlmZm3GGGAlnfIWDgOEE758j/9atklNLfRyhKbZTCOIoPqLJXeBLbQ==";
+        url = "https://registry.npmjs.org/webpack/-/webpack-4.39.3.tgz";
+        sha512 = "BXSI9M211JyCVc3JxHWDpze85CvjC842EvpRsVTc/d15YJGlox7GIDd38kJgWrb3ZluyvIjgenbLDMBQPDcxYQ==";
       };
     };
-    "webpack-cli-3.3.6" = {
+    "webpack-cli-3.3.7" = {
       name = "webpack-cli";
       packageName = "webpack-cli";
-      version = "3.3.6";
+      version = "3.3.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.6.tgz";
-        sha512 = "0vEa83M7kJtxK/jUhlpZ27WHIOndz5mghWL2O53kiDoA9DIxSKnfqB92LoqEn77cT4f3H2cZm1BMEat/6AZz3A==";
+        url = "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.7.tgz";
+        sha512 = "OhTUCttAsr+IZSMVwGROGRHvT+QAs8H6/mHIl4SvhAwYywjiylYjpwybGx7WQ9Hkb45FhjtsymkwiRRbGJ1SZQ==";
       };
     };
     "webpack-core-0.6.9" = {
@@ -42918,13 +43216,13 @@ let
         sha512 = "EXy/zXb9kNHI07TIMz1oIUIrPZxQRA8aeJ5XYg5ihV8K4kD1DuA+FY6R96HfdIHzlSzS8HiISAfrm+vVQkZBug==";
       };
     };
-    "webtorrent-0.106.0" = {
+    "webtorrent-0.107.6" = {
       name = "webtorrent";
       packageName = "webtorrent";
-      version = "0.106.0";
+      version = "0.107.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/webtorrent/-/webtorrent-0.106.0.tgz";
-        sha512 = "CTj4J6yj6TuNTfrjRL84tunlCwIM+4hBu/6BfZslgi+iHdiJklUmFra/1WXBsx1madUB6/Ujx1eh4w+FO0on7g==";
+        url = "https://registry.npmjs.org/webtorrent/-/webtorrent-0.107.6.tgz";
+        sha512 = "EMiqSPSNgzfUbxHXCwzrcwWWvdV4t3BWRHFDpoxamxB2ZSqy9ogF42NeptjXKTfmCrMdQxAAnXakYZQyZB5BrA==";
       };
     };
     "whatwg-encoding-1.0.5" = {
@@ -43512,13 +43810,13 @@ let
         sha512 = "GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==";
       };
     };
-    "ws-7.1.1" = {
+    "ws-7.1.2" = {
       name = "ws";
       packageName = "ws";
-      version = "7.1.1";
+      version = "7.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ws/-/ws-7.1.1.tgz";
-        sha512 = "o41D/WmDeca0BqYhsr3nJzQyg9NF5X8l/UdnFNux9cS3lwB+swm8qGWX5rn+aD6xfBU3rGmtHij7g7x6LxFU3A==";
+        url = "https://registry.npmjs.org/ws/-/ws-7.1.2.tgz";
+        sha512 = "gftXq3XI81cJCgkUiAVixA0raD9IVmXqsylCrjRygw4+UOOGzPoxnQ6r/CnVL9i+mDncJo94tSkyrtuuQVBmrg==";
       };
     };
     "wtf-8-1.0.0" = {
@@ -44008,6 +44306,15 @@ let
         sha512 = "ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==";
       };
     };
+    "yargs-11.1.0" = {
+      name = "yargs";
+      packageName = "yargs";
+      version = "11.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz";
+        sha512 = "NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==";
+      };
+    };
     "yargs-12.0.4" = {
       name = "yargs";
       packageName = "yargs";
@@ -44116,15 +44423,6 @@ let
         sha512 = "VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==";
       };
     };
-    "yargs-parser-11.0.0" = {
-      name = "yargs-parser";
-      packageName = "yargs-parser";
-      version = "11.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.0.0.tgz";
-        sha512 = "dvsafRjM45h79WOTvS/dP35Sb31SlGAKz6tFjI97kGC4MJFBuzTZY6TTYHrz0QSMQdkyd8Y+RsOMLr+JY0nPFQ==";
-      };
-    };
     "yargs-parser-11.1.1" = {
       name = "yargs-parser";
       packageName = "yargs-parser";
@@ -44197,6 +44495,15 @@ let
         sha512 = "yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==";
       };
     };
+    "yargs-parser-9.0.2" = {
+      name = "yargs-parser";
+      packageName = "yargs-parser";
+      version = "9.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz";
+        sha1 = "9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077";
+      };
+    };
     "yargs-unparser-1.5.0" = {
       name = "yargs-unparser";
       packageName = "yargs-unparser";
@@ -44206,13 +44513,13 @@ let
         sha512 = "HK25qidFTCVuj/D1VfNiEndpLIeJN78aqgR23nL3y4N0U/91cOAzqfHlF8n2BvoNDcZmJKin3ddNSvOxSr8flw==";
       };
     };
-    "yarn-1.16.0" = {
+    "yarn-1.17.3" = {
       name = "yarn";
       packageName = "yarn";
-      version = "1.16.0";
+      version = "1.17.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/yarn/-/yarn-1.16.0.tgz";
-        sha512 = "cfemyGlnWKA1zopUUgebTPf8C4WkPIZ+TJmklwcEAJ4u6oWPtJeAzrsamaGGh/+b1XWe8W51yzAImC4AWbWR1g==";
+        url = "https://registry.npmjs.org/yarn/-/yarn-1.17.3.tgz";
+        sha512 = "CgA8o7nRZaQvmeF/WBx2FC7f9W/0X59T2IaLYqgMo6637wfp5mMEsM3YXoJtKUspnpmDJKl/gGFhnqS+sON7hA==";
       };
     };
     "yauzl-2.10.0" = {
@@ -44383,25 +44690,25 @@ in
   "@angular/cli" = nodeEnv.buildNodePackage {
     name = "_at_angular_slash_cli";
     packageName = "@angular/cli";
-    version = "8.2.0";
+    version = "8.3.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/@angular/cli/-/cli-8.2.0.tgz";
-      sha512 = "KtjC5Mge93YjPQXxEKnXzQ7pmryizfVunrcKHSwhnzfNdwqSjcfL2evl4oBT07b6RfT0nF8HWn0ATWpiLWwrXQ==";
+      url = "https://registry.npmjs.org/@angular/cli/-/cli-8.3.2.tgz";
+      sha512 = "NFL/QG+u607kQigubTj6Mlv289/6AvBooqkesBGta/Axaqgz3kPqJbz8YJs51mrHpa9rmx0IIncIMeKjHa7vTw==";
     };
     dependencies = [
-      sources."@angular-devkit/architect-0.802.0"
-      sources."@angular-devkit/core-8.2.0"
-      sources."@angular-devkit/schematics-8.2.0"
-      sources."@schematics/angular-8.2.0"
-      sources."@schematics/update-0.802.0"
+      sources."@angular-devkit/architect-0.803.2"
+      sources."@angular-devkit/core-8.3.2"
+      sources."@angular-devkit/schematics-8.3.2"
+      sources."@schematics/angular-8.3.2"
+      sources."@schematics/update-0.803.2"
       sources."@yarnpkg/lockfile-1.1.0"
       sources."JSONStream-1.3.5"
       sources."agent-base-4.3.0"
       sources."agentkeepalive-3.5.2"
       sources."ajv-6.10.2"
       sources."ansi-colors-4.1.1"
-      sources."ansi-escapes-3.2.0"
-      sources."ansi-regex-3.0.0"
+      sources."ansi-escapes-4.2.1"
+      sources."ansi-regex-4.1.0"
       sources."ansi-styles-3.2.1"
       sources."aproba-1.2.0"
       sources."asap-2.0.6"
@@ -44416,12 +44723,12 @@ in
       sources."brace-expansion-1.1.11"
       sources."buffer-from-1.1.1"
       sources."builtins-1.0.3"
-      sources."cacache-12.0.2"
+      sources."cacache-12.0.3"
       sources."caseless-0.12.0"
       sources."chalk-2.4.2"
       sources."chardet-0.7.0"
       sources."chownr-1.1.2"
-      sources."cli-cursor-2.1.0"
+      sources."cli-cursor-3.1.0"
       sources."cli-width-2.2.0"
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
@@ -44439,6 +44746,7 @@ in
       sources."dezalgo-1.0.3"
       sources."duplexify-3.7.1"
       sources."ecc-jsbn-0.1.2"
+      sources."emoji-regex-8.0.0"
       sources."encoding-0.1.12"
       sources."end-of-stream-1.4.1"
       sources."err-code-1.1.2"
@@ -44453,7 +44761,7 @@ in
       sources."fast-deep-equal-2.0.1"
       sources."fast-json-stable-stringify-2.0.0"
       sources."figgy-pudding-3.5.1"
-      sources."figures-2.0.0"
+      sources."figures-3.0.0"
       sources."flush-write-stream-1.1.1"
       sources."forever-agent-0.6.1"
       sources."form-data-2.3.3"
@@ -44466,13 +44774,13 @@ in
       sources."get-stream-4.1.0"
       sources."getpass-0.1.7"
       sources."glob-7.1.4"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-1.0.3"
       sources."has-flag-3.0.0"
       sources."has-symbols-1.0.0"
-      sources."hosted-git-info-2.8.2"
+      sources."hosted-git-info-2.8.4"
       sources."http-cache-semantics-3.8.1"
       (sources."http-proxy-agent-2.1.0" // {
         dependencies = [
@@ -44495,11 +44803,11 @@ in
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
       sources."ini-1.3.5"
-      sources."inquirer-6.5.0"
+      sources."inquirer-6.5.1"
       sources."ip-1.1.5"
       sources."is-callable-1.1.4"
       sources."is-date-object-1.0.1"
-      sources."is-fullwidth-code-point-2.0.0"
+      sources."is-fullwidth-code-point-3.0.0"
       sources."is-promise-2.1.0"
       sources."is-regex-1.0.4"
       sources."is-symbol-1.0.2"
@@ -44521,32 +44829,32 @@ in
       sources."make-fetch-happen-5.0.0"
       sources."mime-db-1.40.0"
       sources."mime-types-2.1.24"
-      sources."mimic-fn-1.2.0"
+      sources."mimic-fn-2.1.0"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
-      sources."minipass-2.3.5"
+      sources."minipass-2.5.0"
       sources."minizlib-1.2.1"
       sources."mississippi-3.0.0"
       sources."mkdirp-0.5.1"
       sources."move-concurrently-1.0.1"
       sources."ms-2.1.2"
-      sources."mute-stream-0.0.7"
+      sources."mute-stream-0.0.8"
       sources."node-fetch-npm-2.0.2"
       (sources."normalize-package-data-2.5.0" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       sources."npm-bundled-1.0.6"
       (sources."npm-package-arg-6.1.0" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       sources."npm-packlist-1.4.4"
       (sources."npm-pick-manifest-2.2.3" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       sources."npm-registry-fetch-4.0.0"
@@ -44554,14 +44862,14 @@ in
       sources."object-keys-1.1.1"
       sources."object.getownpropertydescriptors-2.0.3"
       sources."once-1.4.0"
-      sources."onetime-2.0.1"
+      sources."onetime-5.1.0"
       sources."open-6.4.0"
       sources."os-homedir-1.0.2"
       sources."os-tmpdir-1.0.2"
       sources."osenv-0.1.5"
-      (sources."pacote-9.5.4" // {
+      (sources."pacote-9.5.5" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       sources."parallel-transform-1.1.0"
@@ -44581,7 +44889,7 @@ in
       })
       sources."punycode-2.1.1"
       sources."qs-6.5.2"
-      sources."read-package-json-2.0.13"
+      sources."read-package-json-2.1.0"
       sources."read-package-tree-5.3.1"
       (sources."readable-stream-2.3.6" // {
         dependencies = [
@@ -44591,9 +44899,9 @@ in
       sources."readdir-scoped-modules-1.1.0"
       sources."request-2.88.0"
       sources."resolve-1.12.0"
-      sources."restore-cursor-2.0.0"
+      sources."restore-cursor-3.1.0"
       sources."retry-0.10.1"
-      sources."rimraf-2.6.3"
+      sources."rimraf-2.7.1"
       sources."run-async-2.3.0"
       sources."run-queue-1.0.3"
       sources."rxjs-6.4.0"
@@ -44602,7 +44910,7 @@ in
       sources."semver-6.3.0"
       (sources."semver-intersect-1.4.0" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       sources."signal-exit-3.0.2"
@@ -44624,21 +44932,13 @@ in
       sources."ssri-6.0.1"
       sources."stream-each-1.2.3"
       sources."stream-shift-1.0.0"
-      (sources."string-width-2.1.1" // {
-        dependencies = [
-          sources."strip-ansi-4.0.0"
-        ];
-      })
+      sources."string-width-4.1.0"
       (sources."string_decoder-1.1.1" // {
         dependencies = [
           sources."safe-buffer-5.1.2"
         ];
       })
-      (sources."strip-ansi-5.2.0" // {
-        dependencies = [
-          sources."ansi-regex-4.1.0"
-        ];
-      })
+      sources."strip-ansi-5.2.0"
       sources."supports-color-5.5.0"
       sources."symbol-observable-1.2.0"
       sources."tar-4.4.10"
@@ -44653,6 +44953,7 @@ in
       sources."tslib-1.10.0"
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
+      sources."type-fest-0.5.2"
       sources."typedarray-0.0.6"
       sources."unique-filename-1.1.1"
       sources."unique-slug-2.0.2"
@@ -44664,7 +44965,7 @@ in
       sources."uri-js-4.2.2"
       sources."util-deprecate-1.0.2"
       sources."util-promisify-2.1.0"
-      sources."uuid-3.3.2"
+      sources."uuid-3.3.3"
       sources."validate-npm-package-license-3.0.4"
       sources."validate-npm-package-name-3.0.0"
       sources."verror-1.10.0"
@@ -44686,37 +44987,32 @@ in
   "@antora/cli" = nodeEnv.buildNodePackage {
     name = "_at_antora_slash_cli";
     packageName = "@antora/cli";
-    version = "2.0.0";
+    version = "2.1.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/@antora/cli/-/cli-2.0.0.tgz";
-      sha512 = "vgoGTRRFkPtKeMgGoBevYzK97DwT75rxUeE6yAtm50i7e/aIGoXFyCglaXdsyP4FAfENVqN+DWy3ZuKxhPfc7g==";
+      url = "https://registry.npmjs.org/@antora/cli/-/cli-2.1.0.tgz";
+      sha512 = "YgXAVaRYJDf2fLDLWpOKX/8etUiPzQyhQmnUE6SXsGYPi7AR5mUVibIGYrDTVmfeCn4vlQzGRJkhHpnmuT2E7Q==";
     };
     dependencies = [
-      sources."@antora/playbook-builder-2.0.0"
+      sources."@antora/playbook-builder-2.1.0"
       sources."@iarna/toml-2.2.3"
       sources."argparse-1.0.10"
       sources."camelcase-5.3.1"
-      sources."camelcase-keys-5.2.0"
-      sources."commander-2.20.0"
-      (sources."convict-4.4.1" // {
-        dependencies = [
-          sources."json5-1.0.1"
-        ];
-      })
+      sources."camelcase-keys-6.0.1"
+      sources."commander-3.0.0"
+      sources."convict-5.1.0"
       sources."decamelize-1.2.0"
-      sources."deep-freeze-0.0.1"
-      sources."depd-1.1.2"
+      sources."deep-freeze-node-1.1.3"
       sources."esprima-4.0.1"
       sources."js-yaml-3.13.1"
       sources."json5-2.1.0"
       sources."lodash.clonedeep-4.5.0"
-      sources."map-obj-3.1.0"
+      sources."map-obj-4.1.0"
       sources."minimist-1.2.0"
-      sources."moment-2.22.2"
-      sources."quick-lru-1.1.0"
+      sources."moment-2.24.0"
+      sources."quick-lru-4.0.1"
       sources."sprintf-js-1.0.3"
-      sources."validator-10.8.0"
-      sources."yargs-parser-11.0.0"
+      sources."validator-10.11.0"
+      sources."yargs-parser-13.0.0"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -44730,24 +45026,24 @@ in
   "@antora/site-generator-default" = nodeEnv.buildNodePackage {
     name = "_at_antora_slash_site-generator-default";
     packageName = "@antora/site-generator-default";
-    version = "2.0.0";
+    version = "2.1.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/@antora/site-generator-default/-/site-generator-default-2.0.0.tgz";
-      sha512 = "YMor7dPAef4Pqyxbz7/ZqS0k5haxtcIkmEAfTJpGthCtRhrYfOu2iH+ZntnKRCubNdSgs77CRYjpSjm43rQ7FQ==";
+      url = "https://registry.npmjs.org/@antora/site-generator-default/-/site-generator-default-2.1.0.tgz";
+      sha512 = "g2DyxwOer6O/dFTJswqXoW9BGV6viXQUHmHHi8shBIqmKfPNOq7t3aPnUN1zLm5QbbPACaIjbJsNvwwfnGACcw==";
     };
     dependencies = [
-      sources."@antora/asciidoc-loader-2.0.0"
-      sources."@antora/content-aggregator-2.0.0"
-      sources."@antora/content-classifier-2.0.0"
-      sources."@antora/document-converter-2.0.0"
+      sources."@antora/asciidoc-loader-2.1.0"
+      sources."@antora/content-aggregator-2.1.0"
+      sources."@antora/content-classifier-2.1.0"
+      sources."@antora/document-converter-2.1.0"
       sources."@antora/expand-path-helper-1.0.0"
-      sources."@antora/navigation-builder-2.0.0"
-      sources."@antora/page-composer-2.0.0"
-      sources."@antora/playbook-builder-2.0.0"
-      sources."@antora/redirect-producer-2.0.0"
-      sources."@antora/site-mapper-2.0.0"
-      sources."@antora/site-publisher-2.0.0"
-      sources."@antora/ui-loader-2.0.0"
+      sources."@antora/navigation-builder-2.1.0"
+      sources."@antora/page-composer-2.1.0"
+      sources."@antora/playbook-builder-2.1.0"
+      sources."@antora/redirect-producer-2.1.0"
+      sources."@antora/site-mapper-2.1.0"
+      sources."@antora/site-publisher-2.1.0"
+      sources."@antora/ui-loader-2.1.0"
       sources."@babel/runtime-7.5.5"
       sources."@iarna/toml-2.2.3"
       sources."@sindresorhus/is-0.14.0"
@@ -44759,12 +45055,7 @@ in
       sources."balanced-match-1.0.0"
       sources."base64-js-0.0.2"
       sources."benchmark-1.0.0"
-      (sources."bl-2.2.0" // {
-        dependencies = [
-          sources."readable-stream-2.3.6"
-          sources."string_decoder-1.1.1"
-        ];
-      })
+      sources."bl-3.0.0"
       sources."bops-0.0.7"
       sources."brace-expansion-1.1.11"
       sources."buffer-crc32-0.2.13"
@@ -44778,7 +45069,7 @@ in
         ];
       })
       sources."camelcase-5.3.1"
-      sources."camelcase-keys-5.2.0"
+      sources."camelcase-keys-6.0.1"
       sources."clean-git-ref-1.0.3"
       sources."clone-2.1.2"
       sources."clone-buffer-1.0.0"
@@ -44787,25 +45078,25 @@ in
       (sources."cloneable-readable-1.1.3" // {
         dependencies = [
           sources."readable-stream-2.3.6"
+          sources."safe-buffer-5.1.2"
           sources."string_decoder-1.1.1"
         ];
       })
       sources."commander-2.20.0"
       sources."concat-map-0.0.1"
-      sources."convert-source-map-1.6.0"
-      (sources."convict-4.4.1" // {
+      (sources."convert-source-map-1.6.0" // {
         dependencies = [
-          sources."json5-1.0.1"
+          sources."safe-buffer-5.1.2"
         ];
       })
+      sources."convict-5.1.0"
       sources."core-util-is-1.0.2"
       sources."crc-32-1.2.0"
       sources."decamelize-1.2.0"
       sources."decompress-response-3.3.0"
-      sources."deep-freeze-0.0.1"
+      sources."deep-freeze-node-1.1.3"
       sources."defer-to-connect-1.0.2"
       sources."define-properties-1.1.3"
-      sources."depd-1.1.2"
       sources."diff-3.5.0"
       sources."diff-lines-1.1.1"
       sources."duplexer-0.1.1"
@@ -44813,11 +45104,12 @@ in
       (sources."duplexify-3.7.1" // {
         dependencies = [
           sources."readable-stream-2.3.6"
+          sources."safe-buffer-5.1.2"
           sources."string_decoder-1.1.1"
         ];
       })
       sources."end-of-stream-1.4.1"
-      sources."escape-string-regexp-1.0.5"
+      sources."escape-string-regexp-2.0.0"
       sources."esprima-4.0.1"
       sources."event-stream-3.3.4"
       sources."exit-on-epipe-1.0.1"
@@ -44826,14 +45118,16 @@ in
       (sources."flush-write-stream-1.1.1" // {
         dependencies = [
           sources."readable-stream-2.3.6"
+          sources."safe-buffer-5.1.2"
           sources."string_decoder-1.1.1"
         ];
       })
       sources."from-0.1.7"
-      sources."fs-extra-7.0.1"
+      sources."fs-extra-8.1.0"
       (sources."fs-mkdirp-stream-1.0.0" // {
         dependencies = [
           sources."readable-stream-2.3.6"
+          sources."safe-buffer-5.1.2"
           sources."string_decoder-1.1.1"
           sources."through2-2.0.5"
         ];
@@ -44852,16 +45146,18 @@ in
         dependencies = [
           sources."glob-7.1.4"
           sources."readable-stream-2.3.6"
+          sources."safe-buffer-5.1.2"
           sources."string_decoder-1.1.1"
         ];
       })
       sources."globalyzer-0.1.4"
       sources."globrex-0.1.2"
       sources."got-9.6.0"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       (sources."gulp-vinyl-zip-2.1.2" // {
         dependencies = [
           sources."readable-stream-2.3.6"
+          sources."safe-buffer-5.1.2"
           sources."string_decoder-1.1.1"
           sources."through2-2.0.5"
         ];
@@ -44869,7 +45165,7 @@ in
       sources."handlebars-4.1.2"
       sources."has-symbols-1.0.0"
       sources."http-cache-semantics-4.0.3"
-      sources."ignore-5.1.2"
+      sources."ignore-5.1.4"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
       sources."is-absolute-1.0.0"
@@ -44893,6 +45189,7 @@ in
       (sources."lazystream-1.0.0" // {
         dependencies = [
           sources."readable-stream-2.3.6"
+          sources."safe-buffer-5.1.2"
           sources."string_decoder-1.1.1"
         ];
       })
@@ -44900,10 +45197,10 @@ in
       sources."lodash-4.17.15"
       sources."lodash.clonedeep-4.5.0"
       sources."lowercase-keys-1.0.1"
-      sources."map-obj-3.1.0"
+      sources."map-obj-4.1.0"
       sources."map-stream-0.1.0"
       sources."marky-1.2.1"
-      sources."matcher-1.1.1"
+      sources."matcher-2.0.0"
       sources."mime-db-1.40.0"
       sources."mime-types-2.1.24"
       sources."mimic-response-1.0.1"
@@ -44911,7 +45208,7 @@ in
       sources."minimatch-all-1.1.0"
       sources."minimist-1.2.0"
       sources."minimisted-2.0.0"
-      sources."moment-2.22.2"
+      sources."moment-2.24.0"
       sources."multi-progress-2.0.0"
       sources."neo-async-2.6.1"
       sources."nick-0.1.3"
@@ -44930,6 +45227,7 @@ in
       (sources."ordered-read-streams-1.0.1" // {
         dependencies = [
           sources."readable-stream-2.3.6"
+          sources."safe-buffer-5.1.2"
           sources."string_decoder-1.1.1"
         ];
       })
@@ -44947,14 +45245,22 @@ in
       sources."pump-2.0.1"
       sources."pumpify-1.5.1"
       sources."queue-4.5.1"
-      sources."quick-lru-1.1.0"
+      sources."quick-lru-4.0.1"
       sources."readable-stream-3.4.0"
       sources."regenerator-runtime-0.13.3"
       sources."remove-bom-buffer-3.0.0"
       (sources."remove-bom-stream-1.2.0" // {
         dependencies = [
-          sources."readable-stream-2.3.6"
-          sources."string_decoder-1.1.1"
+          (sources."readable-stream-2.3.6" // {
+            dependencies = [
+              sources."safe-buffer-5.1.2"
+            ];
+          })
+          (sources."string_decoder-1.1.1" // {
+            dependencies = [
+              sources."safe-buffer-5.1.2"
+            ];
+          })
           sources."through2-2.0.5"
         ];
       })
@@ -44963,7 +45269,7 @@ in
       sources."require-from-string-2.0.2"
       sources."resolve-options-1.1.0"
       sources."responselike-1.0.2"
-      sources."safe-buffer-5.1.2"
+      sources."safe-buffer-5.2.0"
       sources."sha.js-2.4.11"
       sources."simple-concat-1.0.0"
       sources."simple-get-3.0.3"
@@ -44974,12 +45280,13 @@ in
       sources."stream-combiner-0.0.4"
       sources."stream-shift-1.0.0"
       sources."stream-source-0.3.5"
-      sources."string_decoder-1.2.0"
+      sources."string_decoder-1.3.0"
       sources."through-2.3.8"
       sources."through2-3.0.1"
       (sources."through2-filter-3.0.0" // {
         dependencies = [
           sources."readable-stream-2.3.6"
+          sources."safe-buffer-5.1.2"
           sources."string_decoder-1.1.1"
           sources."through2-2.0.5"
         ];
@@ -44989,6 +45296,7 @@ in
       (sources."to-through-2.0.0" // {
         dependencies = [
           sources."readable-stream-2.3.6"
+          sources."safe-buffer-5.1.2"
           sources."string_decoder-1.1.1"
           sources."through2-2.0.5"
         ];
@@ -45000,13 +45308,14 @@ in
       sources."universalify-0.1.2"
       sources."url-parse-lax-3.0.0"
       sources."util-deprecate-1.0.2"
-      sources."validator-10.8.0"
+      sources."validator-10.11.0"
       sources."value-or-function-3.0.0"
       sources."varint-0.0.3"
       sources."vinyl-2.2.0"
       (sources."vinyl-fs-3.0.3" // {
         dependencies = [
           sources."readable-stream-2.3.6"
+          sources."safe-buffer-5.1.2"
           sources."string_decoder-1.1.1"
           sources."through2-2.0.5"
         ];
@@ -45017,7 +45326,7 @@ in
       sources."xdg-basedir-3.0.0"
       sources."xmlhttprequest-1.8.0"
       sources."xtend-4.0.2"
-      sources."yargs-parser-11.0.0"
+      sources."yargs-parser-13.0.0"
       sources."yauzl-2.10.0"
       sources."yazl-2.5.1"
     ];
@@ -45033,10 +45342,10 @@ in
   "@vue/cli" = nodeEnv.buildNodePackage {
     name = "_at_vue_slash_cli";
     packageName = "@vue/cli";
-    version = "3.10.0";
+    version = "3.11.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/@vue/cli/-/cli-3.10.0.tgz";
-      sha512 = "0A2wsUPAoiiqr4B/EAlz1SPUNbq0pbyt4I8V6fiwie5oJXaxfJ8Vl8rpSUsZ2PzwpowgdiutjFkOxvFmhHAkQQ==";
+      url = "https://registry.npmjs.org/@vue/cli/-/cli-3.11.0.tgz";
+      sha512 = "dhnkqsg1TRyaauKl7j8b0n5N8vB1Vm6cBqU4n2Re0LeYzO4UUE6KlOAt1zTVn+5Nx45V1NAoPWff1iefPDTT8g==";
     };
     dependencies = [
       sources."@akryum/winattr-3.0.0"
@@ -45045,7 +45354,7 @@ in
       sources."@babel/code-frame-7.5.5"
       (sources."@babel/core-7.5.5" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       sources."@babel/generator-7.5.5"
@@ -45121,7 +45430,7 @@ in
       sources."@babel/plugin-transform-unicode-regex-7.4.4"
       (sources."@babel/preset-env-7.5.5" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       sources."@babel/preset-flow-7.0.0"
@@ -45131,14 +45440,10 @@ in
       sources."@babel/traverse-7.5.5"
       sources."@babel/types-7.5.5"
       sources."@hapi/address-2.0.0"
-      sources."@hapi/hoek-6.2.4"
-      sources."@hapi/joi-15.1.0"
-      sources."@hapi/marker-1.0.0"
-      (sources."@hapi/topo-3.1.2" // {
-        dependencies = [
-          sources."@hapi/hoek-8.1.0"
-        ];
-      })
+      sources."@hapi/bourne-1.3.2"
+      sources."@hapi/hoek-8.2.1"
+      sources."@hapi/joi-15.1.1"
+      sources."@hapi/topo-3.1.3"
       sources."@mrmlnc/readdir-enhanced-2.2.1"
       sources."@nodelib/fs.stat-1.1.3"
       sources."@protobufjs/aspromise-1.1.2"
@@ -45152,36 +45457,36 @@ in
       sources."@protobufjs/pool-1.1.0"
       sources."@protobufjs/utf8-1.1.0"
       sources."@types/accepts-1.3.5"
-      sources."@types/body-parser-1.17.0"
+      sources."@types/body-parser-1.17.1"
       sources."@types/connect-3.4.32"
       sources."@types/cookies-0.7.2"
-      sources."@types/cors-2.8.5"
+      sources."@types/cors-2.8.6"
       sources."@types/events-3.0.0"
-      sources."@types/express-4.17.0"
-      sources."@types/express-serve-static-core-4.16.7"
+      sources."@types/express-4.17.1"
+      sources."@types/express-serve-static-core-4.16.9"
+      sources."@types/fs-capacitor-2.0.0"
       sources."@types/glob-7.1.1"
-      sources."@types/graphql-14.2.3"
-      sources."@types/graphql-upload-8.0.0"
-      sources."@types/http-assert-1.5.0"
+      sources."@types/graphql-upload-8.0.3"
+      sources."@types/http-assert-1.5.1"
       sources."@types/keygrip-1.0.1"
       sources."@types/koa-2.0.49"
       sources."@types/koa-compose-3.2.4"
       sources."@types/long-4.0.0"
       sources."@types/mime-2.0.1"
       sources."@types/minimatch-3.0.3"
-      sources."@types/node-12.6.9"
+      sources."@types/node-12.7.3"
       sources."@types/range-parser-1.2.3"
-      sources."@types/serve-static-1.13.2"
-      sources."@types/ws-6.0.2"
+      sources."@types/serve-static-1.13.3"
+      sources."@types/ws-6.0.3"
       sources."@types/zen-observable-0.8.0"
-      sources."@vue/cli-shared-utils-3.10.0"
-      (sources."@vue/cli-ui-3.10.0" // {
+      sources."@vue/cli-shared-utils-3.11.0"
+      (sources."@vue/cli-ui-3.11.0" // {
         dependencies = [
           sources."clone-2.1.2"
         ];
       })
-      sources."@vue/cli-ui-addon-webpack-3.10.0"
-      sources."@vue/cli-ui-addon-widgets-3.10.0"
+      sources."@vue/cli-ui-addon-webpack-3.11.0"
+      sources."@vue/cli-ui-addon-widgets-3.11.0"
       sources."@wry/context-0.4.4"
       sources."@wry/equality-0.1.9"
       sources."abbrev-1.1.1"
@@ -45198,15 +45503,11 @@ in
         ];
       })
       sources."apollo-cache-1.3.2"
-      (sources."apollo-cache-control-0.8.1" // {
-        dependencies = [
-          sources."graphql-extensions-0.8.1"
-        ];
-      })
-      sources."apollo-cache-inmemory-1.6.2"
-      sources."apollo-client-2.6.3"
-      sources."apollo-datasource-0.6.1"
-      sources."apollo-engine-reporting-1.4.3"
+      sources."apollo-cache-control-0.8.2"
+      sources."apollo-cache-inmemory-1.6.3"
+      sources."apollo-client-2.6.4"
+      sources."apollo-datasource-0.6.2"
+      sources."apollo-engine-reporting-1.4.4"
       sources."apollo-engine-reporting-protobuf-0.4.0"
       sources."apollo-env-0.5.1"
       sources."apollo-graphql-0.3.3"
@@ -45217,17 +45518,13 @@ in
       sources."apollo-link-state-0.4.2"
       sources."apollo-link-ws-1.0.18"
       sources."apollo-server-caching-0.5.0"
-      sources."apollo-server-core-2.8.1"
-      sources."apollo-server-env-2.4.1"
-      sources."apollo-server-errors-2.3.1"
-      sources."apollo-server-express-2.8.1"
-      sources."apollo-server-plugin-base-0.6.1"
-      sources."apollo-server-types-0.2.1"
-      (sources."apollo-tracing-0.8.1" // {
-        dependencies = [
-          sources."graphql-extensions-0.8.1"
-        ];
-      })
+      sources."apollo-server-core-2.9.1"
+      sources."apollo-server-env-2.4.2"
+      sources."apollo-server-errors-2.3.2"
+      sources."apollo-server-express-2.9.1"
+      sources."apollo-server-plugin-base-0.6.2"
+      sources."apollo-server-types-0.2.2"
+      sources."apollo-tracing-0.8.2"
       sources."apollo-upload-client-10.0.1"
       sources."apollo-utilities-1.3.2"
       sources."arg-4.1.1"
@@ -45235,10 +45532,7 @@ in
       sources."arr-diff-4.0.0"
       sources."arr-flatten-1.1.0"
       sources."arr-union-3.1.0"
-      sources."array-filter-0.0.1"
       sources."array-flatten-1.1.1"
-      sources."array-map-0.0.0"
-      sources."array-reduce-0.0.0"
       sources."array-union-1.0.2"
       sources."array-uniq-1.0.3"
       sources."array-unique-0.3.2"
@@ -45280,7 +45574,7 @@ in
       sources."brace-expansion-1.1.11"
       sources."braces-2.3.2"
       sources."browserslist-4.6.6"
-      sources."buffer-5.2.1"
+      sources."buffer-5.4.2"
       sources."buffer-alloc-1.2.0"
       sources."buffer-alloc-unsafe-1.1.0"
       sources."buffer-crc32-0.2.13"
@@ -45299,7 +45593,7 @@ in
       sources."chalk-2.4.2"
       sources."chardet-0.7.0"
       sources."cheerio-1.0.0-rc.3"
-      sources."chokidar-2.1.6"
+      sources."chokidar-2.1.8"
       sources."ci-info-1.6.0"
       (sources."class-utils-0.3.6" // {
         dependencies = [
@@ -45325,7 +45619,7 @@ in
       sources."cli-width-2.2.0"
       sources."clipboard-2.0.4"
       sources."clone-1.0.4"
-      sources."cmd-shim-2.0.2"
+      sources."cmd-shim-2.1.0"
       sources."collection-visit-1.0.0"
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
@@ -45343,9 +45637,8 @@ in
       sources."cookie-0.4.0"
       sources."cookie-signature-1.0.6"
       sources."copy-descriptor-0.1.1"
-      sources."core-js-3.1.4"
-      sources."core-js-compat-3.1.4"
-      sources."core-js-pure-3.1.4"
+      sources."core-js-3.2.1"
+      sources."core-js-compat-3.2.1"
       sources."core-util-is-1.0.2"
       sources."cors-2.8.5"
       sources."create-error-class-3.0.2"
@@ -45417,7 +45710,7 @@ in
       sources."ecc-jsbn-0.1.2"
       sources."ee-first-1.1.1"
       sources."ejs-2.6.2"
-      sources."electron-to-chromium-1.3.215"
+      sources."electron-to-chromium-1.3.245"
       sources."encodeurl-1.0.2"
       sources."end-of-stream-1.4.1"
       sources."entities-1.1.2"
@@ -45437,7 +45730,7 @@ in
         dependencies = [
           sources."cross-spawn-6.0.5"
           sources."get-stream-4.1.0"
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       (sources."expand-brackets-2.1.4" // {
@@ -45493,12 +45786,12 @@ in
         dependencies = [
           sources."make-dir-2.1.0"
           sources."pify-4.0.1"
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       sources."find-up-3.0.0"
       sources."fkill-6.2.0"
-      sources."flow-parser-0.104.0"
+      sources."flow-parser-0.106.3"
       sources."for-in-1.0.2"
       sources."forever-agent-0.6.1"
       sources."form-data-2.3.3"
@@ -45538,15 +45831,15 @@ in
       })
       sources."good-listener-1.2.2"
       sources."got-6.7.1"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."graceful-readlink-1.0.1"
-      sources."graphql-14.4.2"
+      sources."graphql-14.5.4"
       (sources."graphql-anywhere-4.2.4" // {
         dependencies = [
           sources."ts-invariant-0.3.3"
         ];
       })
-      sources."graphql-extensions-0.9.1"
+      sources."graphql-extensions-0.10.1"
       sources."graphql-subscriptions-1.1.0"
       sources."graphql-tag-2.10.1"
       sources."graphql-tools-4.0.5"
@@ -45587,7 +45880,7 @@ in
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
       sources."ini-1.3.5"
-      sources."inquirer-6.5.0"
+      sources."inquirer-6.5.2"
       sources."into-stream-2.0.1"
       sources."invariant-2.2.4"
       sources."ipaddr.js-1.9.0"
@@ -45651,7 +45944,6 @@ in
       sources."json-stringify-safe-5.0.1"
       sources."json5-2.1.0"
       sources."jsonfile-4.0.0"
-      sources."jsonify-0.0.0"
       sources."jsprim-1.4.1"
       sources."kind-of-6.0.2"
       sources."latest-version-3.1.0"
@@ -45702,7 +45994,7 @@ in
       sources."ms-2.0.0"
       sources."mute-stream-0.0.7"
       sources."nan-2.14.0"
-      sources."nanoid-2.0.3"
+      sources."nanoid-2.0.4"
       (sources."nanomatch-1.2.13" // {
         dependencies = [
           sources."extend-shallow-3.0.2"
@@ -45722,21 +46014,21 @@ in
       sources."node-fetch-2.6.0"
       sources."node-ipc-9.1.1"
       sources."node-modules-regexp-1.0.0"
-      (sources."node-notifier-5.4.2" // {
+      (sources."node-notifier-5.4.3" // {
         dependencies = [
-          sources."is-wsl-2.1.0"
+          sources."semver-5.7.1"
         ];
       })
-      (sources."node-releases-1.1.26" // {
+      (sources."node-releases-1.1.28" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       (sources."nodemon-1.19.1" // {
         dependencies = [
           sources."debug-3.2.6"
           sources."ms-2.1.2"
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       sources."nopt-1.0.10"
@@ -45769,16 +46061,16 @@ in
       sources."once-1.4.0"
       sources."onetime-2.0.1"
       sources."open-6.4.0"
-      sources."optimism-0.9.6"
+      sources."optimism-0.10.2"
       sources."ora-3.4.0"
       sources."os-tmpdir-1.0.2"
       sources."p-finally-1.0.0"
-      sources."p-limit-2.2.0"
+      sources."p-limit-2.2.1"
       sources."p-locate-3.0.0"
       sources."p-try-2.2.0"
       (sources."package-json-4.0.1" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       sources."parse-git-config-2.0.3"
@@ -45806,7 +46098,7 @@ in
       sources."pinkie-promise-2.0.1"
       sources."pirates-4.0.1"
       sources."pkg-dir-3.0.0"
-      (sources."portfinder-1.0.21" // {
+      (sources."portfinder-1.0.23" // {
         dependencies = [
           sources."debug-2.6.9"
         ];
@@ -45820,7 +46112,7 @@ in
       sources."proto-list-1.2.4"
       (sources."protobufjs-6.8.8" // {
         dependencies = [
-          sources."@types/node-10.14.14"
+          sources."@types/node-10.14.17"
         ];
       })
       sources."proxy-addr-2.0.5"
@@ -45856,8 +46148,8 @@ in
           sources."is-extendable-1.0.1"
         ];
       })
-      sources."regexp-tree-0.1.11"
-      sources."regexpu-core-4.5.4"
+      sources."regexp-tree-0.1.12"
+      sources."regexpu-core-4.5.5"
       sources."registry-auth-token-3.4.0"
       sources."registry-url-3.1.0"
       sources."regjsgen-0.5.0"
@@ -45881,7 +46173,7 @@ in
       sources."restore-cursor-2.0.0"
       sources."ret-0.1.15"
       sources."retry-0.12.0"
-      sources."rimraf-2.6.3"
+      sources."rimraf-2.7.1"
       sources."rss-parser-3.7.2"
       sources."run-async-2.3.0"
       sources."rxjs-6.5.2"
@@ -45899,7 +46191,7 @@ in
       sources."semver-6.3.0"
       (sources."semver-diff-2.1.0" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       (sources."send-0.17.1" // {
@@ -45918,7 +46210,7 @@ in
       sources."sha.js-2.4.11"
       sources."shebang-command-1.2.0"
       sources."shebang-regex-1.0.0"
-      sources."shell-quote-1.6.1"
+      sources."shell-quote-1.7.1"
       sources."shellwords-0.1.1"
       sources."shortid-2.2.14"
       sources."signal-exit-3.0.2"
@@ -46060,7 +46352,7 @@ in
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       sources."type-is-1.6.18"
-      sources."typescript-3.5.3"
+      sources."typescript-3.6.2"
       sources."unbzip2-stream-1.3.3"
       (sources."undefsafe-2.0.2" // {
         dependencies = [
@@ -46096,7 +46388,7 @@ in
       sources."util-deprecate-1.0.2"
       sources."util.promisify-1.0.0"
       sources."utils-merge-1.0.1"
-      sources."uuid-3.3.2"
+      sources."uuid-3.3.3"
       sources."validate-npm-package-name-3.0.0"
       sources."vary-1.1.2"
       sources."verror-1.10.0"
@@ -46338,10 +46630,10 @@ in
   alloy = nodeEnv.buildNodePackage {
     name = "alloy";
     packageName = "alloy";
-    version = "1.14.0";
+    version = "1.14.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/alloy/-/alloy-1.14.0.tgz";
-      sha512 = "42iwEb64YKWuX7E73Q6zIz7/eP6p3SvacSR02LVoTfveitVXTXw5lzW9JFmBQRqua1kdN+YeaPgx8ocz8Ea3wQ==";
+      url = "https://registry.npmjs.org/alloy/-/alloy-1.14.1.tgz";
+      sha512 = "AbKwsUIrmy4jj6QbQr9QZcDRtmEw1vp+cx9BoX+0KHi+pDu9ZoFFYN1hIkojlnGWzd1R2xZshB/p8LsMyZ1ndw==";
     };
     dependencies = [
       sources."@babel/code-frame-7.5.5"
@@ -46396,7 +46688,7 @@ in
         ];
       })
       sources."globals-11.12.0"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."has-color-0.1.7"
       sources."has-flag-3.0.0"
       sources."homedir-polyfill-1.0.3"
@@ -46428,7 +46720,7 @@ in
       sources."resolve-1.12.0"
       sources."safe-buffer-5.1.2"
       sources."sax-0.5.8"
-      sources."semver-5.7.0"
+      sources."semver-5.7.1"
       sources."source-map-0.6.1"
       sources."strip-ansi-0.1.1"
       sources."supports-color-5.5.0"
@@ -46476,7 +46768,7 @@ in
       sources."mkdirp-0.5.1"
       sources."once-1.4.0"
       sources."path-is-absolute-1.0.1"
-      sources."rimraf-2.6.3"
+      sources."rimraf-2.7.1"
       sources."tmp-0.1.0"
       sources."tmp-promise-1.1.0"
       sources."wrappy-1.0.2"
@@ -46499,7 +46791,7 @@ in
       sha512 = "MMiK5sFfIocNMWCc5PshUCAe6aY4P13/GCmSwudOziA/pFdQMHU8jhu+jU2SSWFug4K1ugeuCwtMXe43oL0PhQ==";
     };
     dependencies = [
-      sources."@types/node-8.10.51"
+      sources."@types/node-8.10.53"
       sources."JSV-4.0.2"
       sources."adal-node-0.1.28"
       sources."ajv-6.10.2"
@@ -46654,8 +46946,9 @@ in
       })
       sources."date-utils-1.2.21"
       sources."dateformat-1.0.2-1.2.3"
-      sources."deep-equal-1.0.1"
+      sources."deep-equal-1.1.0"
       sources."defaults-1.0.3"
+      sources."define-properties-1.1.3"
       sources."delayed-stream-1.0.0"
       sources."duplexer-0.1.1"
       sources."easy-table-1.1.0"
@@ -46679,6 +46972,7 @@ in
       })
       sources."from-0.1.7"
       sources."fs.realpath-1.0.0"
+      sources."function-bind-1.1.1"
       sources."galaxy-0.1.12"
       sources."generate-function-2.3.1"
       sources."generate-object-property-1.2.0"
@@ -46695,6 +46989,7 @@ in
           sources."commander-2.20.0"
         ];
       })
+      sources."has-1.0.3"
       sources."has-ansi-2.0.0"
       sources."has-color-0.1.7"
       sources."hash-base-3.0.4"
@@ -46706,10 +47001,13 @@ in
       sources."i-0.3.6"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
+      sources."is-arguments-1.0.4"
       sources."is-buffer-1.1.6"
+      sources."is-date-object-1.0.1"
       sources."is-my-ip-valid-1.0.0"
       sources."is-my-json-valid-2.20.0"
       sources."is-property-1.0.2"
+      sources."is-regex-1.0.4"
       sources."is-stream-1.1.0"
       sources."is-typedarray-1.0.0"
       sources."isarray-1.0.0"
@@ -46773,6 +47071,8 @@ in
         ];
       })
       sources."oauth-sign-0.8.2"
+      sources."object-is-1.0.1"
+      sources."object-keys-1.1.1"
       sources."omelette-0.3.2"
       sources."once-1.4.0"
       sources."openssl-wrapper-0.3.4"
@@ -46806,6 +47106,7 @@ in
           sources."isarray-0.0.1"
         ];
       })
+      sources."regexp.prototype.flags-1.2.0"
       (sources."request-2.88.0" // {
         dependencies = [
           sources."assert-plus-1.0.0"
@@ -46821,7 +47122,7 @@ in
         ];
       })
       sources."revalidator-0.1.8"
-      sources."rimraf-2.6.3"
+      sources."rimraf-2.7.1"
       sources."safe-buffer-5.2.0"
       sources."safer-buffer-2.1.2"
       sources."sax-1.2.4"
@@ -46867,7 +47168,7 @@ in
           sources."async-0.2.10"
         ];
       })
-      sources."uuid-3.3.2"
+      sources."uuid-3.3.3"
       sources."validator-5.2.0"
       (sources."verror-1.10.0" // {
         dependencies = [
@@ -46902,10 +47203,10 @@ in
   azure-functions-core-tools = nodeEnv.buildNodePackage {
     name = "azure-functions-core-tools";
     packageName = "azure-functions-core-tools";
-    version = "2.7.1505";
+    version = "2.7.1585";
     src = fetchurl {
-      url = "https://registry.npmjs.org/azure-functions-core-tools/-/azure-functions-core-tools-2.7.1505.tgz";
-      sha512 = "3v1lDv6zwhGi2Qb8rNFA3tR+8h/vlufuanRgbw2ofPCPBCC29yiyQs2+IiCTBHVAxcBPN0h5rsELstoZ3S2Odw==";
+      url = "https://registry.npmjs.org/azure-functions-core-tools/-/azure-functions-core-tools-2.7.1585.tgz";
+      sha512 = "jxtiDsa1M5eMmXyjrkX8b2jl+7QKsjWifF8ralXI9DJYh1jJATUKGAPw56n5SJFbsxZlxxdxDoboOkgFP4aeog==";
     };
     dependencies = [
       sources."agent-base-4.3.0"
@@ -46932,7 +47233,7 @@ in
       sources."fs.realpath-1.0.0"
       sources."fstream-1.0.12"
       sources."glob-7.1.3"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."has-flag-3.0.0"
       sources."https-proxy-agent-2.2.1"
       sources."inflight-1.0.6"
@@ -46978,11 +47279,11 @@ in
       sha512 = "GqW24myNihrUroXdL40AemizC3lBvr2wOiF0GzxYWqsBsJvi6CQor0Y9t10jOGn11evMhncmR2f2LoQdjsNpqw==";
     };
     dependencies = [
-      sources."abab-2.0.0"
+      sources."abab-2.0.1"
       sources."acorn-5.7.3"
       (sources."acorn-globals-4.3.3" // {
         dependencies = [
-          sources."acorn-6.2.1"
+          sources."acorn-6.3.0"
         ];
       })
       sources."acorn-walk-6.2.0"
@@ -47029,9 +47330,9 @@ in
       sources."domexception-1.0.1"
       sources."ecc-jsbn-0.1.2"
       sources."end-of-stream-1.4.1"
-      sources."escodegen-1.11.1"
+      sources."escodegen-1.12.0"
       sources."esprima-3.1.3"
-      sources."estraverse-4.2.0"
+      sources."estraverse-4.3.0"
       sources."esutils-2.0.3"
       sources."expand-template-2.0.3"
       sources."extend-3.0.2"
@@ -47082,7 +47383,7 @@ in
       })
       sources."nan-2.14.0"
       sources."napi-build-utils-1.0.1"
-      sources."node-abi-2.10.0"
+      sources."node-abi-2.11.0"
       sources."noop-logger-0.1.1"
       sources."npmlog-4.1.2"
       sources."number-is-nan-1.0.1"
@@ -47115,7 +47416,7 @@ in
       sources."safe-buffer-5.2.0"
       sources."safer-buffer-2.1.2"
       sources."sax-1.2.4"
-      sources."semver-5.7.0"
+      sources."semver-5.7.1"
       sources."set-blocking-2.0.0"
       sources."signal-exit-3.0.2"
       sources."simple-concat-1.0.0"
@@ -47154,7 +47455,7 @@ in
       sources."uri-js-4.2.2"
       sources."urijs-1.19.1"
       sources."util-deprecate-1.0.2"
-      sources."uuid-3.3.2"
+      sources."uuid-3.3.3"
       sources."verror-1.10.0"
       sources."vscode-jsonrpc-4.0.0"
       sources."vscode-languageserver-4.4.2"
@@ -47231,14 +47532,14 @@ in
       sources."find-up-1.1.2"
       (sources."fs-extra-0.26.7" // {
         dependencies = [
-          sources."graceful-fs-4.2.1"
+          sources."graceful-fs-4.2.2"
         ];
       })
       sources."fs.realpath-1.0.0"
       sources."get-stdin-4.0.1"
       sources."glob-6.0.4"
-      sources."graceful-fs-3.0.11"
-      sources."hosted-git-info-2.8.2"
+      sources."graceful-fs-3.0.12"
+      sources."hosted-git-info-2.8.4"
       sources."indent-string-2.1.0"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
@@ -47249,22 +47550,21 @@ in
       sources."is-utf8-0.2.1"
       (sources."jsonfile-2.4.0" // {
         dependencies = [
-          sources."graceful-fs-4.2.1"
+          sources."graceful-fs-4.2.2"
         ];
       })
       (sources."klaw-1.3.1" // {
         dependencies = [
-          sources."graceful-fs-4.2.1"
+          sources."graceful-fs-4.2.2"
         ];
       })
       (sources."load-json-file-1.1.0" // {
         dependencies = [
-          sources."graceful-fs-4.2.1"
+          sources."graceful-fs-4.2.2"
         ];
       })
       sources."lodash-4.2.1"
       sources."loud-rejection-1.6.0"
-      sources."lru-cache-5.1.1"
       sources."map-obj-1.0.1"
       sources."meow-3.7.0"
       sources."mime-db-1.40.0"
@@ -47288,7 +47588,7 @@ in
       sources."path-parse-1.0.6"
       (sources."path-type-1.1.0" // {
         dependencies = [
-          sources."graceful-fs-4.2.1"
+          sources."graceful-fs-4.2.2"
         ];
       })
       sources."pify-2.3.0"
@@ -47301,12 +47601,12 @@ in
       sources."redent-1.0.0"
       sources."repeating-2.0.1"
       sources."resolve-1.12.0"
-      (sources."rimraf-2.6.3" // {
+      (sources."rimraf-2.7.1" // {
         dependencies = [
           sources."glob-7.1.4"
         ];
       })
-      sources."semver-5.7.0"
+      sources."semver-5.7.1"
       sources."signal-exit-3.0.2"
       sources."sort-keys-1.1.2"
       sources."sort-keys-length-1.0.1"
@@ -47325,7 +47625,6 @@ in
       sources."trim-newlines-1.0.0"
       sources."validate-npm-package-license-3.0.4"
       sources."wrappy-1.0.2"
-      sources."yallist-3.0.3"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -47339,20 +47638,16 @@ in
   browserify = nodeEnv.buildNodePackage {
     name = "browserify";
     packageName = "browserify";
-    version = "16.3.0";
+    version = "16.5.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/browserify/-/browserify-16.3.0.tgz";
-      sha512 = "BWaaD7alyGZVEBBwSTYx4iJF5DswIGzK17o8ai9w4iKRbYpk3EOiprRHMRRA8DCZFmFeOdx7A385w2XdFvxWmg==";
+      url = "https://registry.npmjs.org/browserify/-/browserify-16.5.0.tgz";
+      sha512 = "6bfI3cl76YLAnCZ75AGu/XPOsqUhRyc0F/olGIJeCxtfxF2HvPKEcmjU9M8oAPxl4uBY1U7Nry33Q6koV3f2iw==";
     };
     dependencies = [
       sources."JSONStream-1.3.5"
-      sources."acorn-6.2.1"
-      sources."acorn-dynamic-import-4.0.0"
-      sources."acorn-node-1.7.0"
-      sources."acorn-walk-6.2.0"
-      sources."array-filter-0.0.1"
-      sources."array-map-0.0.0"
-      sources."array-reduce-0.0.0"
+      sources."acorn-7.0.0"
+      sources."acorn-node-1.8.2"
+      sources."acorn-walk-7.0.0"
       sources."asn1.js-4.10.1"
       (sources."assert-1.5.0" // {
         dependencies = [
@@ -47377,7 +47672,7 @@ in
       sources."browserify-rsa-4.0.1"
       sources."browserify-sign-4.0.4"
       sources."browserify-zlib-0.2.0"
-      sources."buffer-5.2.1"
+      sources."buffer-5.4.2"
       sources."buffer-from-1.1.1"
       sources."buffer-xor-1.0.3"
       sources."builtin-status-codes-3.0.0"
@@ -47471,18 +47766,18 @@ in
       sources."safe-buffer-5.2.0"
       sources."sha.js-2.4.11"
       sources."shasum-1.0.2"
-      sources."shell-quote-1.6.1"
+      sources."shell-quote-1.7.1"
       sources."simple-concat-1.0.0"
       sources."source-map-0.5.7"
       sources."stream-browserify-2.0.2"
       sources."stream-combiner2-1.1.1"
-      sources."stream-http-2.8.3"
-      sources."stream-splicer-2.0.1"
-      (sources."string_decoder-1.2.0" // {
+      (sources."stream-http-3.1.0" // {
         dependencies = [
-          sources."safe-buffer-5.1.2"
+          sources."readable-stream-3.4.0"
         ];
       })
+      sources."stream-splicer-2.0.1"
+      sources."string_decoder-1.3.0"
       (sources."subarg-1.0.0" // {
         dependencies = [
           sources."minimist-1.2.0"
@@ -47492,7 +47787,6 @@ in
       sources."through-2.3.8"
       sources."through2-2.0.5"
       sources."timers-browserify-1.4.2"
-      sources."to-arraybuffer-1.0.1"
       sources."tty-browserify-0.0.1"
       sources."typedarray-0.0.6"
       sources."umd-3.0.3"
@@ -47579,6 +47873,9 @@ in
       sources."castv2-0.1.9"
       sources."castv2-client-1.2.0"
       sources."chalk-1.0.0"
+      sources."chrome-dgram-3.0.2"
+      sources."chrome-dns-1.0.1"
+      sources."chrome-net-3.3.3"
       sources."chromecast-player-0.2.3"
       sources."chromecast-scanner-0.5.0"
       sources."cli-width-1.1.1"
@@ -47587,14 +47884,13 @@ in
       sources."codepage-1.4.0"
       sources."colour-0.7.1"
       sources."combined-stream-1.0.8"
-      sources."commander-2.20.0"
+      sources."commander-3.0.0"
       sources."compact2string-1.4.1"
       sources."concat-map-0.0.1"
       (sources."concat-stream-2.0.0" // {
         dependencies = [
           sources."readable-stream-3.4.0"
-          sources."safe-buffer-5.1.2"
-          sources."string_decoder-1.2.0"
+          sources."string_decoder-1.3.0"
         ];
       })
       sources."core-util-is-1.0.2"
@@ -47645,12 +47941,12 @@ in
       sources."getpass-0.1.7"
       sources."glob-7.1.4"
       sources."got-1.2.2"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-ansi-1.0.3"
       sources."hat-0.0.3"
-      sources."hosted-git-info-2.8.2"
+      sources."hosted-git-info-2.8.4"
       sources."http-signature-1.2.0"
       sources."immediate-chunk-store-1.0.8"
       sources."indent-string-2.1.0"
@@ -47679,14 +47975,13 @@ in
           sources."k-bucket-2.0.1"
         ];
       })
-      sources."k-rpc-socket-1.8.0"
+      sources."k-rpc-socket-1.11.1"
       sources."keypress-0.2.1"
       sources."load-json-file-1.1.0"
       sources."lodash-3.10.1"
       sources."long-2.4.0"
       sources."loud-rejection-1.6.0"
       sources."lru-2.0.1"
-      sources."lru-cache-5.1.1"
       sources."magnet-uri-5.2.4"
       sources."map-obj-1.0.1"
       (sources."mdns-js-1.0.3" // {
@@ -47812,7 +48107,7 @@ in
       sources."repeating-2.0.1"
       sources."request-2.88.0"
       sources."resolve-1.12.0"
-      sources."rimraf-2.6.3"
+      sources."rimraf-2.7.1"
       sources."router-0.6.2"
       sources."run-parallel-1.1.9"
       sources."run-series-1.1.8"
@@ -47821,7 +48116,7 @@ in
       sources."safe-buffer-5.2.0"
       sources."safer-buffer-2.1.2"
       sources."sax-1.2.4"
-      sources."semver-5.7.0"
+      sources."semver-5.7.1"
       sources."signal-exit-3.0.2"
       sources."simple-concat-1.0.0"
       sources."simple-get-2.8.1"
@@ -47894,7 +48189,7 @@ in
       sources."utfx-1.0.1"
       sources."util-deprecate-1.0.2"
       sources."utp-0.0.7"
-      sources."uuid-3.3.2"
+      sources."uuid-3.3.3"
       sources."validate-npm-package-license-3.0.4"
       sources."verror-1.10.0"
       sources."voc-1.1.0"
@@ -47913,7 +48208,6 @@ in
       sources."xmldom-0.1.27"
       sources."xspfr-0.3.1"
       sources."xtend-4.0.2"
-      sources."yallist-3.0.3"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -47984,7 +48278,7 @@ in
       sources."commander-2.20.0"
       sources."debug-3.2.6"
       sources."escape-string-regexp-1.0.5"
-      sources."follow-redirects-1.7.0"
+      sources."follow-redirects-1.8.1"
       sources."has-flag-3.0.0"
       sources."humanize-plus-1.8.2"
       sources."is-buffer-1.1.6"
@@ -48037,7 +48331,7 @@ in
       sources."eventemitter3-3.1.2"
       sources."fast-safe-stringify-2.0.6"
       sources."fecha-2.3.3"
-      sources."follow-redirects-1.7.0"
+      sources."follow-redirects-1.8.1"
       sources."http-proxy-1.17.0"
       sources."inherits-2.0.4"
       sources."is-arrayish-0.3.2"
@@ -48053,12 +48347,12 @@ in
       sources."process-nextick-args-2.0.1"
       sources."readable-stream-3.4.0"
       sources."requires-port-1.0.0"
-      sources."safe-buffer-5.1.2"
+      sources."safe-buffer-5.2.0"
       sources."simple-swizzle-0.2.2"
       sources."stack-trace-0.0.10"
       sources."statsd-parser-0.0.4"
       sources."strftime-0.10.0"
-      sources."string_decoder-1.2.0"
+      sources."string_decoder-1.3.0"
       sources."text-hex-1.0.0"
       sources."triple-beam-1.3.0"
       sources."util-deprecate-1.0.2"
@@ -48066,6 +48360,7 @@ in
       (sources."winston-transport-4.3.0" // {
         dependencies = [
           sources."readable-stream-2.3.6"
+          sources."safe-buffer-5.1.2"
           sources."string_decoder-1.1.1"
         ];
       })
@@ -48093,7 +48388,7 @@ in
       sources."@types/events-3.0.0"
       sources."@types/glob-7.1.1"
       sources."@types/minimatch-3.0.3"
-      sources."@types/node-12.6.9"
+      sources."@types/node-12.7.3"
       sources."abbrev-1.1.1"
       sources."accepts-1.3.7"
       sources."ajv-6.10.2"
@@ -48321,7 +48616,7 @@ in
           sources."get-stream-3.0.0"
         ];
       })
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-1.0.3"
@@ -48333,7 +48628,7 @@ in
           sources."kind-of-4.0.0"
         ];
       })
-      sources."hosted-git-info-2.8.2"
+      sources."hosted-git-info-2.8.4"
       (sources."http-errors-1.7.2" // {
         dependencies = [
           sources."inherits-2.0.3"
@@ -48350,7 +48645,7 @@ in
       sources."inherits-2.0.4"
       sources."ini-1.3.5"
       sources."init-package-json-1.10.3"
-      (sources."inquirer-6.5.0" // {
+      (sources."inquirer-6.5.2" // {
         dependencies = [
           sources."mute-stream-0.0.7"
         ];
@@ -48407,7 +48702,7 @@ in
       sources."lodash.debounce-4.0.8"
       sources."loud-rejection-2.1.0"
       sources."lowercase-keys-1.0.1"
-      sources."lru-cache-5.1.1"
+      sources."lru-cache-4.1.5"
       sources."macos-release-2.3.0"
       sources."make-dir-1.3.0"
       sources."map-cache-0.2.2"
@@ -48436,7 +48731,7 @@ in
       sources."nice-try-1.0.5"
       sources."nopt-4.0.1"
       sources."normalize-package-data-2.5.0"
-      sources."npm-package-arg-6.1.0"
+      sources."npm-package-arg-6.1.1"
       sources."npm-run-path-2.0.2"
       sources."oauth-sign-0.9.0"
       (sources."object-copy-0.1.0" // {
@@ -48513,7 +48808,7 @@ in
           sources."pify-4.0.1"
         ];
       })
-      (sources."read-package-json-2.0.13" // {
+      (sources."read-package-json-2.1.0" // {
         dependencies = [
           sources."slash-1.0.0"
         ];
@@ -48542,7 +48837,7 @@ in
       sources."safe-regex-1.1.0"
       sources."safer-buffer-2.1.2"
       sources."sax-1.1.4"
-      sources."semver-5.7.0"
+      sources."semver-5.7.1"
       sources."semver-diff-2.1.0"
       (sources."send-0.17.1" // {
         dependencies = [
@@ -48636,8 +48931,6 @@ in
           sources."cross-spawn-5.1.0"
           sources."execa-0.7.0"
           sources."get-stream-3.0.0"
-          sources."lru-cache-4.1.5"
-          sources."yallist-2.1.2"
         ];
       })
       sources."through-2.3.8"
@@ -48682,7 +48975,7 @@ in
       sources."url-parse-lax-1.0.0"
       sources."use-3.1.1"
       sources."utils-merge-1.0.1"
-      sources."uuid-3.3.2"
+      sources."uuid-3.3.3"
       sources."valid-identifier-0.0.2"
       sources."validate-npm-package-license-3.0.4"
       sources."validate-npm-package-name-3.0.0"
@@ -48701,7 +48994,7 @@ in
       sources."xdg-basedir-3.0.0"
       sources."xmlbuilder-9.0.7"
       sources."xmldom-0.1.27"
-      sources."yallist-3.0.3"
+      sources."yallist-2.1.2"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -48726,7 +49019,7 @@ in
       sources."@types/events-3.0.0"
       sources."@types/glob-7.1.1"
       sources."@types/minimatch-3.0.3"
-      sources."@types/node-12.6.9"
+      sources."@types/node-12.7.3"
       sources."arr-diff-4.0.0"
       sources."arr-flatten-1.1.0"
       sources."arr-union-3.1.0"
@@ -48836,14 +49129,14 @@ in
       })
       sources."glob-to-regexp-0.3.0"
       sources."globby-9.2.0"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."has-value-1.0.0"
       (sources."has-values-1.0.0" // {
         dependencies = [
           sources."kind-of-4.0.0"
         ];
       })
-      sources."hosted-git-info-2.8.2"
+      sources."hosted-git-info-2.8.4"
       sources."ignore-4.0.6"
       sources."indent-string-3.2.0"
       sources."inflight-1.0.6"
@@ -48875,7 +49168,6 @@ in
       })
       sources."locate-path-2.0.0"
       sources."loud-rejection-1.6.0"
-      sources."lru-cache-5.1.1"
       sources."make-dir-2.1.0"
       sources."map-cache-0.2.2"
       sources."map-obj-2.0.0"
@@ -48938,7 +49230,7 @@ in
       sources."ret-0.1.15"
       sources."safe-buffer-5.2.0"
       sources."safe-regex-1.1.0"
-      sources."semver-5.7.0"
+      sources."semver-5.7.1"
       (sources."set-value-2.0.1" // {
         dependencies = [
           sources."extend-shallow-2.0.1"
@@ -49024,7 +49316,6 @@ in
       sources."use-3.1.1"
       sources."validate-npm-package-license-3.0.4"
       sources."wrappy-1.0.2"
-      sources."yallist-3.0.3"
       sources."yargs-parser-10.1.0"
     ];
     buildInputs = globalBuildInputs;
@@ -49055,7 +49346,7 @@ in
       sources."@cycle/run-3.4.0"
       sources."@cycle/time-0.10.1"
       sources."@types/cookiejar-2.1.1"
-      sources."@types/node-12.6.9"
+      sources."@types/node-12.7.3"
       sources."@types/superagent-3.8.2"
       sources."ansi-escapes-3.2.0"
       sources."ansi-regex-2.1.1"
@@ -49094,7 +49385,7 @@ in
       sources."extend-3.0.2"
       sources."external-editor-2.2.0"
       sources."figures-2.0.0"
-      sources."form-data-2.5.0"
+      sources."form-data-2.5.1"
       sources."formidable-1.2.1"
       sources."has-ansi-2.0.0"
       sources."has-flag-3.0.0"
@@ -49134,7 +49425,7 @@ in
       sources."performance-now-2.1.0"
       sources."process-nextick-args-2.0.1"
       sources."pseudomap-1.0.2"
-      sources."qs-6.7.0"
+      sources."qs-6.8.0"
       sources."quicktask-1.1.0"
       sources."raf-3.3.2"
       sources."readable-stream-2.3.6"
@@ -49187,10 +49478,10 @@ in
   create-react-app = nodeEnv.buildNodePackage {
     name = "create-react-app";
     packageName = "create-react-app";
-    version = "3.0.1";
+    version = "3.1.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/create-react-app/-/create-react-app-3.0.1.tgz";
-      sha512 = "uOLGMyegGQbm7/kWbHUzsqM16MiehRItBq3WXamzYsKLXdXXAHxEEX57WqcFwd/XybeD/1/KSYkroJdEyk7swA==";
+      url = "https://registry.npmjs.org/create-react-app/-/create-react-app-3.1.1.tgz";
+      sha512 = "EaK59gIwEsSZjjIN4MyG0DkXcatF3cEXYODIH7rDrlUremb7iwi5RzZGGISmPIrfywLC82Qom/8CXiT8hwixPQ==";
     };
     dependencies = [
       sources."ansi-escapes-3.2.0"
@@ -49207,17 +49498,17 @@ in
       sources."cli-width-2.2.0"
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
-      sources."commander-2.19.0"
+      sources."commander-2.20.0"
       sources."concat-map-0.0.1"
       sources."core-util-is-1.0.2"
       (sources."cross-spawn-6.0.5" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       sources."debug-2.6.9"
       sources."duplexer2-0.0.2"
-      sources."envinfo-7.1.0"
+      sources."envinfo-7.3.1"
       sources."escape-string-regexp-1.0.5"
       sources."external-editor-3.1.0"
       sources."figures-2.0.0"
@@ -49226,13 +49517,13 @@ in
       sources."fstream-1.0.12"
       sources."fstream-ignore-1.0.5"
       sources."glob-7.1.4"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."has-flag-3.0.0"
       sources."hyperquest-2.1.3"
       sources."iconv-lite-0.4.24"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
-      sources."inquirer-6.2.2"
+      sources."inquirer-6.5.0"
       sources."is-fullwidth-code-point-2.0.0"
       sources."is-promise-2.1.0"
       sources."isarray-0.0.1"
@@ -49254,12 +49545,12 @@ in
       sources."process-nextick-args-2.0.1"
       sources."readable-stream-1.1.14"
       sources."restore-cursor-2.0.0"
-      sources."rimraf-2.6.3"
+      sources."rimraf-2.7.1"
       sources."run-async-2.3.0"
       sources."rxjs-6.5.2"
       sources."safe-buffer-5.1.2"
       sources."safer-buffer-2.1.2"
-      sources."semver-6.0.0"
+      sources."semver-6.3.0"
       sources."shebang-command-1.2.0"
       sources."shebang-regex-1.0.0"
       sources."signal-exit-3.0.2"
@@ -49326,7 +49617,7 @@ in
       sources."cross-spawn-5.1.0"
       sources."escape-string-regexp-1.0.5"
       sources."fs-extra-4.0.3"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."has-flag-3.0.0"
       sources."isexe-2.0.0"
       sources."jsonfile-4.0.0"
@@ -49335,7 +49626,7 @@ in
       sources."path-exists-3.0.0"
       sources."pseudomap-1.0.2"
       sources."regenerator-runtime-0.11.1"
-      sources."semver-5.7.0"
+      sources."semver-5.7.1"
       sources."shebang-command-1.2.0"
       sources."shebang-regex-1.0.0"
       sources."source-map-0.5.7"
@@ -49454,6 +49745,9 @@ in
       sources."capture-stack-trace-1.0.1"
       sources."caseless-0.12.0"
       sources."chalk-2.4.2"
+      sources."chrome-dgram-3.0.2"
+      sources."chrome-dns-1.0.1"
+      sources."chrome-net-3.3.3"
       sources."ci-info-1.6.0"
       sources."circular-append-file-1.0.1"
       (sources."class-utils-0.3.6" // {
@@ -49616,7 +49910,7 @@ in
       sources."global-4.3.2"
       sources."global-dirs-0.1.1"
       sources."got-6.7.1"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-1.0.3"
@@ -49630,14 +49924,14 @@ in
       })
       sources."http-methods-0.1.0"
       sources."http-signature-1.2.0"
-      (sources."hypercore-7.5.1" // {
+      (sources."hypercore-7.6.1" // {
         dependencies = [
           sources."codecs-2.0.0"
           sources."unordered-set-2.0.1"
         ];
       })
       sources."hypercore-crypto-1.0.0"
-      (sources."hypercore-protocol-6.11.1" // {
+      (sources."hypercore-protocol-6.12.0" // {
         dependencies = [
           sources."varint-5.0.0"
         ];
@@ -49702,7 +49996,7 @@ in
           sources."k-bucket-4.0.1"
         ];
       })
-      (sources."k-rpc-socket-1.8.0" // {
+      (sources."k-rpc-socket-1.11.1" // {
         dependencies = [
           sources."bencode-2.0.1"
         ];
@@ -49711,7 +50005,7 @@ in
       sources."kind-of-6.0.2"
       sources."last-one-wins-1.0.4"
       sources."latest-version-3.1.0"
-      sources."length-prefixed-message-3.0.3"
+      sources."length-prefixed-message-3.0.4"
       sources."lodash.throttle-4.1.1"
       sources."lowercase-keys-1.0.1"
       sources."lru-3.1.0"
@@ -49835,12 +50129,13 @@ in
       sources."resolve-url-0.2.1"
       sources."ret-0.1.15"
       sources."revalidator-0.1.8"
-      sources."rimraf-2.6.3"
+      sources."rimraf-2.7.1"
+      sources."run-series-1.1.8"
       sources."rusha-0.8.13"
       sources."safe-buffer-5.2.0"
       sources."safe-regex-1.1.0"
       sources."safer-buffer-2.1.2"
-      sources."semver-5.7.0"
+      sources."semver-5.7.1"
       sources."semver-diff-2.1.0"
       (sources."set-value-2.0.1" // {
         dependencies = [
@@ -49891,7 +50186,7 @@ in
         ];
       })
       sources."sodium-javascript-0.5.5"
-      (sources."sodium-native-2.4.5" // {
+      (sources."sodium-native-2.4.6" // {
         dependencies = [
           sources."node-gyp-build-4.1.0"
         ];
@@ -50010,7 +50305,7 @@ in
           sources."unordered-set-2.0.1"
         ];
       })
-      sources."uuid-3.3.2"
+      sources."uuid-3.3.3"
       sources."varint-3.0.1"
       sources."verror-1.10.0"
       sources."which-1.3.1"
@@ -50206,10 +50501,10 @@ in
   elasticdump = nodeEnv.buildNodePackage {
     name = "elasticdump";
     packageName = "elasticdump";
-    version = "6.3.3";
+    version = "6.7.5";
     src = fetchurl {
-      url = "https://registry.npmjs.org/elasticdump/-/elasticdump-6.3.3.tgz";
-      sha512 = "Ie0l2UPxw5owgBMT5zhYSZCS4cEXmIqcFiyLoPgArYgb2MNPPYLGFFBq7v8mvKzYAnl8zZcpGoXD4yzNM+lGxA==";
+      url = "https://registry.npmjs.org/elasticdump/-/elasticdump-6.7.5.tgz";
+      sha512 = "jTM69hMvs2l2oMyYN7GBLt9GxyzeADwPmwzNO2yt4yewb3vB6J0dQqkLExxe6oVcfwlFk20eT3PAgFsVMlp5sw==";
     };
     dependencies = [
       sources."JSONStream-1.3.5"
@@ -50218,7 +50513,7 @@ in
       sources."assert-plus-1.0.0"
       sources."async-2.6.3"
       sources."asynckit-0.4.0"
-      sources."aws-sdk-2.504.0"
+      sources."aws-sdk-2.520.0"
       sources."aws-sign2-0.7.0"
       sources."aws4-1.8.0"
       sources."base64-js-1.3.1"
@@ -50231,8 +50526,10 @@ in
       sources."core-util-is-1.0.2"
       sources."dashdash-1.14.1"
       sources."decimal.js-10.2.0"
+      sources."delay-4.3.0"
       sources."delayed-stream-1.0.0"
       sources."ecc-jsbn-0.1.2"
+      sources."eventemitter3-4.0.0"
       sources."events-1.1.1"
       sources."extend-3.0.2"
       sources."extsprintf-1.3.0"
@@ -50269,6 +50566,9 @@ in
       sources."minimist-0.0.10"
       sources."oauth-sign-0.9.0"
       sources."optimist-0.6.1"
+      sources."p-finally-1.0.0"
+      sources."p-queue-6.1.1"
+      sources."p-timeout-3.1.0"
       sources."performance-now-2.1.0"
       sources."process-nextick-args-2.0.1"
       sources."psl-1.3.0"
@@ -50344,7 +50644,7 @@ in
     dependencies = [
       sources."ansi-regex-2.1.1"
       sources."ansi-styles-2.2.1"
-      sources."anymatch-3.0.3"
+      sources."anymatch-3.1.0"
       sources."async-each-1.0.3"
       sources."async-limiter-1.0.1"
       sources."binary-extensions-2.0.0"
@@ -50371,7 +50671,7 @@ in
       sources."encodeurl-1.0.2"
       sources."es5-ext-0.10.50"
       sources."es6-iterator-2.0.3"
-      sources."es6-promisify-6.0.1"
+      sources."es6-promisify-6.0.2"
       sources."es6-symbol-3.1.1"
       sources."es6-weak-map-2.0.3"
       sources."escape-html-1.0.3"
@@ -50386,7 +50686,7 @@ in
       })
       sources."fill-range-7.0.1"
       sources."finalhandler-1.1.1"
-      (sources."follow-redirects-1.7.0" // {
+      (sources."follow-redirects-1.8.1" // {
         dependencies = [
           sources."debug-3.2.6"
           sources."ms-2.1.2"
@@ -50435,9 +50735,9 @@ in
       sources."pseudomap-1.0.2"
       sources."querystringify-2.1.1"
       sources."range-parser-1.2.1"
-      sources."readdirp-3.1.1"
+      sources."readdirp-3.1.2"
       sources."requires-port-1.0.0"
-      sources."semver-5.7.0"
+      sources."semver-5.7.1"
       sources."send-0.16.2"
       sources."serve-static-1.13.2"
       sources."setprototypeof-1.1.0"
@@ -50560,18 +50860,13 @@ in
       sources."get-stream-3.0.0"
       sources."globals-9.18.0"
       sources."got-7.1.0"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."has-ansi-3.0.0"
       sources."has-flag-3.0.0"
       sources."has-symbol-support-x-1.4.2"
       sources."has-to-string-tag-x-1.4.1"
       sources."home-or-tmp-2.0.0"
-      (sources."hosted-git-info-2.8.2" // {
-        dependencies = [
-          sources."lru-cache-5.1.1"
-          sources."yallist-3.0.3"
-        ];
-      })
+      sources."hosted-git-info-2.8.4"
       sources."import-jsx-1.3.2"
       sources."imurmurhash-0.1.4"
       sources."indent-string-3.2.0"
@@ -50658,7 +50953,7 @@ in
       sources."private-0.1.8"
       sources."prop-types-15.7.2"
       sources."pseudomap-1.0.2"
-      sources."react-is-16.8.6"
+      sources."react-is-16.9.0"
       sources."read-pkg-1.1.0"
       (sources."read-pkg-up-1.0.1" // {
         dependencies = [
@@ -50678,7 +50973,7 @@ in
       sources."resolve-from-3.0.0"
       sources."restore-cursor-2.0.0"
       sources."safe-buffer-5.2.0"
-      sources."semver-5.7.0"
+      sources."semver-5.7.1"
       sources."shebang-command-1.2.0"
       sources."shebang-regex-1.0.0"
       sources."signal-exit-3.0.2"
@@ -50749,16 +51044,16 @@ in
   eslint = nodeEnv.buildNodePackage {
     name = "eslint";
     packageName = "eslint";
-    version = "6.1.0";
+    version = "6.2.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/eslint/-/eslint-6.1.0.tgz";
-      sha512 = "QhrbdRD7ofuV09IuE2ySWBz0FyXCq0rriLTZXZqaWSI79CVtHVRdkFuFTViiqzZhkCgfOh9USpriuGN2gIpZDQ==";
+      url = "https://registry.npmjs.org/eslint/-/eslint-6.2.2.tgz";
+      sha512 = "mf0elOkxHbdyGX1IJEUsNBzCDdyoUgljF3rRlgfyYh0pwGnreLc0jjD6ZuleOibjmnUWZLY2eXwSooeOgGJ2jw==";
     };
     dependencies = [
       sources."@babel/code-frame-7.5.5"
       sources."@babel/highlight-7.5.0"
-      sources."acorn-6.2.1"
-      sources."acorn-jsx-5.0.1"
+      sources."acorn-7.0.0"
+      sources."acorn-jsx-5.0.2"
       sources."ajv-6.10.2"
       sources."ansi-escapes-3.2.0"
       sources."ansi-regex-3.0.0"
@@ -50777,7 +51072,7 @@ in
       sources."concat-map-0.0.1"
       (sources."cross-spawn-6.0.5" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       sources."debug-4.1.1"
@@ -50786,13 +51081,13 @@ in
       sources."emoji-regex-7.0.3"
       sources."escape-string-regexp-1.0.5"
       sources."eslint-scope-5.0.0"
-      sources."eslint-utils-1.4.0"
-      sources."eslint-visitor-keys-1.0.0"
-      sources."espree-6.0.0"
+      sources."eslint-utils-1.4.2"
+      sources."eslint-visitor-keys-1.1.0"
+      sources."espree-6.1.1"
       sources."esprima-4.0.1"
       sources."esquery-1.0.1"
       sources."esrecurse-4.2.1"
-      sources."estraverse-4.2.0"
+      sources."estraverse-4.3.0"
       sources."esutils-2.0.3"
       sources."external-editor-3.1.0"
       sources."fast-deep-equal-2.0.1"
@@ -50814,7 +51109,7 @@ in
       sources."imurmurhash-0.1.4"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
-      sources."inquirer-6.5.0"
+      sources."inquirer-6.5.2"
       sources."is-extglob-2.1.1"
       sources."is-fullwidth-code-point-2.0.0"
       sources."is-glob-4.0.1"
@@ -50869,7 +51164,7 @@ in
       })
       sources."strip-json-comments-3.0.1"
       sources."supports-color-5.5.0"
-      (sources."table-5.4.5" // {
+      (sources."table-5.4.6" // {
         dependencies = [
           sources."string-width-3.1.0"
         ];
@@ -50906,8 +51201,8 @@ in
     dependencies = [
       sources."@babel/code-frame-7.5.5"
       sources."@babel/highlight-7.5.0"
-      sources."acorn-6.2.1"
-      sources."acorn-jsx-5.0.1"
+      sources."acorn-7.0.0"
+      sources."acorn-jsx-5.0.2"
       sources."ajv-6.10.2"
       sources."ansi-escapes-3.2.0"
       sources."ansi-regex-3.0.0"
@@ -50927,7 +51222,7 @@ in
       sources."core_d-1.0.1"
       (sources."cross-spawn-6.0.5" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       sources."debug-4.1.1"
@@ -50935,15 +51230,15 @@ in
       sources."doctrine-3.0.0"
       sources."emoji-regex-7.0.3"
       sources."escape-string-regexp-1.0.5"
-      sources."eslint-6.1.0"
+      sources."eslint-6.2.2"
       sources."eslint-scope-5.0.0"
-      sources."eslint-utils-1.4.0"
-      sources."eslint-visitor-keys-1.0.0"
-      sources."espree-6.0.0"
+      sources."eslint-utils-1.4.2"
+      sources."eslint-visitor-keys-1.1.0"
+      sources."espree-6.1.1"
       sources."esprima-4.0.1"
       sources."esquery-1.0.1"
       sources."esrecurse-4.2.1"
-      sources."estraverse-4.2.0"
+      sources."estraverse-4.3.0"
       sources."esutils-2.0.3"
       sources."external-editor-3.1.0"
       sources."fast-deep-equal-2.0.1"
@@ -50965,7 +51260,7 @@ in
       sources."imurmurhash-0.1.4"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
-      sources."inquirer-6.5.0"
+      sources."inquirer-6.5.2"
       sources."is-extglob-2.1.1"
       sources."is-fullwidth-code-point-2.0.0"
       sources."is-glob-4.0.1"
@@ -51023,7 +51318,7 @@ in
       })
       sources."strip-json-comments-3.0.1"
       sources."supports-color-5.5.0"
-      (sources."table-5.4.5" // {
+      (sources."table-5.4.6" // {
         dependencies = [
           sources."string-width-3.1.0"
         ];
@@ -51104,13 +51399,13 @@ in
       sources."fs-extra-1.0.0"
       sources."get-stdin-4.0.1"
       sources."getpass-0.1.7"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-ansi-2.0.0"
       sources."has-flag-3.0.0"
       sources."hasha-2.2.0"
-      sources."hosted-git-info-2.8.2"
+      sources."hosted-git-info-2.8.4"
       sources."http-signature-1.2.0"
       sources."indent-string-2.1.0"
       sources."inherits-2.0.4"
@@ -51140,7 +51435,6 @@ in
       })
       sources."log-update-1.0.2"
       sources."loud-rejection-1.6.0"
-      sources."lru-cache-5.1.1"
       sources."map-obj-1.0.1"
       sources."meow-3.7.0"
       sources."mime-db-1.40.0"
@@ -51198,7 +51492,7 @@ in
       sources."restore-cursor-1.0.1"
       sources."safe-buffer-5.1.2"
       sources."safer-buffer-2.1.2"
-      sources."semver-5.7.0"
+      sources."semver-5.7.1"
       sources."signal-exit-3.0.2"
       sources."spdx-correct-3.1.0"
       sources."spdx-exceptions-2.2.0"
@@ -51223,11 +51517,10 @@ in
       sources."typedarray-0.0.6"
       sources."uri-js-4.2.2"
       sources."util-deprecate-1.0.2"
-      sources."uuid-3.3.2"
+      sources."uuid-3.3.3"
       sources."validate-npm-package-license-3.0.4"
       sources."verror-1.10.0"
       sources."which-1.3.1"
-      sources."yallist-3.0.3"
       sources."yauzl-2.4.1"
       sources."zen-observable-0.5.2"
     ];
@@ -51292,18 +51585,13 @@ in
       sources."generate-function-1.1.0"
       sources."generate-object-property-1.2.0"
       sources."get-stream-3.0.0"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."has-flag-3.0.0"
-      (sources."hosted-git-info-2.8.2" // {
-        dependencies = [
-          sources."lru-cache-5.1.1"
-          sources."yallist-3.0.3"
-        ];
-      })
+      sources."hosted-git-info-2.8.4"
       sources."iconv-lite-0.4.24"
       sources."indent-string-3.2.0"
       sources."inherits-2.0.4"
-      (sources."inquirer-6.5.0" // {
+      (sources."inquirer-6.5.2" // {
         dependencies = [
           sources."ansi-regex-4.1.0"
           sources."strip-ansi-5.2.0"
@@ -51384,7 +51672,7 @@ in
       sources."safe-buffer-5.1.2"
       sources."safer-buffer-2.1.2"
       sources."sec-1.0.0"
-      sources."semver-5.7.0"
+      sources."semver-5.7.1"
       sources."shebang-command-1.2.0"
       sources."shebang-regex-1.0.0"
       sources."signal-exit-3.0.2"
@@ -51507,7 +51795,8 @@ in
       sources."cycle-1.0.3"
       sources."debug-2.6.9"
       sources."decode-uri-component-0.2.0"
-      sources."deep-equal-1.0.1"
+      sources."deep-equal-1.1.0"
+      sources."define-properties-1.1.3"
       (sources."define-property-2.0.2" // {
         dependencies = [
           sources."isobject-3.0.1"
@@ -51547,11 +51836,13 @@ in
       sources."fragment-cache-0.2.1"
       sources."fs.realpath-1.0.0"
       sources."fsevents-1.2.9"
+      sources."function-bind-1.1.1"
       sources."get-value-2.0.6"
       sources."glob-7.1.4"
       sources."glob-base-0.3.0"
       sources."glob-parent-2.0.0"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
+      sources."has-1.0.3"
       (sources."has-value-1.0.0" // {
         dependencies = [
           sources."isobject-3.0.1"
@@ -51576,6 +51867,7 @@ in
           sources."kind-of-6.0.2"
         ];
       })
+      sources."is-arguments-1.0.4"
       sources."is-binary-path-1.0.1"
       sources."is-buffer-1.1.6"
       (sources."is-data-descriptor-1.0.0" // {
@@ -51583,6 +51875,7 @@ in
           sources."kind-of-6.0.2"
         ];
       })
+      sources."is-date-object-1.0.1"
       (sources."is-descriptor-1.0.2" // {
         dependencies = [
           sources."kind-of-6.0.2"
@@ -51601,6 +51894,7 @@ in
       })
       sources."is-posix-bracket-0.1.1"
       sources."is-primitive-2.0.0"
+      sources."is-regex-1.0.4"
       sources."is-windows-1.0.2"
       sources."isarray-1.0.0"
       sources."isobject-2.1.0"
@@ -51656,6 +51950,8 @@ in
           })
         ];
       })
+      sources."object-is-1.0.1"
+      sources."object-keys-1.1.1"
       (sources."object-visit-1.0.1" // {
         dependencies = [
           sources."isobject-3.0.1"
@@ -51749,6 +52045,7 @@ in
       })
       sources."regex-cache-0.4.4"
       sources."regex-not-1.0.2"
+      sources."regexp.prototype.flags-1.2.0"
       sources."remove-trailing-separator-1.1.0"
       sources."repeat-element-1.1.3"
       sources."repeat-string-1.6.1"
@@ -51756,7 +52053,7 @@ in
       sources."resumer-0.0.0"
       sources."ret-0.1.15"
       sources."revalidator-0.1.8"
-      sources."rimraf-2.6.3"
+      sources."rimraf-2.7.1"
       sources."safe-buffer-5.1.2"
       sources."safe-regex-1.1.0"
       (sources."set-value-2.0.1" // {
@@ -51916,7 +52213,7 @@ in
       sources."git-remote-ssb-2.0.4"
       sources."git-ssb-web-2.8.0"
       sources."hashlru-2.3.0"
-      sources."highlight.js-9.15.9"
+      sources."highlight.js-9.15.10"
       sources."increment-buffer-1.0.1"
       sources."inherits-2.0.4"
       sources."ini-1.3.5"
@@ -52001,7 +52298,7 @@ in
       sources."pull-pushable-2.2.0"
       sources."pull-reader-1.3.1"
       sources."pull-skip-footer-0.1.0"
-      sources."pull-stream-3.6.13"
+      sources."pull-stream-3.6.14"
       (sources."pull-through-1.0.18" // {
         dependencies = [
           sources."looper-3.0.0"
@@ -52016,7 +52313,7 @@ in
       sources."ret-0.1.15"
       sources."safe-buffer-5.2.0"
       sources."secret-handshake-1.1.20"
-      sources."semver-5.7.0"
+      sources."semver-5.7.1"
       sources."separator-escape-0.0.0"
       sources."sha.js-2.4.5"
       sources."smart-buffer-4.0.2"
@@ -52029,7 +52326,7 @@ in
         ];
       })
       sources."sodium-chloride-1.1.2"
-      sources."sodium-native-2.4.5"
+      sources."sodium-native-2.4.6"
       sources."split-buffer-1.0.0"
       sources."ssb-avatar-0.2.0"
       sources."ssb-caps-1.1.0"
@@ -52099,10 +52396,10 @@ in
   graphql-cli = nodeEnv.buildNodePackage {
     name = "graphql-cli";
     packageName = "graphql-cli";
-    version = "3.0.12";
+    version = "3.0.14";
     src = fetchurl {
-      url = "https://registry.npmjs.org/graphql-cli/-/graphql-cli-3.0.12.tgz";
-      sha512 = "+6MxnbXHaAcpF574KTmpkXJmwXQmtP8YVaTY3IKBgqHzL5PMmTrrFgbLUbwDVJDZ5sSr/kMZgZFMiAczMYtykw==";
+      url = "https://registry.npmjs.org/graphql-cli/-/graphql-cli-3.0.14.tgz";
+      sha512 = "YNLHnZsePE2rJycM4E79sE4dx9G1S3rRbKdSbQEFEjOr1wHMEVzvZ3mL4Er6yqIYNWNC95HpQjxfCbjBBxRyng==";
     };
     dependencies = [
       sources."@babel/generator-7.0.0-beta.38"
@@ -52303,7 +52600,7 @@ in
       sources."global-modules-1.0.0"
       sources."global-prefix-1.0.2"
       sources."got-6.7.1"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."graphcool-json-schema-1.2.1"
       (sources."graphcool-yml-0.4.15" // {
         dependencies = [
@@ -52316,7 +52613,7 @@ in
           sources."ms-2.1.2"
         ];
       })
-      sources."graphql-14.4.2"
+      sources."graphql-14.5.4"
       (sources."graphql-cli-prepare-1.4.19" // {
         dependencies = [
           sources."chalk-2.3.1"
@@ -52341,12 +52638,7 @@ in
       sources."has-flag-3.0.0"
       sources."header-case-1.0.1"
       sources."homedir-polyfill-1.0.3"
-      (sources."hosted-git-info-2.8.2" // {
-        dependencies = [
-          sources."lru-cache-5.1.1"
-          sources."yallist-3.0.3"
-        ];
-      })
+      sources."hosted-git-info-2.8.4"
       (sources."http-errors-1.7.2" // {
         dependencies = [
           sources."inherits-2.0.3"
@@ -52471,7 +52763,7 @@ in
       sources."mimic-fn-1.2.0"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
-      (sources."minipass-2.3.5" // {
+      (sources."minipass-2.5.0" // {
         dependencies = [
           sources."yallist-3.0.3"
         ];
@@ -52585,13 +52877,13 @@ in
       sources."resolve-dir-1.0.1"
       sources."resolve-from-4.0.0"
       sources."restore-cursor-2.0.0"
-      sources."rimraf-2.6.3"
+      sources."rimraf-2.7.1"
       sources."run-async-2.3.0"
       sources."rxjs-6.5.2"
       sources."safe-buffer-5.2.0"
       sources."safer-buffer-2.1.2"
       sources."scuid-1.1.0"
-      sources."semver-5.7.0"
+      sources."semver-5.7.1"
       sources."semver-diff-2.1.0"
       (sources."send-0.17.1" // {
         dependencies = [
@@ -52677,7 +52969,7 @@ in
       sources."url-regex-3.2.0"
       sources."util-deprecate-1.0.2"
       sources."utils-merge-1.0.1"
-      sources."uuid-3.3.2"
+      sources."uuid-3.3.3"
       sources."validate-npm-package-license-3.0.4"
       sources."validator-10.11.0"
       sources."vary-1.1.2"
@@ -52713,7 +53005,7 @@ in
           sources."mem-4.3.0"
           sources."mimic-fn-2.1.0"
           sources."os-locale-3.1.0"
-          sources."p-limit-2.2.0"
+          sources."p-limit-2.2.1"
           sources."p-locate-3.0.0"
           sources."p-try-2.2.0"
           sources."yargs-parser-11.1.1"
@@ -53054,7 +53346,7 @@ in
       sources."string_decoder-0.10.31"
       sources."strip-ansi-3.0.1"
       sources."supports-color-2.0.0"
-      sources."systeminformation-4.14.4"
+      sources."systeminformation-4.14.8"
       sources."term-canvas-0.0.5"
       sources."wordwrap-0.0.3"
       sources."x256-0.0.2"
@@ -53132,7 +53424,7 @@ in
       sources."buffer-from-1.1.1"
       sources."cache-base-1.0.1"
       sources."camelcase-3.0.0"
-      (sources."chokidar-2.1.6" // {
+      (sources."chokidar-2.1.8" // {
         dependencies = [
           sources."normalize-path-3.0.0"
         ];
@@ -53253,7 +53545,7 @@ in
       sources."global-modules-1.0.0"
       sources."global-prefix-1.0.2"
       sources."glogg-1.0.2"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."gulp-cli-2.2.0"
       sources."gulplog-1.0.0"
       sources."has-symbols-1.0.0"
@@ -53264,7 +53556,7 @@ in
         ];
       })
       sources."homedir-polyfill-1.0.3"
-      sources."hosted-git-info-2.8.2"
+      sources."hosted-git-info-2.8.4"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
       sources."ini-1.3.5"
@@ -53305,7 +53597,6 @@ in
       sources."lead-1.0.0"
       sources."liftoff-3.1.0"
       sources."load-json-file-1.1.0"
-      sources."lru-cache-5.1.1"
       sources."make-iterator-1.0.1"
       sources."map-cache-0.2.2"
       sources."map-visit-1.0.0"
@@ -53396,7 +53687,7 @@ in
       sources."ret-0.1.15"
       sources."safe-buffer-5.1.2"
       sources."safe-regex-1.1.0"
-      sources."semver-5.7.0"
+      sources."semver-5.7.1"
       sources."semver-greatest-satisfied-range-1.1.0"
       sources."set-blocking-2.0.0"
       (sources."set-value-2.0.1" // {
@@ -53511,7 +53802,6 @@ in
       sources."wrappy-1.0.2"
       sources."xtend-4.0.2"
       sources."y18n-3.2.1"
-      sources."yallist-3.0.3"
       sources."yargs-7.1.0"
       sources."yargs-parser-5.0.0"
     ];
@@ -53631,7 +53921,7 @@ in
       sources."global-modules-1.0.0"
       sources."global-prefix-1.0.2"
       sources."glogg-1.0.2"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."gulplog-1.0.0"
       sources."has-value-1.0.0"
       (sources."has-values-1.0.0" // {
@@ -53640,7 +53930,7 @@ in
         ];
       })
       sources."homedir-polyfill-1.0.3"
-      sources."hosted-git-info-2.8.2"
+      sources."hosted-git-info-2.8.4"
       sources."inherits-2.0.4"
       sources."ini-1.3.5"
       sources."interpret-1.2.0"
@@ -53684,7 +53974,6 @@ in
       sources."lcid-1.0.0"
       sources."liftoff-3.1.0"
       sources."load-json-file-1.1.0"
-      sources."lru-cache-5.1.1"
       (sources."make-iterator-1.0.1" // {
         dependencies = [
           sources."kind-of-6.0.2"
@@ -53769,7 +54058,7 @@ in
       sources."ret-0.1.15"
       sources."safe-buffer-5.1.2"
       sources."safe-regex-1.1.0"
-      sources."semver-5.7.0"
+      sources."semver-5.7.1"
       sources."semver-greatest-satisfied-range-1.1.0"
       sources."set-blocking-2.0.0"
       (sources."set-value-2.0.1" // {
@@ -53852,7 +54141,6 @@ in
       sources."which-module-1.0.0"
       sources."wrap-ansi-2.1.0"
       sources."y18n-3.2.1"
-      sources."yallist-3.0.3"
       sources."yargs-7.1.0"
       sources."yargs-parser-5.0.0"
     ];
@@ -54002,7 +54290,7 @@ in
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       sources."uri-js-4.2.2"
-      sources."uuid-3.3.2"
+      sources."uuid-3.3.3"
       sources."verror-1.10.0"
       sources."wrappy-1.0.2"
       sources."xml-1.0.1"
@@ -54031,7 +54319,7 @@ in
       sources."debug-3.2.6"
       sources."ecstatic-3.3.2"
       sources."eventemitter3-3.1.2"
-      sources."follow-redirects-1.7.0"
+      sources."follow-redirects-1.8.1"
       sources."he-1.2.0"
       sources."http-proxy-1.17.0"
       sources."mime-1.6.0"
@@ -54048,7 +54336,7 @@ in
           sources."minimist-0.0.10"
         ];
       })
-      (sources."portfinder-1.0.21" // {
+      (sources."portfinder-1.0.23" // {
         dependencies = [
           sources."debug-2.6.9"
           sources."ms-2.0.0"
@@ -54084,7 +54372,7 @@ in
       sources."balanced-match-1.0.0"
       sources."brace-expansion-1.1.11"
       sources."cmdln-4.4.0"
-      sources."color-convert-2.0.0"
+      sources."color-convert-2.0.1"
       sources."color-name-1.1.4"
       sources."concat-map-0.0.1"
       sources."core-util-is-1.0.2"
@@ -54106,9 +54394,9 @@ in
       sources."once-1.4.0"
       sources."path-is-absolute-1.0.1"
       sources."readable-stream-3.4.0"
-      sources."safe-buffer-5.1.2"
+      sources."safe-buffer-5.2.0"
       sources."sprintf-js-1.0.3"
-      sources."string_decoder-1.2.0"
+      sources."string_decoder-1.3.0"
       sources."tabula-1.10.0"
       sources."util-deprecate-1.0.2"
       sources."verror-1.10.0"
@@ -54141,7 +54429,7 @@ in
       sources."concat-map-0.0.1"
       sources."core-util-is-1.0.2"
       sources."cycle-1.0.3"
-      sources."dtrace-provider-0.8.7"
+      sources."dtrace-provider-0.8.8"
       sources."eyes-0.1.8"
       sources."glob-6.0.4"
       sources."imap-0.8.19"
@@ -54200,7 +54488,7 @@ in
       sources."commander-2.11.0"
       sources."node-fetch-2.6.0"
       sources."safe-buffer-5.1.2"
-      sources."semver-5.7.0"
+      sources."semver-5.7.1"
       sources."source-map-0.7.3"
       sources."ultron-1.1.1"
       sources."ws-3.3.3"
@@ -54217,23 +54505,23 @@ in
   ionic = nodeEnv.buildNodePackage {
     name = "ionic";
     packageName = "ionic";
-    version = "5.2.3";
+    version = "5.2.7";
     src = fetchurl {
-      url = "https://registry.npmjs.org/ionic/-/ionic-5.2.3.tgz";
-      sha512 = "4TX29yrOhlcSFX8LRoB3ss2PaSyV6DBVnnCC7S/hBhmN0jS6/bQS7nO7gafvX8he08MF9DEfz5GVqXvME9a4og==";
+      url = "https://registry.npmjs.org/ionic/-/ionic-5.2.7.tgz";
+      sha512 = "RmcjD4vQInfYGZrJvkJuxl7yrjhQ8Q+3rYoT/FWTc9NkWjHHgAMZW+QAPAsexXbzihmwTWLbcyew5z4chlrTXg==";
     };
     dependencies = [
-      sources."@ionic/cli-framework-2.1.2"
-      sources."@ionic/discover-2.0.2"
-      sources."@ionic/utils-array-1.0.1"
-      sources."@ionic/utils-fs-2.0.3"
-      sources."@ionic/utils-network-1.0.1"
-      sources."@ionic/utils-object-1.0.1"
-      sources."@ionic/utils-process-1.0.1"
-      sources."@ionic/utils-stream-2.0.0"
-      sources."@ionic/utils-subprocess-1.0.3"
-      sources."@ionic/utils-terminal-1.0.1"
-      sources."@types/node-8.10.51"
+      sources."@ionic/cli-framework-2.1.6"
+      sources."@ionic/discover-2.0.5"
+      sources."@ionic/utils-array-1.2.0"
+      sources."@ionic/utils-fs-2.0.6"
+      sources."@ionic/utils-network-1.0.4"
+      sources."@ionic/utils-object-1.0.4"
+      sources."@ionic/utils-process-1.0.4"
+      sources."@ionic/utils-stream-2.0.3"
+      sources."@ionic/utils-subprocess-1.0.7"
+      sources."@ionic/utils-terminal-1.0.4"
+      sources."@types/node-8.10.53"
       sources."agent-base-4.3.0"
       sources."ansi-escapes-3.2.0"
       sources."ansi-regex-3.0.0"
@@ -54260,7 +54548,7 @@ in
       sources."core-util-is-1.0.2"
       (sources."cross-spawn-6.0.5" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       sources."data-uri-to-buffer-2.0.1"
@@ -54273,6 +54561,7 @@ in
       (sources."duplexer2-0.1.4" // {
         dependencies = [
           sources."readable-stream-2.3.6"
+          sources."safe-buffer-5.1.2"
           sources."string_decoder-1.1.1"
         ];
       })
@@ -54282,9 +54571,9 @@ in
       sources."es6-promise-4.2.8"
       sources."es6-promisify-5.0.0"
       sources."escape-string-regexp-1.0.5"
-      sources."escodegen-1.11.1"
+      sources."escodegen-1.12.0"
       sources."esprima-3.1.3"
-      sources."estraverse-4.2.0"
+      sources."estraverse-4.3.0"
       sources."esutils-2.0.3"
       sources."execa-1.0.0"
       sources."extend-3.0.2"
@@ -54292,7 +54581,7 @@ in
       sources."fast-levenshtein-2.0.6"
       sources."figures-2.0.0"
       sources."file-uri-to-path-1.0.0"
-      sources."form-data-2.5.0"
+      sources."form-data-2.5.1"
       sources."formidable-1.2.1"
       sources."fs-extra-8.1.0"
       sources."fs-minipass-1.2.6"
@@ -54307,7 +54596,7 @@ in
       sources."get-stream-4.1.0"
       sources."get-uri-2.0.3"
       sources."glob-7.1.4"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."has-flag-3.0.0"
       sources."http-errors-1.7.3"
       (sources."http-proxy-agent-2.1.0" // {
@@ -54325,7 +54614,7 @@ in
       sources."imurmurhash-0.1.4"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
-      (sources."inquirer-6.5.0" // {
+      (sources."inquirer-6.5.2" // {
         dependencies = [
           (sources."string-width-2.1.1" // {
             dependencies = [
@@ -54377,7 +54666,7 @@ in
       sources."mimic-fn-1.2.0"
       sources."minimatch-3.0.4"
       sources."minimist-1.2.0"
-      (sources."minipass-2.3.5" // {
+      (sources."minipass-2.5.0" // {
         dependencies = [
           sources."yallist-3.0.3"
         ];
@@ -54418,15 +54707,15 @@ in
       sources."proxy-from-env-1.0.0"
       sources."pseudomap-1.0.2"
       sources."pump-3.0.0"
-      sources."qs-6.7.0"
+      sources."qs-6.8.0"
       sources."raw-body-2.4.1"
       sources."readable-stream-3.4.0"
       sources."restore-cursor-2.0.0"
-      sources."rimraf-2.6.3"
+      sources."rimraf-3.0.0"
       sources."rsvp-3.6.2"
       sources."run-async-2.3.0"
       sources."rxjs-6.5.2"
-      sources."safe-buffer-5.1.2"
+      sources."safe-buffer-5.2.0"
       sources."safer-buffer-2.1.2"
       sources."sax-1.1.4"
       sources."semver-6.3.0"
@@ -54449,6 +54738,7 @@ in
       (sources."stream-combiner2-1.1.1" // {
         dependencies = [
           sources."readable-stream-2.3.6"
+          sources."safe-buffer-5.1.2"
           sources."string_decoder-1.1.1"
         ];
       })
@@ -54458,7 +54748,7 @@ in
           sources."is-fullwidth-code-point-3.0.0"
         ];
       })
-      sources."string_decoder-1.2.0"
+      sources."string_decoder-1.3.0"
       (sources."strip-ansi-5.2.0" // {
         dependencies = [
           sources."ansi-regex-4.1.0"
@@ -54490,20 +54780,20 @@ in
       sources."unpipe-1.0.0"
       sources."untildify-4.0.0"
       sources."util-deprecate-1.0.2"
-      sources."uuid-3.3.2"
+      sources."uuid-3.3.3"
       sources."which-1.3.1"
       sources."windows-release-3.2.0"
       sources."wordwrap-1.0.0"
       (sources."wrap-ansi-6.0.0" // {
         dependencies = [
-          sources."ansi-styles-4.0.0"
-          sources."color-convert-2.0.0"
+          sources."ansi-styles-4.1.0"
+          sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
         ];
       })
       sources."wrappy-1.0.2"
       sources."write-file-atomic-3.0.0"
-      sources."ws-7.1.1"
+      sources."ws-7.1.2"
       sources."xregexp-2.0.0"
       sources."yallist-2.1.2"
     ];
@@ -54582,7 +54872,7 @@ in
       sources."assertion-error-1.1.0"
       sources."balanced-match-1.0.0"
       sources."brace-expansion-1.1.11"
-      sources."bufrw-1.2.1"
+      sources."bufrw-1.3.0"
       sources."chai-4.2.0"
       sources."chai-as-promised-7.1.1"
       sources."chalk-2.4.2"
@@ -54595,11 +54885,12 @@ in
       sources."error-7.0.2"
       sources."escape-string-regexp-1.0.5"
       sources."fast-deep-equal-2.0.1"
-      sources."fast-json-patch-2.2.0"
+      sources."fast-json-patch-2.2.1"
       sources."fs.realpath-1.0.0"
       sources."get-func-name-2.0.0"
       sources."glob-7.1.4"
       sources."has-flag-3.0.0"
+      sources."hexer-1.5.0"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
       sources."iterare-1.2.0"
@@ -54611,6 +54902,7 @@ in
       sources."lodash-4.17.15"
       sources."long-2.4.0"
       sources."minimatch-3.0.4"
+      sources."minimist-1.2.0"
       sources."mz-2.7.0"
       sources."node-int64-0.4.0"
       sources."object-assign-4.1.1"
@@ -54619,6 +54911,7 @@ in
       sources."opentracing-0.14.4"
       sources."path-is-absolute-1.0.1"
       sources."pathval-1.1.0"
+      sources."process-0.10.1"
       sources."rxjs-5.5.12"
       sources."semaphore-async-await-1.5.1"
       sources."string-similarity-2.0.0"
@@ -54630,7 +54923,7 @@ in
       sources."thriftrw-3.11.3"
       sources."type-detect-4.0.8"
       sources."typescript-3.0.3"
-      sources."uuid-3.3.2"
+      sources."uuid-3.3.3"
       sources."vscode-jsonrpc-4.0.0"
       sources."vscode-languageserver-5.2.1"
       sources."vscode-languageserver-protocol-3.14.1"
@@ -54659,12 +54952,12 @@ in
     };
     dependencies = [
       sources."@cronvel/get-pixels-3.3.1"
-      sources."abab-2.0.0"
+      sources."abab-2.0.1"
       sources."abbrev-1.1.1"
       sources."acorn-5.7.3"
       (sources."acorn-globals-4.3.3" // {
         dependencies = [
-          sources."acorn-6.2.1"
+          sources."acorn-6.3.0"
         ];
       })
       sources."acorn-walk-6.2.0"
@@ -54710,7 +55003,7 @@ in
       sources."chalk-2.4.2"
       sources."charenc-0.0.2"
       sources."chownr-1.1.2"
-      sources."chroma-js-2.0.4"
+      sources."chroma-js-2.0.6"
       sources."clean-css-4.2.1"
       sources."cliss-0.0.2"
       sources."code-point-at-1.1.0"
@@ -54762,9 +55055,9 @@ in
       sources."entities-1.1.2"
       sources."es6-promise-pool-2.5.0"
       sources."escape-string-regexp-1.0.5"
-      sources."escodegen-1.11.1"
+      sources."escodegen-1.12.0"
       sources."esprima-3.1.3"
-      sources."estraverse-4.2.0"
+      sources."estraverse-4.3.0"
       sources."esutils-2.0.3"
       sources."expand-template-2.0.3"
       sources."extend-3.0.2"
@@ -54776,11 +55069,11 @@ in
       sources."file-type-10.11.0"
       sources."file-uri-to-path-1.0.0"
       sources."find-up-2.1.0"
-      sources."follow-redirects-1.7.0"
+      sources."follow-redirects-1.8.1"
       sources."for-each-property-0.0.4"
       sources."for-each-property-deep-0.0.3"
       sources."forever-agent-0.6.1"
-      sources."form-data-2.5.0"
+      sources."form-data-2.5.1"
       sources."format-0.2.2"
       sources."fs-constants-1.0.0"
       sources."fs-copy-file-sync-1.1.1"
@@ -54797,7 +55090,7 @@ in
       sources."getpass-0.1.7"
       sources."github-from-package-0.0.0"
       sources."glob-7.1.4"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-ansi-2.0.0"
@@ -54901,7 +55194,7 @@ in
       sources."mimic-response-1.0.1"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
-      sources."minipass-2.3.5"
+      sources."minipass-2.5.0"
       sources."minizlib-1.2.1"
       sources."mkdirp-0.5.1"
       sources."moment-2.24.0"
@@ -54913,9 +55206,9 @@ in
       sources."needle-2.4.0"
       sources."nextgen-events-1.1.1"
       sources."no-case-2.3.2"
-      (sources."node-abi-2.10.0" // {
+      (sources."node-abi-2.11.0" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       sources."node-bitmap-0.0.1"
@@ -54924,7 +55217,7 @@ in
       sources."node-persist-2.1.0"
       (sources."node-pre-gyp-0.11.0" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       sources."noop-logger-0.1.1"
@@ -55001,7 +55294,7 @@ in
       sources."requires-port-1.0.0"
       sources."resolve-url-0.2.1"
       sources."retry-0.10.1"
-      sources."rimraf-2.6.3"
+      sources."rimraf-2.7.1"
       sources."safe-buffer-5.2.0"
       sources."safer-buffer-2.1.2"
       sources."sax-1.2.4"
@@ -55009,7 +55302,7 @@ in
       sources."server-destroy-1.0.1"
       sources."set-blocking-2.0.0"
       sources."setimmediate-1.0.5"
-      sources."seventh-0.7.27"
+      sources."seventh-0.7.28"
       sources."sharp-0.22.1"
       sources."signal-exit-3.0.2"
       sources."simple-concat-1.0.0"
@@ -55025,7 +55318,7 @@ in
       sources."source-map-url-0.4.0"
       sources."split-skip-0.0.2"
       sources."sprintf-js-1.1.2"
-      sources."sqlite3-4.0.9"
+      sources."sqlite3-4.1.0"
       sources."sshpk-1.16.1"
       sources."stealthy-require-1.1.1"
       sources."strict-uri-encode-1.1.0"
@@ -55071,7 +55364,7 @@ in
           sources."q-0.9.7"
         ];
       })
-      sources."terminal-kit-1.29.3"
+      sources."terminal-kit-1.31.1"
       (sources."tkwidgets-0.5.26" // {
         dependencies = [
           sources."is-fullwidth-code-point-2.0.0"
@@ -55106,7 +55399,7 @@ in
       sources."urix-0.1.0"
       sources."url-parse-1.4.7"
       sources."util-deprecate-1.0.2"
-      sources."uuid-3.3.2"
+      sources."uuid-3.3.3"
       sources."valid-url-1.0.9"
       sources."verror-1.10.0"
       sources."w3c-hr-time-1.0.1"
@@ -55146,10 +55439,10 @@ in
   js-beautify = nodeEnv.buildNodePackage {
     name = "js-beautify";
     packageName = "js-beautify";
-    version = "1.10.1";
+    version = "1.10.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/js-beautify/-/js-beautify-1.10.1.tgz";
-      sha512 = "4y8SHOIRC+/YQ2gs3zJEKBUraQerq49FJYyXRpdzUGYQzCq8q9xtIh0YXial1S5KmonVui4aiUb6XaGyjE51XA==";
+      url = "https://registry.npmjs.org/js-beautify/-/js-beautify-1.10.2.tgz";
+      sha512 = "ZtBYyNUYJIsBWERnQP0rPN9KjkrDfJcMjuVGcvXOUJrD1zmOGwhRwQ4msG+HJ+Ni/FA7+sRQEMYVzdTQDvnzvQ==";
     };
     dependencies = [
       sources."abbrev-1.1.1"
@@ -55176,7 +55469,7 @@ in
       sources."path-is-absolute-1.0.1"
       sources."proto-list-1.2.4"
       sources."pseudomap-1.0.2"
-      sources."semver-5.7.0"
+      sources."semver-5.7.1"
       sources."sigmund-1.0.1"
       sources."wrappy-1.0.2"
       sources."yallist-2.1.2"
@@ -55227,7 +55520,7 @@ in
       sources."catharsis-0.8.11"
       sources."entities-1.1.2"
       sources."escape-string-regexp-2.0.0"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."js2xmlparser-4.0.0"
       sources."klaw-3.0.0"
       sources."linkify-it-2.2.0"
@@ -55367,7 +55660,7 @@ in
       sources."delayed-stream-1.0.0"
       sources."esprima-4.0.1"
       sources."extend-3.0.2"
-      sources."form-data-2.5.0"
+      sources."form-data-2.5.1"
       sources."formidable-1.2.1"
       sources."graphlib-2.1.7"
       sources."inherits-2.0.4"
@@ -55383,7 +55676,7 @@ in
       sources."path-loader-1.0.10"
       sources."process-nextick-args-2.0.1"
       sources."punycode-2.1.1"
-      sources."qs-6.7.0"
+      sources."qs-6.8.0"
       sources."readable-stream-2.3.6"
       sources."safe-buffer-5.1.2"
       sources."slash-2.0.0"
@@ -55507,7 +55800,7 @@ in
           sources."get-stream-4.1.0"
         ];
       })
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-flag-3.0.0"
@@ -55566,7 +55859,7 @@ in
       sources."minimist-1.2.0"
       sources."morgan-1.9.1"
       sources."ms-2.0.0"
-      sources."nanoid-2.0.3"
+      sources."nanoid-2.0.4"
       sources."negotiator-0.6.2"
       sources."normalize-url-4.3.0"
       sources."npm-run-path-2.0.2"
@@ -55577,7 +55870,7 @@ in
       sources."once-1.4.0"
       sources."p-cancelable-1.1.0"
       sources."p-finally-1.0.0"
-      sources."p-limit-2.2.0"
+      sources."p-limit-2.2.1"
       sources."p-locate-3.0.0"
       sources."p-try-2.2.0"
       sources."package-json-6.5.0"
@@ -55588,7 +55881,7 @@ in
       sources."path-to-regexp-0.1.7"
       sources."performance-now-2.1.0"
       sources."pify-3.0.0"
-      sources."please-upgrade-node-3.1.1"
+      sources."please-upgrade-node-3.2.0"
       sources."pluralize-7.0.0"
       sources."prepend-http-2.0.0"
       sources."proxy-addr-2.0.5"
@@ -55616,7 +55909,7 @@ in
       sources."semver-compare-1.0.0"
       (sources."semver-diff-2.1.0" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       (sources."send-0.17.1" // {
@@ -55657,7 +55950,7 @@ in
       sources."uri-js-4.2.2"
       sources."url-parse-lax-3.0.0"
       sources."utils-merge-1.0.1"
-      sources."uuid-3.3.2"
+      sources."uuid-3.3.3"
       sources."vary-1.1.2"
       sources."verror-1.10.0"
       sources."which-1.3.1"
@@ -55715,15 +56008,15 @@ in
   karma = nodeEnv.buildNodePackage {
     name = "karma";
     packageName = "karma";
-    version = "4.2.0";
+    version = "4.3.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/karma/-/karma-4.2.0.tgz";
-      sha512 = "fmCuxN1rwJxTdZfOXK5LjlmS4Ana/OvzNMpkyLL/TLE8hmgSkpVpMYQ7RTVa8TNKRVQDZNl5W1oF5cfKfgIMlA==";
+      url = "https://registry.npmjs.org/karma/-/karma-4.3.0.tgz";
+      sha512 = "NSPViHOt+RW38oJklvYxQC4BSQsv737oQlr/r06pCM+slDOr4myuI1ivkRmp+3dVpJDfZt2DmaPJ2wkx+ZZuMQ==";
     };
     dependencies = [
       sources."accepts-1.3.7"
       sources."after-0.8.2"
-      sources."anymatch-3.0.3"
+      sources."anymatch-3.1.0"
       sources."arraybuffer.slice-0.0.7"
       sources."async-2.6.3"
       sources."async-limiter-1.0.1"
@@ -55752,7 +56045,7 @@ in
       sources."connect-3.7.0"
       sources."content-type-1.0.4"
       sources."cookie-0.3.1"
-      sources."core-js-3.1.4"
+      sources."core-js-3.2.1"
       sources."custom-event-1.0.1"
       sources."date-format-2.1.0"
       sources."debug-2.6.9"
@@ -55779,7 +56072,7 @@ in
       sources."fill-range-7.0.1"
       sources."finalhandler-1.1.2"
       sources."flatted-2.0.1"
-      (sources."follow-redirects-1.7.0" // {
+      (sources."follow-redirects-1.8.1" // {
         dependencies = [
           sources."debug-3.2.6"
           sources."ms-2.1.2"
@@ -55790,7 +56083,7 @@ in
       sources."fsevents-2.0.7"
       sources."glob-7.1.4"
       sources."glob-parent-5.0.0"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."has-binary2-1.0.3"
       sources."has-cors-1.1.0"
       sources."http-errors-1.7.2"
@@ -55838,10 +56131,10 @@ in
       sources."qs-6.7.0"
       sources."range-parser-1.2.1"
       sources."raw-body-2.4.0"
-      sources."readdirp-3.1.1"
+      sources."readdirp-3.1.2"
       sources."requires-port-1.0.0"
       sources."rfdc-1.1.4"
-      sources."rimraf-2.6.3"
+      sources."rimraf-2.7.1"
       sources."safe-buffer-5.2.0"
       sources."safer-buffer-2.1.2"
       sources."setprototypeof-1.1.1"
@@ -55931,7 +56224,7 @@ in
       sources."glob-7.1.4"
       sources."glob-parent-3.1.0"
       sources."glob-stream-6.1.0"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."has-symbols-1.0.0"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
@@ -56053,9 +56346,9 @@ in
       sources."end-of-stream-1.4.1"
       sources."entities-1.1.2"
       sources."escape-string-regexp-1.0.5"
-      sources."escodegen-1.11.1"
+      sources."escodegen-1.12.0"
       sources."esprima-3.1.3"
-      sources."estraverse-4.2.0"
+      sources."estraverse-4.3.0"
       sources."esutils-2.0.3"
       sources."execa-1.0.0"
       sources."extend-3.0.2"
@@ -56143,7 +56436,7 @@ in
       sources."p-defer-1.0.0"
       sources."p-finally-1.0.0"
       sources."p-is-promise-2.1.0"
-      sources."p-limit-2.2.0"
+      sources."p-limit-2.2.1"
       sources."p-locate-3.0.0"
       sources."p-try-2.2.0"
       sources."parse5-1.5.1"
@@ -56170,12 +56463,12 @@ in
       sources."require-main-filename-1.0.1"
       sources."restore-cursor-2.0.0"
       sources."revalidator-0.1.8"
-      sources."rimraf-2.6.3"
+      sources."rimraf-2.7.1"
       sources."safe-buffer-5.2.0"
       sources."safer-buffer-2.1.2"
       sources."sax-1.2.4"
       sources."secure-keys-1.0.0"
-      sources."semver-5.7.0"
+      sources."semver-5.7.1"
       sources."set-blocking-2.0.0"
       sources."shebang-command-1.2.0"
       sources."shebang-regex-1.0.0"
@@ -56201,7 +56494,7 @@ in
           sources."async-0.9.2"
         ];
       })
-      sources."uuid-3.3.2"
+      sources."uuid-3.3.3"
       sources."verror-1.10.0"
       sources."wcwidth-1.0.1"
       sources."webidl-conversions-2.0.1"
@@ -56265,13 +56558,13 @@ in
       (sources."@evocateur/libnpmpublish-1.2.2" // {
         dependencies = [
           sources."aproba-2.0.0"
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       sources."@evocateur/npm-registry-fetch-4.0.0"
-      (sources."@evocateur/pacote-9.6.3" // {
+      (sources."@evocateur/pacote-9.6.5" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       sources."@lerna/add-3.16.2"
@@ -56369,7 +56662,7 @@ in
       sources."@types/events-3.0.0"
       sources."@types/glob-7.1.1"
       sources."@types/minimatch-3.0.3"
-      sources."@types/node-12.6.9"
+      sources."@types/node-12.7.3"
       sources."@zkochan/cmd-shim-3.1.0"
       sources."JSONStream-1.3.5"
       sources."abbrev-1.1.1"
@@ -56422,7 +56715,7 @@ in
       sources."builtins-1.0.3"
       sources."byline-5.0.0"
       sources."byte-size-5.0.1"
-      sources."cacache-12.0.2"
+      sources."cacache-12.0.3"
       sources."cache-base-1.0.1"
       sources."call-me-maybe-1.0.1"
       sources."caller-callsite-2.0.0"
@@ -56512,7 +56805,7 @@ in
       sources."cosmiconfig-5.2.1"
       (sources."cross-spawn-6.0.5" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       sources."currently-unhandled-0.4.1"
@@ -56678,7 +56971,7 @@ in
           sources."pify-4.0.1"
         ];
       })
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       (sources."handlebars-4.1.2" // {
         dependencies = [
           sources."source-map-0.6.1"
@@ -56696,7 +56989,7 @@ in
           sources."kind-of-4.0.0"
         ];
       })
-      sources."hosted-git-info-2.8.2"
+      sources."hosted-git-info-2.8.4"
       sources."http-cache-semantics-3.8.1"
       sources."http-proxy-agent-2.1.0"
       sources."http-signature-1.2.0"
@@ -56720,10 +57013,10 @@ in
       sources."ini-1.3.5"
       (sources."init-package-json-1.10.3" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
-      (sources."inquirer-6.5.0" // {
+      (sources."inquirer-6.5.2" // {
         dependencies = [
           sources."ansi-regex-4.1.0"
           sources."strip-ansi-5.2.0"
@@ -56820,7 +57113,7 @@ in
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
       sources."minimist-options-3.0.2"
-      sources."minipass-2.3.5"
+      sources."minipass-2.5.0"
       sources."minizlib-1.2.1"
       sources."mississippi-3.0.0"
       (sources."mixin-deep-1.3.2" // {
@@ -56849,21 +57142,21 @@ in
       sources."nopt-3.0.6"
       (sources."normalize-package-data-2.5.0" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       sources."normalize-url-3.3.0"
       sources."npm-bundled-1.0.6"
-      sources."npm-lifecycle-3.1.2"
-      (sources."npm-package-arg-6.1.0" // {
+      sources."npm-lifecycle-3.1.3"
+      (sources."npm-package-arg-6.1.1" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       sources."npm-packlist-1.4.4"
-      (sources."npm-pick-manifest-2.2.3" // {
+      (sources."npm-pick-manifest-3.0.1" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       sources."npm-run-path-2.0.2"
@@ -56900,7 +57193,7 @@ in
       sources."p-defer-1.0.0"
       sources."p-finally-1.0.0"
       sources."p-is-promise-2.1.0"
-      sources."p-limit-2.2.0"
+      sources."p-limit-2.2.1"
       sources."p-locate-3.0.0"
       sources."p-map-2.1.0"
       sources."p-map-series-1.0.0"
@@ -56946,8 +57239,8 @@ in
       sources."qs-6.5.2"
       sources."quick-lru-1.1.0"
       sources."read-1.0.7"
-      sources."read-cmd-shim-1.0.1"
-      (sources."read-package-json-2.0.13" // {
+      sources."read-cmd-shim-1.0.4"
+      (sources."read-package-json-2.1.0" // {
         dependencies = [
           sources."slash-1.0.0"
         ];
@@ -56992,7 +57285,7 @@ in
       sources."restore-cursor-2.0.0"
       sources."ret-0.1.15"
       sources."retry-0.10.1"
-      sources."rimraf-2.6.3"
+      sources."rimraf-2.7.1"
       sources."run-async-2.3.0"
       sources."run-queue-1.0.3"
       sources."rxjs-6.5.2"
@@ -57159,7 +57452,7 @@ in
       sources."use-3.1.1"
       sources."util-deprecate-1.0.2"
       sources."util-promisify-2.1.0"
-      sources."uuid-3.3.2"
+      sources."uuid-3.3.3"
       sources."validate-npm-package-license-3.0.4"
       sources."validate-npm-package-name-3.0.0"
       sources."verror-1.10.0"
@@ -57183,7 +57476,7 @@ in
         dependencies = [
           sources."make-dir-2.1.0"
           sources."pify-4.0.1"
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       (sources."write-pkg-3.2.0" // {
@@ -57209,10 +57502,10 @@ in
   less = nodeEnv.buildNodePackage {
     name = "less";
     packageName = "less";
-    version = "3.9.0";
+    version = "3.10.3";
     src = fetchurl {
-      url = "https://registry.npmjs.org/less/-/less-3.9.0.tgz";
-      sha512 = "31CmtPEZraNUtuUREYjSqRkeETFdyEHSEPAGq4erDlUXtda7pzNmctdljdIagSb589d/qXGWiiP31R5JVf+v0w==";
+      url = "https://registry.npmjs.org/less/-/less-3.10.3.tgz";
+      sha512 = "vz32vqfgmoxF1h3K4J+yKCtajH0PWmjkIFgbs5d78E/c/e+UQTnI+lWK+1eQRE95PXM2mC3rJlLSSP9VQHnaow==";
     };
     dependencies = [
       sources."ajv-6.10.2"
@@ -57238,7 +57531,7 @@ in
       sources."forever-agent-0.6.1"
       sources."form-data-2.3.3"
       sources."getpass-0.1.7"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."http-signature-1.2.0"
@@ -57275,7 +57568,7 @@ in
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       sources."uri-js-4.2.2"
-      sources."uuid-3.3.2"
+      sources."uuid-3.3.3"
       sources."verror-1.10.0"
     ];
     buildInputs = globalBuildInputs;
@@ -57350,7 +57643,7 @@ in
         ];
       })
       sources."cache-base-1.0.1"
-      sources."chokidar-2.1.6"
+      sources."chokidar-2.1.8"
       (sources."class-utils-0.3.6" // {
         dependencies = [
           sources."define-property-0.2.5"
@@ -57432,7 +57725,7 @@ in
           sources."is-glob-3.1.0"
         ];
       })
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."has-value-1.0.0"
       (sources."has-values-1.0.0" // {
         dependencies = [
@@ -57618,7 +57911,7 @@ in
       sources."use-3.1.1"
       sources."util-deprecate-1.0.2"
       sources."utils-merge-1.0.1"
-      sources."uuid-3.3.2"
+      sources."uuid-3.3.3"
       sources."vary-1.1.2"
       sources."websocket-driver-0.7.3"
       sources."websocket-extensions-0.1.3"
@@ -57774,7 +58067,7 @@ in
       sources."github-slugger-1.2.1"
       sources."glob-base-0.3.0"
       sources."glob-parent-2.0.0"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       (sources."has-binary2-1.0.3" // {
@@ -58116,7 +58409,7 @@ in
       sources."use-3.1.1"
       sources."util-deprecate-1.0.2"
       sources."utils-merge-1.0.1"
-      sources."uuid-3.3.2"
+      sources."uuid-3.3.3"
       sources."vary-1.1.2"
       sources."verror-1.10.0"
       sources."ws-6.1.4"
@@ -58225,7 +58518,7 @@ in
       sources."@types/events-3.0.0"
       sources."@types/glob-7.1.1"
       sources."@types/minimatch-3.0.3"
-      sources."@types/node-12.6.9"
+      sources."@types/node-12.7.3"
       sources."@webassemblyjs/ast-1.8.5"
       sources."@webassemblyjs/floating-point-hex-parser-1.8.5"
       sources."@webassemblyjs/helper-api-error-1.8.5"
@@ -58247,7 +58540,7 @@ in
       sources."@xtuc/ieee754-1.2.0"
       sources."@xtuc/long-4.2.2"
       sources."ace.improved-0.2.1"
-      sources."acorn-6.2.1"
+      sources."acorn-6.3.0"
       sources."ajv-6.10.2"
       sources."ajv-errors-1.0.1"
       sources."ajv-keywords-3.4.1"
@@ -58352,14 +58645,14 @@ in
       sources."babel-plugin-jest-hoist-23.2.0"
       sources."babel-plugin-minify-builtins-0.5.0"
       sources."babel-plugin-minify-constant-folding-0.5.0"
-      sources."babel-plugin-minify-dead-code-elimination-0.5.0"
+      sources."babel-plugin-minify-dead-code-elimination-0.5.1"
       sources."babel-plugin-minify-flip-comparisons-0.4.3"
-      sources."babel-plugin-minify-guarded-expressions-0.4.3"
+      sources."babel-plugin-minify-guarded-expressions-0.4.4"
       sources."babel-plugin-minify-infinity-0.4.3"
       sources."babel-plugin-minify-mangle-names-0.5.0"
       sources."babel-plugin-minify-numeric-literals-0.4.3"
       sources."babel-plugin-minify-replace-0.5.0"
-      sources."babel-plugin-minify-simplify-0.5.0"
+      sources."babel-plugin-minify-simplify-0.5.1"
       sources."babel-plugin-minify-type-constructors-0.4.3"
       sources."babel-plugin-syntax-flow-6.18.0"
       sources."babel-plugin-syntax-object-rest-spread-6.13.0"
@@ -58376,7 +58669,7 @@ in
       sources."babel-plugin-transform-simplify-comparison-operators-6.9.4"
       sources."babel-plugin-transform-undefined-to-void-6.9.4"
       sources."babel-preset-jest-23.2.0"
-      sources."babel-preset-minify-0.5.0"
+      sources."babel-preset-minify-0.5.1"
       (sources."babel-runtime-6.26.0" // {
         dependencies = [
           sources."regenerator-runtime-0.11.1"
@@ -58419,7 +58712,7 @@ in
       sources."browserify-sign-4.0.4"
       sources."browserify-zlib-0.2.0"
       sources."browserslist-4.6.6"
-      sources."buffer-5.2.1"
+      sources."buffer-5.4.2"
       sources."buffer-alloc-1.2.0"
       sources."buffer-alloc-unsafe-1.1.0"
       sources."buffer-crc32-0.2.13"
@@ -58428,7 +58721,7 @@ in
       sources."buffer-xor-1.0.3"
       sources."builtin-modules-2.0.0"
       sources."builtin-status-codes-3.0.0"
-      sources."cacache-12.0.2"
+      sources."cacache-12.0.3"
       (sources."cache-base-1.0.1" // {
         dependencies = [
           sources."isobject-3.0.1"
@@ -58450,7 +58743,7 @@ in
         ];
       })
       sources."cherow-1.6.9"
-      (sources."chokidar-2.1.6" // {
+      (sources."chokidar-2.1.8" // {
         dependencies = [
           sources."array-unique-0.3.2"
           sources."braces-2.3.2"
@@ -58518,12 +58811,11 @@ in
       sources."copy-concurrently-1.0.5"
       sources."copy-descriptor-0.1.1"
       sources."core-js-2.6.9"
-      (sources."core-js-compat-3.1.4" // {
+      (sources."core-js-compat-3.2.1" // {
         dependencies = [
           sources."semver-6.3.0"
         ];
       })
-      sources."core-js-pure-3.1.4"
       sources."core-util-is-1.0.2"
       sources."create-ecdh-4.0.3"
       sources."create-hash-1.2.0"
@@ -58600,7 +58892,7 @@ in
       })
       sources."duplexer3-0.1.4"
       sources."duplexify-3.7.1"
-      sources."electron-to-chromium-1.3.215"
+      sources."electron-to-chromium-1.3.245"
       sources."elliptic-6.5.0"
       sources."emoji-regex-7.0.3"
       sources."emojis-list-2.1.0"
@@ -58610,9 +58902,9 @@ in
       sources."error-ex-1.3.2"
       sources."escape-string-regexp-1.0.5"
       sources."eslint-scope-3.7.1"
-      sources."eslint-visitor-keys-1.0.0"
+      sources."eslint-visitor-keys-1.1.0"
       sources."esrecurse-4.2.1"
-      sources."estraverse-4.2.0"
+      sources."estraverse-4.3.0"
       sources."estree-walker-0.6.1"
       sources."esutils-2.0.3"
       sources."events-3.0.0"
@@ -58795,7 +59087,7 @@ in
           sources."p-cancelable-1.1.0"
         ];
       })
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."graceful-readlink-1.0.1"
       sources."has-ansi-2.0.0"
       sources."has-flag-3.0.0"
@@ -58821,7 +59113,7 @@ in
       sources."hash.js-1.1.7"
       sources."hmac-drbg-1.0.1"
       sources."homedir-polyfill-1.0.3"
-      sources."hosted-git-info-2.8.2"
+      sources."hosted-git-info-2.8.4"
       sources."http-cache-semantics-3.8.1"
       sources."https-browserify-1.0.0"
       sources."ieee754-1.1.13"
@@ -58905,8 +59197,6 @@ in
       })
       sources."locate-path-2.0.0"
       sources."lodash-4.17.15"
-      sources."lodash.isplainobject-4.0.6"
-      sources."lodash.some-4.6.0"
       sources."log-symbols-2.2.0"
       sources."loose-envify-1.4.0"
       sources."lowercase-keys-1.0.1"
@@ -58976,7 +59266,7 @@ in
           sources."punycode-1.4.1"
         ];
       })
-      sources."node-releases-1.1.26"
+      sources."node-releases-1.1.28"
       sources."normalize-package-data-2.5.0"
       sources."normalize-path-2.1.1"
       (sources."normalize-url-2.0.1" // {
@@ -59060,7 +59350,7 @@ in
         dependencies = [
           sources."find-up-3.0.0"
           sources."locate-path-3.0.0"
-          sources."p-limit-2.2.0"
+          sources."p-limit-2.2.1"
           sources."p-locate-3.0.0"
           sources."p-try-2.2.0"
         ];
@@ -59157,8 +59447,8 @@ in
       sources."regenerator-transform-0.14.1"
       sources."regex-cache-0.4.4"
       sources."regex-not-1.0.2"
-      sources."regexp-tree-0.1.11"
-      sources."regexpu-core-4.5.4"
+      sources."regexp-tree-0.1.12"
+      sources."regexpu-core-4.5.5"
       sources."regjsgen-0.5.0"
       (sources."regjsparser-0.6.0" // {
         dependencies = [
@@ -59199,7 +59489,7 @@ in
       sources."restore-cursor-2.0.0"
       sources."ret-0.1.15"
       sources."retry-0.12.0"
-      sources."rimraf-2.6.3"
+      sources."rimraf-2.7.1"
       sources."ripemd160-2.0.2"
       sources."rollup-0.67.0"
       sources."rollup-plugin-babel-4.0.3"
@@ -59217,8 +59507,8 @@ in
       sources."safe-regex-1.1.0"
       sources."schema-utils-1.0.0"
       sources."seek-bzip-1.0.5"
-      sources."semver-5.7.0"
-      sources."serialize-javascript-1.7.0"
+      sources."semver-5.7.1"
+      sources."serialize-javascript-1.9.0"
       sources."set-blocking-2.0.0"
       (sources."set-value-2.0.1" // {
         dependencies = [
@@ -59313,7 +59603,7 @@ in
       sources."supports-color-2.0.0"
       sources."tapable-1.1.3"
       sources."tar-stream-1.6.2"
-      (sources."terser-4.1.3" // {
+      (sources."terser-4.2.1" // {
         dependencies = [
           sources."commander-2.20.0"
           sources."source-map-0.6.1"
@@ -59328,7 +59618,7 @@ in
       sources."through-2.3.8"
       sources."through2-2.0.5"
       sources."timed-out-4.0.1"
-      sources."timers-browserify-2.0.10"
+      sources."timers-browserify-2.0.11"
       sources."to-arraybuffer-1.0.1"
       sources."to-buffer-1.1.1"
       sources."to-fast-properties-2.0.0"
@@ -59388,7 +59678,7 @@ in
       sources."vm-browserify-1.1.0"
       sources."watchpack-1.6.0"
       sources."wcwidth-1.0.1"
-      (sources."webpack-4.39.1" // {
+      (sources."webpack-4.39.3" // {
         dependencies = [
           sources."arr-diff-4.0.0"
           sources."array-unique-0.3.2"
@@ -59430,7 +59720,7 @@ in
           sources."ms-2.0.0"
         ];
       })
-      (sources."webpack-cli-3.3.6" // {
+      (sources."webpack-cli-3.3.7" // {
         dependencies = [
           sources."supports-color-6.1.0"
         ];
@@ -59470,7 +59760,7 @@ in
         dependencies = [
           sources."find-up-3.0.0"
           sources."locate-path-3.0.0"
-          sources."p-limit-2.2.0"
+          sources."p-limit-2.2.1"
           sources."p-locate-3.0.0"
           sources."p-try-2.2.0"
           sources."require-main-filename-2.0.0"
@@ -59583,7 +59873,7 @@ in
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       sources."uri-js-4.2.2"
-      sources."uuid-3.3.2"
+      sources."uuid-3.3.3"
       sources."verror-1.10.0"
     ];
     buildInputs = globalBuildInputs;
@@ -59651,10 +59941,10 @@ in
   meguca = nodeEnv.buildNodePackage {
     name = "meguca";
     packageName = "meguca";
-    version = "1.1.4";
+    version = "1.1.6";
     src = fetchurl {
-      url = "https://registry.npmjs.org/meguca/-/meguca-1.1.4.tgz";
-      sha512 = "ccvNbLwUeWRLWO9l0dZj1G0T+n10MRtORrvuq8/UYBgCKzdmvHW5FTU/3T2yO2P3AK+6Ghsey/+6KBiJpokeSg==";
+      url = "https://registry.npmjs.org/meguca/-/meguca-1.1.6.tgz";
+      sha512 = "kqg6t8mUUpb4WwD+4WqgS41AejdSkIEmPCB7v2D7ioxtLFiCaQUlu+K8rT6qOe3PmMacZ2sZsmdIs5jtYtxPig==";
     };
     dependencies = [
       (sources."@gulp-sourcemaps/identity-map-1.0.2" // {
@@ -59676,7 +59966,7 @@ in
         dependencies = [
           sources."glob-7.1.4"
           sources."minimatch-3.0.4"
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
           sources."uglify-js-2.8.29"
         ];
       })
@@ -59775,7 +60065,6 @@ in
       sources."concat-map-0.0.1"
       sources."convert-source-map-1.6.0"
       sources."copy-descriptor-0.1.1"
-      sources."core-js-2.5.7"
       sources."core-util-is-1.0.2"
       sources."cryptiles-2.0.5"
       (sources."css-2.2.4" // {
@@ -59806,7 +60095,6 @@ in
       sources."deprecated-0.0.1"
       sources."detect-file-1.0.0"
       sources."detect-newline-2.1.0"
-      sources."dom4-2.1.3"
       (sources."duplexer2-0.0.2" // {
         dependencies = [
           sources."isarray-0.0.1"
@@ -59886,7 +60174,7 @@ in
       sources."fragment-cache-0.2.1"
       (sources."fs-mkdirp-stream-1.0.0" // {
         dependencies = [
-          sources."graceful-fs-4.2.1"
+          sources."graceful-fs-4.2.2"
           sources."readable-stream-2.3.6"
           sources."string_decoder-1.1.1"
           sources."through2-2.0.5"
@@ -59917,7 +60205,7 @@ in
         ];
       })
       sources."glogg-1.0.2"
-      sources."graceful-fs-3.0.11"
+      sources."graceful-fs-3.0.12"
       sources."gulp-3.9.1"
       (sources."gulp-clean-css-3.10.0" // {
         dependencies = [
@@ -59941,7 +60229,7 @@ in
       })
       (sources."gulp-sourcemaps-2.6.4" // {
         dependencies = [
-          sources."graceful-fs-4.2.1"
+          sources."graceful-fs-4.2.2"
           sources."readable-stream-2.3.6"
           sources."source-map-0.6.1"
           sources."string_decoder-1.1.1"
@@ -59958,7 +60246,7 @@ in
           sources."extend-shallow-1.1.4"
           sources."glob-7.1.4"
           sources."glob-stream-6.1.0"
-          sources."graceful-fs-4.2.1"
+          sources."graceful-fs-4.2.2"
           sources."kind-of-1.1.0"
           sources."minimatch-3.0.4"
           sources."ordered-read-streams-1.0.1"
@@ -60060,7 +60348,7 @@ in
       sources."lead-1.0.0"
       (sources."less-2.7.3" // {
         dependencies = [
-          sources."graceful-fs-4.2.1"
+          sources."graceful-fs-4.2.2"
         ];
       })
       sources."liftoff-2.5.0"
@@ -60328,7 +60616,7 @@ in
       sources."use-3.1.1"
       sources."user-home-1.1.1"
       sources."util-deprecate-1.0.2"
-      sources."uuid-3.3.2"
+      sources."uuid-3.3.3"
       sources."v8flags-2.1.1"
       sources."value-or-function-3.0.0"
       (sources."verror-1.10.0" // {
@@ -60346,7 +60634,7 @@ in
         dependencies = [
           sources."clone-2.1.2"
           sources."clone-stats-1.0.0"
-          sources."graceful-fs-4.2.1"
+          sources."graceful-fs-4.2.2"
           sources."vinyl-2.2.0"
         ];
       })
@@ -60454,7 +60742,7 @@ in
       sources."p-defer-1.0.0"
       sources."p-finally-1.0.0"
       sources."p-is-promise-2.1.0"
-      sources."p-limit-2.2.0"
+      sources."p-limit-2.2.1"
       sources."p-locate-3.0.0"
       sources."p-try-2.2.0"
       sources."path-exists-3.0.0"
@@ -60463,7 +60751,7 @@ in
       sources."pump-3.0.0"
       sources."require-directory-2.1.1"
       sources."require-main-filename-2.0.0"
-      sources."semver-5.7.0"
+      sources."semver-5.7.1"
       sources."set-blocking-2.0.0"
       sources."shebang-command-1.2.0"
       sources."shebang-regex-1.0.0"
@@ -60533,7 +60821,7 @@ in
       sources."delayed-stream-1.0.0"
       sources."esprima-4.0.1"
       sources."extend-3.0.2"
-      sources."form-data-2.5.0"
+      sources."form-data-2.5.1"
       sources."formidable-1.2.1"
       sources."graphlib-2.1.7"
       sources."inherits-2.0.4"
@@ -60554,7 +60842,7 @@ in
       sources."path-loader-1.0.10"
       sources."process-nextick-args-2.0.1"
       sources."punycode-2.1.1"
-      sources."qs-6.7.0"
+      sources."qs-6.8.0"
       sources."readable-stream-2.3.6"
       sources."safe-buffer-5.1.2"
       sources."slash-2.0.0"
@@ -60593,7 +60881,7 @@ in
       sources."isstream-0.1.2"
       sources."lodash-4.17.15"
       sources."msgpack-lite-0.1.26"
-      sources."semver-5.7.0"
+      sources."semver-5.7.1"
       sources."stack-trace-0.0.10"
       sources."traverse-0.6.6"
       sources."which-1.3.1"
@@ -60674,7 +60962,7 @@ in
       sources."gauge-2.7.4"
       sources."getpass-0.1.7"
       sources."glob-7.1.4"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-unicode-2.0.1"
@@ -60695,7 +60983,7 @@ in
       sources."mime-types-2.1.24"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
-      sources."minipass-2.3.5"
+      sources."minipass-2.5.0"
       sources."minizlib-1.2.1"
       sources."mkdirp-0.5.1"
       sources."nopt-3.0.6"
@@ -60712,7 +61000,7 @@ in
       sources."qs-6.5.2"
       sources."readable-stream-2.3.6"
       sources."request-2.88.0"
-      sources."rimraf-2.6.3"
+      sources."rimraf-2.7.1"
       sources."safe-buffer-5.1.2"
       sources."safer-buffer-2.1.2"
       sources."semver-5.3.0"
@@ -60732,7 +61020,7 @@ in
       sources."tweetnacl-0.14.5"
       sources."uri-js-4.2.2"
       sources."util-deprecate-1.0.2"
-      sources."uuid-3.3.2"
+      sources."uuid-3.3.3"
       sources."verror-1.10.0"
       sources."which-1.3.1"
       sources."wide-align-1.1.3"
@@ -60857,14 +61145,14 @@ in
         ];
       })
       sources."glob-5.0.15"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."har-schema-1.0.5"
       sources."har-validator-4.2.1"
       sources."has-unicode-2.0.1"
       sources."hawk-3.1.3"
       sources."headless-0.1.7"
       sources."hoek-2.16.3"
-      sources."hosted-git-info-2.8.2"
+      sources."hosted-git-info-2.8.4"
       sources."http-errors-1.7.2"
       sources."http-signature-1.1.1"
       sources."iconv-lite-0.4.24"
@@ -60896,7 +61184,6 @@ in
       sources."load-json-file-1.1.0"
       sources."lodash-2.4.2"
       sources."loud-rejection-1.6.0"
-      sources."lru-cache-5.1.1"
       sources."map-obj-1.0.1"
       sources."media-typer-0.3.0"
       sources."meow-3.7.0"
@@ -60918,8 +61205,8 @@ in
       (sources."node-pre-gyp-0.6.39" // {
         dependencies = [
           sources."glob-7.1.4"
-          sources."rimraf-2.6.3"
-          sources."semver-5.7.0"
+          sources."rimraf-2.7.1"
+          sources."semver-5.7.1"
         ];
       })
       sources."nopt-4.0.1"
@@ -61007,7 +61294,7 @@ in
       (sources."tar-pack-3.4.1" // {
         dependencies = [
           sources."glob-7.1.4"
-          sources."rimraf-2.6.3"
+          sources."rimraf-2.7.1"
         ];
       })
       sources."toidentifier-1.0.0"
@@ -61024,7 +61311,7 @@ in
       sources."untildify-2.1.0"
       sources."util-deprecate-1.0.2"
       sources."utils-merge-1.0.1"
-      sources."uuid-3.3.2"
+      sources."uuid-3.3.3"
       sources."v8-debug-1.0.1"
       sources."v8-profiler-5.7.0"
       sources."validate-npm-package-license-3.0.4"
@@ -61054,7 +61341,6 @@ in
       sources."xmldom-0.1.27"
       sources."xtend-4.0.2"
       sources."y18n-3.2.1"
-      sources."yallist-3.0.3"
       sources."yargs-3.32.0"
     ];
     buildInputs = globalBuildInputs;
@@ -61103,7 +61389,7 @@ in
       sources."isarray-1.0.0"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
-      sources."minipass-2.3.5"
+      sources."minipass-2.5.0"
       sources."minizlib-1.2.1"
       sources."mkdirp-0.5.1"
       sources."ms-2.1.2"
@@ -61126,11 +61412,11 @@ in
         ];
       })
       sources."readable-stream-2.3.6"
-      sources."rimraf-2.6.3"
+      sources."rimraf-2.7.1"
       sources."safe-buffer-5.1.2"
       sources."safer-buffer-2.1.2"
       sources."sax-1.2.4"
-      sources."semver-5.7.0"
+      sources."semver-5.7.1"
       sources."set-blocking-2.0.0"
       sources."signal-exit-3.0.2"
       sources."string-width-1.0.2"
@@ -61342,7 +61628,7 @@ in
           sources."string_decoder-1.1.1"
         ];
       })
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-unicode-2.0.1"
@@ -61436,7 +61722,7 @@ in
       sources."mime-types-2.1.24"
       sources."minimatch-3.0.4"
       sources."minimist-1.2.0"
-      (sources."minipass-2.3.5" // {
+      (sources."minipass-2.5.0" // {
         dependencies = [
           sources."yallist-3.0.3"
         ];
@@ -61471,12 +61757,12 @@ in
       sources."next-tick-1.0.0"
       (sources."node-pre-gyp-0.12.0" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
-      sources."node-red-node-email-1.6.2"
+      sources."node-red-node-email-1.6.3"
       sources."node-red-node-feedparser-0.1.14"
-      sources."node-red-node-rbe-0.2.4"
+      sources."node-red-node-rbe-0.2.5"
       sources."node-red-node-sentiment-0.1.4"
       sources."node-red-node-tail-0.0.2"
       sources."node-red-node-twitter-1.1.5"
@@ -61545,7 +61831,7 @@ in
         ];
       })
       sources."retry-0.6.1"
-      sources."rimraf-2.6.3"
+      sources."rimraf-2.7.1"
       sources."safe-buffer-5.1.2"
       sources."safer-buffer-2.1.2"
       sources."sax-1.2.4"
@@ -61569,10 +61855,14 @@ in
       sources."stream-shift-1.0.0"
       sources."streamsearch-0.1.2"
       sources."string-width-1.0.2"
-      sources."string_decoder-1.2.0"
+      (sources."string_decoder-1.3.0" // {
+        dependencies = [
+          sources."safe-buffer-5.2.0"
+        ];
+      })
       sources."strip-ansi-3.0.1"
       sources."strip-json-comments-2.0.1"
-      sources."tail-2.0.2"
+      sources."tail-2.0.3"
       (sources."tar-4.4.10" // {
         dependencies = [
           sources."yallist-3.0.3"
@@ -61616,7 +61906,7 @@ in
       })
       sources."util-deprecate-1.0.2"
       sources."utils-merge-1.0.1"
-      sources."uuid-3.3.2"
+      sources."uuid-3.3.3"
       sources."vary-1.1.2"
       sources."verror-1.10.0"
       (sources."websocket-stream-5.5.0" // {
@@ -61707,11 +61997,11 @@ in
       sources."gauge-2.7.4"
       sources."getpass-0.1.7"
       sources."glob-7.1.4"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-unicode-2.0.1"
-      sources."hosted-git-info-2.8.2"
+      sources."hosted-git-info-2.8.4"
       sources."http-signature-1.2.0"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
@@ -61726,12 +62016,11 @@ in
       sources."json-stringify-safe-5.0.1"
       sources."jsonfile-1.0.1"
       sources."jsprim-1.4.1"
-      sources."lru-cache-5.1.1"
       sources."mime-db-1.40.0"
       sources."mime-types-2.1.24"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
-      sources."minipass-2.3.5"
+      sources."minipass-2.5.0"
       sources."minizlib-1.2.1"
       sources."mkdirp-0.5.1"
       sources."ncp-0.4.2"
@@ -61739,17 +62028,17 @@ in
       sources."nopt-3.0.6"
       (sources."normalize-package-data-2.5.0" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
-      (sources."npm-package-arg-6.1.0" // {
+      (sources."npm-package-arg-6.1.1" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       (sources."npm-registry-client-8.6.0" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       (sources."npmconf-2.1.3" // {
@@ -61817,7 +62106,7 @@ in
       sources."uid-number-0.0.5"
       sources."uri-js-4.2.2"
       sources."util-deprecate-1.0.2"
-      sources."uuid-3.3.2"
+      sources."uuid-3.3.3"
       sources."validate-npm-package-license-3.0.4"
       sources."validate-npm-package-name-3.0.0"
       sources."verror-1.10.0"
@@ -61879,7 +62168,7 @@ in
       sources."camelcase-4.1.0"
       sources."capture-stack-trace-1.0.1"
       sources."chalk-2.4.2"
-      sources."chokidar-2.1.6"
+      sources."chokidar-2.1.8"
       sources."ci-info-1.6.0"
       (sources."class-utils-0.3.6" // {
         dependencies = [
@@ -61968,7 +62257,7 @@ in
       })
       sources."global-dirs-0.1.1"
       sources."got-6.7.1"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."has-flag-3.0.0"
       sources."has-value-1.0.0"
       (sources."has-values-1.0.0" // {
@@ -62066,7 +62355,7 @@ in
       sources."ret-0.1.15"
       sources."safe-buffer-5.1.2"
       sources."safe-regex-1.1.0"
-      sources."semver-5.7.0"
+      sources."semver-5.7.1"
       sources."semver-diff-2.1.0"
       (sources."set-value-2.0.1" // {
         dependencies = [
@@ -62190,10 +62479,10 @@ in
   npm = nodeEnv.buildNodePackage {
     name = "npm";
     packageName = "npm";
-    version = "6.10.2";
+    version = "6.11.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/npm/-/npm-6.10.2.tgz";
-      sha512 = "B6n5dgmsl1fpBYhor2OTEn9Md0r63/FpQocDn4WNT4gIQRQZLql9g+mk8s3j9qZD370kUTzwDaOBSmDdNGK3NA==";
+      url = "https://registry.npmjs.org/npm/-/npm-6.11.2.tgz";
+      sha512 = "OAkXqI4bm5MUvqVvqe6rxCXmJqrln8VDlkdftpOoayHKazz8IOCJAiCuKmz0TchL224EAKeG86umuD6RYNpuEg==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -62207,10 +62496,10 @@ in
   npm-check-updates = nodeEnv.buildNodePackage {
     name = "npm-check-updates";
     packageName = "npm-check-updates";
-    version = "3.1.20";
+    version = "3.1.21";
     src = fetchurl {
-      url = "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-3.1.20.tgz";
-      sha512 = "mc9BAoOYSTwP/IvoA+ofdkWSipwRvhgC0qop1PvlMZojgzi7N/dykdxOIWrw0OlZPnEKvXkKFEuPk97LrvXE1A==";
+      url = "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-3.1.21.tgz";
+      sha512 = "t7KygdHZ1cF2jS6kcOPiUg6s53Sq5jcOqHnddOe92qW7Xd4mh9AUT52OYYQ0YfAiP7VIdZ5379/G/atG6J0WDA==";
     };
     dependencies = [
       sources."@sindresorhus/is-0.14.0"
@@ -62229,7 +62518,7 @@ in
       sources."brace-expansion-1.1.11"
       sources."buffer-from-1.1.1"
       sources."builtins-1.0.3"
-      sources."cacache-12.0.2"
+      sources."cacache-12.0.3"
       (sources."cacheable-request-6.1.0" // {
         dependencies = [
           sources."get-stream-5.1.0"
@@ -62248,7 +62537,7 @@ in
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
       sources."colors-1.0.3"
-      sources."commander-2.20.0"
+      sources."commander-3.0.0"
       sources."concat-map-0.0.1"
       sources."concat-stream-1.6.2"
       sources."configstore-4.0.0"
@@ -62300,11 +62589,11 @@ in
       sources."glob-7.1.4"
       sources."global-dirs-0.1.1"
       sources."got-9.6.0"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."has-ansi-2.0.0"
       sources."has-flag-3.0.0"
       sources."has-yarn-2.1.0"
-      sources."hosted-git-info-2.8.2"
+      sources."hosted-git-info-2.8.4"
       sources."http-cache-semantics-3.8.1"
       sources."http-proxy-agent-2.1.0"
       sources."https-proxy-agent-2.2.2"
@@ -62360,7 +62649,7 @@ in
       sources."mimic-response-1.0.1"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
-      sources."minipass-2.3.5"
+      sources."minipass-2.5.0"
       sources."minizlib-1.2.1"
       sources."mississippi-3.0.0"
       sources."mkdirp-0.5.1"
@@ -62377,20 +62666,20 @@ in
       sources."node-fetch-npm-2.0.2"
       (sources."normalize-package-data-2.5.0" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       sources."normalize-url-4.3.0"
       sources."npm-bundled-1.0.6"
-      (sources."npm-package-arg-6.1.0" // {
+      (sources."npm-package-arg-6.1.1" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       sources."npm-packlist-1.4.4"
-      (sources."npm-pick-manifest-2.2.3" // {
+      (sources."npm-pick-manifest-3.0.1" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       sources."npm-registry-fetch-4.0.0"
@@ -62403,13 +62692,13 @@ in
       sources."osenv-0.1.5"
       sources."p-cancelable-1.1.0"
       sources."p-finally-1.0.0"
-      sources."p-limit-2.2.0"
+      sources."p-limit-2.2.1"
       sources."p-locate-4.1.0"
       sources."p-try-2.2.0"
       sources."package-json-6.5.0"
-      (sources."pacote-9.5.4" // {
+      (sources."pacote-9.5.8" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       sources."parallel-transform-1.1.0"
@@ -62460,14 +62749,14 @@ in
       sources."resolve-1.12.0"
       sources."responselike-1.0.2"
       sources."retry-0.10.1"
-      sources."rimraf-2.6.3"
+      sources."rimraf-2.7.1"
       sources."run-queue-1.0.3"
       sources."safe-buffer-5.2.0"
       sources."safer-buffer-2.1.2"
       sources."semver-6.3.0"
       (sources."semver-diff-2.1.0" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       sources."semver-utils-1.1.4"
@@ -62605,7 +62894,7 @@ in
       sources."fs.realpath-1.0.0"
       (sources."fstream-0.1.31" // {
         dependencies = [
-          sources."graceful-fs-3.0.11"
+          sources."graceful-fs-3.0.12"
           sources."mkdirp-0.5.1"
         ];
       })
@@ -62670,7 +62959,7 @@ in
       })
       sources."request-2.88.0"
       sources."retry-0.6.0"
-      sources."rimraf-2.6.3"
+      sources."rimraf-2.7.1"
       sources."safe-buffer-5.2.0"
       sources."safer-buffer-2.1.2"
       sources."semver-4.3.6"
@@ -62707,7 +62996,7 @@ in
       sources."underscore.string-2.3.3"
       sources."uri-js-4.2.2"
       sources."util-deprecate-1.0.2"
-      sources."uuid-3.3.2"
+      sources."uuid-3.3.3"
       sources."verror-1.10.0"
       sources."walk-2.3.14"
       sources."wide-align-1.1.3"
@@ -62911,12 +63200,12 @@ in
       sources."@parcel/watcher-1.12.0"
       sources."@parcel/workers-1.11.0"
       sources."@types/q-1.5.2"
-      sources."abab-2.0.0"
+      sources."abab-2.0.1"
       sources."abbrev-1.1.1"
       sources."acorn-5.7.3"
       (sources."acorn-globals-4.3.3" // {
         dependencies = [
-          sources."acorn-6.2.1"
+          sources."acorn-6.3.0"
         ];
       })
       sources."acorn-walk-6.2.0"
@@ -63010,7 +63299,7 @@ in
       sources."caniuse-lite-1.0.30000989"
       sources."caseless-0.12.0"
       sources."chalk-2.4.2"
-      sources."chokidar-2.1.6"
+      sources."chokidar-2.1.8"
       sources."cipher-base-1.0.4"
       sources."class-utils-0.3.6"
       sources."cli-cursor-2.1.0"
@@ -63145,7 +63434,7 @@ in
       sources."ecc-jsbn-0.1.2"
       sources."editorconfig-0.15.3"
       sources."ee-first-1.1.1"
-      sources."electron-to-chromium-1.3.215"
+      sources."electron-to-chromium-1.3.245"
       sources."elliptic-6.5.0"
       sources."encodeurl-1.0.2"
       sources."entities-1.1.2"
@@ -63156,7 +63445,7 @@ in
       sources."escape-string-regexp-1.0.5"
       sources."escodegen-1.9.1"
       sources."esprima-3.1.3"
-      sources."estraverse-4.2.0"
+      sources."estraverse-4.3.0"
       sources."esutils-2.0.3"
       sources."etag-1.8.1"
       sources."events-3.0.0"
@@ -63203,7 +63492,7 @@ in
       })
       sources."glob-to-regexp-0.3.0"
       sources."globals-11.12.0"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."grapheme-breaker-0.3.2"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
@@ -63232,7 +63521,7 @@ in
       sources."html-tags-1.2.0"
       (sources."htmlnano-0.2.4" // {
         dependencies = [
-          sources."terser-4.1.3"
+          sources."terser-4.2.1"
         ];
       })
       (sources."htmlparser2-3.10.1" // {
@@ -63252,7 +63541,6 @@ in
       sources."inherits-2.0.4"
       sources."ini-1.3.5"
       sources."invariant-2.2.4"
-      sources."ip-regex-2.1.0"
       sources."is-absolute-url-2.1.0"
       (sources."is-accessor-descriptor-1.0.0" // {
         dependencies = [
@@ -63295,7 +63583,7 @@ in
       sources."isexe-2.0.0"
       sources."isobject-3.0.1"
       sources."isstream-0.1.2"
-      sources."js-beautify-1.10.1"
+      sources."js-beautify-1.10.2"
       sources."js-levenshtein-1.1.6"
       sources."js-tokens-4.0.0"
       (sources."js-yaml-3.13.1" // {
@@ -63304,11 +63592,11 @@ in
         ];
       })
       sources."jsbn-0.1.1"
-      (sources."jsdom-15.1.1" // {
+      (sources."jsdom-14.1.0" // {
         dependencies = [
-          sources."acorn-6.2.1"
-          sources."escodegen-1.11.1"
-          sources."ws-7.1.1"
+          sources."acorn-6.3.0"
+          sources."escodegen-1.12.0"
+          sources."ws-6.2.1"
         ];
       })
       sources."jsesc-2.5.2"
@@ -63384,7 +63672,7 @@ in
           sources."punycode-1.4.1"
         ];
       })
-      sources."node-releases-1.1.26"
+      sources."node-releases-1.1.28"
       sources."nopt-4.0.1"
       sources."normalize-html-whitespace-1.0.0"
       sources."normalize-path-3.0.0"
@@ -63493,7 +63781,7 @@ in
       sources."postcss-svgo-4.0.2"
       sources."postcss-unique-selectors-4.0.1"
       sources."postcss-value-parser-3.3.1"
-      sources."posthtml-0.11.4"
+      sources."posthtml-0.11.6"
       sources."posthtml-parser-0.4.1"
       sources."posthtml-render-1.1.5"
       sources."prelude-ls-1.1.2"
@@ -63529,8 +63817,8 @@ in
           sources."is-extendable-1.0.1"
         ];
       })
-      sources."regexp-tree-0.1.11"
-      sources."regexpu-core-4.5.4"
+      sources."regexp-tree-0.1.12"
+      sources."regexpu-core-4.5.5"
       sources."regjsgen-0.5.0"
       (sources."regjsparser-0.6.0" // {
         dependencies = [
@@ -63547,11 +63835,7 @@ in
         ];
       })
       sources."request-promise-core-1.1.2"
-      (sources."request-promise-native-1.0.7" // {
-        dependencies = [
-          sources."tough-cookie-2.5.0"
-        ];
-      })
+      sources."request-promise-native-1.0.7"
       sources."resolve-1.12.0"
       sources."resolve-from-3.0.0"
       sources."resolve-url-0.2.1"
@@ -63559,7 +63843,7 @@ in
       sources."ret-0.1.15"
       sources."rgb-regex-1.0.1"
       sources."rgba-regex-1.0.0"
-      sources."rimraf-2.6.3"
+      sources."rimraf-2.7.1"
       sources."ripemd160-2.0.2"
       sources."safe-buffer-5.1.2"
       sources."safe-regex-1.1.0"
@@ -63567,7 +63851,7 @@ in
       sources."safer-eval-1.3.5"
       sources."sax-1.2.4"
       sources."saxes-3.1.11"
-      sources."semver-5.7.0"
+      sources."semver-5.7.1"
       (sources."send-0.17.1" // {
         dependencies = [
           (sources."debug-2.6.9" // {
@@ -63639,7 +63923,7 @@ in
       sources."symbol-tree-3.2.4"
       sources."terser-3.17.0"
       sources."through2-2.0.5"
-      sources."timers-browserify-2.0.10"
+      sources."timers-browserify-2.0.11"
       sources."timsort-0.3.0"
       sources."tiny-inflate-1.0.2"
       sources."to-arraybuffer-1.0.1"
@@ -63654,7 +63938,7 @@ in
       })
       sources."to-regex-range-2.1.1"
       sources."toidentifier-1.0.0"
-      sources."tough-cookie-3.0.1"
+      sources."tough-cookie-2.5.0"
       sources."tr46-1.0.1"
       sources."trim-right-1.0.1"
       sources."tty-browserify-0.0.0"
@@ -63662,10 +63946,10 @@ in
       sources."tweetnacl-0.14.5"
       sources."type-check-0.3.2"
       sources."typedarray-0.0.6"
-      (sources."uncss-0.17.0" // {
+      (sources."uncss-0.17.2" // {
         dependencies = [
           sources."cssesc-3.0.0"
-          sources."is-absolute-url-3.0.0"
+          sources."is-absolute-url-3.0.1"
           sources."postcss-selector-parser-6.0.2"
         ];
       })
@@ -63705,7 +63989,7 @@ in
       })
       sources."util-deprecate-1.0.2"
       sources."util.promisify-1.0.0"
-      sources."uuid-3.3.2"
+      sources."uuid-3.3.3"
       sources."v8-compile-cache-2.1.0"
       sources."vendors-1.0.3"
       sources."verror-1.10.0"
@@ -63791,6 +64075,9 @@ in
       sources."camelcase-keys-2.1.0"
       sources."chalk-1.1.3"
       sources."chardet-0.4.2"
+      sources."chrome-dgram-3.0.2"
+      sources."chrome-dns-1.0.1"
+      sources."chrome-net-3.3.3"
       sources."cli-cursor-2.1.0"
       sources."cli-width-2.2.0"
       sources."clivas-0.2.0"
@@ -63808,8 +64095,9 @@ in
       sources."debug-2.6.9"
       sources."decamelize-1.2.0"
       sources."decompress-response-3.3.0"
-      sources."deep-equal-1.0.1"
+      sources."deep-equal-1.1.0"
       sources."deep-extend-0.6.0"
+      sources."define-properties-1.1.3"
       sources."dns-equal-1.0.0"
       sources."dns-packet-1.3.1"
       sources."dns-txt-2.0.2"
@@ -63828,14 +64116,16 @@ in
         ];
       })
       sources."fs.realpath-1.0.0"
+      sources."function-bind-1.1.1"
       sources."get-browser-rtc-1.0.2"
       sources."get-stdin-4.0.1"
       sources."glob-7.1.4"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
+      sources."has-1.0.3"
       sources."has-ansi-2.0.0"
       sources."has-flag-3.0.0"
       sources."hat-0.0.3"
-      sources."hosted-git-info-2.8.2"
+      sources."hosted-git-info-2.8.4"
       sources."http-headers-3.0.2"
       sources."iconv-lite-0.4.24"
       sources."immediate-chunk-store-1.0.8"
@@ -63859,10 +64149,13 @@ in
       sources."ip-1.1.5"
       sources."ip-set-1.0.2"
       sources."ipaddr.js-1.9.1"
+      sources."is-arguments-1.0.4"
       sources."is-arrayish-0.2.1"
+      sources."is-date-object-1.0.1"
       sources."is-finite-1.0.2"
       sources."is-fullwidth-code-point-1.0.0"
       sources."is-promise-2.1.0"
+      sources."is-regex-1.0.4"
       sources."is-utf8-0.2.1"
       sources."isarray-1.0.0"
       sources."k-bucket-0.6.0"
@@ -63871,13 +64164,12 @@ in
           sources."k-bucket-2.0.1"
         ];
       })
-      sources."k-rpc-socket-1.8.0"
+      sources."k-rpc-socket-1.11.1"
       sources."keypress-0.2.1"
       sources."load-json-file-1.1.0"
       sources."lodash-3.10.1"
       sources."loud-rejection-1.6.0"
       sources."lru-2.0.1"
-      sources."lru-cache-5.1.1"
       sources."magnet-uri-5.2.4"
       sources."map-obj-1.0.1"
       sources."meow-3.7.0"
@@ -63897,6 +64189,8 @@ in
       sources."number-is-nan-1.0.1"
       sources."numeral-2.0.6"
       sources."object-assign-4.1.1"
+      sources."object-is-1.0.1"
+      sources."object-keys-1.1.1"
       sources."once-1.4.0"
       sources."onetime-2.0.1"
       sources."open-0.0.5"
@@ -63953,11 +64247,12 @@ in
       sources."read-pkg-up-1.0.1"
       sources."readable-stream-2.3.6"
       sources."redent-1.0.0"
+      sources."regexp.prototype.flags-1.2.0"
       sources."repeating-2.0.1"
       sources."resolve-1.12.0"
       sources."restore-cursor-2.0.0"
       sources."reverse-http-1.3.0"
-      sources."rimraf-2.6.3"
+      sources."rimraf-2.7.1"
       sources."run-async-2.3.0"
       sources."run-parallel-1.1.9"
       sources."run-series-1.1.8"
@@ -63965,7 +64260,7 @@ in
       sources."rxjs-5.5.12"
       sources."safe-buffer-5.1.2"
       sources."safer-buffer-2.1.2"
-      sources."semver-5.7.0"
+      sources."semver-5.7.1"
       sources."server-destroy-1.0.1"
       sources."signal-exit-3.0.2"
       sources."simple-concat-1.0.0"
@@ -64027,7 +64322,6 @@ in
       sources."xmlbuilder-4.0.0"
       sources."xmldom-0.1.27"
       sources."xtend-4.0.2"
-      sources."yallist-3.0.3"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -64096,7 +64390,7 @@ in
         ];
       })
       sources."brace-expansion-1.1.11"
-      sources."buffer-5.2.1"
+      sources."buffer-5.4.2"
       sources."buffer-alloc-1.2.0"
       sources."buffer-alloc-unsafe-1.1.0"
       sources."buffer-crc32-0.2.13"
@@ -64107,6 +64401,9 @@ in
       sources."bytes-2.1.0"
       sources."callsite-1.0.0"
       sources."caseless-0.12.0"
+      sources."chrome-dgram-3.0.2"
+      sources."chrome-dns-1.0.1"
+      sources."chrome-net-3.3.3"
       sources."combined-stream-1.0.8"
       sources."commander-2.6.0"
       sources."compact2string-1.4.1"
@@ -64223,7 +64520,7 @@ in
       sources."get-browser-rtc-1.0.2"
       sources."getpass-0.1.7"
       sources."glob-7.1.4"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       (sources."has-binary-0.1.7" // {
@@ -64260,7 +64557,7 @@ in
           sources."k-bucket-2.0.1"
         ];
       })
-      (sources."k-rpc-socket-1.8.0" // {
+      (sources."k-rpc-socket-1.11.1" // {
         dependencies = [
           sources."bencode-2.0.1"
         ];
@@ -64357,7 +64654,7 @@ in
       sources."readable-stream-3.4.0"
       sources."request-2.88.0"
       sources."response-time-2.3.2"
-      sources."rimraf-2.6.3"
+      sources."rimraf-2.7.1"
       sources."rndm-1.2.0"
       sources."run-parallel-1.1.9"
       sources."run-series-1.1.8"
@@ -64477,7 +64774,7 @@ in
       sources."util-deprecate-1.0.2"
       sources."utils-merge-1.0.0"
       sources."utp-0.0.7"
-      sources."uuid-3.3.2"
+      sources."uuid-3.3.3"
       sources."vary-1.0.1"
       sources."verror-1.10.0"
       sources."vhost-3.0.2"
@@ -64502,10 +64799,10 @@ in
   pnpm = nodeEnv.buildNodePackage {
     name = "pnpm";
     packageName = "pnpm";
-    version = "3.6.3";
+    version = "3.7.5";
     src = fetchurl {
-      url = "https://registry.npmjs.org/pnpm/-/pnpm-3.6.3.tgz";
-      sha512 = "Hxk8VouMZRh870u0hJHCcumylGO8VV6Id+Fm7S+MyZVGGgtaZlEFFV2HIndVd9nXTksS+RuhINX6jGIVmqTmDg==";
+      url = "https://registry.npmjs.org/pnpm/-/pnpm-3.7.5.tgz";
+      sha512 = "hEigYLg2GHIxHa2zx8kFTIFanfd/efuJL9XPxAjsKElKLySs4LS1yOfZ5uLYI3adv+6WxnrHBAP2lV1yuaJlbA==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -64543,13 +64840,9 @@ in
     };
     dependencies = [
       sources."JSONStream-1.3.5"
-      sources."acorn-6.2.1"
-      sources."acorn-dynamic-import-4.0.0"
-      sources."acorn-node-1.7.0"
-      sources."acorn-walk-6.2.0"
-      sources."array-filter-0.0.1"
-      sources."array-map-0.0.0"
-      sources."array-reduce-0.0.0"
+      sources."acorn-7.0.0"
+      sources."acorn-node-1.8.2"
+      sources."acorn-walk-7.0.0"
       sources."asn1.js-4.10.1"
       (sources."assert-1.5.0" // {
         dependencies = [
@@ -64569,7 +64862,7 @@ in
           sources."resolve-1.1.7"
         ];
       })
-      (sources."browserify-16.3.0" // {
+      (sources."browserify-16.5.0" // {
         dependencies = [
           sources."concat-stream-1.6.2"
         ];
@@ -64587,7 +64880,7 @@ in
       sources."browserify-rsa-4.0.1"
       sources."browserify-sign-4.0.4"
       sources."browserify-zlib-0.2.0"
-      sources."buffer-5.2.1"
+      sources."buffer-5.4.2"
       sources."buffer-crc32-0.2.13"
       sources."buffer-from-1.1.1"
       sources."buffer-xor-1.0.3"
@@ -64633,7 +64926,7 @@ in
       sources."get-assigned-identifiers-1.2.0"
       sources."glob-7.1.4"
       sources."globule-1.2.1"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."has-1.0.3"
       sources."hash-base-3.0.4"
       sources."hash.js-1.1.7"
@@ -64711,13 +65004,13 @@ in
         ];
       })
       sources."resolve-1.12.0"
-      sources."rimraf-2.6.3"
+      sources."rimraf-2.7.1"
       sources."ripemd160-2.0.2"
       sources."safe-buffer-5.2.0"
       sources."sander-0.5.1"
       sources."sha.js-2.4.11"
       sources."shasum-1.0.2"
-      sources."shell-quote-1.6.1"
+      sources."shell-quote-1.7.1"
       sources."simple-concat-1.0.0"
       (sources."sorcery-0.10.0" // {
         dependencies = [
@@ -64728,24 +65021,27 @@ in
       sources."sourcemap-codec-1.4.6"
       sources."stream-browserify-2.0.2"
       sources."stream-combiner2-1.1.1"
-      sources."stream-http-2.8.3"
-      sources."stream-splicer-2.0.1"
-      (sources."string_decoder-1.2.0" // {
+      (sources."stream-http-3.1.0" // {
         dependencies = [
-          sources."safe-buffer-5.1.2"
+          sources."readable-stream-3.4.0"
         ];
       })
+      sources."stream-splicer-2.0.1"
+      sources."string_decoder-1.3.0"
       (sources."subarg-1.0.0" // {
         dependencies = [
           sources."minimist-1.2.0"
         ];
       })
       sources."syntax-error-1.4.0"
-      sources."temp-0.9.0"
+      (sources."temp-0.9.0" // {
+        dependencies = [
+          sources."rimraf-2.6.3"
+        ];
+      })
       sources."through-2.3.8"
       sources."through2-2.0.5"
       sources."timers-browserify-1.4.2"
-      sources."to-arraybuffer-1.0.1"
       sources."tree-kill-1.2.1"
       sources."tty-browserify-0.0.1"
       sources."typedarray-0.0.6"
@@ -64795,15 +65091,21 @@ in
       sources."colors-0.6.2"
       sources."concat-map-0.0.1"
       sources."cycle-1.0.3"
-      sources."deep-equal-1.0.1"
+      sources."deep-equal-1.1.0"
+      sources."define-properties-1.1.3"
       sources."escape-string-regexp-1.0.5"
       sources."eyes-0.1.8"
       sources."fs.realpath-1.0.0"
+      sources."function-bind-1.1.1"
       sources."glob-7.1.4"
+      sources."has-1.0.3"
       sources."has-ansi-2.0.0"
       sources."i-0.3.6"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
+      sources."is-arguments-1.0.4"
+      sources."is-date-object-1.0.1"
+      sources."is-regex-1.0.4"
       sources."isstream-0.1.2"
       sources."minimatch-3.0.4"
       sources."minimist-1.2.0"
@@ -64814,14 +65116,17 @@ in
       })
       sources."mute-stream-0.0.8"
       sources."ncp-0.4.2"
+      sources."object-is-1.0.1"
+      sources."object-keys-1.1.1"
       sources."once-1.4.0"
       sources."path-is-absolute-1.0.1"
       sources."pkginfo-0.4.1"
       sources."prompt-0.2.14"
       sources."read-1.0.7"
+      sources."regexp.prototype.flags-1.2.0"
       sources."revalidator-0.1.8"
-      sources."rimraf-2.6.3"
-      sources."semver-5.7.0"
+      sources."rimraf-2.7.1"
+      sources."semver-5.7.1"
       sources."stack-trace-0.0.10"
       sources."strip-ansi-3.0.1"
       sources."supports-color-2.0.0"
@@ -64865,7 +65170,7 @@ in
       sources."esprima-3.1.3"
       sources."esprima-fb-13001.1001.0-dev-harmony-fb"
       sources."glob-5.0.15"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."iconv-lite-0.4.24"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
@@ -65036,7 +65341,7 @@ in
       sources."uid2-0.0.3"
       sources."uri-js-4.2.2"
       sources."util-0.4.9"
-      sources."uuid-3.3.2"
+      sources."uuid-3.3.3"
       sources."verror-1.10.0"
       sources."xml2js-0.2.4"
       sources."xmlbuilder-0.4.2"
@@ -65385,7 +65690,7 @@ in
       sources."uri-js-4.2.2"
       sources."utf8-2.0.0"
       sources."utils-merge-1.0.1"
-      sources."uuid-3.3.2"
+      sources."uuid-3.3.3"
       sources."vary-1.1.2"
       sources."verror-1.10.0"
       (sources."ws-0.4.31" // {
@@ -65495,7 +65800,7 @@ in
       sources."for-in-1.0.2"
       sources."fragment-cache-0.2.1"
       sources."get-value-2.0.6"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."graceful-readlink-1.0.1"
       sources."has-value-1.0.0"
       (sources."has-values-1.0.0" // {
@@ -65788,24 +66093,29 @@ in
   snyk = nodeEnv.buildNodePackage {
     name = "snyk";
     packageName = "snyk";
-    version = "1.210.0";
+    version = "1.221.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/snyk/-/snyk-1.210.0.tgz";
-      sha512 = "k6/EIX1Dc4Qk8omcKQDm13RRywkKqXoQ0IMz5Nyk1y8sdmg1S78QSWnfTaEPe+OQE1olrtjInrDX3Yu20CnMzg==";
+      url = "https://registry.npmjs.org/snyk/-/snyk-1.221.1.tgz";
+      sha512 = "2NpAeh/r/74dZL8HM/I2OlH/AieTJGKyvF0Ux2YADI/7hSHSLgvrUamH6f53KzwEqDbVdewxzoIc3p9rUMG1Ew==";
     };
     dependencies = [
+      sources."@snyk/cli-interface-2.0.3"
       sources."@snyk/composer-lockfile-parser-1.0.3"
       sources."@snyk/dep-graph-1.12.0"
       sources."@snyk/gemfile-1.2.0"
       sources."@types/agent-base-4.2.0"
-      sources."@types/debug-4.1.4"
+      sources."@types/bunyan-1.8.6"
+      sources."@types/debug-4.1.5"
       sources."@types/events-3.0.0"
-      sources."@types/node-12.6.9"
+      sources."@types/node-12.7.3"
+      sources."@types/restify-4.3.6"
+      sources."@types/semver-5.5.0"
+      sources."@types/xml2js-0.4.3"
       sources."@yarnpkg/lockfile-1.1.0"
       sources."abbrev-1.1.1"
       sources."agent-base-4.3.0"
       sources."ansi-align-2.0.0"
-      sources."ansi-escapes-4.2.1"
+      sources."ansi-escapes-3.2.0"
       sources."ansi-regex-3.0.0"
       sources."ansi-styles-3.2.1"
       sources."ansicolors-0.3.2"
@@ -65850,13 +66160,13 @@ in
       sources."create-error-class-3.0.2"
       (sources."cross-spawn-6.0.5" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       sources."crypto-random-string-1.0.0"
       (sources."data-uri-to-buffer-2.0.1" // {
         dependencies = [
-          sources."@types/node-8.10.51"
+          sources."@types/node-8.10.53"
         ];
       })
       sources."debug-3.2.6"
@@ -65868,15 +66178,16 @@ in
       sources."diff-4.0.1"
       sources."dockerfile-ast-0.0.16"
       sources."dot-prop-4.2.0"
+      sources."dotnet-deps-parser-4.5.0"
       sources."duplexer3-0.1.4"
       sources."email-validator-2.0.4"
       sources."end-of-stream-1.4.1"
       sources."es6-promise-4.2.8"
       sources."es6-promisify-5.0.0"
       sources."escape-string-regexp-1.0.5"
-      sources."escodegen-1.11.1"
+      sources."escodegen-1.12.0"
       sources."esprima-3.1.3"
-      sources."estraverse-4.2.0"
+      sources."estraverse-4.3.0"
       sources."esutils-2.0.3"
       sources."execa-1.0.0"
       sources."extend-3.0.2"
@@ -65907,15 +66218,10 @@ in
           sources."get-stream-3.0.0"
         ];
       })
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."graphlib-2.1.7"
       sources."has-flag-3.0.0"
-      (sources."hosted-git-info-2.8.2" // {
-        dependencies = [
-          sources."lru-cache-5.1.1"
-          sources."yallist-3.0.3"
-        ];
-      })
+      sources."hosted-git-info-2.8.4"
       sources."http-errors-1.7.3"
       (sources."http-proxy-agent-2.1.0" // {
         dependencies = [
@@ -65931,11 +66237,7 @@ in
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
       sources."ini-1.3.5"
-      (sources."inquirer-6.5.0" // {
-        dependencies = [
-          sources."ansi-escapes-3.2.0"
-        ];
-      })
+      sources."inquirer-6.5.2"
       sources."invert-kv-1.0.0"
       sources."ip-1.1.5"
       sources."is-buffer-1.1.6"
@@ -65965,6 +66267,7 @@ in
         dependencies = [
           sources."isarray-1.0.0"
           sources."readable-stream-2.3.6"
+          sources."safe-buffer-5.1.2"
           sources."string_decoder-1.1.1"
         ];
       })
@@ -66016,7 +66319,7 @@ in
       sources."pac-resolver-3.0.0"
       (sources."package-json-4.0.1" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       sources."pako-1.0.10"
@@ -66039,23 +66342,23 @@ in
       sources."rc-1.2.8"
       (sources."readable-stream-3.4.0" // {
         dependencies = [
-          sources."string_decoder-1.2.0"
+          sources."string_decoder-1.3.0"
         ];
       })
       sources."registry-auth-token-3.4.0"
       sources."registry-url-3.1.0"
       sources."restore-cursor-2.0.0"
-      sources."rimraf-2.6.3"
+      sources."rimraf-2.7.1"
       sources."run-async-2.3.0"
       sources."rxjs-6.5.2"
-      sources."safe-buffer-5.1.2"
+      sources."safe-buffer-5.2.0"
       sources."safer-buffer-2.1.2"
       sources."sax-1.2.4"
       sources."secure-keys-1.0.0"
       sources."semver-6.3.0"
       (sources."semver-diff-2.1.0" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       sources."set-immediate-shim-1.0.1"
@@ -66070,7 +66373,7 @@ in
       sources."signal-exit-3.0.2"
       sources."smart-buffer-4.0.2"
       sources."snyk-config-2.2.3"
-      (sources."snyk-docker-plugin-1.25.1" // {
+      (sources."snyk-docker-plugin-1.29.1" // {
         dependencies = [
           sources."debug-4.1.1"
         ];
@@ -66081,19 +66384,19 @@ in
           sources."debug-4.1.1"
         ];
       })
-      (sources."snyk-gradle-plugin-2.12.5" // {
+      (sources."snyk-gradle-plugin-3.0.2" // {
         dependencies = [
           sources."debug-4.1.1"
         ];
       })
       sources."snyk-module-1.9.1"
-      (sources."snyk-mvn-plugin-2.3.3" // {
+      (sources."snyk-mvn-plugin-2.4.0" // {
         dependencies = [
           sources."tslib-1.9.3"
         ];
       })
       sources."snyk-nodejs-lockfile-parser-1.16.0"
-      sources."snyk-nuget-plugin-1.11.3"
+      sources."snyk-nuget-plugin-1.12.1"
       sources."snyk-paket-parser-1.5.0"
       (sources."snyk-php-plugin-1.6.4" // {
         dependencies = [
@@ -66101,14 +66404,15 @@ in
         ];
       })
       sources."snyk-policy-1.13.5"
-      sources."snyk-python-plugin-1.10.2"
+      sources."snyk-python-plugin-1.13.2"
       sources."snyk-resolve-1.0.1"
-      (sources."snyk-resolve-deps-4.0.3" // {
+      (sources."snyk-resolve-deps-4.4.0" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."@types/node-6.14.7"
+          sources."semver-5.7.1"
         ];
       })
-      (sources."snyk-sbt-plugin-2.6.1" // {
+      (sources."snyk-sbt-plugin-2.7.0" // {
         dependencies = [
           sources."tmp-0.1.0"
         ];
@@ -66158,14 +66462,13 @@ in
       sources."tree-kill-1.2.1"
       sources."tslib-1.10.0"
       sources."type-check-0.3.2"
-      sources."type-fest-0.5.2"
       sources."unique-string-1.0.0"
       sources."unpipe-1.0.0"
       sources."unzip-response-2.0.1"
       sources."update-notifier-2.5.0"
       sources."url-parse-lax-1.0.0"
       sources."util-deprecate-1.0.2"
-      sources."uuid-3.3.2"
+      sources."uuid-3.3.3"
       sources."vscode-languageserver-types-3.14.0"
       sources."which-1.3.1"
       sources."widest-line-2.0.1"
@@ -66311,12 +66614,7 @@ in
       sources."color-name-1.1.3"
       sources."configstore-3.1.2"
       sources."create-error-class-3.0.2"
-      (sources."cross-spawn-5.1.0" // {
-        dependencies = [
-          sources."lru-cache-4.1.5"
-          sources."yallist-2.1.2"
-        ];
-      })
+      sources."cross-spawn-5.1.0"
       sources."crypto-random-string-1.0.0"
       sources."currently-unhandled-0.4.1"
       sources."debug-3.1.0"
@@ -66340,9 +66638,9 @@ in
       sources."get-stream-3.0.0"
       sources."global-dirs-0.1.1"
       sources."got-6.7.1"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."has-flag-3.0.0"
-      sources."hosted-git-info-2.8.2"
+      sources."hosted-git-info-2.8.4"
       sources."http-proxy-agent-2.1.0"
       sources."https-proxy-agent-2.2.2"
       sources."import-lazy-2.1.0"
@@ -66369,7 +66667,7 @@ in
       sources."log-update-2.3.0"
       sources."loud-rejection-1.6.0"
       sources."lowercase-keys-1.0.1"
-      sources."lru-cache-5.1.1"
+      sources."lru-cache-4.1.5"
       sources."make-dir-1.3.0"
       sources."map-obj-2.0.0"
       sources."meow-5.0.0"
@@ -66412,7 +66710,7 @@ in
       sources."round-to-3.0.0"
       sources."safe-buffer-5.2.0"
       sources."sax-1.2.4"
-      sources."semver-5.7.0"
+      sources."semver-5.7.1"
       sources."semver-diff-2.1.0"
       sources."shebang-command-1.2.0"
       sources."shebang-regex-1.0.0"
@@ -66445,7 +66743,7 @@ in
       sources."xdg-basedir-3.0.0"
       sources."xml2js-0.4.19"
       sources."xmlbuilder-9.0.7"
-      sources."yallist-3.0.3"
+      sources."yallist-2.1.2"
       sources."yargs-parser-10.1.0"
     ];
     buildInputs = globalBuildInputs;
@@ -66576,7 +66874,7 @@ in
       sources."cross-spawn-6.0.5"
       sources."debug-4.1.1"
       sources."decode-uri-component-0.2.0"
-      sources."deep-equal-1.0.1"
+      sources."deep-equal-1.1.0"
       sources."deep-extend-0.6.0"
       sources."deferred-leveldown-5.1.0"
       sources."define-properties-1.1.3"
@@ -66650,7 +66948,7 @@ in
       sources."glob-parent-2.0.0"
       sources."globby-4.1.0"
       sources."gossip-query-2.0.2"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."has-1.0.3"
       sources."has-ansi-2.0.0"
       sources."has-network-0.0.1"
@@ -66690,6 +66988,7 @@ in
       })
       sources."is-alphabetical-1.0.3"
       sources."is-alphanumerical-1.0.3"
+      sources."is-arguments-1.0.4"
       sources."is-binary-path-1.0.1"
       sources."is-buffer-1.1.6"
       sources."is-callable-1.1.4"
@@ -66848,6 +67147,7 @@ in
         ];
       })
       sources."object-inspect-1.6.0"
+      sources."object-is-1.0.1"
       sources."object-keys-1.1.1"
       (sources."object-visit-1.0.1" // {
         dependencies = [
@@ -66927,7 +67227,7 @@ in
       sources."pull-reader-1.3.1"
       sources."pull-sink-through-0.0.0"
       sources."pull-sort-1.0.2"
-      sources."pull-stream-3.6.13"
+      sources."pull-stream-3.6.14"
       (sources."pull-through-1.0.18" // {
         dependencies = [
           sources."looper-3.0.0"
@@ -67011,6 +67311,7 @@ in
       })
       sources."regex-cache-0.4.4"
       sources."regex-not-1.0.2"
+      sources."regexp.prototype.flags-1.2.0"
       sources."relative-url-1.0.2"
       (sources."remark-3.2.3" // {
         dependencies = [
@@ -67028,7 +67329,7 @@ in
       sources."resumer-0.0.0"
       sources."ret-0.1.15"
       sources."right-pad-1.0.1"
-      (sources."rimraf-2.6.3" // {
+      (sources."rimraf-2.7.1" // {
         dependencies = [
           sources."glob-7.1.4"
         ];
@@ -67039,7 +67340,7 @@ in
       sources."safe-regex-1.1.0"
       sources."secret-handshake-1.1.20"
       sources."secret-stack-6.3.0"
-      sources."semver-5.7.0"
+      sources."semver-5.7.1"
       sources."separator-escape-0.0.0"
       (sources."set-value-2.0.1" // {
         dependencies = [
@@ -67087,7 +67388,7 @@ in
         ];
       })
       sources."sodium-chloride-1.1.2"
-      sources."sodium-native-2.4.5"
+      sources."sodium-native-2.4.6"
       sources."source-map-0.5.7"
       sources."source-map-resolve-0.5.2"
       sources."source-map-url-0.4.0"
@@ -67161,6 +67462,7 @@ in
       sources."supports-color-2.0.0"
       (sources."tape-4.11.0" // {
         dependencies = [
+          sources."deep-equal-1.0.1"
           sources."glob-7.1.4"
         ];
       })
@@ -67260,7 +67562,7 @@ in
       sha512 = "ddyn6GoWoboSze2SSRMKjDGu4i0z1xaQ0KN5BiQInAyeuIXGiZygZBxeJsO02GrQJ88rCb5i9JSR+qMwyBz6Bw==";
     };
     dependencies = [
-      sources."@sailshq/lodash-3.10.3"
+      sources."@sailshq/lodash-3.10.4"
       (sources."@slack/client-3.16.0" // {
         dependencies = [
           sources."bluebird-3.5.5"
@@ -67319,7 +67621,11 @@ in
       sources."async-1.5.2"
       sources."async-limiter-1.0.1"
       sources."asynckit-0.4.0"
-      sources."aws-sdk-2.504.0"
+      (sources."aws-sdk-2.520.0" // {
+        dependencies = [
+          sources."uuid-3.3.2"
+        ];
+      })
       sources."aws-sign2-0.6.0"
       sources."aws4-1.8.0"
       sources."babel-runtime-6.26.0"
@@ -67428,7 +67734,7 @@ in
       sources."dicer-0.2.5"
       sources."doctypes-1.1.0"
       sources."drange-1.1.1"
-      (sources."dtrace-provider-0.8.7" // {
+      (sources."dtrace-provider-0.8.8" // {
         dependencies = [
           sources."nan-2.14.0"
         ];
@@ -67487,7 +67793,7 @@ in
       sources."fd-slicer-1.1.0"
       sources."finalhandler-1.1.2"
       sources."find-up-3.0.0"
-      (sources."follow-redirects-1.7.0" // {
+      (sources."follow-redirects-1.8.1" // {
         dependencies = [
           sources."debug-3.2.6"
           sources."ms-2.1.2"
@@ -67515,7 +67821,7 @@ in
           sources."ms-2.1.2"
         ];
       })
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."graphlib-2.1.7"
       sources."har-schema-2.0.0"
       sources."har-validator-2.0.6"
@@ -67535,12 +67841,7 @@ in
         ];
       })
       sources."hoek-2.16.3"
-      (sources."hosted-git-info-2.8.2" // {
-        dependencies = [
-          sources."lru-cache-5.1.1"
-          sources."yallist-3.0.3"
-        ];
-      })
+      sources."hosted-git-info-2.8.4"
       (sources."http-errors-1.7.2" // {
         dependencies = [
           sources."inherits-2.0.3"
@@ -67711,7 +68012,7 @@ in
       sources."p-defer-1.0.0"
       sources."p-finally-1.0.0"
       sources."p-is-promise-2.1.0"
-      sources."p-limit-2.2.0"
+      sources."p-limit-2.2.1"
       sources."p-locate-3.0.0"
       sources."p-try-2.2.0"
       sources."parse-json-2.2.0"
@@ -67823,7 +68124,7 @@ in
       sources."safe-json-stringify-1.2.0"
       sources."safer-buffer-2.1.2"
       sources."sax-1.2.1"
-      sources."semver-5.7.0"
+      sources."semver-5.7.1"
       (sources."send-0.17.1" // {
         dependencies = [
           sources."ms-2.1.1"
@@ -67901,9 +68202,9 @@ in
       (sources."superagent-3.8.3" // {
         dependencies = [
           sources."debug-3.2.6"
-          sources."form-data-2.5.0"
+          sources."form-data-2.5.1"
           sources."ms-2.1.2"
-          sources."qs-6.7.0"
+          sources."qs-6.8.0"
           sources."readable-stream-2.3.6"
           sources."string_decoder-1.1.1"
         ];
@@ -67916,7 +68217,7 @@ in
           sources."esprima-4.0.1"
           sources."js-yaml-3.13.1"
           sources."lodash-3.10.1"
-          sources."qs-6.7.0"
+          sources."qs-6.8.0"
         ];
       })
       sources."swagger-schema-official-2.0.0-bab6bed"
@@ -67979,7 +68280,7 @@ in
       sources."utf-8-validate-1.2.2"
       sources."util-deprecate-1.0.2"
       sources."utils-merge-1.0.1"
-      sources."uuid-3.3.2"
+      sources."uuid-3.3.3"
       sources."validate-npm-package-license-3.0.4"
       sources."validator-5.7.0"
       sources."vary-1.1.2"
@@ -68226,7 +68527,7 @@ in
       sources."capture-stack-trace-1.0.1"
       sources."chalk-1.1.3"
       sources."charenc-0.0.2"
-      sources."chokidar-2.1.6"
+      sources."chokidar-2.1.8"
       sources."ci-info-1.6.0"
       (sources."class-utils-0.3.6" // {
         dependencies = [
@@ -68336,7 +68637,7 @@ in
       })
       sources."finalhandler-1.1.2"
       sources."for-in-1.0.2"
-      sources."form-data-2.5.0"
+      sources."form-data-2.5.1"
       sources."formidable-1.2.1"
       sources."fragment-cache-0.2.1"
       sources."fresh-0.5.2"
@@ -68353,7 +68654,7 @@ in
       })
       sources."global-dirs-0.1.1"
       sources."got-6.7.1"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       (sources."graphlib-2.1.7" // {
         dependencies = [
           sources."lodash-4.17.15"
@@ -68543,7 +68844,7 @@ in
         dependencies = [
           sources."debug-3.2.6"
           sources."ms-2.1.2"
-          sources."qs-6.7.0"
+          sources."qs-6.8.0"
           sources."superagent-3.8.3"
         ];
       })
@@ -68584,13 +68885,13 @@ in
       sources."resolve-url-0.2.1"
       sources."restore-cursor-1.0.1"
       sources."ret-0.1.15"
-      sources."rimraf-2.6.3"
+      sources."rimraf-2.7.1"
       sources."run-async-0.1.0"
       sources."rx-lite-3.1.2"
       sources."safe-buffer-5.1.2"
       sources."safe-regex-1.1.0"
-      sources."sanitize-filename-1.6.2"
-      sources."semver-5.7.0"
+      sources."sanitize-filename-1.6.3"
+      sources."semver-5.7.1"
       sources."semver-diff-2.1.0"
       (sources."send-0.17.1" // {
         dependencies = [
@@ -68786,7 +69087,7 @@ in
       sha256 = "886069ecc5eedf0371b948e8ff66e7f2943c85fe7cfdaa7183e1a3572d55852b";
     };
     dependencies = [
-      sources."@types/node-12.6.9"
+      sources."@types/node-12.7.3"
       sources."ajv-6.10.2"
       sources."ansi-regex-4.1.0"
       sources."ansi-styles-3.2.1"
@@ -68847,7 +69148,7 @@ in
       sources."ms-2.1.2"
       sources."node-fetch-2.6.0"
       sources."oauth-sign-0.9.0"
-      sources."p-limit-2.2.0"
+      sources."p-limit-2.2.1"
       sources."p-locate-3.0.0"
       sources."p-try-2.2.0"
       sources."path-exists-3.0.0"
@@ -68884,7 +69185,7 @@ in
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-1.0.1"
       sources."uri-js-4.2.2"
-      sources."uuid-3.3.2"
+      sources."uuid-3.3.3"
       sources."verror-1.10.0"
       sources."which-module-2.0.0"
       sources."wrap-ansi-5.1.0"
@@ -68910,7 +69211,7 @@ in
       sha512 = "6jK0DcgziZ0NAitZNncg+do/fKGh8hQJShcVU7dHoAljdckr7qr2oozd4l4kTIA7M+0FoKXy6gvRBLO8oWpTEw==";
     };
     dependencies = [
-      sources."acorn-6.2.1"
+      sources."acorn-6.3.0"
       sources."acorn-loose-6.1.0"
       sources."acorn-walk-6.2.0"
       sources."balanced-match-1.0.0"
@@ -68921,7 +69222,7 @@ in
       sources."errno-0.1.7"
       sources."fs.realpath-1.0.0"
       sources."glob-7.1.4"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
       sources."isarray-1.0.0"
@@ -68998,7 +69299,7 @@ in
       sources."core-util-is-1.0.2"
       sources."crypt-0.0.2"
       sources."debug-4.1.1"
-      sources."deep-equal-1.0.1"
+      sources."deep-equal-1.1.0"
       sources."deep-is-0.1.3"
       sources."define-properties-1.1.3"
       sources."diff-4.0.1"
@@ -69019,15 +69320,16 @@ in
       sources."function-bind-1.1.1"
       sources."get-stdin-5.0.1"
       sources."glob-7.1.4"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."has-1.0.3"
       sources."has-ansi-2.0.0"
       sources."has-symbols-1.0.0"
-      sources."hosted-git-info-2.8.2"
+      sources."hosted-git-info-2.8.4"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
       sources."is-alphabetical-1.0.3"
       sources."is-alphanumerical-1.0.3"
+      sources."is-arguments-1.0.4"
       sources."is-arrayish-0.2.1"
       sources."is-buffer-1.1.6"
       sources."is-callable-1.1.4"
@@ -69057,7 +69359,6 @@ in
       sources."locate-path-2.0.0"
       sources."lodash-4.17.15"
       sources."log-symbols-1.0.2"
-      sources."lru-cache-5.1.1"
       sources."map-like-2.0.0"
       sources."markdown-escapes-1.0.3"
       sources."md5-2.2.1"
@@ -69068,6 +69369,7 @@ in
       sources."normalize-package-data-2.5.0"
       sources."number-is-nan-1.0.1"
       sources."object-assign-4.1.1"
+      sources."object-is-1.0.1"
       sources."object-keys-1.1.1"
       sources."once-1.4.0"
       sources."optionator-0.8.2"
@@ -69100,6 +69402,7 @@ in
         ];
       })
       sources."readable-stream-2.3.6"
+      sources."regexp.prototype.flags-1.2.0"
       sources."remark-frontmatter-1.3.2"
       sources."remark-parse-5.0.0"
       sources."repeat-string-1.6.1"
@@ -69108,7 +69411,7 @@ in
       sources."resolve-1.12.0"
       sources."rimraf-2.6.3"
       sources."safe-buffer-5.1.2"
-      sources."semver-5.7.0"
+      sources."semver-5.7.1"
       sources."slice-ansi-0.0.4"
       sources."spdx-correct-3.1.0"
       sources."spdx-exceptions-2.2.0"
@@ -69158,7 +69461,6 @@ in
       sources."x-is-string-0.1.0"
       sources."xml-escape-1.1.0"
       sources."xtend-4.0.2"
-      sources."yallist-3.0.3"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -69266,12 +69568,7 @@ in
       sources."configstore-3.1.2"
       sources."core-util-is-1.0.2"
       sources."create-error-class-3.0.2"
-      (sources."cross-spawn-5.1.0" // {
-        dependencies = [
-          sources."lru-cache-4.1.5"
-          sources."yallist-2.1.2"
-        ];
-      })
+      sources."cross-spawn-5.1.0"
       sources."crypto-random-string-1.0.0"
       sources."currently-unhandled-0.4.1"
       sources."cuss-1.16.0"
@@ -69301,9 +69598,9 @@ in
       sources."glob-7.1.4"
       sources."global-dirs-0.1.1"
       sources."got-6.7.1"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."has-flag-3.0.0"
-      sources."hosted-git-info-2.8.2"
+      sources."hosted-git-info-2.8.4"
       sources."ignore-3.3.10"
       sources."import-lazy-2.1.0"
       sources."imurmurhash-0.1.4"
@@ -69345,7 +69642,7 @@ in
       sources."lodash.intersection-4.4.0"
       sources."loud-rejection-1.6.0"
       sources."lowercase-keys-1.0.1"
-      sources."lru-cache-5.1.1"
+      sources."lru-cache-4.1.5"
       (sources."make-dir-1.3.0" // {
         dependencies = [
           sources."pify-3.0.0"
@@ -69415,7 +69712,7 @@ in
       sources."retext-equality-3.2.0"
       sources."retext-profanities-4.4.0"
       sources."safe-buffer-5.1.2"
-      sources."semver-5.7.0"
+      sources."semver-5.7.1"
       sources."semver-diff-2.1.0"
       sources."shebang-command-1.2.0"
       sources."shebang-regex-1.0.0"
@@ -69519,7 +69816,7 @@ in
       sources."x-is-string-0.1.0"
       sources."xdg-basedir-3.0.0"
       sources."xtend-4.0.2"
-      sources."yallist-3.0.3"
+      sources."yallist-2.1.2"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -69865,10 +70162,10 @@ in
   thelounge = nodeEnv.buildNodePackage {
     name = "thelounge";
     packageName = "thelounge";
-    version = "3.1.1";
+    version = "3.2.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/thelounge/-/thelounge-3.1.1.tgz";
-      sha512 = "TaYiWjvP5wjKAob3qMr8Ks+C8LfTxIohrhZ8b4DuilHlZCpIeEgADXs2K8u+ZVSMJ6GHOQKvpCogSE30sTL36A==";
+      url = "https://registry.npmjs.org/thelounge/-/thelounge-3.2.0.tgz";
+      sha512 = "yOS19bt2O0l6DGAiJRad6DFMmDHmDVylfInLthNl9YfMfgSoC7aZcT7fofTe9htAE4SRfac9YsgKEtmywQ+MkA==";
     };
     dependencies = [
       sources."@sindresorhus/is-0.14.0"
@@ -69886,6 +70183,7 @@ in
         dependencies = [
           sources."isarray-1.0.0"
           sources."readable-stream-2.3.6"
+          sources."safe-buffer-5.1.2"
           sources."string_decoder-1.1.1"
         ];
       })
@@ -69930,17 +70228,21 @@ in
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
       sources."combined-stream-1.0.8"
-      sources."commander-2.20.0"
+      sources."commander-3.0.0"
       sources."component-bind-1.0.0"
       sources."component-emitter-1.2.1"
       sources."component-inherit-0.0.3"
       sources."concat-map-0.0.1"
       sources."console-control-strings-1.1.0"
-      sources."content-disposition-0.5.3"
+      (sources."content-disposition-0.5.3" // {
+        dependencies = [
+          sources."safe-buffer-5.1.2"
+        ];
+      })
       sources."content-type-1.0.4"
       sources."cookie-0.4.0"
       sources."cookie-signature-1.0.6"
-      sources."core-js-3.1.4"
+      sources."core-js-3.2.1"
       sources."core-util-is-1.0.2"
       sources."css-select-1.2.0"
       sources."css-what-2.1.3"
@@ -69984,13 +70286,17 @@ in
       sources."escape-string-regexp-1.0.5"
       sources."etag-1.8.1"
       sources."eventemitter3-2.0.3"
-      sources."express-4.17.1"
+      (sources."express-4.17.1" // {
+        dependencies = [
+          sources."safe-buffer-5.1.2"
+        ];
+      })
       sources."extend-3.0.2"
       sources."extsprintf-1.2.0"
       sources."fast-deep-equal-2.0.1"
       sources."fast-json-stable-stringify-2.0.0"
       sources."fast-text-encoding-1.0.0"
-      sources."file-type-12.0.1"
+      sources."file-type-12.1.0"
       sources."filename-reserved-regex-2.0.0"
       sources."filenamify-4.1.0"
       sources."finalhandler-1.1.2"
@@ -70006,7 +70312,7 @@ in
       sources."getpass-0.1.7"
       sources."glob-7.1.4"
       sources."got-9.6.0"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."grapheme-splitter-1.0.4"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
@@ -70062,8 +70368,8 @@ in
           sources."assert-plus-0.1.5"
         ];
       })
-      sources."linkify-it-2.1.0"
-      sources."lodash-4.17.14"
+      sources."linkify-it-2.2.0"
+      sources."lodash-4.17.15"
       sources."lodash.assignin-4.2.0"
       sources."lodash.bind-4.2.1"
       sources."lodash.defaults-4.2.0"
@@ -70088,7 +70394,7 @@ in
       sources."minimalistic-assert-1.0.1"
       sources."minimatch-3.0.4"
       sources."minimist-1.2.0"
-      sources."minipass-2.3.5"
+      sources."minipass-2.5.0"
       sources."minizlib-1.2.1"
       (sources."mkdirp-0.5.1" // {
         dependencies = [
@@ -70107,7 +70413,7 @@ in
       sources."negotiator-0.6.2"
       (sources."node-pre-gyp-0.11.0" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       sources."nopt-4.0.1"
@@ -70128,7 +70434,7 @@ in
       sources."p-cancelable-1.1.0"
       sources."p-finally-1.0.0"
       sources."p-try-2.2.0"
-      sources."package-json-6.4.0"
+      sources."package-json-6.5.0"
       sources."parseqs-0.0.5"
       sources."parseuri-0.0.5"
       sources."parseurl-1.3.3"
@@ -70151,7 +70457,7 @@ in
       sources."read-chunk-3.2.0"
       sources."readable-stream-3.4.0"
       sources."regenerator-runtime-0.13.3"
-      sources."registry-auth-token-3.4.0"
+      sources."registry-auth-token-4.0.0"
       sources."registry-url-5.1.0"
       (sources."request-2.88.0" // {
         dependencies = [
@@ -70159,11 +70465,11 @@ in
         ];
       })
       sources."responselike-1.0.2"
-      sources."rimraf-2.6.3"
-      sources."safe-buffer-5.1.2"
+      sources."rimraf-2.7.1"
+      sources."safe-buffer-5.2.0"
       sources."safer-buffer-2.1.2"
       sources."sax-1.2.4"
-      sources."semver-6.2.0"
+      sources."semver-6.3.0"
       (sources."send-0.17.1" // {
         dependencies = [
           sources."ms-2.1.1"
@@ -70200,7 +70506,7 @@ in
       sources."statuses-1.5.0"
       sources."streamsearch-0.1.2"
       sources."string-width-1.0.2"
-      sources."string_decoder-1.2.0"
+      sources."string_decoder-1.3.0"
       sources."strip-ansi-3.0.1"
       sources."strip-json-comments-2.0.1"
       sources."strip-outer-1.0.1"
@@ -70244,7 +70550,7 @@ in
       sources."ws-6.1.4"
       sources."xmlhttprequest-ssl-1.5.5"
       sources."yallist-3.0.3"
-      sources."yarn-1.16.0"
+      sources."yarn-1.17.3"
       sources."yeast-0.1.2"
     ];
     buildInputs = globalBuildInputs;
@@ -70259,10 +70565,10 @@ in
   three = nodeEnv.buildNodePackage {
     name = "three";
     packageName = "three";
-    version = "0.107.0";
+    version = "0.108.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/three/-/three-0.107.0.tgz";
-      sha512 = "vqbKJRLBEviPVa7poEzXocobicwxzsctr5mnymA7n8fEzcVS49rYP0RrwqZ98JqujRoruK+/YzcchNpRP+kXsQ==";
+      url = "https://registry.npmjs.org/three/-/three-0.108.0.tgz";
+      sha512 = "d1ysIXwi8qTlbmMwrTxi5pYiiYIflEr0e48krP0LAY8ndS8c6fkLHn6NvRT+o76/Fs9PBLxFViuI62iGVWwwlg==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -70276,10 +70582,10 @@ in
   tiddlywiki = nodeEnv.buildNodePackage {
     name = "tiddlywiki";
     packageName = "tiddlywiki";
-    version = "5.1.19";
+    version = "5.1.20";
     src = fetchurl {
-      url = "https://registry.npmjs.org/tiddlywiki/-/tiddlywiki-5.1.19.tgz";
-      sha512 = "G7JnwrQJ6d2ue49yaBl7WzmTOV/WH/mm4WgknChr6z8sSUVU+czPoYBXfwqHOuCbdZqWRPjiYfjkdm+eUiWodw==";
+      url = "https://registry.npmjs.org/tiddlywiki/-/tiddlywiki-5.1.20.tgz";
+      sha512 = "ttsftbeaGZ1k6wdvfpRX8cg/OGkEk/3pWEdSHHZn+chTvmE142fpzwMa4YmB3ewLAEXHBHFAHHWXTgWS/dWQHw==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -70338,7 +70644,7 @@ in
       sources."fs.realpath-1.0.0"
       sources."getpass-0.1.7"
       sources."glob-7.1.4"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."http-signature-1.2.0"
@@ -70402,7 +70708,7 @@ in
       sources."uglify-js-3.4.10"
       sources."universalify-0.1.2"
       sources."uri-js-4.2.2"
-      sources."uuid-3.3.2"
+      sources."uuid-3.3.3"
       sources."verror-1.10.0"
       (sources."winston-1.1.2" // {
         dependencies = [
@@ -70426,10 +70732,10 @@ in
   triton = nodeEnv.buildNodePackage {
     name = "triton";
     packageName = "triton";
-    version = "7.3.0";
+    version = "7.5.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/triton/-/triton-7.3.0.tgz";
-      sha512 = "7O44Ds3J1bVeTHW4uZKSaEzxyV4+Dy5P29hQ4G9XgxGMUAVGtfUZEe77gppEqIxoIscDP9LRpzBPim21b6p+8Q==";
+      url = "https://registry.npmjs.org/triton/-/triton-7.5.0.tgz";
+      sha512 = "t1b1B2H0y9jOUqDm2rr9gQsnI0mm0ws47h+pz8sBWw+Ylw+J664bM/usKPevh38J17zlKo3FisAZvSjcOVfIZQ==";
     };
     dependencies = [
       sources."asn1-0.2.4"
@@ -70454,7 +70760,7 @@ in
           sources."assert-plus-1.0.0"
         ];
       })
-      sources."dtrace-provider-0.8.7"
+      sources."dtrace-provider-0.8.8"
       sources."ecc-jsbn-0.1.2"
       sources."extsprintf-1.0.2"
       sources."fast-safe-stringify-1.2.3"
@@ -70581,7 +70887,7 @@ in
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       sources."util-deprecate-1.0.2"
-      sources."uuid-3.3.2"
+      sources."uuid-3.3.3"
       (sources."vasync-1.6.3" // {
         dependencies = [
           sources."extsprintf-1.2.0"
@@ -70677,10 +70983,10 @@ in
   typescript = nodeEnv.buildNodePackage {
     name = "typescript";
     packageName = "typescript";
-    version = "3.5.3";
+    version = "3.6.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz";
-      sha512 = "ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==";
+      url = "https://registry.npmjs.org/typescript/-/typescript-3.6.2.tgz";
+      sha512 = "lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -70694,27 +71000,28 @@ in
   typescript-language-server = nodeEnv.buildNodePackage {
     name = "typescript-language-server";
     packageName = "typescript-language-server";
-    version = "0.3.8";
+    version = "0.4.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/typescript-language-server/-/typescript-language-server-0.3.8.tgz";
-      sha512 = "ohi+libVtaJ0F8asuXeqYlrPV84AkbcpWsp5kBeO6XnCrilwQS+elDrJ+jPu2tfVy3CIUpUbUYUmg4Bq3CA/XQ==";
+      url = "https://registry.npmjs.org/typescript-language-server/-/typescript-language-server-0.4.0.tgz";
+      sha512 = "K8jNOmDFn+QfrCh8ujby2pGDs5rpjYZQn+zvQnf42rxG4IHbfw5CHoMvbGkWPK/J5Gw8/l5K3i03kVZC2IBElg==";
     };
     dependencies = [
       sources."command-exists-1.2.6"
       sources."commander-2.20.0"
       sources."crypto-random-string-1.0.0"
       sources."fs-extra-7.0.1"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."jsonfile-4.0.0"
       sources."p-debounce-1.0.0"
       sources."temp-dir-1.0.0"
       sources."tempy-0.2.1"
       sources."unique-string-1.0.0"
       sources."universalify-0.1.2"
-      sources."vscode-jsonrpc-4.0.0"
-      sources."vscode-languageserver-4.4.2"
-      sources."vscode-languageserver-protocol-3.14.1"
-      sources."vscode-languageserver-types-3.14.0"
+      sources."vscode-jsonrpc-4.1.0-next.3"
+      sources."vscode-languageserver-5.3.0-next.10"
+      sources."vscode-languageserver-protocol-3.15.0-next.8"
+      sources."vscode-languageserver-types-3.15.0-next.4"
+      sources."vscode-textbuffer-1.0.0"
       sources."vscode-uri-1.0.8"
     ];
     buildInputs = globalBuildInputs;
@@ -70820,7 +71127,7 @@ in
       sources."core-util-is-1.0.2"
       (sources."cross-spawn-6.0.5" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       sources."crossroads-0.12.2"
@@ -70845,7 +71152,7 @@ in
       sources."ecc-jsbn-0.1.2"
       (sources."editions-2.1.3" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       sources."ee-first-1.1.1"
@@ -70914,7 +71221,7 @@ in
       sources."getmac-1.4.6"
       sources."getpass-0.1.7"
       sources."glob-7.1.4"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       (sources."has-binary2-1.0.3" // {
@@ -70930,16 +71237,11 @@ in
           sources."mkdirp-0.3.0"
         ];
       })
-      (sources."hosted-git-info-2.8.2" // {
-        dependencies = [
-          sources."lru-cache-5.1.1"
-          sources."yallist-3.0.3"
-        ];
-      })
+      sources."hosted-git-info-2.8.4"
       sources."http-errors-1.7.2"
       sources."http-signature-1.2.0"
       sources."iconv-lite-0.4.24"
-      sources."ignore-5.1.2"
+      sources."ignore-5.1.4"
       sources."indexof-0.0.1"
       sources."inflight-1.0.6"
       sources."inherits-2.0.3"
@@ -70994,18 +71296,18 @@ in
       sources."nopt-1.0.10"
       (sources."normalize-package-data-2.5.0" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       sources."npm-6.9.2"
-      (sources."npm-package-arg-6.1.0" // {
+      (sources."npm-package-arg-6.1.1" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       (sources."npm-registry-client-8.6.0" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       sources."npm-run-path-2.0.2"
@@ -71027,7 +71329,7 @@ in
       sources."p-defer-1.0.0"
       sources."p-finally-1.0.0"
       sources."p-is-promise-2.1.0"
-      sources."p-limit-2.2.0"
+      sources."p-limit-2.2.1"
       sources."p-locate-3.0.0"
       sources."p-try-2.2.0"
       sources."parseqs-0.0.5"
@@ -71149,7 +71451,7 @@ in
       sources."uri-js-4.2.2"
       sources."util-deprecate-1.0.2"
       sources."utils-merge-1.0.1"
-      sources."uuid-3.3.2"
+      sources."uuid-3.3.3"
       sources."validate-npm-package-license-3.0.4"
       sources."validate-npm-package-name-3.0.0"
       sources."vary-1.1.2"
@@ -71289,7 +71591,7 @@ in
       sources."bl-1.2.2"
       sources."bluebird-3.5.5"
       sources."brace-expansion-1.1.11"
-      sources."buffer-5.2.1"
+      sources."buffer-5.4.2"
       sources."buffer-alloc-1.2.0"
       sources."buffer-alloc-unsafe-1.1.0"
       sources."buffer-crc32-0.2.13"
@@ -71364,7 +71666,7 @@ in
       sources."git-clone-0.1.0"
       sources."glob-7.1.4"
       sources."got-6.7.1"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."graceful-readlink-1.0.1"
       sources."gray-matter-2.1.1"
       sources."handlebars-4.1.2"
@@ -71385,7 +71687,7 @@ in
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
       sources."ini-1.3.5"
-      sources."inquirer-6.5.0"
+      sources."inquirer-6.5.2"
       sources."is-3.3.0"
       sources."is-extendable-0.1.1"
       sources."is-fullwidth-code-point-2.0.0"
@@ -71468,7 +71770,7 @@ in
       sources."recursive-readdir-2.2.2"
       sources."request-2.88.0"
       sources."restore-cursor-2.0.0"
-      sources."rimraf-2.6.3"
+      sources."rimraf-2.7.1"
       sources."run-async-2.3.0"
       sources."rxjs-6.5.2"
       sources."safe-buffer-5.2.0"
@@ -71478,7 +71780,7 @@ in
           sources."commander-2.8.1"
         ];
       })
-      sources."semver-5.7.0"
+      sources."semver-5.7.1"
       sources."signal-exit-3.0.2"
       sources."source-map-0.6.1"
       sources."sprintf-js-1.0.3"
@@ -71530,7 +71832,7 @@ in
       sources."url-to-options-1.0.1"
       sources."user-home-2.0.0"
       sources."util-deprecate-1.0.2"
-      sources."uuid-3.3.2"
+      sources."uuid-3.3.3"
       sources."validate-npm-package-name-3.0.0"
       sources."verror-1.10.0"
       sources."ware-1.3.0"
@@ -71554,15 +71856,17 @@ in
   vue-language-server = nodeEnv.buildNodePackage {
     name = "vue-language-server";
     packageName = "vue-language-server";
-    version = "0.0.57";
+    version = "0.0.60";
     src = fetchurl {
-      url = "https://registry.npmjs.org/vue-language-server/-/vue-language-server-0.0.57.tgz";
-      sha512 = "o0CSn0HJdo1/ASh2nY9MZh/dZrq+U+fVfIL4XDL/VRMrFAyr9pPmhT9/pdRZlHPN46r05UhBfGQXnbeOOssguA==";
+      url = "https://registry.npmjs.org/vue-language-server/-/vue-language-server-0.0.60.tgz";
+      sha512 = "Ywj+6kwTKtZtazQD0UvpMgfQZs+TH0/tft2RbCC9jHgkwU9w1h+ceoJ/V1FSQvyouI7+rhFEkfBH9FMH7+x2PQ==";
     };
     dependencies = [
       sources."@babel/code-frame-7.5.5"
       sources."@babel/highlight-7.5.0"
       sources."@emmetio/extract-abbreviation-0.1.6"
+      sources."@mrmlnc/readdir-enhanced-2.2.1"
+      sources."@nodelib/fs.stat-1.1.3"
       sources."@starptech/expression-parser-0.9.0"
       sources."@starptech/hast-util-from-webparser-0.9.0"
       sources."@starptech/prettyhtml-0.9.0"
@@ -71573,28 +71877,42 @@ in
       sources."@starptech/rehype-minify-whitespace-0.9.0"
       sources."@starptech/rehype-webparser-0.9.0"
       sources."@starptech/webparser-0.9.0"
-      sources."@types/node-12.6.9"
+      sources."@types/node-12.7.3"
       sources."@types/unist-2.0.3"
       sources."@types/vfile-3.0.2"
       sources."@types/vfile-message-1.0.1"
       sources."abbrev-1.1.1"
-      sources."acorn-6.2.1"
-      sources."acorn-jsx-5.0.1"
+      sources."acorn-6.3.0"
+      sources."acorn-jsx-5.0.2"
       sources."ajv-6.10.2"
       sources."ajv-keywords-2.1.1"
-      sources."amdefine-1.0.1"
       sources."ansi-align-2.0.0"
       sources."ansi-escapes-3.2.0"
       sources."ansi-regex-3.0.0"
       sources."ansi-styles-3.2.1"
-      sources."anymatch-1.3.2"
+      (sources."anymatch-1.3.2" // {
+        dependencies = [
+          sources."arr-diff-2.0.0"
+          sources."array-unique-0.2.1"
+          sources."braces-1.8.5"
+          sources."expand-brackets-0.1.5"
+          sources."extglob-0.3.2"
+          sources."is-buffer-1.1.6"
+          sources."is-extglob-1.0.0"
+          sources."is-glob-2.0.1"
+          sources."kind-of-3.2.2"
+          sources."micromatch-2.3.11"
+        ];
+      })
       sources."argparse-1.0.10"
-      sources."arr-diff-2.0.0"
+      sources."arr-diff-4.0.0"
       sources."arr-flatten-1.1.0"
       sources."arr-union-3.1.0"
       sources."array-find-index-1.0.2"
       sources."array-iterate-1.1.3"
-      sources."array-unique-0.2.1"
+      sources."array-union-1.0.2"
+      sources."array-uniq-1.0.3"
+      sources."array-unique-0.3.2"
       sources."arrify-1.0.1"
       sources."assign-symbols-1.0.0"
       sources."astral-regex-1.0.0"
@@ -71617,21 +71935,22 @@ in
       (sources."base-0.11.2" // {
         dependencies = [
           sources."define-property-1.0.0"
-          sources."isobject-3.0.1"
         ];
       })
       sources."binary-extensions-1.13.1"
       sources."bootstrap-vue-helper-json-1.1.1"
       sources."boxen-1.3.0"
       sources."brace-expansion-1.1.11"
-      sources."braces-1.8.5"
-      sources."buefy-helper-json-1.0.3"
-      sources."buffer-from-1.1.1"
-      (sources."cache-base-1.0.1" // {
+      (sources."braces-2.3.2" // {
         dependencies = [
-          sources."isobject-3.0.1"
+          sources."extend-shallow-2.0.1"
         ];
       })
+      sources."buefy-helper-json-1.0.3"
+      sources."buffer-from-1.1.1"
+      sources."builtin-modules-1.1.1"
+      sources."cache-base-1.0.1"
+      sources."call-me-maybe-1.0.1"
       (sources."caller-path-0.1.0" // {
         dependencies = [
           sources."callsites-0.2.0"
@@ -71648,7 +71967,13 @@ in
       sources."character-entities-legacy-1.1.3"
       sources."character-reference-invalid-1.1.3"
       sources."chardet-0.7.0"
-      sources."chokidar-1.5.2"
+      (sources."chokidar-1.5.2" // {
+        dependencies = [
+          sources."glob-parent-2.0.0"
+          sources."is-extglob-1.0.0"
+          sources."is-glob-2.0.1"
+        ];
+      })
       sources."ci-info-1.6.0"
       sources."circular-json-0.3.3"
       (sources."class-utils-0.3.6" // {
@@ -71666,21 +71991,13 @@ in
             ];
           })
           sources."is-descriptor-0.1.6"
-          sources."isobject-3.0.1"
           sources."kind-of-5.1.0"
         ];
       })
       sources."cli-boxes-1.0.0"
       sources."cli-cursor-2.1.0"
       sources."cli-width-2.2.0"
-      (sources."cliui-3.2.0" // {
-        dependencies = [
-          sources."ansi-regex-2.1.1"
-          sources."is-fullwidth-code-point-1.0.0"
-          sources."string-width-1.0.2"
-          sources."strip-ansi-3.0.1"
-        ];
-      })
+      sources."cliui-4.1.0"
       sources."clone-1.0.4"
       sources."co-4.6.0"
       sources."code-point-at-1.1.0"
@@ -71706,14 +72023,14 @@ in
       sources."core-js-2.6.9"
       sources."core-util-is-1.0.2"
       sources."create-error-class-3.0.2"
-      (sources."cross-spawn-5.1.0" // {
+      sources."cross-spawn-5.1.0"
+      sources."crypto-random-string-1.0.0"
+      (sources."css-2.2.4" // {
         dependencies = [
-          sources."lru-cache-4.1.5"
-          sources."yallist-2.1.2"
+          sources."source-map-0.6.1"
         ];
       })
-      sources."crypto-random-string-1.0.0"
-      sources."css-parse-1.7.0"
+      sources."css-parse-2.0.0"
       sources."currently-unhandled-0.4.1"
       sources."debug-3.2.6"
       sources."decamelize-1.2.0"
@@ -71726,22 +72043,15 @@ in
       sources."deep-extend-0.6.0"
       sources."deep-is-0.1.3"
       sources."defaults-1.0.3"
-      (sources."define-property-2.0.2" // {
-        dependencies = [
-          sources."isobject-3.0.1"
-        ];
-      })
+      sources."define-property-2.0.2"
+      sources."diff-3.5.0"
+      sources."dir-glob-2.0.0"
       sources."dlv-1.1.3"
       sources."doctrine-3.0.0"
       sources."dot-prop-4.2.0"
       sources."duplexer3-0.1.4"
-      (sources."editorconfig-0.15.3" // {
-        dependencies = [
-          sources."lru-cache-4.1.5"
-          sources."yallist-2.1.2"
-        ];
-      })
-      sources."element-helper-json-2.0.5"
+      sources."editorconfig-0.15.3"
+      sources."element-helper-json-2.0.6"
       sources."emoji-regex-7.0.3"
       sources."error-ex-1.3.2"
       sources."escape-string-regexp-1.0.5"
@@ -71760,17 +72070,45 @@ in
         ];
       })
       sources."eslint-scope-4.0.3"
-      sources."eslint-utils-1.4.0"
-      sources."eslint-visitor-keys-1.0.0"
+      sources."eslint-utils-1.4.2"
+      sources."eslint-visitor-keys-1.1.0"
       sources."espree-5.0.1"
       sources."esprima-4.0.1"
       sources."esquery-1.0.1"
       sources."esrecurse-4.2.1"
-      sources."estraverse-4.2.0"
+      sources."estraverse-4.3.0"
       sources."esutils-2.0.3"
       sources."execa-0.7.0"
-      sources."expand-brackets-0.1.5"
-      sources."expand-range-1.8.2"
+      (sources."expand-brackets-2.1.4" // {
+        dependencies = [
+          sources."debug-2.6.9"
+          sources."define-property-0.2.5"
+          sources."extend-shallow-2.0.1"
+          (sources."is-accessor-descriptor-0.1.6" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          sources."is-buffer-1.1.6"
+          (sources."is-data-descriptor-0.1.4" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          sources."is-descriptor-0.1.6"
+          sources."kind-of-5.1.0"
+          sources."ms-2.0.0"
+        ];
+      })
+      (sources."expand-range-1.8.2" // {
+        dependencies = [
+          sources."fill-range-2.2.4"
+          sources."is-buffer-1.1.6"
+          sources."is-number-2.1.0"
+          sources."isobject-2.1.0"
+          sources."kind-of-3.2.2"
+        ];
+      })
       sources."extend-3.0.2"
       (sources."extend-shallow-3.0.2" // {
         dependencies = [
@@ -71778,15 +72116,25 @@ in
         ];
       })
       sources."external-editor-3.1.0"
-      sources."extglob-0.3.2"
+      (sources."extglob-2.0.4" // {
+        dependencies = [
+          sources."define-property-1.0.0"
+          sources."extend-shallow-2.0.1"
+        ];
+      })
       sources."fast-deep-equal-2.0.1"
+      sources."fast-glob-2.2.7"
       sources."fast-json-stable-stringify-2.0.0"
       sources."fast-levenshtein-2.0.6"
       sources."fault-1.0.3"
       sources."figures-2.0.0"
       sources."file-entry-cache-5.0.1"
       sources."filename-regex-2.0.1"
-      sources."fill-range-2.2.4"
+      (sources."fill-range-4.0.0" // {
+        dependencies = [
+          sources."extend-shallow-2.0.1"
+        ];
+      })
       sources."find-up-2.1.0"
       sources."flat-cache-2.0.1"
       sources."flatted-2.0.1"
@@ -71799,15 +72147,28 @@ in
       sources."fsevents-1.2.9"
       sources."function-bind-1.1.1"
       sources."functional-red-black-tree-1.0.1"
+      sources."get-caller-file-1.0.3"
       sources."get-stream-3.0.0"
       sources."get-value-2.0.6"
       sources."glob-7.1.4"
-      sources."glob-base-0.3.0"
-      sources."glob-parent-2.0.0"
+      (sources."glob-base-0.3.0" // {
+        dependencies = [
+          sources."glob-parent-2.0.0"
+          sources."is-extglob-1.0.0"
+          sources."is-glob-2.0.1"
+        ];
+      })
+      (sources."glob-parent-3.1.0" // {
+        dependencies = [
+          sources."is-glob-3.1.0"
+        ];
+      })
+      sources."glob-to-regexp-0.3.0"
       sources."global-dirs-0.1.1"
       sources."globals-11.12.0"
+      sources."globby-8.0.2"
       sources."got-6.7.1"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."gridsome-helper-json-1.0.3"
       sources."has-1.0.3"
       (sources."has-ansi-2.0.0" // {
@@ -71816,19 +72177,10 @@ in
         ];
       })
       sources."has-flag-3.0.0"
-      (sources."has-value-1.0.0" // {
-        dependencies = [
-          sources."isobject-3.0.1"
-        ];
-      })
+      sources."has-value-1.0.0"
       (sources."has-values-1.0.0" // {
         dependencies = [
           sources."is-buffer-1.1.6"
-          (sources."is-number-3.0.0" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
           sources."kind-of-4.0.0"
         ];
       })
@@ -71839,7 +72191,7 @@ in
       sources."hast-util-parse-selector-2.2.2"
       sources."hast-util-to-string-1.0.2"
       sources."hast-util-whitespace-1.0.3"
-      sources."hosted-git-info-2.8.2"
+      sources."hosted-git-info-2.8.4"
       sources."html-void-elements-1.0.4"
       sources."html-whitespace-sensitive-tag-names-1.0.1"
       sources."iconv-lite-0.4.24"
@@ -71855,56 +72207,45 @@ in
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
       sources."ini-1.3.5"
-      (sources."inquirer-6.5.0" // {
+      (sources."inquirer-6.5.2" // {
         dependencies = [
           sources."ansi-regex-4.1.0"
           sources."strip-ansi-5.2.0"
         ];
       })
       sources."invert-kv-1.0.0"
-      (sources."is-accessor-descriptor-1.0.0" // {
-        dependencies = [
-          sources."kind-of-6.0.2"
-        ];
-      })
+      sources."is-accessor-descriptor-1.0.0"
       sources."is-alphabetical-1.0.3"
       sources."is-alphanumerical-1.0.3"
       sources."is-arrayish-0.2.1"
       sources."is-binary-path-1.0.1"
       sources."is-buffer-2.0.3"
       sources."is-ci-1.2.1"
-      (sources."is-data-descriptor-1.0.0" // {
-        dependencies = [
-          sources."kind-of-6.0.2"
-        ];
-      })
+      sources."is-data-descriptor-1.0.0"
       sources."is-decimal-1.0.3"
-      (sources."is-descriptor-1.0.2" // {
-        dependencies = [
-          sources."kind-of-6.0.2"
-        ];
-      })
+      sources."is-descriptor-1.0.2"
       sources."is-dotfile-1.0.3"
       sources."is-empty-1.2.0"
       sources."is-equal-shallow-0.1.3"
       sources."is-extendable-0.1.1"
-      sources."is-extglob-1.0.0"
+      sources."is-extglob-2.1.1"
       sources."is-fullwidth-code-point-2.0.0"
-      sources."is-glob-2.0.1"
+      sources."is-glob-4.0.1"
       sources."is-hexadecimal-1.0.3"
       sources."is-hidden-1.1.2"
       sources."is-installed-globally-0.1.0"
       sources."is-npm-1.0.0"
-      sources."is-number-2.1.0"
+      (sources."is-number-3.0.0" // {
+        dependencies = [
+          sources."is-buffer-1.1.6"
+          sources."kind-of-3.2.2"
+        ];
+      })
       sources."is-obj-1.0.1"
       sources."is-object-1.0.1"
       sources."is-path-inside-1.0.1"
       sources."is-plain-obj-1.1.0"
-      (sources."is-plain-object-2.0.4" // {
-        dependencies = [
-          sources."isobject-3.0.1"
-        ];
-      })
+      sources."is-plain-object-2.0.4"
       sources."is-posix-bracket-0.1.1"
       sources."is-primitive-2.0.0"
       sources."is-promise-2.1.0"
@@ -71916,8 +72257,8 @@ in
       sources."is-windows-1.0.2"
       sources."isarray-1.0.0"
       sources."isexe-2.0.0"
-      sources."isobject-2.1.0"
-      sources."js-beautify-1.10.1"
+      sources."isobject-3.0.1"
+      sources."js-beautify-1.10.2"
       sources."js-tokens-4.0.0"
       sources."js-yaml-3.13.1"
       sources."json-parse-better-errors-1.0.2"
@@ -71925,11 +72266,7 @@ in
       sources."json-stable-stringify-without-jsonify-1.0.1"
       sources."json5-2.1.0"
       sources."jsonc-parser-1.0.3"
-      (sources."kind-of-3.2.2" // {
-        dependencies = [
-          sources."is-buffer-1.1.6"
-        ];
-      })
+      sources."kind-of-6.0.2"
       sources."latest-version-3.1.0"
       sources."lcid-1.0.0"
       sources."levn-0.3.0"
@@ -71957,19 +72294,21 @@ in
       sources."longest-streak-1.0.0"
       sources."loud-rejection-1.6.0"
       sources."lowercase-keys-1.0.1"
-      sources."lru-cache-5.1.1"
+      sources."lru-cache-4.1.5"
       sources."make-dir-1.3.0"
       sources."map-cache-0.2.2"
       sources."map-obj-2.0.0"
       sources."map-visit-1.0.0"
       sources."markdown-table-0.4.0"
       sources."math-random-1.0.4"
+      sources."mem-1.1.0"
       (sources."meow-5.0.0" // {
         dependencies = [
           sources."read-pkg-up-3.0.0"
         ];
       })
-      sources."micromatch-2.3.11"
+      sources."merge2-1.2.4"
+      sources."micromatch-3.1.10"
       sources."mimic-fn-1.2.0"
       sources."minimatch-3.0.4"
       sources."minimist-1.2.0"
@@ -71988,13 +72327,7 @@ in
       sources."ms-2.1.2"
       sources."mute-stream-0.0.7"
       sources."nan-2.14.0"
-      (sources."nanomatch-1.2.13" // {
-        dependencies = [
-          sources."arr-diff-4.0.0"
-          sources."array-unique-0.3.2"
-          sources."kind-of-6.0.2"
-        ];
-      })
+      sources."nanomatch-1.2.13"
       sources."natural-compare-1.4.0"
       sources."nice-try-1.0.5"
       sources."nopt-4.0.1"
@@ -72009,30 +72342,24 @@ in
         dependencies = [
           sources."define-property-0.2.5"
           sources."is-accessor-descriptor-0.1.6"
+          sources."is-buffer-1.1.6"
           sources."is-data-descriptor-0.1.4"
           (sources."is-descriptor-0.1.6" // {
             dependencies = [
               sources."kind-of-5.1.0"
             ];
           })
+          sources."kind-of-3.2.2"
         ];
       })
-      (sources."object-visit-1.0.1" // {
-        dependencies = [
-          sources."isobject-3.0.1"
-        ];
-      })
+      sources."object-visit-1.0.1"
       sources."object.omit-2.0.1"
-      (sources."object.pick-1.3.0" // {
-        dependencies = [
-          sources."isobject-3.0.1"
-        ];
-      })
+      sources."object.pick-1.3.0"
       sources."once-1.4.0"
       sources."onetime-2.0.1"
       sources."optionator-0.8.2"
       sources."os-homedir-1.0.2"
-      sources."os-locale-1.4.0"
+      sources."os-locale-2.1.0"
       sources."os-tmpdir-1.0.2"
       sources."osenv-0.1.5"
       sources."p-finally-1.0.0"
@@ -72043,9 +72370,15 @@ in
       sources."parent-module-1.0.1"
       sources."parse-entities-1.2.2"
       sources."parse-gitignore-1.0.1"
-      sources."parse-glob-3.0.4"
+      (sources."parse-glob-3.0.4" // {
+        dependencies = [
+          sources."is-extglob-1.0.0"
+          sources."is-glob-2.0.1"
+        ];
+      })
       sources."parse-json-4.0.0"
       sources."pascalcase-0.1.1"
+      sources."path-dirname-1.0.2"
       sources."path-exists-3.0.0"
       sources."path-is-absolute-1.0.1"
       sources."path-is-inside-1.0.2"
@@ -72099,6 +72432,7 @@ in
           sources."write-0.2.1"
         ];
       })
+      sources."prettier-tslint-0.4.2"
       sources."pretty-format-23.6.0"
       sources."process-nextick-args-2.0.1"
       sources."progress-2.0.3"
@@ -72110,7 +72444,6 @@ in
       (sources."randomatic-3.1.1" // {
         dependencies = [
           sources."is-number-4.0.0"
-          sources."kind-of-6.0.2"
         ];
       })
       sources."rc-1.2.8"
@@ -72119,66 +72452,13 @@ in
         dependencies = [
           sources."find-up-3.0.0"
           sources."locate-path-3.0.0"
-          sources."p-limit-2.2.0"
+          sources."p-limit-2.2.1"
           sources."p-locate-3.0.0"
           sources."p-try-2.2.0"
         ];
       })
       sources."readable-stream-2.3.6"
-      (sources."readdirp-2.2.1" // {
-        dependencies = [
-          sources."arr-diff-4.0.0"
-          sources."array-unique-0.3.2"
-          (sources."braces-2.3.2" // {
-            dependencies = [
-              sources."extend-shallow-2.0.1"
-            ];
-          })
-          sources."debug-2.6.9"
-          (sources."expand-brackets-2.1.4" // {
-            dependencies = [
-              sources."define-property-0.2.5"
-              sources."extend-shallow-2.0.1"
-            ];
-          })
-          (sources."extglob-2.0.4" // {
-            dependencies = [
-              sources."define-property-1.0.0"
-              sources."extend-shallow-2.0.1"
-            ];
-          })
-          (sources."fill-range-4.0.0" // {
-            dependencies = [
-              sources."extend-shallow-2.0.1"
-            ];
-          })
-          (sources."is-accessor-descriptor-0.1.6" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          sources."is-buffer-1.1.6"
-          (sources."is-data-descriptor-0.1.4" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          (sources."is-descriptor-0.1.6" // {
-            dependencies = [
-              sources."kind-of-5.1.0"
-            ];
-          })
-          (sources."is-number-3.0.0" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          sources."isobject-3.0.1"
-          sources."kind-of-6.0.2"
-          sources."micromatch-3.1.10"
-          sources."ms-2.0.0"
-        ];
-      })
+      sources."readdirp-2.2.1"
       sources."redent-2.0.0"
       sources."regenerator-runtime-0.11.1"
       sources."regex-cache-0.4.4"
@@ -72203,6 +72483,7 @@ in
       sources."repeat-element-1.1.3"
       sources."repeat-string-1.6.1"
       sources."replace-ext-1.0.0"
+      sources."require-directory-2.1.1"
       sources."require-main-filename-1.0.1"
       sources."require-relative-0.8.7"
       (sources."require-uncached-1.0.3" // {
@@ -72223,10 +72504,10 @@ in
       sources."safe-buffer-5.1.2"
       sources."safe-regex-1.1.0"
       sources."safer-buffer-2.1.2"
-      sources."sax-0.5.8"
-      sources."semver-5.7.0"
+      sources."sax-1.2.4"
+      sources."semver-5.7.1"
       sources."semver-diff-2.1.0"
-      sources."set-blocking-1.0.0"
+      sources."set-blocking-2.0.0"
       (sources."set-value-2.0.1" // {
         dependencies = [
           sources."extend-shallow-2.0.1"
@@ -72237,6 +72518,7 @@ in
       sources."shellsubstitute-1.2.0"
       sources."sigmund-1.0.1"
       sources."signal-exit-3.0.2"
+      sources."slash-1.0.0"
       sources."slice-ansi-2.1.0"
       (sources."snapdragon-0.8.2" // {
         dependencies = [
@@ -72257,17 +72539,20 @@ in
           sources."is-descriptor-0.1.6"
           sources."kind-of-5.1.0"
           sources."ms-2.0.0"
-          sources."source-map-0.5.7"
         ];
       })
       (sources."snapdragon-node-2.1.1" // {
         dependencies = [
           sources."define-property-1.0.0"
-          sources."isobject-3.0.1"
         ];
       })
-      sources."snapdragon-util-3.0.1"
-      sources."source-map-0.1.43"
+      (sources."snapdragon-util-3.0.1" // {
+        dependencies = [
+          sources."is-buffer-1.1.6"
+          sources."kind-of-3.2.2"
+        ];
+      })
+      sources."source-map-0.5.7"
       sources."source-map-resolve-0.5.2"
       sources."source-map-url-0.4.0"
       sources."space-separated-tokens-1.1.4"
@@ -72308,22 +72593,42 @@ in
         dependencies = [
           sources."ansi-regex-2.1.1"
           sources."ansi-styles-2.2.1"
+          sources."camelcase-3.0.0"
           sources."chalk-1.1.3"
+          sources."cliui-3.2.0"
+          sources."find-up-1.1.2"
           sources."glob-7.0.4"
+          sources."is-fullwidth-code-point-1.0.0"
+          sources."load-json-file-1.1.0"
+          sources."os-locale-1.4.0"
+          sources."parse-json-2.2.0"
+          sources."path-exists-2.1.0"
           sources."path-is-absolute-1.0.0"
+          sources."path-type-1.1.0"
+          sources."pify-2.3.0"
+          sources."read-pkg-1.1.0"
+          sources."read-pkg-up-1.0.1"
+          sources."set-blocking-1.0.0"
+          sources."string-width-1.0.2"
           sources."strip-ansi-3.0.1"
+          sources."strip-bom-2.0.0"
           sources."supports-color-2.0.0"
+          sources."yargs-4.7.1"
+          sources."yargs-parser-2.4.1"
         ];
       })
-      (sources."stylus-0.54.5" // {
+      (sources."stylus-0.54.7" // {
         dependencies = [
-          sources."glob-7.0.6"
+          sources."debug-3.1.0"
+          sources."ms-2.0.0"
+          sources."semver-6.3.0"
+          sources."source-map-0.7.3"
         ];
       })
       sources."stylus-supremacy-2.12.7"
       sources."supports-color-5.5.0"
       sources."symbol-0.2.3"
-      (sources."table-5.4.5" // {
+      (sources."table-5.4.6" // {
         dependencies = [
           sources."ansi-regex-4.1.0"
           sources."string-width-3.1.0"
@@ -72335,13 +72640,14 @@ in
       sources."through-2.3.8"
       sources."timed-out-4.0.1"
       sources."tmp-0.0.33"
-      sources."to-object-path-0.3.0"
-      sources."to-regex-3.0.2"
-      (sources."to-regex-range-2.1.1" // {
+      (sources."to-object-path-0.3.0" // {
         dependencies = [
-          sources."is-number-3.0.0"
+          sources."is-buffer-1.1.6"
+          sources."kind-of-3.2.2"
         ];
       })
+      sources."to-regex-3.0.2"
+      sources."to-regex-range-2.1.1"
       (sources."to-vfile-5.0.3" // {
         dependencies = [
           sources."vfile-3.0.1"
@@ -72352,9 +72658,11 @@ in
       sources."trim-trailing-lines-1.1.2"
       sources."trough-1.0.4"
       sources."tslib-1.10.0"
+      sources."tslint-5.19.0"
+      sources."tsutils-2.29.0"
       sources."type-check-0.3.2"
       sources."typedarray-0.0.6"
-      sources."typescript-3.5.3"
+      sources."typescript-3.6.2"
       (sources."typescript-eslint-parser-16.0.1" // {
         dependencies = [
           sources."semver-5.5.0"
@@ -72394,7 +72702,6 @@ in
             ];
           })
           sources."has-values-0.1.4"
-          sources."isobject-3.0.1"
         ];
       })
       sources."untildify-2.1.0"
@@ -72428,10 +72735,10 @@ in
           sources."vscode-languageserver-types-3.14.0"
         ];
       })
-      sources."vscode-jsonrpc-4.1.0-next.2"
-      sources."vscode-languageserver-5.3.0-next.8"
-      sources."vscode-languageserver-protocol-3.15.0-next.6"
-      sources."vscode-languageserver-types-3.15.0-next.2"
+      sources."vscode-jsonrpc-4.1.0-next.3"
+      sources."vscode-languageserver-5.3.0-next.10"
+      sources."vscode-languageserver-protocol-3.15.0-next.8"
+      sources."vscode-languageserver-types-3.15.0-next.4"
       sources."vscode-nls-4.1.1"
       sources."vscode-textbuffer-1.0.0"
       sources."vscode-uri-1.0.8"
@@ -72441,9 +72748,9 @@ in
         ];
       })
       sources."vue-onsenui-helper-json-1.0.2"
-      sources."vuetify-helper-json-1.0.0"
       sources."wcwidth-1.0.1"
       sources."which-1.3.1"
+      sources."which-module-2.0.0"
       sources."widest-line-2.0.1"
       sources."window-size-0.2.0"
       sources."wordwrap-1.0.0"
@@ -72463,24 +72770,10 @@ in
       sources."xdg-basedir-3.0.0"
       sources."xtend-4.0.2"
       sources."y18n-3.2.1"
-      sources."yallist-3.0.3"
-      (sources."yargs-4.7.1" // {
+      sources."yallist-2.1.2"
+      (sources."yargs-11.1.0" // {
         dependencies = [
-          sources."ansi-regex-2.1.1"
-          sources."camelcase-3.0.0"
-          sources."find-up-1.1.2"
-          sources."is-fullwidth-code-point-1.0.0"
-          sources."load-json-file-1.1.0"
-          sources."parse-json-2.2.0"
-          sources."path-exists-2.1.0"
-          sources."path-type-1.1.0"
-          sources."pify-2.3.0"
-          sources."read-pkg-1.1.0"
-          sources."read-pkg-up-1.0.1"
-          sources."string-width-1.0.2"
-          sources."strip-ansi-3.0.1"
-          sources."strip-bom-2.0.0"
-          sources."yargs-parser-2.4.1"
+          sources."yargs-parser-9.0.2"
         ];
       })
       sources."yargs-parser-10.1.0"
@@ -72511,15 +72804,20 @@ in
       sources."@cliqz-oss/firefox-client-0.3.1"
       sources."@cliqz-oss/node-firefox-connect-1.2.1"
       sources."@sindresorhus/is-0.14.0"
+      sources."@snyk/cli-interface-2.0.3"
       sources."@snyk/composer-lockfile-parser-1.0.3"
       sources."@snyk/dep-graph-1.12.0"
       sources."@snyk/gemfile-1.2.0"
       sources."@szmarczak/http-timer-1.1.2"
       sources."@types/agent-base-4.2.0"
-      sources."@types/debug-4.1.4"
+      sources."@types/bunyan-1.8.6"
+      sources."@types/debug-4.1.5"
       sources."@types/events-3.0.0"
       sources."@types/minimatch-3.0.3"
-      sources."@types/node-12.6.9"
+      sources."@types/node-12.7.3"
+      sources."@types/restify-4.3.6"
+      sources."@types/semver-5.5.0"
+      sources."@types/xml2js-0.4.3"
       sources."@yarnpkg/lockfile-1.1.0"
       sources."JSONSelect-0.2.1"
       sources."abbrev-1.1.1"
@@ -72548,7 +72846,7 @@ in
       sources."ajv-keywords-1.5.1"
       sources."ajv-merge-patch-4.1.0"
       sources."ansi-align-2.0.0"
-      sources."ansi-escapes-4.2.1"
+      sources."ansi-escapes-3.2.0"
       sources."ansi-regex-2.1.1"
       sources."ansi-styles-3.2.1"
       sources."ansicolors-0.3.2"
@@ -72559,6 +72857,7 @@ in
           sources."async-2.6.3"
           sources."isarray-1.0.0"
           sources."readable-stream-2.3.6"
+          sources."safe-buffer-5.1.2"
           sources."string_decoder-1.1.1"
         ];
       })
@@ -72566,6 +72865,7 @@ in
         dependencies = [
           sources."isarray-1.0.0"
           sources."readable-stream-2.3.6"
+          sources."safe-buffer-5.1.2"
           sources."string_decoder-1.1.1"
         ];
       })
@@ -72624,8 +72924,16 @@ in
       (sources."bl-1.2.2" // {
         dependencies = [
           sources."isarray-1.0.0"
-          sources."readable-stream-2.3.6"
-          sources."string_decoder-1.1.1"
+          (sources."readable-stream-2.3.6" // {
+            dependencies = [
+              sources."safe-buffer-5.1.2"
+            ];
+          })
+          (sources."string_decoder-1.1.1" // {
+            dependencies = [
+              sources."safe-buffer-5.1.2"
+            ];
+          })
         ];
       })
       sources."bluebird-2.9.34"
@@ -72641,7 +72949,7 @@ in
           sources."extend-shallow-2.0.1"
         ];
       })
-      sources."buffer-5.2.1"
+      sources."buffer-5.4.2"
       sources."buffer-alloc-1.2.0"
       sources."buffer-alloc-unsafe-1.1.0"
       sources."buffer-crc32-0.2.13"
@@ -72670,7 +72978,7 @@ in
       sources."chalk-2.4.2"
       sources."chardet-0.7.0"
       sources."cheerio-1.0.0-rc.3"
-      (sources."chokidar-2.1.6" // {
+      (sources."chokidar-2.1.8" // {
         dependencies = [
           sources."fsevents-1.2.9"
           sources."normalize-path-3.0.0"
@@ -72722,6 +73030,7 @@ in
         dependencies = [
           sources."isarray-1.0.0"
           sources."readable-stream-2.3.6"
+          sources."safe-buffer-5.1.2"
           sources."string_decoder-1.1.1"
         ];
       })
@@ -72730,6 +73039,7 @@ in
         dependencies = [
           sources."isarray-1.0.0"
           sources."readable-stream-2.3.6"
+          sources."safe-buffer-5.1.2"
           sources."string_decoder-1.1.1"
         ];
       })
@@ -72742,13 +73052,14 @@ in
         dependencies = [
           sources."isarray-1.0.0"
           sources."readable-stream-2.3.6"
+          sources."safe-buffer-5.1.2"
           sources."string_decoder-1.1.1"
         ];
       })
       sources."create-error-class-3.0.2"
       (sources."cross-spawn-6.0.5" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       sources."crx-parser-0.1.2"
@@ -72759,7 +73070,7 @@ in
       sources."dashdash-1.14.1"
       (sources."data-uri-to-buffer-2.0.1" // {
         dependencies = [
-          sources."@types/node-8.10.51"
+          sources."@types/node-8.10.53"
         ];
       })
       sources."debounce-1.2.0"
@@ -72771,13 +73082,14 @@ in
       })
       sources."decode-uri-component-0.2.0"
       sources."decompress-response-3.3.0"
-      sources."deep-equal-1.0.1"
+      sources."deep-equal-1.1.0"
       sources."deep-extend-0.6.0"
       sources."deep-is-0.1.3"
       sources."deepcopy-0.6.3"
       sources."deepmerge-3.2.0"
       sources."defaults-1.0.3"
       sources."defer-to-connect-1.0.2"
+      sources."define-properties-1.1.3"
       sources."define-property-2.0.2"
       (sources."degenerator-1.0.4" // {
         dependencies = [
@@ -72799,7 +73111,8 @@ in
       sources."domhandler-2.4.2"
       sources."domutils-1.5.1"
       sources."dot-prop-4.2.0"
-      sources."dtrace-provider-0.8.7"
+      sources."dotnet-deps-parser-4.5.0"
+      sources."dtrace-provider-0.8.8"
       sources."duplexer3-0.1.4"
       sources."ecc-jsbn-0.1.2"
       sources."ecdsa-sig-formatter-1.0.11"
@@ -72819,7 +73132,7 @@ in
       sources."es6-symbol-3.1.1"
       sources."es6-weak-map-2.0.3"
       sources."escape-string-regexp-1.0.5"
-      (sources."escodegen-1.11.1" // {
+      (sources."escodegen-1.12.0" // {
         dependencies = [
           sources."esprima-3.1.3"
         ];
@@ -72830,7 +73143,7 @@ in
           sources."ansi-regex-3.0.0"
           sources."debug-4.1.1"
           sources."ms-2.1.2"
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
           sources."strip-ansi-4.0.0"
           sources."strip-json-comments-2.0.1"
         ];
@@ -72874,18 +73187,18 @@ in
         ];
       })
       sources."eslint-scope-4.0.3"
-      sources."eslint-utils-1.4.0"
+      sources."eslint-utils-1.4.2"
       sources."eslint-visitor-keys-1.0.0"
       (sources."espree-5.0.1" // {
         dependencies = [
-          sources."acorn-6.2.1"
-          sources."acorn-jsx-5.0.1"
+          sources."acorn-6.3.0"
+          sources."acorn-jsx-5.0.2"
         ];
       })
       sources."esprima-4.0.1"
       sources."esquery-1.0.1"
       sources."esrecurse-4.2.1"
-      sources."estraverse-4.2.0"
+      sources."estraverse-4.3.0"
       sources."esutils-2.0.3"
       sources."event-emitter-0.3.5"
       sources."event-to-promise-0.8.0"
@@ -72928,7 +73241,7 @@ in
       })
       sources."extsprintf-1.3.0"
       sources."fast-deep-equal-2.0.1"
-      sources."fast-json-patch-2.2.0"
+      sources."fast-json-patch-2.2.1"
       sources."fast-json-stable-stringify-2.0.0"
       sources."fast-levenshtein-2.0.6"
       sources."fast-redact-1.5.0"
@@ -72968,6 +73281,7 @@ in
           sources."string_decoder-0.10.31"
         ];
       })
+      sources."function-bind-1.1.1"
       sources."functional-red-black-tree-1.0.1"
       (sources."fx-runner-1.0.11" // {
         dependencies = [
@@ -73010,12 +73324,13 @@ in
           sources."get-stream-3.0.0"
         ];
       })
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."graceful-readlink-1.0.1"
       sources."graphlib-2.1.7"
       sources."growly-1.3.0"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
+      sources."has-1.0.3"
       sources."has-ansi-2.0.0"
       sources."has-color-0.1.7"
       sources."has-flag-3.0.0"
@@ -73026,12 +73341,7 @@ in
         ];
       })
       sources."has-yarn-2.1.0"
-      (sources."hosted-git-info-2.8.2" // {
-        dependencies = [
-          sources."lru-cache-5.1.1"
-          sources."yallist-3.0.3"
-        ];
-      })
+      sources."hosted-git-info-2.8.4"
       sources."htmlparser2-3.10.1"
       sources."http-cache-semantics-4.0.3"
       sources."http-errors-1.7.3"
@@ -73057,9 +73367,8 @@ in
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
       sources."ini-1.3.5"
-      (sources."inquirer-6.5.0" // {
+      (sources."inquirer-6.5.2" // {
         dependencies = [
-          sources."ansi-escapes-3.2.0"
           sources."ansi-regex-4.1.0"
           sources."strip-ansi-5.2.0"
         ];
@@ -73073,6 +73382,7 @@ in
           sources."kind-of-6.0.2"
         ];
       })
+      sources."is-arguments-1.0.4"
       sources."is-arrayish-0.2.1"
       sources."is-binary-path-1.0.1"
       sources."is-buffer-1.1.6"
@@ -73082,6 +73392,7 @@ in
           sources."kind-of-6.0.2"
         ];
       })
+      sources."is-date-object-1.0.1"
       (sources."is-descriptor-1.0.2" // {
         dependencies = [
           sources."kind-of-6.0.2"
@@ -73103,6 +73414,7 @@ in
       sources."is-promise-2.1.0"
       sources."is-property-1.0.2"
       sources."is-redirect-1.0.0"
+      sources."is-regex-1.0.4"
       sources."is-relative-0.1.3"
       sources."is-resolvable-1.1.0"
       sources."is-retry-allowed-1.1.0"
@@ -73144,6 +73456,7 @@ in
         dependencies = [
           sources."isarray-1.0.0"
           sources."readable-stream-2.3.6"
+          sources."safe-buffer-5.1.2"
           sources."string_decoder-1.1.1"
         ];
       })
@@ -73157,6 +73470,7 @@ in
         dependencies = [
           sources."isarray-1.0.0"
           sources."readable-stream-2.3.6"
+          sources."safe-buffer-5.1.2"
           sources."string_decoder-1.1.1"
         ];
       })
@@ -73263,7 +73577,7 @@ in
       sources."node-forge-0.7.6"
       (sources."node-notifier-5.4.0" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       (sources."nomnom-1.8.1" // {
@@ -73293,6 +73607,8 @@ in
         ];
       })
       sources."object-hash-1.3.1"
+      sources."object-is-1.0.1"
+      sources."object-keys-1.1.1"
       sources."object-visit-1.0.1"
       sources."object.pick-1.3.0"
       sources."once-1.4.0"
@@ -73313,7 +73629,7 @@ in
       sources."p-defer-1.0.0"
       sources."p-finally-1.0.0"
       sources."p-is-promise-2.1.0"
-      sources."p-limit-2.2.0"
+      sources."p-limit-2.2.1"
       sources."p-locate-3.0.0"
       sources."p-try-2.2.0"
       (sources."pac-proxy-agent-3.0.0" // {
@@ -73325,7 +73641,7 @@ in
       sources."pac-resolver-3.0.0"
       (sources."package-json-4.0.1" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       sources."pako-1.0.10"
@@ -73389,6 +73705,7 @@ in
         dependencies = [
           sources."isarray-1.0.0"
           sources."readable-stream-2.3.6"
+          sources."safe-buffer-5.1.2"
           sources."string_decoder-1.1.1"
         ];
       })
@@ -73401,6 +73718,7 @@ in
       sources."rechoir-0.6.2"
       sources."regenerator-runtime-0.13.3"
       sources."regex-not-1.0.2"
+      sources."regexp.prototype.flags-1.2.0"
       sources."regexpp-2.0.1"
       sources."registry-auth-token-3.4.0"
       sources."registry-url-3.1.0"
@@ -73426,7 +73744,7 @@ in
       sources."run-async-2.3.0"
       sources."rx-lite-3.1.2"
       sources."rxjs-6.5.2"
-      sources."safe-buffer-5.1.2"
+      sources."safe-buffer-5.2.0"
       sources."safe-json-stringify-1.2.0"
       sources."safe-regex-1.1.0"
       sources."safer-buffer-2.1.2"
@@ -73435,7 +73753,7 @@ in
       sources."semver-6.1.1"
       (sources."semver-diff-2.1.0" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       sources."set-blocking-2.0.0"
@@ -73503,7 +73821,7 @@ in
         ];
       })
       sources."snapdragon-util-3.0.1"
-      (sources."snyk-1.210.0" // {
+      (sources."snyk-1.221.1" // {
         dependencies = [
           sources."ansi-regex-4.1.0"
           sources."debug-3.2.6"
@@ -73518,7 +73836,7 @@ in
           sources."ms-2.1.2"
         ];
       })
-      (sources."snyk-docker-plugin-1.25.1" // {
+      (sources."snyk-docker-plugin-1.29.1" // {
         dependencies = [
           sources."debug-4.1.1"
           sources."ms-2.1.2"
@@ -73532,7 +73850,7 @@ in
           sources."tmp-0.0.33"
         ];
       })
-      (sources."snyk-gradle-plugin-2.12.5" // {
+      (sources."snyk-gradle-plugin-3.0.2" // {
         dependencies = [
           sources."debug-4.1.1"
           sources."ms-2.1.2"
@@ -73545,13 +73863,13 @@ in
           sources."ms-2.1.2"
         ];
       })
-      (sources."snyk-mvn-plugin-2.3.3" // {
+      (sources."snyk-mvn-plugin-2.4.0" // {
         dependencies = [
           sources."tslib-1.9.3"
         ];
       })
       sources."snyk-nodejs-lockfile-parser-1.16.0"
-      (sources."snyk-nuget-plugin-1.11.3" // {
+      (sources."snyk-nuget-plugin-1.12.1" // {
         dependencies = [
           sources."debug-3.2.6"
           sources."ms-2.1.2"
@@ -73569,7 +73887,7 @@ in
           sources."ms-2.1.2"
         ];
       })
-      (sources."snyk-python-plugin-1.10.2" // {
+      (sources."snyk-python-plugin-1.13.2" // {
         dependencies = [
           sources."tmp-0.0.33"
         ];
@@ -73580,14 +73898,15 @@ in
           sources."ms-2.1.2"
         ];
       })
-      (sources."snyk-resolve-deps-4.0.3" // {
+      (sources."snyk-resolve-deps-4.4.0" // {
         dependencies = [
+          sources."@types/node-6.14.7"
           sources."debug-3.2.6"
           sources."ms-2.1.2"
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
-      (sources."snyk-sbt-plugin-2.6.1" // {
+      (sources."snyk-sbt-plugin-2.7.0" // {
         dependencies = [
           sources."semver-6.3.0"
         ];
@@ -73649,7 +73968,7 @@ in
           sources."strip-ansi-4.0.0"
         ];
       })
-      sources."string_decoder-1.2.0"
+      sources."string_decoder-1.3.0"
       sources."strip-ansi-3.0.1"
       sources."strip-bom-3.0.0"
       sources."strip-bom-buf-2.0.0"
@@ -73657,7 +73976,7 @@ in
       sources."strip-eof-1.0.0"
       sources."strip-json-comments-3.0.1"
       sources."supports-color-5.5.0"
-      (sources."table-5.4.5" // {
+      (sources."table-5.4.6" // {
         dependencies = [
           sources."ajv-6.10.2"
           sources."ansi-regex-4.1.0"
@@ -73669,6 +73988,7 @@ in
         dependencies = [
           sources."isarray-1.0.0"
           sources."readable-stream-2.3.6"
+          sources."safe-buffer-5.1.2"
           sources."string_decoder-1.1.1"
         ];
       })
@@ -73710,7 +74030,7 @@ in
       sources."tweetnacl-0.14.5"
       sources."type-1.0.3"
       sources."type-check-0.3.2"
-      sources."type-fest-0.5.2"
+      sources."type-fest-0.3.1"
       sources."typedarray-0.0.6"
       sources."underscore-1.6.0"
       sources."union-value-1.0.1"
@@ -73749,7 +74069,6 @@ in
           sources."semver-6.3.0"
           sources."string-width-3.1.0"
           sources."strip-ansi-5.2.0"
-          sources."type-fest-0.3.1"
           sources."url-parse-lax-3.0.0"
         ];
       })
@@ -73759,7 +74078,7 @@ in
       sources."use-3.1.1"
       sources."user-home-2.0.0"
       sources."util-deprecate-1.0.2"
-      sources."uuid-3.3.2"
+      sources."uuid-3.3.3"
       sources."verror-1.10.0"
       sources."vscode-languageserver-types-3.14.0"
       sources."watchpack-1.6.0"
@@ -73816,6 +74135,7 @@ in
         dependencies = [
           sources."isarray-1.0.0"
           sources."readable-stream-2.3.6"
+          sources."safe-buffer-5.1.2"
           sources."string_decoder-1.1.1"
         ];
       })
@@ -73832,10 +74152,10 @@ in
   webpack = nodeEnv.buildNodePackage {
     name = "webpack";
     packageName = "webpack";
-    version = "4.39.1";
+    version = "4.39.3";
     src = fetchurl {
-      url = "https://registry.npmjs.org/webpack/-/webpack-4.39.1.tgz";
-      sha512 = "/LAb2TJ2z+eVwisldp3dqTEoNhzp/TLCZlmZm3GGGAlnfIWDgOEE758j/9atklNLfRyhKbZTCOIoPqLJXeBLbQ==";
+      url = "https://registry.npmjs.org/webpack/-/webpack-4.39.3.tgz";
+      sha512 = "BXSI9M211JyCVc3JxHWDpze85CvjC842EvpRsVTc/d15YJGlox7GIDd38kJgWrb3ZluyvIjgenbLDMBQPDcxYQ==";
     };
     dependencies = [
       sources."@webassemblyjs/ast-1.8.5"
@@ -73858,7 +74178,7 @@ in
       sources."@webassemblyjs/wast-printer-1.8.5"
       sources."@xtuc/ieee754-1.2.0"
       sources."@xtuc/long-4.2.2"
-      sources."acorn-6.2.1"
+      sources."acorn-6.3.0"
       sources."ajv-6.10.2"
       sources."ajv-errors-1.0.1"
       sources."ajv-keywords-3.4.1"
@@ -73910,9 +74230,9 @@ in
       sources."buffer-from-1.1.1"
       sources."buffer-xor-1.0.3"
       sources."builtin-status-codes-3.0.0"
-      sources."cacache-12.0.2"
+      sources."cacache-12.0.3"
       sources."cache-base-1.0.1"
-      sources."chokidar-2.1.6"
+      sources."chokidar-2.1.8"
       sources."chownr-1.1.2"
       sources."chrome-trace-event-1.0.2"
       sources."cipher-base-1.0.4"
@@ -73964,7 +74284,7 @@ in
       sources."errno-0.1.7"
       sources."eslint-scope-4.0.3"
       sources."esrecurse-4.2.1"
-      sources."estraverse-4.2.0"
+      sources."estraverse-4.3.0"
       sources."events-3.0.0"
       sources."evp_bytestokey-1.0.3"
       (sources."expand-brackets-2.1.4" // {
@@ -74020,7 +74340,7 @@ in
           sources."is-glob-3.1.0"
         ];
       })
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."has-value-1.0.0"
       (sources."has-values-1.0.0" // {
         dependencies = [
@@ -74115,7 +74435,7 @@ in
       sources."object.pick-1.3.0"
       sources."once-1.4.0"
       sources."os-browserify-0.3.0"
-      sources."p-limit-2.2.0"
+      sources."p-limit-2.2.1"
       sources."p-locate-3.0.0"
       sources."p-try-2.2.0"
       sources."pako-1.0.10"
@@ -74154,14 +74474,14 @@ in
       sources."repeat-string-1.6.1"
       sources."resolve-url-0.2.1"
       sources."ret-0.1.15"
-      sources."rimraf-2.6.3"
+      sources."rimraf-2.7.1"
       sources."ripemd160-2.0.2"
       sources."run-queue-1.0.3"
       sources."safe-buffer-5.1.2"
       sources."safe-regex-1.1.0"
       sources."schema-utils-1.0.0"
-      sources."semver-5.7.0"
-      sources."serialize-javascript-1.7.0"
+      sources."semver-5.7.1"
+      sources."serialize-javascript-1.9.0"
       (sources."set-value-2.0.1" // {
         dependencies = [
           sources."extend-shallow-2.0.1"
@@ -74231,7 +74551,7 @@ in
       sources."stream-shift-1.0.0"
       sources."string_decoder-1.1.1"
       sources."tapable-1.1.3"
-      (sources."terser-4.1.3" // {
+      (sources."terser-4.2.1" // {
         dependencies = [
           sources."source-map-0.6.1"
         ];
@@ -74242,7 +74562,7 @@ in
         ];
       })
       sources."through2-2.0.5"
-      sources."timers-browserify-2.0.10"
+      sources."timers-browserify-2.0.11"
       sources."to-arraybuffer-1.0.1"
       (sources."to-object-path-0.3.0" // {
         dependencies = [
@@ -74307,10 +74627,10 @@ in
   webpack-cli = nodeEnv.buildNodePackage {
     name = "webpack-cli";
     packageName = "webpack-cli";
-    version = "3.3.6";
+    version = "3.3.7";
     src = fetchurl {
-      url = "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.6.tgz";
-      sha512 = "0vEa83M7kJtxK/jUhlpZ27WHIOndz5mghWL2O53kiDoA9DIxSKnfqB92LoqEn77cT4f3H2cZm1BMEat/6AZz3A==";
+      url = "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.7.tgz";
+      sha512 = "OhTUCttAsr+IZSMVwGROGRHvT+QAs8H6/mHIl4SvhAwYywjiylYjpwybGx7WQ9Hkb45FhjtsymkwiRRbGJ1SZQ==";
     };
     dependencies = [
       sources."ansi-regex-4.1.0"
@@ -74424,7 +74744,7 @@ in
         ];
       })
       sources."global-prefix-1.0.2"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."has-flag-3.0.0"
       sources."has-value-1.0.0"
       (sources."has-values-1.0.0" // {
@@ -74499,7 +74819,7 @@ in
       sources."p-defer-1.0.0"
       sources."p-finally-1.0.0"
       sources."p-is-promise-2.1.0"
-      sources."p-limit-2.2.0"
+      sources."p-limit-2.2.1"
       sources."p-locate-3.0.0"
       sources."p-try-2.2.0"
       sources."parse-passwd-1.0.0"
@@ -74528,7 +74848,7 @@ in
       sources."ret-0.1.15"
       sources."safe-buffer-5.1.2"
       sources."safe-regex-1.1.0"
-      sources."semver-5.7.0"
+      sources."semver-5.7.1"
       sources."set-blocking-2.0.0"
       (sources."set-value-2.0.1" // {
         dependencies = [
@@ -74649,7 +74969,7 @@ in
       sources."bencode-2.0.1"
       sources."binary-search-1.3.6"
       sources."bitfield-3.0.0"
-      (sources."bittorrent-dht-9.0.1" // {
+      (sources."bittorrent-dht-9.0.2" // {
         dependencies = [
           sources."debug-4.1.1"
           sources."ms-2.1.2"
@@ -74662,7 +74982,7 @@ in
           sources."ms-2.1.2"
         ];
       })
-      (sources."bittorrent-tracker-9.12.1" // {
+      (sources."bittorrent-tracker-9.14.4" // {
         dependencies = [
           sources."debug-4.1.1"
           sources."ms-2.1.2"
@@ -74676,7 +74996,6 @@ in
       sources."browserify-package-json-1.0.1"
       sources."buffer-alloc-1.2.0"
       sources."buffer-alloc-unsafe-1.1.0"
-      sources."buffer-equals-1.0.4"
       sources."buffer-fill-1.0.0"
       sources."buffer-from-1.1.1"
       sources."buffer-indexof-1.1.1"
@@ -74686,6 +75005,9 @@ in
       sources."castv2-0.1.9"
       sources."castv2-client-1.2.0"
       sources."charset-1.0.1"
+      sources."chrome-dgram-3.0.2"
+      sources."chrome-dns-1.0.1"
+      sources."chrome-net-3.3.3"
       (sources."chromecasts-1.9.1" // {
         dependencies = [
           sources."mime-1.6.0"
@@ -74693,7 +75015,6 @@ in
       })
       sources."chunk-store-stream-4.1.0"
       sources."clivas-0.2.0"
-      sources."closest-to-2.0.0"
       sources."colour-0.7.1"
       sources."common-tags-1.8.0"
       sources."compact2string-1.4.1"
@@ -74706,7 +75027,7 @@ in
         ];
       })
       sources."core-util-is-1.0.2"
-      sources."create-torrent-4.2.1"
+      sources."create-torrent-4.3.0"
       sources."debug-2.6.9"
       sources."decompress-response-3.3.0"
       (sources."dlnacasts-0.1.0" // {
@@ -74720,9 +75041,11 @@ in
       sources."ee-first-1.1.1"
       sources."elementtree-0.1.7"
       sources."end-of-stream-1.4.1"
+      sources."escape-html-1.0.3"
       sources."executable-4.1.1"
       sources."filestream-5.0.0"
-      (sources."fs-chunk-store-1.7.0" // {
+      sources."freelist-1.0.3"
+      (sources."fs-chunk-store-2.0.1" // {
         dependencies = [
           sources."thunky-1.0.3"
         ];
@@ -74732,6 +75055,8 @@ in
       sources."get-stdin-7.0.0"
       sources."glob-7.1.4"
       sources."he-1.2.0"
+      sources."http-node-git://github.com/feross/http-node#cddd2872f0020ecf5016f326cf5e58c965eef52a"
+      sources."http-parser-js-0.4.13"
       sources."immediate-chunk-store-2.0.0"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
@@ -74745,12 +75070,8 @@ in
       sources."isarray-1.0.0"
       sources."junk-3.1.0"
       sources."k-bucket-5.0.0"
-      (sources."k-rpc-5.0.0" // {
-        dependencies = [
-          sources."k-bucket-4.0.1"
-        ];
-      })
-      sources."k-rpc-socket-1.8.0"
+      sources."k-rpc-5.1.0"
+      sources."k-rpc-socket-1.11.1"
       sources."last-one-wins-1.0.4"
       (sources."load-ip-set-2.1.0" // {
         dependencies = [
@@ -74774,15 +75095,15 @@ in
         ];
       })
       sources."moment-2.24.0"
-      sources."mp4-box-encoding-1.3.0"
-      sources."mp4-stream-3.0.0"
+      sources."mp4-box-encoding-1.4.1"
+      sources."mp4-stream-3.1.0"
       sources."ms-2.0.0"
       (sources."multicast-dns-6.2.3" // {
         dependencies = [
           sources."thunky-1.0.3"
         ];
       })
-      sources."multistream-3.1.0"
+      sources."multistream-4.0.0"
       sources."netmask-1.0.6"
       sources."network-address-1.1.2"
       sources."next-event-1.0.0"
@@ -74801,7 +75122,7 @@ in
         ];
       })
       sources."path-is-absolute-1.0.1"
-      sources."piece-length-1.0.0"
+      sources."piece-length-2.0.1"
       sources."pify-2.3.0"
       (sources."plist-with-patches-0.5.1" // {
         dependencies = [
@@ -74821,13 +75142,13 @@ in
       sources."range-slice-stream-2.0.0"
       sources."readable-stream-3.4.0"
       sources."record-cache-1.1.0"
-      (sources."render-media-3.3.0" // {
+      (sources."render-media-3.3.1" // {
         dependencies = [
           sources."debug-4.1.1"
           sources."ms-2.1.2"
         ];
       })
-      sources."rimraf-2.6.3"
+      sources."rimraf-3.0.0"
       sources."run-parallel-1.1.9"
       sources."run-parallel-limit-1.0.5"
       sources."run-series-1.1.8"
@@ -74844,7 +75165,7 @@ in
         ];
       })
       sources."simple-sha1-2.1.2"
-      (sources."simple-websocket-8.0.0" // {
+      (sources."simple-websocket-8.0.1" // {
         dependencies = [
           sources."debug-4.1.1"
           sources."ms-2.1.2"
@@ -74853,23 +75174,15 @@ in
       sources."speedometer-1.1.0"
       sources."split-1.0.1"
       sources."stream-to-blob-2.0.0"
-      (sources."stream-to-blob-url-2.1.2" // {
-        dependencies = [
-          sources."stream-to-blob-1.0.2"
-        ];
-      })
+      sources."stream-to-blob-url-3.0.0"
       sources."stream-with-known-length-to-buffer-1.0.3"
       sources."string2compact-1.3.0"
-      (sources."string_decoder-1.2.0" // {
-        dependencies = [
-          sources."safe-buffer-5.1.2"
-        ];
-      })
+      sources."string_decoder-1.3.0"
       sources."thirty-two-1.0.2"
       sources."through-2.3.8"
       sources."thunky-0.1.0"
       sources."to-arraybuffer-1.0.1"
-      (sources."torrent-discovery-9.1.2" // {
+      (sources."torrent-discovery-9.2.1" // {
         dependencies = [
           sources."debug-4.1.1"
           sources."ms-2.1.2"
@@ -74890,12 +75203,12 @@ in
           sources."ms-2.1.2"
         ];
       })
-      sources."ut_pex-1.2.1"
+      sources."ut_pex-2.0.0"
       sources."utf-8-validate-5.0.2"
       sources."util-deprecate-1.0.2"
       sources."videostream-3.2.1"
-      sources."vlc-command-1.1.2"
-      (sources."webtorrent-0.106.0" // {
+      sources."vlc-command-1.2.0"
+      (sources."webtorrent-0.107.6" // {
         dependencies = [
           sources."debug-4.1.1"
           sources."ms-2.1.2"
@@ -74904,7 +75217,7 @@ in
       })
       sources."winreg-1.2.4"
       sources."wrappy-1.0.2"
-      sources."ws-7.1.1"
+      sources."ws-7.1.2"
       sources."xml2js-0.4.19"
       sources."xmlbuilder-9.0.7"
       sources."xmldom-0.1.27"
@@ -74938,10 +75251,10 @@ in
   write-good = nodeEnv.buildNodePackage {
     name = "write-good";
     packageName = "write-good";
-    version = "1.0.1";
+    version = "1.0.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/write-good/-/write-good-1.0.1.tgz";
-      sha512 = "wSmjZBTHMOexWmK3AmSORGlWAICD98BF0LORYjkK58tChjjMr/BltpvohCThxmIE2vcHYccXHzSVBd/v8ew71g==";
+      url = "https://registry.npmjs.org/write-good/-/write-good-1.0.2.tgz";
+      sha512 = "1gm9Ouz7mBROF7aC8vvSm/3JtPfTiZ+fegPGCKdxsYhf6VYeStHfVFx2Hnj2kJviHPx5zZkiQ8DytzZMP0Zqwg==";
     };
     dependencies = [
       sources."adverb-where-0.2.1"
@@ -75093,7 +75406,7 @@ in
       sources."config-chain-1.1.12"
       sources."configstore-3.1.2"
       sources."copy-descriptor-0.1.1"
-      sources."core-js-3.1.4"
+      sources."core-js-3.2.1"
       sources."core-util-is-1.0.2"
       sources."create-error-class-3.0.2"
       sources."cross-spawn-6.0.5"
@@ -75107,9 +75420,11 @@ in
       sources."decompress-response-3.3.0"
       sources."deep-extend-0.6.0"
       sources."default-uid-1.0.0"
+      sources."define-properties-1.1.3"
       sources."define-property-2.0.2"
       sources."delayed-stream-1.0.0"
       sources."delegates-1.0.0"
+      sources."detect-node-2.0.4"
       sources."diff-3.5.0"
       (sources."dir-glob-2.0.0" // {
         dependencies = [
@@ -75187,6 +75502,7 @@ in
       sources."from2-2.3.0"
       sources."fs.realpath-1.0.0"
       sources."fullname-3.3.0"
+      sources."function-bind-1.1.1"
       sources."gauge-1.2.7"
       sources."get-stdin-4.0.1"
       sources."get-stream-3.0.0"
@@ -75199,16 +75515,17 @@ in
         ];
       })
       sources."glob-to-regexp-0.3.0"
-      (sources."global-agent-2.0.1" // {
+      (sources."global-agent-2.0.2" // {
         dependencies = [
           sources."semver-6.3.0"
         ];
       })
       sources."global-dirs-0.1.1"
       sources."global-tunnel-ng-2.7.1"
+      sources."globalthis-1.0.0"
       sources."globby-8.0.2"
       sources."got-8.3.2"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."grouped-queue-0.3.3"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
@@ -75227,12 +75544,7 @@ in
           sources."kind-of-4.0.0"
         ];
       })
-      (sources."hosted-git-info-2.8.2" // {
-        dependencies = [
-          sources."lru-cache-5.1.1"
-          sources."yallist-3.0.3"
-        ];
-      })
+      sources."hosted-git-info-2.8.4"
       sources."http-cache-semantics-3.8.1"
       sources."http-signature-1.2.0"
       sources."humanize-string-1.0.2"
@@ -75244,7 +75556,7 @@ in
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
       sources."ini-1.3.5"
-      sources."inquirer-6.5.0"
+      sources."inquirer-6.5.2"
       sources."insight-0.10.3"
       sources."into-stream-3.1.0"
       sources."ip-regex-2.1.0"
@@ -75393,6 +75705,7 @@ in
           sources."kind-of-3.2.2"
         ];
       })
+      sources."object-keys-1.1.1"
       sources."object-visit-1.0.1"
       sources."object.pick-1.3.0"
       sources."once-1.4.0"
@@ -75457,7 +75770,7 @@ in
           sources."find-up-3.0.0"
           sources."load-json-file-4.0.0"
           sources."locate-path-3.0.0"
-          sources."p-limit-2.2.0"
+          sources."p-limit-2.2.1"
           sources."p-locate-3.0.0"
           sources."p-try-2.2.0"
           sources."parse-json-4.0.0"
@@ -75494,7 +75807,7 @@ in
       sources."responselike-1.0.2"
       sources."restore-cursor-2.0.0"
       sources."ret-0.1.15"
-      sources."roarr-2.13.3"
+      sources."roarr-2.14.1"
       sources."root-check-1.0.0"
       sources."run-async-2.3.0"
       sources."rx-4.1.0"
@@ -75503,7 +75816,7 @@ in
       sources."safe-regex-1.1.0"
       sources."safer-buffer-2.1.2"
       sources."scoped-regex-1.0.0"
-      sources."semver-5.7.0"
+      sources."semver-5.7.1"
       sources."semver-compare-1.0.0"
       sources."semver-diff-2.1.0"
       sources."semver-regex-1.0.0"
@@ -75683,7 +75996,7 @@ in
       sources."use-3.1.1"
       sources."user-home-2.0.0"
       sources."util-deprecate-1.0.2"
-      sources."uuid-3.3.2"
+      sources."uuid-3.3.3"
       sources."validate-npm-package-license-3.0.4"
       sources."verror-1.10.0"
       sources."vinyl-1.2.0"

--- a/pkgs/development/node-packages/node-packages-v12.json
+++ b/pkgs/development/node-packages/node-packages-v12.json
@@ -2,5 +2,6 @@
   "nijs"
 , "coffee-script"
 , "grunt-cli"
+, "makam"
 , "node2nix"
 ]

--- a/pkgs/development/node-packages/node-packages-v12.nix
+++ b/pkgs/development/node-packages/node-packages-v12.nix
@@ -724,13 +724,13 @@ let
         sha1 = "dbf743c6c14992593c655568cb66ed32c0122ebe";
       };
     };
-    "graceful-fs-4.2.1" = {
+    "graceful-fs-4.2.2" = {
       name = "graceful-fs";
       packageName = "graceful-fs";
-      version = "4.2.1";
+      version = "4.2.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.1.tgz";
-        sha512 = "b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw==";
+        url = "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz";
+        sha512 = "IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==";
       };
     };
     "grunt-known-options-1.1.1" = {
@@ -814,13 +814,13 @@ let
         sha512 = "eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==";
       };
     };
-    "hosted-git-info-2.8.2" = {
+    "hosted-git-info-2.8.4" = {
       name = "hosted-git-info";
       packageName = "hosted-git-info";
-      version = "2.8.2";
+      version = "2.8.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.2.tgz";
-        sha512 = "CyjlXII6LMsPMyUzxpTt8fzh5QwzGqPmQXgY/Jyf4Zfp27t/FvfhwoE/8laaMUcMy816CkWF20I7NeQhwwY88w==";
+        url = "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz";
+        sha512 = "pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==";
       };
     };
     "http-signature-1.2.0" = {
@@ -1183,15 +1183,6 @@ let
         sha1 = "2009291bb31cea861bbf10a7c15a28caf75c31ec";
       };
     };
-    "lru-cache-5.1.1" = {
-      name = "lru-cache";
-      packageName = "lru-cache";
-      version = "5.1.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz";
-        sha512 = "KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==";
-      };
-    };
     "make-iterator-1.0.1" = {
       name = "make-iterator";
       packageName = "make-iterator";
@@ -1264,13 +1255,13 @@ let
         sha1 = "857fcabfc3397d2625b8228262e86aa7a011b05d";
       };
     };
-    "minipass-2.3.5" = {
+    "minipass-2.5.0" = {
       name = "minipass";
       packageName = "minipass";
-      version = "2.3.5";
+      version = "2.5.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz";
-        sha512 = "Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==";
+        url = "https://registry.npmjs.org/minipass/-/minipass-2.5.0.tgz";
+        sha512 = "9FwMVYhn6ERvMR8XFdOavRz4QK/VJV8elU1x50vYexf9lslDcWe/f4HBRxCPd185ekRSjU6CfYyJCECa/CQy7Q==";
       };
     };
     "minizlib-1.2.1" = {
@@ -1372,13 +1363,13 @@ let
         sha512 = "/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==";
       };
     };
-    "npm-package-arg-6.1.0" = {
+    "npm-package-arg-6.1.1" = {
       name = "npm-package-arg";
       packageName = "npm-package-arg";
-      version = "6.1.0";
+      version = "6.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.0.tgz";
-        sha512 = "zYbhP2k9DbJhA0Z3HKUePUgdB1x7MfIfKssC+WLPFMKTBZKpZh5m13PgexJjCq6KW7j17r0jHWcCpxEqnnncSA==";
+        url = "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.1.tgz";
+        sha512 = "qBpssaL3IOZWi5vEKUKW0cO7kzLeT+EQO9W8RsLOZf76KF9E/K9+wH0C7t06HXPpaH8WH5xF1MExLuCwbTqRUg==";
       };
     };
     "npm-registry-client-8.6.0" = {
@@ -1831,13 +1822,13 @@ let
         sha1 = "300bc6e0e86374f7ba61068b5b1ecd57fc6532da";
       };
     };
-    "semver-5.7.0" = {
+    "semver-5.7.1" = {
       name = "semver";
       packageName = "semver";
-      version = "5.7.0";
+      version = "5.7.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz";
-        sha512 = "Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==";
+        url = "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz";
+        sha512 = "sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==";
       };
     };
     "semver-6.1.3" = {
@@ -2200,13 +2191,13 @@ let
         sha1 = "450d4dc9fa70de732762fbd2d4a28981419a0ccf";
       };
     };
-    "uuid-3.3.2" = {
+    "uuid-3.3.3" = {
       name = "uuid";
       packageName = "uuid";
-      version = "3.3.2";
+      version = "3.3.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz";
-        sha512 = "yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==";
+        url = "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz";
+        sha512 = "pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==";
       };
     };
     "v8flags-3.1.3" = {
@@ -2596,6 +2587,23 @@ in
     production = true;
     bypassCache = false;
   };
+  makam = nodeEnv.buildNodePackage {
+    name = "makam";
+    packageName = "makam";
+    version = "0.7.17";
+    src = fetchurl {
+      url = "https://registry.npmjs.org/makam/-/makam-0.7.17.tgz";
+      sha512 = "d4TZl74LMpFoouO0Yba/fDJKEdVW7FGTBMNCNti0mxI7u/yj4oVBueQf890F8v+oKcS/jfLvl0CBf/pbqOdoXA==";
+    };
+    buildInputs = globalBuildInputs;
+    meta = {
+      description = "The Makam metalanguage -- a tool for rapid language prototyping";
+      homepage = http://astampoulis.github.io/makam/;
+      license = "GPL-3.0";
+    };
+    production = true;
+    bypassCache = false;
+  };
   node2nix = nodeEnv.buildNodePackage {
     name = "node2nix";
     packageName = "node2nix";
@@ -2658,11 +2666,11 @@ in
       sources."gauge-2.7.4"
       sources."getpass-0.1.7"
       sources."glob-7.1.4"
-      sources."graceful-fs-4.2.1"
+      sources."graceful-fs-4.2.2"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-unicode-2.0.1"
-      sources."hosted-git-info-2.8.2"
+      sources."hosted-git-info-2.8.4"
       sources."http-signature-1.2.0"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
@@ -2677,12 +2685,11 @@ in
       sources."json-stringify-safe-5.0.1"
       sources."jsonfile-1.0.1"
       sources."jsprim-1.4.1"
-      sources."lru-cache-5.1.1"
       sources."mime-db-1.40.0"
       sources."mime-types-2.1.24"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
-      sources."minipass-2.3.5"
+      sources."minipass-2.5.0"
       sources."minizlib-1.2.1"
       sources."mkdirp-0.5.1"
       sources."ncp-0.4.2"
@@ -2690,17 +2697,17 @@ in
       sources."nopt-3.0.6"
       (sources."normalize-package-data-2.5.0" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
-      (sources."npm-package-arg-6.1.0" // {
+      (sources."npm-package-arg-6.1.1" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       (sources."npm-registry-client-8.6.0" // {
         dependencies = [
-          sources."semver-5.7.0"
+          sources."semver-5.7.1"
         ];
       })
       (sources."npmconf-2.1.3" // {
@@ -2768,7 +2775,7 @@ in
       sources."uid-number-0.0.5"
       sources."uri-js-4.2.2"
       sources."util-deprecate-1.0.2"
-      sources."uuid-3.3.2"
+      sources."uuid-3.3.3"
       sources."validate-npm-package-license-3.0.4"
       sources."validate-npm-package-name-3.0.0"
       sources."verror-1.10.0"


### PR DESCRIPTION
###### Motivation for this change
makam is a tool for rapid language prototyping. It's developed by Antonis Stampoulis.

The package is distributed through npm, so this is to have it easily installed in Nix.

More info: https://github.com/astampoulis/makam

###### Things done


- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

