### PR TITLE
pythonPackages.pymupdf: init at 1.16.2

### DIFF
--- a/pkgs/development/python-modules/pymupdf/default.nix
+++ b/pkgs/development/python-modules/pymupdf/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, buildPythonPackage, fetchPypi, mupdf, swig }:
+buildPythonPackage rec {
+  pname = "PyMuPDF";
+  version = "1.16.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1bidybzkjsc0kdd18xnhz97p70br8xh8whzwydp3a5m411cm00mg";
+  };
+
+  patchPhase = ''
+    substituteInPlace setup.py \
+        --replace '/usr/include/mupdf' ${mupdf.dev}/include/mupdf
+    '';
+  nativeBuildInputs = [ swig ];
+  buildInputs = [ mupdf ];
+
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Python bindings for MuPDF's rendering library.";
+    homepage = https://github.com/pymupdf/PyMuPDF;
+    maintainers = with maintainers; [ teto ];
+    license =  licenses.agpl3;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -851,6 +851,8 @@ in {
 
   pymysql = callPackage ../development/python-modules/pymysql { };
 
+  pymupdf = callPackage ../development/python-modules/pymupdf { };
+
   Pmw = callPackage ../development/python-modules/Pmw { };
 
   py_stringmatching = callPackage ../development/python-modules/py_stringmatching { };


### PR DESCRIPTION
python bindings for mupdf. Provides the fitz module for
https://github.com/dsanson/termpdf.py that I am trying to package.

NB: when packaging termpdf.py (https://github.com/teto/home/blob/master/config/nixpkgs/overlays/pkgs/termpdf/default.nix), it can't `import fitz`
and looking at the .termpdf.py wrapper, I found the addition (sys.argv[0]...), is that normal ?
```
import sys;import site;import functools;sys.argv[0] = '/nix/store/j7aifx4jh1crvj90l93khrzk7llwzqrr-termpdf.py-0.1.1/bin/termpdf.py';functools.reduce(lambda k, p: site.addsitedir(p, k), ['/nix/store/j7aifx4jh1crvj90l93khrzk7llwzqrr-termpdf.py-0.1.1/lib/python3.7/site-packages','/nix/store/i50wf0cg1l46y4l7x41waypliiapfmry-python3.7-setuptools-41.0.1/lib/python3.7/site-packages'], site._init_pathinfo());
__version__ = "0.1.1"
__license__ = "MIT"
```


###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
