### PR TITLE
nano-wallet: 18.0 -> 19.0

### DIFF
--- a/pkgs/applications/blockchains/nano-wallet/default.nix
+++ b/pkgs/applications/blockchains/nano-wallet/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
 
   pname = "nano-wallet";
-  version = "18.0";
+  version = "19.0";
 
   src = fetchFromGitHub {
     owner = "nanocurrency";
     repo = "raiblocks";
     rev = "V${version}";
-    sha256 = "03f9g1x7rs7vic9yzsjxsh5ddx9ys78rssbfghbccfw9qrwylh3y";
+    sha256 = "1y5fc4cvfqh33imjkh91sqhy5bb9kh0icwyvdgm1cl564vnjax80";
     fetchSubmodules = true;
   };
 
@@ -37,6 +37,12 @@ stdenv.mkDerivation rec {
 
   buildPhase = ''
     make nano_wallet
+  '';
+
+  # Move executables under bin directory
+  postInstall = ''
+    mkdir -p $out/bin
+    mv $out/nano* $out/bin/
   '';
 
   checkPhase = ''

--- a/pkgs/applications/blockchains/nano-wallet/default.nix
+++ b/pkgs/applications/blockchains/nano-wallet/default.nix
@@ -1,4 +1,5 @@
-{lib, stdenv, fetchFromGitHub, cmake, pkgconfig, boost, libGL, qtbase}:
+{ lib, stdenv, fetchFromGitHub, cmake, pkgconfig, wrapQtAppsHook, boost, libGL
+, qtbase}:
 
 stdenv.mkDerivation rec {
 
@@ -32,7 +33,7 @@ stdenv.mkDerivation rec {
     optionToFlag = name: value: "-D${name}=${value}";
   in lib.mapAttrsToList optionToFlag options;
 
-  nativeBuildInputs = [ cmake pkgconfig ];
+  nativeBuildInputs = [ cmake pkgconfig wrapQtAppsHook ];
   buildInputs = [ boost libGL qtbase ];
 
   buildPhase = ''


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update Nano cryptocurrency wallet.

~~**NOTE: This is still work in progress! Any help appreciated.**~~ **EDIT: Works now.**

~~I'm getting the following error when running `nano_wallet`:~~

```
$ nano_wallet
qt.qpa.plugin: Could not find the Qt platform plugin "xcb" in ""
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

Available platform plugins are: wayland-org.kde.kwin.qpa.
```

~~Any ideas how to solve this?~~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
