### PR TITLE
gem-config: fix zookeeper for gcc-8

### DIFF
--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -19,7 +19,7 @@
 
 { lib, fetchurl, writeScript, ruby, kerberos, libxml2, libxslt, python, stdenv, which
 , libiconv, postgresql, v8_3_16_14, clang, sqlite, zlib, imagemagick
-, pkgconfig , ncurses, xapian, gpgme, utillinux, fetchpatch, tzdata, icu, libffi
+, pkgconfig , ncurses, xapian, gpgme, utillinux, tzdata, icu, libffi
 , cmake, libssh2, openssl, mysql, darwin, git, perl, pcre, gecode_3, curl
 , msgpack, qt59, libsodium, snappy, libossp_uuid, lxc, libpcap, xorg, gtk2, buildRubyGem
 , cairo, re2, rake, gobject-introspection, gdk-pixbuf, zeromq, czmq, graphicsmagick, libcxx
@@ -613,5 +613,11 @@ in
 
   zookeeper = attrs: {
     buildInputs = stdenv.lib.optionals stdenv.isDarwin [ darwin.cctools ];
+    dontBuild = false;
+    postPatch = ''
+      sed -i ext/extconf.rb -e "4a \
+        FileUtils.cp '${./zookeeper-ftbfs-with-gcc-8.patch}', 'patches/zkc-3.4.5-gcc-8.patch'
+      "
+    '';
   };
 }

--- a/pkgs/development/ruby-modules/gem-config/zookeeper-ftbfs-with-gcc-8.patch
+++ b/pkgs/development/ruby-modules/gem-config/zookeeper-ftbfs-with-gcc-8.patch
@@ -1,0 +1,11 @@
+--- zkc-3.4.5/c/src/zookeeper.c 2019-09-13 12:05:20.647034862 +0200
++++ zkc-3.4.5/c/src/zookeeper.c 2019-09-13 12:05:49.125360269 +0200
+@@ -3418,7 +3418,7 @@
+ 
+ static const char* format_endpoint_info(const struct sockaddr_storage* ep)
+ {
+-    static char buf[128];
++    static char buf[128 + 6]; // include space for the port :xxxxxx
+     char addrstr[128];
+     void *inaddr;
+ #ifdef WIN32


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/68361

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @zimbatm @alyssais 
