### PR TITLE
openvswitch: fix cross-compilation

### DIFF
--- a/pkgs/os-specific/linux/openvswitch/default.nix
+++ b/pkgs/os-specific/linux/openvswitch/default.nix
@@ -17,9 +17,8 @@ in stdenv.mkDerivation rec {
 
   kernel = optional (_kernel != null) _kernel.dev;
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ makeWrapper utillinux openssl libcap_ng python27
-                  perl procps which ];
+  nativeBuildInputs = [ pkgconfig openssl python27 perl which ];
+  buildInputs = [ makeWrapper utillinux openssl libcap_ng python27 procps ];
 
   configureFlags = [
     "--localstatedir=/var"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5298,7 +5298,7 @@ in
   opentracing-cpp = callPackage ../development/libraries/opentracing-cpp { };
 
   openvswitch = callPackage ../os-specific/linux/openvswitch {
-    openssl = openssl_1_0_2;
+    openssl = __splicedPackages.openssl_1_0_2;
   };
 
   optipng = callPackage ../tools/graphics/optipng {


### PR DESCRIPTION
`openvswitch` depends on both build and host `openssl`. Both must be overridden in `all-packages.nix`. I propose the following:
```nix
openvswitch = callPackage ../os-specific/linux/openvswitch {   
  openssl = __splicedPackages.openssl_1_0_2;
};
```
However, `__splicedPackages` is not used in this way anywhere else in nixpkgs.

A discussion of this sort of case can be found here: https://github.com/NixOS/nixpkgs/issues/49526#issuecomment-434806509.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fixes cross-compilation for `openvswitch`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
