### PR TITLE
ocamlPackages.optint: 0.0.2 -> 0.0.3

### DIFF
--- a/pkgs/development/ocaml-modules/optint/default.nix
+++ b/pkgs/development/ocaml-modules/optint/default.nix
@@ -1,28 +1,18 @@
-{ stdenv, fetchurl, ocaml, findlib, dune }:
+{ lib, buildDunePackage, fetchurl }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.02"
-then throw "optint is not available for OCaml ${ocaml.version}"
-else
-
-stdenv.mkDerivation rec {
-  version = "0.0.2";
-  name = "ocaml${ocaml.version}-optint-${version}";
+buildDunePackage rec {
+  minimumOCamlVersion = "4.03";
+  version = "0.0.3";
+  pname = "optint";
   src = fetchurl {
-    url = "https://github.com/mirage/optint/releases/download/v0.0.2/optint-v0.0.2.tbz";
-    sha256 = "1lmb7nycmkr05y93slqi98i1lcs1w4kcngjzjwz7i230qqjpw9w1";
+    url = "https://github.com/mirage/optint/releases/download/v${version}/optint-v${version}.tbz";
+    sha256 = "0c7r3s6lal9xkixngkj25nqncj4s33ka40bjdi7fz7mly08djycj";
   };
-
-  buildInputs = [ ocaml findlib dune ];
-
-  buildPhase = "dune build";
-
-  inherit (dune) installPhase;
 
   meta = {
     homepage = "https://github.com/mirage/optint";
     description = "Abstract type of integer between x64 and x86 architecture";
-    license = stdenv.lib.licenses.mit;
-    maintainers = [ stdenv.lib.maintainers.vbgl ];
-    inherit (ocaml.meta) platforms;
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.vbgl ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Ensures compatibility with OCaml ≥ 4.08

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

