### PR TITLE
plex-media-player: 2.40.0.1007 -> 2.55.0.1069 + update script

### DIFF
--- a/pkgs/applications/video/plex-media-player/default.nix
+++ b/pkgs/applications/video/plex-media-player/default.nix
@@ -11,14 +11,14 @@ let
   depSrcs = import ./deps.nix { inherit fetchurl; };
 in mkDerivation rec {
   pname = "plex-media-player";
-  version = "2.54.0.1067";
-  vsnHash = "1a7bc4f6";
+  version = "2.55.0.1069";
+  vsnHash = "2369bed9";
 
   src = fetchFromGitHub {
     owner = "plexinc";
     repo = "plex-media-player";
     rev = "v${version}-${vsnHash}";
-    sha256 = "0ml3qngadmic5z7s0k4glizmfrzg4g3mfnzmmyzpbl0zjzvzh2wb";
+    sha256 = "1jq4592sgaia0xy2h7n3vh5i7c84sdh4l64fdc774r4i0bmg66qi";
   };
 
   nativeBuildInputs = [ pkgconfig cmake python3 ];

--- a/pkgs/applications/video/plex-media-player/default.nix
+++ b/pkgs/applications/video/plex-media-player/default.nix
@@ -11,14 +11,14 @@ let
   depSrcs = import ./deps.nix { inherit fetchurl; };
 in mkDerivation rec {
   pname = "plex-media-player";
-  version = "2.53.0.1063";
-  vsnHash = "4c40422c";
+  version = "2.54.0.1067";
+  vsnHash = "1a7bc4f6";
 
   src = fetchFromGitHub {
     owner = "plexinc";
     repo = "plex-media-player";
     rev = "v${version}-${vsnHash}";
-    sha256 = "172jj14ym5cl99ncdxiklf9d9ks87ckrvbcs2ick8wd8pjwa9n1a";
+    sha256 = "0ml3qngadmic5z7s0k4glizmfrzg4g3mfnzmmyzpbl0zjzvzh2wb";
   };
 
   nativeBuildInputs = [ pkgconfig cmake python3 ];

--- a/pkgs/applications/video/plex-media-player/default.nix
+++ b/pkgs/applications/video/plex-media-player/default.nix
@@ -11,14 +11,14 @@ let
   depSrcs = import ./deps.nix { inherit fetchurl; };
 in mkDerivation rec {
   pname = "plex-media-player";
-  version = "2.52.2.1056";
-  vsnHash = "29c49026";
+  version = "2.53.0.1063";
+  vsnHash = "4c40422c";
 
   src = fetchFromGitHub {
     owner = "plexinc";
     repo = "plex-media-player";
     rev = "v${version}-${vsnHash}";
-    sha256 = "14wvw8pdna6bpxz6p0zcwwiaaf38gkizvjn5ryn0ivx8bznnn7fy";
+    sha256 = "172jj14ym5cl99ncdxiklf9d9ks87ckrvbcs2ick8wd8pjwa9n1a";
   };
 
   nativeBuildInputs = [ pkgconfig cmake python3 ];

--- a/pkgs/applications/video/plex-media-player/default.nix
+++ b/pkgs/applications/video/plex-media-player/default.nix
@@ -11,14 +11,14 @@ let
   depSrcs = import ./deps.nix { inherit fetchurl; };
 in mkDerivation rec {
   pname = "plex-media-player";
-  version = "2.51.0.1048";
-  vsnHash = "dda6b0b1";
+  version = "2.52.0.1051";
+  vsnHash = "1f84c4dc";
 
   src = fetchFromGitHub {
     owner = "plexinc";
     repo = "plex-media-player";
     rev = "v${version}-${vsnHash}";
-    sha256 = "0yb5vk26rns201razv3adrly2llflgilyqm127a3jb15gb7ny130";
+    sha256 = "0hkhw20cqxw9j5f4m1q9bsg52cmxclcz9347qp2w9zz1k0p0n8ak";
   };
 
   nativeBuildInputs = [ pkgconfig cmake python3 ];

--- a/pkgs/applications/video/plex-media-player/default.nix
+++ b/pkgs/applications/video/plex-media-player/default.nix
@@ -11,14 +11,14 @@ let
   depSrcs = import ./deps.nix { inherit fetchurl; };
 in mkDerivation rec {
   pname = "plex-media-player";
-  version = "2.52.1.1054";
-  vsnHash = "86a2dc81";
+  version = "2.52.2.1056";
+  vsnHash = "29c49026";
 
   src = fetchFromGitHub {
     owner = "plexinc";
     repo = "plex-media-player";
     rev = "v${version}-${vsnHash}";
-    sha256 = "10ry15rk3rgpdfdj8ci2c1na9wz6sgqzyap37mj6ahm22vcnvkpw";
+    sha256 = "14wvw8pdna6bpxz6p0zcwwiaaf38gkizvjn5ryn0ivx8bznnn7fy";
   };
 
   nativeBuildInputs = [ pkgconfig cmake python3 ];

--- a/pkgs/applications/video/plex-media-player/default.nix
+++ b/pkgs/applications/video/plex-media-player/default.nix
@@ -11,14 +11,14 @@ let
   depSrcs = import ./deps.nix { inherit fetchurl; };
 in mkDerivation rec {
   pname = "plex-media-player";
-  version = "2.52.0.1051";
-  vsnHash = "1f84c4dc";
+  version = "2.52.1.1054";
+  vsnHash = "86a2dc81";
 
   src = fetchFromGitHub {
     owner = "plexinc";
     repo = "plex-media-player";
     rev = "v${version}-${vsnHash}";
-    sha256 = "0hkhw20cqxw9j5f4m1q9bsg52cmxclcz9347qp2w9zz1k0p0n8ak";
+    sha256 = "10ry15rk3rgpdfdj8ci2c1na9wz6sgqzyap37mj6ahm22vcnvkpw";
   };
 
   nativeBuildInputs = [ pkgconfig cmake python3 ];

--- a/pkgs/applications/video/plex-media-player/default.nix
+++ b/pkgs/applications/video/plex-media-player/default.nix
@@ -11,14 +11,14 @@ let
   depSrcs = import ./deps.nix { inherit fetchurl; };
 in mkDerivation rec {
   pname = "plex-media-player";
-  version = "2.42.0.1013";
-  vsnHash = "712b8c6f";
+  version = "2.43.0.1015";
+  vsnHash = "c1291c39";
 
   src = fetchFromGitHub {
     owner = "plexinc";
     repo = "plex-media-player";
     rev = "v${version}-${vsnHash}";
-    sha256 = "0akxmd7hhdlxzkpryl2zygs96av6nnlsrgdlnc3i6210ghmh21p2";
+    sha256 = "0hxznvwjal7wcv3a06m6ysimdb2029ywqpj9kfq534fkyks6fr4s";
   };
 
   nativeBuildInputs = [ pkgconfig cmake python3 ];

--- a/pkgs/applications/video/plex-media-player/default.nix
+++ b/pkgs/applications/video/plex-media-player/default.nix
@@ -11,14 +11,14 @@ let
   depSrcs = import ./deps.nix { inherit fetchurl; };
 in mkDerivation rec {
   pname = "plex-media-player";
-  version = "2.41.0.1010";
-  vsnHash = "286e05db";
+  version = "2.42.0.1013";
+  vsnHash = "712b8c6f";
 
   src = fetchFromGitHub {
     owner = "plexinc";
     repo = "plex-media-player";
     rev = "v${version}-${vsnHash}";
-    sha256 = "1wsybq2zgxqd981vkcw8dk8rbri11ynni5bs1q43k19slx061rm5";
+    sha256 = "0akxmd7hhdlxzkpryl2zygs96av6nnlsrgdlnc3i6210ghmh21p2";
   };
 
   nativeBuildInputs = [ pkgconfig cmake python3 ];

--- a/pkgs/applications/video/plex-media-player/default.nix
+++ b/pkgs/applications/video/plex-media-player/default.nix
@@ -11,14 +11,14 @@ let
   depSrcs = import ./deps.nix { inherit fetchurl; };
 in mkDerivation rec {
   pname = "plex-media-player";
-  version = "2.45.0.1028";
-  vsnHash = "45edbf41";
+  version = "2.47.0.1035";
+  vsnHash = "e74d341b";
 
   src = fetchFromGitHub {
     owner = "plexinc";
     repo = "plex-media-player";
     rev = "v${version}-${vsnHash}";
-    sha256 = "08jki0wd61ixqa2iip99kgraxsih2w30nr9alfhg7dxhmyhnbqsb";
+    sha256 = "1xmrbs38fm1qir52q7harmvbh4h0a5mzrfl8da0h0c32pz3kky46";
   };
 
   nativeBuildInputs = [ pkgconfig cmake python3 ];

--- a/pkgs/applications/video/plex-media-player/default.nix
+++ b/pkgs/applications/video/plex-media-player/default.nix
@@ -11,14 +11,14 @@ let
   depSrcs = import ./deps.nix { inherit fetchurl; };
 in mkDerivation rec {
   pname = "plex-media-player";
-  version = "2.43.0.1015";
-  vsnHash = "c1291c39";
+  version = "2.44.0.1018";
+  vsnHash = "8f77cbb9";
 
   src = fetchFromGitHub {
     owner = "plexinc";
     repo = "plex-media-player";
     rev = "v${version}-${vsnHash}";
-    sha256 = "0hxznvwjal7wcv3a06m6ysimdb2029ywqpj9kfq534fkyks6fr4s";
+    sha256 = "0djwkaknf8idsd4hw0cw174y90wr1h3nadal982g1ids3jkz4w56";
   };
 
   nativeBuildInputs = [ pkgconfig cmake python3 ];

--- a/pkgs/applications/video/plex-media-player/default.nix
+++ b/pkgs/applications/video/plex-media-player/default.nix
@@ -5,35 +5,10 @@ let
   # During compilation, a CMake bundle is downloaded from `artifacts.plex.tv`,
   # which then downloads a handful of web client-related files. To enable
   # sandboxed builds, we manually download them and save them so these files
-  # are fetched ahead-of-time instead of during the CMake build. Whenever
-  # plex-media-player is updated, the versions for these files are changed,
-  # so the build IDs (and SHAs) below will need to be updated!
-  depSrcs = rec {
-    webClientBuildId = "141-4af71961b12c68";
-    webClientDesktopBuildId = "3.104.2-1b12c68";
-    webClientTvBuildId = "4.3.0-4af7196";
-
-    webClient = fetchurl {
-      url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/buildid.cmake";
-      sha256 = "0fpkd1s49dbiqqlijxbillqd71a78p8y2sc23mwp0lvcmxrg265p";
-    };
-    webClientDesktopHash = fetchurl {
-      url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-desktop-${webClientDesktopBuildId}.tar.xz.sha1";
-      sha256 = "0sb0j44lwqz9zbm98nba4x6c1jxdzvs36ynwfg527avkxxna0f8f";
-    };
-    webClientDesktop = fetchurl {
-      url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-desktop-${webClientDesktopBuildId}.tar.xz";
-      sha256 = "0dxa0ka0igfsryzda4r5clwdl47ah78nmlmgj9d5pgsvyvzjp87z";
-    };
-    webClientTvHash = fetchurl {
-      url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-tv-${webClientTvBuildId}.tar.xz.sha1";
-      sha256 = "086w1bavk2aqsyhv9zi5fynk31zf61sl91r6gjrdrz656wfk5bxa";
-    };
-    webClientTv = fetchurl {
-      url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-tv-${webClientTvBuildId}.tar.xz";
-      sha256 = "12vbgsfnj0j2y5jd73dpi08hqsr9888sma41nvd4ydsd7qblm455";
-    };
-  };
+  # are fetched ahead-of-time instead of during the CMake build. To update
+  # plex-media-player use the update.sh script, so the versions and hashes
+  # for these files are are also updated!
+  depSrcs = import ./deps.nix { inherit fetchurl; };
 in mkDerivation rec {
   pname = "plex-media-player";
   version = "2.40.0.1007";
@@ -60,6 +35,8 @@ in mkDerivation rec {
   '';
 
   cmakeFlags = [ "-DCMAKE_BUILD_TYPE=RelWithDebInfo" "-DQTROOT=${qtbase}" ];
+
+  passthru.updateScript = ./update.sh;
 
   meta = with stdenv.lib; {
     description = "Streaming media player for Plex";

--- a/pkgs/applications/video/plex-media-player/default.nix
+++ b/pkgs/applications/video/plex-media-player/default.nix
@@ -11,14 +11,14 @@ let
   depSrcs = import ./deps.nix { inherit fetchurl; };
 in mkDerivation rec {
   pname = "plex-media-player";
-  version = "2.47.0.1035";
-  vsnHash = "e74d341b";
+  version = "2.48.0.1038";
+  vsnHash = "11b21f57";
 
   src = fetchFromGitHub {
     owner = "plexinc";
     repo = "plex-media-player";
     rev = "v${version}-${vsnHash}";
-    sha256 = "1xmrbs38fm1qir52q7harmvbh4h0a5mzrfl8da0h0c32pz3kky46";
+    sha256 = "05vrzpy3xbgghybxx45f5q1cqr9xr9vljp8321qn6pwpyk4k0scc";
   };
 
   nativeBuildInputs = [ pkgconfig cmake python3 ];

--- a/pkgs/applications/video/plex-media-player/default.nix
+++ b/pkgs/applications/video/plex-media-player/default.nix
@@ -11,14 +11,14 @@ let
   depSrcs = import ./deps.nix { inherit fetchurl; };
 in mkDerivation rec {
   pname = "plex-media-player";
-  version = "2.40.0.1007";
-  vsnHash = "5482132c";
+  version = "2.41.0.1010";
+  vsnHash = "286e05db";
 
   src = fetchFromGitHub {
     owner = "plexinc";
     repo = "plex-media-player";
     rev = "v${version}-${vsnHash}";
-    sha256 = "0ibdh5g8x32iy74q97jfsmxd08wnyrzs3gfiwjfgc10vaa1qdhli";
+    sha256 = "1wsybq2zgxqd981vkcw8dk8rbri11ynni5bs1q43k19slx061rm5";
   };
 
   nativeBuildInputs = [ pkgconfig cmake python3 ];

--- a/pkgs/applications/video/plex-media-player/default.nix
+++ b/pkgs/applications/video/plex-media-player/default.nix
@@ -11,14 +11,14 @@ let
   depSrcs = import ./deps.nix { inherit fetchurl; };
 in mkDerivation rec {
   pname = "plex-media-player";
-  version = "2.44.0.1018";
-  vsnHash = "8f77cbb9";
+  version = "2.45.0.1028";
+  vsnHash = "45edbf41";
 
   src = fetchFromGitHub {
     owner = "plexinc";
     repo = "plex-media-player";
     rev = "v${version}-${vsnHash}";
-    sha256 = "0djwkaknf8idsd4hw0cw174y90wr1h3nadal982g1ids3jkz4w56";
+    sha256 = "08jki0wd61ixqa2iip99kgraxsih2w30nr9alfhg7dxhmyhnbqsb";
   };
 
   nativeBuildInputs = [ pkgconfig cmake python3 ];

--- a/pkgs/applications/video/plex-media-player/default.nix
+++ b/pkgs/applications/video/plex-media-player/default.nix
@@ -11,14 +11,14 @@ let
   depSrcs = import ./deps.nix { inherit fetchurl; };
 in mkDerivation rec {
   pname = "plex-media-player";
-  version = "2.50.0.1045";
-  vsnHash = "37e9e857";
+  version = "2.51.0.1048";
+  vsnHash = "dda6b0b1";
 
   src = fetchFromGitHub {
     owner = "plexinc";
     repo = "plex-media-player";
     rev = "v${version}-${vsnHash}";
-    sha256 = "14jszqik58ikhi207hfwmc05siq6r8f54gfm7q3nvvcgq9ncrd03";
+    sha256 = "0yb5vk26rns201razv3adrly2llflgilyqm127a3jb15gb7ny130";
   };
 
   nativeBuildInputs = [ pkgconfig cmake python3 ];

--- a/pkgs/applications/video/plex-media-player/default.nix
+++ b/pkgs/applications/video/plex-media-player/default.nix
@@ -11,14 +11,14 @@ let
   depSrcs = import ./deps.nix { inherit fetchurl; };
 in mkDerivation rec {
   pname = "plex-media-player";
-  version = "2.49.0.1041";
-  vsnHash = "bf8608f7";
+  version = "2.50.0.1045";
+  vsnHash = "37e9e857";
 
   src = fetchFromGitHub {
     owner = "plexinc";
     repo = "plex-media-player";
     rev = "v${version}-${vsnHash}";
-    sha256 = "1xsh0jxa59bvl9j8vqfi61r25x3c71xzjxdaawjxgkxl5cs6ysxz";
+    sha256 = "14jszqik58ikhi207hfwmc05siq6r8f54gfm7q3nvvcgq9ncrd03";
   };
 
   nativeBuildInputs = [ pkgconfig cmake python3 ];

--- a/pkgs/applications/video/plex-media-player/default.nix
+++ b/pkgs/applications/video/plex-media-player/default.nix
@@ -11,14 +11,14 @@ let
   depSrcs = import ./deps.nix { inherit fetchurl; };
 in mkDerivation rec {
   pname = "plex-media-player";
-  version = "2.48.0.1038";
-  vsnHash = "11b21f57";
+  version = "2.49.0.1041";
+  vsnHash = "bf8608f7";
 
   src = fetchFromGitHub {
     owner = "plexinc";
     repo = "plex-media-player";
     rev = "v${version}-${vsnHash}";
-    sha256 = "05vrzpy3xbgghybxx45f5q1cqr9xr9vljp8321qn6pwpyk4k0scc";
+    sha256 = "1xsh0jxa59bvl9j8vqfi61r25x3c71xzjxdaawjxgkxl5cs6ysxz";
   };
 
   nativeBuildInputs = [ pkgconfig cmake python3 ];

--- a/pkgs/applications/video/plex-media-player/deps.nix
+++ b/pkgs/applications/video/plex-media-player/deps.nix
@@ -1,28 +1,28 @@
 { fetchurl }:
 
 rec {
-  webClientBuildId = "179-6104f84e50e175";
+  webClientBuildId = "180-afec74de50e175";
   webClientDesktopBuildId = "4.29.2-e50e175";
-  webClientTvBuildId = "4.29.2-6104f84";
+  webClientTvBuildId = "4.29.3-afec74d";
 
   webClient = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/buildid.cmake";
-    sha256 = "0s27r4aqmk6pmg5ggw7zaf78vxhjv49ndbx0qjary65mn6vy2dpi";
+    sha256 = "0rabrg3lk9vgpswk8npa54hzqf2v8ghqqnysxpwn12wrp1pc2rr9";
   };
   webClientDesktopHash = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-desktop-${webClientDesktopBuildId}.tar.xz.sha1";
-    sha256 = "0a2g8kr253lh1dpl0dldp9q77ywvpv9yax4srkj8w6h5vwj7qxai";
+    sha256 = "02b5yq4yc411qlg2dkw5j9lrr3cn2y4d27sin0skf6qza180473g";
   };
   webClientDesktop = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-desktop-${webClientDesktopBuildId}.tar.xz";
-    sha256 = "18nkk3nisfbd6y6008p4xmz0nys5ahkysyi54ly15wqd7d0cpvjd";
+    sha256 = "0l3xv48kr2rx878a40zrgwif2ga2ikv6fdcbq9pylycnmm41pxmh";
   };
   webClientTvHash = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-tv-${webClientTvBuildId}.tar.xz.sha1";
-    sha256 = "1s5537mbqbjg5fcgkvicl7ry5qfcl1cmq84qd651bhddnr44r01d";
+    sha256 = "0wq115y2xrgwqrzr43nhkq8ba237z20yfp426ki2kdypsq8fjqka";
   };
   webClientTv = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-tv-${webClientTvBuildId}.tar.xz";
-    sha256 = "15cb3923zhs6phv5ribzlbv3smm0zv0jjq93s90mrhpnxgczqw16";
+    sha256 = "1wax1qslm226l2w53m2fnl849jw349qhg3rjghx7vip5pmb43vw9";
   };
 }

--- a/pkgs/applications/video/plex-media-player/deps.nix
+++ b/pkgs/applications/video/plex-media-player/deps.nix
@@ -1,28 +1,28 @@
 { fetchurl }:
 
 rec {
-  webClientBuildId = "176-21c9724ca0ff70";
-  webClientDesktopBuildId = "4.26.1-ca0ff70";
-  webClientTvBuildId = "4.29.1-21c9724";
+  webClientBuildId = "179-6104f84e50e175";
+  webClientDesktopBuildId = "4.29.2-e50e175";
+  webClientTvBuildId = "4.29.2-6104f84";
 
   webClient = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/buildid.cmake";
-    sha256 = "0l1p5s116h16qhifkcjg1h5wifyl753cndl65nz9z1f3lx5nz3l3";
+    sha256 = "0s27r4aqmk6pmg5ggw7zaf78vxhjv49ndbx0qjary65mn6vy2dpi";
   };
   webClientDesktopHash = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-desktop-${webClientDesktopBuildId}.tar.xz.sha1";
-    sha256 = "1sfmkgny5sjj0vl4lymp4pzs8v7zsszx8ild0qac7jap81c5qwhn";
+    sha256 = "0a2g8kr253lh1dpl0dldp9q77ywvpv9yax4srkj8w6h5vwj7qxai";
   };
   webClientDesktop = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-desktop-${webClientDesktopBuildId}.tar.xz";
-    sha256 = "0bd7gwyrnsv8v1ld5kqb5hwxrjqmf3ziy5xh742jdp0fdvlk7c8p";
+    sha256 = "18nkk3nisfbd6y6008p4xmz0nys5ahkysyi54ly15wqd7d0cpvjd";
   };
   webClientTvHash = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-tv-${webClientTvBuildId}.tar.xz.sha1";
-    sha256 = "10vchj0d21qh683vgm71mrznw0dq9rfb6166bw2nyqk8rbr73zf7";
+    sha256 = "1s5537mbqbjg5fcgkvicl7ry5qfcl1cmq84qd651bhddnr44r01d";
   };
   webClientTv = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-tv-${webClientTvBuildId}.tar.xz";
-    sha256 = "0amr42mnc7l54ikvq0f86ffbkkhxw29qxhbfmp3g1k66ckpz7dnd";
+    sha256 = "15cb3923zhs6phv5ribzlbv3smm0zv0jjq93s90mrhpnxgczqw16";
   };
 }

--- a/pkgs/applications/video/plex-media-player/deps.nix
+++ b/pkgs/applications/video/plex-media-player/deps.nix
@@ -1,28 +1,28 @@
 { fetchurl }:
 
 rec {
-  webClientBuildId = "172-17d1db2564f6ac";
-  webClientDesktopBuildId = "4.27.0-564f6ac";
+  webClientBuildId = "173-17d1db2ca0ff70";
+  webClientDesktopBuildId = "4.26.1-ca0ff70";
   webClientTvBuildId = "4.27.1-17d1db2";
 
   webClient = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/buildid.cmake";
-    sha256 = "0k62gn0kc3kd9g0vqdzay8ln98l6kg7hiqhzzbnfhhn531zdh83b";
+    sha256 = "0dlcr37cc4rq71j5ki1q6i4rh34rvlpv1pdlnsh4g3k3br513y0f";
   };
   webClientDesktopHash = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-desktop-${webClientDesktopBuildId}.tar.xz.sha1";
-    sha256 = "1mnw8c8acb0ds7k9hxz85cq3flg8as4izmlxhsm7h42n00dcz3qg";
+    sha256 = "1d54w82g12y1rc5didfpqr0fg1z372by5kygznz260my1cb78gk0";
   };
   webClientDesktop = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-desktop-${webClientDesktopBuildId}.tar.xz";
-    sha256 = "14h9wsmrkhksvyh22rryqzvcc2dqgxhpj9xfrh0q5m43lldw2afr";
+    sha256 = "1ghv1s4mnbkk02plkfp092n59dga0kviwm9wdv95h71nx7h0ixc5";
   };
   webClientTvHash = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-tv-${webClientTvBuildId}.tar.xz.sha1";
-    sha256 = "0qsic7dv290kvwraa6b6r8ghx22wkbb2hr2b6ix3w56wwc06a1x4";
+    sha256 = "0pxl4jxx1yjzi6a1pipkkz4b7fqncry1y0dimf5imbk3jrb15w24";
   };
   webClientTv = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-tv-${webClientTvBuildId}.tar.xz";
-    sha256 = "0jpbszf7q0h482nsqlvyymjlgc2sd4qan6pf7gq3vn0yswkjdaxq";
+    sha256 = "1w2x0fy5ayg185zpcmgphfgybrfrvrnij2z0xgab318v6c2fra0v";
   };
 }

--- a/pkgs/applications/video/plex-media-player/deps.nix
+++ b/pkgs/applications/video/plex-media-player/deps.nix
@@ -1,28 +1,28 @@
 { fetchurl }:
 
 rec {
-  webClientBuildId = "173-17d1db2ca0ff70";
+  webClientBuildId = "176-21c9724ca0ff70";
   webClientDesktopBuildId = "4.26.1-ca0ff70";
-  webClientTvBuildId = "4.27.1-17d1db2";
+  webClientTvBuildId = "4.29.1-21c9724";
 
   webClient = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/buildid.cmake";
-    sha256 = "0dlcr37cc4rq71j5ki1q6i4rh34rvlpv1pdlnsh4g3k3br513y0f";
+    sha256 = "0l1p5s116h16qhifkcjg1h5wifyl753cndl65nz9z1f3lx5nz3l3";
   };
   webClientDesktopHash = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-desktop-${webClientDesktopBuildId}.tar.xz.sha1";
-    sha256 = "1d54w82g12y1rc5didfpqr0fg1z372by5kygznz260my1cb78gk0";
+    sha256 = "1sfmkgny5sjj0vl4lymp4pzs8v7zsszx8ild0qac7jap81c5qwhn";
   };
   webClientDesktop = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-desktop-${webClientDesktopBuildId}.tar.xz";
-    sha256 = "1ghv1s4mnbkk02plkfp092n59dga0kviwm9wdv95h71nx7h0ixc5";
+    sha256 = "0bd7gwyrnsv8v1ld5kqb5hwxrjqmf3ziy5xh742jdp0fdvlk7c8p";
   };
   webClientTvHash = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-tv-${webClientTvBuildId}.tar.xz.sha1";
-    sha256 = "0pxl4jxx1yjzi6a1pipkkz4b7fqncry1y0dimf5imbk3jrb15w24";
+    sha256 = "10vchj0d21qh683vgm71mrznw0dq9rfb6166bw2nyqk8rbr73zf7";
   };
   webClientTv = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-tv-${webClientTvBuildId}.tar.xz";
-    sha256 = "1w2x0fy5ayg185zpcmgphfgybrfrvrnij2z0xgab318v6c2fra0v";
+    sha256 = "0amr42mnc7l54ikvq0f86ffbkkhxw29qxhbfmp3g1k66ckpz7dnd";
   };
 }

