### PR TITLE
vboot_reference: use the right ar when cross-compiling

### DIFF
--- a/pkgs/tools/system/vboot_reference/default.nix
+++ b/pkgs/tools/system/vboot_reference/default.nix
@@ -19,6 +19,11 @@ stdenv.mkDerivation rec {
 
   patches = [ ./dont_static_link.patch ];
 
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace "ar qc" '${stdenv.cc.bintools.targetPrefix}ar qc'
+  '';
+
   preBuild = ''
     patchShebangs scripts
   '';


### PR DESCRIPTION
###### Motivation for this change

Allow cross-compilation of vboot_reference.

The Makefile from upstream chromeos doesn't allow setting or using `AR` to refer to the right `ar`.

An alternative fix would be to make a proper patch, but the patch would more likely need to be updated on updating the package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
   - ☑️ macOS
   - ☑️ other Linux distributions
- ☑️ Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ✔️ Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- ✔️ Tested execution of all binary files (usually in `./result/bin/`)
- ☑️ Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ✔️ Ensured that relevant documentation is up to date
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @thefloweringash 