### PR TITLE
wifi-password: init at 0.1.0

### DIFF
--- a/pkgs/os-specific/darwin/wifi-password/default.nix
+++ b/pkgs/os-specific/darwin/wifi-password/default.nix
@@ -21,6 +21,6 @@ stdenv.mkDerivation rec {
     description = "Get the password of the wifi you're on";
     platforms = stdenv.lib.platforms.darwin;
     license = stdenv.lib.licenses.mit;
-    maintainer = stdenv.lib.maintainers.nikitavoloboev;
+    maintainers = [ stdenv.lib.maintainers.nikitavoloboev ];
   };
 }

--- a/pkgs/os-specific/darwin/wifi-password/default.nix
+++ b/pkgs/os-specific/darwin/wifi-password/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  version = "0.1.0";
+  pname = "wifi-password";
+
+  src = fetchFromGitHub {
+    owner = "rauchg";
+    repo = pname;
+    rev = version;
+    sha256 = "0sfvb40h7rz9jzp4l9iji3jg80paklqsbmnk5h7ipsv2xbsplp64";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp wifi-password.sh $out/bin/wifi-password
+  '';
+
+  meta = {
+    homepage = https://github.com/rauchg/wifi-password;
+    description = "Get the password of the wifi you're on";
+    platforms = stdenv.lib.platforms.darwin;
+    license = stdenv.lib.licenses.mit;
+    maintainer = stdenv.lib.maintainers.nikitavoloboev;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24831,4 +24831,6 @@ in
 
   nix-store-gcs-proxy = callPackage ../tools/nix/nix-store-gcs-proxy {};
 
+  wifi-password = callPackage ../os-specific/darwin/wifi-password {};
+
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Package I use.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @zimbatm 
