### PR TITLE
python3.pkgs.libcloud: 2.5.0 -> 2.6.0

### DIFF
--- a/pkgs/development/python-modules/libcloud/default.nix
+++ b/pkgs/development/python-modules/libcloud/default.nix
@@ -11,11 +11,11 @@
 
 buildPythonPackage rec {
   pname = "apache-libcloud";
-  version = "2.5.0";
+  version = "2.6.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1dj8jh5ccjv7qbydf49cw17py7z3jjkaxk4jj2gx6mq2f4w304wg";
+    sha256 = "1spjkw5nxhbawblj5db8izff05kjw425iyydipajb7qh73vm25r0";
   };
 
   checkInputs = [ mock pytest pytestrunner requests-mock ];


### PR DESCRIPTION
###### Motivation for this change
https://libcloud.readthedocs.io/en/latest/changelog.html#changes-in-apache-libcloud-2-6-0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @FRidh 
