### PR TITLE
gpscorrelate: enable NLS

### DIFF
--- a/pkgs/applications/misc/gpscorrelate/default.nix
+++ b/pkgs/applications/misc/gpscorrelate/default.nix
@@ -3,14 +3,16 @@
 
 stdenv.mkDerivation rec {
   pname = "gpscorrelate";
-  version = "unstable-2019-06-05";
+  version = "unstable-2019-09-03";
 
   src = fetchFromGitHub {
     owner = "dfandrich";
     repo = pname;
-    rev = "80b14fe7c10c1cc8f62c13f517c062577ce88c85";
-    sha256 = "1gaan0nd7ai0bwilfnkza7lg5mz87804mvlygj0gjc672izr37r6";
+    rev = "e1dd44a34f67b1ab7201440e60a840258ee448d2";
+    sha256 = "0gjwwdqh9dprzylmmnk3gm41khka9arkij3i9amd8y7d49pm9rlv";
   };
+
+  patches = [ ./fix-localedir.diff ];
 
   nativeBuildInputs = [
     desktop-file-utils
@@ -31,11 +33,12 @@ stdenv.mkDerivation rec {
     "GTK=3"
     "CC=cc"
     "CXX=c++"
+    "CFLAGS=-DENABLE_NLS"
   ];
 
   doCheck = true;
 
-  installTargets = [ "install" "install-desktop-file" ];
+  installTargets = [ "install" "install-po" "install-desktop-file" ];
 
   meta = with stdenv.lib; {
     description = "A GPS photo correlation tool, to add EXIF geotags";
@@ -59,5 +62,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     homepage = "https://github.com/dfandrich/gpscorrelate";
     platforms = platforms.linux;
+    maintainers = with maintainers; [ sikmir ];
   };
 }

--- a/pkgs/applications/misc/gpscorrelate/fix-localedir.diff
+++ b/pkgs/applications/misc/gpscorrelate/fix-localedir.diff
@@ -1,0 +1,27 @@
+diff --git i/Makefile w/Makefile
+index 47919ca..408fd68 100644
+--- i/Makefile
++++ w/Makefile
+@@ -33,8 +33,9 @@ datadir  = $(prefix)/share
+ mandir   = $(datadir)/man
+ docdir   = $(datadir)/doc/gpscorrelate
+ applicationsdir = $(datadir)/applications
++localedir = ${datadir}/locale
+ 
+-DEFS = -DPACKAGE_VERSION=\"$(PACKAGE_VERSION)\"
++DEFS = -DPACKAGE_VERSION=\"$(PACKAGE_VERSION)\" -DPACKAGE_LOCALE_DIR=\"$(localedir)\"
+ 
+ TARGETS = gpscorrelate-gui$(EXEEXT) gpscorrelate$(EXEEXT) doc/gpscorrelate.1 doc/gpscorrelate.html
+ 
+diff --git i/main-gui.c w/main-gui.c
+index fdace6f..8a6197b 100644
+--- i/main-gui.c
++++ w/main-gui.c
+@@ -40,6 +40,7 @@
+ int main(int argc, char* argv[])
+ {
+ 	/* Initialize gettext (gtk_init initializes the locale) */
++	(void) bindtextdomain(TEXTDOMAIN, PACKAGE_LOCALE_DIR);
+ 	(void) textdomain(TEXTDOMAIN);
+ 	(void) bind_textdomain_codeset(TEXTDOMAIN, "UTF-8");
+ 


### PR DESCRIPTION
###### Motivation for this change

Enable NLS support.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
