### PR TITLE
maintainer scripts: fix hydra-eval-failures script

### DIFF
--- a/maintainers/scripts/hydra-eval-failures.py
+++ b/maintainers/scripts/hydra-eval-failures.py
@@ -11,13 +11,15 @@ import click
 import requests
 from pyquery import PyQuery as pq
 
+def map_dict (f, d):
+    for k,v in d.items():
+        d[k] = f(v)
 
 maintainers_json = subprocess.check_output([
-    'nix-instantiate', '-E', 'import ./maintainers/maintainer-list.nix {}', '--eval', '--json'
+    'nix-instantiate', '-A', 'lib.maintainers', '--eval', '--strict', '--json'
 ])
 maintainers = json.loads(maintainers_json)
-MAINTAINERS = {v: k for k, v in maintainers.items()}
-
+MAINTAINERS = map_dict(lambda v: v.get('github', None), maintainers)
 
 def get_response_text(url):
     return pq(requests.get(url).text)  # IO
@@ -38,30 +40,39 @@ def get_maintainers(attr_name):
             '-A',
             '.'.join(nixname[1:]) + '.meta',
             EVAL_FILE[nixname[0]],
+            '--arg',
+            'nixpkgs',
+            './.',
             '--json'])
         meta = json.loads(meta_json)
-        if meta.get('maintainers'):
-            return [MAINTAINERS[name] for name in meta['maintainers'] if MAINTAINERS.get(name)]
+        return meta.get('maintainers', [])
     except:
        return []
+
+def filter_github_users(maintainers):
+    github_only = []
+    for i in maintainers:
+        if i.get('github'):
+            github_only.append(i)
+    return github_only
 
 def print_build(table_row):
     a = pq(table_row)('a')[1]
     print("- [ ] [{}]({})".format(a.text, a.get('href')), flush=True)
-    
-    maintainers = get_maintainers(a.text)
-    if maintainers:
-        print("  - maintainers: {}".format(", ".join(map(lambda u: '@' + u, maintainers))))
+
+    job_maintainers = filter_github_users(get_maintainers(a.text))
+    if job_maintainers:
+        print("  - maintainers: {}".format(" ".join(map(lambda u: '@' + u.get('github'), job_maintainers))))
     # TODO: print last three persons that touched this file
     # TODO: pinpoint the diff that broke this build, or maybe it's transient or maybe it never worked?
-    
+
     sys.stdout.flush()
 
 @click.command()
 @click.option(
     '--jobset',
-    default="nixos/release-17.09",
-    help='Hydra project like nixos/release-17.09')
+    default="nixos/release-19.09",
+    help='Hydra project like nixos/release-19.09')
 def cli(jobset):
     """
     Given a Hydra project, inspect latest evaluation
@@ -91,6 +102,7 @@ def cli(jobset):
     print('\nDependency failures:')
     for tr in d('img[alt="Dependency failed"]').parents('tr'):
         print_build(tr)
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Can't figure out what is wrong with the nix-shell shebang line, but I was able to get this working with `nix-shell  -p 'python3.withPackages(ps: with ps; [ requests pyquery click ipython ])' --run "python maintainers/scripts/hydra-eval-failures.py"`.

This can also be simplified further as the `.meta.maintainers` returns all maintainers attributes associated with that derivation/test but I wanted to push what I had before getting too crazy refactoring.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
