### PR TITLE
terraform-lsp: 0.0.5 -> 0.0.6

### DIFF
--- a/pkgs/development/tools/misc/terraform-lsp/default.nix
+++ b/pkgs/development/tools/misc/terraform-lsp/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "terraform-lsp";
-  version = "0.0.5";
+  version = "0.0.6";
 
   src = fetchFromGitHub {
     owner = "juliosueiras";
     repo = pname;
     rev = "v${version}";
-    sha256 = "018ypvmd9cwys5l7rm1c7b9jf8fljdk0m22id32d88jiw4iwq44m";
+    sha256 = "1nalypaw64kdv5zmmb0xgkajhs2gf71ivbxvgwpgvlv2lyidawx5";
   };
 
-  modSha256 = "1196fn69nnplj7sz5mffawf58j9n7h211shv795gknvfnwavh344";
+  modSha256 = "1mb3169vdlv4h10k15pg88s48s2b6y7v5frk9j9ahg52grygcqb2";
 
   meta = with lib; {
     description = "Language Server Protocol for Terraform";


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Changelog: https://github.com/juliosueiras/terraform-lsp/releases/tag/v0.0.6


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
