### PR TITLE
repmgr: init at 4.4.0

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/repmgr.nix
+++ b/pkgs/servers/sql/postgresql/ext/repmgr.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, postgresql, openssl, zlib, readline }:
+
+stdenv.mkDerivation rec {
+  pname = "repmgr";
+  version = "4.4.0";
+
+  src = fetchFromGitHub {
+    owner = "2ndQuadrant";
+    repo = "repmgr";
+    rev = "v${version}";
+    sha256 = "185789f7igvlqyqcb8kf42jjq8g0wbs2aqd9kimrq5kf4srwgpim";
+  };
+
+  installPhase = ''
+    mkdir -p $out/{lib,share/postgresql/extension}
+
+    cp *.so      $out/lib
+    cp *.sql     $out/share/postgresql/extension
+    cp *.control $out/share/postgresql/extension
+  '';
+
+  buildInputs = [ postgresql openssl zlib readline ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://repmgr.org/";
+    description = "Replication manager for PostgreSQL cluster";
+    license = licenses.postgresql;
+    maintainers = with maintainers; [ zimbatm ];
+  };
+}

--- a/pkgs/servers/sql/postgresql/packages.nix
+++ b/pkgs/servers/sql/postgresql/packages.nix
@@ -50,4 +50,6 @@ self: super: {
     pg_partman = super.callPackage ./ext/pg_partman.nix { };
 
     pg_safeupdate = super.callPackage ./ext/pg_safeupdate.nix { };
+
+    repmgr = super.callPackage ./ext/repmgr.nix { };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
