### PR TITLE
usbguard: 0.7.4 -> 0.7.5

### DIFF
--- a/pkgs/os-specific/linux/usbguard/default.nix
+++ b/pkgs/os-specific/linux/usbguard/default.nix
@@ -1,11 +1,8 @@
 {
   stdenv, fetchurl, lib,
-  pkgconfig, libxml2, libxslt,
-  dbus-glib, libcap_ng, libqb, libseccomp, polkit, protobuf, audit,
-  withGui ? true,
-  qtbase ? null,
-  qttools ? null,
-  qtsvg ? null,
+  pkgconfig, libxslt, libxml2, docbook_xml_dtd_45, docbook_xsl, asciidoc,
+  dbus-glib, libcap_ng, libqb, libseccomp, polkit, protobuf,
+  audit,
   libgcrypt ? null,
   libsodium ? null
 }:
@@ -15,20 +12,23 @@ with stdenv.lib;
 assert libgcrypt != null -> libsodium == null;
 
 stdenv.mkDerivation rec {
-  version = "0.7.4";
+  version = "0.7.5";
   pname = "usbguard";
 
   repo = "https://github.com/USBGuard/usbguard";
 
   src = fetchurl {
     url = "${repo}/releases/download/${pname}-${version}/${pname}-${version}.tar.gz";
-    sha256 = "1qkskd6q5cwlh2cpcsbzmmmgk6w63z0825wlb2sjwqq3kfgwjb3k";
+    sha256 = "0jj56sls13ryfgz6vajq8p4dm3grgb6rf2cmga6sckmzd4chk65b";
   };
 
   nativeBuildInputs = [
+    asciidoc
     pkgconfig
     libxslt # xsltproc
     libxml2 # xmllint
+    docbook_xml_dtd_45
+    docbook_xsl
   ];
 
   buildInputs = [
@@ -41,8 +41,7 @@ stdenv.mkDerivation rec {
     audit
   ]
   ++ (lib.optional (libgcrypt != null) libgcrypt)
-  ++ (lib.optional (libsodium != null) libsodium)
-  ++ (lib.optionals withGui [ qtbase qtsvg qttools ]);
+  ++ (lib.optional (libsodium != null) libsodium);
 
   configureFlags = [
     "--with-bundled-catch"
@@ -51,8 +50,7 @@ stdenv.mkDerivation rec {
     "--with-polkit"
   ]
   ++ (lib.optional (libgcrypt != null) "--with-crypto-library=gcrypt")
-  ++ (lib.optional (libsodium != null) "--with-crypto-library=sodium")
-  ++ (lib.optional withGui "--with-gui-qt=qt5");
+  ++ (lib.optional (libsodium != null) "--with-crypto-library=sodium");
 
   enableParallelBuilding = true;
 

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -373,6 +373,7 @@ mapAliases ({
   ucsFonts = ucs-fonts; # added 2016-07-15
   ultrastardx-beta = ultrastardx; # added 2017-08-12
   usb_modeswitch = usb-modeswitch; # added 2016-05-10
+  usbguard-nox = usbguard; # added 2019-09-04
   v4l_utils = v4l-utils; # added 2019-08-07
   vimbWrapper = vimb; # added 2015-01
   vimprobable2Wrapper = vimprobable2; # added 2015-01

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16527,7 +16527,7 @@ in
 
   upower = callPackage ../os-specific/linux/upower { };
 
-  usbguard = libsForQt5.callPackage ../os-specific/linux/usbguard {
+  usbguard = callPackage ../os-specific/linux/usbguard {
     libgcrypt = null;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16531,10 +16531,6 @@ in
     libgcrypt = null;
   };
 
-  usbguard-nox = usbguard.override {
-    withGui = false;
-  };
-
   usbtop = callPackage ../os-specific/linux/usbtop { };
 
   usbutils = callPackage ../os-specific/linux/usbutils { };


### PR DESCRIPTION
###### Motivation for this change

https://github.com/USBGuard/usbguard/releases/tag/usbguard-0.7.5

* no longer needs/uses qt as of 0.7.5
* asciidoctor -> asciidoc, drop pandoc
  (pandoc only seems to be used as part of doc spell-check
   which we don't enable anyway)
* docbook bits


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @