### PR TITLE
nixosTests.systemd: only run sysctl test on x86_64

### DIFF
--- a/nixos/tests/systemd.nix
+++ b/nixos/tests/systemd.nix
@@ -86,17 +86,17 @@ import ./make-test.nix ({ pkgs, ... }: {
       $machine->succeed('test -e /tmp/shared/shutdown-test');
     };
 
-   # Test settings from /etc/sysctl.d/50-default.conf are applied
-   subtest "systemd sysctl settings are applied", sub {
-     $machine->waitForUnit('multi-user.target');
-     $machine->succeed('sysctl net.core.default_qdisc | grep -q "fq_codel"');
-   };
-
    # Test cgroup accounting is enabled
    subtest "systemd cgroup accounting is enabled", sub {
      $machine->waitForUnit('multi-user.target');
      $machine->succeed('systemctl show testservice1.service -p IOAccounting | grep -q "yes"');
      $machine->succeed('systemctl status testservice1.service | grep -q "CPU:"');
+   };
+  '' + pkgs.lib.optionalString pkgs.stdenv.isx86_64 ''
+   # Test settings from /etc/sysctl.d/50-default.conf are applied
+   subtest "systemd sysctl settings are applied", sub {
+     $machine->waitForUnit('multi-user.target');
+     $machine->succeed('sysctl net.core.default_qdisc | grep -q "fq_codel"');
    };
   '';
 })


### PR DESCRIPTION
it seems `CONFIG_NET_SCHED` isn't included in arm/aarch64 defconfig (yet?),
so this test would fail on these architectures.

###### Motivation for this change
nixosTests.systemd is broken on aarch64.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @aszlig @disassembler, followup of discussion in #67798.
