### PR TITLE
parity: 2.5.7 -> 2.5.8,  parity-beta: 2.6.2 -> 2.6.3 

### DIFF
--- a/pkgs/applications/blockchains/parity/beta.nix
+++ b/pkgs/applications/blockchains/parity/beta.nix
@@ -1,6 +1,6 @@
 let
-  version     = "2.6.2";
-  sha256      = "1j4249m5k3bi7di0wq6fm64zv3nlpgmg4hr5hnn94fyc09nz9n1r";
-  cargoSha256 = "1wr0i54zc3l6n0x6cvlq9zfy3bw9w5fcvdz4vmyym9r1nkvk31s7";
+  version     = "2.6.3";
+  sha256      = "1sk2l00si230qrc414drj6gw3sk64ym090xq10qbzzbix8yb8fzq";
+  cargoSha256 = "1q6cbms7j1h726bvq38npxkjkmz14b5ir9c4z7pb0jcy7gkplyxx";
 in
   import ./parity.nix { inherit version sha256 cargoSha256; }

--- a/pkgs/applications/blockchains/parity/default.nix
+++ b/pkgs/applications/blockchains/parity/default.nix
@@ -1,6 +1,6 @@
 let
-  version     = "2.5.7";
-  sha256      = "0aprs71cbf98dsvjz0kydngkvdg5x7dijji8j6xadgvsarl1ljnj";
-  cargoSha256 = "11mr5q5aynli9xm4wnxcypl3ij7f4b0p7l557yi9n0cvdraw8ki4";
+  version     = "2.5.8";
+  sha256      = "01cmr1zakgc452arc7qkd2860l99hvs49m941ba96pzkpkhm3dfa";
+  cargoSha256 = "1kdy0bnmyqx4rhpq0a8gliy6mws68n035kfkxrfa6cxr2cn53dyb";
 in
   import ./parity.nix { inherit version sha256 cargoSha256; }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update `parity` to the latest release.
- https://github.com/paritytech/parity-ethereum/releases/tag/v2.5.8
- https://github.com/paritytech/parity-ethereum/releases/tag/v2.6.3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @akru
