### PR TITLE
cascadia-code: init at 1909.16

### DIFF
--- a/pkgs/data/fonts/cascadia-code/default.nix
+++ b/pkgs/data/fonts/cascadia-code/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  pname = "cascadia-code";
+  version = "1909.16";
+
+  src = fetchurl {
+    url = "https://github.com/microsoft/cascadia-code/releases/download/v${version}/Cascadia.ttf";
+    sha256 = "14qxvjhg1sswf3zssc4bkmjg5qy9k2md0zkhdq3zjh5w7wqmsj60";
+  };
+
+  dontUnpack = true;
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/fonts/truetype
+    cp $src $out/share/fonts/truetype/Cascadia.ttf
+
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/microsoft/cascadia-code;
+    description = "A fun, new monospaced font that includes programming ligatures by Microsoft.";
+    license = licenses.ofl;
+    maintainers = with maintainers; [ eadwu ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16595,6 +16595,8 @@ in
 
   charis-sil = callPackage ../data/fonts/charis-sil { };
 
+  cascadia-code = callPackage ../data/fonts/cascadia-code { };
+
   cherry = callPackage ../data/fonts/cherry { };
 
   cnstrokeorder = callPackage ../data/fonts/cnstrokeorder {};


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
