### PR TITLE
macvim: work around ibtool issue

### DIFF
--- a/pkgs/applications/editors/vim/macvim.nix
+++ b/pkgs/applications/editors/vim/macvim.nix
@@ -48,7 +48,11 @@ stdenv.mkDerivation {
   # The sparkle patch modified the nibs, so we have to recompile them
   postPatch = ''
     for nib in MainMenu Preferences; do
-      /usr/bin/ibtool --compile src/MacVim/English.lproj/$nib.nib/keyedobjects.nib src/MacVim/English.lproj/$nib.nib
+      # redirect stdin/stdout/stderr to /dev/null because ibtool marks them nonblocking
+      # and not redirecting screws with subsequent commands.
+      # redirecting stderr is unfortunate but I don't know of a reasonable way to remove O_NONBLOCK
+      # from the fds.
+      /usr/bin/ibtool --compile src/MacVim/English.lproj/$nib.nib/keyedobjects.nib src/MacVim/English.lproj/$nib.nib >/dev/null 2>/dev/null </dev/null
     done
   '';
 


### PR DESCRIPTION
###### Motivation for this change
It seems that /usr/bin/ibtool marks stdin/stdout/stderr as nonblocking, which can cause the subsequent build phase to fail when it tries to write to stdout. I don't know why this problem just started happening for me, but preventing ibtool from inheriting fds fixes the problem.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I can't actually build this on my system because I've already upgraded to Xcode 11 GM and MacVim won't compile with Xcode 11 at the moment. I'm tracking that down separately. But I've confirmed that with this change, I no longer get the stdout write error, and ibtool does still patch the nibs as expected.