### PR TITLE
google-cloud-cpp: 0.11.0 -> 0.12.0

### DIFF
--- a/pkgs/development/libraries/google-cloud-cpp/default.nix
+++ b/pkgs/development/libraries/google-cloud-cpp/default.nix
@@ -55,6 +55,9 @@ in stdenv.mkDerivation rec {
     sed -e 's,''${CMAKE_INSTALL_LIBDIR},lib64,g' \
         -e 's,;lib64,lib,g' \
         -i cmake/ExternalProjectHelper.cmake
+
+    # Remove check_cxx_compiler_flag calls. they cause compilation failure when this package is used with pkgs.enableDebugging
+    sed -e 's,check_cxx_compiler_flag(-W,#check_cxx_compiler_flag(-W,g' -i cmake/GoogleCloudCppCommon.cmake
   '';
 
   preFixup = ''

--- a/pkgs/development/libraries/google-cloud-cpp/default.nix
+++ b/pkgs/development/libraries/google-cloud-cpp/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, grpc, curl, cmake, pkgconfig, fetchFromGitHub, doxygen, protobuf, crc32c, c-ares, nlohmann_json, fetchurl }:
+{ stdenv, grpc, curl, cmake, pkgconfig, fetchFromGitHub, doxygen, protobuf, crc32c, c-ares, nlohmann_json, fetchurl, runCommand, gnutar }:
 let
   googleapis_rev = "a8ee1416f4c588f2ab92da72e7c1f588c784d3e6";
   googleapis = fetchurl {
@@ -6,15 +6,31 @@ let
     url = "https://github.com/googleapis/googleapis/archive/${googleapis_rev}.tar.gz";
     sha256 = "1kxi27r034p7jfldhvgpbn6rqqqddycnja47m6jyjxj4rcmrp2kb";
   };
+
+  googleapis-cpp-cmakefiles-rev = "v0.1.1";
+  googleapis-cpp-cmakefiles = fetchurl {
+    name = "${googleapis-cpp-cmakefiles-rev}.tar.gz";
+    url = "https://github.com/googleapis/cpp-cmakefiles/archive/${googleapis-cpp-cmakefiles-rev}.tar.gz";
+    sha256 = "e8143e9132a57bd868f3014c0bc382205885c53a2a425b3c2dbb8f9feaa8366c";
+  };
+
+  patched-googleapis-cpp-cmakefiles = runCommand "googleapis-cpp-cmakefiles.tar.gz" {
+    buildInputs = [ gnutar ];
+  } ''
+    tar xf ${googleapis-cpp-cmakefiles}
+    sed -e 's,https://github.com/googleapis/googleapis/archive/${googleapis_rev}.tar.gz,file://${googleapis},' \
+        -i cpp-cmakefiles-*/CMakeLists.txt
+    tar czf $out cpp-cmakefiles*/
+  '';
 in stdenv.mkDerivation rec {
   pname = "google-cloud-cpp";
-  version = "0.11.0";
+  version = "0.12.0";
 
   src = fetchFromGitHub {
     owner = "googleapis";
     repo = "google-cloud-cpp";
     rev = "v${version}";
-    sha256 = "1w942gzyv01ym1cv2a417x92zxra9s2v3xz5crcv84j919f616f8";
+    sha256 = "1r651xy3mc834ia7v8kks9vij02yl8p3w34qwd9qiaggz6ffyj8f";
   };
 
   buildInputs = [ curl grpc protobuf nlohmann_json crc32c c-ares c-ares.cmake-config ];
@@ -28,7 +44,11 @@ in stdenv.mkDerivation rec {
         -e "s,JSON_SHA256 .*,JSON_SHA256 ''${NLOHMANN_SHA256}," \
         -i cmake/DownloadNlohmannJson.cmake
 
-    sed -e 's,https://github.com/googleapis/googleapis/archive/${googleapis_rev}.tar.gz,file://${googleapis},' \
+		GOOGLEAPIS_CPP_CMAKEFILES_SHA256=$(sha256sum ${patched-googleapis-cpp-cmakefiles} | cut -f1 -d' ')
+
+    # just here to make ${googleapis} available during runtime…
+    sed -e 's,https://github.com/googleapis/cpp-cmakefiles/archive/${googleapis-cpp-cmakefiles-rev}.tar.gz,file://${patched-googleapis-cpp-cmakefiles},' \
+        -e "s,${googleapis-cpp-cmakefiles.outputHash},''${GOOGLEAPIS_CPP_CMAKEFILES_SHA256}," \
         -i cmake/external/googleapis.cmake
 
     # Fixup the library path. It would build a path like /build/external//nix/store/…-foo/lib/foo.so for each library instead of /build/external/lib64/foo.so


### PR DESCRIPTION
###### Motivation for this change

My first attempt at updating the package. The packaging gained yet another indirection because they decided to move a few CMake files to another repositorry which in turn also pull down yet another repository of CMake files…

cc @flokli

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nixos/nixpkgs/67769)
<!-- Reviewable:end -->
