### PR TITLE
pythonPackages.premailer: fix build

### DIFF
--- a/pkgs/development/python-modules/premailer/default.nix
+++ b/pkgs/development/python-modules/premailer/default.nix
@@ -1,16 +1,10 @@
 { lib, buildPythonPackage, fetchPypi,
-  cssselect, cssutils, lxml, mock, nose, requests
+  cssselect, cssutils, lxml, mock, nose, requests, cachetools
 }:
 
 buildPythonPackage rec {
   pname = "premailer";
   version = "3.3.0";
-
-  meta = {
-    description = "Turns CSS blocks into style attributes ";
-    homepage = https://github.com/peterbe/premailer;
-    license = lib.licenses.bsd3;
-  };
 
   src = fetchPypi {
     inherit pname version;
@@ -18,5 +12,11 @@ buildPythonPackage rec {
   };
 
   buildInputs = [ mock nose ];
-  propagatedBuildInputs = [ cssselect cssutils lxml requests ];
+  propagatedBuildInputs = [ cachetools cssselect cssutils lxml requests ];
+
+  meta = {
+    description = "Turns CSS blocks into style attributes ";
+    homepage = https://github.com/peterbe/premailer;
+    license = lib.licenses.bsd3;
+  };
 }


### PR DESCRIPTION
##### Motivation for this change
noticed it was broken while reviewing another package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
```
[1 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/69063
2 package were build:
python27Packages.premailer python37Packages.premailer
```