### PR TITLE
haskell.compiler.ghcjs86: Bump ghc-8.6 branch, fix build.

### DIFF
--- a/pkgs/development/compilers/ghcjs-ng/8.6/dep-overrides.nix
+++ b/pkgs/development/compilers/ghcjs-ng/8.6/dep-overrides.nix
@@ -2,6 +2,10 @@
 
 let inherit (haskellLib) doJailbreak dontHaddock;
 in self: super: {
+  ghc-api-ghcjs = super.ghc-api-ghcjs.override
+  {
+    happy = self.happy_1_19_5;
+  };
   haddock-library-ghcjs = doJailbreak super.haddock-library-ghcjs;
   haddock-api-ghcjs = doJailbreak (dontHaddock super.haddock-api-ghcjs);
 }

--- a/pkgs/development/compilers/ghcjs-ng/8.6/git.json
+++ b/pkgs/development/compilers/ghcjs-ng/8.6/git.json
@@ -1,6 +1,6 @@
 {
   "url": "https://github.com/ghcjs/ghcjs",
-  "rev": "75c61af32d73def4409d1fe7b64659c1d28cd075",
-  "sha256": "18pixn6xdz6qp941yhxfnmwi463jnpskmg473lv07vvgy4hpgjhj",
+  "rev": "e87195eaa2bc7e320e18cf10386802bc90b7c874",
+  "sha256": "02mwkf7aagxqi142gcmq048244apslrr72p568akcab9s0fn2gvy",
   "fetchSubmodules": true
 }

--- a/pkgs/development/compilers/ghcjs-ng/8.6/stage0.nix
+++ b/pkgs/development/compilers/ghcjs-ng/8.6/stage0.nix
@@ -59,20 +59,21 @@
     }) {};
 
   ghc-api-ghcjs = callPackage
-    ({ mkDerivation, array, base, binary, bytestring, containers
+    ({ mkDerivation, alex, array, base, binary, bytestring, containers
     , deepseq, directory, filepath, ghc-boot, ghc-boot-th, ghc-heap
-    , ghci-ghcjs, hpc, process, stdenv, template-haskell-ghcjs
+    , ghci-ghcjs, happy, hpc, process, stdenv, template-haskell-ghcjs
     , terminfo, time, transformers, unix
     }:
     mkDerivation {
       pname = "ghc-api-ghcjs";
-      version = "8.6.2";
+      version = "8.6.5";
       src = configuredSrc + /lib/ghc-api-ghcjs;
       libraryHaskellDepends = [
         array base binary bytestring containers deepseq directory filepath
         ghc-boot ghc-boot-th ghc-heap ghci-ghcjs hpc process
         template-haskell-ghcjs terminfo time transformers unix
       ];
+      libraryToolDepends = [ alex happy ];
       homepage = "http://www.haskell.org/ghc/";
       description = "The GHC API (customized for GHCJS)";
       license = stdenv.lib.licenses.bsd3;
@@ -107,7 +108,7 @@
         base binary bytestring containers ghc-prim ghci-ghcjs
         template-haskell-ghcjs
       ];
-      homepage = "https://github.com/ghcjs";
+      homepage = "http://github.com/ghcjs";
       license = stdenv.lib.licenses.mit;
     }) {};
 

--- a/pkgs/development/compilers/ghcjs-ng/common-overrides.nix
+++ b/pkgs/development/compilers/ghcjs-ng/common-overrides.nix
@@ -1,8 +1,7 @@
-{ haskellLib, alex, happy }:
+{ haskellLib }:
 
 let inherit (haskellLib) addBuildTools appendConfigureFlag dontHaddock doJailbreak;
 in self: super: {
-  ghc-api-ghcjs = addBuildTools super.ghc-api-ghcjs [alex happy];
   ghcjs = dontHaddock (appendConfigureFlag (doJailbreak super.ghcjs) "-fno-wrapper-install");
   haddock-library-ghcjs = dontHaddock super.haddock-library-ghcjs;
   system-fileio = doJailbreak super.system-fileio;

--- a/pkgs/development/compilers/ghcjs-ng/default.nix
+++ b/pkgs/development/compilers/ghcjs-ng/default.nix
@@ -34,7 +34,6 @@ let
 
       (callPackage ./common-overrides.nix {
         inherit haskellLib;
-        inherit (bootPkgs) alex happy;
       })
       ghcjsDepOverrides
     ]);


### PR DESCRIPTION
This fixes the GHCJS 8.6 build. Previously the build was failing because the utils/makePackages.sh script was booting the GHC source tree before copying in the lib/* extra packages. This caused cabal to fail, since those packages are mentioned in GHCJS' cabal.project file. Bumping the ghc-8.6 branch fixed this.

ghc-api-ghcjs requires happy >= 1.19 && < 1.19.12, so happy 1.19.5 is used.

Tested on macOS, will test on Linux.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).