### PR TITLE
qtwebkit: fixing build / reducing build log size

### DIFF
--- a/pkgs/development/libraries/qt-5/modules/qtwebkit.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebkit.nix
@@ -51,8 +51,12 @@ qtModule {
   '';
 
   NIX_CFLAGS_COMPILE =
-    # with gcc7 this warning blows the log over Hydra's limit
-    [ "-Wno-expansion-to-defined" ]
+    [
+      # with gcc7 this warning blows the log over Hydra's limit
+      "-Wno-expansion-to-defined"
+      # with gcc8, -Wclass-memaccess became part of -Wall and this too exceeds the logging limit
+      "-Wno-class-memaccess"
+    ]
     # with clang this warning blows the log over Hydra's limit
     ++ optional stdenv.isDarwin "-Wno-inconsistent-missing-override"
     ++ optionals flashplayerFix


### PR DESCRIPTION
###### Motivation for this change

GCC 8 introduced a new type of warning `-Wclass-memaccess` which
is included in `-Wall`. This warning spits out *a million* of lines
like the following:

```
[...]
/build/source/Source/WTF/wtf/Vector.h:128:15: warning: 'void* memcpy(void*, const void*, size_t)' writing to an object of type 'class WTF::RefPtr<WebCore::TransformOperation>' with no trivial copy-assignment; use copy-assignment or copy-initialization instead [-Wclass-memaccess]
         memcpy(dst, src, reinterpret_cast<const char*>(srcEnd) - reinterpret_cast<const char*>(src));
[...]
```

Logs demonstrating the issue:
https://hydra.nixos.org/build/100205478/nixlog/1

While I don't think disabling warnings is the best way to deal with this,
there is alrady precedent for this package and I don't feel confident enough
to either patch or bump this package.

Please view this as a low-friction sub-optimal suggestion in case nobody else
has a better fix.

The build is currently still running on my machine, as it takes a while, but the log is definitely not as spammy anymore.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @abbradar
cc @periklis

https://github.com/NixOS/nixpkgs/issues/68361