### PR TITLE
libgdata: 0.17.10 → 0.17.11

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -145,6 +145,7 @@ in
   latestKernel.login = handleTest ./login.nix { latestKernel = true; };
   ldap = handleTest ./ldap.nix {};
   leaps = handleTest ./leaps.nix {};
+  libgdata = handleTest ./libgdata.nix {};
   libxmlb = handleTest ./libxmlb.nix {};
   lidarr = handleTest ./lidarr.nix {};
   lightdm = handleTest ./lightdm.nix {};

--- a/nixos/tests/libgdata.nix
+++ b/nixos/tests/libgdata.nix
@@ -1,0 +1,21 @@
+# run installed tests
+import ./make-test.nix ({ pkgs, ... }:
+
+{
+  name = "libgdata";
+
+  meta = {
+    maintainers = pkgs.libgdata.meta.maintainers;
+  };
+
+  machine = { pkgs, ... }: {
+    environment.systemPackages = with pkgs; [ gnome-desktop-testing ];
+    # # GLib-GIO-DEBUG: _g_io_module_get_default: Found default implementation dummy (GDummyTlsBackend) for ‘gio-tls-backend’
+    # Bail out! libgdata:ERROR:../gdata/tests/common.c:134:gdata_test_init: assertion failed (child_error == NULL): TLS support is not available (g-tls-error-quark, 0)
+    services.gnome3.glib-networking.enable = true;
+  };
+
+  testScript = ''
+    $machine->succeed("gnome-desktop-testing-runner -d '${pkgs.libgdata.installedTests}/share'");
+  '';
+})

--- a/pkgs/development/libraries/libgdata/default.nix
+++ b/pkgs/development/libraries/libgdata/default.nix
@@ -1,6 +1,5 @@
 { stdenv
 , fetchurl
-, fetchpatch
 , pkgconfig
 , meson
 , ninja
@@ -22,32 +21,17 @@
 
 stdenv.mkDerivation rec {
   pname = "libgdata";
-  version = "0.17.10";
+  version = "0.17.11";
 
   outputs = [ "out" "dev" "installedTests" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "04mh2p5x2iidfx0d1cablxbi3hvna8cmlddc1mm4387n0grx3ly1";
+    sha256 = "11m99sh2k679rnsvqsi95s1l0r8lkvj61dmwg1pnxvsd5q91g6bb";
   };
 
   patches = [
     ./installed-tests-path.patch
-    (fetchpatch {
-      # Meson fixes
-      url = "https://gitlab.gnome.org/GNOME/libgdata/commit/f6d0e3f3b6fa8e8ee9569372c5709c1fb84af2c1.diff";
-      sha256 = "00yrppn0s21i41r9mwzvrrv7j5dida09kh7i44kv8hrbrlfag7bm";
-    })
-    (fetchpatch {
-      # Meson minor fixes
-      url = "https://gitlab.gnome.org/GNOME/libgdata/commit/b653f602b3c2b518101c5d909e1651534c22757a.diff";
-      sha256 = "1bn0rffsvkzjl59aw8dmq1wil58x1fshz0m6xabpn79ffvbjld8j";
-    })
-    (fetchpatch {
-      # Meson: Fix G_LOG_DOMAIN
-      url = "https://gitlab.gnome.org/GNOME/libgdata/commit/5d318e0bf905d0f1a8b3fe1e47ee7847739082e3.diff";
-      sha256 = "11i2blq811d53433kdq4hhsscgkrq5f50d9ih4ixgs3j47hg7b1w";
-    })
   ];
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/libgdata/default.nix
+++ b/pkgs/development/libraries/libgdata/default.nix
@@ -3,6 +3,7 @@
 , pkgconfig
 , meson
 , ninja
+, nixosTests
 , vala
 , gettext
 , libxml2
@@ -70,6 +71,10 @@ stdenv.mkDerivation rec {
     updateScript = gnome3.updateScript {
       packageName = pname;
       versionPolicy = "none"; # Stable version has not been updated for a long time.
+    };
+
+    tests = {
+      installedTests = nixosTests.libgdata;
     };
   };
 

--- a/pkgs/development/libraries/libgdata/installed-tests-path.patch
+++ b/pkgs/development/libraries/libgdata/installed-tests-path.patch
@@ -1,5 +1,5 @@
 diff --git a/gdata/tests/meson.build b/gdata/tests/meson.build
-index 52154e7a..1a44d1d8 100644
+index 05184deb..3a9392d4 100644
 --- a/gdata/tests/meson.build
 +++ b/gdata/tests/meson.build
 @@ -1,5 +1,12 @@
@@ -17,17 +17,17 @@ index 52154e7a..1a44d1d8 100644
  
  tests_sources = files(
    'common.c',
-@@ -48,7 +55,7 @@ foreach test_name, extra_args: tests
+@@ -49,7 +56,7 @@ foreach test_name, extra_args: tests
      dependencies: common_deps + extra_args.get('dependencies', []),
      sources: tests_sources,
-     install: install_tests,
+     install: install_tests and not should_fail,
 -    install_dir: tests_execdir,
 +    install_dir: tests_bindir,
    )
  
    test(
-@@ -63,7 +70,7 @@ if install_tests
-   foreach test_name, extra_args: tests
+@@ -65,7 +72,7 @@ if install_tests
+     should_fail = extra_args.get('should_fail', false)
      tests_conf = {
        'TEST_TYPE': 'session',
 -      'TEST_ABS_PATH': gdata_prefix / tests_execdir / test_name,
@@ -35,10 +35,10 @@ index 52154e7a..1a44d1d8 100644
      }
  
      configure_file (
-@@ -71,13 +78,13 @@ if install_tests
+@@ -73,13 +80,13 @@ if install_tests
        output: test_name + '.test',
        configuration: tests_conf,
-       install: true,
+       install: not should_fail,
 -      install_dir: tests_metadir,
 +      install_dir: tests_datadir,
      )
@@ -51,7 +51,7 @@ index 52154e7a..1a44d1d8 100644
    )
  
    test_data = [
-@@ -96,6 +103,6 @@ if install_tests
+@@ -98,6 +105,6 @@ if install_tests
  
    install_data(
      test_data,
@@ -60,7 +60,7 @@ index 52154e7a..1a44d1d8 100644
    )
  endif
 diff --git a/meson.build b/meson.build
-index 7d2f5254..bed3e189 100644
+index 50441abb..5fc773b1 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -20,9 +20,9 @@ gdata_api_version_minor = 0


### PR DESCRIPTION
https://download.gnome.org/sources/libgdata/0.17/libgdata-0.17.11.news

Reverse dependencies tested:
- [x] gnome3.gnome-online-miners
- [x] gnome-photos
- [x] gnome3.gnome-documents
- [x] grilo-plugins
- [x] shotwell
- [x] gnome3.evolution