### PR TITLE
spleen: 1.0.5 -> 1.3.0

### DIFF
--- a/pkgs/data/fonts/spleen/default.nix
+++ b/pkgs/data/fonts/spleen/default.nix
@@ -2,7 +2,7 @@
 
 let
   pname = "spleen";
-  version = "1.0.5";
+  version = "1.3.0";
 in fetchurl {
   name = "${pname}-${version}";
   url = "https://github.com/fcambus/spleen/releases/download/${version}/spleen-${version}.tar.gz";
@@ -10,14 +10,13 @@ in fetchurl {
   downloadToTemp = true;
   recursiveHash = true;
   postFetch = ''
-    tar xf $downloadedFile --strip=1
+    tar xvf $downloadedFile --strip=1
     d="$out/share/fonts/X11/misc/spleen"
     gzip -n9 *.pcf
-    install -Dm644 *.pcf.gz  -t $d
-    install -Dm644 *.bdf -t $d
+    install -Dm644 *.{pcf.gz,psfu,bdf} -t $d
     install -m644 fonts.alias-spleen $d/fonts.alias
   '';
-  sha256 = "0144a0lkkl5qx0a8sapymcayj5lp5cs9nfgpbmg3427n41pkqfbb";
+  sha256 = "1l1ksl8xnz1yh7jl8h2g25a7wfm9xgj3lay8ddqzlxzydkkm110q";
 
   meta = with lib; {
     description = "Monospaced bitmap fonts";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

https://github.com/fcambus/spleen/releases/tag/1.3.0
https://github.com/fcambus/spleen/releases/tag/1.2.0
https://github.com/fcambus/spleen/releases/tag/1.1.0

Also, install psfu files for console use.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).