### PR TITLE
Fix color-theme-solarized

### DIFF
--- a/pkgs/applications/editors/emacs-modes/color-theme-solarized/default.nix
+++ b/pkgs/applications/editors/emacs-modes/color-theme-solarized/default.nix
@@ -1,6 +1,6 @@
-{stdenv, fetchzip, emacs, colorTheme}:
+{stdenv, fetchzip, emacs, color-theme}:
 let
-  commit = "412713a0fcedd520d208a7b783fea03d710bcc61";
+  commit = "f3ca8902ea056fb8e46cb09f09c96294e31cd4ee";
 in
 stdenv.mkDerivation {
   name = "color-theme-solarized-1.0.0";
@@ -8,15 +8,14 @@ stdenv.mkDerivation {
   src = fetchzip {
 
     url = "https://github.com/sellout/emacs-color-theme-solarized/archive/${commit}.zip";
-    sha256 = "1xd2yk7p39zxgcf91s80pqknzdxw9d09cppjb87g7ihj6f0wxqjv";
+    sha256 = "16d7adqi07lzzr0qipl1fbag9l8kiyr3xrqxi528pimcisbg85d3";
   };
 
   buildInputs = [ emacs ];
-  propagatedUserEnvPkgs = [ colorTheme ];
-
+  propagatedUserEnvPkgs = [ color-theme ];
 
   buildPhase = ''
-    emacs -L . -L ${colorTheme}/share/emacs/site-lisp --batch -f batch-byte-compile *.el
+    emacs -L . -L ${color-theme}/share/emacs/site-lisp/elpa/color-theme-* --batch -f batch-byte-compile *.el
   '';
 
   installPhase = ''
@@ -30,8 +29,5 @@ stdenv.mkDerivation {
     maintainers = [ maintainers.samuelrivas ];
     license = licenses.mit;
     platforms = platforms.all;
-
-    # Fails with `solarized-definitions.el:786:1:Warning: the function `rotatef' is not known to`
-    broken = true;
   };
 }

--- a/pkgs/applications/editors/emacs-modes/manual-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/manual-packages.nix
@@ -143,9 +143,7 @@
   # From old emacsPackages (pre emacsPackagesNg)
   cedet = callPackage ./cedet { };
   cedille = callPackage ./cedille { cedille = pkgs.cedille; };
-  colorThemeSolarized = callPackage ./color-theme-solarized {
-    colorTheme = self.color-theme;
-  };
+  colorThemeSolarized = callPackage ./color-theme-solarized { };
   emacsSessionManagement = callPackage ./session-management-for-emacs { };
   hsc3-mode = callPackage ./hsc3 { };
   hol_light_mode = callPackage ./hol_light { };


### PR DESCRIPTION
I suspect there is something wrong with the elpa package generator. Emacs'
setup-hook adds the `site-lisp` directory to `load-path`, but elpa packages end
up having their code in `site-lisp/elpa/package-version, and thus emacs cannot
load them.

If that worked, adding `color-theme` as `builInput` might be better than
explicitly adding its `site-lisp` to the `load-path` in the `buildPhase`

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
