### PR TITLE
monero-gui: cleanup

### DIFF
--- a/pkgs/applications/blockchains/monero-gui/default.nix
+++ b/pkgs/applications/blockchains/monero-gui/default.nix
@@ -1,5 +1,4 @@
-{ stdenv, fetchFromGitHub
-, wrapQtAppsHook, makeDesktopItem
+{ mkDerivation, lib, makeDesktopItem, fetchFromGitHub
 , qtbase, qmake, qtmultimedia, qttools
 , qtgraphicaleffects, qtdeclarative
 , qtlocation, qtquickcontrols, qtquickcontrols2
@@ -9,22 +8,10 @@
 , hidapi
 }:
 
-with stdenv.lib;
+with lib;
 
-let
-  qmlPath = qmlLib: "${qmlLib}/${qtbase.qtQmlPrefix}";
-
-  qml2ImportPath = concatMapStringsSep ":" qmlPath [
-    qtbase.bin qtmultimedia.bin qtgraphicaleffects
-    qtdeclarative.bin qtlocation.bin
-    qtquickcontrols qtquickcontrols2.bin
-    qtwebchannel.bin qtwebengine.bin qtxmlpatterns
-  ];
-
-in
-
-stdenv.mkDerivation rec {
-  name = "monero-gui-${version}";
+mkDerivation rec {
+  pname = "monero-gui";
   version = "0.14.1.2";
 
   src = fetchFromGitHub {
@@ -34,7 +21,7 @@ stdenv.mkDerivation rec {
     sha256 = "1rm043r6y2mzy8pclnzbjjfxgps8pkfa2b92p66k8y8rdmgq6m1k";
   };
 
-  nativeBuildInputs = [ qmake pkgconfig wrapQtAppsHook ];
+  nativeBuildInputs = [ qmake pkgconfig ];
 
   buildInputs = [
     qtbase qtmultimedia qtgraphicaleffects
@@ -46,9 +33,7 @@ stdenv.mkDerivation rec {
     cppzmq hidapi
   ];
 
-  patches = [
-    ./move-log-file.patch
-  ];
+  patches = [ ./move-log-file.patch ];
 
   postPatch = ''
     echo '


### PR DESCRIPTION
###### Motivation for this change
Cleanup some leftovers after the WrapQtAppsHook change

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
