### PR TITLE
duplicity: Add backblaze-b2 as a build input to duplicity

### DIFF
--- a/pkgs/tools/backup/duplicity/default.nix
+++ b/pkgs/tools/backup/duplicity/default.nix
@@ -2,7 +2,8 @@
 , gnutar
 , par2cmdline
 , utillinux
-, rsync, makeWrapper }:
+, rsync
+, backblaze-b2, makeWrapper }:
 
 python2Packages.buildPythonApplication rec {
   pname = "duplicity";
@@ -40,10 +41,10 @@ python2Packages.buildPythonApplication rec {
   ];
 
   buildInputs = [ librsync makeWrapper python2Packages.wrapPython ];
-  propagatedBuildInputs = with python2Packages; [
+  propagatedBuildInputs = [ backblaze-b2 ] ++ (with python2Packages; [
     boto cffi cryptography ecdsa enum idna pygobject3 fasteners
     ipaddress lockfile paramiko pyasn1 pycrypto six
-  ];
+  ]);
   checkInputs = [
     gnupg  # Add 'gpg' to PATH.
     gnutar  # Add 'tar' to PATH.


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add backblaze b2 support to duplicity.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @peti 
