### PR TITLE
netcat: fix default path to ca-bundle

### DIFF
--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, lib, cmake }:
+{ stdenv, fetchurl, lib, cmake, cacert }:
 
 let
 
@@ -10,6 +10,10 @@ let
       url = "mirror://openbsd/LibreSSL/${pname}-${version}.tar.gz";
       inherit sha256;
     };
+
+    postPatch = ''
+      substituteInPlace tls/tls_config.c --replace '"/etc/ssl/cert.pem"' '"${cacert}/etc/ssl/certs/ca-bundle.crt"'
+    '';
 
     nativeBuildInputs = [ cmake ];
 


### PR DESCRIPTION
netcat's default path to CA bundle is wrong on NixOS

```
# nc -c  -vvv  8.8.8.8 443
nc: failed to open CA file '/etc/ssl/cert.pem': No such file or directory
```
