### PR TITLE
liblapack: enable LAPACKE interface

### DIFF
--- a/pkgs/development/libraries/science/math/liblapack/default.nix
+++ b/pkgs/development/libraries/science/math/liblapack/default.nix
@@ -23,7 +23,6 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ python2 ];
 
   cmakeFlags = [
-    "-DUSE_OPTIMIZED_BLAS=ON"
     "-DCMAKE_Fortran_FLAGS=-fPIC"
     "-DLAPACKE=ON"
   ]

--- a/pkgs/development/libraries/science/math/liblapack/default.nix
+++ b/pkgs/development/libraries/science/math/liblapack/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation {
   cmakeFlags = [
     "-DUSE_OPTIMIZED_BLAS=ON"
     "-DCMAKE_Fortran_FLAGS=-fPIC"
+    "-DLAPACKE=ON"
   ]
   ++ (optional shared "-DBUILD_SHARED_LIBS=ON");
 


### PR DESCRIPTION
###### Motivation for this change
Enable building the C api (https://github.com/NixOS/nixpkgs/issues/68811).


###### Things done
* enable `LAPACKE`: creates `liblapack.a` + header files.
* remove optimized blas flag. This cmake flag has no effect since no external blas
library is provided in the build inputs.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`. Some build failures that are unrelated to lapack.
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @ttuegel 
