### PR TITLE
treewide: build some unfree packages locally

### DIFF
--- a/pkgs/applications/editors/jetbrains/common.nix
+++ b/pkgs/applications/editors/jetbrains/common.nix
@@ -77,4 +77,6 @@ with stdenv; lib.makeOverridable mkDerivation rec {
     ln -s "$item/share/applications" $out/share
   '';
 
+} // stdenv.lib.optionalAttrs (!(meta.license.free or true)) {
+  preferLocalBuild = true;
 }

--- a/pkgs/applications/misc/xmind/default.nix
+++ b/pkgs/applications/misc/xmind/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
     sha256 = "0jxq2fiq69q9ly0m6hx2qfybqad22sl42ciw636071khpqgc885f";
   };
 
+  preferLocalBuild = true;
+
   patches = [ ./java-env-config-fixes.patch ];
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/applications/networking/remote/teamviewer/default.nix
+++ b/pkgs/applications/networking/remote/teamviewer/default.nix
@@ -54,6 +54,7 @@ mkDerivation rec {
   '';
 
   dontStrip = true;
+  preferLocalBuild = true;
 
   meta = with lib; {
     homepage = http://www.teamviewer.com;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Unfree packages aren't distributed by our binary cache due to legal
reasons[1] and are usually a prebuilt binary that requires some patching.
When using distributed builds[2], those are uploaded to another build
machine as fixed-output derivations from `fetchurl` are built locally[3]
which takes a certain amount of time and resources with almost no gain
as the build process is trivial in contrast to the up/download to a
remote builder.

This is why I figured that at least some of the packages should be
explicitly built locally, I've done something simlar for
`citrix_workspace` already in the past[4].

The following packages are affected by this:

* `idea.*` (excluding free derivatives)
* `xmind`
* `teamviewer`

[1] https://nixos.wiki/wiki/FAQ/How_can_I_install_a_proprietary_or_unfree_package%3F#More_precision
[2] https://nixos.wiki/wiki/Distributed_build
[3] https://github.com/NixOS/nixpkgs/blob/267c8d6b2fea05bc811c8e2c2f4529b1436eeb9a/pkgs/build-support/fetchurl/default.nix#L95
[4] 87f818d9b21b16b067048a6ee0178b782886f0f0


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
