### PR TITLE
webmacs: init at version 0.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2808,6 +2808,11 @@
     githubId = 26877687;
     name = "Yurii Izorkin";
   };
+  jacg = {
+    name = "Jacek Generowicz";
+    email = "jacg@my-post-office.net";
+    githubId = "2570854";
+  };
   jasoncarr = {
     email = "jcarr250@gmail.com";
     github = "jasoncarr0";

--- a/pkgs/applications/networking/browsers/webmacs/default.nix
+++ b/pkgs/applications/networking/browsers/webmacs/default.nix
@@ -1,0 +1,73 @@
+{ lib
+, mkDerivationWith
+, fetchFromGitHub
+, python3Packages
+, herbstluftwm
+}:
+
+mkDerivationWith python3Packages.buildPythonApplication rec {
+  pname = "webmacs";
+  version = "0.8";
+
+  disabled = python3Packages.isPy27;
+
+  src = fetchFromGitHub {
+    owner = "parkouss";
+    repo = "webmacs";
+    rev = version;
+    fetchSubmodules = true;
+    sha256 = "1hzb9341hybgrqcy1w20hshm6xaiby4wbjpjkigf4zq389407368";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    pyqtwebengine
+    setuptools
+    dateparser
+    jinja2
+    pygments
+  ];
+
+  dontWrapQtApps = true;
+
+  makeWrapperArgs = [ "\${qtWrapperArgs[@]}" ];
+
+  # See https://github.com/parkouss/webmacs/blob/1a04fb7bd3f33d39cb4d71621b48c2458712ed39/setup.py#L32
+  # Don't know why they're using CC for g++.
+  preConfigure = ''
+   export CC=$CXX
+  '';
+
+  doCheck = false; # test dependencies not packaged up yet
+
+  checkInputs = [
+    python3Packages.pytest
+    #python3Packages.pytest-xvfb
+    #python3Packages.pytest-qt
+    python3Packages.pytestCheckHook
+    herbstluftwm
+
+    # The following are listed in test-requirements.txt but appear not
+    # to be needed at present:
+
+    # python3Packages.pytest-mock
+    # python3Packages.flake8
+  ];
+
+  meta = with lib; {
+    description = "Keyboard-based web browser with Emacs/conkeror heritage";
+    longDescription = ''
+      webmacs is yet another browser for keyboard-based web navigation.
+
+      It mainly targets emacs-like navigation, and started as a clone (in terms of
+      features) of conkeror.
+
+      Based on QtWebEngine and Python 3. Fully customizable in Python.
+    '';
+    homepage = https://webmacs.readthedocs.io/en/latest/;
+    changelog = https://github.com/parkouss/webmacs/blob/master/CHANGELOG.md;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ jacg ];
+    platforms = platforms.all;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21190,6 +21190,8 @@ in
 
   wayv = callPackage ../tools/X11/wayv {};
 
+  webmacs = libsForQt5.callPackage ../applications/networking/browsers/webmacs {};
+
   webtorrent_desktop = callPackage ../applications/video/webtorrent_desktop {};
 
   wrapWeechat = callPackage ../applications/networking/irc/weechat/wrapper.nix { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This package was not available in nixpkgs, before.

(The check phase is disabled at present, at is depends on a number of things that are not available in nixpkgs. I plan to contribute these as well, but wanted to keep my first contribution down to a manageable and easily-reviewable size.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
