### PR TITLE
cpustat: init at 0.02.09

### DIFF
--- a/pkgs/os-specific/linux/cpustat/default.nix
+++ b/pkgs/os-specific/linux/cpustat/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, lib, fetchurl, ncurses }:
+
+stdenv.mkDerivation rec {
+  pname = "cpustat";
+  version = "0.02.09";
+  src = fetchurl {
+    url = "https://kernel.ubuntu.com/~cking/tarballs/${pname}/${pname}-${version}.tar.xz";
+    sha256 = "12xahv65yrhs5r830clkl1qnwg3dnrk5qn3zsznzbv1iy2f3cj7y";
+  };
+  buildInputs = [ ncurses ];
+  installFlags = [
+    "BINDIR=${placeholder "out"}/bin"
+    "MANDIR=${placeholder "out"}/share/man/man8"
+  ];
+  meta = with lib; {
+    description = "CPU usage monitoring tool";
+    homepage = "https://kernel.ubuntu.com/~cking/cpustat/";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/os-specific/linux/cpustat/default.nix
+++ b/pkgs/os-specific/linux/cpustat/default.nix
@@ -3,15 +3,19 @@
 stdenv.mkDerivation rec {
   pname = "cpustat";
   version = "0.02.09";
+
   src = fetchurl {
     url = "https://kernel.ubuntu.com/~cking/tarballs/${pname}/${pname}-${version}.tar.xz";
     sha256 = "12xahv65yrhs5r830clkl1qnwg3dnrk5qn3zsznzbv1iy2f3cj7y";
   };
+
   buildInputs = [ ncurses ];
+
   installFlags = [
     "BINDIR=${placeholder "out"}/bin"
     "MANDIR=${placeholder "out"}/share/man/man8"
   ];
+
   meta = with lib; {
     description = "CPU usage monitoring tool";
     homepage = "https://kernel.ubuntu.com/~cking/cpustat/";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15408,6 +15408,8 @@ in
 
   cifs-utils = callPackage ../os-specific/linux/cifs-utils { };
 
+  cpustat = callPackage ../os-specific/linux/cpustat { };
+
   cockroachdb = callPackage ../servers/sql/cockroachdb { };
 
   conky = callPackage ../os-specific/linux/conky ({


### PR DESCRIPTION
###### Motivation for this change

CPU usage monitoring tool.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).