### PR TITLE
pythonPackages.percol: mark broken

### DIFF
--- a/pkgs/development/python-modules/percol/default.nix
+++ b/pkgs/development/python-modules/percol/default.nix
@@ -1,7 +1,5 @@
-{ stdenv
-, buildPythonPackage
-, fetchPypi
-, isPy3k
+{ lib, buildPythonPackage, fetchPypi, isPy3k
+, six
 }:
 
 buildPythonPackage rec {
@@ -14,11 +12,14 @@ buildPythonPackage rec {
     sha256 = "7a649c6fae61635519d12a6bcacc742241aad1bff3230baef2cedd693ed9cfe8";
   };
 
-  meta = with stdenv.lib; {
+  propagatedBuildInputs = [ six ];
+
+  meta = with lib; {
     homepage = https://github.com/mooz/percol;
     description = "Adds flavor of interactive filtering to the traditional pipe concept of shell";
     license = licenses.mit;
     maintainers = with maintainers; [ koral ];
+    broken = true; # missing cmigemo package which is missing libmigemo.so
+    # also doesn't support python3
   };
-
 }


### PR DESCRIPTION

###### Motivation for this change
#68361

tried fixing it, but it required cmigemo package which we don't have, when I tried adding that, it needed libmigemo.so which I didn't know where to get. So I gave up and marked it broken.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
