### PR TITLE
kdeFrameworks: 5.61.0 -> 5.62.0

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/extra-cmake-modules/nix-lib-path.patch
+++ b/pkgs/development/libraries/kde-frameworks/extra-cmake-modules/nix-lib-path.patch
@@ -1,8 +1,8 @@
 diff --git a/kde-modules/KDEInstallDirs.cmake b/kde-modules/KDEInstallDirs.cmake
-index 275fd65..a04596c 100644
+index 0acd33f..c04b0a5 100644
 --- a/kde-modules/KDEInstallDirs.cmake
 +++ b/kde-modules/KDEInstallDirs.cmake
-@@ -232,34 +232,6 @@
+@@ -236,35 +236,6 @@
  # GNUInstallDirs code deals with re-configuring, but that is dealt with
  # by the _define_* macros in this module).
  set(_LIBDIR_DEFAULT "lib")
@@ -17,6 +17,7 @@ index 275fd65..a04596c 100644
 -# See https://wiki.debian.org/Multiarch
 -if((CMAKE_SYSTEM_NAME MATCHES "Linux|kFreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "GNU")
 -   AND NOT CMAKE_CROSSCOMPILING
+-   AND NOT EXISTS "/etc/arch-release"
 -   AND NOT DEFINED ENV{FLATPAK_ID})
 -  if (EXISTS "/etc/debian_version") # is this a debian system ?
 -    if(CMAKE_LIBRARY_ARCHITECTURE)

--- a/pkgs/development/libraries/kde-frameworks/fetch.sh
+++ b/pkgs/development/libraries/kde-frameworks/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/frameworks/5.61/ )
+WGET_ARGS=( https://download.kde.org/stable/frameworks/5.62/ )

--- a/pkgs/development/libraries/kde-frameworks/kconfigwidgets/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kconfigwidgets/default.nix
@@ -1,13 +1,13 @@
 {
   mkDerivation, lib, extra-cmake-modules,
-  kauth, kcodecs, kconfig, kdoctools, kguiaddons, ki18n, kwidgetsaddons, qtbase,
+  kauth, kcodecs, kconfig, kdoctools, kguiaddons, ki18n, kwidgetsaddons, qttools, qtbase,
 }:
 
 mkDerivation {
   name = "kconfigwidgets";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
-  buildInputs = [ kguiaddons ki18n qtbase ];
+  buildInputs = [ kguiaddons ki18n qtbase qttools ];
   propagatedBuildInputs = [ kauth kcodecs kconfig kwidgetsaddons ];
   patches = [ ./0001-qdiriterator-follow-symlinks.patch ];
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/kde-frameworks/kiconthemes/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kiconthemes/default.nix
@@ -2,7 +2,7 @@
   mkDerivation, lib, copyPathsToStore,
   extra-cmake-modules,
   breeze-icons, karchive, kcoreaddons, kconfigwidgets, ki18n, kitemviews,
-  qtbase, qtsvg,
+  qtbase, qtsvg, qttools,
 }:
 
 mkDerivation {
@@ -13,5 +13,5 @@ mkDerivation {
   buildInputs = [
     breeze-icons karchive kcoreaddons kconfigwidgets ki18n kitemviews
   ];
-  propagatedBuildInputs = [ qtbase qtsvg ];
+  propagatedBuildInputs = [ qtbase qtsvg qttools ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kio/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kio/default.nix
@@ -1,6 +1,6 @@
 {
   mkDerivation, lib, copyPathsToStore,
-  extra-cmake-modules, kdoctools,
+  extra-cmake-modules, kdoctools, qttools,
   karchive, kbookmarks, kcompletion, kconfig, kconfigwidgets, kcoreaddons,
   kdbusaddons, ki18n, kiconthemes, kitemviews, kjobwidgets, knotifications,
   kservice, ktextwidgets, kwallet, kwidgetsaddons, kwindowsystem, kxmlgui,
@@ -18,7 +18,7 @@ mkDerivation {
   ];
   propagatedBuildInputs = [
     kbookmarks kcompletion kconfig kcoreaddons kitemviews kjobwidgets kservice
-    kxmlgui qtbase solid
+    kxmlgui qtbase qttools solid
   ];
   patches = (copyPathsToStore (lib.readPathsFromFile ./. ./series));
 }

--- a/pkgs/development/libraries/kde-frameworks/knewstuff.nix
+++ b/pkgs/development/libraries/kde-frameworks/knewstuff.nix
@@ -3,7 +3,7 @@
   extra-cmake-modules,
   attica, karchive, kcompletion, kconfig, kcoreaddons, ki18n, kiconthemes,
   kio, kitemviews, kservice, ktextwidgets, kwidgetsaddons, kxmlgui, qtbase,
-  qtdeclarative,
+  qtdeclarative, kirigami2,
 }:
 
 mkDerivation {
@@ -12,7 +12,7 @@ mkDerivation {
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [
     karchive kcompletion kconfig kcoreaddons ki18n kiconthemes kio kitemviews
-    ktextwidgets kwidgetsaddons qtbase qtdeclarative
+    ktextwidgets kwidgetsaddons qtbase qtdeclarative kirigami2
   ];
   propagatedBuildInputs = [ attica kservice kxmlgui ];
 }

--- a/pkgs/development/libraries/kde-frameworks/knewstuff.nix
+++ b/pkgs/development/libraries/kde-frameworks/knewstuff.nix
@@ -1,5 +1,5 @@
 {
-  mkDerivation, lib,
+  mkDerivation, lib, fetchpatch,
   extra-cmake-modules,
   attica, karchive, kcompletion, kconfig, kcoreaddons, ki18n, kiconthemes,
   kio, kitemviews, kservice, ktextwidgets, kwidgetsaddons, kxmlgui, qtbase,
@@ -15,4 +15,10 @@ mkDerivation {
     ktextwidgets kwidgetsaddons qtbase qtdeclarative kirigami2
   ];
   propagatedBuildInputs = [ attica kservice kxmlgui ];
+
+  patches = [ (fetchpatch {
+    url = "https://github.com/KDE/knewstuff/commit/dbf788c10130eaa3f5ea37a7f22eb4569471aa04.patch";
+    sha256 = "1225rgqg1j120nvhgsahvsq2xlkg91lr37zp14x19krixxgx521j";
+    revert = true;
+  }) ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kplotting.nix
+++ b/pkgs/development/libraries/kde-frameworks/kplotting.nix
@@ -1,5 +1,5 @@
 { mkDerivation, lib
-, extra-cmake-modules, qtbase
+, extra-cmake-modules, qttools, qtbase
 }:
 
 mkDerivation {
@@ -9,6 +9,6 @@ mkDerivation {
     broken = builtins.compareVersions qtbase.version "5.7.0" < 0;
   };
   nativeBuildInputs = [ extra-cmake-modules ];
-  propagatedBuildInputs = [ qtbase ];
+  propagatedBuildInputs = [ qtbase qttools ];
   outputs = [ "out" "dev" ];
 }

--- a/pkgs/development/libraries/kde-frameworks/ktextwidgets.nix
+++ b/pkgs/development/libraries/kde-frameworks/ktextwidgets.nix
@@ -1,6 +1,6 @@
 {
   mkDerivation, lib,
-  extra-cmake-modules,
+  extra-cmake-modules, qttools,
   kcompletion, kconfig, kconfigwidgets, ki18n, kiconthemes, kservice,
   kwindowsystem, qtbase, sonnet,
 }:
@@ -12,5 +12,5 @@ mkDerivation {
   buildInputs = [
     kcompletion kconfig kconfigwidgets kiconthemes kservice kwindowsystem
   ];
-  propagatedBuildInputs = [ ki18n qtbase sonnet ];
+  propagatedBuildInputs = [ ki18n qtbase qttools sonnet ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kwindowsystem/platform-plugins-path.patch
+++ b/pkgs/development/libraries/kde-frameworks/kwindowsystem/platform-plugins-path.patch
@@ -1,13 +1,13 @@
-Index: kwindowsystem-5.32.0/src/pluginwrapper.cpp
-===================================================================
---- kwindowsystem-5.32.0.orig/src/pluginwrapper.cpp
-+++ kwindowsystem-5.32.0/src/pluginwrapper.cpp
-@@ -37,14 +37,9 @@ Q_GLOBAL_STATIC(KWindowSystemPluginWrapp
+diff --git a/src/pluginwrapper.cpp b/src/pluginwrapper.cpp
+index 8e6298a..210989a 100644
+--- a/src/pluginwrapper.cpp
++++ b/src/pluginwrapper.cpp
+@@ -37,14 +37,10 @@ Q_GLOBAL_STATIC(KWindowSystemPluginWrapper, s_pluginWrapper)
  static QStringList pluginCandidates()
  {
      QStringList ret;
 -    foreach (const QString &path, QCoreApplication::libraryPaths()) {
--        QDir pluginDir(path + QLatin1Literal("/kf5/org.kde.kwindowsystem.platforms"));
+-        QDir pluginDir(path + QLatin1String("/kf5/org.kde.kwindowsystem.platforms"));
 -        if (!pluginDir.exists()) {
 -            continue;
 -        }
@@ -15,7 +15,8 @@ Index: kwindowsystem-5.32.0/src/pluginwrapper.cpp
 -            ret << pluginDir.absoluteFilePath(entry);
 -        }
 +    QDir pluginDir(QLatin1String(NIXPKGS_QT_PLUGIN_PATH) + QLatin1Literal("/kf5/org.kde.kwindowsystem.platforms"));
-+    foreach (const QString &entry, pluginDir.entryList(QDir::Files | QDir::NoDotAndDotDot)) {
++    const auto entries = pluginDir.entryList(QDir::Files | QDir::NoDotAndDotDot);
++    for (const QString &entry : entries) {
 +        ret << pluginDir.absoluteFilePath(entry);
      }
      return ret;

--- a/pkgs/development/libraries/kde-frameworks/kxmlgui.nix
+++ b/pkgs/development/libraries/kde-frameworks/kxmlgui.nix
@@ -1,6 +1,6 @@
 {
   mkDerivation, lib,
-  extra-cmake-modules,
+  extra-cmake-modules, qttools,
   attica, kconfig, kconfigwidgets, kglobalaccel, ki18n, kiconthemes, kitemviews,
   ktextwidgets, kwindowsystem, qtbase, sonnet,
 }:
@@ -13,5 +13,5 @@ mkDerivation {
     attica kglobalaccel ki18n kiconthemes kitemviews ktextwidgets kwindowsystem
     sonnet
   ];
-  propagatedBuildInputs = [ kconfig kconfigwidgets qtbase ];
+  propagatedBuildInputs = [ kconfig kconfigwidgets qtbase qttools ];
 }

--- a/pkgs/development/libraries/kde-frameworks/srcs.nix
+++ b/pkgs/development/libraries/kde-frameworks/srcs.nix
@@ -3,635 +3,635 @@
 
 {
   attica = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/attica-5.61.0.tar.xz";
-      sha256 = "9d3ad34c17223333b5a77144cc5a9d941cbb7baa01ab4a2ffe34ae9398c90dde";
-      name = "attica-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/attica-5.62.0.tar.xz";
+      sha256 = "86b5388c93dd3375dbdca23b20d539af5ed9516f6a573e32549baac3200d029f";
+      name = "attica-5.62.0.tar.xz";
     };
   };
   baloo = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/baloo-5.61.0.tar.xz";
-      sha256 = "dd559e06237843f51d68eb5001b835037d4b2f6d62b7dc4d040961f9863632f1";
-      name = "baloo-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/baloo-5.62.0.tar.xz";
+      sha256 = "454e6808a5fe523785e5e67b7c0453fd1b6c42035aaf8084c39ad30bcbbc8d1a";
+      name = "baloo-5.62.0.tar.xz";
     };
   };
   bluez-qt = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/bluez-qt-5.61.0.tar.xz";
-      sha256 = "0ea647de61fcc18a85c660fa8e05fe93072a713a8d00a018ba8e99ea790e5d27";
-      name = "bluez-qt-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/bluez-qt-5.62.0.tar.xz";
+      sha256 = "545a6c76042a077f04b0a6c2b8dfbe3b5b1a582edaae4454d7a57c06ab033715";
+      name = "bluez-qt-5.62.0.tar.xz";
     };
   };
   breeze-icons = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/breeze-icons-5.61.0.tar.xz";
-      sha256 = "1d260a01a2617f5f755d2eb38423af19bf4a1a2ccfa9339b441b4f6be6381c30";
-      name = "breeze-icons-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/breeze-icons-5.62.0.tar.xz";
+      sha256 = "5858100f1a87dc865f44cde159aaee025ec46f894f544c75086ea0e8f9555951";
+      name = "breeze-icons-5.62.0.tar.xz";
     };
   };
   extra-cmake-modules = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/extra-cmake-modules-5.61.0.tar.xz";
-      sha256 = "a86a3b12c8a540af822131a8d65586d985267b1d642c29b4815b6c7870bc126c";
-      name = "extra-cmake-modules-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/extra-cmake-modules-5.62.0.tar.xz";
+      sha256 = "e07acfecef1b4c7a481a253b58b75072a4f887376301108ed2c753b5002adcd4";
+      name = "extra-cmake-modules-5.62.0.tar.xz";
     };
   };
   frameworkintegration = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/frameworkintegration-5.61.0.tar.xz";
-      sha256 = "a1a2bbb15d287b67643750cb5414ceb10c6583861dd5c00118010d409f106efb";
-      name = "frameworkintegration-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/frameworkintegration-5.62.0.tar.xz";
+      sha256 = "0d43d6cd008359eac4840c8b6e12d2b17eeb53c95111af1f7e8ca6ae8e6aca2c";
+      name = "frameworkintegration-5.62.0.tar.xz";
     };
   };
   kactivities = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kactivities-5.61.0.tar.xz";
