### PR TITLE
vimacs: init at 2016-03-24

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4878,6 +4878,12 @@
     githubId = 19479662;
     name = "Kajetan Champlewski";
   };
+  millerjason = {
+    email = "mailings-github@millerjason.com";
+    github = "millerjason";
+    githubId = 7610974;
+    name = "Jason Miller";
+  };
   miltador = {
     email = "miltador@yandex.ua";
     name = "Vasiliy Solovey";

--- a/pkgs/applications/editors/vim/vimacs.nix
+++ b/pkgs/applications/editors/vim/vimacs.nix
@@ -1,0 +1,34 @@
+{ stdenv, config, vim_configurable, macvim, vimPlugins
+, useMacvim ? stdenv.isDarwin && (config.vimacs.macvim or true)
+, vimacsExtraArgs ? "" }:
+
+stdenv.mkDerivation rec {
+  pname = "vimacs";
+  version = vimPackage.version;
+  vimPackage = if useMacvim then macvim else vim_configurable;
+
+  buildInputs = [ vimPackage vimPlugins.vimacs ];
+
+  buildCommand = ''
+    mkdir -p "$out"/bin
+    cp "${vimPlugins.vimacs}"/share/vim-plugins/vimacs/bin/vim $out/bin/vimacs
+    substituteInPlace "$out"/bin/vimacs \
+      --replace '-vim}' '-@bin@/bin/vim}' \
+      --replace '-gvim}' '-@bin@/bin/vim -g}' \
+      --replace '--cmd "let g:VM_Enabled = 1"' \
+                '--cmd "let g:VM_Enabled = 1" --cmd "set rtp^=@rtp@" ${vimacsExtraArgs}' \
+      --replace @rtp@ ${vimPlugins.vimacs.rtp} \
+      --replace @bin@ ${vimPackage}
+    for prog in vm gvm gvimacs vmdiff vimacsdiff
+    do
+      ln -s "$out"/bin/vimacs $out/bin/$prog
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Vim-Improved eMACS: Emacs emulation for Vim";
+    homepage = "http://algorithm.com.au/code/vimacs";
+    license = licenses.gpl2Plus;
+    maintainers = with stdenv.lib.maintainers; [ millerjason ];
+  };
+}

--- a/pkgs/misc/vim-plugins/generated.nix
+++ b/pkgs/misc/vim-plugins/generated.nix
@@ -5888,6 +5888,17 @@ let
     };
   };
 
+  vimacs = buildVimPluginFrom2Nix {
+    pname = "vimacs";
+    version = "2016-03-24";
+    src = fetchFromGitHub {
+      owner = "andrep";
+      repo = "vimacs";
+      rev = "7b8e297722d55089f0f0535fe6422533c98112fb";
+      sha256 = "0x92jcpdlvxhhdpwkv7ig9ya7s96yqjy6ms9xnx8djkf12xql16f";
+    };
+  };
+
   vimagit = buildVimPluginFrom2Nix {
     pname = "vimagit";
     version = "2020-01-12";

--- a/pkgs/misc/vim-plugins/overrides.nix
+++ b/pkgs/misc/vim-plugins/overrides.nix
@@ -460,6 +460,21 @@ self: super: {
       };
     });
 
+  vimacs = super.vimacs.overrideAttrs(old: {
+    buildPhase = ''
+      substituteInPlace bin/vim \
+        --replace '/usr/bin/vim' 'vim' \
+        --replace '/usr/bin/gvim' 'gvim'
+      # remove unnecessary duplicated bin wrapper script
+      rm -r plugin/vimacs
+    '';
+    meta = with stdenv.lib; {
+      description = "Vim-Improved eMACS: Emacs emulation plugin for Vim";
+      homepage = "http://algorithm.com.au/code/vimacs";
+      license = licenses.gpl2Plus;
+      maintainers = with stdenv.lib.maintainers; [ millerjason ];
+    };
+  });
 
   vimshell-vim = super.vimshell-vim.overrideAttrs(old: {
     dependencies = with super; [ vimproc-vim ];

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -9,6 +9,7 @@ alvan/vim-closetag
 alx741/vim-hindent
 alx741/vim-stylishask
 amiorin/ctrlp-z
+andrep/vimacs
 andreshazard/vim-logreview
 andsild/peskcolor.vim
 andviro/flake8-vim

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22447,6 +22447,8 @@ in
     gtk3 = if stdenv.isDarwin then gtk3-x11 else gtk3;
   });
 
+  vimacs = callPackage ../applications/editors/vim/vimacs.nix { };
+
   qpdfview = libsForQt5.callPackage ../applications/misc/qpdfview {};
 
   qtile = callPackage ../applications/window-managers/qtile {


### PR DESCRIPTION
	modified:   maintainers/maintainer-list.nix
	new file:   pkgs/applications/editors/vim/vimacs.nix
	modified:   pkgs/misc/vim-plugins/generated.nix
	modified:   pkgs/misc/vim-plugins/overrides.nix
	modified:   pkgs/top-level/all-packages.nix

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

vimacs is a vim-based editor with emacs key bindings

It is both a plugin as well as a wrapper around vim.  The wrapper is needed to set up vim as a modeless editor.

For the nix derivation, I've added the RTP and overrides to the wrapper commands allowing users to find this usable without any complex customization in vimrc.  This should let it co-exist happily with the original vim they are using.

I've tested vimacs (vm) and gvimacs (gvm) on both darwin and Linux built with --pure.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
