### PR TITLE
pythonPackages.entrance: init at 1.1.10 (and janus init at 0.4.0)

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5898,6 +5898,12 @@
       fingerprint = "ADF4 C13D 0E36 1240 BD01  9B51 D1DE 6D7F 6936 63A5";
     }];
   };
+  simonchatts = {
+    email = "code@chatts.net";
+    github = "simonchatts";
+    githubId = 11135311;
+    name = "Simon Chatterjee";
+  };
   simonvandel = {
     email = "simon.vandel@gmail.com";
     github = "simonvandel";

--- a/pkgs/development/python-modules/entrance/default.nix
+++ b/pkgs/development/python-modules/entrance/default.nix
@@ -1,0 +1,45 @@
+{ lib, fetchPypi, buildPythonPackage, pythonOlder, routerFeatures
+, janus, ncclient, paramiko, pyyaml, sanic }:
+
+let
+  # The `routerFeatures` flag optionally brings in some somewhat heavy
+  # dependencies, in order to enable interacting with routers
+  opts = if routerFeatures then {
+      prePatch = ''
+        substituteInPlace ./setup.py --replace "extra_deps = []" "extra_deps = router_feature_deps"
+      '';
+      extraBuildInputs = [ janus ncclient paramiko ];
+    } else {
+      prePatch = "";
+      extraBuildInputs = [];
+    };
+
+in
+
+buildPythonPackage rec {
+  pname = "entrance";
+  version = "1.1.10";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "080qkvkmfw4004cl721l5bvpg001xz8vs6q59dg797kqxfrwk5kw";
+  };
+
+  # The versions of `sanic` and `websockets` in nixpkgs only support 3.6 or later
+  disabled = pythonOlder "3.6";
+
+  # No useful tests
+  doCheck = false;
+
+  propagatedBuildInputs = [ pyyaml sanic ] ++ opts.extraBuildInputs;
+
+  prePatch = opts.prePatch;
+
+  meta = with lib; {
+    description = "A server framework for web apps with an Elm frontend";
+    homepage = https://github.com/ensoft/entrance;
+    license = licenses.mit;
+    maintainers = with maintainers; [ simonchatts ];
+  };
+}
+

--- a/pkgs/development/python-modules/janus/default.nix
+++ b/pkgs/development/python-modules/janus/default.nix
@@ -1,0 +1,20 @@
+{ lib, buildPythonPackage, fetchPypi, pytest }:
+
+buildPythonPackage rec {
+  pname = "janus";
+  version = "0.4.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "cfc221683160b91b35bae1917e2957b78dad10a2e634f4f8ed119ed72e2a88ef";
+  };
+
+ checkInputs = [ pytest ];
+
+  meta = with lib; {
+    description = "Mixed sync-async queue";
+    homepage = "https://github.com/aio-libs/janus";
+    license = licenses.asl20;
+    maintainers = [ maintainers.simonchatts ];
+  };
+}

--- a/pkgs/development/python-modules/janus/default.nix
+++ b/pkgs/development/python-modules/janus/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, pytest }:
+{ lib, buildPythonPackage, fetchPypi, pytest, pythonOlder }:
 
 buildPythonPackage rec {
   pname = "janus";
@@ -9,7 +9,9 @@ buildPythonPackage rec {
     sha256 = "cfc221683160b91b35bae1917e2957b78dad10a2e634f4f8ed119ed72e2a88ef";
   };
 
- checkInputs = [ pytest ];
+  disabled = pythonOlder "3.6";
+
+  checkInputs = [ pytest ];
 
   meta = with lib; {
     description = "Mixed sync-async queue";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -689,6 +689,8 @@ in {
 
   inquirer = callPackage ../development/python-modules/inquirer { };
 
+  janus = callPackage ../development/python-modules/janus { };
+
   jira = callPackage ../development/python-modules/jira { };
 
   jwcrypto = callPackage ../development/python-modules/jwcrypto { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -563,6 +563,10 @@ in {
 
   diff-match-patch = callPackage ../development/python-modules/diff-match-patch { };
 
+  entrance = callPackage ../development/python-modules/entrance { routerFeatures = false; };
+
+  entrance-with-router-features = callPackage ../development/python-modules/entrance { routerFeatures = true; };
+
   eradicate = callPackage ../development/python-modules/eradicate {  };
 
   face = callPackage ../development/python-modules/face { };


### PR DESCRIPTION
###### Motivation for this change

Support the [entrance](https://github.com/ensoft/entrance) Python package. 

Note:

 - **This requires PRs [#68226](https://github.com/NixOS/nixpkgs/pull/68226) and [#68321](https://github.com/NixOS/nixpkgs/pull/68321) to be merged before this will work correctly.**
 - This also brings in the [janus](https://github.com/aio-libs/janus) Python package, since it's a dependency.
 - The `entrance` Python package can be installed in a "lean" default mode with minimal dependencies, or a "with-router-features" mode that adds functionality but also some fairly heavy dependencies. These are exposed as two derivations.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

The package's [sample applications](https://github.com/ensoft/entrance/tree/master/samples) have been run, on both NixOS and macOS, exercising both the "lean" and "with-router-features" options.