### PR TITLE
anki: fix startup

### DIFF
--- a/pkgs/games/anki/default.nix
+++ b/pkgs/games/anki/default.nix
@@ -19,6 +19,7 @@
 , glibcLocales
 , nose
 , jsonschema
+, setuptools
 , send2trash
 , CoreAudio
 # This little flag adds a huge number of dependencies, but we assume that
@@ -87,7 +88,7 @@ buildPythonApplication rec {
 
     propagatedBuildInputs = [
       pyqtwebengine sqlalchemy beautifulsoup4 send2trash pyaudio requests decorator
-      markdown jsonschema
+      markdown jsonschema setuptools
     ]
       ++ lib.optional plotsSupport matplotlib
       ++ lib.optional stdenv.isDarwin [ CoreAudio ]


### PR DESCRIPTION
###### Motivation for this change

Fixes #68601.

Related: #68314

This fixes startup of anki, which currently shows this in a dialog:

```
Error during startup:
Traceback (most recent call last):
  File "/nix/store/0h395dwc6b80n5xg93p86ywaz6kpz6ck-anki-2.1.15/lib/python3.7/site-packages/aqt/main.py", line 46, in __init__
    self.setupAddons()
  File "/nix/store/0h395dwc6b80n5xg93p86ywaz6kpz6ck-anki-2.1.15/lib/python3.7/site-packages/aqt/main.py", line 657, in setupAddons
    import aqt.addons
  File "/nix/store/0h395dwc6b80n5xg93p86ywaz6kpz6ck-anki-2.1.15/lib/python3.7/site-packages/aqt/addons.py", line 9, in <module>
    import markdown
  File "/nix/store/knq8798kl0xzzr7ii4bchskg1c8mq6pj-python3.7-Markdown-3.1.1/lib/python3.7/site-packages/markdown/__init__.py", line 25, in <module>
    from .core import Markdown, markdown, markdownFromFile
  File "/nix/store/knq8798kl0xzzr7ii4bchskg1c8mq6pj-python3.7-Markdown-3.1.1/lib/python3.7/site-packages/markdown/core.py", line 29, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Tested on release-19.09 and it works fine after this change.

###### Notify maintainers

cc @oxij @the-kenny @Profpatsch @enzime

@FRidh @worldofpeace 

committers please cherry-pick to release-19.09