### PR TITLE
aws-adfs: 1.12.3 -> 1.17.0

### DIFF
--- a/pkgs/development/python-modules/aws-adfs/default.nix
+++ b/pkgs/development/python-modules/aws-adfs/default.nix
@@ -2,12 +2,12 @@
 , pytest, pytestrunner, pytestcov, mock, glibcLocales, lxml, boto3, requests, click, configparser }:
 
 buildPythonPackage rec {
-  version = "1.12.3";
   pname = "aws-adfs";
+  version = "1.17.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "b7df3fbe0572eb12294b2e072327ca97fd94d435b39cc10612e460cde914b831";
+    sha256 = "0wnsmwjpfhxilmvrqvwilcf3h9p5m5ixi5gn9bgkr3gwd2laxf54";
   };
 
   # Relax version constraint
@@ -24,10 +24,10 @@ buildPythonPackage rec {
   checkInputs = [ glibcLocales pytest pytestrunner pytestcov mock ];
   propagatedBuildInputs = [ lxml boto3 requests click configparser ];
 
-  meta = {
+  meta = with lib; {
     description = "Command line tool to ease aws cli authentication against ADFS";
     homepage = https://github.com/venth/aws-adfs;
-    license = lib.licenses.psfl;
-    maintainers = [ lib.maintainers.bhipple ];
+    license = licenses.psfl;
+    maintainers = [ maintainers.bhipple ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9156,6 +9156,8 @@ in
 
   awf = callPackage ../development/tools/misc/awf { };
 
+  aws-adfs = with python3Packages; toPythonApplication aws-adfs;
+
   electron_6 = callPackage ../development/tools/electron/6.x.nix { };
 
   electron_5 = callPackage ../development/tools/electron/5.x.nix { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Routine upgrade to latest version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
