### PR TITLE
django-extensions: 2.1.4 -> 2.2.1

### DIFF
--- a/pkgs/development/python-modules/django-extensions/default.nix
+++ b/pkgs/development/python-modules/django-extensions/default.nix
@@ -3,32 +3,37 @@
 , django, shortuuid, python-dateutil, pytest
 , pytest-django, pytestcov, mock, vobject
 , werkzeug, glibcLocales, factory_boy
+, fetchpatch
 }:
 
 buildPythonPackage rec {
   pname = "django-extensions";
-  version = "2.1.9";
+  version = "2.2.1";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = version;
-    sha256 = "08vggm6wrn5cbf8brfprif0rjrkqz06wddsw0ir1skkk8q2sp1b2";
+    sha256 = "1g7lg0iwmzfdb747fkfgcy890axpfyzv3606axhyd6cvkbg2mz4d";
   };
 
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/${pname}/${pname}/commit/e30b30c9a5c688b41e39b0e1e9dba1e5f0589adf.patch";
+      sha256 = "1dfpadqcdyq62pwws5dvhy0zb3r3b8flznhqni85l0vbk0cki0dd";
+    })
+  ];
   postPatch = ''
     substituteInPlace setup.py --replace "'tox'," ""
-
-    # not yet pytest 5 compatible?
-    rm tests/management/commands/test_set_fake_emails.py
-    rm tests/management/commands/test_set_fake_passwords.py
-    rm tests/management/commands/test_validate_templates.py
 
     # pip should not be used during tests...
     rm tests/management/commands/test_pipchecker.py
   '';
 
   propagatedBuildInputs = [ six ] ++ lib.optional (pythonOlder "3.5") typing;
+
+  # Some of the tests use localhost networking.
+  __darwinAllowLocalNetworking = true;
 
   checkInputs = [
     django shortuuid python-dateutil pytest


### PR DESCRIPTION
This updates `django-extensions` to version `2.2.1`, which also fixes the pytest5 build failures.

The `pipchecker` tests all try to execute `pip` inside the sandbox with either specific version requirements or a `git+https` repository and are therefore removed because they fail.

`nix-review` shows two failed pkgs that depend on `django-extensions` (`python3.7-django-q-1.0.1` and `python3.7-HyperKitty-1.2.2`). They seem to fail due to pytest5 incompatibility.

###### Motivation for this change

The `django-extensions` build is currently failing.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers
