### PR TITLE
ceph: 14.2.1 -> 14.2.3

### DIFF
--- a/nixos/tests/ceph.nix
+++ b/nixos/tests/ceph.nix
@@ -1,7 +1,7 @@
 import ./make-test.nix ({pkgs, lib, ...}: rec {
   name = "All-in-one-basic-ceph-cluster";
   meta = with pkgs.stdenv.lib.maintainers; {
-    maintainers = [ lejonet ];
+    maintainers = [ johanot lejonet ];
   };
 
   nodes = {

--- a/pkgs/tools/filesystems/ceph/default.nix
+++ b/pkgs/tools/filesystems/ceph/default.nix
@@ -89,14 +89,15 @@ let
     ps.six
   ]);
 
-  version = "14.2.1";
+  version = "14.2.3";
 in rec {
   ceph = stdenv.mkDerivation {
-    name="ceph-${version}";
+    pname = "ceph";
+    inherit version;
 
     src = fetchurl {
       url = "http://download.ceph.com/tarballs/ceph-${version}.tar.gz";
-      sha256 = "0qa9p8xp26d45h3jfj1rbwhmqv44f9n1mvccmpzaf2i05v42kmzb";
+      sha256 = "1pa8czb205pz4vjfh82gsgickj3cdjrx51mcx7acsyqgp3dfvl33";
     };
 
     patches = [
@@ -181,7 +182,7 @@ in rec {
         homepage = https://ceph.com/;
         description = "Tools needed to mount Ceph's RADOS Block Devices";
         license = with licenses; [ lgpl21 gpl2 bsd3 mit publicDomain ];
-        maintainers = with maintainers; [ adev ak krav ];
+        maintainers = with maintainers; [ adev ak johanot krav ];
         platforms = platforms.unix;
       };
     } ''


### PR DESCRIPTION

###### Motivation for this change
Latest bugfix release from yesterday: https://ceph.io/releases/v14-2-3-nautilus-released/
The ceph test runs without errors locally.

- also; package pname and add myself as maintainer on ceph-client and test.

cc @srhb 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