--- a/pkgs/applications/video/plex-media-player/deps.nix
+++ b/pkgs/applications/video/plex-media-player/deps.nix
@@ -1,28 +1,28 @@
 { fetchurl }:
 
 rec {
-  webClientBuildId = "168-8a312e779b9a92";
-  webClientDesktopBuildId = "4.24.1-79b9a92";
-  webClientTvBuildId = "4.25.1-8a312e7";
+  webClientBuildId = "171-f635f96564f6ac";
+  webClientDesktopBuildId = "4.27.0-564f6ac";
+  webClientTvBuildId = "4.27.1-f635f96";
 
   webClient = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/buildid.cmake";
-    sha256 = "0ji5pz5qhmspifzaxj8wd1xzr6gqbb09i6r548agpsc9s58myn09";
+    sha256 = "0fdmmf3y8d0zx9lw6l3llwryz3wcb8v72zrwzv0s1mn0yd2znayl";
   };
   webClientDesktopHash = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-desktop-${webClientDesktopBuildId}.tar.xz.sha1";
-    sha256 = "0sxaci93pbsfmddg5s4j8dz9r5xjf3dnxch3jnqlrqs5ylm62ndn";
+    sha256 = "0dwkizsz9r4h6dlq3qcshqv1anc2h3yd5g5d7hc9dxd37wyjzsag";
   };
   webClientDesktop = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-desktop-${webClientDesktopBuildId}.tar.xz";
