### PR TITLE
upower: 0.99.10 -> 0.99.11

### DIFF
--- a/nixos/modules/services/hardware/upower.nix
+++ b/nixos/modules/services/hardware/upower.nix
@@ -5,8 +5,11 @@
 with lib;
 
 let
+
   cfg = config.services.upower;
+
 in
+
 {
 
   ###### interface
@@ -49,42 +52,8 @@ in
 
     services.udev.packages = [ cfg.package ];
 
-    systemd.services.upower =
-      { description = "Power Management Daemon";
-        path = [ pkgs.glib.out ]; # needed for gdbus
-        serviceConfig =
-          { Type = "dbus";
-            BusName = "org.freedesktop.UPower";
-            ExecStart = "@${cfg.package}/libexec/upowerd upowerd";
-            Restart = "on-failure";
-            # Upstream lockdown:
-            # Filesystem lockdown
-            ProtectSystem = "strict";
-            # Needed by keyboard backlight support
-            ProtectKernelTunables = false;
-            ProtectControlGroups = true;
-            ReadWritePaths = "/var/lib/upower";
-            ProtectHome = true;
-            PrivateTmp = true;
+    systemd.packages = [ cfg.package ];
 
-            # Network
-            # PrivateNetwork=true would block udev's netlink socket
-            RestrictAddressFamilies = "AF_UNIX AF_NETLINK";
-
-            # Execute Mappings
-            MemoryDenyWriteExecute = true;
-
-            # Modules
-            ProtectKernelModules = true;
-
-            # Real-time
-            RestrictRealtime = true;
-
-            # Privilege escalation
-            NoNewPrivileges = true;
-          };
-      };
-  
     # The upower daemon seems to get stuck after doing a suspend
     # (i.e. subsequent suspend requests will say "Sleep has already
     # been requested and is pending").  So as a workaround, restart

--- a/nixos/modules/services/hardware/upower.nix
+++ b/nixos/modules/services/hardware/upower.nix
@@ -54,15 +54,6 @@ in
 
     systemd.packages = [ cfg.package ];
 
-    # The upower daemon seems to get stuck after doing a suspend
-    # (i.e. subsequent suspend requests will say "Sleep has already
-    # been requested and is pending").  So as a workaround, restart
-    # the daemon.
-    powerManagement.resumeCommands =
-      ''
-        ${config.systemd.package}/bin/systemctl try-restart upower
-      '';
-
   };
 
 }

--- a/nixos/modules/services/hardware/upower.nix
+++ b/nixos/modules/services/hardware/upower.nix
@@ -84,12 +84,7 @@ in
             NoNewPrivileges = true;
           };
       };
-
-    system.activationScripts.upower =
-      ''
-        mkdir -m 0755 -p /var/lib/upower
-      '';
-
+  
     # The upower daemon seems to get stuck after doing a suspend
     # (i.e. subsequent suspend requests will say "Sleep has already
     # been requested and is pending").  So as a workaround, restart

--- a/pkgs/os-specific/linux/upower/default.nix
+++ b/pkgs/os-specific/linux/upower/default.nix
@@ -1,20 +1,24 @@
 { stdenv
 , fetchurl
 , pkgconfig
-, dbus-glib
-, intltool
 , libxslt
 , docbook_xsl
 , udev
 , libgudev
 , libusb1
+, glib
 , gobject-introspection
-, useSystemd ? true, systemd
+, gettext
+, systemd
+, useIMobileDevice ? true
+, libimobiledevice
 }:
 
 stdenv.mkDerivation rec {
   pname = "upower";
   version = "0.99.11";
+
+  outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = https://gitlab.freedesktop.org/upower/upower/uploads/93cfe7c8d66ed486001c4f3f55399b7a/upower-0.99.11.tar.xz;
@@ -22,32 +26,33 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
+    docbook_xsl
+    gettext
+    gobject-introspection
+    libxslt
     pkgconfig
   ];
 
   buildInputs = [
-    dbus-glib
-    intltool
-    libxslt
-    docbook_xsl
-    udev
     libgudev
     libusb1
-    gobject-introspection
+    udev
+    systemd
   ]
-  ++ stdenv.lib.optional useSystemd systemd
+  ++ stdenv.lib.optional useIMobileDevice libimobiledevice
   ;
 
+  propagatedBuildInputs = [
+    glib
+  ];
+
   configureFlags = [
-    "--with-backend=linux"
     "--localstatedir=/var"
-  ]
-  ++ stdenv.lib.optional useSystemd [
+    "--with-backend=linux"
     "--with-systemdsystemunitdir=${placeholder "out"}/etc/systemd/system"
     "--with-systemdutildir=${placeholder "out"}/lib/systemd"
     "--with-udevrulesdir=${placeholder "out"}/lib/udev/rules.d"
-  ]
-  ;
+  ];
 
   doCheck = false; # fails with "env: './linux/integration-test': No such file or directory"
 

--- a/pkgs/os-specific/linux/upower/default.nix
+++ b/pkgs/os-specific/linux/upower/default.nix
@@ -14,11 +14,11 @@
 
 stdenv.mkDerivation rec {
   pname = "upower";
-  version = "0.99.10";
+  version = "0.99.11";
 
   src = fetchurl {
-    url = https://gitlab.freedesktop.org/upower/upower/uploads/c438511024b9bc5a904f8775cfc8e4c4/upower-0.99.10.tar.xz;
-    sha256 = "17d2bclv5fgma2y3g8bsn9pdvspn1zrzismzdnzfivc0f2wm28k4";
+    url = https://gitlab.freedesktop.org/upower/upower/uploads/93cfe7c8d66ed486001c4f3f55399b7a/upower-0.99.11.tar.xz;
+    sha256 = "1vxxvmz2cxb1qy6ibszaz5bskqdy9nd9fxspj9fv3gfmrjzzzdb4";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

https://gitlab.freedesktop.org/upower/upower/-/tags/UPOWER_0_99_11

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).