### PR TITLE
sqldiff: init at 3.33.0

### DIFF
--- a/pkgs/development/libraries/sqlite/default.nix
+++ b/pkgs/development/libraries/sqlite/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   pname = "sqlite";
   version = "3.33.0";
 
-  # NB! Make sure to update analyzer.nix src (in the same directory).
+  # NB! Make sure to update ./tools.nix src (in the same directory).
   src = fetchurl {
     url = "https://sqlite.org/2020/sqlite-autoconf-${archiveVersion version}.tar.gz";
     sha256 = "05dvdfaxd552gj5p7k0i72sfam7lykaw1g2pfn52jnppqx42qshh";

--- a/pkgs/development/libraries/sqlite/tools.nix
+++ b/pkgs/development/libraries/sqlite/tools.nix
@@ -4,11 +4,11 @@ let
   archiveVersion = import ./archive-version.nix stdenv.lib;
   mkTool = { pname, makeTarget, description, homepage }: stdenv.mkDerivation rec {
     inherit pname;
-    version = "3.28.0";
+    version = "3.30.0";
 
     src = assert version == sqlite.version; fetchurl {
       url = "https://sqlite.org/2019/sqlite-src-${archiveVersion version}.zip";
-      sha256 = "15v57b113bpgcshfsx5jw93szar3da94rr03i053xhl15la7jllh";
+      sha256 = "0d4i87q0f618pmrgax0mr5x7m8bywikrwjvixag3biyhgl5rx7fd";
     };
 
     nativeBuildInputs = [ unzip ];

--- a/pkgs/development/libraries/sqlite/tools.nix
+++ b/pkgs/development/libraries/sqlite/tools.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, unzip, sqlite, tcl }:
+{ stdenv, fetchurl, unzip, sqlite, tcl, Foundation }:
 
 let
   archiveVersion = import ./archive-version.nix stdenv.lib;
@@ -12,7 +12,7 @@ let
     };
 
     nativeBuildInputs = [ unzip ];
-    buildInputs = [ tcl ];
+    buildInputs = [ tcl ] ++ stdenv.lib.optional stdenv.isDarwin Foundation;
 
     makeFlags = [ makeTarget ];
 

--- a/pkgs/development/libraries/sqlite/tools.nix
+++ b/pkgs/development/libraries/sqlite/tools.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchurl, unzip, sqlite, tcl }:
+
+let
+  archiveVersion = import ./archive-version.nix stdenv.lib;
+  mkTool = { pname, makeTarget, description, homepage }: stdenv.mkDerivation rec {
+    inherit pname;
+    version = "3.28.0";
+
+    src = assert version == sqlite.version; fetchurl {
+      url = "https://sqlite.org/2019/sqlite-src-${archiveVersion version}.zip";
+      sha256 = "15v57b113bpgcshfsx5jw93szar3da94rr03i053xhl15la7jllh";
+    };
+
+    nativeBuildInputs = [ unzip ];
+    buildInputs = [ tcl ];
+
+    makeFlags = [ makeTarget ];
+
+    installPhase = "install -Dt $out/bin ${makeTarget}";
+
+    meta = with stdenv.lib; {
+      inherit description homepage;
+      downloadPage = http://sqlite.org/download.html;
+      license = licenses.publicDomain;
+      maintainers = with maintainers; [ pesterhazy johnazoidberg ];
+      platforms = platforms.unix;
+    };
+  };
+in
+{
+  sqldiff = mkTool {
+    pname = "sqldiff";
+    makeTarget = "sqldiff";
+    description = "A tool that displays the differences between SQLite databases";
+    homepage = "https://www.sqlite.org/sqldiff.html";
+  };
+  sqlite-analyzer = mkTool {
+    pname = "sqlite-analyzer";
+    makeTarget = "sqlite3_analyzer";
+    description = "A tool that shows statistics about SQLite databases";
+    homepage = "https://www.sqlite.org/sqlanalyze.html";
+  };
+}

--- a/pkgs/development/libraries/sqlite/tools.nix
+++ b/pkgs/development/libraries/sqlite/tools.nix
@@ -4,11 +4,11 @@ let
   archiveVersion = import ./archive-version.nix stdenv.lib;
   mkTool = { pname, makeTarget, description, homepage }: stdenv.mkDerivation rec {
     inherit pname;
-    version = "3.30.0";
+    version = "3.33.0";
 
     src = assert version == sqlite.version; fetchurl {
-      url = "https://sqlite.org/2019/sqlite-src-${archiveVersion version}.zip";
-      sha256 = "0d4i87q0f618pmrgax0mr5x7m8bywikrwjvixag3biyhgl5rx7fd";
+      url = "https://sqlite.org/2020/sqlite-src-${archiveVersion version}.zip";
+      sha256 = "1f09srlrmcab1sf8j2d89s2kvknlbxk7mbsiwpndw9mall27dgwh";
     };
 
     nativeBuildInputs = [ unzip ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15412,9 +15412,9 @@ in
 
   sqlite = lowPrio (callPackage ../development/libraries/sqlite { });
 
-  sqlite-analyzer = lowPrio (callPackage ../development/libraries/sqlite/tools.nix { }).sqlite-analyzer;
-
-  sqldiff = lowPrio (callPackage ../development/libraries/sqlite/tools.nix { }).sqldiff;
+  inherit (callPackage ../development/libraries/sqlite/tools.nix {
+    inherit (darwin.apple_sdk.frameworks) Foundation;
+  }) sqlite-analyzer sqldiff;
 
   sqlar = callPackage ../development/libraries/sqlite/sqlar.nix { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15412,7 +15412,9 @@ in
 
   sqlite = lowPrio (callPackage ../development/libraries/sqlite { });
 
-  sqlite-analyzer = lowPrio (callPackage ../development/libraries/sqlite/analyzer.nix { });
+  sqlite-analyzer = lowPrio (callPackage ../development/libraries/sqlite/tools.nix { }).sqlite-analyzer;
+
+  sqldiff = lowPrio (callPackage ../development/libraries/sqlite/tools.nix { }).sqldiff;
 
   sqlar = callPackage ../development/libraries/sqlite/sqlar.nix { };
 


### PR DESCRIPTION
###### Motivation for this change
It's part of the SQLite tools: https://www.sqlite.org/download.html, https://www.sqlite.org/sqldiff.html
and can be built from the sources that we already have.
It generates SQL statements that represent the difference of two SQLite databases.

@pesterhazy why did you add `lowPrio` to the `sqlite-analyzer` package?
It's not included in any other derivation, right?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).