### PR TITLE
Don't use deprecated dbusdirs

### DIFF
--- a/pkgs/applications/display-managers/lightdm/default.nix
+++ b/pkgs/applications/display-managers/lightdm/default.nix
@@ -53,6 +53,11 @@ stdenv.mkDerivation rec {
       url = "https://src.fedoraproject.org/rpms/lightdm/raw/4cf0d2bed8d1c68970b0322ccd5dbbbb7a0b12bc/f/lightdm-1.25.1-disable_dmrc.patch";
       sha256 = "06f7iabagrsiws2l75sx2jyljknr9js7ydn151p3qfi104d1541n";
     })
+    # Don't use etc/dbus-1/system.d
+    (fetchpatch {
+      url = "https://github.com/canonical/lightdm/commit/a99376f5f51aa147aaf81287d7ce70db76022c47.patch";
+      sha256 = "1zyx1qqajrmqcf9hbsapd39gmdanswd9l78rq7q6rdy4692il3yn";
+    })
   ];
 
   preConfigure = "NOCONFIGURE=1 ./autogen.sh";

--- a/pkgs/applications/display-managers/sddm/default.nix
+++ b/pkgs/applications/display-managers/sddm/default.nix
@@ -46,6 +46,7 @@ in mkDerivation {
     "-DQT_IMPORTS_DIR=${placeholder "out"}/${qtbase.qtQmlPrefix}"
     "-DCMAKE_INSTALL_SYSCONFDIR=${placeholder "out"}/etc"
     "-DSYSTEMD_SYSTEM_UNIT_DIR=${placeholder "out"}/lib/systemd/system"
+    "-DDBUS_CONFIG_DIR=${placeholder "out"}/share/dbus-1/system.d"
   ];
 
   postInstall = ''

--- a/pkgs/desktops/mate/mate-settings-daemon/default.nix
+++ b/pkgs/desktops/mate/mate-settings-daemon/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, pkgconfig, intltool, glib, dbus-glib, libxklavier,
   libcanberra-gtk3, libnotify, nss, polkit, gnome3, gtk3, mate,
   pulseaudioSupport ? stdenv.config.pulseaudio or true, libpulseaudio,
-  wrapGAppsHook }:
+  wrapGAppsHook, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "mate-settings-daemon";
@@ -11,6 +11,14 @@ stdenv.mkDerivation rec {
     url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "0yr5v6b9hdk20j29smbw1k4fkyg82i5vlflmgly0vi5whgc74gym";
   };
+
+  patches = [
+    # Don't use etc/dbus-1/system.d
+    (fetchpatch {
+      url = "https://patch-diff.githubusercontent.com/raw/mate-desktop/mate-settings-daemon/pull/296.patch";
+      sha256 = "00dfn8h47zw3wr7yya82vvp19wsw51whn8jwgayn4hkjd161s9nm";
+    })
+  ];
 
   nativeBuildInputs = [
     pkgconfig

--- a/pkgs/development/libraries/accountsservice/default.nix
+++ b/pkgs/development/libraries/accountsservice/default.nix
@@ -70,6 +70,11 @@ stdenv.mkDerivation rec {
       url = "https://gitlab.freedesktop.org/accountsservice/accountsservice/commit/0e712e935abd26499ff5995ab363e5bfd9ee7c4c.patch";
       sha256 = "1y60a5fmgfqjzprwpizilrazqn3mggdlgc5sgcpsprsp62fv78rl";
     })
+    # Don't use etc/dbus-1/system.d
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/accountsservice/accountsservice/commit/ced73d0fcbd2a54085a660d260482fc70d79bd5c.patch";
+      sha256 = "0s7fknfgxl8hnf6givmhfg4586fjb2n64i9arh1w7xnq7x9x8d4c";
+    })
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/avahi/default.nix
+++ b/pkgs/development/libraries/avahi/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
 
   configureFlags =
     [ "--disable-qt3" "--disable-gdbm" "--disable-mono"
-      "--disable-gtk"
+      "--disable-gtk" "--with-dbus-sys=${placeholder "out"}/share/dbus-1/system.d"
       (stdenv.lib.enableFeature gtk3Support "gtk3")
       "--${if qt4Support then "enable" else "disable"}-qt4"
       (stdenv.lib.enableFeature withPython "python")

--- a/pkgs/development/libraries/flatpak/default.nix
+++ b/pkgs/development/libraries/flatpak/default.nix
@@ -61,6 +61,7 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--with-system-bubblewrap=${bubblewrap}/bin/bwrap"
     "--with-system-dbus-proxy=${xdg-dbus-proxy}/bin/xdg-dbus-proxy"
+    "--dbus_config_dir=${placeholder "out"}/share/dbus-1/system.d"
     "--localstatedir=/var"
     "--enable-installed-tests"
   ];

