### PR TITLE
django: don't wrap binary files twice

### DIFF
--- a/pkgs/development/python-modules/django/1_11.nix
+++ b/pkgs/development/python-modules/django/1_11.nix
@@ -21,11 +21,6 @@ buildPythonPackage rec {
     })
   ];
 
-  # patch only $out/bin to avoid problems with starter templates (see #3134)
-  postFixup = ''
-    wrapPythonProgramsIn $out/bin "$out $pythonPath"
-  '';
-
   propagatedBuildInputs = [ pytz ];
 
   # too complicated to setup

--- a/pkgs/development/python-modules/django/1_8.nix
+++ b/pkgs/development/python-modules/django/1_8.nix
@@ -15,11 +15,6 @@ buildPythonPackage rec {
   # too complicated to setup
   doCheck = false;
 
-  # patch only $out/bin to avoid problems with starter templates (see #3134)
-  postFixup = ''
-    wrapPythonProgramsIn $out/bin "$out $pythonPath"
-  '';
-
   meta = with stdenv.lib; {
     description = "A high-level Python Web framework";
     homepage = https://www.djangoproject.com/;

--- a/pkgs/development/python-modules/django/2_1.nix
+++ b/pkgs/development/python-modules/django/2_1.nix
@@ -24,11 +24,6 @@ buildPythonPackage rec {
     })
   ];
 
-  # patch only $out/bin to avoid problems with starter templates (see #3134)
-  postFixup = ''
-    wrapPythonProgramsIn $out/bin "$out $pythonPath"
-  '';
-
   propagatedBuildInputs = [ pytz ];
 
   # too complicated to setup


### PR DESCRIPTION
###### Motivation for this change

The bin directory of Django version `1.8`, `1.11` and `2.1` contains the `django-admin` command wrapped twice:

```
/nix/store/bhyg18ljfyjvjs9gs3yns0nidlj9ni4f-python3.7-Django-1.11.23/bin
├── django-admin
├── django-admin.py
├── .django-admin.py-wrapped
├── ..django-admin.py-wrapped-wrapped
├── .django-admin-wrapped
└── ..django-admin-wrapped-wrapped
```

This change removes the second wrapper and only keeps the wrapping done by `buildPythonPackage`.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers
