### PR TITLE
cue: 0.0.3 -> 0.0.9

### DIFF
--- a/pkgs/development/tools/cue/default.nix
+++ b/pkgs/development/tools/cue/default.nix
@@ -1,16 +1,17 @@
-{ buildGoModule, fetchgit, stdenv }:
+{ buildGoModule, fetchFromGitHub, stdenv }:
 
 buildGoModule rec {
   pname = "cue";
-  version = "0.0.3";
+  version = "0.0.9";
 
-  src = fetchgit {
-    url = "https://cue.googlesource.com/cue";
+  src = fetchFromGitHub {
+    owner = "cuelang";
+    repo = "cue";
     rev = "v${version}";
-    sha256 = "1abvvgicr64ssiprkircih2nrbcr1yqxf1qkl21kh0ww1xfp0rw7";
+    sha256 = "1nnwfvw8pkzqqzkw3g32szpwwnwnyyghd3wk3qq3gzbj43ac38bp";
   };
 
-  modSha256 = "0r5vbplcfq1rsp2jnixq6lfbpcv7grf0q38na76qy7pjb57zikb6";
+  modSha256 = "18fd2sa8xgskky0nrjf3qndv8crrwbp9nq9f4i68bdc82p8a7gfs";
 
   subPackages = [ "cmd/cue" ];
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Upstream update
Blocks https://github.com/NixOS/nixpkgs/pull/68135

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @solson 
