### PR TITLE
rtags: 2.16 -> 2.33

### DIFF
--- a/pkgs/development/libraries/rct/default.nix
+++ b/pkgs/development/libraries/rct/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchFromGitHub
+, cmake
+, cppunit
+, openssl
+, pkgconfig
+, zlib
+
+, withTests ? true
+}:
+
+stdenv.mkDerivation rec {
+  pname = "rct";
+  version = "unstable-2019-07-21";
+
+  src = fetchFromGitHub {
+    owner = "andersbakken";
+    repo = "rct";
+    rev = "7bd3732c232a1843990f67f41f1d86cb2c16f341";
+    sha256 = "13lb6hsgys257a1ry0ngwl0gm979947x8fbrl6idjzdjbzq8jh4n";
+  };
+
+  outputs = [ "out" "dev" ];
+
+  cmakeFlags = [ "-DRCT_WITH_TESTS=${if withTests then "ON" else "OFF"}" ];
+
+  nativeBuildInputs = [ cmake cppunit pkgconfig ];
+  buildInputs = [ openssl zlib ];
+
+  enableParallelBuilding = true;
+
+  doCheck = withTests;
+  # put librct.{so,dylib} on path
+  preCheck = ''
+    export LD_LIBRARY_PATH=$PWD:$LD_LIBRARY_PATH
+  '';
+
+  meta = with stdenv.lib; {
+    description= "A set of c++ tools that provide nicer (more Qt-like) APIs on top of stl classes with a friendly license";
+    homepage = https://github.com/Andersbakken/rct;
+    license = licenses.bsdOriginal;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ jonringer ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5808,6 +5808,8 @@ in
 
   rc = callPackage ../shells/rc { };
 
+  rct = callPackage ../development/libraries/rct { };
+
   rdma-core = callPackage ../os-specific/linux/rdma-core { };
 
   react-native-debugger = callPackage ../development/tools/react-native-debugger { };


### PR DESCRIPTION
###### Motivation for this change
fixing broken @ryantm builds

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @


```
$ nix path-info -Sh ./result
/nix/store/g00c4zqpwnbqq9i9jrixmq4b0mq6bwyj-rtags-2.16   955.7M
$ nix path-info -Sh ./result
/nix/store/v3rnjr3ir1x5pdbld7d3hx65ms75y3qx-rtags-2.33   955.7M
```