### PR TITLE
bdf2psf: fix /usr/share -> /share, and don't install env-vars

### DIFF
--- a/pkgs/data/fonts/gohufont/default.nix
+++ b/pkgs/data/fonts/gohufont/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     # convert bdf to psf fonts
     build=$(pwd)
     mkdir psf
-    cd ${bdf2psf}/usr/share/bdf2psf
+    cd ${bdf2psf}/share/bdf2psf
     for i in $bdf/*.bdf; do
       bdf2psf \
         --fb "$i" standard.equivalents \

--- a/pkgs/tools/misc/bdf2psf/default.nix
+++ b/pkgs/tools/misc/bdf2psf/default.nix
@@ -17,8 +17,7 @@ stdenv.mkDerivation rec {
   unpackPhase = "dpkg-deb -x $src .";
   installPhase = "
     substituteInPlace usr/bin/bdf2psf --replace /usr/bin/perl ${perl}/bin/perl
-    mv usr/bin .
-    cp -r . $out
+    mv usr $out
   ";
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

(instead install what we want directly)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @