### PR TITLE
pythonPackages.hug: enable tests

### DIFF
--- a/pkgs/development/python-modules/hug/default.nix
+++ b/pkgs/development/python-modules/hug/default.nix
@@ -1,7 +1,11 @@
-{ lib , buildPythonPackage, fetchPypi, isPy27
+{ lib , buildPythonPackage, fetchFromGitHub, isPy27
 , falcon
 , pytestrunner
 , requests
+, pytest
+, marshmallow
+, mock
+, numpy
 }:
 
 buildPythonPackage rec {
@@ -9,16 +13,22 @@ buildPythonPackage rec {
   version = "2.6.0";
   disabled = isPy27;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "0iamrzjy8z1xibynkgfl6cn2sbm66awxbp75b26pi32fc41d0k50";
+  src = fetchFromGitHub {
+    owner = "hugapi";
+    repo = pname;
+    rev = version;
+    sha256 = "05rsv16g7ph100p8kl4l2jba0y4wcpp3xblc02mfp67zp1279vaq";
   };
 
   nativeBuildInputs = [ pytestrunner ];
   propagatedBuildInputs = [ falcon requests ];
 
-  # tests are not shipped in the tarball
-  doCheck = false;
+  checkInputs = [ mock marshmallow pytest numpy ];
+  checkPhase = ''
+    mv hug hug.hidden
+    # some tests attempt network access
+    PATH=$out/bin:$PATH pytest -k "not (test_request or test_datagram_request)"
+  '';
 
   meta = with lib; {
     description = "A Python framework that makes developing APIs as simple as possible, but no simpler";


### PR DESCRIPTION
WFM non-nixos linux x86_64 & macos 10.13

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
