### PR TITLE
mpv, ffmpeg: use addOpenGLRunpath to fix CUDA-accelerated playback

### DIFF
--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -1,6 +1,6 @@
 { config, stdenv, fetchurl, fetchFromGitHub, makeWrapper
-, docutils, perl, pkgconfig, python3, which, ffmpeg_4
-, freefont_ttf, freetype, libass, libpthreadstubs, mujs
+, addOpenGLRunpath, docutils, perl, pkgconfig, python3, which
+, ffmpeg_4, freefont_ttf, freetype, libass, libpthreadstubs, mujs
 , nv-codec-headers, lua, libuchardet, libiconv ? null, darwin
 
 , waylandSupport ? stdenv.isLinux
@@ -135,8 +135,7 @@ in stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [
-    docutils makeWrapper perl
-    pkgconfig python3 which
+    addOpenGLRunpath docutils makeWrapper perl pkgconfig python3 which
   ];
 
   buildInputs = [
@@ -214,11 +213,17 @@ in stdenv.mkDerivation rec {
       ${wrapperFlags}
   '';
 
+  # Set RUNPATH so that libcuda in /run/opengl-driver(-32)/lib can be found.
+  # See the explanation in addOpenGLRunpath.
+  postFixup = optionalString stdenv.isLinux ''
+    addOpenGLRunpath $out/bin/.mpv-wrapped
+  '';
+
   meta = with stdenv.lib; {
     description = "A media player that supports many video formats (MPlayer and mplayer2 fork)";
     homepage = https://mpv.io;
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ AndersonTorres fuuzetsu fpletz globin ];
+    maintainers = with maintainers; [ AndersonTorres fuuzetsu fpletz globin ivan ];
     platforms = platforms.darwin ++ platforms.linux;
 
     longDescription = ''


### PR DESCRIPTION
###### Motivation for this change

This fixes #67780.

Currently, using `mpv --hwdec=nvdec --msg-level=vd=debug ...` on NVIDIA results in:

```
[vd] Opening decoder hevc
[vd] Looking at hwdec hevc-nvdec...
Cannot load libcuda.so.1
[vd] Could not create device.
[vd] No hardware decoding available for this codec.
```

With just mpv patched, ffmpeg cannot load libnvcuvid.so.1:

```
[vd] Opening decoder hevc
[vd] Looking at hwdec hevc-nvdec...
[vd] Trying hardware decoding via hevc-nvdec.
[vd] Selected codec: hevc (HEVC (High Efficiency Video Coding))
[vd] Pixel formats supported by decoder: vaapi_vld cuda yuv420p10le
[vd] Codec profile: Main 10 (0x2)
[vd] Requesting pixfmt 'cuda' from decoder.
[ffmpeg/video] hevc: Cannot load libnvcuvid.so.1
[ffmpeg/video] hevc: Failed loading nvcuvid.
[ffmpeg/video] hevc: Failed setup for format cuda: hwaccel initialisation returned error.
```

With both mpv and ffmpeg patched, it works:

```
[vd] Opening decoder hevc
[vd] Looking at hwdec hevc-nvdec...
[vd] Trying hardware decoding via hevc-nvdec.
[vd] Selected codec: hevc (HEVC (High Efficiency Video Coding))
[vd] Pixel formats supported by decoder: vaapi_vld cuda yuv420p10le
[vd] Codec profile: Main 10 (0x2)
[vd] Requesting pixfmt 'cuda' from decoder.
Using hardware decoding (nvdec).
[vd] Decoder format: 3840x2160 cuda[p010] bt.2020-ncl/bt.2020/pq/limited/auto SP=10.000000 CL=unknown (auto 0.000000/0.000000/0.000000)
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I tested a very similar commit on master, not staging.

###### Notify maintainers

mpv: cc @AndersonTorres @Fuuzetsu @fpletz @globin
ffmpeg: cc @codyopel @Fuuzetsu 