### PR TITLE
ruby_2_6: patch use-after-free

### DIFF
--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -1,5 +1,5 @@
 { stdenv, buildPackages, lib
-, fetchurl, fetchFromSavannah, fetchFromGitHub
+, fetchurl, fetchpatch, fetchFromSavannah, fetchFromGitHub
 , zlib, openssl, gdbm, ncurses, readline, groff, libyaml, libffi, autoreconfHook, bison
 , autoconf, libiconv, libobjc, libunwind, Foundation
 , buildEnv, bundler, bundix
@@ -34,7 +34,7 @@ let
     };
     self = lib.makeOverridable (
       { stdenv, buildPackages, lib
-      , fetchurl, fetchFromSavannah, fetchFromGitHub
+      , fetchurl, fetchpatch, fetchFromSavannah, fetchFromGitHub
       , useRailsExpress ? true
       , rubygemsSupport ? true
       , zlib, zlibSupport ? true
@@ -90,7 +90,7 @@ let
 
         patches =
           (import ./patchsets.nix {
-            inherit patchSet useRailsExpress ops;
+            inherit patchSet useRailsExpress ops fetchpatch;
             patchLevel = ver.patchLevel;
           }).${ver.majMinTiny};
 

--- a/pkgs/development/interpreters/ruby/patchsets.nix
+++ b/pkgs/development/interpreters/ruby/patchsets.nix
@@ -1,4 +1,4 @@
-{ patchSet, useRailsExpress, ops, patchLevel }:
+{ patchSet, useRailsExpress, ops, patchLevel, fetchpatch }:
 
 {
   "2.3.8" = ops useRailsExpress [
@@ -16,7 +16,12 @@
     "${patchSet}/patches/ruby/2.5/head/railsexpress/02-improve-gc-stats.patch"
     "${patchSet}/patches/ruby/2.5/head/railsexpress/03-more-detailed-stacktrace.patch"
   ];
-  "2.6.4" = ops useRailsExpress [
+  "2.6.4" = [
+    (fetchpatch {
+      url = "https://git.ruby-lang.org/ruby.git/patch/?id=ade1283ca276f7d589ffd3539fbc7b9817f682d5";
+      sha256 = "1vgrckmzz0ykyxgzyp8fcifa93xz2hvyfil79bw1gc3xx94wnnxd";
+    })
+  ] ++ ops useRailsExpress [
     "${patchSet}/patches/ruby/2.6/head/railsexpress/01-fix-broken-tests-caused-by-ad.patch"
     "${patchSet}/patches/ruby/2.6/head/railsexpress/02-improve-gc-stats.patch"
     "${patchSet}/patches/ruby/2.6/head/railsexpress/03-more-detailed-stacktrace.patch"


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

See https://bugs.ruby-lang.org/issues/16136.

This patch is on Ruby trunk, but hasn't been backported (yet?).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
