### PR TITLE
kepubify: init at 2.3.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2812,6 +2812,12 @@
     github = "johannesloetzsch";
     name = "Johannes Lötzsch";
   };
+  jacobdillon = {
+    email = "jacob.dillon@uconn.edu";
+    github = "jacobdillon";
+    githubId = 6379443;
+    name = "Jacob Dillon";
+  };
   jagajaga = {
     email = "ars.seroka@gmail.com";
     github = "jagajaga";

--- a/pkgs/applications/misc/kepubify/default.nix
+++ b/pkgs/applications/misc/kepubify/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  pname = "kepubify";
+  version = "2.3.3";
+
+
+  goPackagePath = "github.com/geek1011/kepubify";
+
+  src = fetchFromGitHub {
+    owner = "geek1011";
+    repo = "kepubify";
+    rev = "v${version}";
+    sha256 = "1k8ips0dkbg607v81vjw3q86h3ls7mrpx62nhw6wsmix3cssms7y";
+  };
+
+  goDeps = ./deps.nix;
+
+  meta = with lib; {
+    description = "Converts epubs to kepubs";
+    homepage = https://pgaskin.net/kepubify/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ jacobdillon ];
+  };
+}

--- a/pkgs/applications/misc/kepubify/deps.nix
+++ b/pkgs/applications/misc/kepubify/deps.nix
@@ -1,0 +1,156 @@
+# file generated from go.mod using vgo2nix (https://github.com/adisbladis/vgo2nix)
+[
+  {
+    goPackagePath = "github.com/PuerkitoBio/goquery";
+    fetch = {
+      type = "git";
+      url = "https://github.com/PuerkitoBio/goquery";
+      rev = "v1.4.1";
+      sha256 = "11010z9ask21r0dskvm2pbh3z8951bnpcqg8aqa213if4h34gaa2";
+    };
+  }
+  {
+    goPackagePath = "github.com/andybalholm/cascadia";
+    fetch = {
+      type = "git";
+      url = "https://github.com/andybalholm/cascadia";
+      rev = "v1.0.0";
+      sha256 = "09j8cavbhqqdxjqrkwbc40g8p0i49zf3184rpjm5p2rjbprcghcc";
+    };
+  }
+  {
+    goPackagePath = "github.com/beevik/etree";
+    fetch = {
+      type = "git";
+      url = "https://github.com/beevik/etree";
+      rev = "v1.1.0";
+      sha256 = "12dqgh8swrnk8c1bwqmq4mgd65rj4waxgb02filkm3f52vyxryxn";
+    };
+  }
+  {
+    goPackagePath = "github.com/davecgh/go-spew";
+    fetch = {
+      type = "git";
+      url = "https://github.com/davecgh/go-spew";
+      rev = "v1.1.1";
+      sha256 = "0hka6hmyvp701adzag2g26cxdj47g21x6jz4sc6jjz1mn59d474y";
+    };
+  }
+  {
+    goPackagePath = "github.com/geek1011/koboutils";
+    fetch = {
+      type = "git";
+      url = "https://github.com/geek1011/koboutils";
+      rev = "v1.1.0";
+      sha256 = "168zwbwj2lihl0a5ljfv7wk6m1bl6f7mscjygsimpp0glacy5gq7";
+    };
+  }
+  {
+    goPackagePath = "github.com/mattn/go-isatty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-isatty";
+      rev = "v0.0.4";
+      sha256 = "0zs92j2cqaw9j8qx1sdxpv3ap0rgbs0vrvi72m40mg8aa36gd39w";
+    };
+  }
+  {
+    goPackagePath = "github.com/mattn/go-sqlite3";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-sqlite3";
+      rev = "v1.9.0";
+      sha256 = "14vw8bwyaz9lrd1rqhfri5cwpimiimhp75pkbqxxsjsr5jz89s7m";
+    };
+  }
+  {
+    goPackagePath = "github.com/mattn/go-zglob";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-zglob";
+      rev = "v0.0.1";
+      sha256 = "1sncdyq5fbd42al4amyy91h7vlzm3wm6c9vl8za2pjgfgsd581fz";
+    };
+  }
+  {
+    goPackagePath = "github.com/pmezard/go-difflib";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pmezard/go-difflib";
+      rev = "v1.0.0";
+      sha256 = "0c1cn55m4rypmscgf0rrb88pn58j3ysvc2d0432dp3c6fqg6cnzw";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/pflag";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/pflag";
+      rev = "v1.0.3";
+      sha256 = "1cj3cjm7d3zk0mf1xdybh0jywkbbw7a6yr3y22x9sis31scprswd";
+    };
+  }
+  {
+    goPackagePath = "github.com/stretchr/testify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/testify";
+      rev = "v1.2.2";
+      sha256 = "0dlszlshlxbmmfxj5hlwgv3r22x0y1af45gn1vd198nvvs3pnvfs";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev = "c2843e01d9a2";
+      sha256 = "01xgxbj5r79nmisdvpq48zfy8pzaaj90bn6ngd4nf33j9ar1dp8r";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev = "f3200d17e092";
+      sha256 = "1mskh7p80dd8j1ffy16917d3cyy7lfh1gb56n4rq9g1bwckz4lwy";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sync";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sync";
+      rev = "112230192c58";
+      sha256 = "05i2k43j2d0llq768hg5pf3hb2yhfzp9la1w5wp0rsnnzblr0lfn";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev = "d0b11bdaac8a";
+      sha256 = "18yfsmw622l7gc5sqriv5qmck6903vvhivpzp8i3xfy3z33dybdl";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/text";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/text";
+      rev = "v0.3.0";
+      sha256 = "0r6x6zjzhr8ksqlpiwm5gdd7s209kwk5p4lw54xjvz10cs3qlq19";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/tools";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/tools";
+      rev = "7be61e1b0e51";
+      sha256 = "0jwi2sgb98ywl8dxrn130zfnb1716pmmm8z1j8vkf8wcdzp82yzw";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23811,6 +23811,8 @@ in
 
   keynav = callPackage ../tools/X11/keynav { };
 
+  kepubify = callPackage ../applications/misc/kepubify { };
+
   kompose = callPackage ../applications/networking/cluster/kompose { };
 
   kontemplate = callPackage ../applications/networking/cluster/kontemplate { };


### PR DESCRIPTION
Also added myself to the list of maintainers.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
