### PR TITLE
xmlsec: add library path to lt_dladdsearchdir

### DIFF
--- a/pkgs/development/libraries/xmlsec/default.nix
+++ b/pkgs/development/libraries/xmlsec/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, libxml2, gnutls, libxslt, pkgconfig, libgcrypt, libtool
-, openssl, nss, makeWrapper }:
+, openssl, nss }:
 
 let
   version = "1.2.28";
@@ -13,9 +13,16 @@ stdenv.mkDerivation {
     sha256 = "1m12caglhyx08g8lh2sl3nkldlpryzdx2d572q73y3m33s0w9vhk";
   };
 
+  patches = [
+    ./lt_dladdsearchdir.patch
+  ];
+  postPatch = ''
+    substituteAllInPlace src/dl.c
+  '';
+
   outputs = [ "out" "dev" ];
 
-  nativeBuildInputs = [ makeWrapper pkgconfig ];
+  nativeBuildInputs = [ pkgconfig ];
 
   buildInputs = [ libxml2 gnutls libxslt libgcrypt libtool openssl nss ];
 
@@ -32,10 +39,6 @@ stdenv.mkDerivation {
   postInstall = ''
     moveToOutput "bin/xmlsec1-config" "$dev"
     moveToOutput "lib/xmlsec1Conf.sh" "$dev"
-  '';
-
-  postFixup = ''
-    wrapProgram "$out/bin/xmlsec1" --prefix LD_LIBRARY_PATH ":" "$out/lib"
   '';
 
   meta = {

--- a/pkgs/development/libraries/xmlsec/lt_dladdsearchdir.patch
+++ b/pkgs/development/libraries/xmlsec/lt_dladdsearchdir.patch
@@ -1,0 +1,16 @@
+diff --git a/src/dl.c b/src/dl.c
+index b13f9d46..d761855b 100644
+--- a/src/dl.c
++++ b/src/dl.c
+@@ -346,6 +346,11 @@ xmlSecCryptoDLInit(void) {
+         xmlSecIOError("lt_dlinit", NULL, NULL);
+         return(-1);
+     }
++    ret = lt_dladdsearchdir("@out@/lib");
++    if(ret != 0) {
++      xmlSecIOError("lt_dladdsearchdir", NULL, NULL);
++      return(-1);
++    }
+ #endif /* XMLSEC_DL_LIBLTDL */
+ 
+     return(0);


### PR DESCRIPTION
###### Motivation for this change

When linking to `libxmlsec`, the linking binary/library has to ensure that the `xmlsec` `$out/lib` directory is in the `LD_LIBRARY_PATH`, to esure `libxmlsec` can find and load the crypto libraries. `xmlsec1` uses `wrapProgram` for this, but when an intermediate library is linking `libxmlsec`, it has no control over the `LD_LIBRARY_PATH` (like [python-xmlsec](https://github.com/NixOS/nixpkgs/compare/master...B4dM4n:python-xmlsec) ).

Adding `$out/lib` to `lt_dladdsearchdir` during library initialization works around `LD_LIBRARY_PATH` and ensures the crypto libraries can always be found.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers
