### PR TITLE
libnotify: use 3rd party patch to support replacing a notification

### DIFF
--- a/pkgs/development/libraries/libnotify/default.nix
+++ b/pkgs/development/libraries/libnotify/default.nix
@@ -22,10 +22,20 @@ stdenv.mkDerivation rec {
   patches = [
     # Fix darwin build
     # https://gitlab.gnome.org/GNOME/libnotify/merge_requests/9
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/libnotify/commit/55eb69247fe2b479ea43311503042fc03bf4e67d.patch";
-      sha256 = "1hlb5b7c5axiyir1i5j2pi94bm2gyr1ybkp6yaqy7yk6iiqlvv50";
-    })
+    (
+      fetchpatch {
+        url = "https://gitlab.gnome.org/GNOME/libnotify/commit/55eb69247fe2b479ea43311503042fc03bf4e67d.patch";
+        sha256 = "1hlb5b7c5axiyir1i5j2pi94bm2gyr1ybkp6yaqy7yk6iiqlvv50";
+      }
+    )
+
+    # add support for replacing an existing notification
+    (
+      fetchpatch {
+        url = "https://launchpadlibrarian.net/105791133/print-and-replace-id-v3.patch";
+        sha256 = "1lfk5msv81brz7f7srxi4s4l02nasskzmpq0b9ch8hbn79z86g0b";
+      }
+    )
   ];
 
   mesonFlags = [
@@ -55,8 +65,8 @@ stdenv.mkDerivation rec {
   };
 
   meta = with stdenv.lib; {
-    homepage = https://developer.gnome.org/notification-spec/;
     description = "A library that sends desktop notifications to a notification daemon";
+    homepage = "https://developer.gnome.org/notification-spec/";
     platforms = platforms.unix;
     maintainers = gnome3.maintainers;
     license = licenses.lgpl21;


### PR DESCRIPTION
###### Motivation for this change

While the dbus notification interface supports replacing an existing notification, ```notify-send``` does not.

This uses a very simple 3rd party patch to add this functionality.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @jtojnar 
