### PR TITLE
fmt: 5.3.0 -> 6.0.0

### DIFF
--- a/pkgs/development/libraries/fmt/default.nix
+++ b/pkgs/development/libraries/fmt/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, cmake, enableShared ? true }:
 
 stdenv.mkDerivation rec {
-  version = "5.3.0";
+  version = "6.0.0";
   pname = "fmt";
 
   src = fetchFromGitHub {
     owner = "fmtlib";
     repo = "fmt";
     rev = version;
-    sha256 = "1hl9s69a5ql5nckc0ifh2fzlgsgv1wsn6yhqkpnrhasqkhj0hgv4";
+    sha256 = "0yfrw6by4h27k3psv9x1q7z2kdbz7pkwxidr494bpa6ppglij6ba";
   };
 
   outputs = [ "out" "dev" ];
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   doCheck = true;
-  # preCheckHook ensures the test binaries can find libfmt.so.5
+  # preCheckHook ensures the test binaries can find libfmt.so
   preCheck = if enableShared
              then "export LD_LIBRARY_PATH=\"$PWD\""
              else "";


### PR DESCRIPTION
###### Motivation for this change
Updating package to latest upstream release

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
