### PR TITLE
aucdtect: pname was wrong

### DIFF
--- a/pkgs/tools/audio/aucdtect/default.nix
+++ b/pkgs/tools/audio/aucdtect/default.nix
@@ -3,26 +3,29 @@
 with lib;
 
 stdenv.mkDerivation rec {
-  pname = "aucdtext";
+  pname = "aucdtect";
   version = "0.8-2";
 
   src = fetchurl {
-    url = "http://www.true-audio.com/ftp/aucdtect-${version}.i586.rpm";
+    url = "http://www.true-audio.com/ftp/${pname}-${version}.i586.rpm";
     sha256 = "1lp5f0rq5b5n5il0c64m00gcfskarvgqslpryms9443d200y6mmd";
   };
 
   unpackCmd = "${rpmextract}/bin/rpmextract $src";
 
   installPhase = ''
-    mkdir -p $out/bin
-    install -m755 local/bin/auCDtect $out/bin/aucdtect
+    runHook preInstall
+
+    install -Dm755 local/bin/auCDtect $out/bin/aucdtect
+
+    runHook postInstall
   '';
 
   dontStrip = true;
 
   meta = with stdenv.lib; {
     description = "Verify authenticity of lossless audio files";
-    homepage = http://tausoft.org;
+    homepage = "http://tausoft.org";
     license = licenses.unfreeRedistributable;
     maintainers = with maintainers; [ peterhoeg ];
     platforms = platforms.linux;


### PR DESCRIPTION
##### Motivation for this change

```pname``` was wrong.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
