### PR TITLE
pythonPackages.chart-studio: init at 1.0.0

### DIFF
--- a/pkgs/development/python-modules/chart-studio/default.nix
+++ b/pkgs/development/python-modules/chart-studio/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildPythonPackage, fetchPypi
+, plotly
+}:
+
+buildPythonPackage rec {
+  version = "1.0.0";
+  pname = "chart-studio";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1qv5xsa1rplbmn5c02nbp01l2ydhydq3vhqqz4zvnlm5adjpg4qj";
+  };
+
+  propagatedBuildInputs = [ plotly ];
+
+  # Packaged from the plotly repo, no good way to retrieve only chart-studio tests
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Utilities for interfacing with plotly's Chart Studio";
+    homepage = https://plot.ly/python/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1784,6 +1784,8 @@ in {
 
   characteristic = callPackage ../development/python-modules/characteristic { };
 
+  chart-studio = callPackage ../development/python-modules/chart-studio { };
+
   cheetah = callPackage ../development/python-modules/cheetah { };
 
   cherrypy = if isPy3k then


### PR DESCRIPTION
###### Motivation for this change
the `plotly` package moved the `plotly.plotly` functionality into this package, eventually it will be needed by many packages

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[nix-shell:/home/jon/.cache/nix-review/pr-68679]$ nix path-info -Sh ./results/python*
/nix/store/4nh5xj9vv9wiwnlphhxcqwwyyk3y2km5-python3.7-chart-studio-1.0.0         180.1M
/nix/store/w2g9hv30v00l05qmw8hs8p42g218n6s7-python2.7-chart-studio-1.0.0         185.6M
```
```
[2 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/68679
2 package were build:
python27Packages.chart-studio python37Packages.chart-studio
```