### PR TITLE
gamemode: init at 1.4

### DIFF
--- a/pkgs/games/gamemode/default.nix
+++ b/pkgs/games/gamemode/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, meson, ninja, fetchFromGitHub, systemd, pkgconfig, dbus }:
+
+stdenv.mkDerivation rec {
+  pname = "gamemode";
+  version = "1.4";
+
+  nativeBuildInputs = [ meson ninja pkgconfig ];
+
+  buildInputs = [ systemd dbus ];
+
+  src = fetchFromGitHub {
+    owner = "FeralInteractive";
+    repo = "gamemode";
+    rev = "7ced21f4b30cc4ceb67928889bc57af8784f1009";
+    sha256 = "19s73yblbv8c7dw41sb713cjy1y6wr2srn9wvqdcsqgc159z4sj2";
+    fetchSubmodules = true;
+  };
+
+  mesonFlags = "-Dwith-systemd-user-unit-dir=share/systemd/user";
+
+  patches = [ ./gamemoderun.patch ];
+
+  meta = with stdenv.lib; {
+    description = "Optimise Linux system performance on demand";
+    homepage = https://github.com/FeralInteractive/GameMode/;
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.leo60228 ];
+  };
+}

--- a/pkgs/games/gamemode/gamemoderun.patch
+++ b/pkgs/games/gamemode/gamemoderun.patch
@@ -1,0 +1,15 @@
+diff --git a/data/gamemoderun.in b/data/gamemoderun.in
+index 659e33e..3c7399c 100755
+--- a/data/gamemoderun.in
++++ b/data/gamemoderun.in
+@@ -5,6 +5,9 @@
+ # appropriate path depending on whether the app is 32- or 64-bit.
+ GAMEMODEAUTO="@GAMEMODE_PREFIX@/\$LIB/libgamemodeauto.so.0"
+ 
++GAMEMODE="@GAMEMODE_PREFIX@/\$LIB/"
++
+ LD_PRELOAD="${GAMEMODEAUTO}${LD_PRELOAD:+:$LD_PRELOAD}"
++LD_LIBRARY_PATH="${GAMEMODE}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+ 
+-exec $GAMEMODERUNEXEC env LD_PRELOAD="${LD_PRELOAD}" "$@"
++exec $GAMEMODERUNEXEC env LD_PRELOAD="${LD_PRELOAD}" LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" "$@"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22154,6 +22154,8 @@ in
 
   gambatte = callPackage ../games/gambatte { };
 
+  gamemode = callPackage ../games/gamemode { };
+
   garden-of-coloured-lights = callPackage ../games/garden-of-coloured-lights { allegro = allegro4; };
 
   gargoyle = callPackage ../games/gargoyle {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
[GameMode](https://github.com/FeralInteractive/gamemode) is a pretty popular package. It requires a daemon as well, which I have not written a NixOS module for due to a lack of experience. If necessary, I can add it to this or a separate PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
   - Had issues with it while reinstalling NixOS, so disabled it
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).