### PR TITLE
haskellPackages.matplotlib: unmark as broken

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -332,6 +332,7 @@ self: super: {
   lensref = dontCheck super.lensref;
   lucid = dontCheck super.lucid; #https://github.com/chrisdone/lucid/issues/25
   lvmrun = disableHardening (dontCheck super.lvmrun) ["format"];
+  matplotlib = dontCheck super.matplotlib;
   memcache = dontCheck super.memcache;
   MemoTrie = dontHaddock (dontCheck super.MemoTrie);
   metrics = dontCheck super.metrics;

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -1281,7 +1281,6 @@ default-package-overrides:
   - massiv-test ==0.1.0
   - mathexpr ==0.3.0.0
   - math-functions ==0.3.1.0
-  - matplotlib ==0.7.4
   - matrices ==0.5.0
   - matrix ==0.3.6.1
   - matrix-market-attoparsec ==0.1.0.8


### PR DESCRIPTION
###### Motivation for this change
Wanted to use matplotlib in haskell.
The package is broken because the test are failing. This is due to a runtime dependency on python. I can confirm that the package works fine if python and matplotlib are installed in the environment.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested the library is usable
- [x] Tested compilation of all pkgs that depend on this change using (none)
- [x] Tested execution of all binary files (none)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @peti