--- a/pkgs/development/libraries/geoclue/default.nix
+++ b/pkgs/development/libraries/geoclue/default.nix
@@ -43,6 +43,7 @@ stdenv.mkDerivation rec {
     "--sysconfdir=/etc"
     "-Dsysconfdir_install=${placeholder "out"}/etc"
     "-Ddbus-srv-user=geoclue"
+    "-Ddbus-sys-dir=${placeholder "out"}/share/dbus-1/system.d"
   ] ++ optionals stdenv.isDarwin [
     "-D3g-source=false"
     "-Dcdma-source=false"

--- a/pkgs/development/libraries/polkit/default.nix
+++ b/pkgs/development/libraries/polkit/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, glib, expat, pam, perl
+{ stdenv, fetchurl, pkgconfig, glib, expat, pam, perl, fetchpatch
 , intltool, spidermonkey_60 , gobject-introspection, libxslt, docbook_xsl, dbus
 , docbook_xml_dtd_412, gtk-doc, coreutils
 , useSystemd ? stdenv.isLinux, systemd
@@ -21,6 +21,14 @@ stdenv.mkDerivation rec {
     url = "https://www.freedesktop.org/software/${pname}/releases/${pname}-${version}.tar.gz";
     sha256 = "1c9lbpndh5zis22f154vjrhnqw65z8s85nrgl42v738yf6g0q5w8";
   };
+
+  patches = [
+    # Don't use etc/dbus-1/system.d
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/polkit/polkit/merge_requests/11.patch";
+      sha256 = "17lv7xj5ksa27iv4zpm4zwd4iy8zbwjj4ximslfq3sasiz9kxhlp";
+    })
+  ];
 
   postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
     sed -i -e "s/-Wl,--as-needed//" configure.ac

--- a/pkgs/misc/cups/cups-pk-helper.nix
+++ b/pkgs/misc/cups/cups-pk-helper.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, intltool, pkgconfig, glib, polkit, cups }:
+{ stdenv, fetchurl, intltool, pkgconfig, glib, polkit, cups, fetchpatch }:
 
 stdenv.mkDerivation rec {
   version = "0.2.6";
@@ -11,6 +11,14 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig intltool ];
   buildInputs = [ glib polkit cups ];
+
+  patches = [
+    # Don't use etc/dbus-1/system.d
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/cups-pk-helper/cups-pk-helper/merge_requests/2.patch";
+      sha256 = "1kamhr5kn8c1y0q8xbip0fgr7maf3dyddlvab4n0iypk7rwwikl0";
+    })
+  ];
 
   meta = with stdenv.lib; {
     description = "PolicyKit helper to configure cups with fine-grained privileges";

--- a/pkgs/misc/cups/default.nix
+++ b/pkgs/misc/cups/default.nix
@@ -48,6 +48,7 @@ stdenv.mkDerivation rec {
   ] ++ optionals stdenv.isLinux [
     "--enable-dbus"
     "--enable-pam"
+    "--with-dbusdir=${placeholder "out"}/share/dbus-1"
   ] ++ optional (libusb != null) "--enable-libusb"
     ++ optional (gnutls != null) "--enable-ssl"
     ++ optional (avahi != null) "--enable-avahi"
@@ -81,7 +82,6 @@ stdenv.mkDerivation rec {
       "STATEDIR=$(TMPDIR)/dummy"
       # Idem for /etc.
       "PAMDIR=$(out)/etc/pam.d"
-      "DBUSDIR=$(out)/etc/dbus-1"
       "XINETD=$(out)/etc/xinetd.d"
       "SERVERROOT=$(out)/etc/cups"
       # Idem for /usr.

--- a/pkgs/os-specific/linux/bluez/default.nix
+++ b/pkgs/os-specific/linux/bluez/default.nix
@@ -48,12 +48,12 @@ stdenv.mkDerivation rec {
     "--enable-library"
     "--enable-cups"
     "--enable-pie"
-    "--with-dbusconfdir=$(out)/etc"
-    "--with-dbussystembusdir=$(out)/share/dbus-1/system-services"
-    "--with-dbussessionbusdir=$(out)/share/dbus-1/services"
-    "--with-systemdsystemunitdir=$(out)/etc/systemd/system"
-    "--with-systemduserunitdir=$(out)/etc/systemd/user"
-    "--with-udevdir=$(out)/lib/udev"
+    "--with-dbusconfdir=${placeholder "out"}/share"
+    "--with-dbussystembusdir=${placeholder "out"}/share/dbus-1/system-services"
+    "--with-dbussessionbusdir=${placeholder "out"}/share/dbus-1/services"
+    "--with-systemdsystemunitdir=${placeholder "out"}/etc/systemd/system"
+    "--with-systemduserunitdir=${placeholder "out"}/etc/systemd/user"
+    "--with-udevdir=${placeholder "out"}/lib/udev"
     ] ++ optional enableWiimote [ "--enable-wiimote" ]
       ++ optional enableMidi    [ "--enable-midi" ]
       ++ optional enableSixaxis [ "--enable-sixaxis" ]);
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
   # Work around `make install' trying to create /var/lib/bluetooth.
   installFlags = "statedir=$(TMPDIR)/var/lib/bluetooth";
 
-  makeFlags = "rulesdir=$(out)/lib/udev/rules.d";
+  makeFlags = "rulesdir=${placeholder "out"}/lib/udev/rules.d";
 
   postInstall = ''
     mkdir -p $test/{bin,test}

--- a/pkgs/os-specific/linux/firmware/fwupd/default.nix
+++ b/pkgs/os-specific/linux/firmware/fwupd/default.nix
@@ -2,6 +2,7 @@
 
 { stdenv
 , fetchurl
+, fetchpatch
 , substituteAll
 , gtk-doc
 , pkgconfig
@@ -152,6 +153,11 @@ stdenv.mkDerivation rec {
       src = ./installed-tests-path.patch;
       # needs a different set of modules than po/make-images
       inherit installedTestsPython;
+    })
+    # Don't use etc/dbus-1/system.d
+    (fetchpatch {
+      url = "https://github.com/fwupd/fwupd/commit/41a25be6f4b371c367904284e9251cd461ad5cfe.patch";
+      sha256 = "0vv3x2pq5bpmg9c8ax5dsqcblw45n7jmzgw6p8h4asyjy57mzhaq";
     })
   ];
 

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -56,7 +56,7 @@ in stdenv.mkDerivation {
   #dontAddPrefix = true;
 
   mesonFlags = [
-    "-Ddbuspolicydir=${placeholder "out"}/etc/dbus-1/system.d"
+    "-Ddbuspolicydir=${placeholder "out"}/share/dbus-1/system.d"
     "-Ddbussessionservicedir=${placeholder "out"}/share/dbus-1/services"
     "-Ddbussystemservicedir=${placeholder "out"}/share/dbus-1/system-services"
     "-Dpamconfdir=${placeholder "out"}/etc/pam.d"

--- a/pkgs/os-specific/linux/wpa_supplicant/default.nix
+++ b/pkgs/os-specific/linux/wpa_supplicant/default.nix
@@ -88,7 +88,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/etc/dbus-1/system.d $out/share/dbus-1/system-services $out/etc/systemd/system
     cp -v "dbus/"*service $out/share/dbus-1/system-services
     sed -e "s@/sbin/wpa_supplicant@$out&@" -i "$out/share/dbus-1/system-services/"*
-    cp -v dbus/dbus-wpa_supplicant.conf $out/etc/dbus-1/system.d
+    cp -v dbus/dbus-wpa_supplicant.conf $out/share/dbus-1/system.d
     cp -v "systemd/"*.service $out/etc/systemd/system
     rm $out/share/man/man8/wpa_priv.8
     install -Dm444 wpa_supplicant.conf $out/share/doc/wpa_supplicant/wpa_supplicant.conf.example

--- a/pkgs/tools/bluetooth/blueman/default.nix
+++ b/pkgs/tools/bluetooth/blueman/default.nix
@@ -3,7 +3,7 @@
 , gnome3, librsvg, wrapGAppsHook, gobject-introspection
 , withNetworkManager ?
     config.networking.networkmanager.enable or false, networkmanager
-, withPulseAudio ? config.pulseaudio or stdenv.isLinux, libpulseaudio }:
+, withPulseAudio ? config.pulseaudio or stdenv.isLinux, libpulseaudio, fetchpatch }:
 
 let
   pythonPackages = python3Packages;
