### PR TITLE
Various cross-compilation fixes

### DIFF
--- a/pkgs/os-specific/linux/bridge-utils/autoconf-ar.patch
+++ b/pkgs/os-specific/linux/bridge-utils/autoconf-ar.patch
@@ -1,0 +1,25 @@
+diff --git a/configure.in b/configure.in
+index 5e3f89b..19be6d9 100644
+--- a/configure.in
++++ b/configure.in
+@@ -9,6 +9,7 @@ dnl Checks for programs.
+ AC_PROG_CC
+ AC_PROG_INSTALL
+ AC_PROG_RANLIB
++AC_CHECK_TOOL([AR], [ar])
+ 
+ dnl Checks for header files.
+ AC_HEADER_STDC
+diff --git a/libbridge/Makefile.in b/libbridge/Makefile.in
+index 20512c4..83c802b 100644
+--- a/libbridge/Makefile.in
++++ b/libbridge/Makefile.in
+@@ -1,7 +1,7 @@
+ 
+ KERNEL_HEADERS=-I@KERNEL_HEADERS@
+ 
+-AR=ar
++AR=@AR@
+ RANLIB=@RANLIB@
+ 
+ CC=@CC@

--- a/pkgs/os-specific/linux/bridge-utils/default.nix
+++ b/pkgs/os-specific/linux/bridge-utils/default.nix
@@ -8,11 +8,12 @@ stdenv.mkDerivation rec {
     sha256 = "42f9e5fb8f6c52e63a98a43b81bd281c227c529f194913e1c51ec48a393b6688";
   };
 
-  # Remove patch once the kernel headers are updated
-  patches = [ ./add-ip6-header.patch ];
+  patches = [
+    ./autoconf-ar.patch
+    ./add-ip6-header.patch # Remove patch once the kernel headers are updated
+  ];
 
   nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = [ ];
 
   postInstall = ''
     # The bridge utils build does not fail even if the brctl binary

--- a/pkgs/os-specific/linux/drbd/default.nix
+++ b/pkgs/os-specific/linux/drbd/default.nix
@@ -10,7 +10,8 @@ stdenv.mkDerivation rec {
 
   patches = [ ./pass-force.patch ];
 
-  buildInputs = [ flex perl ];
+  nativeBuildInputs = [ flex ];
+  buildInputs = [ perl ];
 
   configureFlags = [
     "--without-distro"

--- a/pkgs/tools/system/lshw/default.nix
+++ b/pkgs/tools/system/lshw/default.nix
@@ -13,11 +13,18 @@ stdenv.mkDerivation rec {
     sha256 = "0brwra4jld0d53d7jsgca415ljglmmx1l2iazpj4ndilr48yy8mf";
   };
 
-  patches = [ (fetchpatch {
-    # fix crash in scan_dmi_sysfs() when run as non-root
-    url = "https://github.com/lyonel/lshw/commit/fbdc6ab15f7eea0ddcd63da355356ef156dd0d96.patch";
-    sha256 = "147wyr5m185f8swsmb4q1ahs9r1rycapbpa2548aqbv298bbish3";
-  })];
+  patches = [
+    (fetchpatch {
+      # fix crash in scan_dmi_sysfs() when run as non-root
+      url = "https://github.com/lyonel/lshw/commit/fbdc6ab15f7eea0ddcd63da355356ef156dd0d96.patch";
+      sha256 = "147wyr5m185f8swsmb4q1ahs9r1rycapbpa2548aqbv298bbish3";
+    })
+    (fetchpatch {
+      # support cross-compilation
+      url = "https://github.com/lyonel/lshw/commit/8486d25cea9b68794504fbd9e5c6e294bac6cb07.patch";
+      sha256 = "08f0wnxsq0agvsc66bhc7lxvk564ir0pp8pg3cym6a621prb9lm0";
+    })
+  ];
 
   nativeBuildInputs = [ pkgconfig ];
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

To fix cross-compilation for:
- `bridge-utils`
- `drbd`
- `lshw`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
