### PR TITLE
pythonPackage.cli-helpers: disable python2 tests

### DIFF
--- a/pkgs/development/python-modules/cli-helpers/default.nix
+++ b/pkgs/development/python-modules/cli-helpers/default.nix
@@ -1,14 +1,11 @@
-{ lib
-, buildPythonPackage
-, fetchPypi
-, configobj
-, terminaltables
-, tabulate
+{ lib, buildPythonPackage, fetchPypi, isPy27
 , backports_csv
-, wcwidth
-, pytest
+, configobj
 , mock
-, isPy27
+, pytest
+, tabulate
+, terminaltables
+, wcwidth
 }:
 
 buildPythonPackage rec {
@@ -26,6 +23,9 @@ buildPythonPackage rec {
     tabulate
     wcwidth
   ] ++ (lib.optionals isPy27 [ backports_csv ]);
+
+  # namespace collision between backport.csv and backports.configparser
+  doCheck = !isPy27;
 
   checkInputs = [ pytest mock ];
 


### PR DESCRIPTION
###### Motivation for this change
#68361

There's an import error with the `backports` namespace. I tried to even add the `__path__ = pkg.extend(__path__,__name)` hack to the affected backports packages, but it still didn't work (but worked using nix-shell). It was weird. Decided to just check on python3 since python2 is EOL in 3.5 months.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[1 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/68708
1 package were build:
python27Packages.cli-helpers
```