### PR TITLE
bazel-remote: 2019-01-12 -> 2020-01-29

### DIFF
--- a/pkgs/build-support/build-bazel-package/default.nix
+++ b/pkgs/build-support/build-bazel-package/default.nix
@@ -145,7 +145,6 @@ in stdenv.mkDerivation (fBuildAttrs // {
   buildPhase = fBuildAttrs.buildPhase or ''
     runHook preBuild
 
-    '' + lib.optionalString stdenv.isDarwin ''
     # Bazel sandboxes the execution of the tools it invokes, so even though we are
     # calling the correct nix wrappers, the values of the environment variables
     # the wrappers are expecting will not be set. So instead of relying on the
@@ -168,7 +167,6 @@ in stdenv.mkDerivation (fBuildAttrs // {
       linkopts+=( "--linkopt=$flag" )
       host_linkopts+=( "--host_linkopt=$flag" )
     done
-    '' + ''
 
     BAZEL_USE_CPP_ONLY_TOOLCHAIN=1 \
     USER=homeless-shelter \
@@ -177,12 +175,10 @@ in stdenv.mkDerivation (fBuildAttrs // {
       --output_user_root="$bazelUserRoot" \
       build \
       -j $NIX_BUILD_CORES \
-      '' + lib.optionalString stdenv.isDarwin ''
       "''${copts[@]}" \
       "''${host_copts[@]}" \
       "''${linkopts[@]}" \
       "''${host_linkopts[@]}" \
-      '' + ''
       $bazelFlags \
       $bazelBuildFlags \
       $bazelTarget

--- a/pkgs/development/tools/build-managers/bazel/bazel-remote/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel-remote/default.nix
@@ -8,18 +8,24 @@
 
 buildBazelPackage rec {
   name = "bazel-remote-${version}";
-  version = "2019-01-12";
+  version = "2020-01-29";
 
   src = fetchFromGitHub {
     owner = "buchgr";
     repo = "bazel-remote";
-    rev = "3f65b6ccf69e223950c77275a743d0d3a04a8583";
-    sha256 = "0fklrlylmc55yzhm3m1f211x5gmk7hpqjb7k5kml7n3gw3npbjda";
+    rev = "ae9378321552dd14066332f8fa55076040228cb7";
+    sha256 = "1jbd319n255cmmncnjfdkdcpx0x62asp3dqwgl6vimx4dqqj8v1p";
   };
 
   nativeBuildInputs = [ go git ];
 
   bazelTarget = "//:bazel-remote";
+
+  removeRulesCC = false;
+
+  # this is to work around `test -f` failing when called by gazelle
+  # https://github.com/bazelbuild/bazel-gazelle/blob/v0.19.1/internal/go_repository.bzl#L135
+  patches = [ ./disable_build_file_generation.patch ];
 
   fetchAttrs = {
     preBuild = ''
@@ -28,12 +34,11 @@ buildBazelPackage rec {
       # tell rules_go to use the Go binary found in the PATH
       sed -e 's:go_register_toolchains():go_register_toolchains(go_version = "host"):g' -i WORKSPACE
 
-      # update gazelle to work around https://github.com/golang/go/issues/29850
-      sed -e 's,https://github.com/bazelbuild/bazel-gazelle/releases/download/0.15.0/bazel-gazelle-0.15.0.tar.gz,https://github.com/bazelbuild/bazel-gazelle/releases/download/0.16.0/bazel-gazelle-0.16.0.tar.gz,g' -i WORKSPACE
-      sed -e 's,6e875ab4b6bf64a38c352887760f21203ab054676d9c1b274963907e0768740d,7949fc6cc17b5b191103e97481cf8889217263acf52e00b560683413af204fcb,g' -i WORKSPACE
-
       # tell rules_go to invoke GIT with custom CAINFO path
       export GIT_SSL_CAINFO="${cacert}/etc/ssl/certs/ca-bundle.crt"
+
+      # force gazelle to use the nix go cache rather than its own
+      # export GO_REPOSITORY_USE_HOST_CACHE=1
     '';
 
     preInstall = ''
@@ -47,6 +52,11 @@ buildBazelPackage rec {
       rm -rf $bazelOut/external/{go_sdk,\@go_sdk.marker}
       sed -e '/^FILE:@go_sdk.*/d' -i $bazelOut/external/\@*.marker
 
+      # Remove the gazelle repository cache as it contains built binaries
+      chmod -R u+w $bazelOut/external/bazel_gazelle_go_repository_cache
+      rm -rf $bazelOut/external/{bazel_gazelle_go_repository_cache,\@bazel_gazelle_go_repository_cache.marker}
+      sed -e '/^FILE:@bazel_gazelle_go_repository_cache.*/d' -i $bazelOut/external/\@*.marker
+
       # Remove the gazelle tools, they contain go binaries that are built
       # non-deterministically. As long as the gazelle version matches the tools
       # should be equivalent.
@@ -54,7 +64,7 @@ buildBazelPackage rec {
       sed -e '/^FILE:@bazel_gazelle_go_repository_tools.*/d' -i $bazelOut/external/\@*.marker
     '';
 
-    sha256 = "1wvyv3w5y6vj6qs6v5qyd356j1lxc3mf7n3j2pcib1bqmx3igw35";
+    sha256 = "1n66hg1w5jv2rc8q4sjlaf0agvxr713aa40mbkhgjv57x9j7bgn0";
   };
 
   buildAttrs = {
@@ -75,7 +85,6 @@ buildBazelPackage rec {
     description = "A remote HTTP/1.1 cache for Bazel.";
     license = licenses.asl20;
     maintainers = [ maintainers.uri-canva ];
-    platforms = platforms.darwin;
-    broken = true; # global variable '_layer' is referenced before assignment.
+    platforms = platforms.darwin ++ platforms.linux;
   };
 }

--- a/pkgs/development/tools/build-managers/bazel/bazel-remote/disable_build_file_generation.patch
+++ b/pkgs/development/tools/build-managers/bazel/bazel-remote/disable_build_file_generation.patch
@@ -1,0 +1,24 @@
+From 3f5abd591b93ebdbc1ae82e5c29cf26024222f5f Mon Sep 17 00:00:00 2001
+From: Uri Baghin <uri@canva.com>
+Date: Thu, 30 Jan 2020 16:47:36 +1100
+Subject: [PATCH] Disable build file generation for remote apis.
+
+---
+ WORKSPACE | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/WORKSPACE b/WORKSPACE
+index f9ebafa..52e4e0b 100644
+--- a/WORKSPACE
++++ b/WORKSPACE
+@@ -208,6 +208,7 @@ http_archive(
+ 
+ go_repository(
+     name = "com_github_bazelbuild_remote_apis",
++    build_file_generation = "off",
+     importpath = "github.com/bazelbuild/remote-apis",
+     sum = "h1:OPH+hf+ICw8WEp2CV2ncfdyWPC30Cmw8b5NKun0n5IQ=",
+     version = "v0.0.0-20191119143007-b5123b1bb285",
+-- 
+2.25.0
+


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update it and fix it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Profpatsch @abbradar 
