### PR TITLE
certmgr: 1.6.4 -> 2.0.1, improvements for nixos module

### DIFF
--- a/nixos/modules/services/cluster/kubernetes/pki.nix
+++ b/nixos/modules/services/cluster/kubernetes/pki.nix
@@ -200,7 +200,7 @@ in
 
     services.certmgr = {
       enable = true;
-      package = pkgs.certmgr-selfsigned;
+      package = pkgs.certmgr;
       svcManager = "command";
       specs =
         let
@@ -209,14 +209,14 @@ in
             authority = {
               inherit remote;
               file.path = cert.caCert;
-              root_ca = cert.caCert;
+              rootCA = cert.caCert;
               profile = "default";
-              auth_key_file = certmgrAPITokenPath;
+              authKeyFile = certmgrAPITokenPath;
             };
             certificate = {
               path = cert.cert;
             };
-            private_key = cert.privateKeyOptions;
+            privateKey = cert.privateKeyOptions;
             request = {
               inherit (cert) CN hosts;
               key = {

--- a/nixos/modules/services/security/certmgr.nix
+++ b/nixos/modules/services/security/certmgr.nix
@@ -5,9 +5,26 @@ with lib;
 let
   cfg = config.services.certmgr;
 
+  mkFileMeta = file: {
+    inherit (file) path owner group mode;
+  };
+
+  mkSpec = spec: {
+    inherit (spec) service action request;
+    authority = {
+      inherit (spec.authority) name remote label profile;
+      root_ca = spec.authority.rootCA;
+      auth_key = spec.authority.authKey;
+      auth_key_file = spec.authority.authKeyFile;
+      file = mkFileMeta spec.authority.file;
+    };
+    certificate = mkFileMeta spec.certificate;
+    private_key = mkFileMeta spec.privateKey;
+  };
+
   specs = mapAttrsToList (n: v: rec {
-    name = n + ".json";
-    path = if isAttrs v then pkgs.writeText name (builtins.toJSON v) else v;
+    name = "${if isAttrs v then v.name else n}.json";
+    path = if isAttrs v then pkgs.writeText name (builtins.toJSON (mkSpec v)) else v;
   }) cfg.specs;
 
   allSpecs = pkgs.linkFarm "certmgr.d" specs;
@@ -28,12 +45,143 @@ let
       [ spec ]
   ) (attrValues cfg.specs));
 
-  preStart = ''
-    ${concatStringsSep " \\\n" (["mkdir -p"] ++ map escapeShellArg specPaths)}
-    ${cfg.package}/bin/certmgr -f ${certmgrYaml} check
-  '';
-in
-{
+  trustOnBootstrapAuthorities =
+    unique (map (spec: { inherit (spec.authority) rootCA remote; })
+      (filter
+        (spec: isAttrs spec && spec.authority.trustOnBootstrap)
+        (attrValues cfg.specs)));
+
+  fileOptions = {
+    options = {
+      path = mkOption {
+        type = types.path;
+        description = "Generated certmgr file path.";
+      };
+
+      owner = mkOption {
+        type = types.str;
+        default = "root";
+        description = "Generated certmgr file owner.";
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "root";
+        description = "Generated certmgr file group.";
+      };
+
+      mode = mkOption {
+        type = types.str;
+        default = "0600";
+        description = "Generated certmgr file mode.";
+      };
+    };
+  };
+
+  specOptions = { name, ... }: {
+    options = {
+      name = mkOption {
+        type = types.str;
+        default = name;
+        description = "Certmgr spec name";
+      };
+
+      service = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "The service on which to perform &lt;action&gt; after fetching.";
+      };
+
+      action = mkOption {
+        type = with types; addCheck str (x: cfg.svcManager == "command" || elem x ["restart" "reload" "nop"]);
+        default = "nop";
+        description = "The action to take after fetching.";
+      };
+
+      # These ought all to be specified according to certmgr spec def.
+      authority = mkOption {
+        type = types.submodule {
+          options = {
+            name = mkOption {
+              type = types.nullOr types.str;
+              default = null;
+              description = "Name of the global CA as defined in config file";
+            };
+
+            remote = mkOption {
+              type = types.nullOr types.str;
+              default = null;
+              description = "CFSSL remote address";
+            };
+
+            label = mkOption {
+              type = types.nullOr types.str;
+              default = null;
+              description = "CA label";
+            };
+
+            profile = mkOption {
+              type = types.nullOr types.str;
+              default = null;
+              description = "Name of the cfssl profile to use";
+            };
+
+            authKey = mkOption {
+              type = types.nullOr types.str;
+              default = null;
+              description = "Authentication key to use for cfssl authentication";
+            };
+
+            authKeyFile = mkOption {
+              type = types.nullOr types.path;
+              default = null;
+              description = "Authentication key file path";
+            };
+
+            file = mkOption {
+              type = types.nullOr (types.submodule fileOptions);
+              default = null;
+              description = "File where to output certificate authority.";
+            };
+
+            rootCA = mkOption {
+              type = types.nullOr types.path;
+              default = null;
+              description = "Path to rootca used for verification of selfsigned certs.";
+            };
+
+            trustOnBootstrap = mkOption {
+              type = types.bool;
+              default = false;
+              description = "Whether to trust CA on bootstrap";
+            };
+          };
+        };
+        default = {};
+        description = "certmgr spec authority object.";
+      };
+
+      certificate = mkOption {
+        type = types.nullOr (types.submodule fileOptions);
+        default = null;
+        description = "certmgr spec ceritificate file metadata.";
+      };
+
+      privateKey = mkOption {
+        type = types.nullOr (types.submodule fileOptions);
+        default = null;
+        description = "certmgr spec private key file metadata.";
+      };
+
+      request = mkOption {
+        type = types.nullOr types.attrs;
+        default = null;
+        description = "certmgr spec request object.";
+      };
+    };
+  };
+
+in {
   options.services.certmgr = {
     enable = mkEnableOption "certmgr";
 
@@ -45,7 +193,7 @@ in
     };
 
     defaultRemote = mkOption {
-      type = types.str;
+      type = types.nullOr types.str;
       default = "127.0.0.1:8888";
       description = "The default CA host:port to use.";
     };
@@ -57,7 +205,7 @@ in
     };
 
     renewInterval = mkOption {
-      default = "30m";
+      default = "2m";
       type = types.str;
       description = "How often to check certificate expirations and how often to update the cert_next_expires metric.";
     };
@@ -81,21 +229,28 @@ in
         exampleCert =
         let
           domain = "example.com";
-          secret = name: "/var/lib/secrets/''${name}.pem";
+          secretsPath = "/var/lib/secrets";
         in {
           service = "nginx";
           action = "reload";
           authority = {
-            file.path = secret "ca";
+            remote = "ca.example.net:8888",
+            authKeyFile = "''${secretsPath}/auth-key.secret";
+            label = "www_ca";
+            profile = "three-month";
+            file.path = "''${secretsPath}/ca.pem";
+            trustOnBootstrap = true;
           };
           certificate = {
-            path = secret domain;
+            path = "''${secretsPath}/nginx.crt";
+            owner = "nginx";
+            group = "nginx";
           };
-          private_key = {
-            owner = "root";
-            group = "root";
+          privateKey = {
+            path = "''${secretsPath}/nginx.key";
+            owner = "nginx";
+            group = "nginx";
             mode = "0600";
-            path = secret "''${domain}-key";
           };
           request = {
             CN = domain;
@@ -113,42 +268,7 @@ in
         otherCert = "/var/certmgr/specs/other-cert.json";
       }
       '';
-      type = with types; attrsOf (either (submodule {
-        options = {
-          service = mkOption {
-            type = nullOr str;
-            default = null;
-            description = "The service on which to perform &lt;action&gt; after fetching.";
-          };
-
-          action = mkOption {
-            type = addCheck str (x: cfg.svcManager == "command" || elem x ["restart" "reload" "nop"]);
-            default = "nop";
-            description = "The action to take after fetching.";
-          };
-
-          # These ought all to be specified according to certmgr spec def.
-          authority = mkOption {
-            type = attrs;
-            description = "certmgr spec authority object.";
-          };
-
-          certificate = mkOption {
-            type = nullOr attrs;
-            description = "certmgr spec certificate object.";
-          };
-
-          private_key = mkOption {
-            type = nullOr attrs;
-            description = "certmgr spec private_key object.";
-          };
-
-          request = mkOption {
-            type = nullOr attrs;
-            description = "certmgr spec request object.";
-          };
-        };
-    }) path);
+      type = with types; attrsOf (either (submodule specOptions) path);
       description = ''
         Certificate specs as described by:
         <link xlink:href="https://github.com/cloudflare/certmgr#certificate-specs" />
@@ -167,29 +287,50 @@ in
       '';
     };
 
+    ensurePreStart = mkOption {
+      default = true;
+      type = types.bool;
+      description = "Whether to ensure that certs are present before starting service.";
+    };
   };
 
   config = mkIf cfg.enable {
-    assertions = [
-      {
-        assertion = cfg.specs != {};
-        message = "Certmgr specs cannot be empty.";
-      }
-      {
-        assertion = !any (hasAttrByPath [ "authority" "auth_key" ]) (attrValues cfg.specs);
-        message = ''
-          Inline services.certmgr.specs are added to the Nix store rendering them world readable.
-          Specify paths as specs, if you want to use include auth_key - or use the auth_key_file option."
-        '';
-      }
+    warnings = [
+      (mkIf (any (spec: isAttrs spec && spec.authority.authKey != null) (attrValues cfg.specs)) ''
+        Inline services.certmgr.specs are added to the Nix store rendering them world readable.
+        Specify paths as specs, if you want to use include authKey - or use the authKeyFile option.
+      '')
     ];
+
+    services.cfssl.enable = mkDefault true;
 
     systemd.services.certmgr = {
       description = "certmgr";
-      path = mkIf (cfg.svcManager == "command") [ pkgs.bash ];
-      after = [ "network-online.target" ];
+      path = with pkgs; [ cfg.package curl cfssl ] ++
+        (optional (cfg.svcManager == "command") pkgs.bash);
+      after = [ "network-online.target" "cfssl.service" ];
       wantedBy = [ "multi-user.target" ];
-      inherit preStart;
+      preStart = ''
+        ${concatStringsSep " \\\n" (["mkdir -p"] ++ map escapeShellArg (unique specPaths))}
+
+        ${optionalString (trustOnBootstrapAuthorities != []) (concatMapStrings (authority: ''
+        if [ ! -f ${authority.rootCA} ]; then
+          authority_json=$(mktemp --tmpdir certmgr-XXXX)
+          until curl --fail-early -fskd '{}' ${authority.remote}/api/v1/cfssl/info -o $authority_json; do
+            echo "error fetching root ca '${authority.rootCA}' from '${authority.remote}/api/v1/cfssl/info'"
+            sleep 2
+          done
+          cfssljson -f $authority_json -stdout >${authority.rootCA}
+          rm $authority_json
+        fi
+        '') trustOnBootstrapAuthorities)}
+
+        ${if cfg.ensurePreStart then ''
+        certmgr -f ${certmgrYaml} ensure --enableActions
+        '' else ''
+        certmgr -f ${certmgrYaml} check
+        ''}
+      '';
 
       serviceConfig = {
         Restart = "always";

--- a/pkgs/tools/security/certmgr/default.nix
+++ b/pkgs/tools/security/certmgr/default.nix
@@ -1,43 +1,25 @@
-{ stdenv, buildGoPackage, fetchFromGitHub, fetchpatch }:
+{ stdenv, lib, buildGoPackage, fetchFromGitHub, fetchpatch }:
 
-let
-  generic = { patches ? [] }:
-    buildGoPackage rec {
-      version = "1.6.4";
-      pname = "certmgr";
+with lib;
 
-      goPackagePath = "github.com/cloudflare/certmgr/";
+buildGoPackage rec {
+  pname = "certmgr";
+  version = "2.0.1";
 
-      src = fetchFromGitHub {
-        owner = "cloudflare";
-        repo = "certmgr";
-        rev = "v${version}";
-        sha256 = "0glvyp61ya21pdm2bsvq3vfhmmxc2998vxc6hiyc79ijsv9n6jqi";
-      };
+  goPackagePath = "github.com/cloudflare/certmgr/";
 
-      inherit patches;
+  src = fetchFromGitHub {
+    owner = "cloudflare";
+    repo = "certmgr";
+    rev = "v${version}";
+    sha256 = "03whd80q5dqhby5qi7d1l113cafhfc41lmhgw13bw952zjv3q209";
+  };
 
-      meta = with stdenv.lib; {
-        homepage = https://cfssl.org/;
-        description = "Cloudflare's certificate manager";
-        platforms = platforms.linux;
-        license = licenses.bsd2;
-        maintainers = with maintainers; [ johanot srhb ];
-      };
-    };
-in
-{
-  certmgr = generic {};
-
-  certmgr-selfsigned = generic {
-    # The following patch makes it possible to use a self-signed x509 cert
-    # for the cfssl apiserver.
-    # TODO: remove patch when PR is merged.
-    patches = [
-      (fetchpatch {
-        url    = "https://github.com/cloudflare/certmgr/pull/51.patch";
-        sha256 = "0jhsw159d2mgybvbbn6pmvj4yqr5cwcal5fjwkcn9m4f4zlb6qrs";
-      })
-    ];
+  meta = {
+    homepage = https://cfssl.org/;
+    description = "Cloudflare's certificate manager";
+    platforms = platforms.linux;
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ johanot srhb offline ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2180,8 +2180,7 @@ in
     ceph-client;
   ceph-dev = ceph;
 
-  inherit (callPackages ../tools/security/certmgr { })
-    certmgr certmgr-selfsigned;
+  certmgr = callPackages ../tools/security/certmgr { };
 
   cfdg = callPackage ../tools/graphics/cfdg { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update of certmgr and improvement of nixos module. I'm working on kubernetes module refactoring (TODO: pull request link here) that had a lot of logic inside kubernetes that would be much better fit to be directly inside cfssl module.

###### Things done

- certmgr: 1.6.4 -> 2.0.1
- more explicit configuration options
- support for trusting selfsigned cfssl certs on bootstrap
- support for ensuring certs are generated before startup, so other
  services depending on certmgr can be sure certs are already in place

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
