### PR TITLE
Switch my qt packages to qt-specific mkDerivation

### DIFF
--- a/pkgs/applications/audio/sfxr-qt/default.nix
+++ b/pkgs/applications/audio/sfxr-qt/default.nix
@@ -1,11 +1,14 @@
-{ stdenv, fetchFromGitHub
+{ lib
+, mkDerivation
+, fetchFromGitHub
 , cmake
-, qtbase, qtquickcontrols2
+, qtbase
+, qtquickcontrols2
 , SDL
 , python3
 }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "sfxr-qt";
   version = "1.2.0";
   src = fetchFromGitHub {
@@ -20,12 +23,13 @@ stdenv.mkDerivation rec {
     (python3.withPackages (pp: with pp; [ pyyaml jinja2 ]))
   ];
   buildInputs = [
-    qtbase qtquickcontrols2
+    qtbase
+    qtquickcontrols2
     SDL
   ];
   configurePhase = "cmake . -DCMAKE_INSTALL_PREFIX=$out";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://github.com/agateau/sfxr-qt;
     description = "A sound effect generator, QtQuick port of sfxr";
     license = licenses.gpl2;

--- a/pkgs/applications/graphics/drawpile/default.nix
+++ b/pkgs/applications/graphics/drawpile/default.nix
@@ -1,4 +1,5 @@
-{ stdenv
+{ lib
+, mkDerivation
 , fetchurl
 , cmake
 , extra-cmake-modules
@@ -31,7 +32,7 @@
 , enableKisTablet ? false # enable improved graphics tablet support
 }:
 
-with stdenv.lib;
+with lib;
 
 let
   commonDeps = [
@@ -57,7 +58,7 @@ let
     qtx11extras
   ];
 
-in stdenv.mkDerivation rec {
+in mkDerivation rec {
   pname = "drawpile";
   version = "2.1.11";
 


### PR DESCRIPTION
###### Motivation for this change

Just learned about it in #63330 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

