### PR TITLE
macvim: fix compatibility with Xcode 11

### DIFF
--- a/pkgs/applications/editors/vim/macvim.nix
+++ b/pkgs/applications/editors/vim/macvim.nix
@@ -102,6 +102,9 @@ stdenv.mkDerivation {
     substituteInPlace src/auto/config.mk --replace "PERL_CFLAGS	=" "PERL_CFLAGS	= -I${darwin.libutil}/include"
 
     substituteInPlace src/MacVim/vimrc --subst-var-by CSCOPE ${cscope}/bin/cscope
+
+    # Work around weird code-signing issue
+    substituteInPlace src/auto/config.mk --replace "XCODEFLAGS''\t=" "XCODEFLAGS''\t= CODE_SIGN_IDENTITY="
   '';
 
   postInstall = ''

--- a/pkgs/applications/editors/vim/macvim.patch
+++ b/pkgs/applications/editors/vim/macvim.patch
@@ -18,6 +18,21 @@ index e519018de..556a4127d 100644
  				PRODUCT_BUNDLE_IDENTIFIER = org.vim.MacVim;
  				PRODUCT_NAME = MacVim;
  				VERSIONING_SYSTEM = "apple-generic";
+diff --git a/src/MacVim/PSMTabBarControl/source/PSMTabBarCell.m b/src/MacVim/PSMTabBarControl/source/PSMTabBarCell.m
+index 6f1a06e46..a12e2cea4 100644
+--- a/src/MacVim/PSMTabBarControl/source/PSMTabBarCell.m
++++ b/src/MacVim/PSMTabBarControl/source/PSMTabBarCell.m
+@@ -13,7 +13,9 @@
+ #import "PSMTabDragAssistant.h"
+ 
+ 
+-@implementation PSMTabBarCell
++@implementation PSMTabBarCell {
++    id _controlView;
++}
+ 
+ #pragma mark -
+ #pragma mark Creation/Destruction
 diff --git a/src/MacVim/vimrc b/src/MacVim/vimrc
 index 23a06bf37..dfb10fe94 100644
 --- a/src/MacVim/vimrc
@@ -77,6 +92,18 @@ diff --git a/src/auto/configure b/src/auto/configure
 index 9e6a82f4a..3c6d1a89b 100755
 --- a/src/auto/configure
 +++ b/src/auto/configure
+@@ -4705,10 +4705,8 @@ fi
+ rm -f core conftest.err conftest.$ac_objext \
+     conftest$ac_exeext conftest.$ac_ext
+   else
+-    if test -z "$MACOSX_DEPLOYMENT_TARGET"; then
+-      macosx_deployment_target=`/usr/bin/sw_vers -productVersion|/usr/bin/sed -e 's/^\([0-9]*\.[0-9]*\).*/\1/'`
++      macosx_deployment_target=${MACOSX_DEPLOYMENT_TARGET:-10.12}
+       XCODEFLAGS="$XCODEFLAGS MACOSX_DEPLOYMENT_TARGET=$macosx_deployment_target"
+-    fi
+   fi
+ 
+ 
 @@ -5829,10 +5829,7 @@ $as_echo "not found" >&6; }
  
      for path in "${vi_cv_path_mzscheme_pfx}/lib" "${SCHEME_LIB}"; do


### PR DESCRIPTION
###### Motivation for this change
This fixes several Xcode 11 incompatibilities with MacVim, including an issue where it wasn't inheriting the deployment target correctly to begin with.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I haven't actually tested but I'm pretty sure this package doesn't compile under sandbox, so don't bother trying.

Also see https://github.com/NixOS/nixpkgs/pull/68528. I tested by building with both patches applied simultaneously.

I haven't actually tested compiling this with Xcode 10.3 via Nix, but I did test the patches independently with Xcode 10.3 in a separate checkout of the MacVim project.