### PR TITLE
ape: 6.7-131003 -> 2019-08-10

### DIFF
--- a/pkgs/applications/misc/ape/default.nix
+++ b/pkgs/applications/misc/ape/default.nix
@@ -1,33 +1,33 @@
 { stdenv, swiProlog, makeWrapper,
   fetchFromGitHub,
-  lexicon ? "lexicon/clex_lexicon.pl",
+  lexicon ? "prolog/lexicon/clex_lexicon.pl",
   pname ? "ape",
   description ? "Parser for Attempto Controlled English (ACE)",
   license ? with stdenv.lib; licenses.lgpl3
   }:
 
 stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
-  version = "6.7-131003";
+  inherit pname;
+  version = "2019-08-10";
 
   buildInputs = [ swiProlog makeWrapper ];
 
   src = fetchFromGitHub {
      owner = "Attempto";
      repo = "APE";
-     rev = version;
-     sha256 = "0cw47qjg4896kw3vps6rfs02asvscsqvcfdiwgfmqb3hvykb1sdx";
+     rev = "113b81621262d7a395779465cb09397183e6f74c";
+     sha256 = "0xyvna2fbr18hi5yvm0zwh77q02dfna1g4g53z9mn2rmlfn2mhjh";
   };
 
   patchPhase = ''
     # We move the file first to avoid "same file" error in the default case
     cp ${lexicon} new_lexicon.pl
-    rm lexicon/clex_lexicon.pl
-    cp new_lexicon.pl lexicon/clex_lexicon.pl
+    rm prolog/lexicon/clex_lexicon.pl
+    cp new_lexicon.pl prolog/lexicon/clex_lexicon.pl
   '';
 
   buildPhase = ''
-    make build
+    make SHELL=${stdenv.shell} build
   '';
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change
Wouldn't build anymore.

###### Things done

Tested with:

```
> ./result/bin/ape -text "John waits." -cdrsxml -csyntax                                     
<?xml version="1.0" encoding="UTF-8"?>                                                       
                                                                                             
<apeResult>                                                                                  
  <duration tokenizer="0.000" parser="0.001" refres="0.000"/>                                
  <syntax>[[specification,[s,[np,[pname,'John']],[vp,[vbar,[vbar,[v,waits]]]]],'.']]</syntax>
  <drsxml>&lt;?xml version="1.0" encoding="UTF-8"?&gt;                                       
                                                                                             
&lt;DRS domain="A"&gt;                                                                       
  &lt;predicate                                                                              
      ref="A"                                                                                
      verb="wait"                                                                            
      subj="named('John')"                                                                   
      sentid="1"                                                                             
      tokid="2"/&gt;                                                                         
&lt;/DRS&gt;</drsxml>                                                                        
  <messages/>                                                                                
</apeResult>                                                                                 
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @yrashk #68361