### PR TITLE
nodejs-12_x: 12.5.0 -> 12.10.0

### DIFF
--- a/pkgs/development/web/nodejs/disable-libatomic-darwin.patch
+++ b/pkgs/development/web/nodejs/disable-libatomic-darwin.patch
@@ -1,0 +1,11 @@
+--- a/node.gyp
++++ b/node.gyp
+@@ -289,7 +289,7 @@
+           '-Wl,-bnoerrmsg',
+         ],
+       }],
+-      ['(OS=="linux" or OS=="mac") and llvm_version!=0', {
++      ['OS=="linux" and llvm_version!=0', {
+         'libraries': ['-latomic'],
+       }],
+     ],

--- a/pkgs/development/web/nodejs/v12.nix
+++ b/pkgs/development/web/nodejs/v12.nix
@@ -1,10 +1,12 @@
-{ callPackage, openssl, icu, enableNpm ? true }:
+{ stdenv, callPackage, openssl, icu, enableNpm ? true }:
 
 let
   buildNodejs = callPackage ./nodejs.nix { inherit openssl icu; };
 in
   buildNodejs {
     inherit enableNpm;
-    version = "12.5.0";
-    sha256 = "08haqs104lw44l92bxfii18sdn7y1k07cz3p0ni9bhw7kh4vf5c7";
+    version = "12.10.0";
+    sha256 = "1k9hxqs23c3sxpr843ix8nidlca8wn30x0sq998j47wjc1ybh595";
+
+    patches = stdenv.lib.optionals stdenv.isDarwin [ ./disable-libatomic-darwin.patch ];
   }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Requires https://github.com/NixOS/nixpkgs/pull/68748

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
