### PR TITLE
gtk3.setupHook: clear icon-theme.cache in preFixup

### DIFF
--- a/doc/languages-frameworks/gnome.xml
+++ b/doc/languages-frameworks/gnome.xml
@@ -32,7 +32,7 @@
    <title>Icons</title>
 
    <para>
-    When an application uses icons, an icon theme should be available in <envar>XDG_DATA_DIRS</envar>. The package for the default, icon-less <link xlink:href="https://www.freedesktop.org/wiki/Software/icon-theme/">hicolor-icon-theme</link> contains <link linkend="ssec-gnome-hooks-hicolor-icon-theme">a setup hook</link> that will pick up icon themes from <literal>buildInputs</literal> and pass it to our wrapper. Unfortunately, relying on that would mean every user has to download the theme included in the package expression no matter their preference. For that reason, we leave the installation of icon theme on the user. If you use one of the desktop environments, you probably already have an icon theme installed.
+    When an application uses icons, an icon theme should be available in <envar>XDG_DATA_DIRS</envar> during runtime. The package for the default, icon-less <link xlink:href="https://www.freedesktop.org/wiki/Software/icon-theme/">hicolor-icon-theme</link> (should be propagated by every icon theme) contains <link linkend="ssec-gnome-hooks-hicolor-icon-theme">a setup hook</link> that will pick up icon themes from <literal>buildInputs</literal> and pass it to our wrapper. Unfortunately, relying on that would mean every user has to download the theme included in the package expression no matter their preference. For that reason, we leave the installation of icon theme on the user. If you use one of the desktop environments, you probably already have an icon theme installed.
    </para>
   </section>
 

--- a/doc/languages-frameworks/gnome.xml
+++ b/doc/languages-frameworks/gnome.xml
@@ -34,6 +34,10 @@
    <para>
     When an application uses icons, an icon theme should be available in <envar>XDG_DATA_DIRS</envar> during runtime. The package for the default, icon-less <link xlink:href="https://www.freedesktop.org/wiki/Software/icon-theme/">hicolor-icon-theme</link> (should be propagated by every icon theme) contains <link linkend="ssec-gnome-hooks-hicolor-icon-theme">a setup hook</link> that will pick up icon themes from <literal>buildInputs</literal> and pass it to our wrapper. Unfortunately, relying on that would mean every user has to download the theme included in the package expression no matter their preference. For that reason, we leave the installation of icon theme on the user. If you use one of the desktop environments, you probably already have an icon theme installed.
    </para>
+
+   <para>
+    To avoid costly file system access when locating icons, GTK, <link xlink:href="https://woboq.com/blog/qicon-reads-gtk-icon-cache-in-qt57.html">as well as Qt</link>, can rely on <filename>icon-theme.cache</filename> files from the themes’ top-level directories. These files are generated using <command>gtk-update-icon-cache</command>, which is expected to be run whenever an icon is added or removed to an icon theme (typically an application icon into <literal>hicolor</literal> theme) and some programs do indeed run this after icon installation. However, since packages are installed into their own prefix by Nix, this would lead to conflicts. For that reason, <package>gtk3</package> provides a <link xlink:href="#ssec-gnome-hooks-gtk-drop-icon-theme-cache">setup hook</link> that will clean the file from installation. Since most applications only ship their own icon that will be loaded on start-up, it should not affect them too much. On the other hand, icon themes are much larger and more widely used so we need to cache them. Because we recommend installing icon themes globally, we will generate the cache files from all packages in a profile using a NixOS module. You can enable the cache generation using <option>gtk.iconCache.enable</option> option if your desktop environment does not already do that.
+   </para>
   </section>
 
   <section xml:id="ssec-gnome-themes">
@@ -89,6 +93,11 @@ preFixup = ''
     <listitem xml:id="ssec-gnome-hooks-glib">
      <para>
       <package>glib</package> setup hook will populate <envar>GSETTINGS_SCHEMAS_PATH</envar> and then <package>wrapGAppsHook</package> will prepend it to <envar>XDG_DATA_DIRS</envar>.
+     </para>
+    </listitem>
+    <listitem xml:id="ssec-gnome-hooks-gtk-drop-icon-theme-cache">
+     <para>
+      One of <package>gtk3</package>’s setup hooks will remove <filename>icon-theme.cache</filename> files from package’s icon theme directories to avoid conflicts. Icon theme packages should prevent this with <code>dontDropIconThemeCache = true;</code>.
      </para>
     </listitem>
     <listitem xml:id="ssec-gnome-hooks-dconf">

--- a/pkgs/applications/audio/lollypop/default.nix
+++ b/pkgs/applications/audio/lollypop/default.nix
@@ -11,7 +11,6 @@
 , appstream-glib
 , desktop-file-utils
 , totem-pl-parser
-, hicolor-icon-theme
 , gobject-introspection
 , wrapGAppsHook
 , lastFMSupport ? true
@@ -51,7 +50,6 @@ python3.pkgs.buildPythonApplication rec  {
     gst-plugins-ugly
     gstreamer
     gtk3
-    hicolor-icon-theme
     libsoup
     totem-pl-parser
   ] ++ lib.optional lastFMSupport libsecret;

--- a/pkgs/applications/audio/pulseeffects/default.nix
+++ b/pkgs/applications/audio/pulseeffects/default.nix
@@ -32,7 +32,6 @@
 , rubberband
 , mda_lv2
 , lsp-plugins
-, hicolor-icon-theme
 }:
 
 let
@@ -86,7 +85,6 @@ in stdenv.mkDerivation rec {
     dbus
     fftwFloat
     zita-convolver
-    hicolor-icon-theme
   ];
 
   postPatch = ''

--- a/pkgs/applications/editors/gnome-builder/default.nix
+++ b/pkgs/applications/editors/gnome-builder/default.nix
@@ -13,7 +13,6 @@
 , gtk-doc
 , gtk3
 , gtksourceview4
-, hicolor-icon-theme
 , json-glib
 , jsonrpc-glib
 , libdazzle
@@ -56,7 +55,6 @@ stdenv.mkDerivation rec {
     docbook_xml_dtd_43
     gobject-introspection
     gtk-doc
-    hicolor-icon-theme
     (meson.override ({ inherit stdenv; }))
     ninja
     pkgconfig

--- a/pkgs/applications/graphics/avocode/default.nix
+++ b/pkgs/applications/graphics/avocode/default.nix
@@ -1,6 +1,6 @@
 { stdenv, makeDesktopItem, fetchurl, unzip
 , gdk-pixbuf, glib, gtk3, atk, at-spi2-atk, pango, cairo, freetype, fontconfig, dbus, nss, nspr, alsaLib, cups, expat, udev, gnome3
-, xorg, mozjpeg, makeWrapper, wrapGAppsHook, hicolor-icon-theme, libuuid, at-spi2-core
+, xorg, mozjpeg, makeWrapper, wrapGAppsHook, libuuid, at-spi2-core
 }:
 
 stdenv.mkDerivation rec {
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [makeWrapper wrapGAppsHook];
-  buildInputs = [ unzip gtk3 gnome3.adwaita-icon-theme hicolor-icon-theme ];
+  buildInputs = [ unzip gtk3 gnome3.adwaita-icon-theme ];
 
   # src is producing multiple folder on unzip so we must
   # override unpackCmd to extract it into newly created folder

--- a/pkgs/applications/graphics/dia/default.nix
+++ b/pkgs/applications/graphics/dia/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchgit, autoconf, automake, libtool, gtk2, pkgconfig, perlPackages,
 libxml2, gettext, python, libxml2Python, docbook5, docbook_xsl,
-libxslt, intltool, libart_lgpl, withGNOME ? false, libgnomeui, hicolor-icon-theme,
+libxslt, intltool, libart_lgpl, withGNOME ? false, libgnomeui,
 gtk-mac-integration-gtk2 }:
 
 stdenv.mkDerivation {
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
 
   buildInputs =
     [ gtk2 libxml2 gettext python libxml2Python docbook5
-      libxslt docbook_xsl libart_lgpl hicolor-icon-theme ]
+      libxslt docbook_xsl libart_lgpl ]
       ++ stdenv.lib.optional withGNOME libgnomeui
       ++ stdenv.lib.optional stdenv.isDarwin gtk-mac-integration-gtk2;
 

--- a/pkgs/applications/graphics/glabels/default.nix
+++ b/pkgs/applications/graphics/glabels/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, barcode, gnome3, autoreconfHook
 , gtk3, gtk-doc, libxml2, librsvg , libtool, libe-book, gsettings-desktop-schemas
-, intltool, itstool, makeWrapper, pkgconfig, hicolor-icon-theme
+, intltool, itstool, makeWrapper, pkgconfig
 }:
 
 stdenv.mkDerivation rec {
@@ -17,7 +17,6 @@ stdenv.mkDerivation rec {
     barcode gtk3 gtk-doc gnome3.yelp-tools
     gnome3.gnome-common gsettings-desktop-schemas
     itstool libxml2 librsvg libe-book libtool
-    hicolor-icon-theme
   ];
 
   preFixup = ''

--- a/pkgs/applications/graphics/ideogram/default.nix
+++ b/pkgs/applications/graphics/ideogram/default.nix
@@ -11,7 +11,6 @@
 , pantheon
 , desktop-file-utils
 , xorg
-, hicolor-icon-theme
 , wrapGAppsHook
 }:
 
@@ -28,7 +27,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     desktop-file-utils
-    hicolor-icon-theme # for setup-hook
     meson
     ninja
     pantheon.vala

--- a/pkgs/applications/graphics/inkscape/default.nix
+++ b/pkgs/applications/graphics/inkscape/default.nix
@@ -2,7 +2,7 @@
 , libpng, zlib, popt, boehmgc, libxml2, libxslt, glib, gtkmm2
 , glibmm, libsigcxx, lcms, boost, gettext, makeWrapper
 , gsl, python2, poppler, imagemagick, libwpg, librevenge
-, libvisio, libcdr, libexif, potrace, cmake, hicolor-icon-theme
+, libvisio, libcdr, libexif, potrace, cmake
 , librsvg, wrapGAppsHook
 }:
 
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     libXft libpng zlib popt boehmgc
     libxml2 libxslt glib gtkmm2 glibmm libsigcxx lcms boost gettext
     gsl poppler imagemagick libwpg librevenge
-    libvisio libcdr libexif potrace hicolor-icon-theme
+    libvisio libcdr libexif potrace
 
     librsvg # for loading icons
 

--- a/pkgs/applications/graphics/mypaint/default.nix
+++ b/pkgs/applications/graphics/mypaint/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, gtk3, intltool, json_c, lcms2, libpng, librsvg, gobject-introspection, hicolor-icon-theme
+{ stdenv, fetchFromGitHub, gtk3, intltool, json_c, lcms2, libpng, librsvg, gobject-introspection
 , gdk-pixbuf, pkgconfig, python2Packages, scons, swig, wrapGAppsHook }:
 
 let
@@ -21,7 +21,7 @@ in stdenv.mkDerivation {
   ];
 
   buildInputs = [
-    gtk3 gdk-pixbuf json_c lcms2 libpng librsvg pycairo pygobject3 python hicolor-icon-theme
+    gtk3 gdk-pixbuf json_c lcms2 libpng librsvg pycairo pygobject3 python
   ];
 
   propagatedBuildInputs = [ numpy ];

--- a/pkgs/applications/graphics/vimiv/default.nix
+++ b/pkgs/applications/graphics/vimiv/default.nix
@@ -1,5 +1,5 @@
 { lib, python3Packages, fetchFromGitHub, imagemagick, librsvg, gtk3, jhead
-, hicolor-icon-theme, gnome3
+, gnome3
 
 # Test requirements
 , dbus, xvfb_run, xdotool
@@ -38,7 +38,7 @@ python3Packages.buildPythonApplication rec {
   '';
 
   checkInputs = [ python3Packages.nose dbus.daemon xvfb_run xdotool ];
-  buildInputs = [ hicolor-icon-theme gnome3.adwaita-icon-theme librsvg ];
+  buildInputs = [ gnome3.adwaita-icon-theme librsvg ];
   propagatedBuildInputs = with python3Packages; [ pillow pygobject3 gtk3 ];
 
   makeWrapperArgs = [

--- a/pkgs/applications/graphics/xournalpp/default.nix
+++ b/pkgs/applications/graphics/xournalpp/default.nix
@@ -10,7 +10,6 @@
 , glib
 , gsettings-desktop-schemas
 , gtk3
-, hicolor-icon-theme
 , libsndfile
 , libxml2
 , libzip
@@ -38,7 +37,6 @@ stdenv.mkDerivation rec {
     [ glib
       gsettings-desktop-schemas
       gtk3
-      hicolor-icon-theme
       libsndfile
       libxml2
       libzip

--- a/pkgs/applications/misc/appeditor/default.nix
+++ b/pkgs/applications/misc/appeditor/default.nix
@@ -8,7 +8,6 @@
 , gettext
 , glib
 , gtk3
-, hicolor-icon-theme
 , libgee
 , wrapGAppsHook }:
 
@@ -36,7 +35,6 @@ stdenv.mkDerivation rec {
   buildInputs = [
     glib
     gtk3
-    hicolor-icon-theme
     pantheon.granite
     libgee
   ];

--- a/pkgs/applications/misc/clipit/default.nix
+++ b/pkgs/applications/misc/clipit/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, intltool, pkgconfig, gtk2, xdotool, hicolor-icon-theme }:
+{ fetchurl, stdenv, intltool, pkgconfig, gtk2, xdotool }:
 
 stdenv.mkDerivation rec {
   pname = "clipit";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ intltool gtk2 xdotool hicolor-icon-theme ];
+  buildInputs = [ intltool gtk2 xdotool ];
 
   meta = with stdenv.lib; {
     description = "Lightweight GTK Clipboard Manager";

--- a/pkgs/applications/misc/gxmessage/default.nix
+++ b/pkgs/applications/misc/gxmessage/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, gtk3, intltool, pkgconfig, texinfo, hicolor-icon-theme }:
+{ stdenv, fetchurl, gtk3, intltool, pkgconfig, texinfo }:
 
 stdenv.mkDerivation rec {
   pname = "gxmessage";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ intltool gtk3 texinfo hicolor-icon-theme ];
+  buildInputs = [ intltool gtk3 texinfo ];
 
   meta = {
     description = "A GTK enabled dropin replacement for xmessage";

--- a/pkgs/applications/misc/kupfer/default.nix
+++ b/pkgs/applications/misc/kupfer/default.nix
@@ -6,7 +6,6 @@
 , gtk3
 , libwnck3
 , keybinder3
-, hicolor-icon-theme
 , wrapGAppsHook
 , wafHook
 }:
@@ -27,7 +26,7 @@ buildPythonApplication rec {
     # For setup hook
     gobject-introspection wafHook
   ];
-  buildInputs = [ hicolor-icon-theme docutils libwnck3 keybinder3 ];
+  buildInputs = [ docutils libwnck3 keybinder3 ];
   propagatedBuildInputs = [ pygobject3 gtk3 pyxdg dbus-python pycairo ];
 
   # without strictDeps kupfer fails to build: Could not find the python module 'gi.repository.Gtk'

--- a/pkgs/applications/misc/megasync/default.nix
+++ b/pkgs/applications/misc/megasync/default.nix
@@ -7,7 +7,6 @@
 , doxygen
 , fetchFromGitHub
 , ffmpeg
-, hicolor-icon-theme
 , libmediainfo
 , libraw
 , libsodium
@@ -51,7 +50,6 @@ mkDerivation rec {
     cryptopp
     curl
     ffmpeg
-    hicolor-icon-theme
     libmediainfo
     libraw
     libsodium

--- a/pkgs/applications/misc/orca/default.nix
+++ b/pkgs/applications/misc/orca/default.nix
@@ -1,7 +1,7 @@
 { stdenv, pkgconfig, fetchurl, buildPythonApplication
 , autoreconfHook, wrapGAppsHook, gobject-introspection
 , intltool, yelp-tools, itstool, libxmlxx3
-, python, pygobject3, gtk3, gnome3, substituteAll, hicolor-icon-theme
+, python, pygobject3, gtk3, gnome3, substituteAll
 , at-spi2-atk, at-spi2-core, pyatspi, dbus, dbus-python, pyxdg
 , xkbcomp, procps, lsof, coreutils, gsettings-desktop-schemas
 , speechd, brltty, liblouis, setproctitle, gst_all_1, gst-python
@@ -31,7 +31,6 @@ buildPythonApplication rec {
   nativeBuildInputs = [
     autoreconfHook wrapGAppsHook pkgconfig libxmlxx3
     intltool yelp-tools itstool gobject-introspection
-    hicolor-icon-theme # setup-hook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/applications/misc/redshift/default.nix
+++ b/pkgs/applications/misc/redshift/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, autoconf, automake, gettext, intltool
 , libtool, pkgconfig, wrapGAppsHook, wrapPython, gobject-introspection
-, gtk3, python, pygobject3, hicolor-icon-theme, pyxdg
+, gtk3, python, pygobject3, pyxdg
 
 , withQuartz ? stdenv.isDarwin, ApplicationServices
 , withRandr ? stdenv.isLinux, libxcb
@@ -50,7 +50,6 @@ stdenv.mkDerivation rec {
     gobject-introspection
     gtk3
     python
-    hicolor-icon-theme
   ] ++ stdenv.lib.optional  withRandr        libxcb
     ++ stdenv.lib.optional  withGeoclue      geoclue
     ++ stdenv.lib.optional  withDrm          libdrm

--- a/pkgs/applications/misc/roxterm/default.nix
+++ b/pkgs/applications/misc/roxterm/default.nix
@@ -1,5 +1,5 @@
 { at-spi2-core, cmake, dbus, dbus-glib, docbook_xsl, epoxy, fetchpatch, fetchFromGitHub
-, glib, gtk3, harfbuzz, hicolor-icon-theme, libXdmcp, libXtst, libpthreadstubs
+, glib, gtk3, harfbuzz, libXdmcp, libXtst, libpthreadstubs
 , libselinux, libsepol, libtasn1, libxkbcommon, libxslt, p11-kit, pcre
 , pkgconfig, stdenv, utillinuxMinimal, vte, wrapGAppsHook, xmlto
 }:
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
   buildInputs =
     [ gtk3 dbus dbus-glib vte pcre harfbuzz libpthreadstubs libXdmcp
-      utillinuxMinimal glib hicolor-icon-theme docbook_xsl xmlto libselinux
+      utillinuxMinimal glib docbook_xsl xmlto libselinux
       libsepol libxkbcommon epoxy at-spi2-core libXtst libtasn1 p11-kit
     ];
 

--- a/pkgs/applications/misc/synapse/default.nix
+++ b/pkgs/applications/misc/synapse/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, gettext, pkgconfig, glib, libnotify, gtk3, libgee
-, keybinder3, json-glib, zeitgeist, vala, hicolor-icon-theme, gobject-introspection
+, keybinder3, json-glib, zeitgeist, vala, gobject-introspection
 }:
 
 let
@@ -20,7 +20,6 @@ in stdenv.mkDerivation rec {
   ];
   buildInputs = [
     glib libnotify gtk3 libgee keybinder3 json-glib zeitgeist
-    hicolor-icon-theme
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/misc/tilix/default.nix
+++ b/pkgs/applications/misc/tilix/default.nix
@@ -16,7 +16,6 @@
 , glib
 , wrapGAppsHook
 , libunwind
-, hicolor-icon-theme
 }:
 
 stdenv.mkDerivation {
@@ -38,7 +37,6 @@ stdenv.mkDerivation {
   nativeBuildInputs = [
     desktop-file-utils
     dmd
-    hicolor-icon-theme # for setup-hook
     meson
     ninja
     pkgconfig

--- a/pkgs/applications/misc/tint2/default.nix
+++ b/pkgs/applications/misc/tint2/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitLab, pkgconfig, cmake, gettext, cairo, pango, pcre
 , glib, imlib2, gtk2, libXinerama, libXrender, libXcomposite, libXdamage
 , libX11, libXrandr, librsvg, libpthreadstubs, libXdmcp
-, libstartup_notification, hicolor-icon-theme, wrapGAppsHook
+, libstartup_notification, wrapGAppsHook
 }:
 
 stdenv.mkDerivation rec {
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ cairo pango pcre glib imlib2 gtk2 libXinerama libXrender
     libXcomposite libXdamage libX11 libXrandr librsvg libpthreadstubs
-    libXdmcp libstartup_notification hicolor-icon-theme ];
+    libXdmcp libstartup_notification ];
 
   postPatch = ''
     for f in ./src/launcher/apps-common.c \

--- a/pkgs/applications/misc/tootle/default.nix
+++ b/pkgs/applications/misc/tootle/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub
 , meson, ninja, pkgconfig, python3, libgee, gsettings-desktop-schemas
 , gnome3, pantheon, gobject-introspection, wrapGAppsHook
-, gtk3, json-glib, glib, glib-networking, hicolor-icon-theme
+, gtk3, json-glib, glib, glib-networking
 }:
 
 let
@@ -27,7 +27,7 @@ in stdenv.mkDerivation {
     wrapGAppsHook
   ];
   buildInputs = [
-    gtk3 pantheon.granite json-glib glib glib-networking hicolor-icon-theme
+    gtk3 pantheon.granite json-glib glib glib-networking
     libgee gnome3.libsoup gsettings-desktop-schemas
   ];
 

--- a/pkgs/applications/misc/udiskie/default.nix
+++ b/pkgs/applications/misc/udiskie/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, asciidoc-full, gettext
-, gobject-introspection, gtk3, hicolor-icon-theme, libappindicator-gtk3, libnotify, librsvg
+, gobject-introspection, gtk3, libappindicator-gtk3, libnotify, librsvg
 , udisks2, wrapGAppsHook
 , python3Packages
 }:
@@ -23,7 +23,6 @@ python3Packages.buildPythonApplication rec {
   ];
 
   buildInputs = [
-    hicolor-icon-theme
     librsvg              # required for loading svg icons (udiskie uses svg icons)
     gobject-introspection
     libnotify

--- a/pkgs/applications/misc/ulauncher/default.nix
+++ b/pkgs/applications/misc/ulauncher/default.nix
@@ -10,7 +10,6 @@
 , libappindicator
 , intltool
 , wmctrl
-, hicolor-icon-theme
 , xvfb_run
 }:
 
@@ -36,7 +35,6 @@ python27Packages.buildPythonApplication rec  {
   buildInputs = [
     gnome3.adwaita-icon-theme
     gobject-introspection
-    hicolor-icon-theme
     keybinder3
     libappindicator
     libnotify

--- a/pkgs/applications/misc/viking/default.nix
+++ b/pkgs/applications/misc/viking/default.nix
@@ -1,6 +1,6 @@
 { fetchurl, stdenv, makeWrapper, pkgconfig, intltool, gettext, gtk2, expat, curl
 , gpsd, bc, file, gnome-doc-utils, libexif, libxml2, libxslt, scrollkeeper
-, docbook_xml_dtd_412, gexiv2, sqlite, gpsbabel, expect, hicolor-icon-theme
+, docbook_xml_dtd_412, gexiv2, sqlite, gpsbabel, expect
 , geoclue2, liboauth, nettle }:
 
 stdenv.mkDerivation rec {
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ makeWrapper intltool gettext gtk2 expat curl gpsd bc file gnome-doc-utils
-    libexif libxml2 libxslt scrollkeeper docbook_xml_dtd_412 gexiv2 sqlite hicolor-icon-theme
+    libexif libxml2 libxslt scrollkeeper docbook_xml_dtd_412 gexiv2 sqlite
     geoclue2 liboauth nettle
   ];
 

--- a/pkgs/applications/misc/xpad/default.nix
+++ b/pkgs/applications/misc/xpad/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl
 , autoreconfHook, pkgconfig, wrapGAppsHook
-, glib, intltool, gtk3, gtksourceview, hicolor-icon-theme }:
+, glib, intltool, gtk3, gtksourceview }:
 
 stdenv.mkDerivation rec {
   pname = "xpad";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook pkgconfig wrapGAppsHook ];
 
-  buildInputs = [ glib intltool gtk3 gtksourceview hicolor-icon-theme ];
+  buildInputs = [ glib intltool gtk3 gtksourceview ];
 
   meta = with stdenv.lib; {
     description = "A sticky note application for jotting down things to remember";

--- a/pkgs/applications/networking/browsers/ephemeral/default.nix
+++ b/pkgs/applications/networking/browsers/ephemeral/default.nix
@@ -4,7 +4,6 @@
 , gettext
 , glib
 , gtk3
-, hicolor-icon-theme
 , libgee
 , libdazzle
 , meson
@@ -43,7 +42,6 @@ stdenv.mkDerivation rec {
     glib
     glib-networking
     gtk3
-    hicolor-icon-theme
     libdazzle
     libgee
     pantheon.granite

--- a/pkgs/applications/networking/feedreaders/feedreader/default.nix
+++ b/pkgs/applications/networking/feedreaders/feedreader/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, meson, ninja, pkgconfig, vala, gettext, python3
 , appstream-glib, desktop-file-utils, wrapGAppsHook, gnome-online-accounts
-, gtk3, libgee, libpeas, librest, webkitgtk, gsettings-desktop-schemas, hicolor-icon-theme
+, gtk3, libgee, libpeas, librest, webkitgtk, gsettings-desktop-schemas
 , curl, glib, gnome3, gst_all_1, json-glib, libnotify, libsecret, sqlite, gumbo, libxml2
 }:
 
@@ -24,7 +24,6 @@ stdenv.mkDerivation rec {
     curl glib json-glib libnotify libsecret sqlite gumbo gtk3
     libgee libpeas gnome3.libsoup librest webkitgtk gsettings-desktop-schemas
     gnome-online-accounts
-    hicolor-icon-theme # for setup hook
   ] ++ (with gst_all_1; [
     gstreamer gst-plugins-base gst-plugins-good
   ]);

--- a/pkgs/applications/networking/instant-messengers/fractal/default.nix
+++ b/pkgs/applications/networking/instant-messengers/fractal/default.nix
@@ -10,7 +10,6 @@
 , rustPlatform
 , pkgconfig
 , gtksourceview
-, hicolor-icon-theme
 , glib
 , libhandy
 , gtk3
@@ -61,7 +60,6 @@ rustPlatform.buildRustPackage rec {
     gst_all_1.gstreamer
     gtk3
     gtksourceview
-    hicolor-icon-theme
     libhandy
     openssl
     sqlite

--- a/pkgs/applications/networking/irc/hexchat/default.nix
+++ b/pkgs/applications/networking/irc/hexchat/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, fetchpatch, pkgconfig, gtk2, lua, perl, python3
 , pciutils, dbus-glib, libcanberra-gtk2, libproxy
 , libsexy, enchant2, libnotify, openssl, isocodes
-, desktop-file-utils, hicolor-icon-theme
+, desktop-file-utils
 , meson, ninja
 }:
 
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     gtk2 lua perl python3 pciutils dbus-glib libcanberra-gtk2 libproxy
-    libsexy libnotify openssl desktop-file-utils hicolor-icon-theme
+    libsexy libnotify openssl desktop-file-utils
     isocodes
   ];
 

--- a/pkgs/applications/networking/mailreaders/balsa/default.nix
+++ b/pkgs/applications/networking/mailreaders/balsa/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, pkgconfig, intltool, glib, gtk3, gmime, gnutls,
   webkitgtk, libesmtp, openssl, libnotify, gtkspell3, gpgme,
   libcanberra-gtk3, libsecret, gtksourceview, gobject-introspection,
-  hicolor-icon-theme, wrapGAppsHook
+  wrapGAppsHook
 }:
 
 stdenv.mkDerivation rec {
@@ -17,7 +17,6 @@ stdenv.mkDerivation rec {
     pkgconfig
     intltool
     gobject-introspection
-    hicolor-icon-theme
     wrapGAppsHook
   ];
 

--- a/pkgs/applications/networking/mailreaders/claws-mail/default.nix
+++ b/pkgs/applications/networking/mailreaders/claws-mail/default.nix
@@ -1,8 +1,8 @@
 { config, fetchurl, stdenv, wrapGAppsHook, autoreconfHook
-, curl, dbus, dbus-glib, enchant, gtk2, gnutls, gnupg, gpgme, hicolor-icon-theme
+, curl, dbus, dbus-glib, enchant, gtk2, gnutls, gnupg, gpgme
 , libarchive, libcanberra-gtk2, libetpan, libnotify, libsoup, libxml2, networkmanager
 , openldap, perl, pkgconfig, poppler, python, shared-mime-info, webkitgtk24x-gtk2
-, glib-networking, gsettings-desktop-schemas, libSM, libytnef, libical 
+, glib-networking, gsettings-desktop-schemas, libSM, libytnef, libical
 # Build options
 # TODO: A flag to build the manual.
 # TODO: Plugins that complain about their missing dependencies, even when
@@ -56,7 +56,7 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = with python.pkgs; [ python ] ++ optionals enablePluginPython [ pygtk pygobject2 ];
 
   buildInputs =
-    [ curl dbus dbus-glib gtk2 gnutls gsettings-desktop-schemas hicolor-icon-theme
+    [ curl dbus dbus-glib gtk2 gnutls gsettings-desktop-schemas
       libetpan perl glib-networking libSM libytnef
     ]
     ++ optional enableSpellcheck enchant

--- a/pkgs/applications/networking/newsreaders/liferea/default.nix
+++ b/pkgs/applications/networking/newsreaders/liferea/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, pkgconfig, intltool, python3Packages, wrapGAppsHook
 , glib, libxml2, libxslt, sqlite, libsoup , webkitgtk, json-glib, gst_all_1
 , libnotify, gtk3, gsettings-desktop-schemas, libpeas, dconf, librsvg
-, gobject-introspection, glib-networking, hicolor-icon-theme
+, gobject-introspection, glib-networking
 }:
 
 stdenv.mkDerivation rec {
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     glib gtk3 webkitgtk libxml2 libxslt sqlite libsoup gsettings-desktop-schemas
     libpeas gsettings-desktop-schemas json-glib dconf gobject-introspection
-    librsvg glib-networking libnotify hicolor-icon-theme
+    librsvg glib-networking libnotify
   ] ++ (with gst_all_1; [
     gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad
   ]);

--- a/pkgs/applications/networking/p2p/torrential/default.nix
+++ b/pkgs/applications/networking/p2p/torrential/default.nix
@@ -6,7 +6,6 @@
 , curl
 , glib
 , gtk3
-, hicolor-icon-theme
 , libb64
 , libevent
 , libgee
@@ -14,7 +13,8 @@
 , libunity
 , miniupnpc
 , openssl
-, wrapGAppsHook }:
+, wrapGAppsHook
+}:
 
 stdenv.mkDerivation rec {
   pname = "torrential";
@@ -39,7 +39,6 @@ stdenv.mkDerivation rec {
     curl
     glib
     gtk3
-    hicolor-icon-theme
     libb64
     libevent
     libgee

--- a/pkgs/applications/networking/p2p/transmission-remote-gtk/default.nix
+++ b/pkgs/applications/networking/p2p/transmission-remote-gtk/default.nix
@@ -1,6 +1,5 @@
 { stdenv, autoconf, automake, libtool, wrapGAppsHook, fetchFromGitHub, pkgconfig
-, intltool, gtk3, json-glib, curl, glib, autoconf-archive, appstream-glib
-, hicolor-icon-theme }:
+, intltool, gtk3, json-glib, curl, glib, autoconf-archive, appstream-glib }:
 
 
 stdenv.mkDerivation rec {
@@ -22,7 +21,7 @@ stdenv.mkDerivation rec {
     appstream-glib
   ];
 
-  buildInputs = [ gtk3 json-glib curl glib hicolor-icon-theme ];
+  buildInputs = [ gtk3 json-glib curl glib ];
 
   doCheck = false; # fails with style validation error
 

--- a/pkgs/applications/networking/p2p/transmission/default.nix
+++ b/pkgs/applications/networking/p2p/transmission/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, intltool, file, wrapGAppsHook
-, openssl, curl, libevent, inotify-tools, systemd, zlib, hicolor-icon-theme
+, openssl, curl, libevent, inotify-tools, systemd, zlib
 , enableGTK3 ? false, gtk3
 , enableSystemd ? stdenv.isLinux
 , enableDaemon ? true
@@ -22,8 +22,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ intltool file openssl curl libevent zlib ]
     ++ optionals enableGTK3 [ gtk3 ]
     ++ optionals enableSystemd [ systemd ]
-    ++ optionals stdenv.isLinux [ inotify-tools ]
-    ++ optionals enableGTK3 [ hicolor-icon-theme ];
+    ++ optionals stdenv.isLinux [ inotify-tools ];
 
   postPatch = ''
     substituteInPlace ./configure \

--- a/pkgs/applications/networking/ping/default.nix
+++ b/pkgs/applications/networking/ping/default.nix
@@ -8,7 +8,6 @@
 , glib
 , gtk3
 , gtksourceview
-, hicolor-icon-theme
 , json-glib
 , libsoup
 , libgee
@@ -38,7 +37,6 @@ stdenv.mkDerivation rec {
     glib
     gtk3
     gtksourceview
-    hicolor-icon-theme
     json-glib
     libgee
     libsoup

--- a/pkgs/applications/networking/remote/remmina/default.nix
+++ b/pkgs/applications/networking/remote/remmina/default.nix
@@ -6,7 +6,7 @@
 , libsecret, libsoup, spice-protocol, spice-gtk, epoxy, at-spi2-core
 , openssl, gsettings-desktop-schemas, json-glib
 # The themes here are soft dependencies; only icons are missing without them.
-, hicolor-icon-theme, gnome3
+, gnome3
 }:
 
 with stdenv.lib;
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     pcre libdbusmenu-gtk3 libappindicator-gtk3
     libvncserver libpthreadstubs libXdmcp libxkbcommon
     libsecret libsoup spice-protocol spice-gtk epoxy at-spi2-core
-    openssl hicolor-icon-theme gnome3.adwaita-icon-theme json-glib
+    openssl gnome3.adwaita-icon-theme json-glib
   ];
 
   cmakeFlags = [

--- a/pkgs/applications/networking/weather/meteo/default.nix
+++ b/pkgs/applications/networking/weather/meteo/default.nix
@@ -1,7 +1,6 @@
 { stdenv, fetchFromGitLab, vala, python3, pkgconfig, meson, ninja, gtk3
 , json-glib, libsoup, webkitgtk, geocode-glib
-, libappindicator, desktop-file-utils, appstream, wrapGAppsHook
-, hicolor-icon-theme }:
+, libappindicator, desktop-file-utils, appstream, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   pname = "meteo";
@@ -28,7 +27,6 @@ stdenv.mkDerivation rec {
   buildInputs = [
     geocode-glib
     gtk3
-    hicolor-icon-theme
     json-glib
     libappindicator
     libsoup

--- a/pkgs/applications/office/gnucash/default.nix
+++ b/pkgs/applications/office/gnucash/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     boost icu libxml2 libxslt gettext swig isocodes gtk3 glibcLocales
-    webkitgtk dconf hicolor-icon-theme libofx aqbanking gwenhywfar libdbi
+    webkitgtk dconf libofx aqbanking gwenhywfar libdbi
     libdbiDrivers guile
     perlWrapper perl
   ] ++ (with perlPackages; [ FinanceQuote DateManip ]);

--- a/pkgs/applications/office/grisbi/default.nix
+++ b/pkgs/applications/office/grisbi/default.nix
@@ -1,5 +1,5 @@
 { fetchurl, stdenv, gtk, pkgconfig, libgsf, libofx, intltool, wrapGAppsHook
-, hicolor-icon-theme, libsoup, gnome3 }:
+, libsoup, gnome3 }:
 
 stdenv.mkDerivation rec {
   pname = "grisbi";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig wrapGAppsHook ];
-  buildInputs = [ gtk libgsf libofx intltool hicolor-icon-theme libsoup
+  buildInputs = [ gtk libgsf libofx intltool libsoup
     gnome3.adwaita-icon-theme ];
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/office/homebank/default.nix
+++ b/pkgs/applications/office/homebank/default.nix
@@ -1,5 +1,5 @@
 { fetchurl, stdenv, gtk, pkgconfig, libofx, intltool, wrapGAppsHook
-, hicolor-icon-theme, libsoup, gnome3 }:
+, libsoup, gnome3 }:
 
 stdenv.mkDerivation rec {
   name = "homebank-5.2.7";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig wrapGAppsHook ];
-  buildInputs = [ gtk libofx intltool hicolor-icon-theme libsoup
+  buildInputs = [ gtk libofx intltool libsoup
     gnome3.adwaita-icon-theme ];
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/office/paperwork/default.nix
+++ b/pkgs/applications/office/paperwork/default.nix
@@ -1,6 +1,6 @@
 { lib, python3Packages, gtk3, cairo
 , aspellDicts, buildEnv
-, gnome3, hicolor-icon-theme, librsvg
+, gnome3, librsvg
 , xvfb_run, dbus, libnotify
 }:
 
@@ -48,7 +48,7 @@ python3Packages.buildPythonApplication rec {
 
   checkInputs = [ xvfb_run dbus.daemon ] ++ (with python3Packages; [ paperwork-backend ]);
   buildInputs = [
-    gnome3.adwaita-icon-theme hicolor-icon-theme libnotify librsvg
+    gnome3.adwaita-icon-theme libnotify librsvg
   ];
 
   # A few parts of chkdeps need to have a display and a dbus session, so we not

--- a/pkgs/applications/office/timetable/default.nix
+++ b/pkgs/applications/office/timetable/default.nix
@@ -2,7 +2,6 @@
 , fetchFromGitHub
 , glib
 , gtk3
-, hicolor-icon-theme
 , json-glib
 , libgee
 , meson
@@ -37,7 +36,6 @@ stdenv.mkDerivation rec {
   buildInputs = [
     glib
     gtk3
-    hicolor-icon-theme
     json-glib
     libgee
     pantheon.granite

--- a/pkgs/applications/office/vnote/default.nix
+++ b/pkgs/applications/office/vnote/default.nix
@@ -1,4 +1,4 @@
-{ lib, mkDerivation, fetchFromGitHub, qmake, qtbase, qtwebengine, hicolor-icon-theme }:
+{ lib, mkDerivation, fetchFromGitHub, qmake, qtbase, qtwebengine }:
 
 let
   description = "A note-taking application that knows programmers and Markdown better";
@@ -15,7 +15,7 @@ in mkDerivation rec {
   };
 
   nativeBuildInputs = [ qmake ];
-  buildInputs = [ qtbase qtwebengine hicolor-icon-theme ];
+  buildInputs = [ qtbase qtwebengine ];
 
   meta = with lib; {
     inherit description;

--- a/pkgs/applications/search/catfish/default.nix
+++ b/pkgs/applications/search/catfish/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, file, which, intltool, gobject-introspection,
-  findutils, xdg_utils, gnome3, gtk3, pythonPackages, hicolor-icon-theme,
+  findutils, xdg_utils, gnome3, gtk3, pythonPackages,
   wrapGAppsHook
 }:
 
@@ -29,7 +29,6 @@ pythonPackages.buildPythonApplication rec {
     pythonPackages.pyxdg
     pythonPackages.ptyprocess
     pythonPackages.pycairo
-    hicolor-icon-theme
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/applications/version-management/gitkraken/default.nix
+++ b/pkgs/applications/version-management/gitkraken/default.nix
@@ -2,7 +2,7 @@
 , libXfixes, atk, gtk3, libXrender, pango, gnome3, cairo, freetype, fontconfig
 , libX11, libXi, libxcb, libXext, libXcursor, glib, libXScrnSaver, libxkbfile, libXtst
 , nss, nspr, cups, fetchurl, expat, gdk-pixbuf, libXdamage, libXrandr, dbus
-, dpkg, makeDesktopItem, openssl, wrapGAppsHook, hicolor-icon-theme, at-spi2-atk, libuuid
+, dpkg, makeDesktopItem, openssl, wrapGAppsHook, at-spi2-atk, libuuid
 , e2fsprogs, krb5
 }:
 
@@ -70,7 +70,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ makeWrapper wrapGAppsHook ];
-  buildInputs = [ dpkg gtk3 gnome3.adwaita-icon-theme hicolor-icon-theme ];
+  buildInputs = [ dpkg gtk3 gnome3.adwaita-icon-theme ];
 
   unpackCmd = ''
     mkdir out

--- a/pkgs/applications/version-management/smartgithg/default.nix
+++ b/pkgs/applications/version-management/smartgithg/default.nix
@@ -6,7 +6,6 @@
 , glib
 , gnome3
 , wrapGAppsHook
-, hicolor-icon-theme
 , libXtst
 , which
 }:
@@ -22,7 +21,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ wrapGAppsHook ];
 
-  buildInputs = [ jre gnome3.adwaita-icon-theme hicolor-icon-theme gtk3 ];
+  buildInputs = [ jre gnome3.adwaita-icon-theme gtk3 ];
 
   preFixup = with stdenv.lib; ''
     gappsWrapperArgs+=( \

--- a/pkgs/applications/video/olive-editor/default.nix
+++ b/pkgs/applications/video/olive-editor/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, pkgconfig, which, qmake, mkDerivation,
-  qtbase, qtmultimedia, frei0r, opencolorio, hicolor-icon-theme, ffmpeg-full,
+  qtbase, qtmultimedia, frei0r, opencolorio, ffmpeg-full,
   CoreFoundation  }:
 
 mkDerivation rec {
@@ -13,9 +13,9 @@ mkDerivation rec {
     sha256 = "15q4qwf5rc3adssywl72jrhkpqk55ihpd5h5wf07baw0s47vv5kq";
   };
 
-  nativeBuildInputs = [ 
-    pkgconfig 
-    which 
+  nativeBuildInputs = [
+    pkgconfig
+    which
     qmake
   ];
 
@@ -26,7 +26,6 @@ mkDerivation rec {
     qtbase
     qtmultimedia
     qtmultimedia.dev
-    hicolor-icon-theme
   ] ++ stdenv.lib.optional stdenv.isDarwin CoreFoundation;
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/video/screenkey/default.nix
+++ b/pkgs/applications/video/screenkey/default.nix
@@ -10,7 +10,6 @@
 , libXtst
 , wrapGAppsHook
 , gnome3
-, hicolor-icon-theme
 }:
 buildPythonApplication rec {
   pname = "screenkey";
@@ -40,7 +39,6 @@ buildPythonApplication rec {
 
   buildInputs = [
     gnome3.adwaita-icon-theme
-    hicolor-icon-theme
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/data/icons/arc-icon-theme/default.nix
+++ b/pkgs/data/icons/arc-icon-theme/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, gtk3, moka-icon-theme }:
+{ stdenv, fetchFromGitHub, autoreconfHook, gtk3, moka-icon-theme, hicolor-icon-theme }:
 
 stdenv.mkDerivation rec {
   name = "${package-name}-${version}";
@@ -13,6 +13,12 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ autoreconfHook gtk3 moka-icon-theme ];
+
+  propagatedBuildInputs = [
+    hicolor-icon-theme
+  ];
+
+  dontDropIconThemeCache = true;
 
   postFixup = "gtk-update-icon-cache $out/share/icons/Arc";
 

--- a/pkgs/data/icons/elementary-xfce-icon-theme/default.nix
+++ b/pkgs/data/icons/elementary-xfce-icon-theme/default.nix
@@ -11,7 +11,13 @@ stdenv.mkDerivation rec {
     sha256 = "16msdrazhbv80cvh5ffvgj13xmkpf87r7mq6xz071fza6nv7g0jn";
   };
 
-  nativeBuildInputs = [ pkgconfig gdk-pixbuf librsvg optipng gtk3 hicolor-icon-theme ];
+  nativeBuildInputs = [ pkgconfig gdk-pixbuf librsvg optipng gtk3 ];
+
+  propagatedBuildInputs = [
+    hicolor-icon-theme
+  ];
+
+  dontDropIconThemeCache = true;
 
   postPatch = ''
     substituteInPlace svgtopng/Makefile --replace "-O0" "-O"

--- a/pkgs/data/icons/faba-icon-theme/default.nix
+++ b/pkgs/data/icons/faba-icon-theme/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, meson, ninja, python3, gtk3, pantheon }:
+{ stdenv, fetchFromGitHub, meson, ninja, python3, gtk3, pantheon, hicolor-icon-theme }:
 
 stdenv.mkDerivation rec {
   name = "${package-name}-${version}";
@@ -13,6 +13,12 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ meson ninja python3 gtk3 pantheon.elementary-icon-theme ];
+
+  propagatedBuildInputs = [
+    hicolor-icon-theme
+  ];
+
+  dontDropIconThemeCache = true;
 
   postPatch = ''
     patchShebangs meson/post_install.py

--- a/pkgs/data/icons/faba-mono-icons/default.nix
+++ b/pkgs/data/icons/faba-mono-icons/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, gtk3, moka-icon-theme }:
+{ stdenv, fetchFromGitHub, autoreconfHook, gtk3, moka-icon-theme, hicolor-icon-theme }:
 
 stdenv.mkDerivation rec {
   pname = "faba-mono-icons";
@@ -12,6 +12,12 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ autoreconfHook gtk3 moka-icon-theme ];
+
+  propagatedBuildInputs = [
+    hicolor-icon-theme
+  ];
+
+  dontDropIconThemeCache = true;
 
   postFixup = ''
     for theme in $out/share/icons/*; do

--- a/pkgs/data/icons/hicolor-icon-theme/setup-hook.sh
+++ b/pkgs/data/icons/hicolor-icon-theme/setup-hook.sh
@@ -1,21 +1,13 @@
+# shellcheck shell=bash
+
 # Populate XDG_ICON_DIRS
 hicolorIconThemeHook() {
 
     # where to find icon themes
     if [ -d "$1/share/icons" ]; then
-      addToSearchPath XDG_ICON_DIRS $1/share
+      addToSearchPath XDG_ICON_DIRS "$1/share"
     fi
-	
 }
 
 # I think this is meant to be a runtime dep
-addEnvHooks "$hostOffset" hicolorIconThemeHook
-
-# Remove icon cache
-hicolorPreFixupPhase() {
-    rm -f $out/share/icons/hicolor/icon-theme.cache
-    rm -f $out/share/icons/HighContrast/icon-theme.cache
-}
-
-preFixupPhases="$preFixupPhases hicolorPreFixupPhase"
-
+addEnvHooks "${hostOffset:?}" hicolorIconThemeHook

--- a/pkgs/data/icons/iconpack-obsidian/default.nix
+++ b/pkgs/data/icons/iconpack-obsidian/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, gtk3 }:
+{ stdenv, fetchFromGitHub, gtk3, hicolor-icon-theme }:
 
 stdenv.mkDerivation rec {
   pname = "iconpack-obsidian";
@@ -12,6 +12,12 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ gtk3 ];
+
+  propagatedBuildInputs = [
+    hicolor-icon-theme
+  ];
+
+  dontDropIconThemeCache = true;
 
   installPhase = ''
      mkdir -p $out/share/icons

--- a/pkgs/data/icons/maia-icon-theme/default.nix
+++ b/pkgs/data/icons/maia-icon-theme/default.nix
@@ -21,9 +21,11 @@ stdenv.mkDerivation {
     kdeFrameworks.kwindowsystem
   ];
 
-  buildInputs = [
+  propagatedBuildInputs = [
     hicolor-icon-theme
   ];
+
+  dontDropIconThemeCache = true;
 
   postFixup = ''
     for theme in $out/share/icons/*; do

--- a/pkgs/data/icons/moka-icon-theme/default.nix
+++ b/pkgs/data/icons/moka-icon-theme/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, meson, ninja, gtk3, python3, faba-icon-theme }:
+{ stdenv, fetchFromGitHub, meson, ninja, gtk3, python3, faba-icon-theme, hicolor-icon-theme }:
 
 stdenv.mkDerivation rec {
   pname = "moka-icon-theme";
@@ -12,6 +12,12 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ meson ninja gtk3 python3 faba-icon-theme ];
+
+  propagatedBuildInputs = [
+    hicolor-icon-theme
+  ];
+
+  dontDropIconThemeCache = true;
 
   postPatch = ''
     patchShebangs meson/post_install.py

--- a/pkgs/data/icons/numix-icon-theme-circle/default.nix
+++ b/pkgs/data/icons/numix-icon-theme-circle/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, gtk3, numix-icon-theme }:
+{ stdenv, fetchFromGitHub, gtk3, numix-icon-theme, hicolor-icon-theme }:
 
 stdenv.mkDerivation rec {
   pname = "numix-icon-theme-circle";
@@ -12,6 +12,12 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ gtk3 numix-icon-theme ];
+
+  propagatedBuildInputs = [
+    hicolor-icon-theme
+  ];
+
+  dontDropIconThemeCache = true;
 
   installPhase = ''
     install -dm 755 $out/share/icons

--- a/pkgs/data/icons/numix-icon-theme-square/default.nix
+++ b/pkgs/data/icons/numix-icon-theme-square/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, gtk3, numix-icon-theme }:
+{ stdenv, fetchFromGitHub, gtk3, numix-icon-theme, hicolor-icon-theme }:
 
 stdenv.mkDerivation rec {
   pname = "numix-icon-theme-square";
@@ -12,6 +12,12 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ gtk3 numix-icon-theme ];
+
+  propagatedBuildInputs = [
+    hicolor-icon-theme
+  ];
+
+  dontDropIconThemeCache = true;
 
   installPhase = ''
     mkdir -p $out/share/icons

--- a/pkgs/data/icons/numix-icon-theme/default.nix
+++ b/pkgs/data/icons/numix-icon-theme/default.nix
@@ -11,7 +11,13 @@ stdenv.mkDerivation rec {
     sha256 = "0clh55kmhc52d33dfm2c6h3lg6ddfh8a088ir9lv1camn9kj55bd";
   };
 
-  nativeBuildInputs = [ gtk3 hicolor-icon-theme ];
+  nativeBuildInputs = [ gtk3 ];
+
+  propagatedBuildInputs = [
+    hicolor-icon-theme
+  ];
+
+  dontDropIconThemeCache = true;
 
   installPhase = ''
     mkdir -p $out/share/icons

--- a/pkgs/data/icons/paper-icon-theme/default.nix
+++ b/pkgs/data/icons/paper-icon-theme/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, meson, ninja, gtk3, python3 }:
+{ stdenv, fetchFromGitHub, meson, ninja, gtk3, python3, hicolor-icon-theme }:
 
 stdenv.mkDerivation rec {
   pname = "paper-icon-theme";
@@ -12,6 +12,12 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ meson ninja gtk3 python3 ];
+
+  propagatedBuildInputs = [
+    hicolor-icon-theme
+  ];
+
+  dontDropIconThemeCache = true;
 
   postPatch = ''
     patchShebangs meson/post_install.py

--- a/pkgs/data/icons/papirus-icon-theme/default.nix
+++ b/pkgs/data/icons/papirus-icon-theme/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, gtk3 }:
+{ stdenv, fetchFromGitHub, gtk3, hicolor-icon-theme }:
 
 stdenv.mkDerivation rec {
   pname = "papirus-icon-theme";
@@ -12,6 +12,12 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ gtk3 ];
+
+  propagatedBuildInputs = [
+    hicolor-icon-theme
+  ];
+
+  dontDropIconThemeCache = true;
 
   installPhase = ''
      mkdir -p $out/share/icons

--- a/pkgs/data/icons/tango-icon-theme/default.nix
+++ b/pkgs/data/icons/tango-icon-theme/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, intltool, pkgconfig, iconnamingutils, imagemagick, librsvg
-, gtk/*any version*/
+, gtk/*any version*/, hicolor-icon-theme
 }:
 
 stdenv.mkDerivation rec {
@@ -14,6 +14,12 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ intltool iconnamingutils imagemagick librsvg ];
+
+  propagatedBuildInputs = [
+    hicolor-icon-theme
+  ];
+
+  dontDropIconThemeCache = true;
 
   configureFlags = [ "--enable-png-creation" ];
 

--- a/pkgs/data/icons/vanilla-dmz/default.nix
+++ b/pkgs/data/icons/vanilla-dmz/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchzip, xorg }:
+{ stdenv, lib, fetchzip, xorg, hicolor-icon-theme }:
 
 stdenv.mkDerivation rec {
   pname = "vanilla-dmz";
@@ -8,6 +8,10 @@ stdenv.mkDerivation rec {
     sha256 = "1l0c0svk7dy0d7icg7j2181wdn3fvks5gmyqnvjk749ppy5ks8mj";
   };
   buildInputs = [ xorg.xcursorgen ];
+  propagatedBuildInputs = [
+    hicolor-icon-theme
+  ];
+  dontDropIconThemeCache = true;
   buildPhase = ''
     cd DMZ-White/pngs; ./make.sh; cd -
     cd DMZ-Black/pngs; ./make.sh; cd -

--- a/pkgs/data/icons/zafiro-icons/default.nix
+++ b/pkgs/data/icons/zafiro-icons/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, gtk3 }:
+{ stdenv, fetchFromGitHub, gtk3, hicolor-icon-theme }:
 
 stdenv.mkDerivation rec {
   pname = "zafiro-icons";
@@ -12,6 +12,12 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ gtk3 ];
+
+  propagatedBuildInputs = [
+    hicolor-icon-theme
+  ];
+
+  dontDropIconThemeCache = true;
 
   installPhase = ''
     mkdir -p $out/share/icons/Zafiro-icons

--- a/pkgs/desktops/deepin/dde-session-ui/default.nix
+++ b/pkgs/desktops/deepin/dde-session-ui/default.nix
@@ -1,7 +1,7 @@
 { stdenv, mkDerivation, fetchFromGitHub, pkgconfig, qmake, dbus, dde-daemon,
   dde-qt-dbus-factory, deepin, deepin-desktop-schemas,
   deepin-gettext-tools, deepin-icon-theme, deepin-wallpapers, dtkcore,
-  dtkwidget, gnugrep, gsettings-qt, hicolor-icon-theme, lightdm_qt,
+  dtkwidget, gnugrep, gsettings-qt, lightdm_qt,
   onboard, qtsvg, qttools, qtx11extras, setxkbmap, utillinux, which,
   xkeyboard_config, xorg, xrandr, wrapGAppsHook }:
 
@@ -36,7 +36,6 @@ mkDerivation rec {
     dtkwidget
     gnugrep
     gsettings-qt
-    hicolor-icon-theme
     lightdm_qt
     onboard
     qtsvg

--- a/pkgs/desktops/deepin/deepin-icon-theme/default.nix
+++ b/pkgs/desktops/deepin/deepin-icon-theme/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, gtk3, xcursorgen, papirus-icon-theme, deepin }:
+{ stdenv, fetchFromGitHub, gtk3, xcursorgen, papirus-icon-theme, deepin, hicolor-icon-theme }:
 
 stdenv.mkDerivation rec {
   pname = "deepin-icon-theme";
@@ -14,6 +14,12 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ gtk3 xcursorgen ];
 
   buildInputs = [ papirus-icon-theme ];
+
+  propagatedBuildInputs = [
+    hicolor-icon-theme
+  ];
+
+  dontDropIconThemeCache = true;
 
   postPatch = ''
     patchShebangs tools/hicolor.links

--- a/pkgs/desktops/gnome-3/apps/ghex/default.nix
+++ b/pkgs/desktops/gnome-3/apps/ghex/default.nix
@@ -6,7 +6,6 @@
 , ninja
 , python3
 , gnome3
-, hicolor-icon-theme
 , desktop-file-utils
 , appstream-glib
 , gettext
@@ -32,7 +31,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     desktop-file-utils
     gettext
-    hicolor-icon-theme # for setup-hook
     itstool
     meson
     ninja

--- a/pkgs/desktops/gnome-3/apps/gnome-sound-recorder/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-sound-recorder/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, gettext, gobject-introspection, wrapGAppsHook, gjs, glib, gtk3, gdk-pixbuf, gst_all_1, gnome3
-, meson, ninja, python3, hicolor-icon-theme, desktop-file-utils }:
+, meson, ninja, python3, desktop-file-utils }:
 
 stdenv.mkDerivation rec {
   pname = "gnome-sound-recorder";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     pkgconfig gettext meson ninja gobject-introspection
-    wrapGAppsHook python3 hicolor-icon-theme desktop-file-utils
+    wrapGAppsHook python3 desktop-file-utils
   ];
   buildInputs = [ gjs glib gtk3 gdk-pixbuf ] ++ (with gst_all_1; [ gstreamer.dev gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad ]);
 

--- a/pkgs/desktops/gnome-3/core/dconf-editor/default.nix
+++ b/pkgs/desktops/gnome-3/core/dconf-editor/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, meson, ninja, vala, libxslt, pkgconfig, glib, gtk3, gnome3, python3
-, libxml2, gettext, docbook_xsl, hicolor-icon-theme, wrapGAppsHook, gobject-introspection }:
+, libxml2, gettext, docbook_xsl, wrapGAppsHook, gobject-introspection }:
 
 let
   pname = "dconf-editor";
@@ -15,7 +15,6 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [
     meson ninja vala libxslt pkgconfig wrapGAppsHook
     gettext docbook_xsl libxml2 gobject-introspection python3
-    hicolor-icon-theme # for setup-hook
   ];
 
   buildInputs = [ glib gtk3 gnome3.dconf ];

--- a/pkgs/desktops/gnome-3/core/gnome-color-manager/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-color-manager/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, meson, ninja, pkgconfig, gettext, itstool, desktop-file-utils, gnome3, glib, gtk3, libexif, libtiff, colord, colord-gtk, libcanberra-gtk3, lcms2, vte, exiv2, hicolor-icon-theme }:
+{ stdenv, fetchurl, meson, ninja, pkgconfig, gettext, itstool, desktop-file-utils, gnome3, glib, gtk3, libexif, libtiff, colord, colord-gtk, libcanberra-gtk3, lcms2, vte, exiv2 }:
 
 let
   pname = "gnome-color-manager";
@@ -13,8 +13,6 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     meson ninja pkgconfig gettext itstool desktop-file-utils
-    # setup-hook
-    hicolor-icon-theme
   ];
 
   buildInputs = [ glib gtk3 libexif libtiff colord colord-gtk libcanberra-gtk3 lcms2 vte exiv2 ];

--- a/pkgs/desktops/gnome-3/core/gnome-software/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-software/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, substituteAll, pkgconfig, meson, ninja, gettext, gnome3, wrapGAppsHook, packagekit, ostree
 , glib, appstream-glib, libsoup, polkit, isocodes, gspell, libxslt, gobject-introspection, flatpak, fwupd
-, gtk3, gsettings-desktop-schemas, gnome-desktop, libxmlb, gnome-online-accounts, hicolor-icon-theme
+, gtk3, gsettings-desktop-schemas, gnome-desktop, libxmlb, gnome-online-accounts
 , json-glib, libsecret, valgrind-light, docbook_xsl, docbook_xml_dtd_42, docbook_xml_dtd_43, gtk-doc, desktop-file-utils }:
 
 let
@@ -28,7 +28,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     meson ninja pkgconfig gettext wrapGAppsHook libxslt docbook_xml_dtd_42 docbook_xml_dtd_43
     valgrind-light docbook_xsl gtk-doc desktop-file-utils gobject-introspection
-    hicolor-icon-theme # for setup-hook
   ];
 
   buildInputs = [

--- a/pkgs/desktops/gnome-3/core/gnome-terminal/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-terminal/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, libxml2, gnome3, dconf, nautilus
 , gtk3, gsettings-desktop-schemas, vte, intltool, which, libuuid, vala
-, desktop-file-utils, itstool, wrapGAppsHook, hicolor-icon-theme }:
+, desktop-file-utils, itstool, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   pname = "gnome-terminal";
@@ -20,7 +20,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     pkgconfig intltool itstool which libxml2
     vala desktop-file-utils wrapGAppsHook
-    hicolor-icon-theme # for setup-hook
   ];
 
   # Silly ./configure, it looks for dbus file from gnome-shell in the

--- a/pkgs/desktops/gnome-3/games/gnome-robots/default.nix
+++ b/pkgs/desktops/gnome-3/games/gnome-robots/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, gnome3, gtk3, wrapGAppsHook
 , librsvg, libcanberra-gtk3, gettext, itstool, libxml2, libgnome-games-support
-, libgee, meson, ninja, python3, desktop-file-utils , hicolor-icon-theme, adwaita-icon-theme }:
+, libgee, meson, ninja, python3, desktop-file-utils, adwaita-icon-theme }:
 
 stdenv.mkDerivation rec {
   pname = "gnome-robots";
@@ -18,7 +18,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     pkgconfig meson ninja python3
     libxml2 wrapGAppsHook gettext itstool desktop-file-utils
-    hicolor-icon-theme # For setup-hook
   ];
   buildInputs = [
     gtk3 librsvg libcanberra-gtk3 libgnome-games-support libgee adwaita-icon-theme

--- a/pkgs/desktops/gnome-3/misc/gitg/default.nix
+++ b/pkgs/desktops/gnome-3/misc/gitg/default.nix
@@ -24,7 +24,6 @@
 , meson
 , ninja
 , python3
-, hicolor-icon-theme
 , libdazzle
 }:
 
