### PR TITLE
nixos/mysql: add authentication option

### DIFF
--- a/nixos/modules/services/databases/mysql.nix
+++ b/nixos/modules/services/databases/mysql.nix
@@ -153,6 +153,20 @@ in
                 Name of the user to ensure.
               '';
             };
+          authentication_option = mkOption {
+              type = types.str;
+              default = "socket";
+              description = ''
+                Authentication option to use either socket or password. If password is used password_hash has to be set.
+              '';
+            };
+          password_hash = mkOption {
+              type = types.str;
+              default = "";
+              description = ''
+                Password hash to set for user, default is empty, which means no password.
+              '';
+            };
             ensurePermissions = mkOption {
               type = types.attrsOf types.str;
               default = {};
@@ -406,7 +420,7 @@ in
 
                 ${concatMapStrings (user:
                   ''
-                    ( echo "CREATE USER IF NOT EXISTS '${user.name}'@'localhost' IDENTIFIED WITH ${if isMariaDB then "unix_socket" else "auth_socket"};"
+                    ( echo "CREATE USER IF NOT EXISTS '${user.name}'@'localhost' ${optionalString  (user.authentication_option == "password") ''IDENTIFIED BY PASSWORD '${user.password_hash}' ''} ${optionalString  (user.authentication_option == "socket") ''IDENTIFIED WITH  ${if isMariaDB then "unix_socket" else "auth_socket"} ''};"
                       ${concatStringsSep "\n" (mapAttrsToList (database: permission: ''
                         echo "GRANT ${permission} ON ${database} TO '${user.name}'@'localhost';"
                       '') user.ensurePermissions)}
@@ -423,3 +437,4 @@ in
   };
 
 }
+


### PR DESCRIPTION
Add an authentication option to be able to create mysql users that do
not authenticate using the unix_socket plugin, since this requires the
username to exist on the host system.
(https://mariadb.com/kb/en/library/authentication-plugin-unix-socket/)

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
