### PR TITLE
matrix-synapse: fix startup

### DIFF
--- a/pkgs/servers/matrix-synapse/default.nix
+++ b/pkgs/servers/matrix-synapse/default.nix
@@ -36,6 +36,7 @@ in buildPythonApplication rec {
   ];
 
   propagatedBuildInputs = [
+    setuptools
     bcrypt
     bleach
     canonicaljson


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Currently, `setuptools` isn't propagated automatically to python
packages[1] which causes the following error when starting
`matrix-synapse`:

```
Traceback (most recent call last):
   File "/nix/store/xxkds7821mrahfx75az0sq3ryf69m612-matrix-synapse-1.3.1/bin/.homeserver-wrapped", line 39, in <module>
     import synapse.config.logger
   File "/nix/store/xxkds7821mrahfx75az0sq3ryf69m612-matrix-synapse-1.3.1/lib/python3.7/site-packages/synapse/config/logger.py", line 27, in <module>
     from synapse.app import _base as appbase
   File "/nix/store/xxkds7821mrahfx75az0sq3ryf69m612-matrix-synapse-1.3.1/lib/python3.7/site-packages/synapse/app/__init__.py", line 18, in <module>
     from synapse import python_dependencies  # noqa:E402
   File "/nix/store/xxkds7821mrahfx75az0sq3ryf69m612-matrix-synapse-1.3.1/lib/python3.7/site-packages/synapse/python_dependencies.py", line 19, in <module>
     from pkg_resources import (
 No module named 'pkg_resources'
```

[1] https://github.com/NixOS/nixpkgs/pull/68314



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
