### PR TITLE
twister: 0.9.34 -> 2019-08-19

### DIFF
--- a/pkgs/applications/networking/p2p/twister/default.nix
+++ b/pkgs/applications/networking/p2p/twister/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, autoconf, automake, libtool, pkgconfig, python2
+{ stdenv, fetchFromGitHub, fetchpatch, autoconf, automake, libtool, pkgconfig, python2
 , boost, db, openssl, geoip, libiconv, miniupnpc
 , srcOnly, fetchgit
 }:
@@ -17,12 +17,13 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "twister";
-  version = "0.9.34";
+  version = "2019-08-19";
 
-  src = fetchurl {
-    url = "https://github.com/miguelfreitas/twister-core/"
-        + "archive/v${version}.tar.gz";
-    sha256 = "1bi8libivd9y2bn9fc7vbc5q0jnal0pykpzgri6anqaww22y58jq";
+  src = fetchFromGitHub {
+    owner = "miguelfreitas";
+    repo = "twister-core";
+    rev = "31faf3f63e461ea0a9b23081567a4a552cf06873";
+    sha256 = "0xh1lgnl9nd86jr0mp7m8bkd7r5j4d6chd0y73h2xv4aq5sld0sp";
   };
 
   configureFlags = [
@@ -39,12 +40,6 @@ in stdenv.mkDerivation rec {
     autoconf automake libtool python2
     boostPython db openssl geoip miniupnpc libiconv
   ];
-
-  patches = stdenv.lib.singleton (fetchpatch {
-    url = "https://github.com/miguelfreitas/twister-core/commit/"
-        + "dd4f5a176958ea6ed855dc3fcef79680c1c0c92c.patch";
-    sha256 = "06fgmqnjyl83civ3ixiq673k8zjgm8n2w4w46nsh810nprqim8s6";
-  });
 
   postPatch = ''
     sed -i -e '/-htmldir/s|(default: [^)]*)|(default: ${twisterHTML})|' \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20872,9 +20872,7 @@ in
 
   tuxguitar = callPackage ../applications/editors/music/tuxguitar { };
 
-  twister = callPackage ../applications/networking/p2p/twister {
-    boost = boost160;
-  };
+  twister = callPackage ../applications/networking/p2p/twister { };
 
   twmn = libsForQt5.callPackage ../applications/misc/twmn { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Wouldn't build with OpenSSL 1.1.x anymore. The new revision makes it work

Development is still going on, but the last release was in 2015: https://github.com/miguelfreitas/twister-core/issues/433

The daemon runs but I don't know how to test more.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc #68361