### PR TITLE
ocamlPackages.ppx_deriving_protobuf: init at 2.7

### DIFF
--- a/pkgs/development/ocaml-modules/ppx_deriving_protobuf/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving_protobuf/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, buildDunePackage, cppo, ppx_tools, ppx_deriving
+, ppxfind }:
+
+buildDunePackage rec {
+  pname = "ppx_deriving_protobuf";
+  version = "2.7";
+
+  src = fetchFromGitHub {
+    owner = "ocaml-ppx";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0aq4f3gbkhhai0c8i5mcw2kpqy8l610f4dknwkrxh0nsizwbwryn";
+  };
+
+  buildInputs = [ cppo ppx_tools ppxfind ppx_deriving ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/ocaml-ppx/ppx_deriving_protobuf";
+    description = "A Protocol Buffers codec generator for OCaml";
+    license = licenses.mit;
+    maintainers = [ maintainers.vyorkin ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -692,6 +692,8 @@ let
       then callPackage ../development/ocaml-modules/ppx_deriving {}
       else null;
 
+    ppx_deriving_protobuf = callPackage ../development/ocaml-modules/ppx_deriving_protobuf {};
+
     ppx_deriving_yojson = callPackage ../development/ocaml-modules/ppx_deriving_yojson {};
 
     ppx_gen_rec = callPackage ../development/ocaml-modules/ppx_gen_rec {};


### PR DESCRIPTION
###### Motivation for this change

Add [ppx_deriving_protobuf](https://github.com/ocaml-ppx/ppx_deriving_protobuf): A Protocol Buffers codec generator for OCaml.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
