### PR TITLE
ocamlPackages.js_of_ocaml*: 3.3.0 -> 3.4.0

### DIFF
--- a/pkgs/development/ocaml-modules/mtime/default.nix
+++ b/pkgs/development/ocaml-modules/mtime/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchurl, ocaml, findlib, ocamlbuild, topkg, js_of_ocaml
-, jsooSupport ? true
+, jsooSupport ? lib.versionAtLeast ocaml.version "4.03"
 }:
 
 with lib;

--- a/pkgs/development/ocaml-modules/xtmpl/default.nix
+++ b/pkgs/development/ocaml-modules/xtmpl/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
     sha256 = "1hq6y4rhz958q40145k4av8hx8jyvspg78xf741samd7vc3jd221";
   };
 
+  patches = [ ./jsoo.patch ];
+
   buildInputs = [ ocaml findlib ppx_tools js_of_ocaml js_of_ocaml-ppx ];
   propagatedBuildInputs = [ iri re ];
 

--- a/pkgs/development/ocaml-modules/xtmpl/jsoo.patch
+++ b/pkgs/development/ocaml-modules/xtmpl/jsoo.patch
@@ -1,0 +1,26 @@
+diff --git a/xtmpl_js.ml b/xtmpl_js.ml
+index e0d3894..991d1b3 100644
+--- a/xtmpl_js.ml
++++ b/xtmpl_js.ml
+@@ -25,6 +25,8 @@
+ 
+ (** *)
+ 
++open Js_of_ocaml
++
+ let log s = Firebug.console##log (Js.string s);;
+ 
+ module X = Xtmpl_rewrite
+diff --git a/xtmpl_js.mli b/xtmpl_js.mli
+index d709896..5ed471c 100644
+--- a/xtmpl_js.mli
++++ b/xtmpl_js.mli
+@@ -25,6 +25,8 @@
+ 
+ (** Convenient functions to use in JS code *)
+ 
++open Js_of_ocaml
++
+ (** Create a new tree of DOM nodes from a given XML tree.
+   Errors are logged to the firebug console.
+   @param doc Default is [Dom_html.document].

--- a/pkgs/development/tools/ocaml/js_of_ocaml/compiler.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/compiler.nix
@@ -1,35 +1,26 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, dune
+{ lib, fetchFromGitHub, buildDunePackage
 , cmdliner, cppo, yojson
 }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.02"
-then throw "js_of_ocaml-compiler is not available for OCaml ${ocaml.version}"
-else
-
-stdenv.mkDerivation rec {
+buildDunePackage rec {
 	pname = "js_of_ocaml-compiler";
-	version = "3.3.0";
+	version = "3.4.0";
 
 	src = fetchFromGitHub {
 		owner = "ocsigen";
 		repo = "js_of_ocaml";
 		rev = version;
-		sha256 = "0bg8x2s3f24c8ia2g293ikd5yg0yjw3hkdgdql59c8k2amqin8f8";
+		sha256 = "0c537say0f3197zn8d83nrihabrxyn28xc6d7c9c3l0vvrv6qvfj";
 	};
 
-	buildInputs = [ ocaml findlib dune cmdliner cppo ];
+	buildInputs = [ cmdliner cppo ];
 
 	propagatedBuildInputs = [ yojson ];
 
-	buildPhase = "dune build -p js_of_ocaml-compiler";
-
-	inherit (dune) installPhase;
-
 	meta = {
 		description = "Compiler from OCaml bytecode to Javascript";
-		license = stdenv.lib.licenses.gpl2;
-		maintainers = [ stdenv.lib.maintainers.vbgl ];
+		license = lib.licenses.gpl2;
+		maintainers = [ lib.maintainers.vbgl ];
 		inherit (src.meta) homepage;
-		inherit (ocaml.meta) platforms;
 	};
 }


### PR DESCRIPTION
###### Motivation for this change

Compatibility with OCaml 4.08

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

