### PR TITLE
nomacs: build using Qt mkDerivation (+ translations)

### DIFF
--- a/pkgs/applications/graphics/nomacs/default.nix
+++ b/pkgs/applications/graphics/nomacs/default.nix
@@ -52,6 +52,7 @@ stdenv.mkDerivation rec {
                 "-DENABLE_RAW=ON"
                 "-DENABLE_TIFF=ON"
                 "-DENABLE_QUAZIP=ON"
+                "-DENABLE_TRANSLATIONS=ON"
                 "-DUSE_SYSTEM_QUAZIP=ON"];
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/graphics/nomacs/default.nix
+++ b/pkgs/applications/graphics/nomacs/default.nix
@@ -1,9 +1,8 @@
 { stdenv
+, mkDerivation
 , fetchFromGitHub
 , cmake
 , pkgconfig
-, wrapGAppsHook
-, gsettings-desktop-schemas
 
 , qtbase
 , qttools
@@ -38,8 +37,7 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [cmake
-                       pkgconfig
-                       wrapGAppsHook];
+                       pkgconfig];
 
   buildInputs = [qtbase
                  qttools
@@ -48,8 +46,7 @@ stdenv.mkDerivation rec {
                  opencv
                  libraw
                  libtiff
-                 quazip
-                 gsettings-desktop-schemas];
+                 quazip];
 
   cmakeFlags = ["-DENABLE_OPENCV=ON"
                 "-DENABLE_RAW=ON"


### PR DESCRIPTION
`nomacs` fails to run on unstable with the following error:
```
qt.qpa.plugin: Could not find the Qt platform plugin "xcb" in ""
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
```

Using the Qt `mkDerivation` fixes this.

This PR also enables translations, which I can split off if necessary.

###### Motivation for this change

Further to #65399

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after) (`322.2M -> 362.4M`)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @ahmedtd
