### PR TITLE
pythonPackages.ssdp: disable python2 tests

### DIFF
--- a/pkgs/development/python-modules/ssdp/default.nix
+++ b/pkgs/development/python-modules/ssdp/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
+, isPy27
 , pbr
 , pytest
 }:
@@ -16,7 +17,9 @@ buildPythonPackage rec {
 
   buildInputs = [ pbr ];
   checkInputs = [ pytest ];
-  propagatedBuildInputs = [ ];
+
+  # test suite uses new async primitives
+  doCheck = !isPy27;
 
   meta = with stdenv.lib; {
     homepage = https://github.com/codingjoe/ssdp;


### PR DESCRIPTION
###### Motivation for this change
#68361

test suite now uses the `async` keyword, which python<3.7 can't handle
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[1 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/68813
1 package were build:
python27Packages.ssdp
```