### PR TITLE
pythonPackages.labelbox: init at 2.1

### DIFF
--- a/pkgs/development/python-modules/labelbox/default.nix
+++ b/pkgs/development/python-modules/labelbox/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, requests
+, jinja2
+, pillow
+, rasterio
+, shapely
+}:
+
+buildPythonPackage rec {
+  pname = "labelbox";
+  version = "2.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "f97f01bf030b115d8b7f7b12a10ec5efe54750ad66b6b3567550b517a543ad11";
+  };
+
+  propagatedBuildInputs = [ jinja2 requests pillow rasterio shapely ];
+
+  # Test cases are not running on pypi or GitHub
+  doCheck = false;   
+
+  meta = with lib; {
+    homepage = https://github.com/Labelbox/Labelbox;
+    description = "Platform API for LabelBox";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ rakesh4g ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -715,6 +715,8 @@ in {
   jwcrypto = callPackage ../development/python-modules/jwcrypto { };
 
   kconfiglib = callPackage ../development/python-modules/kconfiglib { };
+  
+  labelbox = callPackage ../development/python-modules/labelbox { };
 
   lammps-cython = callPackage ../development/python-modules/lammps-cython {
     mpi = pkgs.openmpi;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @CMCDragonkai 
