### PR TITLE
nixos/nextcloud: fix postgresql/redis test

### DIFF
--- a/nixos/tests/nextcloud/with-postgresql-and-redis.nix
+++ b/nixos/tests/nextcloud/with-postgresql-and-redis.nix
@@ -27,7 +27,7 @@ in {
           dbtype = "pgsql";
           dbname = "nextcloud";
           dbuser = "nextcloud";
-          dbhost = "localhost:5432";
+          dbhost = "/run/postgresql";
           inherit adminuser;
           adminpassFile = toString (pkgs.writeText "admin-pass-file" ''
             ${adminpass}
@@ -61,8 +61,8 @@ in {
   testScript = let
     configureRedis = pkgs.writeScript "configure-redis" ''
       #!${pkgs.stdenv.shell}
-      nextcloud-occ config:system:set redis 'host' --value 'localhost:6379' --type string
-      nextcloud-occ config:system:set redis 'port' --value 0 --type integer
+      nextcloud-occ config:system:set redis 'host' --value 'localhost' --type string
+      nextcloud-occ config:system:set redis 'port' --value 6379 --type integer
       nextcloud-occ config:system:set memcache.local --value '\OC\Memcache\Redis' --type string
       nextcloud-occ config:system:set memcache.locking --value '\OC\Memcache\Redis' --type string
     '';

--- a/nixos/tests/nextcloud/with-postgresql-and-redis.nix
+++ b/nixos/tests/nextcloud/with-postgresql-and-redis.nix
@@ -27,7 +27,7 @@ in {
           dbtype = "pgsql";
           dbname = "nextcloud";
           dbuser = "nextcloud";
-          dbhost = "/run/postgresql";
+          dbhost = "localhost:5432";
           inherit adminuser;
           adminpassFile = toString (pkgs.writeText "admin-pass-file" ''
             ${adminpass}
@@ -36,47 +36,14 @@ in {
       };
 
       services.redis = {
-        unixSocket = "/var/run/redis/redis.sock";
         enable = true;
-        extraConfig = ''
-          unixsocketperm 770
-        '';
-      };
-
-      systemd.services.redis = {
-        preStart = ''
-          mkdir -p /var/run/redis
-          chown ${config.services.redis.user}:${config.services.nginx.group} /var/run/redis
-        '';
-        serviceConfig.PermissionsStartOnly = true;
       };
 
       systemd.services.nextcloud-setup= {
         requires = ["postgresql.service"];
         after = [
           "postgresql.service"
-          "chown-redis-socket.service"
         ];
-      };
-
-      # At the time of writing, redis creates its socket with the "nobody"
-      # group.  I figure this is slightly less bad than making the socket world
-      # readable.
-      systemd.services.chown-redis-socket = {
-        enable = true;
-        script = ''
-          until ${pkgs.redis}/bin/redis-cli ping; do
-            echo "waiting for redis..."
-            sleep 1
-          done
-          chown ${config.services.redis.user}:${config.services.nginx.group} /var/run/redis/redis.sock
-        '';
-        after = [ "redis.service" ];
-        requires = [ "redis.service" ];
-        wantedBy = [ "redis.service" ];
-        serviceConfig = {
-          Type = "oneshot";
-        };
       };
 
       services.postgresql = {
@@ -94,7 +61,7 @@ in {
   testScript = let
     configureRedis = pkgs.writeScript "configure-redis" ''
       #!${pkgs.stdenv.shell}
-      nextcloud-occ config:system:set redis 'host' --value '/var/run/redis/redis.sock' --type string
+      nextcloud-occ config:system:set redis 'host' --value 'localhost:6379' --type string
       nextcloud-occ config:system:set redis 'port' --value 0 --type integer
       nextcloud-occ config:system:set memcache.local --value '\OC\Memcache\Redis' --type string
       nextcloud-occ config:system:set memcache.locking --value '\OC\Memcache\Redis' --type string


### PR DESCRIPTION
##### Motivation for this change
While reviewing ##68435, I noticed one of the tests were failing on master.

`redis.user` option was removed  here  #67845

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @flokli @eqyiel @Infinisil 
