### PR TITLE
freecad: fix missing app icon and name when running under Wayland

### DIFF
--- a/pkgs/applications/graphics/freecad/default.nix
+++ b/pkgs/applications/graphics/freecad/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, mkDerivation, fetchurl, cmake, ninja, coin3d, xercesc, ode, eigen, qt5, opencascade-occt, gts
-, hdf5, vtk, medfile, zlib, python3Packages, swig, gfortran, libXmu
-, soqt, libf2c, libGLU, makeWrapper, pkgconfig
-, mpi ? null }:
+{ stdenv, mkDerivation, fetchurl, fetchpatch, cmake, ninja, coin3d, xercesc, ode
+, eigen, qtbase, qttools, qtwebkit, opencascade-occt, gts, hdf5, vtk, medfile
+, zlib, python3Packages, swig, gfortran, libXmu, soqt, libf2c, libGLU
+, makeWrapper, pkgconfig, mpi ? null }:
 
 assert mpi != null;
 
@@ -19,12 +19,19 @@ in mkDerivation rec {
   nativeBuildInputs = [ cmake ninja pkgconfig pythonPackages.pyside2-tools ];
   buildInputs = [ cmake coin3d xercesc ode eigen opencascade-occt gts
     zlib swig gfortran soqt libf2c makeWrapper mpi vtk hdf5 medfile
-    libGLU libXmu
-  ] ++ (with qt5; [
-    qtbase qttools qtwebkit
-  ]) ++ (with pythonPackages; [
+    libGLU libXmu qtbase qttools qtwebkit
+  ] ++ (with pythonPackages; [
     matplotlib pycollada shiboken2 pyside2 pyside2-tools pivy python boost
   ]);
+
+  # Fix missing app icon on Wayland. Has been upstreamed and should be safe to
+  # remove in versions >= 0.19
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/FreeCAD/FreeCAD/commit/c4d2a358ca125d51d059dfd72dcbfba326196dfc.patch";
+      sha256 = "0yqc9zrxgi2c2xcidm8wh7a9yznkphqvjqm9742qm5fl20p8gl4h";
+    })
+  ];
 
   cmakeFlags = [
     "-DBUILD_QT5=ON"


### PR DESCRIPTION
###### Motivation for this change

Fixes the problem where the app icon would not show under Gnome/Wayland.

Wayland needs to know the name of the .desktop file to show a dock icon and application name.

See: https://community.kde.org/Guidelines_and_HOWTOs/Wayland_Porting_Notes#Application_Icon

Tested on Gnome/Wayland with the QT backend forced to Wayland, ie `QT_QPA_PLATFORM=wayland`. If `QT_QPA_PLATFORM` is unset (or is set to `xcb`) it uses XWayland.

The patch has been upstreamed and can be removed once a new release is available.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @viric @gebner 
