### PR TITLE
pythonPackages.junit-xml: init at 1.8

### DIFF
--- a/pkgs/development/python-modules/junit-xml/default.nix
+++ b/pkgs/development/python-modules/junit-xml/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, six
+, pytest
+, pytest-sugar
+}:
+
+buildPythonPackage rec {
+  pname = "junit-xml";
+  version = "1.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "08fw86azza6d3l3nx34kq69cpwmmfqpn7xrb8pdlxmhr1941qbv0";
+  };
+
+  propagatedBuildInputs = [ six ];
+
+  checkInputs = [ pytest pytest-sugar ];
+
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with lib; {
+    description = "Creates JUnit XML test result documents that can be read by tools such as Jenkins";
+    homepage = https://github.com/kyrus/python-junit-xml;
+    maintainers = with maintainers; [ multun ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -773,6 +773,8 @@ in {
 
   jira = callPackage ../development/python-modules/jira { };
 
+  junit-xml = callPackage ../development/python-modules/junit-xml { };
+
   junitparser = callPackage ../development/python-modules/junitparser { };
 
   jwcrypto = callPackage ../development/python-modules/jwcrypto { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This is needed to update python-sphinx.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

