### PR TITLE
alpine: fix links

### DIFF
--- a/pkgs/applications/networking/mailreaders/alpine/default.nix
+++ b/pkgs/applications/networking/mailreaders/alpine/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   version = "2.21";
 
   src = fetchurl {
-    url = "http://alpine.freeiz.com/alpine/release/src/${pname}-${version}.tar.xz";
+    url = "http://alpine.x10host.com/alpine/release/src/${pname}-${version}.tar.xz";
     sha256 = "0f3llxrmaxw7w9w6aixh752md3cdc91mwfmbarkm8s413f4bcc30";
   };
 
@@ -22,11 +22,11 @@ stdenv.mkDerivation rec {
     "--with-passfile=.pine-passfile"
   ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Console mail reader";
-    license = stdenv.lib.licenses.asl20;
-    maintainers = [stdenv.lib.maintainers.raskin];
-    platforms = stdenv.lib.platforms.linux;
-    homepage = https://www.washington.edu/alpine/;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ raskin ];
+    platforms = platforms.linux;
+    homepage = "http://alpine.x10host.com/";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

These links are not available anymore:
> Homepage: ~https://www.washington.edu/alpine/~
> Sources: ~http://alpine.freeiz.com/alpine/release/src/alpine-2.21.tar.xz~

New ones:
> Homepage: http://alpine.x10host.com/
> Sources: http://alpine.x10host.com/alpine/release/src/alpine-2.21.tar.xz

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @7c6f434c