@@ -28,6 +28,14 @@ in stdenv.mkDerivation rec {
                 ++ pythonPath
                 ++ lib.optional withPulseAudio libpulseaudio
                 ++ lib.optional withNetworkManager networkmanager;
+
+  patches = [
+    # Don't use etc/dbus-1/system.d
+    (fetchpatch {
+      url = "https://patch-diff.githubusercontent.com/raw/blueman-project/blueman/pull/1103.patch";
+      sha256 = "0zqdi6ya97jljwinn10n9q6bixl23ww55c0pkhskn140qnrj42wf";
+    })
+  ];
 
   postPatch = lib.optionalString withPulseAudio ''
     sed -i 's,CDLL(",CDLL("${libpulseaudio.out}/lib/,g' blueman/main/PulseAudioUtils.py

--- a/pkgs/tools/graphics/zbar/default.nix
+++ b/pkgs/tools/graphics/zbar/default.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--without-python"
   ] ++ (if enableDbus then [
-    "--with-dbusconfdir=${placeholder "out"}/etc"
+    "--with-dbusconfdir=${placeholder "out"}/share"
   ] else [
     "--without-dbus"
   ]) ++ (if enableVideo then [

--- a/pkgs/tools/misc/rpm-ostree/default.nix
+++ b/pkgs/tools/misc/rpm-ostree/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, ostree, rpm, which, autoconf, automake, libtool, pkgconfig, cargo, rustc,
   gobject-introspection, gtk-doc, libxml2, libxslt, docbook_xsl, docbook_xml_dtd_42, docbook_xml_dtd_43, gperf, cmake,
   libcap, glib, systemd, json-glib, libarchive, libsolv, librepo, polkit,
-  bubblewrap, pcre, check, python, json_c, libmodulemd_1, utillinux, sqlite, cppunit }:
+  bubblewrap, pcre, check, python, json_c, libmodulemd_1, utillinux, sqlite, cppunit, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "rpm-ostree";
@@ -17,6 +17,12 @@ stdenv.mkDerivation rec {
     # https://github.com/NixOS/nixpkgs/pull/50953#issuecomment-449777169
     # https://github.com/NixOS/nixpkgs/pull/50953#issuecomment-452177080
     ./fix-introspection-build.patch
+
+    # Don't use etc/dbus-1/system.d
+    (fetchpatch {
+      url = "https://github.com/coreos/rpm-ostree/commit/60053d0d3d2279d120ae7007c6048e499d2c4d14.patch";
+      sha256 = "0ig21zip09iy2da7ksg87jykaj3q8jyzh8r7yrpzyql85qxiwm0m";
+    })
   ];
 
   outputs = [ "out" "dev" "man" "devdoc" ];

--- a/pkgs/tools/misc/snapper/default.nix
+++ b/pkgs/tools/misc/snapper/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub
 , autoreconfHook, pkgconfig, docbook_xsl, libxslt, docbook_xml_dtd_45
 , acl, attr, boost, btrfs-progs, dbus, diffutils, e2fsprogs, libxml2
-, lvm2, pam, python, utillinux }:
+, lvm2, pam, python, utillinux, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "snapper";
@@ -21,6 +21,14 @@ stdenv.mkDerivation rec {
   buildInputs = [
     acl attr boost btrfs-progs dbus diffutils e2fsprogs libxml2
     lvm2 pam python utillinux
+  ];
+
+  patches = [
+    # Don't use etc/dbus-1/system.d
+    (fetchpatch {
+      url = "https://github.com/openSUSE/snapper/commit/c51708aea22d9436da287cba84424557ad03644b.patch";
+      sha256 = "106pf7pv8z3q37c8ckmgwxs1phf2fy7l53a9g5xq5kk2rjj1cx34";
+    })
   ];
 
   postPatch = ''

--- a/pkgs/tools/networking/connman/default.nix
+++ b/pkgs/tools/networking/connman/default.nix
@@ -26,8 +26,8 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--sysconfdir=\${out}/etc"
     "--localstatedir=/var"
-    "--with-dbusconfdir=\${out}/etc"
-    "--with-dbusdatadir=\${out}/usr/share"
+    "--with-dbusconfdir=${placeholder "out"}/share"
+    "--with-dbusdatadir=${placeholder "out"}/share"
     "--disable-maintainer-mode"
     "--enable-openconnect=builtin"
     "--with-openconnect=${openconnect}/sbin/openconnect"

--- a/pkgs/tools/networking/dnsmasq/default.nix
+++ b/pkgs/tools/networking/dnsmasq/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
     substituteInPlace $out/Library/LaunchDaemons/uk.org.thekelleys.dnsmasq.plist \
       --replace "/usr/local/sbin" "$out/bin"
   '' + optionalString stdenv.isLinux ''
-    install -Dm644 dbus/dnsmasq.conf $out/etc/dbus-1/system.d/dnsmasq.conf
+    install -Dm644 dbus/dnsmasq.conf $out/share/dbus-1/system.d/dnsmasq.conf
     install -Dm755 contrib/lease-tools/dhcp_lease_time $out/bin/dhcp_lease_time
     install -Dm755 contrib/lease-tools/dhcp_release $out/bin/dhcp_release
     install -Dm755 contrib/lease-tools/dhcp_release6 $out/bin/dhcp_release6

--- a/pkgs/tools/networking/network-manager/fortisslvpn/default.nix
+++ b/pkgs/tools/networking/network-manager/fortisslvpn/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, substituteAll, openfortivpn, intltool, pkgconfig, file, gtk3,
-networkmanager, ppp, libsecret, withGnome ? true, gnome3 }:
+networkmanager, ppp, libsecret, withGnome ? true, gnome3, fetchpatch }:
 
 let
   pname = "NetworkManager-fortisslvpn";
