### PR TITLE
uvloop: fix darwin build

### DIFF
--- a/pkgs/development/python-modules/uvloop/darwin_sandbox.patch
+++ b/pkgs/development/python-modules/uvloop/darwin_sandbox.patch
@@ -1,0 +1,28 @@
+diff --git a/tests/test_pipes.py b/tests/test_pipes.py
+index d883abf..2e74d7a 100644
+--- a/tests/test_pipes.py
++++ b/tests/test_pipes.py
+@@ -2,6 +2,7 @@ import asyncio
+ import io
+ import os
+ import socket
++import unittest
+ 
+ from uvloop import _testbase as tb
+ 
+@@ -96,6 +97,7 @@ class _BasePipeTest:
+         # extra info is available
+         self.assertIsNotNone(proto.transport.get_extra_info('pipe'))
+ 
++    @unittest.skip("darwin sandbox")
+     def test_read_pty_output(self):
+         proto = MyReadPipeProto(loop=self.loop)
+ 
+@@ -198,6 +200,7 @@ class _BasePipeTest:
+         self.loop.run_until_complete(proto.done)
+         self.assertEqual('CLOSED', proto.state)
+ 
++    @unittest.skip("darwin sandbox")
+     def test_write_pty(self):
+         master, slave = os.openpty()
+         os.set_blocking(master, False)

--- a/pkgs/development/python-modules/uvloop/default.nix
+++ b/pkgs/development/python-modules/uvloop/default.nix
@@ -20,6 +20,8 @@ buildPythonPackage rec {
     sha256 = "0blcnrd5vky2k1m1p1skx4516dr1jx76yyb0c6fi82si6mqd0b4l";
   };
 
+  patches = lib.optional stdenv.isDarwin ./darwin_sandbox.patch;
+
   buildInputs = [
     libuv
   ] ++ lib.optionals stdenv.isDarwin [ CoreServices ApplicationServices ];
@@ -30,6 +32,9 @@ buildPythonPackage rec {
   '';
 
   checkInputs = [ pyopenssl psutil ];
+
+  # Some of the tests use localhost networking.
+  __darwinAllowLocalNetworking = true;
 
   meta = with lib; {
     description = "Fast implementation of asyncio event loop on top of libuv";


### PR DESCRIPTION
###### Motivation for this change

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers
