### PR TITLE
networkmanager,modemmanager: fix service symlinks for systemd v243

### DIFF
--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -468,11 +468,15 @@ in {
         mkdir -m 700 -p /etc/ipsec.d
         mkdir -m 755 -p ${stateDirs}
       '';
+
+      aliases = [ "dbus-org.freedesktop.NetworkManager.service" ];
     };
 
     systemd.services.NetworkManager-wait-online = {
       wantedBy = [ "network-online.target" ];
     };
+
+    systemd.services.ModemManager.aliases = [ "dbus-org.freedesktop.ModemManager1.service" ];
 
     systemd.services.nm-setup-hostsdirs = mkIf dynamicHostsEnabled {
       wantedBy = [ "NetworkManager.service" ];
@@ -495,6 +499,7 @@ in {
 
       # useful binaries for user-specified hooks
       path = [ pkgs.iproute pkgs.utillinux pkgs.coreutils ];
+      aliases = [ "dbus-org.freedesktop.nm-dispatcher.service" ];
     };
 
     # Turn off NixOS' network management when networking is managed entirely by NetworkManager

--- a/pkgs/tools/networking/modem-manager/default.nix
+++ b/pkgs/tools/networking/modem-manager/default.nix
@@ -32,13 +32,6 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  postInstall = ''
-    # systemd in NixOS doesn't use `systemctl enable`, so we need to establish
-    # aliases ourselves.
-    ln -s $out/etc/systemd/system/ModemManager.service \
-      $out/etc/systemd/system/dbus-org.freedesktop.ModemManager1.service
-  '';
-
   meta = with stdenv.lib; {
     description = "WWAN modem manager, part of NetworkManager";
     homepage = https://www.freedesktop.org/wiki/Software/ModemManager/;

--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -97,11 +97,6 @@ in stdenv.mkDerivation rec {
   '';
 
   postInstall = ''
-    # systemd in NixOS doesn't use `systemctl enable`, so we need to establish
-    # aliases ourselves.
-    ln -s $out/etc/systemd/system/NetworkManager-dispatcher.service $out/etc/systemd/system/dbus-org.freedesktop.nm-dispatcher.service
-    ln -s $out/etc/systemd/system/NetworkManager.service $out/etc/systemd/system/dbus-org.freedesktop.NetworkManager.service
-
     # Add the legacy service name from before #51382 to prevent NetworkManager
     # from not starting back up:
     # TODO: remove this once 19.10 is released


### PR DESCRIPTION
###### Motivation for this change

Fixes problems such as:

systemd[1]: Failed to put bus name to hashmap: File exists
systemd[1]: dbus-org.freedesktop.nm-dispatcher.service: Two services allocated for the same bus name org.freedesktop.nm_dispatcher, refusing operation.

Problem is that systemd treats symlinks to files outside the service
path differently, causing our old workaround to look like two separate services.

These symlinks are intended to be a means for manually emulating
the behavior of the `Alias=` directive in these services.
Unfortunately even making these symlinks relative isn't enough,
since they don't make it to where it matters--
that only makes the links in /etc/static/systemd/system/*
relative, with systemd still being shown non-relative links
in /etc/systemd/system/*.

To fix this, drop all of this at the package level
and instead simply specify the aliases in the NixOS modules.

Also handle the same for modemmanager,
since the networkmanager NixOS module also handles that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify potential reviewers

cc @worldofpeace