### PR TITLE
keepassxc: use qt's wrapper

### DIFF
--- a/pkgs/applications/misc/keepassx/community.nix
+++ b/pkgs/applications/misc/keepassx/community.nix
@@ -103,6 +103,7 @@ mkDerivation rec {
   ++ stdenv.lib.optional withKeePassKeeShareSecure quazip
   ++ stdenv.lib.optional stdenv.isDarwin qtmacextras;
 
+  dontWrapQtApps = true;
   preFixup = if stdenv.isDarwin then ''
     wrapQtApp $out/Applications/KeePassXC.app/Contents/MacOS/KeePassXC
   '' else ''

--- a/pkgs/applications/misc/keepassx/community.nix
+++ b/pkgs/applications/misc/keepassx/community.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, makeWrapper, qttools
+{ stdenv, mkDerivation, fetchFromGitHub, cmake, qttools
 
 , curl
 , glibcLocales
@@ -30,7 +30,7 @@
 
 with stdenv.lib;
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "keepassxc";
   version = "2.4.3";
 
@@ -103,9 +103,10 @@ stdenv.mkDerivation rec {
   ++ stdenv.lib.optional withKeePassKeeShareSecure quazip
   ++ stdenv.lib.optional stdenv.isDarwin qtmacextras;
 
-  preFixup = optionalString stdenv.isDarwin ''
-    # Make it work without Qt in PATH.
+  preFixup = if stdenv.isDarwin then ''
     wrapQtApp $out/Applications/KeePassXC.app/Contents/MacOS/KeePassXC
+  '' else ''
+    wrapQtApp $out/bin/keepassxc
   '';
 
   meta = {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

KeepassXC fails to start

```
qt.qpa.plugin: Could not find the Qt platform plugin "xcb" in ""
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
```

See https://github.com/NixOS/nixpkgs/issues/65399

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @jonafato
