### PR TITLE
pgformatter: init at 4.0

### DIFF
--- a/pkgs/development/tools/pgformatter/default.nix
+++ b/pkgs/development/tools/pgformatter/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, perlPackages, fetchFromGitHub, shortenPerlShebang }:
+
+perlPackages.buildPerlPackage rec {
+  pname = "pgformatter";
+  version = "4.0";
+
+  src = fetchFromGitHub {
+    owner = "darold";
+    repo = "pgFormatter";
+    rev = "v${version}";
+    sha256 = "09p242s406mf469p66zp1jmp9pxcim2vk1v6qsxnrbzicchsn5i2";
+  };
+
+  outputs = [ "out" ];
+
+  makeMakerFlags = [ "INSTALLDIRS=vendor" ];
+
+  # Makefile.PL only accepts DESTDIR and INSTALLDIRS, but we need to set more to make this work for NixOS.
+  patchPhase = ''
+    substituteInPlace pg_format \
+      --replace "#!/usr/bin/env perl" "#!/usr/bin/perl"
+    substituteInPlace Makefile.PL \
+      --replace "'DESTDIR'      => \$DESTDIR," "'DESTDIR'      => '$out/'," \
+      --replace "'INSTALLDIRS'  => \$INSTALLDIRS," "'INSTALLDIRS'  => \$INSTALLDIRS, 'INSTALLVENDORLIB' => 'bin/lib', 'INSTALLVENDORBIN' => 'bin', 'INSTALLVENDORSCRIPT' => 'bin', 'INSTALLVENDORMAN1DIR' => 'share/man/man1', 'INSTALLVENDORMAN3DIR' => 'share/man/man3',"
+  '';
+
+  nativeBuildInputs = stdenv.lib.optional stdenv.isDarwin shortenPerlShebang;
+  postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
+    shortenPerlShebang $out/bin/pg_format
+  '';
+
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "A PostgreSQL SQL syntax beautifier that can work as a console program or as a CGI";
+    homepage = "https://github.com/darold/pgFormatter";
+    maintainers = [ maintainers.marsam ];
+    license = [ licenses.postgresql licenses.artistic2 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3701,6 +3701,8 @@ in
 
   pgf_graphics = callPackage ../tools/graphics/pgf { };
 
+  pgformatter = callPackage ../development/tools/pgformatter { };
+
   pgloader = callPackage ../development/tools/pgloader { };
 
   pigz = callPackage ../tools/compression/pigz { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
supersedes and closes https://github.com/NixOS/nixpkgs/pull/49646

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
