### PR TITLE
dgraph: 0.8.2 -> 1.0.17

### DIFF
--- a/pkgs/servers/dgraph/default.nix
+++ b/pkgs/servers/dgraph/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   pname = "dgraph";
-  version = "0.8.2";
+  version = "1.0.17";
 
   goPackagePath = "github.com/dgraph-io/dgraph";
 
@@ -10,32 +10,26 @@ buildGoPackage rec {
     owner = "dgraph-io";
     repo = "dgraph";
     rev = "v${version}";
-    sha256 = "0zc5bda8m2srjbk0gy1nnm0bya8if0kmk1szqr1qv3xifdzmi4nf";
+    sha256 = "05z1xwbd76q49zyqahh9krvq78dgkzr22qc6srr4djds0l7y6x5i";
   };
 
-  extraOutputsToInstall = [ "dashboard" ];
+  # see licensing
+  buildFlags = [ "-tags oss" ];
 
   goDeps = ./deps.nix;
-  subPackages = [ "cmd/dgraph" "cmd/dgraphloader" "cmd/bulkloader"];
-
-  # let's move the dashboard to a different output, to prevent $bin from
-  # depending on $out
-  # TODO: provide a proper npm application for the dashboard.
-  postPatch = ''
-    mv dashboard/* $dashboard
-  '';
+  subPackages = [ "dgraph"];
 
   preBuild = ''
     export buildFlagsArray="-ldflags=\
-      -X github.com/dgraph-io/dgraph/x.dgraphVersion=${version} \
-      -X github.com/dgraph-io/dgraph/cmd/dgraph/main.uiDir=$dashboard/src/assets/"
+      -X github.com/dgraph-io/dgraph/x.dgraphVersion=${version}"
   '';
 
   meta = {
     homepage = "https://dgraph.io/";
     description = "Fast, Distributed Graph DB";
     maintainers = with stdenv.lib.maintainers; [ sigma ];
-    license = stdenv.lib.licenses.agpl3;
+    # Apache 2.0 because we use only build tag "oss"
+    license = stdenv.lib.licenses.asl20;
     platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/servers/dgraph/deps.nix
+++ b/pkgs/servers/dgraph/deps.nix
@@ -1,11 +1,47 @@
 [
   {
+    goPackagePath = "cloud.google.com/go";
+    fetch = {
+      type = "git";
+      url = "https://code.googlesource.com/gocloud";
+      rev = "v0.34.0";
+      sha256 = "1kclgclwar3r37zbvb9gg3qxbgzkb50zk3s9778zlh2773qikmai";
+    };
+  }
+  {
+    goPackagePath = "contrib.go.opencensus.io/exporter/jaeger";
+    fetch = {
+      type = "git";
+      url = "https://github.com/census-ecosystem/opencensus-go-exporter-jaeger";
+      rev = "v0.1.0";
+      sha256 = "0dhf0fhjfk8m6zx7xys5mj51c8gxvlahi4y5fx8l7b7b56bh1rmy";
+    };
+  }
+  {
+    goPackagePath = "contrib.go.opencensus.io/exporter/prometheus";
+    fetch = {
+      type = "git";
+      url = "https://github.com/census-ecosystem/opencensus-go-exporter-prometheus";
+      rev = "6bf73eaafbe9";
+      sha256 = "1509l1xcgp662j7rglmrs35innpbi2s0r14vj9ps6d55j42kifm0";
+    };
+  }
+  {
     goPackagePath = "github.com/AndreasBriese/bbloom";
     fetch = {
       type = "git";
       url = "https://github.com/AndreasBriese/bbloom";
-      rev = "28f7e881ca57bc00e028f9ede9f0d9104cfeef5e";
-      sha256 = "03cqhqvdz8c9by5w5ls4kwnnwlm6b2kkslc6m120fanw1lgamfzp";
+      rev = "e2d15f34fcf9";
+      sha256 = "05kkrsmpragy69bj6s80pxlm3pbwxrkkx7wgk0xigs6y2n6ylpds";
+    };
+  }
+  {
+    goPackagePath = "github.com/BurntSushi/toml";
+    fetch = {
+      type = "git";
+      url = "https://github.com/BurntSushi/toml";
+      rev = "v0.3.1";
+      sha256 = "1fjdwwfzyzllgiwydknf1pwjvy49qxfsczqx5gz3y0izs7as99j6";
     };
   }
   {
@@ -13,8 +49,26 @@
     fetch = {
       type = "git";
       url = "https://github.com/MakeNowJust/heredoc";
-      rev = "1d91351acdc1cb2f2c995864674b754134b86ca7";
+      rev = "1d91351acdc1";
       sha256 = "0ia1r8ibqmx6zv3wmsvgkpqlhwk79z9l38nzp4gd4f1kcb46856x";
+    };
+  }
+  {
+    goPackagePath = "github.com/apache/thrift";
+    fetch = {
+      type = "git";
+      url = "https://github.com/apache/thrift";
+      rev = "v0.12.0";
+      sha256 = "0g2g61rs189nimg3631wxfwdx12dsdz70qvncczlyvn34pcj7yby";
+    };
+  }
+  {
+    goPackagePath = "github.com/armon/consul-api";
+    fetch = {
+      type = "git";
+      url = "https://github.com/armon/consul-api";
+      rev = "eb2c6b5be1b6";
+      sha256 = "1j6fdr1sg36qy4n4xjl7brq739fpm5npq98cmvklzjc9qrx98nk9";
     };
   }
   {
@@ -22,17 +76,17 @@
     fetch = {
       type = "git";
       url = "https://github.com/beorn7/perks";
-      rev = "4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9";
-      sha256 = "1hrybsql68xw57brzj805xx2mghydpdiysv3gbhr7f5wlxj2514y";
+      rev = "v1.0.0";
+      sha256 = "1i1nz1f6g55xi2y3aiaz5kqfgvknarbfl4f0sx4nyyb4s7xb1z9x";
     };
   }
   {
-    goPackagePath = "github.com/bkaradzic/go-lz4";
+    goPackagePath = "github.com/bgentry/speakeasy";
     fetch = {
       type = "git";
-      url = "https://github.com/bkaradzic/go-lz4";
-      rev = "7224d8d8f27ef618c0a95f1ae69dbb0488abc33a";
-      sha256 = "10lmya17vdqg2pvqni0p73iahni48s1v11ya9a0hcz4jh5vw4dkb";
+      url = "https://github.com/bgentry/speakeasy";
+      rev = "v0.1.0";
+      sha256 = "02dfrj0wyphd3db9zn2mixqxwiz1ivnyc5xc7gkz58l5l27nzp8s";
     };
   }
   {
@@ -40,17 +94,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/blevesearch/bleve";
-      rev = "a7ebb8480579777c6cd1c4750d2e6b5ff2b49bdd";
-      sha256 = "121jhd158slf4050kmghz25jrvv7gbsan31wr0nxyw9z32lyf6yx";
-    };
-  }
-  {
-    goPackagePath = "github.com/blevesearch/blevex";
-    fetch = {
-      type = "git";
-      url = "https://github.com/blevesearch/blevex";
-      rev = "507dcd576550f9f3260f11495ba2de4e96773a3e";
-      sha256 = "0i9azysvia99fjpx525qnc5rcgv45hfvl3zcs58gvgqyxpzpc78z";
+      rev = "e1f5e6cdcd76";
+      sha256 = "1b2iip9vz71lqvjmj8v21sisk0z2gdsjd5v9750v3q4a3ik3x8m2";
     };
   }
   {
@@ -58,7 +103,7 @@
     fetch = {
       type = "git";
       url = "https://github.com/blevesearch/go-porterstemmer";
-      rev = "23a2c8e5cf1f380f27722c6d2ae8896431dc7d0e";
+      rev = "v1.0.2";
       sha256 = "0rcfbrad79xd114h3dhy5d3zs3b5bcgqwm3h5ih1lk69zr9wi91d";
     };
   }
@@ -67,17 +112,26 @@
     fetch = {
       type = "git";
       url = "https://github.com/blevesearch/segment";
-      rev = "762005e7a34fd909a84586299f1dd457371d36ee";
+      rev = "762005e7a34f";
       sha256 = "1nrm145sm0xlhqy3d12yipnb16ikjz9ykjcskmkgm7vjm47xkmfl";
     };
   }
   {
-    goPackagePath = "github.com/cockroachdb/cmux";
+    goPackagePath = "github.com/blevesearch/snowballstem";
     fetch = {
       type = "git";
-      url = "https://github.com/cockroachdb/cmux";
-      rev = "30d10be492927e2dcae0089c374c455d42414fcb";
-      sha256 = "0ixif6hwcm2dpi1si5ah49dmdyy5chillz1048jpvjzwzxyfv1nx";
+      url = "https://github.com/blevesearch/snowballstem";
+      rev = "26b06a2c243d";
+      sha256 = "096wgbpb7qyx055451gam3zb26acaiazjmd58av7ykslmb7wa5gm";
+    };
+  }
+  {
+    goPackagePath = "github.com/client9/misspell";
+    fetch = {
+      type = "git";
+      url = "https://github.com/client9/misspell";
+      rev = "v0.3.4";
+      sha256 = "1vwf33wsc4la25zk9nylpbp9px3svlmldkm0bha4hp56jws4q9cs";
     };
   }
   {
@@ -85,7 +139,7 @@
     fetch = {
       type = "git";
       url = "https://github.com/codahale/hdrhistogram";
-      rev = "3a0bb77429bd3a61596f5e8a3172445844342120";
+      rev = "3a0bb77429bd";
       sha256 = "1zampgfjbxy192cbwdi7g86l1idxaam96d834wncnpfdwgh5kl57";
     };
   }
@@ -94,8 +148,53 @@
     fetch = {
       type = "git";
       url = "https://github.com/coreos/etcd";
-      rev = "9d43462d174c664f5edf313dec0de31e1ef4ed47";
-      sha256 = "0qxqjxhhciaacag1jz2rlncmlgw861ig2yx993ylvfm30jvyj2cj";
+      rev = "v3.3.10";
+      sha256 = "1x2ii1hj8jraba8rbxz6dmc03y3sjxdnzipdvg6fywnlq1f3l3wl";
+    };
+  }
+  {
+    goPackagePath = "github.com/coreos/go-etcd";
+    fetch = {
+      type = "git";
+      url = "https://github.com/coreos/go-etcd";
+      rev = "v2.0.0";
+      sha256 = "1xb34hzaa1lkbq5vkzy9vcz6gqwj7hp6cdbvyack2bf28dwn33jj";
+    };
+  }
+  {
+    goPackagePath = "github.com/coreos/go-semver";
+    fetch = {
+      type = "git";
+      url = "https://github.com/coreos/go-semver";
+      rev = "v0.2.0";
+      sha256 = "1gghi5bnqj50hfxhqc1cxmynqmh2yk9ii7ab9gsm75y5cp94ymk0";
+    };
+  }
+  {
+    goPackagePath = "github.com/coreos/go-systemd";
+    fetch = {
+      type = "git";
+      url = "https://github.com/coreos/go-systemd";
+      rev = "39ca1b05acc7";
+      sha256 = "1kzqrrzqspa5qm7kwslxl3m16lqzns23c24rv474ajzwmj3ixmx1";
+    };
+  }
+  {
+    goPackagePath = "github.com/coreos/pkg";
+    fetch = {
+      type = "git";
+      url = "https://github.com/coreos/pkg";
+      rev = "3ac0863d7acf";
+      sha256 = "0l5ans1ls2gknkrnhymgc0zbgg5nqjbjbqc51r611adcr0m6gg8l";
+    };
+  }
+  {
+    goPackagePath = "github.com/cpuguy83/go-md2man";
+    fetch = {
+      type = "git";
+      url = "https://github.com/cpuguy83/go-md2man";
+      rev = "v1.0.10";
+      sha256 = "1bqkf2bvy1dns9zd24k81mh2p1zxsx2nhq5cj8dz2vgkv1xkh60i";
     };
   }
   {
@@ -103,8 +202,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/davecgh/go-spew";
-      rev = "6d212800a42e8ab5c146b8ace3490ee17e5225f9";
-      sha256 = "01i0n1s4j7khb7n6mz2wymniz37q0vbzkgfv7rbi6p9hpg227q93";
+      rev = "v1.1.1";
+      sha256 = "0hka6hmyvp701adzag2g26cxdj47g21x6jz4sc6jjz1mn59d474y";
     };
   }
   {
@@ -112,8 +211,26 @@
     fetch = {
       type = "git";
       url = "https://github.com/dgraph-io/badger";
-      rev = "64df7f57d9ee20d7b28de4a3eea90bf8d7310a77";
-      sha256 = "1ikgzn2l62kb238n0wm6s95py5ypv71p09w7zyvzkjf34x675mzz";
+      rev = "v1.6.0";
+      sha256 = "1vzibjqhb10q6s2chbzlwndij2d9ybjnq7h28hx4akr119avd0d5";
+    };
+  }
+  {
+    goPackagePath = "github.com/dgraph-io/dgo";
+    fetch = {
+      type = "git";
+      url = "https://github.com/dgraph-io/dgo";
+      rev = "f8969c1ddf8f";
+      sha256 = "08ycdpxry15r9vgaqrqxcdbw8z216asqarhxq76smi5a82mr56qa";
+    };
+  }
+  {
+    goPackagePath = "github.com/dgrijalva/jwt-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/dgrijalva/jwt-go";
+      rev = "v3.2.0";
+      sha256 = "08m27vlms74pfy5z79w67f9lk9zkx6a9jd68k3c4msxy75ry36mp";
     };
   }
   {
@@ -121,8 +238,71 @@
     fetch = {
       type = "git";
       url = "https://github.com/dgryski/go-farm";
-      rev = "d1e51a4af19092715f4ce7d8257fe5bc8f8be727";
-      sha256 = "00iijjzdg8g6jbzhdbfw8s2rf0k25gxw4x7h7r6mkxcq18n69182";
+      rev = "6a90982ecee2";
+      sha256 = "1x3l4jgps0v1bjvd446kj4dp0ckswjckxgrng9afm275ixnf83ix";
+    };
+  }
+  {
+    goPackagePath = "github.com/dustin/go-humanize";
+    fetch = {
+      type = "git";
+      url = "https://github.com/dustin/go-humanize";
+      rev = "v1.0.0";
+      sha256 = "1kqf1kavdyvjk7f8kx62pnm7fbypn9z1vbf8v2qdh3y7z7a0cbl3";
+    };
+  }
+  {
+    goPackagePath = "github.com/fatih/color";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fatih/color";
+      rev = "v1.7.0";
+      sha256 = "0v8msvg38r8d1iiq2i5r4xyfx0invhc941kjrsg5gzwvagv55inv";
+    };
+  }
+  {
+    goPackagePath = "github.com/fsnotify/fsnotify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fsnotify/fsnotify";
+      rev = "v1.4.7";
+      sha256 = "07va9crci0ijlivbb7q57d2rz9h27zgn2fsm60spjsqpdbvyrx4g";
+    };
+  }
+  {
+    goPackagePath = "github.com/ghodss/yaml";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ghodss/yaml";
+      rev = "25d852aebe32";
+      sha256 = "1w9yq0bxzygc4qwkwwiy7k1k1yviaspcqqv18255k2xkjv5ipccz";
+    };
+  }
+  {
+    goPackagePath = "github.com/go-ini/ini";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-ini/ini";
+      rev = "v1.39.0";
+      sha256 = "0j7pyl5v7xfzkhsyz193iq56ilan69pp11g2n5jw1k4h4g8s4k9b";
+    };
+  }
+  {
+    goPackagePath = "github.com/go-kit/kit";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-kit/kit";
+      rev = "v0.8.0";
+      sha256 = "1rcywbc2pvab06qyf8pc2rdfjv7r6kxdv2v4wnpqnjhz225wqvc0";
+    };
+  }
+  {
+    goPackagePath = "github.com/go-logfmt/logfmt";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-logfmt/logfmt";
+      rev = "v0.4.0";
+      sha256 = "06smxc112xmixz78nyvk3b2hmc7wasf2sl5vxj1xz62kqcq9lzm9";
     };
   }
   {
@@ -130,8 +310,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/gogo/protobuf";
-      rev = "e57a569e1882958f6b188cb42231d6db87701f2a";
-      sha256 = "0r3jpmp6wp4xyrh1ikr8iqld3rg4r1yhv99zxw5zd7d2zprw9yfc";
+      rev = "v1.2.0";
+      sha256 = "1c3y5m08mvrgvlw0kb9pldh3kkqcj99pa8gqmk1g3hp8ih3b2dv0";
     };
   }
   {
@@ -139,8 +319,35 @@
     fetch = {
       type = "git";
       url = "https://github.com/golang/geo";
-      rev = "31fb0106dc4a947e5aaee1fe186e56447f839510";
+      rev = "31fb0106dc4a";
       sha256 = "00w4kwm98hrgr3ggfdk1h7qa5gp00z4s0j0iwgwd9rgadb59kb2c";
+    };
+  }
+  {
+    goPackagePath = "github.com/golang/glog";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/glog";
+      rev = "23def4e6c14b";
+      sha256 = "0jb2834rw5sykfr937fxi8hxi2zy80sj2bdn9b3jb4b26ksqng30";
+    };
+  }
+  {
+    goPackagePath = "github.com/golang/groupcache";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/groupcache";
+      rev = "02826c3e7903";
+      sha256 = "0w46bsllddfij66nrg8jbfjsr54birvfww8a2fj9fmgyig5syn2x";
+    };
+  }
+  {
+    goPackagePath = "github.com/golang/mock";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/mock";
+      rev = "v1.1.1";
+      sha256 = "0ap8wb6pdl6ccmdb43advjll2ly4sz26wsc3axw0hbrjrybybzgy";
     };
   }
   {
@@ -148,8 +355,17 @@
     fetch = {
       type = "git";
       url = "https://github.com/golang/protobuf";
-      rev = "2bba0603135d7d7f5cb73b2125beeda19c09f4ef";
-      sha256 = "1xy0bj66qks2xlzxzlfma16w7m8g6rrwawmlhlv68bcw2k5hvvib";
+      rev = "v1.3.2";
+      sha256 = "1k1wb4zr0qbwgpvz9q5ws9zhlal8hq7dmq62pwxxriksayl6hzym";
+    };
+  }
+  {
+    goPackagePath = "github.com/google/btree";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/btree";
+      rev = "e89373fe6b4a";
+      sha256 = "0jlkjjlf8ilifgsb2bv0jfgl4cxl1bypx7a6pjkwz3xf6k8jd7mj";
     };
   }
   {
@@ -157,8 +373,188 @@
     fetch = {
       type = "git";
       url = "https://github.com/google/codesearch";
-      rev = "a45d81b686e85d01f2838439deaf72126ccd5a96";
+      rev = "v1.0.0";
       sha256 = "12bv3yz0l3bmsxbasfgv7scm9j719ch6pmlspv4bd4ix7wjpyhny";
+    };
+  }
+  {
+    goPackagePath = "github.com/google/go-cmp";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/go-cmp";
+      rev = "v0.3.0";
+      sha256 = "1hyxx3434zshl2m9ja78gwlkg1rx9yl6diqa7dnjb31xz5x4gbjj";
+    };
+  }
+  {
+    goPackagePath = "github.com/google/uuid";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/uuid";
+      rev = "v1.0.0";
+      sha256 = "1922bjrnx66692dm0rrc1ckmznsaqx920ww4jzsds3xzrwf15mqv";
+    };
+  }
+  {
+    goPackagePath = "github.com/gorilla/websocket";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gorilla/websocket";
+      rev = "4201258b820c";
+      sha256 = "1kpdg3m46kp15ixl9ahhchhadyiblz0qpcxzylp8jhffc1rnxjb7";
+    };
+  }
+  {
+    goPackagePath = "github.com/grpc-ecosystem/go-grpc-middleware";
+    fetch = {
+      type = "git";
+      url = "https://github.com/grpc-ecosystem/go-grpc-middleware";
+      rev = "f849b5445de4";
+      sha256 = "0hscypgj0nd1407jp6y4qrnrr0mrhc4wgxz9b3mj1cs3pkvi61vc";
+    };
+  }
+  {
+    goPackagePath = "github.com/grpc-ecosystem/go-grpc-prometheus";
+    fetch = {
+      type = "git";
+      url = "https://github.com/grpc-ecosystem/go-grpc-prometheus";
+      rev = "v1.2.0";
+      sha256 = "1lzk54h7np32b3acidg1ggbn8ppbnns0m71gcg9d1qkkdh8zrijl";
+    };
+  }
+  {
+    goPackagePath = "github.com/grpc-ecosystem/grpc-gateway";
+    fetch = {
+      type = "git";
+      url = "https://github.com/grpc-ecosystem/grpc-gateway";
+      rev = "v1.4.1";
+      sha256 = "0lqpwwyhgw12iw2pfynb8wb06dqfj26rr55sh1v02nvrxbpzfp0a";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/golang-lru";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/golang-lru";
+      rev = "v0.5.0";
+      sha256 = "12k2cp2k615fjvfa5hyb9k2alian77wivds8s65diwshwv41939f";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/hcl";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/hcl";
+      rev = "v1.0.0";
+      sha256 = "0q6ml0qqs0yil76mpn4mdx4lp94id8vbv575qm60jzl1ijcl5i66";
+    };
+  }
+  {
+    goPackagePath = "github.com/hpcloud/tail";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hpcloud/tail";
+      rev = "v1.0.0";
+      sha256 = "1njpzc0pi1acg5zx9y6vj9xi6ksbsc5d387rd6904hy6rh2m6kn0";
+    };
+  }
+  {
+    goPackagePath = "github.com/inconshreveable/mousetrap";
+    fetch = {
+      type = "git";
+      url = "https://github.com/inconshreveable/mousetrap";
+      rev = "v1.0.0";
+      sha256 = "1mn0kg48xkd74brf48qf5hzp0bc6g8cf5a77w895rl3qnlpfw152";
+    };
+  }
+  {
+    goPackagePath = "github.com/jonboulle/clockwork";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jonboulle/clockwork";
+      rev = "v0.1.0";
+      sha256 = "1pqxhsdavbp1n5grgyx2j6ylvql2fzn2cvpsgkc8li69dil7sibl";
+    };
+  }
+  {
+    goPackagePath = "github.com/json-iterator/go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/json-iterator/go";
+      rev = "v1.1.6";
+      sha256 = "08caswxvdn7nvaqyj5kyny6ghpygandlbw9vxdj7l5vkp7q0s43r";
+    };
+  }
+  {
+    goPackagePath = "github.com/julienschmidt/httprouter";
+    fetch = {
+      type = "git";
+      url = "https://github.com/julienschmidt/httprouter";
+      rev = "v1.2.0";
+      sha256 = "1k8bylc9s4vpvf5xhqh9h246dl1snxrzzz0614zz88cdh8yzs666";
+    };
+  }
+  {
+    goPackagePath = "github.com/konsorten/go-windows-terminal-sequences";
+    fetch = {
+      type = "git";
+      url = "https://github.com/konsorten/go-windows-terminal-sequences";
+      rev = "v1.0.1";
+      sha256 = "1lchgf27n276vma6iyxa0v1xds68n2g8lih5lavqnx5x6q5pw2ip";
+    };
+  }
+  {
+    goPackagePath = "github.com/kr/logfmt";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kr/logfmt";
+      rev = "b84e30acd515";
+      sha256 = "02ldzxgznrfdzvghfraslhgp19la1fczcbzh7wm2zdc6lmpd1qq9";
+    };
+  }
+  {
+    goPackagePath = "github.com/kr/pty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kr/pty";
+      rev = "v1.0.0";
+      sha256 = "1c8xbp4d4fbmvml70nc7w3jii2fxv4q0141d2zmzi480d5h8xvrv";
+    };
+  }
+  {
+    goPackagePath = "github.com/magiconair/properties";
+    fetch = {
+      type = "git";
+      url = "https://github.com/magiconair/properties";
+      rev = "v1.8.0";
+      sha256 = "1a10362wv8a8qwb818wygn2z48lgzch940hvpv81hv8gc747ajxn";
+    };
+  }
+  {
+    goPackagePath = "github.com/mattn/go-colorable";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-colorable";
+      rev = "v0.0.9";
+      sha256 = "1nwjmsppsjicr7anq8na6md7b1z84l9ppnlr045hhxjvbkqwalvx";
+    };
+  }
+  {
+    goPackagePath = "github.com/mattn/go-isatty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-isatty";
+      rev = "v0.0.4";
+      sha256 = "0zs92j2cqaw9j8qx1sdxpv3ap0rgbs0vrvi72m40mg8aa36gd39w";
+    };
+  }
+  {
+    goPackagePath = "github.com/mattn/go-runewidth";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-runewidth";
+      rev = "v0.0.2";
+      sha256 = "0vkrfrz3fzn5n6ix4k8s0cg0b448459sldq8bp4riavsxm932jzb";
     };
   }
   {
@@ -166,8 +562,107 @@
     fetch = {
       type = "git";
       url = "https://github.com/matttproud/golang_protobuf_extensions";
-      rev = "c12348ce28de40eed0136aa2b644d0ee0650e56c";
+      rev = "v1.0.1";
       sha256 = "1d0c1isd2lk9pnfq2nk0aih356j30k3h1gi2w0ixsivi5csl7jya";
+    };
+  }
+  {
+    goPackagePath = "github.com/minio/minio-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/minio/minio-go";
+      rev = "774475480ffe";
+      sha256 = "1rnzvij1cnqb3brwpyv79bdbaa1sgygyw1x84376fli2pj0n3572";
+    };
+  }
+  {
+    goPackagePath = "github.com/mitchellh/go-homedir";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mitchellh/go-homedir";
+      rev = "v1.1.0";
+      sha256 = "0ydzkipf28hwj2bfxqmwlww47khyk6d152xax4bnyh60f4lq3nx1";
+    };
+  }
+  {
+    goPackagePath = "github.com/mitchellh/mapstructure";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mitchellh/mapstructure";
+      rev = "v1.1.2";
+      sha256 = "03bpv28jz9zhn4947saqwi328ydj7f6g6pf1m2d4m5zdh5jlfkrr";
+    };
+  }
+  {
+    goPackagePath = "github.com/modern-go/concurrent";
+    fetch = {
+      type = "git";
+      url = "https://github.com/modern-go/concurrent";
+      rev = "bacd9c7ef1dd";
+      sha256 = "0s0fxccsyb8icjmiym5k7prcqx36hvgdwl588y0491gi18k5i4zs";
+    };
+  }
+  {
+    goPackagePath = "github.com/modern-go/reflect2";
+    fetch = {
+      type = "git";
+      url = "https://github.com/modern-go/reflect2";
+      rev = "v1.0.1";
+      sha256 = "06a3sablw53n1dqqbr2f53jyksbxdmmk8axaas4yvnhyfi55k4lf";
+    };
+  }
+  {
+    goPackagePath = "github.com/mwitkow/go-conntrack";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mwitkow/go-conntrack";
+      rev = "cc309e4a2223";
+      sha256 = "0nbrnpk7bkmqg9mzwsxlm0y8m7s9qd9phr1q30qlx2qmdmz7c1mf";
+    };
+  }
+  {
+    goPackagePath = "github.com/olekukonko/tablewriter";
+    fetch = {
+      type = "git";
+      url = "https://github.com/olekukonko/tablewriter";
+      rev = "a0225b3f23b5";
+      sha256 = "0bp9r6xzy6d3p7l2hjmvr25y3rp3p8c9xv1agkllkksm45ng6681";
+    };
+  }
+  {
+    goPackagePath = "github.com/onsi/ginkgo";
+    fetch = {
+      type = "git";
+      url = "https://github.com/onsi/ginkgo";
+      rev = "v1.7.0";
+      sha256 = "14wgpdrvpc35rdz3859bz53sc1g4vpr1fysy15wy3ff9gmqs14yg";
+    };
+  }
+  {
+    goPackagePath = "github.com/onsi/gomega";
+    fetch = {
+      type = "git";
+      url = "https://github.com/onsi/gomega";
+      rev = "v1.4.3";
+      sha256 = "1c8rqg5i2hz3snmq7s41yar1zjnzilb0fyiyhkg83v97afcfx79v";
+    };
+  }
+  {
+    goPackagePath = "github.com/paulmach/go.geojson";
+    fetch = {
+      type = "git";
+      url = "https://github.com/paulmach/go.geojson";
+      rev = "40612a87147b";
+      sha256 = "037j7apv0jljhvn6vk85nhy0ql862nxr5zbmi6a30qdfclrf2q4k";
+    };
+  }
+  {
+    goPackagePath = "github.com/pelletier/go-toml";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pelletier/go-toml";
+      rev = "v1.2.0";
+      sha256 = "1fjzpcjng60mc3a4b2ql5a00d5gah84wj740dabv9kq67mpg8fxy";
     };
   }
   {
@@ -175,8 +670,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/pkg/errors";
-      rev = "17b591df37844cde689f4d5813e5cea0927d8dd2";
-      sha256 = "1f400f1682h1wdjknlh1ad95rbss09g0ia36a8w102bf2f1qfq8l";
+      rev = "v0.8.1";
+      sha256 = "0g5qcb4d4fd96midz0zdk8b9kz8xkzwfa8kr1cliqbg8sxsy5vd1";
     };
   }
   {
@@ -184,7 +679,7 @@
     fetch = {
       type = "git";
       url = "https://github.com/pkg/profile";
-      rev = "5b67d428864e92711fcbd2f8629456121a56d91f";
+      rev = "v1.2.1";
       sha256 = "0blqmvgqvdbqmh3fp9pfdxc9w1qfshrr0zy9whj0sn372bw64qnr";
     };
   }
@@ -193,7 +688,7 @@
     fetch = {
       type = "git";
       url = "https://github.com/pmezard/go-difflib";
-      rev = "792786c7400a136282c1664665ae0a8db921c6c2";
+      rev = "v1.0.0";
       sha256 = "0c1cn55m4rypmscgf0rrb88pn58j3ysvc2d0432dp3c6fqg6cnzw";
     };
   }
@@ -202,8 +697,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/prometheus/client_golang";
-      rev = "310ce84375bb84c5cbbf0d05069c92daa5673740";
-      sha256 = "11awb5bjkwqj7va3v7fgniwqkjqhmhjkp01rdvnv4xfp1laxwn7v";
+      rev = "v1.0.0";
+      sha256 = "1f03ndyi3jq7zdxinnvzimz3s4z2374r6dikkc8i42xzb6d1bli6";
     };
   }
   {
@@ -211,8 +706,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/prometheus/client_model";
-      rev = "6f3806018612930941127f2a7c6c453ba2c527d2";
-      sha256 = "1413ibprinxhni51p0755dp57r9wvbw7xgj9nmdaxmhzlqhc86j4";
+      rev = "fd36f4220a90";
+      sha256 = "1bs5d72k361llflgl94c22n0w53j30rsfh84smgk8mbjbcmjsaa5";
     };
   }
   {
@@ -220,8 +715,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/prometheus/common";
-      rev = "0866df4b85a18d652b6965be022d007cdf076822";
-      sha256 = "0zw4rxs6zh9vgxz5wwhjnwa6mgac8jh7mb63viircgh08r889chp";
+      rev = "v0.6.0";
+      sha256 = "1q16br348117ffycxdwsldb0i39p34miclfa8z93k6vjwnrqbh2l";
     };
   }
   {
@@ -229,8 +724,98 @@
     fetch = {
       type = "git";
       url = "https://github.com/prometheus/procfs";
-      rev = "e645f4e5aaa8506fc71d6edbc5c4ff02c04c46f2";
-      sha256 = "18hwygbawbqilz7h8fl25xpbciwalkslb4igqn4cr9d8sqp7d3np";
+      rev = "v0.0.2";
+      sha256 = "0s7pvs7fgnfpmym3cd0k219av321h9sf3yvdlnn3qy0ps280lg7k";
+    };
+  }
+  {
+    goPackagePath = "github.com/russross/blackfriday";
+    fetch = {
+      type = "git";
+      url = "https://github.com/russross/blackfriday";
+      rev = "v1.5.2";
+      sha256 = "0jzbfzcywqcrnym4gxlz6nphmm1grg6wsl4f0r9x384rn83wkj7c";
+    };
+  }
+  {
+    goPackagePath = "github.com/sirupsen/logrus";
+    fetch = {
+      type = "git";
+      url = "https://github.com/sirupsen/logrus";
+      rev = "v1.2.0";
+      sha256 = "0r6334x2bls8ddznvzaldx4g88msjjns4mlks95rqrrg7h0ijigg";
+    };
+  }
+  {
+    goPackagePath = "github.com/soheilhy/cmux";
+    fetch = {
+      type = "git";
+      url = "https://github.com/soheilhy/cmux";
+      rev = "v0.1.4";
+      sha256 = "1f736g68d9vwlyfb6g0fxkr0r875369xafk30cz8kaq5niaqwv0h";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/afero";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/afero";
+      rev = "v1.1.2";
+      sha256 = "0miv4faf5ihjfifb1zv6aia6f6ik7h1s4954kcb8n6ixzhx9ck6k";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/cast";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/cast";
+      rev = "v1.3.0";
+      sha256 = "0xq1ffqj8y8h7dcnm0m9lfrh0ga7pssnn2c1dnr09chqbpn4bdc5";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/cobra";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/cobra";
+      rev = "v0.0.5";
+      sha256 = "0z4x8js65mhwg1gf6sa865pdxfgn45c3av9xlcc1l3xjvcnx32v2";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/jwalterweatherman";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/jwalterweatherman";
+      rev = "v1.0.0";
+      sha256 = "093fmmvavv84pv4q84hav7ph3fmrq87bvspjj899q0qsx37yvdr8";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/pflag";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/pflag";
+      rev = "v1.0.3";
+      sha256 = "1cj3cjm7d3zk0mf1xdybh0jywkbbw7a6yr3y22x9sis31scprswd";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/viper";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/viper";
+      rev = "v1.3.2";
+      sha256 = "1829hvf805kda65l59r17wvid7y0vr390s23zfhf4w7vdb4wp3zh";
+    };
+  }
+  {
+    goPackagePath = "github.com/stretchr/objx";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/objx";
+      rev = "v0.1.1";
+      sha256 = "0iph0qmpyqg4kwv8jsx6a56a7hhqq8swrazv40ycxk9rzr0s8yls";
     };
   }
   {
@@ -238,17 +823,17 @@
     fetch = {
       type = "git";
       url = "https://github.com/stretchr/testify";
-      rev = "976c720a22c8eb4eb6a0b4348ad85ad12491a506";
-      sha256 = "0a2gxvqzacrj9k8h022zhr8fchhn9afc6a511m07j71dzw9g4y3m";
+      rev = "v1.3.0";
+      sha256 = "0wjchp2c8xbgcbbq32w3kvblk6q6yn533g78nxl6iskq6y95lxsy";
     };
   }
   {
-    goPackagePath = "github.com/tebeka/snowball";
+    goPackagePath = "github.com/tmc/grpc-websocket-proxy";
     fetch = {
       type = "git";
-      url = "https://github.com/tebeka/snowball";
-      rev = "6b06bd306c4e4442a63e546752278920ae487934";
-      sha256 = "110akijkb55k5h7m6mra8fircvi4sxd5xq7lcjgyiqj96srq8v2k";
+      url = "https://github.com/tmc/grpc-websocket-proxy";
+      rev = "89b8d40f7ca8";
+      sha256 = "1bg6m0cycy5sww175zkbnhi9lvzb08iicc8xka8klrgaa9mc5nsk";
     };
   }
   {
@@ -256,8 +841,107 @@
     fetch = {
       type = "git";
       url = "https://github.com/twpayne/go-geom";
-      rev = "6753ad11e46b04e21b3f286b342e73a8c4be8216";
+      rev = "6753ad11e46b";
       sha256 = "0qyrdnp7j7lmj0qb0p7k45m757zvbwn78s1apiy46zfnb5415df1";
+    };
+  }
+  {
+    goPackagePath = "github.com/ugorji/go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ugorji/go";
+      rev = "e444a5086c43";
+      sha256 = "1ri318sf41fdzhj186dg96pixvlhmk1255ymccc9zfayy3z6li3h";
+    };
+  }
+  {
+    goPackagePath = "github.com/urfave/cli";
+    fetch = {
+      type = "git";
+      url = "https://github.com/urfave/cli";
+      rev = "v1.20.0";
+      sha256 = "0y6f4sbzkiiwrxbl15biivj8c7qwxnvm3zl2dd3mw4wzg4x10ygj";
+    };
+  }
+  {
+    goPackagePath = "github.com/willf/bitset";
+    fetch = {
+      type = "git";
+      url = "https://github.com/willf/bitset";
+      rev = "71fa2377963f";
+      sha256 = "092lpf2qm3zyvm35inam4b7y3kjpvpx7ylkgn31x6wbxfbamp37a";
+    };
+  }
+  {
+    goPackagePath = "github.com/xiang90/probing";
+    fetch = {
+      type = "git";
+      url = "https://github.com/xiang90/probing";
+      rev = "43a291ad63a2";
+      sha256 = "1z22ms16j5j42775mf31isanwx2pwr1d8wqw8006dczjv36qnz5i";
+    };
+  }
+  {
+    goPackagePath = "github.com/xordataexchange/crypt";
+    fetch = {
+      type = "git";
+      url = "https://github.com/xordataexchange/crypt";
+      rev = "b2862e3d0a77";
+      sha256 = "04q3856anpzl4gdfgmg7pbp9cx231nkz3ymq2xp27rnmmwhfxr8y";
+    };
+  }
+  {
+    goPackagePath = "go.etcd.io/bbolt";
+    fetch = {
+      type = "git";
+      url = "https://github.com/etcd-io/bbolt";
+      rev = "v1.3.2";
+      sha256 = "13d5l6p6c5wvkr6vn9hkhz9c593qifn7fgx0hg4d6jcvg1y0bnm2";
+    };
+  }
+  {
+    goPackagePath = "go.etcd.io/etcd";
+    fetch = {
+      type = "git";
+      url = "https://github.com/etcd-io/etcd";
+      rev = "a943ad0ee4c9";
+      sha256 = "1p0s383qw7rdcg2zs5ysk70dkjhpyyqn2qgqgbxdvrv5cjgna1hm";
+    };
+  }
+  {
+    goPackagePath = "go.opencensus.io";
+    fetch = {
+      type = "git";
+      url = "https://github.com/census-instrumentation/opencensus-go";
+      rev = "v0.21.0";
+      sha256 = "14s0a12xdzjvad0dgksgv8m3hh7nc585abvjkvyk6r67a29lxj6x";
+    };
+  }
+  {
+    goPackagePath = "go.uber.org/atomic";
+    fetch = {
+      type = "git";
+      url = "https://github.com/uber-go/atomic";
+      rev = "v1.3.2";
+      sha256 = "11pzvjys5ddjjgrv94pgk9pnip9yyb54z7idf33zk7p7xylpnsv6";
+    };
+  }
+  {
+    goPackagePath = "go.uber.org/multierr";
+    fetch = {
+      type = "git";
+      url = "https://github.com/uber-go/multierr";
+      rev = "v1.1.0";
+      sha256 = "1slfc6syvw8cvr6rbrjsy6ja5w8gsx0f8aq8qm16rp2x5c2pj07w";
+    };
+  }
+  {
+    goPackagePath = "go.uber.org/zap";
+    fetch = {
+      type = "git";
+      url = "https://github.com/uber-go/zap";
+      rev = "v1.9.1";
+      sha256 = "19a1i6fipqj8w7h6qjmg1sfbg18yzzqsgfn0vmr55hkgc0y6nmny";
     };
   }
   {
@@ -265,8 +949,26 @@
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/crypto";
-      rev = "22ddb68eccda408bbf17759ac18d3120ce0d4f3f";
-      sha256 = "07ks6qal02iz24vv54qyb90wmsg9vwqc14abf68rakprpy26qwsg";
+      rev = "c2843e01d9a2";
+      sha256 = "01xgxbj5r79nmisdvpq48zfy8pzaaj90bn6ngd4nf33j9ar1dp8r";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/exp";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/exp";
+      rev = "509febef88a4";
+      sha256 = "02isrh39z8znrp5znplzy0dip2gnrl3jm1355raliyvhnhg04j6q";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/lint";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/lint";
+      rev = "5614ed5bae6f";
+      sha256 = "0fzn0zjv0x92xvfdq3a0v9w5sgkhr7hxkfy9zaqi8i57807z8bnx";
     };
   }
   {
@@ -274,8 +976,26 @@
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/net";
-      rev = "d1e1b351919c6738fdeb9893d5c998b161464f0c";
-      sha256 = "0qzbfah03z992zyygfp7imjjas5np2gcar5aanx5y3av5g68ggjp";
+      rev = "da137c7871d7";
+      sha256 = "1qsiyr3irmb6ii06hivm9p2c7wqyxczms1a9v1ss5698yjr3fg47";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/oauth2";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/oauth2";
+      rev = "e64efc72b421";
+      sha256 = "0djvwz2avx7knsjbl434vw1wqbrg53xp1kh599gfixn5icrggz4m";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sync";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sync";
+      rev = "e225da77a7e6";
+      sha256 = "0bh3583smcfw6jw3w6lp0za93rz7hpxfdz8vhxng75b7a6vdlw4p";
     };
   }
   {
@@ -283,8 +1003,8 @@
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/sys";
-      rev = "abf9c25f54453410d0c6668e519582a9e1115027";
-      sha256 = "0dmpqjfif2zg6776d366js60k21g81jvsr3jm9dc7fv7w3282al4";
+      rev = "04f50cda93cb";
+      sha256 = "0hmfsz9y1ingwsn482hlzzmzs7kr3cklm0ana0mbdk70isw2bxnw";
     };
   }
   {
@@ -292,8 +1012,44 @@
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/text";
-      rev = "1cbadb444a806fd9430d14ad08967ed91da4fa0a";
-      sha256 = "0ih9ysagh4ylj08393497sscf3yziybc6acg4mrh0wa7mld75j56";
+      rev = "v0.3.0";
+      sha256 = "0r6x6zjzhr8ksqlpiwm5gdd7s209kwk5p4lw54xjvz10cs3qlq19";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/time";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/time";
+      rev = "fbb02b2291d2";
+      sha256 = "0jjqcv6rzihlgg4i797q80g1f6ch5diz2kxqh6488gwkb6nds4h4";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/tools";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/tools";
+      rev = "e65039ee4138";
+      sha256 = "0c094599cf70wdrms49a3879qkq122pqlp2av444gs2pvc8apdcx";
+    };
+  }
+  {
+    goPackagePath = "google.golang.org/api";
+    fetch = {
+      type = "git";
+      url = "https://code.googlesource.com/google-api-go-client";
+      rev = "v0.3.2";
+      sha256 = "1x1nbsd3gjgmv833gpgq79m5d15p31k1dfn8gglkvjanjiin747j";
+    };
+  }
+  {
+    goPackagePath = "google.golang.org/appengine";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/appengine";
+      rev = "v1.4.0";
+      sha256 = "06zl7w4sxgdq2pl94wy9ncii6h0z3szl4xpqds0sv3b3wbdlhbnn";
     };
   }
   {
@@ -301,8 +1057,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/google/go-genproto";
-      rev = "1e559d0a00eef8a9a43151db4665280bd8dd5886";
-      sha256 = "1dfm8zd9mif1aswks79wgyi7n818s5brbdnnrrlg79whfhaf20hd";
+      rev = "5fe7a883aa19";
+      sha256 = "0qjkwig0r42q0j2qv57s4ahsgmmp41dz3ih3rnaqg0619n5w7lbs";
     };
   }
   {
@@ -310,8 +1066,71 @@
     fetch = {
       type = "git";
       url = "https://github.com/grpc/grpc-go";
-      rev = "f92cdcd7dcdc69e81b2d7b338479a19a8723cfa3";
-      sha256 = "1li8rn2s4f8qc77npamlm2ijin44scb8vvd8c4cr0l7za2m89jfn";
+      rev = "v1.19.0";
+      sha256 = "1znqwpj7ix3dpzx4zch0q70sdl3z5lvbb7v3q4i8sf8kas3yv71v";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/airbrake/gobrake.v2";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/airbrake/gobrake.v2";
+      rev = "v2.0.9";
+      sha256 = "1x06f7n7qlyzqgyz0sdfcidf3w4ldn6zs6qx2mhibggk2z4whcjw";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/alecthomas/kingpin.v2";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/alecthomas/kingpin.v2";
+      rev = "v2.2.6";
+      sha256 = "0mndnv3hdngr3bxp7yxfd47cas4prv98sqw534mx7vp38gd88n5r";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/check.v1";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/check.v1";
+      rev = "20d25e280405";
+      sha256 = "0k1m83ji9l1a7ng8a7v40psbymxasmssbrrhpdv2wl4rhs0nc3np";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/cheggaaa/pb.v1";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/cheggaaa/pb.v1";
+      rev = "v1.0.25";
+      sha256 = "0vxqiw6f3xyv0zy3g4lksf8za0z8i0hvfpw92hqimsy84f79j3dp";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/fsnotify.v1";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/fsnotify.v1";
+      rev = "v1.4.7";
+      sha256 = "07va9crci0ijlivbb7q57d2rz9h27zgn2fsm60spjsqpdbvyrx4g";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/gemnasium/logrus-airbrake-hook.v2";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/gemnasium/logrus-airbrake-hook.v2";
+      rev = "v2.1.2";
+      sha256 = "0sbg0dn6cysmf8f2bi209jwl4jnpiwp4rdghnxlzirw3c32ms5y5";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/tomb.v1";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/tomb.v1";
+      rev = "dd632973f1e7";
+      sha256 = "1lqmq1ag7s4b3gc3ddvr792c5xb5k6sfn0cchr3i2s7f1c231zjv";
     };
   }
   {
@@ -319,8 +1138,17 @@
     fetch = {
       type = "git";
       url = "https://gopkg.in/yaml.v2";
-      rev = "a5b47d31c556af34a302ce5d659e6fea44d90de0";
-      sha256 = "0v6l48fshdjrqzyq1kwn22gy7vy434xdr1i0lm3prsf6jbln9fam";
+      rev = "v2.2.2";
+      sha256 = "01wj12jzsdqlnidpyjssmj0r4yavlqy7dwrg7adqd8dicjc4ncsa";
+    };
+  }
+  {
+    goPackagePath = "honnef.co/go/tools";
+    fetch = {
+      type = "git";
+      url = "https://github.com/dominikh/go-tools";
+      rev = "c2f93a96b099";
+      sha256 = "07lg29aiap80ca9f201jzng9vjr168cv3qmvjmbd7v5pmww9kmr8";
     };
   }
 ]


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
dgraph: 0.8.2 -> 1.0.17

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
