### PR TITLE
video-transcoding: init at 0.25.2

### DIFF
--- a/pkgs/tools/video/video-transcoding/Gemfile
+++ b/pkgs/tools/video/video-transcoding/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'video_transcoding'

--- a/pkgs/tools/video/video-transcoding/Gemfile.lock
+++ b/pkgs/tools/video/video-transcoding/Gemfile.lock
@@ -1,0 +1,13 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    video_transcoding (0.25.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  video_transcoding
+
+BUNDLED WITH
+   1.17.2

--- a/pkgs/tools/video/video-transcoding/default.nix
+++ b/pkgs/tools/video/video-transcoding/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, lib, bundlerApp, makeWrapper
+, ffmpeg, handbrake, mkvtoolnix-cli, mp4v2
+}:
+
+bundlerApp rec {
+  pname = "video_transcoding";
+  gemdir = ./.;
+  exes = [
+    "convert-video"
+    "detect-crop"
+    "query-handbrake-log"
+    "transcode-video"
+  ];
+
+  buildInputs = [ makeWrapper ];
+  postBuild = ''
+    wrapProgram $out/bin/convert-video --prefix PATH : \
+      ${lib.makeBinPath [ ffmpeg handbrake mkvtoolnix-cli mp4v2 ]}
+    wrapProgram $out/bin/detect-crop --prefix PATH : \
+      ${lib.makeBinPath [ ffmpeg handbrake ]}
+    wrapProgram $out/bin/transcode-video --prefix PATH : \
+      ${lib.makeBinPath [ ffmpeg handbrake mkvtoolnix-cli mp4v2 ]}
+  '';
+
+  meta = with lib; {
+    description = "Tools to transcode, inspect and convert videos";
+    homepage    = https://github.com/donmelton/video_transcoding;
+    license     = licenses.mit;
+    maintainers = [ maintainers.bdesham ];
+    platforms   = platforms.all;
+  };
+}

--- a/pkgs/tools/video/video-transcoding/gemset.nix
+++ b/pkgs/tools/video/video-transcoding/gemset.nix
@@ -1,0 +1,12 @@
+{
+  video_transcoding = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0x964zsa3nvchfcp3n8jbi4mx6vv5zmqb31ksp498c2kqmjc42fb";
+      type = "gem";
+    };
+    version = "0.25.2";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2807,6 +2807,8 @@ in
     inherit (pythonPackages) sphinx;
   };
 
+  video-transcoding = callPackage ../tools/video/video-transcoding { };
+
   wallutils = callPackage ../tools/graphics/wallutils { };
 
   wev = callPackage ../tools/misc/wev { };


### PR DESCRIPTION
###### Motivation for this change

Adds [video_transcoding](https://github.com/donmelton/video_transcoding), a set of Ruby scripts that provide a simplified interface to (and reasonable defaults for) handbrake-cli, ffmpeg, and other tools.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).