### PR TITLE
linuxPackages*.intel-speed-select (5.3+)

### DIFF
--- a/pkgs/os-specific/linux/intel-speed-select/default.nix
+++ b/pkgs/os-specific/linux/intel-speed-select/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, kernel }:
+
+stdenv.mkDerivation {
+  pname = "intel-speed-select";
+  inherit (kernel) src version;
+
+  makeFlags = [ "bindir=${placeholder "out"}/bin" ];
+
+  postPatch = ''
+    cd tools/power/x86/intel-speed-select
+    sed -i 's,/usr,,g' Makefile
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Tool to enumerate and control the Intel Speed Select Technology features";
+    homepage = https://www.kernel.org/;
+    license = licenses.gpl2;
+    platforms = [ "i686-linux" "x86_64-linux" ]; # x86-specific
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15795,6 +15795,8 @@ in
 
     e1000e = if stdenv.lib.versionOlder kernel.version "4.10" then  callPackage ../os-specific/linux/e1000e {} else null;
 
+    intel-speed-select = if stdenv.lib.versionAtLeast kernel.version "5.3" then callPackage ../os-specific/linux/intel-speed-select { } else null;
+
     ixgbevf = callPackage ../os-specific/linux/ixgbevf {};
 
     it87 = callPackage ../os-specific/linux/it87 {};


### PR DESCRIPTION
###### Motivation for this change

Add new utility for Intel Speed Select testing and control.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - I don't have any hardware that supports ISST, so tested what I could.
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).