### PR TITLE
devpi-server: 4.9.0 -> 5.1.0

### DIFF
--- a/pkgs/development/tools/devpi-server/default.nix
+++ b/pkgs/development/tools/devpi-server/default.nix
@@ -1,20 +1,21 @@
- { stdenv, python3Packages, nginx }:
+{ stdenv, python3Packages, nginx }:
 
 python3Packages.buildPythonApplication rec {
-  name = "${pname}-${version}";
   pname = "devpi-server";
-  version = "4.9.0";
+  version = "5.1.0";
 
   src = python3Packages.fetchPypi {
     inherit pname version;
-    sha256 = "0cx0nv1qqv8lg6p1v8dv5val0dxnc3229c15imibl9wrhrffjbg9";
+    sha256 = "254fceee846532a5fec4e6bf52a59eb8f236efc657678a542b5200da4bb3abbc";
   };
 
   propagatedBuildInputs = with python3Packages; [
+    py
     appdirs
     devpi-common
     execnet
     itsdangerous
+    repoze_lru
     passlib
     pluggy
     pyramid
@@ -24,13 +25,12 @@ python3Packages.buildPythonApplication rec {
 
   checkInputs = with python3Packages; [
     beautifulsoup4
-    mock
     nginx
     pytest
-    pytest-flakes
+    pytest-flake8
     pytestpep8
     webtest
-  ];
+  ] ++ stdenv.lib.optionals isPy27 [ mock ];
 
   # test_genconfig.py needs devpi-server on PATH
   checkPhase = ''


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
supersedes and closes https://github.com/NixOS/nixpkgs/pull/59957

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
