### PR TITLE
plan9port: do not use which in builder.sh

### DIFF
--- a/pkgs/tools/system/plan9port/builder.sh
+++ b/pkgs/tools/system/plan9port/builder.sh
@@ -22,7 +22,7 @@ plan9portLinkFlags()
 configurePhase()
 {
     (
-        echo CC9=\"$(which $CC)\"
+        echo CC9=\"$(command -v $CC)\"
         echo CFLAGS=\"$NIX_CFLAGS_COMPILE\"
         echo LDFLAGS=\"$(plan9portLinkFlags)\"
         echo X11=\"${libXt_dev}/include\"


### PR DESCRIPTION
Removing the build time dependency on `which` on the previous commit for
this package broke builder.sh ( my fault, sorry :( )

###### Motivation for this change

Make plan9port build again

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @AndersonTorres