### PR TITLE
nixos/lib/utils: Make the set recursive again, unbreak eval

### DIFF
--- a/nixos/lib/utils.nix
+++ b/nixos/lib/utils.nix
@@ -1,6 +1,6 @@
 pkgs: with pkgs.lib;
 
-{
+rec {
 
   # Check whenever fileSystem is needed for boot
   fsNeededForBoot = fs: fs.neededForBoot


### PR DESCRIPTION
#66274 and 08f68313a47a2093dc0f408a706b2c125bc59c95 had a logical conflict that broke eval. This fixes it.