### PR TITLE
coz: init at 0.2.0

### DIFF
--- a/pkgs/development/tools/analysis/coz/default.nix
+++ b/pkgs/development/tools/analysis/coz/default.nix
@@ -1,0 +1,52 @@
+{ stdenv
+, fetchFromGitHub
+, libelfin
+, ncurses
+, python3
+, makeWrapper
+}:
+stdenv.mkDerivation rec {
+  pname = "coz";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "plasma-umass";
+    repo = "coz";
+    rev = version;
+    sha256 = "0a55q3s8ih1r9x6fp7wkg3n5h1yd9pcwg74k33d1r94y3j3m0znr";
+  };
+
+  postConfigure = ''
+    # This is currently hard-coded. Will be fixed in the next release.
+    sed -e "s|/usr/lib/|$out/lib/|" -i ./coz
+  '';
+
+  nativeBuildInputs = [
+    ncurses
+    makeWrapper
+  ];
+
+  buildInputs = [
+    libelfin
+    (python3.withPackages (p: [ p.docutils ]))
+  ];
+
+  installPhase = ''
+    mkdir -p $out/share/man/man1
+    make install prefix=$out
+
+    # fix executable includes
+    chmod -x $out/include/coz.h
+
+    # make sure that PYTHONPATH doesn't leak from the environment
+    wrapProgram $out/bin/coz \
+      --unset PYTHONPATH
+  '';
+
+  meta = {
+    homepage = "https://github.com/plasma-umass/coz";
+    description = "Coz: Causal Profiling";
+    license = stdenv.lib.licenses.bsd2;
+    maintainers = with stdenv.lib.maintainers; [ zimbatm ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25008,4 +25008,6 @@ in
 
   qubes-core-vchan-xen = callPackage ../applications/qubes/qubes-core-vchan-xen {};
 
+  coz = callPackage ../development/tools/analysis/coz {};
+
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

profiling nix

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
