### PR TITLE
network-interfaces.nix: escape '.' in interface names passed to sysctl

### DIFF
--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -1092,7 +1092,7 @@ in
         destination = "/etc/udev/rules.d/98-${name}";
         text = ''
           # enable and prefer IPv6 privacy addresses by default
-          ACTION=="add", SUBSYSTEM=="net", RUN+="echo 2 > /proc/sys/net/ipv6/conf/%k/use_tempaddr"
+          ACTION=="add", SUBSYSTEM=="net", RUN+="${pkgs.coreutils}/bin/echo 2 > /proc/sys/net/ipv6/conf/%k/use_tempaddr"
         '';
       })
       (pkgs.writeTextFile rec {

--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -967,9 +967,9 @@ in
       "net.ipv6.conf.default.disable_ipv6" = mkDefault (!cfg.enableIPv6);
       "net.ipv6.conf.all.forwarding" = mkDefault (any (i: i.proxyARP) interfaces);
     } // listToAttrs (flip concatMap (filter (i: i.proxyARP) interfaces)
-        (i: forEach [ "4" "6" ] (v: nameValuePair "net.ipv${v}.conf.${i.name}.proxy_arp" true)))
+        (i: forEach [ "4" "6" ] (v: nameValuePair "net.ipv${v}.conf.${replaceChars ["."] ["/"] i.name}.proxy_arp" true)))
       // listToAttrs (forEach (filter (i: i.preferTempAddress) interfaces)
-        (i: nameValuePair "net.ipv6.conf.${i.name}.use_tempaddr" 2));
+        (i: nameValuePair "net.ipv6.conf.${replaceChars ["."] ["/"] i.name}.use_tempaddr" 2));
 
     # Capabilities won't work unless we have at-least a 4.3 Linux
     # kernel because we need the ambient capability
@@ -1092,7 +1092,7 @@ in
         destination = "/etc/udev/rules.d/98-${name}";
         text = ''
           # enable and prefer IPv6 privacy addresses by default
-          ACTION=="add", SUBSYSTEM=="net", RUN+="${pkgs.procps}/bin/sysctl net.ipv6.conf.%k.use_tempaddr=2"
+          ACTION=="add", SUBSYSTEM=="net", RUN+="echo 2 > /proc/sys/net/ipv6/conf/%k/use_tempaddr"
         '';
       })
       (pkgs.writeTextFile rec {
@@ -1100,7 +1100,7 @@ in
         destination = "/etc/udev/rules.d/99-${name}";
         text = concatMapStrings (i: ''
           # enable IPv6 privacy addresses but prefer EUI-64 addresses for ${i.name}
-          ACTION=="add", SUBSYSTEM=="net", RUN+="${pkgs.procps}/bin/sysctl net.ipv6.conf.${i.name}.use_tempaddr=1"
+          ACTION=="add", SUBSYSTEM=="net", RUN+="${pkgs.procps}/bin/sysctl net.ipv6.conf.${replaceChars ["."] ["/"] i.name}.use_tempaddr=1"
         '') (filter (i: !i.preferTempAddress) interfaces);
       })
     ] ++ lib.optional (cfg.wlanInterfaces != {})


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/62835#pullrequestreview-285094670

@lheckemann