### PR TITLE
libXi: 1.7.9 -> 1.7.10

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -898,11 +898,11 @@ lib.makeScope newScope (self: with self; {
   }) {};
 
   libXi = callPackage ({ stdenv, pkgconfig, fetchurl, xorgproto, libX11, libXext, libXfixes }: stdenv.mkDerivation {
-    name = "libXi-1.7.9";
+    name = "libXi-1.7.10";
     builder = ./builder.sh;
     src = fetchurl {
-      url = mirror://xorg/individual/lib/libXi-1.7.9.tar.bz2;
-      sha256 = "0idg1wc01hndvaa820fvfs7phvd1ymf0lldmq6386i7rhkzvirn2";
+      url = mirror://xorg/individual/lib/libXi-1.7.10.tar.bz2;
+      sha256 = "0q8hz3slga3w3ch8wp0k7ay9ilhz315qnab0w1y2x9w3cf7hv8rn";
     };
     hardeningDisable = [ "bindnow" "relro" ];
     nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -190,7 +190,7 @@ mirror://xorg/individual/lib/libXfixes-5.0.3.tar.bz2
 mirror://xorg/individual/lib/libXfont-1.5.4.tar.bz2
 mirror://xorg/individual/lib/libXfont2-2.0.3.tar.bz2
 mirror://xorg/individual/lib/libXft-2.3.3.tar.bz2
-mirror://xorg/individual/lib/libXi-1.7.9.tar.bz2
+mirror://xorg/individual/lib/libXi-1.7.10.tar.bz2
 mirror://xorg/individual/lib/libXinerama-1.1.4.tar.bz2
 mirror://xorg/individual/lib/libxkbfile-1.1.0.tar.bz2
 mirror://xorg/individual/lib/libXmu-1.1.3.tar.bz2


### PR DESCRIPTION
###### Motivation for this change

https://lists.x.org/archives/xorg-announce/2019-June/002999.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).