### PR TITLE
okta-aws: init at 2.0.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -554,6 +554,12 @@
     githubId = 1296771;
     name = "Anders Riutta";
   };
+  arnarg = {
+    email = "arnarg@fastmail.com";
+    github = "arnarg";
+    githubId = 1291396;
+    name = "Arnar Ingason";
+  };
   arobyn = {
     email = "shados@shados.net";
     github = "shados";

--- a/pkgs/tools/security/okta-aws/builder.sh
+++ b/pkgs/tools/security/okta-aws/builder.sh
@@ -1,0 +1,95 @@
+source $stdenv/setup
+
+buildPhase() {
+  mvn package
+}
+
+# okta-aws-cli-assume-role repository doesn't have any of the scripts that
+# should be put in bin/. There is a install.sh script that creates them but
+# it also downloads a pre-compiled jar that we previously built from source.
+# Instead I copied the script creation steps from install.sh and run that in
+# installPhase.
+installPhase() {
+  mkdir -p $out/bin
+  mkdir -p $out/share
+
+  # Install compiled JAR file
+  cp ./target/okta-aws-cli-$version.jar $out/share/
+  ln -s okta-aws-cli-$version.jar $out/share/okta-aws-cli.jar
+
+  # Create bash functions
+  bash_functions="$out/bash_functions"
+  cat <<EOF >>"${bash_functions}"
+#OktaAWSCLI
+function okta-aws {
+    $out/bin/withokta "aws --profile \$1" "\$@"
+}
+EOF
+  
+  # Create fish shell functions
+  fishFunctionsDir="$out/fish_functions"
+  mkdir -p "${fishFunctionsDir}"
+  cat <<EOF >"${fishFunctionsDir}/okta-aws.fish"
+function okta-aws
+    $out/bin/withokta "aws --profile \$argv[1]" \$argv
+end
+EOF
+
+  # Suppress "Your profile name includes a 'profile ' prefix" warnings
+  # from AWS Java SDK (Resolves https://github.com/oktadeveloper/okta-aws-cli-assume-role/issues/233)
+  loggingProperties="$out/logging.properties"
+  cat <<EOF >"${loggingProperties}"
+com.amazonaws.auth.profile.internal.BasicProfileConfigLoader = NONE
+EOF
+
+  # Create withokta command
+  cat <<EOF >"$out/bin/withokta"
+#!/bin/bash
+export PATH=@jre@/bin:@awscli@/bin:\$PATH
+command="\$1"
+profile=\$2
+shift;
+shift;
+if [ "\$3" == "logout" ]
+then
+    command="logout"
+fi
+env OKTA_PROFILE=\$profile java \
+    -Djava.util.logging.config.file=$out/logging.properties \
+    -classpath $out/share/okta-aws-cli.jar \
+    com.okta.tools.WithOkta \$command "\$@"
+EOF
+  chmod +x "$out/bin/withokta"
+
+  # Create okta-credential_process command
+  cat <<EOF >"$out/bin/okta-credential_process"
+#!/bin/bash
+export PATH=@jre@/bin:@awscli@/bin:\$PATH
+roleARN="\$1"
+shift;
+env OKTA_AWS_ROLE_TO_ASSUME="\$roleARN" \
+    java -classpath $out/share/okta-aws-cli.jar com.okta.tools.CredentialProcess
+EOF
+  chmod +x "$out/bin/okta-credential_process"
+
+  # Create okta-listroles command
+  cat <<EOF >"$out/bin/okta-listroles"
+#!/bin/bash
+export PATH=@jre@/bin:@awscli@/bin:\$PATH
+java -classpath $out/share/okta-aws-cli.jar com.okta.tools.ListRoles
+EOF
+  chmod +x "$out/bin/okta-listroles"
+
+  # awscli
+  cat <<EOF >"$out/bin/awscli"
+#!/bin/bash
+export PATH=@jre@/bin:@awscli@/bin:\$PATH
+$out/bin/withokta aws default "$@"
+EOF
+  chmod +x "$out/bin/awscli"
+
+  # Run postInstall hook
+  runHook postInstall
+}
+
+genericBuild

--- a/pkgs/tools/security/okta-aws/default.nix
+++ b/pkgs/tools/security/okta-aws/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, awscli, jdk11, maven, ... }:
+
+stdenv.mkDerivation rec {
+  name = "okta-aws-${version}";
+  version = "2.0.4";
+
+  src = fetchFromGitHub {
+    owner = "oktadeveloper";
+    repo = "okta-aws-cli-assume-role";
+    rev = "v${version}";
+    sha256 = "0dp4ychyqsz9vyplk416xl4x6b7zqf7zsjyybg53rxjw5h85640r";
+  };
+
+  buildInputs = [ (maven.override {jdk = jdk11;}) ];
+
+  builder = ./builder.sh;
+
+  postInstall = ''
+    export jre=${jdk11}
+    export awscli=${awscli}
+    substituteAllInPlace $out/bin/withokta
+    substituteAllInPlace $out/bin/okta-credential_process
+    substituteAllInPlace $out/bin/okta-listroles
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Okta AWS CLI Assume Role Tool";
+    homepage = "https://github.com/oktadeveloper/okta-aws-cli-assume-role";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ arnarg ];
+    platforms = platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -679,6 +679,8 @@ in
 
   aws-okta = callPackage ../tools/security/aws-okta { };
 
+  okta-aws = callPackage ../tools/security/okta-aws { };
+
   aws-rotate-key = callPackage ../tools/admin/aws-rotate-key { };
 
   aws_shell = pythonPackages.callPackage ../tools/admin/aws_shell { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
This is different from aws-okta.
I use this tool for authenticating to AWS with okta.

I'd love to not have the whole `jdk11` as a runtime dependency but it doesn't have a jre output. This program requires [Java 11](https://github.com/oktadeveloper/okta-aws-cli-assume-role/blob/master/pom.xml#L180-L186).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
