### PR TITLE
protonmail-bridge: 1.1.6-1 -> 1.2.2-1

### DIFF
--- a/pkgs/applications/networking/protonmail-bridge/default.nix
+++ b/pkgs/applications/networking/protonmail-bridge/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, lib, qtbase, qtmultimedia, qtsvg, qtdeclarative, qttools, qtgraphicaleffects, qtquickcontrols2, full
-, libsecret, libGL, libpulseaudio, glib, wrapQtAppsHook, makeDesktopItem, mkDerivation }:
+, libsecret, libGL, libpulseaudio, glib, wrapQtAppsHook, mkDerivation }:
 
 let
   version = "1.2.2-1";
@@ -10,17 +10,6 @@ let
 
     To work, gnome-keyring service must be enabled.
   '';
-
-  desktopItem = makeDesktopItem {
-    name = "protonmail-bridge";
-    exec = "protonmail-bridge";
-    icon = "protonmail-bridge";
-    comment = stdenv.lib.replaceStrings ["\n"] [" "] description;
-    desktopName = "ProtonMail Bridge";
-    genericName = "ProtonMail Bridge for Linux";
-    categories = "Utility;Security;Network;Email";
-  };
-
 in mkDerivation {
   pname = "protonmail-bridge";
   inherit version;
@@ -37,12 +26,10 @@ in mkDerivation {
   '';
 
   installPhase = ''
-    mkdir -p $out/{bin,lib,share/applications}
-    mkdir -p $out/share/{applications,icons/hicolor/scalable/apps}
+    mkdir -p $out/{bin,lib,share}
 
     cp -r usr/lib/protonmail/bridge/protonmail-bridge $out/lib
-    cp usr/share/icons/protonmail/ProtonMail_Bridge.svg $out/share/icons/hicolor/scalable/apps/protonmail-bridge.svg
-    cp ${desktopItem}/share/applications/* $out/share/applications
+    cp -r usr/share $out
 
     ln -s $out/lib/protonmail-bridge $out/bin/protonmail-bridge
   '';
@@ -67,6 +54,10 @@ in mkDerivation {
       --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
       --set-rpath "${rpath}" \
       $out/lib/protonmail-bridge
+
+    substituteInPlace $out/share/applications/ProtonMail_Bridge.desktop \
+      --replace "/usr/" "$out/" \
+      --replace "Exec=protonmail-bridge" "Exec=$out/bin/protonmail-bridge"
   '';
 
   buildInputs = [ qtbase qtquickcontrols2 qtmultimedia qtgraphicaleffects qtdeclarative ];

--- a/pkgs/applications/networking/protonmail-bridge/default.nix
+++ b/pkgs/applications/networking/protonmail-bridge/default.nix
@@ -2,7 +2,7 @@
 , libsecret, libGL, libpulseaudio, glib, wrapQtAppsHook, makeDesktopItem, mkDerivation }:
 
 let
-  version = "1.1.6-1";
+  version = "1.2.2-1";
 
   description = ''
     An application that runs on your computer in the background and seamlessly encrypts
@@ -27,7 +27,7 @@ in mkDerivation {
 
   src = fetchurl {
     url = "https://protonmail.com/download/protonmail-bridge_${version}_amd64.deb";
-    sha256 = "108dql9q5znsqjkrs41pc6psjbg5bz09rdmjl036xxbvsdvq4a8r";
+    sha256 = "16hfa07wdqcns79395wjdglg2cjyblqgz1hx8rl15qm7n5f24ckl";
   };
 
   sourceRoot = ".";


### PR DESCRIPTION
###### Motivation for this change

Update protonmail-bridge

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
