### PR TITLE
nixos-generators: init at 1.0.0

### DIFF
--- a/pkgs/tools/nix/nixos-generators/default.nix
+++ b/pkgs/tools/nix/nixos-generators/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, lib, fetchFromGitHub, makeWrapper, coreutils, jq, findutils, nix  }:
+
+stdenv.mkDerivation rec {
+  pname = "nixos-generators";
+  version = "1.0.0";
+  src = fetchFromGitHub {
+    owner = "nix-community";
+    repo = "nixos-generators";
+    rev = version;
+    sha256 = "10xncifdfhilxclxyf72h7dcfn8yn1h34qbkvdq9l76ghv5qjniq";
+  };
+  nativeBuildInputs = [ makeWrapper ];
+  installFlags = [ "PREFIX=$(out)" ];
+  postFixup = ''
+    wrapProgram $out/bin/nixos-generate \
+      --prefix PATH : ${lib.makeBinPath [ jq coreutils findutils nix ] }
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Collection of image builders";
+    homepage    = "https://github.com/nix-community/nixos-generators";
+    license     = licenses.mit;
+    maintainers = with maintainers; [ lassulus ];
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24103,6 +24103,8 @@ in
 
   nixos-container = callPackage ../tools/virtualization/nixos-container { };
 
+  nixos-generators = callPackage ../tools/nix/nixos-generators { };
+
   norwester-font = callPackage ../data/fonts/norwester  {};
 
   nut = callPackage ../applications/misc/nut { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

add nixos-generators into nixpkgs, this was asked for by several people.
closes https://github.com/nix-community/nixos-generators/issues/34

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
