### PR TITLE
mbed-cli: 1.9.1 -> 1.10.2

### DIFF
--- a/pkgs/development/python-modules/mbed-os-tools/default.nix
+++ b/pkgs/development/python-modules/mbed-os-tools/default.nix
@@ -1,0 +1,38 @@
+{ lib, buildPythonPackage, fetchPypi
+, appdirs, beautifulsoup4, colorama, fasteners, future, intelhex
+, junit-xml , lockfile, prettytable, pyserial, requests, six
+}:
+
+buildPythonPackage rec {
+  pname = "mbed-os-tools";
+  version = "0.0.12";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0fcgw0mlwapj0sy4dd7lx2z2a6ck2ambx6mymwi0c4sa48n4d8x6";
+  };
+
+  propagatedBuildInputs = [
+    appdirs
+    beautifulsoup4
+    colorama
+    fasteners
+    future
+    intelhex
+    junit-xml
+    lockfile
+    prettytable
+    pyserial
+    requests
+    six
+  ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = https://github.com/ARMmbed/mbed-os-tools;
+    description = "List processing tools and functional utilities";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ rvolosatovs ];
+  };
+}

--- a/pkgs/development/tools/mbed-cli/default.nix
+++ b/pkgs/development/tools/mbed-cli/default.nix
@@ -1,20 +1,54 @@
-{ lib, python3Packages, git, mercurial }:
+{ lib, python3Packages, git, mercurial, substituteAll }:
 
 with python3Packages;
 
 buildPythonApplication rec {
   pname = "mbed-cli";
-  version = "1.9.1";
+  version = "1.10.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1228plh55id03qywsw0ai88ypdpbh9iz18jfcyhn21pci7mj77fv";
+    sha256 = "0d26rbsyx813i025wmppf020wab1ik20ndi4alnrkp2wzjb59p9n";
   };
+
+  nativeBuildInputs = [
+    git
+    mercurial
+  ];
+
+  propagatedBuildInputs = [
+    mbed-os-tools
+    pip
+    pyserial
+
+    # Some of mbed-os dependencies.
+    # `mbed update -v` still fails with:
+    #   [mbed] ERROR: Missing Python modules were not auto-installed.
+    #     The Mbed OS tools in this program require the following Python modules: mbed_cloud_sdk, mbed_ls, mbed_host_tests, mbed_greentea, manifest_tool, icetea, cmsis_pack_manager
+    #     You can install all missing modules by running "pip install -r requirements.txt" in "/tmp/test-mbed/mbed-os"
+    #     On Posix systems (Linux, etc) you might have to switch to superuser account or use "sudo"
+    click
+    jinja2
+    jsonschema
+    psutil
+    pycryptodome
+    pyelftools
+    pyusb
+    pyyaml
+  ];
 
   checkInputs = [
     git
     mercurial
     pytest
+  ];
+
+  patches = [
+    (substituteAll {
+      src = ./fix-paths.patch;
+      inherit mercurial git;
+      python = python.withPackages(ps: propagatedBuildInputs);
+    })
   ];
 
   checkPhase = ''

--- a/pkgs/development/tools/mbed-cli/fix-paths.patch
+++ b/pkgs/development/tools/mbed-cli/fix-paths.patch
@@ -1,0 +1,22 @@
+diff --git a/mbed/mbed.py b/mbed/mbed.py
+index 2edb549..d619918 100755
+--- a/mbed/mbed.py
++++ b/mbed/mbed.py
+@@ -56,13 +56,13 @@ from contextlib import contextmanager
+ ver = '1.10.2'
+ 
+ # Default paths to Mercurial and Git
+-hg_cmd = 'hg'
+-git_cmd = 'git'
++hg_cmd = '@mercurial@/bin/hg'
++git_cmd = '@git@/bin/git'
+ 
+ # override python command when running standalone Mbed CLI
+-python_cmd = sys.executable
++python_cmd = '@python@/bin/python'
+ if os.path.basename(python_cmd).startswith('mbed'):
+-    python_cmd = 'python'
++    python_cmd = '@python@/bin/python'
+ 
+ ignores = [
+     # Version control folders

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4082,6 +4082,8 @@ in {
 
   MechanicalSoup = callPackage ../development/python-modules/MechanicalSoup { };
 
+  mbed-os-tools = callPackage ../development/python-modules/mbed-os-tools { };
+
   meld3 = callPackage ../development/python-modules/meld3 { };
 
   meliae = callPackage ../development/python-modules/meliae {};


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Upstream update
`mbed-os-tools` is added as dependency to `mbed-cli`
Replaces #53956 
~Depends on #67730 (I will remove the [WIP] from the title, once that PR is merged and this one is rebased)~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).