### PR TITLE
xorg.{xbacklight,xlock,libICE}: bump

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -664,11 +664,11 @@ lib.makeScope newScope (self: with self; {
   }) {};
 
   libICE = callPackage ({ stdenv, pkgconfig, fetchurl, xorgproto, xtrans }: stdenv.mkDerivation {
-    name = "libICE-1.0.9";
+    name = "libICE-1.0.10";
     builder = ./builder.sh;
     src = fetchurl {
-      url = mirror://xorg/individual/lib/libICE-1.0.9.tar.bz2;
-      sha256 = "00p2b6bsg6kcdbb39bv46339qcywxfl4hsrz8asm4hy6q7r34w4g";
+      url = mirror://xorg/individual/lib/libICE-1.0.10.tar.bz2;
+      sha256 = "0j638yvmyna2k4mz465jywgdybgdchdqppfx6xfazg7l5khxr1kg";
     };
     hardeningDisable = [ "bindnow" "relro" ];
     nativeBuildInputs = [ pkgconfig ];
@@ -1392,11 +1392,11 @@ lib.makeScope newScope (self: with self; {
   }) {};
 
   xbacklight = callPackage ({ stdenv, pkgconfig, fetchurl, libxcb, xcbutil }: stdenv.mkDerivation {
-    name = "xbacklight-1.2.2";
+    name = "xbacklight-1.2.3";
     builder = ./builder.sh;
     src = fetchurl {
-      url = mirror://xorg/individual/app/xbacklight-1.2.2.tar.bz2;
-      sha256 = "0pmzaz4kp38qv2lqiw5rnqhwzmwrq65m1x5j001mmv99wh9isnk1";
+      url = mirror://xorg/individual/app/xbacklight-1.2.3.tar.bz2;
+      sha256 = "1plssg0s3pbslg6rfzxp9sx8ryvn8l32zyvc8zp9zsbsfwjg69rs";
     };
     hardeningDisable = [ "bindnow" "relro" ];
     nativeBuildInputs = [ pkgconfig ];
@@ -1535,11 +1535,11 @@ lib.makeScope newScope (self: with self; {
   }) {};
 
   xclock = callPackage ({ stdenv, pkgconfig, fetchurl, libX11, libXaw, libXft, libxkbfile, libXmu, xorgproto, libXrender, libXt }: stdenv.mkDerivation {
-    name = "xclock-1.0.8";
+    name = "xclock-1.0.9";
     builder = ./builder.sh;
     src = fetchurl {
-      url = mirror://xorg/individual/app/xclock-1.0.8.tar.bz2;
-      sha256 = "0m92zhamh15my9f2rqa14q41d6k2cn468azm3g7g3w9n7942024k";
+      url = mirror://xorg/individual/app/xclock-1.0.9.tar.bz2;
+      sha256 = "1fr3q4rszgx7x2zxy2ip592a3fgx20hfwac49p2l5b7jqsr1ying";
     };
     hardeningDisable = [ "bindnow" "relro" ];
     nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -27,9 +27,9 @@ mirror://xorg/individual/app/twm-1.0.10.tar.bz2
 mirror://xorg/individual/app/viewres-1.0.5.tar.bz2
 mirror://xorg/individual/app/x11perf-1.6.1.tar.bz2
 mirror://xorg/individual/app/xauth-1.1.tar.bz2
-mirror://xorg/individual/app/xbacklight-1.2.2.tar.bz2
+mirror://xorg/individual/app/xbacklight-1.2.3.tar.bz2
 mirror://xorg/individual/app/xcalc-1.1.0.tar.bz2
-mirror://xorg/individual/app/xclock-1.0.8.tar.bz2
+mirror://xorg/individual/app/xclock-1.0.9.tar.bz2
 mirror://xorg/individual/app/xcmsdb-1.0.5.tar.bz2
 mirror://xorg/individual/app/xcompmgr-1.1.8.tar.bz2
 mirror://xorg/individual/app/xconsole-1.0.7.tar.bz2
@@ -173,7 +173,7 @@ mirror://xorg/individual/lib/libAppleWM-1.4.1.tar.bz2
 mirror://xorg/individual/lib/libdmx-1.1.4.tar.bz2
 mirror://xorg/individual/lib/libfontenc-1.1.4.tar.bz2
 mirror://xorg/individual/lib/libFS-1.0.8.tar.bz2
-mirror://xorg/individual/lib/libICE-1.0.9.tar.bz2
+mirror://xorg/individual/lib/libICE-1.0.10.tar.bz2
 mirror://xorg/individual/lib/libpciaccess-0.16.tar.bz2
 mirror://xorg/individual/lib/libSM-1.2.3.tar.bz2
 mirror://xorg/individual/lib/libWindowsWM-1.0.1.tar.bz2


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @