### PR TITLE
graphviz: stable_release_2.40.1 tag disappeared

### DIFF
--- a/pkgs/tools/graphics/graphviz/default.nix
+++ b/pkgs/tools/graphics/graphviz/default.nix
@@ -1,5 +1,5 @@
 import ./base.nix rec {
-  rev = "stable_release_${version}";
+  rev = "67cd2e5121379a38e0801cc05cce5033f8a2a609";
   version = "2.40.1";
   sha256 = "1xjqq3g2n6jgwp5xzyvibgrxawlskkpam69fjjz9ksrrjas2qwzj";
  }


### PR DESCRIPTION
###### Motivation for this change

Upstream graphviz sources seem to have deleted the release tag for 2.40.1 that we were using for some reason, resulting in a 404 on fetch: https://gitlab.com/graphviz/graphviz/commit/67cd2e5121379a38e0801cc05cce5033f8a2a609

This just switches to the git revision the tag pointed to (or I assume it did -- the hash is the same so seems safe enough).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @yegortimoshenko
