### PR TITLE
rss2email: 3.9 -> 3.10

### DIFF
--- a/nixos/modules/services/mail/rss2email.nix
+++ b/nixos/modules/services/mail/rss2email.nix
@@ -43,9 +43,8 @@ in {
           <literal>[DEFAULT]</literal> block along with the
           <literal>to</literal> parameter.
 
-          See
-          <literal>https://github.com/rss2email/rss2email/blob/master/r2e.1</literal>
-          for more information on which parameters are accepted.
+          See <literal>man r2e</literal> for more information on which
+          parameters are accepted.
         '';
       };
 

--- a/pkgs/applications/networking/feedreaders/rss2email/default.nix
+++ b/pkgs/applications/networking/feedreaders/rss2email/default.nix
@@ -4,15 +4,13 @@ with pythonPackages;
 
 buildPythonApplication rec {
   pname = "rss2email";
-  version = "3.9"; # TODO: on next bump, the manpage will be updated.
-  # Update nixos/modules/services/mail/rss2email.nix to point to it instead of
-  # to the online r2e.1
+  version = "3.10";
 
   propagatedBuildInputs = [ feedparser beautifulsoup4 html2text ];
 
   src = fetchurl {
     url = "mirror://pypi/r/rss2email/${pname}-${version}.tar.gz";
-    sha256 = "02wj9zhmc2ym8ba1i0z9pm1c622z2fj7fxwagnxbvpr1402ahmr5";
+    sha256 = "1yjgbgpq9jjmpywwk6n4lzb2k7mqgdgfgm4jckv4zy0fn595pih1";
   };
 
   outputs = [ "out" "man" "doc" ];
@@ -30,14 +28,12 @@ buildPythonApplication rec {
 
     # copy documentation
     mkdir -p $doc/share/doc/rss2email
-    cp AUTHORS COPYING CHANGELOG README $doc/share/doc/rss2email/
+    cp AUTHORS COPYING CHANGELOG README.rst $doc/share/doc/rss2email/
   '';
 
-  # The tests currently fail, see
-  # https://github.com/rss2email/rss2email/issues/14
-  # postCheck = ''
-  #   env PYTHONPATH=.:$PYTHONPATH python ./test/test.py
-  # '';
+  postCheck = ''
+    env PATH=$out/bin:$PATH python ./test/test.py
+  '';
 
   meta = with lib; {
     description = "A tool that converts RSS/Atom newsfeeds to email.";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Profpatsch 

@GrahamcOfBorg build rss2email nixosTests.rss2email
