### PR TITLE
mirage: fix build failure

### DIFF
--- a/pkgs/applications/graphics/mirage/default.nix
+++ b/pkgs/applications/graphics/mirage/default.nix
@@ -11,6 +11,8 @@ pythonPackages.buildPythonApplication rec {
 
     doCheck = false;
 
+    nativeBuildInputs = [ gettext ];
+
     buildInputs = [ stdenv libX11 gettext ];
 
     patchPhase = ''


### PR DESCRIPTION
This adds the missing `msgfmt` binary from the `gettext` package to the build `PATH`.

###### Motivation for this change

The mirage build is currently failing and not available in `19.03`.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers
