### PR TITLE
decred: 1.1.2 -> 1.5.0

### DIFF
--- a/pkgs/applications/blockchains/dcrd.nix
+++ b/pkgs/applications/blockchains/dcrd.nix
@@ -1,34 +1,24 @@
-{ stdenv, lib, go, buildGoPackage, dep, fetchgit, git, cacert }:
+{ lib, buildGoModule, fetchFromGitHub }:
 
-buildGoPackage rec {
+buildGoModule rec {
   pname = "dcrd";
-  version = "1.1.2";
-  rev = "refs/tags/v${version}";
-  goPackagePath = "github.com/decred/dcrd";
+  version = "1.5.1";
 
-  buildInputs = [ go git dep cacert ];
-
-  GIT_SSL_CAINFO = "${cacert}/etc/ssl/certs/ca-bundle.crt";
-  NIX_SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
-
-  src = fetchgit {
-    inherit rev;
-    url = "https://${goPackagePath}";
-    sha256 = "0xcynipdn9zmmralxj0hjrwyanvhkwfj2b1vvjk5zfc95s2xc1q9";
+  src = fetchFromGitHub {
+    owner = "decred";
+    repo = "dcrd";
+    rev = "refs/tags/release-v${version}";
+    sha256 = "1ggw289y1f4dqvj3w60q9bahq8bblbfjymn5xy04ldylr3qlxm9x";
   };
 
-  preBuild = ''
-    export CWD=$(pwd)
-    cd go/src/github.com/decred/dcrd
-    dep ensure
-    go install . ./cmd/...
-    cd $CWD
-  '';
+  vendorSha256 = "03aw6mcvp1vr01ppxy673jf5hdryd5032cxndlkaiwg005mxp1dy";
+
+  subPackages = [ "." "cmd/dcrctl" "cmd/promptsecret" ];
 
   meta = {
     homepage = "https://decred.org";
     description = "Decred daemon in Go (golang)";
     license = with lib.licenses; [ isc ];
-    broken = stdenv.isLinux; # 2018-04-10
+    maintainers = with lib.maintainers; [ juaningan ];
   };
 }

--- a/pkgs/applications/blockchains/dcrwallet.nix
+++ b/pkgs/applications/blockchains/dcrwallet.nix
@@ -1,43 +1,24 @@
-{ stdenv, lib, go, buildGoPackage, dep, fetchgit, git, cacert }:
+{ lib, buildGoModule, fetchFromGitHub }:
 
-buildGoPackage rec {
+buildGoModule rec {
   pname = "dcrwallet";
-  version = "1.1.2";
-  rev = "refs/tags/v${version}";
-  goPackagePath = "github.com/decred/dcrwallet";
+  version = "1.5.1";
 
-  buildInputs = [ go git dep cacert ];
-
-  GIT_SSL_CAINFO = "${cacert}/etc/ssl/certs/ca-bundle.crt";
-  NIX_SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
-
-  src = fetchgit {
-    inherit rev;
-    url = "https://${goPackagePath}";
-    sha256 = "058im4vmcmxcl5ir14h17wik5lagp2ay0p8qc3r99qmpfwvvz39x";
+  src = fetchFromGitHub {
+    owner = "decred";
+    repo = "dcrwallet";
+    rev = "refs/tags/v${version}";
+    sha256 = "0ij2mwvdxg78p9qbdf9wm7aaphfg4j8lqgrjyjsj3kyi1l458ds9";
   };
 
-  preBuild = ''
-    export CWD=$(pwd)
-    cd go/src/github.com/decred/dcrwallet
-    dep ensure
-  '';
+  vendorSha256 = "0qrrr92cad399xwr64qa9h41wqqaj0dy5mw248g5v53zars541w7";
 
-  buildPhase = ''
-    runHook preBuild
-    go build
-  '';
-
-  installPhase = ''
-    mkdir -pv $out/bin
-    cp -v dcrwallet $out/bin
-  '';
-
+  subPackages = [ "." ];
 
   meta = {
     homepage = "https://decred.org";
-    description = "Decred daemon in Go (golang)";
+    description = "A secure Decred wallet daemon written in Go (golang)";
     license = with lib.licenses; [ isc ];
-    broken = stdenv.isLinux; # 2018-04-10
+    maintainers = with lib.maintainers; [ juaningan ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Old version was outdated and broken.
Also migrated to new buildGoModule.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @juaningan 
