### PR TITLE
targetcli: 2.1.fb49 -> 2.1.51

### DIFF
--- a/pkgs/development/python-modules/configshell/default.nix
+++ b/pkgs/development/python-modules/configshell/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonPackage rec {
   pname = "configshell";
-  version = "1.1.fb25";
+  version = "1.1.26";
 
   src = fetchFromGitHub {
     owner = "open-iscsi";
     repo ="${pname}-fb";
     rev = "v${version}";
-    sha256 = "0zpr2n4105qqsklyfyr9lzl1rhxjcv0mnsl57hgk0m763w6na90h";
+    sha256 = "0y2mk4y3462k2vmrydfrf5zvq55nbqxrjh0dhz8nsz5km4fzaxng";
   };
 
   propagatedBuildInputs = [ pyparsing six urwid ];

--- a/pkgs/development/python-modules/configshell/default.nix
+++ b/pkgs/development/python-modules/configshell/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonPackage rec {
   pname = "configshell";
-  version = "1.1.26";
+  version = "1.1.27";
 
   src = fetchFromGitHub {
     owner = "open-iscsi";
     repo ="${pname}-fb";
     rev = "v${version}";
-    sha256 = "0y2mk4y3462k2vmrydfrf5zvq55nbqxrjh0dhz8nsz5km4fzaxng";
+    sha256 = "1nldzq3097xqgzd8qxv36ydvx6vj2crwanihz53k46is0myrwcnn";
   };
 
   propagatedBuildInputs = [ pyparsing six urwid ];

--- a/pkgs/development/python-modules/rtslib/default.nix
+++ b/pkgs/development/python-modules/rtslib/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonPackage rec {
   pname = "rtslib";
-  version = "2.1.fb69";
+  version = "2.1.70";
 
   src = fetchFromGitHub {
     owner = "open-iscsi";
     repo ="${pname}-fb";
     rev = "v${version}";
-    sha256 = "17rlcrd9757nq91pa8xjr7147k7mxxp8zdka7arhlgsp3kcnbsfd";
+    sha256 = "14f527c28j43w5v1pasrk98jvrpqxa0gmqiafn1rim0x1yrwanjm";
   };
 
   propagatedBuildInputs = [ six pyudev pygobject3 ];

--- a/pkgs/development/python-modules/rtslib/default.nix
+++ b/pkgs/development/python-modules/rtslib/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonPackage rec {
   pname = "rtslib";
-  version = "2.1.70";
+  version = "2.1.71";
 
   src = fetchFromGitHub {
     owner = "open-iscsi";
     repo ="${pname}-fb";
     rev = "v${version}";
-    sha256 = "14f527c28j43w5v1pasrk98jvrpqxa0gmqiafn1rim0x1yrwanjm";
+    sha256 = "0cn9azi44hf59mp47207igv72kjbkyz4rsvgzmwbpz0s57b0hnab";
   };
 
   propagatedBuildInputs = [ six pyudev pygobject3 ];

--- a/pkgs/os-specific/linux/targetcli/default.nix
+++ b/pkgs/os-specific/linux/targetcli/default.nix
@@ -2,16 +2,20 @@
 
 python.pkgs.buildPythonApplication rec {
   pname = "targetcli";
-  version = "2.1.fb49";
+  version = "2.1.50";
 
   src = fetchFromGitHub {
     owner = "open-iscsi";
     repo = "${pname}-fb";
     rev = "v${version}";
-    sha256 = "093dmwc5g6yz4cdgpbfszmc97i7nd286w4x447dvg22hvwvjwqhh";
+    sha256 = "0xrvby63i39rvi778bnvnxacghaix63q72vzxdc3i87ji1ki58hc";
   };
 
   propagatedBuildInputs = with python.pkgs; [ configshell rtslib ];
+
+  postInstall = ''
+    install -D targetcli.8 -t $out/share/man/man8/
+  '';
 
   meta = with stdenv.lib; {
     description = "A command shell for managing the Linux LIO kernel target";

--- a/pkgs/os-specific/linux/targetcli/default.nix
+++ b/pkgs/os-specific/linux/targetcli/default.nix
@@ -2,19 +2,20 @@
 
 python.pkgs.buildPythonApplication rec {
   pname = "targetcli";
-  version = "2.1.50";
+  version = "2.1.51";
 
   src = fetchFromGitHub {
     owner = "open-iscsi";
     repo = "${pname}-fb";
     rev = "v${version}";
-    sha256 = "0xrvby63i39rvi778bnvnxacghaix63q72vzxdc3i87ji1ki58hc";
+    sha256 = "07i9kyr525hlk32amzgycirwgwykdbjy5fmw6ji0nnhvk2jh4arn";
   };
 
   propagatedBuildInputs = with python.pkgs; [ configshell rtslib ];
 
   postInstall = ''
     install -D targetcli.8 -t $out/share/man/man8/
+    install -D targetclid.8 -t $out/share/man/man8/
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
##### Motivation for this change
Regular update. Now the man page is also installed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
