### PR TITLE
pythonPackages.flask: 1.0.3 -> 1.0.4

### DIFF
--- a/pkgs/development/python-modules/flask/default.nix
+++ b/pkgs/development/python-modules/flask/default.nix
@@ -2,12 +2,12 @@
 , itsdangerous, click, werkzeug, jinja2, pytest }:
 
 buildPythonPackage rec {
-  version = "1.0.3";
+  version = "1.0.4";
   pname = "Flask";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "ad7c6d841e64296b962296c2c2dabc6543752985727af86a975072dea984b6f3";
+    sha256 = "ed1330220a321138de53ec7c534c3d90cf2f7af938c7880fc3da13aa46bf870f";
   };
 
   checkInputs = [ pytest ];


### PR DESCRIPTION
###### Motivation for this change

A recent pytest update broke this package and others, [which is an issue that the 1.0.4 release addresses](https://flask.palletsprojects.com/en/1.1.x/changelog/#version-1-0-4). There is also #64332 which would supercede this, though it's been sitting for a while now so I'm submitting this in case a minor version bump is more palatable or likely to cause less breakage.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @