### PR TITLE
pythonPackages.z3-solver: init at 4.8.5.0

### DIFF
--- a/pkgs/development/python-modules/z3-solver/default.nix
+++ b/pkgs/development/python-modules/z3-solver/default.nix
@@ -1,0 +1,31 @@
+{ buildPythonPackage
+, fetchPypi
+, lib
+, setuptools
+}:
+
+buildPythonPackage rec {
+  pname = "z3-solver";
+  version = "4.8.5.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0qpfhpdvlmif94ckbf5lwqfn0jv9j8f5ph38pqlzp60w4lh80xpj";
+  };
+
+  propagatedBuildInputs = [ setuptools ];
+
+  setupPyBuildFlags = [
+     "--plat-name x86_64-linux"
+   ];
+
+  # tests require other angr related components
+  doCheck = false;
+
+  meta = with lib; {
+    description = "angr's version of the python binding for the Z3 theorem prover";
+    homepage = "https://github.com/angr/z3";
+    license = licenses.mit;
+    maintainers = [ maintainers.pamplemousse ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6196,6 +6196,8 @@ in {
     inherit python;
   })).python;
 
+  z3-solver = callPackage ../development/python-modules/z3-solver { };
+
   zeroc-ice = callPackage ../development/python-modules/zeroc-ice { };
 
   zm-py = callPackage ../development/python-modules/zm-py { };


### PR DESCRIPTION
###### Motivation for this change

I am trying to make [angr](http://angr.io/), the binary analysis framework, available on NixOS.
This is part of the modules it requires.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).