### PR TITLE
sasview: 4.2.0 -> 4.2.2

### DIFF
--- a/pkgs/applications/science/misc/sasview/default.nix
+++ b/pkgs/applications/science/misc/sasview/default.nix
@@ -17,7 +17,7 @@ in
 
 python.pkgs.buildPythonApplication rec {
   pname = "sasview";
-  version = "4.2.0";
+  version = "4.2.2";
 
   checkInputs = with python.pkgs; [
     pytest
@@ -61,7 +61,7 @@ python.pkgs.buildPythonApplication rec {
     owner = "SasView";
     repo = "sasview";
     rev = "v${version}";
-    sha256 = "0k3486h46k6406h0vla8h68fd78wh3dcaq5w6f12jh6g4cjxv9qa";
+    sha256 = "0w0n02vswmhhbwqk1z6ahq5z46sa8bp20j3l6w82jqsj5d2f10xz";
   };
 
   patches = [ ./pyparsing-fix.patch ./local_config.patch ];

--- a/pkgs/applications/science/misc/sasview/local_config.patch
+++ b/pkgs/applications/science/misc/sasview/local_config.patch
@@ -13,10 +13,3 @@ index ece08fd4c..926768593 100644
  
  def make_custom_config_path(user_dir):
      """
-@@ -116,4 +116,4 @@ def load_custom_config(path):
- 
-     from sas.sasview import custom_config
-     logger.info("GuiManager custom_config defaults to sas.sasview.custom_config")
--    return custom_config
-\ No newline at end of file
-+    return custom_config


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
