### PR TITLE
pythonPackages.minidb: disable python2 tests

### DIFF
--- a/pkgs/development/python-modules/minidb/default.nix
+++ b/pkgs/development/python-modules/minidb/default.nix
@@ -1,29 +1,31 @@
-{ stdenv
-, buildPythonPackage
-, fetchurl
+{ lib, buildPythonPackage, fetchFromGitHub, isPy3k
 , nose
+, pytest
 }:
 
 buildPythonPackage rec {
   pname = "minidb";
   version = "2.0.2";
 
-  src = fetchurl {
-    url = "https://github.com/thp/minidb/archive/${version}.tar.gz";
-    sha256 = "17rvkpq8v7infvbgsi48vnxamhxb3f635nqn0sln7yyvh4i9k8a0";
+  src = fetchFromGitHub {
+    owner = "thp";
+    repo = "minidb";
+    rev = version;
+    sha256 = "14y5vf8vhgviczhzy9h3xv99fjvrg975nz4w1fj5c1jv37da1lq3";
   };
 
-  checkInputs = [ nose ];
-
+  # module imports are incompatible with python2
+  doCheck = isPy3k;
+  checkInputs = [ nose pytest ];
   checkPhase = ''
-    nosetests test
+    pytest
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A simple SQLite3-based store for Python objects";
-    homepage = https://thp.io/2010/minidb/;
-    license = stdenv.lib.licenses.isc;
-    maintainers = [ stdenv.lib.maintainers.tv ];
+    homepage = "https://thp.io/2010/minidb/";
+    license = licenses.isc;
+    maintainers = [ maintainers.tv ];
   };
 
 }


### PR DESCRIPTION

###### Motivation for this change
 #68361

python2 couldn't do the module imports in the test suite, so I disabled them.

Cleaned up the expression a bit.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
