### PR TITLE
linuxPackages.fwts-efi-runtime: init

### DIFF
--- a/pkgs/os-specific/linux/fwts/module.nix
+++ b/pkgs/os-specific/linux/fwts/module.nix
@@ -1,0 +1,31 @@
+{ stdenv, fwts, kernel }:
+
+stdenv.mkDerivation rec {
+  pname = "fwts-efi-runtime";
+  version = "${fwts.version}-${kernel.version}";
+
+  inherit (fwts) src;
+
+  sourceRoot = "source/efi_runtime";
+
+  postPatch = ''
+    substituteInPlace Makefile --replace \
+      '/lib/modules/$(KVER)/build' \
+      '${kernel.dev}/lib/modules/${kernel.modDirVersion}/build'
+  '';
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  hardeningDisable = [ "pic" ];
+
+  makeFlags = [
+    "INSTALL_MOD_PATH=${placeholder "out"}"
+  ];
+
+  meta = with stdenv.lib; {
+    inherit (fwts.meta) homepage license;
+    description = fwts.meta.description + "(efi-runtime kernel module)";
+    maintainers = with maintainers; [ dtzWill ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15808,6 +15808,8 @@ in
 
     evdi = callPackage ../os-specific/linux/evdi { };
 
+    fwts-efi-runtime = callPackage ../os-specific/linux/fwts/module.nix { };
+
     hyperv-daemons = callPackage ../os-specific/linux/hyperv-daemons { };
 
     e1000e = if stdenv.lib.versionOlder kernel.version "4.10" then  callPackage ../os-specific/linux/e1000e {} else null;


### PR DESCRIPTION
###### Motivation for this change

Add expression for building the kernel module 'efi-runtime'
to enable FWTS testing of EFI bits.

Builds from FWTS source, but separately so it matches a given kernel.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

-----

Once installed and loaded,
with `modprobe efi_runtime` or `insmod` the module file directly,
this enables UEFI tests like so:


```
$ sudo fwts --uefitests
```

Without the module, most of the tests do nothing (abort as unsupported).