### PR TITLE
pythonPackages.ncclient: enable Python 3 support

### DIFF
--- a/pkgs/development/python-modules/lxml/default.nix
+++ b/pkgs/development/python-modules/lxml/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [ libxml2.dev libxslt.dev ];
-  buildInputs = [ libxml2 libxslt ];
+  propagatedBuildInputs = [ libxml2 libxslt ];
 
   hardeningDisable = stdenv.lib.optional stdenv.isDarwin "format";
 

--- a/pkgs/development/python-modules/ncclient/default.nix
+++ b/pkgs/development/python-modules/ncclient/default.nix
@@ -4,8 +4,6 @@
 , paramiko
 , selectors2
 , lxml
-, libxml2
-, libxslt
 , nose
 , rednose
 }:
@@ -22,7 +20,7 @@ buildPythonPackage rec {
   checkInputs = [ nose rednose ];
 
   propagatedBuildInputs = [
-    paramiko lxml libxml2 libxslt selectors2
+    paramiko lxml selectors2
   ];
 
   checkPhase = ''


### PR DESCRIPTION
###### Motivation for this change

The actual code in the currently-packaged `ncclient` Python package, along with all its dependencies, support Python 3. But currently the way they're packaged breaks this:
```
$ nix-shell -p python3Packages.ncclient
error: libxslt not supported for interpreter python3.7
```
The problem is a broken dependency. The (interesting subset of the) actual code dependencies is like this (where P.foo means pythonPackages.foo):
```
                         +--> libxml2
                         |
P.ncclient --> P.lxml ---+
                         |
                         +--> libxslt
```
so the ultimate dependency is on the plain old C libraries for `libxml2` and `libxslt`.

Unfortunately, the Python `lxml` derivation [fails to propagate the dependency](https://github.com/NixOS/nixpkgs/blob/d42ed9b401666e905f797a5f994264a0942fad97/pkgs/development/python-modules/lxml/default.nix#L18) on these two C libraries, and so `ncclient` tries to [add them back](https://github.com/NixOS/nixpkgs/blob/d42ed9b401666e905f797a5f994264a0942fad97/pkgs/development/python-modules/ncclient/default.nix#L25). But it actually depends on the Python package wrappers, like this:
```
       +--> P.libxml2 -->+-> libxml2
       |                 |
P.ncclient --> P.lxml ---+
       |                 |
       +--> P.libxslt -->+-> libxslt
                 ^
                 |
 Doesn't currently support Python 3
```
and since `P.libxslt` doesn't support Python 3, unnecessarily breaks the chain.

There is [an issue](https://github.com/NixOS/nixpkgs/issues/59214) to enable Python 3 support for `P.libxslt`. But simply fixing the dependencies seems a quick and correct fix for this case.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Test reproduction

If anyone wants to reproduce a test, then there is a simple standalone [netconf server here](https://github.com/choppsv1/netconf/tree/master/example). If you run that, and use this `client.py` code:
```python
from ncclient import manager
with manager.connect(host='127.0.0.1', port=8300, username='admin', password='admin', hostkey_verify=False) as m:
  print(m.get_config(source='running').data_xml)
```
then before this fix, python3 fails as above. With the fix, both
```
nix-shell --pure -p python2 -p python2Packages.ncclient --command 'python2 client.py'
nix-shell --pure -p python3 -p python3Packages.ncclient --command 'python3 client.py'
```
give the correct output:
```xml
<?xml version="1.0" encoding="UTF-8"?><nc:data xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
    <sys:system xmlns:sys="urn:ietf:params:xml:ns:yang:ietf-system">
      <sys:hostname>ibex</sys:hostname>
      <sys:clock>
        <sys:timezone-utc-offset>0</sys:timezone-utc-offset>
      </sys:clock>
    </sys:system>
  </nc:data>
```

###### Notify maintainers

cc @sjourdois @xnaveira