### PR TITLE
codeowners: add cdepillabout to CODEOWNERS for Haskell-related packages

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -58,11 +58,11 @@
 /doc/languages-frameworks/python.section.md     @FRidh
 
 # Haskell
-/pkgs/development/compilers/ghc                       @basvandijk
-/pkgs/development/haskell-modules                     @basvandijk
-/pkgs/development/haskell-modules/default.nix         @basvandijk
-/pkgs/development/haskell-modules/generic-builder.nix @basvandijk
-/pkgs/development/haskell-modules/hoogle.nix          @basvandijk
+/pkgs/development/compilers/ghc                       @basvandijk @cdepillabout
+/pkgs/development/haskell-modules                     @basvandijk @cdepillabout
+/pkgs/development/haskell-modules/default.nix         @basvandijk @cdepillabout
+/pkgs/development/haskell-modules/generic-builder.nix @basvandijk @cdepillabout
+/pkgs/development/haskell-modules/hoogle.nix          @basvandijk @cdepillabout
 
 # Perl
 /pkgs/development/interpreters/perl @volth


### PR DESCRIPTION
This commit adds myself as a CODEOWNER for the Haskell-related packages.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I'd like to help review the Haskell-related issues and PRs.  Adding myself to the CODEOWNERS makes it easy for me to pinged for reviews on PRs automatically, as well as making it simple for users submitting issues to know to ping me.

I hope to take some of the pressure off of other people who frequently do reviews for Haskell-related changes, like @peti, @Infinisil, @domenkozar, @basvandijk, etc.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
