### PR TITLE
nomad: 0.9.4 -> 0.9.5

### DIFF
--- a/pkgs/applications/networking/cluster/nomad/default.nix
+++ b/pkgs/applications/networking/cluster/nomad/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   pname = "nomad";
-  version = "0.9.4";
+  version = "0.9.5";
   rev = "v${version}";
 
   goPackagePath = "github.com/hashicorp/nomad";
@@ -10,14 +10,26 @@ buildGoPackage rec {
 
   src = fetchFromGitHub {
     owner = "hashicorp";
-    repo = "nomad";
+    repo = pname;
     inherit rev;
-    sha256 = "1jgvnmmrz7ffpm6aamdrvklj94n7b43swk9cycqhlfbnzijianpn";
+    sha256 = "01491470idb11z0ab4anb5caw46vy9s94a17l92j0z2f3f4k6xfl";
   };
 
-  # We disable Nvidia GPU scheduling on Linux, as it doesn't work there:
-  # Ref: https://github.com/hashicorp/nomad/issues/5535
-  buildFlags = stdenv.lib.optionalString (stdenv.isLinux) "-tags nonvidia";
+  # ui:
+  #  Nomad release commits include the compiled version of the UI, but the file
+  #  is only included if we build with the ui tag.
+  # nonvidia:
+  #  We disable Nvidia GPU scheduling on Linux, as it doesn't work there:
+  #  Ref: https://github.com/hashicorp/nomad/issues/5535
+  preBuild = let
+    tags = ["ui"]
+      ++ stdenv.lib.optional stdenv.isLinux "nonvidia";
+    tagsString = stdenv.lib.concatStringsSep " " tags;
+  in ''
+    export buildFlagsArray=(
+      -tags="${tagsString}"
+    )
+ '';
 
   meta = with stdenv.lib; {
     homepage = https://www.nomadproject.io/;


### PR DESCRIPTION
###### Motivation for this change

This commit updates nomad from 0.9.4 to 0.9.5.

It also introduces the 'ui' build tag as it is incredibly useful when
working in development and production environments - and the assets are
included in release commits.

The method of including multiple tags, where some are optional was taken
from `gitea` as buildFlags was not handling nested quotes well.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @rushmorem @pradeepchhetri