### PR TITLE
chromium: add patch to fix performance regression with fonts

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -138,6 +138,13 @@ let
       ./patches/jumbo-sorted.patch
       ./patches/no-build-timestamps.patch
       ./patches/widevine.patch
+      # Revert "Implement GetFallbackFont on Linux" to fix a performance regression
+      # Remove after https://bugs.chromium.org/p/chromium/issues/detail?id=1003997 is fixed
+      (fetchpatch {
+        url = "https://github.com/chromium/chromium/commit/5a32abe4247f80fdb55c55a289b906b0e42faa5f.patch";
+        sha256 = "1a4jqmki6cyi2dwvaszh01db2diqnz1d50mhpdpby3dd1cw0xmfy";
+        revert = true;
+      })
 
       # Unfortunately, chromium regularly breaks on major updates and
       # then needs various patches backported in order to be compiled with GCC.


### PR DESCRIPTION
###### Motivation for this change

This fixes a font-related performance regression in Chromium 77: https://bugs.chromium.org/p/chromium/issues/detail?id=1003997

The issue can be very annoying, with 4.5 second pauses and an inability to scroll through bookmark folders.

It is not clear exactly which fonts (or how many) need to be installed to see this problem, but I reverted the relevant commit and confirmed that this fixed the issue in `chromium`, `chromiumBeta`, and `chromiumDev`.

The reverted commit appears to be self-contained and not related to any security bugs. This patch will be hopefully be removed by the time Chromium 78 is released.

If accepted to master, please also cherry-pick to release-19.09.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @bendlas 
and previous committers @andir @samueldr