### PR TITLE
chiaki: init at 1.0.3

### DIFF
--- a/pkgs/games/chiaki/default.nix
+++ b/pkgs/games/chiaki/default.nix
@@ -1,0 +1,31 @@
+{ lib, mkDerivation, fetchFromGitHub
+, cmake, ffmpeg, libopus, qtbase, qtmultimedia, qtsvg, pkgconfig, protobuf
+, python3Packages, SDL2 }:
+
+mkDerivation rec {
+  pname = "chiaki";
+  version = "1.0.3";
+
+  src = fetchFromGitHub {
+    rev = "v${version}";
+    owner = "thestr4ng3r";
+    repo = "chiaki";
+    fetchSubmodules = true;
+    sha256 = "09c6izprqqvhn1vbr2897ql05w5c7iqakm6jn795a5faghjm1mah";
+  };
+
+  nativeBuildInputs = [
+    cmake pkgconfig protobuf python3Packages.python python3Packages.protobuf
+  ];
+  buildInputs = [ ffmpeg libopus qtbase qtmultimedia qtsvg protobuf SDL2 ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    homepage = "https://github.com/thestr4ng3r/chiaki";
+    description = "Free and Open Source PS4 Remote Play Client";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ delroth ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21832,6 +21832,8 @@ in
 
   chessx = libsForQt59.callPackage ../games/chessx { };
 
+  chiaki = libsForQt5.callPackage ../games/chiaki { };
+
   chocolateDoom = callPackage ../games/chocolate-doom { };
 
   crispyDoom = callPackage ../games/crispy-doom { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Chiaki is a new open source client for the PS4 remote play protocol.

Note: I put it in `pkgs/games`, it's not a perfect fit but other gaming-centric apps like `steam` are there already, so there's precedent (thought emulators are in `misc`... so there's also negative precedent).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).