### PR TITLE
go: Update version to 1.13

### DIFF
--- a/pkgs/development/compilers/go/1.12.nix
+++ b/pkgs/development/compilers/go/1.12.nix
@@ -30,11 +30,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "go";
-  version = "1.12.9";
+  version = "1.13";
 
   src = fetchurl {
     url = "https://dl.google.com/go/go${version}.src.tar.gz";
-    sha256 = "1z32imbwmpkzgyh5c3vi7rbvzbq94xjk5qi2xm9sccj7kknmc3mb";
+    sha256 = "08pibdkfrn0909rzjzn3q1wj1whk1af058qxvbbyyhhx22vbih1z";
   };
 
   # perl is used for testing go vet
@@ -70,25 +70,25 @@ stdenv.mkDerivation rec {
     sed -i 's,/usr/bin,'"`pwd`", src/os/os_test.go
     sed -i 's,/bin/pwd,'"`type -P pwd`", src/os/os_test.go
     # Disable the unix socket test
-    sed -i '/TestShutdownUnix/areturn' src/net/net_test.go
+    sed -i '/TestShutdownUnix/at.Skip("Broken in nix")' src/net/net_test.go
     # Disable the hostname test
-    sed -i '/TestHostname/areturn' src/os/os_test.go
+    sed -i '/TestHostname/at.Skip("Broken in nix")' src/os/os_test.go
     # ParseInLocation fails the test
-    sed -i '/TestParseInSydney/areturn' src/time/format_test.go
+    sed -i '/TestParseInSydney/at.Skip("Broken in nix")' src/time/format_test.go
     # Remove the api check as it never worked
     sed -i '/src\/cmd\/api\/run.go/ireturn nil' src/cmd/dist/test.go
     # Remove the coverage test as we have removed this utility
-    sed -i '/TestCoverageWithCgo/areturn' src/cmd/go/go_test.go
+    sed -i '/TestCoverageWithCgo/at.Skip("Broken in nix")' src/cmd/go/go_test.go
     # Remove the timezone naming test
-    sed -i '/TestLoadFixed/areturn' src/time/time_test.go
+    sed -i '/TestLoadFixed/at.Skip("Broken in nix")' src/time/time_test.go
     # Remove disable setgid test
-    sed -i '/TestRespectSetgidDir/areturn' src/cmd/go/internal/work/build_test.go
+    sed -i '/TestRespectSetgidDir/at.Skip("Broken in nix")' src/cmd/go/internal/work/build_test.go
     # Remove cert tests that conflict with NixOS's cert resolution
-    sed -i '/TestEnvVars/areturn' src/crypto/x509/root_unix_test.go
+    sed -i '/TestEnvVars/at.Skip("Broken in nix")' src/crypto/x509/root_unix_test.go
     # TestWritevError hangs sometimes
-    sed -i '/TestWritevError/areturn' src/net/writev_test.go
+    sed -i '/TestWritevError/at.Skip("Broken in nix")' src/net/writev_test.go
     # TestVariousDeadlines fails sometimes
-    sed -i '/TestVariousDeadlines/areturn' src/net/timeout_test.go
+    sed -i '/TestVariousDeadlines/at.Skip("Broken in nix")' src/net/timeout_test.go
 
     sed -i 's,/etc/protocols,${iana-etc}/etc/protocols,' src/net/lookup_unix.go
     sed -i 's,/etc/services,${iana-etc}/etc/services,' src/net/port_unix.go
@@ -107,15 +107,15 @@ stdenv.mkDerivation rec {
     sed -i 's,"/etc","'"$TMPDIR"'",' src/os/os_test.go
     sed -i 's,/_go_os_test,'"$TMPDIR"'/_go_os_test,' src/os/path_test.go
 
-    sed -i '/TestChdirAndGetwd/areturn' src/os/os_test.go
-    sed -i '/TestCredentialNoSetGroups/areturn' src/os/exec/exec_posix_test.go
-    sed -i '/TestRead0/areturn' src/os/os_test.go
-    sed -i '/TestSystemRoots/areturn' src/crypto/x509/root_darwin_test.go
+    sed -i '/TestChdirAndGetwd/at.Skip("Broken in nix")' src/os/os_test.go
+    sed -i '/TestCredentialNoSetGroups/at.Skip("Broken in nix")' src/os/exec/exec_posix_test.go
+    sed -i '/TestRead0/at.Skip("Broken in nix")' src/os/os_test.go
+    sed -i '/TestSystemRoots/at.Skip("Broken in nix")' src/crypto/x509/root_darwin_test.go
 
-    sed -i '/TestGoInstallRebuildsStalePackagesInOtherGOPATH/areturn' src/cmd/go/go_test.go
-    sed -i '/TestBuildDashIInstallsDependencies/areturn' src/cmd/go/go_test.go
+    sed -i '/TestGoInstallRebuildsStalePackagesInOtherGOPATH/at.Skip("Broken in nix")' src/cmd/go/go_test.go
+    sed -i '/TestBuildDashIInstallsDependencies/at.Skip("Broken in nix")' src/cmd/go/go_test.go
 
-    sed -i '/TestDisasmExtld/areturn' src/cmd/objdump/objdump_test.go
+    sed -i '/TestDisasmExtld/at.Skip("Broken in nix")' src/cmd/objdump/objdump_test.go
 
     sed -i 's/unrecognized/unknown/' src/cmd/link/internal/ld/lib.go
 
@@ -199,7 +199,6 @@ stdenv.mkDerivation rec {
   '';
 
   preInstall = ''
-    rm -r pkg/{bootstrap,obj}
     # Contains the wrong perl shebang when cross compiling,
     # since it is not used for anything we can deleted as well.
     rm src/regexp/syntax/make_perl_groups.pl
@@ -229,7 +228,7 @@ stdenv.mkDerivation rec {
   disallowedReferences = [ goBootstrap ];
 
   meta = with stdenv.lib; {
-    branch = "1.12";
+    branch = "1.13";
     homepage = http://golang.org/;
     description = "The Go Programming language";
     license = licenses.bsd3;

--- a/pkgs/development/compilers/go/creds-test.patch
+++ b/pkgs/development/compilers/go/creds-test.patch
@@ -1,6 +1,8 @@
---- source.org/src/syscall/creds_test.go	1970-01-01 01:00:01.000000000 +0100
-+++ source/src/syscall/creds_test.go	2018-02-22 10:43:47.223615358 +0000
-@@ -76,8 +76,8 @@
+diff --git a/src/syscall/creds_test.go b/src/syscall/creds_test.go
+index 524689a..c7993ce 100644
+--- a/src/syscall/creds_test.go
++++ b/src/syscall/creds_test.go
+@@ -76,8 +76,8 @@ func TestSCMCredentials(t *testing.T) {
  			if sys, ok := err.(*os.SyscallError); ok {
  				err = sys.Err
  			}

--- a/pkgs/development/compilers/go/remove-test-pie.patch
+++ b/pkgs/development/compilers/go/remove-test-pie.patch
@@ -1,14 +1,13 @@
---- source.org/src/cmd/dist/test.go	2018-02-22 10:40:40.089632339 +0000
-+++ source/src/cmd/dist/test.go	2018-02-22 10:56:53.075193788 +0000
-@@ -526,21 +526,6 @@
+diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
+index f63c946..f02eff7 100644
+--- a/src/cmd/dist/test.go
++++ b/src/cmd/dist/test.go
+@@ -574,29 +574,6 @@ func (t *tester) registerTests() {
  		})
  	}
  
 -	// Test internal linking of PIE binaries where it is supported.
--	if goos == "linux" && goarch == "amd64" && !isAlpineLinux() {
--		// Issue 18243: We don't have a way to set the default
--		// dynamic linker used in internal linking mode. So
--		// this test is skipped on Alpine.
+-	if goos == "linux" && (goarch == "amd64" || goarch == "arm64") {
 -		t.tests = append(t.tests, distTest{
 -			name:    "pie_internal",
 -			heading: "internal linking of -buildmode=pie",
@@ -17,8 +16,19 @@
 -				return nil
 -			},
 -		})
+-		// Also test a cgo package.
+-		if t.cgoEnabled {
+-			t.tests = append(t.tests, distTest{
+-				name:    "pie_internal_cgo",
+-				heading: "internal linking of -buildmode=pie",
+-				fn: func(dt *distTest) error {
+-					t.addCmd(dt, "src", t.goTest(), "os/user", "-buildmode=pie", "-ldflags=-linkmode=internal", t.timeout(60))
+-					return nil
+-				},
+-			})
+-		}
 -	}
 -
  	// sync tests
- 	t.tests = append(t.tests, distTest{
- 		name:    "sync_cpu",
+ 	if goos != "js" { // js doesn't support -cpu=10
+ 		t.tests = append(t.tests, distTest{

--- a/pkgs/development/compilers/go/remove-tools-1.11.patch
+++ b/pkgs/development/compilers/go/remove-tools-1.11.patch
@@ -1,8 +1,8 @@
 diff --git a/src/go/build/build.go b/src/go/build/build.go
-index b68a712..b60bf19 100644
+index f854760..daab37f 100644
 --- a/src/go/build/build.go
 +++ b/src/go/build/build.go
-@@ -1708,7 +1708,7 @@ func init() {
+@@ -1757,7 +1757,7 @@ func init() {
  }
  
  // ToolDir is the directory containing build tools.

--- a/pkgs/development/compilers/go/ssl-cert-file-1.12.1.patch
+++ b/pkgs/development/compilers/go/ssl-cert-file-1.12.1.patch
@@ -1,35 +1,19 @@
-diff -Naur a/src/crypto/x509/root_cgo_darwin.go b/src/crypto/x509/root_cgo_darwin.go
---- a/src/crypto/x509/root_cgo_darwin.go	2019-03-15 11:33:55.920232337 -0700
-+++ b/src/crypto/x509/root_cgo_darwin.go	2019-03-15 11:34:53.323180897 -0700
-@@ -270,11 +270,20 @@
+diff --git a/src/crypto/x509/root_cgo_darwin.go b/src/crypto/x509/root_cgo_darwin.go
+index 255a8d3..d8166d8 100644
+--- a/src/crypto/x509/root_cgo_darwin.go
++++ b/src/crypto/x509/root_cgo_darwin.go
+@@ -280,10 +280,21 @@ int CopyPEMRoots(CFDataRef *pemRoots, CFDataRef *untrustedPemRoots, bool debugDa
  import "C"
  import (
-	"errors"
+ 	"errors"
 +	"io/ioutil"
 +	"os"
-	"unsafe"
+ 	"unsafe"
  )
-
+ 
  func loadSystemRoots() (*CertPool, error) {
-	roots := NewCertPool()
 +	if file := os.Getenv("NIX_SSL_CERT_FILE"); file != "" {
-+		data, err := ioutil.ReadFile(file)
-+		if err == nil {
-+			roots.AppendCertsFromPEM(data)
-+			return roots, nil
-+		}
-+	}
-
-	var data C.CFDataRef = 0
-	var untrustedData C.CFDataRef = 0
-diff -Naur a/src/crypto/x509/root_darwin.go b/src/crypto/x509/root_darwin.go
---- a/src/crypto/x509/root_darwin.go	2019-03-15 11:33:55.920232337 -0700
-+++ b/src/crypto/x509/root_darwin.go	2019-03-15 11:36:21.205123541 -0700
-@@ -92,6 +92,14 @@
-		verifyCh    = make(chan rootCandidate)
-	)
-
-+	if file := os.Getenv("NIX_SSL_CERT_FILE"); file != "" {
++		roots := NewCertPool()
 +		data, err := ioutil.ReadFile(file)
 +		if err == nil {
 +			roots.AppendCertsFromPEM(data)
@@ -37,16 +21,17 @@ diff -Naur a/src/crypto/x509/root_darwin.go b/src/crypto/x509/root_darwin.go
 +		}
 +	}
 +
-	// Using 4 goroutines to pipe into verify-cert seems to be
-	// about the best we can do. The verify-cert binary seems to
-	// just RPC to another server with coarse locking anyway, so
-diff -Naur a/src/crypto/x509/root_unix.go b/src/crypto/x509/root_unix.go
---- a/src/crypto/x509/root_unix.go	2019-03-15 11:33:55.920232337 -0700
-+++ b/src/crypto/x509/root_unix.go	2019-03-15 11:37:15.737326340 -0700
-@@ -38,6 +38,13 @@
-
- func loadSystemRoots() (*CertPool, error) {
-	roots := NewCertPool()
+ 	var data, untrustedData C.CFDataRef
+ 	err := C.CopyPEMRoots(&data, &untrustedData, C.bool(debugDarwinRoots))
+ 	if err == -1 {
+diff --git a/src/crypto/x509/root_darwin.go b/src/crypto/x509/root_darwin.go
+index 2f6a8b8..bd8dba1 100644
+--- a/src/crypto/x509/root_darwin.go
++++ b/src/crypto/x509/root_darwin.go
+@@ -91,6 +91,13 @@ func execSecurityRoots() (*CertPool, error) {
+ 		wg          sync.WaitGroup
+ 		verifyCh    = make(chan rootCandidate)
+ 	)
 +	if file := os.Getenv("NIX_SSL_CERT_FILE"); file != "" {
 +		data, err := ioutil.ReadFile(file)
 +		if err == nil {
@@ -54,6 +39,24 @@ diff -Naur a/src/crypto/x509/root_unix.go b/src/crypto/x509/root_unix.go
 +			return roots, nil
 +		}
 +	}
-
-	files := certFiles
-	if f := os.Getenv(certFileEnv); f != "" {
+ 
+ 	// Using 4 goroutines to pipe into verify-cert seems to be
+ 	// about the best we can do. The verify-cert binary seems to
+diff --git a/src/crypto/x509/root_unix.go b/src/crypto/x509/root_unix.go
+index 48de50b..750e12c 100644
+--- a/src/crypto/x509/root_unix.go
++++ b/src/crypto/x509/root_unix.go
+@@ -38,6 +38,13 @@ func (c *Certificate) systemVerify(opts *VerifyOptions) (chains [][]*Certificate
+ 
+ func loadSystemRoots() (*CertPool, error) {
+ 	roots := NewCertPool()
++	if file := os.Getenv("NIX_SSL_CERT_FILE"); file != "" {
++		data, err := ioutil.ReadFile(file)
++		if err == nil {
++			roots.AppendCertsFromPEM(data)
++			return roots, nil
++		}
++	}
+ 
+ 	files := certFiles
+ 	if f := os.Getenv(certFileEnv); f != "" {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
