### PR TITLE
stress-ng: 0.10.02 -> 0.10.05, fix w/musl

### DIFF
--- a/pkgs/tools/system/stress-ng/default.nix
+++ b/pkgs/tools/system/stress-ng/default.nix
@@ -21,6 +21,8 @@ stdenv.mkDerivation rec {
     substituteInPlace Makefile --replace "/usr" ""
   '';
 
+  NIX_CFLAGS_COMPILE = stdenv.lib.optional stdenv.hostPlatform.isMusl "-D_LINUX_SYSINFO_H=1";
+
   # Won't build on i686 because the binary will be linked again in the
   # install phase without checking the dependencies. This will prevent
   # triggering the rebuild. Why this only happens on i686 remains a

--- a/pkgs/tools/system/stress-ng/default.nix
+++ b/pkgs/tools/system/stress-ng/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   pname = "stress-ng";
-  version = "0.10.02";
+  version = "0.10.05";
 
   src = fetchurl {
     url = "https://kernel.ubuntu.com/~cking/tarballs/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "100daxz0j80jhmpfnqa78mvfwq1qj7zb67y7w9f747a0f1havvim";
+    sha256 = "0hkghs99fl8kzg3lkkd4w6cj5133zr9a415py0ng60kzrfffmgdy";
   };
 
   # All platforms inputs then Linux-only ones


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @c0bw3b