### PR TITLE
pastel: init at 0.5.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4361,6 +4361,12 @@
     githubId = 39034;
     name = "Max Treskin";
   };
+  mtrsk = {
+    email = "marcos.schonfinkel@protonmail.com";
+    github = "mtrsk";
+    githubId = 16356569;
+    name = "Marcos Benevides";
+  };
   mudri = {
     email = "lamudri@gmail.com";
     github = "laMudri";

--- a/pkgs/tools/misc/pastel/default.nix
+++ b/pkgs/tools/misc/pastel/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, lib, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "pastel";
+  version = "0.5.3";
+
+  src = fetchFromGitHub {
+    owner = "sharkdp";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0f54p3pzfp7xrwlqn61l7j41vmgcfph3bhq2khxh5apfwwdx9nng";
+  };
+
+  cargoSha256 = "05yvlm7z3zfn8qd8nb9zpch9xsfzidrpyrgg2vij3h3q095mdm66";
+
+  meta = with lib; {
+    description = "A rust command-line tool to generate, analyze, convert and manipulate colors";
+    homepage = "https://github.com/sharkdp/pastel";
+    license = with licenses; [ mit asl20 ];
+    maintainers = with maintainers; [ mtrsk ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1900,6 +1900,8 @@ in
 
   pyznap = python3Packages.callPackage ../tools/backup/pyznap {};
 
+  pastel = callPackage ../tools/misc/pastel {};
+
   procs = callPackage ../tools/admin/procs {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Adds [sharkdp/pastel](https://github.com/sharkdp/pastel) to nixpkgs.

###### Things done

This is my fist derivation/packaging sent to `nixpkgs`, any feedback is always welcome.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
