### PR TITLE
platformio: 3.6.6 -> 4.0.3

### DIFF
--- a/pkgs/development/arduino/platformio/chrootenv.nix
+++ b/pkgs/development/arduino/platformio/chrootenv.nix
@@ -3,19 +3,8 @@
 let
   pio-pkgs = pkgs:
     let
-      python = pkgs.python.override {
+      python = pkgs.python3.override {
         packageOverrides = self: super: {
-
-          # https://github.com/platformio/platformio-core/issues/349
-          click = super.click.overridePythonAttrs (oldAttrs: rec {
-            version = "5.1";
-            src = oldAttrs.src.override {
-              inherit version;
-              sha256 = "678c98275431fad324275dec63791e4a17558b40e5a110e20a82866139a85a5a";
-            };
-            postPatch = "";
-          });
-
           platformio = self.callPackage ./core.nix { };
         };
       };
@@ -38,7 +27,7 @@ in buildFHSUserEnv {
 
   meta = with lib; {
     description = "An open source ecosystem for IoT development";
-    homepage = http://platformio.org;
+    homepage = "https://platformio.org";
     maintainers = with maintainers; [ mog ];
     license = licenses.asl20;
     platforms = with platforms; linux;

--- a/pkgs/development/arduino/platformio/core.nix
+++ b/pkgs/development/arduino/platformio/core.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, buildPythonApplication, fetchFromGitHub
 , bottle, click, colorama
 , lockfile, pyserial, requests
-, pytest, semantic-version, tox
+, pytest, semantic-version, tox, tabulate
 , git
 }:
 
@@ -35,6 +35,7 @@ let
     "test_builder.py::test_build_unflags"
     "test_misc.py::test_api_cache"
     "test_misc.py::test_ping_internet_ips"
+    "test_misc.py::test_platformio_cli"
     "test_pkgmanifest.py::test_packages"
   ]) ++ (map (e: "--ignore=tests/${e}") [
     "commands/test_boards.py"
@@ -46,19 +47,20 @@ let
 
 in buildPythonApplication rec {
   pname = "platformio";
-  version = "3.6.6";
+  version = "4.0.3";
 
   # pypi tarballs don't contain tests - https://github.com/platformio/platformio-core/issues/1964
   src = fetchFromGitHub {
     owner = "platformio";
     repo = "platformio-core";
     rev = "v${version}";
-    sha256 = "1qwd6684y2xagl375sv8fm6a535hcdqx296hknjlbvsgc1jc514a";
+    sha256 = "1naaa53cc7n7zyqggqjvvgkcq8cyzngdf904y9ag0x1vvb70f8j9";
   };
 
   propagatedBuildInputs =  [
     bottle click colorama git lockfile
     pyserial requests semantic-version
+    tabulate
   ];
 
   HOME = "/tmp";

--- a/pkgs/development/arduino/platformio/fix-searchpath.patch
+++ b/pkgs/development/arduino/platformio/fix-searchpath.patch
@@ -1,6 +1,6 @@
---- ./platformio/util.py-old	2017-09-29 01:20:08.174548250 +0200
-+++ ./platformio/util.py	2017-09-29 01:19:48.410485308 +0200
-@@ -395,7 +395,7 @@
+--- ./platformio/proc.py-old	2017-09-29 01:20:08.174548250 +0200
++++ ./platformio/proc.py	2017-09-29 01:19:48.410485308 +0200
+@@ -164,7 +164,7 @@
                  isdir(join(p, "click")) or isdir(join(p, "platformio")))
          if all(conditions):
              _PYTHONPATH.append(p)

--- a/pkgs/development/python-modules/semantic-version/default.nix
+++ b/pkgs/development/python-modules/semantic-version/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "semantic_version";
-  version = "2.6.0";
+  version = "2.8.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1h2l9xyg1zzsda6kjcmfcgycbvrafwci283vcr1v5sbk01l2hhra";
+    sha256 = "1lnnpxmf3z1rcfr5n562vbraq236s13wlj8fmw2kwr2mrq7lqb8r";
   };
 
   # ModuleNotFoundError: No module named 'tests'


### PR DESCRIPTION
###### Motivation for this change

Also move to py3. We have provisioning for overriding python packages which was needed for pio3, which is no longer the case as upstream fixed support for click v6, but I am leaving it in, in case we need another override again (likely).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @mog @makefu
