### PR TITLE
particl-core: 0.17.1.2 -> 0.18.1.3

### DIFF
--- a/pkgs/applications/blockchains/particl/particl-core.nix
+++ b/pkgs/applications/blockchains/particl/particl-core.nix
@@ -1,51 +1,47 @@
-{ stdenv
-, autoreconfHook
-, boost
-, db48
-, fetchurl
-, libevent
-, miniupnpc
-, openssl
-, pkgconfig
-, zeromq
-, zlib
-, unixtools
-, python3
-}:
+{ stdenv, fetchFromGitHub, autoreconfHook, boost, db48, fetchurl, libevent
+, miniupnpc, openssl, pkgconfig, zeromq, zlib, unixtools, python3 }:
 
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
   pname = "particl-core";
-  version = "0.17.1.2";
 
-  src = fetchurl {
-    url = "https://github.com/particl/particl-core/archive/v${version}.tar.gz";
-    sha256 = "16hcyxwp6yrypwvxz6i2987z3jmpk47xcgnsgh9klih8baqg64p5";
+  version = "0.18.1.3";
+
+  src = fetchFromGitHub {
+    owner = "particl";
+    repo = "particl-core";
+    rev = "v${version}";
+    sha256 = "1djfg5zhf9c0pvfybj56rq3rl9n41b9mmdsq7znrxh2zjkkiqdwy";
   };
 
   nativeBuildInputs = [ pkgconfig autoreconfHook ];
-  buildInputs = [ openssl db48 boost zlib miniupnpc libevent zeromq unixtools.hexdump python3 ];
 
-  configureFlags = [
-    "--disable-bench"
-    "--with-boost-libdir=${boost.out}/lib"
-  ] ++ optionals (!doCheck) [
-    "--enable-tests=no"
-  ];
+  buildInputs =
+    [ openssl db48 boost zlib miniupnpc libevent zeromq unixtools.hexdump ];
+
+  configureFlags = [ "--disable-bench" "--with-boost-libdir=${boost.out}/lib" ]
+    ++ optionals (!doCheck) [ "--enable-tests=no" ];
+
+  checkInputs = [ python3 ];
 
   # Always check during Hydra builds
   doCheck = true;
+
+  checkFlags = [ "LC_ALL=C.UTF-8" ];
+
   preCheck = "patchShebangs test";
+
   enableParallelBuilding = true;
 
   meta = {
-    description = "Privacy-Focused Marketplace & Decentralized Application Platform";
-    longDescription= ''
+    description =
+      "Privacy-Focused Marketplace & Decentralized Application Platform";
+    longDescription = ''
       An open source, decentralized privacy platform built for global person to person eCommerce.
       RPC daemon and CLI client only.
     '';
-    homepage = https://particl.io/;
+    homepage = "https://particl.io/";
     maintainers = with maintainers; [ demyanrogozhin ];
     license = licenses.mit;
     platforms = platforms.unix;


### PR DESCRIPTION
###### Motivation for this change

Particl blockchain planned hardfork happened at 2019.07.16, minimal compatible version of Particl Core is v0.18.0.10.
For details see:
https://particl.news/hardfork-announcement-ringct-bulletproofs-ready-for-part-july-9df87794bd42

Changelog:
https://github.com/particl/particl-core/blob/0.18/doc/release-notes-particl.md

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).