### PR TITLE
pythondialog: init at 3.4.0

### DIFF
--- a/pkgs/development/python-modules/pythondialog/default.nix
+++ b/pkgs/development/python-modules/pythondialog/default.nix
@@ -1,0 +1,27 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, isPy3k
+}:
+
+buildPythonPackage rec {
+  pname = "pythondialog";
+  version = "3.4.0";
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1728ghsran47jczn9bhlnkvk5bvqmmbihabgif5h705b84r1272c";
+  };
+
+  patchPhase = ''
+    substituteInPlace dialog.py --replace ":/bin:/usr/bin" ":$out/bin"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A Python interface to the UNIX dialog utility and mostly-compatible programs";
+    homepage = "http://pythondialog.sourceforge.net/";
+    license = licenses.lgpl3;
+  };
+
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3253,6 +3253,8 @@ in {
     cudaSupport = false;
   };
 
+  pythondialog = callPackage ../development/python-modules/pythondialog { };
+
   python2-pythondialog = callPackage ../development/python-modules/python2-pythondialog { };
 
   pyRFC3339 = callPackage ../development/python-modules/pyrfc3339 { };


### PR DESCRIPTION
###### Motivation for this change

pythondialog is only present in a backported Python 2 version. This adds the Python 3 package.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
