### PR TITLE
Fix broken user generation in roon-server

### DIFF
--- a/nixos/modules/services/audio/roon-server.nix
+++ b/nixos/modules/services/audio/roon-server.nix
@@ -66,7 +66,8 @@ in {
       if cfg.user == "roon-server" then {
         isSystemUser = true;
         description = "Roon Server user";
-        groups = [ cfg.group "audio" ];
+        group = cfg.group;
+        extraGroups = [ "audio" ];
       }
       else {};
   };


### PR DESCRIPTION
Didn't notice this till I tried removing my custom roon user from the one I was testing with. There's not a 'groups' option for users, only group (primary group) and extraGroups. Use these.

###### Motivation for this change
Fixes breakage.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

