### PR TITLE
mapproxy: init at 1.12.0

### DIFF
--- a/pkgs/applications/misc/mapproxy/default.nix
+++ b/pkgs/applications/misc/mapproxy/default.nix
@@ -1,0 +1,63 @@
+{ lib
+, pkgs
+, python
+}:
+let
+  py = python.override {
+    packageOverrides = self: super: {
+      pyproj = super.pyproj.overridePythonAttrs (oldAttrs: rec {
+      version = "1.9.6";
+      src = pkgs.fetchFromGitHub {
+        owner = "pyproj4";
+        repo = "pyproj";
+        rev = "v${version}rel";
+        sha256 = "sha256:18v4h7jx4mcc0x2xy8y7dfjq9bzsyxs8hdb6v67cabvlz2njziqy";
+      };
+      nativeBuildInputs = with python.pkgs; [ cython ];
+      patches = [ ];
+      checkPhase = ''
+        runHook preCheck
+        pushd unittest  # changing directory should ensure we're importing the global pyproj
+        ${python.interpreter} test.py && ${python.interpreter} -c "import doctest, pyproj, sys; sys.exit(doctest.testmod(pyproj)[0])"
+        popd
+        runHook postCheck
+      '';
+      });
+    };
+  };
+in
+with py.pkgs;
+buildPythonApplication rec {
+  pname = "MapProxy";
+  version = "1.12.0";
+  src = fetchPypi {
+  inherit pname version;
+  sha256 = "622e3a7796ef861ba21e42231b49c18d00d75f03eaf3f01a2b7687be7568e2ec";
+  };
+  prePatch = ''
+    substituteInPlace mapproxy/util/ext/serving.py --replace "args = [sys.executable] + sys.argv" "args = sys.argv"
+  '';
+  propagatedBuildInputs = [
+    pillow
+    pyyaml
+    pyproj
+    shapely
+    gdal
+    lxml
+    setuptools
+  ];
+  # Tests are disabled:
+  # 1) Dependency list is huge.
+  #    https://github.com/mapproxy/mapproxy/blob/master/requirements-tests.txt
+  #
+  # 2) There are security issues with package Riak
+  #    https://github.com/NixOS/nixpkgs/issues/33876
+  #    https://github.com/NixOS/nixpkgs/pull/56480
+  doCheck = false;
+  meta = with lib; {
+  description = "MapProxy is an open source proxy for geospatial data";
+  homepage = https://mapproxy.org/;
+  license = licenses.asl20;
+  maintainers = with maintainers; [ rakesh4g ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1927,6 +1927,8 @@ in
 
   lynis = callPackage ../tools/security/lynis { };
 
+  mapproxy = callPackage ../applications/misc/mapproxy { };
+
   marlin-calc = callPackage ../tools/misc/marlin-calc {};
 
   mathics = with python2Packages; toPythonApplication mathics;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @CMCDragonkai 
