### PR TITLE
pythonPackages.lightgbm: fix build

### DIFF
--- a/pkgs/development/python-modules/lightgbm/default.nix
+++ b/pkgs/development/python-modules/lightgbm/default.nix
@@ -21,6 +21,8 @@ buildPythonPackage rec {
     cmake
   ];
 
+  dontUseCmakeConfigure = true;
+
   # we never actually explicitly call the install command so this is the only way
   # to inject these options to it - however, openmp-library doesn't appear to have
   # any effect, so we have to inject it into NIX_LDFLAGS manually below


### PR DESCRIPTION
###### Motivation for this change
#68361

fix build
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
