### PR TITLE
fail2ban: 0.10.5 -> 0.11.1

### DIFF
--- a/nixos/modules/services/security/fail2ban.nix
+++ b/nixos/modules/services/security/fail2ban.nix
@@ -139,19 +139,15 @@ in
 
       path = [ cfg.package cfg.packageFirewall pkgs.iproute ];
 
-      preStart = ''
-        mkdir -p /var/lib/fail2ban
-      '';
-
       unitConfig.Documentation = "man:fail2ban(1)";
 
       serviceConfig = {
-        Type = "forking";
         ExecStart = "${cfg.package}/bin/fail2ban-server -xf start";
         ExecStop = "${cfg.package}/bin/fail2ban-server stop";
         ExecReload = "${cfg.package}/bin/fail2ban-server reload";
+        Type = "simple";
+        Restart = "on-failure";
         PIDFile = "/run/fail2ban/fail2ban.pid";
-        Restart = "always";
 
         ReadOnlyDirectories = "/";
         ReadWriteDirectories = "/run/fail2ban /var/tmp /var/lib";

--- a/nixos/modules/services/security/fail2ban.nix
+++ b/nixos/modules/services/security/fail2ban.nix
@@ -250,12 +250,26 @@ in
         Type = "simple";
         Restart = "on-failure";
         PIDFile = "/run/fail2ban/fail2ban.pid";
-
-        ReadOnlyDirectories = "/";
-        ReadWriteDirectories = "/run/fail2ban /var/tmp /var/lib";
-        PrivateTmp = "true";
+        # Capabilities
+        CapabilityBoundingSet = [ "CAP_AUDIT_READ" "CAP_DAC_READ_SEARCH" "CAP_NET_ADMIN" "CAP_NET_RAW" ];
+        # Security
+        NoNewPrivileges = true;
+        # Directory
         RuntimeDirectory = "fail2ban";
-        CapabilityBoundingSet = "CAP_DAC_READ_SEARCH CAP_NET_ADMIN CAP_NET_RAW";
+        RuntimeDirectoryMode = "0750";
+        StateDirectory = "fail2ban";
+        StateDirectoryMode = "0750";
+        LogsDirectory = "fail2ban";
+        LogsDirectoryMode = "0750";
+        # Sandboxing
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        ProtectHostname = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
       };
     };
 

--- a/nixos/modules/services/security/fail2ban.nix
+++ b/nixos/modules/services/security/fail2ban.nix
@@ -55,6 +55,13 @@ in
         description = "The fail2ban package to use for running the fail2ban service.";
       };
 
+      packageFirewall = mkOption {
+        default = pkgs.iptables;
+        type = types.package;
+        example = "pkgs.nftables";
+        description = "The firewall package used by fail2ban service.";
+      };
+
       daemonConfig = mkOption {
         default = ''
           [Definition]
@@ -103,7 +110,6 @@ in
 
   };
 
-
   ###### implementation
 
   config = mkIf cfg.enable {
@@ -131,7 +137,7 @@ in
       restartTriggers = [ fail2banConf jailConf pathsConf ];
       reloadIfChanged = true;
 
-      path = [ cfg.package pkgs.iptables pkgs.iproute ];
+      path = [ cfg.package cfg.packageFirewall pkgs.iproute ];
 
       preStart = ''
         mkdir -p /var/lib/fail2ban

--- a/pkgs/tools/security/fail2ban/default.nix
+++ b/pkgs/tools/security/fail2ban/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, python3, gamin }:
 
-let version = "0.10.5"; in
+let version = "0.11.1"; in
 
 python3.pkgs.buildPythonApplication {
   pname = "fail2ban";
@@ -10,7 +10,7 @@ python3.pkgs.buildPythonApplication {
     owner  = "fail2ban";
     repo   = "fail2ban";
     rev    = version;
-    sha256 = "1s8g46vkwhqnagj69v4wvcasypzkmq7awhfbxahffrypcpad5ach";
+    sha256 = "0kqvkxpb72y3kgmxf6g36w67499c6gcd2a9yyblagwx12y05f1sh";
   };
 
   pythonPath = with python3.pkgs;
@@ -50,7 +50,7 @@ python3.pkgs.buildPythonApplication {
   '';
 
   meta = with stdenv.lib; {
-    homepage    = http://www.fail2ban.org/;
+    homepage    = https://www.fail2ban.org/;
     description = "A program that scans log files for repeated failing login attempts and bans IP addresses";
     license     = licenses.gpl2Plus;
     maintainers = with maintainers; [ eelco lovek323 fpletz ];


### PR DESCRIPTION
###### Motivation for this change
Update package to version 0.11.1.
Update service configuration and add options bantime-increment.

In PR created symlinks to files:
```
/etc/fail2ban/fail2ban.conf
/etc/fail2ban/jail.conf
/etc/fail2ban/paths-common.conf
/etc/fail2ban/paths-debian.conf
```
And all changes are generated to files:
```
/etc/fail2ban/fail2ban/fail2ban.local
/etc/fail2ban/fail2ban/jail.local
```
See https://github.com/fail2ban/fail2ban/wiki/Proper-fail2ban-configuration

The result is a configuration example with nftables
```
  services.fail2ban = {
    enable = false;
    package = pkgs.fail2ban_0_11;
    packageFirewall = pkgs.nftables;
    banaction = "nftables-multiport";
    banaction-allports = "nftables-allport";
    bantime-increment.enable = true;
    ignoreIP = [ "192.168.0.0/16" ];
    daemonConfig = ''
      [Definition]
      loglevel     = DEBUG
      logtarget    = SYSLOG
      socket       = /run/fail2ban/fail2ban.sock
      pidfile      = /run/fail2ban/fail2ban.pid
      dbfile       = /var/lib/fail2ban/fail2ban.sqlite3
    '';
    jails = {
      sshd = ''
        maxretry = 2
        mode     = aggressive
      '';
    };
  };
```

Result
`fail2ban-client status`
```
Status
|- Number of jail:      1
`- Jail list:   sshd
```
`nft list chain inet filter input`
```
table inet filter {
        chain input {
                type filter hook input priority filter; policy drop;
                tcp dport { 22 } ip saddr @f2b-sshd reject
...
        }
}
```
`nft list set inet filter f2b-sshd`
```
table inet filter {
        set f2b-sshd {
                type ipv4_addr
                elements = { 49.88.112.77, 49.88.112.85,
                             49.88.112.90, 51.75.64.86,
                             51.77.211.94, 92.63.194.26,
                             113.22.213.202, 183.131.82.99,
                             193.32.163.182, 218.98.26.168,
                             218.98.26.178, 218.98.40.142,
                             222.186.15.160, 222.186.30.165,
                             222.186.42.241, 222.186.52.124 }
        }
}

```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
