### PR TITLE
oracle-instantclient: 18.1.0.0.0 -> 19.3.0.0.0 (x86_64-darwin)

### DIFF
--- a/pkgs/development/libraries/oracle-instantclient/default.nix
+++ b/pkgs/development/libraries/oracle-instantclient/default.nix
@@ -1,6 +1,5 @@
 { stdenv
 , fetchurl
-, requireFile
 , autoPatchelfHook
 , fixDarwinDylibNames
 , unzip
@@ -23,7 +22,7 @@ let
   # determine the version number, there might be different ones per architecture
   version = {
     x86_64-linux = "19.3.0.0.0";
-    x86_64-darwin = "18.1.0.0.0";
+    x86_64-darwin = "19.3.0.0.0";
   }.${stdenv.hostPlatform.system} or throwSystem;
 
   # hashes per component and architecture
@@ -35,18 +34,15 @@ let
       odbc    = "1g1z6pdn76dp440fh49pm8ijfgjazx4cvxdi665fsr62h62xkvch";
     };
     x86_64-darwin = {
-      basic   = "fac3cdaaee7526f6c50ff167edb4ba7ab68efb763de24f65f63fb48cc1ba44c0";
-      sdk     = "98e6d797f1ce11e59b042b232f62380cec29ec7d5387b88a9e074b741c13e63a";
-      sqlplus = "02e66dc52398fced75e7efcb6b4372afcf617f7d88344fb7f0f4bb2bed371f3b";
-      odbc    = "5d0cdd7f9dd2e27affbc9b36ef9fc48e329713ecd36905fdd089366e365ae8a2";
+      basic   = "f4335c1d53e8188a3a8cdfb97494ff87c4d0f481309284cf086dc64080a60abd";
+      sdk     = "b46b4b87af593f7cfe447cfb903d1ae5073cec34049143ad8cdc9f3e78b23b27";
+      sqlplus = "f7565c3cbf898b0a7953fbb0017c5edd9d11d1863781588b7caf3a69937a2e9e";
+      odbc    = "f91da40684abaa866aa059eb26b1322f2d527670a1937d678404c991eadeb725";
     };
   }.${stdenv.hostPlatform.system} or throwSystem;
 
   # rels per component and architecture, optional
   rels = {
-    x86_64-darwin = {
-      sdk = "2";
-    };
   }.${stdenv.hostPlatform.system} or {};
 
   # convert platform to oracle architecture names
@@ -55,28 +51,23 @@ let
     x86_64-darwin = "macos.x64";
   }.${stdenv.hostPlatform.system} or throwSystem;
 
+  shortArch = {
+    x86_64-linux = "linux";
+    x86_64-darwin = "macos";
+  }.${stdenv.hostPlatform.system} or throwSystem;
+
   # calculate the filename of a single zip file
   srcFilename = component: arch: version: rel:
     "instantclient-${component}-${arch}-${version}" +
     (optionalString (rel != "") "-${rel}") +
-    (optionalString (arch == "linux.x64") "dbru") + # ¯\_(ツ)_/¯
+    (optionalString (arch == "linux.x64" || arch == "macos.x64") "dbru") + # ¯\_(ツ)_/¯
     ".zip";
 
-  # fetcher for the clickthrough artifacts (requiring manual download)
-  fetchClickThrough =  srcFilename: hash: (requireFile {
-    name = srcFilename;
-    url = "https://www.oracle.com/database/technologies/instant-client/downloads.html";
-    sha256 = hash;
-  });
-
   # fetcher for the non clickthrough artifacts
-  fetchSimple = srcFilename: hash: fetchurl {
-    url = "https://download.oracle.com/otn_software/linux/instantclient/193000/${srcFilename}";
+  fetcher = srcFilename: hash: fetchurl {
+    url = "https://download.oracle.com/otn_software/${shortArch}/instantclient/193000/${srcFilename}";
     sha256 = hash;
   };
-
-  # pick the appropriate fetcher depending on the platform
-  fetcher = if stdenv.hostPlatform.system == "x86_64-linux" then fetchSimple else fetchClickThrough;
 
   # assemble srcs
   srcs = map (component:


### PR DESCRIPTION
macos binaries are available without having to login, so we can also
remove the `requireFile` fetcher.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @cjbj