### PR TITLE
redshift-wlr: Init at 2019-04-17

### DIFF
--- a/pkgs/applications/misc/redshift/default.nix
+++ b/pkgs/applications/misc/redshift/default.nix
@@ -11,82 +11,108 @@
 , withGeoclue ? withGeolocation && stdenv.isLinux, geoclue
 }:
 
-stdenv.mkDerivation rec {
-  pname = "redshift";
-  version = "1.12";
+let
+  mkRedshift =
+    { pname, version, src, meta }:
+    stdenv.mkDerivation rec {
+      inherit pname version src meta;
 
-  src = fetchFromGitHub {
-    owner = "jonls";
-    repo = "redshift";
-    rev = "v${version}";
-    sha256 = "12cb4gaqkybp4bkkns8pam378izr2mwhr2iy04wkprs2v92j7bz6";
+      patches = [
+        # https://github.com/jonls/redshift/pull/575
+        ./575.patch
+      ];
+
+      nativeBuildInputs = [
+        autoconf
+        automake
+        gettext
+        intltool
+        libtool
+        pkgconfig
+        wrapGAppsHook
+        wrapPython
+      ];
+
+      configureFlags = [
+        "--enable-randr=${if withRandr then "yes" else "no"}"
+        "--enable-geoclue2=${if withGeoclue then "yes" else "no"}"
+        "--enable-drm=${if withDrm then "yes" else "no"}"
+        "--enable-quartz=${if withQuartz then "yes" else "no"}"
+        "--enable-corelocation=${if withCoreLocation then "yes" else "no"}"
+      ];
+
+      buildInputs = [
+        gobject-introspection
+        gtk3
+        python
+      ] ++ stdenv.lib.optional  withRandr        libxcb
+        ++ stdenv.lib.optional  withGeoclue      geoclue
+        ++ stdenv.lib.optional  withDrm          libdrm
+        ++ stdenv.lib.optional  withQuartz       ApplicationServices
+        ++ stdenv.lib.optionals withCoreLocation [ CoreLocation Foundation Cocoa ]
+        ;
+
+      pythonPath = [ pygobject3 pyxdg ];
+
+      preConfigure = "./bootstrap";
+
+      postFixup = "wrapPythonPrograms";
+
+      # the geoclue agent may inspect these paths and expect them to be
+      # valid without having the correct $PATH set
+      postInstall = ''
+        substituteInPlace $out/share/applications/redshift.desktop \
+          --replace 'Exec=redshift' "Exec=$out/bin/redshift"
+        substituteInPlace $out/share/applications/redshift.desktop \
+          --replace 'Exec=redshift-gtk' "Exec=$out/bin/redshift-gtk"
+      '';
+
+      enableParallelBuilding = true;
+    };
+in
+rec {
+  redshift = mkRedshift rec {
+    pname = "redshift";
+    version = "1.12";
+
+    src = fetchFromGitHub {
+      owner = "jonls";
+      repo = "redshift";
+      rev = "v${version}";
+      sha256 = "12cb4gaqkybp4bkkns8pam378izr2mwhr2iy04wkprs2v92j7bz6";
+    };
+
+    meta = with stdenv.lib; {
+      description = "Screen color temperature manager";
+      longDescription = ''
+        Redshift adjusts the color temperature according to the position
+        of the sun. A different color temperature is set during night and
+        daytime. During twilight and early morning, the color temperature
+        transitions smoothly from night to daytime temperature to allow
+        your eyes to slowly adapt. At night the color temperature should
+        be set to match the lamps in your room.
+      '';
+      license = licenses.gpl3Plus;
+      homepage = http://jonls.dk/redshift;
+      platforms = platforms.unix;
+      maintainers = with maintainers; [ yegortimoshenko globin ];
+    };
   };
 
-  patches = [
-    # https://github.com/jonls/redshift/pull/575
-    ./575.patch
-  ];
+  redshift-wlr = mkRedshift {
+    pname = "redshift-wlr";
+    version = "2019-04-17";
 
-  nativeBuildInputs = [
-    autoconf
-    automake
-    gettext
-    intltool
-    libtool
-    pkgconfig
-    wrapGAppsHook
-    wrapPython
-  ];
+    src = fetchFromGitHub {
+      owner = "minus7";
+      repo = "redshift";
+      rev = "eecbfedac48f827e96ad5e151de8f41f6cd3af66";
+      sha256 = "0rs9bxxrw4wscf4a8yl776a8g880m5gcm75q06yx2cn3lw2b7v22";
+    };
 
-  configureFlags = [
-    "--enable-randr=${if withRandr then "yes" else "no"}"
-    "--enable-geoclue2=${if withGeoclue then "yes" else "no"}"
-    "--enable-drm=${if withDrm then "yes" else "no"}"
-    "--enable-quartz=${if withQuartz then "yes" else "no"}"
-    "--enable-corelocation=${if withCoreLocation then "yes" else "no"}"
-  ];
-
-  buildInputs = [
-    gobject-introspection
-    gtk3
-    python
-  ] ++ stdenv.lib.optional  withRandr        libxcb
-    ++ stdenv.lib.optional  withGeoclue      geoclue
-    ++ stdenv.lib.optional  withDrm          libdrm
-    ++ stdenv.lib.optional  withQuartz       ApplicationServices
-    ++ stdenv.lib.optionals withCoreLocation [ CoreLocation Foundation Cocoa ]
-    ;
-
-  pythonPath = [ pygobject3 pyxdg ];
-
-  preConfigure = "./bootstrap";
-
-  postFixup = "wrapPythonPrograms";
-
-  # the geoclue agent may inspect these paths and expect them to be
-  # valid without having the correct $PATH set
-  postInstall = ''
-    substituteInPlace $out/share/applications/redshift.desktop \
-      --replace 'Exec=redshift' "Exec=$out/bin/redshift"
-    substituteInPlace $out/share/applications/redshift.desktop \
-      --replace 'Exec=redshift-gtk' "Exec=$out/bin/redshift-gtk"
-  '';
-
-  enableParallelBuilding = true;
-
-  meta = with stdenv.lib; {
-    description = "Screen color temperature manager";
-    longDescription = ''
-      Redshift adjusts the color temperature according to the position
-      of the sun. A different color temperature is set during night and
-      daytime. During twilight and early morning, the color temperature
-      transitions smoothly from night to daytime temperature to allow
-      your eyes to slowly adapt. At night the color temperature should
-      be set to match the lamps in your room.
-    '';
-    license = licenses.gpl3Plus;
-    homepage = http://jonls.dk/redshift;
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ yegortimoshenko globin ];
+    meta = redshift.meta // {
+      description = redshift.meta.description + "(with wlroots patches)";
+      homepage = https://github.com/minus7/redshift;
+    };
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23367,11 +23367,11 @@ in
 
   plasma-applet-volumewin7mixer = libsForQt5.callPackage ../applications/misc/plasma-applet-volumewin7mixer { };
 
-  redshift = callPackage ../applications/misc/redshift {
+  inherit (callPackages ../applications/misc/redshift {
     inherit (python3Packages) python pygobject3 pyxdg wrapPython;
     inherit (darwin.apple_sdk.frameworks) CoreLocation ApplicationServices Foundation Cocoa;
     geoclue = geoclue2;
-  };
+  }) redshift redshift-wlr;
 
   redshift-plasma-applet = libsForQt5.callPackage ../applications/misc/redshift-plasma-applet { };
 


### PR DESCRIPTION
redshift-wlr is a fork of redshift that adds support for the
wlr-gamma-control protocol. This supports sway and any other Wayland
compositors that implement the standard in the future.

###### Motivation for this change
I use Sway and having a wlroots-compatible version of redshift available would make things more convenient. The name redshift-wlr is the name used on the Sway wiki and for the AUR packages.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @yegortimoshenko @globin
