### PR TITLE
bazel: 0.28.1 -> 0.29.0

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/bash-tools-test.nix
+++ b/pkgs/development/tools/build-managers/bazel/bash-tools-test.nix
@@ -1,4 +1,4 @@
-{ writeText, bazel, runLocal, bazelTest }:
+{ writeText, bazel, runLocal, bazelTest, distDir }:
 
 # Tests that certain executables are available in bazel-executed bash shells.
 
@@ -35,7 +35,7 @@ let
     inherit workspaceDir;
 
     bazelScript = ''
-      ${bazel}/bin/bazel build :tool_usage
+      ${bazel}/bin/bazel build :tool_usage --distdir=${distDir}
       cp bazel-genfiles/output.txt $out
       echo "Testing content" && [ "$(cat $out | wc -l)" == "2" ] && echo "OK"
     '';

--- a/pkgs/development/tools/build-managers/bazel/cpp-test.nix
+++ b/pkgs/development/tools/build-managers/bazel/cpp-test.nix
@@ -8,6 +8,7 @@
 , runtimeShell
 , writeScript
 , writeText
+, distDir
 }:
 
 let
@@ -42,6 +43,7 @@ let
     bazelScript = ''
       ${bazel}/bin/bazel \
         build --verbose_failures \
+        --distdir=${distDir} \
           //...
     '';
   };

--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -22,11 +22,11 @@
 }:
 
 let
-  version = "0.28.1";
+  version = "0.29.0";
 
   src = fetchurl {
     url = "https://github.com/bazelbuild/bazel/releases/download/${version}/bazel-${version}-dist.zip";
-    sha256 = "0503fax70w7h6v00mkrrrgf1m5n0vkjqs76lyg95alhzc4yldsic";
+    sha256 = "01cb6f2e808bd016cf0e217e12373c9efb808123e58b37885be8364458d3a40a";
   };
 
   # Update with `eval $(nix-build -A bazel.updater)`,
@@ -46,11 +46,15 @@ let
       srcs.io_bazel_rules_sass
       srcs.platforms
       (if stdenv.hostPlatform.isDarwin
-       then srcs.${"java_tools_javac11_darwin-v2.0.zip"}
-       else srcs.${"java_tools_javac11_linux-v2.0.zip"})
+       then srcs.${"java_tools_javac11_darwin-v4.0.zip"}
+       else srcs.${"java_tools_javac11_linux-v4.0.zip"})
       srcs.${"coverage_output_generator-v1.0.zip"}
       srcs.build_bazel_rules_nodejs
-      srcs.${"android_tools_pkg-0.7.tar.gz"}
+      srcs.${"android_tools_pkg-0.8.tar.gz"}
+      srcs.${"0.27.1.tar.gz"}
+      srcs.rules_pkg
+      srcs.rules_cc
+      srcs.rules_java
       ]);
 
   distDir = runCommand "bazel-deps" {} ''
