### PR TITLE
Fix typo in customisation.nix

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -47,7 +47,7 @@ rec {
 
 
   /* `makeOverridable` takes a function from attribute set to attribute set and
-     injects `override` attibute which can be used to override arguments of
+     injects `override` attribute which can be used to override arguments of
      the function.
 
        nix-repl> x = {a, b}: { result = a + b; }


### PR DESCRIPTION
###### Motivation for this change

Found a typo in a source file
