### PR TITLE
 Revert "pytest: Add pytest_4 as its own attribute" 

### DIFF
--- a/pkgs/applications/office/paperless/default.nix
+++ b/pkgs/applications/office/paperless/default.nix
@@ -112,7 +112,9 @@ let
       pyocr = pyocrWithUserTesseract super;
       # These are pre-release versions, hence they are private to this pkg
       django-filter = self.callPackage ./python-modules/django-filter.nix {};
-      django-crispy-forms = self.callPackage ./python-modules/django-crispy-forms.nix {};
+      django-crispy-forms = self.callPackage ./python-modules/django-crispy-forms.nix {
+        pytest = self.callPackage ../../../development/python-modules/pytest/4.nix {};
+      };
     };
   };
 

--- a/pkgs/applications/office/paperless/python-modules/django-crispy-forms.nix
+++ b/pkgs/applications/office/paperless/python-modules/django-crispy-forms.nix
@@ -1,5 +1,5 @@
 { lib, buildPythonPackage, fetchFromGitHub
-, pytest_4, pytest-django, django }:
+, pytest, pytest-django, django }:
 
 buildPythonPackage {
   pname = "django-crispy-forms";
@@ -19,7 +19,7 @@ buildPythonPackage {
     export sourceRoot=source-
   '';
 
-  checkInputs = [ pytest_4 pytest-django django ];
+  checkInputs = [ pytest pytest-django django ];
 
   checkPhase = ''
     PYTHONPATH="$(pwd):$PYTHONPATH" \

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1991,17 +1991,15 @@ in {
 
   pyhepmc = callPackage ../development/python-modules/pyhepmc { };
 
-  pytest = if isPy3k then self.pytest_5 else self.pytest_4;
-
-  pytest_5 = callPackage ../development/python-modules/pytest {
-    # hypothesis tests require pytest that causes dependency cycle
-    hypothesis = self.hypothesis.override { doCheck = false; };
-  };
-
-  pytest_4 = callPackage ../development/python-modules/pytest/4.nix {
-    # hypothesis tests require pytest that causes dependency cycle
-    hypothesis = self.hypothesis.override { doCheck = false; };
-  };
+  pytest = if isPy3k then
+    callPackage ../development/python-modules/pytest {
+      # hypothesis tests require pytest that causes dependency cycle
+      hypothesis = self.hypothesis.override { doCheck = false; };
+    }
+  else callPackage ../development/python-modules/pytest/4.nix {
+      # hypothesis tests require pytest that causes dependency cycle
+      hypothesis = self.hypothesis.override { doCheck = false; };
+    };
 
   pytest-helpers-namespace = callPackage ../development/python-modules/pytest-helpers-namespace { };
 


### PR DESCRIPTION
###### Motivation for this change
We cannot have pytest_4 as a toplevel attribute because having multiple
versions on the PYTHONPATH isn't possible. Therefore we have to call it
directly here.

As reminded by @jonringer: https://github.com/NixOS/nixpkgs/pull/68687#issuecomment-531493806

NixOS test for paperless still works.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Ma27 
