### PR TITLE
bat: 0.11.0 -> 0.12.0

### DIFF
--- a/pkgs/tools/misc/bat/default.nix
+++ b/pkgs/tools/misc/bat/default.nix
@@ -1,24 +1,26 @@
-{ stdenv, rustPlatform, fetchFromGitHub, cmake, pkgconfig, zlib
+{ stdenv, rustPlatform, fetchFromGitHub, llvmPackages, pkgconfig, zlib
 , Security, libiconv
 }:
 
 rustPlatform.buildRustPackage rec {
   pname   = "bat";
-  version = "0.11.0";
+  version = "0.12.0";
 
   src = fetchFromGitHub {
     owner  = "sharkdp";
     repo   = pname;
     rev    = "v${version}";
-    sha256 = "0yyvlplskjvxb2cspqsvfsnahd5m0s83psrp777ng0wc0kr1adbw";
+    sha256 = "07qxghplqq8km4kp9zas2acw302a77y72x3ix1272kb1zxhw4as6";
     fetchSubmodules = true;
   };
 
-  cargoSha256 = "078n31c0isvxvna0s1m12xv4bkh15rb2nixfyg4c501mlkalb517";
+  cargoSha256 = "0j9wxv21a91yfvbbvgn5ms5zi1aipj1k2g42mfdvvw2vsdzqagxz";
 
-  nativeBuildInputs = [ cmake pkgconfig zlib ];
+  nativeBuildInputs = [ pkgconfig llvmPackages.libclang zlib ];
 
   buildInputs = stdenv.lib.optionals stdenv.isDarwin [ Security libiconv ];
+
+  LIBCLANG_PATH = "${llvmPackages.libclang}/lib";
 
   postInstall = ''
     install -m 444 -Dt $out/share/man/man1 doc/bat.1


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
https://github.com/sharkdp/bat/releases/tag/v0.12.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @lilyball