-    sha256 = "18nhjy4g6sr8qd8nygmp2gz0jdr8hqman5pa70flws614pj3qzb4";
+    sha256 = "1an257wm1rb777xyp8sa6ghrjzam6hfahqqskj4inljggymvxkxs";
   };
   webClientTvHash = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-tv-${webClientTvBuildId}.tar.xz.sha1";
-    sha256 = "1fvp336rg37g78p3qgm8yyllpvlscfh71ymriv8zv06k1zx77j52";
+    sha256 = "0220mw0r1s4ay8inwvl0bagjv0iddlbm8mv4yaw124grrclhk5yy";
   };
   webClientTv = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-tv-${webClientTvBuildId}.tar.xz";
-    sha256 = "0dh3zghbqk9jk8sl5jmi5ih1qi4lbv8vjp41xi1xd7wjy7v1mk3v";
+    sha256 = "1mz83rbnwncxm178krvbdd8andiba3gfmaajy2gj4api7z97l7ki";
   };
 }

--- a/pkgs/applications/video/plex-media-player/deps.nix
+++ b/pkgs/applications/video/plex-media-player/deps.nix
@@ -1,28 +1,28 @@
 { fetchurl }:
 
 rec {
-  webClientBuildId = "171-f635f96564f6ac";
+  webClientBuildId = "172-17d1db2564f6ac";
   webClientDesktopBuildId = "4.27.0-564f6ac";
-  webClientTvBuildId = "4.27.1-f635f96";
+  webClientTvBuildId = "4.27.1-17d1db2";
 
   webClient = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/buildid.cmake";
-    sha256 = "0fdmmf3y8d0zx9lw6l3llwryz3wcb8v72zrwzv0s1mn0yd2znayl";
+    sha256 = "0k62gn0kc3kd9g0vqdzay8ln98l6kg7hiqhzzbnfhhn531zdh83b";
   };
   webClientDesktopHash = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-desktop-${webClientDesktopBuildId}.tar.xz.sha1";
