### PR TITLE
treewide: fix string escapes

### DIFF
--- a/nixos/modules/programs/less.nix
+++ b/nixos/modules/programs/less.nix
@@ -54,8 +54,8 @@ in
         type = types.attrsOf types.str;
         default = {};
         example = {
-          h = "noaction 5\e(";
-          l = "noaction 5\e)";
+          h = "noaction 5\\e(";
+          l = "noaction 5\\e)";
         };
         description = "Defines new command keys.";
       };

--- a/nixos/modules/services/mail/rspamd.nix
+++ b/nixos/modules/services/mail/rspamd.nix
@@ -68,7 +68,7 @@ let
           replaced with <literal>rspamd_proxy</literal>.
         '';
         apply = let
-            from = "services.rspamd.workers.\”${name}\".type";
+            from = "services.rspamd.workers.\"${name}\".type";
             files = options.type.files;
             warning = "The option `${from}` defined in ${showFiles files} has enum value `proxy` which has been renamed to `rspamd_proxy`";
           in x: if x == "proxy" then traceWarning warning "rspamd_proxy" else x;

--- a/nixos/modules/services/monitoring/graphite.nix
+++ b/nixos/modules/services/monitoring/graphite.nix
@@ -239,7 +239,7 @@ in {
         description = "Any metrics received which match one of the experssions will be dropped.";
         default = null;
         type = types.nullOr types.str;
-        example = "^some\.noisy\.metric\.prefix\..*";
+        example = "^some\\.noisy\\.metric\\.prefix\\..*";
       };
 
       whitelist = mkOption {

--- a/nixos/modules/services/networking/prosody.nix
+++ b/nixos/modules/services/networking/prosody.nix
@@ -465,7 +465,7 @@ in
 
       modules_enabled = {
 
-        ${ lib.concatStringsSep "\n\ \ " (lib.mapAttrsToList
+        ${ lib.concatStringsSep "\n  " (lib.mapAttrsToList
           (name: val: optionalString val "${toLua name};")
         cfg.modules) }
         ${ lib.concatStringsSep "\n" (map (x: "${toLua x};") cfg.package.communityModules)}

--- a/nixos/modules/services/web-apps/matomo.nix
+++ b/nixos/modules/services/web-apps/matomo.nix
@@ -115,7 +115,7 @@ in {
             Either this option or the webServerUser option is mandatory.
             Set this to {} to just enable the virtualHost if you don't need any customization.
             If enabled, then by default, the <option>serverName</option> is
-            <literal>${user}.''${config.networking.hostName}.''${config.networking.domain}</literal>,
+            <literal>''${user}.''${config.networking.hostName}.''${config.networking.domain}</literal>,
             SSL is active, and certificates are acquired via ACME.
             If this is set to null (the default), no nginx virtualHost will be configured.
         '';

--- a/nixos/modules/services/web-apps/matomo.nix
+++ b/nixos/modules/services/web-apps/matomo.nix
@@ -105,8 +105,8 @@ in {
         default = null;
         example = {
           serverAliases = [
-            "matomo.$\{config.networking.domain\}"
-            "stats.$\{config.networking.domain\}"
+            "matomo.\${config.networking.domain}"
+            "stats.\${config.networking.domain}"
           ];
           enableACME = false;
         };
@@ -115,7 +115,7 @@ in {
             Either this option or the webServerUser option is mandatory.
             Set this to {} to just enable the virtualHost if you don't need any customization.
             If enabled, then by default, the <option>serverName</option> is
-            <literal>${user}.$\{config.networking.hostName\}.$\{config.networking.domain\}</literal>,
+            <literal>${user}.''${config.networking.hostName}.''${config.networking.domain}</literal>,
             SSL is active, and certificates are acquired via ACME.
             If this is set to null (the default), no nginx virtualHost will be configured.
         '';
@@ -275,7 +275,7 @@ in {
           fastcgi_pass unix:${phpSocket};
         '';
         # Any other attempt to access any php files is forbidden
-        locations."~* ^.+\.php$".extraConfig = ''
+        locations."~* ^.+\\.php$".extraConfig = ''
           return 403;
         '';
         # Disallow access to unneeded directories
@@ -284,7 +284,7 @@ in {
           return 403;
         '';
         # Disallow access to several helper files
-        locations."~* \.(?:bat|git|ini|sh|txt|tpl|xml|md)$".extraConfig = ''
+        locations."~* \\.(?:bat|git|ini|sh|txt|tpl|xml|md)$".extraConfig = ''
           return 403;
         '';
         # No crawling of this site for bots that obey robots.txt - no useful information here.

--- a/nixos/modules/services/web-apps/restya-board.nix
+++ b/nixos/modules/services/web-apps/restya-board.nix
@@ -235,7 +235,7 @@ in
 
       locations."/".root = "${runDir}/client";
 
-      locations."~ \.php$" = {
+      locations."~ \\.php$" = {
         tryFiles = "$uri =404";
         extraConfig = ''
           include ${pkgs.nginx}/conf/fastcgi_params;
@@ -246,7 +246,7 @@ in
         '';
       };
 
-      locations."~* \.(css|js|less|html|ttf|woff|jpg|jpeg|gif|png|bmp|ico)" = {
+      locations."~* \\.(css|js|less|html|ttf|woff|jpg|jpeg|gif|png|bmp|ico)" = {
         root = "${runDir}/client";
         extraConfig = ''
           if (-f $request_filename) {

--- a/nixos/modules/services/web-apps/tt-rss.nix
+++ b/nixos/modules/services/web-apps/tt-rss.nix
@@ -548,7 +548,7 @@ let
             index = "index.php";
           };
 
-          locations."~ \.php$" = {
+          locations."~ \\.php$" = {
             extraConfig = ''
               fastcgi_split_path_info ^(.+\.php)(/.+)$;
               fastcgi_pass unix:${config.services.phpfpm.pools.${cfg.pool}.socket};

--- a/pkgs/applications/video/kino/default.nix
+++ b/pkgs/applications/video/kino/default.nix
@@ -80,7 +80,7 @@ stdenv.mkDerivation {
 
   postInstall = "
     rpath=`patchelf --print-rpath \$out/bin/kino`;
-    for i in $\buildInputs; do
+    for i in $buildInputs; do
       echo adding \$i/lib
       rpath=\$rpath\${rpath:+:}\$i/lib
     done

--- a/pkgs/development/tools/misc/ctags/wrapped.nix
+++ b/pkgs/development/tools/misc/ctags/wrapped.nix
@@ -27,10 +27,10 @@ with pkgs.stdenv.lib;
 
   # don't scan version control directories
   defaultArgs = [
-    "--exclude=\.svn"
-    "--exclude=\.hg"
-    "--exclude=\.git"
-    "--exclude=\_darcs"
+    "--exclude=.svn"
+    "--exclude=.hg"
+    "--exclude=.git"
+    "--exclude=_darcs"
     "--sort=yes"
   ];
 
@@ -38,8 +38,8 @@ with pkgs.stdenv.lib;
   asLang = [
     "--langdef=ActionScript"
     "--langmap=ActionScript:.as"
-    "--regex-ActionScript=/function[ \\t]+([A-Za-z0-9_]+)[ \\t]*\\(/\1/f,function,functions/"
-    "--regex-ActionScript=/function[ \\t]+(set|get)[ \\t]+([A-Za-z0-9_]+)[ \\t]*\\(/\2/p,property,properties/"
+    "--regex-ActionScript=/function[ \\t]+([A-Za-z0-9_]+)[ \\t]*\\(/\\1/f,function,functions/"
+    "--regex-ActionScript=/function[ \\t]+(set|get)[ \\t]+([A-Za-z0-9_]+)[ \\t]*\\(/\\2/p,property,properties/"
     "--regex-ActionScript=/interface[ \\t]+[a-z0-9_.]*([A-Z][A-Za-z0-9_]+)/\\1/i,interface,interfaces/"
     "--regex-ActionScript=/package[ \\t]+([^ \\t]*)/\\1/p/"
     "--regex-ActionScript=/class[ \\t]+[a-z0-9_.]*([A-Z][A-Za-z0-9_]+)/\\1/c,class,classes/"
@@ -67,7 +67,7 @@ with pkgs.stdenv.lib;
   nixLang = [
     "--langdef=NIX"
     "--langmap=NIX:.nix"
-    "--regex-NIX=/\([^ \\t*]*\)[ \\t]*=/\\1/f/"
+    "--regex-NIX=/([^ \\t*]*)[ \\t]*=/\\1/f/"
   ];
 
   rubyLang = [

--- a/pkgs/os-specific/darwin/apple-source-releases/system_cmds/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/system_cmds/default.nix
@@ -14,8 +14,8 @@ appleDerivation {
   #                    + lib.optionalString hostPlatform.isAarch32 "-D__arm__";
   NIX_CFLAGS_COMPILE = [ "-DDAEMON_UID=1"
                          "-DDAEMON_GID=1"
-                         "-DDEFAULT_AT_QUEUE=\'a\'"
-                         "-DDEFAULT_BATCH_QUEUE=\'b\'"
+                         "-DDEFAULT_AT_QUEUE='a'"
+                         "-DDEFAULT_BATCH_QUEUE='b'"
                          "-DPERM_PATH=\"/usr/lib/cron/\""
                          "-DOPEN_DIRECTORY"
                          "-DNO_DIRECT_RPC"

--- a/pkgs/tools/typesetting/tex/texlive/combine.nix
+++ b/pkgs/tools/typesetting/tex/texlive/combine.nix
@@ -136,9 +136,9 @@ in buildEnv {
     script =
       writeText "hyphens.sed" (
         # pick up the header
-        "1,/^\% from/p;"
+        "1,/^% from/p;"
         # pick up all sections matching packages that we combine
-        + lib.concatMapStrings (pname: "/^\% from ${pname}:$/,/^\%/p;\n") pnames
+        + lib.concatMapStrings (pname: "/^% from ${pname}:$/,/^%/p;\n") pnames
       );
   in ''
     (


### PR DESCRIPTION
Nix parser is very relaxing and allows any character after `\` in strings
When the character following `\` is not one of the six which require escaping (`"` `r` `n` `$` `\` `t`) then `\` is silently skipped

so `"\1"` is the same as just`"1"`

This makes writing string constants which have `\` character (regular expressions, etc) challenging and error-prone.