### PR TITLE
pythonPackages.sanic: 19.3.1 -> 19.6.3 (and fix websockets and other issues)

### DIFF
--- a/pkgs/development/python-modules/datasette/default.nix
+++ b/pkgs/development/python-modules/datasette/default.nix
@@ -3,7 +3,6 @@
 , fetchFromGitHub
 , click
 , click-default-group
-, sanic
 , jinja2
 , hupper
 , pint
@@ -14,17 +13,20 @@
 , black
 , aiohttp
 , beautifulsoup4
+, uvicorn
+, asgiref
+, aiofiles
 }:
 
 buildPythonPackage rec {
   pname = "datasette";
-  version = "0.28";
+  version = "0.29.3";
 
   src = fetchFromGitHub {
     owner = "simonw";
     repo = "datasette";
     rev = version;
-    sha256 = "1m2s03gyq0ghjc3s0b5snpinisddywpgii2f0zqa3v4ljmzanx7h";
+    sha256 = "0cib7pd4z240ncck0pskzvizblhwkr42fsjpd719wdxy4scs7yqa";
   };
 
   buildInputs = [ pytestrunner ];
@@ -32,11 +34,12 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     click
     click-default-group
-    sanic
     jinja2
     hupper
     pint
     pluggy
+    uvicorn
+    aiofiles
   ];
 
   checkInputs = [
@@ -45,6 +48,7 @@ buildPythonPackage rec {
     aiohttp
     beautifulsoup4
     black
+    asgiref
   ];
 
   postConfigure = ''
@@ -52,8 +56,9 @@ buildPythonPackage rec {
       --replace "click-default-group==1.2" "click-default-group" \
       --replace "Sanic==0.7.0" "Sanic" \
       --replace "hupper==1.0" "hupper" \
-      --replace "pint==0.8.1" "pint" \
-      --replace "Jinja2==2.10.1" "Jinja2"
+      --replace "pint~=0.8.1" "pint" \
+      --replace "Jinja2==2.10.1" "Jinja2" \
+      --replace "uvicorn~=0.8.4" "uvicorn"
   '';
 
   # many tests require network access

--- a/pkgs/development/python-modules/sanic/default.nix
+++ b/pkgs/development/python-modules/sanic/default.nix
@@ -15,15 +15,76 @@
 , pytest-sanic
 , pytest-sugar
 , pytest-benchmark
+
+# required just httpcore / requests-async
+, h11
+, h2
+, certifi
+, chardet
+, idna
+, requests
+, rfc3986
+, uvicorn
 }:
+
+let
+
+  # This version of sanic depends on two packages that have been deprecated by
+  # their development teams:
+  #
+  # - requests-async [where first line of pypi says to use `http3` instead now]
+  # - httpcore       [where the homepage redirects to `http3` now]
+  #
+  # Since no other packages in nixpkg depend on these right now, define these
+  # packages just as local dependencies here, to avoid bloat.
+
+  httpcore = buildPythonPackage rec {
+    pname = "httpcore";
+    version = "0.3.0";
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "0n3bamaixxhcm27gf1ws3g6rkamvqx87087c88r6hyyl52si1ycn";
+    };
+
+    propagatedBuildInputs = [ certifi chardet h11 h2 idna rfc3986 ];
+
+    # relax pinned old version of h11
+    postConfigure = ''
+      substituteInPlace setup.py \
+        --replace "h11==0.8.*" "h11"
+      '';
+
+    # LICENCE.md gets propagated without this, causing collisions
+    postInstall = ''
+      rm $out/LICENSE.md
+    '';
+  };
+
+  requests-async = buildPythonPackage rec {
+    pname = "requests-async";
+    version = "0.5.0";
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "8731420451383196ecf2fd96082bfc8ae5103ada90aba185888499d7784dde6f";
+    };
+
+    propagatedBuildInputs = [ requests httpcore ];
+
+    # LICENCE.md gets propagated without this, causing collisions
+    postInstall = ''
+      rm $out/LICENSE.md
+    '';
+  };
+
+in
 
 buildPythonPackage rec {
   pname = "sanic";
-  version = "19.3.1";
+  version = "19.6.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "ce434eb154872ca64493a6c3a288f11fd10bca0de7be7bf9f1d0d063185e51ec";
+    sha256 = "0b1qqsvdjkibrw5kgr0pm7n7jzb1403132wjmb0lx3k5wyvqfi95";
   };
 
   propagatedBuildInputs = [
@@ -31,6 +92,7 @@ buildPythonPackage rec {
     aiofiles
     websockets
     multidict
+    requests-async
     uvloop
     ujson
   ];
@@ -44,11 +106,20 @@ buildPythonPackage rec {
     pytest-sanic
     pytest-sugar
     pytest-benchmark
+    uvicorn
   ];
 
+  # Sanic says it needs websockets 7.x, but the changelog for 8.x is actually
+  # nearly compatible with sanic's use. So relax this constraint, with a small
+  # required code change.
   postConfigure = ''
-    substituteInPlace setup.py \
-      --replace "websockets>=6.0,<7.0" "websockets"
+    substituteInPlace setup.py --replace \
+      "websockets>=7.0,<8.0"             \
+      "websockets>=7.0,<9.0"
+    substituteInPlace sanic/websocket.py --replace    \
+           "self.websocket.subprotocol = subprotocol" \
+           "self.websocket.subprotocol = subprotocol
+            self.websocket.is_client = False"
   '';
 
   # 10/500 tests ignored due to missing directory and

--- a/pkgs/development/python-modules/uvicorn/default.nix
+++ b/pkgs/development/python-modules/uvicorn/default.nix
@@ -43,6 +43,12 @@ buildPythonPackage rec {
     pytest
   '';
 
+  # LICENCE.md gets propagated without this, causing collisions
+  # see https://github.com/encode/uvicorn/issues/392
+  postInstall = ''
+    rm $out/LICENSE.md
+  '';
+
   meta = with lib; {
     homepage = https://www.uvicorn.org/;
     description = "The lightning-fast ASGI server";

--- a/pkgs/development/python-modules/websockets/default.nix
+++ b/pkgs/development/python-modules/websockets/default.nix
@@ -3,6 +3,7 @@
 , buildPythonPackage
 , pythonOlder
 , pytest
+, stdenv
 }:
 
 buildPythonPackage rec {
@@ -17,6 +18,9 @@ buildPythonPackage rec {
   };
 
   disabled = pythonOlder "3.3";
+
+  # Tests fail on Darwin with `OSError: AF_UNIX path too long`
+  doCheck = !stdenv.isDarwin;
 
   meta = with lib; {
     description = "WebSocket implementation in Python 3";


### PR DESCRIPTION
###### Motivation for this change

In `pythonPackages`, the `sanic` package requires `websockets` version 6.x, but the default provided is version 7.0.

The current workaround is just to [delete the version bounds](https://github.com/NixOS/nixpkgs/blob/1a1a7ed26652545dc6a2e2bd02f7812e1b37d196/pkgs/development/python-modules/sanic/default.nix#L51) on this dependency. This moves the problem to runtime: the first time the websocket functionality is actually used, it fails (see below for a test case and resulting crash).

The change here brings in the correct version of the `websockets` Python package, so that this works.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Test case

In case useful, here's a minimal concrete test case.

If this is `server.py`:
```python
from sanic import Sanic
from sanic.websocket import WebSocketProtocol

app = Sanic()

@app.websocket('/ws')
async def foo(req, ws):
  await ws.send('hello from websocket!')

app.run(protocol=WebSocketProtocol)
```
and you run this server via
```
nix-shell --pure -p 'python3.withPackages(p: [p.sanic])' --command 'python server.py'
```
(along with an assumed `-I nixpkgs=<path to nixpkgs>`), and invoke a test client:
```
nix-shell -p websocat --command 'websocat ws://127.0.0.1:8000/ws'
```
then with the current code, you get a crashdump:
```
[2019-09-08 19:35:50 +0100] [1688] [ERROR] Exception occurred while handling uri: 'ws://127.0.0.1:8000/ws'
Traceback (most recent call last):
  File "/nix/store/034m3rj9j27zvdldvpn6bdzpm0h3fn7c-python3-3.7.4-env/lib/python3.7/site-packages/sanic/app.py", line 917, in handle_request
    response = await response
  File "/nix/store/034m3rj9j27zvdldvpn6bdzpm0h3fn7c-python3-3.7.4-env/lib/python3.7/site-packages/sanic/app.py", line 473, in websocket_handler
    ws = await protocol.websocket_handshake(request, subprotocols)
  File "/nix/store/034m3rj9j27zvdldvpn6bdzpm0h3fn7c-python3-3.7.4-env/lib/python3.7/site-packages/sanic/websocket.py", line 69, in websocket_handshake
    key = handshake.check_request(request.headers)
  File "/nix/store/034m3rj9j27zvdldvpn6bdzpm0h3fn7c-python3-3.7.4-env/lib/python3.7/site-packages/websockets/handshake.py", line 82, in check_request
    [parse_connection(value) for value in headers.get_all('Connection')], []
AttributeError: 'multidict._multidict.CIMultiDict' object has no attribute 'get_all'
```
With the code changes here, you just see the correct client output:
```
hello from websocket!
```

###### Notify maintainers

cc @costrouc