-      sha256 = "0d7d7e5bd68541ad1dcf1f96c7205330cb7b075c6ff0d8b46774e781eff84af5";
-      name = "kactivities-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kactivities-5.62.0.tar.xz";
+      sha256 = "b466b8921adad6d887f93f760634dfa344ae52df83c58dd7ae75174961def85b";
+      name = "kactivities-5.62.0.tar.xz";
     };
   };
   kactivities-stats = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kactivities-stats-5.61.0.tar.xz";
-      sha256 = "9062eb0f189f1b50674e65a7db9a4b821c628acd1ac650000cebbf1f7bdf0068";
-      name = "kactivities-stats-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kactivities-stats-5.62.0.tar.xz";
+      sha256 = "e6850a59d2e3dd566c77aa2b2fdc684737634b59755dcc7de231b8b496acbc1a";
+      name = "kactivities-stats-5.62.0.tar.xz";
     };
   };
   kapidox = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kapidox-5.61.0.tar.xz";
-      sha256 = "3c948c87c7f7b16a3835f7df8387c110efe5fefecf8a7d6ffa1cae647be0669f";
-      name = "kapidox-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kapidox-5.62.0.tar.xz";
+      sha256 = "6aa3928b26acc23f5271ba0591d64a55c342e36ae16094e09be1ef038538952f";
+      name = "kapidox-5.62.0.tar.xz";
     };
   };
   karchive = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/karchive-5.61.0.tar.xz";
-      sha256 = "457ed420449630625cb161fcc9bedc7c6a16527f48d6db4008aea76cdb948387";
-      name = "karchive-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/karchive-5.62.0.tar.xz";
+      sha256 = "99980ebdc16dd9ac062fcfda0974c0ce894c09a395caf914518646ffdc48e3ca";
+      name = "karchive-5.62.0.tar.xz";
     };
   };
   kauth = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kauth-5.61.0.tar.xz";
-      sha256 = "b04458f32046b2dd61b48118646180df63d2c843cb2d53560aaa15168df087f1";
-      name = "kauth-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kauth-5.62.0.tar.xz";
+      sha256 = "31162621200df4b927719e34ce62004c51e79b9d785f9c3056c6902f80eeefe6";
+      name = "kauth-5.62.0.tar.xz";
     };
   };
   kbookmarks = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kbookmarks-5.61.0.tar.xz";
-      sha256 = "24f87ff1acc5f0c257518f67af277b454566e607f82eb09e75b4a6ed02403377";
-      name = "kbookmarks-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kbookmarks-5.62.0.tar.xz";
+      sha256 = "69318784fa5feaee3e60bb159fb6c827475a8ce28a74bedf5939ad592c29ea4f";
+      name = "kbookmarks-5.62.0.tar.xz";
     };
   };
   kcmutils = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kcmutils-5.61.0.tar.xz";
-      sha256 = "b8b79ef2f4513fbe5e4c61cf4726ed33b95efffabdd512fcc2dcff23c23cdfa7";
-      name = "kcmutils-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kcmutils-5.62.0.tar.xz";
+      sha256 = "93fd9b7b97cb4488f2007a4f518159129f0caafc05a004be56c87dd355870b1b";
+      name = "kcmutils-5.62.0.tar.xz";
     };
   };
   kcodecs = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kcodecs-5.61.0.tar.xz";
-      sha256 = "4604323e44c1be7547f25b43b71bd541048c3d036a7fc5ca74e5ece9792ff5ee";
-      name = "kcodecs-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kcodecs-5.62.0.tar.xz";
+      sha256 = "1b015be0200444f1ce18ecc5c05dbafde62575a8e094e48698b4b64f43f307b1";
+      name = "kcodecs-5.62.0.tar.xz";
     };
   };
   kcompletion = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kcompletion-5.61.0.tar.xz";
-      sha256 = "68697be65d6c9e0053fc3e504170d23c3162c05a0a9027249c575bc6dc8bd3ec";
-      name = "kcompletion-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kcompletion-5.62.0.tar.xz";
+      sha256 = "af774190ca1a0e4d335485548d6e5c1e02042a5d0e29a3c0db17c24e3656edec";
+      name = "kcompletion-5.62.0.tar.xz";
     };
   };
   kconfig = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kconfig-5.61.0.tar.xz";
-      sha256 = "94c0e292a5d57e014aa745be6b59a989118ead1252d56c768f2719b5c6471372";
-      name = "kconfig-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kconfig-5.62.0.tar.xz";
+      sha256 = "fffe16924245e34d6267e67a6d425dc7b4fdab405968bffa4fff7bea5779bb51";
+      name = "kconfig-5.62.0.tar.xz";
     };
   };
   kconfigwidgets = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kconfigwidgets-5.61.0.tar.xz";
