### PR TITLE
gst_all_1.gst-vaapi: patch to Remove Mesa from drivers white list

### DIFF
--- a/pkgs/development/libraries/gstreamer/vaapi/default.nix
+++ b/pkgs/development/libraries/gstreamer/vaapi/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, meson, ninja, pkgconfig, gst-plugins-base, bzip2, libva, wayland
 , libdrm, udev, xorg, libGLU_combined, gstreamer, gst-plugins-bad, nasm
-, libvpx, python
+, libvpx, python, fetchpatch
 }:
 
 stdenv.mkDerivation rec {
@@ -11,6 +11,15 @@ stdenv.mkDerivation rec {
     url = "${meta.homepage}/src/gstreamer-vaapi/gstreamer-vaapi-${version}.tar.xz";
     sha256 = "07qpynamiz0lniqajcaijh3n7ixs4lfk9a5mfk50sng0dricwzsf";
   };
+
+  patches = [
+    # See: https://mail.gnome.org/archives/distributor-list/2019-September/msg00000.html
+    # Note that the patch has now been actually accepted upstream.
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/gstreamer/gstreamer-vaapi/commit/a90daabb84f983d2fa05ff3159f7ad59aa648b55.patch";
+      sha256 = "0p2qygq6b5h6nxjdfnlzbsyih43hjq5c94ag8sbyyb8pmnids9rb";
+    })
+  ];
 
   outputs = [ "out" "dev" ];
 

--- a/pkgs/development/libraries/gstreamer/vaapi/default.nix
+++ b/pkgs/development/libraries/gstreamer/vaapi/default.nix
@@ -37,8 +37,6 @@ stdenv.mkDerivation rec {
   '';
 
   mesonFlags = [
-    # Enables all features, so that we know when new dependencies are necessary.
-    "-Dauto_features=enabled"
     "-Dexamples=disabled" # requires many dependencies and probably not useful for our users
   ];
 


### PR DESCRIPTION
###### Motivation for this change
See https://mail.gnome.org/archives/distributor-list/2019-September/msg00000.html

Patch has been now merged upstream.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