@@ -102,7 +106,7 @@ let
   remote_java_tools = stdenv.mkDerivation {
     name = "remote_java_tools_${system}";
 
-    src = srcDepsSet."java_tools_javac11_${system}-v2.0.zip";
+    src = srcDepsSet."java_tools_javac11_${system}-v4.0.zip";
 
     nativeBuildInputs = [ autoPatchelfHook unzip ];
     buildInputs = [ gcc-unwrapped ];
@@ -217,18 +221,18 @@ stdenv.mkDerivation rec {
       };
 
     in {
-      bashTools = callPackage ./bash-tools-test.nix { inherit runLocal bazelTest; };
-      cpp = callPackage ./cpp-test.nix { inherit runLocal bazelTest bazel-examples; };
-      java = callPackage ./java-test.nix { inherit runLocal bazelTest bazel-examples; };
-      protobuf = callPackage ./protobuf-test.nix { inherit runLocal bazelTest; };
-      pythonBinPath = callPackage ./python-bin-path-test.nix { inherit runLocal bazelTest; };
+      bashTools = callPackage ./bash-tools-test.nix { inherit runLocal bazelTest distDir; };
+      cpp = callPackage ./cpp-test.nix { inherit runLocal bazelTest bazel-examples distDir; };
+      java = callPackage ./java-test.nix { inherit runLocal bazelTest bazel-examples distDir; };
+      protobuf = callPackage ./protobuf-test.nix { inherit runLocal bazelTest distDir; };
+      pythonBinPath = callPackage ./python-bin-path-test.nix { inherit runLocal bazelTest distDir; };
 
-      bashToolsWithNixHacks = callPackage ./bash-tools-test.nix { inherit runLocal bazelTest; bazel = bazelWithNixHacks; };
+      bashToolsWithNixHacks = callPackage ./bash-tools-test.nix { inherit runLocal bazelTest distDir; bazel = bazelWithNixHacks; };
 
-      cppWithNixHacks = callPackage ./cpp-test.nix { inherit runLocal bazelTest bazel-examples; bazel = bazelWithNixHacks; };
-      javaWithNixHacks = callPackage ./java-test.nix { inherit runLocal bazelTest bazel-examples; bazel = bazelWithNixHacks; };
-      protobufWithNixHacks = callPackage ./protobuf-test.nix { inherit runLocal bazelTest; bazel = bazelWithNixHacks; };
-      pythonBinPathWithNixHacks = callPackage ./python-bin-path-test.nix { inherit runLocal bazelTest; bazel = bazelWithNixHacks; };
+      cppWithNixHacks = callPackage ./cpp-test.nix { inherit runLocal bazelTest bazel-examples distDir; bazel = bazelWithNixHacks; };
+      javaWithNixHacks = callPackage ./java-test.nix { inherit runLocal bazelTest bazel-examples distDir; bazel = bazelWithNixHacks; };
+      protobufWithNixHacks = callPackage ./protobuf-test.nix { inherit runLocal bazelTest distDir; bazel = bazelWithNixHacks; };
+      pythonBinPathWithNixHacks = callPackage ./python-bin-path-test.nix { inherit runLocal bazelTest distDir; bazel = bazelWithNixHacks; };
 
       # downstream packages using buildBazelPackage
       # fixed-output hashes of the fetch phase need to be spot-checked manually
@@ -462,6 +466,7 @@ stdenv.mkDerivation rec {
     # the reference to .name
     mkdir $out/etc
     echo "build --override_repository=${remote_java_tools.name}=${remote_java_tools}" > $out/etc/bazelrc
+    echo "build --distdir=${distDir}" >> $out/etc/bazelrc
 
     # shell completion files
     mkdir -p $out/share/bash-completion/completions $out/share/zsh/site-functions

--- a/pkgs/development/tools/build-managers/bazel/java-test.nix
+++ b/pkgs/development/tools/build-managers/bazel/java-test.nix
@@ -9,6 +9,7 @@
 , runtimeShell
 , writeScript
 , writeText
+, distDir
 }:
 
 let
@@ -44,6 +45,7 @@ let
     bazelScript = ''
       ${bazel}/bin/bazel \
         run \
+        --distdir=${distDir} \
           --host_javabase='@local_jdk//:jdk' \
           --java_toolchain='@bazel_tools//tools/jdk:toolchain_hostjdk8' \
           --javabase='@local_jdk//:jdk' \

--- a/pkgs/development/tools/build-managers/bazel/protobuf-test.nix
+++ b/pkgs/development/tools/build-managers/bazel/protobuf-test.nix
@@ -10,6 +10,7 @@
 , runtimeShell
 , writeScript
 , writeText
+, distDir
 }:
 
 let
@@ -141,6 +142,7 @@ let
     bazelScript = ''
       ${bazel}/bin/bazel \
         build \
+        --distdir=${distDir} \
           --host_javabase='@local_jdk//:jdk' \
           --java_toolchain='@bazel_tools//tools/jdk:toolchain_hostjdk8' \
           --javabase='@local_jdk//:jdk' \

--- a/pkgs/development/tools/build-managers/bazel/python-bin-path-test.nix
+++ b/pkgs/development/tools/build-managers/bazel/python-bin-path-test.nix
@@ -1,4 +1,4 @@
-{ writeText, bazel, bazelTest, runLocal }:
+{ writeText, bazel, bazelTest, runLocal, distDir }:
 
 let
   WORKSPACE = writeText "WORKSPACE" ''
@@ -45,6 +45,7 @@ let
     bazelScript = ''
       ${bazel}/bin/bazel \
         run \
+      --distdir=${distDir} \
           //python:bin
     '';
   };

--- a/pkgs/development/tools/build-managers/bazel/src-deps.json
+++ b/pkgs/development/tools/build-managers/bazel/src-deps.json
@@ -7,12 +7,28 @@
             "https://github.com/bazelbuild/rules_nodejs/archive/0.16.2.zip"
         ]
     },
