### PR TITLE
mxisd: 1.4.5 -> 1.4.6 ☺ ma1sd: init at 2.1.1

### DIFF
--- a/nixos/modules/services/networking/mxisd.nix
+++ b/nixos/modules/services/networking/mxisd.nix
@@ -3,6 +3,15 @@
 with lib;
 
 let
+
+  isMa1sd =
+    package:
+    lib.hasPrefix "ma1sd" package.name;
+
+  isMxisd =
+    package:
+    lib.hasPrefix "mxisd" package.name;
+
   cfg = config.services.mxisd;
 
   server = optionalAttrs (cfg.server.name != null) { inherit (cfg.server) name; }
@@ -12,37 +21,41 @@ let
     matrix.domain = cfg.matrix.domain;
     key.path = "${cfg.dataDir}/signing.key";
     storage = {
-      provider.sqlite.database = "${cfg.dataDir}/mxisd.db";
+      provider.sqlite.database = if isMa1sd cfg.package
+                                 then "${cfg.dataDir}/ma1sd.db"
+                                 else "${cfg.dataDir}/mxisd.db";
     };
   } // optionalAttrs (server != {}) { inherit server; };
 
   # merges baseConfig and extraConfig into a single file
   fullConfig = recursiveUpdate baseConfig cfg.extraConfig;
 
