### PR TITLE
Fix dontRecurseIntoAttrs + add to lib + doc

### DIFF
--- a/doc/functions/library/attrsets.xml
+++ b/doc/functions/library/attrsets.xml
@@ -1728,4 +1728,48 @@ recursiveUpdate
 ]]></programlisting>
   </example>
  </section>
+
+ <section xml:id="function-library-lib.attrsets.recurseIntoAttrs">
+  <title><function>lib.attrsets.recurseIntoAttrs</function></title>
+
+  <subtitle><literal>recurseIntoAttrs :: AttrSet -> AttrSet</literal>
+  </subtitle>
+
+  <xi:include href="./locations.xml" xpointer="lib.attrsets.recurseIntoAttrs" />
+
+  <para>
+   Make various Nix tools consider the contents of the resulting
+   attribute set when looking for what to build, find, etc.
+  </para>
+
+  <para>
+   This function only affects a single attribute set; it does not apply itself recursively for nested attribute sets.
+  </para>
+
+  <variablelist>
+   <varlistentry>
+    <term>
+     <varname>attrs</varname>
+    </term>
+    <listitem>
+     <para>
+      An attribute set to scan for derivations.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+
+  <example xml:id="function-library-lib.attrsets.recurseIntoAttrs-example">
+   <title>Making Nix look inside an attribute set</title>
+<programlisting><![CDATA[
+{ pkgs ? import <nixpkgs> {} }:
+{
+  myTools = pkgs.lib.recurseIntoAttrs {
+    inherit (pkgs) hello figlet;
+  };
+}
+]]></programlisting>
+  </example>
+ </section>
+
 </section>

--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -475,6 +475,9 @@ rec {
 
   /* Make various Nix tools consider the contents of the resulting
      attribute set when looking for what to build, find, etc.
+
+     This function only affects a single attribute set; it does not
+     apply itself recursively for nested attribute sets.
    */
   recurseIntoAttrs =
     attrs: attrs // { recurseForDerivations = true; };

--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -473,6 +473,12 @@ rec {
   /* Pick the outputs of packages to place in buildInputs */
   chooseDevOutputs = drvs: builtins.map getDev drvs;
 
+  /* Make various Nix tools consider the contents of the resulting
+     attribute set when looking for what to build, find, etc.
+   */
+  recurseIntoAttrs =
+    attrs: attrs // { recurseForDerivations = true; };
+
   /*** deprecated stuff ***/
 
   zipWithNames = zipAttrsWithNames;

--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -479,6 +479,11 @@ rec {
   recurseIntoAttrs =
     attrs: attrs // { recurseForDerivations = true; };
 
+  /* Undo the effect of recurseIntoAttrs.
+   */
+  dontRecurseIntoAttrs =
+    attrs: attrs // { recurseForDerivations = false; };
+
   /*** deprecated stuff ***/
 
   zipWithNames = zipAttrsWithNames;

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -71,7 +71,7 @@ let
       zipAttrsWithNames zipAttrsWith zipAttrs recursiveUpdateUntil
       recursiveUpdate matchAttrs overrideExisting getOutput getBin
       getLib getDev chooseDevOutputs zipWithNames zip
-      recurseIntoAttrs;
+      recurseIntoAttrs dontRecurseIntoAttrs;
     inherit (lists) singleton forEach foldr fold foldl foldl' imap0 imap1
       concatMap flatten remove findSingle findFirst any all count
       optional optionals toList range partition zipListsWith zipLists

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -70,7 +70,8 @@ let
       genAttrs isDerivation toDerivation optionalAttrs
       zipAttrsWithNames zipAttrsWith zipAttrs recursiveUpdateUntil
       recursiveUpdate matchAttrs overrideExisting getOutput getBin
-      getLib getDev chooseDevOutputs zipWithNames zip;
+      getLib getDev chooseDevOutputs zipWithNames zip
+      recurseIntoAttrs;
     inherit (lists) singleton forEach foldr fold foldl foldl' imap0 imap1
       concatMap flatten remove findSingle findFirst any all count
       optional optionals toList range partition zipListsWith zipLists

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -62,9 +62,9 @@ in
 
   inherit (lib) lowPrio hiPrio appendToName makeOverridable;
 
-  # Applying this to an attribute set will cause nix-env to look
-  # inside the set for derivations.
-  recurseIntoAttrs = attrs: attrs // { recurseForDerivations = true; };
+  # Make various Nix tools consider the contents of the resulting
+  # attribute set when looking for what to build, find, etc.
+  inherit (lib) recurseIntoAttrs;
 
   # This is intended to be the reverse of recurseIntoAttrs, as it is
   # defined now it exists mainly for documentation purposes, but you

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -72,7 +72,7 @@ in
   # the Attrs which is useful for testing massive changes. Ideally,
   # every package subset not marked with recurseIntoAttrs should be
   # marked with this.
-  dontRecurseIntoAttrs = x: x;
+  inherit (lib) dontRecurseIntoAttrs;
 
   stringsWithDeps = lib.stringsWithDeps;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -62,8 +62,6 @@ in
 
   inherit (lib) lowPrio hiPrio appendToName makeOverridable;
 
-  # Make various Nix tools consider the contents of the resulting
-  # attribute set when looking for what to build, find, etc.
   inherit (lib) recurseIntoAttrs;
 
   # This is intended to be the reverse of recurseIntoAttrs, as it is


### PR DESCRIPTION

###### Motivation for this change

 - `dontRecurseIntoAttrs` didn't do what it said
 - it and `recurseIntoAttrs` are valid and useful outside a full nixpkgs invocation

Additionally, I will soon backport *only* the `lib.recurseIntoAttrs` addition to 19.03 and 19.09.
The `dont` fix might kill someone's build setup, when they have a `with lib` inside a `with pkgs`... 

(Reminder: avoid `with;` use `inherit`.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
