### PR TITLE
README.md: improve content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,48 +1,113 @@
-[<img src="https://nixos.org/logo/nixos-hires.png" width="500px" alt="logo" />](https://nixos.org/nixos)
+<p align="center">
+  <a href="https://nixos.org/nixos"><img src="https://nixos.org/logo/nixos-hires.png" width="500px" alt="NixOS logo" /></a>
+</p>
 
-[![Code Triagers Badge](https://www.codetriage.com/nixos/nixpkgs/badges/users.svg)](https://www.codetriage.com/nixos/nixpkgs)
-[![Open Collective supporters](https://opencollective.com/nixos/tiers/supporter/badge.svg?label=Supporter&color=brightgreen)](https://opencollective.com/nixos)
+<p align="center">
+  <a href="https://www.codetriage.com/nixos/nixpkgs"><img src="https://www.codetriage.com/nixos/nixpkgs/badges/users.svg" alt="Code Triagers badge" /></a>
+  <a href="https://opencollective.com/nixos"><img src="https://opencollective.com/nixos/tiers/supporter/badge.svg?label=Supporter&color=brightgreen" alt="Open Collective supporters" /></a>
+</p>
 
-Nixpkgs is a collection of packages for the [Nix](https://nixos.org/nix/) package
-manager. It is periodically built and tested by the [Hydra](https://hydra.nixos.org/)
-build daemon as so-called channels. To get channel information via git, add
-[nixpkgs-channels](https://github.com/NixOS/nixpkgs-channels.git) as a remote:
+[Nixpkgs](https://github.com/nixos/nixpkgs) is a collection of over
+40,000 software packages that can be installed with the
+[Nix](https://nixos.org/nix/) package manager. It also implements
+[NixOS](https://nixos.org/nixos/), a purely-functional Linux distribution.
 
-```
-% git remote add channels https://github.com/NixOS/nixpkgs-channels.git
-```
+# Manuals
 
-For stability and maximum binary package support, it is recommended to maintain
-custom changes on top of one of the channels, e.g. `nixos-19.03` for the latest
-release and `nixos-unstable` for the latest successful build of master:
+* [NixOS Manual](https://nixos.org/nixos/manual) - how to install, configure, and maintain a purely-functional Linux distribution
+* [Nixpkgs Manual](https://nixos.org/nixpkgs/manual/) - contributing to Nixpkgs and using programming-language-specific Nix expressions
+* [Nix Package Manager Manual](https://nixos.org/nix/manual) - how to write Nix expresssions (programs), and how to use Nix command line tools
 
-```
-% git remote update channels
-% git rebase channels/nixos-19.03
-```
-
-For pull requests, please rebase onto nixpkgs `master`.
-
-[NixOS](https://nixos.org/nixos/) Linux distribution source code is located inside
-`nixos/` folder.
-
-* [NixOS installation instructions](https://nixos.org/nixos/manual/#ch-installation)
-* [Documentation (Nix Expression Language chapter)](https://nixos.org/nix/manual/#ch-expression-language)
-* [Manual (How to write packages for Nix)](https://nixos.org/nixpkgs/manual/)
-* [Manual (NixOS)](https://nixos.org/nixos/manual/)
-* [Community maintained wiki](https://nixos.wiki/)
-* [Continuous package builds for unstable/master](https://hydra.nixos.org/jobset/nixos/trunk-combined)
-* [Continuous package builds for 19.03 release](https://hydra.nixos.org/jobset/nixos/release-19.03)
-* [Tests for unstable/master](https://hydra.nixos.org/job/nixos/trunk-combined/tested#tabs-constituents)
-* [Tests for 19.03 release](https://hydra.nixos.org/job/nixos/release-19.03/tested#tabs-constituents)
-
-Communication:
+# Community
 
 * [Discourse Forum](https://discourse.nixos.org/)
 * [IRC - #nixos on freenode.net](irc://irc.freenode.net/#nixos)
+* [NixOS Weekly](https://weekly.nixos.org/)
+* [Community-maintained wiki](https://nixos.wiki/)
 
-Note: MIT license does not apply to the packages built by Nixpkgs, merely to
-the package descriptions (Nix expressions, build scripts, and so on). It also
-might not apply to patches included in Nixpkgs, which may be derivative works
-of the packages to which they apply. The aforementioned artifacts are all
-covered by the licenses of the respective packages.
+# Other Project Repositories
+
+The sources of all offical Nix-related projects are in the [NixOS
+organization on GitHub](https://github.com/NixOS/). Here are some of
+the main ones:
+
+* [Nix](https://github.com/NixOS/nix) - the purely functional package manager
+* [NixOps](https://github.com/NixOS/nixops) - the tool to remotely deploy NixOS machines
+* [Nix RFCs](https://github.com/NixOS/rfcs) - the formal process for making substantial changes to the community
+* [NixOS homepage](https://github.com/NixOS/nixos-homepage) - the [NixOS.org](https://nixos.org) website
+* [hydra](https://github.com/NixOS/hydra) - our continuous integration system
+* [NixOS Artwork](https://github.com/NixOS/nixos-artwork) - NixOS artwork
+
+# Continuous Integration and Distribution
+
+Nixpkgs and NixOS are built and tested by our continuous integration
+system, [Hydra](https://hydra.nixos.org/).
+
+* [Continuous package builds for unstable/master](https://hydra.nixos.org/jobset/nixos/trunk-combined)
+* [Continuous package builds for the NixOS 19.03 release](https://hydra.nixos.org/jobset/nixos/release-19.03)
+* [Tests for unstable/master](https://hydra.nixos.org/job/nixos/trunk-combined/tested#tabs-constituents)
+* [Tests for the NixOS 19.03 release](https://hydra.nixos.org/job/nixos/release-19.03/tested#tabs-constituents)
+
+Artifacts successfully built with Hydra are published to cache at
+https://cache.nixos.org/. When successful build and test criteria are
+met, the Nixpkgs expressions are distributed via [Nix
+channels](https://nixos.org/nix/manual/#sec-channels). The channels
+are provided via a read-only mirror of the Nixpkgs repository called
+[nixpkgs-channels](https://github.com/NixOS/nixpkgs-channels).
+
+# Contributing
+
+Nixpkgs is among the most active projects on GitHub. While thousands
+of open issues and pull requests might seem a lot at first, it helps
+consider it in the context of the scope of the project. Nixpkgs
+describes how to build over 40,000 pieces of software and implements a
+Linux distribution. The [GitHub Insights](https://github.com/NixOS/nixpkgs/pulse)
+page gives a sense of the project activity.
+
+Community contributions are always welcome through GitHub Issues and
+Pull Requests. When pull requests are made, our tooling automation bot,
+[OfBorg](https://github.com/NixOS/ofborg) will perform various checks
+to help ensure expression quality.
+
+The *Nixpkgs maintainers* are people who have assigned themselves to
+maintain specific individual packages. We encourage people who care
+about a package to assign themselves as a maintainer. When a pull
+request is made against a package, OfBorg will notify the appropriate
+maintainer(s). The *Nixpkgs committers* are people who have been given
+permission to merge.
+
+Most contributions are based on and merged into these branches:
+
+* `master` is the main branch where all small contributions go
+* `staging` is branched from master, changes that have a big impact on
+  Hydra builds go to this branch
+* `staging-next` is branched from staging and only fixes to stabilize
+  and security fixes with a big impact on Hydra builds should be
+  contributed to this branch. This branch is merged into master when
+  deemed of sufficiently high quality
+
+For more information about contributing to the project, please visit
+the [contributing page](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
+
+# Donations
+
+The infrastructure for NixOS and related projects is maintained by a
+nonprofit organization, the [NixOS
+Foundation](https://nixos.org/nixos/foundation.html). To ensure the
+continuity and expansion of the NixOS infrastructure, we are looking
+for donations to our organization.
+
+You can donate to the NixOS foundation by using Open Collective:
+
+<a href="https://opencollective.com/nixos#support"><img src="https://opencollective.com/nixos/tiers/supporter.svg?width=890" /></a>
+
+# License
+
+Nixpkgs is licensed under the [MIT License](COPYING).
+
+Note: MIT license does not apply to the packages built by Nixpkgs,
+merely to the files in this repository (the Nix expressions, build
+scripts, NixOS modules, etc.). It also might not apply to patches
+included in Nixpkgs, which may be derivative works of the packages to
+which they apply. The aforementioned artifacts are all covered by the
+licenses of the respective packages.


### PR DESCRIPTION
###### Motivation for this change

I was initially motivated by @zimbatm's [comment on my RFC](https://github.com/NixOS/rfcs/pull/51#discussion_r317402968). Also, the README file is prominent documentation and marketing that new users see and it was previously pretty light on content.

I realize some of this is duplicated from the NixOS homepage, but I think it is good to have information here too.

[Rendered link](https://github.com/ryantm/nixpkgs/blob/readme/README.md)