### PR TITLE
radeontool: 1.5 -> 1.6.3

### DIFF
--- a/pkgs/os-specific/linux/radeontools/default.nix
+++ b/pkgs/os-specific/linux/radeontools/default.nix
@@ -1,33 +1,25 @@
-{ stdenv, fetchurl, pciutils }:
+{ stdenv, fetchurl
+, autoreconfHook
+, pciutils
+, pkgconfig
+, xorg
+}:
 
-stdenv.mkDerivation {
-  name = "radeontool-1.5";
-
-  inherit pciutils;
-
-  # Don't know wether it's a good idea to hardcode the lspci path..
-  # But it will work on nix..
-  postUnpack = ''
-    cd $sourceRoot
-    sed -i "s%lspci%$pciutils/sbin/lspci%g" radeontool.c
-    cd ..
-  '';
+stdenv.mkDerivation rec {
+  pname = "radeontool";
+  version = "1.6.3";
 
   src = fetchurl {
-    url = http://fdd.com/software/radeon/radeontool-1.5.tar.gz;
-    sha256 = "0qbkawhhq0y0gqbbql7q04y0v0hims5c4jkjsbc1y03rf9kr10ar";
+    url = "https://people.freedesktop.org/~airlied/radeontool/${pname}-${version}.tar.gz";
+    sha256 = "0mjk9wr9rsb17yy92j6yi16hfpa6v5r1dbyiy60zp4r125wr63za";
   };
 
-  installPhase = ''
-    mkdir -p $out/bin
-    chmod +x lightwatch.pl
-    cp radeontool lightwatch.pl $out/bin
-  '';
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  buildInputs = [ xorg.libpciaccess ];
 
-  meta = {
-    description = "Control the backlight and external video output of ATI Radeon Mobility graphics cards";
-    homepage = http://fdd.com/software/radeon/;
-    license = stdenv.lib.licenses.zlib;
-    broken = true;
+  meta = with stdenv.lib; {
+    description = "Lowlevel tools to tweak register and dump state on radeon GPUs";
+    homepage = "https://airlied.livejournal.com/";
+    license = licenses.zlib;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
fixing broken @ryantm updates

I don't have a radeon card, so i couldn't fully test, but the binaries are properly linked and seem to work.

Essentally followed the archlinux build https://git.archlinux.org/svntogit/community.git/tree/trunk/PKGBUILD?h=packages/radeontool
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
# was broken before
$ nix path-info -Sh ./result
/nix/store/5mcnbpfg7ivlfrq24vagqgg4l88g31zy-radeontool-1.6.3      27.2M
```
```
[1 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/68220
1 package were build:
radeontools
```