### PR TITLE
add config.environment.ld-linux

### DIFF
--- a/nixos/modules/system/activation/activation-script.nix
+++ b/nixos/modules/system/activation/activation-script.nix
@@ -162,6 +162,16 @@ in
         <literal>/usr/bin/env</literal>.
       '';
     };
+
+    environment.ld-linux = mkOption {
+      default = false;
+      type = types.bool;
+      visible = false;
+      description = ''
+        Install symlink to ld-linux(8) system-wide to allow running unmodified ELF binaries.
+        It might be useful to run games or executables distributed inside jar files.
+      '';
+    };
   };
 
 
@@ -197,6 +207,27 @@ in
         rm -f /usr/bin/env
         rmdir --ignore-fail-on-non-empty /usr/bin /usr
       '';
+
+    system.activationScripts.ld-linux =
+      concatStrings (
+        mapAttrsToList
+          (target: source:
+            if config.environment.ld-linux then ''
+              mkdir -m 0755 -p $(dirname ${target})
+              ln -sfn ${escapeShellArg source} ${target}.tmp
+              mv -f ${target}.tmp ${target} # atomically replace
+            '' else ''
+              rm -f ${target}
+              rmdir --ignore-fail-on-non-empty $(dirname ${target})
+            '')
+          {
+            "i686-linux"   ."/lib/ld-linux.so.2"          = "${pkgs.glibc.out}/lib/ld-linux.so.2";
+            "x86_64-linux" ."/lib/ld-linux.so.2"          = "${pkgs.pkgsi686Linux.glibc.out}/lib/ld-linux.so.2";
+            "x86_64-linux" ."/lib64/ld-linux-x86-64.so.2" = "${pkgs.glibc.out}/lib64/ld-linux-x86-64.so.2";
+            "aarch64-linux"."/lib/ld-linux-aarch64.so.1"  = "${pkgs.glibc.out}/lib/ld-linux-aarch64.so.1";
+            "armv7l-linux" ."/lib/ld-linux-armhf.so.3"    = "${pkgs.glibc.out}/lib/ld-linux-armhf.so.3";
+          }.${pkgs.stdenv.system} or {}
+      );
 
     system.activationScripts.specialfs =
       ''

--- a/nixos/modules/system/activation/activation-script.nix
+++ b/nixos/modules/system/activation/activation-script.nix
@@ -205,7 +205,7 @@ in
       ''
       else ''
         rm -f /usr/bin/env
-        rmdir --ignore-fail-on-non-empty /usr/bin /usr
+        rmdir -p /usr/bin || true
       '';
 
     system.activationScripts.ld-linux =
@@ -218,7 +218,7 @@ in
               mv -f ${target}.tmp ${target} # atomically replace
             '' else ''
               rm -f ${target}
-              rmdir --ignore-fail-on-non-empty $(dirname ${target})
+              rmdir $(dirname ${target}) || true
             '')
           {
             "i686-linux"   ."/lib/ld-linux.so.2"          = "${pkgs.glibc.out}/lib/ld-linux.so.2";


### PR DESCRIPTION
Add option to install symlink to `ld-linux(8)` system-wide to allow running unmodified ELF binaries.

It might be useful to run games or executables distributed inside jar files as discussed
https://discourse.nixos.org/t/runtime-alternative-to-patchelf-set-interpreter/3539
https://discourse.nixos.org/t/running-binaries-without-fhs-and-patchelf/1828

It is the third concession to FHS after `/bin/sh` and `/usr/bin/env`,
but unlike `config.environment.binsh` and `config.environment.usrbinenv` this new option is disabled by default

cc @