@@ -16,6 +16,11 @@ in stdenv.mkDerivation {
     (substituteAll {
       src = ./fix-paths.patch;
       inherit openfortivpn;
+    })
+    # Don't use etc/dbus-1/system.d
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/NetworkManager-fortisslvpn/merge_requests/11.patch";
+      sha256 = "0l7l2r1njh62lh2pf497ibf99sgkvjsj58xr76qx3jxgq9zfw6n9";
     })
   ];
 

--- a/pkgs/tools/networking/network-manager/iodine/default.nix
+++ b/pkgs/tools/networking/network-manager/iodine/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, substituteAll, iodine, intltool, pkgconfig, networkmanager, libsecret, gtk3
-, withGnome ? true, gnome3 }:
+, withGnome ? true, gnome3, fetchpatch }:
 
 let
   pname = "NetworkManager-iodine";
@@ -16,6 +16,11 @@ in stdenv.mkDerivation {
     (substituteAll {
       src = ./fix-paths.patch;
       inherit iodine;
+    })
+    # Don't use etc/dbus-1/system.d
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/network-manager-iodine/merge_requests/2.patch";
+      sha256 = "108pkf0mddj32s46k7jkmpwcaq2ylci4dqpp7wck3zm9q2jffff2";
     })
   ];
 

--- a/pkgs/tools/networking/network-manager/openconnect/default.nix
+++ b/pkgs/tools/networking/network-manager/openconnect/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, substituteAll, openconnect, intltool, pkgconfig, autoreconfHook, networkmanager, gcr, libsecret, file
-, gtk3, withGnome ? true, gnome3, kmod }:
+, gtk3, withGnome ? true, gnome3, kmod, fetchpatch }:
 
 let
   pname   = "NetworkManager-openconnect";