-  configFile = pkgs.writeText "mxisd-config.yaml" (builtins.toJSON fullConfig);
+  configFile = if isMa1sd cfg.package
+               then pkgs.writeText "ma1sd-config.yaml" (builtins.toJSON fullConfig)
+               else pkgs.writeText "mxisd-config.yaml" (builtins.toJSON fullConfig);
 
 in {
   options = {
     services.mxisd = {
-      enable = mkEnableOption "mxisd matrix federated identity server";
+      enable = mkEnableOption "matrix federated identity server";
 
       package = mkOption {
         type = types.package;
         default = pkgs.mxisd;
         defaultText = "pkgs.mxisd";
-        description = "The mxisd package to use";
+        description = "The mxisd/ma1sd package to use";
       };
 
       dataDir = mkOption {
         type = types.str;
         default = "/var/lib/mxisd";
-        description = "Where data mxisd uses resides";
+        description = "Where data mxisd/ma1sd uses resides";
       };
 
       extraConfig = mkOption {
         type = types.attrs;
         default = {};
-        description = "Extra options merged into the mxisd configuration";
+        description = "Extra options merged into the mxisd/ma1sd configuration";
       };
 
       matrix = {
@@ -62,7 +75,7 @@ in {
           type = types.nullOr types.str;
           default = null;
           description = ''
-            Public hostname of mxisd, if different from the Matrix domain.
+            Public hostname of mxisd/ma1sd, if different from the Matrix domain.
           '';
         };
 
@@ -103,11 +116,13 @@ in {
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
 
-      serviceConfig = {
+      serviceConfig = let
+        executable = if isMa1sd cfg.package then "ma1sd" else "mxisd";
+      in {
         Type = "simple";
         User = "mxisd";
         Group = "mxisd";
-        ExecStart = "${cfg.package}/bin/mxisd -c ${configFile}";
+        ExecStart = "${cfg.package}/bin/${executable} -c ${configFile}";
         WorkingDirectory = cfg.dataDir;
         Restart = "on-failure";
       };

--- a/nixos/tests/mxisd.nix
+++ b/nixos/tests/mxisd.nix
@@ -10,12 +10,22 @@ import ./make-test.nix ({ pkgs, ... } : {
       services.mxisd.enable = true;
       services.mxisd.matrix.domain = "example.org";
     };
+
+    server_ma1sd = args : {
+      services.mxisd.enable = true;
+      services.mxisd.matrix.domain = "example.org";
+      services.mxisd.package = pkgs.ma1sd;
+    };
   };
 
   testScript = ''
     startAll;
     $server_mxisd->waitForUnit("mxisd.service");
     $server_mxisd->waitForOpenPort(8090);
-    $server_mxisd->succeed("curl -Ssf \"http://127.0.0.1:8090/_matrix/identity/api/v1\"")
+    $server_mxisd->succeed("curl -Ssf \"http://127.0.0.1:8090/_matrix/identity/api/v1\"");
+    $server_ma1sd->waitForUnit("mxisd.service");
+    $server_ma1sd->waitForOpenPort(8090);
+    $server_ma1sd->succeed("curl -Ssf \"http://127.0.0.1:8090/_matrix/identity/api/v1\"")
+
   '';
 })

--- a/pkgs/servers/ma1sd/0001-gradle.patch
+++ b/pkgs/servers/ma1sd/0001-gradle.patch
@@ -1,0 +1,20 @@
+--- a/build.gradle	2019-09-01 16:17:17.815513296 +0200
++++ b/build.gradle	2019-09-01 16:21:14.688832785 +0200
+@@ -73,7 +73,7 @@
+ 
+ buildscript {
+     repositories {
+-        jcenter()
++REPLACE
+     }
+ 
+     dependencies {
+@@ -83,7 +83,7 @@
+ }
+ 
+ repositories {
+-    jcenter()
++REPLACE
+ }
+ 
+ dependencies {

--- a/pkgs/servers/ma1sd/default.nix
+++ b/pkgs/servers/ma1sd/default.nix
@@ -1,0 +1,70 @@
+{ stdenv, fetchFromGitHub, jre, git, gradle_5, perl, makeWrapper }:
+
+let
+  name = "ma1sd-${version}";
+  version = "2.1.1";
+  rev = "a112a5e57cb38ad282939d2dcb9c1476e038af39";
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "ma1uta";
+    repo = "ma1sd";
+    sha256 = "1qibn6m6mvxwnbiypxlgkaqg6in358vkf0q47410rv1dx1gjcnv5";
+  };
+
+
+  deps = stdenv.mkDerivation {
+    name = "${name}-deps";
+    inherit src;
+    nativeBuildInputs = [ gradle_5 perl git ];
+
+    buildPhase = ''
+      export MA1SD_BUILD_VERSION=${rev}
+      export GRADLE_USER_HOME=$(mktemp -d);
+      gradle --no-daemon build -x test
+    '';
+
+    # perl code mavenizes pathes (com.squareup.okio/okio/1.13.0/a9283170b7305c8d92d25aff02a6ab7e45d06cbe/okio-1.13.0.jar -> com/squareup/okio/okio/1.13.0/okio-1.13.0.jar)
+    installPhase = ''
+      find $GRADLE_USER_HOME/caches/modules-2 -type f -regex '.*\.\(jar\|pom\)' \
+        | perl -pe 's#(.*/([^/]+)/([^/]+)/([^/]+)/[0-9a-f]{30,40}/([^/\s]+))$# ($x = $2) =~ tr|\.|/|; "install -Dm444 $1 \$out/$x/$3/$4/$5" #e' \
+        | sh
+    '';
+
+    dontStrip = true;
+
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+    outputHash = "1w9cxq0rlzyh7bzqr3v3vn2cjhpn7hhc5lk9qzwj7sdj4jn2qxq6";
+  };
+
+in
+stdenv.mkDerivation {
+  inherit name src version;
+  nativeBuildInputs = [ gradle_5 perl makeWrapper ];
+  buildInputs = [ jre ];
+
+  patches = [ ./0001-gradle.patch ];
+
+  buildPhase = ''
+    export MA1SD_BUILD_VERSION=${rev}
+    export GRADLE_USER_HOME=$(mktemp -d)
+
+    sed -ie "s#REPLACE#mavenLocal(); maven { url '${deps}' }#g" build.gradle
+    gradle --offline --no-daemon build -x test
+  '';
+
+  installPhase = ''
+    install -D build/libs/source.jar $out/lib/ma1sd.jar
+    makeWrapper ${jre}/bin/java $out/bin/ma1sd --add-flags "-jar $out/lib/ma1sd.jar"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "a federated matrix identity server; fork of mxisd";
+    homepage = https://github.com/ma1uta/ma1sd;
+    license = licenses.agpl3;
+    maintainers = with maintainers; [ mguentner ];
+    platforms = platforms.all;
+  };
+
+}

--- a/pkgs/servers/mxisd/default.nix
+++ b/pkgs/servers/mxisd/default.nix
@@ -2,14 +2,14 @@
 
 let
   name = "mxisd-${version}";
-  version = "1.4.5";
-  rev = "a964b073bfa7552e94fe51f48e18830b1051b0b7";
+  version = "1.4.6";
+  rev = "6e9601cb3a18281857c3cefd20ec773023b577d2";
 
   src = fetchFromGitHub {
     inherit rev;
     owner = "kamax-matrix";
     repo = "mxisd";
-    sha256 = "1h1lx531rjswh0m2zdsmfizrkkx9bh414v9m321hbbfzk3f98fkk";
+    sha256 = "07gpdgbz281506p2431qn92bvdza6ap3jfq5b7xdm7nwrry80pzd";
   };
 
 

--- a/pkgs/servers/mxisd/default.nix
+++ b/pkgs/servers/mxisd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, jre, git, gradle_4_10, perl, makeWrapper }:
+{ stdenv, fetchFromGitHub, jre, git, gradle_4, perl, makeWrapper }:
 
 let
   name = "mxisd-${version}";
@@ -16,7 +16,7 @@ let
   deps = stdenv.mkDerivation {
     name = "${name}-deps";
     inherit src;
-    nativeBuildInputs = [ gradle_4_10 perl git ];
+    nativeBuildInputs = [ gradle_4 perl git ];
 
     buildPhase = ''
       export MXISD_BUILD_VERSION=${rev}
@@ -41,7 +41,7 @@ let
 in
 stdenv.mkDerivation {
   inherit name src version;
-  nativeBuildInputs = [ gradle_4_10 perl makeWrapper ];
+  nativeBuildInputs = [ gradle_4 perl makeWrapper ];
   buildInputs = [ jre ];
 
   patches = [ ./0001-gradle.patch ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4331,6 +4331,8 @@ in
 
   kzipmix = pkgsi686Linux.callPackage ../tools/compression/kzipmix { };
 
+  ma1sd = callPackage ../servers/ma1sd { };
+
   mailcatcher = callPackage ../development/web/mailcatcher { };
 
   makebootfat = callPackage ../tools/misc/makebootfat { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

mxisd is now EOL: https://github.com/kamax-matrix/mxisd/blob/master/EOL.md
@ma1uta forked to https://github.com/ma1uta/ma1sd, NixOS supports both :champagne: :tada: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).