### PR TITLE
nixos/railcar: remove use of the deprecated string type

### DIFF
--- a/nixos/modules/virtualisation/railcar.nix
+++ b/nixos/modules/virtualisation/railcar.nix
@@ -25,7 +25,7 @@ let
   mount = with types; (submodule {
     options = {
       type = mkOption {
-        type = string;
+        type = str;
         default = "none";
         description = ''
           The type of the filesystem to be mounted.
@@ -37,11 +37,11 @@ let
         '';
       };
       source = mkOption {
-        type = string;
+        type = str;
         description = "Source for the in-container mount";
       };
       options = mkOption {
-        type = loaOf (string);
+        type = loaOf (str);
         default = [ "bind" ];
         description = ''
           Mount options of the filesystem to be used.
@@ -64,7 +64,7 @@ in
       type = with types; loaOf (submodule ({ name, config, ... }: {
         options = {
           cmd = mkOption {
-            type = types.string;
+            type = types.lines;
             description = "Command or script to run inside the container";
           };
 
@@ -83,19 +83,19 @@ in
           };
 
           runType = mkOption {
-            type = types.string;
+            type = types.str;
             default = "oneshot";
             description = "The systemd service run type";
           };
 
           os = mkOption {
-            type = types.string;
+            type = types.str;
             default = "linux";
             description = "OS type of the container";
           };
 
           arch = mkOption {
-            type = types.string;
+            type = types.str;
             default = "x86_64";
             description = "Computer architecture type of the container";
           };


### PR DESCRIPTION
###### Motivation for this change

This fixes the warning being emitted by nixos-rebuild switch:

```
building Nix...
building the system configuration...
trace: warning: types.string is deprecated because it quietly concatenates strings
```

The type started emitting a warning in #66346.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @alyssais @edef1c @spacekookie @Infinisil 
