### PR TITLE
fprintd: 0.8.1 -> 0.9.0, libfprint: 0.99 -> 1.0

### DIFF
--- a/nixos/modules/services/security/fprintd.nix
+++ b/nixos/modules/services/security/fprintd.nix
@@ -50,13 +50,6 @@ in
 
     systemd.packages = [ cfg.package ];
 
-
-    # The upstream unit does not use StateDirectory, and will
-    # fail if the directory it needs is not present. Should be
-    # fixed when https://gitlab.freedesktop.org/libfprint/fprintd/merge_requests/5
-    # is merged.
-    systemd.services.fprintd.serviceConfig.StateDirectory = "fprint";
-
   };
 
 }

--- a/pkgs/development/libraries/libfprint/default.nix
+++ b/pkgs/development/libraries/libfprint/default.nix
@@ -1,11 +1,27 @@
-{ thinkpad ? false, stdenv, fetchFromGitHub, fetchurl, pkgconfig, meson, ninja, libusb, pixman, glib, nss, gtk3
-, coreutils, gtk-doc, docbook_xsl, docbook_xml_dtd_43, openssl ? null }:
+{ thinkpad ? false
+, stdenv
+, fetchFromGitHub
+, fetchurl
+, pkgconfig
+, meson
+, ninja
+, libusb
+, pixman
+, glib
+, nss
+, gtk3
+, coreutils
+, gtk-doc
+, docbook_xsl
+, docbook_xml_dtd_43
+, openssl ? null
+}:
 
 assert thinkpad -> openssl != null;
 
 stdenv.mkDerivation rec {
   pname = "libfprint" + stdenv.lib.optionalString thinkpad "-thinkpad";
-  version = "0.99.0";
+  version = "1.0";
 
   src = {
     libfprint-thinkpad =
@@ -16,19 +32,36 @@ stdenv.mkDerivation rec {
         sha256 = "1vps1wrp7hskf13f7jrv0dwry2fcid76x2w463wplngp63cj7b3b";
       };
     libfprint = fetchurl {
-      url = "https://gitlab.freedesktop.org/libfprint/libfprint/uploads/82ba3cef5bdf72997df711eacdb13c0f/libfprint-${version}.tar.xz";
-      sha256 = "16r4nl40y0jri57jiqmdz4s87byblx22lbhyvqpljd6mqm5rg187";
+      url = "https://gitlab.freedesktop.org/libfprint/libfprint/uploads/aff93e9921d1cff53d7c070944952ff9/libfprint-${version}.tar.xz";
+      sha256 = "0v84pd12v016m8iimhq39fgzamlarqccsr7d98cvrrwrzrgcixrd";
     };
   }.${pname};
 
-  buildInputs = [ libusb pixman glib nss gtk3 ]
-    ++ stdenv.lib.optional thinkpad openssl;
+  nativeBuildInputs = [
+    pkgconfig
+    meson
+    ninja
+    gtk-doc
+    docbook_xsl
+    docbook_xml_dtd_43
+  ];
 
-  nativeBuildInputs = [ pkgconfig meson ninja gtk-doc docbook_xsl docbook_xml_dtd_43 ];
+  buildInputs = [
+    libusb
+    pixman
+    glib
+    nss
+    gtk3
+  ]
+  ++ stdenv.lib.optional thinkpad openssl
+  ;
 
-  mesonFlags = [ "-Dudev_rules_dir=lib/udev/rules.d" "-Dx11-examples=false" ];
+  mesonFlags = [
+    "-Dudev_rules_dir=${placeholder "out"}/lib/udev/rules.d"
+    "-Dx11-examples=false"
+  ];
 
-  preConfigure = ''
+  postPatch = ''
     substituteInPlace libfprint/meson.build \
       --replace /bin/echo ${coreutils}/bin/echo
   '';

--- a/pkgs/tools/security/fprintd/default.nix
+++ b/pkgs/tools/security/fprintd/default.nix
@@ -1,26 +1,49 @@
 { thinkpad ? false
-, stdenv, fetchurl, pkgconfig, intltool, libfprint-thinkpad ? null
-, libfprint ? null, glib, dbus-glib, polkit, nss, pam, systemd }:
+, stdenv
+, fetchurl
+, pkgconfig
+, intltool
+, libfprint-thinkpad ? null
+, libfprint ? null
+, glib
+, dbus-glib
+, polkit
+, nss
+, pam
+, systemd
+}:
 
 stdenv.mkDerivation rec {
   pname = "fprintd" + stdenv.lib.optionalString thinkpad "-thinkpad";
-  version = "0.8.1";
+  version = "0.9.0";
 
   src = fetchurl {
-    url = "https://gitlab.freedesktop.org/libfprint/fprintd/uploads/bdd9f91909f535368b7c21f72311704a/fprintd-${version}.tar.xz";
-    sha256 = "124s0g9syvglgsmqnavp2a8c0zcq8cyaph8p8iyvbla11vfizs9l";
+    url = "https://gitlab.freedesktop.org/libfprint/fprintd/uploads/9dec4b63d1f00e637070be1477ce63c0/fprintd-${version}.tar.xz";
+    sha256 = "182gcnwb6zjwmk0dn562rjmpbk7ac7dhipbfdhfic2sn1jzis49p";
   };
 
-  buildInputs = [ glib dbus-glib polkit nss pam systemd ]
-    ++ stdenv.lib.optional thinkpad libfprint-thinkpad
-    ++ stdenv.lib.optional (!thinkpad) libfprint;
+  nativeBuildInputs = [
+    intltool
+    pkgconfig
+  ];
 
-  nativeBuildInputs = [ pkgconfig intltool ];
+  buildInputs = [
+    glib
+    dbus-glib
+    polkit
+    nss
+    pam
+    systemd
+  ]
+  ++ stdenv.lib.optional thinkpad libfprint-thinkpad
+  ++ stdenv.lib.optional (!thinkpad) libfprint
+  ;
 
-  configureFlags = [ 
-    "--with-systemdsystemunitdir=${placeholder "out"}/lib/systemd/system" 
-    "--localstatedir=/var" 
-    "--sysconfdir=${placeholder "out"}/etc" 
+  configureFlags = [
+    # is hardcoded to /var/lib/fprint, this is for the StateDirectory install target
+    "--localstatedir=${placeholder "out"}/var"
+    "--sysconfdir=${placeholder "out"}/etc"
+    "--with-systemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
   ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
Fixes https://github.com/NixOS/nixpkgs/issues/68876

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
