### PR TITLE
z-lua: substitute lua+lfs for interpreter, fix lfs

### DIFF
--- a/pkgs/tools/misc/z-lua/default.nix
+++ b/pkgs/tools/misc/z-lua/default.nix
@@ -1,6 +1,8 @@
 { stdenv, fetchFromGitHub, lua }:
 
-stdenv.mkDerivation rec {
+let
+  lualfs = lua.withPackages (p: with p; [ luafilesystem ]);
+in stdenv.mkDerivation rec {
   pname = "z-lua";
   version = "1.7.3";
 
@@ -13,7 +15,13 @@ stdenv.mkDerivation rec {
 
   dontBuild = true;
 
-  buildInputs = [ (lua.withPackages (p: with p; [ luafilesystem ])) ];
+  postPatch = ''
+    substituteInPlace z.lua --replace \
+      '.. os.interpreter() ..' \
+      '.. "${lualfs}/bin/lua" ..'
+  '';
+
+  buildInputs = [ lualfs ];
 
   installPhase = ''
     install -Dm755 z.lua $out/bin/z


### PR DESCRIPTION
###### Motivation for this change

I thought this was already accomplished (sorry! :(), but wrapping doesn't work
since z-lua exports the interpreter as $ZLUA_LUAEXE which it uses to
invoke itself from the various shell init / hooks.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @marsam