### PR TITLE
ibus-engines.mozc: fix build

### DIFF
--- a/pkgs/tools/inputmethods/ibus-engines/ibus-mozc/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-mozc/default.nix
@@ -1,5 +1,5 @@
-{ clangStdenv, fetchFromGitHub, which, ninja, python, gyp, pkgconfig, protobuf
-, ibus, gtk2, zinnia, qt5, libxcb }:
+{ clangStdenv, fetchFromGitHub, fetchpatch, which, ninja, python, gyp, pkgconfig
+, protobuf, ibus, gtk2, zinnia, qt5, libxcb }:
 
 let
   japanese_usage_dictionary = fetchFromGitHub {
@@ -30,6 +30,14 @@ in clangStdenv.mkDerivation rec {
     rev    = "afb03ddfe72dde4cf2409863a3bfea160f7a66d8";
     sha256 = "0w2dy2j9x5nc7x3g95j17r3m60vbfyn5j617h7js9xryv33yzpgx";
   };
+
+  patches = [
+    # https://github.com/google/mozc/pull/444 - fix for gcc8 STL
+    (fetchpatch {
+      url = "https://github.com/google/mozc/commit/82d38f929882a9c62289b179c6fe41efed249987.patch";
+      sha256 = "07cja1b7qfsd3i76nscf1zwiav74h7d6h2g9g2w4bs3h1mc9jwla";
+    })
+  ];
 
   postUnpack = ''
     rmdir $sourceRoot/src/third_party/japanese_usage_dictionary/


### PR DESCRIPTION
###### Motivation for this change

This fixes the build after the gcc8 upgrade:

```
FAILED: obj/engine/engine.engine.o
clang++ -MMD -MF obj/engine/engine.engine.o.d -DOS_LINUX -DMOZC_BUILD -DCHANNEL_DEV -DENABLE_GTK_RENDERER -DNDEBUG -DQT_NO_DEBUG -DNO_LOGGING -DIGNORE_HELP_FLAG -DIGNORE_INVALID_FLAG -I/build/source/src -Igen -Igen/proto_out -Wall -Wno-char-subscripts -Wno-sign-compare -Wno-deprecated-declarations -Wwrite-strings -Wno-unknown-warning-option -Wno-inconsistent-missing-override -fPIC -fno-exceptions -fmessage-length=0 -fno-strict-aliasing -funsigned-char -pipe -pthread -fno-omit-frame-pointer -fstack-protector --param=ssp-buffer-size=4 -Wtype-limits -O2 -Wno-deprecated -Wno-covered-switch-default -Wno-unnamed-type-template-args -Wno-c++11-narrowing -std=gnu++0x -std=gnu++0x  -c ../../engine/engine.cc -o obj/engine/engine.engine.o
In file included from ../../engine/engine.cc:30:
In file included from /build/source/src/engine/engine.h:33:
In file included from /nix/store/pcs8pq4a5rkym1hzibqz7da45fxkmig7-gcc-8.3.0/include/c++/8.3.0/memory:62:
In file included from /nix/store/pcs8pq4a5rkym1hzibqz7da45fxkmig7-gcc-8.3.0/include/c++/8.3.0/bits/stl_algobase.h:66:
/nix/store/pcs8pq4a5rkym1hzibqz7da45fxkmig7-gcc-8.3.0/include/c++/8.3.0/bits/stl_iterator_base_funcs.h:183:2: error: cannot decrement value of type 'mozc::ZeroQueryDict::iterator'
        --__i;
        ^ ~~~
/nix/store/pcs8pq4a5rkym1hzibqz7da45fxkmig7-gcc-8.3.0/include/c++/8.3.0/bits/stl_iterator_base_funcs.h:206:12: note: in instantiation of function template specialization 'std::__advance<mozc::ZeroQueryDict::iterator, long>' requested here
      std::__advance(__i, __d, std::__iterator_category(__i));
           ^
/nix/store/pcs8pq4a5rkym1hzibqz7da45fxkmig7-gcc-8.3.0/include/c++/8.3.0/bits/stl_algo.h:2137:9: note: in instantiation of function template specialization 'std::advance<mozc::ZeroQueryDict::iterator, long>' requested here
          std::advance(__middle, __half);
               ^
/nix/store/pcs8pq4a5rkym1hzibqz7da45fxkmig7-gcc-8.3.0/include/c++/8.3.0/bits/stl_algo.h:2190:19: note: in instantiation of function template specialization 'std::__equal_range<mozc::ZeroQueryDict::iterator, unsigned long, __gnu_cxx::__ops::_Iter_less_val, __gnu_cxx::__ops::_Val_less_iter>' requested here
      return std::__equal_range(__first, __last, __val,
                  ^
/build/source/src/prediction/zero_query_dict.h:213:17: note: in instantiation of function template specialization 'std::equal_range<mozc::ZeroQueryDict::iterator, unsigned long>' requested here
    return std::equal_range(begin(), end(), iter.index());
                ^
1 error generated.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Did not run this on master but the build inputs are identical to #68445, so this probably works as it does on release-19.09.

###### Notify maintainers

cc @gebner @ericsagnes
