### PR TITLE
pyocclient: init at 0.4

### DIFF
--- a/pkgs/development/python-modules/pyocclient/default.nix
+++ b/pkgs/development/python-modules/pyocclient/default.nix
@@ -1,0 +1,26 @@
+{ lib, python37Packages  }:
+
+python37Packages.buildPythonPackage rec {
+  pname = "pyocclient";
+  version = "0.4";
+
+  src = python37Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "19k3slrk2idixsdw61in9a3jxglvkigkn5kvwl37lj8hrwr4yq6q";
+  };
+
+  doCheck = false;
+
+  propagatedBuildInputs = with python37Packages; [
+    requests
+    six
+    ];
+
+  meta = with lib; {
+    homepage = https://github.com/owncloud/pyocclient/;
+    description = "Nextcloud / Owncloud library for python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
+  };
+
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4421,6 +4421,8 @@ in {
 
   pyproj = callPackage ../development/python-modules/pyproj { };
 
+  pyocclient = callPackage ../development/python-modules/pyocclient {};
+
   pyqrcode = callPackage ../development/python-modules/pyqrcode { };
 
   pyrr = callPackage ../development/python-modules/pyrr { };


### PR DESCRIPTION
pyocclient: init at 0.4

###### Motivation for this change
Owncloud / Nextcloud interface python library

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
