### PR TITLE
imv: 3.1.2 -> 4.0.1

### DIFF
--- a/pkgs/applications/graphics/imv/default.nix
+++ b/pkgs/applications/graphics/imv/default.nix
@@ -1,26 +1,52 @@
-{ stdenv, fetchFromGitHub, SDL2, SDL2_ttf
+{ stdenv, fetchFromGitHub
 , freeimage, fontconfig, pkgconfig
 , asciidoc, docbook_xsl, libxslt, cmocka
-, librsvg
+, librsvg, pango, libxkbcommon, wayland
+, libGLU
 }:
 
 stdenv.mkDerivation rec {
   pname = "imv";
-  version = "3.1.2";
+  version = "4.0.1";
 
   src = fetchFromGitHub {
     owner  = "eXeC64";
     repo   = "imv";
     rev    = "v${version}";
-    sha256 = "0gg362x2f7hli6cr6s7dmlanh4cqk7fd2pmk4zs9438jvqklf4cl";
+    sha256 = "sha256:01fbkbwwsyr00k3mwans8jfb9p4gl02v6z62vgx0pkgrzxjkcz07";
   };
 
+  preBuild = ''
+    # Version is 4.0.1, but Makefile was not updated
+    sed -i 's/echo v4\.0\.0/echo v4.0.1/' Makefile
+  '';
+
+  nativeBuildInputs = [
+    asciidoc
+    cmocka
+    docbook_xsl
+    libxslt
+  ];
+
   buildInputs = [
-    SDL2 SDL2_ttf freeimage fontconfig pkgconfig
-    asciidoc docbook_xsl libxslt cmocka librsvg
+    freeimage
+    libGLU
+    librsvg
+    libxkbcommon
+    pango
+    pkgconfig
+    wayland
   ];
 
   installFlags = [ "PREFIX=$(out)" "CONFIGPREFIX=$(out)/etc" ];
+
+  postFixup = ''
+    # The `bin/imv` script assumes imv-wayland or imv-x11 in PATH,
+    # so we have to fix those to the binaries we installed into the /nix/store
+
+    sed -i "s|\bimv-wayland\b|$out/bin/imv-wayland|" $out/bin/imv
+    sed -i "s|\bimv-x11\b|$out/bin/imv-x11|" $out/bin/imv
+  '';
 
   doCheck = true;
 


### PR DESCRIPTION
###### Motivation for this change

Update `imv` to version 4.0.1.  Changelog: https://github.com/eXeC64/imv/blob/a6deca0ad390d29ada6d72584a1be835a3913139/CHANGELOG#L4-L40

I kept the standard imv build, that produces both x11 and wayland versions.  We could also separate `imv` or/and add flags to enable which version is actually build to keep the dependency smaller.  Given however that the closure size decreased from `~140M` to `123M` I think it's okay for now as it is.  

Also separated the stuff needed to build the manpage into `nativeBuildInputs`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @rnhmjoj 
