### PR TITLE
coqPackages.stdpp: 1.1 -> 1.2.1; coqPackages.iris: 3.1.0 -> 3.2.0

### DIFF
--- a/pkgs/development/coq-modules/iris/default.nix
+++ b/pkgs/development/coq-modules/iris/default.nix
@@ -1,15 +1,18 @@
-{ stdenv, fetchzip, coq, ssreflect, stdpp }:
+{ stdenv, fetchFromGitLab, coq, stdpp }:
 
 stdenv.mkDerivation rec {
-  version = "3.1.0";
+  version = "3.2.0";
   name = "coq${coq.coq-version}-iris-${version}";
-  src = fetchzip {
-    url = "https://gitlab.mpi-sws.org/FP/iris-coq/-/archive/iris-${version}/iris-coq-iris-${version}.tar.gz";
-    sha256 = "0ipdb061jj205avxifshxkpyxxqykigmlxk2n5nvxj62gs3rl5j1";
+  src = fetchFromGitLab {
+    domain = "gitlab.mpi-sws.org";
+    owner = "iris";
+    repo = "iris";
+    rev = "iris-${version}";
+    sha256 = "10dfi7qx6j5w6kbmbrf05xh18jwxr9iz5g7y0f6157msgvl081xs";
   };
 
   buildInputs = [ coq ];
-  propagatedBuildInputs = [ ssreflect stdpp ];
+  propagatedBuildInputs = [ stdpp ];
 
   enableParallelBuilding = true;
 
@@ -24,7 +27,7 @@ stdenv.mkDerivation rec {
   };
 
   passthru = {
-    compatibleCoqVersions = v: builtins.elem v [ "8.6" "8.7" "8.8" ];
+    compatibleCoqVersions = v: builtins.elem v [ "8.7" "8.8" "8.9" "8.10" ];
   };
 
 }

--- a/pkgs/development/coq-modules/stdpp/default.nix
+++ b/pkgs/development/coq-modules/stdpp/default.nix
@@ -1,10 +1,14 @@
-{ stdenv, fetchzip, coq }:
+{ stdenv, fetchFromGitLab, coq }:
 
-stdenv.mkDerivation {
-  name = "coq${coq.coq-version}-stdpp-1.1";
-  src = fetchzip {
-    url = "https://gitlab.mpi-sws.org/robbertkrebbers/coq-stdpp/-/archive/coq-stdpp-1.1.0/coq-stdpp-coq-stdpp-1.1.0.tar.gz";
-    sha256 = "0z8zl288x9w32w06sjax01jcpy12wd5i3ygps58dl2hfy7r3lwg0";
+stdenv.mkDerivation rec {
+  name = "coq${coq.coq-version}-stdpp-${version}";
+  version = "1.2.1";
+  src = fetchFromGitLab {
+    domain = "gitlab.mpi-sws.org";
+    owner = "iris";
+    repo = "stdpp";
+    rev = "coq-stdpp-${version}";
+    sha256 = "1lczybg1jq9drbi8nzrlb0k199x4n07aawjwfzrl3qqc0w8kmvdz";
   };
 
   buildInputs = [ coq ];
@@ -14,7 +18,7 @@ stdenv.mkDerivation {
   installFlags = [ "COQLIB=$(out)/lib/coq/${coq.coq-version}/" ];
 
   meta = {
-    homepage = "https://gitlab.mpi-sws.org/robbertkrebbers/coq-stdpp";
+    inherit (src.meta) homepage;
     description = "An extended “Standard Library” for Coq";
     inherit (coq.meta) platforms;
     license = stdenv.lib.licenses.bsd3;
@@ -22,7 +26,7 @@ stdenv.mkDerivation {
   };
 
   passthru = {
-    compatibleCoqVersions = v: builtins.elem v [ "8.6" "8.7" "8.8" ];
+    compatibleCoqVersions = v: builtins.elem v [ "8.7" "8.8" "8.9" "8.10" ];
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change

Ensures compatibility with Coq ≥ 8.9

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

