### PR TITLE
pythonPackages.lmdb: fix build

### DIFF
--- a/pkgs/development/python-modules/lmdb/default.nix
+++ b/pkgs/development/python-modules/lmdb/default.nix
@@ -16,7 +16,6 @@ buildPythonPackage rec {
 
   checkInputs = [ pytest cffi ];
   checkPhase = ''
-    export PYTHONPATH=.:$PYTHONPATH
     py.test
   '';
 
@@ -24,7 +23,7 @@ buildPythonPackage rec {
     description = "Universal Python binding for the LMDB 'Lightning' Database";
     homepage = "https://github.com/dw/py-lmdb";
     license = licenses.openldap;
-    maintainers = with maintainers; [ copumpkin ];
+    maintainers = with maintainers; [ copumpkin ivan ];
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change

This fixes:

```
pythonCatchConflictsPhase
Found duplicated packages in closure for dependency 'lmdb':
  lmdb 0.97 (/build/lmdb-0.97)
  lmdb 0.97 (/nix/store/js0iimri6y9yqgfc111jzp3mrv5ic9cj-python3.7-lmdb-0.97/lib/python3.7/site-packages)

Package duplicates found in closure, see above. Usually this happens if two packages depend on different version of the same dependency.
builder for '/nix/store/9bcn2m3r5v8slmpj31hxw05j906qgl5l-python3.7-lmdb-0.97.drv' failed with exit code 1
```

This may have been broken by https://github.com/NixOS/nixpkgs/commit/f7e28bf5d8181926e600a222cb70180519d09726

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I confirmed that `pythonPackages.lmdb` and `python3Packages.lmdb` build on NixOS x86_64 and macOS 10.14.

###### Notify maintainers

cc @copumpkin @FRidh 
