### PR TITLE
system.extraSystemBuilderCmds: work around length limit

### DIFF
--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -90,7 +90,7 @@ let
 
       echo -n "${toString config.system.extraDependencies}" > $out/extra-dependencies
 
-      ${config.system.extraSystemBuilderCmds}
+      . ${pkgs.writeShellScript "extra-system-builder" config.system.extraSystemBuilderCmds}
     '';
 
   # Putting it all together.  This builds a store path containing


### PR DESCRIPTION
when `config.system.extraSystemBuilderCmds` is long, system activator fails with "bash: Argument list too long"