-    "1ca560df1cf6e280f987af2f8d08a5edc7ac6b54.tar.gz": {
-        "name": "1ca560df1cf6e280f987af2f8d08a5edc7ac6b54.tar.gz",
-        "sha256": "3ca1b3d453a977aeda60dd335feb812771addfd0d0c61751b34b9681aa4d6534",
+    "0.27.1.tar.gz": {
+        "name": "0.27.1.tar.gz",
+        "sha256": "28cb3666da80fbc62d4c46814f5468dd5d0b59f9064c0b933eee3140d706d330",
         "urls": [
-            "https://mirror.bazel.build/github.com/bazelbuild/skydoc/archive/1ca560df1cf6e280f987af2f8d08a5edc7ac6b54.tar.gz",
-            "https://github.com/bazelbuild/skydoc/archive/1ca560df1cf6e280f987af2f8d08a5edc7ac6b54.tar.gz"
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/0.27.1.tar.gz",
+            "https://github.com/bazelbuild/bazel-toolchains/archive/0.27.1.tar.gz"
+        ]
+    },
+    "0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip": {
+        "name": "0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip",
+        "sha256": "36fa66d4d49debd71d05fba55c1353b522e8caef4a20f8080a3d17cdda001d89",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip",
+            "https://github.com/bazelbuild/rules_cc/archive/0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip"
+        ]
+    },
+    "41c28e43dffbae39c52dd4b91932d1209e5a8893.tar.gz": {
+        "name": "41c28e43dffbae39c52dd4b91932d1209e5a8893.tar.gz",
+        "sha256": "fdc34621839104b57363a258eab9d821b02ff7837923cfe7fb6fd67182780829",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/skydoc/archive/41c28e43dffbae39c52dd4b91932d1209e5a8893.tar.gz",
+            "https://github.com/bazelbuild/skydoc/archive/41c28e43dffbae39c52dd4b91932d1209e5a8893.tar.gz"
         ]
     },
     "441afe1bfdadd6236988e9cac159df6b5a9f5a98.zip": {
@@ -23,6 +39,14 @@
             "https://github.com/bazelbuild/platforms/archive/441afe1bfdadd6236988e9cac159df6b5a9f5a98.zip"
         ]
     },
+    "7cf3cefd652008d0a64a419c34c13bdca6c8f178.zip": {
+        "name": "7cf3cefd652008d0a64a419c34c13bdca6c8f178.zip",
+        "sha256": "bc81f1ba47ef5cc68ad32225c3d0e70b8c6f6077663835438da8d5733f917598",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_java/archive/7cf3cefd652008d0a64a419c34c13bdca6c8f178.zip",
+            "https://github.com/bazelbuild/rules_java/archive/7cf3cefd652008d0a64a419c34c13bdca6c8f178.zip"
+        ]
+    },
     "8ccf4f1c351928b55d5dddf3672e3667f6978d60.tar.gz": {
         "name": "8ccf4f1c351928b55d5dddf3672e3667f6978d60.tar.gz",
         "sha256": "d868ce50d592ef4aad7dec4dd32ae68d2151261913450fac8390b3fd474bb898",
@@ -31,29 +55,28 @@
             "https://github.com/bazelbuild/rules_sass/archive/8ccf4f1c351928b55d5dddf3672e3667f6978d60.tar.gz"
         ]
     },
