### PR TITLE
microsoft_gsl: Fix gcc8 build

### DIFF
--- a/pkgs/development/libraries/microsoft_gsl/default.nix
+++ b/pkgs/development/libraries/microsoft_gsl/default.nix
@@ -20,6 +20,9 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ catch cmake ];
   buildPhase = if nativeBuild then "make" else "true";
 
+  # https://github.com/microsoft/GSL/issues/806
+  cmakeFlags = [ "-DCMAKE_CXX_FLAGS=-Wno-catch-value" ];
+
   installPhase = ''
     mkdir -p $out/include
     mv ../include/ $out/


### PR DESCRIPTION
###### Motivation for this change
Build breaks with our new GCC version and all the warnings we enable.
Until upstream fixes microsoft/GSL#806, we'll have to disable this warning.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @thoughtpolice @xwvvvvwx @yuriaisaka
