### PR TITLE
xbps: 0.56 -> 0.57

### DIFF
--- a/pkgs/tools/package-management/xbps/default.nix
+++ b/pkgs/tools/package-management/xbps/default.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
 
   patches = [ ./cert-paths.patch ];
 
+  NIX_CFLAGS_COMPILE = [ "-Wno-error=unused-result" ];
+
   postPatch = ''
     # fix unprefixed ranlib (needed on cross)
     substituteInPlace lib/Makefile \

--- a/pkgs/tools/package-management/xbps/default.nix
+++ b/pkgs/tools/package-management/xbps/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "xbps";
-  version = "0.56";
+  version = "0.57";
 
   src = fetchFromGitHub {
     owner = "void-linux";
     repo = "xbps";
     rev = version;
-    sha256 = "0hqvq6fq62l5sgm4fy3zb0ks889d21mqz4f4my3iifs6c9f50na2";
+    sha256 = "1aaa0h265lx85hmcvg7zpg7iiq6dzzlyxqazn1s387ss709i5gxn";
   };
 
   nativeBuildInputs = [ pkgconfig which ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @dtzWill ;)