### PR TITLE
chmlib: 0.4 -> 0.4a

### DIFF
--- a/pkgs/development/libraries/chmlib/default.nix
+++ b/pkgs/development/libraries/chmlib/default.nix
@@ -1,17 +1,21 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchFromGitHub, autoreconfHook }:
 
 stdenv.mkDerivation rec {
-  name = "chmlib-0.40";
+  name = "chmlib-0.40a";
 
-  src = fetchurl {
-    url = "${meta.homepage}/${name}.tar.bz2";
-    sha256 = "18zzb4x3z0d7fjh1x5439bs62dmgsi4c1pg3qyr7h5gp1i5xcj9l";
+  src = fetchFromGitHub {
+    owner = "jedwing";
+    repo = "CHMLib";
+    rev = "2bef8d063ec7d88a8de6fd9f0513ea42ac0fa21f";
+    sha256 = "1hah0nw0l05npva2r35ywwd0kzyiiz4vamghm6d71h8170iva6m9";
   };
+
+  nativeBuildInputs = [ autoreconfHook ];
 
   meta = {
     homepage = http://www.jedrea.com/chmlib;
     license = stdenv.lib.licenses.lgpl2;
     description = "A library for dealing with Microsoft ITSS/CHM format files";
-    platforms = ["x86_64-linux" "i686-linux" "x86_64-darwin"];
+    platforms = ["x86_64-linux" "i686-linux" "x86_64-darwin" "aarch64-linux"];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Bump `chmlib` and fix build against `aarch64`. (The cross compiler stdenv appears broken on master atm, but I've tested the commit on a known working branch)

The versioning for `chmlib` doesn't appear very precise -- however the commit used here specifically updates the README to read 0.4a, so I believe that is correct as a version name.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
