### PR TITLE
pythonPackages.pyarrow: fix build

### DIFF
--- a/pkgs/development/python-modules/pyarrow/default.nix
+++ b/pkgs/development/python-modules/pyarrow/default.nix
@@ -25,6 +25,8 @@ buildPythonPackage rec {
     "-DCMAKE_POLICY_DEFAULT_CMP0025=NEW"
   ];
 
+  dontUseCmakeConfigure = true;
+
   preBuild = ''
     export PYARROW_PARALLEL=$NIX_BUILD_CORES
   '';


### PR DESCRIPTION
###### Motivation for this change
#68361

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[9 built (1 failed), 0.0 MiB DL]
error: build of '/nix/store/daw1wrx102p6grdq0yvn3qgj7430sdvd-env.drv' failed
https://github.com/NixOS/nixpkgs/pull/68693
1 package failed to build:
python37Packages.ibis-framework

10 package were build:
python27Packages.awkward python27Packages.google_cloud_bigquery python27Packages.pyarrow python27Packages.uproot python27Packages.uproot-methods python37Packages.awkward python37Packages.google_cloud_bigquery python37Packages.pyarrow python37Packages.uproot python37Packages.uproot-methods
```
ibis-framework seems to be broken for other issues (one of which is a pytest5 issue), but they don't seem to be related to pyarrow