### PR TITLE
agave: 10 -> 14

### DIFF
--- a/pkgs/data/fonts/agave/default.nix
+++ b/pkgs/data/fonts/agave/default.nix
@@ -2,18 +2,18 @@
 
 let
   pname = "agave";
-  version = "10";
+  version = "14";
 in fetchurl {
   name = "${pname}-${version}";
-  url = "https://github.com/agarick/agave/releases/download/v${version}/agave-r.ttf";
+  url = "https://github.com/agarick/agave/releases/download/v${version}/Agave-Regular.ttf";
 
   downloadToTemp = true;
   recursiveHash = true;
   postFetch = ''
-    install -D $downloadedFile $out/share/fonts/truetype/agave-r.ttf
+    install -D $downloadedFile $out/share/fonts/truetype/Agave-Regular.ttf
   '';
 
-  sha256 = "1mfj6a9sp00mjz7420yyrbbs5bqks3fz2slwgcppklxnz0890r9f";
+  sha256 = "14hr6cdn5xbfpszj4qyfqbwmjyrkmi83yl0g9j3y3jw561jwy27j";
 
   meta = with lib; {
     description = "truetype monospaced typeface designed for X environments";


### PR DESCRIPTION
###### Motivation for this change

https://github.com/agarick/agave/releases/tag/v14
https://github.com/agarick/agave/releases/tag/v13
https://github.com/agarick/agave/releases/tag/v12
https://github.com/agarick/agave/releases/tag/v11

^_^

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @