### PR TITLE
pythonPackages.tvnamer: pytest belongs in checkInputs

### DIFF
--- a/pkgs/development/python-modules/tvnamer/default.nix
+++ b/pkgs/development/python-modules/tvnamer/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
     sha256 = "75e38454757c77060ad3782bd071682d6d316de86f9aec1c2042d236f93aec7b";
   };
 
-  buildInputs = [ pytest ];
+  checkInputs = [ pytest ];
   propagatedBuildInputs = [ tvdb_api ];
 
   # a ton of tests fail with: IOError: tvnamer/main.py could not be found in . or ..


### PR DESCRIPTION
###### Motivation for this change

Minor cleanup.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
