### PR TITLE
bayescan: init at 2.1

### DIFF
--- a/pkgs/applications/science/biology/bayescan/default.nix
+++ b/pkgs/applications/science/biology/bayescan/default.nix
@@ -1,0 +1,39 @@
+{stdenv, fetchurl, unzip, llvmPackages}:
+
+stdenv.mkDerivation rec {
+
+  pname = "bayescan";
+  version = "2.1";
+  src = fetchurl {
+    url = "http://cmpg.unibe.ch/software/BayeScan/files/BayeScan${version}.zip";
+    sha256 = "0ismima8j8z0zj9yc267rpf7z90w57b2pbqzjnayhc3ab8mcbfy6";
+  };
+
+  nativeBuildInputs = [ unzip ];
+  buildInputs = stdenv.lib.optional stdenv.cc.isClang llvmPackages.openmp;
+
+  # Disable FORTIFY_SOURCE or the binary fails with "buffer overflow"
+  hardeningDisable = [ "fortify" ];
+
+  sourceRoot = "BayeScan${version}/source";
+
+  postPatch = ''
+    substituteInPlace Makefile --replace "-static" "" \
+                               --replace "g++" "c++"
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/share/doc/bayescan
+    cp bayescan_${version} $out/bin
+    cp -r ../*pdf ../input_examples ../"R functions" $out/share/doc/bayescan
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Detecting natural selection from population-based genetic data";
+    homepage    = "http://cmpg.unibe.ch/software/BayeScan";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.bzizou ];
+    platforms   = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/applications/science/biology/bayescan/default.nix
+++ b/pkgs/applications/science/biology/bayescan/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Detecting natural selection from population-based genetic data";
     homepage = "http://cmpg.unibe.ch/software/BayeScan";
-    license = licenses.gpl2;
+    license = licenses.gpl3;
     maintainers = [ maintainers.bzizou ];
     platforms = stdenv.lib.platforms.all;
   };

--- a/pkgs/applications/science/biology/bayescan/default.nix
+++ b/pkgs/applications/science/biology/bayescan/default.nix
@@ -1,9 +1,9 @@
-{stdenv, fetchurl, unzip, llvmPackages}:
+{ stdenv, fetchurl, unzip, llvmPackages }:
 
 stdenv.mkDerivation rec {
-
   pname = "bayescan";
   version = "2.1";
+
   src = fetchurl {
     url = "http://cmpg.unibe.ch/software/BayeScan/files/BayeScan${version}.zip";
     sha256 = "0ismima8j8z0zj9yc267rpf7z90w57b2pbqzjnayhc3ab8mcbfy6";
@@ -31,9 +31,9 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Detecting natural selection from population-based genetic data";
-    homepage    = "http://cmpg.unibe.ch/software/BayeScan";
+    homepage = "http://cmpg.unibe.ch/software/BayeScan";
     license = licenses.gpl2;
     maintainers = [ maintainers.bzizou ];
-    platforms   = stdenv.lib.platforms.all;
+    platforms = stdenv.lib.platforms.all;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21860,6 +21860,8 @@ in
     stdenv = overrideCC stdenv gcc49;
   };
 
+  bayescan = callPackage ../applications/science/biology/bayescan { };
+
   bedtools = callPackage ../applications/science/biology/bedtools { };
 
   bcftools = callPackage ../applications/science/biology/bcftools { };


### PR DESCRIPTION

###### Motivation for this change
Tool used into my computing center

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
