### PR TITLE
pythonPackages.mulpyplexer: init at 0.08

### DIFF
--- a/pkgs/development/python-modules/mulpyplexer/default.nix
+++ b/pkgs/development/python-modules/mulpyplexer/default.nix
@@ -1,0 +1,21 @@
+{ buildPythonPackage
+, fetchPypi
+, lib
+}:
+
+buildPythonPackage rec {
+  pname = "mulpyplexer";
+  version = "0.08";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "ca930b229e21fe0ed259788e2d871eb13e54d17e29d7f25347573ae87768c5fe";
+  };
+
+  meta = with lib; {
+    description = "Multiplex interactions with lists of python objects";
+    homepage = "https://github.com/zardus/mulpyplexer";
+    license = licenses.bsd2;
+    maintainers = [ maintainers.pamplemousse ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -740,6 +740,8 @@ in {
   msrestazure = callPackage ../development/python-modules/msrestazure { };
   msrest = callPackage ../development/python-modules/msrest { };
 
+  mulpyplexer = callPackage ../development/python-modules/mulpyplexer { };
+
   multiset = callPackage ../development/python-modules/multiset { };
 
   mwclient = callPackage ../development/python-modules/mwclient { };


### PR DESCRIPTION
###### Motivation for this change

I am trying to make [angr](http://angr.io/), the binary analysis framework, available on NixOS.
This is part of the modules it requires.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).