### PR TITLE
 thunderbird, thunderbird-bin: 68.0 -> 68.1.0 [High security fixes]

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,615 +1,615 @@
 {
-  version = "68.0";
+  version = "68.1.0";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/ar/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/ar/thunderbird-68.1.0.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "4fad3c7c4099f70253bfee450bcefe458bec61430720fcadde1fe8a1cbb2e62a18d9c55943f850c57f8d788c973774e24590823086cfacbbb2ccd8a99ce4faae";
+      sha512 = "b9bb22bdbe013358c03e804e3c51ad387dca503b9e0074db70494eb3f331d72bd8679db929972e75b39f2464d384753bcab9947d1a843a69167d7b3706952c35";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/ast/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/ast/thunderbird-68.1.0.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "aac850773381d7fdb4d50fafe670449301f073f7388f92a1ca38d9b7256ffcd244b63e9fc0ff2f8ef5ccd853b97016b7e05eb751be1bdc8df9623481f15d55e6";
+      sha512 = "e00382241343bbd8a86e31dfcf5bbb060b46e5db6211cfa54c7192361353e2c4fe3d0ad3f4e0319ec1a0dc1f4590b7bc0271e5658bc468986d8e27a64d9924da";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/be/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/be/thunderbird-68.1.0.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "6521d818984bbfba195e847735c1228ff637d3079cff1f5a461ac20a079d325adfc1d7b2eca54f63e584a5cbd2007cef42a625597276a1810158931335f09cd9";
+      sha512 = "f043c8aa5dac0d5e2f9da628d6659f654cc39726677424e4b5e5005e97bf202575f569ebdee346d37cc8d4d59da188e6cfe1bd6bf7df1acafe26b489242b4a9f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/bg/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/bg/thunderbird-68.1.0.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "a0a738b6877225a5b98691d53a8f4a4bf575472a0d5feb8b77a67cd1fc9951772f1ab507b7ba460c0b62b87ab476c5c94130cbe7275692e3a99e5d2ef0bd89bd";
+      sha512 = "61fcf864145fb4fd4a05bff47bd23a7be8444f9d067eec246399c3a7ce48db8744ba4a9cb42e28a215a5bb1b336a57c51d1a32e6564f42c8b9fd4dba5f629d9f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/br/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/br/thunderbird-68.1.0.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "58d21d9e55abed644eb16ba98a5fb3277e0a31b935d279b09745262952895c2c2aed31817e6157410137ff82fc5d242b64268f646c3b7b691c55c5f3ea36e0e6";
+      sha512 = "1cdc9b2a8ee82bb087a51ac013644ff3da5f1e161fca23fb24feae8076cef6c5aff5316f83a8ecfa4f08c3a8642501a333d3ef95b46b8f899ce78b79d027af4c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/ca/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/ca/thunderbird-68.1.0.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "cd401259f2cc4ec71ff9d936a1f2f64a064afafed2e305bb359f79eddf1159cd6a7c84ce54cde6be94f6acd295dbedf54017d9f4592ee3637eea00496c7cfbf1";
+      sha512 = "1b73ca87f3067ec2a84990c7c58060b11286dd653f4b8b4c18a44f5540ea195d25f995539de39b6e1de6cbbe54c890bf30f6d88157e000e30c69f4d32a4ae8f0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/cak/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/cak/thunderbird-68.1.0.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "45ea4af30ff93500d1671c6a0eeda993692b7204a7504a91ad30bfd5155add5af902205240fd62f80abe339224e686473f2d13f466ba96269347207ed3f628b5";
+      sha512 = "1b2ec85786a842c7554f52b1ff72c4e5611a76bca94c4b8e9a79604d6b85d7f2deba906bbeca355dfd0c5a6c241d9bd397f4e0dfebd802cdb0c35162a02fd879";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/cs/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/cs/thunderbird-68.1.0.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "9f81f92a3b1710d006cda79f1b92923c1ea637a24654bd622af9be1f53a0024c5daa77619443514c9e607cb62f96403f5b7f426b3692227c0b56d1b14f51ca97";
+      sha512 = "69df6542c5037815d3a80be764eaa809dd351f75417e4362a258df5e17e36aef6d8f8653429f4218f196ff096252e0304c2cca1cccbf8693d119bc05f1072067";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/cy/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/cy/thunderbird-68.1.0.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "c90467a78bc82667d974b1e94227b7d4185878654188967d97c11e419ec7a03e4e5e3636466a0b6d35beaa98b717a26341e3a652c3b21083ad8ad0b23f063ed1";
+      sha512 = "5dc63d2746475f0045f7749e45bbc3f755b187521b0ca877ffab9386bb1bbe9b4fd66f9cc6bdac516ba591e71d71f02a75b5c965a610a3efbee3b59815d8deda";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/da/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/da/thunderbird-68.1.0.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "f49bd5689d2a4dd311b22a23da9f26559685f1c4663eb1e482b45b79544ab4401a17701f33b6ad083e7a8983185fcb16fca4c8026138f24be495c6cbb6401488";
+      sha512 = "89427a2b66dbd71cdfbb299a14ce7ed61ab4836e473854ea8b2ec522de64870f8886f6ae86428c9b1c86733aaa4ac7c732a708fccdd70d3e112d2f651c0dc762";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/de/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/de/thunderbird-68.1.0.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "579d979cfa0bbe50fd0bbf0d15b38d90579bc065b488a2e9d4e3f18f505e71c50225d92185559578146097110760ed3807e1aefad4862d99e247447478d6bc42";
+      sha512 = "34130ec994f6ee6a407313ccc61d43b0375046f59f75d4fb619776d5c880993802c16a3b8ec28dc7053b4ae89f91f1c2046da7d884d150aa7c3b65edd1650b21";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/dsb/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/dsb/thunderbird-68.1.0.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "8d16bf47d368a670cadb6a2655933d5b49a796272f7dafd948cac95a2ae541561a38fa418cd4ed0c4aa79ef63a441ee769eeb2a071734abf2cc1ba243d4f3ba5";
+      sha512 = "0b9c02a1e31f8f3120fb9ed520c53505dc247440ba2e189cbc58569be5ce6e0c33de220ebda17754338aa680cf5c8aac3ad7f5da14e0cbefc29f32db2446618a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/el/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/el/thunderbird-68.1.0.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "579b9114af9fda86e79e6812946da858945e2034ed2f00e4244724ecdd680b7db5601a4d573b530dc15207caac9245f6883343684eb43f3ae2abb64853c0b54f";
+      sha512 = "1d8e2efc2c9a7375a2ce0f2137165756800a680209d18612420581963f13774fc7780ac0ccda24a485996531d1e82e027b42a671f1c8fce5e8ccf0887f72ac6f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/en-GB/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/en-GB/thunderbird-68.1.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "f7caed8c3b49714e4449ef971ed1a21e40f28625c84e9342f63e5f73743689ee2c0e9ed4845f6667bd22732c62bd707db425f22a5c074dff8622cc4536ba9c29";
+      sha512 = "79684a833afe5d1025088d6f91e023c81832e9df83751926c5d9bc05fecb7f53d6efd096f55d65d45fa07309497cf5bed2e3b00cc4a80cc1e4ed2a0fe44d02a8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/en-US/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/en-US/thunderbird-68.1.0.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "257528761f0eca38528ded4b31329886093418f562aa2fac73b3a5bedda51fe80b34758c10afae1735cf37b37a86413dcf08642aecb1e8bea1fb6b0b94ade5c7";
+      sha512 = "7a29cf0a238e44a2051b53e5476bc8f622dffd088251b66d951ad6874fba5fba180f440c80c7d5ae154c688d3e29fcc6c889f0031d81a018b7fd1dfd53f112a5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/es-AR/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/es-AR/thunderbird-68.1.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "70a10e329b1031a2fd2ffb2b60459f0238ff3f5e5d80533f4be6cb22ae77692ec079ca3e146bd9a59edd09c266cec92d922a18ba45f8626a4bd44e290d3c0927";
+      sha512 = "d9d62f94af40ba69240b792b3ef2d93efef20b01b4289e992f7d1192147029574f86fa21aed5ad54489d1e5ec1f3b80cd9601e71e2ba9c903582ccd7aed278a8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/es-ES/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/es-ES/thunderbird-68.1.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "a03098ad7d83b86cd316c56b69589370fb8bad041b93f90f61514b04e3d0e78385f779ed715c6e22e45597d1bf03676046cbc1eae7896bb2a309af3683c8bd1e";
+      sha512 = "d720320494b2c8431004e0d1ac24ff8fef83bc0977f44653d0fdab99fbc9a1aee6d5aecd7cbf6002e3746d04156f47aeb57367f2b30f4690efba36c3297fbeb0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/et/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/et/thunderbird-68.1.0.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "44efeaf030580dd7b55770627678808e34d689e85191852c2e5fcb223a0fdd0e5386f21f03524d0983aeded7f8ed99382ff2c372c8c5a1fdfe218bd5b10ccd80";
+      sha512 = "8d9ba13604fab4eb9a3dec8894b04d52f9677d5f82695512680ff03740a66e96786f69476071741c8086a09070fd03786e8fae7f94bb3bec9075331fe4dc144b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/eu/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/eu/thunderbird-68.1.0.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "c670be5932d7e8bea28cffda7c119cfdfd5823f76b2c97251ec23ec16e420a8b7feb5f2251d89750b956d3bf3baff5d17393c05d8c265d0a98cc3faea8f85735";
+      sha512 = "e40110a94b3d7fb42707287dc695ea09b082fa3262d05b39a0c09002c32722630711f1b0131441c919b23130ed133338239060726cfc9d6c0b49822558081313";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/fi/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/fi/thunderbird-68.1.0.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "36aa0b47e9b5d91fbc812a3d63503924a8ca227d7b7084c1159419092b17da9c1b6e89fa046c636dbcff7776f9a1d8465e660b47f1753505f0d2eb85da9c3a7a";
+      sha512 = "d8778ddba26f544a4721b9118ce5726b04fdf09758272b35ca16c14aea61d0b8271888344e742feb4d4e758182e97b01758acd53ad622a66117e3eb0d4a6d336";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/fr/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/fr/thunderbird-68.1.0.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "b1e7d345d3dd38725227b5e09c4f3cfcf29ed3a98b0580fbf6ae1ecab4414d09e307423495b75769a8d2ee3ab4700cd6eba3d95ce05612e1d8290d3f5a3ba988";
+      sha512 = "2cd546d40bedf09b58703b0b11a5c9349d702540ae714942e0152a19cbecee51f37c7e217fadfc719ecfebf914f9ffad6b3070bb6471d395e8f5ff8ada754551";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/fy-NL/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/fy-NL/thunderbird-68.1.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "4065a083f49006dacf64f084c1bf26c4c1b8d53bca7eba7a56d66bb035eaae2c4528687c5c1e2213f92adbba17ff92eb54f897d3b0ef6d27b8effbee66ca555b";
+      sha512 = "03f52224f145917f64e8962b68bcf3810543b5bf0508dca7965c5a385c4f87bc7d236dac217594fdd2a10afe31da8aadc674eaf7b226e189b598011a8b9e223a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/ga-IE/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/ga-IE/thunderbird-68.1.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "2ae9a0860513e90d1742e5c17220b2367e61273eba04738cd29e9ab497b86f9a1d78b38b21da84b1f214f3368ee114d376b05eabe0aac9a1ec07ca6a4b399070";
+      sha512 = "931257466ce7134b9852c2627f34efebc031b3dfc9fb7b5e344665da7fa52ac1fcd12a8848fd9a264a900e98ee3383d3ee6c251de58c1432127a8ce8f1c100e1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/gd/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/gd/thunderbird-68.1.0.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "d2315aca9d8e5bb35b21cab46a48e51f09200b056da2682201c32eb4fd3d0379a24a6926ebcf11e9c70d70fd20152fc24d5197a78cdb3c8ea3cc2399d784b463";
+      sha512 = "ee3573fe9af5fae39aa053061ef82207ae6669e6764637f6ddef5f8ee3cebf362dfecf5cf5e9e208392f3fe79a0c1a56aba28f372e2e279b33a1f1e3a58851f3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/gl/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/gl/thunderbird-68.1.0.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "52d9210e857c1b6cb665a2ffa71cfa5e67c3718b210e2b4b42839d8f25987170f1603fa55d324003a4be821ba74093ff92d632e688e44b87ebf51dafd02f69a2";
+      sha512 = "73ba3965d522aac8f9d5af87856a7e2f71cb7ed850f240be56eab9426f91e5356810a12da7cb91bc223cb14eeae3ecb89a2afeca48641ce4debefdaed05aeed6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/he/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/he/thunderbird-68.1.0.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "e7b5a16950be233fe8a49152184270a901bdb4bcc14769401d4b5a21fd2a3ab9d395ed8f6b61081330386723725252fceff09bf9fdde3a71135a98d8ae45089b";
+      sha512 = "abd4f47d571037c4340dd3118a517f3421a3e3597efa1ad7ab14cf537d4b4e226144beb0a6c54a45ec272ab428ee8ed95083d31554ef2aa0022712dd832a1585";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/hr/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/hr/thunderbird-68.1.0.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "1ed224dc0864009edc6389f9b3b063f56b15be982c2e2915f1a2f773bfc78e6b81ec0ab02e03f7ade08f47260be597003f8119116576f4fe5dd490e85cd3d4ab";
+      sha512 = "32a18d8666fc2b7566807a010d94bf5503b375c5330687aa58efc2bc6464e4f910947ea513a6ebb6b7eadef0e552138a5349583e6894b3166ef6f8d53d5cf67b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/hsb/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/hsb/thunderbird-68.1.0.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "f4bcd8a199bafd544687b1e890694dac2b598d4fd79818ab19441ae9be579a9928fd8c7fbae43e322fced15ff39314fbc88be94ce2fe12b5d2ec2ba003a219a3";
+      sha512 = "58794aecdb5f3824e94f2bde4e4080d4922648bac632cfdffbc5304329af64f9e5ef01fc587c4e19e88f206004cc4254503513d7bfddecdb6778de89e4ca6bc5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/hu/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/hu/thunderbird-68.1.0.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "28223aec237fce2f07b0c3b454a8339bbd2f195d6e263c5a5723e04bd5df1128d58a6bc6c7275cdbeefd5161a405a2d6340303faa79d9330abd0e70de9facbfb";
+      sha512 = "c7881770fc75a6b1eecc5c481e2de134a241b7a497e19ff2abf08aaecf65006f054090a53b028202becf7776d3939742fa71156e6761f981ff7a00ca0d1d7d3f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/hy-AM/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/hy-AM/thunderbird-68.1.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "d7dea23905f8bc8dfde92082f90278b76477eb3036c7fc4abe656e37af9d389d37f3b166492df210eeab03750d85cbcaf1340aaa26ab723ca1b70299b4a64ab6";
+      sha512 = "80f5fd19da8e07a6d40c19c645eb8fd6964f9904cd14df36374170c4d395146d168728953d1619965f04b3f2295df3d379650e97f8320587816ee088e2f17a9e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/id/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/id/thunderbird-68.1.0.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "f55ad81a1dc80838a9ab045899e0f16bb077d05d73119705f820f6fe8c8c7a550e05cc68cb7ca0aa8861cbd70bc9f061ba51a4749db6c37d90e7e7bda5dcccdf";
+      sha512 = "efffdd32086ca57e93b1ebcb40484a3c2243d6b088c70d7b20bcdb38925e7fb64be4446c98980a53738f54dadb54a2d17016adc69bd2a47a9719bb7bb982f729";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/is/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/is/thunderbird-68.1.0.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "503c236102a15428e41a21b458ecc29986abff4e434f4e26ec9741b2facf39a8fc2ae9dff5aeb32fe3c9ca0dcb6e914a2acf229ae9caecdc4f064380f126ecf7";
+      sha512 = "277d1137675c6304b28f43273c5a3fbcdf0d2188cbaa38911d784df98b3429eb6d2667b818a292e4c3bd4019b2b682463c2d01faa0a034cb4fc1dd49ba8aab33";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/it/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/it/thunderbird-68.1.0.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "51a736932baa5c810a29de46eba64b0fcd2703da38ba9449b6b06a9412562e80853367416c5b4d6c6834eb7a2186f434e426099ede56d9342860e4f3561455eb";
+      sha512 = "6932697d769f98dcd32f3dcda57dfa154314e29bfd2c1b11a2b9a8aeb8395f00fdb0d1c71b8e9d405d1540cde21547a910a55024b799e270759d8638a3d11512";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/ja/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/ja/thunderbird-68.1.0.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "7a00080835155d301f65a35684d81f8e3a3be23d927d939da84a2a887057bca0b75d5b580a004b4f797af504a6812f71951bc3c75ccb24dad60b6cca770cc7a1";
+      sha512 = "034021e89c471429367807f04d79dbe877d0ebc94f584fa6c0bec3a29f279f1d6dfc85f709b26e9d11c8ebcc1f42adb9a458137c032a73ae2b69f7238d31ce76";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/ka/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/ka/thunderbird-68.1.0.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "eaf67c64275495fcb08aca63953406cd7815ec356ee0a1edca8a5e8dacd924a9c11e35dbe4ad17a1617199a5f66489bb553a7a5177eb629223b49a9adccff803";
+      sha512 = "7af1caeda9babac2a4c9b456233e86be32bcd14b6dd81cc18a1874dafe86c5b80099d0ce388a70fe6e74bb7b0d00d3b7ce810ffcbae143eadf6d8c4367567c27";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/kab/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/kab/thunderbird-68.1.0.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "9432bbba0965b6da04495b79ef4db3bdbe69476b20650b4d6407d921cf07d09950368f0c13211ea6743b621d486bf71dce0e60d8ceefd82b48a8f2581a3fd7ee";
+      sha512 = "d8e7e7d423f36d40ce05cf1378278c47049fca0ba415466028dd821b12970fb78fbadfbb7b7390ec446aede490f07f979b94ef890a43a710e3a1f66a0c68937a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/kk/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/kk/thunderbird-68.1.0.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "9bfb99694bcf1227162607e2b674abb00343e4da3876999430d6014cbd4f4aa6c6e9ddca7c7f3b144d101c1a5a6d38772e3750f5feb41d1f304b89a8c1e6ec15";
+      sha512 = "339c8e86693a34c8a2da5e47924e545f0fa55d5314db73c6bb23df3eabed29dd6cf47662a8c4e43c381ede5098aba72887739993b4e71db75e41de3d1d777c3a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/ko/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/ko/thunderbird-68.1.0.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "fd260740ccd74afae7af664775954acfd176b47176f48b5300f11bd77bc31205d0bbc2d06a701486e9742ffb38ad4aa2b253041b9d9518a4b9c7dbbe41aca264";
+      sha512 = "ba80df01778f8fa95dd32bf0af55afe7fa828a489c4682e6a8891636281031170b9fff77ae4f2e4bbaae9124946b0429e55bbed741973d80da868d94e29991e8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/lt/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/lt/thunderbird-68.1.0.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "fb7a7b6d0c7d58d13b3ec20c8176ee793cac5c53bf849e3b3c4aaeff0f3e897cc35e61a9dfa4055c691fd56f280f7b31e04999922c29ecc89294ea6eeac16cd3";
+      sha512 = "32e93ec3203b70c2dced59a376bf7379879b5361f55a396d533e1f10727482b357344c9890864279eff9aa6d75feb1b36a67f2293c51d3a3222183f62c51e477";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/ms/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/ms/thunderbird-68.1.0.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "7490a8169079569143c63f85e7da299d28ea423fb95265e2e86ec724ff0da641e24a2e9ea612d180d523973522f40c250bfd56e66ee39b28cb9acf57f6be6831";
+      sha512 = "29190352e1bbfe30b1e98d2a7fa20268488d82aefbdb4de1f8c2e197ed9f196be8256050f48d71ec6475b707d93d0570002fb175cd88fac89aca5e7140a7cbfe";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/nb-NO/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/nb-NO/thunderbird-68.1.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "7256820ea97851319e51616f6eb45617983e76e74b46ae62a02e22d13e2dd6abd590fd265aa6c88ac14b2f0276219580b6b9fbd956f1eaa38e6a93329b9c9621";
+      sha512 = "8e076d0967b0b79ac2cc9ade63e1bea4d27db1c050f792f1d1da01758a576fad884fdda32a02d58d45cf4c615f38c44bebc80c6e864ee076212f280398602892";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/nl/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/nl/thunderbird-68.1.0.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "00f32145c861abd8f151d7840d0f01eb9d4190df65e5a179f999f3149477f2de7f796782eb7ef912fcbec005d65c76974185d1c0105dea862cbc22c821bc906d";
+      sha512 = "7bee338542f949d86700d9b67d26c059232ba96cba991e491e6380f1ef914e7ee2747c9c73907e393bcc83c7f05ec6e656d869980c2c03ba0a548ae120793030";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/nn-NO/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/nn-NO/thunderbird-68.1.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "3ac255b5bb4b352833fd56d5aceaba6d0ada571630a993729970ae99d5067f05ba22e6ef50fa7dd099c0eb5874f11aeed32718c56a80538e28b401ee6b7900a2";
+      sha512 = "33b67ce4100a61461a238189e06b623a067e5f1b550fe5f20b5686f597408f3d7eaf45c92bbf5ffe58ff96c99fac9b9e282b024e40829d4d9d4422e54cb7293b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/pl/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/pl/thunderbird-68.1.0.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "19ab4bde9314dbed1bca7565698a7b1231767ef9cc792a49e7e9d679453ae8209e6f68c63ea0a24bd9e3a97328dceeedd109bfe28038108b52b9dad366f28787";
+      sha512 = "860c606fffb3ae85193b4c919783c94ea1a84c2579316cef98adc247d7d595b01dc6c2e84662641c7285dfc65097f710d7d2605efd960847739ab4acfc296836";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/pt-BR/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/pt-BR/thunderbird-68.1.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "68e28b657b885e7823dca0d091f2609556d560a50b5e6c285cdf467ae2b09743406baa2e544f17997519c219e0d4e8911115d30e7b0c35f09b956e28b311f8d8";
+      sha512 = "3093207072a79d9556c4e1ca2fa75d990a3952d583f0a4fe8c850a4911b1af19e3ac08a357d239d66b22c397f6722b8625fee03ca1f2b6a8f21dc61fca348541";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/pt-PT/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/pt-PT/thunderbird-68.1.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "41623568d2e78b821a89480836f8d8c739f6983b80ce26017d12fd9363016158fa6c629e030f63aba6e730e554b7717fd2ee58e0246aa82b46fe55d5d6be9933";
+      sha512 = "5d29ed9a8e8c768a3749801dc191b27aecf7994a4afa02e70de823ed1eabe4e936bd7686830359aa48321681396aff29ead762ab28c7bda6f8aec36117e8cadc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/rm/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/rm/thunderbird-68.1.0.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "a2cabac0ff5e3bb4a8dde4e884ba4647792e0935ef0a61b56470c67d3ba9c2310a07c2d2da51f7b4cb5fc3e841dd385a2c64ff29d263333a91e2044a4ad3190e";
+      sha512 = "cf342acfbb9ab92b7bf483ad3227730dc3923ee107ae42a0fb05c6070256e43a4d3c1647c1fa2c4dec7adbc8c018a185bd3d91e598d09eac43ec679d3c25063b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/ro/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/ro/thunderbird-68.1.0.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "2e9da10d1f88352687175fa48fb70f8a73cf3ab1d84958a79c4a46526b3640e264d98611806bb234f579d616fe7d1dbb2d4c6ba55a389363034f85a97283bb64";
+      sha512 = "ae13fc229198a5c5327dd4d9d948f1a5eaf699877c48c1c961ca084e79075f479f4b270fed1c9ce22f420fecd4332a30594d4d2dc87bb114d1e3518e3a4a7071";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/ru/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/ru/thunderbird-68.1.0.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "5f4bd3d3657479446ff070cfdb33e16a527c6f1615f37fb4c4e32c12b89c62d5649fa5c3d826723be47fa9795575bd33ccf37c2aebb555c218aba8f9d68ec3a9";
+      sha512 = "f51b1f99c16af5f24702f0bfd433c71c7ae899ded5f101aea2dcdc16f1cc9e1b7b18f26a4fd0ca9296c5e9007067e35bd9cc322bddfe07f58795147547fc0c56";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/si/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/si/thunderbird-68.1.0.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "b47d2aea81327089445c9f57a1508406c534907c7b574006886828846e6deaab04e35de2781d55d882f05c0a89f65fa7c386547d6581064af4fc3bf4e879e379";
+      sha512 = "26bc664b1623523d644ee231666a4489421ba31d1f0b52b5f4a4164343672333070c3781c577e370e7d97d42b61783077c74d1f38d37565776c752a2310c3a1c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/sk/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/sk/thunderbird-68.1.0.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "4295204bb89789704da6830d33e92a77df165737c291c74a94fa532309c89505fb796151e0855b4e0bad8658fecaadc9978580ac72e2a2f24a4022909bb64aa2";
+      sha512 = "46470afe078d1ef2e48b3732fdc02ff3c9104a727b4d94cae1b9c54f6d2b4771e5784cfb3e6350ab8a205f8ba010a82a2b2fe92313eb351496a19a99df75179a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/sl/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/sl/thunderbird-68.1.0.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "598fe5bd04e04a73db04eb630e02dd7cc7af34d0381e6877626c8885bc4b879e1f35362afb8cfeb1bbafffc5b7ea14c8efe9b35b5e30056d04fa0126b8663679";
+      sha512 = "9bb5b0c979fede4dfdaf8f4965bfed1ad78d14168efb797fc216ac2527434047c3e6b65eb9dd1e607f55b22f6f28e49b0ff58c272c0708cf5ae1f9ce96b2c796";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/sq/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/sq/thunderbird-68.1.0.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "0b657daedc98db51179cebf547d5f278d2d632bdb552878b4af29427ab8fad62f8d6c1ab2c3a38cbd8e67b670d6d613bdb1d4f535a0c69d0d1ca607d0b10bd43";
+      sha512 = "440870b75e47aa277c5453bd997709d2f9e59e0aa86e2fa7f5aa95ad39b139d8e9b7b8a7dd44765d8f8d5ec18c5ce6a284ab40d4aca01b251bcd9e2183be4976";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/sr/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/sr/thunderbird-68.1.0.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "10efa11b9c9ba56142c8a321a25a7e875f3d02fd17f73bd3061ffc71823aeb1269f9a864aae88a4fc434d1c4a01d227c0be605ffa7f4ef6421db98c0141c839e";
+      sha512 = "bced610dbc95e7cab982f40376fb7cce8e672f8533a66816f01667ba69d73dfcb00e95a80b42273c1ec7ada9cef8c14af1c426cda2f8425e3f77a3a0e393a611";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/sv-SE/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/sv-SE/thunderbird-68.1.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "c77d10b35edef7e59f4e6c48cd4352c4fb7d05b0140aba12be42b3e3a3df609ebc86f2f5a3993fa172ec0ac118726314bc9042335101241637481a2e1a4d1c00";
+      sha512 = "af139912f563710b05c274d1b89012e27a3997b582d379e3561011fed7c77994447c3054433e0fd4b5db8417d5b43b63e840d313cef1fc7a8aa7baf0655982e1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/tr/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/tr/thunderbird-68.1.0.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "3d52693efb05379802d62fb9e40c4b1856b45ee948032634d4c4bde7bbae67327f963e0f1096fd5d7a15d4341af1ecf3d9ee96eed45146859d8e8e5d403d660a";
+      sha512 = "50693e4638f8fea5a7f609924ef65c8d7ea4f4ffff79320651481e1a7f5cdf69edc2fd987137a0d655077959cbd8f32218d2f78fd55790084e2d46d3ecd70cf6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/uk/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/uk/thunderbird-68.1.0.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "c09734ab8e6428c6ed270887a0add934a7058d5e9c895864b1128e0fd39d57e13789bab38cafaf7cdbac1a71c8884407698c4bdfcf48aeec6604a457ed57c48d";
+      sha512 = "c24943567c110ce8cff6da066d0bd0081621d8c397e6569c57b63eef3098963a55215083aa655fa9c98adf9babfcedecfd72204c1a68604c851e1a5c1a1b0102";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/uz/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/uz/thunderbird-68.1.0.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "083a83ae3c6083934fbe49f1e65ceadc5b5459f0f29ae0df9901b6d9b29d0a105cbde94357c1ee0a9677ec923fd1d419c618db0e843cdf320c087108990b89ec";
+      sha512 = "e02a86c848a013a84824246db3e29e889e1f5cc1b743a3a9b567b914a46100a808779fc13b897b04e8c698e14cf474fcea907e25e937e5c8b4ccb997f06d8e85";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/vi/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/vi/thunderbird-68.1.0.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "6ba1573c9a170d1d827b6d17941c25e3852f7b66be2eaf7a3e9ab02278f19a38b801d7b9b0c266dc4f38f1190f9c83990eaa51f4734ddb38f43ea3e1bd23b72b";
+      sha512 = "de6d6794796f5b60cfffa9eee92906237fd692b21ffc3925c7866ea9660d26366f5fd3c847b2dfecc418b631c6241dad4e509e58e391c414a37587c6185c2655";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/zh-CN/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/zh-CN/thunderbird-68.1.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "74ee429901cb520d07361a4b621c9be06253cf93300f0f91e3633d3b375e4e9a6a58823d4bbfed60519734ca5705f2cd0da4bdc7db0f578ec300f1d705e9b7b1";
+      sha512 = "d5835538fe615544a07e93a2088b65eae6c3c36b75ca2b9f6605974d929a36dd226d848e2394611809538106f56c1703ebedb5c0776593e998935bd322a4e27d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-x86_64/zh-TW/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/zh-TW/thunderbird-68.1.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "d720029e0720fa972d694712a85bdae94b1ff51213c4e56b84dff6d293a2a9831f5cd4efeb44070010eba1486b9358929f64546ce7ebb7cee29a7bcd4a1cd650";
+      sha512 = "9dfaa7dc83725fa795cf1b2e45e7af760dc6c38999b05a0968e46d4b5676a4b9f705ebb63ff400ec6600d83a6be26eb4c2638671a539b59b6ea37002ea9b97ac";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/ar/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/ar/thunderbird-68.1.0.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "823b3cf50f8d23d1d0ba8583d2b10146e2eb0ff4a9401527557fae8e8db997ecc66d0bf5a091323bbd37dd6222bacb73fb9818de8740963b929a8893e4ec9391";
+      sha512 = "17733249e5c2c33899fde89a5b2dea2592fe0414419c235f4d853917990a05664d52a05f1f1a290ece4bdb3646008b0aa0af1e495e5b8af0c08f5b9962bed5aa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/ast/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/ast/thunderbird-68.1.0.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "f0087ab3189e8fd194d2ef6d5d2f9c3e14d592d5217a8fea19ba5189e806f9d484332f9d342a15549651a75bcfa673f21cd7666265fc185ec58c814814902ec4";
+      sha512 = "95b40d08b988146db7175232c9d9be92175cc3fdd73ba5e205e6543dbdb9e6e33579edeec73b6961a7ace574d3466c162d0665ffbd3705de15b7ea4cf6d7b77d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/be/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/be/thunderbird-68.1.0.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "edb358214e93142d73c92ab3dcf6240cd08614c2d0e9ea506492023be46d7b7f6273dc767ae034762c052db3b0a093dd027187afb272b2a55fc3126b06ffb78a";
+      sha512 = "d2f4ad38d81306c1637ae8612221bb462409373b3cfa70a08d0f2872aceccd8087835eccc014f4009680e9e36b6cfecc9bcb95328dcb8f6c9ef11c432e2d3c6f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/bg/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/bg/thunderbird-68.1.0.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "f3268fced7a81b5046332f975906ac79b8ab5ac888dc1c81085dd7cd1b1a414988208d426bd305f67cbd913c58de857c844809ae6e6ab5a2a520d7d6b149b731";
+      sha512 = "f2c74a0609eff929202d13719fce167577b2ae0e1a0c98b75b359bfcddcb531907a466e184ece24d904bd592ab41654f2dcc2500defece0aede3be3826dcc8eb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/br/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/br/thunderbird-68.1.0.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "c1be2ec4d4e64a2a9b32b974eecd182ad9d1fa23b775769e8535e742479ed6be2a222272d7c5b141393f0c752d4af704758912bbac1c17f445b3bf277c12eb9a";
+      sha512 = "1f1ff89743c398443a18230ec0eadeb51a8d57633bb7c242f7003e472b0ea206dde50a9d20880ddfbc9ee36a3ca28135662ed21d6e8cb779627120c70f0aedea";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/ca/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/ca/thunderbird-68.1.0.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "ac0c2508b89812ba63d0bb770adc2292127243fe31bf140a4ab88c953750fc2f699c5ed2afb9a400cec48dc14d927b08dc96d5b110e2f2d90e81d1532ba9d916";
+      sha512 = "608232b5bc7a93cd786d84662e59e3b186bb1de51cbe0f720cf4e80e65a93e09a24f06abfba63785c0cdba997a6fa871497998f1953f57a98ea6b9e224235ffe";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/cak/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/cak/thunderbird-68.1.0.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "4d73beb37469131b7e7747c85a73027e1eaf008100eee21e27d36b4736ffdb4cc3ca3606726e36033de64504f058ec9d4193797a09c2a591675636a5c00fc890";
+      sha512 = "5e77fc07093e5b2cbb345f21b48415a5c7d987ab0a82540f398ef33c7051f1917fb448fe23401ec3683c87379aeecb287be5ffcf6a124df9a464401f242d1e3c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/cs/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/cs/thunderbird-68.1.0.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "635ec13ec9fd688ccb9c690ccb4d64228f1f47755ce24c4806f5f47655af1279b9ee758fe15c0fcbd43c830edf66383bfa3d84d35137209a4af41aa59565f554";
+      sha512 = "036304985db3ecccbe50a9b3d8c19dcc269f7c6987c1101c9443ea5fb2d14e71390ccdf6f0000c972af631863398a02cba1c05566c6be4ab3e79396c049e0e16";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/cy/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/cy/thunderbird-68.1.0.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "afb546562f92c93639a407598d9c6654b64776cb68db7ddb07c0d17f83d122d9e7bb974238ee5cdb90876bca3ea30356cc5eef28b11ccf082ef72c0343dc42d0";
+      sha512 = "4de3a065234e921f9ae7250409ba24bc54230af61b4993c3686a77e1e165874995f7c60b45ab136c6b3f3047461e86c19207952b870019df06dd164054b65dc2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/da/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/da/thunderbird-68.1.0.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "f7b7d183312d11d02200890afe4e81c793b658729119d9f81ac2ca58714244ece9d64d1b9d9f34c79f1d00b574e24192ce066debf873c4b740c35208cfaec16e";
+      sha512 = "69e190f9263438c88b445821b56b93c052613fd67a1f1918b135c719e4358bea46d3a79bc135d50b254fa686d8cba013daf89d40ccc5212062cb177bdab4d667";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/de/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/de/thunderbird-68.1.0.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "e6b3ba227c8e84273e6dadcb59d6691187512666efcb63244740a56273c5b765c65d21607e4f07a508e5e63ed0812162ad767fcb1140b89b2c155da945586179";
+      sha512 = "ce4cf8c1e11f4813ce173bd08ceed9ef26b2117771ca87ef16c001e1a49f5385a6a3ecf4bf7561d48aa6c7e63d307c2fbde77ef8a51fa0aa9b66f4f98386bff3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/dsb/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/dsb/thunderbird-68.1.0.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "84d39965568de9c87c280beb43330aec4ba6cdebf59a9c4f566b6bc01fbe15cc3987e87d9c24a9e746283cc54ec1ebaaff99952de7ff0aa9b6f05f36b1295d09";
+      sha512 = "9007c92825220ff9685c599b1c6e39fe3e96888621ce5dd15f5ef9d812c09a29ef72a6eb2f68cd8eab78b5519b6c26cc957ed04f3c9798ea0305fa4f5c8bb962";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/el/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/el/thunderbird-68.1.0.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "0942b5c8c7ee792d264824c6837d5857679feae9073fd2451b92dc0f31290360a24f7cd708e550955e798d2decb9f0c3a21dc8ba7bb5f226ba8ba9f502ef870f";
+      sha512 = "e619576813260ec68a26226a83a540c58aea7e87d3b0ca35f6ae7bd9e0dcaaf54ab12f57cebf669060191e3affc42df1585a3ce4aa18f82f6afe469b85de495c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/en-GB/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/en-GB/thunderbird-68.1.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "12fb5086fd012d85f35a41125b7e5ebf37ec34e9215db9b2a4c67f924d3bfa738698ba15bfa2e51f8cbe0d81cdfe5de4bfecd54b0fe6cc7163c753444e56bb9e";
+      sha512 = "0810f25326d8a08628aa55d5c15e6144f833454019087fa20f2c128bbaa4380f9f2a07714b0d8ac0f3fabb5b6065e7b2efe6e80975e5e47e81749da9f4e6be94";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/en-US/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/en-US/thunderbird-68.1.0.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "6004186b0b27165a4d54191a9c2daef34b580c2d97b1e0472e8d8d863e3df51ed56ef17abb7c6944f4da214772780b5c69785b9ad22ca26ba1a8f0390beedc19";
+      sha512 = "adc1dddf36116435b3948810cd9d647febfc97d62443032100b0f2d722913aa051d44244f057c29cb8c6cf494fc67b3044b83ebfd5eacbc36b6cd9c88361078e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/es-AR/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/es-AR/thunderbird-68.1.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "6a547a1d0450de1089df18baae81100d3fb9934c963459ec83ae81504e7a1ec7abf595766c84fe8d321f901150a68b7e172888028f3b992b4b6b74ba98ca4efe";
+      sha512 = "a9433a5de45477f432c6906b640909880650443e5e3a65a839e9c055d887befedc8c22c76675700886dc128ad190fa0ecdbbf2c5f18e650219b33a78105eac63";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/es-ES/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/es-ES/thunderbird-68.1.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "e1256da3c8938776b11444790f20a68f056f7407f444f0884dfa1c52260309d4adfc64fe95168dd8263e4aea650362ab9fa08930559c7f0e97b3489c172c81fd";
+      sha512 = "a128e46d7d2cce449a261f857a221232d2d89a7d999bc074ad5d1aec741f766516f3882cc2603d6284458208c2ed36dcb81e214039222c9c15450e96e73d0283";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/et/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/et/thunderbird-68.1.0.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "a5d7cd5e3171d44dbf91f067231301940e8a622a6729333512b49bc037022bc2058fa548c044a40b7ebea5d3199402276a34eeec5cb21b2070d7cfd96737def1";
+      sha512 = "521d004b432fd27ed6b167263253b3a3c89aa22ee5e06a4a434da6948a8c2af4fe27e17a1ef962e7caedf7d15ab27b98384545069abfaaf41871cd5878fdbf72";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/eu/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/eu/thunderbird-68.1.0.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "08047c83e28397d265712dbd5a533799b2bba97d90f83b93be8377a544226ea0dff22f5b5e2cd5314c24608825048f3e59c6fc348959d63e1acb81d10d687f46";
+      sha512 = "df8afc11cddf0c06d05bee455833bc5d786789a709baeade7b64e8f815c42f399fca1442a8b64271fea7e45fed4408ee923293cec953e0406b093f0b94120861";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/fi/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/fi/thunderbird-68.1.0.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "ae407ee0dde2be8a8f89979b5dcacebd13fcfa42fddce48773e8f26ffbb503acc6b17a90170a0d72d550400397c17a725f9bf6f65d842f0f281fc58eaf9dbc53";
+      sha512 = "51e05f21e01dfa0fc3c5d0463d80e87a38e50dff612a7632f9a5cd440f037a438a555e3640cdddd794ebe04eb2cc15c549db7ac829c91ac488b73b66808496a9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/fr/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/fr/thunderbird-68.1.0.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "a776215a9ba91de0500cc7fda245afa19a49b51b60089c55444aa452c5aca06cf3b95e66448147cdbc3df063348c28bbde3f3c2a6e19deed26e1b33dec565b25";
+      sha512 = "9448860f48fd93383a24fead6af1102af855270749e817f720e2afac152949e47fcc9ce6fd0d2c60d3dd958c855af47a54a38e85975acf05496a7f67d2af72fa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/fy-NL/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/fy-NL/thunderbird-68.1.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "5302a5709fc4485eff607fd0b5e75f15bb600a14d20661cc4f7280b0bf5c156a40a51045182ff0d31c89d4009c5a516015843ec9fef1fb1134cfa80c511c05ad";
+      sha512 = "e9a27da8b86e2ec3593056a19001dd656b8bde07edc918ec18f266de377c697eb0ea3a10fedb223e58db53ae5970d2b9753b46fa87db938e5568283ba136bd2b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/ga-IE/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/ga-IE/thunderbird-68.1.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "4b9cfa317f8ae5accb2c96731bd7fcbaf2eebaaee76bc7383d247cac9db6708b7c4c03d2faf3a6e7e6620b3eb696e9bb3fd18c3dfd1f3ce12e4bc65bb86955ed";
+      sha512 = "b346fe3863ab7944ac33a8204eea7a458a0131c879eae26be66928bed930aa29ba74a5b0e39aa939f0320fb8e5fb0a5e31599235daed526f920b92240763633f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/gd/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/gd/thunderbird-68.1.0.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "8738b93fd18972456158c28d4146ec8548e97339d7b4ff044ace814213d27940b02f9b889b5809525d5bba46a5b3ff4a570c14b3b9a5fe276b4aec515b62055b";
+      sha512 = "e921a3c2720aad333febe7e1d69579eeda4f641fe32c1b6235fb6c01480ab7c87bcb47020b0dc2e4225746b277d8c6b288aaec86125ad48da9fbe3452f30e01a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/gl/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/gl/thunderbird-68.1.0.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "c556343f99d39f6ff41f0b05af606ada89e6b95938886f8d0b1ccd7b77f336ae40a8debb003d2bfc865548c5e9e055859d6d353e169a4f2ee7ada7cb8687cc47";
+      sha512 = "dd581aab660e96d7b0283bacab74d5635610301fbf40e95bc85edb5e177492f2a9c786a4fa722024fd57e2f2158fa339c161fba605ae428b5c03fa983b70d176";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/he/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/he/thunderbird-68.1.0.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "b6eed03bdebfc334c8852a15989c024883b99f600b9aa58f8344976b63f1f9590aa9b78a2a27b081a1e5256443801f01c1f638f1e4f8c0c2a78e695a5e2f590a";
+      sha512 = "2ab68acb57eadab585bedaef3f79369cd7a0c08030d24bc3361a0e08ff796f28f345cae15fbd78bd1fe2c275f8d4fb7058194ef44dcddd3e8f92b69f92482321";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/hr/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/hr/thunderbird-68.1.0.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "aa4527614db13978d03cf07444109dbc63b7788a2cff924b5566c98d9316031f1c0fb74839b5be78030959f85147c1c1e50edca5605b5cbe2ad3bbbb257c24ad";
+      sha512 = "975be725774e200f39b77cbb16ad364fb5d901ef46a85da9f297b61140e5be61cbf48de9f2ea0236d4580a27be97e87c195b92d9286133ac5aac2a35b1b7e5f7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/hsb/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/hsb/thunderbird-68.1.0.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "92b1e17c825a60da17bc9942b689337246f301843637fe420284fe89aad4ab2f30101201330d5319a7e6a2bd87567bf7aa7b35bfbc13b1399ed54973afacf4ec";
+      sha512 = "5d501e9b7a39a518da0a82c1a89f398adaa449753b4dadc6ff8fa610bfc152016e6f70c1a944cc85e72fcaea5aba21a04d5abea2f2e045ca1c9212a37d31c461";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/hu/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/hu/thunderbird-68.1.0.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "5e0c03de66a9098e290fb93545cb46be41d7e91c865cb3fcff9dee7d141fa113cf7bfc14cbbf1e8f9e3979e6602116081958c22a83ea043015cc5adfb738e5ea";
+      sha512 = "4cf2c82e4d965c3ff51e40823f876811834cf7602d9cca30011346c2bdb6e222b7d37f28db79b6507350cd833db312aaf30c13ae245c93a6b1118d9abb132571";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/hy-AM/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/hy-AM/thunderbird-68.1.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "3df1da5c3d18ee3705e5d5013a752920863fdcee8a1c021bfde28603862a7c56e60a65b46b98af5d66fc5066c1580ab5484d86dd278d64d5d800b3840361b812";
+      sha512 = "d13d91b889903bdbbae1e12b96f07bfc6f5a6cb734a45fb87402ac44df9fcca703e067b1d1554a41c9b7e2e31703021eeeedd3ecd8b27536b548a3b2d89a1f27";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/id/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/id/thunderbird-68.1.0.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "786a5839f311df656fd4a0687819a47589f5a6ebac6f76e1f643136286d43b2f27744dfcc116341a8905b5e1da4ec0ad1f1eb4998e188d2e87ea487c6826fb32";
+      sha512 = "7c199788cead727742dfebbcdf6ddfe4491be31a3f4dcc7ae05d25413101036cad7fae399f6b390002f55f60214ea66399d5bfdc515557351b309d174b83fa55";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/is/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/is/thunderbird-68.1.0.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "53e4f76d41e1f8af240ecec249bd3ef3c787c6ff69320694bc682a876a76be22ed59abf0bc83691c7ea96d1e16f5a4c859e2b62528c99261f562012dbd035a9f";
+      sha512 = "33ac7dae65efc4792f92fed4eb0062302ef601f6bceef4d1eaa6b4a7fd75427607e8ebd7f6df70073bcbcc89f057b0689e365cea960428b5e57f9f1e810d6e48";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/it/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/it/thunderbird-68.1.0.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "8ecb5594e5252be84f97a55b37f5089220a3e5c1565686fe02f00d94a1418a9460e4c1f25724243c82b3c9442eb8cfbff3c3c9470971921469f2fd71aec66860";
+      sha512 = "231acc8648e2e377a8ca6d22c273957506fd1c21f226ddd681fd3a91940cb151df4f0eb05885ec0325629bb0cfdd3ed500af6047970b43b898a37586e4612502";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/ja/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/ja/thunderbird-68.1.0.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "7f9ed4fbdc0549c6ab704f80676218980a4b2609086437f57e22e9750e5a34d7506c1ee43ec48031a28322cdf4dcde6bd14c05fd032244acf33310fb6aa8e9a2";
+      sha512 = "90b8ca0d72fef8fbeae34027c95e3391452d72b53b40ecd59b1d2d2b07c6ef2e4d787bb2e927bf3d4b7837ea4cf2f10a0d3ccb0a6c98992e6fd857717c8ab04a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/ka/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/ka/thunderbird-68.1.0.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "bab15aa28fc92850d374f76ae9898c9408176db9b9e19cbdb49f7b586172c20eed0cb358f3cd4b5fcc2a4740188c0f041cf617a63743a42648c7e33dd0fb79e8";
+      sha512 = "271415dafa136d326b89ea3a58b852e2526c86f45d63f383fa250ace14f71b1b915dac3810a04507d9ca4437c640065520f9f3d9d032cb7eb84aad1f7b3517ba";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/kab/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/kab/thunderbird-68.1.0.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "26b1055333e508666dd24706da824c5cf9d5f87d1d1cb1c4d42894b836412205a7cc7ff73f764d8f2a1852138923bb02a6b2a2c3c92d1fe9307529533b6360e9";
+      sha512 = "c0b4fe65e9937bf897e7512ff6f267993c324c772232317e1314ce035a282f313b8385eee8c13e7b131eb0fabaa1b62345fbcd6289a5172d78aa3abf7f716bb2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/kk/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/kk/thunderbird-68.1.0.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "d946c82a8c35d82147812ef16e4573ae559dbfe65f4a6e5fc7dd107fb57fc6ba2a47f8a3655344e9e6172628692ad7815045830ee27bb10aab0d71483936d6ac";
+      sha512 = "b8c7ddd098540ef8354eda1f2a3a06987d11cb7e0c4af4e170d507ec540e743a7d2527188c18e045df99576ed44990a800e7f7ce212042eb03b02339be9f86af";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/ko/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/ko/thunderbird-68.1.0.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "3b9d9e70c097a1b7958c6854bc2da121f44921962d873e7f90fee85ce2214725223482aebcd503205e32501648c774199eced7ff34effb428dbc738f1ba4b963";
+      sha512 = "a33dbf6ef3aef69644261ea1c1cf3986fcda5c9d0b28996c46e3d8e53d3d7f8e9e6b62f1b03f2816267b483a84295ad99e888cf76c5c192e9a9dbadd78ce7d8b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/lt/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/lt/thunderbird-68.1.0.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "0cf99a6aec58d2f56f6a52fc5fee17b9e1d5abd0ece53073cc392c71452e1415c94ad0af003dd0a97fc5c6744a1a2243aef69dc44b831be51108b769e5bff87d";
+      sha512 = "3bf1cd599707a2728fbf46beadb7d8d1832c0c271e98647ac7d2de1be78b8c1b5d0af4ac246af01eaf4b2a57154f6068065fbbb2019346b663cafeb40edd5b71";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/ms/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/ms/thunderbird-68.1.0.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "8b4697a312aafdd88a5ecdf898a796bddb91e80b4c8c9c342fce765ee0f4dd494114324a51d6379468756a44bc71cb6f46b8fabc7ca733d9d85d08069f18526d";
+      sha512 = "563c413b21e2fda6f412a1826b1191097d4df1ade8d12e031522e122bedea6ae23a2d3b047e870030c9b4901a5869c9439107d8a7ebc6380c758bd741e0b4128";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/nb-NO/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/nb-NO/thunderbird-68.1.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "ad6275f8343dd36ed039524875b41ab9c8bafd2a1e54291b98c16b0ab35f9bea1bfee3fce86070317fad2f25d46d0aa9ef0824e4ad88e0879a33ae753c61ab2d";
+      sha512 = "c9062949faf5cbfe8bde2b0f330f76b438e1606360364a90f0e35026fd52952d6aff7c6925fd1ce569b24f41409d0b63540dbeb0ae82260604d5faaee723bc2e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/nl/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/nl/thunderbird-68.1.0.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "49f586a62969e6ea5638eb95f812e7d4a891ef55f381633792ed0820ad098cc527dc9490c3a1ce52246526f0a8cf00eb16666c6a7f932a68c6d440e151b452cd";
+      sha512 = "b8b385db8fd2385a88d12c1ba23bf812592beca14e44d9c33456ebad16a40db8e7d886779565a4d617fc56f7a6d651dc8da171b1c727481895d05777bc0eb3c1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/nn-NO/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/nn-NO/thunderbird-68.1.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "1f04f2bf7a60472eff1b546608cfb26e41f31a273d1037e0d73530029a757dfcd95e2c1b85a6990b6f7eec28138835fe096266a00dd094b4db74007cd59ef00d";
+      sha512 = "3c88ea8dffc71524402416d9222c859dafc5bd5799651a948bb318a7d2f91ca2c00fa4158e6019949f9a1d72a2d85a0c9d2a3c9a8caf052e8743fcb5dd0dccb6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/pl/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/pl/thunderbird-68.1.0.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "f232e4b6cfcea81ed70e56e9812b8e0783205f49b846d29338ad09457db9a18e4fbb35738bf5e9abce42855c13c1839605aa343cb7d33d0110b68d634183e697";
+      sha512 = "c6ba1f98ebc44af63d8cd8052fd306d3a8920c33eb5b3be563c0fe203d5d07806bc5db7ff88847c3ee2d82c62d0811a086fa91e8253eec3a3977091569f40a20";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/pt-BR/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/pt-BR/thunderbird-68.1.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "2527ec08fc23d01712574e3c8419273ac82111c5f2b4b6040cd8f3292aeadb36021029b01bc319d8ca52177db39f1a446acd5537a6e8f42800eb22c3e2d7cb30";
+      sha512 = "cbd4c0f1b14cb04b98ef6f2e4ce53d655b58ae9a11047eeb1959ac1c4ef4370507194dd1149372fd1dad4ceedf91c39f3bde4fdf07b5d925f27dc8eb5041be67";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/pt-PT/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/pt-PT/thunderbird-68.1.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "c91d9d0becade1508a3212693f5fcdeb917fe5df5d63b54de125b76786dc3787a7f5f220eb48add1dd1eee95f7eb120b1c1dc85dc0bd91688c883be9219f3d7d";
+      sha512 = "ec08c628708a7bbcb00df2122e5fc463e1b0e1c031e9130369ddfee12db3cfe9219f7939756fc47abab8514c6cea642bb653ee420818ad625a33caada7005993";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/rm/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/rm/thunderbird-68.1.0.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "45a4f608eb5e64f24ee385328a3a568aa2ad3284169019423c8b414790779cd079c2d73b290716f18227210ab5eff50625bd6688498bc027228b8fff51fda5b6";
+      sha512 = "4520dfb1529220e40cf2e1aca44cbc2af750fcceee3639d7ef334e9488034b18bc6e73b5b7a37204346da53a44da099f4f7f65d5b3dbdeac6d6934918c02cca3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/ro/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/ro/thunderbird-68.1.0.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "e344d838e2f79dd8ff79cf2e7ff2a1d8f6c7e64f29cf870d8a6fad9b3dee31de6c0a80d3007dd498dffb816c00dc8429150bc6b49a5b6eb10b633a4e942ca725";
+      sha512 = "49e54dd1cca8038ab6c34e9980b6b36117aa157b6555ba440f0d7c8c4d909253989b9a50d25c7c18529136fa26d0ff94474d17e43156afba171948c9c05e16a6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/ru/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/ru/thunderbird-68.1.0.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "8dbfd4f8969703623388a55e790b722933f2c1faf702ff5c7fdfe3cdab8f62fc4ea69f9303edf94a41a71be1b8c5a2ddfa5509d4c8abe260c91b7075349afe64";
+      sha512 = "6d297592bcf0c9b97c40f1053a95385e6c2510aa0ddfafd25085bc6a954fb5460f59f18f65477d8c93af829cd2a053b389b5dcec35a7ac7766d72c29064e5687";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/si/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/si/thunderbird-68.1.0.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "f1808e9648caa00afab0609dac1cb564dbf6e5bef75446071997cc9913da8470e54cb254282fc6e8b839e88b003ef18426609a97cd1affb93659fcb519913a5c";
+      sha512 = "f602557748517324943b5ff276f4efdeca1c5083662bc9f0b0bdba8c10510cee834b3883870a98d51d406f58e338a09d0589b3bc0891bfbd88b895cca02fd360";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/sk/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/sk/thunderbird-68.1.0.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "7d5b480a44dae0d2f5348261ecad04348ebb7943a757fe83c0fb154da251b423ba21840c5d1fbf8d7979dd30c2d5e7b18e90d0ad033a1e96d6f6587407a24cc9";
+      sha512 = "7b6980d2b5131bd9a43a29efa2f1e97c60e15410a63224d839548d777fd8b4c4d65ccfc7756227cf900f7420b12231c3d48f062133cb6f21bbdcdcdb179f2e47";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/sl/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/sl/thunderbird-68.1.0.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "f76e1f01b8da8a2ba344dd3bedfa4301df03fabf9848fa189d522995cd48d81f8d00f11e01722868acb1993d4e79977122e04e3d208629b2e398c715777194e1";
+      sha512 = "ecc38fb4fde66b7b213b1cfeb8ab170b3e685d0a28c7e071e19a85509ec74e79fb6eb61104c47f0eef1a77e1e1a52b292469a364747eeccc701c522452c58351";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/sq/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/sq/thunderbird-68.1.0.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "cff32ee84324724dea5612e5b48b22adc63d8b9428c5937f84c94da83bcf5f2aadda6ab81c5f9bced6d693689bc38bf15c764d4ab4809cacec3bb54cd82745f7";
+      sha512 = "3ff668c6ed28bdb2f3d388ab8ecb1bf3b2b38bb29046b8559f7b9f9c6fa32db226c4620f472ba5a982b473e3e3f4aee04aa3746e57738b512dcb37fdfd5ecfc5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/sr/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/sr/thunderbird-68.1.0.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "96d25f7d952e204751cd601932713418cd495d11364430a37ecfa36333113a6132209b8e8f0ec337799ed02b71b388f43e22a53fa168f17e4d15e7594170299a";
+      sha512 = "4c71511375333802f903cb632963933054a969c02a3fb23f4416e0cb3c21e18147bbffb28572f8ac90aa5bc3c4138b25590c42610c20a14b5e8eddb1edf28c28";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/sv-SE/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/sv-SE/thunderbird-68.1.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "8bc790d7951469e2dfa2499622464cf55427a6bc93dec50b18f014ac079ec0579b91a11680e4104f7d6a38f60d467e9fb3c9ee7ab83b64f8dae2c1e979150bd3";
+      sha512 = "5d7d569f4eb9ed738f54139a90e9a01e9e771a553af193357d45765bd54815a096ddc31ac69620d6f14516e8f41f1c0fb8f16a848e13273d0c18b9c047d85fb4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/tr/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/tr/thunderbird-68.1.0.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "2c40fa3e6ecfb68507897e669bed229ed98e1b4a3998b55b59523d3cec1fc5553cfacbd9be3d55f7a32b612ee662dfda7c8a21a4c26c750d48b87d31368a9942";
+      sha512 = "fc8892f85032d9fcce76c3fa971531f4039b8bb9e1812776bb3e7c5b68474543b5db4007f79e81abc1685c74f0574201236aab8a2df05ac10fcaade7c57ca3c2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/uk/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/uk/thunderbird-68.1.0.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "5eee26a500c1d4bf71222987523cc3e5f144aca02c17c88a01d4b68f9ac5e1298407460c69504d0a7b1e5727755cb32e2ae523cd97766419848c1b6dc0a30bf0";
+      sha512 = "80335f326bde31f4b1e269cd756b4b41ff3a632023f09447abf6d1964381f8f9657a4f47ed6af63a3eb0cd4e84e5bced595eec07cc0a9e30ad8d3cf3d08026df";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/uz/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/uz/thunderbird-68.1.0.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "51a0fc8dc30cc82f7d3b222167aaa8ea0225b4136ebacee38687cdc1235c0720da14cd2a3e1875a4c4bfa3bb8fd9045541ca6df736115312ac49a2db2ef83639";
+      sha512 = "2434a8a063b0d1019220579bc83160217d5c269b24ad83a9ed0969425a1fc9d9ed8b190c291d87c34379928aa6c2329d3b5ad287b44177dd61f680081cd7caf9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/vi/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/vi/thunderbird-68.1.0.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "bb02dd69a8c8d514666fedb9d7de520f6ea89740956ddcd9d7f90175bca6f7bcf79b573c6e5ecd6fdfcdd15aa2a35881e8877074fbb795019eccff52cb943a91";
+      sha512 = "0e33f1a2f8cd67bdb523180af0b8afa5fbbb3628b0b9407f2a4ae609c7155b33fd85a1f23d9b74097fefb045fd0b437f58971cc4c4d5f391398d6ea7429b921e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/zh-CN/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/zh-CN/thunderbird-68.1.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "408599229da40b2ce1a23ec1e5b12c7f4a24fb63524d792d50764cdfbcc6774dd7f651ba2dce46bccd94937e24b4b08d8bf37b6fb839c61540dfbf36f6d3e6b2";
+      sha512 = "27d1d9b3c30ab1dd863362139f91b79ffb7e36e87ff1f7f07162ea3e86a58962136e43cca3212e4263908f63dfe3a3c53bb3db3085e5b4bf07e0ff88408822d8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.0/linux-i686/zh-TW/thunderbird-68.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/zh-TW/thunderbird-68.1.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "d75c9bfc6234fa0ddc56b7c1dace76b789e29c0cb03ff17395eeba020a82431e457271e95117731963f2666295b94746d0370bf0e85f9c3646836830684bca45";
+      sha512 = "2141f0ad5d11daf3a94f3a737801ec0234a7f2d869320d4859d771ab92a6e59bf13139b4048a7239640635051a9228e6cbf55746402ed35cb398d93a3d129439";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -25,11 +25,11 @@ let
   gcc = if stdenv.cc.isGNU then stdenv.cc.cc else stdenv.cc.cc.gcc;
 in stdenv.mkDerivation rec {
   pname = "thunderbird";
-  version = "68.0";
+  version = "68.1.0";
 
   src = fetchurl {
     url = "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
-    sha512 = "2cz583rwfpj4z5cwg2vfy4ha0pz4xs9g7li078rmk6x19haiv8s9fwijd82xgxax0afn8wk80bq5kd8yz38l9432f6bar8xnwb21y4i";
+    sha512 = "06036nawpm987q33567nhz55qybbcl55h5rdhjbhck5qmyj1qi383xqac5niwyk7c0gaq4ygwc5a24pysf85crjdway2zmqyjxp2apb";
   };
 
   # from firefox, but without sound libraries


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

- High security fixes
- Offer to configure Exchange accounts for Office365.
- Other fixes

https://www.thunderbird.net/en-US/thunderbird/68.1.0/releasenotes/
https://www.mozilla.org/en-US/security/advisories/mfsa2019-30/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @nbp, @edolstra, @fuuzetsu
