### PR TITLE
really check requiredKernelConfig

### DIFF
--- a/lib/kernel.nix
+++ b/lib/kernel.nix
@@ -4,6 +4,39 @@ with lib;
 {
 
 
+  /*
+    Converts the kernel final configuration file into a structured nix config
+    Example:
+      loadConfig linux.configfile.outPath
+    returns
+        { IDE = "y"; ... }
+   */
+  loadConfig = configFilename: let
+
+    lines = filter (x: builtins.typeOf x == "string")
+        (builtins.split "\n" (builtins.readFile configFilename));
+
+    parseLine = line:
+      let
+        # String options have double quotes, e.g. 'CONFIG_NLS_DEFAULT="utf8"' and allow escaping.
+        match_freeform = builtins.match ''^CONFIG_([A-Za-z0-9_]+)="(.*)"$'' line;
+        match_tristate = builtins.match ''^CONFIG_([A-Za-z0-9_]+)=(.*)$'' line;
+        match_unset = builtins.match ''^# CONFIG_([A-Za-z0-9_]+) is not set$'' line;
+        match = if (match_freeform != null && (length match_freeform == 2) ) then
+          { "${head match_freeform}" = last match_freeform; }
+        else if (match_tristate != null && (length match_tristate == 2)) then
+          { "${head match_tristate}" = last match_tristate; }
+        else if (match_unset != null) then
+          { "${head match_unset}" = "n"; }
+        else
+          {}
+        ;
+
+      in
+        match;
+    in
+      builtins.foldl' (prev: line: prev // (parseLine line) ) {} lines ;
+
   # Keeping these around in case we decide to change this horrible implementation :)
   option = x:
       x // { optional = true; };

--- a/nixos/modules/system/boot/kernel.nix
+++ b/nixos/modules/system/boot/kernel.nix
@@ -319,11 +319,13 @@ in
       (isYes "BINFMT_ELF")
     ] ++ (optional (randstructSeed != "") (isYes "GCC_PLUGIN_RANDSTRUCT"));
 
-    assertions = let
+    # nixpkgs kernels are assumed to have all required features
+    assertions = if config.boot.kernelPackages.kernel ? features then [] else
+      let
         structuredCfg = lib.kernel.loadConfig config.boot.kernelPackages.kernel.configfile;
 
         # temporary duplicate of os-specific/linux/kernel/manual-config.nix
-        # it will be removed in favor of lib.kernel functions
+        # they will be consolidated in lib/kernel.nix
         cfg = let attrName = attr: attr; in {
           isSet = attr: hasAttr (attrName attr) cfg;
 


### PR DESCRIPTION
###### Motivation for this change
I want the system.requiredKernelConfig to check the final config rather than a structured config that can be ignored during the kernel configuration generation.

I have several follow up PRs. Here is a meta issue with what I intent to accomplish: https://github.com/NixOS/nixpkgs/issues/69014

The lib.kernel.loadConfig function is a translation to nix of https://github.com/NixOS/nixpkgs/blob/e598c4001fda0088506cdc12bf8053705c46676d/pkgs/os-specific/linux/kernel/generate-config.pl#L124.
Hopefully we can replace the perl part with the nix one afterwards.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
