### PR TITLE
faudio, wine, vkd3d: add faudio 19.10 and vkd3d 1.1 to wine

### DIFF
--- a/pkgs/development/libraries/faudio/default.nix
+++ b/pkgs/development/libraries/faudio/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, cmake, SDL2}:
+
+#TODO: tests
+
+stdenv.mkDerivation rec {
+	pname = "faudio";
+  version = "19.10";
+
+  src = fetchFromGitHub {
+    owner = "FNA-XNA";
+    repo = "FAudio";
+    rev = version;
+    sha256 = "1z7j803nxhgvjwpxr1m5d490yji727v7pn0ghhipbrfxlwzkw1sz";
+  };
+
+	nativeBuildInputs = [cmake];
+
+  buildInputs = [ SDL2 ];
+
+  meta = with stdenv.lib; {
+    description = "XAudio reimplementation focusing to develop a fully accurate DirectX audio library";
+    homepage = "https://github.com/FNA-XNA/FAudio";
+    license = licenses.zlib;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.marius851000 ];
+  };
+}

--- a/pkgs/misc/emulators/wine/base.nix
+++ b/pkgs/misc/emulators/wine/base.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, pkgArches,
+{ stdenv, lib, pkgArches, callPackage,
   name, version, src, monos, geckos, platforms,
   pkgconfig, fontforge, makeWrapper, flex, bison,
   supportFlags,
@@ -7,6 +7,9 @@
 
 with import ./util.nix { inherit lib; };
 
+let
+  vkd3d = callPackage ./vkd3d.nix {};
+in
 stdenv.mkDerivation ((lib.optionalAttrs (buildScript != null) {
   builder = buildScript;
 }) // rec {
@@ -46,8 +49,10 @@ stdenv.mkDerivation ((lib.optionalAttrs (buildScript != null) {
   ++ lib.optional udevSupport            pkgs.udev
   ++ lib.optional vulkanSupport          pkgs.vulkan-loader
   ++ lib.optional sdlSupport             pkgs.SDL2
+  ++ lib.optional faudioSupport          pkgs.faudio
+  ++ lib.optional vkd3dSupport           vkd3d
   ++ lib.optionals gstreamerSupport      (with pkgs.gst_all_1;
-    [ gstreamer gst-plugins-base gst-plugins-good gst-plugins-ugly gst-libav 
+    [ gstreamer gst-plugins-base gst-plugins-good gst-plugins-ugly gst-libav
     (gst-plugins-bad.override { enableZbar = false; }) ])
   ++ lib.optionals gtkSupport    [ pkgs.gtk3 pkgs.glib ]
   ++ lib.optionals openclSupport [ pkgs.opencl-headers pkgs.ocl-icd ]

--- a/pkgs/misc/emulators/wine/default.nix
+++ b/pkgs/misc/emulators/wine/default.nix
@@ -43,6 +43,8 @@
   xmlSupport ? false,
   vulkanSupport ? false,
   sdlSupport ? false,
+  faudioSupport ? false,
+  vkd3dSupport ? false,
 }:
 
 let wine-build = build: release:
@@ -54,7 +56,8 @@ let wine-build = build: release:
                   netapiSupport cursesSupport vaSupport pcapSupport v4lSupport saneSupport
                   gsmSupport gphoto2Support ldapSupport fontconfigSupport alsaSupport
                   pulseaudioSupport xineramaSupport gtkSupport openclSupport xmlSupport tlsSupport
-                  openglSupport gstreamerSupport udevSupport vulkanSupport sdlSupport;
+                  openglSupport gstreamerSupport udevSupport vulkanSupport sdlSupport faudioSupport
+                  vkd3dSupport;
         };
       });
 

--- a/pkgs/misc/emulators/wine/vkd3d.nix
+++ b/pkgs/misc/emulators/wine/vkd3d.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl, vulkan-headers, spirv-headers, vulkan-loader }:
+
+#TODO: MoltenVK
+#TODO: unstable
+
+stdenv.mkDerivation rec {
+  pname = "vkd3d";
+  version = "1.1";
+
+  src = fetchurl {
+    url = "https://dl.winehq.org/vkd3d/source/vkd3d-${version}.tar.xz";
+    sha256 = "1dkayp95g1691w7n2yn1q9y7klq5xa921dgmn9a5vil0rihxqnj9";
+  };
+
+  buildInputs = [ vulkan-headers spirv-headers vulkan-loader ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "A 3d library build on top on Vulkan with a similar api to DirectX 12";
+    homepage = "https://source.winehq.org/git/vkd3d.git";
+    license = licenses.lgpl21;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.marius851000 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1614,6 +1614,8 @@ in
 
   fast-cli = nodePackages.fast-cli;
 
+  faudio = callPackage ../development/libraries/faudio { };
+
   fd = callPackage ../tools/misc/fd { };
 
   fdroidserver = python3Packages.callPackage ../development/tools/fdroidserver { };

--- a/pkgs/top-level/wine-packages.nix
+++ b/pkgs/top-level/wine-packages.nix
@@ -44,6 +44,8 @@ rec {
     gsmSupport = true;
     gphoto2Support = true;
     ldapSupport = true;
+    faudioSupport = true;
+    vkd3dSupport = true;
   };
 
   stable = base.override { wineRelease = "stable"; };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Faudio is needed for some game (for example, Spyro Reignited Trilogy)
###### Things done
Added the faudio package version 19.09.
Added it as an optional dependancies of wine.
Enable it when the full wine is asked

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


Spyro Reignited trilogy now lauch.
Not tested on darwin (could be important, as this is a full wine dependancies)
###### Notify maintainers

cc @avnik @bendlas