### PR TITLE
python3Package.hug: 2.4.8 -> 2.6.0

### DIFF
--- a/pkgs/development/python-modules/hug/default.nix
+++ b/pkgs/development/python-modules/hug/default.nix
@@ -1,27 +1,26 @@
-{ stdenv
-, buildPythonPackage
-, fetchPypi
-, isPy27
+{ lib , buildPythonPackage, fetchPypi, isPy27
 , falcon
+, pytestrunner
 , requests
 }:
 
 buildPythonPackage rec {
   pname = "hug";
-  version = "2.4.8";
+  version = "2.6.0";
   disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "2b33904660d07df3a6a998a52d1a36e2855e56dc9ffc4eddb2158e32d1ce7621";
+    sha256 = "0iamrzjy8z1xibynkgfl6cn2sbm66awxbp75b26pi32fc41d0k50";
   };
 
+  nativeBuildInputs = [ pytestrunner ];
   propagatedBuildInputs = [ falcon requests ];
 
   # tests are not shipped in the tarball
   doCheck = false;
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A Python framework that makes developing APIs as simple as possible, but no simpler";
     homepage = https://github.com/timothycrosley/hug;
     license = licenses.mit;


### PR DESCRIPTION
###### Motivation for this change
#68361

bumped while fixing build
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
#broken before
$ nix path-info -Sh ./result
/nix/store/g1jnib0p9kzfwjdw020idgsf6780kbz5-python3.7-hug-2.6.0  106.2M
```
```
[1 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/68690
1 package were build:
python37Packages.hug
```