### PR TITLE
shunit2: init at 2019-08-10

### DIFF
--- a/pkgs/tools/misc/shunit2/default.nix
+++ b/pkgs/tools/misc/shunit2/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation {
+  pname = "shunit2";
+  version = "2019-08-10";
+
+  src = fetchFromGitHub {
+    owner = "kward";
+    repo = "shunit2";
+    rev = "ba130d69bbff304c0c6a9c5e8ab549ae140d6225";
+    sha256 = "1bsn8dhxbjfmh01lq80yhnld3w3fw1flh7nwx12csrp58zsvlmgk";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin/
+    cp ./shunit2 $out/bin/shunit2
+    chmod +x $out/bin/shunit2
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/shunit2
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/kward/shunit2;
+    description = "A xUnit based unit test framework for Bourne based shell scripts.";
+    maintainers = with maintainers; [ cdepillabout utdemir ];
+    license = licenses.asl20;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6088,6 +6088,8 @@ in
 
   shrikhand = callPackage ../data/fonts/shrikhand { };
 
+  shunit2 = callPackage ../tools/misc/shunit2 { };
+
   sic = callPackage ../applications/networking/irc/sic { };
 
   siege = callPackage ../tools/networking/siege {};


### PR DESCRIPTION
###### Motivation for this change

shunit2 is a small shell script for unit testing command line applications.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @cdepillabout