### PR TITLE
victor-mono: 1.2.1 -> 1.2.5

### DIFF
--- a/pkgs/data/fonts/victor-mono/default.nix
+++ b/pkgs/data/fonts/victor-mono/default.nix
@@ -2,7 +2,7 @@
 
 let
   pname = "victor-mono";
-  version = "1.2.1";
+  version = "1.2.5";
 in fetchFromGitHub rec {
   name = "${pname}-${version}";
 
@@ -26,7 +26,7 @@ in fetchFromGitHub rec {
     unzip -j VictorMonoAll.zip \*.otf -d $out/share/fonts/opentype/${pname}
   '';
 
-  sha256 = "0347n3kdyrbg42rxcgnyghi21qz5iz6w30v7ms2vjal7pfm6h2vn";
+  sha256 = "0dj5h45qk6abggj6mgm19sb0a7q0v4x41f2zds1ab79yd22gbjns";
 
   meta = with lib; {
     description = "Free programming font with cursive italics and ligatures";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Harder, better, faster, stronger.  Well, newer anyway! ;)

https://github.com/rubjo/victor-mono/releases/tag/v1.2.2
https://github.com/rubjo/victor-mono/releases/tag/v1.2.3
https://github.com/rubjo/victor-mono/releases/tag/v1.2.4
https://github.com/rubjo/victor-mono/releases/tag/v1.2.5

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @