### PR TITLE
dupd: init at 1.7

### DIFF
--- a/pkgs/tools/misc/dupd/default.nix
+++ b/pkgs/tools/misc/dupd/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, fetchFromGitHub, perl, which
+, openssl, sqlite }:
+
+# Instead of writing directly into $HOME, we change the default db location
+# from $HOME/.dupd_sqlite to $HOME/.cache/dupd.sqlite3
+
+stdenv.mkDerivation rec {
+  pname = "dupd";
+  version = "1.7";
+
+  src = fetchFromGitHub {
+    owner = "jvirkki";
+    repo  = "dupd";
+    rev   = version;
+    sha256 = "0vg4vbiwjc5p22cisj8970mym4y2r29fcm08ibik92786vsbxcqk";
+  };
+
+  postPatch = ''
+    patchShebangs tests
+
+    # tests need HOME to write the database
+    export HOME=$TMPDIR
+
+    mkdir -p $HOME/.cache
+
+    for f in man/dupd man/dupd.1 src/main.c tests/test.56 tests/test.57 ; do
+      substituteInPlace $f --replace .dupd_sqlite .cache/dupd.sqlite3
+    done
+  '';
+
+  buildInputs = [ openssl sqlite ];
+
+  nativeBuildInputs = [ perl which ];
+
+  makeFlags = [
+    "INSTALL_PREFIX=$(out)"
+  ];
+
+  enableParallelBuilding = true;
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "CLI utility to find duplicate files";
+    homepage = http://www.virkki.com/dupd;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ peterhoeg ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17967,6 +17967,8 @@ in
 
   japa = callPackage ../applications/audio/japa { };
 
+  dupd = callPackage ../tools/misc/dupd { };
+
   jdupes = callPackage ../tools/misc/jdupes { };
 
   jedit = callPackage ../applications/editors/jedit { };


### PR DESCRIPTION
###### Motivation for this change

I needed this some time ago.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ x Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
