### PR TITLE
pythonPackages.itanium_demangler: init at 1.0

### DIFF
--- a/pkgs/development/python-modules/itanium_demangler/default.nix
+++ b/pkgs/development/python-modules/itanium_demangler/default.nix
@@ -1,0 +1,30 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "itanium_demangler";
+  version = "1.0"; # pulled from pypi version
+
+  src = fetchFromGitHub {
+    owner = "whitequark";
+    repo = "python-${pname}";
+    rev = "29c77860be48e6dafe3496e4d9d0963ce414e366";
+    sha256 = "0qm95l6542nk63986w9lgzkxg824l31714i584s02rh9xwfg1xfx";
+  };
+
+  checkInputs = [ pytest ];
+
+  checkPhase = ''
+    pytest tests/test.py
+  '';
+
+  meta = with lib; {
+    description = "A pure Python parser for the Itanium C++ ABI symbol mangling language";
+    homepage = "https://github.com/whitequark/python-itanium_demangler";
+    license = licenses.bsd0;
+    maintainers = [ maintainers.pamplemousse ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -710,6 +710,8 @@ in {
 
   inquirer = callPackage ../development/python-modules/inquirer { };
 
+  itanium_demangler = callPackage ../development/python-modules/itanium_demangler { };
+
   janus = callPackage ../development/python-modules/janus { };
 
   jira = callPackage ../development/python-modules/jira { };


### PR DESCRIPTION
###### Motivation for this change

I am trying to make [angr](http://angr.io/), the binary analysis framework, available on NixOS.
This is part of the modules it requires.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).