### PR TITLE
qtcreator: use Qt mkDerivation

### DIFF
--- a/pkgs/development/tools/qtcreator/default.nix
+++ b/pkgs/development/tools/qtcreator/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, fetchurl, fetchgit, fetchpatch, makeWrapper
+{ mkDerivation, lib, fetchurl, fetchgit, fetchpatch
 , qtbase, qtquickcontrols, qtscript, qtdeclarative, qmake, llvmPackages_8
 , withDocumentation ? false
 }:
 
-with stdenv.lib;
+with lib;
 
 let
   baseVersion = "4.9";
@@ -21,7 +21,7 @@ let
   });
 in
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "qtcreator";
   version = "${baseVersion}.${revision}";
 


### PR DESCRIPTION
###### Motivation for this change

Fix runtime error:
```
qt.qpa.plugin: Could not find the Qt platform plugin "xcb" in ""
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
```

References #65399.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```bash
$ nix path-info -Sh /nix/store/3j51l64vmpldw7rmz82wnbw6yirk8pd9-qtcreator-4.9.1
/nix/store/3j51l64vmpldw7rmz82wnbw6yirk8pd9-qtcreator-4.9.1	   1.6G
$ nix path-info -Sh /nix/store/8nfkfnzh6nk5223imr31fbylzc7hbpxk-qtcreator-4.9.1
/nix/store/8nfkfnzh6nk5223imr31fbylzc7hbpxk-qtcreator-4.9.1	   1.7G
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @akaWolf 
