### PR TITLE
kdenlive: Avoid exposing configurable paths to melt

### DIFF
--- a/pkgs/applications/kde/kdenlive.nix
+++ b/pkgs/applications/kde/kdenlive.nix
@@ -70,10 +70,13 @@ mkDerivation {
     kpurpose
     kdeclarative
   ];
+  patches = [ ./mlt-path.patch ];
+  inherit mlt;
   postPatch =
     # Module Qt5::Concurrent must be included in `find_package` before it is used.
     ''
       sed -i CMakeLists.txt -e '/find_package(Qt5 REQUIRED/ s|)| Concurrent)|'
+      substituteAllInPlace src/kdenlivesettings.kcfg
     '';
   meta = {
     license = with lib.licenses; [ gpl2Plus ];

--- a/pkgs/applications/kde/mlt-path.patch
+++ b/pkgs/applications/kde/mlt-path.patch
@@ -1,0 +1,22 @@
+diff -ruN old/src/kdenlivesettings.kcfg new/src/kdenlivesettings.kcfg
+--- old/src/kdenlivesettings.kcfg	2019-09-10 23:20:27.555392353 -0400
++++ new/src/kdenlivesettings.kcfg	2019-09-10 23:25:47.533964155 -0400
+@@ -378,14 +378,14 @@
+ </group>
+ 
+   <group name="env">
+-    <entry name="mltpath" type="Path">
++    <entry name="mltpath" type="Path" hidden="true">
+       <label>Mlt framework install path.</label>
+-      <default></default>
++      <default>@mlt@/share/mlt/profiles</default>
+     </entry>
+ 
+-    <entry name="rendererpath" type="Path">
++    <entry name="rendererpath" type="Path" hidden="true">
+       <label>Mlt melt renderer install path.</label>
+-      <default></default>
++      <default>@mlt@/bin/melt</default>
+     </entry>
+ 
+     <entry name="ffmpegpath" type="Path">


### PR DESCRIPTION
kdenlive's configuration stores two paths to the `mlt` package. These
may be set in the GUI under `Settings -> Configure Kdenlive ->
Environment`, and are persisted in $XDG_CONFIG_HOME/.kdenliverc

A problem I encountered was `kdenlive` holding on to old `mlt` paths
in these settings after a nixpkgs update, causing video rendering to fail.

The C++ class kdenlive uses for these settings is automatically
generated, so what this patch does is edit the declaration of the
relevant settings to provide default values with the absolute path of
`mlt` known at build time, and mark those settings as hidden.

In testing, I've found that changing `mlt` and rebuilding `kdenlive`
causes updated paths to appear in the GUI, and no entries to be added
to the kdenliverc file.

A shortcoming of this patch is that existing users will already have paths
stored in their `kdenliverc` files that can cause trouble. The hope is
that an approach like the one taken here will reduce this sort
of breakage moving forward.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
