### PR TITLE
nixos: remove dependencies on local-fs.target

### DIFF
--- a/nixos/modules/services/computing/boinc/client.nix
+++ b/nixos/modules/services/computing/boinc/client.nix
@@ -111,7 +111,7 @@ in
 
       systemd.services.boinc = {
         description = "BOINC Client";
-        after = ["network.target" "local-fs.target"];
+        after = ["network.target"];
         wantedBy = ["multi-user.target"];
         script = ''
           ${fhsEnvExecutable} --dir ${cfg.dataDir} --redirectio ${allowRemoteGuiRpcFlag}

--- a/nixos/modules/services/desktops/profile-sync-daemon.nix
+++ b/nixos/modules/services/desktops/profile-sync-daemon.nix
@@ -34,7 +34,7 @@ in {
           psd = {
             enable = true;
             description = "Profile Sync daemon";
-            wants = [ "psd-resync.service" "local-fs.target" ];
+            wants = [ "psd-resync.service" ];
             wantedBy = [ "default.target" ];
             path = with pkgs; [ rsync kmod gawk nettools utillinux profile-sync-daemon ];
             unitConfig = {

--- a/nixos/modules/services/hardware/triggerhappy.nix
+++ b/nixos/modules/services/hardware/triggerhappy.nix
@@ -102,7 +102,6 @@ in
 
     systemd.services.triggerhappy = {
       wantedBy = [ "multi-user.target" ];
-      after = [ "local-fs.target" ];
       description = "Global hotkey daemon";
       serviceConfig = {
         ExecStart = "${pkgs.triggerhappy}/bin/thd ${optionalString (cfg.user != "root") "--user ${cfg.user}"} --socket ${socket} --triggers ${configFile} --deviceglob /dev/input/event*";

--- a/nixos/modules/services/misc/airsonic.nix
+++ b/nixos/modules/services/misc/airsonic.nix
@@ -105,7 +105,7 @@ in {
   config = mkIf cfg.enable {
     systemd.services.airsonic = {
       description = "Airsonic Media Server";
-      after = [ "local-fs.target" "network.target" ];
+      after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
 
       preStart = ''

--- a/nixos/modules/services/misc/mediatomb.nix
+++ b/nixos/modules/services/misc/mediatomb.nix
@@ -259,7 +259,7 @@ in {
   config = mkIf cfg.enable {
     systemd.services.mediatomb = {
       description = "MediaTomb media Server";
-      after = [ "local-fs.target" "network.target" ];
+      after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
       path = [ pkgs.mediatomb ];
       serviceConfig.ExecStart = "${pkgs.mediatomb}/bin/mediatomb -p ${toString cfg.port} ${if cfg.interface!="" then "-e ${cfg.interface}" else ""} ${if cfg.customCfg then "" else "-c ${mtConf}"} -m ${cfg.dataDir}";

--- a/nixos/modules/services/misc/mwlib.nix
+++ b/nixos/modules/services/misc/mwlib.nix
@@ -165,7 +165,7 @@ in
 
   }; # options.services
 
-  config = { 
+  config = {
 
     systemd.services.mwlib-nserve = mkIf cfg.nserve.enable
     {
@@ -191,7 +191,6 @@ in
       description = "mwlib job queue server";
 
       wantedBy = [ "multi-user.target" ];
-      after = [ "network.target" "local-fs.target" ];
 
       preStart = ''
         mkdir -pv '${cfg.qserve.datadir}'
@@ -218,7 +217,7 @@ in
       description = "mwlib worker";
 
       wantedBy = [ "multi-user.target" ];
-      after = [ "network.target" "local-fs.target" ];
+      after = [ "network.target" ];
 
       preStart = ''
         mkdir -pv '${cfg.nslave.cachedir}'

--- a/nixos/modules/services/misc/serviio.nix
+++ b/nixos/modules/services/misc/serviio.nix
@@ -10,7 +10,7 @@ let
     #!${pkgs.bash}/bin/sh
 
     SERVIIO_HOME=${pkgs.serviio}
-    
+
     # Setup the classpath
     SERVIIO_CLASS_PATH="$SERVIIO_HOME/lib/*:$SERVIIO_HOME/config"
 
@@ -21,13 +21,13 @@ let
     # Execute the JVM in the foreground
     exec ${pkgs.jre}/bin/java -Xmx512M -Xms20M -XX:+UseG1GC -XX:GCTimeRatio=1 -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 $JAVA_OPTS -classpath "$SERVIIO_CLASS_PATH" org.serviio.MediaServer "$@"
   '';
-  
+
 in {
 
   ###### interface
   options = {
     services.serviio = {
-      
+
       enable = mkOption {
         type = types.bool;
         default = false;
@@ -52,7 +52,7 @@ in {
   config = mkIf cfg.enable {
     systemd.services.serviio = {
       description = "Serviio Media Server";
-      after = [ "local-fs.target" "network.target" ];
+      after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
       path = [ pkgs.serviio ];
       serviceConfig = {
@@ -64,7 +64,7 @@ in {
     };
 
     users.users = [
-      { 
+      {
         name = "serviio";
         group = "serviio";
         home = cfg.dataDir;
@@ -75,16 +75,16 @@ in {
     ];
 
     users.groups = [
-      { name = "serviio";} 
+      { name = "serviio";}
     ];
 
     networking.firewall = {
-      allowedTCPPorts = [ 
+      allowedTCPPorts = [
         8895  # serve UPnP responses
         23423 # console
         23424 # mediabrowser
       ];
-      allowedUDPPorts = [ 
+      allowedUDPPorts = [
         1900 # UPnP service discovey
       ];
     };

--- a/nixos/modules/services/misc/subsonic.nix
+++ b/nixos/modules/services/misc/subsonic.nix
@@ -105,7 +105,7 @@ let cfg = config.services.subsonic; in {
   config = mkIf cfg.enable {
     systemd.services.subsonic = {
       description = "Personal media streamer";
-      after = [ "local-fs.target" "network.target" ];
+      after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
       script = ''
         ${pkgs.jre}/bin/java -Xmx${toString cfg.maxMemory}m \

--- a/nixos/modules/services/network-filesystems/glusterfs.nix
+++ b/nixos/modules/services/network-filesystems/glusterfs.nix
@@ -156,7 +156,7 @@ in
       wantedBy = [ "multi-user.target" ];
 
       requires = lib.optional cfg.useRpcbind "rpcbind.service";
-      after = [ "network.target" "local-fs.target" ] ++ lib.optional cfg.useRpcbind "rpcbind.service";
+      after = [ "network.target" ] ++ lib.optional cfg.useRpcbind "rpcbind.service";
 
       preStart = ''
         install -m 0755 -d /var/log/glusterfs

--- a/nixos/modules/services/network-filesystems/ipfs.nix
+++ b/nixos/modules/services/network-filesystems/ipfs.nix
@@ -236,7 +236,6 @@ in {
     systemd.services.ipfs-init = recursiveUpdate commonEnv {
       description = "IPFS Initializer";
 
-      after = [ "local-fs.target" ];
       before = [ "ipfs.service" "ipfs-offline.service" "ipfs-norouting.service" ];
 
       script = ''
@@ -263,21 +262,21 @@ in {
     systemd.services.ipfs = recursiveUpdate baseService {
       description = "IPFS Daemon";
       wantedBy = mkIf (cfg.defaultMode == "online") [ "multi-user.target" ];
-      after = [ "network.target" "local-fs.target" "ipfs-init.service" ];
+      after = [ "network.target" "ipfs-init.service" ];
       conflicts = [ "ipfs-offline.service" "ipfs-norouting.service"];
     };
 
     systemd.services.ipfs-offline = recursiveUpdate baseService {
       description = "IPFS Daemon (offline mode)";
       wantedBy = mkIf (cfg.defaultMode == "offline") [ "multi-user.target" ];
-      after = [ "local-fs.target" "ipfs-init.service" ];
+      after = [ "ipfs-init.service" ];
       conflicts = [ "ipfs.service" "ipfs-norouting.service"];
     };
 
     systemd.services.ipfs-norouting = recursiveUpdate baseService {
       description = "IPFS Daemon (no routing mode)";
       wantedBy = mkIf (cfg.defaultMode == "norouting") [ "multi-user.target" ];
-      after = [ "local-fs.target" "ipfs-init.service" ];
+      after = [ "ipfs-init.service" ];
       conflicts = [ "ipfs.service" "ipfs-offline.service"];
     };
 

--- a/nixos/modules/services/networking/aria2.nix
+++ b/nixos/modules/services/networking/aria2.nix
@@ -109,7 +109,7 @@ in
 
     systemd.services.aria2 = {
       description = "aria2 Service";
-      after = [ "local-fs.target" "network.target" ];
+      after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
       preStart = ''
         if [[ ! -e "${sessionFile}" ]]

--- a/nixos/modules/services/networking/logmein-hamachi.nix
+++ b/nixos/modules/services/networking/logmein-hamachi.nix
@@ -35,7 +35,7 @@ in
       description = "LogMeIn Hamachi Daemon";
 
       wantedBy = [ "multi-user.target" ];
-      after = [ "network.target" "local-fs.target" ];
+      after = [ "network.target" ];
 
       serviceConfig = {
         Type = "forking";

--- a/nixos/modules/services/networking/minidlna.nix
+++ b/nixos/modules/services/networking/minidlna.nix
@@ -96,7 +96,7 @@ in
       { description = "MiniDLNA Server";
 
         wantedBy = [ "multi-user.target" ];
-        after = [ "network.target" "local-fs.target" ];
+        after = [ "network.target" ];
 
         serviceConfig =
           { User = "minidlna";

--- a/nixos/modules/services/networking/resilio.nix
+++ b/nixos/modules/services/networking/resilio.nix
@@ -249,7 +249,7 @@ in
     systemd.services.resilio = with pkgs; {
       description = "Resilio Sync Service";
       wantedBy    = [ "multi-user.target" ];
-      after       = [ "network.target" "local-fs.target" ];
+      after       = [ "network.target" ];
       serviceConfig = {
         Restart   = "on-abort";
         UMask     = "0002";

--- a/nixos/modules/services/scheduling/fcron.nix
+++ b/nixos/modules/services/scheduling/fcron.nix
@@ -143,7 +143,6 @@ in
     };
     systemd.services.fcron = {
       description = "fcron daemon";
-      after = [ "local-fs.target" ];
       wantedBy = [ "multi-user.target" ];
 
       path = [ pkgs.fcron ];

--- a/nixos/modules/services/security/tor.nix
+++ b/nixos/modules/services/security/tor.nix
@@ -722,7 +722,6 @@ in
     systemd.services.tor-init =
       { description = "Tor Daemon Init";
         wantedBy = [ "tor.service" ];
-        after = [ "local-fs.target" ];
         script = ''
           install -m 0700 -o tor -g tor -d ${torDirectory} ${torDirectory}/onion
           install -m 0750 -o tor -g tor -d ${torRunDirectory}

--- a/nixos/modules/services/security/usbguard.nix
+++ b/nixos/modules/services/security/usbguard.nix
@@ -195,7 +195,7 @@ in {
       description = "USBGuard daemon";
 
       wantedBy = [ "basic.target" ];
-      wants = [ "systemd-udevd.service" "local-fs.target" ];
+      wants = [ "systemd-udevd.service" ];
 
       # make sure an empty rule file and required directories exist
       preStart = ''

--- a/nixos/modules/services/system/cgmanager.nix
+++ b/nixos/modules/services/system/cgmanager.nix
@@ -14,7 +14,6 @@ in {
   config = mkIf cfg.enable {
     systemd.services.cgmanager = {
       wantedBy = [ "multi-user.target" ];
-      after = [ "local-fs.target" ];
       description = "Cgroup management daemon";
       restartIfChanged = false;
       serviceConfig = {

--- a/nixos/modules/services/system/cloud-init.nix
+++ b/nixos/modules/services/system/cloud-init.nix
@@ -112,8 +112,6 @@ in
     systemd.services.cloud-init-local =
       { description = "Initial cloud-init job (pre-networking)";
         wantedBy = [ "multi-user.target" ];
-        wants = [ "local-fs.target" ];
-        after = [ "local-fs.target" ];
         path = path;
         serviceConfig =
           { Type = "oneshot";
@@ -127,9 +125,9 @@ in
     systemd.services.cloud-init =
       { description = "Initial cloud-init job (metadata service crawler)";
         wantedBy = [ "multi-user.target" ];
-        wants = [ "local-fs.target" "network-online.target" "cloud-init-local.service"
+        wants = [ "network-online.target" "cloud-init-local.service"
                   "sshd.service" "sshd-keygen.service" ];
-        after = [ "local-fs.target" "network-online.target" "cloud-init-local.service" ];
+        after = [ "network-online.target" "cloud-init-local.service" ];
         before = [ "sshd.service" "sshd-keygen.service" ];
         requires = [ "network.target "];
         path = path;

--- a/nixos/modules/services/torrent/transmission.nix
+++ b/nixos/modules/services/torrent/transmission.nix
@@ -102,7 +102,7 @@ in
   config = mkIf cfg.enable {
     systemd.services.transmission = {
       description = "Transmission BitTorrent Service";
-      after = [ "local-fs.target" "network.target" ] ++ optional apparmor "apparmor.service";
+      after = [ "network.target" ] ++ optional apparmor "apparmor.service";
       requires = mkIf apparmor [ "apparmor.service" ];
       wantedBy = [ "multi-user.target" ];
 

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -659,7 +659,7 @@ in
     systemd.services.display-manager =
       { description = "X11 Server";
 
-        after = [ "systemd-udev-settle.service" "local-fs.target" "acpid.service" "systemd-logind.service" ];
+        after = [ "systemd-udev-settle.service" "acpid.service" "systemd-logind.service" ];
         wants = [ "systemd-udev-settle.service" ];
 
         restartIfChanged = false;

--- a/nixos/modules/virtualisation/azure-agent.nix
+++ b/nixos/modules/virtualisation/azure-agent.nix
@@ -166,7 +166,6 @@ in
 
       wantedBy = [ "sshd.service" "waagent.service" ];
       before = [ "sshd.service" "waagent.service" ];
-      after = [ "local-fs.target" ];
 
       path  = [ pkgs.coreutils ];
       script =

--- a/nixos/modules/virtualisation/azure-image.nix
+++ b/nixos/modules/virtualisation/azure-image.nix
@@ -26,7 +26,6 @@ in
 
       wantedBy = [ "sshd.service" "waagent.service" ];
       before = [ "sshd.service" "waagent.service" ];
-      after = [ "local-fs.target" ];
 
       path  = [ pkgs.coreutils ];
       script =

--- a/nixos/tests/hocker-fetchdocker/machine.nix
+++ b/nixos/tests/hocker-fetchdocker/machine.nix
@@ -11,8 +11,8 @@
   systemd.services.docker-load-fetchdocker-image = {
     description = "Docker load hello-world-container";
     wantedBy    = [ "multi-user.target" ];
-    wants       = [ "docker.service" "local-fs.target" ];
-    after       = [ "docker.service" "local-fs.target" ];
+    wants       = [ "docker.service" ];
+    after       = [ "docker.service" ];
 
     script = ''
       ${pkgs.hello-world-container}/compositeImage.sh | ${pkgs.docker}/bin/docker load


### PR DESCRIPTION
Since https://github.com/NixOS/nixpkgs/pull/61321, local-fs.target is
part of sysinit.target again, meaning units without
DefaultDependencies=no will automatically depend on it, and the manual
set dependencies can be dropped.

###### Motivation for this change
There's still a lot of now-redundant dependencies on `local-fs.target` in the NixOS module system.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).