### PR TITLE
pythonPackages.uamq: 1.1.0 -> 1.2.2

### DIFF
--- a/pkgs/development/python-modules/azure-servicebus/default.nix
+++ b/pkgs/development/python-modules/azure-servicebus/default.nix
@@ -10,12 +10,12 @@
 
 buildPythonPackage rec {
   pname = "azure-servicebus";
-  version = "0.50.0";
+  version = "0.50.1";
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "c5864cfc69402e3e2897e61b3bd224ade28d9e33dad849e4bd6afad26a3d2786";
+    sha256 = "0i8ls5h2ny12h9gnqwyq13ysvxgdq7b1kxirj4n58dfy94a182gv";
   };
 
   buildInputs = [

--- a/pkgs/development/python-modules/uamqp/default.nix
+++ b/pkgs/development/python-modules/uamqp/default.nix
@@ -1,24 +1,21 @@
-{ CFNetwork
-, Security
-, buildPythonPackage
+{ lib, buildPythonPackage, fetchPypi, isPy3k
 , certifi
+, CFNetwork
 , cmake
 , enum34
-, fetchPypi
-, isPy3k
-, lib
 , openssl
-, stdenv
+, Security
 , six
+, stdenv
 }:
 
 buildPythonPackage rec {
   pname = "uamqp";
-  version = "1.1.0";
+  version = "1.2.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "d3d4ff94bf290adb82fe8c19af709a21294bac9b27c821b9110165a34b922015";
+    sha256 = "0wmyw2l2pha5s6khih96lkfa90zyfy2mqsg8cx6vplmrmpx2s52i";
   };
 
   buildInputs = [
@@ -30,6 +27,8 @@ buildPythonPackage rec {
   ] ++ lib.optionals stdenv.isDarwin [
     CFNetwork Security
   ];
+
+  dontUseCmakeConfigure = true;
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
###### Motivation for this change
 #68361

properly builds and linked
```

$ find ./result/ -name *.so
./result/lib/python3.7/site-packages/uamqp/c_uamqp.cpython-37m-x86_64-linux-gnu.so
$ ldd ./result/lib/python3.7/site-packages/uamqp/c_uamqp.cpython-37m-x86_64-linux-gnu.so
        linux-vdso.so.1 (0x00007ffefe449000)
        libssl.so.1.1 => /nix/store/nrnnvdy72487sv5n83qa04lafbl6nbcl-openssl-1.1.1c/lib/libssl.so.1.1 (0x00007f821ee62000)
        libcrypto.so.1.1 => /nix/store/nrnnvdy72487sv5n83qa04lafbl6nbcl-openssl-1.1.1c/lib/libcrypto.so.1.1 (0x00007f821eb73000)
        libpython3.7m.so.1.0 => /nix/store/k0igqpz995nmxwf6piyd5jjpcc7gcnyc-python3-3.7.4/lib/libpython3.7m.so.1.0 (0x00007f821e831000)
        libpthread.so.0 => /nix/store/6yaj6n8l925xxfbcd65gzqx3dz7idrnn-glibc-2.27/lib/libpthread.so.0 (0x00007f821e810000)
        libc.so.6 => /nix/store/6yaj6n8l925xxfbcd65gzqx3dz7idrnn-glibc-2.27/lib/libc.so.6 (0x00007f821e65a000)
        libdl.so.2 => /nix/store/6yaj6n8l925xxfbcd65gzqx3dz7idrnn-glibc-2.27/lib/libdl.so.2 (0x00007f821e653000)
        libcrypt.so.1 => /nix/store/6yaj6n8l925xxfbcd65gzqx3dz7idrnn-glibc-2.27/lib/libcrypt.so.1 (0x00007f821e619000)
        libncursesw.so.6 => /nix/store/kvia4rwy9y4wis4v2kb9y758gj071p5v-ncurses-6.1-20190112/lib/libncursesw.so.6 (0x00007f821e5a7000)
        libutil.so.1 => /nix/store/6yaj6n8l925xxfbcd65gzqx3dz7idrnn-glibc-2.27/lib/libutil.so.1 (0x00007f821e5a2000)
        libm.so.6 => /nix/store/6yaj6n8l925xxfbcd65gzqx3dz7idrnn-glibc-2.27/lib/libm.so.6 (0x00007f821e40c000)
        libgcc_s.so.1 => /nix/store/6yaj6n8l925xxfbcd65gzqx3dz7idrnn-glibc-2.27/lib/libgcc_s.so.1 (0x00007f821e1f4000)
        /nix/store/iykxb0bmfjmi7s53kfg6pjbfpd8jmza6-glibc-2.27/lib64/ld-linux-x86-64.so.2 (0x00007f821f104000)
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[2 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/68726
4 package were build:
python27Packages.azure-servicebus python27Packages.uamqp python37Packages.azure-servicebus python37Packages.uamqp
```