### PR TITLE
nvidia module: set LD_LIBRARY_PATH

### DIFF
--- a/nixos/modules/hardware/video/nvidia.nix
+++ b/nixos/modules/hardware/video/nvidia.nix
@@ -176,6 +176,8 @@ in
 
     hardware.opengl.package = nvidia_x11.out;
     hardware.opengl.package32 = nvidia_libs32;
+    # Needed for libcuda.so, which is CUDA driver.
+    hardware.opengl.setLdLibraryPath = true;
 
     environment.systemPackages = [ nvidia_x11.bin nvidia_x11.settings ]
       ++ lib.filter (p: p != null) [ nvidia_x11.persistenced ];

--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -2,7 +2,7 @@
 , ilmbase, libXi, libX11, libXext, libXrender
 , libjpeg, libpng, libsamplerate, libsndfile
 , libtiff, libGLU_combined, openal, opencolorio, openexr, openimageio, openjpeg_1, python3Packages
-, zlib, fftw, opensubdiv, freetype, jemalloc, ocl-icd, addOpenGLRunpath
+, zlib, fftw, opensubdiv, freetype, jemalloc, ocl-icd
 , jackaudioSupport ? false, libjack2
 , cudaSupport ? config.cudaSupport or false, cudatoolkit
 , colladaSupport ? true, opencollada
@@ -22,7 +22,8 @@ stdenv.mkDerivation rec {
     sha256 = "1h550jisdbis50hxwk5kxrvrk1a6sh2fsri3yyj66vhzbi87x7fd";
   };
 
-  nativeBuildInputs = [ cmake ] ++ optional cudaSupport addOpenGLRunpath;
+  nativeBuildInputs = [ cmake ];
+
   buildInputs =
     [ boost ffmpeg gettext glew ilmbase
       libXi libX11 libXext libXrender
@@ -74,15 +75,6 @@ stdenv.mkDerivation rec {
       wrapProgram $out/bin/blender \
         --prefix PYTHONPATH : ${python3Packages.numpy}/${python.sitePackages}
     '';
-
-  # Set RUNPATH so that libcuda and libnvrtc in /run/opengl-driver(-32)/lib can be
-  # found. See the explanation in libglvnd.
-  postFixup = optionalString cudaSupport ''
-    for program in $out/bin/blender $out/bin/.blender-wrapped; do
-      isELF "$program" || continue
-      addOpenGLRunpath "$program"
-    done
-  '';
 
   meta = with stdenv.lib; {
     description = "3D Creation/Animation/Publishing System";

--- a/pkgs/development/compilers/cudatoolkit/default.nix
+++ b/pkgs/development/compilers/cudatoolkit/default.nix
@@ -1,7 +1,6 @@
 { lib, stdenv, makeWrapper, fetchurl, requireFile, perl, ncurses5, expat, python27, zlib
 , gcc48, gcc49, gcc5, gcc6, gcc7
 , xorg, gtk2, gdk-pixbuf, glib, fontconfig, freetype, unixODBC, alsaLib, glibc
-, addOpenGLRunpath
 }:
 
 let
@@ -40,7 +39,7 @@ let
 
       outputs = [ "out" "lib" "doc" ];
 
-      nativeBuildInputs = [ perl makeWrapper addOpenGLRunpath ];
+      nativeBuildInputs = [ perl makeWrapper ];
       buildInputs = [ gdk-pixbuf ]; # To get $GDK_PIXBUF_MODULE_FILE via setup-hook
       runtimeDependencies = [
         ncurses5 expat python zlib glibc
@@ -146,15 +145,6 @@ let
           fi
           patchelf --set-rpath "$rpath2" --force-rpath $i
         done < <(find $out $lib $doc -type f -print0)
-      '';
-
-      # Set RPATH so that libcuda and other libraries in
-      # /run/opengl-driver(-32)/lib can be found. See the explanation in
-      # addOpenGLRunpath.  Don't try to figure out which libraries really need
-      # it, just patch all (but not the stubs libraries). Note that
-      # --force-rpath prevents changing RPATH (set above) to RUNPATH.
-      postFixup = ''
-        addOpenGLRunpath --force-rpath {$out,$lib}/lib/lib*.so
       '';
 
       # cuda-gdb doesn't run correctly when not using sandboxing, so

--- a/pkgs/development/libraries/science/math/cudnn/generic.nix
+++ b/pkgs/development/libraries/science/math/cudnn/generic.nix
@@ -7,7 +7,6 @@
 , lib
 , cudatoolkit
 , fetchurl
-, addOpenGLRunpath
 }:
 
 stdenv.mkDerivation rec {
@@ -20,8 +19,6 @@ stdenv.mkDerivation rec {
     inherit sha256;
   };
 
-  nativeBuildInputs = [ addOpenGLRunpath ];
-
   installPhase = ''
     function fixRunPath {
       p=$(patchelf --print-rpath $1)
@@ -32,12 +29,6 @@ stdenv.mkDerivation rec {
     mkdir -p $out
     cp -a include $out/include
     cp -a lib64 $out/lib64
-  '';
-
-  # Set RUNPATH so that libcuda in /run/opengl-driver(-32)/lib can be found.
-  # See the explanation in addOpenGLRunpath.
-  postFixup = ''
-    addOpenGLRunpath $out/lib/lib*.so
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/libraries/science/math/nccl/default.nix
+++ b/pkgs/development/libraries/science/math/nccl/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, which, cudatoolkit, addOpenGLRunpath }:
+{ stdenv, fetchFromGitHub, which, cudatoolkit }:
 
 stdenv.mkDerivation rec {
   name = "nccl-${version}-cuda-${cudatoolkit.majorVersion}";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  nativeBuildInputs = [ which addOpenGLRunpath ];
+  nativeBuildInputs = [ which ];
 
   buildInputs = [ cudatoolkit ];
 
@@ -28,10 +28,6 @@ stdenv.mkDerivation rec {
 
   postFixup = ''
     moveToOutput lib/libnccl_static.a $dev
-
-    # Set RUNPATH so that libnvidia-ml in /run/opengl-driver(-32)/lib can be found.
-    # See the explanation in addOpenGLRunpath.
-    addOpenGLRunpath $out/lib/lib*.so
   '';
 
   NIX_CFLAGS_COMPILE = [ "-Wno-unused-function" ];


### PR DESCRIPTION
It's needed for CUDA driver, which applications are supposed to dlopen() and
which is a driver version-dependent.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Tested on Tensorflow which works now. I'll merge in several days unless there are better ideas.
