### PR TITLE
nixopsUnstable: 1.7pre2764_932bf43 -> 1.7pre2844_b7cac11

### DIFF
--- a/pkgs/tools/package-management/nixops/unstable.nix
+++ b/pkgs/tools/package-management/nixops/unstable.nix
@@ -5,9 +5,9 @@
 # Then copy the URL to the tarball.
 
 callPackage ./generic.nix (rec {
-  version = "1.7pre2764_932bf43";
+  version = "1.7pre2844_b7cac11";
   src = fetchurl {
-    url = "https://hydra.nixos.org/build/92372343/download/2/nixops-${version}.tar.bz2";
-    sha256 = "f35bf81bf2805473ea54248d0ee92d163d00a1992f3f75d17e8cf430db1f9919";
+    url = "https://hydra.nixos.org/build/99910702/download/2/nixops-${version}.tar.bz2";
+    sha256 = "0fxvcbpf9xapl9qc4mcvmn18y1l4gsg43hcn88yzq0dmr5xw891f";
   };
 })


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
Should be the last tarball before the plugin overhaul.
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @aminechikhaoui @eelco @rob @domenkozar
