### PR TITLE
exempi: 2.4.5 -> 2.5.1

### DIFF
--- a/pkgs/development/libraries/exempi/default.nix
+++ b/pkgs/development/libraries/exempi/default.nix
@@ -1,23 +1,13 @@
 { stdenv, fetchurl, fetchpatch, expat, zlib, boost, libiconv, darwin }:
 
 stdenv.mkDerivation rec {
-  name = "exempi-2.4.5";
+  pname = "exempi";
+  version = "2.5.1";
 
   src = fetchurl {
-    url = "https://libopenraw.freedesktop.org/download/${name}.tar.bz2";
+    url = "https://libopenraw.freedesktop.org/download/${pname}-${version}.tar.bz2";
     sha256 = "07i29xmg8bqriviaf4vi1mwha4lrw85kfla29cfym14fp3z8aqa0";
   };
-
-  patches = [
-    # CVE-2018-12648
-    # https://gitlab.freedesktop.org/libopenraw/exempi/issues/9
-    # remove with exempi > 2.4.5
-    (fetchpatch {
-      name = "CVE-2018-12648.patch";
-      url = https://gitlab.freedesktop.org/libopenraw/exempi/commit/8ed2f034705fd2d032c81383eee8208fd4eee0ac.patch;
-      sha256 = "1nh8irk5p26868875wq5n8g92xp4crfb8fdd8gyna76ldyzqqx9q";
-    })
-  ];
 
   configureFlags = [
     "--with-boost=${boost.dev}"


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
fixing more @r-ryantm failed updates

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[63 built, 506 copied (1532.4 MiB), 336.4 MiB DL]
https://github.com/NixOS/nixpkgs/pull/67782
35 package were build:
deja-dup dropbox-cli empathy exempi gnome-photos gnome3.cheese gnome3.eog gnome3.file-roller gnome3.gnome-books gnome3.gnome-boxes gnome3.gnome-contacts gnome3.gnome-control-center gnome3.gnome-documents gnome3.gnome-terminal gnome3.gnome-tweak-tool gnome3.gnome-user-share gnome3.nautilus gnome3.nautilus-python gnome3.totem gnome3.tracker-miners gnomeExtensions.gsconnect mate.atril mate.caja mate.caja-dropbox mate.caja-extensions mate.caja-with-extensions mate.engrampa mate.eom mate.mate-user-share mate.python-caja ocrmypdf pantheon.extra-elementary-contracts python27Packages.python-xmp-toolkit python37Packages.pikepdf python37Packages.python-xmp-toolkit
```