### PR TITLE
make_ext4fs: init at unstable-2017-05-21

### DIFF
--- a/pkgs/tools/filesystems/make_ext4fs/0001-uuid-add-facilities-to-parse-and-print-UUIDs.patch
+++ b/pkgs/tools/filesystems/make_ext4fs/0001-uuid-add-facilities-to-parse-and-print-UUIDs.patch
@@ -1,0 +1,80 @@
+From fbc430543d68c9695a59b433a51451cbedb0f310 Mon Sep 17 00:00:00 2001
+From: Samuel Dionne-Riel <samuel@dionne-riel.com>
+Date: Thu, 29 Aug 2019 15:07:36 -0400
+Subject: [PATCH 1/2] uuid: add facilities to parse and print UUIDs
+
+Signed-off-by: Samuel Dionne-Riel <samuel@dionne-riel.com>
+---
+ uuid.c | 41 +++++++++++++++++++++++++++++++++++++++++
+ uuid.h |  6 ++++++
+ 2 files changed, 47 insertions(+)
+
+diff --git a/uuid.c b/uuid.c
+index 7ded43a..c74c45c 100644
+--- a/uuid.c
++++ b/uuid.c
+@@ -59,3 +59,44 @@ void generate_uuid(const char *namespace, const char *name, u8 result[16])
+ 	uuid->clk_seq_hi_res &= ~(1 << 6);
+ 	uuid->clk_seq_hi_res |= 1 << 7;
+ }
++
++void parse_uuid(const char *input, uint8_t result [16])
++{
++	int i;
++	int u = 0;
++	if (strlen(input) != UUID_STR_LEN-1) {
++		fprintf(stderr, "UUID MUST be in the format 00112233-4455-6677-8899-AABBCCDDEEFF.\n");
++		abort();
++	}
++	for (i = 0; i < UUID_STR_LEN - 1; i++) {
++		if (!(i == 8 || i == 13 || i == 18 || i == 23)) {
++			char pair[3] = "00";
++			strncpy(pair, input + i, 2);
++			result[u] = strtol(pair, NULL, 16);
++			/* This handled a pair, let's move one more further along. */
++			i++;
++			/* Move to the next byte. */
++			u++;
++		}
++	}
++}
++
++void uuid_to_string(const uint8_t uuid [16], char result [UUID_STR_LEN])
++{
++	int i;
++	/* Index in uuid */
++	int u = 0;
++	for (i = 0; i < UUID_STR_LEN-1; i++) {
++		/* Handles separators */
++		if (i == 8 || i == 13 || i == 18 || i == 23) {
++			strcpy(result+i, "-");
++		} else {
++			/* Writes three bytes, two chars for the current byte, and a \0 */
++			snprintf(result+i, 3, "%02X", uuid[u]);
++			/* This is handled a pair, let's move one more further along. */
++			i++;
++			/* Move to the next byte. */
++			u++;
++		}
++	}
++}
+diff --git a/uuid.h b/uuid.h
+index ff1b438..21ba165 100644
+--- a/uuid.h
++++ b/uuid.h
+@@ -19,6 +19,12 @@
+ 
+ #include "ext4_utils.h"
+ 
++#define UUID_STR_LEN 36+1
++
+ void generate_uuid(const char *namespace, const char *name, u8 result[16]);
+ 
++void parse_uuid(const char *input, uint8_t result [16]);
++
++void uuid_to_string(const uint8_t uuid [16], char result [UUID_STR_LEN]);
++
+ #endif
+-- 
+2.25.3
+

