### PR TITLE
dante: add darwin support

### DIFF
--- a/pkgs/servers/dante/default.nix
+++ b/pkgs/servers/dante/default.nix
@@ -11,15 +11,15 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ pam libkrb5 cyrus_sasl miniupnpc ];
 
-  configureFlags = [
-    "--with-libc=libc.so.6"
-  ];
+  configureFlags = ["--with-libc=libc${stdenv.targetPlatform.extensions.sharedLibrary}"];
+
+  dontAddDisableDepTrack = stdenv.isDarwin;
 
   meta = with stdenv.lib; {
     description = "A circuit-level SOCKS client/server that can be used to provide convenient and secure network connectivity.";
     homepage    = "https://www.inet.no/dante/";
     maintainers = [ maintainers.arobyn ];
     license     = licenses.bsdOriginal;
-    platforms   = platforms.linux;
+    platforms   = platforms.linux ++ platforms.darwin;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
This is a dependency of aerc that I want to install.
I looked at how homebrew does it: https://github.com/Homebrew/homebrew-core/blob/master/Formula/dante.rb

It seems that dependency tracking is a requirement on Mac OS.
When compiled with `--with-libc=libc.so.6` socksify fails with: `socksify: error: dante client not built with preloading support.`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
