### PR TITLE
shuriken: init at 0.5.2

### DIFF
--- a/pkgs/applications/audio/shuriken/default.nix
+++ b/pkgs/applications/audio/shuriken/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, qmake, alsaLib, jack2, rubberband, aubio, libsndfile
+, liblo, libsamplerate }:
+
+stdenv.mkDerivation rec {
+  name = "shuriken-${version}";
+  version = "0.5.2";
+  src = fetchFromGitHub {
+    owner = "rock-hopper";
+    repo = "shuriken";
+    rev = "v${version}";
+    sha256 = "1mvrh6zp0fwii96kv3qfga5kvy7imxkccq51iy6qnbf7bxfkb52s";
+  };
+
+  nativeBuildInputs = [ qmake ];
+  qmakeFlags = [ "./Shuriken.pro" ];
+  buildInputs = [ alsaLib jack2 rubberband aubio libsndfile liblo libsamplerate ];
+
+  preBuild = ''
+    mkdir -p lib
+    pushd src/SndLibShuriken
+    ./configure --without-audio --without-s7
+    make -w
+    mv -v libsndlib_shuriken.a ../../lib/
+    popd
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Shuriken beat slicer";
+    homepage = https://github.com/rock-hopper/shuriken;
+    license = licenses.gpl2;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19627,6 +19627,8 @@ in
 
   shogun = callPackage ../applications/science/machine-learning/shogun { };
 
+  shuriken = callPackage ../applications/audio/shuriken { inherit (qt5) qmake; };
+
   sky = callPackage ../applications/networking/instant-messengers/sky {};
 
   smplayer = libsForQt5.callPackage ../applications/video/smplayer { };


### PR DESCRIPTION

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
