### PR TITLE
wireshark: 3.2.1 -> {2.6.12, 3.0.7, 3.2.1}

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19013,14 +19013,22 @@ in
 
   welle-io = libsForQt5.callPackage ../applications/radio/welle-io { };
 
-  wireshark = callPackage ../applications/networking/sniffers/wireshark {
+  inherit (callPackages ../applications/networking/sniffers/wireshark {
     inherit (darwin.apple_sdk.frameworks) ApplicationServices SystemConfiguration;
-  };
-  wireshark-qt = wireshark;
+  })
+    wireshark-qt_2_6
+    wireshark-cli_2_6
+    wireshark-qt_3_0
+    wireshark-cli_3_0
+    wireshark-qt_3_2
+    wireshark-cli_3_2;
+
+  wireshark = wireshark-qt;
+  wireshark-qt = wireshark-qt_3_2;
+  wireshark-cli = wireshark-cli_3_2;
 
   # The GTK UI is deprecated by upstream. You probably want the QT version.
   wireshark-gtk = throw "wireshark-gtk is not supported anymore. Use wireshark-qt or wireshark-cli instead.";
-  wireshark-cli = wireshark.override { withQt = false; };
 
   sngrep = callPackage ../applications/networking/sniffers/sngrep {};
 


### PR DESCRIPTION
Motivation of restoring 2.x is:
1. libwiretap has breaking API changes in 3.0
2. 2.4 and 2.6 branches are active upstream
   2.4.16 is two months old, 2.6.11 is 5 days old

cc @teto