### PR TITLE
nixos/doc/manual: Fix Makefile

### DIFF
--- a/nixos/doc/manual/Makefile
+++ b/nixos/doc/manual/Makefile
@@ -24,7 +24,7 @@ fix-misc-xml:
 clean:
 	rm -f manual-combined.xml generated
 
-generated: ./options-to-docbook.xsl
+generated:
 	nix-build ../../release.nix \
 		--attr manualGeneratedSources.x86_64-linux \
 		--out-link ./generated


### PR DESCRIPTION
We had `./options-to-docbook.xsl` as a dependency for `generated` target but it was moved to a package in https://github.com/NixOS/nixpkgs/pull/66328.

cc @domenkozar