### PR TITLE
nixos/unifi: add test and additional config options [WIP]

### DIFF
--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -137,6 +137,9 @@ with lib;
     # tarsnap
     (mkRemovedOptionModule [ "services" "tarsnap" "cachedir" ] "Use services.tarsnap.archives.<name>.cachedir")
 
+    # unifi
+    (mkRemovedOptionModule [ "services" "unifi" "dataDir" ] "To use external storage, configure unifi to use an external Mongo instance and configure that accordingly.")
+
     # alsa
     (mkRenamedOptionModule [ "sound" "enableMediaKeys" ] [ "sound" "mediaKeys" "enable" ])
 

--- a/nixos/tests/unifi.nix
+++ b/nixos/tests/unifi.nix
@@ -1,0 +1,45 @@
+import ./make-test.nix ({ pkgs, ... }:
+
+let
+  httpPort = 8080;
+  httpsPort = 18443;
+
+in rec {
+  name = "unifi";
+
+  meta = with pkgs.stdenv.lib; {
+    maintainers = with maintainers; [ peterhoeg ];
+  };
+
+  nodes = {
+    server = { pkgs, ... }: {
+      boot.kernelPackages = kernel;
+      services.unifi = {
+        enable = true;
+        openPorts = true;
+        unifiPackage = pkgs.unifiStable;
+        inherit httpPort httpsPort;
+      };
+      nixpkgs.config.allowUnfree = true;
+    };
+
+    client = { pkgs, ... }: {
+      environment.systemPackages = with pkgs; [ curl ];
+    };
+  };
+
+  testScript = ''
+    startAll;
+
+    $server->waitForOpenPort(${toString httpPort});
+
+    $server->waitUntilSucceeds("test -d /var/lib/unifi/data");
+    $server->waitUntilSucceeds("test -d /var/lib/unifi/logs");
+    $server->waitUntilSucceeds("test -d /var/lib/unifi/run");
+
+    $server->waitUntilSucceeds("test -L /var/lib/unifi/webapps/ROOT");
+    $server->waitUntilSucceeds("test -f /var/lib/unifi/data/system.properties");
+
+    $client->waitUntilSucceeds("curl --insecure --silent https://server:${toString httpsPort}");
+  '';
+})


### PR DESCRIPTION
###### Motivation for this change

This allows having the controller listen on custom ports + to set advanced options via ```system.properties```.

We remove the ability to configure where the data is stored and just force things to be under ```/var/lib/unifi``` as someone with specific database requirements can use an external mongodb instance now and configure that to place the data in a custom location.

Furthermore, we add a proper nixos test.

The thing I would love some input on is how we handle migration in case a custom ```dataDir``` was set in the past.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @erictapen 
