### PR TITLE
taglib: fix ogg file corruption

### DIFF
--- a/pkgs/development/libraries/taglib/default.nix
+++ b/pkgs/development/libraries/taglib/default.nix
@@ -1,10 +1,13 @@
-{stdenv, fetchurl, zlib, cmake, fetchpatch}:
+{ stdenv, fetchurl, cmake, fetchpatch
+, zlib
+}:
 
 stdenv.mkDerivation rec {
-  name = "taglib-1.11.1";
+  pname = "taglib";
+  version = "1.11.1";
 
   src = fetchurl {
-    url = "http://taglib.org/releases/${name}.tar.gz";
+    url = "http://taglib.org/releases/${pname}-${version}.tar.gz";
     sha256 = "0ssjcdjv4qf9liph5ry1kngam1y7zp8fzr9xv4wzzrma22kabldn";
   };
 
@@ -22,6 +25,13 @@ stdenv.mkDerivation rec {
       url = "https://github.com/taglib/taglib/commit/272648ccfcccae30e002ccf34a22e075dd477278.patch";
       sha256 = "0p397qq4anvcm0p8xs68mxa8hg6dl07chg260lc6k2929m34xv72";
     })
+
+    (fetchpatch {
+      # many consumers of taglib have started vendoring taglib due to this bug
+      name = "fix_ogg_corruption.patch";
+      url = "https://github.com/taglib/taglib/commit/9336c82da3a04552168f208cd7a5fa4646701ea4.patch";
+      sha256 = "01wlwk4gmfxdg5hjj9jmrain7kia89z0zsdaf5gn3nibmy5bq70r";
+    })
   ];
 
   nativeBuildInputs = [ cmake ];
@@ -31,8 +41,8 @@ stdenv.mkDerivation rec {
   cmakeFlags = [ "-DBUILD_SHARED_LIBS=ON" ];
 
   meta = with stdenv.lib; {
-    homepage = http://taglib.org/;
-    repositories.git = git://github.com/taglib/taglib.git;
+    homepage = "http://taglib.org/";
+    repositories.git = "git://github.com/taglib/taglib.git";
     description = "A library for reading and editing audio file metadata.";
     longDescription = ''
       TagLib is a library for reading and editing the meta-data of several


### PR DESCRIPTION
###### Motivation for this change

taglib hasn't had a release for ages, but the most recent release 1.11.1 has a nasty file corruption bug triggered by writing a tag to an ogg file thereby breaking it completely.

Several pieces of software do basic version tests to see if they should use the system-provided taglib or their own vendored version due to this bug.

This just fixes the corruption bug (a one-liner) - the consumers of the library need to be told to not use the vendored version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
