### PR TITLE
urlview: fix path to url_handler.sh

### DIFF
--- a/pkgs/applications/misc/urlview/default.nix
+++ b/pkgs/applications/misc/urlview/default.nix
@@ -31,10 +31,21 @@ stdenv.mkDerivation rec {
 
   patches = debianPatches;
 
-  meta = {
+  postPatch = ''
+    substituteInPlace urlview.c \
+      --replace '/etc/urlview/url_handler.sh' "$out/etc/urlview/url_handler.sh"
+  '';
+
+  postInstall = ''
+    install -Dm755 url_handler.sh $out/etc/urlview/url_handler.sh
+    patchShebangs $out/etc/urlview
+  '';
+
+  meta = with stdenv.lib; {
     description = "Extract URLs from text";
     homepage = https://packages.qa.debian.org/u/urlview.html;
-    license = stdenv.lib.licenses.gpl2;
-    platforms = with stdenv.lib.platforms; linux ++ darwin;
+    license = licenses.gpl2;
+    platforms = with platforms; linux ++ darwin;
+    maintainers = with maintainers; [ ma27 ];
   };
 }


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

By default, `/etc/urlview/url_handler.sh` is used which breaks by
default with the following error:

```
sh: /etc/urlview/url_handler.sh: No such file or directory
```

With this change, the script will be copied to `$out` and `urlview` will
be patched accordingly.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
