### PR TITLE
librecad: 2.1.3 -> 2.2.0-rc1

### DIFF
--- a/pkgs/applications/misc/librecad/default.nix
+++ b/pkgs/applications/misc/librecad/default.nix
@@ -1,42 +1,64 @@
-{ stdenv, fetchurl, qt4, qmake4Hook, muparser, which, boost, pkgconfig }:
+{ mkDerivation, lib, fetchFromGitHub, installShellFiles, pkgconfig, runtimeShell
+, qtbase, qtsvg, qttools, qmake
+, boost, muparser }:
 
-stdenv.mkDerivation rec {
-  version = "2.1.3";
+mkDerivation rec {
   pname = "librecad";
+  version = "2.2.0-rc1";
 
-  src = fetchurl {
-    url = "https://github.com/LibreCAD/LibreCAD/tarball/${version}";
-    name = "${pname}-${version}" + ".tar.gz";
-    sha256 = "1czp8bja61hfav2m7184cq1np1n76w3w6vn0hlkp81hhz9zc62sx";
+  src = fetchFromGitHub {
+    owner = "LibreCAD";
+    repo = "LibreCAD";
+    rev = version;
+    sha256 = "0kwj838hqzbw95gl4x6scli9gj3gs72hdmrrkzwq5rjxam18k3f3";
   };
 
-  patchPhase = ''
-    sed -i -e s,/bin/bash,`type -P bash`, scripts/postprocess-unix.sh
-    sed -i -e s,/usr/share,$out/share, librecad/src/lib/engine/rs_system.cpp
+  patches = [ ./fix_qt_5_11_build.patch ];
+
+  postPatch = ''
+    substituteInPlace scripts/postprocess-unix.sh \
+      --replace /bin/sh ${runtimeShell}
+
+    substituteInPlace librecad/src/lib/engine/rs_system.cpp \
+      --replace /usr/share $out/share
+
+    substituteInPlace librecad/src/main/qc_applicationwindow.cpp \
+      --replace __DATE__ 0
   '';
 
-  qmakeFlags = [ "MUPARSER_DIR=${muparser}" "BOOST_DIR=${boost.dev}" ];
+  qmakeFlags = [
+    "MUPARSER_DIR=${muparser}"
+    "BOOST_DIR=${boost.dev}"
+  ];
 
   installPhase = ''
-    install -m 555 -D unix/librecad $out/bin/librecad
-    install -m 444 -D desktop/librecad.desktop $out/share/applications/librecad.desktop
-    install -m 444 -D desktop/librecad.sharedmimeinfo $out/share/mime/packages/librecad.xml
-    install -m 444 -D desktop/graphics_icons_and_splash/Icon\ LibreCAD/Icon_Librecad.svg \
+    runHook preInstall
+
+    install -Dm555 -t $out/bin                unix/{librecad,ttf2lff}
+    install -Dm444 -t $out/share/applications desktop/librecad.desktop
+    install -Dm644 -t $out/share/pixmaps      librecad/res/main/librecad.png
+    install -Dm444 desktop/librecad.sharedmimeinfo $out/share/mime/packages/librecad.xml
+    install -Dm444 desktop/graphics_icons_and_splash/Icon\ LibreCAD/Icon_Librecad.svg \
       $out/share/icons/hicolor/scalable/apps/librecad.svg
+
+    installManPage desktop/librecad.?
+
     cp -R unix/resources $out/share/librecad
+
+    runHook postInstall
   '';
 
-  buildInputs = [ qt4 muparser which boost ];
-  nativeBuildInputs = [ pkgconfig qmake4Hook ];
+  buildInputs = [ boost muparser qtbase qtsvg ];
+
+  nativeBuildInputs = [ installShellFiles pkgconfig qmake qttools ];
 
   enableParallelBuilding = true;
 
-  meta = {
-    description = "A 2D CAD package based upon Qt";
-    homepage = https://librecad.org;
-    repositories.git = git://github.com/LibreCAD/LibreCAD.git;
-    license = stdenv.lib.licenses.gpl2;
-    maintainers = with stdenv.lib.maintainers; [viric];
-    platforms = with stdenv.lib.platforms; linux;
+  meta = with lib; {
+    description = "2D CAD package based on Qt";
+    homepage = "https://librecad.org";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ viric ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/misc/librecad/fix_qt_5_11_build.patch
+++ b/pkgs/applications/misc/librecad/fix_qt_5_11_build.patch
@@ -1,0 +1,36 @@
+diff --git a/librecad/src/ui/forms/qg_commandwidget.cpp b/librecad/src/ui/forms/qg_commandwidget.cpp
+index 835e47d..2c878e8 100644
+--- a/librecad/src/ui/forms/qg_commandwidget.cpp
++++ b/librecad/src/ui/forms/qg_commandwidget.cpp
+@@ -27,6 +27,7 @@
+ 
+ #include <algorithm>
+ 
++#include <QAction>
+ #include <QKeyEvent>
+ #include <QFileDialog>
+ #include <QSettings>
+diff --git a/librecad/src/ui/generic/colorwizard.cpp b/librecad/src/ui/generic/colorwizard.cpp
+index 2beaceb..84068ad 100644
+--- a/librecad/src/ui/generic/colorwizard.cpp
++++ b/librecad/src/ui/generic/colorwizard.cpp
+@@ -27,6 +27,7 @@
+ #include "colorwizard.h"
+ #include "ui_colorwizard.h"
+ 
++#include <QAction>
+ #include <QColorDialog>
+ #include <QLineEdit>
+ #include <QListWidget>
+diff --git a/librecad/src/ui/generic/widgetcreator.cpp b/librecad/src/ui/generic/widgetcreator.cpp
+index 7c35144..0e394f2 100644
+--- a/librecad/src/ui/generic/widgetcreator.cpp
++++ b/librecad/src/ui/generic/widgetcreator.cpp
+@@ -27,6 +27,7 @@
+ #include "widgetcreator.h"
+ #include "ui_widgetcreator.h"
+ 
++#include <QActionGroup>
+ #include <QSettings>
+ #include <QLineEdit>
+ #include <QPushButton>

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19120,7 +19120,7 @@ in
 
   libowfat = callPackage ../development/libraries/libowfat { };
 
-  librecad = callPackage ../applications/misc/librecad { };
+  librecad = libsForQt5.callPackage ../applications/misc/librecad { };
 
   libreoffice = hiPrio libreoffice-still;
   libreoffice-unwrapped = libreoffice.libreoffice;


### PR DESCRIPTION
###### Motivation for this change

2.2.0 moves to qt5 from qt4, so it looks *much* nicer on a hidpi screen. rc1 is considered stable by upstream.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @viric 
