### PR TITLE
mosquitto: 1.6.4 -> 1.6.6

### DIFF
--- a/pkgs/development/libraries/libwebsockets/default.nix
+++ b/pkgs/development/libraries/libwebsockets/default.nix
@@ -1,28 +1,47 @@
 { fetchFromGitHub, stdenv, cmake, openssl, zlib, libuv }:
 
-stdenv.mkDerivation rec {
-  pname = "libwebsockets";
-  version = "3.2.0";
+let
+  generic = { version, sha256 }: stdenv.mkDerivation rec {
+    pname = "libwebsockets";
+    inherit version;
 
-  src = fetchFromGitHub {
-    owner = "warmcat";
-    repo = "libwebsockets";
-    rev = "v${version}";
+    src = fetchFromGitHub {
+      owner = "warmcat";
+      repo = "libwebsockets";
+      rev = "v${version}";
+      inherit sha256;
+    };
+
+    buildInputs = [ openssl zlib libuv ];
+
+    nativeBuildInputs = [ cmake ];
+
+    cmakeFlags = [ "-DLWS_WITH_PLUGINS=ON" ];
+
+    meta = with stdenv.lib; {
+      description = "Light, portable C library for websockets";
+      longDescription = ''
+        Libwebsockets is a lightweight pure C library built to
+        use minimal CPU and memory resources, and provide fast
+        throughput in both directions.
+      '';
+      homepage = "https://libwebsockets.org/";
+      license = licenses.lgpl21;
+      platforms = platforms.all;
+    };
+  };
+
+in
+rec {
+  libwebsockets_3_1 = generic {
+    sha256 = "1w1wz6snf3cmcpa3f4dci2nz9za2f5rrylxl109id7bcb36xhbdl";
+    version = "3.1.0";
+  };
+
+  libwebsockets_3_2 = generic {
+    version = "3.2.0";
     sha256 = "0ac5755h3w1pl6cznqbvg63dwkqy544fqlhvqyp7s11hgs7jx6l8";
   };
 
-  buildInputs = [ cmake openssl zlib libuv ];
-  cmakeFlags = [ "-DLWS_WITH_PLUGINS=ON" ];
-
-  meta = {
-    description = "Light, portable C library for websockets";
-    longDescription = ''
-      Libwebsockets is a lightweight pure C library built to
-      use minimal CPU and memory resources, and provide fast
-      throughput in both directions.
-    '';
-    homepage = https://github.com/warmcat/libwebsockets;
-    license = stdenv.lib.licenses.lgpl21;
-    platforms = stdenv.lib.platforms.all;
-  };
+  libwebsockets = libwebsockets_3_2;
 }

--- a/pkgs/servers/mqtt/mosquitto/default.nix
+++ b/pkgs/servers/mqtt/mosquitto/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   pname = "mosquitto";
-  version = "1.6.5";
+  version = "1.6.6";
 
   src = fetchFromGitHub {
     owner  = "eclipse";
     repo   = "mosquitto";
     rev    = "v${version}";
-    sha256 = "0scgsi3rvs9s8vxv4r7d5d9ixbsfg4dwnjcy6zxwdz9dfn8qnngj";
+    sha256 = "01a1vf0rgncmhk7v9vnj4gdx0j8jfiy95f2hr4iwqdch7jy5q367";
   };
 
   postPatch = ''

--- a/pkgs/servers/mqtt/mosquitto/default.nix
+++ b/pkgs/servers/mqtt/mosquitto/default.nix
@@ -1,16 +1,16 @@
 { stdenv, lib, fetchFromGitHub, cmake, docbook_xsl, libxslt
-, openssl, libuuid, libwebsockets, c-ares, libuv
+, openssl, libuuid, libwebsockets_3_1, c-ares, libuv
 , systemd ? null, withSystemd ? stdenv.isLinux }:
 
 stdenv.mkDerivation rec {
   pname = "mosquitto";
-  version = "1.6.4";
+  version = "1.6.5";
 
   src = fetchFromGitHub {
     owner  = "eclipse";
     repo   = "mosquitto";
     rev    = "v${version}";
-    sha256 = "1kr1dgc4nzhyg3rzymbv4rka3rpb30rwsy6binb7apnw3n3ff58l";
+    sha256 = "0scgsi3rvs9s8vxv4r7d5d9ixbsfg4dwnjcy6zxwdz9dfn8qnngj";
   };
 
   postPatch = ''
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   '';
 
   buildInputs = [
-    openssl libuuid libwebsockets c-ares libuv
+    openssl libuuid libwebsockets_3_1 c-ares libuv
   ] ++ lib.optional withSystemd systemd;
 
   nativeBuildInputs = [ cmake docbook_xsl libxslt ];
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "An open source MQTT v3.1/3.1.1 broker";
-    homepage = http://mosquitto.org/;
+    homepage = "https://mosquitto.org/";
     license = licenses.epl10;
     maintainers = with maintainers; [ peterhoeg ];
     platforms = platforms.unix;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4561,7 +4561,10 @@ in
 
   librest = callPackage ../development/libraries/librest { };
 
-  libwebsockets = callPackage ../development/libraries/libwebsockets { };
+  inherit (callPackages ../development/libraries/libwebsockets { })
+    libwebsockets_3_1
+    libwebsockets_3_2
+    libwebsockets;
 
   lidarr = callPackage ../servers/lidarr { };
 


### PR DESCRIPTION
###### Motivation for this change

Security update: https://mosquitto.org/blog/2019/09/version-1-6-6-released/

We need the libwebsockets re-init of 3.1.0 in order for this to work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
