### PR TITLE
makeFontsCache: Fix cross-compiling, missing fc-cache

### DIFF
--- a/pkgs/development/libraries/fontconfig/make-fonts-cache.nix
+++ b/pkgs/development/libraries/fontconfig/make-fonts-cache.nix
@@ -13,6 +13,7 @@ runCommand "fc-cache"
   }
   ''
     export FONTCONFIG_FILE=$(pwd)/fonts.conf
+    export PATH=$PATH:${fontconfig}/bin
 
     cat > fonts.conf << EOF
     <?xml version='1.0'?>


### PR DESCRIPTION
This commit fixes missing fc-cache binary from make-fonts-cache.nix build:
```
builder for '/nix/store/az48nr8gdqrw3fliddmi82ghj2ljxrj4-fc-cache.drv' failed with exit code 127; last 1 log lines:
  /nix/store/p3z1lgsi7xymvl7akg531ikwiisqs4x5-stdenv-linux/setup: line 1299: fc-cache: command not found
cannot build derivation '/nix/store/swaxvjsf8h0rsmm9kigp6j3f5q5h4nvg-fc-00-nixos-cache.conf.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/wiaiv0pq7w1xm2i2fqp2ngd1ljb4n6n9-fontconfig-conf.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/4zhiwpiyccs0rs26bs3q0w8fwaxrrgw0-fontconfig-etc.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/xhvljdp9b00fbkapx6cbfs4sjdh49qwv-etc.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/w63q0n0vh7vkdfrjmhb41qy1alx7qa8s-nixos-system-nixos-19.09.git.c814289.drv': 1 dependencies couldn't be built
```

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions (debian)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers
