### PR TITLE
mudlet: 4.0.3 -> 4.1.2

### DIFF
--- a/pkgs/games/mudlet/default.nix
+++ b/pkgs/games/mudlet/default.nix
@@ -6,23 +6,15 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "mudlet";
-  version = "4.0.3";
+  version = "4.1.2";
 
   src = fetchFromGitHub {
     owner = "Mudlet";
     repo = "Mudlet";
     rev = "Mudlet-${version}";
     fetchSubmodules = true;
-    sha256 = "18bl4k0qgh47d9k5ipfvypfj1il678c0ws64a8adn8k21jajzkik";
+    sha256 = "1d6r51cj8a71hmhzsayd2far4hliwz5pnrsaj3dn39m7c0iikgdn";
   };
-
-  patches = [
-    ( fetchpatch {
-      url = "https://github.com/Mudlet/Mudlet/commit/3c8f12b6d757894d92ec2e2c9b12b91f69e8a3b6.patch";
-      name = "hunspell-1.7";
-      sha256 = "09qggls4pzpd8h9h10fbpfd7x3kr7fjp9axdwz98igpwy714n98j";
-    })
-  ];
 
   nativeBuildInputs = [ cmake wrapQtAppsHook qttools which ];
   buildInputs = [
@@ -35,6 +27,8 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   installPhase =  ''
+    mkdir -pv $out/lib
+    cp 3rdparty/edbee-lib/edbee-lib/qslog/lib/libQsLog.so $out/lib
     mkdir -pv $out/bin
     cp src/mudlet $out
     mkdir -pv $out/share/mudlet


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Bump for mudlet. Removed the patch that got accepted upstream and fished out the new qslog.so file. I think it's a bit ugly to jus grab it with cp but I didn't find a better way.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @teto @abbradar 
