### PR TITLE
services.xserver.extraLayouts fixes

### DIFF
--- a/nixos/doc/manual/configuration/x-windows.xml
+++ b/nixos/doc/manual/configuration/x-windows.xml
@@ -280,6 +280,12 @@ xkb_symbols &quot;media&quot;
 <xref linkend="opt-services.xserver.displayManager.sessionCommands"/> = "setxkbmap -keycodes media";
 </programlisting>
   <para>
+    If you are manually starting the X server, you should set the argument
+    <literal>-xkbdir /etc/X11/xkb</literal>, otherwise X won't find your layout files.
+    For example with <command>xinit</command> run
+    <screen><prompt>$ </prompt>xinit -- -xkbdir /etc/X11/xkb</screen>
+  </para>
+  <para>
    To learn how to write layouts take a look at the XKB
   <link xlink:href="https://www.x.org/releases/current/doc/xorg-docs/input/XKB-Enhancing.html#Defining_New_Layouts">
    documentation

--- a/nixos/modules/services/x11/extra-layouts.nix
+++ b/nixos/modules/services/x11/extra-layouts.nix
@@ -158,7 +158,10 @@ in
 
     });
 
-    services.xserver.xkbDir = "${pkgs.xkb_patched}/etc/X11/xkb";
+    services.xserver = {
+      xkbDir = "${pkgs.xkb_patched}/etc/X11/xkb";
+      exportConfiguration = config.services.xserver.displayManager.startx.enable;
+    };
 
   };
 

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -468,7 +468,7 @@ self: super:
         <model>
           <configItem>
             <name>${name}</name>
-            <_description>${layout.description}</_description>
+            <description>${layout.description}</description>
             <vendor>${layout.description}</vendor>
           </configItem>
         </model>
@@ -484,8 +484,8 @@ self: super:
         <layout>
           <configItem>
             <name>${name}</name>
-            <_shortDescription>${name}</_shortDescription>
-            <_description>${layout.description}</_description>
+            <shortDescription>${name}</shortDescription>
+            <description>${layout.description}</description>
             <languageList>
               ${concatMapStrings (lang: "<iso639Id>${lang}</iso639Id>\n") layout.languages}
             </languageList>


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions 
- [x] Tested in a NixOS VM
- [x] Tested compilation of all pkgs that depend on this change (nixos manual)
- [x] Tested execution of all binary files (none)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @dasj19 @infinisil 
