### PR TITLE
linux-kernel: HID_BATTERY_STRENGTH=yes

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -568,6 +568,7 @@ let
     });
 
     misc = {
+      HID_BATTERY_STRENGTH = yes;
       MODULE_COMPRESS    = yes;
       MODULE_COMPRESS_XZ = yes;
       KERNEL_XZ          = yes;


### PR DESCRIPTION
Fixed #68143 by enabling HID_BATTERY_STRENGTH. See the issue and linked reddit thread for more details.

I'm still building my system right now, so I'm not sure if this is good to go yet. Also, I'd like feedback on if there's a better place to add this line.