### PR TITLE
qt5.qtwebengine: reduce log output

### DIFF
--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -103,24 +103,27 @@ EOF
       --replace 'libs = [ "sandbox" ]' 'libs = [ "/usr/lib/libsandbox.1.dylib" ]'
     '');
 
-  NIX_CFLAGS_COMPILE =
-  # it fails when compiled with -march=sandybridge https://github.com/NixOS/nixpkgs/pull/59148#discussion_r276696940
-  # TODO: investigate and fix properly
-    lib.optionals (stdenv.hostPlatform.platform.gcc.arch or "" == "sandybridge") [ "-march=westmere" ] ++
-    lib.optionals stdenv.isDarwin [
-      "-DMAC_OS_X_VERSION_MAX_ALLOWED=MAC_OS_X_VERSION_10_10"
-      "-DMAC_OS_X_VERSION_MIN_REQUIRED=MAC_OS_X_VERSION_10_10"
+  NIX_CFLAGS_COMPILE = [
+    # with gcc8, -Wclass-memaccess became part of -Wall and this exceeds the logging limit
+    "-Wno-class-memaccess"
+  ] ++ lib.optionals (stdenv.hostPlatform.platform.gcc.arch or "" == "sandybridge") [
+    # it fails when compiled with -march=sandybridge https://github.com/NixOS/nixpkgs/pull/59148#discussion_r276696940
+    # TODO: investigate and fix properly
+    "-march=westmere"
+  ] ++ lib.optionals stdenv.isDarwin [
+    "-DMAC_OS_X_VERSION_MAX_ALLOWED=MAC_OS_X_VERSION_10_10"
+    "-DMAC_OS_X_VERSION_MIN_REQUIRED=MAC_OS_X_VERSION_10_10"
 
-      #
-      # Prevent errors like
-      # /nix/store/xxx-apple-framework-CoreData/Library/Frameworks/CoreData.framework/Headers/NSEntityDescription.h:51:7:
-      # error: pointer to non-const type 'id' with no explicit ownership
-      #     id** _kvcPropertyAccessors;
-      #
-      # TODO remove when new Apple SDK is in
-      #
-      "-fno-objc-arc"
-    ];
+    #
+    # Prevent errors like
+    # /nix/store/xxx-apple-framework-CoreData/Library/Frameworks/CoreData.framework/Headers/NSEntityDescription.h:51:7:
+    # error: pointer to non-const type 'id' with no explicit ownership
+    #     id** _kvcPropertyAccessors;
+    #
+    # TODO remove when new Apple SDK is in
+    #
+    "-fno-objc-arc"
+  ];
 
   preConfigure = ''
     export NINJAFLAGS=-j$NIX_BUILD_CORES


### PR DESCRIPTION
Identical fix as 6f1ad0676fafd70df48c193e6bd1c7956ac26e09.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
See https://github.com/NixOS/nixpkgs/issues/68361#issuecomment-531602826

cc @matthewbauer @d-goldin 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
