### PR TITLE
python3Packages.dotnetcore2: init at 2.1.8.1

### DIFF
--- a/pkgs/development/python-modules/dotnetcore2/default.nix
+++ b/pkgs/development/python-modules/dotnetcore2/default.nix
@@ -1,0 +1,59 @@
+{ stdenv, lib, buildPythonPackage, fetchPypi, python, isPy27
+, dotnet-sdk
+, substituteAll
+, distro
+, unzip
+}:
+
+buildPythonPackage rec {
+  pname = "dotnetcore2";
+  version = "2.1.8.1";
+  format = "wheel";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version format;
+    python = "py3";
+    platform = "manylinux1_x86_64";
+    sha256 = "13zrff5j767d3f8drl397sjhl28winsrfa8pa20svf00xfcsy34s";
+  };
+
+  nativeBuildInputs = [ unzip ];
+
+  propagatedBuildInputs = [ distro ];
+
+  # needed to apply patches
+  prePatch = ''
+    unzip dist/dotnet*
+  '';
+
+  patches = [
+    ( substituteAll {
+        src = ./runtime.patch;
+        dotnet = dotnet-sdk;
+      }
+    )
+  ];
+
+  # unfortunately the noraml pip install fails because the manylinux1 format check fails with NixOS
+  installPhase = ''
+    mkdir -p $out/${python.sitePackages}/${pname}
+    # copy metadata
+    cp -r dotnetcore2-2* $out/${python.sitePackages}
+    # copy non-dotnetcore related files
+    cp -r dotnetcore2/{__init__.py,runtime.py} $out/${python.sitePackages}/${pname}
+  '';
+
+  # no tests, ensure it's one useful function works
+  checkPhase = ''
+    ${python.interpreter} -c 'from dotnetcore2 import runtime; print(runtime.get_runtime_path())'
+  '';
+
+  meta = with lib; {
+    description = "DotNet Core runtime";
+    homepage = "https://github.com/dotnet/core";
+    license = licenses.mit;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/development/python-modules/dotnetcore2/runtime.patch
+++ b/pkgs/development/python-modules/dotnetcore2/runtime.patch
@@ -1,0 +1,19 @@
+diff a/dotnetcore2/runtime.py b/dotnetcore2/runtime.py
+--- a/dotnetcore2/runtime.py
++++ b/dotnetcore2/runtime.py
+@@ -39,13 +39,13 @@ def _get_bin_folder() -> str:
+ 
+ 
+ def get_runtime_path():
++    return "@dotnet@/dotnet"
+     search_string = os.path.join(_get_bin_folder(), 'dotnet*')
+     matches = [f for f in glob.glob(search_string, recursive=True)]
+     return matches[0]
+ 
+ def ensure_dependencies() -> Optional[str]:
+-    if dist is None:
+-        return None
++    return None
+ 
+     bin_folder = _get_bin_folder()
+     deps_path = os.path.join(bin_folder, 'deps')

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -523,6 +523,10 @@ in {
 
   dominate = callPackage ../development/python-modules/dominate { };
 
+  dotnetcore2 = callPackage ../development/python-modules/dotnetcore2 {
+    inherit (pkgs) substituteAll dotnet-sdk;
+  };
+
   emcee = callPackage ../development/python-modules/emcee { };
 
   emailthreads = callPackage ../development/python-modules/emailthreads { };


### PR DESCRIPTION

###### Motivation for this change
Upstreaming this from an expression I use at work

why someone felt like packaging this instead of telling users to install it... idk

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc

includes dotnet-sdk closure, i will try to reduce the size of that package
```
$ nix path-info -Sh ./result
/nix/store/jxld4i96bfdk76ic904vkvczr50jpq2d-python3.7-dotnetcore2-2.1.8.1        834.4M
```
```
$ tree ./result/
./result/
├── lib
│   └── python3.7
│       └── site-packages
│           ├── dotnetcore2
│           │   ├── __init__.py
│           │   └── runtime.py
│           └── dotnetcore2-2.1.8.1.dist-info
│               ├── LICENSE.txt
│               ├── METADATA
│               ├── RECORD
│               ├── top_level.txt
│               └── WHEEL
└── nix-support
    └── propagated-build-inputs
```
```
[1 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/67787
1 package were build:
python37Packages.dotnetcore2
```