### PR TITLE
python3Packages.textacy: 0.6.3 -> 0.9.1

### DIFF
--- a/pkgs/development/python-modules/textacy/default.nix
+++ b/pkgs/development/python-modules/textacy/default.nix
@@ -1,69 +1,59 @@
-{ stdenv
-, buildPythonPackage
-, isPy27
-, fetchPypi
+{ lib, buildPythonPackage, fetchPypi, isPy27
 , cachetools
-, cld2-cffi
 , cytoolz
-, ftfy
-, ijson
+, jellyfish
 , matplotlib
 , networkx
 , numpy
 , pyemd
 , pyphen
-, python-Levenshtein
+, pytest
 , requests
 , scikitlearn
 , scipy
 , spacy
-, tqdm
-, unidecode
+, srsly
 }:
 
 buildPythonPackage rec {
   pname = "textacy";
-  version = "0.6.3";
+  version = "0.9.1";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "50402545ac92b1a931c2365e341cb35c4ebe5575525f1dcc5265901ff3895a5f";
+    sha256 = "1jhj02g6kh5vc0z4az7n547siav3gj5571bqpzdryskj6bsma2z1";
   };
 
   propagatedBuildInputs = [
     cachetools
-    cld2-cffi
     cytoolz
-    ftfy
-    ijson
+    jellyfish
     matplotlib
     networkx
     numpy
     pyemd
     pyphen
-    python-Levenshtein
     requests
     scikitlearn
     scipy
     spacy
-    tqdm
-    unidecode
+    srsly
   ];
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "'ftfy>=4.2.0,<5.0.0'," "'ftfy>=5.0.0',"
+  checkInputs = [ pytest ];
+  # almost all tests have to deal with downloading a dataset, only test pure tests
+  checkPhase = ''
+    pytest tests/test_text_utils.py \
+      tests/test_utils.py \
+      tests/preprocessing \
+      tests/datasets/test_base_dataset.py
   '';
 
-  doCheck = false;  # tests want to download data files
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Higher-level text processing, built on spaCy";
     homepage = "http://textacy.readthedocs.io/";
     license = licenses.asl20;
     maintainers = with maintainers; [ rvl ];
-    # ftfy and jellyfish no longer support python2
-    # latest scikitlearn not supported for this: https://github.com/chartbeat-labs/textacy/issues/260
-    broken = true;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
textacy enabled support for scikitlearn>=0.21 with https://github.com/chartbeat-labs/textacy/issues/260, so it can now be added back.

changelog: https://github.com/chartbeat-labs/textacy/releases

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @rvl 

it has matpotlib, scipy, scikitlearn, it's a big closure
```
# it was broken before
$ nix path-info -Sh ./result
/nix/store/qv94zfd077rqs4pf9l0w2wm6aw57ff1k-python3.7-textacy-0.9.1      783.4M
```
```
[1 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/68093
1 package were build:
python37Packages.textacy
```
