### PR TITLE
treewide: don't use single quotes with placeholder

### DIFF
--- a/pkgs/applications/display-managers/lightdm/default.nix
+++ b/pkgs/applications/display-managers/lightdm/default.nix
@@ -67,7 +67,7 @@ stdenv.mkDerivation rec {
     ++ optional withQt5 "--enable-liblightdm-qt5";
 
   installFlags = [
-    "sysconfdir=${placeholder ''out''}/etc"
+    "sysconfdir=${placeholder "out"}/etc"
     "localstatedir=\${TMPDIR}"
   ];
 

--- a/pkgs/applications/misc/gpscorrelate/default.nix
+++ b/pkgs/applications/misc/gpscorrelate/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   ];
 
   makeFlags = [
-    "prefix=${placeholder ''out''}"
+    "prefix=${placeholder "out"}"
     "GTK=3"
     "CC=cc"
     "CXX=c++"

--- a/pkgs/applications/misc/kjv/default.nix
+++ b/pkgs/applications/misc/kjv/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   patches = [ add-apocrypha add-install-target ];
 
   makeFlags = [
-    "PREFIX=${placeholder ''out''}"
+    "PREFIX=${placeholder "out"}"
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/misc/plank/default.nix
+++ b/pkgs/applications/misc/plank/default.nix
@@ -64,8 +64,8 @@ stdenv.mkDerivation rec {
 
   # fix paths
   makeFlags = [
-    "INTROSPECTION_GIRDIR=${placeholder ''out''}/share/gir-1.0/"
-    "INTROSPECTION_TYPELIBDIR=${placeholder ''out''}/lib/girepository-1.0"
+    "INTROSPECTION_GIRDIR=${placeholder "out"}/share/gir-1.0/"
+    "INTROSPECTION_TYPELIBDIR=${placeholder "out"}/lib/girepository-1.0"
   ];
 
   # Make plank's application launcher hidden in Pantheon

--- a/pkgs/applications/misc/web-media-controller/default.nix
+++ b/pkgs/applications/misc/web-media-controller/default.nix
@@ -14,9 +14,9 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkgconfig ];
   buildInputs = [ glib pcre json-glib ];
   cmakeFlags = [
-    "-DCHROMIUM_MANIFEST_DESTINATION=${placeholder ''out''}/etc/chromium/native-messaging-hosts"
-    "-DCHROME_MANIFEST_DESTINATION=${placeholder ''out''}/etc/opt/chrome/native-messaging-hosts"
-    "-DFIREFOX_MANIFEST_DESTINATION=${placeholder ''out''}/lib/mozilla/native-messaging-hosts"
+    "-DCHROMIUM_MANIFEST_DESTINATION=${placeholder "out"}/etc/chromium/native-messaging-hosts"
+    "-DCHROME_MANIFEST_DESTINATION=${placeholder "out"}/etc/opt/chrome/native-messaging-hosts"
+    "-DFIREFOX_MANIFEST_DESTINATION=${placeholder "out"}/lib/mozilla/native-messaging-hosts"
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/networking/dropbox/cli.nix
+++ b/pkgs/applications/networking/dropbox/cli.nix
@@ -53,11 +53,11 @@ stdenv.mkDerivation {
   ];
 
   configureFlags = [
-    "--with-nautilus-extension-dir=${placeholder ''nautilusExtension''}/lib/nautilus/extensions-3.0"
+    "--with-nautilus-extension-dir=${placeholder "nautilusExtension"}/lib/nautilus/extensions-3.0"
   ];
 
   makeFlags = [
-    "EMBLEM_DIR=${placeholder ''nautilusExtension''}/share/nautilus-dropbox/emblems"
+    "EMBLEM_DIR=${placeholder "nautilusExtension"}/share/nautilus-dropbox/emblems"
   ];
 
   meta = {

--- a/pkgs/applications/science/electronics/fped/default.nix
+++ b/pkgs/applications/science/electronics/fped/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   # This uses '/bin/bash', '/usr/local' and 'lex' by default
   makeFlags = [
-    "PREFIX=${placeholder ''out''}"
+    "PREFIX=${placeholder "out"}"
     "LEX=flex"
     "RGBDEF=${netpbm}/share/netpbm/misc/rgb.txt"
   ];

--- a/pkgs/applications/version-management/git-and-tools/git-crypt/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-crypt/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   '';
 
   makeFlags = [
-    "PREFIX=${placeholder ''out''}"
+    "PREFIX=${placeholder "out"}"
     "ENABLE_MAN=yes"
     "DOCBOOK_XSL=${docbook_xsl}/share/xml/docbook-xsl-nons/manpages/docbook.xsl"
   ];

--- a/pkgs/applications/version-management/git-and-tools/git-subrepo/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-subrepo/default.nix
@@ -21,9 +21,9 @@ stdenv.mkDerivation rec {
   ];
 
   makeFlags = [
-    "PREFIX=${placeholder ''out''}"
-    "INSTALL_LIB=${placeholder ''out''}/bin"
-    "INSTALL_MAN=${placeholder ''out''}/share/man/man1"
+    "PREFIX=${placeholder "out"}"
+    "INSTALL_LIB=${placeholder "out"}/bin"
+    "INSTALL_MAN=${placeholder "out"}/share/man/man1"
   ];
 
   patches = [

--- a/pkgs/desktops/deepin/dbus-factory/default.nix
+++ b/pkgs/desktops/deepin/dbus-factory/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     go-dbus-generator
   ];
 
-  makeFlags = [ "GOPATH=${placeholder ''out''}/share/go" ];
+  makeFlags = [ "GOPATH=${placeholder "out"}/share/go" ];
 
   postPatch = ''
     sed -i -e 's:/share/gocode:/share/go:' Makefile

--- a/pkgs/desktops/deepin/deepin-anything/default.nix
+++ b/pkgs/desktops/deepin/deepin-anything/default.nix
@@ -30,7 +30,7 @@ mkDerivation rec {
 
   makeFlags = [
     "DEB_HOST_MULTIARCH="
-    "PREFIX=${placeholder ''out''}"
+    "PREFIX=${placeholder "out"}"
   ];
 
   postPatch = ''

--- a/pkgs/desktops/deepin/deepin-desktop-schemas/default.nix
+++ b/pkgs/desktops/deepin/deepin-desktop-schemas/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     # fix default background url
     sed -i -e 's,/usr/share/backgrounds/default_background.jpg,/usr/share/backgrounds/deepin/desktop.jpg,' \
       overrides/common/com.deepin.wrap.gnome.desktop.override
-      
+
     fixPath ${deepin-wallpapers} /usr/share/backgrounds \
       overrides/common/com.deepin.wrap.gnome.desktop.override
 
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
     #   /usr/share/desktop-directories
   '';
 
-  makeFlags = [ "PREFIX=${placeholder ''out''}" ];
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
 
   doCheck = true;
   checkTarget = "test";

--- a/pkgs/desktops/deepin/deepin-gettext-tools/default.nix
+++ b/pkgs/desktops/deepin/deepin-gettext-tools/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     python3Packages.python
   ];
 
-  makeFlags = [ "PREFIX=${placeholder ''out''}" ];
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
 
   postPatch = ''
     sed -e 's/sudo cp/cp/' -i src/generate_mo.py

--- a/pkgs/desktops/deepin/deepin-gtk-theme/default.nix
+++ b/pkgs/desktops/deepin/deepin-gtk-theme/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   propagatedUserEnvPkgs = [ gtk-engine-murrine ];
 
-  makeFlags = [ "PREFIX=${placeholder ''out''}" ];
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
 
   passthru.updateScript = deepin.updateScript { inherit ;name = "${pname}-${version}"; };
 

--- a/pkgs/desktops/deepin/deepin-icon-theme/default.nix
+++ b/pkgs/desktops/deepin/deepin-icon-theme/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   buildTargets = "all hicolor-links";
   installTargets = "install-icons install-cursors";
-  installFlags = [ "PREFIX=${placeholder ''out''}" ];
+  installFlags = [ "PREFIX=${placeholder "out"}" ];
 
   postInstall = ''
     cp -a ./Sea ./usr/share/icons/hicolor "$out"/share/icons/

--- a/pkgs/desktops/deepin/deepin-sound-theme/default.nix
+++ b/pkgs/desktops/deepin/deepin-sound-theme/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "1sw4nrn7q7wk1hpicm05apyc0mihaw42iqm52wb8ib8gm1qiylr9";
   };
 
-  makeFlags = [ "PREFIX=${placeholder ''out''}" ];
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
 
   passthru.updateScript = deepin.updateScript { inherit ;name = "${pname}-${version}"; };
 

--- a/pkgs/desktops/deepin/go-dbus-factory/default.nix
+++ b/pkgs/desktops/deepin/go-dbus-factory/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "06fqyad9f50gcjsjkh7929yyaprahdjhnd0dr4gl2797a7wysl3f";
   };
 
-  makeFlags = [ "PREFIX=${placeholder ''out''}" ];
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
 
   postPatch = ''
     sed -i -e 's:/share/gocode:/share/go:' Makefile

--- a/pkgs/desktops/deepin/go-dbus-generator/default.nix
+++ b/pkgs/desktops/deepin/go-dbus-generator/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   ];
 
   makeFlags = [
-    "PREFIX=${placeholder ''out''}"
+    "PREFIX=${placeholder "out"}"
     "GOCACHE=$(TMPDIR)/go-cache"
   ];
 

--- a/pkgs/desktops/deepin/go-gir-generator/default.nix
+++ b/pkgs/desktops/deepin/go-gir-generator/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   '';
 
   makeFlags = [
-    "PREFIX=${placeholder ''out''}"
+    "PREFIX=${placeholder "out"}"
     "GOCACHE=$(TMPDIR)/go-cache"
   ];
 

--- a/pkgs/desktops/deepin/qt5dxcb-plugin/default.nix
+++ b/pkgs/desktops/deepin/qt5dxcb-plugin/default.nix
@@ -25,7 +25,7 @@ mkDerivation rec {
   ];
 
   qmakeFlags = [
-    "INSTALL_PATH=${placeholder ''out''}/${qtbase.qtPluginPrefix}/platforms"
+    "INSTALL_PATH=${placeholder "out"}/${qtbase.qtPluginPrefix}/platforms"
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/desktops/gnome-3/core/gnome-keyring/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-keyring/default.nix
@@ -23,8 +23,8 @@ stdenv.mkDerivation rec {
   ];
 
   configureFlags = [
-    "--with-pkcs11-config=${placeholder ''out''}/etc/pkcs11/" # installation directories
-    "--with-pkcs11-modules=${placeholder ''out''}/lib/pkcs11/"
+    "--with-pkcs11-config=${placeholder "out"}/etc/pkcs11/" # installation directories
+    "--with-pkcs11-modules=${placeholder "out"}/lib/pkcs11/"
   ];
 
   postPatch = ''

--- a/pkgs/desktops/gnome-3/core/gnome-user-share/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-user-share/default.nix
@@ -34,8 +34,8 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--with-httpd=${apacheHttpd.out}/bin/httpd"
     "--with-modules-path=${apacheHttpd.dev}/modules"
-    "--with-systemduserunitdir=${placeholder ''out''}/etc/systemd/user"
-    "--with-nautilusdir=${placeholder ''out''}/lib/nautilus/extensions-3.0"
+    "--with-systemduserunitdir=${placeholder "out"}/etc/systemd/user"
+    "--with-nautilusdir=${placeholder "out"}/lib/nautilus/extensions-3.0"
   ];
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/extensions/taskwhisperer/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/taskwhisperer/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   uuid = "taskwhisperer-extension@infinicode.de";
 
   makeFlags = [
-    "INSTALLBASE=${placeholder ''out''}/share/gnome-shell/extensions"
+    "INSTALLBASE=${placeholder "out"}/share/gnome-shell/extensions"
   ];
 
   patches = [

--- a/pkgs/desktops/gnome-3/misc/gnome-applets/default.nix
+++ b/pkgs/desktops/gnome-3/misc/gnome-applets/default.nix
@@ -68,7 +68,7 @@ in stdenv.mkDerivation rec {
   doCheck = true;
 
   configureFlags = [
-    "--with-libpanel-applet-dir=${placeholder ''out''}/share/gnome-panel/applets"
+    "--with-libpanel-applet-dir=${placeholder "out"}/share/gnome-panel/applets"
   ];
 
   passthru = {

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/a11y/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/a11y/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
     switchboard
   ];
 
-  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder ''out''}/lib/switchboard";
+  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder "out"}/lib/switchboard";
 
   meta = with stdenv.lib; {
     description = "Switchboard Universal Access Plug";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/about/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/about/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
     ./remove-update-button.patch
   ];
 
-  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder ''out''}/lib/switchboard";
+  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder "out"}/lib/switchboard";
 
   meta = with stdenv.lib; {
     description = "Switchboard About Plug";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/applications/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/applications/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
     switchboard
   ];
 
