### PR TITLE
uhubctl: unstable-2019-07-31 -> 2.1.0

### DIFF
--- a/pkgs/tools/misc/uhubctl/default.nix
+++ b/pkgs/tools/misc/uhubctl/default.nix
@@ -3,21 +3,20 @@
 , libusb
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "uhubctl";
-  version = "unstable-2019-07-31";
+  version = "2.1.0";
 
   src = fetchFromGitHub {
     owner = "mvp";
     repo = "uhubctl";
-    rev = "1961aa02e9924a54a6219d16c61a0beb0d626e46";
-    sha256 = "15mvqp1xh079nqp0mynh3l1wmw4maa320pn4jr8bz7nh3knmk0n1";
+    rev = "refs/tags/v${version}";
+    sha256 = "1cgmwsf68g49k6q4jvz073bpjhg5p73kk1a4kbgkxmvx01gmbcmq";
   };
 
   buildInputs = [ libusb ];
 
-  installFlags = [ "prefix=$(out)" ];
-
+  installFlags = [ "prefix=${placeholder "out"}" ];
   meta = with stdenv.lib; {
     homepage = "https://github.com/mvp/uhubctl";
     description = "Utility to control USB power per-port on smart USB hubs";


### PR DESCRIPTION
###### Motivation for this change

stable release, notes:
https://github.com/mvp/uhubctl/releases/tag/v2.1.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - Yes but not really tested functionality since don't think I have
    the hardware required :).
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @prusnak