### PR TITLE
wxhexeditor: fix compilation

### DIFF
--- a/pkgs/applications/editors/wxhexeditor/default.nix
+++ b/pkgs/applications/editors/wxhexeditor/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, fetchpatch, wxGTK, autoconf, automake, libtool, python, gettext }:
 
 stdenv.mkDerivation rec {
-  name = "wxHexEditor-${version}";
+  pname = "wxHexEditor";
   version = "0.24";
 
   src = fetchFromGitHub {
@@ -26,11 +26,10 @@ stdenv.mkDerivation rec {
       url = https://github.com/EUA/wxHexEditor/commit/d0fa3ddc3e9dc9b05f90b650991ef134f74eed01.patch;
       sha256 = "1wcb70hrnhq72frj89prcqylpqs74xrfz3kdfdkq84p5qfz9svyj";
     })
+    ./missing-semicolon.patch
   ];
 
-  buildPhase = ''
-    make OPTFLAGS="-fopenmp"
-  '';
+  makeFlags = [ "OPTFLAGS=-fopenmp" ];
 
   meta = {
     description = "Hex Editor / Disk Editor for Huge Files or Devices";

--- a/pkgs/applications/editors/wxhexeditor/missing-semicolon.patch
+++ b/pkgs/applications/editors/wxhexeditor/missing-semicolon.patch
@@ -1,0 +1,35 @@
+diff --git a/src/HexDialogs.cpp b/src/HexDialogs.cpp
+index 091a6f9..12e6a78 100644
+--- a/src/HexDialogs.cpp
++++ b/src/HexDialogs.cpp
+@@ -420,7 +420,7 @@ void FindDialog::OnChar( wxKeyEvent& event ){
+ 	}
+
+ void FindDialog::EventHandler( wxCommandEvent& event ){
+-	WX_CLEAR_ARRAY(parent->HighlightArray )
++	WX_CLEAR_ARRAY(parent->HighlightArray );
+ 	parent->HighlightArray.Shrink();
+
+ 	if( event.GetId() == btnFind->GetId())
+diff --git a/src/HexEditorCtrl/HexEditorCtrl.cpp b/src/HexEditorCtrl/HexEditorCtrl.cpp
+index 7a3b0e2..f12097f 100644
+--- a/src/HexEditorCtrl/HexEditorCtrl.cpp
++++ b/src/HexEditorCtrl/HexEditorCtrl.cpp
+@@ -64,9 +64,9 @@ HexEditorCtrl::~HexEditorCtrl( void ){
+ 	Dynamic_Disconnector();
+ 	Clear();
+
+-	WX_CLEAR_ARRAY(MainTagArray)
+-	WX_CLEAR_ARRAY(HighlightArray)
+-   WX_CLEAR_ARRAY(CompareArray)
++	WX_CLEAR_ARRAY(MainTagArray);
++	WX_CLEAR_ARRAY(HighlightArray);
++   WX_CLEAR_ARRAY(CompareArray);
+
+    MainTagArray.Shrink();
+    HighlightArray.Shrink();
+@@ -1224,4 +1224,3 @@ void wxHugeScrollBar::OnOffsetScroll( wxScrollEvent& event ){
+ #endif
+ 	event.Skip();
+ 	}
+-


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
wxhexeditor failed to compile but I needed it.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers
No maintainer
