### PR TITLE
update-python-libraries: use version key for latest release

### DIFF
--- a/pkgs/development/interpreters/python/update-python-libraries/update-python-libraries.py
+++ b/pkgs/development/interpreters/python/update-python-libraries/update-python-libraries.py
@@ -116,45 +116,11 @@ SEMVER = {
 }
 
 
-def _determine_latest_version(current_version, target, versions):
-    """Determine latest version, given `target`.
-    """
-    current_version = Version(current_version)
-
-    def _parse_versions(versions):
-        for v in versions:
-            try:
-                yield Version(v)
-            except InvalidVersion:
-                pass
-
-    versions = _parse_versions(versions)
-
-    index = SEMVER[target]
-
-    ceiling = list(current_version[0:index])
-    if len(ceiling) == 0:
-        ceiling = None
-    else:
-        ceiling[-1]+=1
-        ceiling = Version(".".join(map(str, ceiling)))
-
-    # We do not want prereleases
-    versions = SpecifierSet(prereleases=PRERELEASES).filter(versions)
-
-    if ceiling is not None:
-        versions = SpecifierSet(f"<{ceiling}").filter(versions)
-
-    return (max(sorted(versions))).raw_version
-
-
 def _get_latest_version_pypi(package, extension, current_version, target):
     """Get latest version and hash from PyPI."""
     url = "{}/{}/json".format(INDEX, package)
     json = _fetch_page(url)
-
-    versions = json['releases'].keys()
-    version = _determine_latest_version(current_version, target, versions)
+    version = json['info']['version']
 
     try:
         releases = json['releases'][version]
@@ -166,6 +132,7 @@ def _get_latest_version_pypi(package, extension, current_version, target):
             sha256 = release['digests']['sha256']
             break
     else:
+        logging.error("Release not found for extension: {}".format(extension))
         sha256 = None
     return version, sha256
 


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
From warehouse API reference [1]:

     GET /pypi/<project_name>/json

     Returns metadata (info) about an individual project at the latest
     version […]

[1] https://warehouse.pypa.io/api-reference/json/#project


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @FRidh
