### PR TITLE
kwin-tiling: init at 2.2

### DIFF
--- a/pkgs/desktops/plasma-5/kwin/scripts/tiling.nix
+++ b/pkgs/desktops/plasma-5/kwin/scripts/tiling.nix
@@ -1,0 +1,44 @@
+{ lib, mkDerivation, fetchFromGitHub
+, kcoreaddons, kwindowsystem, plasma-framework, systemsettings }:
+
+mkDerivation rec {
+  pname = "kwin-tiling";
+  version = "2.2";
+
+  src = fetchFromGitHub {
+    owner = "kwin-scripts";
+    repo = "kwin-tiling";
+    rev = "v${version}";
+    sha256 = "1sx64xv7g9yh3j26zxxrbndv79xam9jq0vs00fczgfv2n0m7j7bl";
+  };
+
+  # This is technically not needed, but we might as well clean up
+  postPatch = ''
+    rm release.sh
+  '';
+
+  buildInputs = [
+    kcoreaddons kwindowsystem plasma-framework systemsettings
+  ];
+
+  dontBuild = true;
+
+  # 1. --global still installs to $HOME/.local/share so we use --packageroot
+  # 2. plasmapkg2 doesn't copy metadata.desktop into place, so we do that manually
+  installPhase = ''
+    runHook preInstall
+
+    plasmapkg2 --type kwinscript --install ${src} --packageroot $out/share/kwin/scripts
+    install -Dm644 ${src}/metadata.desktop $out/share/kservices5/kwin-script-tiling.desktop
+
+    runHook postInstalll
+  '';
+
+  meta = with lib; {
+    description = "Tiling script for kwin";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ peterhoeg ];
+    inherit (src.meta) homepage;
+    inherit (kwindowsystem.meta) platforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22733,6 +22733,8 @@ in
     plasma-workspace-wallpapers polkit-kde-agent powerdevil sddm-kcm
     systemsettings user-manager xdg-desktop-portal-kde;
 
+  kwin-tiling = libsForQt5.callPackage ../desktops/plasma-5/kwin/scripts/tiling.nix { };
+
   ### SCIENCE
 
   ### SCIENCE/CHEMISTY


### PR DESCRIPTION
###### Motivation for this change

Been using this for years.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @bkchr 
