### PR TITLE
ape: update to 6.7.180715 and fix build

### DIFF
--- a/pkgs/applications/misc/ape/default.nix
+++ b/pkgs/applications/misc/ape/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
-  version = "6.7-131003";
+  version = "6.7.180715";
 
   buildInputs = [ swiProlog makeWrapper ];
 
@@ -16,14 +16,12 @@ stdenv.mkDerivation rec {
      owner = "Attempto";
      repo = "APE";
      rev = version;
-     sha256 = "0cw47qjg4896kw3vps6rfs02asvscsqvcfdiwgfmqb3hvykb1sdx";
+     sha256 = "1jnr6y4kc6d5rjy6bbbnn4n7rl6ajpvw4xf4067wjh28c9scjwg3";
   };
 
   patchPhase = ''
-    # We move the file first to avoid "same file" error in the default case
-    cp ${lexicon} new_lexicon.pl
-    rm lexicon/clex_lexicon.pl
-    cp new_lexicon.pl lexicon/clex_lexicon.pl
+    # don't try to force /bin/bash
+    sed -i '/SHELL=\/bin\/bash/d' Makefile
   '';
 
   buildPhase = ''


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
This was broken in 19.09, and an older version to boot. Part of #68361 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @yrashk 
