### PR TITLE
wtf: No longer use vendored dependencies

### DIFF
--- a/pkgs/applications/misc/wtf/default.nix
+++ b/pkgs/applications/misc/wtf/default.nix
@@ -9,6 +9,10 @@ buildGoModule rec {
   pname = "wtf";
   version = "0.21.0";
 
+  overrideModAttrs = _oldAttrs : _oldAttrs // {
+    preBuild = ''export GOPROXY="https://gocenter.io"'';
+  };
+
   src = fetchFromGitHub {
     owner = "wtfutil";
     repo = pname;
@@ -16,20 +20,11 @@ buildGoModule rec {
     sha256 = "0sd8vrx7nak0by4whdmd9jzr66zm48knv1w1aqi90709fv98brm9";
   };
 
-  modSha256 = "1nqnjpkrjbb75yfbzh3v3vc4xy5a2aqm9jr40hwq589a4l9p5pw2";
+  modSha256 = "0jgq9ql27x0kdp59l5drisl5v7v7sx2wy3zqjbr3bqyh3vdx19ic";
 
   buildFlagsArray = [ "-ldflags=-s -w -X main.version=${version}" ];
 
   nativeBuildInputs = [ makeWrapper ];
-
-  # As per https://github.com/wtfutil/wtf/issues/501, one of the
-  # dependencies can't be fetched, so vendored dependencies should
-  # be used instead
-  modBuildPhase = ''
-    runHook preBuild
-    make build -mod=vendor
-    runHook postBuild
-  '';
 
   postInstall = ''
     wrapProgram "$out/bin/wtf" --prefix PATH : "${ncurses.dev}/bin"


### PR DESCRIPTION
###### Motivation for this change

The project once could not be build because a dependency disappeared.(see here: https://github.com/wtfutil/wtf/issues/501)

That's why the project's maintainer included vendored dependencies right in the upstream project. Those dependencies are apparently not updated alongside the main go.mod dependencies.

The go modules utilized by the project and the vendored dependencies already
diverged, so the nix build of `wtf` was slightly out-of-date regarding the
official binary.

The gocenter proxy provides "immutable re-usable Go modules" which should avoid the problem of any dependency suddenly vanishing.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @marsam @kalbasit 
