### PR TITLE
pythonPackages.pyvmomi: init at 6.7.1.2018.12

### DIFF
--- a/pkgs/development/python-modules/pyvmomi/default.nix
+++ b/pkgs/development/python-modules/pyvmomi/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildPythonPackage, fetchFromGitHub, requests }:
+
+buildPythonPackage rec {
+  pname = "pyvmomi";
+  version = "6.7.1.2018.12";
+
+  src = fetchFromGitHub {
+    owner = "vmware";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1pgl95rbghidbyr8hndjzfzgb1yjchfcknlqgg3qbqvljnz9hfja";
+  };
+
+  # requires old version of vcrpy
+  doCheck = false;
+
+  propagatedBuildInputs = [ requests ];
+
+  meta = with lib; {
+    description = "Python SDK for the VMware vSphere API that allows you to manage ESX, ESXi, and vCenter";
+    homepage = "https://github.com/vmware/pyvmomi";
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4431,6 +4431,8 @@ in {
 
   pyupdate = callPackage ../development/python-modules/pyupdate {};
 
+  pyvmomi = callPackage ../development/python-modules/pyvmomi { };
+
   pyx = callPackage ../development/python-modules/pyx { };
 
   mmpython = callPackage ../development/python-modules/mmpython { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @