### PR TITLE
cargo-sync-readme: init at 1.0

### DIFF
--- a/pkgs/development/tools/rust/cargo-sync-readme/default.nix
+++ b/pkgs/development/tools/rust/cargo-sync-readme/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, rustPlatform, fetchFromGitHub }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cargo-sync-readme";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "phaazon";
+    repo = pname;
+    rev = version;
+    sha256 = "1c38q87fyfmj6nlwdpavb1xxpi26ncywkgqcwbvblad15c6ydcyc";
+  };
+
+  cargoSha256 = "1x15q6wv5278hm3ns2wmw4i8602g35y1jyv1b8wa5i4dnh52dj83";
+
+  meta = with stdenv.lib; {
+    description = "A cargo plugin that generates a Markdown section in your README based on your Rust documentation";
+    homepage = "https://github.com/phaazon/cargo-sync-readme";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ b4dm4n ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9397,6 +9397,7 @@ in
     inherit (darwin.apple_sdk.frameworks) Security;
   };
   cargo-sweep = callPackage ../development/tools/rust/cargo-sweep { };
+  cargo-sync-readme = callPackage ../development/tools/rust/cargo-sync-readme {};
   cargo-udeps = callPackage ../development/tools/rust/cargo-udeps {
     inherit (darwin.apple_sdk.frameworks) CoreServices Security;
   };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
