### PR TITLE
dep: 0.5.1 -> 0.5.4

### DIFF
--- a/pkgs/development/tools/dep/default.nix
+++ b/pkgs/development/tools/dep/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   pname = "dep";
-  version = "0.5.1";
+  version = "0.5.4";
   rev = "v${version}";
 
   goPackagePath = "github.com/golang/dep";
@@ -12,7 +12,7 @@ buildGoPackage rec {
     inherit rev;
     owner = "golang";
     repo = "dep";
-    sha256 = "1a5vq5v3ikg6iysbywxr5hcjnbv76nzhk50rd3iq3v2fnyq38dv2";
+    sha256 = "02akzbjar1v01rdal746vk6mklff29yk2mqfyjk1zrs0mlg38ygd";
   };
 
   buildFlagsArray = ("-ldflags=-s -w -X main.commitHash=${rev} -X main.version=${version}");


### PR DESCRIPTION
###### Motivation for this change

Bringing in the latest stable version of the tool

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @rvolosatovs
