### PR TITLE
wmic-bin: add at 0.5.0

### DIFF
--- a/pkgs/servers/monitoring/plugins/wmic-bin.nix
+++ b/pkgs/servers/monitoring/plugins/wmic-bin.nix
@@ -1,0 +1,46 @@
+{ stdenv, lib, fetchFromGitHub, autoPatchelfHook, popt }:
+
+stdenv.mkDerivation rec {
+  pname = "wmic-bin";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "R-Vision";
+    repo = "wmi-client";
+    rev = version;
+    sha256 = "1w1mdbiwz37wzry1q38h8dyjaa6iggmsb9wcyhhlawwm1vj50w48";
+  };
+
+  buildInputs = [ popt ];
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  dontConfigure = true;
+  dontBuild = true;
+  doInstallCheck = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 bin/wmic_ubuntu_x64 $out/bin/wmic
+    install -Dm644 -t $out/share/doc/wmic LICENSE README.md
+
+    runHook postInstall
+  '';
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    $out/bin/wmic --help >/dev/null
+
+    runHook postInstallCheck
+  '';
+
+  meta = with stdenv.lib; {
+    description = "WMI client for Linux (binary)";
+    homepage    = "https://www.openvas.org";
+    license     = licenses.mit;
+    maintainers = with maintainers; [ peterhoeg ];
+    platforms   = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24728,6 +24728,8 @@ in
 
   hy = callPackage ../development/interpreters/hy {};
 
+  wmic-bin = callPackage ../servers/monitoring/plugins/wmic-bin.nix { };
+
   check-uptime = callPackage ../servers/monitoring/plugins/uptime.nix { };
 
   ghc-standalone-archive = callPackage ../os-specific/darwin/ghc-standalone-archive { inherit (darwin) cctools; };


### PR DESCRIPTION
###### Motivation for this change

Getting the ```wmic``` client to compile on NixOS is next to impossible as it is based on an ancient version of samba that requires an ancient toolchain in order to build.

So let's just package a binary that at least works.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
