### PR TITLE
xflux-gui: 1.1.10 -> 1.2.0

### DIFF
--- a/pkgs/tools/misc/xflux/gui.nix
+++ b/pkgs/tools/misc/xflux/gui.nix
@@ -1,39 +1,42 @@
-{ stdenv, fetchFromGitHub, pythonPackages
-, gnome_python
-, libappindicator-gtk2, xflux, librsvg, wrapGAppsHook
+{ stdenv, fetchFromGitHub, buildPythonApplication, python3Packages, wrapGAppsHook
+, xflux, librsvg, gtk3, gobject-introspection, pango, gdk-pixbuf, atk
+, pexpect, pyGtkGlade, pygobject3, pyxdg, libappindicator-gtk3
 }:
-pythonPackages.buildPythonApplication rec {
+buildPythonApplication rec {
   pname = "xflux-gui";
-  version = "1.1.10";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     repo = "xflux-gui";
     owner = "xflux-gui";
     rev = "v${version}";
-    sha256 = "1k67qg9y4c0n9ih0syx81ixbdl2x89gd4arwh71316cshskn0rc8";
+    sha256 = "09zphcd9821ink63636swql4g85hg6lpsazqg1mawlk9ikc8zbps";
   };
 
-  propagatedBuildInputs = with pythonPackages; [
-    pexpect
-    pyGtkGlade
-    pygobject2
+  propagatedBuildInputs = [
     pyxdg
-    libappindicator-gtk2
-    gnome_python
+    pexpect
+    pygobject3
   ];
 
-  buildInputs = [ xflux librsvg ];
+  buildInputs = [
+    xflux gtk3
+  ];
 
-  nativeBuildInputs = [ wrapGAppsHook ];
+  nativeBuildInputs = [
+    wrapGAppsHook gobject-introspection
+    pango gdk-pixbuf atk libappindicator-gtk3
+  ];
 
   postPatch = ''
-     substituteInPlace src/fluxgui/xfluxcontroller.py --replace "pexpect.spawn(\"xflux\"" "pexpect.spawn(\"${xflux}/bin/xflux\""
+     substituteInPlace src/fluxgui/xfluxcontroller.py \
+       --replace "pexpect.spawn(\"xflux\"" "pexpect.spawn(\"${xflux}/bin/xflux\""
   '';
 
   postFixup = ''
     wrapGAppsHook
     wrapPythonPrograms
-    patchPythonScript $out/${pythonPackages.python.sitePackages}/fluxgui/fluxapp.py
+    patchPythonScript $out/${python3Packages.python.sitePackages}/fluxgui/fluxapp.py
   '';
 
   meta = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7098,9 +7098,7 @@ in
   xe-guest-utilities = callPackage ../tools/virtualization/xe-guest-utilities { };
 
   xflux = callPackage ../tools/misc/xflux { };
-  xflux-gui = callPackage ../tools/misc/xflux/gui.nix {
-    gnome_python = gnome2.gnome_python;
-  };
+  xflux-gui = python3Packages.callPackage ../tools/misc/xflux/gui.nix { };
 
   xfsprogs = callPackage ../tools/filesystems/xfsprogs { };
   libxfs = xfsprogs.dev;


### PR DESCRIPTION
###### Motivation for this change
Didn't build with the old version because they dropped Python2 and
changed some dependencies.

Works fine. Applet works and changes my screen tint.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @sheenobu
