### PR TITLE
nixos/airsonic: Fix user configuration

### DIFF
--- a/nixos/modules/services/misc/airsonic.nix
+++ b/nixos/modules/services/misc/airsonic.nix
@@ -131,7 +131,7 @@ in {
           -jar ${pkgs.airsonic}/webapps/airsonic.war
         '';
         Restart = "always";
-        User = "airsonic";
+        User = cfg.user;
         UMask = "0022";
       };
     };
@@ -143,11 +143,12 @@ in {
       };
     };
 
-    users.users.airsonic = {
-      description = "Airsonic service user";
-      name = cfg.user;
-      home = cfg.home;
-      createHome = true;
+    users.users = optionalAttrs (cfg.user == "airsonic") {
+      airsonic = {
+        description = "Airsonic service user";
+        home = cfg.home;
+        createHome = true;
+      };
     };
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The service used to start with `User = airsonic` regardless of `cfg.user`. This PR also replaces the weird `users.users.airsonic.name = cfg.user` construction with "create a user if default name (airsonic) is specified, otherwise leave user mgt to the admin" logic.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @disassembler