### PR TITLE
zeroc-ice-36: fix build for gcc8

### DIFF
--- a/pkgs/development/libraries/zeroc-ice/3.6.nix
+++ b/pkgs/development/libraries/zeroc-ice/3.6.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, mcpp, bzip2, expat, openssl, db5
+{ stdenv, lib, fetchFromGitHub, fetchpatch, mcpp, bzip2, expat, openssl, db5
 , darwin, libiconv, Security
 , cpp11 ? false
 }:
@@ -25,6 +25,16 @@ stdenv.mkDerivation rec {
     substituteInPlace config/Make.rules.Darwin \
         --replace xcrun ""
   '';
+
+  patches = [
+    # Fixes compilation issues with GCC 8 using one of the patches
+    # provided in https://github.com/zeroc-ice/ice/issues/82
+    ( fetchpatch {
+      url = "https://github.com/zeroc-ice/ice/commit/a6a4981616b669432ff7b588179d6e93694d9e3f.patch";
+      sha256 = "17j5r7gsa3izrm7zln4mrp7l16h532gvmpas0kzglybicbiz7d56";
+      stripLen = 1;
+    })
+  ];
 
   preBuild = ''
     makeFlagsArray+=(


### PR DESCRIPTION
###### Motivation for this change

The build was broken failing on unneccessary memsets.
This issue was fixed upstream in 3.7 and discussed in
https://github.com/zeroc-ice/ice/issues/82

The patch pertaining to the error causing the actual failure still
applies nicely onto the 3.6 version.

Hydra logs of breakage: https://hydra.nixos.org/build/100440955/nixlog/1

This is supposed to unblock some downstream builds, like `murmur` in the context of
https://github.com/NixOS/nixpkgs/issues/68361

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @abbradar
