### PR TITLE
ocamlPackages.ppx_deriving_rpc: init at 5.9.0

### DIFF
--- a/pkgs/development/ocaml-modules/ppx_deriving_rpc/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving_rpc/default.nix
@@ -1,0 +1,18 @@
+{ lib, buildDunePackage, rpclib, ppxfind, ppx_deriving, cppo }:
+
+buildDunePackage rec {
+  pname = "ppx_deriving_rpc";
+
+  inherit (rpclib) version src;
+
+  buildInputs = [ ppxfind cppo ];
+
+  propagatedBuildInputs = [ rpclib ppx_deriving ];
+
+  meta = with lib; {
+    homepage = "https://github.com/mirage/ocaml-rpc";
+    description = "Ppx deriver for ocaml-rpc";
+    license = licenses.isc;
+    maintainers = [ maintainers.vyorkin ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -696,6 +696,8 @@ let
 
     ppx_deriving_protobuf = callPackage ../development/ocaml-modules/ppx_deriving_protobuf {};
 
+    ppx_deriving_rpc = callPackage ../development/ocaml-modules/ppx_deriving_rpc {};
+
     ppx_deriving_yojson = callPackage ../development/ocaml-modules/ppx_deriving_yojson {};
 
     ppx_gen_rec = callPackage ../development/ocaml-modules/ppx_gen_rec {};


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Adds [ppx_deriving_rpc](https://github.com/mirage/ocaml-rpc/blob/v5.9.0/ppx_deriving_rpc.opam) -- Ppx deriver for ocaml-rpc.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

So I've just inherited the `src` and `version` attributes since this seems a right thing to do in such cases.