### PR TITLE
snscrape: fix startup

### DIFF
--- a/pkgs/development/python-modules/snscrape/default.nix
+++ b/pkgs/development/python-modules/snscrape/default.nix
@@ -3,6 +3,7 @@
 , isPy3k
 , fetchPypi
 , setuptools_scm
+, setuptools
 , requests
 , lxml
 , beautifulsoup4
@@ -26,7 +27,7 @@ buildPythonPackage rec {
   '';
 
   nativeBuildInputs = [ setuptools_scm ];
-  propagatedBuildInputs = [ requests lxml beautifulsoup4 ];
+  propagatedBuildInputs = [ setuptools requests lxml beautifulsoup4 ];
 
   meta = with lib; {
     homepage = https://github.com/JustAnotherArchivist/snscrape;


### PR DESCRIPTION
###### Motivation for this change

This fixes snscrape startup:

```
Traceback (most recent call last):
  File "/nix/store/607z14x0spsz1lsh0fg9cbyc9lr038mi-python3.7-snscrape-0.3.0/bin/.snscrape-wrapped", line 11, in <module>
    sys.exit(main())
  File "/nix/store/607z14x0spsz1lsh0fg9cbyc9lr038mi-python3.7-snscrape-0.3.0/lib/python3.7/site-packages/snscrape/cli.py", line 218, in main
    args = parse_args()
  File "/nix/store/607z14x0spsz1lsh0fg9cbyc9lr038mi-python3.7-snscrape-0.3.0/lib/python3.7/site-packages/snscrape/cli.py", line 154, in parse_args
    import snscrape.version
  File "/nix/store/607z14x0spsz1lsh0fg9cbyc9lr038mi-python3.7-snscrape-0.3.0/lib/python3.7/site-packages/snscrape/version.py", line 1, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```

Related: https://github.com/NixOS/nixpkgs/pull/68314

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @FRidh 