### PR TITLE
anki: 2.1.11 -> 2.1.14

### DIFF
--- a/pkgs/games/anki/default.nix
+++ b/pkgs/games/anki/default.nix
@@ -18,6 +18,7 @@
 , pytest
 , glibcLocales
 , nose
+, jsonschema
 , send2trash
 , CoreAudio
 # This little flag adds a huge number of dependencies, but we assume that
@@ -31,10 +32,10 @@ let
     # when updating, also update rev-manual to a recent version of
     # https://github.com/dae/ankidocs
     # The manual is distributed independently of the software.
-    version = "2.1.11";
-    sha256-pkg = "0rcjam7f017yg0fx5apdc309lsx59lfw33nikczz7hrw6gby6z3q";
-    rev-manual = "f933104fecd8a83c33494bdb2b59817a3318202f";
-    sha256-manual = "12j4x1bh8x6yinym4d1ard32vfl22iq2wz1lfwz6s3ljhggkc52h";
+    version = "2.1.14";
+    sha256-pkg = "0yw2lij8h6cbvyybsyypzw1l0r1si1gh82fzsyyzcyxd4h4m3f4l";
+    rev-manual = "04210375b949a6555095962bba547ae27b39fe77";
+    sha256-manual = "03kyjsz30ri0l6zq7x13xnq7naapm8vh9yybsm6f67hvd1k1ycrd";
 
     manual = stdenv.mkDerivation {
       name = "anki-manual-${version}";
@@ -84,7 +85,7 @@ buildPythonApplication rec {
 
     propagatedBuildInputs = [
       pyqtwebengine sqlalchemy beautifulsoup4 send2trash pyaudio requests decorator
-      markdown
+      markdown jsonschema
     ]
       ++ lib.optional plotsSupport matplotlib
       ++ lib.optional stdenv.isDarwin [ CoreAudio ]

--- a/pkgs/games/anki/default.nix
+++ b/pkgs/games/anki/default.nix
@@ -32,10 +32,10 @@ let
     # when updating, also update rev-manual to a recent version of
     # https://github.com/dae/ankidocs
     # The manual is distributed independently of the software.
-    version = "2.1.14";
-    sha256-pkg = "0yw2lij8h6cbvyybsyypzw1l0r1si1gh82fzsyyzcyxd4h4m3f4l";
-    rev-manual = "04210375b949a6555095962bba547ae27b39fe77";
-    sha256-manual = "03kyjsz30ri0l6zq7x13xnq7naapm8vh9yybsm6f67hvd1k1ycrd";
+    version = "2.1.15";
+    sha256-pkg = "12dvyf3j9df4nrhhnqbzd9b21rpzkh4i6yhhangn2zf7ch0pclss";
+    rev-manual = "8f6387867ac37ef3fe9d0b986e70f898d1a49139";
+    sha256-manual = "0pm5slxn78r44ggvbksz7rv9hmlnsvn9z811r6f63dsc8vm6mfml";
 
     manual = stdenv.mkDerivation {
       name = "anki-manual-${version}";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
