### PR TITLE
xfstests: 2018-04-11 -> 2019-09-08

### DIFF
--- a/pkgs/tools/misc/xfstests/default.nix
+++ b/pkgs/tools/misc/xfstests/default.nix
@@ -4,12 +4,12 @@
 , time, utillinux, which, writeScript, xfsprogs, runtimeShell }:
 
 stdenv.mkDerivation {
-  name = "xfstests-2018-04-11";
+  name = "xfstests-2019-09-08";
 
   src = fetchgit {
     url = "git://git.kernel.org/pub/scm/fs/xfs/xfstests-dev.git";
-    rev = "fdf6d4bc862bb3269c95986fdaf1c59271762ad6";
-    sha256 = "16j1kcmj0xq6s2qw4hll5r5cz7q4vbbsy2nh1g5aaq7xsl3h8mhb";
+    rev = "0837e907988a5f410cae0ae714f42f9c4242e072";
+    sha256 = "1f5cv0vwc1g9difzp69k49rc5nfd08y72vdg318j25nv3rwv7wc9";
   };
 
   nativeBuildInputs = [
@@ -23,6 +23,9 @@ stdenv.mkDerivation {
   enableParallelBuilding = true;
 
   patchPhase = ''
+    substituteInPlace Makefile \
+      --replace "cp include/install-sh ." "cp -f include/install-sh ."
+
     # Patch the destination directory
     sed -i include/builddefs.in -e "s|^PKG_LIB_DIR\s*=.*|PKG_LIB_DIR=$out/lib/xfstests|"
 


### PR DESCRIPTION
###### Motivation for this change
Build would fail before because it couldn't find some header.
This is fixed in the new revision - sadly there hasn't been a new release in 8 years.

#68361

###### Things done
Ran a simple test and that runs the tests. I don't know how to interpret the output, but it looks like the program is working.
```
> sudo mkfs.ext4 /dev/sda
> sudo mount /dev/sda /mnt
> sudo env TEST_DIR=/mnt TEST_DEV=/dev/sda ./result/bin/xfstests-check -g quick
......... lots of tests ........
Failed 3 of 478 tests
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @dezgeg