-    sha256 = "0dwkizsz9r4h6dlq3qcshqv1anc2h3yd5g5d7hc9dxd37wyjzsag";
+    sha256 = "1mnw8c8acb0ds7k9hxz85cq3flg8as4izmlxhsm7h42n00dcz3qg";
   };
   webClientDesktop = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-desktop-${webClientDesktopBuildId}.tar.xz";
-    sha256 = "1an257wm1rb777xyp8sa6ghrjzam6hfahqqskj4inljggymvxkxs";
+    sha256 = "14h9wsmrkhksvyh22rryqzvcc2dqgxhpj9xfrh0q5m43lldw2afr";
   };
   webClientTvHash = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-tv-${webClientTvBuildId}.tar.xz.sha1";
-    sha256 = "0220mw0r1s4ay8inwvl0bagjv0iddlbm8mv4yaw124grrclhk5yy";
+    sha256 = "0qsic7dv290kvwraa6b6r8ghx22wkbb2hr2b6ix3w56wwc06a1x4";
   };
   webClientTv = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-tv-${webClientTvBuildId}.tar.xz";
-    sha256 = "1mz83rbnwncxm178krvbdd8andiba3gfmaajy2gj4api7z97l7ki";
+    sha256 = "0jpbszf7q0h482nsqlvyymjlgc2sd4qan6pf7gq3vn0yswkjdaxq";
   };
 }

--- a/pkgs/applications/video/plex-media-player/deps.nix
+++ b/pkgs/applications/video/plex-media-player/deps.nix
@@ -1,0 +1,28 @@
+{ fetchurl }:
+
+rec {
+  webClientBuildId = "141-4af71961b12c68";
+  webClientDesktopBuildId = "3.104.2-1b12c68";
+  webClientTvBuildId = "4.3.0-4af7196";
+
+  webClient = fetchurl {
+    url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/buildid.cmake";
+    sha256 = "0fpkd1s49dbiqqlijxbillqd71a78p8y2sc23mwp0lvcmxrg265p";
+  };
+  webClientDesktopHash = fetchurl {
+    url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-desktop-${webClientDesktopBuildId}.tar.xz.sha1";
+    sha256 = "0sb0j44lwqz9zbm98nba4x6c1jxdzvs36ynwfg527avkxxna0f8f";
+  };
+  webClientDesktop = fetchurl {
+    url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-desktop-${webClientDesktopBuildId}.tar.xz";
+    sha256 = "0dxa0ka0igfsryzda4r5clwdl47ah78nmlmgj9d5pgsvyvzjp87z";
+  };
+  webClientTvHash = fetchurl {
+    url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-tv-${webClientTvBuildId}.tar.xz.sha1";
+    sha256 = "086w1bavk2aqsyhv9zi5fynk31zf61sl91r6gjrdrz656wfk5bxa";
+  };
+  webClientTv = fetchurl {
+    url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-tv-${webClientTvBuildId}.tar.xz";
+    sha256 = "12vbgsfnj0j2y5jd73dpi08hqsr9888sma41nvd4ydsd7qblm455";
+  };
+}

--- a/pkgs/applications/video/plex-media-player/deps.nix
+++ b/pkgs/applications/video/plex-media-player/deps.nix
@@ -1,28 +1,28 @@
 { fetchurl }:
 
 rec {
-  webClientBuildId = "141-4af71961b12c68";
+  webClientBuildId = "144-56c0a921b12c68";
   webClientDesktopBuildId = "3.104.2-1b12c68";
-  webClientTvBuildId = "4.3.0-4af7196";
+  webClientTvBuildId = "4.5.1-56c0a92";
 
   webClient = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/buildid.cmake";
-    sha256 = "0fpkd1s49dbiqqlijxbillqd71a78p8y2sc23mwp0lvcmxrg265p";
+    sha256 = "0ivw949f6b22i7rn9nqvw0iz3cmppc9g88qlx57dhghslsgr7llc";
   };
   webClientDesktopHash = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-desktop-${webClientDesktopBuildId}.tar.xz.sha1";
-    sha256 = "0sb0j44lwqz9zbm98nba4x6c1jxdzvs36ynwfg527avkxxna0f8f";
+    sha256 = "04d2r6awlfzgvxxdz3qj9xd5dfnlmljasj5r6bjjv3ary41f1764";
   };
   webClientDesktop = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-desktop-${webClientDesktopBuildId}.tar.xz";
-    sha256 = "0dxa0ka0igfsryzda4r5clwdl47ah78nmlmgj9d5pgsvyvzjp87z";
+    sha256 = "1mg2w7y9idhzfafz47ic0zyqzhjlr4x3kakfx4vajlsbp5894hb3";
   };
   webClientTvHash = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-tv-${webClientTvBuildId}.tar.xz.sha1";
-    sha256 = "086w1bavk2aqsyhv9zi5fynk31zf61sl91r6gjrdrz656wfk5bxa";
+    sha256 = "0mxsj8shll0d3y0wf2zvxvn69axcqjbr5zrj8rpvdvi1mnpscxrj";
   };
   webClientTv = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-tv-${webClientTvBuildId}.tar.xz";
-    sha256 = "12vbgsfnj0j2y5jd73dpi08hqsr9888sma41nvd4ydsd7qblm455";
+    sha256 = "0d3szjjxlxzqmn3bxirnmzlhspckg7cl96fpwnrqhbc3m2fmbqj1";
   };
 }

--- a/pkgs/applications/video/plex-media-player/deps.nix
+++ b/pkgs/applications/video/plex-media-player/deps.nix
@@ -1,28 +1,28 @@
 { fetchurl }:
 
 rec {
-  webClientBuildId = "149-466665d1b12c68";
+  webClientBuildId = "151-ce86ded1b12c68";
   webClientDesktopBuildId = "3.104.2-1b12c68";
-  webClientTvBuildId = "4.9.0-466665d";
+  webClientTvBuildId = "4.11.1-ce86ded";
 
   webClient = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/buildid.cmake";
-    sha256 = "1ir1z543hsswsfnxchr8kbw7h9gnhbb11n3qyw2njkyxc7g7m2r8";
+    sha256 = "1pl1qfb9wdfrcsasq66gz85819x4zrknkc7655n78xllly55j28s";
   };
   webClientDesktopHash = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-desktop-${webClientDesktopBuildId}.tar.xz.sha1";
-    sha256 = "02zrldnh875k8f03rsf349gsgabx8h46z3sddn4jrwwkwdpnhyr0";
+    sha256 = "1s28lfm96jrghz2c8d4yap3dl6y1gxd0svvdnva6jjl205361a6q";
   };
   webClientDesktop = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-desktop-${webClientDesktopBuildId}.tar.xz";
-    sha256 = "18b44rsqqd1ma4rpl2cl6vanw2s6fpnqq6yqxnq3ypxqd5lgzw3c";
+    sha256 = "1k1agr0332hlr5a9xdkfnqpppppwgnmvwd43slw7j5f8r6j4hfsf";
   };
   webClientTvHash = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-tv-${webClientTvBuildId}.tar.xz.sha1";
-    sha256 = "1mg04kp8w0mpmz2154q2yibl9wfy6gw7g4rvjd1ss9q3q0csy4wr";
+    sha256 = "0xm9shp04ri99fd2lahx5ijf27qhyxji7zsdkm80zwwaqzzb13xw";
   };
   webClientTv = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-tv-${webClientTvBuildId}.tar.xz";
-    sha256 = "1infhlcrij42rzpabrcz4gpvnkcylxvivj2i9f9ial1l9nyxhgny";
+    sha256 = "0fyk2rvn9mc2xwavmki81yp40d9gz8dd6jajjyhq7mdgsp55xw3b";
   };
 }

