### PR TITLE
zeroc-ice: fix on Darwin

### DIFF
--- a/pkgs/development/libraries/zeroc-ice/default.nix
+++ b/pkgs/development/libraries/zeroc-ice/default.nix
@@ -33,7 +33,7 @@ in stdenv.mkDerivation rec {
     ++ lib.optionals stdenv.isDarwin [ darwin.cctools libiconv Security ];
 
   prePatch = lib.optional stdenv.isDarwin ''
-    substituteInPlace Make.rules.Darwin \
+    substituteInPlace config/Make.rules \
         --replace xcrun ""
   '';
 

--- a/pkgs/development/python-modules/zeroc-ice/default.nix
+++ b/pkgs/development/python-modules/zeroc-ice/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, openssl, bzip2 }:
+{ stdenv, lib, buildPythonPackage, fetchPypi, openssl, bzip2, darwin, libiconv, Security }:
 
 buildPythonPackage rec {
   pname = "zeroc-ice";
@@ -9,7 +9,12 @@ buildPythonPackage rec {
     sha256 = "1bs7h3k9nd1gls2azgp8gz9407cslxbi2x1gspab8p87a61pjim8";
   };
 
-  buildInputs = [ openssl bzip2 ];
+  buildInputs = [ openssl bzip2 ]
+    ++ lib.optionals stdenv.isDarwin [ darwin.cctools libiconv Security ];
+
+  postPatch = lib.optional stdenv.isDarwin ''
+    sed -i '/xcrun/d' setup.py
+  '';
 
   meta = with stdenv.lib; {
     homepage = https://zeroc.com/;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6192,7 +6192,9 @@ in {
     inherit python;
   })).python;
 
-  zeroc-ice = callPackage ../development/python-modules/zeroc-ice { };
+  zeroc-ice = callPackage ../development/python-modules/zeroc-ice {
+    inherit (pkgs.darwin.apple_sdk.frameworks) Security;
+  };
 
   zm-py = callPackage ../development/python-modules/zm-py { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fix Darwin build (forgot to test it in the original PR).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).