-  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder ''out''}/lib/switchboard";
+  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder "out"}/lib/switchboard";
 
   meta = with stdenv.lib; {
     description = "Switchboard Applications Plug";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/bluetooth/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/bluetooth/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     switchboard
   ];
 
-  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder ''out''}/lib/switchboard";
+  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder "out"}/lib/switchboard";
 
   meta = with stdenv.lib; {
     description = "Switchboard Bluetooth Plug";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/datetime/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/datetime/default.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
     ./clock-format.patch
   ];
 
-  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder ''out''}/lib/switchboard";
+  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder "out"}/lib/switchboard";
 
   meta = with stdenv.lib; {
     description = "Switchboard Date & Time Plug";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/display/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/display/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
     switchboard
   ];
 
-  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder ''out''}/lib/switchboard";
+  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder "out"}/lib/switchboard";
 
   meta = with stdenv.lib; {
     description = "Switchboard Displays Plug";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/keyboard/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/keyboard/default.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder ''out''}/lib/switchboard";
+  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder "out"}/lib/switchboard";
 
   meta = with stdenv.lib; {
     description = "Switchboard Keyboard Plug";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/mouse-touchpad/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/mouse-touchpad/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
     switchboard
   ];
 
-  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder ''out''}/lib/switchboard";
+  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder "out"}/lib/switchboard";
 
   meta = with stdenv.lib; {
     description = "Switchboard Mouse & Touchpad Plug";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/network/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/network/default.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
   ];
 
 
