### PR TITLE
kdepim-addons: add missing dependency

### DIFF
--- a/pkgs/applications/kde/kdepim-addons.nix
+++ b/pkgs/applications/kde/kdepim-addons.nix
@@ -5,7 +5,7 @@
   incidenceeditor, kcalcore, kcalutils, kconfig, kdbusaddons, kdeclarative,
   kdepim-apps-libs, kholidays, ki18n, kmime, ktexteditor, ktnef, libgravatar,
   libksieve, mailcommon, mailimporter, messagelib, poppler, prison, kpkpass,
-  kitinerary
+  kitinerary, kontactinterface
 }:
 
 mkDerivation {
@@ -20,6 +20,6 @@ mkDerivation {
     incidenceeditor kcalcore kcalutils kconfig kdbusaddons kdeclarative
     kdepim-apps-libs kholidays ki18n kmime ktexteditor ktnef libgravatar
     libksieve mailcommon mailimporter messagelib poppler prison kpkpass
-    kitinerary
+    kitinerary kontactinterface
   ];
 }


### PR DESCRIPTION
###### Motivation for this change

Fixes the build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
