### PR TITLE
pythonPackages.dyndnsc: init at 0.5.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -692,6 +692,16 @@
     githubId = 135230;
     name = "Aycan iRiCAN";
   };
+  b4dm4n = {
+    email = "fabianm88@gmail.com";
+    github = "B4dM4n";
+    githubId = 448169;
+    name = "Fabian Möller";
+    keys = [{
+      longkeyid = "rsa4096/0x754B5C0963C42C5";
+      fingerprint = "6309 E212 29D4 DA30 AF24  BDED 754B 5C09 63C4 2C50";
+    }];
+  };
   babariviere = {
     email = "babariviere@protonmail.com";
     github = "babariviere";

--- a/pkgs/applications/networking/dyndns/dyndnsc/default.nix
+++ b/pkgs/applications/networking/dyndns/dyndnsc/default.nix
@@ -1,0 +1,40 @@
+{ lib, buildPythonPackage, fetchPypi, isPy27, pytestrunner, setuptools, daemonocle, dnspython
+, netifaces, requests, bottle, pytest, ndg-httpsclient, ipy, mock }:
+
+buildPythonPackage rec {
+  pname = "dyndnsc";
+  version = "0.5.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1p8dgfhvks1bjvq8gww4yvi3g8fam2m5irirkf7xjhs8g38r8bjb";
+  };
+  postPatch = ''
+    # loosen some dependency requirements
+    substituteInPlace setup.py \
+      --replace "pytest>=3.2.5,<5.0.0" "pytest>=3.2.5" \
+      --replace '"argparse",' "" \
+      --replace "bottle==" "bottle>="
+
+    # skip test that needs internet
+    substituteInPlace dyndnsc/tests/detector/test_dnswanip.py \
+      --replace "def test_dnswanip_detector_ipv4" "@pytest.mark.skip"$'\n'"    def test_dnswanip_detector_ipv4"
+  '';
+
+  nativeBuildInputs = [ pytestrunner ];
+
+  propagatedBuildInputs = [ daemonocle dnspython netifaces requests setuptools ]
+    ++ lib.optionals isPy27 [ ndg-httpsclient ipy ];
+
+  checkInputs = [ bottle pytest ] ++ lib.optional isPy27 mock;
+
+  # Some of the tests use localhost networking.
+  __darwinAllowLocalNetworking = true;
+
+  meta = with lib; {
+    description = "Dynamic dns update client written in Python";
+    homepage = "https://github.com/infothrill/python-dyndnsc";
+    license = licenses.mit;
+    maintainers = with maintainers; [ b4dm4n ];
+  };
+}

--- a/pkgs/development/python-modules/daemonocle/default.nix
+++ b/pkgs/development/python-modules/daemonocle/default.nix
@@ -1,0 +1,20 @@
+{ lib, buildPythonPackage, fetchPypi, click, psutil }:
+
+buildPythonPackage rec {
+  pname = "daemonocle";
+  version = "1.0.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0s5b9llh3975ix60sxcgjiq0wr5sii4as5hqk8m31433bzaliz58";
+  };
+
+  propagatedBuildInputs = [ click psutil ];
+
+  meta = with lib; {
+    homepage = "http://github.com/jnrbsn/daemonocle";
+    description = "A Python library for creating super fancy Unix daemons";
+    license = licenses.mit;
+    maintainers = with maintainers; [ b4dm4n ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2759,6 +2759,8 @@ in
 
   dvtm-unstable = callPackage ../tools/misc/dvtm/unstable.nix {};
 
+  dyndnsc = python3Packages.callPackage ../applications/networking/dyndns/dyndnsc { };
+
   ecmtools = callPackage ../tools/cd-dvd/ecm-tools { };
 
   e2tools = callPackage ../tools/filesystems/e2tools { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -489,6 +489,8 @@ in {
 
   curio = callPackage ../development/python-modules/curio { };
 
+  daemonocle = callPackage ../development/python-modules/daemonocle { };
+
   dendropy = callPackage ../development/python-modules/dendropy { };
 
   dependency-injector = callPackage ../development/python-modules/dependency-injector { };


### PR DESCRIPTION
###### Motivation for this change

This adds the `dyndnsc` Python package and a new dependency.

The package builds and runs fine as `python3Packages.dyndnsc` and `python2Packages.dyndnsc`.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
