### PR TITLE
latex2html: 2018 -> 2019.2

### DIFF
--- a/pkgs/tools/misc/latex2html/default.nix
+++ b/pkgs/tools/misc/latex2html/default.nix
@@ -1,17 +1,16 @@
-{ stdenv, fetchurl, makeWrapper
+{ stdenv, fetchFromGitHub, makeWrapper
 , ghostscript, netpbm, perl }:
 # TODO: withTex
 
-# Ported from Homebrew.
-# https://github.com/Homebrew/homebrew-core/blob/21834573f690407d34b0bbf4250b82ec38dda4d6/Formula/latex2html.rb
-
 stdenv.mkDerivation rec {
   pname = "latex2html";
-  version = "2018";
+  version = "2019.2";
 
-  src = fetchurl {
-    url = "http://mirrors.ctan.org/support/latex2html/latex2html-${version}.tar.gz";
-    sha256 = "1qnlg8ajh0amy9gy8rh8sp1l224ak54264i3dhk7rrv9s4k7bqq9";
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1bcdhbaxf334wlxzkw5samj2y2q173709y0km3x8xs4bbh70ds6c";
   };
 
   buildInputs = [ ghostscript netpbm perl ];


### PR DESCRIPTION
###### Motivation for this change

- Update to latest version
- Use GitHub instead of CTAN

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
  - [x] `latex2html`
  - [ ] `pstoimg`
  - [ ] `texepand` (called internally by `latex2html`?)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).