@@ -16,6 +16,11 @@ in stdenv.mkDerivation {
     (substituteAll {
       src = ./fix-paths.patch;
       inherit kmod openconnect;
+    })
+    # Don't use etc/dbus-1/system.d
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/NetworkManager-openconnect/merge_requests/9.patch";
+      sha256 = "0yd2dmq6gq6y4czr7dqdgaiqvw2vyv2gikznpfdxyfn2v1pcrk9m";
     })
   ];
 

--- a/pkgs/tools/networking/network-manager/openvpn/default.nix
+++ b/pkgs/tools/networking/network-manager/openvpn/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, substituteAll, openvpn, intltool, libxml2, pkgconfig, file, networkmanager, libsecret
-, gtk3, withGnome ? true, gnome3, kmod }:
+, gtk3, withGnome ? true, gnome3, kmod, fetchpatch }:
 
 let
   pname = "NetworkManager-openvpn";
@@ -16,6 +16,11 @@ in stdenv.mkDerivation {
     (substituteAll {
       src = ./fix-paths.patch;
       inherit kmod openvpn;
+    })
+    # Don't use etc/dbus-1/system.d
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/NetworkManager-openvpn/merge_requests/13.patch";
+      sha256 = "06cvqi28v72dd53fw8ix95mqj885xhwi8qcs2q7hvm5bvnhwn704";
     })
   ];
 

--- a/pkgs/tools/networking/network-manager/vpnc/default.nix
+++ b/pkgs/tools/networking/network-manager/vpnc/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, substituteAll, vpnc, intltool, pkgconfig, networkmanager, libsecret
-, gtk3, withGnome ? true, gnome3, kmod, file }:
+, gtk3, withGnome ? true, gnome3, kmod, file, fetchpatch }:
 let
   pname = "NetworkManager-vpnc";
   version = "1.2.6";
@@ -15,6 +15,11 @@ in stdenv.mkDerivation {
     (substituteAll {
       src = ./fix-paths.patch;
       inherit vpnc kmod;
+    })
+    # Don't use etc/dbus-1/system.d
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/NetworkManager-vpnc/merge_requests/5.patch";
+      sha256 = "0z0x5vqmrsap3ynamhya7gh6c6k5grhj2vqpy76alnv9xns8dzi6";
     })
   ];
 

--- a/pkgs/tools/networking/strongswan/default.nix
+++ b/pkgs/tools/networking/strongswan/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl
+{ stdenv, fetchurl, fetchpatch
 , pkgconfig, autoreconfHook
 , gmp, python, iptables, ldns, unbound, openssl, pcsclite
 , openresolv
@@ -38,6 +38,12 @@ stdenv.mkDerivation rec {
     ./ext_auth-path.patch
     ./firewall_defaults.patch
     ./updown-path.patch
+
+    # Don't use etc/dbus-1/system.d
+    (fetchpatch {
+      url = "https://patch-diff.githubusercontent.com/raw/strongswan/strongswan/pull/150.patch";
+      sha256 = "1irfxb99blb8v3hs0kmlhzkkwbmds1p0gq319z8lmacz36cgyj2c";
+    })
   ];
 
   postPatch = optionalString stdenv.isLinux ''

--- a/pkgs/tools/package-management/disnix/default.nix
+++ b/pkgs/tools/package-management/disnix/default.nix
@@ -8,6 +8,10 @@ stdenv.mkDerivation {
     sha256 = "1kc4520zjc1z72mknylfvrsyda9rbmm5c9mw8w13zhdwg3zbna06";
   };
 
+  configureFlags = [
+    " --with-dbus-sys=${placeholder "out"}/share/dbus-1/system.d"
+  ];
+
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ glib libxml2 libxslt getopt nixUnstable libintl libiconv dysnomia ];
 

--- a/pkgs/tools/package-management/packagekit/default.nix
+++ b/pkgs/tools/package-management/packagekit/default.nix
@@ -39,8 +39,8 @@ stdenv.mkDerivation rec {
     "--disable-offline-update"
     "--localstatedir=/var"
     "--sysconfdir=/etc"
-    "--with-dbus-sys=$(out)/etc/dbus-1/system.d"
-    "--with-systemdsystemunitdir=$(out)/lib/systemd/system/"
+    "--with-dbus-sys=${placeholder "out"}/share/dbus-1/system.d"
+    "--with-systemdsystemunitdir=${placeholder "out"}/lib/systemd/system/"
   ]
   ++ lib.optional enableNixBackend "--enable-nix"
   ++ lib.optional (!enableBashCompletion) "--disable-bash-completion"

