### PR TITLE
tokei: 9.1.1 -> 10.0.1

### DIFF
--- a/pkgs/development/tools/misc/tokei/Cargo.lock.patch
+++ b/pkgs/development/tools/misc/tokei/Cargo.lock.patch
@@ -1,0 +1,13 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index db09bc4..1e4892d 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -961,7 +961,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "tokei"
+-version = "10.0.0"
++version = "10.0.1"
+ dependencies = [
+  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "dirs 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/pkgs/development/tools/misc/tokei/default.nix
+++ b/pkgs/development/tools/misc/tokei/default.nix
@@ -2,26 +2,35 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "tokei";
-  version = "9.1.1";
+  version = "10.0.1";
 
   src = fetchFromGitHub {
     owner = "XAMPPRocky";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0gz8m5j9p7hwylyl7cdxbli9rpy1p6lsrbym4zk647819pg4k1jp";
+    sha256 = "0g8p4f8g9zb1fqzzb1qi28idskahi5nldsma6rydjyrgi9gynpa0";
   };
 
-  cargoSha256 = "19h0ybi9qq5shvr7zix0gb24a29lqkvyfc5xbgps8wqgfrhx4nqa";
+  cargoSha256 = "0pwq1scll5ga8rw4lx97s915zvp7v171b6316cin54f2zzpbrxx5";
+
+  # Patch for v10.0.1 Cargo.lock issue
+  patches = [ ./Cargo.lock.patch ];
 
   buildInputs = stdenv.lib.optionals stdenv.isDarwin [
     libiconv darwin.apple_sdk.frameworks.Security
   ];
 
+  # enable all output formats
+  cargoBuildFlags = [ "--features" "all" ];
+
   meta = with stdenv.lib; {
-    description = "Program that displays statistics about your code";
+    description = "A program that allows you to count your code, quickly";
+    longDescription = ''
+      Tokei is a program that displays statistics about your code. Tokei will show number of files, total lines within those files and code, comments, and blanks grouped by language.
+    '';
     homepage = https://github.com/XAMPPRocky/tokei;
     license = with licenses; [ asl20 /* or */ mit ];
-    maintainers = with maintainers; [ gebner ];
+    maintainers = with maintainers; [ gebner lilyball ];
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
Enable all crate features, which gets us alternative output formats.

Update description and add long description to match what's in the GitHub repo.

Add myself as a maintainer.

###### Motivation for this change
The package was out of date and I wanted JSON output.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I built this with no feature flags, with all feature flags, and with just `includesJSONOutput` and tested that the supported output formats for each build were as expected.