### PR TITLE
wtf: 0.21.0 -> 0.22.0 & rename binary

### DIFF
--- a/pkgs/applications/misc/wtf/default.nix
+++ b/pkgs/applications/misc/wtf/default.nix
@@ -7,7 +7,7 @@
 
 buildGoModule rec {
   pname = "wtf";
-  version = "0.21.0";
+  version = "0.22.0";
 
   overrideModAttrs = _oldAttrs : _oldAttrs // {
     preBuild = ''export GOPROXY="https://gocenter.io"'';
@@ -17,10 +17,10 @@ buildGoModule rec {
     owner = "wtfutil";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0sd8vrx7nak0by4whdmd9jzr66zm48knv1w1aqi90709fv98brm9";
-  };
+    sha256 = "1d8lp94cw8rh9r9y64awxafhw9fmp33v3m761gzy500hrxal2rzb";
+   };
 
-  modSha256 = "0jgq9ql27x0kdp59l5drisl5v7v7sx2wy3zqjbr3bqyh3vdx19ic";
+  modSha256 = "0m180571j4564py5mzdcbyypk71fdlp2vkfdwi6q85nd2q94sx6h";
 
   buildFlagsArray = [ "-ldflags=-s -w -X main.version=${version}" ];
 

--- a/pkgs/applications/misc/wtf/default.nix
+++ b/pkgs/applications/misc/wtf/default.nix
@@ -27,7 +27,8 @@ buildGoModule rec {
   nativeBuildInputs = [ makeWrapper ];
 
   postInstall = ''
-    wrapProgram "$out/bin/wtf" --prefix PATH : "${ncurses.dev}/bin"
+    mv "$out/bin/wtf" "$out/bin/wtfutil"
+    wrapProgram "$out/bin/wtfutil" --prefix PATH : "${ncurses.dev}/bin"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

New version released.

And adapt the name of the binary to what upstream uses.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
