### PR TITLE
pythonPackages.zeep: fix pytest5 tests

### DIFF
--- a/pkgs/development/python-modules/zeep/default.nix
+++ b/pkgs/development/python-modules/zeep/default.nix
@@ -1,5 +1,6 @@
 { fetchPypi
 , lib
+, fetchpatch
 , buildPythonPackage
 , isPy3k
 , appdirs
@@ -32,6 +33,13 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "0e98669cfeb60756231ae185498f9ae21b30b2681786b8de58ed34c3b93e41dd";
   };
+
+  patches = [
+    ( fetchpatch {
+        url = "https://github.com/mvantellingen/python-zeep/pull/1006/commits/ba7edd6bf2b31023b31e8f17c161e1d6d5af3d29.patch";
+        sha256 = "1j0jd5hmh457im9sbawaqf6pnfy36fhr9wqdim8wk5da9ixr0ajs";
+     })
+  ];
 
   propagatedBuildInputs = [
     appdirs


### PR DESCRIPTION
###### Motivation for this change
help with #68361 for the sunpy package (which is still broken for other reasons)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[1 built (1 failed), 5 copied (0.6 MiB), 0.1 MiB DL]
error: build of '/nix/store/f9yzaamv7bmdlrh8690sgchk2v6p6gjh-env.drv' failed
https://github.com/NixOS/nixpkgs/pull/68677
1 package failed to build:
python37Packages.sunpy

2 package were build:
python27Packages.zeep python37Packages.zeep
```
```
[nix-shell:/home/jon/.cache/nix-review/pr-68677]$ nix path-info -Sh ./results/python*
/nix/store/61zhdgngpz777ygysxjgz6vm3z7rfln2-python3.7-zeep-3.4.0         122.8M
/nix/store/lf0dhdr5yanbl1pv86n6dcs27x3k7r80-python2.7-zeep-3.4.0         117.2M
```