### PR TITLE
pythonPackages.aioesphomeapi: 2.0.1 -> 2.2.0

### DIFF
--- a/pkgs/development/python-modules/aioesphomeapi/default.nix
+++ b/pkgs/development/python-modules/aioesphomeapi/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonPackage rec {
   pname = "aioesphomeapi";
-  version = "2.0.1";
+  version = "2.2.0";
 
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "db09e34dfc148279f303481c7da94b84c9b1442a41794f039c31253e81a58ffb";
+    sha256 = "0znal1hi964acc8bl3z0ikscax7zziks838ld099rjsbffjwmwn5";
   };
 
   propagatedBuildInputs = [ attrs protobuf zeroconf ];
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Python Client for ESPHome native API";
-    homepage = https://github.com/esphome/aioesphomeapi;
+    homepage = "https://github.com/esphome/aioesphomeapi";
     license = licenses.mit;
     maintainers = with maintainers; [ dotlambda ];
 


### PR DESCRIPTION
###### Motivation for this change
The old version is incompatible with the currently packaged version of home-assistant:
```
Unable to import esphome: cannot import name 'HomeassistantServiceCall' from 'aioesphomeapi'
```
https://github.com/esphome/aioesphomeapi/commits/v2.2.0
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
- [x] tested with personal esphome setup