### PR TITLE
go 1.12 -> 1.13

### DIFF
--- a/pkgs/development/compilers/go/1.13.nix
+++ b/pkgs/development/compilers/go/1.13.nix
@@ -1,0 +1,234 @@
+{ stdenv, fetchurl, tzdata, iana-etc, runCommand
+, perl, which, pkgconfig, patch, procps, pcre, cacert, Security, Foundation
+, mailcap, runtimeShell
+, buildPackages, pkgsTargetTarget
+}:
+
+let
+
+  inherit (stdenv.lib) optionals optionalString;
+
+  goBootstrap = runCommand "go-bootstrap" {} ''
+    mkdir $out
+    cp -rf ${buildPackages.go_bootstrap}/* $out/
+    chmod -R u+w $out
+    find $out -name "*.c" -delete
+    cp -rf $out/bin/* $out/share/go/bin/
+  '';
+
+  goarch = platform: {
+    "i686" = "386";
+    "x86_64" = "amd64";
+    "aarch64" = "arm64";
+    "arm" = "arm";
+    "armv5tel" = "arm";
+    "armv6l" = "arm";
+    "armv7l" = "arm";
+  }.${platform.parsed.cpu.name} or (throw "Unsupported system");
+
+in
+
+stdenv.mkDerivation rec {
+  pname = "go";
+  version = "1.13";
+
+  src = fetchurl {
+    url = "https://dl.google.com/go/go${version}.src.tar.gz";
+    sha256 = "08pibdkfrn0909rzjzn3q1wj1whk1af058qxvbbyyhhx22vbih1z";
+  };
+
+  # perl is used for testing go vet
+  nativeBuildInputs = [ perl which pkgconfig patch procps ];
+  buildInputs = [ cacert pcre ]
+    ++ optionals stdenv.isLinux [ stdenv.cc.libc.out ]
+    ++ optionals (stdenv.hostPlatform.libc == "glibc") [ stdenv.cc.libc.static ];
+
+
+  propagatedBuildInputs = optionals stdenv.isDarwin [ Security Foundation ];
+
+  hardeningDisable = [ "all" ];
+
+  prePatch = ''
+    patchShebangs ./ # replace /bin/bash
+
+    # This source produces shell script at run time,
+    # and thus it is not corrected by patchShebangs.
+    substituteInPlace misc/cgo/testcarchive/carchive_test.go \
+      --replace '#!/usr/bin/env bash' '#!${runtimeShell}'
+
+    # Patch the mimetype database location which is missing on NixOS.
+    substituteInPlace src/mime/type_unix.go \
+      --replace '/etc/mime.types' '${mailcap}/etc/mime.types'
+
+    # Disable failing tests
+    rm src/crypto/x509/root_unix_test.go
+    rm src/net/timeout_test.go
+    rm src/net/writev_test.go
+    rm src/time/time_test.go
+    rm src/cmd/go/internal/work/build_test.go
+
+    # !!! substituteInPlace does not seems to be effective.
+    # The os test wants to read files in an existing path. Just don't let it be /usr/bin.
+    # Disable the unix socket test
+    sed -i '/TestShutdownUnix/at.SkipNow()' src/net/net_test.go
+    # Disable the readline parse test
+    sed -i '/TestReadLine/at.SkipNow()' src/net/parse_test.go
+    # Disable the read dir names test
+    sed -i '/TestReaddirnamesOneAtATime/at.SkipNow()' src/os/os_test.go
+    # Disiable the change dir and workinf dir test
+    sed -i '/TestChdirAndGetwd/at.SkipNow()' src/os/os_test.go
+    # ParseInLocation fails the test
+    sed -i '/TestParseInSydney/at.SkipNow()' src/time/format_test.go
+    # Remove the api check as it never worked
+    sed -i '/src\/cmd\/api\/run.go/ireturn nil' src/cmd/dist/test.go
+    # Remove the coverage test as we have removed this utility
+    sed -i '/TestCoverageWithCgo/at.SkipNow()' src/cmd/go/go_test.go
+
+    sed -i 's,/etc/protocols,${iana-etc}/etc/protocols,' src/net/lookup_unix.go
+    sed -i 's,/etc/services,${iana-etc}/etc/services,' src/net/port_unix.go
+
+    # Disable cgo lookup tests not works, they depend on resolver
+    rm src/net/cgo_unix_test.go
+
+  '' + optionalString stdenv.isLinux ''
+    sed -i 's,/usr/share/zoneinfo/,${tzdata}/share/zoneinfo/,' src/time/zoneinfo_unix.go
+  '' + optionalString stdenv.isAarch32 ''
+    echo '#!${runtimeShell}' > misc/cgo/testplugin/test.bash
+  '' + optionalString stdenv.isDarwin ''
+    substituteInPlace src/race.bash --replace \
+      "sysctl machdep.cpu.extfeatures | grep -qv EM64T" true
+    sed -i 's,strings.Contains(.*sysctl.*,true {,' src/cmd/dist/util.go
+    sed -i 's,"/etc","'"$TMPDIR"'",' src/os/os_test.go
+    sed -i 's,/_go_os_test,'"$TMPDIR"'/_go_os_test,' src/os/path_test.go
+
+    sed -i '/TestChdirAndGetwd/areturn' src/os/os_test.go
+    sed -i '/TestCredentialNoSetGroups/areturn' src/os/exec/exec_posix_test.go
+    sed -i '/TestRead0/areturn' src/os/os_test.go
+    sed -i '/TestSystemRoots/areturn' src/crypto/x509/root_darwin_test.go
+
+    sed -i '/TestGoInstallRebuildsStalePackagesInOtherGOPATH/areturn' src/cmd/go/go_test.go
+    sed -i '/TestBuildDashIInstallsDependencies/areturn' src/cmd/go/go_test.go
+
+    sed -i '/TestDisasmExtld/areturn' src/cmd/objdump/objdump_test.go
+
+    sed -i 's/unrecognized/unknown/' src/cmd/link/internal/ld/lib.go
+
+    # TestCurrent fails because Current is not implemented on Darwin
+    sed -i 's/TestCurrent/testCurrent/g' src/os/user/user_test.go
+    sed -i 's/TestLookup/testLookup/g' src/os/user/user_test.go
+
+    touch $TMPDIR/group $TMPDIR/hosts $TMPDIR/passwd
+  '';
+
+  patches = [
+    ./remove-tools-1.11.patch
+    # ./ssl-cert-file-1.12.1.patch
+    # ./remove-test-pie.patch
+    ./remove-test-pie-1.13.patch
+    ./creds-test.patch
+    ./go-1.9-skip-flaky-19608.patch
+    ./go-1.9-skip-flaky-20072.patch
+    ./skip-external-network-tests.patch
+    ./skip-nohup-tests.patch
+    # breaks under load: https://github.com/golang/go/issues/25628
+    ./skip-test-extra-files-on-386.patch
+  ];
+
+  postPatch = ''
+    find . -name '*.orig' -exec rm {} ';'
+  '';
+
+  GOOS = stdenv.targetPlatform.parsed.kernel.name;
+  GOARCH = goarch stdenv.targetPlatform;
+  # GOHOSTOS/GOHOSTARCH must match the building system, not the host system.
+  # Go will nevertheless build a for host system that we will copy over in
+  # the install phase.
+  GOHOSTOS = stdenv.buildPlatform.parsed.kernel.name;
+  GOHOSTARCH = goarch stdenv.buildPlatform;
+
+  # {CC,CXX}_FOR_TARGET must be only set for cross compilation case as go expect those
+  # to be different from CC/CXX
+  CC_FOR_TARGET = if (stdenv.buildPlatform != stdenv.targetPlatform) then
+      "${pkgsTargetTarget.stdenv.cc}/bin/${pkgsTargetTarget.stdenv.cc.targetPrefix}cc"
+    else
+      null;
+  CXX_FOR_TARGET = if (stdenv.buildPlatform != stdenv.targetPlatform) then
+      "${pkgsTargetTarget.stdenv.cc}/bin/${pkgsTargetTarget.stdenv.cc.targetPrefix}c++"
+    else
+      null;
+
+  GOARM = toString (stdenv.lib.intersectLists [(stdenv.hostPlatform.parsed.cpu.version or "")] ["5" "6" "7"]);
+  GO386 = 387; # from Arch: don't assume sse2 on i686
+  CGO_ENABLED = 1;
+  # Hopefully avoids test timeouts on Hydra
+  GO_TEST_TIMEOUT_SCALE = 3;
+
+  # Indicate that we are running on build infrastructure
+  # Some tests assume things like home directories and users exists
+  GO_BUILDER_NAME = "nix";
+
+  GOROOT_BOOTSTRAP="${goBootstrap}/share/go";
+
+  postConfigure = ''
+    export GOCACHE=$TMPDIR/go-cache
+    # this is compiled into the binary
+    export GOROOT_FINAL=$out/share/go
+
+    export PATH=$(pwd)/bin:$PATH
+
+    # Independent from host/target, CC should produce code for the building system.
+    export CC=${buildPackages.stdenv.cc}/bin/cc
+    ulimit -a
+  '';
+
+  postBuild = ''
+    (cd src && ./make.bash)
+  '';
+
+  doCheck = stdenv.hostPlatform == stdenv.targetPlatform && !stdenv.isDarwin;
+
+  checkPhase = ''
+    runHook preCheck
+    (cd src && HOME=$TMPDIR GOCACHE=$TMPDIR/go-cache ./run.bash --no-rebuild)
+    runHook postCheck
+  '';
+
+  preInstall = ''
+    rm -r pkg/obj
+    # Contains the wrong perl shebang when cross compiling,
+    # since it is not used for anything we can deleted as well.
+    rm src/regexp/syntax/make_perl_groups.pl
+  '' + (if (stdenv.buildPlatform != stdenv.hostPlatform) then ''
+    mv bin/*_*/* bin
+    rmdir bin/*_*
+    ${optionalString (!(GOHOSTARCH == GOARCH && GOOS == GOHOSTOS)) ''
+      rm -rf pkg/${GOHOSTOS}_${GOHOSTARCH} pkg/tool/${GOHOSTOS}_${GOHOSTARCH}
+    ''}
+  '' else if (stdenv.hostPlatform != stdenv.targetPlatform) then ''
+    rm -rf bin/*_*
+    ${optionalString (!(GOHOSTARCH == GOARCH && GOOS == GOHOSTOS)) ''
+      rm -rf pkg/${GOOS}_${GOARCH} pkg/tool/${GOOS}_${GOARCH}
+    ''}
+  '' else "");
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $GOROOT_FINAL
+    cp -a bin pkg src lib misc api doc $GOROOT_FINAL
+    ln -s $GOROOT_FINAL/bin $out/bin
+    runHook postInstall
+  '';
+
+  setupHook = ./setup-hook.sh;
+
+  disallowedReferences = [ goBootstrap ];
+
+  meta = with stdenv.lib; {
+    branch = "1.13";
+    homepage = http://golang.org/;
+    description = "The Go Programming language";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ cstrahan orivej velovix mic92 rvolosatovs ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/development/compilers/go/remove-test-pie-1.13.patch
+++ b/pkgs/development/compilers/go/remove-test-pie-1.13.patch
@@ -1,0 +1,32 @@
+--- source.org/src/cmd/dist/test.go	2019-09-03 19:07:47.000000000 +0200
++++ source/src/cmd/dist/test.go	2019-09-04 12:42:30.789674346 +0200
+@@ -574,29 +574,6 @@
+ 		})
+ 	}
+ 
+-	// Test internal linking of PIE binaries where it is supported.
+-	if goos == "linux" && (goarch == "amd64" || goarch == "arm64") {
+-		t.tests = append(t.tests, distTest{
+-			name:    "pie_internal",
+-			heading: "internal linking of -buildmode=pie",
+-			fn: func(dt *distTest) error {
+-				t.addCmd(dt, "src", t.goTest(), "reflect", "-buildmode=pie", "-ldflags=-linkmode=internal", t.timeout(60))
+-				return nil
+-			},
+-		})
+-		// Also test a cgo package.
+-		if t.cgoEnabled {
+-			t.tests = append(t.tests, distTest{
+-				name:    "pie_internal_cgo",
+-				heading: "internal linking of -buildmode=pie",
+-				fn: func(dt *distTest) error {
+-					t.addCmd(dt, "src", t.goTest(), "os/user", "-buildmode=pie", "-ldflags=-linkmode=internal", t.timeout(60))
+-					return nil
+-				},
+-			})
+-		}
+-	}
+-
+ 	// sync tests
+ 	if goos != "js" { // js doesn't support -cpu=10
+ 		t.tests = append(t.tests, distTest{

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7927,7 +7927,11 @@ in
     inherit (darwin.apple_sdk.frameworks) Security Foundation;
   };
 
-  go = go_1_12;
+  go_1_13 = callPackage ../development/compilers/go/1.13.nix {
+    inherit (darwin.apple_sdk.frameworks) Security Foundation;
+  };
+
+  go = go_1_13;
 
   go-repo-root = callPackage ../development/tools/go-repo-root { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

New version release of Go

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
