### PR TITLE
sudo-font: 0.37 -> 0.40

### DIFF
--- a/pkgs/data/fonts/sudo/default.nix
+++ b/pkgs/data/fonts/sudo/default.nix
@@ -1,11 +1,11 @@
 { lib, fetchzip }:
 
 let
-  version = "0.37";
+  version = "0.40";
 in fetchzip rec {
   name = "sudo-font-${version}";
   url = "https://github.com/jenskutilek/sudo-font/releases/download/v${version}/sudo.zip";
-  sha256 = "16x6vs016wz6rmd4p248ri9fn35xq7r3dc8hv4w2c4rz1xl8c099";
+  sha256 = "1nf025sjps4yysf6zkns5fzjgls6xdpifh7bz4ray9x8h5pz0z64";
 
   postFetch = ''
     mkdir -p $out/share/fonts/truetype/


### PR DESCRIPTION
###### Motivation for this change

https://github.com/jenskutilek/sudo-font/releases/tag/v0.38
https://github.com/jenskutilek/sudo-font/releases/tag/v0.39
https://github.com/jenskutilek/sudo-font/releases/tag/v0.40

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @