### PR TITLE
Docker-related cross-compilation fixes

### DIFF
--- a/pkgs/applications/networking/cluster/cni/default.nix
+++ b/pkgs/applications/networking/cluster/cni/default.nix
@@ -17,6 +17,6 @@ buildGoPackage rec {
     license = licenses.asl20;
     homepage = https://github.com/containernetworking/cni;
     maintainers = with maintainers; [ offline vdemeester ];
-    platforms = [ "x86_64-linux" ];
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
   };
 }

--- a/pkgs/applications/virtualization/containerd/default.nix
+++ b/pkgs/applications/virtualization/containerd/default.nix
@@ -18,7 +18,8 @@ buildGoPackage rec {
 
   hardeningDisable = [ "fortify" ];
 
-  buildInputs = [ btrfs-progs go-md2man utillinux ];
+  nativeBuildInputs = [ go-md2man utillinux ];
+  buildInputs = [ btrfs-progs ];
   buildFlags = "VERSION=v${version}";
 
   BUILDTAGS = []

--- a/pkgs/applications/virtualization/tini/default.nix
+++ b/pkgs/applications/virtualization/tini/default.nix
@@ -18,7 +18,8 @@ stdenv.mkDerivation rec {
     "-DPR_GET_CHILD_SUBREAPER=37"
   ];
 
-  buildInputs = [ cmake glibc glibc.static ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ glibc glibc.static ];
 
   meta = with stdenv.lib; {
     description = "A tiny but valid init for containers";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Motivation for this change

Fixes cross-compilation for:
- `cni`
- `tini`
- `containerd`
- `docker`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
