### PR TITLE
httplz: Fix build with openssl_1_0_2

### DIFF
--- a/pkgs/tools/networking/httplz/default.nix
+++ b/pkgs/tools/networking/httplz/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, rustPlatform, pkgs, darwin }:
+{ stdenv, lib, fetchFromGitHub, rustPlatform, openssl, pkgconfig, darwin, libiconv }:
 
 rustPlatform.buildRustPackage rec {
   pname = "httplz";
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "0q9ng8vf01k65zmcm7bbkqyrkj5hs86zdxwrfj98f4xqxrm75rf6";
   };
 
-  buildInputs = with pkgs; [ openssl pkgconfig ] ++ lib.optionals stdenv.isDarwin [ libiconv darwin.apple_sdk.frameworks.Security ];
+  buildInputs = [ openssl pkgconfig ] ++ lib.optionals stdenv.isDarwin [ libiconv darwin.apple_sdk.frameworks.Security ];
 
   cargoBuildFlags = [ "--bin httplz" ];
   cargoPatches = [ ./cargo-lock.patch ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3855,7 +3855,7 @@ in
 
   httping = callPackage ../tools/networking/httping {};
 
-  httplz = callPackage ../tools/networking/httplz { };
+  httplz = callPackage ../tools/networking/httplz { openssl = openssl_1_0_2; };
 
   httpfs2 = callPackage ../tools/filesystems/httpfs { };
 


### PR DESCRIPTION
###### Motivation for this change
The rust crate dependency that wraps OpenSSL doesn't support the Openssl
1.1.

Serves my local directory fine on NixOS unstable with `./result/bin/httplz`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @bbigras 
