### PR TITLE
buildkite-agent-metrics: init at 5.1.0

### DIFF
--- a/pkgs/servers/monitoring/buildkite-agent-metrics/default.nix
+++ b/pkgs/servers/monitoring/buildkite-agent-metrics/default.nix
@@ -1,14 +1,10 @@
 { lib, go, buildGoPackage, fetchFromGitHub }:
 
-let
-  goPackagePath = "github.com/buildkite/buildkite-agent-metrics";
-in
 buildGoPackage rec {
   pname = "buildkite-agent-metrics";
   version = "5.1.0";
   goDeps = ./deps.nix;
-
-  inherit goPackagePath;
+  goPackagePath = "github.com/buildkite/buildkite-agent-metrics";
 
   preBuild = ''
     rm -rf go/src/${goPackagePath}/vendor

--- a/pkgs/servers/monitoring/buildkite-agent-metrics/default.nix
+++ b/pkgs/servers/monitoring/buildkite-agent-metrics/default.nix
@@ -1,0 +1,45 @@
+{ lib, go, buildGoPackage, fetchFromGitHub }:
+
+let
+  goPackagePath = "github.com/buildkite/buildkite-agent-metrics";
+in
+buildGoPackage rec {
+  pname = "buildkite-agent-metrics";
+  version = "5.1.0";
+  goDeps = ./deps.nix;
+
+  inherit goPackagePath;
+
+  preBuild = ''
+    rm -rf go/src/${goPackagePath}/vendor
+  '';
+
+  src = fetchFromGitHub {
+    rev = "v${version}";
+    owner = "buildkite";
+    repo = "buildkite-agent-metrics";
+    sha256 = "1dx8vhp07yc5c02la7iq5mxxj2lglsm4jzfb5vsac0vn70c9dwci";
+  };
+
+  buildFlagsArray = let
+    t = "${goPackagePath}/vendor/github.com/buildkite/buildkite-agent-metrics/version";
+  in ''
+    -ldflags=
+       -X ${t}.Version=${version}
+       -X ${t}.Revision=unknown
+       -X ${t}.Branch=unknown
+       -X ${t}.BuildUser=nix@nixpkgs
+       -X ${t}.BuildDate=unknown
+       -X ${t}.GoVersion=${lib.getVersion go}
+  '';
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "A command-line tool (and Lambda) for collecting Buildkite agent metrics";
+    homepage = "https://github.com/buildkite/buildkite-agent-metrics";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/servers/monitoring/buildkite-agent-metrics/deps.nix
+++ b/pkgs/servers/monitoring/buildkite-agent-metrics/deps.nix
@@ -1,0 +1,840 @@
+# file generated from go.mod using vgo2nix (https://github.com/adisbladis/vgo2nix)
+[
+  {
+    goPackagePath = "cloud.google.com/go";
+    fetch = {
+      type = "git";
+      url = "https://code.googlesource.com/gocloud";
+      rev = "v0.37.2";
+      sha256 = "1w6crdxy9vzd8vm672hng22spwld6d60z58kbr28dkiiz694wqvs";
+    };
+  }
+  {
+    goPackagePath = "github.com/BurntSushi/toml";
+    fetch = {
+      type = "git";
+      url = "https://github.com/BurntSushi/toml";
+      rev = "v0.3.1";
+      sha256 = "1fjdwwfzyzllgiwydknf1pwjvy49qxfsczqx5gz3y0izs7as99j6";
+    };
+  }
+  {
+    goPackagePath = "github.com/DataDog/datadog-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/DataDog/datadog-go";
+      rev = "281ae9f2d895";
+      sha256 = "1n82vl636zcpfrhh7yhmszvdxdba5hn2fjl39dvnk0a8pm2afmkx";
+    };
+  }
+  {
+    goPackagePath = "github.com/Shopify/sarama";
+    fetch = {
+      type = "git";
+      url = "https://github.com/Shopify/sarama";
+      rev = "v1.19.0";
+      sha256 = "0q1z3pvcd011yprwzws2s293v4cjvsszhai6vnfrahjcbsz79q0z";
+    };
+  }
+  {
+    goPackagePath = "github.com/Shopify/toxiproxy";
+    fetch = {
+      type = "git";
+      url = "https://github.com/Shopify/toxiproxy";
+      rev = "v2.1.4";
+      sha256 = "07yhsvscdv1qjfc2fyyh9qsrrdwrrw04wadk5gaq4qddcway7vig";
+    };
+  }
+  {
+    goPackagePath = "github.com/alecthomas/template";
+    fetch = {
+      type = "git";
+      url = "https://github.com/alecthomas/template";
+      rev = "a0175ee3bccc";
+      sha256 = "0qjgvvh26vk1cyfq9fadyhfgdj36f1iapbmr5xp6zqipldz8ffxj";
+    };
+  }
+  {
+    goPackagePath = "github.com/alecthomas/units";
+    fetch = {
+      type = "git";
+      url = "https://github.com/alecthomas/units";
+      rev = "2efee857e7cf";
+      sha256 = "1j65b91qb9sbrml9cpabfrcf07wmgzzghrl7809hjjhrmbzri5bl";
+    };
+  }
+  {
+    goPackagePath = "github.com/anmitsu/go-shlex";
+    fetch = {
+      type = "git";
+      url = "https://github.com/anmitsu/go-shlex";
+      rev = "648efa622239";
+      sha256 = "10rgdp5d106iisgz25ic8k6f44s9adh4sjh6fyxq9ccm21gw49b7";
+    };
+  }
+  {
+    goPackagePath = "github.com/apache/thrift";
+    fetch = {
+      type = "git";
+      url = "https://github.com/apache/thrift";
+      rev = "v0.12.0";
+      sha256 = "0g2g61rs189nimg3631wxfwdx12dsdz70qvncczlyvn34pcj7yby";
+    };
+  }
+  {
+    goPackagePath = "github.com/aws/aws-lambda-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/aws/aws-lambda-go";
+      rev = "v1.6.0";
+      sha256 = "06v2yfvn4sn116lds0526a8mfrsng4vafrdjf1dhpalqarrbdvmz";
+    };
+  }
+  {
+    goPackagePath = "github.com/aws/aws-sdk-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/aws/aws-sdk-go";
+      rev = "v1.15.66";
+      sha256 = "1xhg624f3xp6ciw2s4f0yxgd54fycc0i1xiwzcg0yih5dvn0h6rb";
+    };
+  }
+  {
+    goPackagePath = "github.com/beorn7/perks";
+    fetch = {
+      type = "git";
+      url = "https://github.com/beorn7/perks";
+      rev = "3a771d992973";
+      sha256 = "1l2lns4f5jabp61201sh88zf3b0q793w4zdgp9nll7mmfcxxjif3";
+    };
+  }
+  {
+    goPackagePath = "github.com/bradfitz/go-smtpd";
+    fetch = {
+      type = "git";
+      url = "https://github.com/bradfitz/go-smtpd";
+      rev = "deb6d6237625";
+      sha256 = "1i33brqd44h0a9hbdnclka0hfg0f6qi5xy23f0ap9yixkhj4k9p6";
+    };
+  }
+  {
+    goPackagePath = "github.com/client9/misspell";
+    fetch = {
+      type = "git";
+      url = "https://github.com/client9/misspell";
+      rev = "v0.3.4";
+      sha256 = "1vwf33wsc4la25zk9nylpbp9px3svlmldkm0bha4hp56jws4q9cs";
+    };
+  }
+  {
+    goPackagePath = "github.com/coreos/go-systemd";
+    fetch = {
+      type = "git";
+      url = "https://github.com/coreos/go-systemd";
+      rev = "c6f51f82210d";
+      sha256 = "1vnccmnkjl6n539l4cliz6sznpqn6igf5v7mbmsgahb838742clb";
+    };
+  }
+  {
+    goPackagePath = "github.com/davecgh/go-spew";
+    fetch = {
+      type = "git";
+      url = "https://github.com/davecgh/go-spew";
+      rev = "v1.1.1";
+      sha256 = "0hka6hmyvp701adzag2g26cxdj47g21x6jz4sc6jjz1mn59d474y";
+    };
+  }
+  {
+    goPackagePath = "github.com/eapache/go-resiliency";
+    fetch = {
+      type = "git";
+      url = "https://github.com/eapache/go-resiliency";
+      rev = "v1.1.0";
+      sha256 = "1zmgw3c4w5r6m2r340n4jc5l5ll3m3nbszqrmrgbqc2xixxyk2gx";
+    };
+  }
+  {
+    goPackagePath = "github.com/eapache/go-xerial-snappy";
+    fetch = {
+      type = "git";
+      url = "https://github.com/eapache/go-xerial-snappy";
+      rev = "776d5712da21";
+      sha256 = "0ncc41dv7xwb1znyzmzh7cvs6j5fzz0f1n8h1v3grl9ma6s1si9d";
+    };
+  }
+  {
+    goPackagePath = "github.com/eapache/queue";
+    fetch = {
+      type = "git";
+      url = "https://github.com/eapache/queue";
+      rev = "v1.1.0";
+      sha256 = "07dp54n94gn3gsvdcki56yqh7py7wqqigxbamhxwgbr05n61fqyg";
+    };
+  }
+  {
+    goPackagePath = "github.com/flynn/go-shlex";
+    fetch = {
+      type = "git";
+      url = "https://github.com/flynn/go-shlex";
+      rev = "3f9db97f8568";
+      sha256 = "1j743lysygkpa2s2gii2xr32j7bxgc15zv4113b0q9jhn676ysia";
+    };
+  }
+  {
+    goPackagePath = "github.com/fsnotify/fsnotify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fsnotify/fsnotify";
+      rev = "v1.4.7";
+      sha256 = "07va9crci0ijlivbb7q57d2rz9h27zgn2fsm60spjsqpdbvyrx4g";
+    };
+  }
+  {
+    goPackagePath = "github.com/gliderlabs/ssh";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gliderlabs/ssh";
+      rev = "v0.1.1";
+      sha256 = "0bylkc7yg8bxxffhchikcnzwli5n95cfmbji6v2a4mn1h5n36mdm";
+    };
+  }
+  {
+    goPackagePath = "github.com/go-kit/kit";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-kit/kit";
+      rev = "v0.8.0";
+      sha256 = "1rcywbc2pvab06qyf8pc2rdfjv7r6kxdv2v4wnpqnjhz225wqvc0";
+    };
+  }
+  {
+    goPackagePath = "github.com/go-logfmt/logfmt";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-logfmt/logfmt";
+      rev = "v0.3.0";
+      sha256 = "1gkgh3k5w1xwb2qbjq52p6azq3h1c1rr6pfwjlwj1zrijpzn2xb9";
+    };
+  }
+  {
+    goPackagePath = "github.com/go-stack/stack";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-stack/stack";
+      rev = "v1.8.0";
+      sha256 = "0wk25751ryyvxclyp8jdk5c3ar0cmfr8lrjb66qbg4808x66b96v";
+    };
+  }
+  {
+    goPackagePath = "github.com/gogo/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gogo/protobuf";
+      rev = "v1.2.0";
+      sha256 = "1c3y5m08mvrgvlw0kb9pldh3kkqcj99pa8gqmk1g3hp8ih3b2dv0";
+    };
+  }
+  {
+    goPackagePath = "github.com/golang/glog";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/glog";
+      rev = "23def4e6c14b";
+      sha256 = "0jb2834rw5sykfr937fxi8hxi2zy80sj2bdn9b3jb4b26ksqng30";
+    };
+  }
+  {
+    goPackagePath = "github.com/golang/mock";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/mock";
+      rev = "v1.2.0";
+      sha256 = "12ddj2g8ab87id6n2n67vnbhq6p8dvgsq1pzpqfriym4dk8w54fg";
+    };
+  }
+  {
+    goPackagePath = "github.com/golang/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/protobuf";
+      rev = "v1.2.0";
+      sha256 = "0kf4b59rcbb1cchfny2dm9jyznp8ri2hsb14n8iak1q8986xa0ab";
+    };
+  }
+  {
+    goPackagePath = "github.com/golang/snappy";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/snappy";
+      rev = "2e65f85255db";
+      sha256 = "05w6mpc4qcy0pv8a2bzng8nf4s5rf5phfang4jwy9rgf808q0nxf";
+    };
+  }
+  {
+    goPackagePath = "github.com/google/btree";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/btree";
+      rev = "4030bb1f1f0c";
+      sha256 = "0ba430m9fbnagacp57krgidsyrgp3ycw5r7dj71brgp5r52g82p6";
+    };
+  }
+  {
+    goPackagePath = "github.com/google/go-cmp";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/go-cmp";
+      rev = "v0.2.0";
+      sha256 = "1fbv0x27k9sn8svafc0hjwsnckk864lv4yi7bvzrxvmd3d5hskds";
+    };
+  }
+  {
+    goPackagePath = "github.com/google/go-github";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/go-github";
+      rev = "v17.0.0";
+      sha256 = "1kvw95l77a5n5rgal9n1xjh58zxb3a40ij1j722b1h4z8yg9jhg4";
+    };
+  }
+  {
+    goPackagePath = "github.com/google/go-querystring";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/go-querystring";
+      rev = "v1.0.0";
+      sha256 = "0xl12bqyvmn4xcnf8p9ksj9rmnr7s40pvppsdmy8n9bzw1db0iwz";
+    };
+  }
+  {
+    goPackagePath = "github.com/google/martian";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/martian";
+      rev = "v2.1.0";
+      sha256 = "197hil6vrjk50b9wvwyzf61csid83whsjj6ik8mc9r2lryxlyyrp";
+    };
+  }
+  {
+    goPackagePath = "github.com/google/pprof";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/pprof";
+      rev = "3ea8567a2e57";
+      sha256 = "09rhjn3ms0a72dw0yzbp237p7yhqma772zspddn6mgkh3gi3kn4c";
+    };
+  }
+  {
+    goPackagePath = "github.com/googleapis/gax-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/googleapis/gax-go";
+      rev = "v2.0.4";
+      sha256 = "1iwnm6ky1x53lgs44mw3hpdkjzrm5qd0kfs50m0qcq2ml5m1cwdm";
+    };
+  }
+  {
+    goPackagePath = "github.com/gorilla/context";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gorilla/context";
+      rev = "v1.1.1";
+      sha256 = "03p4hn87vcmfih0p9w663qbx9lpsf7i7j3lc7yl7n84la3yz63m4";
+    };
+  }
+  {
+    goPackagePath = "github.com/gorilla/mux";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gorilla/mux";
+      rev = "v1.6.2";
+      sha256 = "0pvzm23hklxysspnz52mih6h1q74vfrdhjfm1l3sa9r8hhqmmld2";
+    };
+  }
+  {
+    goPackagePath = "github.com/gregjones/httpcache";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gregjones/httpcache";
+      rev = "9cad4c3443a7";
+      sha256 = "0wjdwcwqqcx2d5y68qvhg6qyj977il5ijmnn9h9cd6wjbdy0ay6s";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/golang-lru";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/golang-lru";
+      rev = "v0.5.0";
+      sha256 = "12k2cp2k615fjvfa5hyb9k2alian77wivds8s65diwshwv41939f";
+    };
+  }
+  {
+    goPackagePath = "github.com/hpcloud/tail";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hpcloud/tail";
+      rev = "v1.0.0";
+      sha256 = "1njpzc0pi1acg5zx9y6vj9xi6ksbsc5d387rd6904hy6rh2m6kn0";
+    };
+  }
+  {
+    goPackagePath = "github.com/jellevandenhooff/dkim";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jellevandenhooff/dkim";
+      rev = "f50fe3d243e1";
+      sha256 = "0qf5pypxfpciivj0v728i24rfjwhnwm07945mj6p3cw4gdphqhm0";
+    };
+  }
+  {
+    goPackagePath = "github.com/jmespath/go-jmespath";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jmespath/go-jmespath";
+      rev = "c2b33e8439af";
+      sha256 = "1r6w7ydx8ydryxk3sfhzsk8m6f1nsik9jg3i1zhi69v4kfl4d5cz";
+    };
+  }
+  {
+    goPackagePath = "github.com/jstemmer/go-junit-report";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jstemmer/go-junit-report";
+      rev = "af01ea7f8024";
+      sha256 = "1lp3n94ris12hac02wi31f3whs88lcrzwgdg43a5j6cafg9p1d0s";
+    };
+  }
+  {
+    goPackagePath = "github.com/julienschmidt/httprouter";
+    fetch = {
+      type = "git";
+      url = "https://github.com/julienschmidt/httprouter";
+      rev = "v1.2.0";
+      sha256 = "1k8bylc9s4vpvf5xhqh9h246dl1snxrzzz0614zz88cdh8yzs666";
+    };
+  }
+  {
+    goPackagePath = "github.com/konsorten/go-windows-terminal-sequences";
+    fetch = {
+      type = "git";
+      url = "https://github.com/konsorten/go-windows-terminal-sequences";
+      rev = "v1.0.1";
+      sha256 = "1lchgf27n276vma6iyxa0v1xds68n2g8lih5lavqnx5x6q5pw2ip";
+    };
+  }
+  {
+    goPackagePath = "github.com/kr/logfmt";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kr/logfmt";
+      rev = "b84e30acd515";
+      sha256 = "02ldzxgznrfdzvghfraslhgp19la1fczcbzh7wm2zdc6lmpd1qq9";
+    };
+  }
+  {
+    goPackagePath = "github.com/kr/pty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kr/pty";
+      rev = "v1.1.3";
+      sha256 = "0knzlvndfgjm2k23vhp2xj1cv3fm31vbg5b20gdl1vnxk7rh549h";
+    };
+  }
+  {
+    goPackagePath = "github.com/matttproud/golang_protobuf_extensions";
+    fetch = {
+      type = "git";
+      url = "https://github.com/matttproud/golang_protobuf_extensions";
+      rev = "v1.0.1";
+      sha256 = "1d0c1isd2lk9pnfq2nk0aih356j30k3h1gi2w0ixsivi5csl7jya";
+    };
+  }
+  {
+    goPackagePath = "github.com/mwitkow/go-conntrack";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mwitkow/go-conntrack";
+      rev = "cc309e4a2223";
+      sha256 = "0nbrnpk7bkmqg9mzwsxlm0y8m7s9qd9phr1q30qlx2qmdmz7c1mf";
+    };
+  }
+  {
+    goPackagePath = "github.com/newrelic/go-agent";
+    fetch = {
+      type = "git";
+      url = "https://github.com/newrelic/go-agent";
+      rev = "v2.7.0";
+      sha256 = "0ry6syzpm5pdh2g6b1zr6wa5ph4fhahx0dh7lmpp8gx7lk9pj4n7";
+    };
+  }
+  {
+    goPackagePath = "github.com/onsi/ginkgo";
+    fetch = {
+      type = "git";
+      url = "https://github.com/onsi/ginkgo";
+      rev = "v1.7.0";
+      sha256 = "14wgpdrvpc35rdz3859bz53sc1g4vpr1fysy15wy3ff9gmqs14yg";
+    };
+  }
+  {
+    goPackagePath = "github.com/onsi/gomega";
+    fetch = {
+      type = "git";
+      url = "https://github.com/onsi/gomega";
+      rev = "v1.4.3";
+      sha256 = "1c8rqg5i2hz3snmq7s41yar1zjnzilb0fyiyhkg83v97afcfx79v";
+    };
+  }
+  {
+    goPackagePath = "github.com/openzipkin/zipkin-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/openzipkin/zipkin-go";
+      rev = "v0.1.6";
+      sha256 = "0fyf69w66khj3dxdpqydwjdhhhyhlh3caxa5ybnd1h2f6b5gbvvv";
+    };
+  }
+  {
+    goPackagePath = "github.com/pierrec/lz4";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pierrec/lz4";
+      rev = "v2.0.5";
+      sha256 = "0y5rh7z01zycd59nnjpkqq0ydyjmcg9j1xw15q1i600l9j9g617p";
+    };
+  }
+  {
+    goPackagePath = "github.com/pkg/errors";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pkg/errors";
+      rev = "v0.8.0";
+      sha256 = "001i6n71ghp2l6kdl3qq1v2vmghcz3kicv9a5wgcihrzigm75pp5";
+    };
+  }
+  {
+    goPackagePath = "github.com/pmezard/go-difflib";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pmezard/go-difflib";
+      rev = "v1.0.0";
+      sha256 = "0c1cn55m4rypmscgf0rrb88pn58j3ysvc2d0432dp3c6fqg6cnzw";
+    };
+  }
+  {
+    goPackagePath = "github.com/prometheus/client_golang";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/client_golang";
+      rev = "3c4408c8b829";
+      sha256 = "06d9cxxxkglks8fpfg3spxscyrq4lw7fckm4p6f0wshq65am2lxw";
+    };
+  }
+  {
+    goPackagePath = "github.com/prometheus/client_model";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/client_model";
+      rev = "56726106282f";
+      sha256 = "19y4qs9mkxiiab5sh3b7cccjpl3xbp6sy8812ig9f1zg8vzkzj7j";
+    };
+  }
+  {
+    goPackagePath = "github.com/prometheus/common";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/common";
+      rev = "v0.2.0";
+      sha256 = "02kym6lcfnlq23qbv277jr0q1n7jj0r14gqg93c7wn7gc44jv3vp";
+    };
+  }
+  {
+    goPackagePath = "github.com/prometheus/procfs";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/procfs";
+      rev = "bf6a532e95b1";
+      sha256 = "0k65i2ikf3jp6863mpc1raf928i78r8jd7zn9djx6f4izls6l6j1";
+    };
+  }
+  {
+    goPackagePath = "github.com/rcrowley/go-metrics";
+    fetch = {
+      type = "git";
+      url = "https://github.com/rcrowley/go-metrics";
+      rev = "3113b8401b8a";
+      sha256 = "1m5q5dsvkqz809aag6dyan74wdrp69g2mb9killbv7z4ls2mlfr3";
+    };
+  }
+  {
+    goPackagePath = "github.com/sirupsen/logrus";
+    fetch = {
+      type = "git";
+      url = "https://github.com/sirupsen/logrus";
+      rev = "v1.2.0";
+      sha256 = "0r6334x2bls8ddznvzaldx4g88msjjns4mlks95rqrrg7h0ijigg";
+    };
+  }
+  {
+    goPackagePath = "github.com/stretchr/objx";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/objx";
+      rev = "v0.1.1";
+      sha256 = "0iph0qmpyqg4kwv8jsx6a56a7hhqq8swrazv40ycxk9rzr0s8yls";
+    };
+  }
+  {
+    goPackagePath = "github.com/stretchr/testify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/testify";
+      rev = "v1.2.2";
+      sha256 = "0dlszlshlxbmmfxj5hlwgv3r22x0y1af45gn1vd198nvvs3pnvfs";
+    };
+  }
+  {
+    goPackagePath = "github.com/tarm/serial";
+    fetch = {
+      type = "git";
+      url = "https://github.com/tarm/serial";
+      rev = "98f6abe2eb07";
+      sha256 = "1yj4jiv2f3x3iawxdflrlmdan0k9xsbnccgc9yz658rmif1ag3pb";
+    };
+  }
+  {
+    goPackagePath = "go.opencensus.io";
+    fetch = {
+      type = "git";
+      url = "https://github.com/census-instrumentation/opencensus-go";
+      rev = "v0.19.2";
+      sha256 = "1vlik5xwwrhcyy9yx2yc3y02y6hp9q80591hbhncv9c8wwfg9gjc";
+    };
+  }
+  {
+    goPackagePath = "go4.org";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go4org/go4";
+      rev = "417644f6feb5";
+      sha256 = "013cvdg4fj15l9xg84br0vkb2d99j04s5b4g7zssqhng8dkwgr37";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/build";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/build";
+      rev = "5284462c4bec";
+      sha256 = "0w649zbs4n64b6rjx92hy7vc1y9sv4khhk5igbz8w7sxvz8778ij";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev = "c2843e01d9a2";
+      sha256 = "01xgxbj5r79nmisdvpq48zfy8pzaaj90bn6ngd4nf33j9ar1dp8r";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/exp";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/exp";
+      rev = "509febef88a4";
+      sha256 = "02isrh39z8znrp5znplzy0dip2gnrl3jm1355raliyvhnhg04j6q";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/lint";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/lint";
+      rev = "5614ed5bae6f";
+      sha256 = "0fzn0zjv0x92xvfdq3a0v9w5sgkhr7hxkfy9zaqi8i57807z8bnx";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev = "d8887717615a";
+      sha256 = "1wfm6ngxjyj7v5a2dqib6lw8bb2rdnf1kl48diykxjrsddn0s163";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/oauth2";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/oauth2";
+      rev = "e64efc72b421";
+      sha256 = "0djvwz2avx7knsjbl434vw1wqbrg53xp1kh599gfixn5icrggz4m";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/perf";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/perf";
+      rev = "6e6d33e29852";
+      sha256 = "1cyiy459bkjqnzgk051lsksz46hdkjc34q33zf946kiv3hilp1v2";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sync";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sync";
+      rev = "e225da77a7e6";
+      sha256 = "0bh3583smcfw6jw3w6lp0za93rz7hpxfdz8vhxng75b7a6vdlw4p";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev = "d0b11bdaac8a";
+      sha256 = "18yfsmw622l7gc5sqriv5qmck6903vvhivpzp8i3xfy3z33dybdl";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/text";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/text";
+      rev = "17ff2d5776d2";
+      sha256 = "1rrh2mnmyxr45nsvy42zq3w3ly6gw6rl993knwvf1w71kyv0jjnj";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/time";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/time";
+      rev = "85acf8d2951c";
+      sha256 = "0yqnxsrarjk4qkda8kcxzmk7y90kkkxzx9iwryzrk7bzs87ky3xc";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/tools";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/tools";
+      rev = "e65039ee4138";
+      sha256 = "0c094599cf70wdrms49a3879qkq122pqlp2av444gs2pvc8apdcx";
+    };
+  }
+  {
+    goPackagePath = "google.golang.org/api";
+    fetch = {
+      type = "git";
+      url = "https://code.googlesource.com/google-api-go-client";
+      rev = "v0.3.0";
+      sha256 = "1vvrhiq2zs677iz2j6s9iv4q3j3nhxz5ci9y4zrak248lrdln0zk";
+    };
+  }
+  {
+    goPackagePath = "google.golang.org/appengine";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/appengine";
+      rev = "v1.4.0";
+      sha256 = "06zl7w4sxgdq2pl94wy9ncii6h0z3szl4xpqds0sv3b3wbdlhbnn";
+    };
+  }
+  {
+    goPackagePath = "google.golang.org/genproto";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/go-genproto";
+      rev = "f467c93bbac2";
+      sha256 = "05v3lqp6s1vj7nlzq029mylmbm2896yak5jknxl0ygzv0y1yika2";
+    };
+  }
+  {
+    goPackagePath = "google.golang.org/grpc";
+    fetch = {
+      type = "git";
+      url = "https://github.com/grpc/grpc-go";
+      rev = "v1.19.0";
+      sha256 = "1znqwpj7ix3dpzx4zch0q70sdl3z5lvbb7v3q4i8sf8kas3yv71v";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/alecthomas/kingpin.v2";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/alecthomas/kingpin.v2";
+      rev = "v2.2.6";
+      sha256 = "0mndnv3hdngr3bxp7yxfd47cas4prv98sqw534mx7vp38gd88n5r";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/check.v1";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/check.v1";
+      rev = "788fd7840127";
+      sha256 = "0v3bim0j375z81zrpr5qv42knqs0y2qv2vkjiqi5axvb78slki1a";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/fsnotify.v1";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/fsnotify.v1";
+      rev = "v1.4.7";
+      sha256 = "07va9crci0ijlivbb7q57d2rz9h27zgn2fsm60spjsqpdbvyrx4g";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/inf.v0";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/inf.v0";
+      rev = "v0.9.1";
+      sha256 = "00k5iqjcp371fllqxncv7jkf80hn1zww92zm78cclbcn4ybigkng";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/tomb.v1";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/tomb.v1";
+      rev = "dd632973f1e7";
+      sha256 = "1lqmq1ag7s4b3gc3ddvr792c5xb5k6sfn0cchr3i2s7f1c231zjv";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/yaml.v2";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/yaml.v2";
+      rev = "v2.2.2";
+      sha256 = "01wj12jzsdqlnidpyjssmj0r4yavlqy7dwrg7adqd8dicjc4ncsa";
+    };
+  }
+  {
+    goPackagePath = "grpc.go4.org";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go4org/grpc";
+      rev = "11d0a25b4919";
+      sha256 = "1d6akp2b3aa2viwbikc3jndhiljgjj87r4z7mg5b03f97f2wmz4f";
+    };
+  }
+  {
+    goPackagePath = "honnef.co/go/tools";
+    fetch = {
+      type = "git";
+      url = "https://github.com/dominikh/go-tools";
+      rev = "3f1c8253044a";
+      sha256 = "0d3vgh0fgfj1z7i648g1s6x2pwxd07sxfjwg1xn3yagr9h06jh3h";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14533,6 +14533,8 @@ in
 
   bosun = callPackage ../servers/monitoring/bosun { };
 
+  buildkite-agent-metrics = callPackage ../servers/monitoring/buildkite-agent-metrics { };
+
   cayley = callPackage ../servers/cayley { };
 
   charybdis = callPackage ../servers/irc/charybdis { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

A command-line tool for collecting Buildkite agent metrics, focusing on enabling auto-scaling.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

None yet.
