### PR TITLE
crun: init at 0.8

### DIFF
--- a/pkgs/applications/virtualization/crun/default.nix
+++ b/pkgs/applications/virtualization/crun/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, lib, fetchFromGitHub, autoreconfHook, go-md2man, pkgconfig
+, libcap, libseccomp, python3, systemd, yajl }:
+
+stdenv.mkDerivation rec {
+  pname = "crun";
+  version = "0.8";
+
+  src = fetchFromGitHub {
+    owner = "containers";
+    repo = pname;
+    rev = version;
+    sha256 = "1anvlgw373031w0pp0b28l10yrnyhbj192n60bbbjahw487dk2fi";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ autoreconfHook go-md2man pkgconfig python3 ];
+
+  buildInputs = [ libcap libseccomp systemd yajl ];
+
+  enableParallelBuilding = true;
+
+  # the tests require additional permissions
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A fast and lightweight fully featured OCI runtime and C library for running containers";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    inherit (src.meta) homepage;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17690,6 +17690,8 @@ in
 
   cpp_ethereum = callPackage ../applications/misc/cpp-ethereum { };
 
+  crun = callPackage ../applications/virtualization/crun {};
+
   csdp = callPackage ../applications/science/math/csdp { };
 
   ctop = callPackage ../tools/system/ctop { };


### PR DESCRIPTION
###### Motivation for this change

An alternative to the ```runc``` container runtime.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
