### PR TITLE
buildRustCrate: add support for renaming crates

### DIFF
--- a/pkgs/build-support/rust/build-rust-crate/build-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/build-crate.nix
@@ -1,13 +1,13 @@
 { lib, stdenv, echo_build_heading, noisily, makeDeps }:
 { crateName,
   dependencies,
-  crateFeatures, libName, release, libPath,
+  crateFeatures, crateRenames, libName, release, libPath,
   crateType, metadata, crateBin, hasCrateBin,
   extraRustcOpts, verbose, colors }:
 
   let
 
-    deps = makeDeps dependencies;
+    deps = makeDeps dependencies crateRenames;
     rustcOpts =
       lib.lists.foldl' (opts: opt: opts + " " + opt)
         (if release then "-C opt-level=3" else "-C debuginfo=2")

--- a/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
@@ -9,6 +9,7 @@
 , crateHomepage
 , crateFeatures
 , crateName
+, crateRenames
 , crateVersion
 , extraLinkFlags
 , extraRustcOpts
@@ -24,7 +25,7 @@ let version_ = lib.splitString "-" crateVersion;
     rustcOpts = lib.lists.foldl' (opts: opt: opts + " " + opt)
         (if release then "-C opt-level=3" else "-C debuginfo=2")
         (["-C codegen-units=$NIX_BUILD_CORES"] ++ extraRustcOpts);
-    buildDeps = makeDeps buildDependencies;
+    buildDeps = makeDeps buildDependencies crateRenames;
     authors = lib.concatStringsSep ":" crateAuthors;
     optLevel = if release then 3 else 0;
     completeDepsDir = lib.concatStringsSep " " completeDeps;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Before this change, `buildRustCrate` always called `rustc` with

```
--extern libName=[...]libName[...]
```

However, Cargo permits using a different name under which a dependency
is known to a crate. For example, rand 0.7.0 uses:

```toml
[dependencies]
getrandom_package = { version = "0.1.1", package = "getrandom", optional = true }
```

Which introduces the `getrandom` dependency such that it is known as
`getrandom_package` to the rand crate. In this case, the correct `extern`
flag is of the form

```
--extern getrandom_package=[...]getrandom[...]
```

which is currently not supported. In order to support such cases, this
change introduces a `crateRenames` argument to `buildRustCrate`. This
argument is an attribute set of dependencies that should be
renamed. In this case, `crateRenames` would be:

```
{
  "getrandom" = "getrandom_package";
}
```

The `extern` options are then built such that if the `libName` occurs as
an attribute in this set, it value will be used as the local
name. Otherwise `libName` will be used as before.

This change should not affect existing derivations that use `buildRustCrate` --
an empty attrset is used for crateRenames when this argument is not provided,
applying the old behavior.

Please review very carefully, I have never looked at the `buildRustCrate`
code before ;).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

ping @P-E-Meunier @kolloch 

cc @
