### PR TITLE
kexi: patch error due to Qt 5.13

### DIFF
--- a/pkgs/applications/office/kexi/default.nix
+++ b/pkgs/applications/office/kexi/default.nix
@@ -1,5 +1,5 @@
 {
-  mkDerivation, lib, fetchurl, extra-cmake-modules, kdoctools,
+  mkDerivation, lib, fetchurl, fetchpatch, extra-cmake-modules, kdoctools,
   boost, qttools, qtwebkit,
   breeze-icons, karchive, kcodecs, kcompletion, kconfig, kconfigwidgets, kcoreaddons,
   kcrash, kguiaddons, ki18n, kiconthemes, kitemviews, kio, ktexteditor, ktextwidgets,
@@ -27,6 +27,17 @@ mkDerivation rec {
   ];
 
   propagatedUserEnvPkgs = [ kproperty ];
+
+  patches = [
+    # Changes in Qt 5.13 mean that QDate isn't exported from certain places,
+    # which the build was relying on. This patch explicitly imports QDate where
+    # needed.
+    # Should be unnecessary with kexi >= 3.3
+    (fetchpatch {
+      url = "https://cgit.kde.org/kexi.git/patch/src/plugins/forms/widgets/kexidbdatepicker.cpp?id=511d99b7745a6ce87a208bdbf69e631f1f136d53";
+      sha256 = "0m5cwq2v46gb1b12p7acck6dadvn7sw4xf8lkqikj9hvzq3r1dnj";
+    })
+  ];
 
   meta = with lib; {
     description = "A open source visual database applications creator, a long-awaited competitor for programs like MS Access or Filemaker";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This build was failing in 19.09 #68361 

I've fixed the build, but the executable still doesn't run properly for me, giving me:
```
$ result/bin/kexi-3.2 

(process:19064): Gtk-WARNING **: 10:18:21.423: Locale not supported by C library.
	Using the fallback 'C' locale.
Gtk-Message: 10:18:21.456: Failed to load module "canberra-gtk-module"
Gtk-Message: 10:18:21.456: Failed to load module "canberra-gtk-module"
qt.glx: qglx_findConfig: Failed to finding matching FBConfig (8 8 8 0)
qt.glx: qglx_findConfig: Failed to finding matching FBConfig (1 8 8 0)
qt.glx: qglx_findConfig: Failed to finding matching FBConfig (1 1 8 0)
qt.glx: qglx_findConfig: Failed to finding matching FBConfig (1 1 1 0)
qt.glx: qglx_findConfig: Failed to finding matching FBConfig (1 1 1 0)
qt.glx: qglx_findConfig: Failed to finding matching FBConfig (8 8 8 0)
qt.glx: qglx_findConfig: Failed to finding matching FBConfig (1 8 8 0)
qt.glx: qglx_findConfig: Failed to finding matching FBConfig (1 1 8 0)
qt.glx: qglx_findConfig: Failed to finding matching FBConfig (1 1 1 0)
qt.glx: qglx_findConfig: Failed to finding matching FBConfig (1 1 1 0)
Could not initialize GLX
Aborted (core dumped)
```

EDIT: apparently this only fails on Nix-on-other-Linux, possibly only with an NVidia graphics card.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @cillianderoiste 
