### PR TITLE
Ktorrent: cherry-pick 5.1.0 -> 5.1.2 update to 19.09

### DIFF
--- a/pkgs/applications/networking/p2p/ktorrent/default.nix
+++ b/pkgs/applications/networking/p2p/ktorrent/default.nix
@@ -7,11 +7,11 @@
 
 stdenv.mkDerivation rec {
   pname = "ktorrent";
-  version = "${libktorrent.mainVersion}.0";
+  version = "${libktorrent.mainVersion}";
 
   src = fetchurl {
     url    = "mirror://kde/stable/ktorrent/${libktorrent.mainVersion}/${pname}-${version}.tar.xz";
-    sha256 = "18w6qh09k84qpzaxxb76a4g59k4mx5wk897vqp1wwv80g0pqhmrw";
+    sha256 = "0kwd0npxfg4mdh7f3xadd2zjlqalpb1jxk61505qpcgcssijf534";
   };
 
   nativeBuildInputs = [ cmake kdoctools extra-cmake-modules ];
@@ -20,24 +20,6 @@ stdenv.mkDerivation rec {
     qtbase qtscript
     karchive kcrash kdnssd ki18n kio knotifications knotifyconfig kross kcmutils kwindowsystem
     libktorrent taglib libgcrypt kplotting
-  ];
-
-  patches = [
-    # Fix build with CMake 3.11
-    (fetchpatch {
-      url = "https://cgit.kde.org/ktorrent.git/patch/?id=672c5076de7e3a526d9bdbb484a69e9386bc49f8";
-      sha256 = "1cn4rnbhadrsxqx50fawpd747azskavbjraygr6s11rh1wbfrxid";
-    })
-
-    # Fix build against Qt 5.11
-    (fetchpatch {
-      url = "https://cgit.kde.org/ktorrent.git/patch/?id=7876857d204188016a135a25938d9f8530fba4e8";
-      sha256 = "1wnmfzkhf6y7fd0z2djwphs6i9lsg7fcrj8fqmbyi0j57dvl9gxl";
-    })
-    (fetchpatch {
-      url = "https://cgit.kde.org/ktorrent.git/patch/?id=36d112e56e56541d439326a267eb906da8b3ee60";
-      sha256 = "1d41pqniljhwqs6awa644s6ks0zwm9sr0hpfygc63wyxnpcrsw2y";
-    })
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/libktorrent/default.nix
+++ b/pkgs/development/libraries/libktorrent/default.nix
@@ -4,14 +4,15 @@
 }:
 
 let
-    mainVersion = "5.1";
+  mainVersion = "5.1.2";
 
 in stdenv.mkDerivation rec {
-  name = "libktorrent-2.1";
+  pname = "libktorrent";
+  version = "2.1.1";
 
   src = fetchurl {
-    url    = "mirror://kde/stable/ktorrent/${mainVersion}/${name}.tar.xz";
-    sha256 = "0vz2dwc4xd80q56g6r5bx5wqdl9fxcibxmw2irahqhbkxk7drvry";
+    url    = "mirror://kde/stable/ktorrent/${mainVersion}/${pname}-${version}.tar.xz";
+    sha256 = "0051zh8bb4p9wmcfn5ql987brhsaiw9880xdck7b5dm1a05mri2w";
   };
 
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
#68361 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @NixOS/backports 
