### PR TITLE
samba4Full: fix build

### DIFF
--- a/pkgs/servers/samba/4.x.nix
+++ b/pkgs/servers/samba/4.x.nix
@@ -3,7 +3,7 @@
 , docbook_xml_dtd_42, readline
 , popt, iniparser, libbsd, libarchive, libiconv, gettext
 , krb5Full, zlib, openldap, cups, pam, avahi, acl, libaio, fam, libceph, glusterfs
-, gnutls, ncurses, libunwind, systemd, jansson, lmdb, gpgme
+, gnutls, ncurses, libunwind, systemd, jansson, lmdb, gpgme, libuuid
 
 , enableLDAP ? false
 , enablePrinting ? false
@@ -29,28 +29,27 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" "man" ];
 
-  patches =
-    [ ./4.x-no-persistent-install.patch
-      ./patch-source3__libads__kerberos_keytab.c.patch
-      ./4.x-no-persistent-install-dynconfig.patch
-      ./4.x-fix-makeflags-parsing.patch
-    ];
+  patches = [
+    ./4.x-no-persistent-install.patch
+    ./patch-source3__libads__kerberos_keytab.c.patch
+    ./4.x-no-persistent-install-dynconfig.patch
+    ./4.x-fix-makeflags-parsing.patch
+  ];
 
   nativeBuildInputs = optionals stdenv.isDarwin [ rpcgen fixDarwinDylibNames ];
 
-  buildInputs =
-    [ python pkgconfig perl libxslt docbook_xsl docbook_xml_dtd_42 /*
-      docbook_xml_dtd_45 */ readline popt iniparser jansson
-      libbsd libarchive zlib fam libiconv gettext libunwind krb5Full
-    ]
-    ++ optionals stdenv.isLinux [ libaio systemd ]
+  buildInputs = [
+    python pkgconfig perl libxslt docbook_xsl docbook_xml_dtd_42 /*
+    docbook_xml_dtd_45 */ readline popt iniparser jansson
+    libbsd libarchive zlib fam libiconv gettext libunwind krb5Full
+  ] ++ optionals stdenv.isLinux [ libaio systemd ]
     ++ optional enableLDAP openldap
     ++ optional (enablePrinting && stdenv.isLinux) cups
     ++ optional enableMDNS avahi
     ++ optionals enableDomainController [ gnutls gpgme lmdb ]
     ++ optional enableRegedit ncurses
     ++ optional (enableCephFS && stdenv.isLinux) libceph
-    ++ optional (enableGlusterFS && stdenv.isLinux) glusterfs
+    ++ optionals (enableGlusterFS && stdenv.isLinux) [ glusterfs libuuid ]
     ++ optional enableAcl acl
     ++ optional enablePam pam;
 
@@ -67,25 +66,24 @@ stdenv.mkDerivation rec {
        --replace "bld.SAMBA_BINARY('resolvconftest'" "True or bld.SAMBA_BINARY('resolvconftest'"
   '';
 
-  configureFlags =
-    [ "--with-static-modules=NONE"
-      "--with-shared-modules=ALL"
-      "--with-system-mitkrb5"
-      "--with-system-mitkdc" krb5Full
-      "--enable-fhs"
-      "--sysconfdir=/etc"
-      "--localstatedir=/var"
-      "--disable-rpath"
-    ]
-    ++ [(if enableDomainController
+  configureFlags = [
+    "--with-static-modules=NONE"
+    "--with-shared-modules=ALL"
+    "--with-system-mitkrb5"
+    "--with-system-mitkdc" krb5Full
+    "--enable-fhs"
+    "--sysconfdir=/etc"
+    "--localstatedir=/var"
+    "--disable-rpath"
+  ] ++ singleton (if enableDomainController
          then "--with-experimental-mit-ad-dc"
-         else "--without-ad-dc")]
+         else "--without-ad-dc")
     ++ optionals (!enableLDAP) [ "--without-ldap" "--without-ads" ]
     ++ optional (!enableAcl) "--without-acl-support"
     ++ optional (!enablePam) "--without-pam";
 
   preBuild = ''
-      export MAKEFLAGS="-j $NIX_BUILD_CORES"
+    export MAKEFLAGS="-j $NIX_BUILD_CORES"
   '';
 
   # Some libraries don't have /lib/samba in RPATH but need it.
@@ -105,7 +103,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = https://www.samba.org/;
+    homepage = "https://www.samba.org";
     description = "The standard Windows interoperability suite of programs for Linux and Unix";
     license = licenses.gpl3;
     platforms = platforms.unix;


### PR DESCRIPTION

###### Motivation for this change
#68361

###### Things done

The pkgconfig requirements for glusterfs-api were not satisfied without
uuid, resulting in Waf not setting the correct API version for glusterfs
during the build and consequently incompatible function calls in samba.
This adds libuuid to satisfy the requirements.
I also reformatted the file a bit.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).