### PR TITLE
gnome-multi-writer: init at 3.32.1

### DIFF
--- a/pkgs/applications/misc/gnome-multi-writer/default.nix
+++ b/pkgs/applications/misc/gnome-multi-writer/default.nix
@@ -1,0 +1,62 @@
+{ stdenv
+, fetchurl
+, appstream-glib
+, desktop-file-utils
+, gettext
+, glib
+, gnome3
+, gtk3
+, gusb
+, libcanberra-gtk3
+, libgudev
+, meson
+, ninja
+, pkgconfig
+, wrapGAppsHook
+, polkit
+, udisks
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gnome-multi-writer";
+  version = "3.32.1";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "1apdd8yi12zagf82k376a9wmdm27wzwdxpm2wf2pnwkaf786rmdw";
+  };
+
+  nativeBuildInputs = [
+    appstream-glib
+    desktop-file-utils
+    gettext
+    meson
+    ninja
+    pkgconfig
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    glib
+    gtk3
+    gusb
+    libcanberra-gtk3
+    libgudev
+    polkit
+    udisks
+  ];
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = pname;
+    };
+  };
+
+  meta = with stdenv.lib; {
+    description = "Tool for writing an ISO file to multiple USB devices at once";
+    homepage = https://wiki.gnome.org/Apps/MultiWriter;
+    license = licenses.gpl2Plus;
+    maintainers = gnome3.maintainers;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9589,6 +9589,8 @@ in
 
   gnome-latex = callPackage ../applications/editors/gnome-latex/default.nix { };
 
+  gnome-multi-writer = callPackage ../applications/misc/gnome-multi-writer {};
+
   gnome-online-accounts = callPackage ../development/libraries/gnome-online-accounts { };
 
   gnome-video-effects = callPackage ../development/libraries/gnome-video-effects { };


### PR DESCRIPTION
###### Motivation for this change
Another branch that I forgot to PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
