### PR TITLE
nm-tray: init at 0.4.3

### DIFF
--- a/pkgs/tools/networking/network-manager/tray.nix
+++ b/pkgs/tools/networking/network-manager/tray.nix
@@ -1,0 +1,31 @@
+{ lib, mkDerivation, fetchFromGitHub, cmake, qttools, qtbase, networkmanager-qt, modemmanager-qt }:
+
+mkDerivation rec {
+  pname = "nm-tray";
+  version = "0.4.3";
+
+  src = fetchFromGitHub {
+    owner = "palinek";
+    repo = pname;
+    rev = version;
+    sha256 = "08c86kd613wlvw9571q7a3lb7g6skyyasjw6h1g543rbl4jn2c2v";
+  };
+
+  postPatch = ''
+    sed -i -e '1i#include <QMetaEnum>' src/nmmodel.cpp
+  '';
+
+  nativeBuildInputs = [ cmake qttools ];
+
+  cmakeFlags = [ "-DWITH_MODEMMANAGER_SUPPORT=ON" ];
+
+  buildInputs = [ qtbase networkmanager-qt modemmanager-qt ];
+
+  meta = with lib; {
+    description = "Simple Network Manager frontend written in Qt";
+    homepage = "https://github.com/palinek/nm-tray";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ dtzWill ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4981,6 +4981,8 @@ in
 
   networkmanager_dmenu = callPackage ../tools/networking/network-manager/dmenu.nix  { };
 
+  nm-tray = libsForQt5.callPackage ../tools/networking/network-manager/tray.nix { };
+
   newsboat = callPackage ../applications/networking/feedreaders/newsboat {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
###### Motivation for this change

"Simple Network Manager frontend written in Qt"

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).