### PR TITLE
pythonPackages.ana: init at 0.06

### DIFF
--- a/pkgs/development/python-modules/ana/default.nix
+++ b/pkgs/development/python-modules/ana/default.nix
@@ -1,0 +1,24 @@
+{ buildPythonPackage
+, fetchPypi
+, future
+, pkgs
+}:
+
+buildPythonPackage rec {
+  pname = "ana";
+  version = "0.06";
+
+  propagatedBuildInputs = [ future ];
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "5fa16e511773a0efc6ac9294f93eee583612ffb580859737eed07e703947d6f8";
+  };
+
+  meta = with pkgs.lib; {
+    description = "Easy distributed data storage for stuff";
+    homepage = "https://github.com/zardus/ana";
+    license = licenses.bsd2;
+    maintainers = [ maintainers.pamplemousse ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -163,6 +163,8 @@ in {
 
   aioamqp = callPackage ../development/python-modules/aioamqp { };
 
+  ana = callPackage ../development/python-modules/ana { };
+
   ansicolor = callPackage ../development/python-modules/ansicolor { };
 
   anytree = callPackage ../development/python-modules/anytree {


### PR DESCRIPTION
###### Motivation for this change

I am trying to make [angr](http://angr.io/), the binary analysis framework, available on NixOS.
This is part of the modules it requires.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).