### PR TITLE
openssl: Fix Windows cross compilation

### DIFF
--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -92,7 +92,7 @@ let
           rm "$out/lib/"*.a
       fi
 
-    '' +
+    '' + stdenv.lib.optionalString (!stdenv.targetPlatform.isWindows)
     ''
       mkdir -p $bin
       substituteInPlace $out/bin/c_rehash --replace ${buildPackages.perl} ${perl}

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -92,10 +92,14 @@ let
           rm "$out/lib/"*.a
       fi
 
-    '' + stdenv.lib.optionalString (!stdenv.targetPlatform.isWindows)
+    '' +
     ''
       mkdir -p $bin
+    '' + stdenv.lib.optionalString (!stdenv.hostPlatform.isWindows)
+    ''
       substituteInPlace $out/bin/c_rehash --replace ${buildPackages.perl} ${perl}
+    '' +
+    ''
       mv $out/bin $bin/
 
       mkdir $dev
@@ -107,7 +111,7 @@ let
       rmdir $out/etc/ssl/{certs,private}
     '';
 
-    postFixup = ''
+    postFixup = stdenv.lib.optionalString (!stdenv.hostPlatform.isWindows) ''
       # Check to make sure the main output doesn't depend on perl
       if grep -r '${buildPackages.perl}' $out; then
         echo "Found an erroneous dependency on perl ^^^" >&2


### PR DESCRIPTION
Replacing `buildPackages.perl` with `perl` will require `perl` to be built for the targetPackages, hence cross compile perl when cross compiling openssl. This hopelessly fails when cross compiling to windows.