### PR TITLE
linuxPackages.exfat-nofuse: 2018-04-16 -> 2019-09-06

### DIFF
--- a/pkgs/os-specific/linux/exfat/default.nix
+++ b/pkgs/os-specific/linux/exfat/default.nix
@@ -6,13 +6,13 @@ assert lib.versionAtLeast kernel.version  "4.2" || lib.versionOlder kernel.versi
 
 stdenv.mkDerivation rec {
   name = "exfat-nofuse-${version}-${kernel.version}";
-  version = "2018-04-16";
+  version = "2019-09-06";
 
   src = fetchFromGitHub {
-    owner = "dorimanx";
+    owner = "AdrianBan";
     repo = "exfat-nofuse";
-    rev = "01c30ad52625a7261e1b0d874553b6ca7af25966";
-    sha256 = "0n1ibamf1yj8iqapc86lfscnky9p07ngsi4f2kpv3d5r2s6mzsh6";
+    rev = "5536f067373c196f152061f5000fe0032dc07c48";
+    sha256 = "00mhadsv2iw8z00a6170hwbvk3afx484nn3irmd5f5kmhs34sw7k";
   };
 
   hardeningDisable = [ "pic" ];
@@ -27,18 +27,9 @@ stdenv.mkDerivation rec {
     install -m644 -b -D exfat.ko $out/lib/modules/${kernel.modDirVersion}/kernel/fs/exfat/exfat.ko
   '';
 
-  patches = [
-    # fix compile-errors in 4.18 and 4.20
-    # ref: https://github.com/dorimanx/exfat-nofuse/pull/137
-    (fetchpatch {
-      url = https://github.com/dorimanx/exfat-nofuse/compare/01c30ad52625a7261e1b0d874553b6ca7af25966...f93a47e6414d567a1e7f6ab7f34b015b20f9a050.patch ;
-      sha256 = "0w57pi9h6dwjxfgc3zpwy6sr4zw42hn1zj72f7wgfpqrx6d8xkh5";
-    } )
-  ];
-
   meta = {
     description = "exfat kernel module";
-    homepage = https://github.com/dorimanx/exfat-nofuse;
+    inherit (src.meta) homepage;
     license = lib.licenses.gpl2;
     maintainers = with lib.maintainers; [ makefu ];
     platforms = lib.platforms.linux;


### PR DESCRIPTION


###### Motivation for this change

Upstream repository is unmaintained since 2018, maintainership got taken
over by AdrianBan ( https://github.com/dorimanx/exfat-nofuse/issues/145#issuecomment-528632096 )

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [N/A] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers
that would be me, i guess
cc @