--- a/pkgs/tools/filesystems/make_ext4fs/0002-make_ext4fs-allow-setting-a-specific-UUID.patch
+++ b/pkgs/tools/filesystems/make_ext4fs/0002-make_ext4fs-allow-setting-a-specific-UUID.patch
@@ -1,0 +1,129 @@
+From f36e1d9ea6b34ae1ed2bd481e56ce93174652061 Mon Sep 17 00:00:00 2001
+From: Samuel Dionne-Riel <samuel@dionne-riel.com>
+Date: Thu, 29 Aug 2019 15:11:04 -0400
+Subject: [PATCH 2/2] make_ext4fs: allow setting a specific UUID
+
+The UUID was previously only reproducibly generated using a combination
+of a fixed namespace and the label of the partition. This change allows
+projects to specify a desired UUID instead.
+
+Signed-off-by: Samuel Dionne-Riel <samuel@dionne-riel.com>
+---
+ ext4_sb.h          |  3 +++
+ ext4_utils.c       | 13 ++++++++++++-
+ make_ext4fs.c      |  5 +++++
+ make_ext4fs_main.c |  9 +++++++--
+ 4 files changed, 27 insertions(+), 3 deletions(-)
+
+diff --git a/ext4_sb.h b/ext4_sb.h
+index d6416a7..68f5cb1 100644
+--- a/ext4_sb.h
++++ b/ext4_sb.h
+@@ -18,6 +18,7 @@
+ #define _EXT4_UTILS_EXT4_SB_H_
+ 
+ #include "ext4_kernel_headers.h"
++#include <stdbool.h>
+ 
+ #define EXT4_SUPER_MAGIC 0xEF53
+ 
+@@ -42,6 +43,8 @@ struct fs_info {
+ 	uint32_t reserve_pcnt;
+ 	const char *label;
+ 	uint8_t no_journal;
++	bool with_uuid;
++	uint8_t uuid[16];
+ };
+ 
+ int ext4_parse_sb(struct ext4_super_block *sb, struct fs_info *info);
+diff --git a/ext4_utils.c b/ext4_utils.c
+index 1a886d7..7d3fd43 100644
+--- a/ext4_utils.c
++++ b/ext4_utils.c
+@@ -221,7 +221,13 @@ void ext4_fill_in_sb()
+ 	sb->s_feature_compat = info.feat_compat;
+ 	sb->s_feature_incompat = info.feat_incompat;
+ 	sb->s_feature_ro_compat = info.feat_ro_compat;
+-	generate_uuid("extandroid/make_ext4fs", info.label, sb->s_uuid);
++	if (info.with_uuid) {
++		memset(sb->s_uuid, 0, sizeof(sb->s_uuid));
++		memcpy(sb->s_uuid, info.uuid, sizeof(sb->s_uuid));
++	}
++	else {
++		generate_uuid("extandroid/make_ext4fs", info.label, sb->s_uuid);
++	}
+ 	memset(sb->s_volume_name, 0, sizeof(sb->s_volume_name));
+ 	strncpy(sb->s_volume_name, info.label, sizeof(sb->s_volume_name));
+ 	memset(sb->s_last_mounted, 0, sizeof(sb->s_last_mounted));
+@@ -521,6 +527,11 @@ int read_ext(int fd, int verbose)
+ 		printf("    Inodes per group: %d\n", info.inodes_per_group);
+ 		printf("    Inode size: %d\n", info.inode_size);
+ 		printf("    Label: %s\n", info.label);
++		if (info.with_uuid) {
++			char uuid[UUID_STR_LEN] = { 0 };
++			uuid_to_string(info.uuid, uuid);
++			printf("    UUID: %s\n", uuid);
++		}
+ 		printf("    Blocks: %"PRIu64"\n", aux_info.len_blocks);
+ 		printf("    Block groups: %d\n", aux_info.groups);
+ 		printf("    Reserved block group size: %d\n", info.bg_desc_reserve_blocks);
+diff --git a/make_ext4fs.c b/make_ext4fs.c
+index 051052b..f486eed 100644
+--- a/make_ext4fs.c
++++ b/make_ext4fs.c
+@@ -451,6 +451,11 @@ int make_ext4fs_internal(int fd, const char *_directory,
+ 	printf("    Inode size: %d\n", info.inode_size);
+ 	printf("    Journal blocks: %d\n", info.journal_blocks);
+ 	printf("    Label: %s\n", info.label);
++	if (info.with_uuid) {
++		char uuid[UUID_STR_LEN] = { 0 };
++		uuid_to_string(info.uuid, uuid);
++		printf("    UUID: %s\n", uuid);
++	}
+ 
+ 	ext4_create_fs_aux_info();
+ 
+diff --git a/make_ext4fs_main.c b/make_ext4fs_main.c
+index 88254c3..e957a03 100644
+--- a/make_ext4fs_main.c
++++ b/make_ext4fs_main.c
+@@ -27,6 +27,7 @@
+ 
+ #include "ext4_utils.h"
+ #include "canned_fs_config.h"
++#include "uuid.h"
+ 
+ extern struct fs_info info;
+ 
+@@ -35,7 +36,7 @@ static void usage(char *path)
+ {
+ 	fprintf(stderr, "%s [ -l <len> ] [ -j <journal size> ] [ -b <block_size> ]\n", basename(path));
+ 	fprintf(stderr, "    [ -g <blocks per group> ] [ -i <inodes> ] [ -I <inode size> ]\n");
+-	fprintf(stderr, "    [ -m <reserved blocks percent> ] [ -L <label> ] [ -f ]\n");
++	fprintf(stderr, "    [ -m <reserved blocks percent> ] [ -L <label> ] [ -U <uuid> ] [ -f ]\n");
+ 	fprintf(stderr, "    [ -S file_contexts ] [ -C fs_config ] [ -T timestamp ]\n");
+ 	fprintf(stderr, "    [ -z | -s ] [ -w ] [ -c ] [ -J ] [ -v ] [ -B <block_list_file> ]\n");
+ 	fprintf(stderr, "    <filename> [<directory>]\n");
+@@ -58,7 +59,7 @@ int main(int argc, char **argv)
+ 	time_t fixed_time = -1;
+ 	FILE* block_list_file = NULL;
+ 
+-	while ((opt = getopt(argc, argv, "l:j:b:g:i:I:L:T:C:B:m:fwzJsctv")) != -1) {
++	while ((opt = getopt(argc, argv, "l:j:b:g:i:I:L:T:C:B:m:U:fwzJsctv")) != -1) {
+ 		switch (opt) {
+ 		case 'l':
+ 			info.len = parse_num(optarg);
+@@ -81,6 +82,10 @@ int main(int argc, char **argv)
+ 		case 'L':
+ 			info.label = optarg;
+ 			break;
++		case 'U':
++			info.with_uuid = true;
++			parse_uuid(optarg, info.uuid);
++			break;
+ 		case 'f':
+ 			force = 1;
+ 			break;
+-- 
+2.25.3
+

--- a/pkgs/tools/filesystems/make_ext4fs/default.nix
+++ b/pkgs/tools/filesystems/make_ext4fs/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchgit, zlib }:
+
+stdenv.mkDerivation {
+  pname = "make_ext4fs";
+  version = "unstable-2017-05-21";
+
+  src = fetchgit {
+    url = "git://git.openwrt.org/project/make_ext4fs.git";
+    rev = "eebda1d55d9701ace2700d7ae461697fadf52d1f";
+    sha256 = "03lqd5qy3nli9mmnlbgxwsplwz8v10cyjyzl1fxcfz8jvzr00c61";
+  };
+
+  buildInputs = [
+    zlib
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp make_ext4fs $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://git.openwrt.org/?p=project/make_ext4fs.git;
+    description = "Standalone fork of Android make_ext4fs utility";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.samueldr ];
+  };
+}

--- a/pkgs/tools/filesystems/make_ext4fs/default.nix
+++ b/pkgs/tools/filesystems/make_ext4fs/default.nix
@@ -10,6 +10,11 @@ stdenv.mkDerivation {
     sha256 = "03lqd5qy3nli9mmnlbgxwsplwz8v10cyjyzl1fxcfz8jvzr00c61";
   };
 
+  patches = [
+    ./0001-uuid-add-facilities-to-parse-and-print-UUIDs.patch
+    ./0002-make_ext4fs-allow-setting-a-specific-UUID.patch
+  ];
+
   buildInputs = [
     zlib
   ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13706,6 +13706,8 @@ in
 
   opencl-clang = callPackage ../development/libraries/opencl-clang { };
 
+  make_ext4fs = callPackage ../tools/filesystems/make_ext4fs {};
+
   mapnik = callPackage ../development/libraries/mapnik { };
 
   marisa = callPackage ../development/libraries/marisa {};


### PR DESCRIPTION
###### Motivation for this change

The upstream tools for ext4 does not create reproducible images. [`make_ext4fs`](), from the OpenWRT project (initially from the now merged LEDE project) [is recommended by Reproducible Builds](https://reproducible-builds.org/docs/system-images/) for the purpose of reproducibly producing ext4fs filesystems.

This is needed if we want `sd_image` to be reproducible. This is also [work needed towards mobile-nixos](https://github.com/samueldr/mobile-nixos/tree/feature/image-builder).

###### Things to do

 * [ ] **Have other contributors review the patches.**

I have [written a patch adding support to specify an UUID](https://github.com/mobile-nixos/make_ext4fs/compare/feature/UUID). I do not think I should be trusted with bare C. I want both stylistic review (though desire it to be good for use upstream) and a security review. Though, I figure the security issues are likely of extremely low severity, if any. I may have done a off-by-one or two in the code, though from testing if there are they are benign.

This is the *only* reason this PR is a draft. The quality of the patches are still unknown. Once the patches have been reviewed I will do the process with upstream to get them upstreamed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ☑️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ☑️ NixOS
   - 🔲 macOS
   - 🔲 other Linux distributions
- 🔲 Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ☑️ Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- ☑️ Tested execution of all binary files (usually in `./result/bin/`)
- ☑️ Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ☑️ Ensured that relevant documentation is up to date
- ☑️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Of note: I have a test harness in the image-builder work for mobile-nixos which tests software. It will continue testing it while I expand the scope of the image building. Additionally, that image-builder infra is intended to be upstreamed in NixOS proper.