### PR TITLE
LIBCLANG_PATH hook

### DIFF
--- a/pkgs/applications/version-management/pijul/default.nix
+++ b/pkgs/applications/version-management/pijul/default.nix
@@ -10,6 +10,7 @@ rustPlatform.buildRustPackage rec {
   };
 
   nativeBuildInputs = [ pkgconfig clang ];
+  bulidInputs = [ libclang ];
 
   postInstall = ''
     mkdir -p $out/share/{bash-completion/completions,zsh/site-functions,fish/vendor_completions.d}
@@ -17,8 +18,6 @@ rustPlatform.buildRustPackage rec {
     $out/bin/pijul generate-completions --zsh > $out/share/zsh/site-functions/_pijul
     $out/bin/pijul generate-completions --fish > $out/share/fish/vendor_completions.d/pijul.fish
   '';
-
-  LIBCLANG_PATH = libclang + "/lib";
 
   buildInputs = [ openssl libsodium nettle libclang ] ++ stdenv.lib.optionals stdenv.isDarwin
     (with darwin.apple_sdk.frameworks; [ CoreServices Security ]);

--- a/pkgs/development/compilers/llvm/7/clang/default.nix
+++ b/pkgs/development/compilers/llvm/7/clang/default.nix
@@ -55,6 +55,8 @@ let
 
     outputs = [ "out" "lib" "python" ];
 
+    setupHook = ../../clang-setup-hook.sh;
+
     # Clang expects to find LLVMgold in its own prefix
     postInstall = ''
       if [ -e ${llvm}/lib/LLVMgold.so ]; then

--- a/pkgs/development/compilers/llvm/8/clang/default.nix
+++ b/pkgs/development/compilers/llvm/8/clang/default.nix
@@ -51,6 +51,8 @@ let
       ./compiler-rt-baremetal.patch
     ];
 
+    setupHook = ../../clang-setup-hook.sh;
+
     postPatch = ''
       sed -i -e 's/DriverArgs.hasArg(options::OPT_nostdlibinc)/true/' \
              -e 's/Args.hasArg(options::OPT_nostdlibinc)/true/' \

--- a/pkgs/development/compilers/llvm/clang-setup-hook.sh
+++ b/pkgs/development/compilers/llvm/clang-setup-hook.sh
@@ -1,0 +1,1 @@
+export LIBCLANG_PATH="@lib@/lib"

--- a/pkgs/development/interpreters/wasmtime/default.nix
+++ b/pkgs/development/interpreters/wasmtime/default.nix
@@ -19,8 +19,6 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [ python cmake clang ];
   buildInputs = [ llvmPackages.libclang ];
 
-  LIBCLANG_PATH = "${llvmPackages.libclang}/lib";
-
   meta = with lib; {
     description = "Standalone JIT-style runtime for WebAsssembly, using Cranelift";
     homepage = https://github.com/CraneStation/wasmtime;

--- a/pkgs/development/tools/rq/default.nix
+++ b/pkgs/development/tools/rq/default.nix
@@ -18,7 +18,6 @@ buildRustPackage rec {
   buildInputs = [ llvmPackages.clang-unwrapped v8 ];
 
   configurePhase = ''
-    export LIBCLANG_PATH="${llvmPackages.clang-unwrapped}/lib"
     export V8_SOURCE="${v8}"
   '';
 

--- a/pkgs/development/tools/rust/bindgen/default.nix
+++ b/pkgs/development/tools/rust/bindgen/default.nix
@@ -20,10 +20,6 @@ rustPlatform.buildRustPackage rec {
 
   propagatedBuildInputs = [ clang ]; # to populate NIX_CXXSTDLIB_COMPILE
 
-  configurePhase = ''
-    export LIBCLANG_PATH="${libclang}/lib"
-  '';
-
   postInstall = ''
     mv $out/bin/{bindgen,.bindgen-wrapped};
     substituteAll ${./wrapper.sh} $out/bin/bindgen

--- a/pkgs/development/tools/rust/cargo-expand/default.nix
+++ b/pkgs/development/tools/rust/cargo-expand/default.nix
@@ -16,8 +16,6 @@ rustPlatform.buildRustPackage rec {
   buildInputs = [ llvmPackages.libclang ]
     ++ stdenv.lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Security;
 
-  LIBCLANG_PATH = "${llvmPackages.libclang}/lib";
-
   meta = with stdenv.lib; {
     description = "A utility and Cargo subcommand designed to let people expand macros in their Rust source code";
     homepage = https://github.com/dtolnay/cargo-expand;

--- a/pkgs/tools/backup/rdedup/default.nix
+++ b/pkgs/tools/backup/rdedup/default.nix
@@ -19,13 +19,9 @@ rustPlatform.buildRustPackage rec {
     ./v3.1.1-fix-Cargo.lock.patch
   ];
 
-  nativeBuildInputs = [ pkgconfig llvmPackages.libclang clang_39 ];
-  buildInputs = [ openssl libsodium lzma ]
+  nativeBuildInputs = [ pkgconfig clang_39 ];
+  buildInputs = [ openssl libsodium lzma llvmPackages.libclang ]
     ++ (stdenv.lib.optional stdenv.isDarwin Security);
-
-  configurePhase = ''
-    export LIBCLANG_PATH="${llvmPackages.libclang}/lib"
-  '';
 
   meta = with stdenv.lib; {
     description = "Data deduplication with compression and public key encryption";

--- a/pkgs/tools/security/sequoia/default.nix
+++ b/pkgs/tools/security/sequoia/default.nix
@@ -25,7 +25,6 @@ rustPlatform.buildRustPackage rec {
     cargo
     rustc
     git
-    llvmPackages.libclang
     llvmPackages.clang
     ensureNewerSourcesForZipFilesHook
   ] ++
@@ -42,6 +41,7 @@ rustPlatform.buildRustPackage rec {
     sqlite
     nettle
     capnproto
+    llvmPackages.libclang
   ]
     ++ lib.optionals pythonSupport [ pythonPackages.python pythonPackages.cffi ]
     ++ lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Security ]
@@ -54,8 +54,6 @@ rustPlatform.buildRustPackage rec {
   buildFlags = [
     "build-release"
   ];
-
-  LIBCLANG_PATH = "${llvmPackages.libclang}/lib";
 
   postPatch = ''
     # otherwise, the check fails because we delete the `.git` in the unpack phase

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7386,6 +7386,7 @@ in
   };
 
   clang = llvmPackages.clang;
+  libclang = llvmPackages.libclang;
   clang-manpages = llvmPackages.clang-manpages;
 
   clang-sierraHack = clang.override {


### PR DESCRIPTION
Rust’s clang-sys has a few ways to handle finding libclang:

> libclang shared libraries will be searched for in the following directories:

> the directory provided by the LIBCLANG_PATH environment variable
> the bin and lib directories in the directory provided by llvm-config --libdir
> the directories provided by LD_LIBRARY_PATH environment variable
> a list of likely directories for the target platform (e.g., /usr/local/lib on Linux)
> macOS only: the toolchain directory in the directory provided by xcode-select --print-path

The other methods don’t work. LLVM still does not support pkg-config,
llvm-config won’t have the libclang because we build clang and llvm
separately, and LD_LIBRARY_PATH shouldn’t be messed with.

More discussion here:

https://discourse.nixos.org/t/how-to-correctly-populate-a-clang-and-llvm-development-environment-using-nix-shell/3864/2


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
