### PR TITLE
terra updates

### DIFF
--- a/pkgs/development/compilers/terra/default.nix
+++ b/pkgs/development/compilers/terra/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchFromGitHub, fetchurl, llvmPackages, ncurses, lua }:
+{ stdenv, fetchurl, fetchFromGitHub
+, llvmPackages, ncurses, lua
+}:
 
 let
   luajitArchive = "LuaJIT-2.0.5.tar.gz";
@@ -49,9 +51,9 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A low-level counterpart to Lua";
-    homepage = http://terralang.org/;
-    platforms = platforms.x86_64;
-    maintainers = with maintainers; [ jb55 ];
-    license = licenses.mit;
+    homepage    = http://terralang.org/;
+    platforms   = platforms.x86_64;
+    maintainers = with maintainers; [ jb55 thoughtpolice ];
+    license     = licenses.mit;
   };
 }

--- a/pkgs/development/compilers/terra/default.nix
+++ b/pkgs/development/compilers/terra/default.nix
@@ -5,21 +5,23 @@
 let
   luajitArchive = "LuaJIT-2.0.5.tar.gz";
   luajitSrc = fetchurl {
-    url = "http://luajit.org/download/${luajitArchive}";
+    url    = "http://luajit.org/download/${luajitArchive}";
     sha256 = "0yg9q4q6v028bgh85317ykc9whgxgysp76qzaqgq55y6jy11yjw7";
   };
 in
 
 stdenv.mkDerivation rec {
-  pname = "terra-git";
-  version = "1.0.0-beta1";
+  pname = "terra";
+  version = "1.0.0pre1175_${builtins.substring 0 7 src.rev}";
 
   src = fetchFromGitHub {
-    owner = "zdevito";
-    repo = "terra";
-    rev = "release-${version}";
-    sha256 = "1blv3mbmlwb6fxkck6487ck4qq67cbwq6s1zlp86hy2wckgf8q2c";
+    owner  = "zdevito";
+    repo   = "terra";
+    rev    = "ef6a75ffee15a30f3c74f4e6943851cfbc0fec3d";
+    sha256 = "0aky17vbv3d9zng34hp17p9zb00dbzwhvzsdjzrrqvk9lmyvix0s";
   };
+
+  hardeningDisable = [ "fortify" ];
 
   outputs = [ "bin" "dev" "out" "static" ];
 

--- a/pkgs/development/compilers/terra/default.nix
+++ b/pkgs/development/compilers/terra/default.nix
@@ -23,6 +23,8 @@ stdenv.mkDerivation rec {
 
   outputs = [ "bin" "dev" "out" "static" ];
 
+  patches = [ ./nix-cflags.patch ];
+
   postPatch = ''
     substituteInPlace Makefile --replace \
       '-lcurses' '-lncurses'

--- a/pkgs/development/compilers/terra/nix-cflags.patch
+++ b/pkgs/development/compilers/terra/nix-cflags.patch
@@ -1,0 +1,19 @@
+diff --git a/src/terralib.lua b/src/terralib.lua
+index 351238d..f26591b 100644
+--- a/src/terralib.lua
++++ b/src/terralib.lua
+@@ -3395,6 +3395,14 @@ function terra.includecstring(code,cargs,target)
+     	args:insert("-internal-isystem")
+     	args:insert(path)
+     end
++
++    -- NOTE(aseipp): include relevant Nix header files
++    local nix_cflags = os.getenv('NIX_CFLAGS_COMPILE')
++    if nix_cflags ~= nil then
++        for w in nix_cflags:gmatch("%S+") do
++          args:insert(w)
++        end
++    end
+     
+     if cargs then
+         args:insertall(cargs)

--- a/pkgs/development/compilers/terra/nix-cflags.patch
+++ b/pkgs/development/compilers/terra/nix-cflags.patch
@@ -1,13 +1,16 @@
 diff --git a/src/terralib.lua b/src/terralib.lua
-index 351238d..f26591b 100644
+index 351238d..e638c90 100644
 --- a/src/terralib.lua
 +++ b/src/terralib.lua
-@@ -3395,6 +3395,14 @@ function terra.includecstring(code,cargs,target)
+@@ -3395,6 +3395,17 @@ function terra.includecstring(code,cargs,target)
      	args:insert("-internal-isystem")
      	args:insert(path)
      end
 +
 +    -- NOTE(aseipp): include relevant Nix header files
++    args:insert("-isystem")
++    args:insert("@NIX_LIBC_INCLUDE@")
++
 +    local nix_cflags = os.getenv('NIX_CFLAGS_COMPILE')
 +    if nix_cflags ~= nil then
 +        for w in nix_cflags:gmatch("%S+") do


### PR DESCRIPTION
###### Motivation

Updates to the latest Terra to fix a few bugs, and also includes a patch to automatically search `NIX_CFLAGS_COMPILE` for C compiler options. This means the following Terra program works out of the box (whereas you had to fix it before):

```lua
#! /usr/bin/env nix-shell
--[[
#! nix-shell -i terra -p terra glibc
--]]

C = terralib.includec("stdio.h")

-- The keyword 'terra' introduces a new Terra function.
terra hello(argc : int, argv : &rawstring)
  -- Here we call a C function from Terra
  C.printf("Hello, Terra!\n")
  return 0
end

hello:compile()
hello:printpretty(false)
hello:disas()
hello(0, nil)
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS

###### Notify maintainers

cc @jb55 
