### PR TITLE
cacert: simplify setupHook

### DIFF
--- a/pkgs/data/misc/cacert/setup-hook.sh
+++ b/pkgs/data/misc/cacert/setup-hook.sh
@@ -1,7 +1,3 @@
-cacertHook() {
-    export NIX_SSL_CERT_FILE=@out@/etc/ssl/certs/ca-bundle.crt
-    # left for compatibility
-    export SSL_CERT_FILE=@out@/etc/ssl/certs/ca-bundle.crt
-}
-
-addEnvHooks "$targetOffset" cacertHook
+export NIX_SSL_CERT_FILE=@out@/etc/ssl/certs/ca-bundle.crt
+# left for compatibility
+export SSL_CERT_FILE=@out@/etc/ssl/certs/ca-bundle.crt


### PR DESCRIPTION
Currently, the `cacert` `setupHook`, which sets `NIX_SSL_CERT_FILE`, triggers for each dependency at `$targetOffset`. It does not trigger in cases where there are no such dependencies. When not cross-compiling, `cacert` triggers on itself, but, when cross compiling, a dependency at `$targetOffset` is often lacking.

I propose directly setting `NIX_SSL_CERT_FILE` in the `setupHook`, but perhaps there is a more idiomatic way of implementing this sort of hook.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

To make the `cacert` `setupHook` more robust, particularly in the case of cross-compilation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
