### PR TITLE
nut: fix build with openssl 1.1

### DIFF
--- a/pkgs/applications/misc/nut/default.nix
+++ b/pkgs/applications/misc/nut/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, pkgconfig, neon, libusb, openssl, udev, avahi, freeipmi
-, libtool, makeWrapper }:
+{ stdenv, fetchurl, fetchpatch, autoreconfHook, pkgconfig, neon, libusb
+, openssl, udev, avahi, freeipmi, libtool, makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "nut-2.7.4";
@@ -9,9 +9,18 @@ stdenv.mkDerivation rec {
     sha256 = "19r5dm07sfz495ckcgbfy0pasx0zy3faa0q7bih69lsjij8q43lq";
   };
 
+  patches = [
+    # patching the autoconf scripts requires autoreconfHook to recreate ./configure
+    (fetchpatch {
+      name = "support-openssl-1.1.patch";
+      url = "https://patch-diff.githubusercontent.com/raw/networkupstools/nut/pull/504.patch";
+      sha256 = "0jyns8iynkf5920831dl93n16rrkqqg5hb97w9gdq62910d8scdx";
+    })
+  ];
+
   buildInputs = [ neon libusb openssl udev avahi freeipmi libtool ];
 
-  nativeBuildInputs = [ pkgconfig makeWrapper ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig makeWrapper ];
 
   configureFlags =
     [ "--with-all"


### PR DESCRIPTION
fixes breakage from #22357

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

nut fails to build with openssl 1.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @nbp 
