### PR TITLE
i3lock-fancy: Bugfix, make scrot overwrite file

### DIFF
--- a/pkgs/applications/window-managers/i3/lock-fancy.nix
+++ b/pkgs/applications/window-managers/i3/lock-fancy.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     sed -i -e 's|icon="/usr/share/i3lock-fancy/icons/lock.png"|icon="'$out'/share/i3lock-fancy/icons/lock.png"|' i3lock-fancy
     sed -i -e "s|getopt |${getopt}/bin/getopt |" i3lock-fancy
     sed -i -e "s|fc-match |${fontconfig.bin}/bin/fc-match |" i3lock-fancy
-    sed -i -e "s|shot=(import -window root)|shot=(${scrot}/bin/scrot -z)|" i3lock-fancy
+    sed -i -e "s|shot=(import -window root)|shot=(${scrot}/bin/scrot -z -o)|" i3lock-fancy
     rm Makefile
   '';
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

After commit  https://github.com/resurrecting-open-source-projects/scrot/commit/489e3229045962be2f63535ecd70cd15e6e2414d scrot will no longer overwrite files unless the `-o` option is given. This commit makes the i3lock-fancy use `scrot -z -o` instead of just `scrot -z`.


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @garbas , @vcunat , @NeQuissimus , @rail , @jokogr 
