### PR TITLE
libressl: fixing nc for version>=2.9

### DIFF
--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, lib, cmake }:
+{ stdenv, fetchurl, lib, cmake, cacert }:
 
 let
 
@@ -29,6 +29,12 @@ let
     # removing ./configure pre-config.
     preConfigure = ''
       rm configure
+    '';
+
+    # Since 2.9.x the default location can't be configured from the build using
+    # DEFAULT_CA_FILE anymore, instead we have to patch the default value.
+    postPatch = lib.optionalString (lib.versionAtLeast version "2.9.2") ''
+      substituteInPlace ./tls/tls_config.c --replace '"/etc/ssl/cert.pem"' '"${cacert}/etc/ssl/certs/ca-bundle.crt"'
     '';
 
     enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change

This addresses https://github.com/NixOS/nixpkgs/issues/68286

When `-R` (CA file location) is not specified, nc tries to fall back to
a default location. In 2.8 this was still configurable at compile time,
but was changed somewhere after. This replaces `/etc/ssl/cert.pem`
with `$out/etc/ssl/cert.pem` in the code directly.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @thoughtpolice 
cc @fpletz 

cc @andir 
