### PR TITLE
filebot: init at 4.8.5

### DIFF
--- a/pkgs/applications/video/filebot/default.nix
+++ b/pkgs/applications/video/filebot/default.nix
@@ -1,0 +1,58 @@
+{ stdenv, fetchurl, openjdk8, makeWrapper, autoPatchelfHook
+
+, zlib, libzen, libmediainfo, curl, libmms, glib
+}:
+
+let
+  curlWithGnuTls = curl.override { gnutlsSupport = true; sslSupport = false; };
+
+in
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "filebot";
+  version = "4.8.5";
+
+  src = fetchurl {
+    # This is a closed-source application, hence downloading a binary package.
+    url = "https://get.filebot.net/filebot/FileBot_4.8.5/FileBot_4.8.5-portable.tar.xz";
+    sha256 = "1c2a97rkv57cvy4arnmw9f3zdvxwb5zfvr9iqgpn9rkda00f2hy8";
+  };
+
+  unpackPhase = ''tar xvf $src'';
+
+  nativeBuildInputs = [ makeWrapper autoPatchelfHook
+                        # The following are lib dependencies for autoPatchelfHook to work.
+                        stdenv.cc.cc.lib zlib libzen libmediainfo curlWithGnuTls libmms glib ];
+
+  buildPhase = '''';
+  installPhase = ''
+    mkdir -p $out/opt
+    # Since FileBot has depenencies on relative paths between files, all required files are copied to the same location as is.
+    cp -r filebot.sh lib/ jar/ $out/opt/
+    mkdir -p $out/bin
+    # Filebot writes to $APP_DATA, which fails due to read-only filesystem. Using current user .local directory instead.
+    substituteInPlace $out/opt/filebot.sh \
+      --replace 'APP_DATA="$FILEBOT_HOME/data/$USER"' 'APP_DATA=''${XDG_DATA_HOME:-$HOME/.local/share}/filebot/data' \
+      --replace '$FILEBOT_HOME/data/.license' '$APP_DATA/.license'
+    wrapProgram $out/opt/filebot.sh \
+      --prefix PATH : ${stdenv.lib.makeBinPath [ openjdk8 ]}
+    # Expose the binary in bin to make runnable.
+    ln -s $out/opt/filebot.sh $out/bin/filebot
+  '';
+
+  patchPhase = '''';
+
+  meta = with stdenv.lib; {
+    description = "The ultimate TV and Movie Renamer";
+    longDescription = ''
+      FileBot is the ultimate tool for organizing and renaming your Movies, TV
+      Shows and Anime as well as fetching subtitles and artwork. It's smart and
+      just works.
+    '';
+    homepage = https://filebot.net;
+    license = licenses.unfreeRedistributable;
+    maintainers = with maintainers; [ gleber ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1622,6 +1622,8 @@ in
     bison = bison2;
   };
 
+  filebot = callPackage ../applications/video/filebot {};
+
   fileshelter = callPackage ../servers/web-apps/fileshelter { };
 
   firecracker = callPackage ../applications/virtualization/firecracker { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
This is a non-free application to rename downloaded media files as per internet databases of medias.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
