### PR TITLE
xorg.libXfont2: 2.0.3 -> 2.0.4

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -872,11 +872,11 @@ lib.makeScope newScope (self: with self; {
   }) {};
 
   libXfont2 = callPackage ({ stdenv, pkgconfig, fetchurl, libfontenc, xorgproto, freetype, xtrans, zlib }: stdenv.mkDerivation {
-    name = "libXfont2-2.0.3";
+    name = "libXfont2-2.0.4";
     builder = ./builder.sh;
     src = fetchurl {
-      url = mirror://xorg/individual/lib/libXfont2-2.0.3.tar.bz2;
-      sha256 = "0klwmimmhm3axpj8pwn5l41lbggh47r5aazhw63zxkbwfgyvg2hf";
+      url = mirror://xorg/individual/lib/libXfont2-2.0.4.tar.bz2;
+      sha256 = "1rk9pjxcm01lbr1dxhnvk4f2qrn6zp068qjbvvz5w0z5d0rin5bd";
     };
     hardeningDisable = [ "bindnow" "relro" ];
     nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -188,7 +188,7 @@ mirror://xorg/individual/lib/libXdmcp-1.1.3.tar.bz2
 mirror://xorg/individual/lib/libXext-1.3.4.tar.bz2
 mirror://xorg/individual/lib/libXfixes-5.0.3.tar.bz2
 mirror://xorg/individual/lib/libXfont-1.5.4.tar.bz2
-mirror://xorg/individual/lib/libXfont2-2.0.3.tar.bz2
+mirror://xorg/individual/lib/libXfont2-2.0.4.tar.bz2
 mirror://xorg/individual/lib/libXft-2.3.3.tar.bz2
 mirror://xorg/individual/lib/libXi-1.7.10.tar.bz2
 mirror://xorg/individual/lib/libXinerama-1.1.4.tar.bz2


### PR DESCRIPTION
###### Motivation for this change

https://lists.x.org/archives/xorg-announce/2019-September/003022.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).