### PR TITLE
pythonPackages.markdown: add missing setuptools to propagatedBuildInput

### DIFF
--- a/pkgs/development/python-modules/markdown/default.nix
+++ b/pkgs/development/python-modules/markdown/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, setuptools
 , nose
 , pyyaml
 }:
@@ -13,6 +14,8 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "2e50876bcdd74517e7b71f3e7a76102050edec255b3983403f1a63e7c8a41e7a";
   };
+
+  propagatedBuildInputs = [ setuptools ];
 
   checkInputs = [ nose pyyaml ];
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Currently setuptools isn't automatically propagated to python packages (https://github.com/NixOS/nixpkgs/pull/68314).

This fixes the following ImportError on application startup:

```
/nix/store/qh7ndfsar3icmwqbiwcla7pc8x1133vg-python2.7-Markdown-3.1.1/bin/markdown_py README.md > README.html.new
Traceback (most recent call last):
  File "/nix/store/qh7ndfsar3icmwqbiwcla7pc8x1133vg-python2.7-Markdown-3.1.1/bin/.markdown_py-wrapped", line 7, in <module>
    from markdown.__main__ import run
  File "/nix/store/qh7ndfsar3icmwqbiwcla7pc8x1133vg-python2.7-Markdown-3.1.1/lib/python2.7/site-packages/markdown/__init__.py", line 25, in <module>
    from .core import Markdown, markdown, markdownFromFile
  File "/nix/store/qh7ndfsar3icmwqbiwcla7pc8x1133vg-python2.7-Markdown-3.1.1/lib/python2.7/site-packages/markdown/core.py", line 29, in <module>
    import pkg_resources
ImportError: No module named pkg_resources
make: *** [Makefile:53: README.html] Error 1
```

Also needs to be backported to 19.09. Also probably fixes the build of bees on 19.09 (https://hydra.nixos.org/build/100463113#tabs-summary).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
