### PR TITLE
brlaser: 4 -> 5

### DIFF
--- a/pkgs/misc/cups/drivers/brlaser/default.nix
+++ b/pkgs/misc/cups/drivers/brlaser/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "brlaser";
-  version = "4";
+  version = "5";
 
   src = fetchFromGitHub {
     owner = "pdewacht";
     repo = "brlaser";
     rev = "v${version}";
-    sha256 = "1yy4mpf68c82h245srh2sd1yip29w6kx14gxk4hxkv496gf55lw5";
+    sha256 = "133fx49wkg1v8r4kcishd035hlsscv8kc2q4jnln5qmyhpyygjyy";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -25,13 +25,29 @@ stdenv.mkDerivation rec {
        This driver is known to work with these printers:
 
            Brother DCP-1510
+           Brother DCP-1602
            Brother DCP-7030
            Brother DCP-7040
            Brother DCP-7055
            Brother DCP-7055W
+           Brother DCP-7060D
            Brother DCP-7065DN
-           Brother HL-L2300D
+           Brother DCP-7080
+           Brother DCP-L2500D
+           Brother DCP-L2540DW
+           Brother HL-1110 series
+           Brother HL-1200 series
+           Brother HL-L2300D series
+           Brother HL-L2320D series
+           Brother HL-L2340D series
+           Brother HL-L2360D series
+           Brother MFC-1910W
+           Brother MFC-7240
            Brother MFC-7360N
+           Brother MFC-7365DN
+           Brother MFC-7840W
+           Brother MFC-L2710DW
+           Lenovo M7605D
       '';
     homepage = https://github.com/pdewacht/brlaser;
     license = licenses.gpl2;


### PR DESCRIPTION
###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @StijnDW 
