### PR TITLE
ocamlPackages.containers: 1.4 → 2.6.1, and related fixes

### DIFF
--- a/pkgs/development/ocaml-modules/containers/default.nix
+++ b/pkgs/development/ocaml-modules/containers/default.nix
@@ -1,53 +1,26 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, ocamlbuild, cppo, gen, sequence, qtest, ounit, result
-, qcheck }:
+{ lib, fetchFromGitHub, buildDunePackage, ocaml
+, iter, result, uchar
+, gen, mdx, ounit, qcheck, uutf
+}:
 
-let
-
-  mkpath = p:
-      "${p}/lib/ocaml/${ocaml.version}/site-lib";
-
-  version = "1.4";
-
-in
-
-stdenv.mkDerivation {
-  name = "ocaml${ocaml.version}-containers-${version}";
+buildDunePackage rec {
+  version = "2.6.1";
+  pname = "containers";
 
   src = fetchFromGitHub {
     owner = "c-cube";
     repo = "ocaml-containers";
     rev = version;
-    sha256 = "1wbarxphdrxvy7qsdp4p837h1zrv0z83pgs5lbz2h3kdnyvz2f1i";
+    sha256 = "02iq01pq6047hab5s8zpprwr21cygvzfcfj2lpsyj823f28crhmv";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild cppo gen sequence qtest ounit qcheck ];
+  buildInputs = [ iter ];
 
-  propagatedBuildInputs = [ result ];
+  checkInputs = lib.optionals doCheck [ gen mdx ounit qcheck uutf ];
 
-  preConfigure = ''
-    # The following is done so that the '#use "topfind"' directive works in the ocaml top-level
-    export HOME="$(mktemp -d)"
-    export OCAML_TOPLEVEL_PATH="${mkpath findlib}"
-    cat <<EOF > $HOME/.ocamlinit
-let () =
-  try Topdirs.dir_directory (Sys.getenv "OCAML_TOPLEVEL_PATH")
-  with Not_found -> ()
-;;
-EOF
-  '';
+  propagatedBuildInputs = [ result uchar ];
 
-  configureFlags = [
-    "--enable-unix"
-    "--enable-thread"
-    "--enable-tests"
-    "--enable-docs"
-    "--disable-bench"
-  ];
-
-  doCheck = true;
-  checkTarget = "test";
-
-  createFindlibDestdir = true;
+  doCheck = !lib.versionAtLeast ocaml.version "4.08";
 
   meta = {
     homepage = https://github.com/c-cube/ocaml-containers;
@@ -62,7 +35,6 @@ EOF
       It also features optional libraries for dealing with strings, and
       helpers for unix and threads.
     '';
-    license = stdenv.lib.licenses.bsd2;
-    platforms = ocaml.meta.platforms or [];
+    license = lib.licenses.bsd2;
   };
 }

--- a/pkgs/development/ocaml-modules/iter/default.nix
+++ b/pkgs/development/ocaml-modules/iter/default.nix
@@ -1,22 +1,20 @@
-{ stdenv, fetchFromGitHub, buildDunePackage, qtest, result }:
+{ lib, fetchFromGitHub, buildDunePackage, ocaml, mdx, qtest, result }:
 
 buildDunePackage rec {
-  pname = "sequence";
-  version = "1.1";
-
-  minimumOCamlVersion = "4.02";
+  pname = "iter";
+  version = "1.2.1";
 
   src = fetchFromGitHub {
     owner = "c-cube";
     repo = pname;
     rev = version;
-    sha256 = "08j37nldw47syq3yw4mzhhvya43knl0d7biddp0q9hwbaxhzgi44";
+    sha256 = "0j2sg50byn0ppmf6l36ksip7zx1d3gv7sc4hbbxs2rmx39jr7vxh";
   };
 
-  buildInputs = [ qtest ];
+  buildInputs = lib.optionals doCheck [ mdx qtest ];
   propagatedBuildInputs = [ result ];
 
-  doCheck = true;
+  doCheck = lib.versionAtLeast ocaml.version "4.04";
 
   meta = {
     homepage = https://github.com/c-cube/sequence;
@@ -27,6 +25,6 @@ buildDunePackage rec {
       like `filter`, `map`, `take`, `drop` and `append` can be performed before the
       sequence is iterated/folded on.
     '';
-    license = stdenv.lib.licenses.bsd2;
+    license = lib.licenses.bsd2;
   };
 }

--- a/pkgs/development/ocaml-modules/mdx/default.nix
+++ b/pkgs/development/ocaml-modules/mdx/default.nix
@@ -1,10 +1,8 @@
-{ stdenv, fetchFromGitHub, buildDunePackage, astring, cmdliner, cppo, fmt, logs, ocaml-migrate-parsetree, ocaml_lwt, pandoc, re }:
+{ lib, fetchFromGitHub, buildDunePackage, ocaml, astring, cmdliner, cppo, fmt, logs, ocaml-migrate-parsetree, ocaml_lwt, pandoc, re }:
 
 buildDunePackage rec {
   pname = "mdx";
   version = "1.4.0";
-
-  minimumOCamlVersion = "4.05";
 
   src = fetchFromGitHub {
     owner = "realworldocaml";
@@ -15,14 +13,16 @@ buildDunePackage rec {
 
   nativeBuildInputs = [ cppo ];
   buildInputs = [ astring cmdliner fmt logs ocaml-migrate-parsetree re ];
-  checkInputs = [ ocaml_lwt pandoc ];
+  checkInputs = lib.optionals doCheck [ ocaml_lwt pandoc ];
 
-  doCheck = true;
+  doCheck = !lib.versionAtLeast ocaml.version "4.08";
+
+  dontStrip = lib.versions.majorMinor ocaml.version == "4.04";
 
   meta = {
     homepage = https://github.com/realworldocaml/mdx;
     description = "Executable OCaml code blocks inside markdown files";
-    license = stdenv.lib.licenses.isc;
-    maintainers = [ stdenv.lib.maintainers.romildo ];
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.romildo ];
   };
 }

--- a/pkgs/development/ocaml-modules/printbox/default.nix
+++ b/pkgs/development/ocaml-modules/printbox/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, buildDunePackage, mdx }:
+{ lib, fetchFromGitHub, buildDunePackage, ocaml, mdx }:
 
 buildDunePackage rec {
   pname = "printbox";
@@ -13,14 +13,14 @@ buildDunePackage rec {
     sha256 = "16nwwpp13hzlcm9xqfxc558afm3i5s802dkj69l9s2vp04lgms5n";
   };
 
-  checkInputs = [ mdx ];
+  checkInputs = lib.optional doCheck mdx;
 
-  doCheck = true;
+  doCheck = !lib.versionAtLeast ocaml.version "4.08";
 
   meta = {
     homepage = https://github.com/c-cube/printbox/;
     description = "Allows to print nested boxes, lists, arrays, tables in several formats";
-    license = stdenv.lib.licenses.isc;
-    maintainers = [ stdenv.lib.maintainers.romildo ];
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.romildo ];
   };
 }

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -304,6 +304,8 @@ let
 
     iso8601 = callPackage ../development/ocaml-modules/iso8601 { };
 
+    iter = callPackage ../development/ocaml-modules/iter { };
+
     javalib = callPackage ../development/ocaml-modules/javalib {
       extlib = ocaml_extlib;
     };
@@ -620,8 +622,6 @@ let
     };
 
     seq = callPackage ../development/ocaml-modules/seq { };
-
-    sequence = callPackage ../development/ocaml-modules/sequence { };
 
     spacetime_lib = callPackage ../development/ocaml-modules/spacetime_lib { };
 


### PR DESCRIPTION
###### Motivation for this change

Compatibility with OCaml 4.08

The tests for `mdx` and `printbox` fail with OCaml 4.08: I’ve thus disabled them.

The old `sequence` library is now named `iter`.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @romildo (mdx, printbox).
