### PR TITLE
[19.09] qolibri: 2018-11-14 -> 2019-07-22

### DIFF
--- a/pkgs/applications/misc/qolibri/default.nix
+++ b/pkgs/applications/misc/qolibri/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchFromGitHub, pkgconfig, cmake, libeb, lzo, qtbase
-, qtmultimedia, qttools, qtwebengine }:
+{ mkDerivation, lib, fetchFromGitHub, pkgconfig, cmake, libeb, lzo
+, qtbase, qtmultimedia, qttools, qtwebengine }:
 
-stdenv.mkDerivation {
+mkDerivation {
   pname = "qolibri";
   version = "2019-07-22";
 
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://github.com/ludios/qolibri;
     description = "EPWING reader for viewing Japanese dictionaries";
     platforms = platforms.linux;

--- a/pkgs/applications/misc/qolibri/default.nix
+++ b/pkgs/applications/misc/qolibri/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation {
   pname = "qolibri";
-  version = "2018-11-14";
+  version = "2019-07-22";
 
   src = fetchFromGitHub {
     owner = "ludios";
     repo = "qolibri";
-    rev = "133a1c33e74d931ad54407f70d84a0016d96981f";
-    sha256 = "16ifix0q8ww4l3xflgxr9j81c0lzlnkjr8fj961x3nxz7288pdg2";
+    rev = "b58f9838d39300cba444eba725a369181c5d746b";
+    sha256 = "0kcc6dvbcmq9y7hk8mp23pydiaqz6f0clg64d1f2y04ppphmah42";
   };
 
   nativeBuildInputs = [ pkgconfig cmake ];


### PR DESCRIPTION
###### Motivation for this change

Backport #67882

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @worldofpeace 
