### PR TITLE
mplayer: 1.3.0 -> 1.4

### DIFF
--- a/pkgs/applications/video/mplayer/default.nix
+++ b/pkgs/applications/video/mplayer/default.nix
@@ -59,20 +59,21 @@ let
   codecs_src =
     let
       dir = http://www.mplayerhq.hu/MPlayer/releases/codecs/;
+      version = "20071007";
     in
     if stdenv.hostPlatform.system == "i686-linux" then fetchurl {
-      url = "${dir}/essential-20071007.tar.bz2";
+      url = "${dir}/essential-${version}.tar.bz2";
       sha256 = "18vls12n12rjw0mzw4pkp9vpcfmd1c21rzha19d7zil4hn7fs2ic";
     } else if stdenv.hostPlatform.system == "x86_64-linux" then fetchurl {
-      url = "${dir}/essential-amd64-20071007.tar.bz2";
+      url = "${dir}/essential-amd64-${version}.tar.bz2";
       sha256 = "13xf5b92w1ra5hw00ck151lypbmnylrnznq9hhb0sj36z5wz290x";
     } else if stdenv.hostPlatform.system == "powerpc-linux" then fetchurl {
-      url = "${dir}/essential-ppc-20071007.tar.bz2";
+      url = "${dir}/essential-ppc-${version}.tar.bz2";
       sha256 = "18mlj8dp4wnz42xbhdk1jlz2ygra6fbln9wyrcyvynxh96g1871z";
     } else null;
 
   codecs = if codecs_src != null then stdenv.mkDerivation {
-    name = "MPlayer-codecs-essential-20071007";
+    pname = "MPlayer-codecs-essential";
 
     src = codecs_src;
 
@@ -89,11 +90,12 @@ let
 in
 
 stdenv.mkDerivation rec {
-  name = "mplayer-1.3.0";
+  pname = "mplayer";
+  version = "1.4";
 
   src = fetchurl {
-    url = "http://www.mplayerhq.hu/MPlayer/releases/MPlayer-1.3.0.tar.xz";
-    sha256 = "0hwqn04bdknb2ic88xd75smffxx63scvz0zvwvjb56nqj9n89l1s";
+    url = "http://www.mplayerhq.hu/MPlayer/releases/MPlayer-${version}.tar.xz";
+    sha256 = "0j5mflr0wnklxsvnpmxvk704hscyn2785hvvihj2i3a7b3anwnc2";
   };
 
   prePatch = ''
@@ -218,6 +220,6 @@ stdenv.mkDerivation rec {
     homepage = http://mplayerhq.hu;
     license = "GPL";
     maintainers = [ stdenv.lib.maintainers.eelco ];
-    platforms = stdenv.lib.platforms.linux ++ stdenv.lib.platforms.darwin;
+    platforms = [ "i686-linux" "x86_64-linux" "x86_64-darwin" ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
