### PR TITLE
pulseaudio: 12.2 -> 13.0

### DIFF
--- a/pkgs/development/libraries/qt-5/5.11/default.nix
+++ b/pkgs/development/libraries/qt-5/5.11/default.nix
@@ -69,6 +69,13 @@ let
     qtwebengine = [
       ./qtwebengine-no-build-skip.patch
       ./qtwebengine-darwin-no-platform-check.patch
+      # https://gitlab.freedesktop.org/pulseaudio/pulseaudio/issues/707
+      # https://bugreports.qt.io/browse/QTBUG-77037
+      (fetchpatch {
+        name = "fix-build-with-pulseaudio-13.0.patch";
+        url = "https://git.archlinux.org/svntogit/packages.git/plain/trunk/qtbug-77037-workaround.patch?h=packages/qt5-webengine&id=fc77d6b3d5ec74e421b58f199efceb2593cbf951";
+        sha256 = "1gv733qfdn9746nbqqxzyjx4ijjqkkb7zb71nxax49nna5bri3am";
+      })
     ];
     qtwebkit = [ ./qtwebkit.patch ];
   };

--- a/pkgs/development/libraries/qt-5/5.12/default.nix
+++ b/pkgs/development/libraries/qt-5/5.12/default.nix
@@ -16,7 +16,7 @@ top-level attribute to `top-level/all-packages.nix`.
 
 {
   newScope,
-  stdenv, fetchurl, fetchFromGitHub, makeSetupHook, makeWrapper,
+  stdenv, fetchurl, fetchpatch, fetchFromGitHub, makeSetupHook, makeWrapper,
   bison, cups ? null, harfbuzz, libGL, perl,
   gstreamer, gst-plugins-base, gtk3, dconf,
   llvmPackages_5,
@@ -60,6 +60,13 @@ let
     qtserialport = [ ./qtserialport.patch ];
     qtwebengine = [
       ./qtwebengine-no-build-skip.patch
+      # https://gitlab.freedesktop.org/pulseaudio/pulseaudio/issues/707
+      # https://bugreports.qt.io/browse/QTBUG-77037
+      (fetchpatch {
+        name = "fix-build-with-pulseaudio-13.0.patch";
+        url = "https://git.archlinux.org/svntogit/packages.git/plain/trunk/qtbug-77037-workaround.patch?h=packages/qt5-webengine&id=fc77d6b3d5ec74e421b58f199efceb2593cbf951";
+        sha256 = "1gv733qfdn9746nbqqxzyjx4ijjqkkb7zb71nxax49nna5bri3am";
+      })
     ]
       ++ optional stdenv.isDarwin ./qtwebengine-darwin-no-platform-check.patch;
     qtwebkit = [ ./qtwebkit.patch ]

--- a/pkgs/development/libraries/qt-5/5.9/default.nix
+++ b/pkgs/development/libraries/qt-5/5.9/default.nix
@@ -53,9 +53,18 @@ let
     ];
     qtserialport = [ ./qtserialport.patch ];
     qttools = [ ./qttools.patch ];
-    qtwebengine = [ ./qtwebengine-no-build-skip.patch ]
-      ++ optional stdenv.cc.isClang ./qtwebengine-clang-fix.patch
+    qtwebengine = [
+      ./qtwebengine-no-build-skip.patch
+      # https://gitlab.freedesktop.org/pulseaudio/pulseaudio/issues/707
+      # https://bugreports.qt.io/browse/QTBUG-77037
+      (fetchpatch {
+        name = "fix-build-with-pulseaudio-13.0.patch";
+        url = "https://git.archlinux.org/svntogit/packages.git/plain/trunk/qtbug-77037-workaround.patch?h=packages/qt5-webengine&id=fc77d6b3d5ec74e421b58f199efceb2593cbf951";
+        sha256 = "1gv733qfdn9746nbqqxzyjx4ijjqkkb7zb71nxax49nna5bri3am";
+      })
+    ] ++ optional stdenv.cc.isClang ./qtwebengine-clang-fix.patch
       ++ optional stdenv.isDarwin ./qtwebengine-darwin-no-platform-check.patch;
