### PR TITLE
Flake support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,5 @@
+{
+    "nonFlakeRequires": {},
+    "requires": {},
+    "version": 1
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,0 @@
-{
-    "nonFlakeRequires": {},
-    "requires": {},
-    "version": 1
-}

--- a/flake.nix
+++ b/flake.nix
@@ -1,3 +1,5 @@
+# Experimental flake interface to Nixpkgs.
+# See https://github.com/NixOS/rfcs/pull/49 for details.
 {
   edition = 201909;
 

--- a/flake.nix
+++ b/flake.nix
@@ -5,10 +5,17 @@
 
   outputs = { self }:
     let
+
       jobs = import ./pkgs/top-level/release.nix {
         nixpkgs = self;
       };
+
       lib = import ./lib;
+
+      systems = [ "x86_64-linux" "i686-linux" "x86_64-darwin" "aarch64-linux" ];
+
+      forAllSystems = f: lib.genAttrs systems (system: f system);
+
     in
     {
       lib = lib // {
@@ -32,7 +39,7 @@
         }).nixos.manual.x86_64-linux;
       };
 
-      legacyPackages = import ./. { system = "x86_64-linux"; };
+      legacyPackages = forAllSystems (system: import ./. { inherit system; });
 
       nixosModules = {
         notDetected = ./nixos/modules/installer/scan/not-detected.nix;

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,4 @@
 {
-  name = "nixpkgs";
-
   epoch = 201909;
 
   description = "A collection of packages for the Nix package manager";

--- a/flake.nix
+++ b/flake.nix
@@ -17,9 +17,9 @@
       };
 
       packages = {
-        inherit (pkgs) hello nix fuse nlohmann_json boost;
+        inherit (pkgs) hello nix fuse nlohmann_json boost firefox;
       };
 
-      legacyPkgs = pkgs;
+      legacyPackages = pkgs;
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,23 @@
+{
+  name = "nixpkgs";
+
+  epoch = 2019;
+
+  description = "A collection of packages for the Nix package manager";
+
+  provides = flakes:
+    let pkgs = import ./. {}; in
+    {
+      lib = import ./lib;
+
+      builders = {
+        inherit (pkgs) stdenv fetchurl;
+      };
+
+      packages = {
+        inherit (pkgs) hello nix fuse nlohmann_json boost;
+      };
+
+      legacyPkgs = pkgs;
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,10 @@
         nixosSystem = import ./nixos/lib/eval-config.nix;
       };
 
+      checks.tarball = (import ./pkgs/top-level/release.nix {
+        nixpkgs = flakes.self;
+      }).tarball;
+
       builders = {
         inherit (pkgs) stdenv fetchurl;
       };

--- a/flake.nix
+++ b/flake.nix
@@ -9,10 +9,19 @@
       jobs = import ./pkgs/top-level/release.nix {
         nixpkgs = self;
       };
+      lib = import ./lib;
     in
     {
-      lib = (import ./lib) // {
-        nixosSystem = import ./nixos/lib/eval-config.nix;
+      lib = lib // {
+        nixosSystem = { modules, ... } @ args:
+          import ./nixos/lib/eval-config.nix (args // {
+            modules = modules ++
+              [ { system.nixos.versionSuffix =
+                    ".${lib.substring 0 8 self.lastModified}.${self.shortRev}";
+                  system.nixos.revision = self.rev;
+                }
+              ];
+          });
       };
 
       checks.tarball = jobs.tarball;

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
 
   description = "A collection of packages for the Nix package manager";
 
-  provides = flakes:
+  outputs = inputs:
     let pkgs = import ./. { system = "x86_64-linux"; }; in
     {
       lib = (import ./lib) // {
@@ -13,7 +13,7 @@
       };
 
       checks.tarball = (import ./pkgs/top-level/release.nix {
-        nixpkgs = flakes.self;
+        nixpkgs = inputs.self;
       }).tarball;
 
       builders = {

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,6 @@
 
   outputs = { self }:
     let
-      pkgs = import ./. { system = "x86_64-linux"; };
       jobs = import ./pkgs/top-level/release.nix {
         nixpkgs = self;
       };
@@ -26,10 +25,6 @@
 
       checks.tarball = jobs.tarball;
 
-      builders = {
-        inherit (pkgs) stdenv fetchurl;
-      };
-
       htmlDocs = {
         nixpkgsManual = jobs.manual;
         nixosManual = (import ./nixos/release-small.nix {
@@ -37,11 +32,7 @@
         }).nixos.manual.x86_64-linux;
       };
 
-      packages = {
-        inherit (pkgs) hello nix fuse nlohmann_json boost firefox;
-      };
-
-      legacyPackages = pkgs;
+      legacyPackages = import ./. { system = "x86_64-linux"; };
 
       nixosModules = {
         notDetected = ./nixos/modules/installer/scan/not-detected.nix;

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   name = "nixpkgs";
 
-  epoch = 2019;
+  epoch = 201906;
 
   description = "A collection of packages for the Nix package manager";
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,15 +1,15 @@
 {
   name = "nixpkgs";
 
-  epoch = 201906;
+  epoch = 201909;
 
   description = "A collection of packages for the Nix package manager";
 
-  outputs = inputs:
+  outputs = { self }:
     let
       pkgs = import ./. { system = "x86_64-linux"; };
       jobs = import ./pkgs/top-level/release.nix {
-        nixpkgs = inputs.self;
+        nixpkgs = self;
       };
     in
     {
@@ -26,7 +26,7 @@
       htmlDocs = {
         nixpkgsManual = jobs.manual;
         nixosManual = (import ./nixos/release-small.nix {
-          nixpkgs = inputs.self;
+          nixpkgs = self;
         }).nixos.manual.x86_64-linux;
       };
 

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,9 @@
   provides = flakes:
     let pkgs = import ./. { system = "x86_64-linux"; }; in
     {
-      lib = import ./lib;
+      lib = (import ./lib) // {
+        nixosSystem = import ./nixos/lib/eval-config.nix;
+      };
 
       builders = {
         inherit (pkgs) stdenv fetchurl;

--- a/flake.nix
+++ b/flake.nix
@@ -42,5 +42,9 @@
       };
 
       legacyPackages = pkgs;
+
+      nixosModules = {
+        notDetected = ./nixos/modules/installer/scan/not-detected.nix;
+      };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -6,18 +6,28 @@
   description = "A collection of packages for the Nix package manager";
 
   outputs = inputs:
-    let pkgs = import ./. { system = "x86_64-linux"; }; in
+    let
+      pkgs = import ./. { system = "x86_64-linux"; };
+      jobs = import ./pkgs/top-level/release.nix {
+        nixpkgs = inputs.self;
+      };
+    in
     {
       lib = (import ./lib) // {
         nixosSystem = import ./nixos/lib/eval-config.nix;
       };
 
-      checks.tarball = (import ./pkgs/top-level/release.nix {
-        nixpkgs = inputs.self;
-      }).tarball;
+      checks.tarball = jobs.tarball;
 
       builders = {
         inherit (pkgs) stdenv fetchurl;
+      };
+
+      htmlDocs = {
+        nixpkgsManual = jobs.manual;
+        nixosManual = (import ./nixos/release-small.nix {
+          nixpkgs = inputs.self;
+        }).nixos.manual.x86_64-linux;
       };
 
       packages = {

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
   description = "A collection of packages for the Nix package manager";
 
   provides = flakes:
-    let pkgs = import ./. {}; in
+    let pkgs = import ./. { system = "x86_64-linux"; }; in
     {
       lib = import ./lib;
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  epoch = 201909;
+  edition = 201909;
 
   description = "A collection of packages for the Nix package manager";
 

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
           });
       };
 
-      checks.tarball = jobs.tarball;
+      checks.x86_64-linux.tarball = jobs.tarball;
 
       htmlDocs = {
         nixpkgsManual = jobs.manual;
@@ -42,7 +42,7 @@
       legacyPackages = forAllSystems (system: import ./. { inherit system; });
 
       nixosModules = {
-        notDetected = ./nixos/modules/installer/scan/not-detected.nix;
+        notDetected = import ./nixos/modules/installer/scan/not-detected.nix;
       };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -23,8 +23,8 @@
           import ./nixos/lib/eval-config.nix (args // {
             modules = modules ++
               [ { system.nixos.versionSuffix =
-                    ".${lib.substring 0 8 self.lastModified}.${self.shortRev}";
-                  system.nixos.revision = self.rev;
+                    ".${lib.substring 0 8 self.lastModified}.${self.shortRev or "dirty"}";
+                  system.nixos.revision = lib.mkIf (self ? rev) self.rev;
                 }
               ];
           });

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -148,7 +148,7 @@ runTests {
             "${builtins.storeDir}/d945ibfx9x185xf04b890y4f9g3cbb63-python-2.7.11";
       in {
         storePath = isStorePath goodPath;
-        storePathDerivation = isStorePath (import ../.. {}).hello;
+        storePathDerivation = isStorePath (import ../.. { system = "x86_64-linux"; }).hello;
         storePathAppendix = isStorePath
           "${goodPath}/bin/python";
         nonAbsolute = isStorePath (concatStrings (tail (stringToCharacters goodPath)));

--- a/lib/tests/release.nix
+++ b/lib/tests/release.nix
@@ -2,7 +2,7 @@
 
 pkgs.runCommandNoCC "nixpkgs-lib-tests" {
   buildInputs = [ pkgs.nix (import ./check-eval.nix) ];
-  NIX_PATH="nixpkgs=${pkgs.path}";
+  NIX_PATH = "nixpkgs=${toString pkgs.path}";
 } ''
     datadir="${pkgs.nix}/share"
     export TEST_ROOT=$(pwd)/test-tmp

--- a/nixos/doc/manual/man-nixos-rebuild.xml
+++ b/nixos/doc/manual/man-nixos-rebuild.xml
@@ -77,7 +77,18 @@
     <option>--builders</option> <replaceable>builder-spec</replaceable>
    </arg>
 
+   <sbr/>
+
+   <arg>
+    <option>--flake</option> <replaceable>flake-uri</replaceable>
+   </arg>
+
+   <arg>
+    <option>--config</option> <replaceable>name</replaceable>
+   </arg>
+
    <sbr />
+
    <arg>
     <group choice='req'>
     <arg choice='plain'>
@@ -508,6 +519,35 @@
      </para>
     </listitem>
    </varlistentry>
+
+   <varlistentry>
+    <term>
+     <option>--flake</option> <replaceable>flake-uri</replaceable>
+    </term>
+    <listitem>
+     <para>
+      Build the NixOS system from the specified flake. The flake must
+      contain an output named
+      <literal>nixosConfigurations.<replaceable>name</replaceable></literal>,
+      where <replaceable>name</replaceable> denotes the name of the
+      configuration and can be specified using the
+      <option>--config</option> option.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term>
+     <option>--config</option> <replaceable>name</replaceable>
+    </term>
+    <listitem>
+     <para>
+      Specifies which NixOS configuration to use from the
+      flake. Defaults to the current hostname.
+     </para>
+    </listitem>
+   </varlistentry>
+
   </variablelist>
 
   <para>

--- a/nixos/doc/manual/man-nixos-rebuild.xml
+++ b/nixos/doc/manual/man-nixos-rebuild.xml
@@ -140,14 +140,17 @@
   <title>Description</title>
 
   <para>
-   This command updates the system so that it corresponds to the configuration
-   specified in <filename>/etc/nixos/configuration.nix</filename>. Thus, every
-   time you modify <filename>/etc/nixos/configuration.nix</filename> or any
-   NixOS module, you must run <command>nixos-rebuild</command> to make the
-   changes take effect. It builds the new system in
-   <filename>/nix/store</filename>, runs its activation script, and stop and
-   (re)starts any system services if needed. Please note that user services need
-   to be started manually as they aren't detected by the activation script at the moment.
+   This command updates the system so that it corresponds to the
+   configuration specified in
+   <filename>/etc/nixos/configuration.nix</filename> or
+   <filename>/etc/nixos/flake.nix</filename>. Thus, every time you
+   modify the configuration or any other NixOS module, you must run
+   <command>nixos-rebuild</command> to make the changes take
+   effect. It builds the new system in
+   <filename>/nix/store</filename>, runs its activation script, and
+   stop and (re)starts any system services if needed. Please note that
+   user services need to be started manually as they aren't detected
+   by the activation script at the moment.
   </para>
 
   <para>
@@ -526,8 +529,10 @@
     </term>
     <listitem>
      <para>
-      Build the NixOS system from the specified flake. The flake must
-      contain an output named
+      Build the NixOS system from the specified flake. It defaults to
+      the directory containing the target of the symlink
+      <filename>/etc/nixos/flake.nix</filename>, if it exists. The
+      flake must contain an output named
       <literal>nixosConfigurations.<replaceable>name</replaceable></literal>,
       where <replaceable>name</replaceable> denotes the name of the
       configuration and can be specified using the
@@ -593,6 +598,21 @@
   <title>Files</title>
 
   <variablelist>
+
+   <varlistentry>
+    <term>
+     <filename>/etc/nixos/flake.nix</filename>
+    </term>
+    <listitem>
+     <para>
+      If this file exists, then <command>nixos-rebuild</command> will
+      use it as if the <option>--flake</option> option was given. This
+      file may be a symlink to a <filename>flake.nix</filename> in an
+      actual flake; thus <filename>/etc/nixos</filename> need not be a
+      flake.
+     </para>
+    </listitem>
+   </varlistentry>
 
    <varlistentry>
     <term>

--- a/nixos/doc/manual/man-nixos-rebuild.xml
+++ b/nixos/doc/manual/man-nixos-rebuild.xml
@@ -83,10 +83,6 @@
     <option>--flake</option> <replaceable>flake-uri</replaceable>
    </arg>
 
-   <arg>
-    <option>--config</option> <replaceable>name</replaceable>
-   </arg>
-
    <sbr />
 
    <arg>
@@ -525,7 +521,7 @@
 
    <varlistentry>
     <term>
-     <option>--flake</option> <replaceable>flake-uri</replaceable>
+     <option>--flake</option> <replaceable>flake-uri</replaceable>[<replaceable>name</replaceable>]
     </term>
     <listitem>
      <para>
@@ -533,22 +529,9 @@
       the directory containing the target of the symlink
       <filename>/etc/nixos/flake.nix</filename>, if it exists. The
       flake must contain an output named
-      <literal>nixosConfigurations.<replaceable>name</replaceable></literal>,
-      where <replaceable>name</replaceable> denotes the name of the
-      configuration and can be specified using the
-      <option>--config</option> option.
-     </para>
-    </listitem>
-   </varlistentry>
-
-   <varlistentry>
-    <term>
-     <option>--config</option> <replaceable>name</replaceable>
-    </term>
-    <listitem>
-     <para>
-      Specifies which NixOS configuration to use from the
-      flake. Defaults to the current hostname.
+      <literal>nixosConfigurations.<replaceable>name</replaceable></literal>. If
+      <replaceable>name</replaceable> is omitted, it default to the
+      current host name.
      </para>
     </listitem>
    </varlistentry>

--- a/nixos/doc/manual/man-nixos-version.xml
+++ b/nixos/doc/manual/man-nixos-version.xml
@@ -12,16 +12,22 @@
  </refnamediv>
  <refsynopsisdiv>
   <cmdsynopsis>
-   <command>nixos-version</command> 
+   <command>nixos-version</command>
    <arg>
     <option>--hash</option>
    </arg>
-    
+
    <arg>
     <option>--revision</option>
    </arg>
+
+   <arg>
+    <option>--json</option>
+   </arg>
+
   </cmdsynopsis>
  </refsynopsisdiv>
+
  <refsection>
   <title>Description</title>
   <para>
@@ -84,12 +90,16 @@
    </variablelist>
   </para>
  </refsection>
+
  <refsection>
   <title>Options</title>
+
   <para>
    This command accepts the following options:
   </para>
+
   <variablelist>
+
    <varlistentry>
     <term>
      <option>--hash</option>
@@ -107,6 +117,21 @@
      </para>
     </listitem>
    </varlistentry>
+
+   <varlistentry>
+    <term>
+     <option>--json</option>
+    </term>
+    <listitem>
+     <para>
+      Print a JSON representation of the versions of NixOS and the
+      top-level configuration flake.
+     </para>
+    </listitem>
+   </varlistentry>
+
   </variablelist>
+
  </refsection>
+
 </refentry>

--- a/nixos/modules/installer/tools/nixos-rebuild.sh
+++ b/nixos/modules/installer/tools/nixos-rebuild.sh
@@ -236,6 +236,12 @@ if [ -z "$_NIXOS_REBUILD_REEXEC" ]; then
     export PATH=@nix@/bin:$PATH
 fi
 
+# Use /etc/nixos/flake.nix if it exists. It can be a symlink to the
+# actual flake.
+if [[ -z $flake && -e /etc/nixos/flake.nix ]]; then
+    flake="$(dirname "$(readlink -f /etc/nixos/flake.nix)")"
+fi
+
 # Re-execute nixos-rebuild from the Nixpkgs tree.
 # FIXME: get nixos-rebuild from $flake.
 if [[ -z $_NIXOS_REBUILD_REEXEC && -n $canRun && -z $fast && -z $flake ]]; then

--- a/nixos/modules/installer/tools/nixos-rebuild.sh
+++ b/nixos/modules/installer/tools/nixos-rebuild.sh
@@ -256,7 +256,7 @@ if [[ -n $flake ]]; then
        flakeAttr="${BASH_REMATCH[2]}"
     fi
     if [[ -z $flakeAttr ]]; then
-        hostname=$(cat /proc/sys/kernel/hostname)
+        read -r hostname < /proc/sys/kernel/hostname
         if [[ -z $hostname ]]; then
             hostname=default
         fi

--- a/nixos/modules/installer/tools/nixos-rebuild.sh
+++ b/nixos/modules/installer/tools/nixos-rebuild.sh
@@ -418,7 +418,7 @@ if [ -z "$rollback" ]; then
         else
             outLink=$tmpDir/result
             nix build "$flake#$flakeAttr.config.system.build.toplevel" \
-              --keep-going "${extraBuildFlags[@]}" "${lockFlags[@]}" --out-link $outLink
+              "${extraBuildFlags[@]}" "${lockFlags[@]}" --out-link $outLink
             pathToConfig="$(readlink -f $outLink)"
         fi
         copyToTarget "$pathToConfig"
@@ -427,7 +427,7 @@ if [ -z "$rollback" ]; then
         if [[ -z $flake ]]; then
             pathToConfig="$(nixBuild '<nixpkgs/nixos>' -A system -k "${extraBuildFlags[@]}")"
         else
-            nix build "$flake#$flakeAttr.config.system.build.toplevel" --keep-going "${extraBuildFlags[@]}" "${lockFlags[@]}"
+            nix build "$flake#$flakeAttr.config.system.build.toplevel" "${extraBuildFlags[@]}" "${lockFlags[@]}"
             pathToConfig="$(readlink -f ./result)"
         fi
     elif [ "$action" = build-vm ]; then

--- a/nixos/modules/installer/tools/nixos-rebuild.sh
+++ b/nixos/modules/installer/tools/nixos-rebuild.sh
@@ -285,10 +285,13 @@ if [[ -n $flake ]]; then
 fi
 
 # Find configuration.nix and open editor instead of building.
-# FIXME: handle flakes
 if [ "$action" = edit ]; then
-    NIXOS_CONFIG=${NIXOS_CONFIG:-$(nix-instantiate --find-file nixos-config)}
-    exec "${EDITOR:-nano}" "$NIXOS_CONFIG"
+    if [[ -z $flake ]]; then
+        NIXOS_CONFIG=${NIXOS_CONFIG:-$(nix-instantiate --find-file nixos-config)}
+        exec "${EDITOR:-nano}" "$NIXOS_CONFIG"
+    else
+        exec nix edit "${lockFlags[@]}" -- "$flake#$flakeAttr"
+    fi
     exit 1
 fi
 

--- a/nixos/modules/installer/tools/nixos-rebuild.sh
+++ b/nixos/modules/installer/tools/nixos-rebuild.sh
@@ -222,7 +222,7 @@ fi
 
 
 # If ‘--upgrade’ is given, run ‘nix-channel --update nixos’.
-if [ -n "$upgrade" -a -z "$_NIXOS_REBUILD_REEXEC" ]; then
+if [[ -n $upgrade && -z $_NIXOS_REBUILD_REEXEC && -z $flake ]]; then
     nix-channel --update nixos
 
     # If there are other channels that contain a file called
@@ -350,7 +350,6 @@ prebuiltNix() {
 
 remotePATH=
 
-# FIXME: get nix from the flake.
 if [[ -n $buildNix && -z $flake ]]; then
     echo "building Nix..." >&2
     nixDrv=
@@ -434,14 +433,14 @@ if [ -z "$rollback" ]; then
         if [[ -z $flake ]]; then
             pathToConfig="$(nixBuild '<nixpkgs/nixos>' -A vm -k "${extraBuildFlags[@]}")"
         else
-            echo "TODO: not implemented" >&2
+            echo "$0: 'build-vm' is not supported with '--flake'" >&2
             exit 1
         fi
     elif [ "$action" = build-vm-with-bootloader ]; then
         if [[ -z $flake ]]; then
             pathToConfig="$(nixBuild '<nixpkgs/nixos>' -A vmWithBootLoader -k "${extraBuildFlags[@]}")"
         else
-            echo "TODO: not implemented" >&2
+            echo "$0: 'build-vm-with-bootloader' is not supported with '--flake'" >&2
             exit 1
         fi
     else

--- a/nixos/modules/installer/tools/nixos-rebuild.sh
+++ b/nixos/modules/installer/tools/nixos-rebuild.sh
@@ -61,7 +61,7 @@ while [ "$#" -gt 0 ]; do
         j="$1"; shift 1
         extraBuildFlags+=("$i" "$j")
         ;;
-      --show-trace|--keep-failed|-K|--keep-going|-k|--verbose|-v|-vv|-vvv|-vvvv|-vvvvv|--fallback|--repair|--no-build-output|-Q|-j*)
+      --show-trace|--keep-failed|-K|--keep-going|-k|--verbose|-v|-vv|-vvv|-vvvv|-vvvvv|--fallback|--repair|--no-build-output|-Q|-j*|-L)
         extraBuildFlags+=("$i")
         ;;
       --option)
@@ -268,7 +268,7 @@ fi
 
 # Resolve the flake.
 if [[ -n $flake ]]; then
-    flake=$(nix flake info --json -- "$flake" | jq -r .url)
+    flake=$(nix flake info --json "${extraBuildFlags[@]}" -- "$flake" | jq -r .url)
 fi
 
 # Find configuration.nix and open editor instead of building.
@@ -401,7 +401,8 @@ if [ -z "$rollback" ]; then
             pathToConfig="$(nixBuild '<nixpkgs/nixos>' --no-out-link -A system "${extraBuildFlags[@]}")"
         else
             outLink=$tmpDir/result
-            nix build "$flake#$flakeAttr.config.system.build.toplevel" --keep-going "${extraBuildFlags[@]}" --out-link $outLink
+            nix build "$flake#$flakeAttr.config.system.build.toplevel" \
+		--keep-going "${extraBuildFlags[@]}" --out-link $outLink
             pathToConfig="$(readlink -f $outLink)"
         fi
         copyToTarget "$pathToConfig"

--- a/nixos/modules/installer/tools/nixos-rebuild.sh
+++ b/nixos/modules/installer/tools/nixos-rebuild.sh
@@ -268,7 +268,7 @@ fi
 
 # Resolve the flake.
 if [[ -n $flake ]]; then
-    flake=$(nix flake info --json -- "$flake" | jq -r .uri)
+    flake=$(nix flake info --json -- "$flake" | jq -r .url)
 fi
 
 # Find configuration.nix and open editor instead of building.

--- a/nixos/modules/installer/tools/nixos-version.sh
+++ b/nixos/modules/installer/tools/nixos-version.sh
@@ -8,6 +8,11 @@ case "$1" in
   --hash|--revision)
     echo "@revision@"
     ;;
+  --json)
+    cat <<EOF
+{"nixosVersion": "@version@", "nixpkgsRevision": "@revision@", "configurationRevision": "@configurationRevision@"}
+EOF
+    ;;
   *)
     echo "@version@ (@codeName@)"
     ;;

--- a/nixos/modules/installer/tools/nixos-version.sh
+++ b/nixos/modules/installer/tools/nixos-version.sh
@@ -6,7 +6,7 @@ case "$1" in
     exit 1
     ;;
   --hash|--revision)
-    if ! [[ @revision@ =~ /[0-9a-f]+/ ]]; then
+    if ! [[ @revision@ =~ ^[0-9a-f]+$ ]]; then
       echo "$0: Nixpkgs commit hash is unknown"
       exit 1
     fi

--- a/nixos/modules/installer/tools/nixos-version.sh
+++ b/nixos/modules/installer/tools/nixos-version.sh
@@ -10,7 +10,7 @@ case "$1" in
     ;;
   --json)
     cat <<EOF
-{"nixosVersion": "@version@", "nixpkgsRevision": "@revision@", "configurationRevision": "@configurationRevision@"}
+@json@
 EOF
     ;;
   *)

--- a/nixos/modules/installer/tools/nixos-version.sh
+++ b/nixos/modules/installer/tools/nixos-version.sh
@@ -6,6 +6,10 @@ case "$1" in
     exit 1
     ;;
   --hash|--revision)
+    if ! [[ @revision@ =~ /[0-9a-f]+/ ]]; then
+      echo "$0: Nixpkgs commit hash is unknown"
+      exit 1
+    fi
     echo "@revision@"
     ;;
   --json)

--- a/nixos/modules/installer/tools/tools.nix
+++ b/nixos/modules/installer/tools/tools.nix
@@ -48,6 +48,7 @@ let
     name = "nixos-version";
     src = ./nixos-version.sh;
     inherit (config.system.nixos) version codeName revision;
+    inherit (config.system) configurationRevision;
   };
 
   nixos-enter = makeProg {

--- a/nixos/modules/installer/tools/tools.nix
+++ b/nixos/modules/installer/tools/tools.nix
@@ -31,6 +31,7 @@ let
       nix = config.nix.package.out;
       nix_x86_64_linux = fallback.x86_64-linux;
       nix_i686_linux = fallback.i686-linux;
+      path = makeBinPath [ pkgs.jq ];
     };
 
   nixos-generate-config = makeProg {

--- a/nixos/modules/installer/tools/tools.nix
+++ b/nixos/modules/installer/tools/tools.nix
@@ -49,6 +49,13 @@ let
     src = ./nixos-version.sh;
     inherit (config.system.nixos) version codeName revision;
     inherit (config.system) configurationRevision;
+    json = builtins.toJSON ({
+      nixosVersion = config.system.nixos.version;
+    } // optionalAttrs (config.system.nixos.revision != null) {
+      nixpkgsRevision = config.system.nixos.revision;
+    } // optionalAttrs (config.system.configurationRevision != null) {
+      configurationRevision = config.system.configurationRevision;
+    });
   };
 
   nixos-enter = makeProg {

--- a/nixos/modules/misc/version.nix
+++ b/nixos/modules/misc/version.nix
@@ -42,8 +42,8 @@ in
 
     nixos.revision = mkOption {
       internal = true;
-      type = types.str;
-      default = trivial.revisionWithDefault "master";
+      type = types.nullOr types.str;
+      default = trivial.revisionWithDefault null;
       description = "The Git revision from which this NixOS configuration was built.";
     };
 

--- a/nixos/modules/misc/version.nix
+++ b/nixos/modules/misc/version.nix
@@ -84,6 +84,12 @@ in
       description = "Default NixOS channel to which the root user is subscribed.";
     };
 
