### PR TITLE
gts: propagate glib

### DIFF
--- a/pkgs/development/libraries/gts/default.nix
+++ b/pkgs/development/libraries/gts/default.nix
@@ -1,17 +1,20 @@
-{ fetchurl, stdenv, glib, pkgconfig, gettext }:
+{ fetchurl, stdenv, pkgconfig, autoreconfHook, gettext, glib }:
 
 
 stdenv.mkDerivation rec {
   pname = "gts";
   version = "0.7.6";
 
+  outputs = [ "bin" "dev" "out" ];
+
   src = fetchurl {
     url = "mirror://sourceforge/gts/${pname}-${version}.tar.gz";
     sha256 = "07mqx09jxh8cv9753y2d2jsv7wp8vjmrd7zcfpbrddz3wc9kx705";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ glib gettext ];
+  nativeBuildInputs = [ pkgconfig autoreconfHook ];
+  buildInputs = [ gettext ];
+  propagatedBuildInputs = [ glib ];
 
   doCheck = false; # fails with "permission denied"
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

GTS's pkgconfig file contains the following line:
```
Requires: glib-2.0,gthread-2.0,gmodule-2.0
```
This causes some build systems (at least CMake, I'm not sure about autotools) to require `glib` to be available when depending on `gts`. Rather than manually adding a dependency on `glib` alongside each usage of `gts`, I thought it might be a good idea to propagate `glib`. This problem with this is that now `gts` has a reference to `glib.dev`, slightly increasing its closure size. I'm not sure if there are any other packages in nixpkgs that have dealt with this issue.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @viric
