### PR TITLE
rfc6555: init at 0.0.0

### DIFF
--- a/pkgs/development/python-modules/rfc6555/default.nix
+++ b/pkgs/development/python-modules/rfc6555/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchPypi, pythonPackages }:
+
+buildPythonPackage rec {
+  pname = "rfc6555";
+  version = "0.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "05sjrd6jc0sdvx0z7d3llk82rx366jlmc7ijam0nalsv66hbn70r";
+  };
+
+  propagatedBuildInputs = with pythonPackages; [ selectors2 ];
+
+  # tests are disabled as rfc6555's 'non-network' tests still require a
+  # functional DNS stack to pass.
+  doCheck = false;
+
+  meta = {
+    description = "Python implementation of the Happy Eyeballs Algorithm";
+    homepage = "https://pypi.org/project/rfc6555";
+    license = stdenv.lib.licenses.asl20;
+    maintainers = with stdenv.lib.maintainers; [ endocrimes ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4658,6 +4658,8 @@ in {
     inherit (pkgs) pkgconfig; # use normal pkgconfig, not the python package
   };
 
+  rfc6555 = callPackage ../development/python-modules/rfc6555 { };
+
   qdarkstyle = callPackage ../development/python-modules/qdarkstyle { };
 
   quamash = callPackage ../development/python-modules/quamash { };


### PR DESCRIPTION
###### Motivation for this change

rfc6555 is a required dependency of OfflineIMAP 7.3.0.

###### Things done


- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers