### PR TITLE
Introduce environment.profileRelativeSessionVariables

### DIFF
--- a/nixos/modules/config/shells-environment.nix
+++ b/nixos/modules/config/shells-environment.nix
@@ -157,6 +157,8 @@ in
     # terminal instead of logging out of X11).
     environment.variables = config.environment.sessionVariables;
 
+    environment.profileRelativeEnvVars = config.environment.profileRelativeSessionVariables;
+
     environment.shellAliases = mapAttrs (name: mkDefault) {
       ls = "ls --color=tty";
       ll = "ls -l";

--- a/nixos/modules/config/system-environment.nix
+++ b/nixos/modules/config/system-environment.nix
@@ -8,6 +8,11 @@ let
 
   cfg = config.environment;
 
+  pamProfiles =
+    map
+      (replaceStrings ["$HOME" "$USER"] ["@{HOME}" "@{PAM_USER}"])
+      cfg.profiles;
+
 in
 
 {
@@ -18,25 +23,76 @@ in
       default = {};
       description = ''
         A set of environment variables used in the global environment.
-        These variables will be set by PAM.
-        The value of each variable can be either a string or a list of
-        strings.  The latter is concatenated, interspersed with colon
-        characters.
+        These variables will be set by PAM early in the login process.
+
+        The value of each session variable can be either a string or a
+        list of strings. The latter is concatenated, interspersed with
+        colon characters.
+
+        Note, due to limitations in the PAM format values may not
+        contain the <literal>"</literal> character.
+
+        Also, these variables are merged into
+        <xref linkend="opt-environment.variables"/> and it is
+        therefore not possible to use PAM style variables such as
+        <code>@{HOME}</code>.
       '';
       type = with types; attrsOf (either str (listOf str));
       apply = mapAttrs (n: v: if isList v then concatStringsSep ":" v else v);
+    };
+
+    environment.profileRelativeSessionVariables = mkOption {
+      type = types.attrsOf (types.listOf types.str);
+      example = { PATH = [ "/bin" ]; MANPATH = [ "/man" "/share/man" ]; };
+      description = ''
+        Attribute set of environment variable used in the global
+        environment. These variables will be set by PAM early in the
+        login process.
+
+        Variable substitution is available as described in
+        <citerefentry>
+          <refentrytitle>pam_env.conf</refentrytitle>
+          <manvolnum>5</manvolnum>
+        </citerefentry>.
+
+        Each attribute maps to a list of relative paths. Each relative
+        path is appended to the each profile of
+        <option>environment.profiles</option> to form the content of
+        the corresponding environment variable.
+
+        Also, these variables are merged into
+        <xref linkend="opt-environment.profileRelativeEnvVars"/> and it is
+        therefore not possible to use PAM style variables such as
+        <code>@{HOME}</code>.
+      '';
     };
 
   };
 
   config = {
 
-    system.build.pamEnvironment = pkgs.writeText "pam-environment"
-       ''
-         ${concatStringsSep "\n" (
-           (mapAttrsToList (n: v: ''${n}="${concatStringsSep ":" v}"'')
-             (zipAttrsWith (const concatLists) ([ (mapAttrs (n: v: [ v ]) cfg.sessionVariables) ]))))}
-       '';
+    system.build.pamEnvironment =
+      let
+        suffixedVariables =
+          flip mapAttrs cfg.profileRelativeSessionVariables (envVar: suffixes:
+            flip concatMap pamProfiles (profile:
+              map (suffix: "${profile}${suffix}") suffixes
+            )
+          );
+
+        pamVariable = n: v:
+          ''${n}   DEFAULT="${concatStringsSep ":" (toList v)}"'';
+
+        pamVariables =
+          concatStringsSep "\n"
+          (mapAttrsToList pamVariable
+          (zipAttrsWith (n: concatLists)
+            [
+              (mapAttrs (n: toList) cfg.sessionVariables)
+              suffixedVariables
+            ]));
+      in
+        pkgs.writeText "pam-environment" "${pamVariables}\n";
 
   };
 

--- a/nixos/modules/config/terminfo.nix
+++ b/nixos/modules/config/terminfo.nix
@@ -12,7 +12,7 @@
       source = "${config.system.path}/share/terminfo";
     };
 
-    environment.profileRelativeEnvVars = {
+    environment.profileRelativeSessionVariables = {
       TERMINFO_DIRS = [ "/share/terminfo" ];
     };
 

--- a/nixos/modules/config/xdg/icons.nix
+++ b/nixos/modules/config/xdg/icons.nix
@@ -7,19 +7,19 @@ with lib;
       type = types.bool;
       default = true;
       description = ''
-        Whether to install files to support the 
+        Whether to install files to support the
         <link xlink:href="https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html">XDG Icon Theme specification</link>.
       '';
     };
   };
 
   config = mkIf config.xdg.icons.enable {
-    environment.pathsToLink = [ 
-      "/share/icons" 
-      "/share/pixmaps" 
+    environment.pathsToLink = [
+      "/share/icons"
+      "/share/pixmaps"
     ];
-    
-    environment.profileRelativeEnvVars = {
+
+    environment.profileRelativeSessionVariables = {
       XCURSOR_PATH = [ "/share/icons" ];
     };
   };

--- a/nixos/modules/programs/environment.nix
+++ b/nixos/modules/programs/environment.nix
@@ -30,7 +30,7 @@ in
       ];
 
     # TODO: move most of these elsewhere
-    environment.profileRelativeEnvVars =
+    environment.profileRelativeSessionVariables =
       { PATH = [ "/bin" ];
         INFOPATH = [ "/info" "/share/info" ];
         KDEDIRS = [ "" ];

--- a/nixos/modules/programs/environment.nix
+++ b/nixos/modules/programs/environment.nix
@@ -23,6 +23,7 @@ in
         XCURSOR_PATH = [ "$HOME/.icons" ];
         XDG_CONFIG_DIRS = [ "/etc/xdg" ]; # needs to be before profile-relative paths to allow changes through environment.etc
         GTK_DATA_PREFIX = "${config.system.path}"; # needed for gtk2 apps to find themes
+        GTK_EXE_PREFIX = "${config.system.path}";
       };
 
     environment.profiles = mkAfter

--- a/nixos/modules/programs/environment.nix
+++ b/nixos/modules/programs/environment.nix
@@ -22,6 +22,7 @@ in
         EDITOR = mkDefault "nano";
         XCURSOR_PATH = [ "$HOME/.icons" ];
         XDG_CONFIG_DIRS = [ "/etc/xdg" ]; # needs to be before profile-relative paths to allow changes through environment.etc
+        GTK_DATA_PREFIX = "${config.system.path}"; # needed for gtk2 apps to find themes
       };
 
     environment.profiles = mkAfter

--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -415,7 +415,7 @@ let
 
           # Session management.
           ${optionalString cfg.setEnvironment ''
-            session required pam_env.so envfile=${config.system.build.pamEnvironment}
+            session required pam_env.so conffile=${config.system.build.pamEnvironment} readenv=0
           ''}
           session required pam_unix.so
           ${optionalString cfg.setLoginUid

--- a/nixos/modules/services/editors/emacs.nix
+++ b/nixos/modules/services/editors/emacs.nix
@@ -95,13 +95,7 @@ in {
 
     environment.systemPackages = [ cfg.package editorScript desktopApplicationFile ];
 
-    environment.variables = {
-      # This is required so that GTK applications launched from Emacs
-      # get properly themed:
-      GTK_DATA_PREFIX = "${config.system.path}";
-    } // (if cfg.defaultEditor then {
-        EDITOR = mkOverride 900 "${editorScript}/bin/emacseditor";
-      } else {});
+    environment.variables.EDITOR = mkIf cfg.defaultEditor (mkOverride 900 "${editorScript}/bin/emacseditor");
   };
 
   meta.doc = ./emacs.xml;

--- a/nixos/modules/services/x11/desktop-managers/enlightenment.nix
+++ b/nixos/modules/services/x11/desktop-managers/enlightenment.nix
@@ -48,10 +48,6 @@ in
     services.xserver.desktopManager.session = [
     { name = "Enlightenment";
       start = ''
-        # Set GTK_DATA_PREFIX so that GTK can find the themes
-        export GTK_DATA_PREFIX=${config.system.path}
-        # find theme engines
-        export GTK_PATH=${config.system.path}/lib/gtk-3.0:${config.system.path}/lib/gtk-2.0
         export XDG_MENU_PREFIX=e-
 
         export GST_PLUGIN_PATH="${GST_PLUGIN_PATH}"

--- a/nixos/modules/services/x11/desktop-managers/mate.nix
+++ b/nixos/modules/services/x11/desktop-managers/mate.nix
@@ -48,12 +48,6 @@ in
       name = "mate";
       bgSupport = true;
       start = ''
-        # Set GTK_DATA_PREFIX so that GTK can find the themes
-        export GTK_DATA_PREFIX=${config.system.path}
-
-        # Find theme engines
-        export GTK_PATH=${config.system.path}/lib/gtk-3.0:${config.system.path}/lib/gtk-2.0
-
         export XDG_MENU_PREFIX=mate-
 
         # Let caja find extensions

--- a/nixos/modules/services/x11/desktop-managers/xfce.nix
+++ b/nixos/modules/services/x11/desktop-managers/xfce.nix
@@ -107,12 +107,6 @@ in
       start = ''
         ${cfg.extraSessionCommands}
 
-        # Set GTK_PATH so that GTK can find the theme engines.
-        export GTK_PATH="${config.system.path}/lib/gtk-2.0:${config.system.path}/lib/gtk-3.0"
-
-        # Set GTK_DATA_PREFIX so that GTK can find the Xfce themes.
-        export GTK_DATA_PREFIX=${config.system.path}
-
         ${pkgs.runtimeShell} ${pkgs.xfce.xinitrc} &
         waitPID=$!
       '';

--- a/nixos/modules/services/x11/desktop-managers/xfce4-14.nix
+++ b/nixos/modules/services/x11/desktop-managers/xfce4-14.nix
@@ -114,12 +114,6 @@ in
       name = "xfce4-14";
       bgSupport = true;
       start = ''
-        # Set GTK_PATH so that GTK can find the theme engines.
-        export GTK_PATH="${config.system.path}/lib/gtk-2.0:${config.system.path}/lib/gtk-3.0"
-
-        # Set GTK_DATA_PREFIX so that GTK can find the Xfce themes.
-        export GTK_DATA_PREFIX=${config.system.path}
-
         ${pkgs.runtimeShell} ${pkgs.xfce4-14.xinitrc} &
         waitPID=$!
       '';

--- a/nixos/modules/services/x11/display-managers/gdm.nix
+++ b/nixos/modules/services/x11/display-managers/gdm.nix
@@ -262,7 +262,7 @@ in
         password required       pam_deny.so
 
         session  required       pam_succeed_if.so audit quiet_success user = gdm
-        session  required       pam_env.so envfile=${config.system.build.pamEnvironment}
+        session  required       pam_env.so conffile=${config.system.build.pamEnvironment} readenv=0
         session  optional       ${pkgs.systemd}/lib/security/pam_systemd.so
         session  optional       pam_keyinit.so force revoke
         session  optional       pam_permit.so

--- a/nixos/modules/services/x11/display-managers/gdm.nix
+++ b/nixos/modules/services/x11/display-managers/gdm.nix
@@ -142,8 +142,6 @@ in
           GDM_X_SERVER_EXTRA_ARGS = toString
             (filter (arg: arg != "-terminate") cfg.xserverArgs);
           XDG_DATA_DIRS = "${cfg.session.desktops}/share/";
-          # Find the mouse
-          XCURSOR_PATH = "~/.icons:${pkgs.gnome3.adwaita-icon-theme}/share/icons";
         } // optionalAttrs (xSessionWrapper != null) {
           # Make GDM use this wrapper before running the session, which runs the
           # configured setupCommands. This relies on a patched GDM which supports

--- a/nixos/modules/services/x11/display-managers/lightdm-greeters/enso-os.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm-greeters/enso-os.nix
@@ -10,32 +10,6 @@ let
   icons = cfg.iconTheme.package;
   cursors = cfg.cursorTheme.package;
 
-  # We need a few things in the environment for the greeter to run with
-  # fonts/icons.
-  wrappedEnsoGreeter = pkgs.runCommand "lightdm-enso-os-greeter" {
-      buildInputs = [ pkgs.makeWrapper ];
-      preferLocalBuild = true;
-    } ''
-      # This wrapper ensures that we actually get themes
-      makeWrapper ${pkgs.lightdm-enso-os-greeter}/bin/pantheon-greeter \
-        $out/greeter \
-        --prefix PATH : "${pkgs.glibc.bin}/bin" \
-        --set GDK_PIXBUF_MODULE_FILE "${pkgs.librsvg.out}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache" \
-        --set GTK_PATH "${theme}:${pkgs.gtk3.out}" \
-        --set GTK_EXE_PREFIX "${theme}" \
-        --set GTK_DATA_PREFIX "${theme}" \
-        --set XDG_DATA_DIRS "${theme}/share:${icons}/share:${cursors}/share" \
-        --set XDG_CONFIG_HOME "${theme}/share"
-
-      cat - > $out/lightdm-enso-os-greeter.desktop << EOF
-      [Desktop Entry]
-      Name=LightDM Greeter
-      Comment=This runs the LightDM Greeter
-      Exec=$out/greeter
-      Type=Application
-      EOF
-    '';
-
   ensoGreeterConf = pkgs.writeText "lightdm-enso-os-greeter.conf" ''
     [greeter]
     default-wallpaper=${ldmcfg.background}
@@ -144,10 +118,16 @@ in {
   config = mkIf (ldmcfg.enable && cfg.enable) {
     environment.etc."lightdm/greeter.conf".source = ensoGreeterConf;
 
+    environment.systemPackages = [
+      cursors
+      icons
+      theme
+    ];
+
     services.xserver.displayManager.lightdm = {
       greeter = mkDefault {
-        package = wrappedEnsoGreeter;
-        name = "lightdm-enso-os-greeter";
+        package = pkgs.lightdm-enso-os-greeter.xgreeters;
+        name = "pantheon-greeter";
       };
 
       greeters = {

--- a/nixos/modules/services/x11/display-managers/lightdm-greeters/gtk.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm-greeters/gtk.nix
@@ -15,34 +15,6 @@ let
   icons = cfg.iconTheme.package;
   cursors = cfg.cursorTheme.package;
 
-  # The default greeter provided with this expression is the GTK greeter.
-  # Again, we need a few things in the environment for the greeter to run with
-  # fonts/icons.
-  wrappedGtkGreeter = pkgs.runCommand "lightdm-gtk-greeter" {
-      buildInputs = [ pkgs.makeWrapper ];
-      preferLocalBuild = true;
-    } ''
-      # This wrapper ensures that we actually get themes
-      makeWrapper ${pkgs.lightdm_gtk_greeter}/sbin/lightdm-gtk-greeter \
-        $out/greeter \
-        --prefix PATH : "${lib.getBin pkgs.stdenv.cc.libc}/bin" \
-        --set GDK_PIXBUF_MODULE_FILE "${pkgs.librsvg.out}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache" \
-        --set GTK_PATH "${theme}:${pkgs.gtk3.out}" \
-        --set GTK_EXE_PREFIX "${theme}" \
-        --set GTK_DATA_PREFIX "${theme}" \
-        --set XDG_DATA_DIRS "${theme}/share:${icons}/share" \
-        --set XDG_CONFIG_HOME "${theme}/share" \
-        --set XCURSOR_PATH "${cursors}/share/icons"
-
-      cat - > $out/lightdm-gtk-greeter.desktop << EOF
-      [Desktop Entry]
-      Name=LightDM Greeter
-      Comment=This runs the LightDM Greeter
-      Exec=$out/greeter
-      Type=Application
-      EOF
-    '';
-
   gtkGreeterConf = writeText "lightdm-gtk-greeter.conf"
     ''
     [greeter]
@@ -185,9 +157,15 @@ in
   config = mkIf (ldmcfg.enable && cfg.enable) {
 
     services.xserver.displayManager.lightdm.greeter = mkDefault {
-      package = wrappedGtkGreeter;
+      package = pkgs.lightdm_gtk_greeter.xgreeters;
       name = "lightdm-gtk-greeter";
     };
+
+    environment.systemPackages = [
+      cursors
+      icons
+      theme
+    ];
 
     environment.etc."lightdm/lightdm-gtk-greeter.conf".source = gtkGreeterConf;
 

--- a/nixos/modules/services/x11/display-managers/lightdm-greeters/mini.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm-greeters/mini.nix
@@ -8,11 +8,6 @@ let
   ldmcfg = dmcfg.lightdm;
   cfg = ldmcfg.greeters.mini;
 
-  xgreeters = pkgs.linkFarm "lightdm-mini-greeter-xgreeters" [{
-    path = "${pkgs.lightdm-mini-greeter}/share/xgreeters/lightdm-mini-greeter.desktop";
-    name = "lightdm-mini-greeter.desktop";
-  }];
-
   miniGreeterConf = pkgs.writeText "lightdm-mini-greeter.conf"
     ''
     [greeter]
@@ -90,7 +85,7 @@ in
     services.xserver.displayManager.lightdm.greeters.gtk.enable = false;
 
     services.xserver.displayManager.lightdm.greeter = mkDefault {
-      package = xgreeters;
+      package = pkgs.lightdm-mini-greeter.xgreeters;
       name = "lightdm-mini-greeter";
     };
 

--- a/nixos/modules/services/x11/display-managers/lightdm.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm.nix
@@ -249,7 +249,7 @@ in
         password required       pam_deny.so
 
         session  required       pam_succeed_if.so audit quiet_success user = lightdm
-        session  required       pam_env.so envfile=${config.system.build.pamEnvironment}
+        session  required       pam_env.so conffile=${config.system.build.pamEnvironment} readenv=0
         session  optional       ${pkgs.systemd}/lib/security/pam_systemd.so
         session  optional       pam_keyinit.so force revoke
         session  optional       pam_permit.so

--- a/nixos/modules/services/x11/display-managers/sddm.nix
+++ b/nixos/modules/services/x11/display-managers/sddm.nix
@@ -242,7 +242,7 @@ in
         password required       pam_deny.so
 
         session  required       pam_succeed_if.so audit quiet_success user = sddm
-        session  required       pam_env.so envfile=${config.system.build.pamEnvironment}
+        session  required       pam_env.so conffile=${config.system.build.pamEnvironment} readenv=0
         session  optional       ${pkgs.systemd}/lib/security/pam_systemd.so
         session  optional       pam_keyinit.so force revoke
         session  optional       pam_permit.so

--- a/nixos/modules/services/x11/display-managers/sddm.nix
+++ b/nixos/modules/services/x11/display-managers/sddm.nix
@@ -219,8 +219,6 @@ in
         # Load themes from system environment
         QT_PLUGIN_PATH = "/run/current-system/sw/" + pkgs.qt5.qtbase.qtPluginPrefix;
         QML2_IMPORT_PATH = "/run/current-system/sw/" + pkgs.qt5.qtbase.qtQmlPrefix;
-
-        XDG_DATA_DIRS = "/run/current-system/sw/share";
       };
 
       execCmd = "exec /run/current-system/sw/bin/sddm";

--- a/pkgs/applications/display-managers/lightdm-enso-os-greeter/default.nix
+++ b/pkgs/applications/display-managers/lightdm-enso-os-greeter/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchgit, pkgconfig
+{ stdenv, fetchgit, pkgconfig, linkFarm, lightdm-enso-os-greeter
 , dbus, pcre, epoxy, libXdmcp, at-spi2-core, libxklavier, libxkbcommon, libpthreadstubs
-, gtk3, vala, cmake, libgee, libX11, lightdm, gdk-pixbuf, clutter-gtk }:
+, gtk3, vala, cmake, libgee, libX11, lightdm, gdk-pixbuf, clutter-gtk, wrapGAppsHook, librsvg }:
 
 stdenv.mkDerivation {
   version = "0.2.1";
@@ -12,12 +12,21 @@ stdenv.mkDerivation {
     sha256 = "11jm181jq1vbn83h235avpdxz7pqq6prqyzki5yryy53mkj4kgxz";
   };
 
+  patches = [
+    ./fix-paths.patch
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkgconfig
+    vala
+    wrapGAppsHook
+  ];
+
   buildInputs = [
     dbus
     gtk3
     pcre
-    vala
-    cmake
     epoxy
     libgee
     libX11
@@ -29,31 +38,21 @@ stdenv.mkDerivation {
     at-spi2-core
     libxkbcommon
     libpthreadstubs
+    librsvg
   ];
-
-  nativeBuildInputs = [
-    pkgconfig
-  ];
-
-  postPatch = ''
-    sed -i "s@\''${CMAKE_INSTALL_PREFIX}/@@" greeter/CMakeLists.txt
-  '';
 
   preConfigure = ''
     cd greeter
   '';
 
-  installFlags = [
-    "DESTDIR=$(out)"
-  ];
-
-  preFixup = ''
-    mv $out/usr/* $out
-    rm -r $out/usr
-  '';
+  passthru.xgreeters = linkFarm "enso-os-greeter-xgreeters" [{
+    path = "${lightdm-enso-os-greeter}/share/xgreeters/pantheon-greeter.desktop";
+    name = "pantheon-greeter.desktop";
+  }];
 
   postFixup = ''
-    rm -r $out/sbin
+    substituteInPlace $out/share/xgreeters/pantheon-greeter.desktop \
+      --replace "pantheon-greeter" "$out/bin/pantheon-greeter"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/display-managers/lightdm-enso-os-greeter/fix-paths.patch
+++ b/pkgs/applications/display-managers/lightdm-enso-os-greeter/fix-paths.patch
@@ -1,0 +1,24 @@
+diff --git a/greeter/CMakeLists.txt b/greeter/CMakeLists.txt
+index 57aebb0..ab50bff 100644
+--- a/greeter/CMakeLists.txt
++++ b/greeter/CMakeLists.txt
+@@ -9,7 +9,6 @@ list (APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
+ set (CONF_DIR "/etc/lightdm")
+ set (DATADIR "${CMAKE_INSTALL_PREFIX}/share")
+ set (PKGDATADIR "${DATADIR}/enso/greeter")
+-set (CMAKE_INSTALL_PREFIX /usr)
+ set (VERSION "1.0.6")
+ 
+ 
+@@ -94,9 +93,9 @@ glib_compile_resources (GLIB_RESOURCES_CSS SOURCE data/css.gresource.xml)
+ add_executable (pantheon-greeter ${VALA_C} ${GLIB_RESOURCES_CSS})
+ target_link_libraries(pantheon-greeter m)
+ 
+-install (TARGETS pantheon-greeter RUNTIME DESTINATION sbin)
++install (TARGETS pantheon-greeter RUNTIME DESTINATION bin)
+ install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/data/pantheon-greeter.desktop DESTINATION share/xgreeters)
+-install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/data/greeter.conf DESTINATION ${CONF_DIR})
++install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/data/greeter.conf DESTINATION etc/lightdm)
+ install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/data/fingerprint.svg DESTINATION ${PKGDATADIR})
+ install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/data/power.svg DESTINATION ${PKGDATADIR})
+ install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/data/checked.svg DESTINATION ${PKGDATADIR})

--- a/pkgs/applications/display-managers/lightdm-mini-greeter/default.nix
+++ b/pkgs/applications/display-managers/lightdm-mini-greeter/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, lightdm, gtk3 }:
+{ stdenv, linkFarm, lightdm-mini-greeter, fetchFromGitHub, autoreconfHook, pkgconfig, lightdm, gtk3, glib, gdk-pixbuf, wrapGAppsHook, librsvg }:
 
 stdenv.mkDerivation rec {
   pname = "lightdm-mini-greeter";
@@ -11,11 +11,11 @@ stdenv.mkDerivation rec {
     sha256 = "1qi0bsqi8z2zv3303ww0kd7bciz6qx8na5bkvgrqlwyvq31czai5";
   };
 
-  nativeBuildInputs = [ autoreconfHook pkgconfig ];
-  buildInputs = [ lightdm gtk3 ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig wrapGAppsHook ];
+  buildInputs = [ lightdm gtk3 glib gdk-pixbuf librsvg ];
 
   configureFlags = [ "--sysconfdir=/etc" ];
-  makeFlags = [ "configdir=$(out)/etc" ];
+  makeFlags = [ "configdir=${placeholder "out"}/etc" ];
 
   postInstall = ''
     substituteInPlace "$out/share/xgreeters/lightdm-mini-greeter.desktop" \

--- a/pkgs/applications/display-managers/lightdm-mini-greeter/default.nix
+++ b/pkgs/applications/display-managers/lightdm-mini-greeter/default.nix
@@ -22,6 +22,11 @@ stdenv.mkDerivation rec {
       --replace "Exec=lightdm-mini-greeter" "Exec=$out/bin/lightdm-mini-greeter"
   '';
 
+  passthru.xgreeters = linkFarm "lightdm-mini-greeter-xgreeters" [{
+    path = "${lightdm-mini-greeter}/share/xgreeters/lightdm-mini-greeter.desktop";
+    name = "lightdm-mini-greeter.desktop";
+  }];
+
   meta = with stdenv.lib; {
     description = "A minimal, configurable, single-user GTK3 LightDM greeter";
     homepage = https://github.com/prikhi/lightdm-mini-greeter;

--- a/pkgs/applications/display-managers/lightdm/gtk-greeter.nix
+++ b/pkgs/applications/display-managers/lightdm/gtk-greeter.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     substituteInPlace "$out/share/xgreeters/lightdm-gtk-greeter.desktop" \
-      --replace "Exec=lightdm-gtk-greeter" "Exec=$out/sbin/lightdm-gtk-greeter"
+      --replace "Exec=lightdm-gtk-greeter" "Exec=$out/bin/lightdm-gtk-greeter"
   '';
 
   passthru.xgreeters = linkFarm "lightdm-gtk-greeter-xgreeters" [{

--- a/pkgs/applications/display-managers/lightdm/gtk-greeter.nix
+++ b/pkgs/applications/display-managers/lightdm/gtk-greeter.nix
@@ -1,7 +1,18 @@
-{ stdenv, fetchurl, lightdm, pkgconfig, intltool
-, hicolor-icon-theme, makeWrapper
-, useGTK2 ? false, gtk2, gtk3 # gtk3 seems better supported
-, exo, at-spi2-core
+{ stdenv
+, lightdm_gtk_greeter
+, fetchurl
+, lightdm
+, pkgconfig
+, intltool
+, linkFarm
+, wrapGAppsHook
+, useGTK2 ? false
+, gtk2
+, gtk3 # gtk3 seems better supported
+, exo
+, at-spi2-core
+, librsvg
+, hicolor-icon-theme
 }:
 
 #ToDo: bad icons with gtk2;
@@ -20,14 +31,15 @@ stdenv.mkDerivation rec {
     sha256 = "1pis5qyg95pg31dvnfqq34bzgj00hg4vs547r8h60lxjk81z8p15";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ lightdm exo intltool makeWrapper hicolor-icon-theme ]
+  nativeBuildInputs = [ pkgconfig intltool wrapGAppsHook ];
+  buildInputs = [ lightdm exo librsvg hicolor-icon-theme ]
     ++ (if useGTK2 then [ gtk2 ] else [ gtk3 ]);
 
   configureFlags = [
     "--localstatedir=/var"
     "--sysconfdir=/etc"
     "--disable-indicator-services-command"
+    "--sbindir=${placeholder "out"}/bin" # for wrapGAppsHook to wrap automatically
   ] ++ stdenv.lib.optional useGTK2 "--with-gtk2";
 
   preConfigure = ''
@@ -44,9 +56,12 @@ stdenv.mkDerivation rec {
   postInstall = ''
     substituteInPlace "$out/share/xgreeters/lightdm-gtk-greeter.desktop" \
       --replace "Exec=lightdm-gtk-greeter" "Exec=$out/sbin/lightdm-gtk-greeter"
-    wrapProgram "$out/sbin/lightdm-gtk-greeter" \
-      --prefix XDG_DATA_DIRS ":" "${hicolor-icon-theme}/share"
   '';
+
+  passthru.xgreeters = linkFarm "lightdm-gtk-greeter-xgreeters" [{
+    path = "${lightdm_gtk_greeter}/share/xgreeters/lightdm-gtk-greeter.desktop";
+    name = "lightdm-gtk-greeter.desktop";
+  }];
 
   meta = with stdenv.lib; {
     homepage = https://launchpad.net/lightdm-gtk-greeter;

--- a/pkgs/misc/themes/clearlooks-phenix/default.nix
+++ b/pkgs/misc/themes/clearlooks-phenix/default.nix
@@ -23,9 +23,6 @@ stdenv.mkDerivation rec {
       The Clearlooks-Phénix project aims at creating a GTK3 port of Clearlooks,
       the default theme for Gnome 2. Style is also included for GTK2, Unity and
       for Metacity, Openbox and Xfwm4 window managers.
-
-      You should install this theme into your user profile and then set
-      GTK_DATA_PREFIX to `~/.nix-profile`.
     '';
     homepage = https://github.com/jpfleury/clearlooks-phenix;
     downloadPage = https://github.com/jpfleury/clearlooks-phenix/releases;


### PR DESCRIPTION
###### Motivation for this change
Fixes the general issue found in #68383. This has been useful for every display-manager.

Thanks @rycee for https://github.com/NixOS/nixpkgs/commit/573648903b364fa5c322e3890cfd209bbc9a09da it was magically just the commit I needed.
Originates from #67942.

This will allow me to fix https://github.com/elementary/greeter/issues/318 and hopefully update it to its latest release.

###### Things to test for display-managers

- [x] lightdm greeters have proper theming

- [x] correct cursor theme is used in gdm

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
