### PR TITLE
cri-tools: 1.15.0 -> 1.16.1

### DIFF
--- a/pkgs/tools/virtualization/cri-tools/default.nix
+++ b/pkgs/tools/virtualization/cri-tools/default.nix
@@ -2,19 +2,19 @@
 
 buildGoPackage rec {
   pname = "cri-tools";
-  version = "1.15.0";
+  version = "1.16.1";
   src = fetchFromGitHub {
     owner = "kubernetes-sigs";
     repo = pname;
     rev = "v${version}";
-    sha256 = "03fhddncwqrdyxz43m3bak9dlrsqzibqqja3p94nic4ydk2hry62";
+    sha256 = "1kpbs9dxwhlmqdqrmsqhp03qs4s7dl8b86lkmg066sicdaw433fn";
   };
 
   goPackagePath = "github.com/kubernetes-sigs/cri-tools";
 
   buildPhase = ''
     pushd go/src/${goPackagePath}
-    make
+    make all install BINDIR=$bin/bin
   '';
 
   meta = with lib; {


### PR DESCRIPTION
##### Motivation for this change

Update cri-tools to the latest release

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

None
