### PR TITLE
raspberrypi-wireless-firmware: 2018-08-20 -> 2019-09-17

### DIFF
--- a/pkgs/os-specific/linux/firmware/raspberrypi-wireless/default.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi-wireless/default.nix
@@ -2,22 +2,22 @@
 
 stdenv.mkDerivation {
   pname = "raspberrypi-wireless-firmware";
-  version = "2018-08-20";
+  version = "2019-09-17";
 
   srcs = [
     (fetchFromGitHub {
       name = "bluez-firmware";
       owner = "RPi-Distro";
       repo = "bluez-firmware";
-      rev = "ade2bae1aaaebede09abb8fb546f767a0e4c7804";
-      sha256 = "07gm76gxp5anv6paryvxcp34a86fkny8kdlzqhzcpfczzglkp6ag";
+      rev = "96eefffcccc725425fd83be5e0704a5c32b79e54";
+      sha256 = "05h57gcxhb2c84h99cyxxx4mzi6kd5fm8pjqkz3nq5vs3nv8cqhr";
     })
     (fetchFromGitHub {
       name = "firmware-nonfree";
       owner = "RPi-Distro";
       repo = "firmware-nonfree";
-      rev = "b518de45ced519e8f7a499f4778100173402ae43";
-      sha256 = "1d5026ic9awji6c67irpwsxpxgsc0dhn11d3abkxi2vvra1pir4g";
+      rev = "130cb86fa30cafbd575d38865fa546350d4c5f9c";
+      sha256 = "0jmhgbpldzz8n8lncpzwfl5ym8zgss05y952rfpwcf9v5c7vgabx";
     })
   ];
 
@@ -41,7 +41,7 @@ stdenv.mkDerivation {
 
   outputHashMode = "recursive";
   outputHashAlgo = "sha256";
-  outputHash = "1s5gb00v42s5izbaw8irs1fwvhh7z9wl07czc0nkw6p91871ivb7";
+  outputHash = "1r4alf1fbj6vkkf54d0anm47ymb6gn2ykl4a2hhd34b0hnf1dnhn";
 
   meta = with stdenv.lib; {
     description = "Firmware for builtin Wifi/Bluetooth devices in the Raspberry Pi 3 and Zero W";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @lopsided98
