### PR TITLE
rappel: init at unstable-2019-07-08 

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4772,6 +4772,12 @@
     githubId = 11016164;
     name = "Fedor Pakhomov";
   };
+  pamplemousse = {
+    email = "xav.maso@gmail.com";
+    github = "Pamplemousse";
+    githubId = 2647236;
+    name = "Xavier Maso";
+  };
   panaeon = {
     email = "vitalii.voloshyn@gmail.com";
     github = "panaeon";

--- a/pkgs/development/misc/rappel/default.nix
+++ b/pkgs/development/misc/rappel/default.nix
@@ -1,0 +1,38 @@
+{ fetchFromGitHub
+, libedit
+, makeWrapper
+, nasm
+, stdenv
+}:
+
+stdenv.mkDerivation rec {
+  pname = "rappel";
+  version = "unstable-2019-07-08";
+
+  src = fetchFromGitHub {
+    owner = "yrp604";
+    repo = "rappel";
+    rev = "95a776f850cf6a7c21923a2100b605408ef038de";
+    sha256 = "0fmd15xa6hswh3x48av4g1sf6rncbiinbj7gbw1ffvqsbcfnsgcr";
+  };
+
+  buildInputs = [ libedit ];
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 -t $out/bin bin/rappel
+    wrapProgram $out/bin/rappel --prefix PATH : "${nasm}/bin"
+
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/yrp604/rappel";
+    description = "A pretty janky assembly REPL";
+    license = licenses.bsdOriginal;
+    maintainers = [ maintainers.pamplemousse ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9109,6 +9109,8 @@ in
 
   mspdebug = callPackage ../development/misc/msp430/mspdebug.nix { };
 
+  rappel = callPackage ../development/misc/rappel/default.nix { };
+
   pharo-vms = callPackage ../development/pharo/vm { };
   pharo = pharo-vms.multi-vm-wrapper;
   pharo-cog32 = pharo-vms.cog32;


### PR DESCRIPTION
##### Motivation for this change

[`rappel`](https://github.com/yrp604/rappel) is an assembly REPL.
Useful to help learning assembly.


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).