### PR TITLE
megacli: requireFile -> fetchurl

### DIFF
--- a/pkgs/tools/misc/megacli/default.nix
+++ b/pkgs/tools/misc/megacli/default.nix
@@ -1,15 +1,13 @@
-{ stdenv, rpmextract, ncurses5, patchelf, requireFile, unzip }:
+{ stdenv, rpmextract, ncurses5, patchelf, fetchurl, unzip }:
 
 stdenv.mkDerivation rec {
   pname = "megacli";
   version = "8.07.14";
 
-  src =
-    requireFile {
-      name = "${builtins.replaceStrings ["."] ["-"] version}_MegaCLI.zip";
-      url = https://docs.broadcom.com/docs/12351587;
-      sha256 = "1sdn58fbmd3fj4nzbajq3gcyw71ilgdh45r5p4sa6xmb7np55cfr";
-    };
+  src = fetchurl {
+    url = "https://docs.broadcom.com/docs-and-downloads/raid-controllers/raid-controllers-common-files/${builtins.replaceStrings ["."] ["-"] version}_MegaCLI.zip";
+    sha256 = "1sdn58fbmd3fj4nzbajq3gcyw71ilgdh45r5p4sa6xmb7np55cfr";
+  };
 
   buildInputs = [rpmextract ncurses5 unzip];
   libPath =


### PR DESCRIPTION
Other distros use direct url (https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=megacli), so `requireFile` for a popular server package (used on many Hetzner servers) is an annoyance.