### PR TITLE
kdbplus: add zlib to libPath

### DIFF
--- a/pkgs/applications/misc/kdbplus/default.nix
+++ b/pkgs/applications/misc/kdbplus/default.nix
@@ -1,10 +1,10 @@
-{ stdenv, requireFile, unzip, rlwrap, bash }:
+{ stdenv, requireFile, unzip, rlwrap, bash, zlib }:
 
 assert (stdenv.hostPlatform.system == "i686-linux");
 
 let
   libPath = stdenv.lib.makeLibraryPath
-    [ stdenv.cc.libc stdenv.cc.cc ];
+    [ stdenv.cc.libc stdenv.cc.cc zlib ];
 in
 stdenv.mkDerivation rec {
   pname = "kdbplus";


### PR DESCRIPTION
Necessary for https://github.com/kxcontrib/websocket to run

###### Motivation for this change

Error when running `pubsub.q` from the repository linked above, `libz.so.1: cannot open shared object file: No such file or directory`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @thoughtpolice 
