### PR TITLE
nixos/nat: create nixos-nat-{pre,post,out} in ip6tables too

### DIFF
--- a/nixos/modules/services/networking/nat.nix
+++ b/nixos/modules/services/networking/nat.nix
@@ -13,20 +13,24 @@ let
   dest = if cfg.externalIP == null then "-j MASQUERADE" else "-j SNAT --to-source ${cfg.externalIP}";
 
   flushNat = ''
-    iptables -w -t nat -D PREROUTING -j nixos-nat-pre 2>/dev/null|| true
-    iptables -w -t nat -F nixos-nat-pre 2>/dev/null || true
-    iptables -w -t nat -X nixos-nat-pre 2>/dev/null || true
-    iptables -w -t nat -D POSTROUTING -j nixos-nat-post 2>/dev/null || true
-    iptables -w -t nat -F nixos-nat-post 2>/dev/null || true
-    iptables -w -t nat -X nixos-nat-post 2>/dev/null || true
+    ip46tables -w -t nat -D PREROUTING -j nixos-nat-pre 2>/dev/null|| true
+    ip46tables -w -t nat -F nixos-nat-pre 2>/dev/null || true
+    ip46tables -w -t nat -X nixos-nat-pre 2>/dev/null || true
+    ip46tables -w -t nat -D POSTROUTING -j nixos-nat-post 2>/dev/null || true
+    ip46tables -w -t nat -F nixos-nat-post 2>/dev/null || true
+    ip46tables -w -t nat -X nixos-nat-post 2>/dev/null || true
+    ip46tables -w -t nat -D OUTPUT -j nixos-nat-out 2>/dev/null || true
+    ip46tables -w -t nat -F nixos-nat-out 2>/dev/null || true
+    ip46tables -w -t nat -X nixos-nat-out 2>/dev/null || true
 
     ${cfg.extraStopCommands}
   '';
 
   setupNat = ''
     # Create subchain where we store rules
-    iptables -w -t nat -N nixos-nat-pre
-    iptables -w -t nat -N nixos-nat-post
+    ip46tables -w -t nat -N nixos-nat-pre
+    ip46tables -w -t nat -N nixos-nat-post
+    ip46tables -w -t nat -N nixos-nat-out
 
     # We can't match on incoming interface in POSTROUTING, so
     # mark packets coming from the external interfaces.
@@ -88,8 +92,9 @@ let
     ${cfg.extraCommands}
 
     # Append our chains to the nat tables
-    iptables -w -t nat -A PREROUTING -j nixos-nat-pre
-    iptables -w -t nat -A POSTROUTING -j nixos-nat-post
+    ip46tables -w -t nat -A PREROUTING -j nixos-nat-pre
+    ip46tables -w -t nat -A POSTROUTING -j nixos-nat-post
+    ip46tables -w -t nat -A OUTPUT -j nixos-nat-out
   '';
 
 in


### PR DESCRIPTION
The motivations are:

1. to add `nixos-nat-out` along with `nixos-nat-pre` and `nixos-nat-post` to support scenarios when output packets are NAT'ed to another destination.
  Examples are: 
    * a webmaster may want to to redirect "website.com:80" and "website.com:443" to unprivileged ports on 127.0.0.1 where a webserver is running.
    * TOR and I2P websites [can be mapped to](https://www.grepular.com/Transparent_Access_to_Tor_Hidden_Services) private address space.

   Those techniques require adding NAT rules to OUTPUT chain along with PREROUTING and POSTROUTING so it would be nice if all NAT rules will be set and cleaned at once.

2. adding `nixos-nat-out`, `nixos-nat-pre` and `nixos-nat-post` to `ip6tables` would simplify setting up NAT66 (i know it is an anti-pattern, but sometimes inevitable). Although `nixos/nat` module does not use `ip6tables` and probably should not support NAT66 at all, `ip6tables` can be used in `extraCommands` and IPv6 NAT rules will be automatically cleaned together with IPv4 NAT rules.