--- a/pkgs/tools/security/fprintd/default.nix
+++ b/pkgs/tools/security/fprintd/default.nix
@@ -1,6 +1,6 @@
 { thinkpad ? false
 , stdenv, fetchurl, pkgconfig, intltool, libfprint-thinkpad ? null
-, libfprint ? null, glib, dbus-glib, polkit, nss, pam, systemd }:
+, libfprint ? null, glib, dbus-glib, polkit, nss, pam, systemd, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "fprintd" + stdenv.lib.optionalString thinkpad "-thinkpad";
@@ -11,16 +11,23 @@ stdenv.mkDerivation rec {
     sha256 = "124s0g9syvglgsmqnavp2a8c0zcq8cyaph8p8iyvbla11vfizs9l";
   };
 
+  patches = [
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/libfprint/fprintd/merge_requests/16.patch";
+      sha256 = "1y39zsmxjll9hip8464qwhq5qg06c13pnafyafgxdph75lvhdll7";
+    })
+  ];
+
   buildInputs = [ glib dbus-glib polkit nss pam systemd ]
     ++ stdenv.lib.optional thinkpad libfprint-thinkpad
     ++ stdenv.lib.optional (!thinkpad) libfprint;
 
   nativeBuildInputs = [ pkgconfig intltool ];
 
-  configureFlags = [ 
-    "--with-systemdsystemunitdir=${placeholder "out"}/lib/systemd/system" 
-    "--localstatedir=/var" 
-    "--sysconfdir=${placeholder "out"}/etc" 
+  configureFlags = [
+    "--with-systemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
+    "--localstatedir=/var"
+    "--sysconfdir=${placeholder "out"}/etc"
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/system/thermald/default.nix
+++ b/pkgs/tools/system/thermald/default.nix
@@ -23,9 +23,10 @@ stdenv.mkDerivation rec {
   '';
 
   configureFlags = [
-    "--sysconfdir=$(out)/etc" "--localstatedir=/var"
-    "--with-dbus-sys-dir=$(out)/etc/dbus-1/system.d"
-    "--with-systemdsystemunitdir=$(out)/etc/systemd/system"
+    "--sysconfdir=${placeholder "out"}/etc"
+    "--localstatedir=/var"
+    "--with-dbus-sys-dir=${placeholder "out"}/share/dbus-1/system.d"
+    "--with-systemdsystemunitdir=${placeholder "out"}/etc/systemd/system"
     ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
✌️etc/dbus-1/system.d for third party packages.
This is a mix of upstream patches of my own, other people's yet to be merged patches, and using the configure flags projects provided.

There's still a few more I'd like to get but didn't have time for
- hplip
- system-config-printer
- ~wpa_supplicant~
- rtkit
- ~rpm-ostree~

###### Upstream PRs/MRs

- [x] https://github.com/fwupd/fwupd/pull/1356
- [x] https://github.com/blueman-project/blueman/pull/1103
- [ ] https://github.com/mate-desktop/mate-settings-daemon/pull/296
- [ ] https://gitlab.gnome.org/GNOME/network-manager-iodine/merge_requests/2
- [ ] https://gitlab.gnome.org/GNOME/NetworkManager-fortisslvpn/merge_requests/11
- [ ] https://gitlab.gnome.org/GNOME/NetworkManager-openconnect/merge_requests/9
- [x] https://gitlab.freedesktop.org/libfprint/fprintd/merge_requests/16
- [ ] https://gitlab.freedesktop.org/cups-pk-helper/cups-pk-helper/merge_requests/2
- [x] https://github.com/coreos/rpm-ostree/pull/1903
- [x] https://github.com/strongswan/strongswan/pull/150
- [ ] https://github.com/svanderburg/disnix/pull/14
- [ ] https://github.com/openSUSE/snapper/pull/492

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
