### PR TITLE
pythonPackages.pivy: fix build

### DIFF
--- a/pkgs/development/python-modules/pivy/default.nix
+++ b/pkgs/development/python-modules/pivy/default.nix
@@ -28,6 +28,9 @@ buildPythonPackage rec {
     "-I${pkgs.qt5.qtbase.dev}/include/QtWidgets"
   ];
 
+  dontUseQmakeConfigure = true;
+  dontUseCmakeConfigure = true;
+
   doCheck = false;
 
   postPatch = ''
@@ -39,6 +42,7 @@ buildPythonPackage rec {
     homepage = http://pivy.coin3d.org/;
     description = "A Python binding for Coin";
     license = licenses.bsd0;
+    maintainers = with maintainers; [ gebner ];
   };
 
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

ZHF #68361

I have absolutely no idea what changed so that we now need to disable qmake and cmake explicitly.  Anyway, it builds now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
