### PR TITLE
recoll: 1.24.5 -> 1.25.22

### DIFF
--- a/pkgs/applications/search/recoll/default.nix
+++ b/pkgs/applications/search/recoll/default.nix
@@ -8,19 +8,19 @@
 assert stdenv.hostPlatform.system != "powerpc-linux";
 
 stdenv.mkDerivation rec {
-  ver = "1.24.5";
-  name = "recoll-${ver}";
+  pname = "recoll";
+  version = "1.25.22";
 
   src = fetchurl {
-    url = "https://www.lesbonscomptes.com/recoll/${name}.tar.gz";
-    sha256 = "10m3a0ghnyipjcxapszlr8adyy2yaaxx4vgrkxrfmz13814z89cv";
+    url = "https://www.lesbonscomptes.com/recoll/${pname}-${version}.tar.gz";
+    sha256 = "1g05m4nfa0hyx0nzf3cl7g8c33y5z78fry3xhhic40xaa94i23ah";
   };
 
-  configureFlags = [ "--enable-recollq" ]
+  configureFlags = [ "--enable-recollq" "--disable-python-module" "--disable-python-chm" ]
     ++ lib.optionals (!withGui) [ "--disable-qtgui" "--disable-x11mon" ]
     ++ (if stdenv.isLinux then [ "--with-inotify" ] else [ "--without-inotify" ]);
 
-  buildInputs = [ xapian file python bison zlib ]
+  buildInputs = [ xapian file python bison zlib libxslt ]
     ++ lib.optional withGui qt4
     ++ lib.optional stdenv.isDarwin libiconv;
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
