### PR TITLE
pythonPackages.sfepy: init at 2019.2

### DIFF
--- a/pkgs/development/python-modules/sfepy/default.nix
+++ b/pkgs/development/python-modules/sfepy/default.nix
@@ -1,0 +1,62 @@
+{ lib
+, buildPythonPackage
+, fetchurl
+, numpy
+, scipy
+, matplotlib
+, pyparsing
+, tables
+, cython
+, python
+, sympy
+}:
+
+buildPythonPackage rec {
+  name = "sfepy_${version}";
+  version = "2019.2";
+
+  src = fetchurl {
+    url="https://github.com/sfepy/sfepy/archive/release_${version}.tar.gz";
+    sha256 = "17dj0wbchcfa6x27yx4d4jix4z4nk6r2640xkqcsw0mf62x5l1pj";
+  };
+
+  propagatedBuildInputs = [
+    numpy
+    cython
+    scipy
+    matplotlib
+    pyparsing
+    tables
+    sympy
+  ];
+
+  postPatch = ''
+    # broken test
+    rm tests/test_homogenization_perfusion.py
+
+    # slow tests
+    rm tests/test_input_*.py
+    rm tests/test_elasticity_small_strain.py
+    rm tests/test_term_call_modes.py
+    rm tests/test_refine_hanging.py
+    rm tests/test_hyperelastic_tlul.py
+    rm tests/test_poly_spaces.py
+    rm tests/test_linear_solvers.py
+    rm tests/test_quadratures.py
+  '';
+
+  checkPhase = ''
+    export HOME=$TMPDIR
+    mv sfepy sfepy.hidden
+    mkdir -p $HOME/.matplotlib
+    echo "backend: ps" > $HOME/.matplotlib/matplotlibrc
+    ${python.interpreter} run_tests.py -o $TMPDIR/test_outputs --raise
+  '';
+
+  meta = with lib; {
+    homepage = https://sfepy.org/;
+    description = "Simple Finite Elements in Python";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ wd15 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4156,6 +4156,8 @@ in {
 
   fipy = callPackage ../development/python-modules/fipy { };
 
+  sfepy = callPackage ../development/python-modules/sfepy { };
+
   pelican = callPackage ../development/python-modules/pelican {
     inherit (pkgs) glibcLocales git;
   };


### PR DESCRIPTION
Add [Sfepy](http://sfepy.org/doc-devel/index.html) finite element solver.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
