### PR TITLE
carp: unstable-2018-09-15 -> 0.3.0

### DIFF
--- a/pkgs/development/compilers/carp/default.nix
+++ b/pkgs/development/compilers/carp/default.nix
@@ -3,19 +3,20 @@
 haskellPackages.mkDerivation rec {
 
   pname = "carp";
-  version = "unstable-2018-09-15";
+  version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "carp-lang";
     repo = "Carp";
-    rev = "cf9286c35cab1c170aa819f7b30b5871b9e812e6";
-    sha256 = "1k6kdxbbaclhi40b9p3fgbkc1x6pc4v0029xjm6gny6pcdci2cli";
+    rev = "v${version}";
+    sha256 = "07yk3gy4l6h3k7sh8al7lgwk75a13zxwfp7siqpb5gnnqr1z3brc";
   };
 
   buildDepends = [ makeWrapper ];
 
   executableHaskellDepends = with haskellPackages; [
-    HUnit blaze-markup blaze-html split cmdargs
+    HUnit blaze-markup blaze-html split cmdargs ansi-terminal cmark
+    edit-distance
   ];
 
   isExecutable = true;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Carp has it's first proper release: https://github.com/carp-lang/Carp/releases/tag/v0.3.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @jluttine 