### PR TITLE
pythonPackages.pybind11: enable tests

### DIFF
--- a/pkgs/development/python-modules/pybind11/default.nix
+++ b/pkgs/development/python-modules/pybind11/default.nix
@@ -1,12 +1,24 @@
-{ lib, buildPythonPackage, fetchPypi, fetchpatch }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, python
+, pytest
+, cmake
+, numpy ? null
+, eigen ? null
+, scipy ? null
+}:
 
 buildPythonPackage rec {
   pname = "pybind11";
   version = "2.3.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "0923ngd2cvck3lhl7584y08n36pm6zqihfm1s69sbdc11xg936hr";
+  src = fetchFromGitHub {
+    owner = "pybind";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "11b6dniri8m05spfd2a19irz82shf4sdca73566bniggrf3zclnf";
   };
 
   patches = [
@@ -14,10 +26,21 @@ buildPythonPackage rec {
       url = https://github.com/pybind/pybind11/commit/44a40dd61e5178985cfb1150cf05e6bfcec73042.patch;
       sha256 = "047nzyfsihswdva96hwchnp4gj2mlbiqvmkdnhxrfi9sji8x31ka";
     })
+    (fetchpatch {
+      name = "pytest-4-excinfo-fix.patch";
+      url = https://github.com/pybind/pybind11/commit/9fd4712121fdbb6202a35be4c788525e6c8ab826.patch;
+      sha256 = "07jjv8jlbszvr2grpm5xqxjac7jb0y68lgb1jcbb93k9vyp1hr33";
+    })
   ];
 
-  # Current PyPi version does not include test suite
-  doCheck = false;
+  checkInputs = [ pytest cmake ]
+    ++ (lib.optional (numpy != null) numpy)
+    ++ (lib.optional (eigen != null) eigen)
+    ++ (lib.optional (scipy != null) scipy);
+  checkPhase = ''
+    cmake ${if eigen != null then "-DEIGEN3_INCLUDE_DIR=${eigen}/include/eigen3" else ""}
+    make -j $NIX_BUILD_CORES pytest
+  '';
 
   meta = {
     homepage = https://github.com/pybind/pybind11;


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
