### PR TITLE
rtmpdump: use OpenSSL 1.1 to fix gstreamer crash

### DIFF
--- a/pkgs/tools/video/rtmpdump/default.nix
+++ b/pkgs/tools/video/rtmpdump/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, zlib
+{ stdenv, fetchgit, fetchpatch, zlib
 , gnutlsSupport ? false, gnutls ? null, nettle ? null
 , opensslSupport ? true, openssl ? null
 }:
@@ -19,6 +19,14 @@ stdenv.mkDerivation rec {
     rev = "fa8646daeb19dfd12c181f7d19de708d623704c0";
     sha256 = "17m9rmnnqyyzsnnxcdl8258hjmw16nxbj1n1lr7fj3kmcs189iig";
   };
+
+  patches = [
+    # Fix build with OpenSSL 1.1
+    (fetchpatch {
+      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/media-video/rtmpdump/files/rtmpdump-openssl-1.1.patch?id=1e7bef484f96e7647f5f0911d3c8caa48131c33b";
+      sha256 = "1wds98pk8qr7shkfl8k49iirxiwd972h18w84bamiqln29wv6ql1";
+    })
+  ];
 
   makeFlags = [ ''prefix=$(out)'' ]
     ++ optional gnutlsSupport "CRYPTO=GNUTLS"

