### PR TITLE
pythonPackages.pefile: init at 2019.4.18

### DIFF
--- a/pkgs/development/python-modules/pefile/default.nix
+++ b/pkgs/development/python-modules/pefile/default.nix
@@ -1,0 +1,30 @@
+{ buildPythonPackage
+, future
+, fetchPypi
+, lib
+}:
+
+buildPythonPackage rec {
+  pname = "pefile";
+  version = "2019.4.18";
+
+  propagatedBuildInputs = [ future ];
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "a5d6e8305c6b210849b47a6174ddf9c452b2888340b8177874b862ba6c207645";
+  };
+
+  # Test data encrypted.
+  doCheck = false;
+
+  # Verify import still works.
+  pythonImportsCheck = [ "pefile" ];
+
+  meta = with lib; {
+    description = "Multi-platform Python module to parse and work with Portable Executable (aka PE) files";
+    homepage = "https://github.com/erocarrera/pefile";
+    license = licenses.mit;
+    maintainers = [ maintainers.pamplemousse ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -835,6 +835,8 @@ in {
 
   pyperf = callPackage ../development/python-modules/pyperf { };
 
+  pefile = callPackage ../development/python-modules/pefile { };
+
   perfplot = callPackage ../development/python-modules/perfplot { };
 
   phonopy = callPackage ../development/python-modules/phonopy { };


### PR DESCRIPTION
###### Motivation for this change

I am trying to make [angr](http://angr.io/), the binary analysis framework, available on NixOS.
This is part of the modules it requires.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).