### PR TITLE
graphviz: 2.40.1 -> 2.42.2

### DIFF
--- a/pkgs/tools/graphics/graphviz/base.nix
+++ b/pkgs/tools/graphics/graphviz/base.nix
@@ -7,7 +7,7 @@
 assert stdenv.isDarwin -> ApplicationServices != null;
 
 let
-  inherit (stdenv.lib) optionals optionalString;
+  inherit (stdenv.lib) optional optionals optionalString;
   raw_patch =
     # https://gitlab.com/graphviz/graphviz/issues/1367 CVE-2018-10196
     fetchpatch {
@@ -17,11 +17,13 @@ let
       excludes = ["tests/*"]; # we don't run them and they don't apply
     };
   # the patch needs a small adaption for older versions
-  patch = if stdenv.lib.versionAtLeast version "2.37" then raw_patch else
+  patchToUse = if stdenv.lib.versionAtLeast version "2.37" then raw_patch else
   stdenv.mkDerivation {
     inherit (raw_patch) name;
     buildCommand = "sed s/dot_root/agroot/g ${raw_patch} > $out";
   };
+  # 2.42 has the patch included
+  patches = optional (stdenv.lib.versionOlder version "2.42") patchToUse;
 in
 
 stdenv.mkDerivation {
@@ -52,9 +54,7 @@ stdenv.mkDerivation {
     "--with-ltdl-include=${libtool}/include"
   ] ++ stdenv.lib.optional (xorg == null) [ "--without-x" ];
 
-  patches = [
-    patch
-  ];
+  inherit patches;
 
   postPatch = ''
     for f in $(find . -name Makefile.in); do

--- a/pkgs/tools/graphics/graphviz/default.nix
+++ b/pkgs/tools/graphics/graphviz/default.nix
@@ -1,5 +1,5 @@
 import ./base.nix rec {
-  rev = "67cd2e5121379a38e0801cc05cce5033f8a2a609";
-  version = "2.40.1";
-  sha256 = "1xjqq3g2n6jgwp5xzyvibgrxawlskkpam69fjjz9ksrrjas2qwzj";
+  rev = "da4c2ec6f24ca1b6d1752c6b5bc4389e55682147"; # use rev as tags have disappeared before
+  version = "2.42.2";
+  sha256 = "0lacl11amyvj04j78m63qifljl4c0nkyy50z4bkg8mg9j4hjdy0x";
  }


### PR DESCRIPTION
###### Motivation for this change

Little uncertain what's going on re:versions,
here's some info:

2.42.0 "Fixes quite a few bugs"[1], which is primary motivation.

[1] https://gitlab.com/graphviz/graphviz/blob/stable_release_2.42.0/ChangeLog

2.42.1 has a note in 2.42.2's ChangeLog[2] which is good but also
interesting as 2.42.2 doesn't have an entry in its own ChangeLog :).
FWIW there are two tags for 2.42.2 but happily they're equivalent.

While a bit verbose, the changes between these versions can be looked at
using git locally or a URL like one of these:

* https://gitlab.com/graphviz/graphviz/compare/stable_release_2.42.0...stable_release_2.42.2
* https://gitlab.com/graphviz/graphviz/compare/stable_release_2.40.1...stable_release_2.42.0

Anyway, looks like a bunch of bugfixes! :)



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).