### PR TITLE
netatalk: use system netatalk

### DIFF
--- a/pkgs/tools/filesystems/netatalk/default.nix
+++ b/pkgs/tools/filesystems/netatalk/default.nix
@@ -1,6 +1,6 @@
 { fetchurl, stdenv, autoreconfHook, pkgconfig, perl, python
 , db, libgcrypt, avahi, libiconv, pam, openssl, acl
-, ed, glibc
+, ed, glibc, libevent
 }:
 
 stdenv.mkDerivation rec{
@@ -18,12 +18,13 @@ stdenv.mkDerivation rec{
 
   nativeBuildInputs = [ autoreconfHook pkgconfig perl python python.pkgs.wrapPython ];
 
-  buildInputs = [ db libgcrypt avahi libiconv pam openssl acl ];
+  buildInputs = [ db libgcrypt avahi libiconv pam openssl acl libevent ];
 
   configureFlags = [
     "--with-bdb=${db.dev}"
     "--with-ssl-dir=${openssl.dev}"
     "--with-lockfile=/run/lock/netatalk"
+    "--with-libevent=${libevent.dev}"
     "--localstatedir=/var/lib"
   ];
 


### PR DESCRIPTION
###### Motivation for this change
Nicer solution for netatalk build (closes #67901)

ZHF #68361 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @jcumming
