### PR TITLE
clightning: 0.7.1 -> 0.7.2.1

### DIFF
--- a/pkgs/applications/blockchains/clightning.nix
+++ b/pkgs/applications/blockchains/clightning.nix
@@ -1,20 +1,20 @@
-{ stdenv, python3, pkgconfig, which, libtool, autoconf, automake,
+{ stdenv, python3, python3Packages, pkgconfig, which, libtool, autoconf, automake,
   autogen, sqlite, gmp, zlib, fetchurl, unzip, fetchpatch }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "clightning-${version}";
-  version = "0.7.1";
+  version = "0.7.2.1";
 
   src = fetchurl {
     url = "https://github.com/ElementsProject/lightning/releases/download/v${version}/clightning-v${version}.zip";
-    sha256 = "557be34410f27a8d55d9f31a40717a8f5e99829f2bd114c24e7ca1dd5f6b7d85";
+    sha256 = "3be716948efc1208b5e6a41e3034e4e4eecc5abbdac769fd1d999a104ac3a2ec";
   };
 
   enableParallelBuilding = true;
 
   nativeBuildInputs = [ autoconf autogen automake libtool pkgconfig which unzip ];
-  buildInputs = [ sqlite gmp zlib python3 ];
+  buildInputs = [ sqlite gmp zlib python3 python3Packages.Mako ];
 
   makeFlags = [ "prefix=$(out) VERSION=v${version}" ];
 


### PR DESCRIPTION
###### Motivation for this change
New release. 

###### Things done

Checked against signed hash. Also requires new dependency "Mako" as mentioned in the release notes (https://github.com/ElementsProject/lightning/releases/tag/v0.7.2.1).

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions (ArchLinux)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @jb55 
