### PR TITLE
plex-mpv-shim: init at 0.2

### DIFF
--- a/pkgs/applications/video/plex-mpv-shim/default.nix
+++ b/pkgs/applications/video/plex-mpv-shim/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildPythonApplication, fetchFromGitHub, mpv, requests }:
+
+buildPythonApplication rec {
+  pname = "plex-mpv-shim";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "iwalton3";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1xcwzmfhz22vh62wb2fz41pfl1r7h8jqlvzimbk7h9fr9x0h7vmh";
+  };
+
+  propagatedBuildInputs = [ mpv requests ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/iwalton3/plex-mpv-shim";
+    description = "Allows casting of videos to MPV via the Plex mobile and web app.";
+    license = licenses.mit;
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20519,6 +20519,8 @@ in
 
   plex-media-player = libsForQt59.callPackage ../applications/video/plex-media-player { };
 
+  plex-mpv-shim = python3Packages.callPackage ../applications/video/plex-mpv-shim { };
+
   plover = recurseIntoAttrs (libsForQt5.callPackage ../applications/misc/plover { });
 
   plugin-torture = callPackage ../applications/audio/plugin-torture { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
See #66808, a promising mpv frontend for Plex.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
