### PR TITLE
pythonPackages.azure: mark as broken

### DIFF
--- a/pkgs/development/python-modules/azure/default.nix
+++ b/pkgs/development/python-modules/azure/default.nix
@@ -34,5 +34,6 @@ buildPythonPackage rec {
     homepage = "https://azure.microsoft.com/en-us/develop/python/";
     license = licenses.asl20;
     maintainers = with maintainers; [ olcai ];
+    broken = true; # this should propagate over 70 azure packages, many of which are not added yet
   };
 }


### PR DESCRIPTION
###### Motivation for this change
#68361

azure-4.0.0 is supposed have around 80ish packages in it. This package may have been valid when it was first added, but that is no longer the case.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
nix-review pr 68707
...
Nothing changed
https://github.com/NixOS/nixpkgs/pull/68707
No packages were successfully build, skip nix-shell
$ git worktree prune
```