### PR TITLE
dotnet-sdk: add darwin support, set myself as maintainer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3858,12 +3858,12 @@
     githubId = 34086;
     name = "Marc Weber";
   };
-	marenz = {
-		email = "marenz@arkom.men";
-		github = "marenz2569";
-		githubId = 12773269;
-		name = "Markus Schmidl";
-	};
+  marenz = {
+    email = "marenz@arkom.men";
+    github = "marenz2569";
+    githubId = 12773269;
+    name = "Markus Schmidl";
+  };
   markus1189 = {
     email = "markus1189@gmail.com";
     github = "markus1189";
@@ -5333,6 +5333,12 @@
     githubId = 3302;
     name = "Renzo Carbonara";
   };
+  reset = {
+    email = "jamie@onemoregame.com";
+    github = "reset";
+    name = "Jamie Winsor";
+    githubId = 54036;
+  };
   retrry = {
     email = "retrry@gmail.com";
     github = "retrry";
@@ -6649,7 +6655,7 @@
     githubId = 1525767;
     name = "Vaibhav Sagar";
   };
-  valebes = {  
+  valebes = {
     email = "valebes@gmail.com";
     github = "valebes";
     githubid = 10956211;

--- a/pkgs/development/compilers/dotnet/sdk/darwin/default.nix
+++ b/pkgs/development/compilers/dotnet/sdk/darwin/default.nix
@@ -1,0 +1,66 @@
+{ stdenv
+, fetchurl
+, darwin
+, curl
+, libcxx
+, zlib
+}:
+
+let
+  inherit (darwin.apple_sdk.frameworks) Security GSS CoreFoundation CoreServices;
+in
+stdenv.mkDerivation rec {
+  version = "2.2.402";
+  netCoreVersion = "2.2.7";
+  pname = "dotnet-sdk";
+
+  src = fetchurl {
+    url = "https://dotnetcli.azureedge.net/dotnet/Sdk/${version}/${pname}-${version}-osx-x64.tar.gz";
+    sha512 = "37p06fmqmym0a41j7nifmz9i8s0lnhdj7kfcz0wn0iyzakjkah6wbg1xv6vl3iq86dcnrql9qnzl2aqbazdrhm7qpgga4g4r8sryxf5";
+  };
+
+  sourceRoot = ".";
+
+  buildPhase = ''
+    runHook preBuild
+
+    find -type f -name "*.dylib" -exec install_name_tool \
+      -change /usr/lib/libSystem.B.dylib ${stdenv.cc.libc}/lib/libSystem.B.dylib \
+      -change /usr/lib/libc++.1.dylib ${libcxx}/lib/libc++.1.dylib \
+      -change /usr/lib/libz.1.dylib ${zlib}/lib/libz.1.dylib \
+      -change /usr/lib/libcurl.4.dylib ${curl}/lib/libcurl.4.dylib \
+      -change /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation \
+        ${CoreFoundation}/Library/Frameworks/CoreFoundation.framework/CoreFoundation \
+      -change /System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices \
+        ${CoreServices}/Library/Frameworks/CoreServices.framework/CoreServices \
+      -change /System/Library/Frameworks/Security.framework/Versions/A/Security \
+        ${Security}/Library/Frameworks/Security.framework/Security \
+      -change /System/Library/Frameworks/GSS.framework/Versions/A/GSS \
+        ${GSS}/Library/Frameworks/GSS.framework/GSS {} \;
+
+    install_name_tool \
+      -change /usr/lib/libc++.1.dylib ${libcxx}/lib/libc++.1.dylib \
+      -change /usr/lib/libSystem.B.dylib ${stdenv.cc.libc}/lib/libSystem.B.dylib \
+      ./dotnet
+
+    echo -n "dotnet-sdk version: "
+    ./dotnet --version
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp -r ./ $out
+    ln -s $out/dotnet $out/bin/dotnet
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://dotnet.github.io/;
+    description = ".NET Core SDK ${version} with .NET Core ${netCoreVersion}";
+    platforms = platforms.darwin;
+    maintainers = with maintainers; [ reset ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -211,7 +211,11 @@ in
 
   dotnetbuildhelpers = callPackage ../build-support/dotnetbuildhelpers { };
 
-  dotnet-sdk = callPackage ../development/compilers/dotnet/sdk { };
+  dotnet-sdk =
+    if stdenv.isDarwin then
+      callPackage ../development/compilers/dotnet/sdk/darwin { }
+    else
+      callPackage ../development/compilers/dotnet/sdk { };
 
   dispad = callPackage ../tools/X11/dispad { };
 


### PR DESCRIPTION
This commit adds support for the dotnet core dotnet-sdk to the Darwin platform. This is my first commit to the nixpkgs repository so it also includes a modification to the maintainers list to include an entry for myself.

Apologies if I've gotten any of the contributing guidelines wrong, I did read them, I promise!

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md] https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).