### PR TITLE
treewide: use libtinfo.so.5 where needed

### DIFF
--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, callPackage, fetchurl
 , python
-, jdk, cmake, libxml2, zlib, python3, ncurses
+, jdk, cmake, libxml2, zlib, python3, ncurses5
 }:
 
 with stdenv.lib;
@@ -34,7 +34,7 @@ let
 
           lldbLibPath=$out/clion-${version}/bin/lldb/linux/lib
           interp="$(cat $NIX_CC/nix-support/dynamic-linker)"
-          ln -s ${ncurses.out}/lib/libncurses.so $lldbLibPath/libtinfo.so.5
+          ln -s ${ncurses5.out}/lib/libtinfo.so.5 $lldbLibPath/libtinfo.so.5
 
           patchelf --set-interpreter $interp \
             --set-rpath "${lib.makeLibraryPath [ libxml2 zlib stdenv.cc.cc.lib ]}:$lldbLibPath" \

--- a/pkgs/applications/radio/tlf/default.nix
+++ b/pkgs/applications/radio/tlf/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, autoreconfHook, autoconf, automake, pkgconfig, glib
-, perl, ncurses, hamlib, xmlrpc_c }:
+, perl, ncurses5, hamlib, xmlrpc_c }:
 
 stdenv.mkDerivation rec {
   pname = "tlf";
@@ -13,15 +13,13 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ autoreconfHook autoconf automake pkgconfig perl ];
-  buildInputs = [ glib ncurses hamlib xmlrpc_c ];
+  buildInputs = [ glib ncurses5 hamlib xmlrpc_c ];
 
   configureFlags = [ "--enable-hamlib" "--enable-fldigi-xmlrpc" ];
 
   postInstall = ''
     mkdir -p $out/lib
-
-    # Hack around lack of libtinfo in NixOS
-    ln -s ${ncurses.out}/lib/libncursesw.so.6 $out/lib/libtinfo.so.5
+    ln -s ${ncurses5.out}/lib/libtinfo.so.5 $out/lib/libtinfo.so.5
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/science/logic/saw-tools/default.nix
+++ b/pkgs/applications/science/logic/saw-tools/default.nix
@@ -34,8 +34,7 @@ stdenv.mkDerivation {
     mv bin $out/bin
     mv doc $out/share
 
-    # Hack around lack of libtinfo in NixOS
-    ln -s ${ncurses.out}/lib/libncursesw.so.5       $out/lib/libtinfo.so.5
+    ln -s ${ncurses.out}/lib/libtinfo.so.5       $out/lib/libtinfo.so.5
     ln -s ${stdenv.cc.libc}/lib/libpthread.so.0 $out/lib/libpthread.so.0
 
     # Add a clang symlink for easy building with a suitable compiler.

--- a/pkgs/applications/science/programming/fdr/default.nix
+++ b/pkgs/applications/science/programming/fdr/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, qtbase, qtx11extras, ncurses, xorg, zlib, python27Packages}:
+{stdenv, fetchurl, qtbase, qtx11extras, ncurses5, xorg, zlib, python27Packages}:
 stdenv.mkDerivation {
   name = "fdr-4.2.3";
   src = fetchurl {
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
     python27Packages.python
     qtbase
     qtx11extras
-    ncurses
+    ncurses5
     xorg.libX11
     xorg.libXft
     zlib
@@ -26,8 +26,7 @@ stdenv.mkDerivation {
     rm -r lib/qt_plugins
 
     cp -r * "$out"
-    # Hack around lack of libtinfo in NixOS
-    ln -s ${ncurses.out}/lib/libncursesw.so.6 $out/lib/libtinfo.so.5
+    ln -s ${ncurses5.out}/lib/libtinfo.so.5 $out/lib/libtinfo.so.5
     ln -s ${qtbase.bin}/${qtbase.qtPluginPrefix} $out/lib/qt_plugins
     ln -s ${zlib.out}/lib/libz.so.1 $out/lib/libz.so.1
 

--- a/pkgs/development/arduino/arduino-core/default.nix
+++ b/pkgs/development/arduino/arduino-core/default.nix
@@ -200,7 +200,7 @@ stdenv.mkDerivation rec {
 
     # avrdude_bin is linked against libtinfo.so.5
     mkdir $out/lib/
-    ln -s ${lib.makeLibraryPath [ncurses5]}/libncursesw.so.5 $out/lib/libtinfo.so.5
+    ln -s ${lib.makeLibraryPath [ncurses5]}/libtinfo.so.5 $out/lib/libtinfo.so.5
 
     ${stdenv.lib.optionalString withTeensyduino ''
       # Patch the Teensy loader binary


### PR DESCRIPTION
This was originally added in

https://github.com/NixOS/nixpkgs/pull/21350

best to use this name for clarity.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
