### PR TITLE
java-service-wrapper: init at 3.5.41

### DIFF
--- a/pkgs/tools/system/java-service-wrapper/default.nix
+++ b/pkgs/tools/system/java-service-wrapper/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchurl
+, jdk
+, ant, cunit, ncurses
+}:
+
+stdenv.mkDerivation rec {
+  pname = "java-service-wrapper";
+  version = "3.5.41";
+
+  src = fetchurl {
+    url = "https://wrapper.tanukisoftware.com/download/${version}/wrapper_${version}_src.tar.gz";
+    sha256 = "0wvazc4y134brn99aa4rc9jdh1h2q3l7qhhvbcs6lhf4ym47sskm";
+  };
+
+  buildInputs = [ jdk ];
+  nativeBuildInputs = [ ant cunit ncurses ];
+
+  buildPhase = ''
+    export ANT_HOME=${ant}
+    export JAVA_HOME=${jdk}/lib/openjdk/jre/
+    export JAVA_TOOL_OPTIONS=-Djava.home=$JAVA_HOME
+    export CLASSPATH=${jdk}/lib/openjdk/lib/tools.jar
+
+    ${if stdenv.isi686 then "./build32.sh" else "./build64.sh"}
+  '';
+
+  installPhase = ''
+    mkdir -p $out/{bin,lib}
+    cp bin/wrapper $out/bin/wrapper
+    cp lib/wrapper.jar $out/lib/wrapper.jar
+    cp lib/libwrapper.so $out/lib/libwrapper.so
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Enables a Java Application to be run as a Windows Service or Unix Daemon";
+    homepage = "https://wrapper.tanukisoftware.com/";
+    license = licenses.gpl2;
+    platforms = [ "x86_64-linux" "i686-linux" ];
+    maintainers = [ maintainers.suhr ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8335,6 +8335,8 @@ in
 
   jasmin = callPackage ../development/compilers/jasmin { };
 
+  java-service-wrapper = callPackage ../tools/system/java-service-wrapper { };
+
   javacard-devkit = pkgsi686Linux.callPackage ../development/compilers/javacard-devkit { };
 
   julia_07 = callPackage ../development/compilers/julia/0.7.nix {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Provide java service wrapper for the i2p package (see https://github.com/NixOS/nixpkgs/pull/67641).

I don't know in which category I should put it, so I put it in misc.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
