### PR TITLE
veracrypt: 1.23 -> 1.23-hotfix-2

### DIFF
--- a/pkgs/applications/misc/veracrypt/default.nix
+++ b/pkgs/applications/misc/veracrypt/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, makeself, yasm, fuse, wxGTK, lvm2 }:
+{ stdenv, fetchurl, pkgconfig, makeself, yasm, fuse, unzip, wxGTK, lvm2 }:
 
 with stdenv.lib;
 
@@ -6,16 +6,17 @@ stdenv.mkDerivation rec {
   pname = "veracrypt";
   name = "${pname}-${version}";
   version = "1.23";
+  minorVersion = "-Hotfix-2";
 
   src = fetchurl {
-    url = "https://launchpad.net/${pname}/trunk/${version}/+download/VeraCrypt_${version}_Source.tar.bz2";
-    sha256 = "009lqi43n2w272sxv7y7dz9sqx15qkx6lszkswr8mwmkpgkm0px1";
+    url = "https://launchpad.net/${pname}/trunk/${version}/+download/VeraCrypt_${version}${minorVersion}_Source.zip";
+    sha256 = "229de81b2478cfa5fa73e74e60798a298cd616e9852b9f47b484c80bc2a2c259";
   };
 
   sourceRoot = "src";
 
   nativeBuildInputs = [ makeself pkgconfig yasm ];
-  buildInputs = [ fuse lvm2 wxGTK ];
+  buildInputs = [ fuse lvm2 unzip wxGTK ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Motivation for this change
Applied upstream hotfix

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @dsferruzza