--- a/pkgs/applications/video/plex-media-player/deps.nix
+++ b/pkgs/applications/video/plex-media-player/deps.nix
@@ -1,28 +1,28 @@
 { fetchurl }:
 
 rec {
-  webClientBuildId = "148-aa5f46f1b12c68";
+  webClientBuildId = "149-466665d1b12c68";
   webClientDesktopBuildId = "3.104.2-1b12c68";
-  webClientTvBuildId = "4.7.1-aa5f46f";
+  webClientTvBuildId = "4.9.0-466665d";
 
   webClient = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/buildid.cmake";
-    sha256 = "1g5p9avx51v1j14ddyyclxawx32m0a3k8q25rci5cbbg5a93crls";
+    sha256 = "1ir1z543hsswsfnxchr8kbw7h9gnhbb11n3qyw2njkyxc7g7m2r8";
   };
   webClientDesktopHash = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-desktop-${webClientDesktopBuildId}.tar.xz.sha1";
-    sha256 = "1ah955659szn0jd602k2487a0mk4nrabjpkqplmd6qdmgpa6hgj9";
+    sha256 = "02zrldnh875k8f03rsf349gsgabx8h46z3sddn4jrwwkwdpnhyr0";
   };
   webClientDesktop = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-desktop-${webClientDesktopBuildId}.tar.xz";
-    sha256 = "0zhpjlnwlgbz01cznvv3gni42qynhbvww2jmr6j2raamgxn1w5xc";
+    sha256 = "18b44rsqqd1ma4rpl2cl6vanw2s6fpnqq6yqxnq3ypxqd5lgzw3c";
   };
   webClientTvHash = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-tv-${webClientTvBuildId}.tar.xz.sha1";
-    sha256 = "0q26q12vvg00swdw24yyvn09144b90nr8653msqpx91x9sm5aiq4";
+    sha256 = "1mg04kp8w0mpmz2154q2yibl9wfy6gw7g4rvjd1ss9q3q0csy4wr";
   };
   webClientTv = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-tv-${webClientTvBuildId}.tar.xz";
-    sha256 = "0gmhk7jgm37arqnxz92qni4qrsbf0sgqgmgsvfs2gkyn1wxj3xqr";
+    sha256 = "1infhlcrij42rzpabrcz4gpvnkcylxvivj2i9f9ial1l9nyxhgny";
   };
 }

--- a/pkgs/applications/video/plex-media-player/deps.nix
+++ b/pkgs/applications/video/plex-media-player/deps.nix
@@ -1,28 +1,28 @@
 { fetchurl }:
 
 rec {
-  webClientBuildId = "144-56c0a921b12c68";
+  webClientBuildId = "148-aa5f46f1b12c68";
   webClientDesktopBuildId = "3.104.2-1b12c68";
-  webClientTvBuildId = "4.5.1-56c0a92";
+  webClientTvBuildId = "4.7.1-aa5f46f";
 
   webClient = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/buildid.cmake";
-    sha256 = "0ivw949f6b22i7rn9nqvw0iz3cmppc9g88qlx57dhghslsgr7llc";
+    sha256 = "1g5p9avx51v1j14ddyyclxawx32m0a3k8q25rci5cbbg5a93crls";
   };
   webClientDesktopHash = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-desktop-${webClientDesktopBuildId}.tar.xz.sha1";
-    sha256 = "04d2r6awlfzgvxxdz3qj9xd5dfnlmljasj5r6bjjv3ary41f1764";
+    sha256 = "1ah955659szn0jd602k2487a0mk4nrabjpkqplmd6qdmgpa6hgj9";
   };
   webClientDesktop = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-desktop-${webClientDesktopBuildId}.tar.xz";
-    sha256 = "1mg2w7y9idhzfafz47ic0zyqzhjlr4x3kakfx4vajlsbp5894hb3";
+    sha256 = "0zhpjlnwlgbz01cznvv3gni42qynhbvww2jmr6j2raamgxn1w5xc";
   };
   webClientTvHash = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-tv-${webClientTvBuildId}.tar.xz.sha1";
-    sha256 = "0mxsj8shll0d3y0wf2zvxvn69axcqjbr5zrj8rpvdvi1mnpscxrj";
+    sha256 = "0q26q12vvg00swdw24yyvn09144b90nr8653msqpx91x9sm5aiq4";
   };
   webClientTv = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-tv-${webClientTvBuildId}.tar.xz";
-    sha256 = "0d3szjjxlxzqmn3bxirnmzlhspckg7cl96fpwnrqhbc3m2fmbqj1";
+    sha256 = "0gmhk7jgm37arqnxz92qni4qrsbf0sgqgmgsvfs2gkyn1wxj3xqr";
   };
 }

--- a/pkgs/applications/video/plex-media-player/deps.nix
+++ b/pkgs/applications/video/plex-media-player/deps.nix
@@ -1,28 +1,28 @@
 { fetchurl }:
 
 rec {
-  webClientBuildId = "159-65a90631b12c68";
+  webClientBuildId = "162-d8d29131b12c68";
   webClientDesktopBuildId = "3.104.2-1b12c68";
-  webClientTvBuildId = "4.17.1-65a9063";
+  webClientTvBuildId = "4.19.1-d8d2913";
 
   webClient = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/buildid.cmake";
-    sha256 = "1zj5rr9naq6p7gw28j7pg50m8n6hc2bcgnk5yvnlxwki19y9fi51";
+    sha256 = "1lbib79g8lswh9ip3knfh0mi1fwqm03h8pdqnkd7f768wj8lspk4";
   };
   webClientDesktopHash = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-desktop-${webClientDesktopBuildId}.tar.xz.sha1";
-    sha256 = "0hb03psy60zrmlwvskmbbx1l39lwqghi2anjcc35i64n9vqxjv8y";
+    sha256 = "1956w742j2hnj2b5hpy4bc3hv6zvr53xljmslcibhhqrr4v0zzkx";
   };
   webClientDesktop = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-desktop-${webClientDesktopBuildId}.tar.xz";
-    sha256 = "11nvivs3l9shdy8gx6rgpar8il5k5cax1dzrnmgczdbhk4amfbvw";
+    sha256 = "0pdzlx3s2x77nhyk929y42gqx5c19njhz22gmfdas5grkbb19qw8";
   };
   webClientTvHash = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-tv-${webClientTvBuildId}.tar.xz.sha1";
-    sha256 = "1yrplhn3sfyp334kh67x8vwxk6q0n1w310y876d19kb4l555s63f";
+    sha256 = "08rrid1bs87mljp14p6ph93lcg9490llghl7sgq658rg6g2cv2js";
   };
   webClientTv = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-tv-${webClientTvBuildId}.tar.xz";
-    sha256 = "0z62fq6726z0jlni6cnwcg09awf5m9lckq74bxc026qzzr3i1789";
+    sha256 = "0q517dw6gxgpd860iragm7ygaskiyvz26k1bhsvph27lib5a5sbx";
   };
 }

--- a/pkgs/applications/video/plex-media-player/deps.nix
+++ b/pkgs/applications/video/plex-media-player/deps.nix
@@ -1,28 +1,28 @@
 { fetchurl }:
 
 rec {
-  webClientBuildId = "153-f23008b1b12c68";
+  webClientBuildId = "159-65a90631b12c68";
   webClientDesktopBuildId = "3.104.2-1b12c68";
-  webClientTvBuildId = "4.13.1-f23008b";
+  webClientTvBuildId = "4.17.1-65a9063";
 
   webClient = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/buildid.cmake";
-    sha256 = "0p4d7y70czb2ynfdrp8i1v569y85aqahad1l3i0fcz154a593jx8";
+    sha256 = "1zj5rr9naq6p7gw28j7pg50m8n6hc2bcgnk5yvnlxwki19y9fi51";
   };
   webClientDesktopHash = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-desktop-${webClientDesktopBuildId}.tar.xz.sha1";
