### PR TITLE
[WIP] pythonPackages.pysmt: init at 0.8.0

### DIFF
--- a/pkgs/development/python-modules/pysmt/default.nix
+++ b/pkgs/development/python-modules/pysmt/default.nix
@@ -1,0 +1,29 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+, nose
+, six
+}:
+
+buildPythonPackage rec {
+  pname = "PySMT";
+  version = "0.8.0";
+
+  propagatedBuildInputs = [ six ];
+
+  src = fetchFromGitHub {
+    owner = "pysmt";
+    repo = "pysmt";
+    rev = "v${version}";
+    sha256 = "1s06vq06x4sm84016vsq7bb74d0wkia4193wzxqzs9pmlqwpjnrf";
+  };
+
+  checkInputs = [ nose ];
+
+  meta = with lib; {
+    description = "A solver-agnostic library for SMT Formulae manipulation and solving";
+    homepage = "https://github.com/pysmt/pysmt";
+    license = licenses.asl20;
+    maintainers = [ maintainers.pamplemousse ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -987,6 +987,8 @@ in {
 
   pyres = callPackage ../development/python-modules/pyres { };
 
+  PySMT = callPackage ../development/python-modules/pysmt { };
+
   pyqt4 = callPackage ../development/python-modules/pyqt/4.x.nix {
     inherit (pkgs) pkgconfig;
   };


### PR DESCRIPTION
###### Motivation for this change

I am trying to make [angr](http://angr.io/), the binary analysis framework, available on NixOS.
This is part of the modules it requires.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).