### PR TITLE
arx-libertatis: 2019-02-16 -> 2019-07-22

### DIFF
--- a/pkgs/games/arx-libertatis/default.nix
+++ b/pkgs/games/arx-libertatis/default.nix
@@ -2,7 +2,8 @@
 , openal, glm, freetype, libGLU, SDL2, epoxy
 , dejavu_fonts, inkscape, optipng, imagemagick
 , withCrashReporter ? !stdenv.isDarwin
-,   qt5  ? null
+,   qtbase ? null
+,   wrapQtAppsHook ? null
 ,   curl ? null
 ,   gdb  ? null
 }:
@@ -20,15 +21,14 @@ stdenv.mkDerivation rec {
     sha256 = "0qrygp09dqhpb5q6a1zl6l03qh9bi7xcahd8hy9177z1cix3k0kz";
   };
 
-
   nativeBuildInputs = [
     cmake inkscape imagemagick optipng
-  ];
+  ] ++ optionals withCrashReporter [ wrapQtAppsHook ];
 
   buildInputs = [
     zlib boost openal glm
     freetype libGLU SDL2 epoxy
-  ] ++ optionals withCrashReporter [ qt5.qtbase curl ]
+  ] ++ optionals withCrashReporter [ qtbase curl ]
     ++ optionals stdenv.isLinux    [ gdb ];
 
   cmakeFlags = [
@@ -38,11 +38,14 @@ stdenv.mkDerivation rec {
   ];
 
   enableParallelBuilding = true;
+  dontWrapQtApps = true;
 
   postInstall = ''
     ln -sf \
       ${dejavu_fonts}/share/fonts/truetype/DejaVuSansMono.ttf \
       $out/share/games/arx/misc/dejavusansmono.ttf
+  '' + optionalString withCrashReporter ''
+    wrapQtApp "$out/libexec/arxcrashreporter"
   '';
   
   meta = {
@@ -51,10 +54,10 @@ stdenv.mkDerivation rec {
       first-person role-playing game / dungeon crawler
       developed by Arkane Studios.
     '';
-    homepage = http://arx-libertatis.org/;
-    license = licenses.gpl3;
+    homepage    = http://arx-libertatis.org/;
+    license     = licenses.gpl3;
     maintainers = with maintainers; [ rnhmjoj ];
-    platforms = platforms.linux;
+    platforms   = platforms.linux;
   };
 
 }

--- a/pkgs/games/arx-libertatis/default.nix
+++ b/pkgs/games/arx-libertatis/default.nix
@@ -12,13 +12,13 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   pname = "arx-libertatis";
-  version = "2019-02-16";
+  version = "2019-07-22";
 
   src = fetchFromGitHub {
-    owner  = "arx";
-    repo   = "ArxLibertatis";
-    rev    = "fbce6ccbc7f58583f33f29b838c38ef527edc267";
-    sha256 = "0qrygp09dqhpb5q6a1zl6l03qh9bi7xcahd8hy9177z1cix3k0kz";
+    owner = "arx";
+    repo = "ArxLibertatis";
+    rev = "db77aa26bb8612f711b65e72b1cd8cf6481700c7";
+    sha256 = "0c88djyzjna17wjcvkgsfx3011m1rba5xdzdldy1hjmafpqgb4jj";
   };
 
   nativeBuildInputs = [
@@ -54,10 +54,10 @@ stdenv.mkDerivation rec {
       first-person role-playing game / dungeon crawler
       developed by Arkane Studios.
     '';
-    homepage    = http://arx-libertatis.org/;
-    license     = licenses.gpl3;
+    homepage = http://arx-libertatis.org/;
+    license = licenses.gpl3;
     maintainers = with maintainers; [ rnhmjoj ];
-    platforms   = platforms.linux;
+    platforms = platforms.linux;
   };
 
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21799,7 +21799,7 @@ in
 
   arena = callPackage ../games/arena {};
 
-  arx-libertatis = callPackage ../games/arx-libertatis {
+  arx-libertatis = libsForQt5.callPackage ../games/arx-libertatis {
     stdenv = gcc6Stdenv;
   };
 


### PR DESCRIPTION
###### Motivation for this change

The crash reporter needs wrapping (#65399). The package also needs its usual update before the 19.09 release.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested execution of the game
- [x] Tested the crash reporter is wrapped and works (by killing -11 the game)
- [x] Tested execution of all binary files
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Btw, here's proof the crash reported is working:
![crash](https://user-images.githubusercontent.com/2817565/64132620-5b971e00-cdd1-11e9-900c-df3b8b1f2397.png)
