### PR TITLE
grub: enable copyKernels by default

### DIFF
--- a/nixos/modules/system/boot/loader/grub/grub.nix
+++ b/nixos/modules/system/boot/loader/grub/grub.nix
@@ -423,7 +423,7 @@ in
       };
 
       copyKernels = mkOption {
-        default = false;
+        default = true;
         type = types.bool;
         description = ''
           Whether the GRUB menu builder should copy kernels and initial


### PR DESCRIPTION
When using filesystems such as ZFS, grub tries to directly access the
root drive to get the kernel. NixOS uses lots of hardlinks and grub
can have a problem reading that, resulting in messages such as:

  Error: external pointer tables not supported
  Error: you need to load the kernel first.

To avoid this issue, copy the kernel to /boot by default. This is how
it's done in gummiboot and probably other bootloaders.

Signed-off-by: William Casarin <jb55@jb55.com>

###### Motivation for this change

My system broke, I want to prevent that from happening to other people.

Fixes #60902

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @spinus @CMCDragonkai @alyssais @spacekookie @fadenb @caadar 