### PR TITLE
Wacomtablet kcm

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6407,6 +6407,12 @@
     githubId = 224674;
     name = "Thomas Pham";
   };
+  Thra11 = {
+    email = "tahall256@protonmail.ch";
+    github = "Thra11";
+    githubId = 1391883;
+    name = "Tom Hall";
+  };
   tilpner = {
     email = "till@hoeppner.ws";
     github = "tilpner";

--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -183,7 +183,8 @@ in
         ++ lib.optional config.hardware.pulseaudio.enable plasma-pa
         ++ lib.optional config.powerManagement.enable powerdevil
         ++ lib.optional config.services.colord.enable colord-kde
-        ++ lib.optionals config.services.samba.enable [ kdenetwork-filesharing pkgs.samba ];
+        ++ lib.optionals config.services.samba.enable [ kdenetwork-filesharing pkgs.samba ]
+        ++ lib.optional config.services.xserver.wacom.enable wacomtablet;
 
       environment.pathsToLink = [
         # FIXME: modules should link subdirs of `/share` rather than relying on this

--- a/pkgs/tools/misc/wacomtablet/default.nix
+++ b/pkgs/tools/misc/wacomtablet/default.nix
@@ -1,0 +1,30 @@
+{ lib, mkDerivation, fetchurl, extra-cmake-modules, qtx11extras,
+  plasma-workspace, libwacom, xf86_input_wacom
+}:
+
+mkDerivation rec {
+  pname = "wacomtablet";
+  version = "3.2.0";
+  src = fetchurl {
+    url = "mirror://kde/stable/${pname}/${version}/${pname}-${version}.tar.xz";
+    sha256 = "197pwpl87gqlnza36bp68jvw8ww25znk08acmi8bpz7n84xfc368";
+  };
+
+  nativeBuildInputs = [ extra-cmake-modules ];
+  buildInputs = [
+    qtx11extras plasma-workspace
+    libwacom xf86_input_wacom
+  ];
+
+  meta = {
+    description = "KDE Configuration Module for Wacom Graphics Tablets";
+    longDescription = ''
+      This module implements a GUI for the Wacom Linux Drivers and extends it
+      with profile support to handle different button / pen layouts per profile.
+    '';
+    homepage = https://cgit.kde.org/wacomtablet.git/about/;
+    license = lib.licenses.gpl2;
+    maintainers = [ lib.maintainers.Thra11 ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24416,6 +24416,8 @@ in
 
   vttest = callPackage ../tools/misc/vttest { };
 
+  wacomtablet = libsForQt5.callPackage ../tools/misc/wacomtablet { };
+
   wasm-pack = callPackage ../development/tools/wasm-pack {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
###### Motivation for this change
Add new package for KDE Wacom Tablet Configuration GUI and optionally include it in the plasma5 package set if `services.xserver.wacom.enable` is true.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers (of related packages)

cc @ttuegel 
cc @abbradar 
cc @cillianderoiste 
