### PR TITLE
gthree: unstable-2019-08-21 → 0.2.0

### DIFF
--- a/pkgs/development/libraries/graphene/default.nix
+++ b/pkgs/development/libraries/graphene/default.nix
@@ -15,7 +15,7 @@
 
 stdenv.mkDerivation rec {
   pname = "graphene";
-  version = "1.9.6";
+  version = "1.10.0";
 
   outputs = [ "out" "devdoc" "installedTests" ];
 
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     owner = "ebassi";
     repo = pname;
     rev = version;
-    sha256 = "0hb7s6g00l7zlf4hlfda55krn0pls9ajz0hcqrh8m656zr18ddwa";
+    sha256 = "16vqwih5bfxv7r3mm7iiha804rpsxzxjfrs4kx76d9q5yg2hayxr";
   };
 
   patches = [

--- a/pkgs/development/libraries/gthree/default.nix
+++ b/pkgs/development/libraries/gthree/default.nix
@@ -15,27 +15,18 @@
 , json-glib
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "gthree";
-  version = "unstable-2019-08-21";
+  version = "0.2.0";
 
   outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchFromGitHub {
     owner = "alexlarsson";
     repo = "gthree";
-    rev = "dac46b0f35e29319c004c7e17b5f345ef4c04cb8";
-    sha256 = "16ixis2g04000zffm44s7ir64vn3byz9a793g2s76aasqybl86i2";
+    rev = version;
+    sha256 = "16ap1ampnzsyhrs84b168d6889lh8sjr2j5sqv9mdbnnhy72p5cd";
   };
-
-  patches = [
-    # correctly declare json-glib in .pc file
-    # https://github.com/alexlarsson/gthree/pull/61
-    (fetchpatch {
-      url = https://github.com/alexlarsson/gthree/commit/784b1f20e0b6eb15f113a51f74c2cba871249861.patch;
-      sha256 = "07vxafaxris5a98w751aw04nlw0l45np1lba08xd16wdzmkadz0x";
-    })
-  ];
 
   nativeBuildInputs = [
     ninja
@@ -64,7 +55,7 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     description = "GObject/GTK port of three.js";
-    homepage = https://github.com/alexlarsson/gthree;
+    homepage = "https://github.com/alexlarsson/gthree";
     license = licenses.mit;
     maintainers = with maintainers; [ jtojnar ];
     platforms = platforms.unix;

--- a/pkgs/games/gnome-hexgl/default.nix
+++ b/pkgs/games/gnome-hexgl/default.nix
@@ -9,15 +9,15 @@
 , gtk3
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "gnome-hexgl";
-  version = "unstable-2019-08-21";
+  version = "0.2.0";
 
   src = fetchFromGitHub {
     owner = "alexlarsson";
     repo = "gnome-hexgl";
-    rev = "c6edde1250b830c7c8ee738905cb39abef67d4a6";
-    sha256 = "17j236damqij8n4a37psvkfxbbc18yw03s3hs0qxgfhl4671wf6z";
+    rev = version;
+    sha256 = "08iy2iciscd2wbhh6v4cpghx8r94v1ffbgla9yb3bcsdhlag0iw4";
   };
 
   nativeBuildInputs = [
@@ -35,7 +35,7 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     description = "Gthree port of HexGL";
-    homepage = https://github.com/alexlarsson/gnome-hexgl;
+    homepage = "https://github.com/alexlarsson/gnome-hexgl";
     license = licenses.mit;
     maintainers = with maintainers; [ jtojnar ];
     platforms = platforms.unix;


### PR DESCRIPTION
https://blogs.gnome.org/alexl/2019/09/09/gthree-ready-to-play/
https://github.com/alexlarsson/gthree/releases/tag/0.2.0
https://github.com/alexlarsson/gnome-hexgl/releases/tag/0.2.0