### PR TITLE
nixos/mptcp: multipath TCP module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1909.xml
+++ b/nixos/doc/manual/release-notes/rl-1909.xml
@@ -154,6 +154,10 @@
     <para>
      <literal>./programs/dwm-status.nix</literal>
     </para>
+    <para>
+      <literal>./nixos/modules/services/networking/mptcp/default.nix</literal> brings multipath TCP support to nixos.
+      It can be enabled via <option>networking.mptcp.enable</option>.
+    </para>
    </listitem>
    <listitem>
     <para>

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -638,6 +638,7 @@
   ./services/networking/monero.nix
   ./services/networking/morty.nix
   ./services/networking/miredo.nix
+  ./services/networking/mptcp/default.nix
   ./services/networking/mstpd.nix
   ./services/networking/mtprotoproxy.nix
   ./services/networking/murmur.nix

--- a/nixos/modules/services/networking/mptcp/default.nix
+++ b/nixos/modules/services/networking/mptcp/default.nix
@@ -1,0 +1,69 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.networking.mptcp;
+
+  mptcpUp = ./mptcp_up_raw;
+in
+{
+  options.networking.mptcp = {
+
+    enable = mkEnableOption "Multipath TCP (MPTCP)";
+
+    debug = mkEnableOption "Debug support";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.linux_mptcp;
+      description = ''
+        Default mptcp kernel to use.
+      '';
+    };
+
+    scheduler = mkOption {
+      type = types.enum [ "redundant" "lowrtt" "roundrobin" "default" ];
+      default = "lowrtt";
+      description = ''
+        How to schedule packets on the different subflows.
+      '';
+    };
+
+    pathManager = mkOption {
+      type = types.enum [ "fullmesh" "ndiffports" "netlink" ];
+      default = "fullmesh";
+      description = ''
+        Subflow creation strategy.
+        Netlink is only available in the development version of mptcp.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable (mkMerge [
+    {
+      # to name routing tables
+      networking.iproute2.enable = true;
+
+      boot.kernelPackages = pkgs.linuxPackagesFor cfg.package;
+
+      boot.kernel.sysctl = {
+        "net.mptcp.mptcp_scheduler" = cfg.scheduler;
+        "net.mptcp.mptcp_path_manager" = cfg.pathManager;
+        "net.ipv4.tcp_congestion_control" = "olia";
+      };
+    }
+
+    (mkIf (!config.networking.networkmanager.enable) {
+      warnings = [ "You have `networkmanager` disabled. Expect things to break." ];
+    })
+
+    # if networkmanager is enabled, handle routing tables
+    (mkIf config.networking.networkmanager.enable {
+      networking.networkmanager.dispatcherScripts = [
+          { source = mptcpUp; type = "basic"; }
+        ];
+     })
+
+   ]);
+}

--- a/nixos/modules/services/networking/mptcp/default.nix
+++ b/nixos/modules/services/networking/mptcp/default.nix
@@ -55,7 +55,9 @@ in
     }
 
     (mkIf (!config.networking.networkmanager.enable) {
-      warnings = [ "You have `networkmanager` disabled. Expect things to break." ];
+      warnings = [
+        "You have `networkmanager` disabled. MPTCP may not be able to use all interfaces."
+      ];
     })
 
     # if networkmanager is enabled, handle routing tables

--- a/nixos/modules/services/networking/mptcp/default.nix
+++ b/nixos/modules/services/networking/mptcp/default.nix
@@ -17,8 +17,9 @@ in
     package = mkOption {
       type = types.package;
       default = pkgs.linux_mptcp;
+      defaultText = "pkgs.linux_mptcp";
       description = ''
-        Default mptcp kernel to use.
+        Default MPTCP kernel to use.
       '';
     };
 

--- a/nixos/modules/services/networking/mptcp/mptcp_up_raw
+++ b/nixos/modules/services/networking/mptcp/mptcp_up_raw
@@ -1,0 +1,50 @@
+#!/bin/sh
+# A script for setting up routing tables for MPTCP
+
+# see http://multipath-tcp.org/pmwiki.php/Users/ConfigureRouting
+# can check with (ins)[root@client:~]# journalctl -b -u NetworkManager-dispatcher.service
+# Copy this script into /etc/network/if-up.d/
+
+set -ex
+STATUS=$2
+
+RT_TABLE=/etc/iproute2/rt_tables
+
+if [ "$DEVICE_IFACE" = "lo" ]; then
+
+	logger -p user.debug -t mptcp "if localhost or $MODE then abort "
+	exit 0
+elif [ -z "$DEVICE_IFACE" ]; then
+	logger -p user.info -t mptcp "Ignoring empty interface"
+	exit 0
+fi
+
+
+if [ $(grep -c "$DEVICE_IFACE" "$RT_TABLE") -eq 0 ]; then
+	echo "Adding new routing table $DEVICE_IFACE"
+
+	logger -p user.info -t mptcp "Adding new routing table $DEVICE_IFACE"
+	NUM=$(wc -l < "$RT_TABLE")
+	# RT_TABLE doesn't contain a newline
+	echo -e "\n$NUM  $DEVICE_IFACE" >> "$RT_TABLE"
+fi
+
+if [ -n "$DHCP4_IP_ADDRESS" ]; then
+	SUBNET=`echo $IP4_ADDRESS_0 | cut -d \   -f 1 | cut -d / -f 2`
+	ip route add to "$DHCP4_NETWORK_NUMBER/$SUBNET" dev "$DEVICE_IFACE" scope link table "$DEVICE_IFACE"
+	ip route add default via $DHCP4_ROUTERS dev "$DEVICE_IFACE" table "$DEVICE_IFACE"
+	ip rule add from "$DHCP4_IP_ADDRESS" table "$DEVICE_IFACE"
+else
+	# PPP-interface
+	IPADDR=`echo $IP4_ADDRESS_0 | cut -d \   -f 1 | cut -d / -f 1`
+
+	# if gateway is set (manual configuration)
+	if [ ! -z "$IP4_GATEWAY" ]; then
+		ip route add default via "$IP4_GATEWAY" dev "$DEVICE_IFACE" table "$DEVICE_IFACE"
+	else
+		ip route add default dev "$DEVICE_IP_IFACE" scope link table "$DEVICE_IFACE"
+	fi
+
+	ip rule add from "$IPADDR" table "$DEVICE_IFACE"
+fi
+


### PR DESCRIPTION
Sane defaults for configuration of MPTCP kernel.

Initial PR at https://github.com/NixOS/nixpkgs/pull/59342. 
I have some trouble fixing the mptcp test (rather my changes to the network testing infrastructure) so that it doesn't break other tests. I do intend to fix this but it may take some time so I would like to merge the module first as it can be useful for others.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
