### PR TITLE
python3Packages.asyncpg: use local patch

### DIFF
--- a/pkgs/development/python-modules/asyncpg/default.nix
+++ b/pkgs/development/python-modules/asyncpg/default.nix
@@ -12,10 +12,7 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (fetchpatch {
-      url = "https://github.com/MagicStack/asyncpg/commit/aaeb7076e5acb045880b46155014c0640624797e.patch";
-      sha256 = "0r6g6pvb39vzci8g67mv9rlrvavqvfz6vlv8988wv53bpz1mss3p";
-    })
+    ./flake8.patch
   ];
 
   checkInputs = [

--- a/pkgs/development/python-modules/asyncpg/flake8.patch
+++ b/pkgs/development/python-modules/asyncpg/flake8.patch
@@ -1,0 +1,37 @@
+From aaeb7076e5acb045880b46155014c0640624797e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Robert=20Sch=C3=BCtz?=
+ <robert.schuetz@stud.uni-heidelberg.de>
+Date: Tue, 22 Jan 2019 08:25:33 +0100
+Subject: [PATCH] Check for .flake8 after importing flake8
+
+This way, tests won't fail if both the flake8 module and the .flake8 file are missing.
+---
+ tests/test__sourcecode.py | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/tests/test__sourcecode.py b/tests/test__sourcecode.py
+index e3dc08c..28ffdea 100644
+--- a/tests/test__sourcecode.py
++++ b/tests/test__sourcecode.py
+@@ -17,16 +17,16 @@ def find_root():
+ class TestFlake8(unittest.TestCase):
+ 
+     def test_flake8(self):
+-        root_path = find_root()
+-        config_path = os.path.join(root_path, '.flake8')
+-        if not os.path.exists(config_path):
+-            raise RuntimeError('could not locate .flake8 file')
+-
+         try:
+             import flake8  # NoQA
+         except ImportError:
+             raise unittest.SkipTest('flake8 module is missing')
+ 
++        root_path = find_root()
++        config_path = os.path.join(root_path, '.flake8')
++        if not os.path.exists(config_path):
++            raise RuntimeError('could not locate .flake8 file')
++
+         try:
+             subprocess.run(
+                 [sys.executable, '-m', 'flake8', '--config', config_path],


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Hash mismatch from `fetchpatch`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
