### PR TITLE
release-notes: add altcoins removal note

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1909.xml
+++ b/nixos/doc/manual/release-notes/rl-1909.xml
@@ -628,6 +628,14 @@
      </itemizedlist>
     </para>
    </listitem>
+   <listitem>
+     <para>
+       The <literal>altcoins</literal> categorization of packages has
+       been removed. You now access these packages at the top level,
+       ie. <literal>nix-shell -p dogecoin</literal> instead of
+       <literal>nix-shell -p altcoins.dogecoin</literal>, etc.
+     </para>
+   </listitem>
   </itemizedlist>
  </section>
 </section>


### PR DESCRIPTION
Release notes for #67687 (bc08b42da4dbdc1c66385bab7a2eae2935e055c0) [1]
Related issue: #25025 [2]

[1] https://github.com/NixOS/nixpkgs/issues/67687
[2] https://github.com/NixOS/nixpkgs/issues/25025

Suggested-by: @mmahut
Signed-off-by: William Casarin <jb55@jb55.com>

###### Motivation for this change
Release notes for altcoins removal

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @mmahut 
