### PR TITLE
konversation: make sure breeze-icons is in buildInputs

### DIFF
--- a/pkgs/applications/networking/irc/konversation/default.nix
+++ b/pkgs/applications/networking/irc/konversation/default.nix
@@ -1,5 +1,6 @@
 { mkDerivation
 , lib
+, breeze-icons
 , fetchurl
 , fetchpatch
 , extra-cmake-modules
@@ -48,6 +49,7 @@ in mkDerivation rec {
   ];
 
   buildInputs = [
+    breeze-icons
     kbookmarks
     karchive
     kconfig


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

When running `konversation`, I was seeing errors like the following:

```
$ konversation
Icon theme "breeze" not found.
Icon theme "breeze" not found.
Error: standard icon theme "breeze" not found!
```

I had seen this before with `okular`:

https://github.com/NixOS/nixpkgs/issues/53750

It looks like the current `okular` derivation adds `breeze-icons` to `buildInputs`, so I thought this might be a good solution for the same problem with `konversation`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @FRidh 
