### PR TITLE
pythonPackage.pycurl2: fix build

### DIFF
--- a/pkgs/development/python-modules/pycurl2/default.nix
+++ b/pkgs/development/python-modules/pycurl2/default.nix
@@ -1,6 +1,4 @@
-{ stdenv
-, buildPythonPackage
-, fetchgit
+{ lib, buildPythonPackage, fetchFromGitHub
 , isPy3k
 , simplejson
 , unittest2
@@ -13,8 +11,9 @@ buildPythonPackage {
   version = "7.20.0";
   disabled = isPy3k;
 
-  src = fetchgit {
-    url = "https://github.com/Lispython/pycurl.git";
+  src = fetchFromGitHub {
+    owner = "Lispython";
+    repo = "pycurl";
     rev = "0f00109950b883d680bd85dc6e8a9c731a7d0d13";
     sha256 = "1qmw3cm93kxj94s71a8db9lwv2cxmr2wjv7kp1r8zildwdzhaw7j";
   };
@@ -22,9 +21,10 @@ buildPythonPackage {
   # error: (6, "Couldn't resolve host 'h.wrttn.me'")
   doCheck = false;
 
-  buildInputs = [ pkgs.curl simplejson unittest2 nose ];
+  nativeBuildInputs = [ pkgs.curl.dev ];
+  buildInputs = [ simplejson unittest2 nose ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://pypi.python.org/pypi/pycurl2;
     description = "A fork from original PycURL library that no maintained from 7.19.0";
     license = licenses.mit;


### PR DESCRIPTION
###### Motivation for this change
#68361

fixing builds :)
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[1 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/68700
1 package were build:
python27Packages.pycurl2
```
```
$ nix path-info -Sh ./results/python27Packages.pycurl2
/nix/store/l9b7vs6n7g0x8w9pd8v1cyckqz4brxcd-python2.7-pycurl2-7.20.0      97.2M
```