### PR TITLE
tippecanoe: init at 1.34.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5834,6 +5834,10 @@
     github = "sikmir";
     githubId = 688044;
     name = "Nikolay Korotkiy";
+    keys = [{
+      longkeyid = "rsa2048/0xD1DE6D7F693663A5";
+      fingerprint = "ADF4 C13D 0E36 1240 BD01  9B51 D1DE 6D7F 6936 63A5";
+    }];
   };
   simonvandel = {
     email = "simon.vandel@gmail.com";

--- a/pkgs/applications/misc/tippecanoe/default.nix
+++ b/pkgs/applications/misc/tippecanoe/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, sqlite, zlib, perl }:
+
+stdenv.mkDerivation rec {
+  pname = "tippecanoe";
+  version = "1.34.3";
+
+  src = fetchFromGitHub {
+    owner = "mapbox";
+    repo = pname;
+    rev = version;
+    sha256 = "08pkxzwp4w5phrk9b0vszxnx8yymp50v0bcw96pz8qwk48z4xm0i";
+  };
+
+  buildInputs = [ sqlite zlib ];
+  checkInputs = [ perl ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  enableParallelBuilding = true;
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "Build vector tilesets from large collections of GeoJSON features";
+    homepage = https://github.com/mapbox/tippecanoe;
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20802,6 +20802,8 @@ in
     inherit (linuxPackages) x86_energy_perf_policy;
   };
 
+  tippecanoe = callPackage ../applications/misc/tippecanoe { };
+
   tmatrix = callPackage ../applications/misc/tmatrix { };
 
   tnef = callPackage ../applications/misc/tnef { };


### PR DESCRIPTION
###### Motivation for this change

https://github.com/mapbox/tippecanoe

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
