### PR TITLE
ghc: don’t use dwarf on windows

### DIFF
--- a/pkgs/development/compilers/ghc/8.2.2.nix
+++ b/pkgs/development/compilers/ghc/8.2.2.nix
@@ -8,7 +8,8 @@
 
 , libiconv ? null, ncurses
 
-, enableDwarf ? !stdenv.isDarwin, elfutils # for DWARF support
+, enableDwarf ? !stdenv.targetPlatform.isDarwin &&
+                !stdenv.targetPlatform.isWindows, elfutils # for DWARF support
 
 , useLLVM ? !stdenv.targetPlatform.isx86 || (stdenv.targetPlatform.isMusl && stdenv.hostPlatform != stdenv.targetPlatform)
 , # LLVM is conceptually a run-time-only depedendency, but for

--- a/pkgs/development/compilers/ghc/8.4.4.nix
+++ b/pkgs/development/compilers/ghc/8.4.4.nix
@@ -7,7 +7,8 @@
 
 , libiconv ? null, ncurses
 
-, enableDwarf ? !stdenv.isDarwin, elfutils # for DWARF support
+, enableDwarf ? !stdenv.targetPlatform.isDarwin &&
+                !stdenv.targetPlatform.isWindows, elfutils # for DWARF support
 
 , useLLVM ? !stdenv.targetPlatform.isx86 || (stdenv.targetPlatform.isMusl && stdenv.hostPlatform != stdenv.targetPlatform)
 , # LLVM is conceptually a run-time-only depedendency, but for

--- a/pkgs/development/compilers/ghc/8.6.4.nix
+++ b/pkgs/development/compilers/ghc/8.6.4.nix
@@ -7,7 +7,8 @@
 
 , libiconv ? null, ncurses
 
-, enableDwarf ? !stdenv.isDarwin, elfutils # for DWARF support
+, enableDwarf ? !stdenv.targetPlatform.isDarwin &&
+                !stdenv.targetPlatform.isWindows, elfutils # for DWARF support
 
 , # GHC can be built with system libffi or a bundled one.
   libffi ? null

--- a/pkgs/development/compilers/ghc/8.6.5.nix
+++ b/pkgs/development/compilers/ghc/8.6.5.nix
@@ -7,7 +7,8 @@
 
 , libiconv ? null, ncurses
 
-, enableDwarf ? !stdenv.isDarwin, elfutils # for DWARF support
+, enableDwarf ? !stdenv.targetPlatform.isDarwin &&
+                !stdenv.targetPlatform.isWindows, elfutils # for DWARF support
 
 , # GHC can be built with system libffi or a bundled one.
   libffi ? null

--- a/pkgs/development/compilers/ghc/8.8.1.nix
+++ b/pkgs/development/compilers/ghc/8.8.1.nix
@@ -7,7 +7,8 @@
 
 , libiconv ? null, ncurses
 
-, enableDwarf ? !stdenv.isDarwin, elfutils # for DWARF support
+, enableDwarf ? !stdenv.targetPlatform.isDarwin &&
+                !stdenv.targetPlatform.isWindows, elfutils # for DWARF support
 
 , # GHC can be built with system libffi or a bundled one.
   libffi ? null

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -7,7 +7,8 @@
 
 , libiconv ? null, ncurses
 
-, enableDwarf ? !stdenv.isDarwin, elfutils # for DWARF support
+, enableDwarf ? !stdenv.targetPlatform.isDarwin &&
+                !stdenv.targetPlatform.isWindows, elfutils # for DWARF support
 
 , useLLVM ? !stdenv.targetPlatform.isx86
 , # LLVM is conceptually a run-time-only depedendency, but for


### PR DESCRIPTION
elfutils don’t work on windows

https://hydra.nixos.org/eval/1541857#tabs-removed

/cc @domenkozar

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
