### PR TITLE
pythonPackages.cooldict: init at unstable-2019-10-29

### DIFF
--- a/pkgs/development/python-modules/cooldict/default.nix
+++ b/pkgs/development/python-modules/cooldict/default.nix
@@ -1,0 +1,29 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+}:
+
+buildPythonPackage rec {
+  pname = "cooldict";
+  version = "unstable-2019-10-29";
+
+  src = fetchFromGitHub {
+    owner = "zardus";
+    repo = pname;
+    rev = "32d56888b555f4513a0e41193bfa49e0e5497a7b";
+    sha256 = "1nwf2gd6mx9nm0s9bg0xd5a7b286ph0789fnadri5yd8qqfwr50i";
+  };
+
+  # No tests in repo.
+  doCheck = false;
+
+  # Verify imports still work.
+  pythonImportsCheck = [ "cooldict" ];
+
+  meta = with lib; {
+    description = "Some useful dict-like structures";
+    homepage = "https://github.com/zardus/cooldict";
+    license = licenses.bsd2;
+    maintainers = [ maintainers.pamplemousse ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -483,6 +483,8 @@ in {
 
   connexion = callPackage ../development/python-modules/connexion { };
 
+  cooldict = callPackage ../development/python-modules/cooldict { };
+
   cozy = callPackage ../development/python-modules/cozy { };
 
   codespell = callPackage ../development/python-modules/codespell { };


### PR DESCRIPTION
###### Motivation for this change

I am trying to make [angr](http://angr.io/), the binary analysis framework, available on NixOS.
This is part of the modules it requires.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).