### PR TITLE
linuxPackages*.turbostat: init

### DIFF
--- a/pkgs/os-specific/linux/turbostat/default.nix
+++ b/pkgs/os-specific/linux/turbostat/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, kernel }:
+
+stdenv.mkDerivation {
+  pname = "turbostat";
+  inherit (kernel) src version;
+
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  postPatch = ''
+    cd tools/power/x86/turbostat
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Report processor frequency and idle statistics";
+    homepage = https://www.kernel.org/;
+    license = licenses.gpl2;
+    platforms = [ "i686-linux" "x86_64-linux" ]; # x86-specific
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15876,6 +15876,8 @@ in
 
     tp_smapi = callPackage ../os-specific/linux/tp_smapi { };
 
+    turbostat = callPackage ../os-specific/linux/turbostat { };
+
     usbip = callPackage ../os-specific/linux/usbip { };
 
     v86d = callPackage ../os-specific/linux/v86d { };


### PR DESCRIPTION
###### Motivation for this change

Fixes #68847.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).