### PR TITLE
gitg: 3.32.0 -> 3.32.1

### DIFF
--- a/pkgs/desktops/gnome-3/misc/gitg/default.nix
+++ b/pkgs/desktops/gnome-3/misc/gitg/default.nix
@@ -30,20 +30,12 @@
 
 stdenv.mkDerivation rec {
   pname = "gitg";
-  version = "3.32.0";
+  version = "3.32.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1wzsv7bh0a2w70f938hkpzbb9xkyrp3bil65c0q3yf2v72nbbn81";
+    sha256 = "0npg4kqpwl992fgjd2cn3fh84aiwpdp9kd8z7rw2xaj2iazsm914";
   };
-
-  patches = [
-    # https://gitlab.gnome.org/GNOME/gitg/issues/213
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/gitg/merge_requests/83.patch";
-      sha256 = "1f7wx1d3k5pnp8zbrqssip57b9jxn3hc7a83psm7fny970qmd18z";
-    })
-  ];
 
   postPatch = ''
     chmod +x meson_post_install.py


### PR DESCRIPTION
###### Motivation for this change
fixing broken @r-ryantm updates

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[5 built, 28 copied (48.4 MiB), 8.1 MiB DL]
https://github.com/NixOS/nixpkgs/pull/68173
1 package were build:
gitg
```