### PR TITLE
haskell-hakyll: add missing files, remove obsolete patch

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -146,16 +146,11 @@ self: super: {
     else super.halive;
 
   # Hakyll's tests are broken on Darwin (3 failures); and they require util-linux
-  hakyll = appendPatch
-    (if pkgs.stdenv.isDarwin
+  hakyll = if pkgs.stdenv.isDarwin
     then dontCheck (overrideCabal super.hakyll (drv: {
       testToolDepends = [];
     }))
-    else super.hakyll)
-    (pkgs.fetchpatch {
-      url = https://github.com/jaspervdj/hakyll/commit/25a4460b75b3c9f3ce339b3311b084d92994f5f1.patch;
-      sha256 = "sha256-F59WHt52LOKGsGoaD3LAIZFEMe9s9WHfGxQgSh9Q8uQ=";
-    });
+    else super.hakyll;
 
   double-conversion = if !pkgs.stdenv.isDarwin
     then super.double-conversion

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -150,7 +150,26 @@ self: super: {
     then dontCheck (overrideCabal super.hakyll (drv: {
       testToolDepends = [];
     }))
-    else super.hakyll;
+    else (overrideCabal super.hakyll (_: {
+      # This postPatch adds two missing files, that are present in the official
+      # sources but got not included in the hackage tarball.  It can be
+      # removed, when https://github.com/jaspervdj/hakyll/pull/732
+      # makes it into a release.
+      postPatch = let
+        embed = pkgs.fetchurl {
+          url = "https://github.com/jaspervdj/hakyll/raw/4819618ef24c44748bbeecb4a92fa4e2369f04f9/tests/data/embed.html";
+          sha256 = "14gj42za0caxfa8ncw6zvglqdwvf33551493c8hpj0ha11s2c1yb";
+        };
+        tomorrow = pkgs.fetchurl {
+          url = "https://github.com/jaspervdj/hakyll/raw/4819618ef24c44748bbeecb4a92fa4e2369f04f9/tests/data/posts/2019/05/10/tomorrow.md";
+          sha256 = "1zbx5qk8hbya9alcswkr67wyf73drls1qs3mqsnafcmihc99ppxw";
+        };
+      in ''
+        ln -s ${embed} tests/data/embed.html
+        mkdir -p tests/data/posts/2019/05/10
+        ln -s ${tomorrow} tests/data/posts/2019/05/10/tomorrow.md
+      '';
+    }));
 
   double-conversion = if !pkgs.stdenv.isDarwin
     then super.double-conversion

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -8691,7 +8691,6 @@ broken-packages:
   - scenegraph
   - schedevr
   - schedule-planner
-  - scheduler
   - schedyield
   - schematic
   - scholdoc

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -5373,7 +5373,6 @@ broken-packages:
   - hakismet
   - hakka
   - hako
-  - hakyll
   - hakyll-agda
   - hakyll-blaze-templates
   - hakyll-contrib

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -7150,9 +7150,6 @@ broken-packages:
   - marxup
   - masakazu-bot
   - MASMGen
-  - massiv
-  - massiv-io
-  - massiv-test
   - master-plan
   - matchable-th
   - matchers


### PR DESCRIPTION
###### Motivation for this change

Unbreak the build.
 
###### Things done

 As the Hackage tarball does not contain all files from the git repo (which is hopefully fixed with https://github.com/jaspervdj/hakyll/pull/732), I manually pulled in two missing files from the newest release. Also I removed an unnecessary patch.

I guess it doesn't really make sense to merge this, as https://github.com/jaspervdj/hakyll/pull/732 will be merged soon probably and we can wait for the next release from upstream. I did this patch more for myself to see wether I fixed the issue. Maybe anyone else wants to use this to temporarily fix their issue with hakyll.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
