### PR TITLE
emacs: use runCommand to generate wrapper

### DIFF
--- a/pkgs/build-support/emacs/wrapper.nix
+++ b/pkgs/build-support/emacs/wrapper.nix
@@ -32,7 +32,7 @@ in customEmacsPackages.emacsWithPackages (epkgs: [ epkgs.evil epkgs.magit ])
 
 */
 
-{ lib, lndir, makeWrapper, runCommand, stdenv }: self:
+{ lib, lndir, makeWrapper, runCommand }: self:
 
 with lib; let inherit (self) emacs; in
 
@@ -45,105 +45,110 @@ let
     else packagesFun;
 in
 
-stdenv.mkDerivation {
-  name = (appendToName "with-packages" emacs).name;
-  nativeBuildInputs = [ emacs lndir makeWrapper ];
-  inherit emacs explicitRequires;
+runCommand
+  (appendToName "with-packages" emacs).name
+  {
+    nativeBuildInputs = [ emacs lndir makeWrapper ];
+    inherit emacs explicitRequires;
 
-  # Store all paths we want to add to emacs here, so that we only need to add
-  # one path to the load lists
-  deps = runCommand "emacs-packages-deps"
-   { inherit explicitRequires lndir emacs; }
-   ''
-     findInputsOld() {
-         local pkg="$1"; shift
-         local var="$1"; shift
-         local propagatedBuildInputsFiles=("$@")
+    preferLocalBuild = true;
+    allowSubstitutes = false;
 
-         # TODO(@Ericson2314): Restore using associative array once Darwin
-         # nix-shell doesn't use impure bash. This should replace the O(n)
-         # case with an O(1) hash map lookup, assuming bash is implemented
-         # well :D.
-         local varSlice="$var[*]"
-         # ''${..-} to hack around old bash empty array problem
-         case "''${!varSlice-}" in
-             *" $pkg "*) return 0 ;;
-         esac
-         unset -v varSlice
+    # Store all paths we want to add to emacs here, so that we only need to add
+    # one path to the load lists
+    deps = runCommand "emacs-packages-deps"
+      { inherit explicitRequires lndir emacs; }
+      ''
+        findInputsOld() {
+          local pkg="$1"; shift
+          local var="$1"; shift
+          local propagatedBuildInputsFiles=("$@")
 
-         eval "$var"'+=("$pkg")'
+          # TODO(@Ericson2314): Restore using associative array once Darwin
+          # nix-shell doesn't use impure bash. This should replace the O(n)
+          # case with an O(1) hash map lookup, assuming bash is implemented
+          # well :D.
+          local varSlice="$var[*]"
+          # ''${..-} to hack around old bash empty array problem
+          case "''${!varSlice-}" in
+              *" $pkg "*) return 0 ;;
+          esac
+          unset -v varSlice
 
-         if ! [ -e "$pkg" ]; then
-             echo "build input $pkg does not exist" >&2
-             exit 1
-         fi
+          eval "$var"'+=("$pkg")'
 
-         local file
-         for file in "''${propagatedBuildInputsFiles[@]}"; do
-             file="$pkg/nix-support/$file"
-             [[ -f "$file" ]] || continue
+          if ! [ -e "$pkg" ]; then
+              echo "build input $pkg does not exist" >&2
+              exit 1
+          fi
 
-             local pkgNext
-             for pkgNext in $(< "$file"); do
-                 findInputsOld "$pkgNext" "$var" "''${propagatedBuildInputsFiles[@]}"
-             done
-         done
-     }
-     mkdir -p $out/bin
-     mkdir -p $out/share/emacs/site-lisp
+          local file
+          for file in "''${propagatedBuildInputsFiles[@]}"; do
+              file="$pkg/nix-support/$file"
+              [[ -f "$file" ]] || continue
 
-     local requires
-     for pkg in $explicitRequires; do
-       findInputsOld $pkg requires propagated-user-env-packages
-     done
-     # requires now holds all requested packages and their transitive dependencies
+              local pkgNext
+              for pkgNext in $(< "$file"); do
+                  findInputsOld "$pkgNext" "$var" "''${propagatedBuildInputsFiles[@]}"
+              done
+          done
+        }
+        mkdir -p $out/bin
+        mkdir -p $out/share/emacs/site-lisp
 
