### PR TITLE
kdbplus: 3.3 -> 3.6

### DIFF
--- a/pkgs/applications/misc/kdbplus/default.nix
+++ b/pkgs/applications/misc/kdbplus/default.nix
@@ -8,17 +8,17 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "kdbplus";
-  version = "3.3";
+  version = "3.6";
 
-  src = requireFile {
+  src = requireFile rec {
     message = ''
       Nix can't download kdb+ for you automatically. Go to
       http://kx.com and download the free, 32-bit version for
-      Linux. Then run "nix-prefetch-url file://\$PWD/linux.zip" in
-      the directory where you saved it. Note you need version 3.3.
+      Linux. Then run "nix-prefetch-url file://\$PWD/${name}" in
+      the directory where you saved it. Note you need version ${version}.
     '';
-    name   = "linux.zip";
-    sha256 = "5fd0837599e24f0f437a8314510888a86ab0787684120a8fcf592299800aa940";
+    name   = "linuxx86.zip";
+    sha256 = "0w6znd9warcqx28vf648n0vgmxyyy9kvsfpsfw37d1kp5finap4p";
   };
 
   dontStrip = true;


### PR DESCRIPTION
#### Motivation for this change

Version bump, the binary required is no longer available from the software's website.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @thoughtpolice 
