### PR TITLE
fix binutils on darwin when cross compiling

### DIFF
--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -22,7 +22,7 @@ let
                   "${stdenv.targetPlatform.config}-";
 in
 
-stdenv.mkDerivation {
+stdenv.mkDerivation ({
   name = targetPrefix + basename;
 
   # HACK to ensure that we preserve source from bootstrap binutils to not rebuild LLVM
@@ -152,4 +152,7 @@ stdenv.mkDerivation {
        collision due to the ld/as wrappers/symlinks in the latter. */
     priority = 10;
   };
-}
+} // lib.optionalAttrs (stdenv.targetPlatform != stdenv.hostPlatform && stdenv.buildPlatform.isDarwin) {
+  # See https://sourceware.org/bugzilla/show_bug.cgi?id=23424
+  CXXFLAGS = "-std=c++11 -Wno-c++11-narrowing";
+})


### PR DESCRIPTION
We can not compile binutils on darwin when cross compiling,
as compiling `gold` results in a compilation error like the following:
```
gold-threads.cc:288:13: error: expected expression
    : once_(PTHREAD_ONCE_INIT)
            ^
/usr/include/pthread.h:210:27: note: expanded from macro 'PTHREAD_ONCE_INIT'
#define PTHREAD_ONCE_INIT {_PTHREAD_ONCE_SIG_init, {0}}
```

This change adds `CXXFLAGS="-std=c++11 -Wno-c++11-narrowing"` when
cross compiling binutils on darwin to silence the error. For reference see
the upstream bug report at https://sourceware.org/bugzilla/show_bug.cgi?id=23424