### PR TITLE
virtualbox: Fix #65564

### DIFF
--- a/pkgs/applications/virtualization/virtualbox/qt-env-vars.patch
+++ b/pkgs/applications/virtualization/virtualbox/qt-env-vars.patch
@@ -1,0 +1,14 @@
+--- a/src/VBox/HostDrivers/Support/SUPR3HardenedMain.cpp
++++ b/src/VBox/HostDrivers/Support/SUPR3HardenedMain.cpp
+@@ -2131,6 +2131,11 @@ static void supR3HardenedMainPurgeEnvironment(char **envp)
+         /** @todo Call NT API to do the same. */
+ #endif
+     }
++
++    /*
++     * NixOS hack: Set QT_PLUGIN_PATH to make Qt find plugins.
++     */
++    setenv("QT_PLUGIN_PATH", "@qtPluginPath@", /*overwrite=*/ 1);
+ }
+ 
+ 


### PR DESCRIPTION
When hardening is enabled, we cannot use a wrapper for VirtualBoxVM, so patch
the source code to set QT_PLUGIN_PATH as required.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

Tested that virtual machines run via the GUI on nixos-unstable both with and without hardening.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @flokli @svanderburg 
