### PR TITLE
ghc: revert "compile with DWARF support by default"

### DIFF
--- a/pkgs/development/compilers/ghc/8.2.2.nix
+++ b/pkgs/development/compilers/ghc/8.2.2.nix
@@ -8,9 +8,6 @@
 
 , libiconv ? null, ncurses
 
-, enableDwarf ? !stdenv.targetPlatform.isDarwin &&
-                !stdenv.targetPlatform.isWindows, elfutils # for DWARF support
-
 , useLLVM ? !stdenv.targetPlatform.isx86 || (stdenv.targetPlatform.isMusl && stdenv.hostPlatform != stdenv.targetPlatform)
 , # LLVM is conceptually a run-time-only depedendency, but for
   # non-x86, we need LLVM to bootstrap later stages, so it becomes a
@@ -72,8 +69,7 @@ let
   # Splicer will pull out correct variations
   libDeps = platform: [ ncurses ]
     ++ stdenv.lib.optional (!enableIntegerSimple) gmp
-    ++ stdenv.lib.optional (platform.libc != "glibc") libiconv
-    ++ stdenv.lib.optional enableDwarf elfutils;
+    ++ stdenv.lib.optional (platform.libc != "glibc") libiconv;
 
   toolsForTarget = [
     pkgsBuildTarget.targetPackages.stdenv.cc
@@ -207,8 +203,6 @@ stdenv.mkDerivation (rec {
   ] ++ stdenv.lib.optionals (targetPlatform.isDarwin && targetPlatform.isAarch64) [
     # fix for iOS: https://www.reddit.com/r/haskell/comments/4ttdz1/building_an_osxi386_to_iosarm64_cross_compiler/d5qvd67/
     "--disable-large-address-space"
-  ] ++ stdenv.lib.optional enableDwarf [
-    "--enable-dwarf-unwind"
   ];
 
   # Don’t add -liconv to LDFLAGS automatically so that GHC will add it itself.

--- a/pkgs/development/compilers/ghc/8.4.4.nix
+++ b/pkgs/development/compilers/ghc/8.4.4.nix
@@ -7,9 +7,6 @@
 
 , libiconv ? null, ncurses
 
-, enableDwarf ? !stdenv.targetPlatform.isDarwin &&
-                !stdenv.targetPlatform.isWindows, elfutils # for DWARF support
-
 , useLLVM ? !stdenv.targetPlatform.isx86 || (stdenv.targetPlatform.isMusl && stdenv.hostPlatform != stdenv.targetPlatform)
 , # LLVM is conceptually a run-time-only depedendency, but for
   # non-x86, we need LLVM to bootstrap later stages, so it becomes a
@@ -74,8 +71,7 @@ let
   # Splicer will pull out correct variations
   libDeps = platform: stdenv.lib.optional enableTerminfo [ ncurses ]
     ++ stdenv.lib.optional (!enableIntegerSimple) gmp
-    ++ stdenv.lib.optional (platform.libc != "glibc" && !targetPlatform.isWindows) libiconv
-    ++ stdenv.lib.optional enableDwarf elfutils;
+    ++ stdenv.lib.optional (platform.libc != "glibc" && !targetPlatform.isWindows) libiconv;
 
   toolsForTarget = [
     pkgsBuildTarget.targetPackages.stdenv.cc
@@ -184,8 +180,6 @@ stdenv.mkDerivation (rec {
   ] ++ stdenv.lib.optionals (targetPlatform.isDarwin && targetPlatform.isAarch64) [
     # fix for iOS: https://www.reddit.com/r/haskell/comments/4ttdz1/building_an_osxi386_to_iosarm64_cross_compiler/d5qvd67/
     "--disable-large-address-space"
-  ] ++ stdenv.lib.optional enableDwarf [
-    "--enable-dwarf-unwind"
   ];
 
   # Make sure we never relax`$PATH` and hooks support for compatability.

--- a/pkgs/development/compilers/ghc/8.6.4.nix
+++ b/pkgs/development/compilers/ghc/8.6.4.nix
@@ -7,9 +7,6 @@
 
 , libiconv ? null, ncurses
 
-, enableDwarf ? !stdenv.targetPlatform.isDarwin &&
-                !stdenv.targetPlatform.isWindows, elfutils # for DWARF support
-
 , # GHC can be built with system libffi or a bundled one.
   libffi ? null
 
@@ -79,8 +76,7 @@ let
   libDeps = platform: stdenv.lib.optional enableTerminfo [ ncurses ]
     ++ [libffi]
     ++ stdenv.lib.optional (!enableIntegerSimple) gmp
-    ++ stdenv.lib.optional (platform.libc != "glibc" && !targetPlatform.isWindows) libiconv
-    ++ stdenv.lib.optional enableDwarf elfutils;
+    ++ stdenv.lib.optional (platform.libc != "glibc" && !targetPlatform.isWindows) libiconv;
 
   toolsForTarget = [
     pkgsBuildTarget.targetPackages.stdenv.cc
@@ -183,8 +179,6 @@ stdenv.mkDerivation (rec {
     "CONF_GCC_LINKER_OPTS_STAGE2=-fuse-ld=gold"
   ] ++ stdenv.lib.optionals (disableLargeAddressSpace) [
     "--disable-large-address-space"
-  ] ++ stdenv.lib.optional enableDwarf [
-    "--enable-dwarf-unwind"
   ];
 
   # Make sure we never relax`$PATH` and hooks support for compatability.

--- a/pkgs/development/compilers/ghc/8.6.5.nix
+++ b/pkgs/development/compilers/ghc/8.6.5.nix
@@ -7,9 +7,6 @@
 
 , libiconv ? null, ncurses
 
-, enableDwarf ? !stdenv.targetPlatform.isDarwin &&
-                !stdenv.targetPlatform.isWindows, elfutils # for DWARF support
-
 , # GHC can be built with system libffi or a bundled one.
   libffi ? null
 
@@ -79,8 +76,7 @@ let
   libDeps = platform: stdenv.lib.optional enableTerminfo [ ncurses ]
     ++ [libffi]
     ++ stdenv.lib.optional (!enableIntegerSimple) gmp
-    ++ stdenv.lib.optional (platform.libc != "glibc" && !targetPlatform.isWindows) libiconv
-    ++ stdenv.lib.optional enableDwarf elfutils;
+    ++ stdenv.lib.optional (platform.libc != "glibc" && !targetPlatform.isWindows) libiconv;
 
   toolsForTarget = [
     pkgsBuildTarget.targetPackages.stdenv.cc
@@ -183,8 +179,6 @@ stdenv.mkDerivation (rec {
     "CONF_GCC_LINKER_OPTS_STAGE2=-fuse-ld=gold"
   ] ++ stdenv.lib.optionals (disableLargeAddressSpace) [
     "--disable-large-address-space"
-  ] ++ stdenv.lib.optional enableDwarf [
-    "--enable-dwarf-unwind"
   ];
 
   # Make sure we never relax`$PATH` and hooks support for compatability.

--- a/pkgs/development/compilers/ghc/8.8.1.nix
+++ b/pkgs/development/compilers/ghc/8.8.1.nix
@@ -7,9 +7,6 @@
 
 , libiconv ? null, ncurses
 
-, enableDwarf ? !stdenv.targetPlatform.isDarwin &&
-                !stdenv.targetPlatform.isWindows, elfutils # for DWARF support
-
 , # GHC can be built with system libffi or a bundled one.
   libffi ? null
 
@@ -79,8 +76,7 @@ let
   libDeps = platform: stdenv.lib.optional enableTerminfo [ ncurses ]
     ++ [libffi]
     ++ stdenv.lib.optional (!enableIntegerSimple) gmp
-    ++ stdenv.lib.optional (platform.libc != "glibc" && !targetPlatform.isWindows) libiconv
-    ++ stdenv.lib.optional enableDwarf elfutils;
+    ++ stdenv.lib.optional (platform.libc != "glibc" && !targetPlatform.isWindows) libiconv;
 
   toolsForTarget = [
     pkgsBuildTarget.targetPackages.stdenv.cc
@@ -168,8 +164,6 @@ stdenv.mkDerivation (rec {
     "CONF_GCC_LINKER_OPTS_STAGE2=-fuse-ld=gold"
   ] ++ stdenv.lib.optionals (disableLargeAddressSpace) [
     "--disable-large-address-space"
-  ] ++ stdenv.lib.optional enableDwarf [
-    "--enable-dwarf-unwind"
   ];
 
   # Make sure we never relax`$PATH` and hooks support for compatability.

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -7,9 +7,6 @@
 
 , libiconv ? null, ncurses
 
-, enableDwarf ? !stdenv.targetPlatform.isDarwin &&
-                !stdenv.targetPlatform.isWindows, elfutils # for DWARF support
-
 , useLLVM ? !stdenv.targetPlatform.isx86
 , # LLVM is conceptually a run-time-only depedendency, but for
   # non-x86, we need LLVM to bootstrap later stages, so it becomes a
@@ -76,8 +73,7 @@ let
   # Splicer will pull out correct variations
   libDeps = platform: stdenv.lib.optional enableTerminfo [ ncurses ]
     ++ stdenv.lib.optional (!enableIntegerSimple) gmp
-    ++ stdenv.lib.optional (platform.libc != "glibc" && !targetPlatform.isWindows) libiconv
-    ++ stdenv.lib.optional enableDwarf elfutils;
+    ++ stdenv.lib.optional (platform.libc != "glibc" && !targetPlatform.isWindows) libiconv;
 
   toolsForTarget = [
     pkgsBuildTarget.targetPackages.stdenv.cc
@@ -180,8 +176,6 @@ stdenv.mkDerivation (rec {
     "CONF_GCC_LINKER_OPTS_STAGE2=-fuse-ld=gold"
   ] ++ stdenv.lib.optionals (disableLargeAddressSpace) [
     "--disable-large-address-space"
-  ] ++ stdenv.lib.optional enableDwarf [
-    "--enable-dwarf-unwind"
   ];
 
   # Make sure we never relax`$PATH` and hooks support for compatability.


### PR DESCRIPTION
This reverts commits 2021578686790d2c733eb1fa9c2034826996b176 and
f4316473d94e0e5eff2736bd24dc802e09752771 from PR #68362.

Fixes https://github.com/NixOS/nixpkgs/issues/69023.

I'm running tests builds right now to verify that this change actually fixes the issue.