### PR TITLE
nix-prefetch-git: Remove some pack file non-determinism

### DIFF
--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -265,7 +265,9 @@ make_deterministic_repo(){
     rm -f .git/config
 
     # Garbage collect unreferenced objects.
-    git gc --prune=all
+    # Note: --keep-largest-pack prevents non-deterministic ordering of packs
+    #   listed in .git/objects/info/packs by only using a single pack
+    git gc --prune=all --keep-largest-pack
     )
 }
 


### PR DESCRIPTION
###### Motivation for this change
While packaging invidious in #67664, I found a piece of non-determinism in git, which `nix-prefetch-git` didn't account for. This PR works around this.

Ping @jonringer @bjornfor 

###### Things done

No hashes needed updating with this change. By default the `.git` directory is removed, only when `leaveDotGit = true;` the function for making it deterministic is called. I applied this little patch:
```diff
diff --git a/pkgs/build-support/fetchgit/default.nix b/pkgs/build-support/fetchgit/default.nix
index 256c86748d2..0d984b8d5de 100644
--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -49,7 +49,7 @@ assert deepClone -> leaveDotGit;
 if md5 != "" then
   throw "fetchgit does not support md5 anymore, please use sha256"
 else
-stdenvNoCC.mkDerivation {
+let drv = stdenvNoCC.mkDerivation {
   inherit name;
   builder = ./builder.sh;
   fetcher = "${./nix-prefetch-git}";  # This must be a string to ensure it's called with bash.
@@ -68,4 +68,4 @@ stdenvNoCC.mkDerivation {
   ];
 
   inherit preferLocalBuild;
-}
+}; in if leaveDotGit then builtins.trace drv.drvPath drv else drv
```

Then I grepped for `leaveDotGit` and `deepClone` (which turns on `leaveDotGit`) to find potential packages. Each of those packages I instantiated with
```
nix-instantiate -A <attribute>
```
so the patch would trace the .drvs that have `leaveDotGit = true;`, then I did
```
nix-store -r <.drv>
nix-store -r <.drv> --check
```

on each of them to verify the hash is still correct.