### PR TITLE
electrum-ltc: remove asymmetric from maintainers

### DIFF
--- a/pkgs/applications/misc/electrum/ltc.nix
+++ b/pkgs/applications/misc/electrum/ltc.nix
@@ -51,7 +51,7 @@ python3Packages.buildPythonApplication rec {
     homepage = https://electrum-ltc.org/;
     license = licenses.mit;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ asymmetric ];
+    maintainers = with maintainers; [ ];
   };
 }
 


### PR DESCRIPTION
Not using the application anymore.

I think the application should actually be **removed**, since it's very susceptible to security issues when it goes out of date, as seen [here](https://github.com/NixOS/nixpkgs/pull/68514).


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
