### PR TITLE
chromium: expose pepperFlash version option

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -10,6 +10,8 @@
 , gnomeKeyringSupport ? false
 , proprietaryCodecs ? true
 , enablePepperFlash ? false
+, pepperFlashVersion ? "32.0.0.238"
+, pepperFlashSHA ? "0jqx68lfqjpy6wbxdi0giclvh9mc9rha92hqdj1nx42v95k3gc65"
 , enableWideVine ? false
 , useVaapi ? false # test video on radeon, before enabling this
 , cupsSupport ? true
@@ -41,7 +43,7 @@ in let
     browser = callPackage ./browser.nix { inherit channel; };
 
     plugins = callPackage ./plugins.nix {
-      inherit enablePepperFlash enableWideVine;
+      inherit enablePepperFlash enableWideVine pepperFlashVersion;
     };
   };
 

--- a/pkgs/applications/networking/browsers/chromium/plugins.nix
+++ b/pkgs/applications/networking/browsers/chromium/plugins.nix
@@ -6,6 +6,8 @@
 , fetchzip
 , patchelfUnstable
 , enablePepperFlash ? false
+, pepperFlashVersion ? "32.0.0.238"
+, pepperFlashSHA ? "0jqx68lfqjpy6wbxdi0giclvh9mc9rha92hqdj1nx42v95k3gc65"
 , enableWideVine ? false
 
 , upstream-info
@@ -100,11 +102,11 @@ let
 
   flash = stdenv.mkDerivation rec {
     pname = "flashplayer-ppapi";
-    version = "32.0.0.238";
+    version = pepperFlashVersion;
 
     src = fetchzip {
       url = "https://fpdownload.adobe.com/pub/flashplayer/pdc/${version}/flash_player_ppapi_linux.x86_64.tar.gz";
-      sha256 = "0jqx68lfqjpy6wbxdi0giclvh9mc9rha92hqdj1nx42v95k3gc65";
+      sha256 = pepperFlashSHA;
       stripRoot = false;
     };
 


### PR DESCRIPTION
###### Motivation for this change

I wanted to get pepperFlash working with Chromium, but the version in 19.03 is no longer available - old versions are removed very quickly upstream. I pulled the Chromium package into an overlay and set it up this way so that I could update the flash version easily in the face of future upstream updates. With this change applied, it's possible to:

```
  nixpkgs.config.chromium = {
    enablePepperFlash = true;
    pepperFlashVersion = "...";
    pepperFlashSHA = "...";
  };
```

in order to update flash.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [?] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Chromium from 19.03 works with this change, but I have not tried it from master.

###### Notify maintainers

cc @bendlas @ivan
