### PR TITLE
Various cross-compilation fixes

### DIFF
--- a/pkgs/development/compilers/dtc/default.nix
+++ b/pkgs/development/compilers/dtc/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchgit, flex, bison, pkgconfig, python2, swig, which }:
+{ stdenv, lib, fetchgit, flex, bison, pkgconfig, which
+, pythonSupport ? stdenv.buildPlatform == stdenv.hostPlatform, python2, swig
+}:
 
 stdenv.mkDerivation rec {
   pname = "dtc";
@@ -10,16 +12,17 @@ stdenv.mkDerivation rec {
     sha256 = "075gj8bbahfdb8dlif3d2dpzjrkyf3bwbcmx96zpwhlgs0da8jxh";
   };
 
-  nativeBuildInputs = [ flex bison pkgconfig swig which ];
-  buildInputs = [ python2 ];
+  nativeBuildInputs = [ flex bison pkgconfig which ] ++ lib.optionals pythonSupport [ python2 swig ];
+  buildInputs = lib.optionals pythonSupport [ python2 ];
 
   postPatch = ''
     patchShebangs pylibfdt/
   '';
 
+  makeFlags = lib.optionals (!pythonSupport) [ "NO_PYTHON=1" ];
   installFlags = [ "INSTALL=install" "PREFIX=$(out)" "SETUP_PREFIX=$(out)" ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Device Tree Compiler";
     homepage = https://git.kernel.org/cgit/utils/dtc/dtc.git;
     license = licenses.gpl2; # dtc itself is GPLv2, libfdt is dual GPL/BSD

--- a/pkgs/os-specific/linux/udisks/2-default.nix
+++ b/pkgs/os-specific/linux/udisks/2-default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     sha256 = "01wx2x8xyal595dhdih7rva2bz7gqzgwdp56gi0ikjdzayx17wcf";
   };
 
-  outputs = [ "out" "man" "dev" "devdoc" ];
+  outputs = [ "out" "man" "dev" ] ++ stdenv.lib.optional (stdenv.hostPlatform == stdenv.buildPlatform) "devdoc";
 
   patches = [
     (substituteAll {
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
   preConfigure = "NOCONFIGURE=1 ./autogen.sh";
 
   configureFlags = [
-    "--enable-gtk-doc"
+    (stdenv.lib.enableFeature (stdenv.buildPlatform == stdenv.hostPlatform) "gtk-doc")
     "--localstatedir=/var"
     "--with-systemdsystemunitdir=$(out)/etc/systemd/system"
     "--with-udevdir=$(out)/lib/udev"

--- a/pkgs/tools/security/gnupg/22.nix
+++ b/pkgs/tools/security/gnupg/22.nix
@@ -24,9 +24,9 @@ stdenv.mkDerivation rec {
   };
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig texinfo ];
   buildInputs = [
-    libgcrypt libassuan libksba libiconv npth gettext texinfo
+    libgcrypt libassuan libksba libiconv npth gettext
     readline libusb gnutls adns openldap zlib bzip2 sqlite
   ];
 

--- a/pkgs/tools/security/pinentry/autoconf-ar.patch
+++ b/pkgs/tools/security/pinentry/autoconf-ar.patch
@@ -1,0 +1,35 @@
+diff -ur a/configure.ac b/configure.ac
+--- a/configure.ac	2019-09-14 11:30:11.584847746 +0000
++++ b/configure.ac	2019-09-14 11:31:26.692355265 +0000
+@@ -81,6 +81,7 @@
+ AC_PROG_CPP
+ AC_PROG_INSTALL
+ AC_PROG_RANLIB
++AC_CHECK_TOOL(AR, ar)
+ # We need to check for cplusplus here because we may not do the test
+ # for Qt and autoconf does does not allow that.
+ AC_PROG_CXX
+diff -ur a/pinentry/Makefile.in b/pinentry/Makefile.in
+--- a/pinentry/Makefile.in	2017-12-03 17:43:23.000000000 +0000
++++ b/pinentry/Makefile.in	2019-09-14 11:32:02.532000236 +0000
+@@ -113,7 +113,7 @@
+ CONFIG_CLEAN_FILES =
+ CONFIG_CLEAN_VPATH_FILES =
+ LIBRARIES = $(noinst_LIBRARIES)
+-AR = ar
++AR = @AR@
+ ARFLAGS = cru
+ AM_V_AR = $(am__v_AR_@AM_V@)
+ am__v_AR_ = $(am__v_AR_@AM_DEFAULT_V@)
+diff -ur a/secmem/Makefile.in b/secmem/Makefile.in
+--- a/secmem/Makefile.in	2017-12-03 17:43:23.000000000 +0000
++++ b/secmem/Makefile.in	2019-09-14 11:31:58.764934552 +0000
+@@ -113,7 +113,7 @@
+ CONFIG_CLEAN_FILES =
+ CONFIG_CLEAN_VPATH_FILES =
+ LIBRARIES = $(noinst_LIBRARIES)
+-AR = ar
++AR = @AR@
+ ARFLAGS = cru
+ AM_V_AR = $(am__v_AR_@AM_V@)
+ am__v_AR_ = $(am__v_AR_@AM_DEFAULT_V@)

--- a/pkgs/tools/security/pinentry/default.nix
+++ b/pkgs/tools/security/pinentry/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, fetchpatch, stdenv, lib, pkgconfig
+{ fetchurl, fetchpatch, stdenv, lib, pkgconfig, autoreconfHook
 , libgpgerror, libassuan
 , libcap ? null, libsecret ? null, ncurses ? null, gtk2 ? null, gcr ? null
 , qt4 ? null, qt5 ? null
@@ -23,7 +23,7 @@ mkDerivation rec {
     sha256 = "0w35ypl960pczg5kp6km3dyr000m1hf0vpwwlh72jjkjza36c1v8";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig autoreconfHook ];
   buildInputs =
     [ libgpgerror libassuan libcap libsecret gtk2 gcr ncurses qt4 ]
     ++ stdenv.lib.optional (qt5 != null) qt5.qtbase;
@@ -32,7 +32,9 @@ mkDerivation rec {
     substituteInPlace pinentry/pinentry-curses.c --replace ncursesw ncurses
   '';
 
-  patches = lib.optionals (gtk2 != null) [
+  patches = [
+    ./autoconf-ar.patch
+  ] ++ lib.optionals (gtk2 != null) [
     (fetchpatch {
       url = "https://salsa.debian.org/debian/pinentry/raw/debian/1.1.0-1/debian/patches/"
           + "0007-gtk2-When-X11-input-grabbing-fails-try-again-over-0..patch";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fixes cross-compilation for:

- `pinentry`
- `gnupg`
- `udisks2`
- `dtc`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
