### PR TITLE
health-check: init at 0.03.02

### DIFF
--- a/pkgs/os-specific/linux/health-check/default.nix
+++ b/pkgs/os-specific/linux/health-check/default.nix
@@ -3,16 +3,21 @@
 stdenv.mkDerivation rec {
   pname = "health-check";
   version = "0.03.02";
+
   src = fetchurl {
     url = "https://kernel.ubuntu.com/~cking/tarballs/${pname}/${pname}-${version}.tar.gz";
     sha256 = "12n2qp5lrlahkgrkwy3mjm0nscz6yhhh80z4xmd2n96pn8f3d4hh";
   };
+
   buildInputs = [ json_c libbsd ];
+
   makeFlags = [ "JSON_OUTPUT=y" "FNOTIFY=y" ];
+
   installFlags = [
     "BINDIR=${placeholder "out"}/bin"
     "MANDIR=${placeholder "out"}/share/man/man8"
   ];
+
   meta = with lib; {
     description = "Process monitoring tool";
     homepage = "https://kernel.ubuntu.com/~cking/health-check/";

--- a/pkgs/os-specific/linux/health-check/default.nix
+++ b/pkgs/os-specific/linux/health-check/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, lib, fetchurl, json_c, libbsd }:
+
+stdenv.mkDerivation rec {
+  pname = "health-check";
+  version = "0.03.02";
+  src = fetchurl {
+    url = "https://kernel.ubuntu.com/~cking/tarballs/${pname}/${pname}-${version}.tar.gz";
+    sha256 = "12n2qp5lrlahkgrkwy3mjm0nscz6yhhh80z4xmd2n96pn8f3d4hh";
+  };
+  buildInputs = [ json_c libbsd ];
+  makeFlags = [ "JSON_OUTPUT=y" "FNOTIFY=y" ];
+  installFlags = [
+    "BINDIR=${placeholder "out"}/bin"
+    "MANDIR=${placeholder "out"}/share/man/man8"
+  ];
+  meta = with lib; {
+    description = "Process monitoring tool";
+    homepage = "https://kernel.ubuntu.com/~cking/health-check/";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15532,6 +15532,8 @@ in
 
   hdparm = callPackage ../os-specific/linux/hdparm { };
 
+  health-check = callPackage ../os-specific/linux/health-check { };
+
   hibernate = callPackage ../os-specific/linux/hibernate { };
 
   hostapd = callPackage ../os-specific/linux/hostapd { };


### PR DESCRIPTION
###### Motivation for this change

Process monitoring tool.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).