### PR TITLE
libzip: 1.3.0 -> 1.5.2, fix pkgconfig paths

### DIFF
--- a/pkgs/development/libraries/libzip/default.nix
+++ b/pkgs/development/libraries/libzip/default.nix
@@ -1,35 +1,29 @@
-{ stdenv, fetchurl, perl, zlib }:
+{ stdenv, fetchurl, cmake, perl, zlib }:
 
 stdenv.mkDerivation rec {
   pname = "libzip";
-  version = "1.3.0";
+  version = "1.5.2";
 
   src = fetchurl {
     url = "https://www.nih.at/libzip/${pname}-${version}.tar.gz";
-    sha256 = "1633dvjc08zwwhzqhnv62rjf1abx8y5njmm8y16ik9iwd07ka6d9";
+    sha256 = "05ay8cbm882br0ir2cmzrvdq8q5mr1bnf53l4305xzigpd54lsdy";
   };
 
+  # Fix pkgconfig file paths
   postPatch = ''
-    patchShebangs test-driver
-    patchShebangs man/handle_links
+    sed -i CMakeLists.txt \
+      -e 's#\\''${exec_prefix}/''${CMAKE_INSTALL_LIBDIR}#''${CMAKE_INSTALL_FULL_LIBDIR}#' \
+      -e 's#\\''${prefix}/''${CMAKE_INSTALL_INCLUDEDIR}#''${CMAKE_INSTALL_FULL_INCLUDEDIR}#'
   '';
 
   outputs = [ "out" "dev" ];
 
-  nativeBuildInputs = [ perl ];
+  nativeBuildInputs = [ cmake perl ];
   propagatedBuildInputs = [ zlib ];
 
   preCheck = ''
-    # regress/runtests is a generated file
+    # regress/runtest is a generated file
     patchShebangs regress
-  '';
-
-  # At least mysqlWorkbench cannot find zipconf.h; I think also openoffice
-  # had this same problem.  This links it somewhere that mysqlworkbench looks.
-  postInstall = ''
-    mkdir -p $dev/lib
-    mv $out/lib/libzip $dev/lib/libzip
-    ( cd $dev/include ; ln -s ../lib/libzip/include/zipconf.h zipconf.h )
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Updates libzip to the latest version and fixes issues with CMake generated pkgconfig file that did not account for split outputs.

`nix-review` shows no new build failures.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
