### PR TITLE
rspamd: disable LuaJIT support on aarch64 [ZHF 19.93]

### DIFF
--- a/pkgs/servers/mail/rspamd/default.nix
+++ b/pkgs/servers/mail/rspamd/default.nix
@@ -1,10 +1,11 @@
 { stdenv, lib, fetchFromGitHub, cmake, perl
 , file, glib, libevent, luajit, openssl, pcre, pkgconfig, sqlite, ragel, icu
-, hyperscan, libfann, gd, jemalloc, openblas
+, hyperscan, libfann, gd, jemalloc, openblas, lua
 , withFann ? true
 , withGd ? false
 , withBlas ? true
 , withHyperscan ? stdenv.isx86_64
+, withLuaJIT ? stdenv.isx86_64
 }:
 
 assert withHyperscan -> stdenv.isx86_64;
@@ -24,11 +25,12 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake pkgconfig perl ];
-  buildInputs = [ glib libevent libmagic luajit openssl pcre sqlite ragel icu jemalloc ]
+  buildInputs = [ glib libevent libmagic openssl pcre sqlite ragel icu jemalloc ]
     ++ lib.optional withFann libfann
     ++ lib.optional withGd gd
     ++ lib.optional withHyperscan hyperscan
-    ++ lib.optional withBlas openblas;
+    ++ lib.optional withBlas openblas
+    ++ lib.optional withLuaJIT luajit ++ lib.optional (!withLuaJIT) lua;
 
   cmakeFlags = [
     "-DDEBIAN_BUILD=ON"
@@ -39,10 +41,11 @@ stdenv.mkDerivation rec {
     "-DENABLE_JEMALLOC=ON"
   ] ++ lib.optional withFann "-DENABLE_FANN=ON"
     ++ lib.optional withHyperscan "-DENABLE_HYPERSCAN=ON"
-    ++ lib.optional withGd "-DENABLE_GD=ON";
+    ++ lib.optional withGd "-DENABLE_GD=ON"
+    ++ lib.optional (!withLuaJIT) "-DENABLE_TORCH=OFF";
 
   meta = with stdenv.lib; {
-    homepage = https://rspamd.com;
+    homepage = "https://rspamd.com";
     license = licenses.asl20;
     description = "Advanced spam filtering system";
     maintainers = with maintainers; [ avnik fpletz globin ];


### PR DESCRIPTION
###### Motivation for this change
#68361

###### Things done

When compiled with LuaJIT support, rspamd segfaults on aarch64.
Without LuaJIT, rspamd falls back to plain Lua and torch support needs to
be disabled.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS (x86_64-linux & aarch64-linux)
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).