### PR TITLE
networkmanager: 1.18.2 -> 1.20.2

### DIFF
--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -195,7 +195,7 @@ in {
 
       dhcp = mkOption {
         type = types.enum [ "dhclient" "dhcpcd" "internal" ];
-        default = "dhclient";
+        default = "internal";
         description = ''
           Which program (or internal library) should be used for DHCP.
         '';

--- a/pkgs/tools/networking/network-manager/fix-install-paths.patch
+++ b/pkgs/tools/networking/network-manager/fix-install-paths.patch
@@ -1,6 +1,8 @@
+diff --git a/meson.build b/meson.build
+index 4105a9c80..3d912557f 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -925,9 +925,9 @@
+@@ -884,9 +884,9 @@ meson.add_install_script(
    join_paths('tools', 'meson-post-install.sh'),
    nm_datadir,
    nm_bindir,
@@ -12,9 +14,11 @@
    enable_docs ? 'install_docs' : '',
    nm_mandir,
  )
+diff --git a/src/settings/plugins/ifcfg-rh/meson.build b/src/settings/plugins/ifcfg-rh/meson.build
+index 58acdcfcb..e3a16d597 100644
 --- a/src/settings/plugins/ifcfg-rh/meson.build
 +++ b/src/settings/plugins/ifcfg-rh/meson.build
-@@ -70,7 +70,7 @@
+@@ -69,7 +69,7 @@ install_data(
  )
  
  meson.add_install_script('sh', '-c',

--- a/pkgs/tools/networking/network-manager/fix-paths.patch
+++ b/pkgs/tools/networking/network-manager/fix-paths.patch
@@ -1,6 +1,8 @@
+diff --git a/clients/common/nm-vpn-helpers.c b/clients/common/nm-vpn-helpers.c
+index 204b7c286..8bdb734c2 100644
 --- a/clients/common/nm-vpn-helpers.c
 +++ b/clients/common/nm-vpn-helpers.c
-@@ -214,10 +214,7 @@
+@@ -215,10 +215,7 @@ nm_vpn_openconnect_authenticate_helper (const char *host,
  		NULL,
  	};
  
@@ -10,21 +12,25 @@
 -		return FALSE;
 +	path = "@openconnect@/bin/openconnect";
  
- 	argv[0] = (char *) path;
- 	argv[1] = "--authenticate";
+ 	if (!g_spawn_sync (NULL,
+ 	                   (char **) NM_MAKE_STRV (path, "--authenticate", host),
+diff --git a/data/84-nm-drivers.rules b/data/84-nm-drivers.rules
+index e398cb9f2..31c56596a 100644
 --- a/data/84-nm-drivers.rules
 +++ b/data/84-nm-drivers.rules
-@@ -7,6 +7,6 @@
+@@ -7,6 +7,6 @@ ACTION!="add|change", GOTO="nm_drivers_end"
  # Determine ID_NET_DRIVER if there's no ID_NET_DRIVER or DRIVERS (old udev?)
  ENV{ID_NET_DRIVER}=="?*", GOTO="nm_drivers_end"
  DRIVERS=="?*", GOTO="nm_drivers_end"
--PROGRAM="/bin/sh -c 'ethtool -i $1 | sed -n s/^driver:\ //p' -- $env{INTERFACE}", RESULT=="?*", ENV{ID_NET_DRIVER}="%c"
-+PROGRAM="@shell@ -c '@ethtool@/bin/ethtool -i $1 | @gnused@/bin/sed -n s/^driver:\ //p' -- $env{INTERFACE}", RESULT=="?*", ENV{ID_NET_DRIVER}="%c"
+-PROGRAM="/bin/sh -c '/usr/sbin/ethtool -i $$1 |/usr/bin/sed -n s/^driver:\ //p' -- $env{INTERFACE}", ENV{ID_NET_DRIVER}="%c"
++PROGRAM="@shell@ -c '@ethtool@/bin/ethtool -i $$1 |@gnused@/bin/sed -n s/^driver:\ //p' -- $env{INTERFACE}", ENV{ID_NET_DRIVER}="%c"
  
  LABEL="nm_drivers_end"
+diff --git a/data/NetworkManager.service.in b/data/NetworkManager.service.in
+index 2f442bf23..c3e797bf4 100644
 --- a/data/NetworkManager.service.in
 +++ b/data/NetworkManager.service.in
-@@ -8,7 +8,7 @@
+@@ -8,7 +8,7 @@ Before=network.target @DISTRO_NETWORK_SERVICE@
  [Service]
  Type=dbus
  BusName=org.freedesktop.NetworkManager
@@ -33,9 +39,11 @@
  #ExecReload=/bin/kill -HUP $MAINPID
  ExecStart=@sbindir@/NetworkManager --no-daemon
  Restart=on-failure
+diff --git a/src/devices/nm-device.c b/src/devices/nm-device.c
+index 823cf48a5..cda16e48d 100644
 --- a/src/devices/nm-device.c
 +++ b/src/devices/nm-device.c
-@@ -12451,14 +12451,14 @@ nm_device_start_ip_check (NMDevice *self)
+@@ -12822,14 +12822,14 @@ nm_device_start_ip_check (NMDevice *self)
  			gw = nm_ip4_config_best_default_route_get (priv->ip_config_4);
  			if (gw) {
  				nm_utils_inet4_ntop (NMP_OBJECT_CAST_IP4_ROUTE (gw)->gateway, buf);
@@ -53,10 +61,10 @@
  			}
  		}
 diff --git a/src/nm-core-utils.c b/src/nm-core-utils.c
-index 6f55e62a7..93721e7fb 100644
+index d896d4d33..4cacb5cb6 100644
 --- a/src/nm-core-utils.c
 +++ b/src/nm-core-utils.c
-@@ -442,7 +442,7 @@ nm_utils_modprobe (GError **error, gboolean suppress_error_logging, const char *
+@@ -446,7 +446,7 @@ nm_utils_modprobe (GError **error, gboolean suppress_error_logging, const char *
  
  	/* construct the argument list */
  	argv = g_ptr_array_sized_new (4);


### PR DESCRIPTION
* libnm-glib is gone 👋️
* correct dbus_conf_dir
* remove legacy service symlink
* upstream defaults to 'internal' for dhcp
  NixOS module reflects this.

https://gitlab.freedesktop.org/NetworkManager/NetworkManager/blob/1.20.2/NEWS

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
