### PR TITLE
Add cri-o service to modules

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -938,6 +938,7 @@
   ./virtualisation/anbox.nix
   ./virtualisation/container-config.nix
   ./virtualisation/containers.nix
+  ./virtualisation/cri-o.nix
   ./virtualisation/docker.nix
   ./virtualisation/docker-containers.nix
   ./virtualisation/ecs-agent.nix

--- a/nixos/modules/virtualisation/cri-o.nix
+++ b/nixos/modules/virtualisation/cri-o.nix
@@ -1,0 +1,106 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.virtualisation.cri-o;
+in
+{
+  options.virtualisation.cri-o = {
+    enable = mkEnableOption "Container Runtime Interface for OCI (CRI-O)";
+
+    storageDriver = mkOption {
+      type = types.enum ["btrfs" "overlay" "vfs"];
+      default = "overlay";
+      description = "Storage driver to be used";
+    };
+
+    logLevel = mkOption {
+      type = types.enum ["trace" "debug" "info" "warn" "error" "fatal"];
+      default = "info";
+      description = "Log level to be used";
+    };
+
+    pauseImage = mkOption {
+      type = types.str;
+      default = "k8s.gcr.io/pause:3.1";
+      description = "Pause image for pod sandboxes to be used";
+    };
+
+    pauseCommand = mkOption {
+      type = types.str;
+      default = "/pause";
+      description = "Pause command to be executed";
+    };
+
+    registries = mkOption {
+      type = types.listOf types.str;
+      default = [ "docker.io" "quay.io" ];
+      description = "Registries to be configured for unqualified image pull";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = with pkgs;
+      [ cri-o cri-tools conmon cni-plugins iptables runc utillinux ];
+    environment.etc."crictl.yaml".text = ''
+      runtime-endpoint: unix:///var/run/crio/crio.sock
+    '';
+    environment.etc."crio/crio.conf".text = ''
+      [crio]
+      storage_driver = "${cfg.storageDriver}"
+
+      [crio.image]
+      pause_image = "${cfg.pauseImage}"
+      pause_command = "${cfg.pauseCommand}"
+      registries = [
+        ${concatMapStringsSep ", " (x: "\"" + x + "\"") cfg.registries}
+      ]
+
+      [crio.runtime]
+      conmon = "${pkgs.conmon}/bin/conmon"
+      log_level = "${cfg.logLevel}"
+      manage_network_ns_lifecycle = true
+    '';
+    environment.etc."containers/policy.json".text = ''
+      {"default": [{"type": "insecureAcceptAnything"}]}
+    '';
+    environment.etc."cni/net.d/20-cri-o-bridge.conf".text = ''
+      {
+        "cniVersion": "0.3.1",
+        "name": "crio-bridge",
+        "type": "bridge",
+        "bridge": "cni0",
+        "isGateway": true,
+        "ipMasq": true,
+        "ipam": {
+          "type": "host-local",
+          "subnet": "10.88.0.0/16",
+          "routes": [
+              { "dst": "0.0.0.0/0" }
+          ]
+        }
+      }
+    '';
+
+    systemd.services.crio = {
+      description = "Container Runtime Interface for OCI (CRI-O)";
+      documentation = [ "https://github.com/cri-o/cri-o" ];
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      path = [ pkgs.utillinux pkgs.runc pkgs.iptables ];
+      serviceConfig = {
+        Type = "notify";
+        ExecStart = "${pkgs.cri-o}/bin/crio";
+        ExecReload = "/bin/kill -s HUP $MAINPID";
+        TasksMax = "infinity";
+        LimitNOFILE = "1048576";
+        LimitNPROC = "1048576";
+        LimitCORE = "infinity";
+        OOMScoreAdjust = "-999";
+        TimeoutStartSec = "0";
+        Restart = "on-abnormal";
+      };
+    };
+  };
+}


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

We need a CRI-O service definition to be able to run it via systemd.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @vdemeester can you please have a look? I would like to push the topic of replacing docker with CRI-O forward in terms of the Kubernetes module.
