### PR TITLE
nbstripout: 0.3.1 -> 0.3.6

### DIFF
--- a/pkgs/applications/version-management/nbstripout/default.nix
+++ b/pkgs/applications/version-management/nbstripout/default.nix
@@ -1,8 +1,8 @@
-{lib, python2Packages, fetchFromGitHub, fetchurl, git, mercurial, coreutils}:
+{lib, python2Packages, git, mercurial, coreutils}:
 
 with python2Packages;
 buildPythonApplication rec {
-  version = "0.3.1";
+  version = "0.3.6";
   pname = "nbstripout";
 
   # Mercurial should be added as a build input but because it's a Python
@@ -12,29 +12,10 @@ buildPythonApplication rec {
   nativeBuildInputs = [ pytestrunner ];
   propagatedBuildInputs = [ ipython nbformat ];
 
-  # PyPI source is currently missing tests. Thus, use GitHub instead.
-  # See: https://github.com/kynan/nbstripout/issues/73
-  # Use PyPI again after it has been fixed in a release.
-  src = fetchFromGitHub {
-    owner = "kynan";
-    repo = pname;
-    rev = version;
-    sha256 = "1jifqmszjzyaqzaw2ir83k5fdb04iyxdad4lclawpb42hbink9ws";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1x6010akw7iqxn7ba5m6malfr2fvaf0bjp3cdh983qn1s7vwlq0r";
   };
-
-  patches = [
-    (
-      # Fix git diff tests by using --no-index.
-      # See: https://github.com/kynan/nbstripout/issues/74
-      #
-      # Remove this patch once the pull request has been merged and a new
-      # release made.
-      fetchurl {
-        url = "https://github.com/jluttine/nbstripout/commit/03e28424fb788dd09a95e99814977b0d0846c0b4.patch";
-        sha256 = "09myfb77a2wh8lqqs9fcpam97vmaw8b7zbq8n5gwn6d80zbl7dn0";
-      }
-    )
-  ];
 
   # for some reason, darwin uses /bin/sh echo native instead of echo binary, so
   # force using the echo binary


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update nbstripout. Switch the source from GitHub to PyPI now that upstream has added tests to the PyPI tarball.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

