### PR TITLE
ddgr: 1.6 -> 1.7

### DIFF
--- a/pkgs/applications/misc/ddgr/default.nix
+++ b/pkgs/applications/misc/ddgr/default.nix
@@ -1,19 +1,25 @@
 {stdenv, fetchFromGitHub, python3}:
 
 stdenv.mkDerivation rec {
-  version = "1.6";
+  version = "1.7";
   pname = "ddgr";
 
   src = fetchFromGitHub {
     owner = "jarun";
     repo = "ddgr";
     rev = "v${version}";
-    sha256 = "04ybbjsf9hpn2p5cjjm15cwvv0mwrmdi19iifrym6ps3rmll0p3c";
+    sha256 = "0kcl8z9w8iwn3pxay1pfahhw6vs2l1dp60yfv3i19in4ac9va7m0";
   };
 
   buildInputs = [ python3 ];
 
   makeFlags = "PREFIX=$(out)";
+
+  preBuild = ''
+    # Version 1.7 was released as 1.6
+    # https://github.com/jarun/ddgr/pull/95
+    sed -i "s/_VERSION_ = '1.6'/_VERSION_ = '1.7'/" ddgr
+  '';
 
   postInstall = ''
     mkdir -p "$out/share/bash-completion/completions/"


### PR DESCRIPTION
###### Motivation for this change
Update `ddgr` to 1.7 (https://github.com/jarun/ddgr/releases/tag/v1.7)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @ceedubs 
