### PR TITLE
mbutil: init at 0.3.0

### DIFF
--- a/pkgs/applications/misc/mbutil/default.nix
+++ b/pkgs/applications/misc/mbutil/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildPythonApplication, fetchFromGitHub, nose }:
+
+buildPythonApplication rec {
+  pname = "mbutil";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "mapbox";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "06d62r89h026asaa4ryzb23m86j0cmbvy54kf4zl5f35sgiha45z";
+  };
+
+  checkInputs = [ nose ];
+  checkPhase = "nosetests";
+
+  meta = with lib; {
+    description = "An importer and exporter for MBTiles";
+    homepage = "https://github.com/mapbox/mbutil";
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ sikmir ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4821,6 +4821,8 @@ in
     boost = boost155;
   };
 
+  mbutil = python3Packages.callPackage ../applications/misc/mbutil { };
+
   mc = callPackage ../tools/misc/mc { };
 
   mcabber = callPackage ../applications/networking/instant-messengers/mcabber { };


### PR DESCRIPTION
###### Motivation for this change

> MBUtil is a utility for importing and exporting the [MBTiles](http://mbtiles.org/) format, typically created with [Mapbox](http://mapbox.com/) [TileMill](http://mapbox.com/tilemill/).

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
