### PR TITLE
mkdocs: update meta-information, set myself as maintainer

### DIFF
--- a/pkgs/development/tools/documentation/mkdocs/default.nix
+++ b/pkgs/development/tools/documentation/mkdocs/default.nix
@@ -1,4 +1,4 @@
-{ lib, python, fetchFromGitHub }:
+{ stdenv, lib, python, fetchFromGitHub }:
 
 with python.pkgs;
 
@@ -35,9 +35,18 @@ buildPythonApplication rec {
     backports_tempfile
   ];
 
-  meta = {
+  meta = with stdenv.lib; {
+    description = "Project documentation with Markdown / static website generator.";
+    longDescription = ''
+      MkDocs is a fast, simple and downright gorgeous static site generator that's
+      geared towards building project documentation. Documentation source files
+      are written in Markdown, and configured with a single YAML configuration file.
+      
+      MkDocs can also be used to generate general-purpose Websites.
+    '';
     homepage = http://mkdocs.org/;
-    description = "Project documentation with Markdown";
     license = lib.licenses.bsd2;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.rkoe ];
   };
 }

--- a/pkgs/development/tools/documentation/mkdocs/default.nix
+++ b/pkgs/development/tools/documentation/mkdocs/default.nix
@@ -36,7 +36,7 @@ buildPythonApplication rec {
   ];
 
   meta = with stdenv.lib; {
-    description = "Project documentation with Markdown / static website generator.";
+    description = "Project documentation with Markdown / static website generator";
     longDescription = ''
       MkDocs is a fast, simple and downright gorgeous static site generator that's
       geared towards building project documentation. Documentation source files


### PR DESCRIPTION
###### Motivation for this change
Improve meta-information and set myself as maintainer (since there was no maintainer, an
I was the only one who updated the package some time ago).

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
