### PR TITLE
cfssl: 1.3.2 -> 1.3.3

### DIFF
--- a/pkgs/tools/security/cfssl/default.nix
+++ b/pkgs/tools/security/cfssl/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   pname = "cfssl";
-  version = "1.3.2";
+  version = "1.3.3";
 
   goPackagePath = "github.com/cloudflare/cfssl";
 
@@ -10,19 +10,8 @@ buildGoPackage rec {
     owner = "cloudflare";
     repo = "cfssl";
     rev = version;
-    sha256 = "0j2gz2vl2pf7ir7sc7jrwmjnr67hk4qhxw09cjx132jbk337jc9x";
+    sha256 = "1y61li4ray4gkzv8my3qy80038v2q7vk35m3vwbbkp8hyy8fk362";
   };
-
-  # The following patch ensures that the auth-key decoder doesn't break,
-  # if the auth-key file contains leading or trailing whitespaces.
-  # https://github.com/cloudflare/cfssl/pull/923 is merged
-  # remove patch when it becomes part of a release.
-  patches = [
-    (fetchpatch {
-      url    = "https://github.com/cloudflare/cfssl/commit/7e13f60773c96644db9dd8d342d42fe3a4d26f36.patch";
-      sha256 = "1z2v2i8yj7qpj8zj5f2q739nhrr9s59jwzfzk52wfgssl4vv5mn5";
-    })
-  ];
 
   meta = with stdenv.lib; {
     homepage = https://cfssl.org/;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update of cfssl to latest version, that does not require manual patching anymore

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
