### PR TITLE
pythonPackages.trezor_agent: adding buildInputs required for GPG

### DIFF
--- a/pkgs/development/python-modules/trezor_agent/default.nix
+++ b/pkgs/development/python-modules/trezor_agent/default.nix
@@ -25,9 +25,9 @@ buildPythonPackage rec{
 
   meta = with stdenv.lib; {
     description = "Using Trezor as hardware SSH agent";
-    homepage = https://github.com/romanz/trezor-agent;
+    homepage = "https://github.com/romanz/trezor-agent";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ np ];
+    maintainers = with maintainers; [ np mmahut ];
   };
 
 }

--- a/pkgs/development/python-modules/trezor_agent/default.nix
+++ b/pkgs/development/python-modules/trezor_agent/default.nix
@@ -8,6 +8,8 @@
 , mnemonic
 , keepkey
 , semver
+, wheel
+, pinentry
 }:
 
 buildPythonPackage rec{
@@ -19,7 +21,7 @@ buildPythonPackage rec{
     sha256 = "e82bf000c1178b1a7612f2a90487eb34c6234d2edb15dc8e310ad875d8298690";
   };
 
-  propagatedBuildInputs = [ trezor libagent ecdsa ed25519 mnemonic keepkey semver ];
+  propagatedBuildInputs = [ trezor libagent ecdsa ed25519 mnemonic keepkey semver wheel pinentry ];
 
   meta = with stdenv.lib; {
     description = "Using Trezor as hardware SSH agent";


### PR DESCRIPTION
###### Motivation for this change

Changes required for GPG support.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @np 
