### PR TITLE
pythonPackages.flaky: 3.5.3 -> 3.6.1

### DIFF
--- a/pkgs/development/python-modules/flaky/default.nix
+++ b/pkgs/development/python-modules/flaky/default.nix
@@ -2,22 +2,29 @@
 , buildPythonPackage
 , fetchPypi
 , mock
+, nose
 , pytest
 }:
 
 buildPythonPackage rec {
   pname = "flaky";
-  version = "3.5.3";
+  version = "3.6.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "12bd5e41f372b2190e8d754b6e5829c2f11dbc764e10b30f57e59f829c9ca1da";
+    sha256 = "8cd5455bb00c677f787da424eaf8c4a58a922d0e97126d3085db5b279a98b698";
   };
 
-  buildInputs = [ mock pytest ];
+  checkInputs = [ mock nose pytest ];
 
-  # waiting for feedback https://github.com/box/flaky/issues/97
-  doCheck = false;
+  checkPhase = ''
+    # based on tox.ini
+    pytest -k 'example and not options' --doctest-modules test/test_pytest/
+    pytest -k 'example and not options' test/test_pytest/
+    pytest -p no:flaky test/test_pytest/test_flaky_pytest_plugin.py
+    nosetests --with-flaky --force-flaky --max-runs 2 test/test_nose/test_nose_options_example.py
+    pytest --force-flaky --max-runs 2  test/test_pytest/test_pytest_options_example.py
+  '';
 
   meta = with stdenv.lib; {
     homepage = https://github.com/box/flaky;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Version update. This update fixes annoying bug https://github.com/box/flaky/issues/156

Might be worth backporting to 19.09.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
