### PR TITLE
CODEOWNERS: add myself for prometheus exporters

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -150,3 +150,8 @@
 /pkgs/applications/editors/emacs-modes @adisbladis
 /pkgs/applications/editors/emacs       @adisbladis
 /pkgs/top-level/emacs-packages.nix     @adisbladis
+
+# Prometheus exporter modules and tests
+/nixos/modules/services/monitoring/prometheus/exporters.nix  @WilliButz
+/nixos/modules/services/monitoring/prometheus/exporters.xml  @WilliButz
+/nixos/tests/prometheus-exporters.nix                        @WilliButz


### PR DESCRIPTION
###### Motivation for this change
I'd like to receive notifications when changes are made to the prometheus exporters module or the corresponding tests.