### PR TITLE
purple-slack: Init at 2019-08-18

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-slack/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-slack/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, pidgin, pkgconfig }:
+
+stdenv.mkDerivation {
+  pname = "purple-slack-unstable";
+  version = "2019-08-18";
+
+  src = fetchFromGitHub {
+    owner = "dylex";
+    repo = "slack-libpurple";
+    rev = "be97802c7fd0b611722d2f551756e2a2672f6084";
+    sha256 = "0l6hwnnv6zzszxkk0a3nli88w5gijvlc9qgkkai0sb4v4c504y5v";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ pidgin ];
+
+  PKG_CONFIG_PURPLE_PLUGINDIR = "${placeholder "out"}/lib/purple-2";
+  PKG_CONFIG_PURPLE_DATAROOTDIR = "${placeholder "out"}/share";
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/dylex/slack-libpurple;
+    description = "Slack plugin for Pidgin";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ eyjhb ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19944,6 +19944,8 @@ in
 
   purple-plugin-pack = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-plugin-pack { };
 
+  purple-slack = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-slack { };
+
   purple-vk-plugin = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-vk-plugin { };
 
   purple-xmpp-http-upload = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-xmpp-http-upload { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Wasn't in the packages.

###### Things done
Tested using Bitlbee, works fine
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @tilpner you did most of the work, maybe you can review and make sure everything is OK.
Anyone else is welcome as well !