-    "android_tools_pkg-0.7.tar.gz": {
-        "name": "android_tools_pkg-0.7.tar.gz",
-        "sha256": "a8e48f2fdee2c34b31f45bd47ce050a75ac774f19e0a1f6694fa49fc11d88718",
+    "android_tools_pkg-0.8.tar.gz": {
+        "name": "android_tools_pkg-0.8.tar.gz",
+        "sha256": "a9eac6e1b27d5549edaaa724b20eb1cdae6253b84f44d5744c30372bd523cfcd",
         "urls": [
-            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.7.tar.gz"
+            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.8.tar.gz"
+        ]
+    },
+    "b0cc14be5da05168b01db282fe93bdf17aa2b9f4.tar.gz": {
+        "name": "b0cc14be5da05168b01db282fe93bdf17aa2b9f4.tar.gz",
+        "sha256": "88b0a90433866b44bb4450d4c30bc5738b8c4f9c9ba14e9661deb123f56a833d",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/b0cc14be5da05168b01db282fe93bdf17aa2b9f4.tar.gz",
+            "https://github.com/bazelbuild/rules_proto/archive/b0cc14be5da05168b01db282fe93bdf17aa2b9f4.tar.gz"
         ]
     },
     "bazel_j2objc": {
         "name": "bazel_j2objc",
-        "sha256": "a36bac432d0dbd8c98249e484b2b69dd5720afa4abb58711a3c3def1c0bfa21d",
-        "strip_prefix": "j2objc-2.0.3",
+        "sha256": "8d3403b5b7db57e347c943d214577f6879e5b175c2b59b7e075c0b6453330e9b",
+        "strip_prefix": "j2objc-2.5",
         "urls": [
-            "https://miirror.bazel.build/github.com/google/j2objc/releases/download/2.0.3/j2objc-2.0.3.zip",
-            "https://github.com/google/j2objc/releases/download/2.0.3/j2objc-2.0.3.zip"
-        ]
-    },
-    "bazel_rbe_toolchains": {
-        "name": "bazel_rbe_toolchains",
-        "sha256": "e2b8644caa15235a488e831264e5dcb014e2cdf3b697319bc1e9d6b0fff0b4b9",
-        "strip_prefix": "bazel_rbe_toolchains-01529a65d21abdf71635ff0c2472043a567ecded",
-        "urls": [
-            "https://mirror.bazel.build/github.com/buchgr/bazel_rbe_toolchains/archive/01529a65d21abdf71635ff0c2472043a567ecded.tar.gz",
-            "https://github.com/buchgr/bazel_rbe_toolchains/archive/01529a65d21abdf71635ff0c2472043a567ecded.tar.gz"
+            "https://miirror.bazel.build/github.com/google/j2objc/releases/download/2.5/j2objc-2.5.zip",
+            "https://github.com/google/j2objc/releases/download/2.5/j2objc-2.5.zip"
         ]
     },
     "bazel_skylib": {
@@ -67,11 +90,11 @@
     },
     "bazel_toolchains": {
         "name": "bazel_toolchains",
-        "sha256": "67335b3563d9b67dc2550b8f27cc689b64fadac491e69ce78763d9ba894cc5cc",
-        "strip_prefix": "bazel-toolchains-cddc376d428ada2927ad359211c3e356bd9c9fbb",
+        "sha256": "28cb3666da80fbc62d4c46814f5468dd5d0b59f9064c0b933eee3140d706d330",
+        "strip_prefix": "bazel-toolchains-0.27.1",
         "urls": [
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/cddc376d428ada2927ad359211c3e356bd9c9fbb.tar.gz",
-            "https://github.com/bazelbuild/bazel-toolchains/archive/cddc376d428ada2927ad359211c3e356bd9c9fbb.tar.gz"
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/0.27.1.tar.gz",
+            "https://github.com/bazelbuild/bazel-toolchains/archive/0.27.1.tar.gz"
         ]
     },
     "build_bazel_rules_nodejs": {
@@ -135,46 +158,46 @@
     },
     "io_bazel_skydoc": {
         "name": "io_bazel_skydoc",
-        "sha256": "3ca1b3d453a977aeda60dd335feb812771addfd0d0c61751b34b9681aa4d6534",
-        "strip_prefix": "skydoc-1ca560df1cf6e280f987af2f8d08a5edc7ac6b54",
+        "sha256": "fdc34621839104b57363a258eab9d821b02ff7837923cfe7fb6fd67182780829",
+        "strip_prefix": "skydoc-41c28e43dffbae39c52dd4b91932d1209e5a8893",
         "urls": [
-            "https://mirror.bazel.build/github.com/bazelbuild/skydoc/archive/1ca560df1cf6e280f987af2f8d08a5edc7ac6b54.tar.gz",
-            "https://github.com/bazelbuild/skydoc/archive/1ca560df1cf6e280f987af2f8d08a5edc7ac6b54.tar.gz"
+            "https://mirror.bazel.build/github.com/bazelbuild/skydoc/archive/41c28e43dffbae39c52dd4b91932d1209e5a8893.tar.gz",
+            "https://github.com/bazelbuild/skydoc/archive/41c28e43dffbae39c52dd4b91932d1209e5a8893.tar.gz"
         ]
     },
