### PR TITLE
Blink + dependencies: update 3.0.3 -> 3.2.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/blink/default.nix
+++ b/pkgs/applications/networking/instant-messengers/blink/default.nix
@@ -1,14 +1,15 @@
 { stdenv, fetchdarcs, pythonPackages, libvncserver, zlib
-, gnutls, libvpx, makeDesktopItem }:
+, gnutls, libvpx, makeDesktopItem, mkDerivationWith }:
 
-pythonPackages.buildPythonApplication rec {
+mkDerivationWith pythonPackages.buildPythonApplication rec {
+
   pname = "blink";
-  version = "3.0.3";
+  version = "3.2.0";
 
   src = fetchdarcs {
     url = http://devel.ag-projects.com/repositories/blink-qt;
     rev = "release-${version}";
-    sha256 = "1vj6zzfvxygz0fzr8bhymcw6j4v8xmr0kba53d6qg285j7hj1bdi";
+    sha256 = "19rcwr5scw48qnj79q1pysw95fz9h98nyc3161qy2kph5g7dwkc3";
   };
 
   patches = [ ./pythonpath.patch ];
@@ -16,9 +17,20 @@ pythonPackages.buildPythonApplication rec {
     sed -i 's|@out@|'"''${out}"'|g' blink/resources.py
   '';
 
-  propagatedBuildInputs = with pythonPackages; [ pyqt5_with_qtwebkit cjson sipsimple twisted google_api_python_client ];
+  propagatedBuildInputs = with pythonPackages; [
+    pyqt5_with_qtwebkit
+    cjson
+    sipsimple
+    twisted
+    google_api_python_client
+  ];
 
-  buildInputs = [ pythonPackages.cython zlib libvncserver libvpx ];
+  buildInputs = [
+    pythonPackages.cython
+    zlib
+    libvncserver
+    libvpx
+  ];
 
   desktopItem = makeDesktopItem {
     name = "Blink";
@@ -30,9 +42,14 @@ pythonPackages.buildPythonApplication rec {
     categories = "Application;Internet;";
   };
 
+  dontWrapQtApps = true;
+
+  makeWrapperArgs = [
+    "\${qtWrapperArgs[@]}"
+    "--prefix LD_LIBRARY_PATH: ${gnutls.out}/lib"
+  ];
+
   postInstall = ''
-    wrapProgram $out/bin/blink \
-      --prefix LD_LIBRARY_PATH ":" ${gnutls.out}/lib
     mkdir -p "$out/share/applications"
     mkdir -p "$out/share/pixmaps"
     cp "$desktopItem"/share/applications/* "$out/share/applications"

--- a/pkgs/development/python-modules/application/default.nix
+++ b/pkgs/development/python-modules/application/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonPackage rec {
   pname = "python-application";
-  version = "2.0.2";
+  version = "2.7.0";
   disabled = isPy3k;
 
   src = fetchdarcs {
     url = "http://devel.ag-projects.com/repositories/${pname}";
     rev = "release-${version}";
-    sha256 = "19dszv44py8qrq0jcjdycxpa7z2p8hi3ijq9gnqdsazbbjzf9svn";
+    sha256 = "1xpyk2v3naxkjhpyris58dxg1lxbraxgjd6f7w1sah5j0sk7psla";
   };
 
   buildInputs = [ zope_interface ];

--- a/pkgs/development/python-modules/eventlib/default.nix
+++ b/pkgs/development/python-modules/eventlib/default.nix
@@ -7,14 +7,14 @@
 
 buildPythonPackage rec {
   pname = "python-eventlib";
-  version = "0.2.2";
+  version = "0.2.4";
   # Judging from SyntaxError
   disabled = isPy3k;
 
   src = fetchdarcs {
     url = "http://devel.ag-projects.com/repositories/${pname}";
     rev = "release-${version}";
-    sha256 = "1zxhpq8i4jwsk7wmfncqfm211hqikj3hp38cfv509924bi76wak8";
+    sha256 = "1w1axsm6w9bl2smzxmyk4in1lsm8gk8ma6y183m83cpj66aqxg4z";
   };
 
   propagatedBuildInputs = [ greenlet ];

--- a/pkgs/development/python-modules/msrplib/default.nix
+++ b/pkgs/development/python-modules/msrplib/default.nix
@@ -8,12 +8,12 @@
 
 buildPythonPackage rec {
   pname = "python-msrplib";
-  version = "0.19";
+  version = "0.19.2";
 
   src = fetchdarcs {
     url = "http://devel.ag-projects.com/repositories/${pname}";
     rev = "release-${version}";
-    sha256 = "0jqvvssbwzq7bwqn3wrjfnpj8zb558mynn2visnlrcma6b57yhwd";
+    sha256 = "0d0krwv4hhspjgppnvh0iz51bvdbz23cjasgrppip7x8b00514gz";
   };
 
   propagatedBuildInputs = [ eventlib application gnutls ];

--- a/pkgs/development/python-modules/xcaplib/default.nix
+++ b/pkgs/development/python-modules/xcaplib/default.nix
@@ -8,13 +8,13 @@
 
 buildPythonPackage rec {
   pname = "python-xcaplib";
-  version = "1.2.0";
+  version = "1.2.1";
   disabled = isPy3k;
 
   src = fetchdarcs {
     url = "http://devel.ag-projects.com/repositories/${pname}";
     rev = "release-${version}";
-    sha256 = "0vna5r4ihv7z1yx6r93954jqskcxky77znzy1m9dg9vna1dgwfdn";
+    sha256 = "15ww8f0a9zh37mypw5s4q1qk44cwf7jlhc9q1z4vjlpvnzimg54v";
   };
 
   propagatedBuildInputs = [ eventlib application ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1100,7 +1100,7 @@ in
 
   bitbucket-cli = python2Packages.bitbucket-cli;
 
-  blink = callPackage ../applications/networking/instant-messengers/blink { };
+  blink = libsForQt5.callPackage ../applications/networking/instant-messengers/blink { };
 
   blockbook = callPackage ../servers/blockbook { };
 


### PR DESCRIPTION
###### Motivation for this change

New version available, with version bump of all the dependencies.

Unsure how to deal with https://github.com/NixOS/nixpkgs/issues/65399 as this is PyQt based... 

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
