### PR TITLE
haskellPackages.dbus: multiple addresses patch

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -86,6 +86,9 @@ self: super: {
     doCheck = !pkgs.stdenv.isDarwin;
   });
 
+  # See #68498 and rblaze/haskell-dbus#37
+  dbus = appendPatch super.dbus ./patches/dbus-session-multiple.patch;
+
   # https://github.com/froozen/kademlia/issues/2
   kademlia = dontCheck super.kademlia;
 

--- a/pkgs/development/haskell-modules/patches/dbus-session-multiple.patch
+++ b/pkgs/development/haskell-modules/patches/dbus-session-multiple.patch
@@ -1,0 +1,21 @@
+diff --git a/lib/DBus/Internal/Address.hs b/lib/DBus/Internal/Address.hs
+index 7365110..c01fad3 100644
+--- a/lib/DBus/Internal/Address.hs
++++ b/lib/DBus/Internal/Address.hs
+@@ -19,6 +19,7 @@ import           Data.Char (digitToInt, ord, chr)
+ import           Data.List (intercalate)
+ import qualified Data.Map
+ import           Data.Map (Map)
++import           Data.Maybe (listToMaybe)
+ import qualified System.Environment
+ import           Text.Printf (printf)
+ 
+@@ -151,7 +152,7 @@ getSystemAddress = do
+ getSessionAddress :: IO (Maybe Address)
+ getSessionAddress = do
+     env <- getenv "DBUS_SESSION_BUS_ADDRESS"
+-    return (env >>= parseAddress)
++    return $ maybe Nothing listToMaybe (env >>= parseAddresses)
+ 
+ -- | Returns the address in the environment variable
+ -- @DBUS_STARTER_ADDRESS@, which must be set.


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
xmonad breaks for me because of #68498. This reintroduces an old patch removed in 87ec7bb087b7d475c9118dcfff8b35ef62f8ce1a (While multiple addresses was upstreamed as `parseAddresses`, that function is not actually used for the env variables, so the issue remains).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
