### PR TITLE
Update to NetBeans 11.1

### DIFF
--- a/pkgs/applications/editors/netbeans/default.nix
+++ b/pkgs/applications/editors/netbeans/default.nix
@@ -8,7 +8,7 @@ let
     name = "netbeans";
     exec = "netbeans";
     comment = "Integrated Development Environment";
-    desktopName = "Netbeans IDE";
+    desktopName = "Apache NetBeans IDE";
     genericName = "Integrated Development Environment";
     categories = "Application;Development;";
     icon = "netbeans";

--- a/pkgs/applications/editors/netbeans/default.nix
+++ b/pkgs/applications/editors/netbeans/default.nix
@@ -3,7 +3,7 @@
 }:
 
 let
-  version = "11.0";
+  version = "11.1";
   desktopItem = makeDesktopItem {
     name = "netbeans";
     exec = "netbeans";
@@ -18,8 +18,8 @@ stdenv.mkDerivation {
   pname = "netbeans";
   inherit version;
   src = fetchurl {
-    url = "mirror://apache/incubator/netbeans/incubating-netbeans/incubating-${version}/incubating-netbeans-${version}-bin.zip";
-    sha512 = "15mv59njrnq3sjfzb0n7xcc79kpixygf37cxvbswnvm651cw6lb1i9w8wbjivh0z4zcf3f62vbmshxh5pkaxqpqsg0iyy6gddfbwzwx";
+    url = "mirror://apache/netbeans/netbeans/${version}/netbeans-${version}-bin.zip";
+    sha512 = "bb061b9258d524b7b53b3b5ee9aa95111f7a391a5e2c5c0bc949164166af9a03d0cebbde2b47a8853fb765307b4c93ce8389a9c87bef26c92c08cdf446314e4d";
   };
 
   buildCommand = ''
@@ -48,7 +48,7 @@ stdenv.mkDerivation {
         convert -resize "$size"x"$size" netbeans_1024x1024x32.png $out/share/icons/hicolor/"$size"x"$size"/apps/netbeans.png
       fi
     done;
-    
+
     # Create desktop item, so we can pick it from the KDE/GNOME menu
     mkdir -pv $out/share/applications
     ln -s ${desktopItem}/share/applications/* $out/share/applications

--- a/pkgs/applications/editors/netbeans/default.nix
+++ b/pkgs/applications/editors/netbeans/default.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "An integrated development environment for Java, C, C++ and PHP";
-    homepage = "https://netbeans.org/";
+    homepage = "https://netbeans.apache.org/";
     license = stdenv.lib.licenses.asl20;
     maintainers = with stdenv.lib.maintainers; [ sander rszibele ];
     platforms = stdenv.lib.platforms.unix;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Updated NetBeans to 11.1 which contains several new features and bugfixes (http://netbeans.apache.org/download/nb111/index.html).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
```
[demo@nixos:~/dev/nix/nixpkgs]$ nix-shell -p nix-review --run "nix-review rev b10b7d07908"
$ git fetch --force https://github.com/NixOS/nixpkgs master:refs/nix-review/0
remote: Enumerating objects: 7, done.
remote: Counting objects: 100% (7/7), done.
remote: Total 7 (delta 5), reused 7 (delta 5), pack-reused 0
Unpacking objects: 100% (7/7), done.
From https://github.com/NixOS/nixpkgs
   8dbca5e3ca4..889537352b5  master     -> refs/nix-review/0
$ git worktree add /home/demo/.cache/nix-review/rev-b10b7d07908327fe00ac698646d9871790c07e8e/nixpkgs 889537352b5e208017dad66dd51b3923b7f2d23f
Preparing worktree (detached HEAD 889537352b5)
Checking out files: 100% (19839/19839), done.
HEAD is now at 889537352b5 h2o: 2.2.6 -> 2.3.0-beta2, enable multi-output
$ nix-env -f /home/demo/.cache/nix-review/rev-b10b7d07908327fe00ac698646d9871790c07e8e/nixpkgs -qaP --xml --out-path --show-trace
$ git merge --no-commit b10b7d07908327fe00ac698646d9871790c07e8e
Automatic merge went well; stopped before committing as requested
$ nix-env -f /home/demo/.cache/nix-review/rev-b10b7d07908327fe00ac698646d9871790c07e8e/nixpkgs -qaP --xml --out-path --show-trace --meta
$ nix build --no-link --keep-going --max-jobs 4 --option build-use-sandbox true -f /home/demo/.cache/nix-review/rev-b10b7d07908327fe00ac698646d9871790c07e8e/build.nix
[4 built, 131 copied (682.4 MiB), 157.4 MiB DL]
1 package were build:
netbeans

[0.0 MiB DL]
$ nix-shell /home/demo/.cache/nix-review/rev-b10b7d07908327fe00ac698646d9871790c07e8e/shell.nix
these paths will be fetched (1.51 MiB download, 8.27 MiB unpacked):
  /nix/store/jpmqrdn1jsghfhf6pndfq0mk17654d57-bash-interactive-4.4-p23-info
  /nix/store/lqg80z4wdkkwszkw6cwmazywvk9kvzvd-bash-interactive-4.4-p23-doc
  /nix/store/r9y9gg5lbsdgaxmhp6idl0k556l0x9hs-readline-7.0p5
  /nix/store/s9l4454hlkrbj5fd5yv1dr9xz1daqswj-bash-interactive-4.4-p23
  /nix/store/v4a4366hrmrwhg55fbq6fz39qvww56qg-bash-interactive-4.4-p23-man
  /nix/store/w4bin8lakab76zmcvixql3x77w7329zs-bash-interactive-4.4-p23-dev
copying path '/nix/store/lqg80z4wdkkwszkw6cwmazywvk9kvzvd-bash-interactive-4.4-p23-doc' from 'https://cache.nixos.org'...
copying path '/nix/store/jpmqrdn1jsghfhf6pndfq0mk17654d57-bash-interactive-4.4-p23-info' from 'https://cache.nixos.org'...
copying path '/nix/store/v4a4366hrmrwhg55fbq6fz39qvww56qg-bash-interactive-4.4-p23-man' from 'https://cache.nixos.org'...
copying path '/nix/store/r9y9gg5lbsdgaxmhp6idl0k556l0x9hs-readline-7.0p5' from 'https://cache.nixos.org'...
copying path '/nix/store/s9l4454hlkrbj5fd5yv1dr9xz1daqswj-bash-interactive-4.4-p23' from 'https://cache.nixos.org'...
copying path '/nix/store/w4bin8lakab76zmcvixql3x77w7329zs-bash-interactive-4.4-p23-dev' from 'https://cache.nixos.org'...
```
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @svanderburg @rszibele 
