### PR TITLE
python3.pkgs.python-jenkins: 1.4.0 -> 1.5.0

### DIFF
--- a/pkgs/development/python-modules/python-jenkins/default.nix
+++ b/pkgs/development/python-modules/python-jenkins/default.nix
@@ -14,11 +14,11 @@
 
 buildPythonPackage rec {
   pname = "python-jenkins";
-  version = "1.4.0";
+  version = "1.5.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1h14hfcwichmppbgxf1k8njw29hchpav1kj574b4lly3j0n2vnag";
+    sha256 = "145w5vri4lygz0pqjclibdw9h72vp86332pszsd5fj7wvz0zf48b";
   };
 
   buildInputs = [ mock ];


### PR DESCRIPTION
###### Motivation for this change
```
35f660a (HEAD -> master, tag: 1.5.0, origin/master, origin/HEAD) Merge "When updating jobs the response body may be empty"
ac7fc35 Merge "Make get_job_info fetch_all_builds work with jobs in folders"
0ab91c7 Remove pin on mock module
748aa20 Update jobs
190fbbb Make get_job_info fetch_all_builds work with jobs in folders
a5615d0 OpenDev Migration Patch
a2c6f6a When updating jobs the response body may be empty
5c28725 Merge "add python 3.6 unit test job"
4a7c4ff Add Python 3.6 classifier to setup.cfg
9f77e68 add python 3.6 unit test job
```

Currently, 2 of the 590 tests fail on Python 3.x. I opened https://bugs.launchpad.net/python-jenkins/+bug/1842963 about that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Ma27 
