### PR TITLE
python3Packages.cherrypy: fix tests after upgrade to pytest5

### DIFF
--- a/pkgs/development/python-modules/cherrypy/default.nix
+++ b/pkgs/development/python-modules/cherrypy/default.nix
@@ -2,6 +2,7 @@
 , setuptools_scm
 , cheroot, portend, more-itertools, zc_lockfile, routes
 , objgraph, pytest, pytestcov, pathpy, requests_toolbelt, pytest-services
+, fetchpatch
 }:
 
 buildPythonPackage rec {
@@ -15,6 +16,22 @@ buildPythonPackage rec {
     inherit version;
     sha256 = "1w3hpsg7q8shdmscmbqk00w90lcw3brary7wl1a56k5h7nx33pj8";
   };
+
+  # Remove patches once 96b34df and 14c12d2
+  # become part of a release - they're currently only present in master.
+  # ref: https://github.com/cherrypy/cherrypy/pull/1791
+  patches = [
+    (fetchpatch {
+      name = "pytest5-1.patch";
+      url = "https://github.com/cherrypy/cherrypy/commit/96b34dfea7853b0189bc0a3878b6ddff0d4e505c.patch";
+      sha256 = "0zy53mahffgkpd844118b42lsk5lkjmig70d60x1i46w6gnr61mi";
+    })
+    (fetchpatch {
+      name = "pytest5-2.patch";
+      url = "https://github.com/cherrypy/cherrypy/commit/14c12d2420a4b3765bb241250bd186e93b2f25eb.patch";
+      sha256 = "0ihcz7b5myn923rq5665b98pz52hnf6fcys2y2inf23r3i07scyz";
+    })
+  ];
 
   propagatedBuildInputs = [
     # required


### PR DESCRIPTION

###### Motivation for this change
Fix cherrypy python3 build after pytest5 upgrade broke the tests: b3ddab852a5229331553e07be6055fb015966b42
See https://github.com/cherrypy/cherrypy/pull/1791 for reference.

@GrahamcOfBorg build python3Packages.cherrypy

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @FRidh
