### PR TITLE
ants: fix build

### DIFF
--- a/pkgs/applications/science/biology/ants/default.nix
+++ b/pkgs/applications/science/biology/ants/default.nix
@@ -1,9 +1,8 @@
-{ stdenv, fetchFromGitHub, fetchpatch, cmake, makeWrapper, itk, vtk }:
+{ stdenv, fetchFromGitHub, fetchpatch, cmake, makeWrapper, itk4, vtk }:
 
 stdenv.mkDerivation rec {
-  _name    = "ANTs";
-  _version = "2.2.0";
-  name  = "${_name}-${_version}";
+  pname    = "ANTs";
+  version = "2.2.0";
 
   src = fetchFromGitHub {
     owner  = "ANTsX";
@@ -21,7 +20,7 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [ cmake makeWrapper ];
-  buildInputs = [ itk vtk ];
+  buildInputs = [ itk4 vtk ];
 
   cmakeFlags = [ "-DANTS_SUPERBUILD=FALSE" "-DUSE_VTK=TRUE" ];
 
@@ -34,7 +33,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = https://github.com/ANTxS/ANTs;
+    homepage = https://github.com/ANTsX/ANTs;
     description = "Advanced normalization toolkit for medical image registration and other processing";
     maintainers = with maintainers; [ bcdarwin ];
     platforms = platforms.unix;

--- a/pkgs/development/libraries/itk/4.x.nix
+++ b/pkgs/development/libraries/itk/4.x.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchurl, cmake, libX11, libuuid, xz, vtk }:
+
+stdenv.mkDerivation rec {
+  name = "itk-4.13.1";
+
+  src = fetchurl {
+    url = mirror://sourceforge/itk/InsightToolkit-4.13.1.tar.xz;
+    sha256 = "0p4cspgbnjsnkjz8nfg092yaxz8qkqi2nkxjdv421d0zrmi0i2al";
+  };
+
+  cmakeFlags = [
+    "-DBUILD_TESTING=OFF"
+    "-DBUILD_EXAMPLES=OFF"
+    "-DBUILD_SHARED_LIBS=ON"
+    "-DModule_ITKMINC=ON"
+    "-DModule_ITKIOMINC=ON"
+    "-DModule_ITKIOTransformMINC=ON"
+    "-DModule_ITKVtkGlue=ON"
+    "-DModule_ITKReview=ON"
+  ];
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [ cmake xz ];
+  buildInputs = [ libX11 libuuid vtk ];
+
+  meta = {
+    description = "Insight Segmentation and Registration Toolkit";
+    homepage = http://www.itk.org/;
+    license = stdenv.lib.licenses.asl20;
+    maintainers = with stdenv.lib.maintainers; [viric];
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11410,6 +11410,8 @@ in
 
   isso = callPackage ../servers/isso { };
 
+  itk4 = callPackage ../development/libraries/itk/4.x.nix { };
+
   itk = callPackage ../development/libraries/itk { };
 
   jasper = callPackage ../development/libraries/jasper { };


### PR DESCRIPTION
###### Motivation for this change
ANTs was broken by #63270

ZHF (#68361)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @bcdarwin