### PR TITLE
caf: 0.17.1 -> 0.17.2; enable openssl; run tests

### DIFF
--- a/pkgs/development/libraries/caf/default.nix
+++ b/pkgs/development/libraries/caf/default.nix
@@ -19,6 +19,12 @@ stdenv.mkDerivation rec {
     "-DCAF_NO_EXAMPLES:BOOL=TRUE"
   ];
 
+  doCheck = true;
+  checkTarget = "test";
+  preCheck = ''
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/lib
+  '';
+
   meta = with stdenv.lib; {
     description = "An open source implementation of the actor model in C++";
     homepage = http://actor-framework.org/;

--- a/pkgs/development/libraries/caf/default.nix
+++ b/pkgs/development/libraries/caf/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "actor-framework";
-  version = "0.17.1";
+  version = "0.17.2";
 
   src = fetchFromGitHub {
     owner = "actor-framework";
     repo = "actor-framework";
     rev = version;
-    sha256 = "1xbq591m3v6pkz4z3dg2lsxr6bxv1lpz4yhdci3vi55y6x9pwyfw";
+    sha256 = "0z9qh580pa1mx9h48npwji24bjyqxm1w93wdcc4inmjzdmrqwzim";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/caf/default.nix
+++ b/pkgs/development/libraries/caf/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake }:
+{ stdenv, fetchFromGitHub, cmake, openssl }:
 
 stdenv.mkDerivation rec {
   pname = "actor-framework";
@@ -13,11 +13,13 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
+  buildInputs = [ openssl ];
+
   meta = with stdenv.lib; {
     description = "An open source implementation of the actor model in C++";
     homepage = http://actor-framework.org/;
     license = licenses.bsd3;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ bobakker ];
+    maintainers = with maintainers; [ bobakker tobim ];
   };
 }

--- a/pkgs/development/libraries/caf/default.nix
+++ b/pkgs/development/libraries/caf/default.nix
@@ -15,6 +15,10 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ openssl ];
 
+  cmakeFlags = [
+    "-DCAF_NO_EXAMPLES:BOOL=TRUE"
+  ];
+
   meta = with stdenv.lib; {
     description = "An open source implementation of the actor model in C++";
     homepage = http://actor-framework.org/;


### PR DESCRIPTION
#### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @bobakker 
