### PR TITLE
rustup: 1.18.3 -> 1.19.0

### DIFF
--- a/pkgs/development/tools/rust/rustup/0001-dynamically-patchelf-binaries.patch
+++ b/pkgs/development/tools/rust/rustup/0001-dynamically-patchelf-binaries.patch
@@ -1,8 +1,8 @@
 diff --git a/src/dist/component/package.rs b/src/dist/component/package.rs
-index e0fdea28..38d9d0e4 100644
+index 4b432785..fa45e87e 100644
 --- a/src/dist/component/package.rs
 +++ b/src/dist/component/package.rs
-@@ -104,10 +104,11 @@ impl Package for DirectoryPackage {
+@@ -109,10 +109,11 @@ impl Package for DirectoryPackage {
              match &*part.0 {
                  "file" => {
                      if self.copy {
@@ -16,10 +16,10 @@ index e0fdea28..38d9d0e4 100644
                  }
                  "dir" => {
                      if self.copy {
-@@ -132,6 +133,22 @@ impl Package for DirectoryPackage {
+@@ -135,6 +136,22 @@ impl Package for DirectoryPackage {
      }
  }
-
+ 
 +fn nix_patchelf_if_needed(dest_path: &Path, src_path: &Path) {
 +    let is_bin = if let Some(p) = src_path.parent() {
 +        p.ends_with("bin")
@@ -36,6 +36,6 @@ index e0fdea28..38d9d0e4 100644
 +    }
 +}
 +
- // On Unix we need to set up the file permissions correctly so
- // binaries are executable and directories readable. This shouldn't be
- // necessary: the source files *should* have the right permissions,
+ #[derive(Debug)]
+ pub struct TarPackage<'a>(DirectoryPackage, temp::Dir<'a>);
+ 

--- a/pkgs/development/tools/rust/rustup/default.nix
+++ b/pkgs/development/tools/rust/rustup/default.nix
@@ -4,16 +4,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "rustup";
-  version = "1.18.3";
+  version = "1.19.0";
 
   src = fetchFromGitHub {
     owner = "rust-lang";
     repo = "rustup.rs";
     rev = version;
-    sha256 = "062l893i9czm1lm0x3arj3vfnjg3fg8q8xvq3y4adakmk6yrcc4x";
+    sha256 = "1c0qz9s09ikgy23yssd57v7b5s005y128sldmq0xd9i1fryp129z";
   };
 
-  cargoSha256 = "1zwlr0zxc97m6xr28ryq5hkrvcns6qg68h7w09sga23xinm3fr11";
+  cargoSha256 = "0rjm01pnb2w39c0jrscmhhsx9gsi3sl9cxd838m77h9pzwsp1h40";
 
   nativeBuildInputs = [ pkgconfig ];
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