--- a/pkgs/tools/video/rtmpdump/default.nix
+++ b/pkgs/tools/video/rtmpdump/default.nix
@@ -9,15 +9,15 @@ assert gnutlsSupport -> gnutlsSupport != null && nettle != null && !opensslSuppo
 assert opensslSupport -> openssl != null && !gnutlsSupport;
 
 with stdenv.lib;
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "rtmpdump";
-  version = "2015-12-30";
+  version = "2019-03-30";
 
   src = fetchgit {
-    url = git://git.ffmpeg.org/rtmpdump;
+    url = "git://git.ffmpeg.org/rtmpdump";
     # Currently the latest commit is used (a release has not been made since 2011, i.e. '2.4')
-    rev = "fa8646daeb19dfd12c181f7d19de708d623704c0";
-    sha256 = "17m9rmnnqyyzsnnxcdl8258hjmw16nxbj1n1lr7fj3kmcs189iig";
+    rev = "c5f04a58fc2aeea6296ca7c44ee4734c18401aa3";
+    sha256 = "07ias612jgmxpam9h418kvlag32da914jsnjsfyafklpnh8gdzjb";
   };
 
   patches = [
@@ -40,9 +40,11 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
+  separateDebugInfo = true;
+
   meta = {
     description = "Toolkit for RTMP streams";
-    homepage    = http://rtmpdump.mplayerhq.hu/;
+    homepage    = "http://rtmpdump.mplayerhq.hu/";
     license     = licenses.gpl2;
     platforms   = platforms.unix;
     maintainers = with maintainers; [ codyopel ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5792,9 +5792,7 @@ in
 
   rt = callPackage ../servers/rt { };
 
-  rtmpdump = callPackage ../tools/video/rtmpdump {
-    openssl = openssl_1_0_2;
-  };
+  rtmpdump = callPackage ../tools/video/rtmpdump { };
   rtmpdump_gnutls = rtmpdump.override { gnutlsSupport = true; opensslSupport = false; };
 
   reaverwps = callPackage ../tools/networking/reaver-wps {};


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Using `rtmpsink` from `gst-plugins-bad` results in a segfault because gstreamer and rtmpdump are compiled with different OpenSSL versions. This is the backtrace:
```
#0  0xf7624d6c in nanosleep () from /nix/store/bhgs196rp1qw2cjzq073cwngw3m93wk1-glibc-2.27/lib/libpthread.so.0
#1  0xf771a358 in g_usleep () from /nix/store/n9hcw9vk2l5hd9b5yw42xqnciksb8171-glib-2.60.4/lib/libglib-2.0.so.0
#2  0x00015d10 in fault_handler_sighandler ()
#3  <signal handler called>
#4  0xf7543e10 in strcmp () from /nix/store/bhgs196rp1qw2cjzq073cwngw3m93wk1-glibc-2.27/lib/libc.so.6
#5  0xf6560344 in lh_insert () from /nix/store/fqgcwd45ryvslaqgxm50l9zmf9kag1fi-openssl-1.0.2s/lib/libcrypto.so.1.0.0
#6  0xf64dff98 in OBJ_NAME_add () from /nix/store/fqgcwd45ryvslaqgxm50l9zmf9kag1fi-openssl-1.0.2s/lib/libcrypto.so.1.0.0
#7  0xf66ca80c in ossl_init_ssl_base_ossl_ () from /nix/store/ghg74fqy28b7ygxbwrj53y2x7ln4nx8s-openssl-1.1.1c/lib/libssl.so.1.1
#8  0xf76222dc in __pthread_once_slow () from /nix/store/bhgs196rp1qw2cjzq073cwngw3m93wk1-glibc-2.27/lib/libpthread.so.0
#9  0xf63f0d18 in CRYPTO_THREAD_run_once () from /nix/store/ghg74fqy28b7ygxbwrj53y2x7ln4nx8s-openssl-1.1.1c/lib/libcrypto.so.1.1
#10 0xf66ca9e4 in OPENSSL_init_ssl () from /nix/store/ghg74fqy28b7ygxbwrj53y2x7ln4nx8s-openssl-1.1.1c/lib/libssl.so.1.1
#11 0xf66ce5e0 in SSL_CTX_new () from /nix/store/ghg74fqy28b7ygxbwrj53y2x7ln4nx8s-openssl-1.1.1c/lib/libssl.so.1.1
#12 0xf67274c8 in RTMP_TLS_Init () from /nix/store/1xv7np1j9pyngb7hk4ishjxykr0jl2yz-rtmpdump-2015-12-30/lib/librtmp.so.1
#13 0xf6727638 in RTMP_Init () from /nix/store/1xv7np1j9pyngb7hk4ishjxykr0jl2yz-rtmpdump-2015-12-30/lib/librtmp.so.1
#14 0xf674e25c in gst_rtmp_sink_start () from /nix/store/c799a6v2wjnl2anj4rz1ak9pgza4gaq0-gst-plugins-bad-1.16.0/lib/gstreamer-1.0/libgstrtmp.so
#15 0xf6f8b100 in gst_base_sink_change_state () from /nix/store/fa12vgg7kqlhvq0q3icrql7w2n9gbakw-gstreamer-1.16.0/lib/libgstbase-1.0.so.0
#16 0xf7818088 in gst_element_change_state () from /nix/store/fa12vgg7kqlhvq0q3icrql7w2n9gbakw-gstreamer-1.16.0/lib/libgstreamer-1.0.so.0
#17 0xf781887c in gst_element_set_state_func () from /nix/store/fa12vgg7kqlhvq0q3icrql7w2n9gbakw-gstreamer-1.16.0/lib/libgstreamer-1.0.so.0
#18 0xf77f07c4 in gst_bin_change_state_func () from /nix/store/fa12vgg7kqlhvq0q3icrql7w2n9gbakw-gstreamer-1.16.0/lib/libgstreamer-1.0.so.0
#19 0xf7818088 in gst_element_change_state () from /nix/store/fa12vgg7kqlhvq0q3icrql7w2n9gbakw-gstreamer-1.16.0/lib/libgstreamer-1.0.so.0
#20 0xf781887c in gst_element_set_state_func () from /nix/store/fa12vgg7kqlhvq0q3icrql7w2n9gbakw-gstreamer-1.16.0/lib/libgstreamer-1.0.so.0
#21 0x0001348c in main ()
```

###### Things done

I used Gentoo's patch to add support for OpenSSL 1.1. I also updated the package to the latest commit.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @codyopel
