### PR TITLE
prusa-slicer: 2.0.0 -> 2.1.0 

### DIFF
--- a/pkgs/applications/misc/prusa-slicer/default.nix
+++ b/pkgs/applications/misc/prusa-slicer/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub, makeWrapper, cmake, pkgconfig
-, boost, curl, expat, glew, libpng, tbb, wxGTK30
+, boost, cereal, curl, expat, glew, libpng, tbb, wxGTK30
 , gtest, nlopt, xorg, makeDesktopItem
 }:
 let
@@ -9,7 +9,7 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "prusa-slicer";
-  version = "2.0.0";
+  version = "2.1.0";
 
   enableParallelBuilding = true;
 
@@ -23,6 +23,7 @@ stdenv.mkDerivation rec {
   # nixpkgs.
   buildInputs = [
     boost
+    cereal
     curl
     expat
     glew
@@ -42,8 +43,8 @@ stdenv.mkDerivation rec {
 
   prePatch = ''
     # In nix ioctls.h isn't available from the standard kernel-headers package
-    # on other distributions. As the copy in glibc seems to be identical to the
-    # one in the kernel, we use that one instead.
+    # like in other distributions. The copy in glibc seems to be identical to the
+    # one in the kernel though, so we use that one instead.
     sed -i 's|"/usr/include/asm-generic/ioctls.h"|<asm-generic/ioctls.h>|g' src/libslic3r/GCodeSender.cpp
   '' + lib.optionalString (lib.versionOlder "2.5" nloptVersion) ''
     # Since version 2.5.0 of nlopt we need to link to libnlopt, as libnlopt_cxx
@@ -54,7 +55,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "prusa3d";
     repo = "PrusaSlicer";
-    sha256 = "135wn2sza2f2kvbja1haxil5kx1b74lc1i7dsa35i1y3phabykhz";
+    sha256 = "172nz01iiqfjzkpcbl78j6almq6av70l71jgrzrcdw6ham1wqnpr";
     rev = "version_${version}";
   };
 

--- a/pkgs/applications/misc/prusa-slicer/default.nix
+++ b/pkgs/applications/misc/prusa-slicer/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub, makeWrapper, cmake, pkgconfig
-, boost, cereal, curl, expat, glew, libpng, tbb, wxGTK30
+, boost, cereal, curl, eigen, expat, glew, libpng, tbb, wxGTK30
 , gtest, nlopt, xorg, makeDesktopItem
 }:
 let
@@ -19,12 +19,11 @@ stdenv.mkDerivation rec {
     pkgconfig
   ];
 
-  # We could add Eigen, but it doesn't currently compile with the version in
-  # nixpkgs.
   buildInputs = [
     boost
     cereal
     curl
+    eigen
     expat
     glew
     libpng
@@ -40,6 +39,11 @@ stdenv.mkDerivation rec {
   # for finding the nlopt library, which doesn't pick up the package in the nix store.
   # We need to set the path via the NLOPT environment variable instead.
   NLOPT = nlopt;
+
+  # Disable compiler warnings that clutter the build log
+  # It seems to be a known issue for Eigen:
+  # http://eigen.tuxfamily.org/bz/show_bug.cgi?id=1221
+  NIX_CFLAGS_COMPILE = "-Wno-ignored-attributes";
 
   prePatch = ''
     # In nix ioctls.h isn't available from the standard kernel-headers package

--- a/pkgs/development/libraries/cereal/default.nix
+++ b/pkgs/development/libraries/cereal/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, cmake }:
+stdenv.mkDerivation rec {
+  pname = "cereal";
+  version = "1.2.2";
+
+  nativeBuildInputs = [ cmake ];
+
+  src = fetchFromGitHub {
+    owner = "USCiLab";
+    repo = "cereal";
+    rev = "v${version}";
+    sha256 = "1ckr8r03ggg5pyzg8yw40d5ssq40h5najvyqlnxc85fxxp8rnrx4";
+  };
+
+  cmakeFlagsArray = [ "-DJUST_INSTALL_CEREAL=yes" ];
+
+  meta = with stdenv.lib; {
+    description = "A header-only C++11 serialization library";
+    homepage    = https://uscilab.github.io/cereal/;
+    platforms   = platforms.all;
+    license     = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -153,6 +153,8 @@ in
 
   castxml = callPackage ../development/tools/castxml { };
 
+  cereal = callPackage ../development/libraries/cereal { };
+
   clj-kondo = callPackage ../development/tools/clj-kondo { };
 
   cmark = callPackage ../development/libraries/cmark { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Preparing for update to 2.1.0.

There is a new dependency needed, cereal. This PR adds a package for that as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
