### PR TITLE
nixos/tests/systemd: Fix x-initrd-mount flakiness

### DIFF
--- a/nixos/tests/systemd.nix
+++ b/nixos/tests/systemd.nix
@@ -71,11 +71,13 @@ import ./make-test.nix ({ pkgs, ... }: {
 
     # Regression test for https://github.com/NixOS/nixpkgs/issues/35268
     subtest "file system with x-initrd.mount is not unmounted", sub {
+      $machine->succeed('mountpoint -q /test-x-initrd-mount');
       $machine->shutdown;
-      $machine->waitForUnit('multi-user.target');
-      # If the file system was unmounted during the shutdown the file system
-      # has a last mount time, because the file system wasn't checked.
-      $machine->fail('dumpe2fs /dev/vdb | grep -q "^Last mount time: *n/a"');
+      system('qemu-img', 'convert', '-O', 'raw',
+             'vm-state-machine/empty2.qcow2', 'x-initrd-mount.raw');
+      my $extinfo = `${pkgs.e2fsprogs}/bin/dumpe2fs x-initrd-mount.raw`;
+      die "File system was not cleanly unmounted: $extinfo"
+        unless $extinfo =~ /^Filesystem state: *clean$/m;
     };
 
     subtest "systemd-shutdown works", sub {


### PR DESCRIPTION
It turns out that checking for the last mount time of an ext4 file system isn't a very reliable way to check whether the file system was properly unmounted.

When creating that test in the first place (88530e02b6fa9b5429dc09972b), I was reluctant to inspect the file system when the VM is down and was searching for a way to check for a clean unmount *after* the file system was mounted again to make sure we don't need to create a 512 MB raw image on the host.

Fortunately however, when converting from qcow2, `qemu-img` actually writes a sparse file, so for most file systems (that is, file systems supporting sparse files) this shouldn't waste a lot of disk space.

So when investigating the flakiness, I found that whenever the test is failing, the unmount of `/test-x-initrd-mount` was done *before* the final step during which systemd remounts+unmounts all the remaining file systems.

I haven't investigated why this is the case, but the test is a regression test for https://github.com/NixOS/nixpkgs/issues/35268, which actually didn't unmount the file system *at* *all*, so really all we need to take care here is whether the unmount has happened and not *how*.

To make sure that checking the filesystem state is enough for this, I temporarily replaced the `$machine->shutdown` call with `$machine->crash` and verified that the file system state is `not clean`.

Fixes: https://github.com/NixOS/nixpkgs/issues/67555