### PR TITLE
pythonPackages.{dlib,face_recognition_models}: fix build/startup

### DIFF
--- a/pkgs/development/python-modules/dlib/default.nix
+++ b/pkgs/development/python-modules/dlib/default.nix
@@ -21,4 +21,7 @@ buildPythonPackage {
   '';
 
   checkInputs = [ pytest more-itertools ];
+
+  enableParallelBuilding = true;
+  dontUseCmakeConfigure = true;
 }

--- a/pkgs/development/python-modules/face_recognition_models/default.nix
+++ b/pkgs/development/python-modules/face_recognition_models/default.nix
@@ -1,4 +1,4 @@
-{ buildPythonPackage, stdenv, fetchPypi }:
+{ buildPythonPackage, stdenv, fetchPypi, setuptools }:
 
 buildPythonPackage rec {
   pname = "face_recognition_models";
@@ -11,6 +11,8 @@ buildPythonPackage rec {
 
   # no module named `tests` as no tests are available
   doCheck = false;
+
+  propagatedBuildInputs = [ setuptools ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/ageitgey/face_recognition_models;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fixes `dlib` and `face_recognition_models`:

* 72ec538: fix dlib by skipping cmake configuration.
* e176117: fix runtime of face_recognition_models by propagating setuptools.

ZHF #68361

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
