### PR TITLE
python37Packages.h11: fixing build

### DIFF
--- a/pkgs/development/python-modules/h11/default.nix
+++ b/pkgs/development/python-modules/h11/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, pytest }:
+{ lib, buildPythonPackage, fetchPypi, fetchpatch, pytest }:
 
 buildPythonPackage rec {
   pname = "h11";
@@ -10,6 +10,16 @@ buildPythonPackage rec {
   };
 
   checkInputs = [ pytest ];
+
+  patches = [
+    # This fixes a broken test case in 0.9.0 with newer versions of pytest,
+    # when this package version is bumped to >0.9.0 it can likely be dropped.
+    # https://github.com/python-hyper/h11/issues/86
+    ( fetchpatch {
+      url = "https://github.com/python-hyper/h11/commit/cc0c63ed9b67f4ee71f087406008be3443712f6c.patch";
+      sha256 = "05ff4fp89xl62ip16w7f4dcw0grvkwyq5d8wzlknsahbxy5f7a8h";
+    })
+  ];
 
   checkPhase = ''
     py.test


### PR DESCRIPTION
###### Motivation for this change

Fixes a broken test-case with more recent pytest versions.
See https://github.com/python-hyper/h11/issues/86

Related: https://github.com/NixOS/nixpkgs/issues/68361

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

No known maintainers.
cc @ryantm as last committer  