### PR TITLE
lib.makeOverridable: Propagate function arguments

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -82,11 +82,12 @@ rec {
         ${if ff ? overrideAttrs then "overrideAttrs" else null} = fdrv:
           overrideResult (x: x.overrideAttrs fdrv);
       })
-      else if lib.isFunction ff then {
-        override = overrideArgs;
-        __functor = self: ff;
-        overrideDerivation = throw "overrideDerivation not yet supported for functors";
-      }
+      else if lib.isFunction ff then
+        # Transform ff into a functor while propagating its arguments
+        lib.setFunctionArgs ff (lib.functionArgs ff) // {
+          override = overrideArgs;
+          overrideDerivation = throw "overrideDerivation not yet supported for functors";
+        }
       else ff;
 
 

--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -86,7 +86,6 @@ rec {
         # Transform ff into a functor while propagating its arguments
         lib.setFunctionArgs ff (lib.functionArgs ff) // {
           override = overrideArgs;
-          overrideDerivation = throw "overrideDerivation not yet supported for functors";
         }
       else ff;
 

--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -67,12 +67,14 @@ rec {
   makeOverridable = f: origArgs:
     let
       ff = f origArgs;
+      # Creates a functor with the same arguments as f
+      copyArgs = g: lib.setFunctionArgs g (lib.functionArgs f);
       overrideWith = newArgs: origArgs // (if lib.isFunction newArgs then newArgs origArgs else newArgs);
 
       # Re-call the function but with different arguments
-      overrideArgs = newArgs: makeOverridable f (overrideWith newArgs);
+      overrideArgs = copyArgs (newArgs: makeOverridable f (overrideWith newArgs));
       # Change the result of the function call by applying g to it
-      overrideResult = g: makeOverridable (args: g (f args)) origArgs;
+      overrideResult = g: makeOverridable (copyArgs (args: g (f args))) origArgs;
     in
       if builtins.isAttrs ff then (ff // {
         override = overrideArgs;

--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -71,13 +71,14 @@ rec {
 
       # Re-call the function but with different arguments
       overrideArgs = newArgs: makeOverridable f (overrideWith newArgs);
+      # Change the result of the function call by applying g to it
+      overrideResult = g: makeOverridable (args: g (f args)) origArgs;
     in
       if builtins.isAttrs ff then (ff // {
         override = overrideArgs;
-        overrideDerivation = fdrv:
-          makeOverridable (args: overrideDerivation (f args) fdrv) origArgs;
+        overrideDerivation = fdrv: overrideResult (x: overrideDerivation x fdrv);
         ${if ff ? overrideAttrs then "overrideAttrs" else null} = fdrv:
-          makeOverridable (args: (f args).overrideAttrs fdrv) origArgs;
+          overrideResult (x: x.overrideAttrs fdrv);
       })
       else if lib.isFunction ff then {
         override = overrideArgs;

--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -68,16 +68,19 @@ rec {
     let
       ff = f origArgs;
       overrideWith = newArgs: origArgs // (if lib.isFunction newArgs then newArgs origArgs else newArgs);
+
+      # Re-call the function but with different arguments
+      overrideArgs = newArgs: makeOverridable f (overrideWith newArgs);
     in
       if builtins.isAttrs ff then (ff // {
-        override = newArgs: makeOverridable f (overrideWith newArgs);
+        override = overrideArgs;
         overrideDerivation = fdrv:
           makeOverridable (args: overrideDerivation (f args) fdrv) origArgs;
         ${if ff ? overrideAttrs then "overrideAttrs" else null} = fdrv:
           makeOverridable (args: (f args).overrideAttrs fdrv) origArgs;
       })
       else if lib.isFunction ff then {
-        override = newArgs: makeOverridable f (overrideWith newArgs);
+        override = overrideArgs;
         __functor = self: ff;
         overrideDerivation = throw "overrideDerivation not yet supported for functors";
       }

--- a/pkgs/applications/graphics/gimp/wrapper.nix
+++ b/pkgs/applications/graphics/gimp/wrapper.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, symlinkJoin, gimp, makeWrapper, gimpPlugins, gnome3, plugins ? null}:
 
 let
-allPlugins = lib.filter (pkg: builtins.isAttrs pkg && pkg.type == "derivation" && !pkg.meta.broken or false) (lib.attrValues gimpPlugins);
+allPlugins = lib.filter (pkg: lib.isDerivation pkg && !pkg.meta.broken or false) (lib.attrValues gimpPlugins);
 selectedPlugins = if plugins == null then allPlugins else plugins;
 extraArgs = map (x: x.wrapArgs or "") selectedPlugins;
 versionBranch = stdenv.lib.versions.majorMinor gimp.version;


### PR DESCRIPTION
###### Motivation for this change

- Propagate the arguments of `f` to `(makeOverridable f args).override`

This allows people to query what arguments they can override for
derivations without having to look at the nix expression with

```
nix-repl> lib.functionArgs pkgs.hello.override
{ fetchurl = false; stdenv = false; }
```

- If `f args` is a function, propagates its arguments to
`makeOverridable f args`

This allows querying function arguments even after it's been
makeOverridable'd. E.g.

```
nix-repl> lib.functionArgs pkgs.fetchgit
{ branchName = true; deepClone = true; fetchSubmodules = true; ... }
```

This is a continuation of https://github.com/NixOS/nixpkgs/pull/47535, this time with correct behavior even when `.overrideDerivation` or `.overrideAttrs` is used.

I took the liberty to remove the `overrideDerivation = throw "overrideDerivation not yet supported for functors";` while I'm at it.

Ping @nbp @Profpatsch 

###### Things done

- [x] Double-checked to make sure the code doesn't change any behavior