-      sha256 = "4cc1e55c5f994abbec03b32bef73bdf54c2613199a446ad63f4ced6e3a0e2165";
-      name = "kconfigwidgets-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kconfigwidgets-5.62.0.tar.xz";
+      sha256 = "6c10810725e0b109c96ddc2246ca1741bcae012296e31caf7b41167a04ae31d6";
+      name = "kconfigwidgets-5.62.0.tar.xz";
     };
   };
   kcoreaddons = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kcoreaddons-5.61.0.tar.xz";
-      sha256 = "6a4ea2eca77944c24fe63d2f7111913db721533d5971497cb5bdd2cac896e813";
-      name = "kcoreaddons-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kcoreaddons-5.62.0.tar.xz";
+      sha256 = "3819e2792a2e61444e337cd1a4cbdc362c18810918376eefc30b203fbd160b41";
+      name = "kcoreaddons-5.62.0.tar.xz";
     };
   };
   kcrash = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kcrash-5.61.0.tar.xz";
-      sha256 = "83e6333ea0cd7d1ded3fa84f126e3c86a010d7bdb7fd183e7c5d42a8b8e74db8";
-      name = "kcrash-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kcrash-5.62.0.tar.xz";
+      sha256 = "9fac9396212148aade4b59665ec1725fa76e229f24c46b601f066e0026eddd2c";
+      name = "kcrash-5.62.0.tar.xz";
     };
   };
   kdbusaddons = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kdbusaddons-5.61.0.tar.xz";
-      sha256 = "f24fadc71670591bb679cde68147e53819f6c3d56126ecbafe59688fc47b347d";
-      name = "kdbusaddons-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kdbusaddons-5.62.0.tar.xz";
+      sha256 = "d32e0b16abcb2b1593a567b0ef12cfb94ec2f08e5b8a3ec56efac19b22ca0152";
+      name = "kdbusaddons-5.62.0.tar.xz";
     };
   };
   kdeclarative = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kdeclarative-5.61.0.tar.xz";
-      sha256 = "464a77f88cce72c1616654c371068c11d51e484e0de5c0c5e032126d71afedaa";
-      name = "kdeclarative-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kdeclarative-5.62.0.tar.xz";
+      sha256 = "804bc6dd1848fe38b9160a680f3d9f9b67d47150ee9683b3d2c5a07b96a12e46";
+      name = "kdeclarative-5.62.0.tar.xz";
     };
   };
   kded = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kded-5.61.0.tar.xz";
-      sha256 = "ca970111cb2d0073305a226cc005e2085952c2a02703168a775f954d27d723bc";
-      name = "kded-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kded-5.62.0.tar.xz";
+      sha256 = "d2d7a979114ca770442cec0f89fe87730ff0c44b98ee64b39c2cada672fc03b1";
+      name = "kded-5.62.0.tar.xz";
     };
   };
   kdelibs4support = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/portingAids/kdelibs4support-5.61.0.tar.xz";
-      sha256 = "ae6f7c10e1fe67ded687f38a8ab3c8d483ae06ae69344bd1e683af752cf40b5c";
-      name = "kdelibs4support-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/portingAids/kdelibs4support-5.62.0.tar.xz";
+      sha256 = "9cc10b4727b8ee3bae46af796e7da5d6ae620c543278814176a389ea178595ed";
+      name = "kdelibs4support-5.62.0.tar.xz";
     };
   };
   kdesignerplugin = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kdesignerplugin-5.61.0.tar.xz";
-      sha256 = "6b204dffbb4897f51143650d75383b5a3ddf4254455e5827d316c7b4ee7b3f33";
-      name = "kdesignerplugin-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/portingAids/kdesignerplugin-5.62.0.tar.xz";
+      sha256 = "b5c0769d0b1df99f456c3c6f22a48e8bdf9c15f00be2e0795ae5bc5170596e47";
+      name = "kdesignerplugin-5.62.0.tar.xz";
     };
   };
   kdesu = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kdesu-5.61.0.tar.xz";
-      sha256 = "398e74bdfe695ec2d7b57ce78f9fce3e19bb447a8eb5924441718a8f7384f888";
-      name = "kdesu-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kdesu-5.62.0.tar.xz";
+      sha256 = "9c22ad0a5c1d948a91846a34066155f64758b69ab005eb423bb02ba06301c80e";
+      name = "kdesu-5.62.0.tar.xz";
     };
   };
   kdewebkit = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/portingAids/kdewebkit-5.61.0.tar.xz";
-      sha256 = "1ee2a00ee3d95df9270e8c3d434568cda8f42151e361bc07fe374bf0f7afe211";
-      name = "kdewebkit-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/portingAids/kdewebkit-5.62.0.tar.xz";
+      sha256 = "5e45a7866b28d69e6d28f821011c020e53cc6e5b59bcdb7a5d9cb7bda37175e4";
+      name = "kdewebkit-5.62.0.tar.xz";
     };
   };
   kdnssd = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kdnssd-5.61.0.tar.xz";
-      sha256 = "02d70e5ee18697867c1a12373c1dbe31e1efba1fcb1e26bba3c75472cd3b271d";
-      name = "kdnssd-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kdnssd-5.62.0.tar.xz";
+      sha256 = "21554c6faf2f7136fb8f7a2908340c120ed0d5dc1475f5aeb8cafed1e4228009";
+      name = "kdnssd-5.62.0.tar.xz";
     };
   };
   kdoctools = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kdoctools-5.61.0.tar.xz";
-      sha256 = "e48d8f8f075171c6b83189999a10552c772c6a7e9a115a2643414f9ecec77c6f";
-      name = "kdoctools-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kdoctools-5.62.0.tar.xz";
+      sha256 = "471ce5106f80af7272d2ea54265bde5a833c8de7716e8bd82f7a5742939c3f48";
+      name = "kdoctools-5.62.0.tar.xz";
     };
   };
   kemoticons = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kemoticons-5.61.0.tar.xz";
-      sha256 = "cfc17de43320fbb353be30ae8d5b448b88da6f83bd23e29d678cd95a4bd7a380";
-      name = "kemoticons-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kemoticons-5.62.0.tar.xz";
+      sha256 = "fab145b2c4106be8a4f0024cb436d02d0fdcbf8666e9a790cc1cd98db1e70313";
+      name = "kemoticons-5.62.0.tar.xz";
     };
   };
   kfilemetadata = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kfilemetadata-5.61.0.tar.xz";
