### PR TITLE
wtf: Add `infocmp` to PATH, fixes #68103

### DIFF
--- a/pkgs/applications/misc/wtf/default.nix
+++ b/pkgs/applications/misc/wtf/default.nix
@@ -1,6 +1,8 @@
 { buildGoModule
 , fetchFromGitHub
 , lib
+, makeWrapper
+, ncurses
 }:
 
 buildGoModule rec {
@@ -18,6 +20,8 @@ buildGoModule rec {
 
   buildFlagsArray = [ "-ldflags=-s -w -X main.version=${version}" ];
 
+  nativeBuildInputs = [ makeWrapper ];
+
   # As per https://github.com/wtfutil/wtf/issues/501, one of the
   # dependencies can't be fetched, so vendored dependencies should
   # be used instead
@@ -25,6 +29,10 @@ buildGoModule rec {
     runHook preBuild
     make build -mod=vendor
     runHook postBuild
+  '';
+
+  postInstall = ''
+    wrapProgram "$out/bin/wtf" --prefix PATH : "${ncurses.dev}/bin"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

`wtf` does not run on some terminals out of the box, see issue #68103.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @kalbasit