-    "java_tools_javac11_darwin-v2.0.zip": {
-        "name": "java_tools_javac11_darwin-v2.0.zip",
-        "sha256": "0ceb0c9ff91256fe33508306bc9cd9e188dcca38df78e70839d426bdaef67a38",
+    "java_tools_javac11_darwin-v4.0.zip": {
+        "name": "java_tools_javac11_darwin-v4.0.zip",
+        "sha256": "fbf5bf22e9aab9c622e4c8c59314a1eef5ea09eafc5672b4f3250dc0b971bbcc",
         "urls": [
-            "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v2.0/java_tools_javac11_darwin-v2.0.zip"
+            "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v4.0/java_tools_javac11_darwin-v4.0.zip"
         ]
     },
-    "java_tools_javac11_linux-v2.0.zip": {
-        "name": "java_tools_javac11_linux-v2.0.zip",
-        "sha256": "074d624fb34441df369afdfd454e75dba821d5d54932fcfee5ba598d17dc1b99",
+    "java_tools_javac11_linux-v4.0.zip": {
+        "name": "java_tools_javac11_linux-v4.0.zip",
+        "sha256": "96e223094a12c842a66db0bb7bb6866e88e26e678f045842911f9bd6b47161f5",
         "urls": [
-            "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v2.0/java_tools_javac11_linux-v2.0.zip"
+            "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v4.0/java_tools_javac11_linux-v4.0.zip"
         ]
     },
-    "java_tools_javac11_windows-v2.0.zip": {
-        "name": "java_tools_javac11_windows-v2.0.zip",
-        "sha256": "2c3fc0ce7d30d60e26f4b8a36e2eadcf9e6a9d5a51b667d3d13b78db53b24251",
+    "java_tools_javac11_windows-v4.0.zip": {
+        "name": "java_tools_javac11_windows-v4.0.zip",
+        "sha256": "a1de51447b2ba2eab923d589ba6c72c289c16e6091e6a3bb3e67a05ef4ad200c",
         "urls": [
-            "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v2.0/java_tools_javac11_windows-v2.0.zip"
+            "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v4.0/java_tools_javac11_windows-v4.0.zip"
         ]
     },
     "java_tools_langtools_javac10": {
         "name": "java_tools_langtools_javac10",
-        "sha256": "e379c71e051eb83e3fc9a08c9b404712707d8920ffcf1e8fd59c844965f0b0dd",
+        "sha256": "0e9c9ac5ef17869de3cb8c3497c4c0d31836ef7b63efe1690506f53783adb212",
         "urls": [
-            "https://mirror.bazel.build/bazel_java_tools/jdk_langtools/langtools_jdk10.zip"
+            "https://mirror.bazel.build/bazel_java_tools/jdk_langtools/langtools_jdk10_v2.zip"
         ]
     },
     "java_tools_langtools_javac11": {
         "name": "java_tools_langtools_javac11",
-        "sha256": "128a63f39d3f828a761f6afcfe3c6115279336a72ea77f60d7b3acf1841c9acb",
+        "sha256": "cf0814fa002ef3d794582bb086516d8c9ed0958f83f19799cdb08949019fe4c7",
         "urls": [
-            "https://mirror.bazel.build/bazel_java_tools/jdk_langtools/langtools_jdk11.zip"
+            "https://mirror.bazel.build/bazel_java_tools/jdk_langtools/langtools_jdk11_v2.zip"
         ]
     },
     "java_tools_langtools_javac12": {
@@ -186,9 +209,9 @@
     },
     "java_tools_langtools_javac9": {
         "name": "java_tools_langtools_javac9",
-        "sha256": "3b6bbc47256acf2f61883901e2d4e3f9b292f5fe154a6912b928805de24cb864",
+        "sha256": "d94befcfb325a9a62aebc2052e631fde2322b4df5c82a19ed260b38ba12a0ad1",
         "urls": [
-            "https://mirror.bazel.build/bazel_java_tools/jdk_langtools/langtools_jdk9.zip"
+            "https://mirror.bazel.build/bazel_java_tools/jdk_langtools/langtools_jdk9_v2.zip"
         ]
     },
     "jdk10-server-release-1804.tar.xz": {
@@ -344,6 +367,49 @@
         "urls": [
             "https://mirror.bazel.build/github.com/bazelbuild/platforms/archive/441afe1bfdadd6236988e9cac159df6b5a9f5a98.zip",
             "https://github.com/bazelbuild/platforms/archive/441afe1bfdadd6236988e9cac159df6b5a9f5a98.zip"
+        ]
+    },
+    "rules_cc": {
+        "name": "rules_cc",
+        "sha256": "36fa66d4d49debd71d05fba55c1353b522e8caef4a20f8080a3d17cdda001d89",
+        "strip_prefix": "rules_cc-0d5f3f2768c6ca2faca0079a997a97ce22997a0c",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip",
+            "https://github.com/bazelbuild/rules_cc/archive/0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip"
+        ]
+    },
+    "rules_java": {
+        "name": "rules_java",
+        "sha256": "bc81f1ba47ef5cc68ad32225c3d0e70b8c6f6077663835438da8d5733f917598",
+        "strip_prefix": "rules_java-7cf3cefd652008d0a64a419c34c13bdca6c8f178",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_java/archive/7cf3cefd652008d0a64a419c34c13bdca6c8f178.zip",
+            "https://github.com/bazelbuild/rules_java/archive/7cf3cefd652008d0a64a419c34c13bdca6c8f178.zip"
+        ]
+    },
+    "rules_pkg": {
+        "name": "rules_pkg",
+        "sha256": "5bdc04987af79bd27bc5b00fe30f59a858f77ffa0bd2d8143d5b31ad8b1bd71c",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/rules_pkg-0.2.0.tar.gz",
+            "https://github.com/bazelbuild/rules_pkg/releases/download/0.2.0/rules_pkg-0.2.0.tar.gz"
+        ]
+    },
+    "rules_pkg-0.2.0.tar.gz": {
+        "name": "rules_pkg-0.2.0.tar.gz",
+        "sha256": "5bdc04987af79bd27bc5b00fe30f59a858f77ffa0bd2d8143d5b31ad8b1bd71c",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/rules_pkg-0.2.0.tar.gz",
+            "https://github.com/bazelbuild/rules_pkg/releases/download/0.2.0/rules_pkg-0.2.0.tar.gz"
+        ]
+    },
+    "rules_proto": {
+        "name": "rules_proto",
+        "sha256": "88b0a90433866b44bb4450d4c30bc5738b8c4f9c9ba14e9661deb123f56a833d",
+        "strip_prefix": "rules_proto-b0cc14be5da05168b01db282fe93bdf17aa2b9f4",
+        "urls": [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/b0cc14be5da05168b01db282fe93bdf17aa2b9f4.tar.gz",
+            "https://github.com/bazelbuild/rules_proto/archive/b0cc14be5da05168b01db282fe93bdf17aa2b9f4.tar.gz"
         ]
     },
     "zulu10.2+3-jdk10.0.1-linux_x64-allmodules.tar.gz": {

--- a/pkgs/development/tools/build-managers/bazel/update-srcDeps.py
+++ b/pkgs/development/tools/build-managers/bazel/update-srcDeps.py
@@ -40,6 +40,11 @@ def rules_sass_dependencies(**kw): pass
 def node_repositories(**kw): pass
 def sass_repositories(**kw): pass
 def register_execution_platforms(*args): pass
+def rbe_autoconfig(*args, **kw): pass
+def rules_pkg_dependencies(*args, **kw): pass
+def winsdk_configure(*args, **kw): pass
+def register_local_rc_exe_toolchains(*args, **kw): pass
+def register_toolchains(*args, **kw): pass
 
 # execute the WORKSPACE like it was python code in this module,
 # using all the function stubs from above.


### PR DESCRIPTION
Note: ~~This is a work in progress. It seems to work, but I cannot build `rules_haskell` for now using this, so I'm not sure.~~ See latest comment, this commit is not responsible for rules_haskell breakage.

- Upgraded dependencies
  - dependencies script upgraded to take into account new WORKSPACE
    rules
- Tests now depends on the `distdir`

Runtime bazel now also depends on the `distdir` setting which appears
in the global configuration file. This increases the bazel closure
size by 85 MO for stuffs which can normally be downloaded at runtime
by bazel. However, any invocation of `buildBazelPackage` (such as in
`bazel-watcher`) may fail in nix sandbox if theses files are not
available at runtime.

If this overhead is too important, we may later evolve to a finer
grained solution, where buildBazelPackage declares the list of
necessary dependencies.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Upstream update.

###### Things done

As said in the commit message, this PR largly increases the size of the bazel closure because now bazel depends on all the `srcDeps` which is, at that time, 85 Mo.

That's a bunch of files that bazel may use at runtime in `buildBazelPackage`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
