### PR TITLE
linux-libre: fixing build / deblobbing

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-libre.nix
+++ b/pkgs/os-specific/linux/kernel/linux-libre.nix
@@ -1,11 +1,11 @@
 { stdenv, lib, fetchsvn, linux
 , scripts ? fetchsvn {
-    url = "https://www.fsfla.org/svn/fsfla/software/linux-libre/releases/tags/";
+    url = "https://www.fsfla.org/svn/fsfla/software/linux-libre/releases/branches/";
 
     # Update this if linux_latest-libre fails to build.
-    # $ curl https://www.fsfla.org/svn/fsfla/software/linux-libre/releases/tags/ | grep -Eo 'Revision [0-9]+'
-    rev = "16604";
-    sha256 = "0d2dh52zv073zr74ilspy0fy3ivys5pq32j7fljs4fwi2bcljf51";
+    # $ curl https://www.fsfla.org/svn/fsfla/software/linux-libre/releases/branches/ | grep -Eo 'Revision [0-9]+'
+    rev = "16791";
+    sha256 = "1lpaka4hs7yrpnrzfybd6radjylwvw2p4aly68pypykqs2srvm7j";
   }
 , ...
 }:
@@ -25,7 +25,7 @@ in linux.override {
       name = "${linux.name}-libre-src";
       src = linux.src;
       buildPhase = ''
-        ${scripts}/${majorMinor}-gnu/deblob-${majorMinor} \
+        ${scripts}/${majorMinor}/deblob-${majorMinor} \
             ${major} ${minor} ${patch}
       '';
       checkPhase = ''


### PR DESCRIPTION
###### Motivation for this change

Build was failing because we were depending on tagged versions of
the deblobbing scripts. The tags are not updated and thus newer
changes required won't be reflected unless the tag is re-created, which
might not be reliably the case.

So bumping revision and switching to use the branches to access the
deblob scripts.

The error from https://hydra.nixos.org/build/100489980/nixlog/1 :

```
[...]
BRCMFMAC - Broadcom IEEE802.11n embedded FullMAC WLAN driver
drivers/net/wireless/broadcom/brcm80211/brcmfmac/firmware.c: disabled non-Free firmware-loading machinery
ERROR: drivers/net/wireless/broadcom/brcm80211/brcmfmac/common.c did not change, something is wrong
Use --force to ignore
builder for '/nix/store/chsp2aqrsww68a4vsrg6qpfivvahw03y-linux-4.19.72-libre-src.drv' failed with exit code 1
```

For context, in our case the missing change is:

```
> diff -u /nix/store/sfc0rrhj5l44zpqgpsymq5750k5wzg8p-tags-r16790/4.19-gnu/deblob-4.19 ../deblob-4.19
--- /nix/store/sfc0rrhj5l44zpqgpsymq5750k5wzg8p-tags-r16790/4.19-gnu/deblob-4.19	1970-01-01 01:00:01.000000000 +0100
+++ ../deblob-4.19	2019-09-14 14:53:44.637404289 +0200
@@ -1879,7 +1879,11 @@

 announce BRCMFMAC - "Broadcom IEEE802.11n embedded FullMAC WLAN driver"
 reject_firmware drivers/net/wireless/broadcom/brcm80211/brcmfmac/firmware.c
-reject_firmware drivers/net/wireless/broadcom/brcm80211/brcmfmac/common.c
+if grep -q firmware_request_nowarn drivers/net/wireless/broadcom/brcm80211/brcmfmac/common.c; then
+  reject_firmware_nowarn drivers/net/wireless/broadcom/brcm80211/brcmfmac/common.c
+else
+  reject_firmware drivers/net/wireless/broadcom/brcm80211/brcmfmac/common.c
+fi
 clean_blob drivers/net/wireless/broadcom/brcm80211/brcmfmac/feature.c
 clean_blob drivers/net/wireless/broadcom/brcm80211/brcmfmac/firmware.h
```

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @alyssais 
ZHF: https://github.com/NixOS/nixpkgs/issues/68361
