### PR TITLE
xchm: 1.23 -> 1.30

### DIFF
--- a/pkgs/applications/misc/xchm/default.nix
+++ b/pkgs/applications/misc/xchm/default.nix
@@ -1,22 +1,30 @@
-{stdenv, fetchurl, wxGTK, chmlib}:
+{ stdenv, fetchFromGitHub, autoreconfHook, wxGTK30, chmlib }:
 
-stdenv.mkDerivation {
-  name = "xchm-1.23";
-  src = fetchurl {
-    url = mirror://sourceforge/xchm/xchm-1.23.tar.gz;
-    sha256 = "0qn0fyxcrn30ndq2asx31k0qkx3grbm16fb1y580wd2gjmh5r3wg";
+stdenv.mkDerivation rec {
+  pname = "xchm";
+  version = "1.30";
+
+  src = fetchFromGitHub {
+    owner = "rzvncj";
+    repo = "xCHM";
+    rev = version;
+    sha256 = "1sjvh06m8jbb28k6y3knas3nkh1dfvff4mlwjs33x12ilhddhr8v";
   };
-  buildInputs = [wxGTK chmlib];
 
-  postConfigure = ''
-    export NIX_LDFLAGS="$NIX_LDFLAGS $(${wxGTK}/lib/wx/config/* --libs | sed -e s@-pthread@@)"
-    echo $NIX_LDFLAGS
+  nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = [ wxGTK30 chmlib ];
+
+  configureFlags = [ "--with-wx-prefix=${wxGTK30}" ];
+
+  preConfigure = ''
+    export LDFLAGS="$LDFLAGS $(${wxGTK30}/bin/wx-config --libs | sed -e s@-pthread@@) -lwx_gtk2u_aui-3.0"
   '';
 
   meta = with stdenv.lib; {
     description = "A viewer for Microsoft HTML Help files";
-    homepage = http://xchm.sourceforge.net;
+    homepage = "https://github.com/rzvncj/xCHM";
     license = licenses.gpl2;
+    maintainers = with maintainers; [ sikmir ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

- 2019-02-24: [xCHM has moved to GitHub](https://sourceforge.net/p/xchm/news/2019/02/xchm-has-moved-to-github/)
- [xCHM 1.26](https://github.com/rzvncj/xCHM/releases/tag/1.26): wxWidgets 3.0 or newer is now required

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```sh
$ nix path-info -Sh /nix/store/ygfp60ljxslzxr5sjwarzw5h9k2vhh58-xchm-1.23
/nix/store/ygfp60ljxslzxr5sjwarzw5h9k2vhh58-xchm-1.23	 298.9M
$ nix path-info -Sh /nix/store/ylkfmgvkii8f945z34pip5a59y6n4har-xchm-1.30/
/nix/store/ylkfmgvkii8f945z34pip5a59y6n4har-xchm-1.30	 166.8M
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
