### PR TITLE
pythonPackage.celery: fix tests

### DIFF
--- a/pkgs/development/python-modules/celery/default.nix
+++ b/pkgs/development/python-modules/celery/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, iana-etc, libredirect
+{ lib, buildPythonPackage, fetchPypi, libredirect
 , case, pytest, boto3, moto, kombu, billiard, pytz, anyjson, amqp, eventlet
 }:
 
@@ -17,19 +17,17 @@ buildPythonPackage rec {
       --replace "pytest>=4.3.1,<4.4.0" pytest
   '';
 
-  # make /etc/protocols accessible to fix socket.getprotobyname('tcp') in sandbox
-  preCheck = stdenv.lib.optionalString stdenv.isLinux ''
-    export NIX_REDIRECTS=/etc/protocols=${iana-etc}/etc/protocols \
-      LD_PRELOAD=${libredirect}/lib/libredirect.so
-  '';
-  postCheck = stdenv.lib.optionalString stdenv.isLinux ''
-    unset NIX_REDIRECTS LD_PRELOAD
+  # ignore test that's incompatible with pytest5
+  # test_eventlet touches network
+  checkPhase = ''
+    pytest -k 'not restore_current_app_fallback' \
+      --ignore=t/unit/concurrency/test_eventlet.py
   '';
 
   checkInputs = [ case pytest boto3 moto ];
   propagatedBuildInputs = [ kombu billiard pytz anyjson amqp eventlet ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://github.com/celery/celery/;
     description = "Distributed task queue";
     license = licenses.bsd3;


### PR DESCRIPTION
###### Motivation for this change
helping with #68361

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[3 built, 4 copied (47.5 MiB), 6.6 MiB DL]
https://github.com/NixOS/nixpkgs/pull/68703
4 package were build:
python27Packages.celery python27Packages.djmail python37Packages.celery python37Packages.djmail
```
```
[nix-shell:~/.cache/nix-review/pr-68703]$ nix path-info -Sh ./results/*
/nix/store/hbfac8lzm3zb8qyqgg515xjdyvw15gn1-python3.7-djmail-1.1.0       136.9M
/nix/store/i5411sx418xp5ak34bvq07x7b6vg4xjw-python2.7-celery-4.3.0       104.3M
/nix/store/mdvq25rkrprvj5cq7rcjingvcs9cadl5-python2.7-djmail-1.1.0       137.1M
/nix/store/zrddd3cf2xs8l0069dpp1ws1iy27az2w-python3.7-celery-4.3.0       105.2M
```