### PR TITLE
robo3t: 1.1.1 -> 1.3.1

### DIFF
--- a/pkgs/applications/misc/robo3t/default.nix
+++ b/pkgs/applications/misc/robo3t/default.nix
@@ -3,11 +3,12 @@
 
 stdenv.mkDerivation rec {
   name = "robo3t-${version}";
-  version = "1.1.1";
+  version = "1.3.1";
+  rev = "7419c406";
 
   src = fetchurl {
-    url = "https://download.robomongo.org/1.1.1/linux/robo3t-${version}-linux-x86_64-c93c6b0.tar.gz";
-    sha256 = "140cn80vg7c8vpdjasqi4b3kyqj4n033lcm3ikz5674x3jr7r5zs";
+    url = "https://download-test.robomongo.org/linux/robo3t-${version}-linux-x86_64-${rev}.tar.gz";
+    sha256 = "1mp5i8iahd4qkwgi5ix98hlg17ivw5da27n0drnr0wk458wn99hi";
   };
 
   icon = fetchurl {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @emanueleperuffo 
