### PR TITLE
prometheus-process-exporter: init at 0.5.0

### DIFF
--- a/pkgs/servers/monitoring/prometheus/process-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/process-exporter.nix
@@ -1,0 +1,31 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  pname = "process-exporter";
+  version = "0.5.0";
+
+  goPackagePath = "github.com/ncabatoff/process-exporter";
+
+  goDeps = ./process-exporter_deps.nix;
+
+  src = fetchFromGitHub {
+    owner = "ncabatoff";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "129vqry3l8waxcyvx83wg0dvh3qg4pr3rl5fw7vmhgdzygbaq3bq";
+  };
+
+  postPatch = ''
+    substituteInPlace proc/read_test.go --replace /bin/cat cat
+  '';
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "Prometheus exporter that mines /proc to report on selected processes";
+    homepage = "https://github.com/ncabatoff/process-exporter";
+    license = licenses.mit;
+    maintainers = with maintainers; [ maintainers."1000101" ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/servers/monitoring/prometheus/process-exporter_deps.nix
+++ b/pkgs/servers/monitoring/prometheus/process-exporter_deps.nix
@@ -1,0 +1,156 @@
+# file generated from go.mod using vgo2nix (https://github.com/adisbladis/vgo2nix)
+[
+  {
+    goPackagePath = "github.com/beorn7/perks";
+    fetch = {
+      type = "git";
+      url = "https://github.com/beorn7/perks";
+      rev = "3a771d992973";
+      sha256 = "1l2lns4f5jabp61201sh88zf3b0q793w4zdgp9nll7mmfcxxjif3";
+    };
+  }
+  {
+    goPackagePath = "github.com/golang/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/protobuf";
+      rev = "v1.1.0";
+      sha256 = "0ya4ha7m20bw048m1159ppqzlvda4x0vdprlbk5sdgmy74h3xcdq";
+    };
+  }
+  {
+    goPackagePath = "github.com/google/go-cmp";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/go-cmp";
+      rev = "v0.2.0";
+      sha256 = "1fbv0x27k9sn8svafc0hjwsnckk864lv4yi7bvzrxvmd3d5hskds";
+    };
+  }
+  {
+    goPackagePath = "github.com/kr/pretty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kr/pretty";
+      rev = "v0.1.0";
+      sha256 = "18m4pwg2abd0j9cn5v3k2ksk9ig4vlwxmlw9rrglanziv9l967qp";
+    };
+  }
+  {
+    goPackagePath = "github.com/kr/pty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kr/pty";
+      rev = "v1.1.1";
+      sha256 = "0383f0mb9kqjvncqrfpidsf8y6ns5zlrc91c6a74xpyxjwvzl2y6";
+    };
+  }
+  {
+    goPackagePath = "github.com/kr/text";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kr/text";
+      rev = "v0.1.0";
+      sha256 = "1gm5bsl01apvc84bw06hasawyqm4q84vx1pm32wr9jnd7a8vjgj1";
+    };
+  }
+  {
+    goPackagePath = "github.com/matttproud/golang_protobuf_extensions";
+    fetch = {
+      type = "git";
+      url = "https://github.com/matttproud/golang_protobuf_extensions";
+      rev = "v1.0.1";
+      sha256 = "1d0c1isd2lk9pnfq2nk0aih356j30k3h1gi2w0ixsivi5csl7jya";
+    };
+  }
+  {
+    goPackagePath = "github.com/ncabatoff/fakescraper";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ncabatoff/fakescraper";
+      rev = "15938421d91a";
+      sha256 = "1in2iakq6xly9r8gk0mfim8n0glbjzpa07hkaj1rlrm0i11jlc6f";
+    };
+  }
+  {
+    goPackagePath = "github.com/ncabatoff/go-seq";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ncabatoff/go-seq";
+      rev = "b08ef85ed833";
+      sha256 = "1x88x285n4wf221pp7ccmh2ai7rgcnwz764gn8k861qg30jl1ky6";
+    };
+  }
+  {
+    goPackagePath = "github.com/ncabatoff/procfs";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ncabatoff/procfs";
+      rev = "9ced60d7b905";
+      sha256 = "19756h4lw5v8f0xr70cl8gd0wfqcnszrhhgawqhyinnir82rz728";
+    };
+  }
+  {
+    goPackagePath = "github.com/prometheus/client_golang";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/client_golang";
+      rev = "v0.8.0";
+      sha256 = "1xqny3147g12n4j03kxm8s9mvdbs3ln6i56c655mybrn9jjy48kd";
+    };
+  }
+  {
+    goPackagePath = "github.com/prometheus/client_model";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/client_model";
+      rev = "5c3871d89910";
+      sha256 = "04psf81l9fjcwascsys428v03fx4fi894h7fhrj2vvcz723q57k0";
+    };
+  }
+  {
+    goPackagePath = "github.com/prometheus/common";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/common";
+      rev = "c7de2306084e";
+      sha256 = "11dqfm2d0m4sjjgyrnayman96g59x2apmvvqby9qmww2qj2k83ig";
+    };
+  }
+  {
+    goPackagePath = "github.com/prometheus/procfs";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/procfs";
+      rev = "ea9eea638872";
+      sha256 = "1j99qszynx2asac82bhzhk0g1nav87nfgkb1cz5a2iywj81liirj";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sync";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sync";
+      rev = "37e7f081c4d4";
+      sha256 = "1bb0mw6ckb1k7z8v3iil2qlqwfj408fvvp8m1cik2b46p7snyjhm";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/check.v1";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/check.v1";
+      rev = "788fd7840127";
+      sha256 = "0v3bim0j375z81zrpr5qv42knqs0y2qv2vkjiqi5axvb78slki1a";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/yaml.v2";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/yaml.v2";
+      rev = "v2.2.1";
+      sha256 = "0dwjrs2lp2gdlscs7bsrmyc5yf6mm4fvgw71bzr9mv2qrd2q73s1";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15080,6 +15080,7 @@ in
   prometheus-openvpn-exporter = callPackage ../servers/monitoring/prometheus/openvpn-exporter.nix { };
   prometheus-postfix-exporter = callPackage ../servers/monitoring/prometheus/postfix-exporter.nix { };
   prometheus-postgres-exporter = callPackage ../servers/monitoring/prometheus/postgres-exporter.nix { };
+  prometheus-process-exporter = callPackage ../servers/monitoring/prometheus/process-exporter.nix { };
   prometheus-pushgateway = callPackage ../servers/monitoring/prometheus/pushgateway.nix { };
   prometheus-rabbitmq-exporter = callPackage ../servers/monitoring/prometheus/rabbitmq-exporter.nix { };
   prometheus-snmp-exporter = callPackage ../servers/monitoring/prometheus/snmp-exporter.nix {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @mmahut 
