### PR TITLE
python3Packages.pikepdf: 1.1.0 -> 1.6.2, pybind11: 2.2.4 -> 2.3.0

### DIFF
--- a/pkgs/development/python-modules/pikepdf/default.nix
+++ b/pkgs/development/python-modules/pikepdf/default.nix
@@ -22,12 +22,12 @@
 
 buildPythonPackage rec {
   pname = "pikepdf";
-  version = "1.1.0";
+  version = "1.6.2";
   disabled = ! isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "14b36r6h3088z2sxp2pqvm171js53hz53mwm1g52iadignjnp0my";
+    sha256 = "1x1b55znr0j4fib69l2h0xq0qmbf2nbxwbwd4f7y8r4sqi20239z";
   };
 
   buildInputs = [
@@ -55,8 +55,11 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ defusedxml lxml ];
 
   postPatch = ''
-    substituteInPlace requirements/test.txt \
-       --replace "pytest >= 3.6.0, < 4.1.0" "pytest >= 4.2.1, < 5"
+    sed -i \
+      -e 's/^pytest .*/pytest/g' \
+      -e 's/^attrs .*/attrs/g' \
+      -e 's/^hypothesis .*/hypothesis/g' \
+      requirements/test.txt
   '';
 
   preBuild = ''
@@ -70,4 +73,3 @@ buildPythonPackage rec {
     maintainers = [ maintainers.kiwi ];
   };
 }
-

--- a/pkgs/development/python-modules/pybind11/default.nix
+++ b/pkgs/development/python-modules/pybind11/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "pybind11";
-  version = "2.2.4";
+  version = "2.3.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1kz1z2cg3q901q9spkdhksmcfiskaghzmbb9ivr5mva856yvnak4";
+    sha256 = "0923ngd2cvck3lhl7584y08n36pm6zqihfm1s69sbdc11xg936hr";
   };
 
   patches = [


### PR DESCRIPTION
###### Motivation for this change

This fixes #67850.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I tested ocrmypdf on NixOS x86_64.

###### Notify maintainers

cc @yuriaisaka @Kiwi @FRidh
