### PR TITLE
cryptpad: 3.0.0 -> 3.0.1

### DIFF
--- a/pkgs/servers/web-apps/cryptpad/generate.sh
+++ b/pkgs/servers/web-apps/cryptpad/generate.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#! nix-shell -i bash -p nodePackages.node2nix nodePackages.bower2nix
+#! nix-shell -i bash  -I nixpkgs=../../../.. -p nodePackages.node2nix nodePackages.bower2nix
 set -euo pipefail
 
 node2nix -6 \

--- a/pkgs/servers/web-apps/cryptpad/node-packages-generated.nix
+++ b/pkgs/servers/web-apps/cryptpad/node-packages-generated.nix
@@ -49,13 +49,13 @@ let
         sha1 = "d32815404d689699f85a4ea4fa8755dd13a96048";
       };
     };
-    "chainpad-server-3.0.3" = {
+    "chainpad-server-3.0.5" = {
       name = "chainpad-server";
       packageName = "chainpad-server";
-      version = "3.0.3";
+      version = "3.0.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/chainpad-server/-/chainpad-server-3.0.3.tgz";
-        sha512 = "NRfV7FFBEYy4ZVX7h0P5znu55X8v5K4iGWeMGihkfWZLKu70GmCPUTwpBCP79dUvnCToKEa4/e8aoSPcvZC8pA==";
+        url = "https://registry.npmjs.org/chainpad-server/-/chainpad-server-3.0.5.tgz";
+        sha512 = "USKOMSHsNjnme81Qy3nQ+ji9eCkBPokYH4T82LVHAI0aayTSCXcTPUDLVGDBCRqe8NsXU4io1WPXn1KiZwB8fA==";
       };
     };
     "content-disposition-0.5.2" = {
@@ -619,14 +619,14 @@ let
   };
 in
 {
-  "cryptpad-git+https://github.com/xwiki-labs/cryptpad.git#3.0.0" = nodeEnv.buildNodePackage {
+  "cryptpad-git+https://github.com/xwiki-labs/cryptpad.git#3.0.1" = nodeEnv.buildNodePackage {
     name = "cryptpad";
     packageName = "cryptpad";
-    version = "3.0.0";
+    version = "3.0.1";
     src = fetchgit {
       url = "https://github.com/xwiki-labs/cryptpad.git";
-      rev = "166ab65cd47a64e020528089244ed5be34f6e3c8";
-      sha256 = "35a3b733b5c128b7c7e1c0e7473f4a6a446d663f4c787745b36b1071205c1fd7";
+      rev = "4e5f6edac4f9a3a7a4756eb543d29dc9d1eef32a";
+      sha256 = "f32a93316b717246d1563baec70f9e1e7e5ec1be4f325a473cc37e656afa13cd";
     };
     dependencies = [
       sources."accepts-1.3.7"
@@ -634,7 +634,7 @@ in
       sources."async-limiter-1.0.1"
       sources."body-parser-1.18.3"
       sources."bytes-3.0.0"
-      sources."chainpad-server-3.0.3"
+      sources."chainpad-server-3.0.5"
       sources."content-disposition-0.5.2"
       sources."content-type-1.0.4"
       sources."cookie-0.3.1"

--- a/pkgs/servers/web-apps/cryptpad/node-packages.json
+++ b/pkgs/servers/web-apps/cryptpad/node-packages.json
@@ -1,3 +1,3 @@
 [
-  { "cryptpad": "git+https://github.com/xwiki-labs/cryptpad.git#3.0.0" }
+  { "cryptpad": "git+https://github.com/xwiki-labs/cryptpad.git#3.0.1" }
 ]


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update to latest stable release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @zimbatm 
