### PR TITLE
pythonPackages.pvlib: 0.6.1 -> 0.6.3

### DIFF
--- a/pkgs/development/python-modules/pvlib/default.nix
+++ b/pkgs/development/python-modules/pvlib/default.nix
@@ -1,27 +1,26 @@
-{ stdenv, buildPythonPackage, fetchFromGitHub, numpy, pandas, pytz, six
-, pytest, mock, pytest-mock }:
+{ stdenv, buildPythonPackage, fetchPypi, pythonOlder, numpy, pandas, pytz, six
+, pytest, mock, pytest-mock, requests }:
 
 buildPythonPackage rec {
   pname = "pvlib";
-  version = "0.6.1";
+  version = "0.6.3";
 
-  # Use GitHub because PyPI release tarball doesn't contain the tests. See:
-  # https://github.com/pvlib/pvlib-python/issues/473
-  src = fetchFromGitHub{
-    owner = "pvlib";
-    repo = "pvlib-python";
-    rev = "v${version}";
-    sha256 = "17h7vz9s829qxnl4byr8458gzgiismrbrn5gl0klhfhwvc5kkdfh";
+  # Support for Python <3.5 dropped in 0.6.3 on June 1, 2019.
+  disabled = pythonOlder "3.5";
+
+  src = fetchPypi{
+    inherit pname version;
+    sha256 = "03nvgpmnscd7rh9jwm2h579zvriq5lva6rsdhb6jckpra5wjkn69";
   };
 
   checkInputs = [ pytest mock pytest-mock ];
-  propagatedBuildInputs = [ numpy pandas pytz six ];
+  propagatedBuildInputs = [ numpy pandas pytz six requests ];
 
   # Skip a few tests that try to access some URLs
   checkPhase = ''
     runHook preCheck
     pushd pvlib/test
-    pytest . -k "not test_read_srml_dt_index and not test_read_srml_month_from_solardata"
+    pytest . -k "not test_read_srml_dt_index and not test_read_srml_month_from_solardata and not test_get_psm3"
     popd
     runHook postCheck
   '';


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Motivation for this change

Update pvlib Python package. This includes the following changes:

- Now that pvlib PyPI package contains tests, use that instead of GitHub.
- Drop support for Python <3.5.
- Add new dependency `requests`.
- Skip yet another new test that tries to use network.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
