### PR TITLE
ociTools: fixing outdated documentation

### DIFF
--- a/doc/functions/ocitools.xml
+++ b/doc/functions/ocitools.xml
@@ -31,10 +31,10 @@
    <title>Build Container</title>
 <programlisting>
 buildContainer {
-  cmd = with pkgs; writeScript "run.sh" ''
+  args = [ (with pkgs; writeScript "run.sh" ''
     #!${bash}/bin/bash
     ${coreutils}/bin/exec ${bash}/bin/bash
-  ''; <co xml:id='ex-ociTools-buildContainer-1' />
+  '').outPath ]; <co xml:id='ex-ociTools-buildContainer-1' />
 
   mounts = {
     "/data" = {
@@ -51,7 +51,7 @@ buildContainer {
    <calloutlist>
     <callout arearefs='ex-ociTools-buildContainer-1'>
      <para>
-      <varname>cmd</varname> specifies the program to run inside the container.
+      <varname>args</varname> specifies a set of arguments to run inside the container.
       This is the only required argument for <varname>buildContainer</varname>.
       All referenced packages inside the derivation will be made available
       inside the container


### PR DESCRIPTION
The documentation was out of date because of last-minute changes to
the `ociTools` API. This should probably be backported to stable to
not confuse everybody ;)

(I guess that means I also PR to `staging-next`?)

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @alyssais @edef1c