### PR TITLE
python37Packages.scikitlearn: patching build

### DIFF
--- a/pkgs/development/python-modules/scikitlearn/default.nix
+++ b/pkgs/development/python-modules/scikitlearn/default.nix
@@ -2,6 +2,7 @@
 , lib
 , buildPythonPackage
 , fetchPypi
+, fetchpatch
 , gfortran, glibcLocales
 , numpy, scipy, pytest, pillow
 , cython
@@ -39,6 +40,15 @@ buildPythonPackage rec {
     joblib
   ];
   checkInputs = [ pytest ];
+
+  patches = [
+    # Fixes tests by changing threshold of a test-case that broke
+    # with numpy versions >= 1.17. This should be removed for versions > 0.21.2.
+	( fetchpatch {
+	  url = "https://github.com/scikit-learn/scikit-learn/commit/b730befc821caec5b984d9ff3aa7bc4bd7f4d9bb.patch";
+	  sha256 = "0z36m05mv6d494qwq0688rgwa7c4bbnm5s2rcjlrp29fwn3fy1bv";
+	})
+  ];
 
   LC_ALL="en_US.UTF-8";
 


### PR DESCRIPTION
###### Motivation for this change

For numpy>=1.17 a test-case broke that required adjustments to
a threshold.

See https://github.com/NixOS/nixpkgs/issues/68494
Related: https://github.com/NixOS/nixpkgs/issues/68361

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @FRidh due to previous discussion of this
