### PR TITLE
litmus: init at 0.13

### DIFF
--- a/pkgs/development/tools/documentation/mkdocs/default.nix
+++ b/pkgs/development/tools/documentation/mkdocs/default.nix
@@ -36,8 +36,18 @@ buildPythonApplication rec {
   ];
 
   meta = {
+    description = "Project documentation with Markdown / static website generator.";
+    longDescription = ''
+      MkDocs is a fast, simple and downright gorgeous static site generator that's
+      geared towards building project documentation. Documentation source files
+      are written in Markdown, and configured with a single YAML configuration file.
+      
+      MkDocs can also be used to generate general-purpose Websites.
+    '';
     homepage = http://mkdocs.org/;
     description = "Project documentation with Markdown";
     license = lib.licenses.bsd2;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.rkoe ];
   };
 }

--- a/pkgs/tools/networking/litmus/default.nix
+++ b/pkgs/tools/networking/litmus/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl, openssl }:
+
+stdenv.mkDerivation rec {
+  version = "0.13";
+  name = "litmus-${version}";
+
+  src = fetchurl {
+    url = http://webdav.org/neon/litmus/litmus-${version}.tar.gz;
+    sha256 = "09d615958121706444db67e09c40df5f753ccf1fa14846fdeb439298aa9ac3ff";
+  };
+    
+  buildInputs = [ openssl ];
+  configureFlags = [ "--with-ssl" ];
+  installFlags = [ "PREFIX=$(out)" ];
+  
+  meta = with stdenv.lib; {
+    description = "WebDAV server protocol compliance test suite";
+    long_description = ''litmus is a WebDAV server test suite, which aims to test whether a server is compliant with the WebDAV protocol as specified in RFC2518.'';
+    homepage = "http://webdav.org/neon/litmus/";
+    license = [ lib.licenses.gpl2 ];
+    platforms = [ platforms.unix ];
+    maintainers = [ maintainers.rkoe ];
+  };
+}


### PR DESCRIPTION
##### Motivation for this change

Add litmus-package, to test WebDAV-servers.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
