### PR TITLE
mle: init at 1.4.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -184,6 +184,12 @@
     githubId = 1250775;
     name = "Adolfo E. García Castro";
   };
+  adsr = {
+    email = "as@php.net";
+    github = "adsr";
+    githubId = 315003;
+    name = "Adam Saponara";
+  };
   aepsil0n = {
     email = "eduard.bopp@aepsil0n.de";
     github = "aepsil0n";

--- a/pkgs/applications/editors/mle/default.nix
+++ b/pkgs/applications/editors/mle/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, termbox, pcre, uthash, lua5_3 }:
+
+stdenv.mkDerivation rec {
+  pname = "mle";
+  version = "1.4.1";
+
+  src = fetchFromGitHub {
+    owner = "adsr";
+    repo = "mle";
+    rev = "v${version}";
+    sha256 = "15i5lzcp0zar2zh34ky9m6pvvi41zgdrl3hmylpgsqnnj4r87vqc";
+  };
+
+  # Fix location of Lua 5.3 header and library
+  postPatch = ''
+    substituteInPlace Makefile --replace "-llua5.3" "-llua";
+    substituteInPlace mle.h    --replace "<lua5.3/" "<";
+  '';
+
+  buildInputs = [ termbox pcre uthash lua5_3 ];
+
+  doCheck = true;
+
+  installFlags = [ "prefix=${placeholder "out"}" ];
+
+  meta = with stdenv.lib; {
+    description = "Small, flexible terminal-based text editor";
+    homepage = "https://github.com/adsr/mle";
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ adsr ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19695,6 +19695,8 @@ in
 
   micro = callPackage ../applications/editors/micro { };
 
+  mle = callPackage ../applications/editors/mle { };
+
   nano = callPackage ../applications/editors/nano { };
 
   nanoblogger = callPackage ../applications/misc/nanoblogger { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Small, flexible, terminal-based text editor

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
