### PR TITLE
ocamlPackages.owee: 0.2 → 0.3; spacetime_lib: 0.1.0 → 0.3.0

### DIFF
--- a/pkgs/development/ocaml-modules/owee/default.nix
+++ b/pkgs/development/ocaml-modules/owee/default.nix
@@ -1,25 +1,21 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib }:
+{ lib, buildDunePackage, fetchFromGitHub }:
 
-stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-owee-${version}";
-  version = "0.2";
+buildDunePackage rec {
+  minimumOCamlVersion = "4.06";
+  pname = "owee";
+  version = "0.3";
 
   src = fetchFromGitHub {
     owner = "let-def";
     repo = "owee";
     rev = "v${version}";
-    sha256 = "025a8sm03mm9qr7grdmdhzx7pyrd0dr7ndr5mbj5baalc0al132z";
+    sha256 = "0jp8ca57488d7sj2nqy4yxcdpda6sxx51yyi8k6888hbinhyqp0j";
   };
-
-  buildInputs = [ ocaml findlib ];
-
-  createFindlibDestdir = true;
 
   meta = {
     description = "An experimental OCaml library to work with DWARF format";
     inherit (src.meta) homepage;
-    inherit (ocaml.meta) platforms;
-    license = stdenv.lib.licenses.mit;
-    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/spacetime_lib/default.nix
+++ b/pkgs/development/ocaml-modules/spacetime_lib/default.nix
@@ -1,30 +1,22 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, owee }:
+{ lib, fetchFromGitHub, buildDunePackage, owee }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.04"
-then throw "spacetime_lib is not available for OCaml ${ocaml.version}" else
-
-stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-spacetime_lib-${version}";
-  version = "0.1.0";
+buildDunePackage rec {
+  pname = "spacetime_lib";
+  version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "lpw25";
     repo = "spacetime_lib";
     rev = version;
-    sha256 = "1g91y6wl3z18jhaz2q03wn54zj6xk1qcjidr1nc6nq9a8906lcq5";
+    sha256 = "0biisgbycr5v3nm5jp8i0h6vq76vzasdjkcgh8yr7fhxc81jgv3p";
   };
 
-  buildInputs = [ ocaml findlib ];
-
   propagatedBuildInputs = [ owee ];
-
-  createFindlibDestdir = true;
 
   meta = {
     description = "An OCaml library providing some simple operations for handling OCaml “spacetime” profiles";
     inherit (src.meta) homepage;
-    inherit (ocaml.meta) platforms;
-    license = stdenv.lib.licenses.mit;
-    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.vbgl ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Compatibility with OCaml 4.08

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
