### PR TITLE
ocamlPackages.ocaml_lwt: 4.1.0 -> 4.2.1

### DIFF
--- a/pkgs/development/ocaml-modules/lwt/4.x.nix
+++ b/pkgs/development/ocaml-modules/lwt/4.x.nix
@@ -1,29 +1,33 @@
-{ stdenv, fetchzip, pkgconfig, ncurses, libev, buildDunePackage, ocaml
+{ lib, fetchzip, pkgconfig, ncurses, libev, buildDunePackage, ocaml
 , cppo, ocaml-migrate-parsetree, ppx_tools_versioned, result
+, mmap, seq
 }:
 
-let inherit (stdenv.lib) optional versionAtLeast; in
+let inherit (lib) optional versionAtLeast; in
 
 buildDunePackage rec {
   pname = "lwt";
-  version = "4.1.0";
+  version = "4.2.1";
 
   src = fetchzip {
     url = "https://github.com/ocsigen/${pname}/archive/${version}.tar.gz";
-    sha256 = "16wnc61kfj54z4q8sn9f5iik37pswz328hcz3z6rkza3kh3s6wmm";
+    sha256 = "1hz24fyhpm7d6603v399pgxvdl236srwagqja41ljvjx83y10ysr";
   };
+
+  postPatch = ''
+    substituteInPlace lwt.opam \
+    --replace 'version: "dev"' 'version: "${version}"'
+  '';
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ cppo ocaml-migrate-parsetree ppx_tools_versioned ]
    ++ optional (!versionAtLeast ocaml.version "4.07") ncurses;
-  propagatedBuildInputs = [ libev result ];
-
-  configurePhase = "ocaml src/util/configure.ml -use-libev true";
+  propagatedBuildInputs = [ libev mmap seq result ];
 
   meta = {
     homepage = "https://ocsigen.org/lwt/";
     description = "A cooperative threads library for OCaml";
-    maintainers = [ stdenv.lib.maintainers.vbgl ];
-    license = stdenv.lib.licenses.lgpl21;
+    maintainers = [ lib.maintainers.vbgl ];
+    license = lib.licenses.mit;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Ensures compatibility with OCaml 4.08

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

