### PR TITLE
rappel: unstable-2019-07-08 -> unstable-2019-09-09

### DIFF
--- a/pkgs/development/misc/rappel/default.nix
+++ b/pkgs/development/misc/rappel/default.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation rec {
   pname = "rappel";
-  version = "unstable-2019-07-08";
+  version = "unstable-2019-09-09";
 
   src = fetchFromGitHub {
     owner = "yrp604";
     repo = "rappel";
-    rev = "95a776f850cf6a7c21923a2100b605408ef038de";
-    sha256 = "0fmd15xa6hswh3x48av4g1sf6rncbiinbj7gbw1ffvqsbcfnsgcr";
+    rev = "31a06762d34880ff2ed7176ca71bd8a6b91b10d5";
+    sha256 = "0wj3hypqfrjra8mwmn32hs5qs6ic81cq3gn1v0b2fba6vkqcsqfy";
   };
 
   buildInputs = [ libedit ];


### PR DESCRIPTION
###### Motivation for this change
follow up to #68282

my linting PR got merged, https://github.com/yrp604/rappel/pull/19

essentially, this just turns down the warnings that gcc7 produces when built with -Wpedantic
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Pamplemousse 

```
$ nix path-info -Sh ./result
/nix/store/qg4szna1xqydaxn2vxd7yjl0hggh84hz-rappel-unstable-2019-07-08    33.9M
$ nix path-info -Sh ./result
/nix/store/p024r8w4wwhgkzrfy3zl52cg8xm2ak2v-rappel-unstable-2019-09-09    34.0M
```
```
[1 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/68379
1 package were build:
rappel
```