### PR TITLE
qogir-icon-theme: init at 2019-09-15

### DIFF
--- a/pkgs/data/icons/qogir-icon-theme/default.nix
+++ b/pkgs/data/icons/qogir-icon-theme/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, gtk3 }:
+
+stdenv.mkDerivation rec {
+  pname = "qogir-icon-theme";
+  version = "2019-09-15";
+
+  src = fetchFromGitHub {
+    owner = "vinceliuice";
+    repo = pname;
+    rev = "4e1b6c693615bc2c7c7a11df6f4b90f2e6fb67db";
+    sha256 = "1vp1wp4fgmy5af8z8nb3m6wgmb6wbwlvx5smf9dxfcn254hdg8g0";
+  };
+
+  nativeBuildInputs = [ gtk3 ];
+
+  installPhase = ''
+    patchShebangs install.sh
+    mkdir -p $out/share/icons
+    name= ./install.sh -d $out/share/icons
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A colorful design icon theme for linux desktops";
+    homepage = https://github.com/vinceliuice/Qogir-icon-theme;
+    license = with licenses; [ gpl3 ];
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16976,6 +16976,8 @@ in
 
   publicsuffix-list = callPackage ../data/misc/publicsuffix-list { };
 
+  qogir-icon-theme = callPackage ../data/icons/qogir-icon-theme { };
+
   qogir-theme = callPackage ../data/themes/qogir { };
 
   redhat-official-fonts = callPackage ../data/fonts/redhat-official { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add [Qogir-icon-theme](https://github.com/vinceliuice/Qogir-icon-theme), A colorful design icon theme for linux desktops.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).