### PR TITLE
openjdk8: replacing jre symlinking with copy

### DIFF
--- a/pkgs/development/compilers/openjdk/8.nix
+++ b/pkgs/development/compilers/openjdk/8.nix
@@ -187,10 +187,9 @@ let
         rm $out/lib/openjdk/bin/{policytool,appletviewer}
       ''}
 
-      # Move the JRE to a separate output
+      # Additionally copy the JRE to a separate output
       mkdir -p $jre/lib/openjdk
-      mv $out/lib/openjdk/jre $jre/lib/openjdk/jre
-      ln -s $jre/lib/openjdk/jre $out/lib/openjdk/jre
+      cp -r $out/lib/openjdk/jre $jre/lib/openjdk/jre
 
       # Setup fallback fonts
       ${lib.optionalString (!headless) ''


### PR DESCRIPTION
###### Motivation for this change

For space optimization reasons, the JRE was linked into the JDK from a
separate output. While this saves some space, it breaks certain
assumptions made in some software, expecting the JRE to reside within
the JDK tree and to be able to reach JDK libraries by traversing
up the folders and similar.

This approach should reduce the need for workarounds in jvm based
builds and other issues at the cost of some storage space.

JDK colosure size delta: +24%
JRE colosure size delta: +4% (this is likely for other reasons)

This addresses https://github.com/NixOS/nixpkgs/issues/37364
and might also supersede https://github.com/NixOS/nixpkgs/pull/68370

I tested this building jogl (removing the workaround) and hadoop.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @edwtjo 
cc @NeQuissimus 
cc @volth 