### PR TITLE
eth-typing: 2.0.0 -> 2.1.0 and eth-utils: 1.4.1 -> 1.7.0

### DIFF
--- a/pkgs/development/python-modules/eth-typing/default.nix
+++ b/pkgs/development/python-modules/eth-typing/default.nix
@@ -2,7 +2,7 @@
 
 buildPythonPackage rec {
   pname = "eth-typing";
-  version = "2.0.0";
+  version = "2.1.0";
 
   # Tests are missing from the PyPI source tarball so let's use GitHub
   # https://github.com/ethereum/eth-typing/issues/8
@@ -10,7 +10,7 @@ buildPythonPackage rec {
     owner = "ethereum";
     repo = pname;
     rev = "v${version}";
-    sha256 = "017rshrz9kzax851hdbd3924jmr06h2sx3xdq7m4dwhgz3pgqfcy";
+    sha256 = "0chrrfw3kdaihgr2ryhljf56bflipzmfxai688xrc2yk7yiqnll5";
   };
 
   # setuptools-markdown uses pypandoc which is broken at the moment

--- a/pkgs/development/python-modules/eth-utils/default.nix
+++ b/pkgs/development/python-modules/eth-utils/default.nix
@@ -3,7 +3,7 @@
 
 buildPythonPackage rec {
   pname = "eth-utils";
-  version = "1.4.1";
+  version = "1.7.0";
 
   # Tests are missing from the PyPI source tarball so let's use GitHub
   # https://github.com/ethereum/eth-utils/issues/130
@@ -11,7 +11,7 @@ buildPythonPackage rec {
     owner = "ethereum";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1bwn7b5f0nzvwiw9zs63wy3qhaxvz2fhjp4wj9djp2337d7195h4";
+    sha256 = "0hhhdz764xgwj5zg3pjzpx10vh54q7kbvlnj9d67qkgwl3fkfgw2";
   };
 
   checkInputs = [ pytest hypothesis ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update eth-utils and eth-typing packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

