### PR TITLE
buildah: minor cleanups

### DIFF
--- a/pkgs/development/tools/buildah/default.nix
+++ b/pkgs/development/tools/buildah/default.nix
@@ -2,30 +2,21 @@
 , gpgme, libgpgerror, lvm2, btrfs-progs, pkgconfig, ostree, libselinux, libseccomp
 }:
 
-let
+buildGoPackage rec {
+  pname = "buildah";
   version = "1.11.0";
 
   src = fetchFromGitHub {
-    rev    = "v${version}";
     owner  = "containers";
     repo   = "buildah";
+    rev    = "v${version}";
     sha256 = "114dmjqacz5hairl1s8qhndzr52lcvh99g565cq5ydscblnzpw1b";
   };
 
-  goPackagePath = "github.com/containers/buildah";
-
-in buildGoPackage {
-  pname = "buildah";
-  inherit version;
-  inherit src;
-
   outputs = [ "bin" "man" "out" ];
 
-  inherit goPackagePath;
+  goPackagePath = "github.com/containers/buildah";
   excludedPackages = [ "tests" ];
-
-  # Optimizations break compilation of libseccomp c bindings
-  hardeningDisable = [ "fortify" ];
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ gpgme libgpgerror lvm2 btrfs-progs ostree libselinux libseccomp ];
@@ -40,10 +31,10 @@ in buildGoPackage {
     make -C docs install PREFIX="$man"
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "A tool which facilitates building OCI images";
-    homepage = https://github.com/containers/buildah;
-    maintainers = with stdenv.lib.maintainers; [ Profpatsch vdemeester ];
-    license = stdenv.lib.licenses.asl20;
+    homepage = "https://github.com/containers/buildah";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ Profpatsch vdemeester ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Had a local 1.10.1 -> 1.11.0 upgrade and this is the leftovers from that as the upgrade is already in master.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
