### PR TITLE
nixos/prometheus-exporters: fix user generation

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -132,14 +132,10 @@ let
     in
     mkIf conf.enable {
       warnings = conf.warnings or [];
-      users.users = (mkIf (conf.user == "${name}-exporter" && !enableDynamicUser) {
-        "${name}-exporter" = {
-          description = ''
-            Prometheus ${name} exporter service user
-          '';
-          isSystemUser = true;
-          inherit (conf) group;
-        };
+      users.users."${name}-exporter" = (mkIf (conf.user == "${name}-exporter" && !enableDynamicUser) {
+        description = "Prometheus ${name} exporter service user";
+        isSystemUser = true;
+        inherit (conf) group;
       });
       users.groups = (mkIf (conf.group == "${name}-exporter" && !enableDynamicUser) {
         "${name}-exporter" = {};


### PR DESCRIPTION
###### Motivation for this change
fixes #67874

##### Things done
The first of the two/three faulty lines was produced by using
```
users.users = mkIf ..
```
instead of
```
users.users.<name> = mkIf ...
```

The second was caused by the use of a multiline string for the user description, which produced a trailing newline in the decription and therefore the second error in /etc/passwd.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).