### PR TITLE
libmypaint: 1.3.0 → 1.4.0

### DIFF
--- a/pkgs/development/libraries/libmypaint/default.nix
+++ b/pkgs/development/libraries/libmypaint/default.nix
@@ -2,32 +2,26 @@
 , autoconf
 , automake
 , fetchFromGitHub
-, fetchpatch
 , glib
 , intltool
 , json_c
 , libtool
 , pkgconfig
+, python2
 }:
 
 stdenv.mkDerivation rec {
   pname = "libmypaint";
-  version = "1.3.0";
+  version = "1.4.0";
+
+  outputs = [ "out" "dev" ];
 
   src = fetchFromGitHub {
     owner = "mypaint";
     repo = "libmypaint";
     rev = "v${version}";
-    sha256 = "0b7aynr6ggigwhjkfzi8x3dwz15blj4grkg9hysbgjh6lvzpy9jc";
+    sha256 = "1ynm2g2wdb9zsymncndlgs6gpcbsa122n52d11161jrj5nrdliaq";
   };
-
-  patches = [
-    # build with automake 1.16
-    (fetchpatch {
-      url = https://github.com/mypaint/libmypaint/commit/40d9077a80be13942476f164bddfabe842ab2a45.patch;
-      sha256 = "1dclh7apgvr2bvzy9z3rgas3hk9pf2hpf5h52q94kmx8s4a47qpi";
-    })
-  ];
 
   nativeBuildInputs = [
     autoconf
@@ -35,6 +29,7 @@ stdenv.mkDerivation rec {
     intltool
     libtool
     pkgconfig
+    python2
   ];
 
   buildInputs = [

--- a/pkgs/development/libraries/libmypaint/default.nix
+++ b/pkgs/development/libraries/libmypaint/default.nix
@@ -1,10 +1,18 @@
-{stdenv, autoconf, automake, fetchFromGitHub, fetchpatch, glib, intltool, json_c, libtool, pkgconfig}:
+{ stdenv
+, autoconf
+, automake
+, fetchFromGitHub
+, fetchpatch
+, glib
+, intltool
+, json_c
+, libtool
+, pkgconfig
+}:
 
-let
-  version = "1.3.0";
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "libmypaint";
-  inherit version;
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "mypaint";
@@ -21,11 +29,22 @@ in stdenv.mkDerivation rec {
     })
   ];
 
-  nativeBuildInputs = [ autoconf automake intltool libtool pkgconfig ];
+  nativeBuildInputs = [
+    autoconf
+    automake
+    intltool
+    libtool
+    pkgconfig
+  ];
 
-  buildInputs = [ glib ];
+  buildInputs = [
+    glib
+  ];
 
-  propagatedBuildInputs = [ json_c ]; # for libmypaint.pc
+  # for libmypaint.pc
+  propagatedBuildInputs = [
+    json_c
+  ];
 
   doCheck = true;
 


### PR DESCRIPTION
http://mypaint.org/blog/2019/09/01/libmypaint-1.4.0-release/

- [x] built GIMP and verified that the mypaint brushes still work.