-    sha256 = "0l6l4w1bb4i2g2azvwbjwy6qxvnlypbnjlmjglmvj572y00y6dpm";
+    sha256 = "0hb03psy60zrmlwvskmbbx1l39lwqghi2anjcc35i64n9vqxjv8y";
   };
   webClientDesktop = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-desktop-${webClientDesktopBuildId}.tar.xz";
-    sha256 = "0nk2rscj67xxv3gr10a605lj6rjr3nxwwg8169rw3sdxiahwd5w8";
+    sha256 = "11nvivs3l9shdy8gx6rgpar8il5k5cax1dzrnmgczdbhk4amfbvw";
   };
   webClientTvHash = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-tv-${webClientTvBuildId}.tar.xz.sha1";
-    sha256 = "0qwk0n0wx9s35ih75l9vvxczsxjw0vcglwxlyw1himv72fp0ivqi";
+    sha256 = "1yrplhn3sfyp334kh67x8vwxk6q0n1w310y876d19kb4l555s63f";
   };
   webClientTv = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-tv-${webClientTvBuildId}.tar.xz";
-    sha256 = "0j3v9fpp1gal8nak03prxy8j30g9bn6mp15sv4x625sd8ss01xl5";
+    sha256 = "0z62fq6726z0jlni6cnwcg09awf5m9lckq74bxc026qzzr3i1789";
   };
 }

--- a/pkgs/applications/video/plex-media-player/deps.nix
+++ b/pkgs/applications/video/plex-media-player/deps.nix
@@ -1,28 +1,28 @@
 { fetchurl }:
 
 rec {
-  webClientBuildId = "151-ce86ded1b12c68";
+  webClientBuildId = "153-f23008b1b12c68";
   webClientDesktopBuildId = "3.104.2-1b12c68";
-  webClientTvBuildId = "4.11.1-ce86ded";
+  webClientTvBuildId = "4.13.1-f23008b";
 
   webClient = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/buildid.cmake";
-    sha256 = "1pl1qfb9wdfrcsasq66gz85819x4zrknkc7655n78xllly55j28s";
+    sha256 = "0p4d7y70czb2ynfdrp8i1v569y85aqahad1l3i0fcz154a593jx8";
   };
   webClientDesktopHash = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-desktop-${webClientDesktopBuildId}.tar.xz.sha1";
-    sha256 = "1s28lfm96jrghz2c8d4yap3dl6y1gxd0svvdnva6jjl205361a6q";
+    sha256 = "0l6l4w1bb4i2g2azvwbjwy6qxvnlypbnjlmjglmvj572y00y6dpm";
   };
   webClientDesktop = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-desktop-${webClientDesktopBuildId}.tar.xz";
-    sha256 = "1k1agr0332hlr5a9xdkfnqpppppwgnmvwd43slw7j5f8r6j4hfsf";
+    sha256 = "0nk2rscj67xxv3gr10a605lj6rjr3nxwwg8169rw3sdxiahwd5w8";
   };
   webClientTvHash = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-tv-${webClientTvBuildId}.tar.xz.sha1";
-    sha256 = "0xm9shp04ri99fd2lahx5ijf27qhyxji7zsdkm80zwwaqzzb13xw";
+    sha256 = "0qwk0n0wx9s35ih75l9vvxczsxjw0vcglwxlyw1himv72fp0ivqi";
   };
   webClientTv = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-tv-${webClientTvBuildId}.tar.xz";
-    sha256 = "0fyk2rvn9mc2xwavmki81yp40d9gz8dd6jajjyhq7mdgsp55xw3b";
+    sha256 = "0j3v9fpp1gal8nak03prxy8j30g9bn6mp15sv4x625sd8ss01xl5";
   };
 }

--- a/pkgs/applications/video/plex-media-player/deps.nix
+++ b/pkgs/applications/video/plex-media-player/deps.nix
@@ -1,28 +1,28 @@
 { fetchurl }:
 
 rec {
-  webClientBuildId = "166-78faf811b12c68";
-  webClientDesktopBuildId = "3.104.2-1b12c68";
-  webClientTvBuildId = "4.23.1-78faf81";
+  webClientBuildId = "168-8a312e779b9a92";
+  webClientDesktopBuildId = "4.24.1-79b9a92";
+  webClientTvBuildId = "4.25.1-8a312e7";
 
   webClient = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/buildid.cmake";
-    sha256 = "140xl65mwa43fkjdrk77n5lp8zfk2zbqj7mjzmc2w4g0vdrrvicd";
+    sha256 = "0ji5pz5qhmspifzaxj8wd1xzr6gqbb09i6r548agpsc9s58myn09";
   };
   webClientDesktopHash = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-desktop-${webClientDesktopBuildId}.tar.xz.sha1";
-    sha256 = "1832acwsxcgdnbgaylribv7nmr80kn2k6bimmvq0cwx5c6dp61z0";
+    sha256 = "0sxaci93pbsfmddg5s4j8dz9r5xjf3dnxch3jnqlrqs5ylm62ndn";
   };
   webClientDesktop = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-desktop-${webClientDesktopBuildId}.tar.xz";
-    sha256 = "06184vza9rq6q1shsa2xclvs7f7ir56gs3yp1c8x20w8qfpszmgk";
+    sha256 = "18nhjy4g6sr8qd8nygmp2gz0jdr8hqman5pa70flws614pj3qzb4";
   };
   webClientTvHash = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-tv-${webClientTvBuildId}.tar.xz.sha1";
-    sha256 = "0c2plqjk65j6810swz76sq7nf02ja06n0761wapaz62c6s3sbwww";
+    sha256 = "1fvp336rg37g78p3qgm8yyllpvlscfh71ymriv8zv06k1zx77j52";
   };
   webClientTv = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-tv-${webClientTvBuildId}.tar.xz";
-    sha256 = "052b6lr57lmwpmb9wi41hy6795c3p5ka3yr3iizw490481pkzlzc";
+    sha256 = "0dh3zghbqk9jk8sl5jmi5ih1qi4lbv8vjp41xi1xd7wjy7v1mk3v";
   };
 }

--- a/pkgs/applications/video/plex-media-player/deps.nix
+++ b/pkgs/applications/video/plex-media-player/deps.nix
@@ -1,28 +1,28 @@
 { fetchurl }:
 
 rec {
-  webClientBuildId = "164-39a91721b12c68";
+  webClientBuildId = "166-78faf811b12c68";
   webClientDesktopBuildId = "3.104.2-1b12c68";
-  webClientTvBuildId = "4.21.1-39a9172";
+  webClientTvBuildId = "4.23.1-78faf81";
 
   webClient = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/buildid.cmake";
-    sha256 = "10aw6md2yqjy862zwp3sacfi150k1zlg53w0171vbszfadlh0jsb";
+    sha256 = "140xl65mwa43fkjdrk77n5lp8zfk2zbqj7mjzmc2w4g0vdrrvicd";
   };
   webClientDesktopHash = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-desktop-${webClientDesktopBuildId}.tar.xz.sha1";
-    sha256 = "1c6z0lfxdnbf9sghl9517czndmq1srzkxppxg6092y0gb97qhv2m";
+    sha256 = "1832acwsxcgdnbgaylribv7nmr80kn2k6bimmvq0cwx5c6dp61z0";
   };
   webClientDesktop = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-desktop-${webClientDesktopBuildId}.tar.xz";
-    sha256 = "0k748743q0m65404rsbv8hwr45jkw8z19xm55sm0pirrkn23w57c";
+    sha256 = "06184vza9rq6q1shsa2xclvs7f7ir56gs3yp1c8x20w8qfpszmgk";
   };
   webClientTvHash = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-tv-${webClientTvBuildId}.tar.xz.sha1";
