### PR TITLE
ocaml: init at 4.09.0

### DIFF
--- a/pkgs/development/compilers/ocaml/4.09.nix
+++ b/pkgs/development/compilers/ocaml/4.09.nix
@@ -1,0 +1,6 @@
+import ./generic.nix {
+  major_version = "4";
+  minor_version = "09";
+  patch_version = "0";
+  sha256 = "1v3z5ar326f3hzvpfljg4xj8b9lmbrl53fn57yih1bkbx3gr3yzj";
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1129,7 +1129,9 @@ in let inherit (pkgs) callPackage; in rec
 
   ocamlPackages_4_08 = mkOcamlPackages (callPackage ../development/compilers/ocaml/4.08.nix { });
 
-  ocamlPackages_latest = ocamlPackages_4_08;
+  ocamlPackages_4_09 = mkOcamlPackages (callPackage ../development/compilers/ocaml/4.09.nix { });
+
+  ocamlPackages_latest = ocamlPackages_4_09;
 
   ocamlPackages = ocamlPackages_4_06;
 }


### PR DESCRIPTION
###### Motivation for this change

Announcement: https://inbox.ocaml.org/caml-list/66833e61-7251-afb6-7154-c69dec487221@inria.fr/T/#u

And for the final version: https://inbox.ocaml.org/caml-list/24c7441e-b1f8-9957-51b7-eecc0999d246@inria.fr/T/#u

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

