### PR TITLE
i3status: 2.12 -> 2.13

### DIFF
--- a/pkgs/applications/window-managers/i3/status.nix
+++ b/pkgs/applications/window-managers/i3/status.nix
@@ -1,18 +1,22 @@
-{ fetchurl, stdenv, libconfuse, yajl, alsaLib, libpulseaudio, libnl, pkgconfig
-  }:
+{ fetchurl, stdenv, libconfuse, yajl, alsaLib, libpulseaudio, libnl, pkgconfig, asciidoc, xmlto, docbook_xml_dtd_45, docbook_xsl }:
 
 stdenv.mkDerivation rec {
-  name = "i3status-2.12";
+  name = "i3status-2.13";
 
   src = fetchurl {
     url = "https://i3wm.org/i3status/${name}.tar.bz2";
-    sha256 = "06krpbijv4yi33nypg6qcn4hilcrdyarsdpd9fmr2cq46qaqiikg";
+    sha256 = "0rhlzb96mw64z2jnhwz9nibc7pxg549626lz5642xxk5hpzwk2ff";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig asciidoc xmlto docbook_xml_dtd_45 docbook_xsl ];
   buildInputs = [ libconfuse yajl alsaLib libpulseaudio libnl ];
 
   makeFlags = [ "all" "PREFIX=$(out)" ];
+
+  # This hack is needed because for unknown reasons configure generates a broken makefile on the 2.13 release under nixos
+  preBuild = ''
+    sed -i -e 's/\$(TEST_LOGS) \$(TEST_LOGS/\$(TEST_LOGS)/g' Makefile
+  '';
 
   meta = {
     description = "A tiling window manager";

--- a/pkgs/applications/window-managers/i3/status.nix
+++ b/pkgs/applications/window-managers/i3/status.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "A tiling window manager";
+    description = "Generates a status line for i3bar, dzen2, xmobar or lemonbar";
     homepage = https://i3wm.org;
     maintainers = [ ];
     license = stdenv.lib.licenses.bsd3;


### PR DESCRIPTION
Update i3status to 2.13.
I needed to add a little hack to get it to build because for reasons
I can't seem to figure out, the configure script generates a broken
Makefile on this release.
The small sed line fixes the syntax error.

###### Motivation for this change
Wanted the new read_file feature for i3status

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @globin 
