### PR TITLE
parity: 2.5.6 -> 2.5.7, parity-beta: 2.6.1 -> 2.6.2

### DIFF
--- a/pkgs/applications/blockchains/parity/beta.nix
+++ b/pkgs/applications/blockchains/parity/beta.nix
@@ -1,6 +1,6 @@
 let
-  version     = "2.6.1";
-  sha256      = "0yvscs2ivy08zla3jhirxhwwaqsn9j5ml4sqbgx6h5rh19c941vh";
-  cargoSha256 = "1s3c44cggajrmc504klf4cyb1s4l5ny48yihs9c3fc0n8d064017";
+  version     = "2.6.2";
+  sha256      = "1j4249m5k3bi7di0wq6fm64zv3nlpgmg4hr5hnn94fyc09nz9n1r";
+  cargoSha256 = "18zd91n04wck3gd8szj4vxn3jq0bzq0h3rg0wcs6nzacbzhcx2sw";
 in
   import ./parity.nix { inherit version sha256 cargoSha256; }

--- a/pkgs/applications/blockchains/parity/default.nix
+++ b/pkgs/applications/blockchains/parity/default.nix
@@ -1,6 +1,6 @@
 let
-  version     = "2.5.6";
-  sha256      = "1qkrqkkgjvm27babd6bidhf1n6vdp8rac1zy5kf61nfzplxzr2dy";
+  version     = "2.5.7";
+  sha256      = "0aprs71cbf98dsvjz0kydngkvdg5x7dijji8j6xadgvsarl1ljnj";
   cargoSha256 = "0aa0nkv3jr7cdzswbxghxxv0y65a59jgs1682ch8vrasi0x17m1x";
 in
   import ./parity.nix { inherit version sha256 cargoSha256; }

--- a/pkgs/applications/blockchains/parity/parity.nix
+++ b/pkgs/applications/blockchains/parity/parity.nix
@@ -7,11 +7,10 @@
 , fetchFromGitHub
 , rustPlatform
 
-, pkgconfig
-, openssl
-, systemd
 , cmake
-, perl
+, openssl
+, pkgconfig
+, systemd
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -26,10 +25,9 @@ rustPlatform.buildRustPackage rec {
     inherit sha256;
   };
 
-  buildInputs = [
-    pkgconfig cmake perl
-    systemd.lib systemd.dev openssl openssl.dev
-  ];
+  nativeBuildInputs = [ cmake pkgconfig ];
+
+  buildInputs = [ openssl systemd ];
 
   cargoBuildFlags = [ "--features final" ];
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update `parity` and `parity-beta` to the latest releases.
- https://github.com/paritytech/parity-ethereum/releases/tag/v2.5.7
- https://github.com/paritytech/parity-ethereum/releases/tag/v2.6.2
- https://www.parity.io/parity-ethereum-security-release-29-8-19/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @akru
