### PR TITLE
rl-1909: make services.gnome3 links sensible

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1909.xml
+++ b/nixos/doc/manual/release-notes/rl-1909.xml
@@ -63,10 +63,10 @@
       like games.
       <itemizedlist>
       <para>This can be achieved with the following options which the desktop manager default enables, excluding <literal>games</literal>.</para>
-      <listitem><para><link linkend="opt-services.gnome3.core-os-services.enable"><literal>services.gnome3.core-os-services.enable</literal></link></para></listitem>
-      <listitem><para><link linkend="opt-services.gnome3.core-shell.enable"><literal>services.gnome3.core-shell.enable</literal></link></para></listitem>
-      <listitem><para><link linkend="opt-services.gnome3.core-utilities.enable"><literal>services.gnome3.core-utilities.enable</literal></link></para></listitem>
-      <listitem><para><link linkend="opt-services.gnome3.games.enable"><literal>services.gnome3.games.enable</literal></link></para></listitem>
+      <listitem><para><xref linkend="opt-services.gnome3.core-os-services.enable"/></para></listitem>
+      <listitem><para><xref linkend="opt-services.gnome3.core-shell.enable"/></para></listitem>
+      <listitem><para><xref linkend="opt-services.gnome3.core-utilities.enable"/></para></listitem>
+      <listitem><para><xref linkend="opt-services.gnome3.games.enable"/></para></listitem>
       </itemizedlist>
       With these options we hope to give users finer grained control over their systems. Prior to this change you'd either have to manually
       disable options or use <option>environment.gnome3.excludePackages</option> which only excluded the optional applications.


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
https://github.com/NixOS/nixpkgs/pull/67522#discussion_r320481049

###### Things done
Built manual, clicked those links.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
