### PR TITLE
hadoop: update

### DIFF
--- a/pkgs/applications/networking/cluster/hadoop/default.nix
+++ b/pkgs/applications/networking/cluster/hadoop/default.nix
@@ -88,6 +88,7 @@ let
         disallowedReferences = [ maven.jdk ];
       };
     in
+      # `binary-distributon` bound to the runtime JRE
       stdenv.mkDerivation {
         pname = "hadoop";
         inherit version;
@@ -126,6 +127,10 @@ let
         installCheckPhase = ''
           $out/bin/hadoop checknative
         '';
+
+        # 3rd party applications using libhadoop.so should set $LD_LIBRARY_PATH to help its dlopen() locating libraries
+        passthru.LD_LIBRARY_PATH = stdenv.lib.makeLibraryPath buildInputs;
+        passthru.openssl = opensslPkg;
 
         meta = with stdenv.lib; {
           homepage = "http://hadoop.apache.org/";

--- a/pkgs/applications/networking/cluster/hadoop/default.nix
+++ b/pkgs/applications/networking/cluster/hadoop/default.nix
@@ -15,9 +15,7 @@ let
       '';
       nativeBuildInputs = [ maven cmake pkgconfig ];
       buildInputs = [ fuse snappy zlib bzip2 opensslPkg protobuf2_5 ] ++ extraBuildInputs;
-      mavenFlags = [ "-Drequire.fuse" "-Drequire.snappy" "-Drequire.bzip2" "-DskipTests" "-Pdist,native" "-e" ]
-        ++ stdenv.lib.optional (stdenv.lib.versionAtLeast version "2.9") "-Drequire.zstd"
-        ++ stdenv.lib.optional (stdenv.lib.versionAtLeast version "3.0") "-Drequire.isal";
+      mavenFlags = [ "-DskipTests" "-Pdist,native" "-e" ];
 
       # perform fake build to make a fixed-output derivation of dependencies downloaded from maven central (~100Mb in ~3000 files)
       fetched-maven-deps = stdenv.mkDerivation {

--- a/pkgs/applications/networking/cluster/hadoop/default.nix
+++ b/pkgs/applications/networking/cluster/hadoop/default.nix
@@ -121,7 +121,7 @@ let
             --set OS_ARCH         "amd64" \
             --set JAVA_HOME       "${jre}" \
             --set LD_LIBRARY_PATH "${jre}/jre/lib/amd64/server:$out/lib/native" \
-            --set CLASSPATH       "$out/share/hadoop/hdfs/hadoop-hdfs-${version}.jar:$out/share/hadoop/common/hadoop-common-${version}.jar$(find $out/share/hadoop/{hdfs,common}/lib -type f -name '*.jar' -printf ':%p')"
+            --set CLASSPATH       "$out/share/hadoop/hdfs/hadoop-hdfs-${version}.jar:$out/share/hadoop/hdfs/hadoop-hdfs-client-${version}.jar:$out/share/hadoop/common/hadoop-common-${version}.jar$(find $out/share/hadoop/{hdfs,common}/lib -type f -name '*.jar' -printf ':%p')"
         '';
 
         doInstallCheck = true;

--- a/pkgs/applications/networking/cluster/hadoop/default.nix
+++ b/pkgs/applications/networking/cluster/hadoop/default.nix
@@ -1,41 +1,44 @@
-{ stdenv, fetchurl, makeWrapper, pkgconfig, which, maven, cmake, jre, bash
-, coreutils, glibc, protobuf2_5, fuse, snappy, zlib, bzip2, openssl, openssl_1_0_2
+{ stdenv, fetchurl, makeWrapper, pkgconfig, which, maven, cmake, jre, bash, nukeReferences
+, coreutils, glibc, protobuf2_5, fuse, snappy, zstd, zlib, bzip2, openssl_1_0_2, openssl_1_1, cyrus_sasl
 }:
 
 let
-  common = { version, sha256, dependencies-sha256, tomcat, opensslPkg ? openssl }:
+  common = { version, sources-sha256, dependencies-sha256, tomcat ? null, opensslPkg, extraBuildInputs ? [], patches ? [] }:
     let
-      # compile the hadoop tarball from sources, it requires some patches
-      binary-distributon = stdenv.mkDerivation rec {
-        name = "hadoop-${version}-bin";
-        src = fetchurl {
-          url = "mirror://apache/hadoop/common/hadoop-${version}/hadoop-${version}-src.tar.gz";
-          inherit sha256;
-        };
+      src = fetchurl {
+        url = "mirror://apache/hadoop/common/hadoop-${version}/hadoop-${version}-src.tar.gz";
+        sha256 = sources-sha256;
+      };
+      postUnpack = stdenv.lib.optionalString (tomcat != null) ''
+        install -D ${tomcat.src} $sourceRoot/hadoop-hdfs-project/hadoop-hdfs-httpfs/downloads/apache-tomcat-${tomcat.version}.tar.gz
+        install -D ${tomcat.src} $sourceRoot/hadoop-common-project/hadoop-kms/downloads/apache-tomcat-${tomcat.version}.tar.gz
+      '';
+      nativeBuildInputs = [ maven cmake pkgconfig ];
+      buildInputs = [ fuse snappy zstd zlib bzip2 opensslPkg protobuf2_5 ] ++ extraBuildInputs;
+      mavenFlags = [ "-Drequire.fuse" "-Drequire.snappy" "-Drequire.bzip2" "-DskipTests" "-Pdist,native" "-e" ]
+        ++ stdenv.lib.optional (stdenv.lib.versionAtLeast version "2.9") "-Drequire.zstd";
 
-        postUnpack = stdenv.lib.optionalString (tomcat != null) ''
-          install -D ${tomcat.src} $sourceRoot/hadoop-hdfs-project/hadoop-hdfs-httpfs/downloads/apache-tomcat-${tomcat.version}.tar.gz
-          install -D ${tomcat.src} $sourceRoot/hadoop-common-project/hadoop-kms/downloads/apache-tomcat-${tomcat.version}.tar.gz
+      # perform fake build to make a fixed-output derivation of dependencies downloaded from maven central (~100Mb in ~3000 files)
+      fetched-maven-deps = stdenv.mkDerivation {
+        pname = "hadoop-maven-deps";
+        inherit version src postUnpack nativeBuildInputs buildInputs patches;
+        dontConfigure = true; # do not trigger cmake hook
+        buildPhase = ''
+          while mvn package -Dmaven.repo.local=$out/.m2 ${stdenv.lib.escapeShellArgs mavenFlags} -Dmaven.wagon.rto=5000; [ $? = 1 ]; do
+            echo "timeout, restart maven to continue downloading"
+          done
         '';
+        # keep only *.{pom,jar,xml,sha1,so,dll,dylib} and delete all ephemeral files with lastModified timestamps inside
+        installPhase = ''find $out/.m2 -type f -regex '.+\(\.lastUpdated\|resolver-status\.properties\|_remote\.repositories\)' -delete'';
+        outputHashAlgo = "sha256";
+        outputHashMode = "recursive";
+        outputHash = dependencies-sha256;
+      };
 
-        # perform fake build to make a fixed-output derivation of dependencies downloaded from maven central (~100Mb in ~3000 files)
-        fetched-maven-deps = stdenv.mkDerivation {
-          name = "hadoop-${version}-maven-deps";
-          inherit src postUnpack nativeBuildInputs buildInputs;
-          buildPhase = ''
-            while mvn package -Dmaven.repo.local=$out/.m2 ${mavenFlags} -Dmaven.wagon.rto=5000; [ $? = 1 ]; do
-              echo "timeout, restart maven to continue downloading"
-            done
-          '';
-          # keep only *.{pom,jar,xml,sha1,so,dll,dylib} and delete all ephemeral files with lastModified timestamps inside
-          installPhase = ''find $out/.m2 -type f -regex '.+\(\.lastUpdated\|resolver-status\.properties\|_remote\.repositories\)' -delete'';
-          outputHashAlgo = "sha256";
-          outputHashMode = "recursive";
-          outputHash = dependencies-sha256;
-        };
-
-        nativeBuildInputs = [ maven cmake pkgconfig ];
-        buildInputs = [ fuse snappy zlib bzip2 opensslPkg protobuf2_5 ];
+      # compile the hadoop tarball from sources, it requires some patches
+      binary-distributon = stdenv.mkDerivation {
+        pname = "hadoop-bin";
+        inherit version src postUnpack nativeBuildInputs buildInputs patches;
         # most of the hardcoded pathes are fixed in 2.9.x and 3.0.0, this list of patched files might be reduced when 2.7.x and 2.8.x will be deprecated
         postPatch = ''
           for file in hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/HardLink.java \
@@ -54,15 +57,36 @@ let
           done
         '';
         dontConfigure = true; # do not trigger cmake hook
-        mavenFlags = "-Drequire.snappy -Drequire.bzip2 -DskipTests -Pdist,native -e";
         buildPhase = ''
           # 'maven.repo.local' must be writable
-          mvn package --offline -Dmaven.repo.local=$(cp -dpR ${fetched-maven-deps}/.m2 ./ && chmod +w -R .m2 && pwd)/.m2 ${mavenFlags}
-          # remove runtime dependency on $jdk/jre/lib/amd64/server/libjvm.so
-          patchelf --set-rpath ${stdenv.lib.makeLibraryPath [glibc]} hadoop-dist/target/hadoop-${version}/lib/native/libhadoop.so.1.0.0
-          patchelf --set-rpath ${stdenv.lib.makeLibraryPath [glibc]} hadoop-dist/target/hadoop-${version}/lib/native/libhdfs.so.0.0.0
+          mvn package --offline -Dmaven.repo.local=$(cp -dpR ${fetched-maven-deps}/.m2 ./ && chmod +w -R .m2 && pwd)/.m2 ${stdenv.lib.escapeShellArgs mavenFlags}
         '';
-        installPhase = "mv hadoop-dist/target/hadoop-${version} $out";
+        installPhase = ''
+          cp -R hadoop-dist/target/hadoop-${version} $out
+
+          # Hadoop-3.2+ produces libhdfs at new location
+          ${stdenv.lib.optionalString (stdenv.lib.versionAtLeast version "3.2") ''
+              cp -d hadoop-hdfs-project/hadoop-hdfs-native-client/target/target/usr/local/lib/libhdfs.{a,so*}    $out/lib/native/
+              cp -d hadoop-hdfs-project/hadoop-hdfs-native-client/target/main/native/libhdfspp/libhdfspp.{a,so*} $out/lib/native/
+            ''}
+
+          install -Dm755 hadoop-hdfs-project/${if stdenv.lib.versionOlder version "2.8" then
+                                                "hadoop-hdfs/target/native"
+                                               else
+                                                "hadoop-hdfs-native-client/target"}/main/native/fuse-dfs/fuse_dfs $out/contrib/fuse-dfs/fuse_dfs
+
+          # remove runtime dependency on build-time maven.jdk (on "''${maven.jdk}/jre/lib/amd64/server/libjvm.so")
+          for f in $(find $out/lib/native -type f -executable); do
+            # `strip -S` fails to strip debug info from libhadoop.so and libhdfs.so
+            # all the references to Nix Store are in rpath and debug info, so nukeReferences can help here
+            ${nukeReferences}/bin/nuke-refs "$f"
+
+            patchelf --set-rpath ${stdenv.lib.makeLibraryPath ([glibc stdenv.cc.cc isal opensslPkg snappy zstd zlib protobuf2_5] ++ extraBuildInputs)} "$f"
+          done
+
+          patchelf --set-rpath ${stdenv.lib.makeLibraryPath [glibc fuse]} "$out/contrib/fuse-dfs/fuse_dfs"
+        '';
+        disallowedReferences = [ maven.jdk ];
       };
     in
       stdenv.mkDerivation {
@@ -87,11 +111,16 @@ let
               mv $n $out/bin.wrapped/
               makeWrapper $out/bin.wrapped/$(basename $n) $n \
                 --prefix PATH : "${stdenv.lib.makeBinPath [ which jre bash coreutils ]}" \
-                --prefix JAVA_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [ opensslPkg snappy zlib bzip2 ]}" \
+                --prefix JAVA_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [ opensslPkg snappy zstd zlib bzip2 ]}" \
                 --set JAVA_HOME "${jre}" \
                 --set HADOOP_PREFIX "$out"
             fi
           done
+          makeWrapper $out/contrib/fuse-dfs/fuse_dfs $out/bin/fuse_dfs_wrapper.sh \
+            --set OS_ARCH         "amd64" \
+            --set JAVA_HOME       "${jre}" \
+            --set LD_LIBRARY_PATH "${jre}/jre/lib/amd64/server:$out/lib/native" \
+            --set CLASSPATH       "$out/share/hadoop/hdfs/hadoop-hdfs-${version}.jar:$out/share/hadoop/common/hadoop-common-${version}.jar$(find $out/share/hadoop/{hdfs,common}/lib -type f -name '*.jar' -printf ':%p')"
         '';
 
         meta = with stdenv.lib; {
@@ -127,35 +156,42 @@ let
 in {
   hadoop_2_7 = common {
     version = "2.7.7";
-    sha256 = "1ahv67f3lwak3kbjvnk1gncq56z6dksbajj872iqd0awdsj3p5rf";
-    dependencies-sha256 = "1lsr9nvrynzspxqcamb10d596zlnmnfpxhkd884gdiva0frm0b1r";
+    sources-sha256 = "1ahv67f3lwak3kbjvnk1gncq56z6dksbajj872iqd0awdsj3p5rf";
+    dependencies-sha256 = "13xlnj54q3xq247pa50mmvfc2w1pdlbk1a07nm9s27vw6jrllgww";
     tomcat = tomcat_6_0_48;
     opensslPkg = openssl_1_0_2;
   };
   hadoop_2_8 = common {
-    version = "2.8.4";
-    sha256 = "16c3ljhrzibkjn3y1bmjxdgf0kn60l23ay5hqpp7vpbnqx52x68w";
-    dependencies-sha256 = "1j4f461487fydgr5978nnm245ksv4xbvskfr8pbmfhcyss6b7w03";
+    version = "2.8.5";
+    sources-sha256 = "0d1xbcdy5qgmh1gh5y8fv1gf0hpwgz3yzkpw6s0bc294bz2pzc35";
+    dependencies-sha256 = "16hmzaxv52hisjc426dykls4p904sjknlmdmji5lp27pxvn0rkji";
     tomcat = tomcat_6_0_48;
     opensslPkg = openssl_1_0_2;
   };
   hadoop_2_9 = common {
-    version = "2.9.1";
-    sha256 = "0qgmpfbpv7f521fkjy5ldzdb4lwiblhs0hyl8qy041ws17y5x7d7";
-    dependencies-sha256 = "1d5i8jj5y746rrqb9lscycnd7acmxlkz64ydsiyqsh5cdqgy2x7x";
+    version = "2.9.2";
+    sources-sha256 = "1nifslax1pgzg6xsny7m5dyg3d8vqfpbzr0dmlxhbwm70pxw62jr";
+    dependencies-sha256 = "0jx51vsy1wa6mbcxfsgz07vdlwkg9n3pkp11dlpgivl0rr4krwij";
     tomcat = tomcat_6_0_48;
     opensslPkg = openssl_1_0_2;
   };
-  hadoop_3_0 = common {
-    version = "3.0.3";
-    sha256 = "1vvkci0kx4b48dg0niifn2d3r4wwq8pb3c5z20wy8pqsqrqhlci5";
-    dependencies-sha256 = "1kzkna9ywacm2m1cirj9cyip66bgqjhid2xf9rrhq6g10lhr8j9m";
-    tomcat = null;
-  };
   hadoop_3_1 = common {
-    version = "3.1.1";
-    sha256 = "04hhdbyd4x1hy0fpy537f8mi0864hww97zap29x7dk1smrffwabd";
-    dependencies-sha256 = "1q63jsxg3d31x0p8hvhpvbly2b07almyzsbhwphbczl3fhlqgiwn";
-    tomcat = null;
+    version = "3.1.2";
+    sources-sha256 = "1dn6pqwpq9jm5123fpmb85w6chds1pinpvcpfqyb3m3mzk4pgwh2";
+    dependencies-sha256 = "0ml0ywn8fpjc14263f144d0vyhbn271pwamyml7d9jhvjk3qnh1h";
+    opensslPkg = openssl_1_1;
+  };
+  hadoop_3_2 = common {
+    version = "3.2.0";
+    sources-sha256 = "0s2mfdph2psih6wynck59g7c909zgfg1ip7gjbl1id8j6y6l83f3";
+    dependencies-sha256 = "1njvfa05d8170kd54wq9igv2vjfzh6sx5g0zaz9v1g29as8n6gb9";
+    opensslPkg = openssl_1_1;
+    extraBuildInputs = [ cyrus_sasl ];
+    patches = [
+      # fix build of oom-killer
+      # https://issues.apache.org/jira/browse/YARN-8498?focusedCommentId=16722705&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-16722705
+      (fetchurl { url    = https://issues.apache.org/jira/secure/attachment/12951988/YARN-8948-01.patch;
+                  sha256 = "1b51miimkv5ycgf9cpvhlxqfc285qa56w1h2mj5hnym6digk8zfm"; })
+    ];
   };
 }

--- a/pkgs/applications/networking/cluster/hadoop/default.nix
+++ b/pkgs/applications/networking/cluster/hadoop/default.nix
@@ -29,6 +29,7 @@ let
         '';
         # keep only *.{pom,jar,xml,sha1,so,dll,dylib} and delete all ephemeral files with lastModified timestamps inside
         installPhase = ''find $out/.m2 -type f -regex '.+\(\.lastUpdated\|resolver-status\.properties\|_remote\.repositories\)' -delete'';
+        dontFixup = true; # do not shrink .so files
         outputHashAlgo = "sha256";
         outputHashMode = "recursive";
         outputHash = dependencies-sha256;
@@ -65,8 +66,8 @@ let
 
           # Hadoop-3.2+ produces libhdfs at new location
           ${stdenv.lib.optionalString (stdenv.lib.versionAtLeast version "3.2") ''
-              cp -d hadoop-hdfs-project/hadoop-hdfs-native-client/target/target/usr/local/lib/libhdfs.{a,so*}    $out/lib/native/
-              cp -d hadoop-hdfs-project/hadoop-hdfs-native-client/target/main/native/libhdfspp/libhdfspp.{a,so*} $out/lib/native/
+              cp -d hadoop-hdfs-project/hadoop-hdfs-native-client/target/native/target/usr/local/lib/libhdfs.{a,so*}  $out/lib/native/
+              cp -d hadoop-hdfs-project/hadoop-hdfs-native-client/target/main/native/libhdfspp/libhdfspp.{a,so*}      $out/lib/native/
             ''}
 
           install -Dm755 hadoop-hdfs-project/${if stdenv.lib.versionOlder version "2.8" then

--- a/pkgs/development/libraries/isa-l/default.nix
+++ b/pkgs/development/libraries/isa-l/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, yasm }:
+
+stdenv.mkDerivation rec {
+  pname = "isa-l";
+  version = "2.27.0";
+
+  src = fetchFromGitHub {
+    owner = "intel";
+    repo = "isa-l";
+    rev = "v${version}";
+    sha256 = "15578isyinikw0ypfrag27ccipcl3djbgfqhidjn11r93pwb5r7z";
+  };
+
+  nativeBuildInputs = [ yasm ];
+  configurePhase = "cp Makefile.unx Makefile";
+  makeFlags = [ "prefix=$(out)" ];
+
+  meta = with stdenv.lib; {
+    description = "Intel(R) Intelligent Storage Acceleration Library";
+    homepage = https://github.com/intel/isa-l;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.volth ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/development/libraries/isa-l/default.nix
+++ b/pkgs/development/libraries/isa-l/default.nix
@@ -1,17 +1,17 @@
-{ stdenv, fetchFromGitHub, yasm }:
+{ stdenv, fetchFromGitHub, nasm }:
 
 stdenv.mkDerivation rec {
   pname = "isa-l";
-  version = "2.27.0";
+  version = "2.28.0";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "isa-l";
     rev = "v${version}";
-    sha256 = "15578isyinikw0ypfrag27ccipcl3djbgfqhidjn11r93pwb5r7z";
+    sha256 = "0zswmyi3r7i7n1k0s3jkkmd3xgjpd5chnqf2ffmz3zk46w8imj15";
   };
 
-  nativeBuildInputs = [ yasm ];
+  nativeBuildInputs = [ nasm ];
   configurePhase = "cp Makefile.unx Makefile";
   makeFlags = [ "prefix=$(out)" ];
 
@@ -20,6 +20,6 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/intel/isa-l;
     license = licenses.bsd3;
     maintainers = [ maintainers.volth ];
-    platforms = [ "x86_64-linux" ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8591,8 +8591,8 @@ in
     hadoop_2_7
     hadoop_2_8
     hadoop_2_9
-    hadoop_3_0
-    hadoop_3_1;
+    hadoop_3_1
+    hadoop_3_2;
   hadoop = hadoop_2_7;
 
   io = callPackage ../development/interpreters/io { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11378,6 +11378,8 @@ in
 
   intel-media-driver = callPackage ../development/libraries/intel-media-driver { };
 
+  isa-l = callPackage ../development/libraries/isa-l { };
+
   intltool = callPackage ../development/tools/misc/intltool { };
 
   ios-cross-compile = callPackage ../development/compilers/ios-cross-compile/9.2.nix {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8591,6 +8591,7 @@ in
     hadoop_2_7
     hadoop_2_8
     hadoop_2_9
+    hadoop_2_10
     hadoop_3_1
     hadoop_3_2;
   hadoop = hadoop_2_7;


### PR DESCRIPTION
 - [x] updated: 2.8.4->2.8.5, 2.9.1->2.9.2, 3.1.1->3.1.3
 - [x] removed: 3.0.x (upstream removed it too)
 - [x] added: 3.2.1
 - [x] install HDFS FUSE driver (it was built but not installed)
 - [x] `name` -> `pname`
 - [x] minor refactoring (`fetched-maven-deps` moved out of `binary-distributon` scope, `sha256` renamed to `sources-sha256`)
 - [x] fix #63520 regression (https://github.com/NixOS/nixpkgs/pull/63520#pullrequestreview-288333354)
 - [x] native `zstd` and `isa-l` libraries
 - [x] fixed closure size: native libraries had link to `maven.jdk` in debug info (which `strip -S` failed to strip on `fixupPhase`), so it happened that `hadoop` closure depended on two java closures
 - [x] fixes #71475

cc @kamilchm @kalbasit @aespinosa  