### PR TITLE
wlr-randr: init at unstable-2019-03-21

### DIFF
--- a/pkgs/tools/misc/wlr-randr/default.nix
+++ b/pkgs/tools/misc/wlr-randr/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, meson, ninja, cmake, pkgconfig, wayland }:
+
+stdenv.mkDerivation rec {
+  pname = "wlr-randr";
+  version = "unstable-2019-03-21";
+
+  src = fetchFromGitHub {
+    owner = "emersion";
+    repo = pname;
+    rev = "c4066aa3249963dc7877119cffce10f3fa8b6304";
+    sha256 = "1ahw4sv07xg5rh9vr7j28636iaxs06vnybm3li6y8dz2sky7hk88";
+  };
+
+  nativeBuildInputs = [ meson ninja cmake pkgconfig ];
+  buildInputs = [ wayland ];
+
+  meta = with stdenv.lib; {
+    license = licenses.mit;
+    description = "An xrandr clone for wlroots compositors";
+    homepage = "https://github.com/emersion/wlr-randr";
+    maintainers = with maintainers; [ ma27 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18722,6 +18722,8 @@ in
 
   super-productivity = callPackage ../applications/networking/super-productivity { };
 
+  wlr-randr = callPackage ../tools/misc/wlr-randr { };
+
   wlroots = callPackage ../development/libraries/wlroots { };
 
   sway = callPackage ../applications/window-managers/sway { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This is a simple clone of `xrandr` for wayland and is recommended by
sway's wiki[1] as replacement for `xrandr`.

Although the package is not stable yet, it's written by some sway
developers and appears to work pretty well.

When adding an additional monitor to your laptop (with the laptop being
"below" the monitor), this can be configured like this:

```
wlr-randr --output eDP-1 --on --pos 0,1080 --output HDMI-A-1 --on --pos 0,0
```

[1] https://github.com/swaywm/sway/wiki/i3-Migration-Guide#common-xorg-apps-used-on-i3-with-wayland-alternatives

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
