### PR TITLE
[staging] meson: fix build on darwin

### DIFF
--- a/pkgs/development/tools/build-managers/meson/fix-objc-linking.patch
+++ b/pkgs/development/tools/build-managers/meson/fix-objc-linking.patch
@@ -1,20 +1,20 @@
 --- a/mesonbuild/environment.py
 +++ b/mesonbuild/environment.py
-@@ -795,7 +795,7 @@
+@@ -944,7 +944,7 @@
                  compiler_type = self.get_gnu_compiler_type(defines)
                  version = self.get_gnu_version_from_defines(defines)
-                 return GnuObjCCompiler(ccache + compiler, version, compiler_type, is_cross, exe_wrap, defines)
--            if out.startswith('Apple LLVM'):
-+            if out.startswith('Apple LLVM') or mesonlib.for_darwin(want_cross, self):
-                 return ClangObjCCompiler(ccache + compiler, version, CompilerType.CLANG_OSX, is_cross, exe_wrap)
-             if out.startswith('clang'):
-                 return ClangObjCCompiler(ccache + compiler, version, CompilerType.CLANG_STANDARD, is_cross, exe_wrap)
-@@ -822,7 +822,7 @@
+                 return GnuObjCCompiler(ccache + compiler, version, compiler_type, for_machine, is_cross, exe_wrap, defines)
+-            if out.startswith('Apple LLVM') or out.startswith('Apple clang'):
++            if out.startswith('Apple LLVM') or out.startswith('Apple clang') or mesonlib.for_darwin(want_cross, self):
+                 return ClangObjCCompiler(ccache + compiler, version, CompilerType.CLANG_OSX, for_machine, is_cross, exe_wrap)
+             if 'windows' in out:
+                 return ClangObjCCompiler(ccache + compiler, version, CompilerType.CLANG_MINGW, for_machine, is_cross, exe_wrap)
+@@ -974,7 +974,7 @@
                  compiler_type = self.get_gnu_compiler_type(defines)
                  version = self.get_gnu_version_from_defines(defines)
-                 return GnuObjCPPCompiler(ccache + compiler, version, compiler_type, is_cross, exe_wrap, defines)
--            if out.startswith('Apple LLVM'):
-+            if out.startswith('Apple LLVM') or mesonlib.for_darwin(want_cross, self):
-                 return ClangObjCPPCompiler(ccache + compiler, version, CompilerType.CLANG_OSX, is_cross, exe_wrap)
-             if out.startswith('clang'):
-                 return ClangObjCPPCompiler(ccache + compiler, version, CompilerType.CLANG_STANDARD, is_cross, exe_wrap)
+                 return GnuObjCPPCompiler(ccache + compiler, version, compiler_type, for_machine, is_cross, exe_wrap, defines)
+-            if out.startswith('Apple LLVM') or out.startswith('Apple clang'):
++            if out.startswith('Apple LLVM') or out.startswith('Apple clang') or mesonlib.for_darwin(want_cross, self):
+                 return ClangObjCPPCompiler(ccache + compiler, version, CompilerType.CLANG_OSX, for_machine, is_cross, exe_wrap)
+             if 'windows' in out:
+                 return ClangObjCPPCompiler(ccache + compiler, version, CompilerType.CLANG_MINGW, for_machine, is_cross, exe_wrap)


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update fix-objc-linking.patch patch for meson 0.51.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
