### PR TITLE
python37Packages.sentry-sdk: Fix tests

### DIFF
--- a/pkgs/development/python-modules/sentry-sdk/default.nix
+++ b/pkgs/development/python-modules/sentry-sdk/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, urllib3, certifi }:
+{ stdenv, buildPythonPackage, fetchPypi, urllib3, certifi, django, flask, tornado, sanic, aiohttp, bottle, rq, falcon, pyramid, celery }:
 
 buildPythonPackage rec {
   pname = "sentry-sdk";
@@ -8,6 +8,8 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "f5819df450d7b0696be69a0c6d70a09e4890a3844ee8ccb7a461794135bd5965";
   };
+
+  buildInputs = [ django flask tornado sanic aiohttp bottle rq falcon pyramid celery ];
 
   propagatedBuildInputs = [ urllib3 certifi ];
 

--- a/pkgs/development/python-modules/sentry-sdk/default.nix
+++ b/pkgs/development/python-modules/sentry-sdk/default.nix
@@ -9,7 +9,7 @@ buildPythonPackage rec {
     sha256 = "f5819df450d7b0696be69a0c6d70a09e4890a3844ee8ccb7a461794135bd5965";
   };
 
-  buildInputs = [ django flask tornado sanic aiohttp bottle rq falcon pyramid celery ];
+  checkInputs = [ django flask tornado sanic aiohttp bottle rq falcon pyramid celery ];
 
   propagatedBuildInputs = [ urllib3 certifi ];
 


### PR DESCRIPTION
Fix `python37Packages.sentry-sdk`, part of #68361 (zero Hydra failures).

This package failed to build because its test suite depends on many third-party packages that Sentry offers integration with if you depend on that package anyway. The test suite tests all of these, but they are not required at runtime unless you already use them, so I added them as `buildInputs`.

###### Motivation for this change

#68361

###### Things done


- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`) — there are none
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @gebner 