-  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder ''out''}/lib/switchboard";
+  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder "out"}/lib/switchboard";
 
   meta = with stdenv.lib; {
     description = "Switchboard Networking Plug";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/notifications/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/notifications/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
     switchboard
   ];
 
-  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder ''out''}/lib/switchboard";
+  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder "out"}/lib/switchboard";
 
   meta = with stdenv.lib; {
     description = "Switchboard Notifications Plug";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/pantheon-shell/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/pantheon-shell/default.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
   '';
 
 
-  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder ''out''}/lib/switchboard";
+  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder "out"}/lib/switchboard";
 
   meta = with stdenv.lib; {
     description = "Switchboard Desktop Plug";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/power/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/power/default.nix
@@ -64,10 +64,10 @@ stdenv.mkDerivation rec {
       --subst-var-by GSD_GSETTINGS_PATH ${elementary-settings-daemon}/share/gsettings-schemas/${elementary-settings-daemon.name}/glib-2.0/schemas
   '';
 
-  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder ''out''}/lib/switchboard";
-  PKG_CONFIG_DBUS_1_SYSTEM_BUS_SERVICES_DIR = "${placeholder ''out''}/share/dbus-1/system-services";
-  PKG_CONFIG_DBUS_1_SYSCONFDIR = "${placeholder ''out''}/etc";
-  PKG_CONFIG_POLKIT_GOBJECT_1_POLICYDIR = "${placeholder ''out''}/share/polkit-1/actions";
+  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder "out"}/lib/switchboard";
+  PKG_CONFIG_DBUS_1_SYSTEM_BUS_SERVICES_DIR = "${placeholder "out"}/share/dbus-1/system-services";
+  PKG_CONFIG_DBUS_1_SYSCONFDIR = "${placeholder "out"}/etc";
+  PKG_CONFIG_POLKIT_GOBJECT_1_POLICYDIR = "${placeholder "out"}/share/polkit-1/actions";
 
   meta = with stdenv.lib; {
     description = "Switchboard Power Plug";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/printers/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/printers/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     switchboard
   ];
 
