### PR TITLE
manual.configuration.userManagement: mkpasswd

### DIFF
--- a/nixos/doc/manual/configuration/user-mgmt.xml
+++ b/nixos/doc/manual/configuration/user-mgmt.xml
@@ -37,7 +37,7 @@
   groups, such as useradd, are no longer available. Passwords may still be
   assigned by setting the user's
   <link linkend="opt-users.users._name__.hashedPassword">hashedPassword</link>
-  option. A hashed password can be generated using <command>nix-shell --pure -p mkpasswd --run "mkpasswd -m sha-512"</command>
+  option. A hashed password can be generated using <command>nix run nixpkgs.mkpasswd -c mkpasswd -m sha-512</command>
  </para>
  <para>
   A user ID (uid) is assigned automatically. You can also specify a uid

--- a/nixos/doc/manual/configuration/user-mgmt.xml
+++ b/nixos/doc/manual/configuration/user-mgmt.xml
@@ -37,12 +37,7 @@
   groups, such as useradd, are no longer available. Passwords may still be
   assigned by setting the user's
   <link linkend="opt-users.users._name__.hashedPassword">hashedPassword</link>
-  option. A hashed password can be generated using <command>mkpasswd -m
-  sha-512</command> after installing the <literal>mkpasswd</literal> package. 
-  (Careful, the default installed <literal> expect </literal> package also 
-   provides a utility with the same name. Use 
-   <literal> nix-env -qA nixos.expect </literal> to install the mkpasswd utility
-   for generating password hash.)
+  option. A hashed password can be generated using <command>nix-shell --pure -p mkpasswd --run "mkpasswd -m sha-512"</command>
  </para>
  <para>
   A user ID (uid) is assigned automatically. You can also specify a uid

--- a/nixos/doc/manual/configuration/user-mgmt.xml
+++ b/nixos/doc/manual/configuration/user-mgmt.xml
@@ -38,7 +38,11 @@
   assigned by setting the user's
   <link linkend="opt-users.users._name__.hashedPassword">hashedPassword</link>
   option. A hashed password can be generated using <command>mkpasswd -m
-  sha-512</command> after installing the <literal>mkpasswd</literal> package.
+  sha-512</command> after installing the <literal>mkpasswd</literal> package. 
+  (Careful, the default installed <literal> expect </literal> package also 
+   provides a utility with the same name. Use 
+   <literal> nix-env -qA nixos.expect </literal> to install the mkpasswd utility
+   for generating password hash.)
  </para>
  <para>
   A user ID (uid) is assigned automatically. You can also specify a uid


### PR DESCRIPTION
Added clarification about mkpasswd in User Management section of the manual

