### PR TITLE
datefudge: 1.22 -> 1.23

### DIFF
--- a/pkgs/tools/system/datefudge/default.nix
+++ b/pkgs/tools/system/datefudge/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation {
   pname = "datefudge";
-  version = "1.22";
+  version = "1.23";
 
   src = fetchgit {
     url = "https://salsa.debian.org/debian/datefudge.git";
-    rev = "fe27db47a0f250fb56164114fff8ae8d5af47ab6";
-    sha256 = "1fmd05r00wx4zc90lbi804jl7xwdl11jq2a1kp5lqimk3yyvfw4c";
+    rev = "090d3aace17640478f7f5119518b2f4196f62617";
+    sha256 = "0r9g8v9xnv60hq3j20wqy34kyig3sc2pisjxl4irn7jjx85f1spv";
   };
 
   patchPhase = ''


### PR DESCRIPTION
###### Motivation for this change

Version bump.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
