### PR TITLE
gnvim: init at 0.1.5

### DIFF
--- a/pkgs/applications/editors/neovim/gnvim/default.nix
+++ b/pkgs/applications/editors/neovim/gnvim/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, rustPlatform, fetchFromGitHub, gtk, webkitgtk }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "gnvim-unwrapped";
+  version = "0.1.5";
+
+  src = fetchFromGitHub {
+    owner = "vhakulinen";
+    repo = "gnvim";
+    rev = version;
+    sha256 = "11gb59lhc1sp5dxj2fdm6072f4nxxay0war3kmchdwsk41nvxlrh";
+  };
+
+  cargoSha256 = "00r5jf5qdw02vcv3522qqrnwj14mip0l58prcncbvyg4pxlm2rb2";
+
+  buildInputs = [ gtk webkitgtk ];
+
+  # The default build script tries to get the version through Git, so we
+  # replace it
+  prePatch = ''
+    cat << EOF > build.rs
+    use std::env;
+    use std::fs::File;
+    use std::io::Write;
+    use std::path::Path;
+
+    fn main() {
+        let out_dir = env::var("OUT_DIR").unwrap();
+        let dest_path = Path::new(&out_dir).join("gnvim_version.rs");
+        let mut f = File::create(&dest_path).unwrap();
+        f.write_all(b"const VERSION: &str = \"${version}\";").unwrap();
+    }
+    EOF
+  '';
+
+  installPhase = ''
+    make install PREFIX="${placeholder "out"}"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "GUI for neovim, without any web bloat";
+    homepage = "https://github.com/vhakulinen/gnvim";
+    license     = licenses.mit;
+    maintainers =  with maintainers; [ minijackson ];
+    inherit version;
+  };
+}

--- a/pkgs/applications/editors/neovim/gnvim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/gnvim/wrapper.nix
@@ -1,0 +1,41 @@
+{ stdenv, gnvim-unwrapped, neovim, makeWrapper }:
+
+stdenv.mkDerivation {
+  pname = "gnvim";
+  version = gnvim-unwrapped.version;
+  buildCommand = if stdenv.isDarwin then ''
+    mkdir -p $out/Applications
+    cp -r ${gnvim-unwrapped}/bin/gnvim.app $out/Applications
+
+    chmod -R a+w "$out/Applications/gnvim.app/Contents/MacOS"
+    wrapProgram "$out/Applications/gnvim.app/Contents/MacOS/gnvim" \
+      --prefix PATH : "${neovim}/bin" \
+      --set GNVIM_RUNTIME_PATH "${gnvim-unwrapped}/share/gnvim/runtime"
+  '' else ''
+    makeWrapper '${gnvim-unwrapped}/bin/gnvim' "$out/bin/gnvim" \
+      --prefix PATH : "${neovim}/bin" \
+      --set GNVIM_RUNTIME_PATH "${gnvim-unwrapped}/share/gnvim/runtime"
+
+    mkdir -p "$out/share"
+    ln -s '${gnvim-unwrapped}/share/icons' "$out/share/icons"
+
+    # copy and fix .desktop file
+    cp -r '${gnvim-unwrapped}/share/applications' "$out/share/applications"
+    # Sed needs a writable directory to do inplace modifications
+    chmod u+rw "$out/share/applications"
+    for file in $out/share/applications/*.desktop; do
+      sed -e "s|Exec=.\\+gnvim\\>|Exec=$out/bin/gnvim|" -i "$file"
+    done
+  '';
+
+  preferLocalBuild = true;
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  passthru.unwrapped = gnvim-unwrapped;
+
+  inherit (gnvim-unwrapped) meta;
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20970,6 +20970,12 @@ in
 
   neovim-qt = libsForQt5.callPackage ../applications/editors/neovim/qt.nix { };
 
+  gnvim-unwrapped = callPackage ../applications/editors/neovim/gnvim {
+    gtk = pkgs.gtk3;
+  };
+
+  gnvim = callPackage ../applications/editors/neovim/gnvim/wrapper.nix { };
+
   neovim-remote = callPackage ../applications/editors/neovim/neovim-remote.nix { pythonPackages = python3Packages; };
 
   vis = callPackage ../applications/editors/vis {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

[Gnvim](https://github.com/vhakulinen/gnvim) a rich Neovim GUI without any web bloat

Based on the neovim-qt derivation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).