### PR TITLE
evtest: 1.33 -> 1.34

### DIFF
--- a/pkgs/applications/misc/evtest/default.nix
+++ b/pkgs/applications/misc/evtest/default.nix
@@ -1,14 +1,15 @@
 { stdenv, fetchgit, autoreconfHook, pkgconfig, libxml2 }:
 
 stdenv.mkDerivation rec {
-  name = "evtest-1.33";
+  pname = "evtest";
+  version = "1.34";
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
   buildInputs = [ libxml2 ];
 
   src = fetchgit {
-    url = "git://anongit.freedesktop.org/evtest";
-    rev = "refs/tags/evtest-1.33";
+    url = "git://anongit.freedesktop.org/${pname}";
+    rev = "refs/tags/${pname}-${version}";
     sha256 = "168gdhzj11f4nk94a6z696sm8v1njzwww69bn6wr97l17897913g";
   };
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @