### PR TITLE
NixOS module for GNU Mailman Core

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -376,6 +376,7 @@
   ./services/mail/mail.nix
   ./services/mail/mailcatcher.nix
   ./services/mail/mailhog.nix
+  ./services/mail/mailman.nix
   ./services/mail/mlmmj.nix
   ./services/mail/offlineimap.nix
   ./services/mail/opendkim.nix

--- a/nixos/modules/services/mail/mailman.nix
+++ b/nixos/modules/services/mail/mailman.nix
@@ -1,0 +1,120 @@
+{ config, pkgs, lib, ... }:          # mailman.nix
+
+with lib;
+
+let
+
+  cfg = config.services.mailman;
+
+  pythonEnv = pkgs.python3.withPackages (ps: [ps.mailman]);
+
+  mailmanExe = with pkgs; stdenv.mkDerivation {
+    name = "mailman-" + python3Packages.mailman.version;
+    unpackPhase = ":";
+    installPhase = ''
+      mkdir -p $out/bin
+      sed >"$out/bin/mailman" <"${pythonEnv}/bin/mailman" \
+        -e "2 iexport MAILMAN_CONFIG_FILE=/etc/mailman.cfg"
+      chmod +x $out/bin/mailman
+    '';
+  };
+
+  mailmanCfg = ''
+    [mailman]
+    site_owner: ${cfg.siteOwner}
+    layout: fhs
+
+    [paths.fhs]
+    bin_dir: ${pkgs.python3Packages.mailman}/bin
+    var_dir: /var/lib/mailman
+    queue_dir: $var_dir/queue
+    log_dir: $var_dir/log
+    lock_dir: $var_dir/lock
+    etc_dir: /etc
+    ext_dir: $etc_dir/mailman.d
+    pid_file: /run/mailman/master.pid
+  '';
+
+in {
+
+  ###### interface
+
+  options = {
+
+    services.mailman = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Enable Mailman on this host. Requires an active Postfix installation.";
+      };
+
+      siteOwner = mkOption {
+        type = types.str;
+        default = "postmaster";
+        description = ''
+          Certain messages that must be delivered to a human, but which can't
+          be delivered to a list owner (e.g. a bounce from a list owner), will
+          be sent to this address. It should point to a human.
+        '';
+      };
+
+
+    };
+  };
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+
+    assertions = [
+      { assertion = cfg.enable -> config.services.postfix.enable;
+        message = "Mailman requires Postfix";
+      }
+      { assertion = config.services.postfix.recipientDelimiter == "+";
+        message = "Postfix's recipientDelimiter must be set to '+'.";
+      }
+    ];
+
+    users.users = singleton {
+      name = "mailman";
+      group = "mailman";
+      uid = config.ids.uids.mailman;
+    };
+
+    users.groups = singleton {
+      name = "mailman";
+      gid = config.ids.gids.mailman;
+    };
+
+    environment = {
+      systemPackages = [ mailmanExe ];
+      etc."mailman.cfg".text = mailmanCfg;
+    };
+
+    services.postfix.config = {
+      # Mailman uses recipient delimiters, so we don't need special handling.
+      owner_request_special = "no";
+    };
+
+    systemd.services.mailman = {
+      description = "GNU Mailman Master Process";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        ExecStart = "${mailmanExe}/bin/mailman start";
+        ExecStop = "${mailmanExe}/bin/mailman stop";
+        User = "mailman";
+        Group = "mailman";
+        Type = "forking";
+        StateDirectory = "mailman";
+        StateDirectoryMode = "0750";
+        RuntimeDirectory = "mailman";
+        PIDFile = "/run/mailman/master.pid";
+      };
+
+    };
+
+  };
+
+}

--- a/nixos/modules/services/mail/postfix.nix
+++ b/nixos/modules/services/mail/postfix.nix
@@ -11,9 +11,10 @@ let
 
   haveAliases = cfg.postmasterAlias != "" || cfg.rootAlias != ""
                       || cfg.extraAliases != "";
-  haveTransport = cfg.transport != "";
+  haveTransport = cfg.transport != "" || config.services.mailman.enable;
   haveVirtual = cfg.virtual != "";
-  haveLocalRecipients = cfg.localRecipients != null;
+  haveLocalRecipients = cfg.localRecipients != null || config.services.mailman.enable;
+  haveRelayDomains = cfg.relayDomains != null || config.services.mailman.enable;
 
   clientAccess =
     optional (cfg.dnsBlacklistOverrides != "")
@@ -752,12 +753,12 @@ in
       // optionalAttrs (cfg.domain != "") { mydomain = cfg.domain; }
       // optionalAttrs (cfg.origin != "") { myorigin =  cfg.origin; }
       // optionalAttrs (cfg.destination != null) { mydestination = cfg.destination; }
-      // optionalAttrs (cfg.relayDomains != null) { relay_domains = cfg.relayDomains; }
+      // optionalAttrs haveRelayDomains { relay_domains = optionals (cfg.relayDomains != null) cfg.relayDomains ++ optional config.services.mailman.enable "hash:/var/lib/mailman/data/postfix_domains"; }
       // optionalAttrs (cfg.recipientDelimiter != "") { recipient_delimiter = cfg.recipientDelimiter; }
       // optionalAttrs haveAliases { alias_maps = [ "${cfg.aliasMapType}:/etc/postfix/aliases" ]; }
-      // optionalAttrs haveTransport { transport_maps = [ "hash:/etc/postfix/transport" ]; }
+      // optionalAttrs haveTransport { transport_maps = [ "hash:/etc/postfix/transport" ] ++ optional config.services.mailman.enable "hash:/var/lib/mailman/data/postfix_lmtp"; }
       // optionalAttrs haveVirtual { virtual_alias_maps = [ "${cfg.virtualMapType}:/etc/postfix/virtual" ]; }
-      // optionalAttrs haveLocalRecipients { local_recipient_maps = [ "hash:/etc/postfix/local_recipients" ] ++ optional haveAliases "$alias_maps"; }
+      // optionalAttrs haveLocalRecipients { local_recipient_maps = [ "hash:/etc/postfix/local_recipients" ] ++ optional haveAliases "$alias_maps" ++ optional config.services.mailman.enable "hash:/var/lib/mailman/data/postfix_lmtp"; }
       // optionalAttrs (cfg.dnsBlacklists != []) { smtpd_client_restrictions = clientRestrictions; }
       // optionalAttrs cfg.useSrs {
         sender_canonical_maps = [ "tcp:127.0.0.1:10001" ];


### PR DESCRIPTION
Enabling this module successfully installs and deploys the mailman core. There is a `mailman` utility in $PATH that can be used to control the installation. I have an extension for Postorius ready in testing that will follow shortly.