### PR TITLE
gixy: fix error - no module named pkg_resources

### DIFF
--- a/pkgs/tools/admin/gixy/default.nix
+++ b/pkgs/tools/admin/gixy/default.nix
@@ -25,6 +25,7 @@ python.pkgs.buildPythonApplication rec {
     pyparsing
     jinja2
     nose
+    setuptools
     six
   ];
 


### PR DESCRIPTION
###### Motivation for this change
Fix this error:
`gixy /nix/store/967yv78zr0yxjwld3lv6z0gllzi3mdg9-nginx.conf `

```
Traceback (most recent call last):
  File "/nix/store/4bg063gqg869h3xkh78dw388kx4zzci2-gixy-0.1.20/bin/.gixy-wrapped", line 11, in <module>
    sys.exit(main())
  File "/nix/store/4bg063gqg869h3xkh78dw388kx4zzci2-gixy-0.1.20/lib/python2.7/site-packages/gixy/cli/main.py", line 153, in main
    formatter = formatters()[config.output_format]()
  File "/nix/store/4bg063gqg869h3xkh78dw388kx4zzci2-gixy-0.1.20/lib/python2.7/site-packages/gixy/formatters/console.py", line 10, in __init__
    self.template = load_template('console.j2')
  File "/nix/store/4bg063gqg869h3xkh78dw388kx4zzci2-gixy-0.1.20/lib/python2.7/site-packages/gixy/formatters/_jinja.py", line 8, in load_template
    env = Environment(loader=PackageLoader('gixy', 'formatters/templates'), trim_blocks=True, lstrip_blocks=True)
  File "/nix/store/17whr42gf4ckf07m64vak2q2dw87qjw8-python2.7-Jinja2-2.10.1/lib/python2.7/site-packages/jinja2/loaders.py", line 222, in __init__
    from pkg_resources import DefaultProvider, ResourceManager, \
ImportError: No module named pkg_resources

```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