+  
     qtwebkit = [ ./qtwebkit.patch ];
     qtvirtualkeyboard = [
       (fetchpatch {

--- a/pkgs/servers/pulseaudio/default.nix
+++ b/pkgs/servers/pulseaudio/default.nix
@@ -1,5 +1,5 @@
-{ lib, stdenv, fetchurl, fetchpatch, pkgconfig, intltool, autoreconfHook
-, libsndfile, libtool, makeWrapper
+{ lib, stdenv, fetchurl, pkgconfig, autoreconfHook
+, libsndfile, libtool, makeWrapper, perlPackages
 , xorg, libcap, alsaLib, glib, gnome3
 , avahi, libjack2, libasyncns, lirc, dbus
 , sbc, bluez5, udev, openssl, fftwFloat
@@ -31,16 +31,16 @@
 
 stdenv.mkDerivation rec {
   name = "${if libOnly then "lib" else ""}pulseaudio-${version}";
-  version = "12.2";
+  version = "13.0";
 
   src = fetchurl {
     url = "http://freedesktop.org/software/pulseaudio/releases/pulseaudio-${version}.tar.xz";
-    sha256 = "0ma0p8iry7fil7qb4pm2nx2pm65kq9hk9xc4r5wkf14nqbzni5l0";
+    sha256 = "0mw0ybrqj7hvf8lqs5gjzip464hfnixw453lr0mqzlng3b5266wn";
   };
 
   outputs = [ "out" "dev" ];
 
-  nativeBuildInputs = [ pkgconfig intltool autoreconfHook makeWrapper ];
+  nativeBuildInputs = [ pkgconfig autoreconfHook makeWrapper perlPackages.perl perlPackages.XMLParser ];
 
   propagatedBuildInputs =
     lib.optionals stdenv.isLinux [ libcap ];
@@ -61,25 +61,10 @@ stdenv.mkDerivation rec {
       ++ lib.optional zeroconfSupport  avahi
   );
 
-  patches = [
-    # The following two patches fix alsalib headers move, remove after the next release
-    (fetchpatch {
-      name = "alsa-asoundlib-include.patch";
-      url = "https://gitlab.freedesktop.org/pulseaudio/pulseaudio/commit/993d3fd89e5611997f1e165bf03edefb0204b0a4.patch";
-      sha256 = "17icnf8026947j1dqw4k16f91vy6zyg7q41zv2j6pxh9fncb1s71";
-    })
-    (fetchpatch {
-      name = "alsa-use-case-include.patch";
-      url = "https://gitlab.freedesktop.org/pulseaudio/pulseaudio/commit/b89d33bb182c42db5ad3987b0e91b7bf62f421e8.patch";
-      sha256 = "0jccpc0dgkb0v4xrkyca2pm2k4i6pvahs9bq4hbg34173p23g5nb";
-    })
-  ];
-
-  preConfigure = ''
-    # Performs and autoreconf
-    export NOCONFIGURE="yes"
+  autoreconfPhase = ''
+    # Performs an autoreconf
     patchShebangs bootstrap.sh
-    ./bootstrap.sh
+    NOCONFIGURE=1 ./bootstrap.sh
 
     # Move the udev rules under $(prefix).
     sed -i "src/Makefile.in" \
@@ -99,11 +84,11 @@ stdenv.mkDerivation rec {
     [ "--localstatedir=/var"
       "--sysconfdir=/etc"
       "--with-access-group=audio"
-      "--with-bash-completion-dir=\${out}/share/bash-completions/completions"
+      "--with-bash-completion-dir=${placeholder "out"}/share/bash-completions/completions"
     ]
     ++ lib.optional (jackaudioSupport && !libOnly) "--enable-jack"
     ++ lib.optional stdenv.isDarwin "--with-mac-sysroot=/"
-    ++ lib.optional (stdenv.isLinux && useSystemd) "--with-systemduserunitdir=\${out}/lib/systemd/user";
+    ++ lib.optional (stdenv.isLinux && useSystemd) "--with-systemduserunitdir=${placeholder "out"}/lib/systemd/user";
 
   enableParallelBuilding = true;
 
@@ -115,8 +100,8 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isDarwin "-I/usr/include";
 
   installFlags =
-    [ "sysconfdir=$(out)/etc"
-      "pulseconfdir=$(out)/etc/pulse"
+    [ "sysconfdir=${placeholder "out"}/etc"
+      "pulseconfdir=${placeholder "out"}/etc/pulse"
     ];
 
   postInstall = lib.optionalString libOnly ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13207,7 +13207,7 @@ in
   qt512 = recurseIntoAttrs (makeOverridable
     (import ../development/libraries/qt-5/5.12) {
       inherit newScope;
-      inherit stdenv fetchurl fetchFromGitHub makeSetupHook makeWrapper;
+      inherit stdenv fetchurl fetchpatch fetchFromGitHub makeSetupHook makeWrapper;
       bison = bison2; # error: too few arguments to function 'int yylex(...
       inherit cups;
       inherit harfbuzz;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

https://www.freedesktop.org/wiki/Software/PulseAudio/Notes/13.0/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).