-  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder ''out''}/lib/switchboard";
+  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder "out"}/lib/switchboard";
 
   meta = with stdenv.lib; {
     description = "Switchboard Printers Plug";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/security-privacy/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/security-privacy/default.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
     zeitgeist
   ];
 
-  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder ''out''}/lib/switchboard";
+  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder "out"}/lib/switchboard";
 
   patches = [
     ./hardcode-gsettings.patch

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/sharing/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/sharing/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
     switchboard
   ];
 
-  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder ''out''}/lib/switchboard";
+  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder "out"}/lib/switchboard";
 
   meta = with stdenv.lib; {
     description = "Switchboard Sharing Plug";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/sound/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/sound/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
     switchboard
   ];
 
-  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder ''out''}/lib/switchboard";
+  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder "out"}/lib/switchboard";
 
   meta = with stdenv.lib; {
     description = "Switchboard Sound Plug";

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/applications-menu/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/applications-menu/default.nix
@@ -70,11 +70,11 @@ stdenv.mkDerivation rec {
    ];
 
   mesonFlags = [
-    "--sysconfdir=${placeholder ''out''}/etc"
+    "--sysconfdir=${placeholder "out"}/etc"
   ];
 
-  PKG_CONFIG_WINGPANEL_2_0_INDICATORSDIR = "${placeholder ''out''}/lib/wingpanel";
-  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder ''out''}/lib/switchboard";
+  PKG_CONFIG_WINGPANEL_2_0_INDICATORSDIR = "${placeholder "out"}/lib/wingpanel";
+  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder "out"}/lib/switchboard";
 
   patches = [
     (substituteAll {

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/bluetooth/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/bluetooth/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
     wingpanel
   ];
 
-  PKG_CONFIG_WINGPANEL_2_0_INDICATORSDIR = "${placeholder ''out''}/lib/wingpanel";
+  PKG_CONFIG_WINGPANEL_2_0_INDICATORSDIR = "${placeholder "out"}/lib/wingpanel";
 
   postPatch = ''
     chmod +x meson/post_install.py

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/datetime/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/datetime/default.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  PKG_CONFIG_WINGPANEL_2_0_INDICATORSDIR = "${placeholder ''out''}/lib/wingpanel";
+  PKG_CONFIG_WINGPANEL_2_0_INDICATORSDIR = "${placeholder "out"}/lib/wingpanel";
 
   postPatch = ''
     chmod +x meson/post_install.py

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/keyboard/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/keyboard/default.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  PKG_CONFIG_WINGPANEL_2_0_INDICATORSDIR = "${placeholder ''out''}/lib/wingpanel";
+  PKG_CONFIG_WINGPANEL_2_0_INDICATORSDIR = "${placeholder "out"}/lib/wingpanel";
 
   meta = with stdenv.lib; {
     description = "Keyboard Indicator for Wingpanel";

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/network/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/network/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
     wingpanel
   ];
 
-  PKG_CONFIG_WINGPANEL_2_0_INDICATORSDIR = "${placeholder ''out''}/lib/wingpanel";
+  PKG_CONFIG_WINGPANEL_2_0_INDICATORSDIR = "${placeholder "out"}/lib/wingpanel";
 
   meta = with stdenv.lib; {
     description = "Network Indicator for Wingpanel";

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/nightlight/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/nightlight/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
     wingpanel
   ];
 
-  PKG_CONFIG_WINGPANEL_2_0_INDICATORSDIR = "${placeholder ''out''}/lib/wingpanel";
+  PKG_CONFIG_WINGPANEL_2_0_INDICATORSDIR = "${placeholder "out"}/lib/wingpanel";
 
   meta = with stdenv.lib; {
     description = "Night Light Indicator for Wingpanel";

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/notifications/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/notifications/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
     wingpanel
   ];
 
-  PKG_CONFIG_WINGPANEL_2_0_INDICATORSDIR = "${placeholder ''out''}/lib/wingpanel";
+  PKG_CONFIG_WINGPANEL_2_0_INDICATORSDIR = "${placeholder "out"}/lib/wingpanel";
 
   meta = with stdenv.lib; {
     description = "Notifications Indicator for Wingpanel";

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/power/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/power/default.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
     wingpanel
   ];
 
-  PKG_CONFIG_WINGPANEL_2_0_INDICATORSDIR = "${placeholder ''out''}/lib/wingpanel";
+  PKG_CONFIG_WINGPANEL_2_0_INDICATORSDIR = "${placeholder "out"}/lib/wingpanel";
 
   postPatch = ''
     chmod +x meson/post_install.py

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/session/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/session/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
     wingpanel
   ];
 
-  PKG_CONFIG_WINGPANEL_2_0_INDICATORSDIR = "${placeholder ''out''}/lib/wingpanel";
+  PKG_CONFIG_WINGPANEL_2_0_INDICATORSDIR = "${placeholder "out"}/lib/wingpanel";
 
   meta = with stdenv.lib; {
     description = "Session Indicator for Wingpanel";

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/sound/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/sound/default.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation rec {
     wingpanel
   ];
 
-  PKG_CONFIG_WINGPANEL_2_0_INDICATORSDIR = "${placeholder ''out''}/lib/wingpanel";
+  PKG_CONFIG_WINGPANEL_2_0_INDICATORSDIR = "${placeholder "out"}/lib/wingpanel";
 
   postPatch = ''
     chmod +x meson/post_install.py

--- a/pkgs/desktops/pantheon/services/contractor/default.nix
+++ b/pkgs/desktops/pantheon/services/contractor/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
     libgee
   ];
 
-  PKG_CONFIG_DBUS_1_SESSION_BUS_SERVICES_DIR = "${placeholder ''out''}/share/dbus-1/services";
+  PKG_CONFIG_DBUS_1_SESSION_BUS_SERVICES_DIR = "${placeholder "out"}/share/dbus-1/services";
 
   meta = with stdenv.lib; {
     description = "A desktop-wide extension service used by elementary OS";

--- a/pkgs/desktops/surf-display/default.nix
+++ b/pkgs/desktops/surf-display/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
        --prefix PATH ':' ${stdenv.lib.makeBinPath buildInputs}
   '';
 
-  makeFlags = [ "PREFIX=${placeholder ''out''}" ];
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
 
   meta = with stdenv.lib; {
     description = "Kiosk browser session manager based on the surf browser";

--- a/pkgs/desktops/xfce4-14/xfce4-session/default.nix
+++ b/pkgs/desktops/xfce4-14/xfce4-session/default.nix
@@ -9,7 +9,7 @@ mkXfceDerivation rec {
 
   buildInputs = [ exo gtk3 glib libxfce4ui libxfce4util libwnck3 xfconf polkit iceauth ];
 
-  configureFlags = [ "--with-xsession-prefix=${placeholder ''out''}" ];
+  configureFlags = [ "--with-xsession-prefix=${placeholder "out"}" ];
 
   # See https://github.com/NixOS/nixpkgs/issues/36468
   NIX_CFLAGS_COMPILE = "-I${glib.dev}/include/gio-unix-2.0";

--- a/pkgs/development/libraries/accountsservice/default.nix
+++ b/pkgs/development/libraries/accountsservice/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
   mesonFlags = [
     "-Dadmin_group=wheel"
     "-Dlocalstatedir=/var"
-    "-Dsystemdsystemunitdir=${placeholder ''out''}/etc/systemd/system"
+    "-Dsystemdsystemunitdir=${placeholder "out"}/etc/systemd/system"
   ];
 
   postPatch = ''

--- a/pkgs/development/libraries/bamf/default.nix
+++ b/pkgs/development/libraries/bamf/default.nix
@@ -55,8 +55,8 @@ stdenv.mkDerivation rec {
 
   # fix paths
   makeFlags = [
-    "INTROSPECTION_GIRDIR=${placeholder ''dev''}/share/gir-1.0/"
-    "INTROSPECTION_TYPELIBDIR=${placeholder ''out''}/lib/girepository-1.0"
+    "INTROSPECTION_GIRDIR=${placeholder "dev"}/share/gir-1.0/"
+    "INTROSPECTION_TYPELIBDIR=${placeholder "out"}/lib/girepository-1.0"
   ];
 
   preConfigure = ''

--- a/pkgs/development/libraries/dee/default.nix
+++ b/pkgs/development/libraries/dee/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--disable-gtk-doc"
-    "--with-pygi-overrides-dir=${placeholder ''py''}/${python3.sitePackages}/gi/overrides"
+    "--with-pygi-overrides-dir=${placeholder "py"}/${python3.sitePackages}/gi/overrides"
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/gnome-menus/default.nix
+++ b/pkgs/development/libraries/gnome-menus/default.nix
@@ -10,8 +10,8 @@ stdenv.mkDerivation rec {
   };
 
   makeFlags = [
-    "INTROSPECTION_GIRDIR=${placeholder ''out''}/share/gir-1.0/"
-    "INTROSPECTION_TYPELIBDIR=${placeholder ''out''}/lib/girepository-1.0"
+    "INTROSPECTION_GIRDIR=${placeholder "out"}/share/gir-1.0/"
+    "INTROSPECTION_TYPELIBDIR=${placeholder "out"}/lib/girepository-1.0"
   ];
 
   nativeBuildInputs = [ pkgconfig gettext ];

--- a/pkgs/development/libraries/graphene/default.nix
+++ b/pkgs/development/libraries/graphene/default.nix
@@ -32,8 +32,8 @@ stdenv.mkDerivation rec {
 
   mesonFlags = [
     "-Dgtk_doc=true"
-    "-Dinstalled_test_datadir=${placeholder ''installedTests''}/share"
-    "-Dinstalled_test_bindir=${placeholder ''installedTests''}/libexec"
+    "-Dinstalled_test_datadir=${placeholder "installedTests"}/share"
+    "-Dinstalled_test_bindir=${placeholder "installedTests"}/libexec"
   ];
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/libaccounts-glib/default.nix
+++ b/pkgs/development/libraries/libaccounts-glib/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   # See: https://gitlab.com/accounts-sso/libaccounts-glib/merge_requests/22
   patches = [ ./py-override.patch ];
 
-  nativeBuildInputs = [ 
+  nativeBuildInputs = [
     check
     docbook_xml_dtd_43
     docbook_xsl
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
   LC_ALL = "en_US.UTF-8";
 
   mesonFlags = [
-    "-Dpy-overrides-dir=${placeholder ''py''}/${python3.sitePackages}/gi/overrides"
+    "-Dpy-overrides-dir=${placeholder "py"}/${python3.sitePackages}/gi/overrides"
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/libdbusmenu/default.nix
+++ b/pkgs/development/libraries/libdbusmenu/default.nix
@@ -49,9 +49,9 @@ stdenv.mkDerivation rec {
   doCheck = false; # generates shebangs in check phase, too lazy to fix
 
   installFlags = [
-    "sysconfdir=${placeholder ''out''}/etc"
+    "sysconfdir=${placeholder "out"}/etc"
     "localstatedir=\${TMPDIR}"
-    "typelibdir=${placeholder ''out''}/lib/girepository-1.0"
+    "typelibdir=${placeholder "out"}/lib/girepository-1.0"
   ];
 
   meta = {

--- a/pkgs/development/libraries/libgdata/default.nix
+++ b/pkgs/development/libraries/libgdata/default.nix
@@ -77,8 +77,8 @@ stdenv.mkDerivation rec {
 
   mesonFlags = [
     "-Dgtk_doc=false"
-    "-Dinstalled_test_bindir=${placeholder ''installedTests''}/libexec"
-    "-Dinstalled_test_datadir=${placeholder ''installedTests''}/share"
+    "-Dinstalled_test_bindir=${placeholder "installedTests"}/libexec"
+    "-Dinstalled_test_datadir=${placeholder "installedTests"}/share"
     "-Dinstalled_tests=true"
   ];
 

--- a/pkgs/development/libraries/libgpiod/default.nix
+++ b/pkgs/development/libraries/libgpiod/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--enable-tools=${if enable-tools then "yes" else "no"}"
     "--enable-bindings-cxx"
-    "--prefix=${placeholder ''out''}"
+    "--prefix=${placeholder "out"}"
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/libirecovery/default.nix
+++ b/pkgs/development/libraries/libirecovery/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
   # as only the `idevicerestore` binary was tested so far (which worked
   # without further configuration).
   configureFlags = [
-    "--with-udevrulesdir=${placeholder ''out''}/lib/udev/rules.d"
+    "--with-udevrulesdir=${placeholder "out"}/lib/udev/rules.d"
     ''--with-udevrule="OWNER=\"root\", GROUP=\"myusergroup\", MODE=\"0660\""''
   ];
 

--- a/pkgs/development/libraries/libmbim/default.nix
+++ b/pkgs/development/libraries/libmbim/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" "man" ];
 
   configureFlags = [
-    "--with-udev-base-dir=${placeholder ''out''}/lib/udev"
+    "--with-udev-base-dir=${placeholder "out"}/lib/udev"
   ];
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/libqmi/default.nix
+++ b/pkgs/development/libraries/libqmi/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" "devdoc" ];
 
   configureFlags = [
-    "--with-udev-base-dir=${placeholder ''out''}/lib/udev"
+    "--with-udev-base-dir=${placeholder "out"}/lib/udev"
   ];
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/libunity/default.nix
+++ b/pkgs/development/libraries/libunity/default.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--disable-static"
-    "--with-pygi-overrides-dir=${placeholder ''py''}/${python3.sitePackages}/gi/overrides"
+    "--with-pygi-overrides-dir=${placeholder "py"}/${python3.sitePackages}/gi/overrides"
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/tracker/default.nix
+++ b/pkgs/development/libraries/tracker/default.nix
@@ -30,8 +30,8 @@ in stdenv.mkDerivation rec {
   LC_ALL = "en_US.UTF-8";
 
   mesonFlags = [
-    "-Ddbus_services=${placeholder ''out''}/share/dbus-1/services"
-    "-Dsystemd_user_services=${placeholder ''out''}/lib/systemd/user"
+    "-Ddbus_services=${placeholder "out"}/share/dbus-1/services"
+    "-Dsystemd_user_services=${placeholder "out"}/lib/systemd/user"
     # TODO: figure out wrapping unit tests, some of them fail on missing gsettings-desktop-schemas
     "-Dfunctional_tests=false"
     "-Ddocs=true"

--- a/pkgs/development/libraries/zeitgeist/default.nix
+++ b/pkgs/development/libraries/zeitgeist/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   preConfigure = "NOCONFIGURE=1 ./autogen.sh";
 
-  configureFlags = [ "--with-session-bus-services-dir=${placeholder ''out''}/share/dbus-1/services" ];
+  configureFlags = [ "--with-session-bus-services-dir=${placeholder "out"}/share/dbus-1/services" ];
 
   nativeBuildInputs = [
     autoconf automake libtool pkgconfig gettext gobject-introspection vala python2Packages.python

--- a/pkgs/os-specific/linux/upower/default.nix
+++ b/pkgs/os-specific/linux/upower/default.nix
@@ -43,9 +43,9 @@ stdenv.mkDerivation rec {
     "--localstatedir=/var"
   ]
   ++ stdenv.lib.optional useSystemd [
-    "--with-systemdsystemunitdir=${placeholder ''out''}/etc/systemd/system"
-    "--with-systemdutildir=${placeholder ''out''}/lib/systemd"
-    "--with-udevrulesdir=${placeholder ''out''}/lib/udev/rules.d"
+    "--with-systemdsystemunitdir=${placeholder "out"}/etc/systemd/system"
+    "--with-systemdutildir=${placeholder "out"}/lib/systemd"
+    "--with-udevrulesdir=${placeholder "out"}/lib/udev/rules.d"
   ]
   ;
 

--- a/pkgs/tools/audio/mp3cat/default.nix
+++ b/pkgs/tools/audio/mp3cat/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   makeFlags = [
-    "PREFIX=${placeholder ''out''}"
+    "PREFIX=${placeholder "out"}"
   ];
 
   installTargets = [

--- a/pkgs/tools/misc/most/default.nix
+++ b/pkgs/tools/misc/most/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "doc" ];
 
   makeFlags = [
-    "DOC_DIR=${placeholder ''doc''}/share/doc/most"
+    "DOC_DIR=${placeholder "doc"}/share/doc/most"
   ];
 
   preConfigure = ''

--- a/pkgs/tools/networking/modem-manager/default.nix
+++ b/pkgs/tools/networking/modem-manager/default.nix
@@ -17,9 +17,9 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--with-polkit"
-    "--with-udev-base-dir=${placeholder ''out''}/lib/udev"
-    "--with-dbus-sys-dir=${placeholder ''out''}/etc/dbus-1/system.d"
-    "--with-systemdsystemunitdir=${placeholder ''out''}/etc/systemd/system"
+    "--with-udev-base-dir=${placeholder "out"}/lib/udev"
+    "--with-dbus-sys-dir=${placeholder "out"}/etc/dbus-1/system.d"
+    "--with-systemdsystemunitdir=${placeholder "out"}/etc/systemd/system"
     "--sysconfdir=/etc"
     "--localstatedir=/var"
     "--with-systemd-suspend-resume"

--- a/pkgs/tools/networking/ofono/default.nix
+++ b/pkgs/tools/networking/ofono/default.nix
@@ -41,8 +41,8 @@ stdenv.mkDerivation rec {
   ];
 
   configureFlags = [
-    "--with-dbusconfdir=${placeholder ''out''}/share"
-    "--with-systemdunitdir=${placeholder ''out''}/lib/systemd/system"
+    "--with-dbusconfdir=${placeholder "out"}/share"
+    "--with-systemdunitdir=${placeholder "out"}/lib/systemd/system"
     "--enable-external-ell"
   ];
 

--- a/pkgs/tools/security/sequoia/default.nix
+++ b/pkgs/tools/security/sequoia/default.nix
@@ -48,7 +48,7 @@ rustPlatform.buildRustPackage rec {
   ;
 
   makeFlags = [
-    "PREFIX=${placeholder ''out''}"
+    "PREFIX=${placeholder "out"}"
   ];
 
   buildFlags = [


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
