### PR TITLE
phc-intel: Don't define the package if the assert would fail.

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15923,7 +15923,7 @@ in
 
     perf = callPackage ../os-specific/linux/kernel/perf.nix { };
 
-    phc-intel = callPackage ../os-specific/linux/phc-intel { };
+    phc-intel = if stdenv.lib.versionAtLeast kernel.version "4.10" then callPackage ../os-specific/linux/phc-intel { } else null;
 
     # Disable for kernels 4.15 and above due to compatibility issues
     prl-tools = if stdenv.lib.versionOlder kernel.version "4.15" then callPackage ../os-specific/linux/prl-tools { } else null;


### PR DESCRIPTION
If the kernel is too old one gets the kernel version assertion error, even if that package is not used. Some code must be going through all defined kernel module packages and ends up triggering the assert.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Assertion failure in VirtualBox tests, see https://github.com/NixOS/nixpkgs/pull/67968#issuecomment-527256292.

I just made the packages conditionally defined like a few other packages.

If someone wants to go looking into the cause, here's a backtrace:

```
error: while evaluating the attribute 'buildCommand' of the derivation 'vm-test-run-virtualbox-headless' at /etc/nixos/nixpkgs/nixos/lib/testing.nix:53:7:
while evaluating the attribute 'testScript' of the derivation 'nixos-test-driver-virtualbox-headless' at /etc/nixos/nixpkgs/pkgs/build-support/trivial-builders.nix:7:14:
while evaluating 'isFunction' at /etc/nixos/nixpkgs/lib/trivial.nix:296:16, called from /etc/nixos/nixpkgs/nixos/lib/testing.nix:111:12:
while evaluating anonymous function at /etc/nixos/nixpkgs/lib/attrsets.nix:234:10, called from undefined position:
while evaluating the attribute 'buildCommand' of the derivation 'virtualbox-image' at /etc/nixos/nixpkgs/pkgs/build-support/trivial-builders.nix:7:14:
while evaluating the attribute 'system.build.kernel' at /etc/nixos/nixpkgs/nixos/modules/system/boot/kernel.nix:192:29:
while evaluating the attribute 'boot.kernelPackages' at undefined position:
while evaluating anonymous function at /etc/nixos/nixpkgs/lib/modules.nix:75:45, called from undefined position:
while evaluating the attribute 'value' at /etc/nixos/nixpkgs/lib/modules.nix:336:9:
while evaluating the option `boot.kernelPackages':
while evaluating 'apply' at /etc/nixos/nixpkgs/nixos/modules/system/boot/kernel.nix:40:15, called from /etc/nixos/nixpkgs/lib/modules.nix:333:35:
while evaluating the attribute 'mergedValue' at /etc/nixos/nixpkgs/lib/modules.nix:368:5:
while evaluating anonymous function at /etc/nixos/nixpkgs/lib/modules.nix:368:32, called from /etc/nixos/nixpkgs/lib/modules.nix:368:19:
while evaluating 'mergeEqualOption' at /etc/nixos/nixpkgs/lib/options.nix:108:27, called from /etc/nixos/nixpkgs/lib/modules.nix:371:8:
while evaluating anonymous function at /etc/nixos/nixpkgs/lib/options.nix:110:23, called from /etc/nixos/nixpkgs/lib/options.nix:110:10:
while evaluating 'callPackageWith' at /etc/nixos/nixpkgs/lib/customisation.nix:108:35, called from /etc/nixos/nixpkgs/pkgs/top-level/all-packages.nix:15898:17:
while evaluating 'makeOverridable' at /etc/nixos/nixpkgs/lib/customisation.nix:67:24, called from /etc/nixos/nixpkgs/lib/customisation.nix:112:8:
while evaluating anonymous function at /etc/nixos/nixpkgs/pkgs/os-specific/linux/phc-intel/default.nix:1:1, called from /etc/nixos/nixpkgs/lib/customisation.nix:69:12:
assertion failed at /etc/nixos/nixpkgs/pkgs/os-specific/linux/phc-intel/default.nix:4:1
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @flokli
