### PR TITLE
gnucash: fix build issue with newer CMake

### DIFF
--- a/pkgs/applications/office/gnucash/default.nix
+++ b/pkgs/applications/office/gnucash/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, pkgconfig, makeWrapper, cmake, gtest
+{ fetchurl, fetchpatch, stdenv, pkgconfig, makeWrapper, cmake, gtest
 , boost, icu, libxml2, libxslt, gettext, swig, isocodes, gtk3, glibcLocales
 , webkitgtk, dconf, hicolor-icon-theme, libofx, aqbanking, gwenhywfar, libdbi
 , libdbiDrivers, guile, perl, perlPackages
@@ -40,6 +40,15 @@ stdenv.mkDerivation rec {
     libdbiDrivers guile
     perlWrapper perl
   ] ++ (with perlPackages; [ FinanceQuote DateManip ]);
+
+  # Included in the maint branch, apparently required by newer CMake
+  patches = [
+    (fetchpatch {
+      name = "fix-cmake-failure.patch";
+      url = "https://github.com/Gnucash/gnucash/commit/ce6c3c22a15102341ca41ddba2a46ea7daf63f17.patch";
+      sha256 = "0h8h8klq5gpsnhw86yyzc2rx21kn5vn12mwiz9amn52s0zzp459b";
+    })
+  ];
 
   propagatedUserEnvPkgs = [ dconf ];
 


### PR DESCRIPTION
#### Motivation for this change

Fix gnucash's build break by incorporating a patch that has been accepted on upstream's `maint` branch.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
