### PR TITLE
power-calibrate: init at 0.01.28

### DIFF
--- a/pkgs/os-specific/linux/power-calibrate/default.nix
+++ b/pkgs/os-specific/linux/power-calibrate/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, lib, fetchurl }:
+
+stdenv.mkDerivation rec {
+  pname = "power-calibrate";
+  version = "0.01.28";
+  src = fetchurl {
+    url = "https://kernel.ubuntu.com/~cking/tarballs/${pname}/${pname}-${version}.tar.gz";
+    sha256 = "1miyjs0vngzfdlsxhn5gndcalzkh28grg4m6faivvp1c6mjp794m";
+  };
+  installFlags = [
+    "BINDIR=${placeholder "out"}/bin"
+    "MANDIR=${placeholder "out"}/share/man/man8"
+  ];
+  meta = with lib; {
+    description = "Tool to calibrate power consumption";
+    homepage = "https://kernel.ubuntu.com/~cking/power-calibrate/";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/os-specific/linux/power-calibrate/default.nix
+++ b/pkgs/os-specific/linux/power-calibrate/default.nix
@@ -3,14 +3,17 @@
 stdenv.mkDerivation rec {
   pname = "power-calibrate";
   version = "0.01.28";
+
   src = fetchurl {
     url = "https://kernel.ubuntu.com/~cking/tarballs/${pname}/${pname}-${version}.tar.gz";
     sha256 = "1miyjs0vngzfdlsxhn5gndcalzkh28grg4m6faivvp1c6mjp794m";
   };
+
   installFlags = [
     "BINDIR=${placeholder "out"}/bin"
     "MANDIR=${placeholder "out"}/share/man/man8"
   ];
+
   meta = with lib; {
     description = "Tool to calibrate power consumption";
     homepage = "https://kernel.ubuntu.com/~cking/power-calibrate/";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15625,6 +15625,8 @@ in
 
   osxfuse = callPackage ../os-specific/darwin/osxfuse { };
 
+  power-calibrate = callPackage ../os-specific/linux/power-calibrate { };
+
   powerstat = callPackage ../os-specific/linux/powerstat { };
 
   smemstat = callPackage ../os-specific/linux/smemstat { };


### PR DESCRIPTION
###### Motivation for this change

Tool to "calibrate" power consumption.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).