-    sha256 = "17vrxp0pjk9ad7b3xw5s0q3x3wbng9l52vbhrh83dkb5maxrb04n";
+    sha256 = "0c2plqjk65j6810swz76sq7nf02ja06n0761wapaz62c6s3sbwww";
   };
   webClientTv = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-tv-${webClientTvBuildId}.tar.xz";
-    sha256 = "0ydk6k5fvc6bpk3i5fs3z4m2aih0wv5zbasgifwmgrqzqr23ac0k";
+    sha256 = "052b6lr57lmwpmb9wi41hy6795c3p5ka3yr3iizw490481pkzlzc";
   };
 }

--- a/pkgs/applications/video/plex-media-player/deps.nix
+++ b/pkgs/applications/video/plex-media-player/deps.nix
@@ -1,28 +1,28 @@
 { fetchurl }:
 
 rec {
-  webClientBuildId = "162-d8d29131b12c68";
+  webClientBuildId = "164-39a91721b12c68";
   webClientDesktopBuildId = "3.104.2-1b12c68";
-  webClientTvBuildId = "4.19.1-d8d2913";
+  webClientTvBuildId = "4.21.1-39a9172";
 
   webClient = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/buildid.cmake";
-    sha256 = "1lbib79g8lswh9ip3knfh0mi1fwqm03h8pdqnkd7f768wj8lspk4";
+    sha256 = "10aw6md2yqjy862zwp3sacfi150k1zlg53w0171vbszfadlh0jsb";
   };
   webClientDesktopHash = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-desktop-${webClientDesktopBuildId}.tar.xz.sha1";
-    sha256 = "1956w742j2hnj2b5hpy4bc3hv6zvr53xljmslcibhhqrr4v0zzkx";
+    sha256 = "1c6z0lfxdnbf9sghl9517czndmq1srzkxppxg6092y0gb97qhv2m";
   };
   webClientDesktop = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-desktop-${webClientDesktopBuildId}.tar.xz";
-    sha256 = "0pdzlx3s2x77nhyk929y42gqx5c19njhz22gmfdas5grkbb19qw8";
+    sha256 = "0k748743q0m65404rsbv8hwr45jkw8z19xm55sm0pirrkn23w57c";
   };
   webClientTvHash = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-tv-${webClientTvBuildId}.tar.xz.sha1";
-    sha256 = "08rrid1bs87mljp14p6ph93lcg9490llghl7sgq658rg6g2cv2js";
+    sha256 = "17vrxp0pjk9ad7b3xw5s0q3x3wbng9l52vbhrh83dkb5maxrb04n";
   };
   webClientTv = fetchurl {
     url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-tv-${webClientTvBuildId}.tar.xz";
-    sha256 = "0q517dw6gxgpd860iragm7ygaskiyvz26k1bhsvph27lib5a5sbx";
+    sha256 = "0ydk6k5fvc6bpk3i5fs3z4m2aih0wv5zbasgifwmgrqzqr23ac0k";
   };
 }

--- a/pkgs/applications/video/plex-media-player/update.sh
+++ b/pkgs/applications/video/plex-media-player/update.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl common-updater-scripts nix-prefetch-scripts jq
+
+set -xeuo pipefail
+
+nixpkgs="$(git rev-parse --show-toplevel)"
+
+oldVersion="$(nix-instantiate --eval -E "with import $nixpkgs {}; plex-media-player.version or (builtins.parseDrvName plex-media-player.name).version" | tr -d '"')"
+latestTag="$(curl -s https://api.github.com/repos/plexinc/plex-media-player/tags  | jq -r '.[] | .name' | sort --version-sort | tail -1)"
+latestVersion="$(expr $latestTag : 'v\(.*\)-.*')"
+latestHash="$(expr $latestTag : 'v.*-\(.*\)')"
+
+if [ ! "$oldVersion" = "$latestVersion" ]; then
+  # update default.nix with the new version and hash
+  expectedHash=$(nix-prefetch-git --url https://github.com/plexinc/plex-media-player.git --rev $latestTag --quiet | jq -r '.sha256')
+  update-source-version plex-media-player --version-key=vsnHash "${latestHash}" 0000
+  update-source-version plex-media-player "${latestVersion}" $expectedHash
+
+  # extract the webClientBuildId from the source folder
+  src="$(nix-build --no-out-link $nixpkgs -A plex-media-player.src)"
+  webClientBuildId="$(grep 'set(WEB_CLIENT_BUILD_ID' $src/CMakeModules/WebClient.cmake | cut -d' ' -f2 | tr -d ')')"
+
+  # retreive the included cmake file and hash
+  { read -r webClientBuildIdHash; read -r webClientBuildIdPath; } < \
+    <(nix-prefetch-url --print-path "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/buildid.cmake")
+  webClientDesktopBuildId="$(grep 'set(DESKTOP_VERSION' $webClientBuildIdPath | cut -d' ' -f2 | tr -d ')')"
+  webClientTvBuildId="$(grep 'set(TV_VERSION' $webClientBuildIdPath | cut -d' ' -f2 | tr -d ')')"
+
+  # get the hashes for the other files
+  webClientDesktopHash="$(nix-prefetch-url "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-desktop-${webClientDesktopBuildId}.tar.xz.sha1")"
+  webClientDesktop="$(nix-prefetch-url "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-desktop-${webClientDesktopBuildId}.tar.xz")"
+  webClientTvHash="$(nix-prefetch-url "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-tv-${webClientTvBuildId}.tar.xz.sha1")"
+  webClientTv="$(nix-prefetch-url "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-tv-${webClientTvBuildId}.tar.xz")"
+
+  # update deps.nix
+  cat > $nixpkgs/pkgs/applications/video/plex-media-player/deps.nix <<EOF
+{ fetchurl }:
+
+rec {
+  webClientBuildId = "${webClientBuildId}";
+  webClientDesktopBuildId = "${webClientDesktopBuildId}";
+  webClientTvBuildId = "${webClientTvBuildId}";
+
+  webClient = fetchurl {
+    url = "https://artifacts.plex.tv/web-client-pmp/\${webClientBuildId}/buildid.cmake";
+    sha256 = "${webClientBuildIdHash}";
+  };
+  webClientDesktopHash = fetchurl {
+    url = "https://artifacts.plex.tv/web-client-pmp/\${webClientBuildId}/web-client-desktop-\${webClientDesktopBuildId}.tar.xz.sha1";
+    sha256 = "${webClientDesktopHash}";
+  };
+  webClientDesktop = fetchurl {
+    url = "https://artifacts.plex.tv/web-client-pmp/\${webClientBuildId}/web-client-desktop-\${webClientDesktopBuildId}.tar.xz";
+    sha256 = "${webClientDesktop}";
+  };
+  webClientTvHash = fetchurl {
+    url = "https://artifacts.plex.tv/web-client-pmp/\${webClientBuildId}/web-client-tv-\${webClientTvBuildId}.tar.xz.sha1";
+    sha256 = "${webClientTvHash}";
+  };
+  webClientTv = fetchurl {
+    url = "https://artifacts.plex.tv/web-client-pmp/\${webClientBuildId}/web-client-tv-\${webClientTvBuildId}.tar.xz";
+    sha256 = "${webClientTv}";
+  };
+}
+EOF
+
+  git add "$nixpkgs"/pkgs/applications/video/plex-media-player/{default,deps}.nix
+  git commit -m "plex-media-player: ${oldVersion} -> ${latestVersion}"
+else
+  echo "plex-media-player is already up-to-date"
+fi


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

In the hope that the update process for the `plex-media-player` stays the same as in the last iterations, the update script should make the `fix one hash per build` process much faster.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @kylewlacy 