-      sha256 = "15f20af053c71c1e5ba6c6ade90b7cce27645b27ee30f1e6e73038e81a2c958e";
-      name = "kfilemetadata-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kfilemetadata-5.62.0.tar.xz";
+      sha256 = "2d8488500b19a7d8f90712775e0353e16957857a89162d6c7b947dd5536245b0";
+      name = "kfilemetadata-5.62.0.tar.xz";
     };
   };
   kglobalaccel = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kglobalaccel-5.61.0.tar.xz";
-      sha256 = "ad6bd2648e39854369555dd8a0823b08d9631f3638472627eb80e01d9902150e";
-      name = "kglobalaccel-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kglobalaccel-5.62.0.tar.xz";
+      sha256 = "b087ec1a23a50787d27e8c5d618d4097375a2f7b6188bc9077a5e60d11e2c04d";
+      name = "kglobalaccel-5.62.0.tar.xz";
     };
   };
   kguiaddons = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kguiaddons-5.61.0.tar.xz";
-      sha256 = "40cefa421b5ad5cf211875a35408ba526a5fb34e5ba19ebbda718dbf6b742520";
-      name = "kguiaddons-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kguiaddons-5.62.0.tar.xz";
+      sha256 = "5fc61818ed054901a8b1a6a56a83ccaf5f38d9ea7c5761fa6279cd7316d81e44";
+      name = "kguiaddons-5.62.0.tar.xz";
     };
   };
   kholidays = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kholidays-5.61.0.tar.xz";
-      sha256 = "ce3d879824a3e429b468008c1ccec5de44c07299d412ea32f9a2a814c27c08c1";
-      name = "kholidays-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kholidays-5.62.0.tar.xz";
+      sha256 = "f9f7cc399b35cef9348b8fbaabb87145b689165a66b874e3250456f6bbdcb329";
+      name = "kholidays-5.62.0.tar.xz";
     };
   };
   khtml = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/portingAids/khtml-5.61.0.tar.xz";
-      sha256 = "5d8612b584eecf96959d56bb75b1470b3b34ff7176cef7a0a15bc2531b21720b";
-      name = "khtml-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/portingAids/khtml-5.62.0.tar.xz";
+      sha256 = "35e3f7e419041f0892ea42c6506b627661137602c25f0f1d6a81537b583682c1";
+      name = "khtml-5.62.0.tar.xz";
     };
   };
   ki18n = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/ki18n-5.61.0.tar.xz";
-      sha256 = "d8c0594268b386ee42823360aa937c664cf04eedac8232bc18a653a9c52491d9";
-      name = "ki18n-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/ki18n-5.62.0.tar.xz";
+      sha256 = "b11a0c94c7149798f3f6592e2c386a682d9c528d1e10a59ed3934a93acbc79cb";
+      name = "ki18n-5.62.0.tar.xz";
     };
   };
   kiconthemes = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kiconthemes-5.61.0.tar.xz";
-      sha256 = "341741abd0b8aeeec8a2a87fe781b4ec1ab593563b1c063cdfdccead3706cdd7";
-      name = "kiconthemes-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kiconthemes-5.62.0.tar.xz";
+      sha256 = "33fb5caf28ee763edeb3def66386a27f6a7b2bac6a6a0f0728dd4b222d11ebfe";
+      name = "kiconthemes-5.62.0.tar.xz";
     };
   };
   kidletime = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kidletime-5.61.0.tar.xz";
-      sha256 = "8fb302dcc5b891ac2f06b5278bd6e08043772f3325bc209175c945280621fca2";
-      name = "kidletime-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kidletime-5.62.0.tar.xz";
+      sha256 = "dd2b6a9f7815c8e84b635e694cbf9ee207996d2cf3adb5a85eadd4a8de37f276";
+      name = "kidletime-5.62.0.tar.xz";
     };
   };
   kimageformats = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kimageformats-5.61.0.tar.xz";
-      sha256 = "5a81359a043e201b29e205dd93559de077e0317d26712cb1c07e624d76aeb207";
-      name = "kimageformats-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kimageformats-5.62.0.tar.xz";
+      sha256 = "65c179e15dd9c81a4515eb9189951641cca4aad9e7456067a208658ce205c2c2";
+      name = "kimageformats-5.62.0.tar.xz";
     };
   };
   kinit = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kinit-5.61.0.tar.xz";
-      sha256 = "1806bba9cc3f4d9c5ed23f49eca30707e8f74a99d35f5022130a46a395f2858f";
-      name = "kinit-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kinit-5.62.0.tar.xz";
+      sha256 = "5c4b066362ab6528b5c9ac654c20cc4eeed87e5384b26b3aa1df968c98c1e21a";
+      name = "kinit-5.62.0.tar.xz";
     };
   };
   kio = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kio-5.61.0.tar.xz";
-      sha256 = "1fa35126f8167bdbe029e515d01c8d4b91a07556ce6d5c9418e0ea10d7c2e44e";
-      name = "kio-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kio-5.62.0.tar.xz";
+      sha256 = "70b5c93d8d0be16f4b454bcdafe9533b654f13ef55e816c9024d4d3c5df52d86";
+      name = "kio-5.62.0.tar.xz";
     };
   };
   kirigami2 = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kirigami2-5.61.0.tar.xz";
-      sha256 = "afdbe922f0627330319f22834d6631af13edb0081c687422d36acb8697a88c30";
-      name = "kirigami2-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kirigami2-5.62.0.tar.xz";
+      sha256 = "b3cc36bddb5e52617075961b2cbaecbb94492523bcc6801a3ad29a35c43bd912";
+      name = "kirigami2-5.62.0.tar.xz";
     };
   };
   kitemmodels = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kitemmodels-5.61.0.tar.xz";
-      sha256 = "47db271ba24904933629ed00f7a4f916a19969967dcfbfd59ae5e98f08f89d68";
-      name = "kitemmodels-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kitemmodels-5.62.0.tar.xz";
+      sha256 = "4ed6c4081cf6493d6f40ab45deb61325346ab8577eadec7ba8af6a36d7a6485e";
+      name = "kitemmodels-5.62.0.tar.xz";
     };
   };
   kitemviews = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kitemviews-5.61.0.tar.xz";
-      sha256 = "0447b361444a853409f65e2fb5650cc95eb799ca54a5d7e15cd6d8ca527002da";
-      name = "kitemviews-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kitemviews-5.62.0.tar.xz";
+      sha256 = "34881a269bdae7e3643ab73290931859437fde72042a066170e7467422408065";
+      name = "kitemviews-5.62.0.tar.xz";
     };
   };
   kjobwidgets = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kjobwidgets-5.61.0.tar.xz";
-      sha256 = "5246c2a230e3b4e9d7ba87c5a6b13b5f96fef6af0d1262f27f91fa0c619cf378";
-      name = "kjobwidgets-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kjobwidgets-5.62.0.tar.xz";
+      sha256 = "e3607167361fdd6874a165881de523505bd00d8fabb755abf62114c017a39c93";
+      name = "kjobwidgets-5.62.0.tar.xz";
     };
   };
   kjs = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/portingAids/kjs-5.61.0.tar.xz";
-      sha256 = "968e1592c98ee260d80644bf4631bf09479512e48fa878887ee3b9d6d57d3d17";
-      name = "kjs-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/portingAids/kjs-5.62.0.tar.xz";
+      sha256 = "aaff97d97e3163f890001b7d2e4c0329fdd9d9c53ce4924233246f3ef6cd5962";
+      name = "kjs-5.62.0.tar.xz";
     };
   };
   kjsembed = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/portingAids/kjsembed-5.61.0.tar.xz";
-      sha256 = "d8e0afad638574c31c89d716d78456ce51ffe6dd03eae6787bc9b4f8b52d5b44";
-      name = "kjsembed-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/portingAids/kjsembed-5.62.0.tar.xz";
+      sha256 = "3763c5f67fa92803b5003a41c5b696524be3d0528018a3d5643abc25b161c23b";
+      name = "kjsembed-5.62.0.tar.xz";
     };
   };
   kmediaplayer = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/portingAids/kmediaplayer-5.61.0.tar.xz";
-      sha256 = "ae15a4a39e6530b505d699fb1b1ab3fd5f0e64d87dd758db17702463e44ce181";
-      name = "kmediaplayer-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/portingAids/kmediaplayer-5.62.0.tar.xz";
+      sha256 = "2d7fa77c085ab0a48e3ce41ec5d6ffa16fbf7194f2d6ace43e37967c0ffb7880";
+      name = "kmediaplayer-5.62.0.tar.xz";
     };
   };
   knewstuff = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/knewstuff-5.61.0.tar.xz";
-      sha256 = "87f8ec030223f5f0e4e39de8407fc0d28542e48e057c1752adb2466c55fe365b";
-      name = "knewstuff-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/knewstuff-5.62.0.tar.xz";
+      sha256 = "5ec7806bf1c5d24a0f393fc48950afefc4bbd1b04b2ad1db59f5f05ecd8f0195";
+      name = "knewstuff-5.62.0.tar.xz";
     };
   };
   knotifications = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/knotifications-5.61.0.tar.xz";
-      sha256 = "f72ce6394465316a5324e38afb07f4f71d5f8e281d09b5cf340246c9905568ac";
-      name = "knotifications-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/knotifications-5.62.0.tar.xz";
+      sha256 = "55ec35bc9ddccd12289d9501b11d453885eabb9caebd4b93199d7c662a147263";
+      name = "knotifications-5.62.0.tar.xz";
     };
   };
   knotifyconfig = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/knotifyconfig-5.61.0.tar.xz";
-      sha256 = "bbd2260a98f70779415369ca1d99807bc3e57f618024b9663d2a462a74169bee";
-      name = "knotifyconfig-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/knotifyconfig-5.62.0.tar.xz";
+      sha256 = "bb51d1a3f69f9faf274ee381d6d267bf4a69edbbdfcfd9efcab76270db4f8e4d";
+      name = "knotifyconfig-5.62.0.tar.xz";
     };
   };
   kpackage = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kpackage-5.61.0.tar.xz";
-      sha256 = "8ff82d14fe0dd92ac774d5cd9cd6334b01574f0f5c584266f97359dde5db9a5f";
-      name = "kpackage-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kpackage-5.62.0.tar.xz";
+      sha256 = "588e6f7b0c066993dbd9b6a0fd2535cd2f1c58ea5bd7ebe1dc381049776bbf62";
+      name = "kpackage-5.62.0.tar.xz";
     };
   };
   kparts = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kparts-5.61.0.tar.xz";
-      sha256 = "f223b38f34f009bb25511ce7d97c607102cbb0a1bd0253ec1b7d1fe1b7c81436";
-      name = "kparts-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kparts-5.62.0.tar.xz";
+      sha256 = "2249e70de0b57f13d8ee7a2840106b5a4aed05a6b73da9245101e0cbc9c846ef";
+      name = "kparts-5.62.0.tar.xz";
     };
   };
   kpeople = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kpeople-5.61.0.tar.xz";
-      sha256 = "549edacd7b63d704dd165bc803ae03f8d9e8c1ba31f8dbaea3f7e12c466b4298";
-      name = "kpeople-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kpeople-5.62.0.tar.xz";
+      sha256 = "e061991f08e6642e61531a630a81927ea0ccd7402f469806a6cfeecf9b5064a2";
+      name = "kpeople-5.62.0.tar.xz";
     };
   };
   kplotting = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kplotting-5.61.0.tar.xz";
-      sha256 = "95781b50bef0e081e48b472b4fcbbcd3301ec45245498261e4a3ec8e42b892ba";
-      name = "kplotting-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kplotting-5.62.0.tar.xz";
+      sha256 = "7472943518a4b0e2fe1877ce47b9f667e178822926985a0efc9c20361097b94e";
+      name = "kplotting-5.62.0.tar.xz";
     };
   };
   kpty = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kpty-5.61.0.tar.xz";
-      sha256 = "b91a88c00d3387927d1f6886a04e6e5bcc615ee1d0e72f647d51320ebf73471c";
-      name = "kpty-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kpty-5.62.0.tar.xz";
+      sha256 = "6efd3a3103f15ee825b220ac309bcce3bbce56e9b915e61a4277a2cb096bcb96";
+      name = "kpty-5.62.0.tar.xz";
     };
   };
   kross = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/portingAids/kross-5.61.0.tar.xz";
-      sha256 = "103837799febbd62365a6445db046a2ee4add13d7d250abf925872cac642986e";
-      name = "kross-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/portingAids/kross-5.62.0.tar.xz";
+      sha256 = "38bf9a57f181d823974a00896d89ae7106488c2ccbd7179e295d297edb338563";
+      name = "kross-5.62.0.tar.xz";
     };
   };
   krunner = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/krunner-5.61.0.tar.xz";
-      sha256 = "f32ea603a9bcb9c2e39231f99bfc6079d118eebbf2c72e0818e2a9cd060543be";
-      name = "krunner-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/krunner-5.62.0.tar.xz";
+      sha256 = "21b9564d07395f0e1c5c09557ffc64eb1929dd8925914fdb581f5daa537b01fc";
+      name = "krunner-5.62.0.tar.xz";
     };
   };
   kservice = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kservice-5.61.0.tar.xz";
-      sha256 = "4489ac4553522bb76604e284338ab37a7a2369eea45dadd96a955fedf8ca99f9";
-      name = "kservice-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kservice-5.62.0.tar.xz";
+      sha256 = "a2e105ae8202fa0d9f443490c56e25083c0b9ee285aa82fa26bb8a14f9999db8";
+      name = "kservice-5.62.0.tar.xz";
     };
   };
   ktexteditor = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/ktexteditor-5.61.0.tar.xz";
-      sha256 = "ae99eacb445f8bc27af379d1ec54e8df4d25f601fc12053bc2928a8c639ad0cb";
-      name = "ktexteditor-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/ktexteditor-5.62.0.tar.xz";
+      sha256 = "e02d54035367071d44a1499a7f6c482491116c5676fa8ceb57b1e9f564975092";
+      name = "ktexteditor-5.62.0.tar.xz";
     };
   };
   ktextwidgets = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/ktextwidgets-5.61.0.tar.xz";
-      sha256 = "a2fddad3dda750ea6bdb104c460e50586946ded3e1f46a8729dbd304016a0b5a";
-      name = "ktextwidgets-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/ktextwidgets-5.62.0.tar.xz";
+      sha256 = "ec34931658cbe3a7ad7419a6e588cd9f9981e9b5ab2400e8b6f2b79b29f83774";
+      name = "ktextwidgets-5.62.0.tar.xz";
     };
   };
   kunitconversion = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kunitconversion-5.61.0.tar.xz";
-      sha256 = "e5ffa3ff954c46b2416823467fcecd37c6ddb8304529703bc9cc3a24b74b6c24";
-      name = "kunitconversion-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kunitconversion-5.62.0.tar.xz";
+      sha256 = "e96ce3efcb6efe3afc0d5cf093971ea89fe2f20660da16349309cf6748446f41";
+      name = "kunitconversion-5.62.0.tar.xz";
     };
   };
   kwallet = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kwallet-5.61.0.tar.xz";
-      sha256 = "628ded35a8f44750a770bf10bba9a763994660923a689eee05f8dfb7e92baec8";
-      name = "kwallet-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kwallet-5.62.0.tar.xz";
+      sha256 = "911d1f3320e7e3d25243e134ba0e42cd5e3ed2ee6c846dbb13777b1a4b338a5b";
+      name = "kwallet-5.62.0.tar.xz";
     };
   };
   kwayland = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kwayland-5.61.0.tar.xz";
-      sha256 = "42d3bc629710e09074006af288986b00683853660648c9364fb09d49db3f0e07";
-      name = "kwayland-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kwayland-5.62.0.tar.xz";
+      sha256 = "c9f513008c91e70b09f5acb76dde332491afde0e94948066c2f1e621bc368eb6";
+      name = "kwayland-5.62.0.tar.xz";
     };
   };
   kwidgetsaddons = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kwidgetsaddons-5.61.0.tar.xz";
-      sha256 = "5abc169f431fba18418f23ff1749414d8318baff868a7b821916cc44508c6891";
-      name = "kwidgetsaddons-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kwidgetsaddons-5.62.0.tar.xz";
+      sha256 = "3a8e75d544783a1f567016f2669c3cfdbf2809b0a3d25afd03d38af62a493671";
+      name = "kwidgetsaddons-5.62.0.tar.xz";
     };
   };
   kwindowsystem = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kwindowsystem-5.61.0.tar.xz";
-      sha256 = "17958b612e751e838aa7a0d4f8c7a8a8d83d3f4ace5498fe1f2b8650a2d8f984";
-      name = "kwindowsystem-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kwindowsystem-5.62.0.tar.xz";
+      sha256 = "116d75216ea001b2fc8688a72bcc6105b0b0966a2c5a084497f3aef80d158a67";
+      name = "kwindowsystem-5.62.0.tar.xz";
     };
   };
   kxmlgui = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kxmlgui-5.61.0.tar.xz";
-      sha256 = "867ff1c3ad464bb6268d00ca290569ef1da7659d3fd2f6349015bc3e2562836b";
-      name = "kxmlgui-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kxmlgui-5.62.0.tar.xz";
+      sha256 = "bc4321b4d44b0af1c2808814b89231a8c9e86de22ca1c0b080a769819ebc5d50";
+      name = "kxmlgui-5.62.0.tar.xz";
     };
   };
   kxmlrpcclient = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/kxmlrpcclient-5.61.0.tar.xz";
-      sha256 = "382b4730e4b32c1d300f8fdb6269e40995ec282ebe1cbb044ab1a2b2b68c3a1a";
-      name = "kxmlrpcclient-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kxmlrpcclient-5.62.0.tar.xz";
+      sha256 = "c284c3e5962d2ed6d0737e5814b85fa4d7926131b7799272cb56c464a12c4530";
+      name = "kxmlrpcclient-5.62.0.tar.xz";
     };
   };
   modemmanager-qt = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/modemmanager-qt-5.61.0.tar.xz";
-      sha256 = "c9883a3aac7415045a03f0bda435a2a5ff7523538868b72dffa8e4b40e88502a";
-      name = "modemmanager-qt-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/modemmanager-qt-5.62.0.tar.xz";
+      sha256 = "b2a6517377b53aca895efd657d553dc5b057a673c07ccb10786031240b11adf5";
+      name = "modemmanager-qt-5.62.0.tar.xz";
     };
   };
   networkmanager-qt = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/networkmanager-qt-5.61.0.tar.xz";
-      sha256 = "1ded63af93957a04292e965ecce06388f183d3adc555b4f3d33337ee15d858c3";
-      name = "networkmanager-qt-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/networkmanager-qt-5.62.0.tar.xz";
+      sha256 = "08f73ced96866b9dfded574a87c9e887dc907fc510d2764a4aa09315511cedf9";
+      name = "networkmanager-qt-5.62.0.tar.xz";
     };
   };
   oxygen-icons5 = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/oxygen-icons5-5.61.0.tar.xz";
-      sha256 = "1ca8f6e42186d069cb4f0581914b147cabc3be3e720c382e77048be134bb1b26";
-      name = "oxygen-icons5-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/oxygen-icons5-5.62.0.tar.xz";
+      sha256 = "c066bc96fd45f3553e3c344c7cef34afda3180c95bf67af6cf20e964fd5c1a00";
+      name = "oxygen-icons5-5.62.0.tar.xz";
     };
   };
   plasma-framework = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/plasma-framework-5.61.0.tar.xz";
-      sha256 = "873d604aadbe21ba38cdb12b778d3baf121a54e6155596f0ebee1840138060fe";
-      name = "plasma-framework-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/plasma-framework-5.62.0.tar.xz";
+      sha256 = "324bf14078459954c355bb6f146b927f6cbf915109365cdc58c1d81c8495bdb4";
+      name = "plasma-framework-5.62.0.tar.xz";
     };
   };
   prison = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/prison-5.61.0.tar.xz";
-      sha256 = "9ebab1755e9d7cb01b2aa6e8b63640eb112d8557073423abdb94faecb42d87ab";
-      name = "prison-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/prison-5.62.0.tar.xz";
+      sha256 = "d7a024881119e2e91fe2ef98ec982f33e87d3f5584c3e4438638e23cf0106fb0";
+      name = "prison-5.62.0.tar.xz";
     };
   };
   purpose = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/purpose-5.61.0.tar.xz";
-      sha256 = "810a660d0a4d6de41e1b4d00fcb039d3b099ceae65ec96261ca8dd1fba458d08";
-      name = "purpose-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/purpose-5.62.0.tar.xz";
+      sha256 = "ed0bdc72b1b95fe988fb2ceba5cc1bd36b5bf00d30c098e9de50fdc36d3b3492";
+      name = "purpose-5.62.0.tar.xz";
     };
   };
   qqc2-desktop-style = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/qqc2-desktop-style-5.61.0.tar.xz";
-      sha256 = "26042c4f939b94caa559cba3ef171ef7bb1490f57c9907f5e4b30a701659abb4";
-      name = "qqc2-desktop-style-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/qqc2-desktop-style-5.62.0.tar.xz";
+      sha256 = "97234e956a7fc09bef0665e9a759d6f370419bd3cd2bbbd700849e4cbe549bfa";
+      name = "qqc2-desktop-style-5.62.0.tar.xz";
     };
   };
   solid = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/solid-5.61.0.tar.xz";
-      sha256 = "c3a032086eacbb836fc102bd77236285ad5a808c0537ff55dbacda539ba3eacf";
-      name = "solid-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/solid-5.62.0.tar.xz";
+      sha256 = "24a01a7e89b2c1e39cb9ebc477f80f5ab966d35fce00f63682b159a15de64cc3";
+      name = "solid-5.62.0.tar.xz";
     };
   };
   sonnet = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/sonnet-5.61.0.tar.xz";
-      sha256 = "4c8818897ea5dac25e0120acfd4e15c44adf2ee76749870b8f70178f1a3d8b29";
-      name = "sonnet-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/sonnet-5.62.0.tar.xz";
+      sha256 = "a1a2d3500d7fc51d94fd6f9d951c83be86436284aeda8416963fc5213956a69a";
+      name = "sonnet-5.62.0.tar.xz";
     };
   };
   syndication = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/syndication-5.61.0.tar.xz";
-      sha256 = "2803b2960dd23492ad002e0f23563c9f06500ddc144dd0be2e3e0ef2f6c1f576";
-      name = "syndication-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/syndication-5.62.0.tar.xz";
+      sha256 = "d315a5a5e691925df44ce30abbd5208b764a72eb42d38dc5b5ca134d71c05462";
+      name = "syndication-5.62.0.tar.xz";
     };
   };
   syntax-highlighting = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/syntax-highlighting-5.61.0.tar.xz";
-      sha256 = "475392c03534d7b5301ff2e02461444e463ad4def985da81ad4b315660416721";
-      name = "syntax-highlighting-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/syntax-highlighting-5.62.0.tar.xz";
+      sha256 = "897fac9ec2e5112d629da464d47223129e547c314369e1518a12c5c94ff2a6fd";
+      name = "syntax-highlighting-5.62.0.tar.xz";
     };
   };
   threadweaver = {
-    version = "5.61.0";
+    version = "5.62.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.61/threadweaver-5.61.0.tar.xz";
-      sha256 = "e7a0cecfaa60c7a8e4bdd4dfe842fb54a344d331a6c62316c147d8dc2a5e5843";
-      name = "threadweaver-5.61.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/threadweaver-5.62.0.tar.xz";
+      sha256 = "aa1704c20c6d38fde4f9988e13cb97356e1c69c7a9d0401870b1515a2814294a";
+      name = "threadweaver-5.62.0.tar.xz";
     };
   };
 }

--- a/pkgs/development/libraries/kde-frameworks/srcs.nix
+++ b/pkgs/development/libraries/kde-frameworks/srcs.nix
@@ -315,11 +315,11 @@
     };
   };
   kio = {
-    version = "5.62.0";
+    version = "5.62.1";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.62/kio-5.62.0.tar.xz";
-      sha256 = "70b5c93d8d0be16f4b454bcdafe9533b654f13ef55e816c9024d4d3c5df52d86";
-      name = "kio-5.62.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.62/kio-5.62.1.tar.xz";
+      sha256 = "4b149085bcfbcd729d808a34bcbd4b11f5f9526aa919c82eaddabc1e88113df0";
+      name = "kio-5.62.1.tar.xz";
     };
   };
   kirigami2 = {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

https://kde.org/announcements/kde-frameworks-5.62.0.php

###### Things done

Tested this for the portion I use on my laptop, not sure if we have any
more exhaustive tests/targets?

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @ttuegel