### PR TITLE
mesa_glu: 9.0.0 -> 9.0.1

### DIFF
--- a/pkgs/development/libraries/mesa-glu/default.nix
+++ b/pkgs/development/libraries/mesa-glu/default.nix
@@ -2,15 +2,12 @@
 
 stdenv.mkDerivation rec {
   pname = "glu";
-  version = "9.0.0";
+  version = "9.0.1";
 
   src = fetchurl {
-    url = "ftp://ftp.freedesktop.org/pub/mesa/glu/${pname}-${version}.tar.bz2";
-    sha256 = "04nzlil3a6fifcmb95iix3yl8mbxdl66b99s62yzq8m7g79x0yhz";
+    url = "ftp://ftp.freedesktop.org/pub/mesa/${pname}/${pname}-${version}.tar.xz";
+    sha256 = "1g2m634p73mixkzv1qz1d0flwm390ydi41bwmchiqvdssqnlqnpv";
   };
-  postPatch = ''
-    echo 'Cflags: -I''${includedir}' >> glu.pc.in
-  '';
 
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs = [ libGL ]


### PR DESCRIPTION
###### Motivation for this change

* source tarball is now xz, not bz2
* pkgconfig was fixed to include Cflags

https://gitlab.freedesktop.org/mesa/glu/compare/glu-9.0.0...glu-9.0.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @