### PR TITLE
Add FPGA tools nMigen and Glasgow

### DIFF
--- a/pkgs/applications/science/logic/symbiyosys/default.nix
+++ b/pkgs/applications/science/logic/symbiyosys/default.nix
@@ -26,6 +26,8 @@ stdenv.mkDerivation rec {
     substituteInPlace $out/bin/sby \
       --replace "##yosys-sys-path##" \
                 "sys.path += [p + \"/share/yosys/python3/\" for p in [\"$out\", \"${yosys}\"]]"
+    substituteInPlace $out/share/yosys/python3/sby_core.py \
+      --replace '"/usr/bin/env", "bash"' '"${bash}/bin/bash"'
   '';
   meta = {
     description = "Tooling for Yosys-based verification flows";

--- a/pkgs/development/compilers/nextpnr/default.nix
+++ b/pkgs/development/compilers/nextpnr/default.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchFromGitHub, cmake
 , boost, python3, eigen
 , icestorm, trellis
+, llvmPackages
 
 , enableGui ? true
 , wrapQtAppsHook
@@ -12,13 +13,13 @@ let
 in
 with stdenv; mkDerivation rec {
   pname = "nextpnr";
-  version = "2019.08.21";
+  version = "2019.08.31";
 
   src = fetchFromGitHub {
     owner  = "yosyshq";
     repo   = "nextpnr";
-    rev    = "c192ba261d77ad7f0a744fb90b01e4a5b63938c4";
-    sha256 = "0g2ar1z89b31qw5vgqj2rrcv9rzncs94184dgcsrz19p866654mf";
+    rev    = "c0b7379e8672b6263152d5e340e62f22179fdc8b";
+    sha256 = "174n962xiwyzy53cn192h9rq95h951k3xy6bs43p5ya592ai5mjh";
   };
 
   nativeBuildInputs
@@ -26,7 +27,8 @@ with stdenv; mkDerivation rec {
     ++ (lib.optional enableGui wrapQtAppsHook);
   buildInputs
      = [ boostPython python3 eigen ]
-    ++ (lib.optional enableGui qtbase);
+    ++ (lib.optional enableGui qtbase)
+    ++ (lib.optional stdenv.cc.isClang llvmPackages.openmp);
 
   enableParallelBuilding = true;
   cmakeFlags =

--- a/pkgs/development/compilers/sdcc/default.nix
+++ b/pkgs/development/compilers/sdcc/default.nix
@@ -34,6 +34,6 @@ stdenv.mkDerivation rec {
     homepage = http://sdcc.sourceforge.net/;
     license = with licenses; if (gputils == null) then gpl2 else unfreeRedistributable;
     maintainers = with maintainers; [ bjornfor yorickvp ];
-    platforms = platforms.linux;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/development/compilers/yosys/default.nix
+++ b/pkgs/development/compilers/yosys/default.nix
@@ -8,14 +8,14 @@ with builtins;
 
 stdenv.mkDerivation rec {
   pname = "yosys";
-  version = "2019.08.21";
+  version = "2019.09.01";
 
   srcs = [
     (fetchFromGitHub {
       owner  = "yosyshq";
       repo   = "yosys";
-      rev    = "fe1b2337fd7950e1d563be5b8ccbaa81688261e4";
-      sha256 = "0z7sngc2z081yyhzh8c2kchg48sp2333hn1wa94q5vsgnyzlqrdw";
+      rev    = "4aa505d1b254b3fbb66af2d95b396a8f077da9d0";
+      sha256 = "16rhwmn1z2ppaq3wycgq713krq48s80a6h57vgzjzj17hgncg7hs";
       name   = "yosys";
     })
 

--- a/pkgs/development/python-modules/fx2/default.nix
+++ b/pkgs/development/python-modules/fx2/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildPythonPackage
+, python
+, fetchFromGitHub
+, sdcc
+, libusb1
+, crcmod
+}:
+
+buildPythonPackage {
+  pname = "fx2";
+  version = "unstable-2019-08-27";
+
+  src = fetchFromGitHub {
+    owner = "whitequark";
+    repo = "libfx2";
+    rev = "dd1e42c7b46ff410dbb18beab46111bb5491400c";
+    sha256 = "0xvlmx6ym0ylrvnlqzf18d475wa0mfci7wkdbv30gl3hgdhsppjz";
+  };
+
+  nativeBuildInputs = [ sdcc ];
+
+  propagatedBuildInputs = [ libusb1 crcmod ];
+
+  preBuild = ''
+    cd software
+    ${python.pythonForBuild.interpreter} setup.py build_ext
+  '';
+
+  preInstall = ''
+    mkdir -p $out/share/libfx2
+    cp -R ../firmware/library/{.stamp,lib,include,fx2{rules,conf}.mk} \
+      $out/share/libfx2
+  '';
+
+  # installCheckPhase tries to run build_ext again and there are no tests
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Chip support package for Cypress EZ-USB FX2 series microcontrollers";
+    homepage = https://github.com/whitequark/libfx2;
+    license = licenses.bsd0;
+    maintainers = with maintainers; [ emily ];
+  };
+}

--- a/pkgs/development/python-modules/glasgow/default.nix
+++ b/pkgs/development/python-modules/glasgow/default.nix
@@ -1,0 +1,66 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, sdcc
+, nmigen
+, fx2
+, libusb1
+, aiohttp
+, pyvcd
+, bitarray
+, crcmod
+, yosys
+, icestorm
+, nextpnr
+}:
+
+buildPythonPackage rec {
+  pname = "glasgow";
+  version = "unstable-2019-08-31";
+  realVersion = lib.substring 0 7 src.rev;
+
+  src = fetchFromGitHub {
+    owner = "GlasgowEmbedded";
+    repo = "Glasgow";
+    rev = "21641a13c6a0daaf8618aff3c5bfffcb26ef6cca";
+    sha256 = "1dpm1jmm4fg8xf17s6h9g5sc09gq8b6xq955sv2x11nrbqf98l4v";
+  };
+
+  nativeBuildInputs = [ sdcc ];
+
+  propagatedBuildInputs = [
+    nmigen
+    fx2
+    libusb1
+    aiohttp
+    pyvcd
+    bitarray
+    crcmod
+  ];
+
+  postPatch = ''
+    substituteInPlace software/setup.py \
+      --replace 'versioneer.get_version()' '"${realVersion}"'
+  '';
+
+  preBuild = ''
+    make -C firmware LIBFX2=${fx2}/share/libfx2
+    cp firmware/glasgow.ihex software/glasgow
+    cd software
+  '';
+
+  # a couple failing tests and also installCheck tries to build_ext again
+  doInstallCheck = false;
+  doCheck = false;
+
+  checkPhase = ''
+    python -m unittest discover
+  '';
+
+  meta = with lib; {
+    description = "Software for Glasgow, a digital interface multitool";
+    homepage = https://github.com/GlasgowEmbedded/Glasgow;
+    license = licenses.bsd0;
+    maintainers = with maintainers; [ emily ];
+  };
+}

--- a/pkgs/development/python-modules/nmigen-boards/default.nix
+++ b/pkgs/development/python-modules/nmigen-boards/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, nmigen
+}:
+
+buildPythonPackage rec {
+  pname = "nmigen-boards";
+  version = "unstable-2019-08-30";
+  realVersion = lib.substring 0 7 src.rev;
+
+  src = fetchFromGitHub {
+    owner = "m-labs";
+    repo = "nmigen-boards";
+    rev = "3b80b3a3749ae8f123ff258a25e81bd21412aed4";
+    sha256 = "01qynxip8bq23jfjc5wjd97vxfvhld2zb8sxphwf0zixrmmyaspi";
+  };
+
+  propagatedBuildInputs = [ nmigen ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace 'versioneer.get_version()' '"${realVersion}"'
+  '';
+
+  meta = with lib; {
+    description = "Board and connector definitions for nMigen";
+    homepage = https://github.com/m-labs/nmigen-boards;
+    license = licenses.bsd0;
+    maintainers = with maintainers; [ emily ];
+  };
+}

--- a/pkgs/development/python-modules/nmigen/default.nix
+++ b/pkgs/development/python-modules/nmigen/default.nix
@@ -1,0 +1,65 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, pyvcd
+, bitarray
+, jinja2
+
+# nmigen.{test,build} call out to these
+, yosys
+, symbiyosys
+, nextpnr ? null
+, icestorm ? null
+, trellis ? null
+
+# for tests
+, yices
+}:
+
+buildPythonPackage rec {
+  pname = "nmigen";
+  version = "unstable-2019-08-31";
+  realVersion = lib.substring 0 7 src.rev;
+
+  src = fetchFromGitHub {
+    owner = "m-labs";
+    repo = "nmigen";
+    rev = "2e206220462c67aa6ae97f7515a2191440fd61b3";
+    sha256 = "0y3w6vd493jqm9b8ppgwzs02v1al8w1n5gylljlsw70ci7fyk4qa";
+  };
+
+  disabled = pythonOlder "3.6";
+
+  propagatedBuildInputs = [ pyvcd bitarray jinja2 ];
+
+  checkInputs = [ yosys yices ];
+
+  postPatch = let
+    tool = pkg: name:
+      if pkg == null then {} else { "${name}" = "${pkg}/bin/${name}"; };
+
+    # Only FOSS toolchain supported out of the box, sorry!
+    toolchainOverrides =
+      tool yosys "yosys" //
+      tool symbiyosys "sby" //
+      tool nextpnr "nextpnr-ice40" //
+      tool nextpnr "nextpnr-ecp5" //
+      tool icestorm "icepack" //
+      tool trellis "ecppack";
+  in ''
+    substituteInPlace setup.py \
+      --replace 'versioneer.get_version()' '"${realVersion}"'
+
+    substituteInPlace nmigen/_toolchain.py \
+      --replace 'overrides = {}' \
+                'overrides = ${builtins.toJSON toolchainOverrides}'
+  '';
+
+  meta = with lib; {
+    description = "A refreshed Python toolbox for building complex digital hardware";
+    homepage = https://github.com/m-labs/nmigen;
+    license = licenses.bsd0;
+    maintainers = with maintainers; [ emily ];
+  };
+}

--- a/pkgs/development/tools/trellis/default.nix
+++ b/pkgs/development/tools/trellis/default.nix
@@ -8,14 +8,16 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "trellis";
-  version = "2019.08.09";
+  version = "2019.09.01";
+  realVersion = with stdenv.lib; with builtins;
+    "1.0-53-g${substring 0 7 (elemAt srcs 0).rev}";
 
   srcs = [
     (fetchFromGitHub {
        owner  = "symbiflow";
        repo   = "prjtrellis";
-       rev    = "a67379179985bb12a611c75d975548cdf6e7d12e";
-       sha256 = "0vqwfsblf7ylz0jnnf532kap5s1d1zcvbavxmb6a4v32b9xfdv35";
+       rev    = "98871e0e2959bc8cb4de3c7ebe2b9eddc4efe00c";
+       sha256 = "1yq7ih2xvhfvdpijmbqjq6jcngl6710kiv66hkww5ih8j5dzsq5l";
        name   = "trellis";
      })
     (fetchFromGitHub {
@@ -32,6 +34,9 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake python3 ];
 
   preConfigure = with builtins; ''
+    substituteInPlace libtrellis/CMakeLists.txt \
+      --replace "git describe --tags" "echo ${realVersion}"
+
     rmdir database && ln -sfv ${elemAt srcs 1} ./database
 
     source environment.sh

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -818,6 +818,8 @@ in
 
   ezstream = callPackage ../tools/audio/ezstream { };
 
+  libfx2 = with python3Packages; toPythonApplication fx2;
+
   fxlinuxprintutil = callPackage ../tools/misc/fxlinuxprintutil { };
 
   genymotion = callPackage ../development/mobile/genymotion { };
@@ -841,6 +843,8 @@ in
   gitless = callPackage ../applications/version-management/gitless { };
 
   gitter = callPackage  ../applications/networking/instant-messengers/gitter { };
+
+  glasgow = with python3Packages; toPythonApplication glasgow;
 
   gucci = callPackage ../tools/text/gucci { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2565,6 +2565,10 @@ in {
 
   Nikola = callPackage ../development/python-modules/Nikola { };
 
+  nmigen = callPackage ../development/python-modules/nmigen { };
+
+  nmigen-boards = callPackage ../development/python-modules/nmigen-boards { };
+
   nxt-python = callPackage ../development/python-modules/nxt-python { };
 
   odfpy = callPackage ../development/python-modules/odfpy { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2329,12 +2329,6 @@ in {
 
   gateone = callPackage ../development/python-modules/gateone { };
 
-  # TODO: Remove after 19.03 is branched off:
-  gcutil = throw ''
-    pythonPackages.gcutil is deprecated and can be replaced with "gcloud
-    compute" from the package google-cloud-sdk.
-  '';
-
   GeoIP = callPackage ../development/python-modules/GeoIP { };
 
   glasgow = callPackage ../development/python-modules/glasgow { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2325,6 +2325,8 @@ in {
 
   future-fstrings = callPackage ../development/python-modules/future-fstrings { };
 
+  fx2 = callPackage ../development/python-modules/fx2 { };
+
   gateone = callPackage ../development/python-modules/gateone { };
 
   # TODO: Remove after 19.03 is branched off:
@@ -2334,6 +2336,8 @@ in {
   '';
 
   GeoIP = callPackage ../development/python-modules/GeoIP { };
+
+  glasgow = callPackage ../development/python-modules/glasgow { };
 
   gmpy = callPackage ../development/python-modules/gmpy { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This PR adds two pieces of FPGA-related software (and also bumps/fixes some of the EDA tools as required):

### nMigen

[nMigen](https://github.com/m-labs/nmigen) is the new version of [M-Labs](http://m-labs.hk/)' popular Python-based hardware description language and build system [Migen](https://m-labs.hk/gateware/migen/) (used in e.g. [MiSoC](https://github.com/m-labs/misoc), [LiteX](https://github.com/enjoy-digital/litex), [ARTIQ](http://m-labs.hk/experiment-control/artiq/), [Milkymist](http://m-labs.hk/gateware/m1/), [HDMI2USB](https://github.com/timvideos/HDMI2USB-litex-firmware)...). Although it hasn't received an official stable release yet, it has a compatibility layer for the original Migen and it's already achieved some serious adoption through e.g. Glasgow (described below) and [Minerva](https://github.com/lambdaconcept/minerva) (a free-gateware RISC-V core), and it's rapidly approaching stabilization. It integrates with the FOSS EDA tools already in nixpkgs (`(symbi)yosys`, `icestorm`, `trellis`, `nextpnr`) as well as supporting proprietary vendor toolchains.

### Glasgow

[Glasgow](https://github.com/GlasgowEmbedded/Glasgow) is an FPGA-based adaptable digital interface multitool/"Scots Army Knife for electronics" powered by nMigen that should be in mass production soon. It uses Python software on the host to synthesize, program and communicate with the FPGA on the fly, and communicates with the on-board microcontroller using [libfx2](https://libfx2.readthedocs.io/en/latest/) (which provides both the Python module `fx2` and `fx2tool(1)`, an end-user bootloader recovery program). It's also intended to serve as a Python framework for development of custom applets.

I'm due to receive a preproduction model soon, so I spent the time to get it packaged for Nix. Glasgow has also not seen a proper release yet, but devices are already in the wild and the plan is for it to be updated in a rolling-release fashion from git commits, so this shouldn't be a major issue.

(These projects aren't mine and I've only made a few contributions to both so far, so hopefully this isn't taken as spamminess but rather rationales for inclusion ^^; I've talked with @whitequark and she's fine to see them packaged as-is.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @thoughtpolice for the yosys/nextpnr changes
cc @FRidh for Python assistance – is there a better way to handle the default `checkPhase` for Python packages unconditionally running the `build_ext` step, even if the build has already been done at an earlier stage?