### PR TITLE
radicale: Fix runtime

### DIFF
--- a/pkgs/servers/radicale/default.nix
+++ b/pkgs/servers/radicale/default.nix
@@ -22,6 +22,7 @@ python3.pkgs.buildPythonApplication rec {
     vobject
     python-dateutil
     passlib
+    setuptools
   ];
 
   checkInputs = with python3.pkgs; [


### PR DESCRIPTION
Needed pkg_resources module, which apparently comes from setuptools
according to https://stackoverflow.com/a/10538412/6605742

###### Motivation for this change
Fixes radicale and therefore the NixOS test as well for #68361 

###### Things done

- [x] Ran the NixOS test successfully
- [x] Run the radicale binary, which now doesn't throw a `pkg_resourceS` error anymore