### PR TITLE
wlrobs: init at tip

### DIFF
--- a/pkgs/applications/video/obs-studio/wlrobs.nix
+++ b/pkgs/applications/video/obs-studio/wlrobs.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchhg, obs-studio, wayland }:
+
+stdenv.mkDerivation rec {
+  pname = "wlrobs-unstable";
+  version = "2019-08-21";
+  src = fetchhg {
+    url = "https://hg.sr.ht/~scoopta/wlrobs";
+    rev = "82e2b93c6f662dfd9d69f7826c0096bef585c3ae";
+    sha256 = "1d2mlybkwyr0jw6paamazla2a1cyj60bs10i0lk9jclxnp780fy6";
+  };
+  buildInputs = [ obs-studio wayland ];
+  sourceRoot = "hg-archive/Release";
+  installPhase = ''
+    PLUGIN_FOLDER="$out/share/obs/obs-plugins/wlrobs/bin/64bit"
+    mkdir -p "$PLUGIN_FOLDER"
+    install libwlrobs.so "$PLUGIN_FOLDER"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "OBS capture plugin for wlroots-based compositors like Sway";
+    longDescription = ''
+      wlrobs is an OBS Studio plugin for capturing the screen under
+      wlroots-based Wayland compositors such as Sway.
+
+      There is not a wrapper which can supply obs-studio plugins so you have
+      to install the plugin somewhat manually:
+
+      nix-env -iA nixos.wlrobs
+      mkdir -p ~/.config/obs-studio/plugins
+      ln -s ~/.nix-profile/share/obs/obs-plugins/wlrobs ~/.config/obs-studio/plugins/
+    '';
+    homepage = "https://hg.sr.ht/~scoopta/wlrobs";
+    maintainers = with maintainers; [ jchw ];
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2832,6 +2832,8 @@ in
 
   wev = callPackage ../tools/misc/wev { };
 
+  wlrobs = callPackage ../applications/video/obs-studio/wlrobs.nix { };
+
   wl-clipboard = callPackage ../tools/misc/wl-clipboard { };
 
   z-lua = callPackage ../tools/misc/z-lua { };


### PR DESCRIPTION
###### Motivation for this change
Allows OBS to capture the screen under some Wayland compositors. Tries to follow the pattern closely from the `linuxbrowser` plugin, including the comment at the top of the file.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
