### PR TITLE
pdfsam-basic: init at 4.0.4

### DIFF
--- a/pkgs/applications/misc/pdfsam-basic/default.nix
+++ b/pkgs/applications/misc/pdfsam-basic/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, makeDesktopItem, fetchurl, jdk11, wrapGAppsHook, glib }:
+
+stdenv.mkDerivation rec {
+  pname = "pdfsam-basic";
+  version = "4.0.4";
+
+  src = fetchurl {
+    url = "https://github.com/torakiki/pdfsam/releases/download/v${version}/pdfsam_${version}-1_amd64.deb";
+    sha256 = "17lhzxlgr4l4dljy0b0avfrgbj9rsfzk1dzg0abqvld4w4igkqbq";
+  };
+
+  unpackPhase = ''
+    ar vx ${src}
+    tar xvf data.tar.gz
+  '';
+
+  nativeBuildInputs = [ wrapGAppsHook ];
+  buildInputs = [ glib ];
+
+  preFixup = ''
+    gappsWrapperArgs+=(--set JAVA_HOME "${jdk11}" --set PDFSAM_JAVA_PATH "${jdk11}")
+  '';
+
+  installPhase = ''
+    cp -R opt/pdfsam-basic/ $out/
+    mkdir -p "$out"/share/icons
+    cp --recursive ${desktopItem}/share/applications $out/share
+    cp $out/icon.svg "$out"/share/icons/pdfsam-basic.svg
+  '';
+
+  desktopItem = makeDesktopItem {
+    name = pname;
+    exec = pname;
+    icon = pname;
+    comment = meta.description;
+    desktopName = "PDFsam Basic";
+    genericName = "PDF Split and Merge";
+    mimeType = "application/pdf;";
+    categories = "Office;Application;";
+  };
+
+  meta = with stdenv.lib; {
+      homepage = "https://github.com/torakiki/pdfsam";
+      description = "Multi-platform software designed to extract pages, split, merge, mix and rotate PDF files";
+      license = licenses.agpl3;
+      platforms = platforms.all;
+      maintainers = with maintainers; [ maintainers."1000101" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19665,6 +19665,8 @@ in
 
   pdfdiff = callPackage ../applications/misc/pdfdiff { };
 
+  pdfsam-basic = callPackage ../applications/misc/pdfsam-basic { };
+
   mupdf = callPackage ../applications/misc/mupdf { };
 
   mystem = callPackage ../applications/misc/mystem { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Init new package for PDF manipulation (split, merge).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc 
