### PR TITLE
mhonarc: 2.6.18 -> 2.6.19, fix build, and cleanup

### DIFF
--- a/pkgs/development/perl-modules/mhonarc.patch
+++ b/pkgs/development/perl-modules/mhonarc.patch
@@ -1,0 +1,26 @@
+diff --git a/lib/mhamain.pl b/lib/mhamain.pl
+index 80980a2..c1259ce 100644
+--- a/lib/mhamain.pl
++++ b/lib/mhamain.pl
+@@ -1562,7 +1562,7 @@ sub signal_catch {
+ ##
+ sub defineIndex2MsgId {
+     no warnings qw(deprecated);
+-    if (!defined(%Index2MsgId)) {
++    unless (%Index2MsgId) {
+ 	foreach (keys %MsgId) {
+ 	    $Index2MsgId{$MsgId{$_}} = $_;
+ 	}
+diff --git a/lib/mhopt.pl b/lib/mhopt.pl
+index 02fb05e..939109b 100644
+--- a/lib/mhopt.pl
++++ b/lib/mhopt.pl
+@@ -865,7 +865,7 @@ sub update_data_1_to_2 {
+ sub update_data_2_1_to_later {
+     no warnings qw(deprecated);
+     # we can preserve filter arguments
+-    if (defined(%main::MIMEFiltersArgs)) {
++    if (%main::MIMEFiltersArgs) {
+ 	warn qq/         preserving MIMEARGS...\n/;
+ 	%readmail::MIMEFiltersArgs = %main::MIMEFiltersArgs;
+ 	$IsDefault{'MIMEARGS'} = 0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4332,6 +4332,8 @@ in
 
   memtester = callPackage ../tools/system/memtester { };
 
+  mhonarc = perlPackages.MHonArc;
+
   minergate = callPackage ../applications/misc/minergate { };
 
   minergate-cli = callPackage ../applications/misc/minergate-cli { };

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -10661,12 +10661,12 @@ let
     };
   };
 
-  MHonArc = buildPerlPackage {
+  MHonArc = buildPerlPackage rec {
     pname = "MHonArc";
     version = "2.6.19";
 
     src = fetchurl {
-      url    = "http://dcssrv1.oit.uci.edu/indiv/ehood/release/MHonArc/tar/MHonArc-2.6.19.tar.gz";
+      url = "https://www.mhonarc.org/release/MHonArc/tar/MHonArc-${version}.tar.gz";
       sha256 = "0ll3v93yji334zqp6xfzfxc0127pmjcznmai1l5q6dzawrs2igzq";
     };
 
@@ -10677,10 +10677,10 @@ let
     installTargets = "install";
 
     meta = with stdenv.lib; {
-      homepage    = http://dcssrv1.oit.uci.edu/indiv/ehood/mhonarch.html;
+      homepage = "https://www.mhonarc.org/";
       description = "A mail-to-HTML converter";
       maintainers = with maintainers; [ lovek323 ];
-      license     = licenses.gpl2;
+      license = licenses.gpl2;
     };
   };
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -10663,11 +10663,11 @@ let
 
   MHonArc = buildPerlPackage {
     pname = "MHonArc";
-    version = "2.6.18";
+    version = "2.6.19";
 
     src = fetchurl {
-      url    = "http://dcssrv1.oit.uci.edu/indiv/ehood/release/MHonArc/tar/MHonArc-2.6.18.tar.gz";
-      sha256 = "1xmf26dfwr8achprc3n1pxgl0mkiyr6pf25wq3dqgzqkghrrsxa2";
+      url    = "http://dcssrv1.oit.uci.edu/indiv/ehood/release/MHonArc/tar/MHonArc-2.6.19.tar.gz";
+      sha256 = "0ll3v93yji334zqp6xfzfxc0127pmjcznmai1l5q6dzawrs2igzq";
     };
     outputs = [ "out" "dev" ]; # no "devdoc"
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -10669,6 +10669,9 @@ let
       url    = "http://dcssrv1.oit.uci.edu/indiv/ehood/release/MHonArc/tar/MHonArc-2.6.19.tar.gz";
       sha256 = "0ll3v93yji334zqp6xfzfxc0127pmjcznmai1l5q6dzawrs2igzq";
     };
+
+    patches = [ ../development/perl-modules/mhonarc.patch ];
+
     outputs = [ "out" "dev" ]; # no "devdoc"
 
     installTargets = "install";


### PR DESCRIPTION
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @lovek323
