### PR TITLE
gnomeExtensions.wsmatrix:  new package

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/wsmatrix.nix
+++ b/pkgs/desktops/gnome-3/extensions/wsmatrix.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, glib }:
+
+stdenv.mkDerivation rec {
+  name = "gnome-shell-wsmatrix-${version}";
+  version = "9543a73df7bac9476f8adeba9d7a14fdacb57b7d";
+
+  src = fetchFromGitHub {
+    owner = "mzur";
+    repo = "gnome-shell-wsmatrix";
+    rev = version;
+    sha256 = "0x5y91pj2pg25pq3a2p05lsyafyg950b4nc1zc5glmsc7s42zzkw";
+  };
+
+  buildInputs = [
+    glib
+  ];
+
+  buildPhase = ''
+    make schemas
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share/gnome-shell/extensions
+    cp -r ${uuid} $out/share/gnome-shell/extensions/${uuid}
+  '';
+
+  uuid = "wsmatrix@martin.zurowietz.de";
+
+  meta = with stdenv.lib; {
+    description = "Arranges workspaces in a configurable grid";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ deepfire ];
+    homepage = https://github.com/mzur/gnome-shell-wsmatrix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22650,6 +22650,7 @@ in
     timepp = callPackage ../desktops/gnome-3/extensions/timepp { };
     topicons-plus = callPackage ../desktops/gnome-3/extensions/topicons-plus { };
     window-corner-preview = callPackage ../desktops/gnome-3/extensions/window-corner-preview { };
+    wsmatrix = callPackage ../desktops/gnome-3/extensions/wsmatrix.nix { };
   };
 
   hsetroot = callPackage ../tools/X11/hsetroot { };


### PR DESCRIPTION
Add the wsmatrix extension to Ghome Shell (compatible with v3.32):

- https://extensions.gnome.org/extension/1485/workspace-matrix/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
