### PR TITLE
Fix desktop tests

### DIFF
--- a/nixos/tests/plasma5.nix
+++ b/nixos/tests/plasma5.nix
@@ -30,6 +30,7 @@ import ./make-test.nix ({ pkgs, ...} :
       enable = true;
       user = "alice";
     };
+    hardware.pulseaudio.enable = true; # needed for the factl test, /dev/snd/* exists without them but udev doesn't care then
     virtualisation.memorySize = 1024;
     environment.systemPackages = [ sddm_theme ];
   };

--- a/nixos/tests/xfce.nix
+++ b/nixos/tests/xfce.nix
@@ -17,6 +17,8 @@ import ./make-test.nix ({ pkgs, ...} : {
       services.xserver.desktopManager.xfce.enable = true;
 
       environment.systemPackages = [ pkgs.xorg.xmessage ];
+
+      hardware.pulseaudio.enable = true; # needed for the factl test, /dev/snd/* exists without them but udev doesn't care then
     };
 
   testScript =

--- a/nixos/tests/xfce.nix
+++ b/nixos/tests/xfce.nix
@@ -19,6 +19,8 @@ import ./make-test.nix ({ pkgs, ...} : {
       environment.systemPackages = [ pkgs.xorg.xmessage ];
 
       hardware.pulseaudio.enable = true; # needed for the factl test, /dev/snd/* exists without them but udev doesn't care then
+
+      virtualisation.memorySize = 1024;
     };
 
   testScript =

--- a/nixos/tests/xfce4-14.nix
+++ b/nixos/tests/xfce4-14.nix
@@ -14,6 +14,8 @@ import ./make-test.nix ({ pkgs, ...} : {
       services.xserver.desktopManager.xfce4-14.enable = true;
 
       hardware.pulseaudio.enable = true; # needed for the factl test, /dev/snd/* exists without them but udev doesn't care then
+  
+      virtualisation.memorySize = 1024;
     };
 
   testScript =

--- a/nixos/tests/xfce4-14.nix
+++ b/nixos/tests/xfce4-14.nix
@@ -12,6 +12,8 @@ import ./make-test.nix ({ pkgs, ...} : {
       services.xserver.displayManager.auto.user = "alice";
 
       services.xserver.desktopManager.xfce4-14.enable = true;
+
+      hardware.pulseaudio.enable = true; # needed for the factl test, /dev/snd/* exists without them but udev doesn't care then
     };
 
   testScript =


### PR DESCRIPTION
###### Motivation for this change
https://hydra.nixos.org/build/100471962
https://hydra.nixos.org/build/100471851
https://hydra.nixos.org/build/100472011

A lot of these tests, though strangely not all, were failing at the
```
$machine->succeed("getfacl /dev/snd/timer | grep -q alice");
```

step which seems to also be done in the login test.

The same issue popped up there so I duplicated the fix https://github.com/NixOS/nixpkgs/commit/f59b4cb8d545d3bb1bd954f9e3267cb7ebec3557.
In general all these tests could be nicer.

I also took the liberty to bump the `memorySize` for the xfce tests https://github.com/NixOS/nixpkgs/commit/5b42b1f40158f6ee6277bab8bb59c5360d2153e0 https://github.com/NixOS/nixpkgs/commit/9f43d809b32c7f0ee3ce13ff3a3454ab7e2e9d18 to what all the other desktop tests have.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
