### PR TITLE
protobuf: add license metadata

### DIFF
--- a/pkgs/development/python-modules/protobuf/default.nix
+++ b/pkgs/development/python-modules/protobuf/default.nix
@@ -59,6 +59,7 @@ buildPythonPackage {
   meta = {
     description = "Protocol Buffers are Google's data interchange format";
     homepage = https://developers.google.com/protocol-buffers/;
+    license = licenses.bsd3;
   };
 
   passthru.protobuf = protobuf;


### PR DESCRIPTION
https://github.com/protocolbuffers/protobuf/blob/master/LICENSE

GitHub doesn't identify it as BSD-3, but it is if you just look at the
license text.

###### Motivation for this change

I was doing writing some automated license check program for work and noticed this license was missing.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

??
