### PR TITLE
scribusUnstable: use harfbuzzFull instead of harfbuzz

### DIFF
--- a/pkgs/applications/office/scribus/unstable.nix
+++ b/pkgs/applications/office/scribus/unstable.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, mkDerivation, pkgconfig, cmake, qtbase, cairo, pixman,
 boost, cups, fontconfig, freetype, hunspell, libjpeg, libtiff, libxml2, lcms2,
-podofo, poppler, poppler_data, python2, harfbuzz, qtimageformats, qttools }:
+podofo, poppler, poppler_data, python2, harfbuzzFull, qtimageformats, qttools }:
 
 let
   pythonEnv = python2.withPackages(ps: [ps.tkinter ps.pillow]);
@@ -20,7 +20,7 @@ mkDerivation rec {
   buildInputs = [
     qtbase cairo pixman boost cups fontconfig
     freetype hunspell libjpeg libtiff libxml2 lcms2 podofo poppler
-    poppler_data pythonEnv harfbuzz qtimageformats qttools
+    poppler_data pythonEnv harfbuzzFull qtimageformats qttools
   ];
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

`scribusUnstable` doesn't build right now.

###### Things done

Use `harfbuzzFull` as a dependency, that makes the build work again.

@GrahamcOfBorg build scribusUnstable

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
