### PR TITLE
gnome3.mutter: fix segfault in dri_flush_front_buffer()

### DIFF
--- a/pkgs/desktops/gnome-3/core/mutter/default.nix
+++ b/pkgs/desktops/gnome-3/core/mutter/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, substituteAll, stdenv, pkgconfig, gnome3, gettext, gobject-introspection, upower, cairo
+{ fetchurl, fetchpatch, substituteAll, stdenv, pkgconfig, gnome3, gettext, gobject-introspection, upower, cairo
 , pango, cogl, clutter, libstartup_notification, zenity, libcanberra-gtk3
 , ninja, xkeyboard_config, libxkbfile, libxkbcommon, libXtst, libinput
 , gsettings-desktop-schemas, glib, gtk3, gnome-desktop
@@ -54,6 +54,13 @@ stdenv.mkDerivation rec {
     (substituteAll {
       src = ./fix-paths.patch;
       inherit zenity;
+    })
+    # Fix a segmentation fault in dri_flush_front_buffer() upon
+    # suspend/resume. This change should be removed when Mutter
+    # is updated to 3.34.
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/mutter/commit/8307c0f7ab60760de53f764e6636893733543be8.diff";
+      sha256 = "1hzfva71xdqvvnx5smjsrjlgyrmc7dj94mpylkak0gwda5si0h2n";
     })
   ];
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The last few months I have run into an issue where if my machine resumes from suspend (Intel NUC8i5, Intel Iris Plus Graphics 655), Mutter segfaults, loses the whole session, and I am back in GDM. Shortened stack trace:

~~~
gdb) bt
#0  0x00007f254fc4bd33 in dri_flush_front_buffer ()
   from /nix/store/38nq875iq0dmvpvzhw2vrc56k7x103lr-mesa-19.1.3/lib/libgbm.so.1
#1  0x00007f253e20c94a in intel_flush_front ()
   from /run/opengl-driver/lib/dri/i965_dri.so
#2  0x00007f253e20c9cc in intel_glFlush ()
   from /run/opengl-driver/lib/dri/i965_dri.so
#3  0x00007f254c4a12fe in dri2_make_current ()
   from /nix/store/jidsgx7f5grm62yypkjgnxw1xxm40ig1-mesa-19.1.3-drivers/lib/libEGL_mesa.so.0
#4  0x00007f254c490585 in eglMakeCurrent ()
   from /nix/store/jidsgx7f5grm62yypkjgnxw1xxm40ig1-mesa-19.1.3-drivers/lib/libEGL_mesa.so.0
#5  0x00007f254fe91ad0 in InternalMakeCurrentVendor.isra.1 ()
   from /nix/store/09m1aqi2i3rnxcnj80c2ixzay94xlhas-libglvnd-1.0.0/lib/libEGL.so.1
#6  0x00007f255193f8f1 in _cogl_winsys_egl_make_current ()
   from /nix/store/qyi7xmdcvh2jlj7v0jh1l114syh7v27y-mutter-3.32.2/lib/mutter-4/libmutter-cogl-4.so.0
#7  0x00007f2551efcdd6 in meta_renderer_native_create_view ()
   from /nix/store/qyi7xmdcvh2jlj7v0jh1l114syh7v27y-mutter-3.32.2/lib/libmutter-4.so.0
#8  0x00007f2551e59c80 in meta_renderer_rebuild_views ()
   from /nix/store/qyi7xmdcvh2jlj7v0jh1l114syh7v27y-mutter-3.32.2/lib/libmutter-4.so.0
#9  0x00007f2551effaf7 in meta_stage_native_rebuild_views ()
   from /nix/store/qyi7xmdcvh2jlj7v0jh1l114syh7v27y-mutter-3.32.2/lib/libmutter-4.so.0
~~~

In the Mutter commit history I found the same call stack with Valgrind errors:

https://gitlab.gnome.org/GNOME/mutter/commit/56ddaaa3809240a357b5e19b5789d1aa49aaecc3

I have applied this patch two days ago and Mutter hasn't crashed since. I guess that NixOS 19.09 will probably not ship with GNOME 3.34, so it would be nice to have this fix in 19.09.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
