### PR TITLE
[19.03] systemd: fix CVE-2019-15718

### DIFF
--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -30,6 +30,14 @@ in stdenv.mkDerivation rec {
     sha256 = "0aczg25ih2gfjq810x8rw6rnpr6sw1lz6z0lvlyw2qphyih68b4x";
   };
 
+  patches = [
+    (fetchpatch {
+      name = "CVE-2019-15718.patch";
+      url = https://github.com/systemd/systemd/pull/13457/commits/35e528018f315798d3bffcb592b32a0d8f5162bd.patch;
+      sha256 = "0m0ypnnllx4r6a2qy1586as15i2qrzxwi1sqdp14rzdwajz1rvnv";
+    })
+  ];
+
   prePatch = let
       # Upstream's maintenance branches are still too intrusive:
       # https://github.com/systemd/systemd-stable/tree/v239-stable


### PR DESCRIPTION
###### Motivation for this change

More details at: https://www.openwall.com/lists/oss-security/2019/09/03/1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @NixOS/security-notifications  
