### PR TITLE
ntopng: Add patch needed to build with newer libpcap

### DIFF
--- a/pkgs/tools/networking/ntopng/0003-New-libpcap-defines-SOCKET.patch
+++ b/pkgs/tools/networking/ntopng/0003-New-libpcap-defines-SOCKET.patch
@@ -1,0 +1,34 @@
+From 9cb650ea96c0e5063775071cfdae072e92c553b8 Mon Sep 17 00:00:00 2001
+From: emanuele-f <faranda@ntop.org>
+Date: Tue, 18 Sep 2018 12:49:57 +0200
+Subject: [PATCH] Compilation fix with new libpcap
+
+SOCKET and INVALID_SOCKET are now defined in pcap.h
+---
+ third-party/mongoose/mongoose.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/third-party/mongoose/mongoose.c b/third-party/mongoose/mongoose.c
+index 6a61cea9b..634c142e3 100644
+--- a/third-party/mongoose/mongoose.c
++++ b/third-party/mongoose/mongoose.c
+@@ -247,7 +247,9 @@ struct pollfd {
+ #define mg_rename(x, y) rename(x, y)
+ #define mg_sleep(x) usleep((x) * 1000)
+ #define ERRNO errno
++#ifndef INVALID_SOCKET
+ #define INVALID_SOCKET (-1)
++#endif
+ 
+ /* ntop */
+ #if ((ULONG_MAX) == (UINT_MAX))
+@@ -270,7 +272,9 @@ struct pollfd {
+ #endif
+ 
+ //#define INT64_FMT PRId64
++#ifndef SOCKET
+ typedef int SOCKET;
++#endif
+ #define WINCDECL
+ 
+ #endif // End of Windows and UNIX specific includes

--- a/pkgs/tools/networking/ntopng/default.nix
+++ b/pkgs/tools/networking/ntopng/default.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation rec {
   patches = [
     ./0001-Undo-weird-modification-of-data_dir.patch
     ./0002-Remove-requirement-to-have-writeable-callback-dir.patch
+    ./0003-New-libpcap-defines-SOCKET.patch
   ];
 
   buildInputs = [ libpcap/* gnutls libgcrypt*/ libxml2 glib geoip geolite-legacy

--- a/pkgs/tools/networking/ntopng/default.nix
+++ b/pkgs/tools/networking/ntopng/default.nix
@@ -63,6 +63,5 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Plus;
     platforms = platforms.linux ++ platforms.darwin;
     maintainers = [ maintainers.bjornfor ];
-    broken = true;  # broken since commit "libpcap: 1.8.1 -> 1.9.0"
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Fix ntopng build https://hydra.nixos.org/build/100449995

#68361

Fixes build errors for the third-party mongoose module:
```
In file included from
/nix/store/r5s3w32ahjzdlzsfrhybc3l2qcpi6yb2-libpcap-1.9.0/include/pcap.h:43,
                 from /build/ntopng-2.0/include/ntop_includes.h:93,
                                  from src/HTTPserver.cpp:22:
/nix/store/r5s3w32ahjzdlzsfrhybc3l2qcpi6yb2-libpcap-1.9.0/include/pcap/pcap.h:958: note: this is the location of the previous definition
   #define INVALID_SOCKET -1

src/../third-party/mongoose/mongoose.c:270:13: error: multiple types in one declaration
 typedef int SOCKET;
             ^~~~~~
```


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