+    configurationRevision = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = "The Git revision of the top-level flake from which this configuration was built.";
+    };
+
   };
 
   config = {

--- a/pkgs/tools/virtualization/nixos-container/nixos-container.pl
+++ b/pkgs/tools/virtualization/nixos-container/nixos-container.pl
@@ -64,6 +64,7 @@ my $configFile;
 my $hostAddress;
 my $localAddress;
 my $flake;
+my $flakeAttr = "container";
 
 GetOptions(
     "help" => sub { showHelp() },
@@ -90,6 +91,11 @@ my $action = $ARGV[0] or die "$0: no action specified\n";
 if (defined $configFile and defined $extraConfig) {
     die "--config and --config-file are mutually incompatible. " .
         "Please define on or the other, but not both";
+}
+
+if (defined $flake && $flake =~ /^(.*)#([^#"]+)$/) {
+    $flake = $1;
+    $flakeAttr = $2;
 }
 
 # Execute the selected action.
@@ -137,7 +143,7 @@ EOF
 
 sub buildFlake {
     system("nix", "build", "-o", "$systemPath.tmp", "--",
-           "$flake:nixosConfigurations.container.config.system.build.toplevel") == 0
+           "$flake#nixosConfigurations.\"$flakeAttr\".config.system.build.toplevel") == 0
         or die "$0: failed to build container from flake '$flake'\n";
     $systemPath = readlink("$systemPath.tmp") or die;
     unlink("$systemPath.tmp");

--- a/pkgs/tools/virtualization/nixos-container/nixos-container.pl
+++ b/pkgs/tools/virtualization/nixos-container/nixos-container.pl
@@ -22,13 +22,27 @@ $ENV{"NIXOS_CONFIG"} = "";
 sub showHelp {
     print <<EOF;
 Usage: nixos-container list
-       nixos-container create <container-name> [--nixos-path <path>] [--system-path <path>] [--config-file <path>] [--config <string>] [--ensure-unique-name] [--auto-start] [--bridge <iface>] [--port <port>] [--host-address <string>] [--local-address <string>]
+       nixos-container create <container-name>
+         [--nixos-path <path>]
+         [--system-path <path>]
+         [--config <string>]
+         [--config-file <path>]
+         [--flake <flakeref>]
+         [--ensure-unique-name]
+         [--auto-start]
+         [--bridge <iface>]
+         [--port <port>]
+         [--host-address <string>]
+         [--local-address <string>]
        nixos-container destroy <container-name>
        nixos-container start <container-name>
        nixos-container stop <container-name>
        nixos-container terminate <container-name>
        nixos-container status <container-name>
-       nixos-container update <container-name> [--config <string>] [--config-file <path>]
+       nixos-container update <container-name>
+         [--config <string>]
+         [--config-file <path>]
+         [--flake <flakeref>]
        nixos-container login <container-name>
        nixos-container root-login <container-name>
        nixos-container run <container-name> -- args...
@@ -49,6 +63,7 @@ my $signal;
 my $configFile;
 my $hostAddress;
 my $localAddress;
+my $flake;
 
 GetOptions(
     "help" => sub { showHelp() },
@@ -63,6 +78,7 @@ GetOptions(
     "config-file=s" => \$configFile,
     "host-address=s" => \$hostAddress,
     "local-address=s" => \$localAddress,
+    "flake=s" => \$flake,
     ) or exit 1;
 
 if (defined $hostAddress and !defined $localAddress or defined $localAddress and !defined $hostAddress) {
@@ -97,8 +113,6 @@ sub writeNixOSConfig {
 
     my $localExtraConfig = "";
 
-
-
     if ($extraConfig) {
         $localExtraConfig = $extraConfig
     } elsif ($configFile) {
@@ -119,6 +133,14 @@ with lib;
 EOF
 
     write_file($nixosConfigFile, $nixosConfig);
+}
+
+sub buildFlake {
+    system("nix", "build", "-o", "$systemPath.tmp", "--",
+           "$flake:nixosConfigurations.container.config.system.build.toplevel") == 0
+        or die "$0: failed to build container from flake '$flake'\n";
+    $systemPath = readlink("$systemPath.tmp") or die;
+    unlink("$systemPath.tmp");
 }
 
 if ($action eq "create") {
@@ -176,6 +198,7 @@ if ($action eq "create") {
     push @conf, "HOST_BRIDGE=$bridge\n";
     push @conf, "HOST_PORT=$port\n";
     push @conf, "AUTO_START=$autoStart\n";
+    push @conf, "FLAKE=$flake\n" if defined $flake;
     write_file($confFile, \@conf);
 
     close($lock);
@@ -191,6 +214,10 @@ if ($action eq "create") {
     mkpath($profileDir, 0, 0755);
 
     # Build/set the initial configuration.
+    if (defined $flake) {
+        buildFlake();
+    }
+
     if (defined $systemPath) {
         system("nix-env", "-p", "$profileDir/system", "--set", $systemPath) == 0
             or die "$0: failed to set initial container configuration\n";
@@ -326,19 +353,35 @@ elsif ($action eq "status") {
 }
 
 elsif ($action eq "update") {
-    my $nixosConfigFile = "$root/etc/nixos/configuration.nix";
 
-    # FIXME: may want to be more careful about clobbering the existing
-    # configuration.nix.
-    if ((defined $extraConfig && $extraConfig ne "") ||
-         (defined $configFile && $configFile ne "")) {
-        writeNixOSConfig $nixosConfigFile;
+    # Unless overriden on the command line, rebuild the flake recorded
+    # in the container config file. FIXME: read the container config
+    # in a more sensible way.
+    if (!defined $flake && !defined $configFile && !defined $extraConfig) {
+        my $s = read_file($confFile);
+        $s =~ /^FLAKE=(.*)$/m;
+        $flake = $1;
     }
 
-    system("nix-env", "-p", "$profileDir/system",
-           "-I", "nixos-config=$nixosConfigFile", "-f", "<nixpkgs/nixos>",
-           "--set", "-A", "system") == 0
-        or die "$0: failed to build container configuration\n";
+    if (defined $flake) {
+        buildFlake();
+        system("nix-env", "-p", "$profileDir/system", "--set", $systemPath) == 0
+            or die "$0: failed to set container configuration\n";
+    } else {
+        my $nixosConfigFile = "$root/etc/nixos/configuration.nix";
+
+        # FIXME: may want to be more careful about clobbering the existing
+        # configuration.nix.
+        if ((defined $extraConfig && $extraConfig ne "") ||
+            (defined $configFile && $configFile ne "")) {
+            writeNixOSConfig $nixosConfigFile;
+        }
+
+        system("nix-env", "-p", "$profileDir/system",
+               "-I", "nixos-config=$nixosConfigFile", "-f", "<nixpkgs/nixos>",
+               "--set", "-A", "system") == 0
+            or die "$0: failed to build container configuration\n";
+    }
 
     if (isContainerRunning) {
         print STDERR "reloading container...\n";

--- a/pkgs/top-level/make-tarball.nix
+++ b/pkgs/top-level/make-tarball.nix
@@ -17,7 +17,10 @@ releaseTools.sourceTarball {
 
   inherit officialRelease;
   version = pkgs.lib.fileContents ../../.version;
-  versionSuffix = "pre${toString nixpkgs.revCount}.${nixpkgs.shortRev}";
+  versionSuffix = "pre${
+    if nixpkgs ? lastModified
+    then builtins.substring 0 8 nixpkgs.lastModified
+    else toString nixpkgs.revCount}.${nixpkgs.shortRev}";
 
   buildInputs = [ nix.out jq lib-tests ];
 

--- a/pkgs/top-level/make-tarball.nix
+++ b/pkgs/top-level/make-tarball.nix
@@ -20,7 +20,7 @@ releaseTools.sourceTarball {
   versionSuffix = "pre${
     if nixpkgs ? lastModified
     then builtins.substring 0 8 nixpkgs.lastModified
-    else toString nixpkgs.revCount}.${nixpkgs.shortRev}";
+    else toString nixpkgs.revCount}.${nixpkgs.shortRev or "dirty"}";
 
   buildInputs = [ nix.out jq lib-tests ];
 
@@ -28,7 +28,7 @@ releaseTools.sourceTarball {
     eval "$preConfigure"
     releaseName=nixpkgs-$VERSION$VERSION_SUFFIX
     echo -n $VERSION_SUFFIX > .version-suffix
-    echo -n ${nixpkgs.rev or nixpkgs.shortRev} > .git-revision
+    echo -n ${nixpkgs.rev or nixpkgs.shortRev or "dirty"} > .git-revision
     echo "release name is $releaseName"
     echo "git-revision is $(cat .git-revision)"
   '';

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -14,9 +14,9 @@
 , supportedSystems ? [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" ]
 , limitedSupportedSystems ? [ "i686-linux" ]
   # Strip most of attributes when evaluating to spare memory usage
-,  scrubJobs ? true
+, scrubJobs ? true
   # Attributes passed to nixpkgs. Don't build packages marked as unfree.
-,  nixpkgsArgs ? { config = { allowUnfree = false; inHydra = true; }; }
+, nixpkgsArgs ? { config = { allowUnfree = false; inHydra = true; }; }
 }:
 
 with import ./release-lib.nix { inherit supportedSystems scrubJobs nixpkgsArgs; };


### PR DESCRIPTION
###### Motivation for this change

This PR:

* Adds a `flake.nix` file to Nixpkgs, making Nixpkgs usable from other flakes.
* Adds flake support to `nixos-rebuild`, enabling hermetic NixOS builds.
* Adds flake support to `nixos-container`.

A typical NixOS system configuration flake looks like this:

```nix
{
  edition = 201909;

  outputs = { self, nixpkgs, dwarffs, hydra }: rec {

    nixosConfigurations.my-server = nixpkgs.lib.nixosSystem {
      system = "x86_64-linux";
      modules =
        [ dwarffs.nixosModules.dwarffs
          nixpkgs.nixosModules.notDetected
          hydra.nixosModules.hydra
          { system.configurationRevision = self.rev;
            /* typical configuration.nix stuff follows */
          }
        ];
    };

  };
}
```
which can be installed by doing
```
# nixos-rebuild switch --flake /path/to/flake --config my-server
```
(`--config` defaults to the host name so it can usually be omitted).

The option `system.configurationRevision` tracks the revision of the top-level flake. This allows the entire configuration to be reproduced reliably. In a running system, it can be queried using `nixos-version`:
```sh
$ nixos-version --json | jq -r .configurationRevision
2c475bc41c13e7a9ae5c16b6c10d8d328cd07ee7
```

Note: `NIX_PATH` is unavailable in flake-based builds. In particular this means that
```nix
imports = [ <nixpkgs/nixos/modules/installer/scan/not-detected.nix> ];
```
in `hardware-configuration.nix` no longer works. Instead you have to use
```nix
modules = [ nixpkgs.nixosModules.notDetected ];
```

`nixos-container` also supports flakes. For example, the following command creates [a container that serves the NixOS homepage](https://github.com/NixOS/nixos-homepage/blob/506001aa51806aac4f3680e61d9c9bee3466ef81/flake.nix#L97-L111):
```
$ nixos-container create homepage --flake nixos-homepage 
$ nixos-container start homepage 
$ curl http://$(nixos-container show-ip homepage)
```

TODO: add flake support to `nixos-install`, add tests.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