-     linkPath() {
-       local pkg=$1
-       local origin_path=$2
-       local dest_path=$3
+        local requires
+        for pkg in $explicitRequires; do
+          findInputsOld $pkg requires propagated-user-env-packages
+        done
+        # requires now holds all requested packages and their transitive dependencies
 
-       # Add the path to the search path list, but only if it exists
-       if [[ -d "$pkg/$origin_path" ]]; then
-         $lndir/bin/lndir -silent "$pkg/$origin_path" "$out/$dest_path"
-       fi
-     }
+        linkPath() {
+          local pkg=$1
+          local origin_path=$2
+          local dest_path=$3
 
-     linkEmacsPackage() {
-       linkPath "$1" "bin" "bin"
-       linkPath "$1" "share/emacs/site-lisp" "share/emacs/site-lisp"
-     }
+          # Add the path to the search path list, but only if it exists
+          if [[ -d "$pkg/$origin_path" ]]; then
+            $lndir/bin/lndir -silent "$pkg/$origin_path" "$out/$dest_path"
+          fi
+        }
 
-     # Iterate over the array of inputs (avoiding nix's own interpolation)
-     for pkg in "''${requires[@]}"; do
-       linkEmacsPackage $pkg
-     done
+        linkEmacsPackage() {
+          linkPath "$1" "bin" "bin"
+          linkPath "$1" "share/emacs/site-lisp" "share/emacs/site-lisp"
+        }
 
-     siteStart="$out/share/emacs/site-lisp/site-start.el"
-     siteStartByteCompiled="$siteStart"c
-     subdirs="$out/share/emacs/site-lisp/subdirs.el"
-     subdirsByteCompiled="$subdirs"c
+        # Iterate over the array of inputs (avoiding nix's own interpolation)
+        for pkg in "''${requires[@]}"; do
+          linkEmacsPackage $pkg
+        done
 
-     # A dependency may have brought the original siteStart or subdirs, delete
-     # it and create our own
-     # Begin the new site-start.el by loading the original, which sets some
-     # NixOS-specific paths. Paths are searched in the reverse of the order
-     # they are specified in, so user and system profile paths are searched last.
-     rm -f $siteStart $siteStartByteCompiled $subdirs $subdirsByteCompiled
-     cat >"$siteStart" <<EOF
-(load-file "$emacs/share/emacs/site-lisp/site-start.el")
-(add-to-list 'load-path "$out/share/emacs/site-lisp")
-(add-to-list 'exec-path "$out/bin")
-EOF
-      # Link subdirs.el from the emacs distribution
-      ln -s $emacs/share/emacs/site-lisp/subdirs.el -T $subdirs
+        siteStart="$out/share/emacs/site-lisp/site-start.el"
+        siteStartByteCompiled="$siteStart"c
+        subdirs="$out/share/emacs/site-lisp/subdirs.el"
+        subdirsByteCompiled="$subdirs"c
 
-     # Byte-compiling improves start-up time only slightly, but costs nothing.
-     $emacs/bin/emacs --batch -f batch-byte-compile "$siteStart" "$subdirs"
-  '';
+        # A dependency may have brought the original siteStart or subdirs, delete
+        # it and create our own
+        # Begin the new site-start.el by loading the original, which sets some
+        # NixOS-specific paths. Paths are searched in the reverse of the order
+        # they are specified in, so user and system profile paths are searched last.
+        rm -f $siteStart $siteStartByteCompiled $subdirs $subdirsByteCompiled
+        cat >"$siteStart" <<EOF
+        (load-file "$emacs/share/emacs/site-lisp/site-start.el")
+        (add-to-list 'load-path "$out/share/emacs/site-lisp")
+        (add-to-list 'exec-path "$out/bin")
+        EOF
+        # Link subdirs.el from the emacs distribution
+        ln -s $emacs/share/emacs/site-lisp/subdirs.el -T $subdirs
 
-  phases = [ "installPhase" ];
-  installPhase = ''
+        # Byte-compiling improves start-up time only slightly, but costs nothing.
+        $emacs/bin/emacs --batch -f batch-byte-compile "$siteStart" "$subdirs"
+      '';
+
+    inherit (emacs) meta;
+  }
+  ''
     mkdir -p "$out/bin"
 
     # Wrap emacs and friends so they find our site-start.el before the original.
@@ -172,6 +177,4 @@ EOF
     for dir in applications icons info man; do
       ln -s $emacs/share/$dir $out/share/$dir
     done
-  '';
-  inherit (emacs) meta;
-}
+  ''

--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -60,7 +60,7 @@ let
   };
 
   emacsWithPackages = import ../build-support/emacs/wrapper.nix {
-    inherit lib lndir makeWrapper stdenv runCommand;
+    inherit lib lndir makeWrapper runCommand;
   };
 
   mkManualPackages = import ../applications/editors/emacs-modes/manual-packages.nix {


### PR DESCRIPTION
This removes the unnecessary compiler build dependency. We also set

    preferLocalBuild = true;
    allowSubstitutes = false;

to not farm out the build on a remote builder or bother with trying to find a binary substitution.