### PR TITLE
nixos/podman: support configuring registries and policy [WIP]

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -118,6 +118,7 @@
   ./programs/npm.nix
   ./programs/oblogout.nix
   ./programs/plotinus.nix
+  ./programs/podman.nix
   ./programs/qt5ct.nix
   ./programs/screen.nix
   ./programs/sedutil.nix

--- a/nixos/modules/programs/podman.nix
+++ b/nixos/modules/programs/podman.nix
@@ -1,0 +1,97 @@
+{ config, pkgs, lib, ... }:
+
+let
+  cfg = config.programs.podman;
+
+  surroundEachWith = str: list:
+    map (e: str + (toString e) + str) list;
+
+  registriesConf = let
+    registryList = list:
+      "registries = [" + (lib.concatStringsSep ", " (surroundEachWith "'" list)) + "]";
+  in lib.concatStringsSep "\n" (lib.mapAttrsToList (type: registries: ''
+    [registries.${type}]
+    ${registryList registries}
+  '') { inherit (cfg.registries) block insecure search; });
+
+in {
+  ###### interface
+
+  options = {
+    programs.podman = with lib; {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whenever to configure <command>podman</command> system-wide.";
+      };
+
+      installSystemWide = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Install packages system-wide.";
+      };
+
+      registries = {
+        search = mkOption {
+          type = types.listOf types.str;
+          default = [ "docker.io" "quay.io" ];
+          description = ''
+            List of repositories to search.
+          '';
+        };
+
+        insecure = mkOption {
+          default = [ ];
+          type = types.listOf types.str;
+          description = ''
+            List of insecure repositories.
+          '';
+        };
+
+        block = mkOption {
+          default = [ ];
+          type = types.listOf types.str;
+          description = ''
+            List of blocked repositories.
+          '';
+        };
+      };
+
+      policy = mkOption {
+        default = {
+          default = [ { type = "reject"; }];
+        };
+        type = types.attrs;
+        example = literalExample ''
+        {
+          default = [ { type = "insecureAcceptAnything"; } ];
+          transports = {
+            docker-daemon = {
+              "" = [ { type = "insecureAcceptAnything"; } ];
+            };
+          };
+        }
+        '';
+        description = ''
+          Signature verification policy file
+          </para>
+          <para>
+          The default will simply reject everything.
+        '';
+      };
+    };
+  };
+
+  ###### implementation
+
+  config = lib.mkIf cfg.enable {
+    environment = {
+      etc."containers/registries.conf".text = registriesConf;
+      etc."containers/policy.json".text = builtins.toJSON cfg.policy;
+
+      systemPackages = lib.mkIf cfg.installSystemWide
+        (with pkgs; [ buildah fuse-overlayfs podman runc slirp4netns ]);
+    };
+  };
+}


### PR DESCRIPTION
##### Motivation for this change

Needed a way to configure podman registries and policy.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
