### PR TITLE
pythonPackages.{colorcet,pytest-mpl}: fix & re-enable all tests on darwin

### DIFF
--- a/pkgs/development/python-modules/colorcet/default.nix
+++ b/pkgs/development/python-modules/colorcet/default.nix
@@ -34,9 +34,9 @@ buildPythonPackage rec {
     export HOME=$(mktemp -d)
     mkdir -p $HOME/.config/matplotlib
     echo "backend: ps" > $HOME/.config/matplotlib/matplotlibrc
+    ln -s $HOME/.config/matplotlib $HOME/.matplotlib
 
-    # disable matplotlib tests on darwin, because it requires a framework build of Python
-    pytest ${stdenv.lib.optionalString stdenv.isDarwin "--ignore=colorcet/tests/test_matplotlib.py"} colorcet
+    pytest colorcet
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/python-modules/pytest-mpl/default.nix
+++ b/pkgs/development/python-modules/pytest-mpl/default.nix
@@ -26,13 +26,11 @@ buildPythonPackage rec {
     pytest
   ];
 
-  # disable tests on darwin, because it requires a framework build of Python
-  doCheck = !stdenv.isDarwin;
-
   checkPhase = ''
     export HOME=$(mktemp -d)
     mkdir -p $HOME/.config/matplotlib
     echo "backend: ps" > $HOME/.config/matplotlib/matplotlibrc
+    ln -s $HOME/.config/matplotlib $HOME/.matplotlib
 
     pytest
   '';


### PR DESCRIPTION
###### Motivation for this change
The `matplotlib` `backend: ps` trick does indeed work for macos too, but `matplotlib` just looks for the the dotfile under `~/.matplotlib` instead. So add a symlink.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @marsam
