### PR TITLE
gnucash: fix cmake configure phase, missing "include(CheckSymbolExists)"

### DIFF
--- a/pkgs/applications/office/gnucash/cmake_check_symbol_exists.patch
+++ b/pkgs/applications/office/gnucash/cmake_check_symbol_exists.patch
@@ -1,0 +1,12 @@
+Index: gnucash-3.6/gnucash/register/register-gnome/CMakeLists.txt
+===================================================================
+--- gnucash-3.6.orig/gnucash/register/register-gnome/CMakeLists.txt
++++ gnucash-3.6/gnucash/register/register-gnome/CMakeLists.txt
+@@ -1,6 +1,7 @@
+ add_subdirectory(test)
+ 
+ #GTK before 3.14 didn't have GDK_MODIFIER_INTENT_DEFAULT_MOD_MASK
++include(CheckSymbolExists)
+ check_symbol_exists(GDK_MODIFIER_INTENT_DEFAULT_MOD_MASK gdk/gdktypes.h have_mod_mask)
+ if (NOT have_mod_mask)
+ if (MAC_INTEGRATION)

--- a/pkgs/applications/office/gnucash/default.nix
+++ b/pkgs/applications/office/gnucash/default.nix
@@ -47,6 +47,8 @@ stdenv.mkDerivation rec {
   # Should probably be removed next version bump
   CXXFLAGS = [ "-Wno-deprecated-declarations" ];
 
+  patches = [ ./cmake_check_symbol_exists.patch ];
+
   postPatch = ''
     patchShebangs .
   '';


### PR DESCRIPTION
###### Motivation for this change

gnucash did not build due to a cmake error. Now it does.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @peti @domenkozar 