### PR TITLE
shattered-pixel-dungeon: init at 0.7.4c

### DIFF
--- a/pkgs/games/shattered-pixel-dungeon/default.nix
+++ b/pkgs/games/shattered-pixel-dungeon/default.nix
@@ -1,0 +1,78 @@
+{ stdenv
+, fetchurl
+, makeWrapper
+, fetchFromGitHub
+, gradle_5
+, perl
+, jre
+, xorg
+, openal
+}:
+
+let
+  pname = "shattered-pixel-dungeon";
+  version = "0.7.4c";
+
+  src = fetchFromGitHub {
+    owner = "00-Evan";
+    repo = "shattered-pixel-dungeon-gdx";
+    rev = "v${version}";
+    sha256 = "0bsr8fnc4pips0dbpizzp347nr875b14vkh4jkgnsv03myq2nva4";
+  };
+
+  postPatch = ''
+    # disable gradle plugins with native code and their targets
+    perl -i.bak1 -pe "s#(^\s*id '.+' version '.+'$)#// \1#" build.gradle
+    perl -i.bak2 -pe "s#(.*)#// \1# if /^(buildscript|task portable|task nsis|task proguard|task tgz|task\(afterEclipseImport\)|launch4j|macAppBundle|buildRpm|buildDeb|shadowJar)/ ... /^}/" build.gradle
+  '';
+
+  # fake build to pre-download deps into fixed-output derivation
+  deps = stdenv.mkDerivation {
+    pname = "${pname}-deps";
+    inherit version src postPatch;
+    nativeBuildInputs = [ gradle_5 perl ];
+    buildPhase = ''
+      export GRADLE_USER_HOME=$(mktemp -d)
+      gradle --no-daemon desktop:dist
+    '';
+    # perl code mavenizes pathes (com.squareup.okio/okio/1.13.0/a9283170b7305c8d92d25aff02a6ab7e45d06cbe/okio-1.13.0.jar -> com/squareup/okio/okio/1.13.0/okio-1.13.0.jar)
+    installPhase = ''
+      find $GRADLE_USER_HOME/caches/modules-2 -type f -regex '.*\.\(jar\|pom\)' \
+        | perl -pe 's#(.*/([^/]+)/([^/]+)/([^/]+)/[0-9a-f]{30,40}/([^/\s]+))$# ($x = $2) =~ tr|\.|/|; "install -Dm444 $1 \$out/$x/$3/$4/$5" #e' \
+        | sh
+    '';
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+    outputHash = "1xi0km54rhlfsis50j1v5pqs6fr36dqkmqgvk0j7qyij7i6qjrnj";
+  };
+
+in stdenv.mkDerivation rec {
+  inherit pname version src postPatch;
+
+  nativeBuildInputs = [ gradle_5 perl makeWrapper ];
+
+  buildPhase = ''
+    export GRADLE_USER_HOME=$(mktemp -d)
+    # point to offline repo
+    sed -ie "s#mavenLocal()#mavenLocal(); maven { url '${deps}' }#g" build.gradle
+    gradle --offline --no-daemon desktop:dist
+  '';
+
+  installPhase = ''
+    install -Dm644 desktop/build/libs/desktop-${version}.jar $out/share/shattered-pixel-dungeon.jar
+    mkdir $out/bin
+    makeWrapper ${jre}/bin/java $out/bin/shattered-pixel-dungeon \
+      --prefix LD_LIBRARY_PATH : ${xorg.libXxf86vm}/lib:${openal}/lib \
+      --add-flags "-jar $out/share/shattered-pixel-dungeon.jar"
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://shatteredpixel.com/";
+    downloadPage = "https://github.com/00-Evan/shattered-pixel-dungeon-gdx/releases";
+    description = "Traditional roguelike game with pixel-art graphics and simple interface";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ fgaz ];
+    platforms = platforms.all;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22324,6 +22324,8 @@ in
 
   sgtpuzzles = callPackage (callPackage ../games/sgt-puzzles) { };
 
+  shattered-pixel-dungeon = callPackage ../games/shattered-pixel-dungeon { };
+
   sienna = callPackage ../games/sienna { love = love_0_10; };
 
   sil = callPackage ../games/sil { };


### PR DESCRIPTION
###### Motivation for this change

https://shatteredpixel.com/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