@@ -66,7 +65,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     gobject-introspection
-    hicolor-icon-theme
     gettext
     meson
     ninja

--- a/pkgs/desktops/gnome-3/misc/gnome-packagekit/default.nix
+++ b/pkgs/desktops/gnome-3/misc/gnome-packagekit/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, meson, ninja, gettext, gnome3, packagekit, polkit
-, gtk3, systemd, wrapGAppsHook, desktop-file-utils, hicolor-icon-theme }:
+, gtk3, systemd, wrapGAppsHook, desktop-file-utils }:
 
 stdenv.mkDerivation rec {
   pname = "gnome-packagekit";
@@ -12,7 +12,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     pkgconfig meson ninja gettext wrapGAppsHook desktop-file-utils
-    hicolor-icon-theme # for setup-hook
   ];
 
   buildInputs = [ gtk3 packagekit systemd polkit ];

--- a/pkgs/desktops/lxqt/obconf-qt/default.nix
+++ b/pkgs/desktops/lxqt/obconf-qt/default.nix
@@ -1,5 +1,5 @@
 { lib, mkDerivation, fetchFromGitHub, cmake, pkgconfig, pcre, qtbase, qttools,
-  qtx11extras, xorg, lxqt-build-tools, openbox, hicolor-icon-theme }:
+  qtx11extras, xorg, lxqt-build-tools, openbox }:
 
 mkDerivation rec {
   pname = "obconf-qt";
@@ -27,7 +27,6 @@ mkDerivation rec {
     xorg.libXdmcp
     xorg.libSM
     openbox
-    hicolor-icon-theme
   ];
 
   meta = with lib; {

--- a/pkgs/desktops/mate/mate-icon-theme-faenza/default.nix
+++ b/pkgs/desktops/mate/mate-icon-theme-faenza/default.nix
@@ -11,7 +11,13 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook gtk3 ];
 
-  buildInputs = [ mate.mate-icon-theme hicolor-icon-theme ];
+  buildInputs = [ mate.mate-icon-theme ];
+
+  propagatedBuildInputs = [
+    hicolor-icon-theme
+  ];
+
+  dontDropIconThemeCache = true;
 
   postInstall = ''
     for theme in "$out"/share/icons/*; do

--- a/pkgs/desktops/mate/mate-icon-theme/default.nix
+++ b/pkgs/desktops/mate/mate-icon-theme/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, iconnamingutils, librsvg, hicolor-icon-theme, gtk3 }:
+{ stdenv, fetchurl, pkgconfig, intltool, iconnamingutils, librsvg, gtk3, hicolor-icon-theme }:
 
 stdenv.mkDerivation rec {
   pname = "mate-icon-theme";
@@ -11,7 +11,13 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig intltool iconnamingutils ];
 
-  buildInputs = [ librsvg hicolor-icon-theme ];
+  buildInputs = [ librsvg ];
+
+  propagatedBuildInputs = [
+    hicolor-icon-theme
+  ];
+
+  dontDropIconThemeCache = true;
 
   postInstall = ''
     for theme in "$out"/share/icons/*; do

--- a/pkgs/desktops/pantheon/artwork/elementary-icon-theme/default.nix
+++ b/pkgs/desktops/pantheon/artwork/elementary-icon-theme/default.nix
@@ -39,6 +39,8 @@ stdenv.mkDerivation rec {
     hicolor-icon-theme
   ];
 
+  dontDropIconThemeCache = true;
+
   mesonFlags = [
     "-Dvolume_icons=false" # Tries to install some icons to /
     "-Dpalettes=false" # Don't install gimp and inkscape palette files

--- a/pkgs/desktops/pantheon/granite/default.nix
+++ b/pkgs/desktops/pantheon/granite/default.nix
@@ -11,7 +11,6 @@
 , gtk3
 , glib
 , gettext
-, hicolor-icon-theme
 , gobject-introspection
 , wrapGAppsHook
 }:
@@ -56,7 +55,6 @@ stdenv.mkDerivation rec {
   buildInputs = [
     glib
     gtk3
-    hicolor-icon-theme
     libgee
   ];
 

--- a/pkgs/desktops/rox/rox-filer/default.nix
+++ b/pkgs/desktops/rox/rox-filer/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, libxml2, gtk, libSM, shared-mime-info, hicolor-icon-theme }:
+{ stdenv, fetchurl, pkgconfig, libxml2, gtk, libSM, shared-mime-info }:
 
 let
   version = "2.11";
@@ -12,7 +12,7 @@ in stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ libxml2 gtk shared-mime-info hicolor-icon-theme libSM ];
+  buildInputs = [ libxml2 gtk shared-mime-info libSM ];
   NIX_LDFLAGS = [ "-ldl" "-lm" ];
 
   patches = [

--- a/pkgs/development/libraries/gnome-online-accounts/default.nix
+++ b/pkgs/development/libraries/gnome-online-accounts/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, vala, glib, libxslt, gtk3, wrapGAppsHook
 , webkitgtk, json-glib, librest, libsecret, gtk-doc, gobject-introspection
-, gettext, icu, glib-networking, hicolor-icon-theme
+, gettext, icu, glib-networking
 , libsoup, docbook_xsl, docbook_xml_dtd_412, gnome3, gcr, kerberos
 }:
 
@@ -31,7 +31,6 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [
     pkgconfig gobject-introspection vala gettext wrapGAppsHook
     libxslt docbook_xsl docbook_xml_dtd_412 gtk-doc
-    hicolor-icon-theme # for setup-hook
   ];
   buildInputs = [
     glib gtk3 webkitgtk json-glib librest libsecret glib-networking icu libsoup

--- a/pkgs/development/libraries/gtk/2.x.nix
+++ b/pkgs/development/libraries/gtk/2.x.nix
@@ -25,9 +25,12 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  setupHook = ./setup-hook.sh;
+  setupHooks =  [
+    ./gtk2-clean-immodules-cache.sh
+    ./drop-icon-theme-cache.sh
+  ];
 
-  nativeBuildInputs = [ setupHook perl pkgconfig gettext gobject-introspection ];
+  nativeBuildInputs = [ setupHooks perl pkgconfig gettext gobject-introspection ];
 
   patches = [
     ./2.0-immodules.cache.patch

--- a/pkgs/development/libraries/gtk/3.x.nix
+++ b/pkgs/development/libraries/gtk/3.x.nix
@@ -49,7 +49,10 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" ];
   outputBin = "dev";
 
-  setupHook = ./gtk3-setup-hook.sh;
+  setupHooks = [
+    ./gtk3-clean-immodules-cache.sh
+    ./drop-icon-theme-cache.sh
+  ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/gtk+/${stdenv.lib.versions.majorMinor version}/gtk+-${version}.tar.xz";
@@ -108,7 +111,7 @@ stdenv.mkDerivation rec {
     pkgconfig
     python3
     sassc
-    setupHook
+    setupHooks
   ];
 
   buildInputs = [

--- a/pkgs/development/libraries/gtk/3.x.nix
+++ b/pkgs/development/libraries/gtk/3.x.nix
@@ -24,7 +24,6 @@
 , libxkbcommon
 , gmp
 , gnome3
-, hicolor-icon-theme
 , gsettings-desktop-schemas
 , sassc
 , x11Support ? stdenv.isLinux
@@ -103,7 +102,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     gettext
     gobject-introspection
-    hicolor-icon-theme # setup-hook
     makeWrapper
     meson
     ninja

--- a/pkgs/development/libraries/gtk/drop-icon-theme-cache.sh
+++ b/pkgs/development/libraries/gtk/drop-icon-theme-cache.sh
@@ -1,15 +1,5 @@
 # shellcheck shell=bash
 
-fixupOutputHooks+=(_gtk3CleanComments)
-
-# Clean comments that link to generator of the file
-_gtk3CleanComments() {
-    local f="${prefix:?}/lib/gtk-3.0/3.0.0/immodules.cache"
-    if [ -f "$f" ]; then
-        sed 's|Created by .*bin/gtk-query-|Created by bin/gtk-query-|' -i "$f"
-    fi
-}
-
 # Packages often run gtk-update-icon-cache to include their icons in themes’ icon cache.
 # However, since each package is installed to its own prefix, the files will only collide.
 dropIconThemeCache() {

--- a/pkgs/development/libraries/gtk/gtk2-clean-immodules-cache.sh
+++ b/pkgs/development/libraries/gtk/gtk2-clean-immodules-cache.sh
@@ -1,0 +1,12 @@
+# shellcheck shell=bash
+
+fixupOutputHooks+=(_gtk2CleanComments)
+
+# Clean comments that link to generator of the file
+_gtk2CleanComments() {
+    local f="${prefix:?}/lib/gtk-2.0/2.10.0/immodules.cache"
+    if [ -f "$f" ]; then
+        sed 's|Created by .*bin/gtk-query-|Created by bin/gtk-query-|' -i "$f"
+    fi
+}
+

--- a/pkgs/development/libraries/gtk/gtk3-clean-immodules-cache.sh
+++ b/pkgs/development/libraries/gtk/gtk3-clean-immodules-cache.sh
@@ -1,10 +1,11 @@
-fixupOutputHooks+=(_gtk2CleanComments)
+# shellcheck shell=bash
+
+fixupOutputHooks+=(_gtk3CleanComments)
 
 # Clean comments that link to generator of the file
-_gtk2CleanComments() {
-    local f="$prefix/lib/gtk-2.0/2.10.0/immodules.cache"
+_gtk3CleanComments() {
+    local f="${prefix:?}/lib/gtk-3.0/3.0.0/immodules.cache"
     if [ -f "$f" ]; then
         sed 's|Created by .*bin/gtk-query-|Created by bin/gtk-query-|' -i "$f"
     fi
 }
-

--- a/pkgs/development/libraries/gtk/gtk3-setup-hook.sh
+++ b/pkgs/development/libraries/gtk/gtk3-setup-hook.sh
@@ -1,10 +1,29 @@
+# shellcheck shell=bash
+
 fixupOutputHooks+=(_gtk3CleanComments)
 
 # Clean comments that link to generator of the file
 _gtk3CleanComments() {
-    local f="$prefix/lib/gtk-3.0/3.0.0/immodules.cache"
+    local f="${prefix:?}/lib/gtk-3.0/3.0.0/immodules.cache"
     if [ -f "$f" ]; then
         sed 's|Created by .*bin/gtk-query-|Created by bin/gtk-query-|' -i "$f"
     fi
 }
 
+# Packages often run gtk-update-icon-cache to include their icons in themes’ icon cache.
+# However, since each package is installed to its own prefix, the files will only collide.
+dropIconThemeCache() {
+    if [[ -z "${dontDropIconThemeCache:-}" ]]; then
+        local icondir="${out:?}/share/icons"
+        if [[ -d "${icondir}" ]]; then
+            # App icons are supposed to go to hicolor theme, since it is a fallback theme as per [icon-theme-spec], but some might still choose to install stylized icons to other themes.
+            find "${icondir}" -name 'icon-theme.cache' -print0 \
+              | while IFS= read -r -d '' file; do
+                echo "Removing ${file}"
+                rm -f "${file}"
+            done
+        fi
+    fi
+}
+
+preFixupPhases="$preFixupPhases dropIconThemeCache"

--- a/pkgs/development/libraries/kde-frameworks/breeze-icons.nix
+++ b/pkgs/development/libraries/kde-frameworks/breeze-icons.nix
@@ -1,10 +1,14 @@
-{ mkDerivation, lib, extra-cmake-modules, gtk3, qtsvg }:
+{ mkDerivation, lib, extra-cmake-modules, gtk3, qtsvg, hicolor-icon-theme }:
 
 mkDerivation {
   name = "breeze-icons";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
   nativeBuildInputs = [ extra-cmake-modules gtk3 ];
   buildInputs = [ qtsvg ];
+  propagatedBuildInputs = [
+    hicolor-icon-theme
+  ];
+  dontDropIconThemeCache = true;
   outputs = [ "out" ]; # only runtime outputs
   postInstall = ''
     gtk-update-icon-cache "''${out:?}/share/icons/breeze"

--- a/pkgs/development/tools/misc/gtkdialog/default.nix
+++ b/pkgs/development/tools/misc/gtkdialog/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, gtk2, pkgconfig, hicolor-icon-theme }:
+{stdenv, fetchurl, gtk2, pkgconfig }:
 
 stdenv.mkDerivation {
   name = "gtkdialog-0.8.3";
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ gtk2 hicolor-icon-theme ];
+  buildInputs = [ gtk2 ];
 
   meta = {
     homepage = https://code.google.com/archive/p/gtkdialog/;

--- a/pkgs/games/gscrabble/default.nix
+++ b/pkgs/games/gscrabble/default.nix
@@ -1,6 +1,6 @@
 { stdenv, buildPythonApplication, fetchFromGitHub
 , gtk3, wrapGAppsHook, gst_all_1, gobject-introspection
-, python3Packages, gnome3, hicolor-icon-theme }:
+, python3Packages, gnome3 }:
 
 buildPythonApplication {
   pname = "gscrabble";
@@ -19,7 +19,7 @@ buildPythonApplication {
 
   buildInputs = with gst_all_1; [
     gst-plugins-base gst-plugins-good gst-plugins-ugly gst-plugins-bad
-    hicolor-icon-theme gnome3.adwaita-icon-theme gtk3 gobject-introspection
+    gnome3.adwaita-icon-theme gtk3 gobject-introspection
   ];
 
   propagatedBuildInputs = with python3Packages; [ gst-python pygobject3 ];

--- a/pkgs/tools/X11/screen-message/default.nix
+++ b/pkgs/tools/X11/screen-message/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, autoreconfHook, pkgconfig, gtk3, hicolor-icon-theme }:
+{ stdenv, fetchurl, autoreconfHook, pkgconfig, gtk3 }:
 
 stdenv.mkDerivation rec {
   pname = "screen-message";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
-  buildInputs = [ gtk3 hicolor-icon-theme ];
+  buildInputs = [ gtk3 ];
 
   # screen-message installs its binary in $(prefix)/games per default
   makeFlags = [ "execgamesdir=$(out)/bin" ];

--- a/pkgs/tools/archivers/xarchiver/default.nix
+++ b/pkgs/tools/archivers/xarchiver/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, gtk3, pkgconfig, intltool, libxslt, hicolor-icon-theme }:
+{ stdenv, fetchFromGitHub, gtk3, pkgconfig, intltool, libxslt }:
 
 stdenv.mkDerivation rec {
   version = "0.5.4.14";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ gtk3 intltool libxslt hicolor-icon-theme ];
+  buildInputs = [ gtk3 intltool libxslt ];
 
   meta = {
     description = "GTK frontend to 7z,zip,rar,tar,bzip2, gzip,arj, lha, rpm and deb (open and extract only)";

--- a/pkgs/tools/misc/gparted/default.nix
+++ b/pkgs/tools/misc/gparted/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, intltool, gettext, makeWrapper, coreutils, gnused, gnome3
-, gnugrep, parted, glib, libuuid, pkgconfig, gtkmm3, libxml2, hicolor-icon-theme
+, gnugrep, parted, glib, libuuid, pkgconfig, gtkmm3, libxml2
 , gpart, hdparm, procps, utillinux, polkit, wrapGAppsHook, substituteAll
 }:
 
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [ "--disable-doc" ];
 
-  buildInputs = [ parted glib libuuid gtkmm3 libxml2 hicolor-icon-theme polkit.bin gnome3.adwaita-icon-theme  ];
+  buildInputs = [ parted glib libuuid gtkmm3 libxml2 polkit.bin gnome3.adwaita-icon-theme  ];
   nativeBuildInputs = [ intltool gettext pkgconfig wrapGAppsHook ];
 
   preFixup = ''


### PR DESCRIPTION
###### Motivation for this change
Packages often run gtk-update-icon-cache to include their icons in themes’ icon cache. However, since each package is installed to its own prefix, the files will only collide. For that reason we are removing the icon-theme.cache from applications.

Previously, we did that in hicolor-icon-theme setup hook but, since it is actually gtk3’s utility that creates the cache, we thought it would be appropriate to let its setup hook handle the clearing.

###### Remaining tasks
- [x] Write up docs explaining `icon-theme.cache`
- [x] Evaluate packages still be using `hicolor-icon-theme`. They should not use it, unless they are an icon theme, in which case, they should propagate it.
- [x] Check for icon themes that have gtk3 in `buildInputs` and be sure to set `dontDropIconThemeCache`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @worldofpeace 
