### PR TITLE
mumble,murmur: 1.2.19 -> 1.3.0

### DIFF
--- a/pkgs/applications/networking/mumble/default.nix
+++ b/pkgs/applications/networking/mumble/default.nix
@@ -1,32 +1,28 @@
-{ stdenv, fetchurl, fetchFromGitHub, fetchpatch, pkgconfig
-, qt4, qmake4Hook, qt5, avahi, boost, libopus, libsndfile, protobuf3_6, speex, libcap
+{ stdenv, fetchurl, fetchFromGitHub, fetchpatch, pkgconfig, mkDerivation
+, qtbase, qttools, qtsvg, qmake, avahi, boost, libopus, libsndfile, protobuf, speex, libcap
 , alsaLib, python
 , jackSupport ? false, libjack2 ? null
 , speechdSupport ? false, speechd ? null
 , pulseSupport ? false, libpulseaudio ? null
-, iceSupport ? false, zeroc-ice ? null, zeroc-ice-36 ? null
+, iceSupport ? false, zeroc-ice ? null
 }:
 
 assert jackSupport -> libjack2 != null;
 assert speechdSupport -> speechd != null;
 assert pulseSupport -> libpulseaudio != null;
-assert iceSupport -> zeroc-ice != null && zeroc-ice-36 != null;
+assert iceSupport -> zeroc-ice != null;
 
 with stdenv.lib;
 let
-  generic = overrides: source: (if source.qtVersion == 5 then qt5.mkDerivation else stdenv.mkDerivation) (source // overrides // {
+  generic = overrides: source: mkDerivation (source // overrides // {
     name = "${overrides.type}-${source.version}";
 
     patches = (source.patches or []) ++ optional jackSupport ./mumble-jack-support.patch;
 
-    nativeBuildInputs = [ pkgconfig python ]
-      ++ { qt4 = [ qmake4Hook ]; qt5 = [ qt5.qmake ]; }."qt${toString source.qtVersion}"
+    nativeBuildInputs = [ pkgconfig python qmake ]
       ++ (overrides.nativeBuildInputs or [ ]);
 
-    # protobuf is freezed to 3.6 because of this bug: https://github.com/mumble-voip/mumble/issues/3617
-    # this could be reverted to the latest version in a future release of mumble as it is already fixed in master
-    buildInputs = [ boost protobuf3_6 avahi ]
-      ++ optional (source.qtVersion == 4) qt4
+    buildInputs = [ boost protobuf avahi ]
       ++ (overrides.buildInputs or [ ]);
 
     qmakeFlags = [
@@ -76,9 +72,8 @@ let
   client = source: generic {
     type = "mumble";
 
-    nativeBuildInputs = optional (source.qtVersion == 5) qt5.qttools;
-    buildInputs = [ libopus libsndfile speex ]
-      ++ optional (source.qtVersion == 5) qt5.qtsvg
+    nativeBuildInputs = [ qttools ];
+    buildInputs = [ libopus libsndfile speex qtsvg ]
       ++ optional stdenv.isLinux alsaLib
       ++ optional jackSupport libjack2
       ++ optional speechdSupport speechd
@@ -107,18 +102,18 @@ let
     '';
   } source;
 
-  server = source: let ice = if source.qtVersion == 4 then zeroc-ice-36 else zeroc-ice; in generic {
+  server = source: generic {
     type = "murmur";
 
     postPatch = optional iceSupport ''
-      grep -Rl '/usr/share/Ice' . | xargs sed -i 's,/usr/share/Ice/,${ice.dev}/share/ice/,g'
+      grep -Rl '/usr/share/Ice' . | xargs sed -i 's,/usr/share/Ice/,${zeroc-ice.dev}/share/ice/,g'
     '';
 
     configureFlags = [
       "CONFIG+=no-client"
     ] ++ optional (!iceSupport) "CONFIG+=no-ice";
 
-    buildInputs = [ libcap ] ++ optional iceSupport ice;
+    buildInputs = [ libcap ] ++ optional iceSupport zeroc-ice;
 
     installPhase = ''
       # bin stuff
@@ -126,48 +121,19 @@ let
     '';
   } source;
 
-  stableSource = rec {
-    version = "1.2.19";
-    qtVersion = 4;
-
-    src = fetchurl {
-      url = "https://github.com/mumble-voip/mumble/releases/download/${version}/mumble-${version}.tar.gz";
-      sha256 = "1s60vaici3v034jzzi20x23hsj6mkjlc0glipjq4hffrg9qgnizh";
-    };
-
-    patches = [
-      # Fix compile error against boost 1.66 (#33655):
-      (fetchpatch {
-        url = "https://github.com/mumble-voip/mumble/commit/"
-            + "ea861fe86743c8402bbad77d8d1dd9de8dce447e.patch";
-        sha256 = "1r50dc8dcl6jmbj4abhnay9div7y56kpmajzqd7ql0pm853agwbh";
-      })
-      # Fixes hang on reconfiguring audio (often including startup)
-      # https://github.com/mumble-voip/mumble/pull/3418
-      (fetchpatch {
-        url = "https://github.com/mumble-voip/mumble/commit/"
-            + "fbbdf2e8ab7d93ed6f7680268ad0689b7eaa71ad.patch";
-        sha256 = "1yhj62mlwm6q42i4aclbia645ha97d3j4ycxhgafr46dbjs0gani";
-      })
-    ];
-  };
-
-  rcSource = rec {
-    version = "1.3.0-rc2";
-    qtVersion = 5;
+  source = rec {
+    version = "1.3.0";
 
     # Needs submodules
     src = fetchFromGitHub {
       owner = "mumble-voip";
       repo = "mumble";
       rev = version;
-      sha256 = "00irlzz5q4drmsfbwrkyy7p7w8a5fc1ip5vyicq3g3cy58dprpqr";
+      sha256 = "0g5ri84gg0x3crhpxlzawf9s9l4hdna6aqw6qbdpx1hjlf5k6g8k";
       fetchSubmodules = true;
     };
   };
 in {
-  mumble     = client stableSource;
-  mumble_rc  = client rcSource;
-  murmur     = server stableSource;
-  murmur_rc  = server rcSource;
+  mumble  = client source;
+  murmur  = server source;
 }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -443,8 +443,8 @@ mapAliases ({
   };
 
   # added 2019-08-01
-  mumble_git = pkgs.mumble_rc;
-  murmur_git = pkgs.murmur_rc;
+  mumble_git = pkgs.mumble;
+  murmur_git = pkgs.murmur;
 
   # added 2019-09-06
   zeroc_ice = pkgs.zeroc-ice;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19667,13 +19667,18 @@ in
 
   multimon-ng = callPackage ../applications/radio/multimon-ng { };
 
-  inherit (callPackages ../applications/networking/mumble {
+  murmur = (libsForQt5.callPackage ../applications/networking/mumble {
+      avahi = avahi-compat;
+      pulseSupport = config.pulseaudio or false;
+      iceSupport = config.murmur.iceSupport or true;
+    }).murmur;
+
+  mumble = (libsForQt5.callPackage ../applications/networking/mumble {
       avahi = avahi-compat;
       jackSupport = config.mumble.jackSupport or false;
       speechdSupport = config.mumble.speechdSupport or false;
       pulseSupport = config.pulseaudio or false;
-      iceSupport = config.murmur.iceSupport or true;
-    }) mumble mumble_rc murmur murmur_rc;
+    }).mumble;
 
   mumble_overlay = callPackage ../applications/networking/mumble/overlay.nix {
     mumble_i686 = if stdenv.hostPlatform.system == "x86_64-linux"


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

[Mumble v1.3.0](https://www.mumble.info/blog/mumble-1.3.0-release-announcement/) was officially released few weeks ago. This PR aims to update the package for both client (mumble) and server (murmur).
This also updates to the qt5's makeDerivation (see #67270).
I removed the now useless murmur_rc and mumble_rc packages, but I don't know how you feel about it?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
