### PR TITLE
[staging]pythonPackages.setuptools_scm: 3.2.0 -> 3.3.3

### DIFF
--- a/pkgs/development/python-modules/setuptools_scm/default.nix
+++ b/pkgs/development/python-modules/setuptools_scm/default.nix
@@ -1,11 +1,12 @@
 { stdenv, buildPythonPackage, fetchPypi, pip }:
+
 buildPythonPackage rec {
   pname = "setuptools_scm";
-  version = "3.2.0";
+  version = "3.3.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "52ab47715fa0fc7d8e6cd15168d1a69ba995feb1505131c3e814eb7087b57358";
+    sha256 = "19cyndx23xmpbhz4qrwmfwsmnnaczd0dw7qg977ksq2dbvxy29dx";
   };
 
   buildInputs = [ pip ];


### PR DESCRIPTION

###### Motivation for this change
noticed it was out of date on repology

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
