### PR TITLE
yubico-pam: unstable-2019-03-19 -> unstable-2019-07-01

### DIFF
--- a/pkgs/development/libraries/yubico-pam/default.nix
+++ b/pkgs/development/libraries/yubico-pam/default.nix
@@ -4,12 +4,12 @@
 
 stdenv.mkDerivation rec {
   pname = "yubico-pam";
-  version = "unstable-2019-03-19";
+  version = "unstable-2019-07-01";
   src = fetchFromGitHub {
     owner = "Yubico";
     repo = pname;
-    rev = "1c6fa66825e77b3ad8df46513d0125bed9bde704";
-    sha256 = "1g41wdwa1wbp391w1crbis4hwz60m3y06rd6j59m003zx40sk9s4";
+    rev = "b5bd00db81e0e0e0ecced65c684080bb56ddc35b";
+    sha256 = "10dq8dqi3jldllj6p8r9hldx9sank9n82c44w8akxrs1vli6nj3m";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig asciidoc libxslt docbook_xsl ];


### PR DESCRIPTION
###### Motivation for this change

Update yubico-pam to a newer version

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @dtzWill 
