### PR TITLE
ocamlPackages.ocaml-protoc: init at 1.2.0

### DIFF
--- a/pkgs/development/ocaml-modules/ocaml-protoc/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-protoc/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, ocaml, fetchFromGitHub, ocamlbuild, findlib, ppx_deriving_protobuf }:
+
+stdenv.mkDerivation rec {
+  name = "ocaml${ocaml.version}-ocaml-protoc-${version}";
+  version = "1.2.0";
+
+  minimumOCamlVersion = "4.02";
+
+  src = fetchFromGitHub {
+    owner = "mransan";
+    repo = "ocaml-protoc";
+    rev = "60d2d4dd55f73830e1bed603cc44d3420430632c";
+    sha256 = "1d1p8ch723z2qa9azmmnhbcpwxbpzk3imh1cgkjjq4p5jwzj8amj";
+  };
+
+  installPhase = ''
+    mkdir -p tmp/bin
+    export PREFIX=`pwd`/tmp
+    make all.install.build
+    make check_install
+    make lib.install
+    make bin.install
+  '';
+
+  buildInputs = [ ocaml findlib ocamlbuild ];
+  propagatedBuildInputs = [ ppx_deriving_protobuf ];
+
+  createFindlibDestdir = true;
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/mransan/ocaml-protoc";
+    description = "A Protobuf Compiler for OCaml";
+    license = licenses.mit;
+    maintainers = [ maintainers.vyorkin ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -664,6 +664,8 @@ let
       then sexplib_108_08_00
       else null;
 
+    ocaml-protoc = callPackage ../development/ocaml-modules/ocaml-protoc { };
+
     ocaml_extlib = callPackage ../development/ocaml-modules/extlib { };
 
     ocb-stubblr = callPackage ../development/ocaml-modules/ocb-stubblr { };
@@ -714,8 +716,6 @@ let
     printbox = callPackage ../development/ocaml-modules/printbox { };
 
     process = callPackage ../development/ocaml-modules/process { };
-
-    ocaml-protoc = callPackage ../development/ocaml-modules/ocaml-protoc { };
 
     ptmap = callPackage ../development/ocaml-modules/ptmap { };
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -715,6 +715,8 @@ let
 
     process = callPackage ../development/ocaml-modules/process { };
 
+    ocaml-protoc = callPackage ../development/ocaml-modules/ocaml-protoc { };
+
     ptmap = callPackage ../development/ocaml-modules/ptmap { };
 
     pycaml = callPackage ../development/ocaml-modules/pycaml { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Adds [ocaml-protoc](https://github.com/mransan/ocaml-protoc) -- A Protobuf Compiler for OCaml.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I had to use the `installPhase` attribute to replicate some of the installation steps mentioned it the `protoc`'s Makefile because the make install is broken for 1.2.0 (for example, there is no `lib.install.byte` in the Makefile that is mentioned here https://github.com/mransan/ocaml-protoc/blob/60d2d4dd55f73830e1bed603cc44d3420430632c/Makefile#L133)