### PR TITLE
vnstat: 2.3 -> 2.4

### DIFF
--- a/pkgs/applications/networking/vnstat/default.nix
+++ b/pkgs/applications/networking/vnstat/default.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   pname = "vnstat";
-  version = "2.3";
+  version = "2.4";
 
   src = fetchurl {
-    sha256 = "138s79dqxrm59xc2s2xch16qkzzjks580sac4ppq8jy5lxrzj2i8";
+    sha256 = "1amb8l97y6acp9j1xs2da3mdk6hykg6drzsps9im8vfmmfcmk5d0";
     url = "https://humdi.net/${pname}/${pname}-${version}.tar.gz";
   };
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @