### PR TITLE
Various: Add support for raspberry pi 4.

### DIFF
--- a/nixos/modules/installer/cd-dvd/sd-image-raspberrypi.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image-raspberrypi.nix
@@ -19,7 +19,7 @@ in
   boot.loader.generic-extlinux-compatible.enable = true;
 
   boot.consoleLogLevel = lib.mkDefault 7;
-  boot.kernelPackages = pkgs.linuxPackages_rpi;
+  boot.kernelPackages = pkgs.linuxPackages_rpi1;
 
   sdImage = {
     populateFirmwareCommands = let

--- a/nixos/modules/installer/cd-dvd/sd-image-raspberrypi4.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image-raspberrypi4.nix
@@ -1,0 +1,31 @@
+# To build, use:
+# nix-build nixos -I nixos-config=nixos/modules/installer/cd-dvd/sd-image-raspberrypi4.nix -A config.system.build.sdImage
+{ config, lib, pkgs, ... }:
+
+{
+  imports = [
+    ../../profiles/base.nix
+    ../../profiles/installation-device.nix
+    ./sd-image.nix
+  ];
+
+  boot.loader.grub.enable = false;
+  boot.loader.raspberryPi.enable = true;
+  boot.loader.raspberryPi.version = 4;
+  boot.kernelPackages = pkgs.linuxPackages_rpi4;
+
+  boot.consoleLogLevel = lib.mkDefault 7;
+
+  sdImage = {
+    firmwareSize = 128;
+    # This is a hack to avoid replicating config.txt from boot.loader.raspberryPi
+    populateFirmwareCommands =
+      "${config.system.build.installBootLoader} ${config.system.build.toplevel} -d ./firmware";
+    # As the boot process is done entirely in the firmware partition.
+    populateRootCommands = "";
+  };
+
+  # the installation media is also the installation target,
+  # so we don't want to provide the installation configuration.nix.
+  installer.cloneConfig = false;
+}

--- a/nixos/modules/system/boot/loader/raspberrypi/raspberrypi-builder.sh
+++ b/nixos/modules/system/boot/loader/raspberrypi/raspberrypi-builder.sh
@@ -71,7 +71,7 @@ addEntry() {
 
     local kernel=$(readlink -f $path/kernel)
     local initrd=$(readlink -f $path/initrd)
-    local dtb_path=$(readlink -f $path/kernel-modules/dtbs)
+    local dtb_path=$(readlink -f $path/dtbs)
 
     if test -n "@copyKernels@"; then
         copyToKernelsDir $kernel; kernel=$result
@@ -113,10 +113,18 @@ done
 fwdir=@firmware@/share/raspberrypi/boot/
 copyForced $fwdir/bootcode.bin  $target/bootcode.bin
 copyForced $fwdir/fixup.dat     $target/fixup.dat
+copyForced $fwdir/fixup4.dat    $target/fixup4.dat
+copyForced $fwdir/fixup4cd.dat  $target/fixup4cd.dat
+copyForced $fwdir/fixup4db.dat  $target/fixup4db.dat
+copyForced $fwdir/fixup4x.dat   $target/fixup4x.dat
 copyForced $fwdir/fixup_cd.dat  $target/fixup_cd.dat
 copyForced $fwdir/fixup_db.dat  $target/fixup_db.dat
 copyForced $fwdir/fixup_x.dat   $target/fixup_x.dat
 copyForced $fwdir/start.elf     $target/start.elf
+copyForced $fwdir/start4.elf    $target/start4.elf
+copyForced $fwdir/start4cd.elf  $target/start4cd.elf
+copyForced $fwdir/start4db.elf  $target/start4db.elf
+copyForced $fwdir/start4x.elf   $target/start4x.elf
 copyForced $fwdir/start_cd.elf  $target/start_cd.elf
 copyForced $fwdir/start_db.elf  $target/start_db.elf
 copyForced $fwdir/start_x.elf   $target/start_x.elf

--- a/nixos/modules/system/boot/loader/raspberrypi/raspberrypi.nix
+++ b/nixos/modules/system/boot/loader/raspberrypi/raspberrypi.nix
@@ -59,7 +59,7 @@ in
 
       version = mkOption {
         default = 2;
-        type = types.enum [ 0 1 2 3 ];
+        type = types.enum [ 0 1 2 3 4 ];
         description = ''
         '';
       };
@@ -97,8 +97,8 @@ in
 
   config = mkIf cfg.enable {
     assertions = singleton {
-      assertion = !pkgs.stdenv.hostPlatform.isAarch64 || cfg.version == 3;
-      message = "Only Raspberry Pi 3 supports aarch64.";
+      assertion = !pkgs.stdenv.hostPlatform.isAarch64 || cfg.version >= 3;
+      message = "Only Raspberry Pi >= 3 supports aarch64.";
     };
 
     system.build.installBootLoader = builder;

--- a/nixos/modules/system/boot/loader/raspberrypi/uboot-builder.nix
+++ b/nixos/modules/system/boot/loader/raspberrypi/uboot-builder.nix
@@ -10,11 +10,13 @@ let
       pkgs.ubootRaspberryPi
     else if version == 2 then
       pkgs.ubootRaspberryPi2
-    else
+    else if version == 3 then
       if isAarch64 then
         pkgs.ubootRaspberryPi3_64bit
       else
-        pkgs.ubootRaspberryPi3_32bit;
+        pkgs.ubootRaspberryPi3_32bit
+    else
+      throw "U-Boot is not yet supported on the raspberry pi 4.";
 
   extlinuxConfBuilder =
     import ../generic-extlinux-compatible/extlinux-conf-builder.nix {

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -180,6 +180,11 @@ in rec {
     inherit system;
   });
 
+  sd_image_raspberrypi4 = forMatchingSystems [ "aarch64-linux" ] (system: makeSdImage {
+    module = ./modules/installer/cd-dvd/sd-image-raspberrypi4.nix;
+    inherit system;
+  });
+
   # A bootable VirtualBox virtual appliance as an OVA file (i.e. packaged OVF).
   ova = forMatchingSystems [ "x86_64-linux" ] (system:
 

--- a/pkgs/os-specific/linux/device-tree/raspberrypi.nix
+++ b/pkgs/os-specific/linux/device-tree/raspberrypi.nix
@@ -11,7 +11,7 @@ stdenvNoCC.mkDerivation {
 
     cp ${raspberrypifw}/share/raspberrypi/boot/bcm*.dtb .
 
-    cp bcm2708-rpi-0-w.dtb bcm2835-rpi-zero-w.dtb
+    cp bcm2708-rpi-zero-w.dtb bcm2835-rpi-zero-w.dtb
     cp bcm2708-rpi-b.dtb bcm2835-rpi-a.dtb
     cp bcm2708-rpi-b.dtb bcm2835-rpi-b.dtb
     cp bcm2708-rpi-b.dtb bcm2835-rpi-b-rev2.dtb
@@ -23,6 +23,7 @@ stdenvNoCC.mkDerivation {
     cp bcm2710-rpi-3-b.dtb bcm2837-rpi-3-b.dtb
     cp bcm2710-rpi-3-b-plus.dtb bcm2837-rpi-3-b-plus.dtb
     cp bcm2710-rpi-cm3.dtb bcm2837-rpi-cm3.dtb
+    cp bcm2711-rpi-4-b.dtb bcm2838-rpi-4-b.dtb
   '';
 
   passthru = {

--- a/pkgs/os-specific/linux/firmware/raspberrypi-wireless/default.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi-wireless/default.nix
@@ -2,22 +2,22 @@
 
 stdenv.mkDerivation {
   pname = "raspberrypi-wireless-firmware";
-  version = "2018-08-20";
+  version = "2019-08-16";
 
   srcs = [
     (fetchFromGitHub {
       name = "bluez-firmware";
       owner = "RPi-Distro";
       repo = "bluez-firmware";
-      rev = "ade2bae1aaaebede09abb8fb546f767a0e4c7804";
-      sha256 = "07gm76gxp5anv6paryvxcp34a86fkny8kdlzqhzcpfczzglkp6ag";
+      rev = "96eefffcccc725425fd83be5e0704a5c32b79e54";
+      sha256 = "05h57gcxhb2c84h99cyxxx4mzi6kd5fm8pjqkz3nq5vs3nv8cqhr";
     })
     (fetchFromGitHub {
       name = "firmware-nonfree";
       owner = "RPi-Distro";
       repo = "firmware-nonfree";
-      rev = "b518de45ced519e8f7a499f4778100173402ae43";
-      sha256 = "1d5026ic9awji6c67irpwsxpxgsc0dhn11d3abkxi2vvra1pir4g";
+      rev = "130cb86fa30cafbd575d38865fa546350d4c5f9c";
+      sha256 = "0jmhgbpldzz8n8lncpzwfl5ym8zgss05y952rfpwcf9v5c7vgabx";
     })
   ];
 
@@ -41,7 +41,7 @@ stdenv.mkDerivation {
 
   outputHashMode = "recursive";
   outputHashAlgo = "sha256";
-  outputHash = "1s5gb00v42s5izbaw8irs1fwvhh7z9wl07czc0nkw6p91871ivb7";
+  outputHash = "1r4alf1fbj6vkkf54d0anm47ymb6gn2ykl4a2hhd34b0hnf1dnhn";
 
   meta = with stdenv.lib; {
     description = "Firmware for builtin Wifi/Bluetooth devices in the Raspberry Pi 3 and Zero W";

--- a/pkgs/os-specific/linux/firmware/raspberrypi/default.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "raspberrypi-firmware";
-  version = "1.20190620+1";
+  version = "1.20190819";
 
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = "firmware";
     rev = version;
-    sha256 = "0gbqlkr50qlmbpwr0n61pb58w0k3sfjfirh2y683rlkp5rlq7mrf";
+    sha256 = "0qzpc092qg748i5s23xa1jk6qpga9wn0441r2awsz0apkysqx5fj";
   };
 
   installPhase = ''

--- a/pkgs/os-specific/linux/kernel/linux-rpi.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rpi.nix
@@ -1,8 +1,8 @@
-{ stdenv, lib, buildPackages, fetchFromGitHub, perl, buildLinux, ... } @ args:
+{ stdenv, lib, buildPackages, fetchFromGitHub, perl, buildLinux, rpiVersion, ... } @ args:
 
 let
-  modDirVersion = "4.14.98";
-  tag = "1.20190215";
+  modDirVersion = "4.19.71";
+  tag = "1.20190906";
 in
 lib.overrideDerivation (buildLinux (args // {
   version = "${modDirVersion}-${tag}";
@@ -11,25 +11,33 @@ lib.overrideDerivation (buildLinux (args // {
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = "linux";
-    rev = "raspberrypi-kernel_${tag}-1";
-    sha256 = "1gc4x7p82m2v1jhahhyl7qfdkflj71ly6p0fpc1vf9sk13hbwgj2";
+    rev = "9532eb3c84d8d952ef28da3d135683ac01adc9b8";
+    sha256 = "0168wz8kkdzbyha41iqlgn1z1kcy4smg89rgxkgadzq78y7fglpl";
   };
 
   defconfig = {
-    armv6l-linux = "bcmrpi_defconfig";
-    armv7l-linux = "bcm2709_defconfig";
-    aarch64-linux = "bcmrpi3_defconfig";
-  }.${stdenv.hostPlatform.system} or (throw "linux_rpi not supported on '${stdenv.hostPlatform.system}'");
+    "1" = "bcmrpi_defconfig";
+    "2" = "bcm2709_defconfig";
+    "3" = "bcmrpi3_defconfig";
+    "4" = "bcm2711_defconfig";
+  }.${toString rpiVersion};
 
   features = {
     efiBootStub = false;
   } // (args.features or {});
 
-  extraMeta.hydraPlatforms = [ "aarch64-linux" ];
-} // (args.argsOverride or {}))) (oldAttrs: {
+  extraMeta = if (rpiVersion < 3) then {
+    platforms = with lib.platforms; [ arm ];
+    hydraPlatforms = [];
+  } else {
+    platforms = with lib.platforms; [ arm aarch64 ];
+    hydraPlatforms = [ "aarch64-linux" ];
+  };
+})) (oldAttrs: {
   postConfigure = ''
     # The v7 defconfig has this set to '-v7' which screws up our modDirVersion.
     sed -i $buildRoot/.config -e 's/^CONFIG_LOCALVERSION=.*/CONFIG_LOCALVERSION=""/'
+    sed -i $buildRoot/include/config/auto.conf -e 's/^CONFIG_LOCALVERSION=.*/CONFIG_LOCALVERSION=""/'
   '';
 
   # Make copies of the DTBs named after the upstream names so that U-Boot finds them.
@@ -56,5 +64,6 @@ lib.overrideDerivation (buildLinux (args // {
     copyDTB bcm2710-rpi-3-b.dtb bcm2837-rpi-3-b.dtb
     copyDTB bcm2710-rpi-3-b-plus.dtb bcm2837-rpi-3-b-plus.dtb
     copyDTB bcm2710-rpi-cm3.dtb bcm2837-rpi-cm3.dtb
+    copyDTB bcm2711-rpi-4-b.dtb bcm2838-rpi-4-b.dtb
   '';
 })

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -194,6 +194,8 @@ mapAliases ({
   libtidy = html-tidy;  # added 2014-12-21
   libudev = udev; # added 2018-04-25
   links = links2; # added 2016-01-31
+  linux_rpi0 = linux_rpi1;
+  linuxPackages_rpi0 = linuxPackages_rpi1;
   lttngTools = lttng-tools;  # added 2014-07-31
   lttngUst = lttng-ust;  # added 2014-07-31
   lua5_1_sockets = lua51Packages.luasocket; # added 2017-05-02

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15692,10 +15692,32 @@ in
     kernelPatches = linux_4_19.kernelPatches;
   };
 
-  linux_rpi = callPackage ../os-specific/linux/kernel/linux-rpi.nix {
+  linux_rpi1 = callPackage ../os-specific/linux/kernel/linux-rpi.nix {
     kernelPatches = with kernelPatches; [
       bridge_stp_helper
     ];
+    rpiVersion = 1;
+  };
+
+  linux_rpi2 = callPackage ../os-specific/linux/kernel/linux-rpi.nix {
+    kernelPatches = with kernelPatches; [
+      bridge_stp_helper
+    ];
+    rpiVersion = 2;
+  };
+
+  linux_rpi3 = callPackage ../os-specific/linux/kernel/linux-rpi.nix {
+    kernelPatches = with kernelPatches; [
+      bridge_stp_helper
+    ];
+    rpiVersion = 3;
+  };
+
+  linux_rpi4 = callPackage ../os-specific/linux/kernel/linux-rpi.nix {
+    kernelPatches = with kernelPatches; [
+      bridge_stp_helper
+    ];
+    rpiVersion = 4;
   };
 
   linux_4_4 = callPackage ../os-specific/linux/kernel/linux-4.4.nix {
@@ -15945,7 +15967,10 @@ in
 
   # Build the kernel modules for the some of the kernels.
   linuxPackages_mptcp = linuxPackagesFor pkgs.linux_mptcp;
-  linuxPackages_rpi = linuxPackagesFor pkgs.linux_rpi;
+  linuxPackages_rpi1 = linuxPackagesFor pkgs.linux_rpi1;
+  linuxPackages_rpi2 = linuxPackagesFor pkgs.linux_rpi2;
+  linuxPackages_rpi3 = linuxPackagesFor pkgs.linux_rpi3;
+  linuxPackages_rpi4 = linuxPackagesFor pkgs.linux_rpi4;
   linuxPackages_4_4 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_4_4);
   linuxPackages_4_9 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_4_9);
   linuxPackages_4_14 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_4_14);


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Run NixOS on the Raspberry Pi 4B #63720. I'm reopening as the WiFi / 4G issues are resolved in the rpi kernel branch now.

**This pull request has breaking changes that need feedback!**

Changes Mage:

- Bumped WiFi and boot firmware for the raspberry pi.
- Updated the default raspberry pi bootloader to work with the rpi4.
- Bumped the kernel. This encountered an interesting issue: The raspberry pi currently has a single kernel image: `linux_rpi`, which uses different `defconfig` settings depending on architecture. The rpi4 has the same architecture as the rpi3, but should use a different `defconfig` setting. I cannot see how to modify the current kernel package backwards-compatibly to do this. As a result, I've split it into several. Feedback on this would be good. It will break any existing builds using this kernel.

Outstanding issues:

- Uboot support is not available upstream, as far as I can tell.
- The raspberry pi sdcard build is broken, both due to the lack of uboot, and because the issue of selecting the correct kernel.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @lopsided98 @dezgeg @tavyc 