### PR TITLE
onboard: Fix gobject-introspection

### DIFF
--- a/pkgs/applications/misc/onboard/default.nix
+++ b/pkgs/applications/misc/onboard/default.nix
@@ -91,6 +91,7 @@ in python3.pkgs.buildPythonApplication rec {
     wrapGAppsHook
     xorg.libXtst
     xorg.libxkbfile
+    gobject-introspection # Temporary fix, see https://github.com/NixOS/nixpkgs/issues/56943
   ] ++ stdenv.lib.optional atspiSupport at-spi2-core;
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/56943

Onboard was not working under `xmonad` (AFAIK it works fine under `gnome`).

Fixed as per ticket #56943 by adding `gobject-introspection` to `buildInputs` (it's already in `nativeBuildInputs`.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @johnramsden
