### PR TITLE
fcitx: use enchant2

### DIFF
--- a/pkgs/tools/inputmethods/fcitx/find-enchant-lib.patch
+++ b/pkgs/tools/inputmethods/fcitx/find-enchant-lib.patch
@@ -1,0 +1,42 @@
+diff --git a/cmake/FindEnchant.cmake b/cmake/FindEnchant.cmake
+index 7c182e6a..5537595e 100644
+--- a/cmake/FindEnchant.cmake
++++ b/cmake/FindEnchant.cmake
+@@ -16,7 +16,7 @@ if(ENCHANT_INCLUDE_DIR AND ENCHANT_LIBRARIES)
+ endif(ENCHANT_INCLUDE_DIR AND ENCHANT_LIBRARIES)
+ 
+ find_package(PkgConfig)
+-pkg_check_modules(PC_ENCHANT enchant)
++pkg_check_modules(PC_ENCHANT enchant-2)
+ 
+ find_path(ENCHANT_INCLUDE_DIR
+   NAMES enchant.h
+@@ -24,7 +24,7 @@ find_path(ENCHANT_INCLUDE_DIR
+   PATH_SUFFIXES "enchant")
+ 
+ find_library(ENCHANT_LIBRARIES
+-  NAMES enchant
++  NAMES enchant-2
+   HINTS ${PC_ENCHANT_LIBRARY_DIRS})
+ 
+ if(ENCHANT_INCLUDE_DIR AND ENCHANT_LIBRARIES)
+@@ -39,7 +39,7 @@ if(ENCHANT_INCLUDE_DIR AND ENCHANT_LIBRARIES)
+   #include <stdlib.h>
+   #include <stddef.h>
+   #include <string.h>
+-  #include <enchant/enchant.h>
++  #include <enchant-2/enchant.h>
+ 
+   EnchantBroker *enchant_broker_init();
+   char **enchant_dict_suggest(EnchantDict *dict, const char *str,
+@@ -78,6 +78,10 @@ if(ENCHANT_INCLUDE_DIR AND ENCHANT_LIBRARIES)
+   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS_BACKUP}")
+ endif()
+ 
++if(ENCHANT_API_COMPATIBLE)
++  set(ENCHANT_LIBRARY_FILENAME ${ENCHANT_LIBRARIES})
++endif(ENCHANT_API_COMPATIBLE)
++
+ include(FindPackageHandleStandardArgs)
+ find_package_handle_standard_args(Enchant DEFAULT_MSG ENCHANT_LIBRARIES
+   ENCHANT_INCLUDE_DIR ENCHANT_API_COMPATIBLE)

--- a/pkgs/tools/inputmethods/fcitx/unwrapped.nix
+++ b/pkgs/tools/inputmethods/fcitx/unwrapped.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, cmake, intltool, gettext
-, libxml2, enchant1, isocodes, icu, libpthreadstubs
+, libxml2, enchant2, isocodes, icu, libpthreadstubs
 , pango, cairo, libxkbfile, libXau, libXdmcp, libxkbcommon
 , dbus, gtk2, gtk3, qt4, extra-cmake-modules
 , xkeyboard_config, pcre, libuuid
@@ -59,6 +59,8 @@ stdenv.mkDerivation rec {
   ''
   ;
 
+  patches = [ ./find-enchant-lib.patch ];
+
   postPatch = ''
     substituteInPlace src/frontend/qt/CMakeLists.txt \
       --replace $\{QT_PLUGINS_DIR} $out/lib/qt4/plugins
@@ -69,7 +71,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake extra-cmake-modules intltool pkgconfig pcre ];
 
   buildInputs = [
-    xkeyboard_config enchant1 gettext isocodes icu libpthreadstubs libXau libXdmcp libxkbfile
+    xkeyboard_config enchant2 gettext isocodes icu libpthreadstubs libXau libXdmcp libxkbfile
     libxkbcommon libxml2 dbus cairo gtk2 gtk3 pango qt4 libuuid
   ];
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Part of #38506.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
