### PR TITLE
git-lfs: 2.7.2 -> 2.8.0, ensure go 1.13 compatibility

### DIFF
--- a/pkgs/applications/version-management/git-lfs/default.nix
+++ b/pkgs/applications/version-management/git-lfs/default.nix
@@ -1,26 +1,32 @@
-{ stdenv, buildGoPackage, fetchFromGitHub }:
+{ stdenv, buildGoModule, fetchFromGitHub, fetchpatch }:
 
-buildGoPackage rec {
+buildGoModule rec {
   pname = "git-lfs";
-  version = "2.7.2";
-
-  goPackagePath = "github.com/git-lfs/git-lfs";
+  version = "2.8.0";
 
   src = fetchFromGitHub {
     rev = "v${version}";
     owner = "git-lfs";
     repo = "git-lfs";
-    sha256 = "1nf40rbdz901vsahg5cm09pznpina6wimmxl0lmh8pn0mi51yzvc";
+    sha256 = "17x9q4g1acf51bxr9lfmd2ym7w740n4ghdi0ncmma77kwabw9d3x";
   };
 
-  preBuild = ''
-    pushd go/src/github.com/git-lfs/git-lfs
-    go generate ./commands
-    popd
-  '';
+  modSha256 = "1rjscc52rh8kxa64canw3baljllp1c639nsn89hs5b86c8v1jav7";
 
-  postInstall = ''
-    rm -v $bin/bin/{man,script,cmd}
+  patches = [
+    (fetchpatch {
+      # Build fails on v2.8.0 with go 1.13 due to invalid dependency version:
+      #   go: github.com/git-lfs/go-ntlm@v0.0.0-20190307203151-c5056e7fa066: invalid pseudo-version: does not match version-control timestamp (2019-04-01T17:57:52Z)
+      # TODO: Remove once https://github.com/git-lfs/git-lfs/commit/cd83f4224ce02398bdbf8b05830d92220d9b8e01 lands in a release.
+      url = "https://github.com/git-lfs/git-lfs/commit/cd83f4224ce02398bdbf8b05830d92220d9b8e01.patch";
+      sha256 = "17nmnlkknglqhzrky5caskbscrjp7kp9b5mfqznh1jx2hbxzlpbj";
+    })
+  ];
+
+  subPackages = [ "." ];
+
+  preBuild = ''
+    go generate ./commands
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Upstream update
Blocks #68135 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @twey
