### PR TITLE
pylightning: init at 0.0.7.3

### DIFF
--- a/pkgs/development/python-modules/pylightning/default.nix
+++ b/pkgs/development/python-modules/pylightning/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  version = "0.0.7.3";
+  pname = "pylightning";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "6a07b62b27e01baaf51165e2dfb8b7d1d47f61aef8304a9da3ca5081608a32c0";
+  };
+
+  meta = with stdenv.lib; {
+    description = "A Python client library for clightning";
+    homepage = https://github.com/ElementsProject/lightning;
+    license = licenses.mit;
+    maintainers = with maintainers; [ jb55 ];
+  };
+
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4229,6 +4229,8 @@ in {
 
   pylibmc = callPackage ../development/python-modules/pylibmc {};
 
+  pylightning = callPackage ../development/python-modules/pylightning { };
+
   pymetar = callPackage ../development/python-modules/pymetar { };
 
   pysftp = callPackage ../development/python-modules/pysftp { };


### PR DESCRIPTION
Needed for clightning plugins

Signed-off-by: William Casarin <jb55@jb55.com>


###### Motivation for this change

Needed for clightning python plugins

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @jonasnick