### PR TITLE
fix wine

### DIFF
--- a/pkgs/misc/emulators/wine/base.nix
+++ b/pkgs/misc/emulators/wine/base.nix
@@ -55,6 +55,8 @@ stdenv.mkDerivation ((lib.optionalAttrs (! isNull buildScript) {
   ++ lib.optionals stdenv.isDarwin (with pkgs.buildPackages.darwin.apple_sdk.frameworks; [
      CoreServices Foundation ForceFeedback AppKit OpenGL IOKit DiskArbitration Security
      ApplicationServices AudioToolbox CoreAudio AudioUnit CoreMIDI OpenAL OpenCL Cocoa Carbon
+     # Needed for CFNotificationCenterAddObserver symbols.
+	   pkgs.buildPackages.darwin.cf-private
   ])
   ++ lib.optionals stdenv.isLinux  (with pkgs.xorg; [
      libXi libXcursor libXrandr libXrender libXxf86vm libXcomposite libXext

--- a/pkgs/misc/emulators/wine/base.nix
+++ b/pkgs/misc/emulators/wine/base.nix
@@ -89,6 +89,15 @@ stdenv.mkDerivation ((lib.optionalAttrs (! isNull buildScript) {
   # and enable doCheck
   doCheck = false;
 
+  # the relevant check in configure.ac will fail under nix as we are not
+  # using the system supplied compiler tools. We will subsequently *not*
+  # pass `-mmacosx-version-min` in the LDFLAGS, and end up with a linked
+  # binary against 10.14 which *does* contain a __DATA,__dyld section and
+  # then horribly fail to run on Mojave.
+  postConfigure = lib.optional (stdenv.hostPlatform.isDarwin) ''
+    sed -i 's|-nostartfiles -nodefaultlibs|-nostartfiles -nodefaultlibs -mmacosx-version-min=10.7|g' loader/Makefile
+  '';
+
   postInstall = let
     links = prefix: pkg: "ln -s ${pkg} $out/${prefix}/${pkg.name}";
   in ''

--- a/pkgs/misc/emulators/wine/sources.nix
+++ b/pkgs/misc/emulators/wine/sources.nix
@@ -12,6 +12,31 @@ let fetchurl = args@{url, sha256, ...}:
   pkgs.fetchFromGitHub { inherit owner repo rev sha256; } // args;
 in rec {
 
+  wine3 = fetchurl rec {
+    version = "3.0.2";
+    url = "https://dl.winehq.org/wine/source/3.0/wine-${version}.tar.xz";
+    sha256 = "1zv3nk31s758ghp4795ym3w8l5868c2dllmjx9245qh9ahvp3mya";
+
+    ## see http://wiki.winehq.org/Gecko
+    gecko32 = fetchurl rec {
+      version = "2.47";
+      url = "http://dl.winehq.org/wine/wine-gecko/${version}/wine_gecko-${version}-x86.msi";
+      sha256 = "0fk4fwb4ym8xn0i5jv5r5y198jbpka24xmxgr8hjv5b3blgkd2iv";
+    };
+    gecko64 = fetchurl rec {
+      version = "2.47";
+      url = "http://dl.winehq.org/wine/wine-gecko/${version}/wine_gecko-${version}-x86_64.msi";
+      sha256 = "0zaagqsji6zaag92fqwlasjs8v9hwjci5c2agn9m7a8fwljylrf5";
+    };
+
+    ## see http://wiki.winehq.org/Mono
+    mono = fetchurl rec {
+      version = "4.7.3";
+      url = "http://dl.winehq.org/wine/wine-mono/${version}/wine-mono-${version}.msi";
+      sha256 = "0fkd22v2vm3ml76x1ngg42byvmry24xb92vpl4j84zhw6wbq0jnj";
+    };
+  };
+
   stable = fetchurl rec {
     version = "4.0";
     url = "https://dl.winehq.org/wine/source/4.0/wine-${version}.tar.xz";


### PR DESCRIPTION
This fixes building wine4 on darwin and also adds wine3 back, as wine4
built with nix fails to run some programs that wine3 is capable of. As such
we add `wine3` back in.