### PR TITLE
gdc: init at 9.3.0

### DIFF
--- a/pkgs/development/compilers/gcc/9/default.nix
+++ b/pkgs/development/compilers/gcc/9/default.nix
@@ -3,6 +3,7 @@
 , langAda ? false
 , langObjC ? stdenv.targetPlatform.isDarwin
 , langObjCpp ? stdenv.targetPlatform.isDarwin
+, langD ? false
 , langGo ? false
 , profiledCompiler ? false
 , staticCompiler ? false
@@ -58,6 +59,7 @@ let majorVersion = "9";
         sha256 = ""; # TODO: uncomment and check hash when available.
       }) */
       ++ optional langAda ../gnat-cflags.patch
+      ++ optional langD ../libphobos.patch
       ++ optional langFortran ../gfortran-driving.patch
       ++ optional (targetPlatform.libc == "musl" && targetPlatform.isPower) ../ppc-musl.patch
       ++ optional (!crossStageStatic && targetPlatform.isMinGW) (fetchpatch {
@@ -136,10 +138,10 @@ stdenv.mkDerivation ({
         )
     else "")
       + stdenv.lib.optionalString targetPlatform.isAvr ''
-	        makeFlagsArray+=(
-	           'LIMITS_H_TEST=false'
-	        )
-	      '';
+          makeFlagsArray+=(
+             'LIMITS_H_TEST=false'
+          )
+        '';
 
   inherit noSysDirs staticCompiler crossStageStatic
     libcCross crossMingw;
@@ -196,6 +198,7 @@ stdenv.mkDerivation ({
       enableShared
 
       langC
+      langD
       langCC
       langFortran
       langAda
@@ -235,14 +238,14 @@ stdenv.mkDerivation ({
 
   inherit
     (import ../common/extra-target-flags.nix {
-      inherit stdenv crossStageStatic libcCross threadsCross;
+      inherit stdenv crossStageStatic langD libcCross threadsCross;
     })
     EXTRA_TARGET_FLAGS
     EXTRA_TARGET_LDFLAGS
     ;
 
   passthru = {
-    inherit langC langCC langObjC langObjCpp langAda langFortran langGo version;
+    inherit langC langCC langObjC langObjCpp langAda langFortran langGo langD version;
     isGNU = true;
   };
 

--- a/pkgs/development/compilers/gcc/common/configure-flags.nix
+++ b/pkgs/development/compilers/gcc/common/configure-flags.nix
@@ -14,6 +14,7 @@
 
 , langC
 , langCC
+, langD ? false
 , langFortran
 , langJava ? false, javaAwtGtk ? false, javaAntlr ? null, javaEcj ? null
 , langAda ? false
@@ -114,6 +115,7 @@ let
         lib.concatStrings (lib.intersperse ","
           (  lib.optional langC        "c"
           ++ lib.optional langCC       "c++"
+          ++ lib.optional langD        "d"
           ++ lib.optional langFortran  "fortran"
           ++ lib.optional langJava     "java"
           ++ lib.optional langAda      "ada"
@@ -173,6 +175,9 @@ let
       "--disable-symvers"
       "libat_cv_have_ifunc=no"
       "--disable-gnu-indirect-function"
+    ]
+    ++ lib.optionals (langD) [
+      "--with-target-system-zlib=yes"
     ]
   ;
 

--- a/pkgs/development/compilers/gcc/common/extra-target-flags.nix
+++ b/pkgs/development/compilers/gcc/common/extra-target-flags.nix
@@ -1,4 +1,4 @@
-{ stdenv, crossStageStatic, libcCross, threadsCross }:
+{ stdenv, crossStageStatic, langD ? false, libcCross, threadsCross }:
 
 let
   inherit (stdenv) lib hostPlatform targetPlatform;
@@ -6,13 +6,13 @@ in
 
 {
   EXTRA_TARGET_FLAGS = let
-      mkFlags = dep: lib.optionals (targetPlatform != hostPlatform && dep != null) ([
+      mkFlags = dep: langD: lib.optionals (targetPlatform != hostPlatform && dep != null && !langD) ([
         "-idirafter ${lib.getDev dep}${dep.incdir or "/include"}"
       ] ++ stdenv.lib.optionals (! crossStageStatic) [
         "-B${lib.getLib dep}${dep.libdir or "/lib"}"
       ]);
-    in mkFlags libcCross
-    ++ lib.optionals (!crossStageStatic) (mkFlags threadsCross)
+    in mkFlags libcCross langD
+    ++ lib.optionals (!crossStageStatic) (mkFlags threadsCross langD)
     ;
 
   EXTRA_TARGET_LDFLAGS = let

--- a/pkgs/development/compilers/gcc/libphobos.patch
+++ b/pkgs/development/compilers/gcc/libphobos.patch
@@ -1,0 +1,119 @@
+diff --git a/Makefile.in b/Makefile.in
+index a375471..83c5ecb 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -804,7 +804,7 @@ BASE_FLAGS_TO_PASS = \
+ 	"STAGE1_LANGUAGES=$(STAGE1_LANGUAGES)" \
+ 	"GNATBIND=$(GNATBIND)" \
+ 	"GNATMAKE=$(GNATMAKE)" \
+-	"GDC=$(GDC)" \
++	"`echo 'GDC=$(GDC)' | sed -e 's/-idirafter [^ ]*//g'`" \
+ 	"GDCFLAGS=$(GDCFLAGS)" \
+ 	"AR_FOR_TARGET=$(AR_FOR_TARGET)" \
+ 	"AS_FOR_TARGET=$(AS_FOR_TARGET)" \
+@@ -817,7 +817,7 @@ BASE_FLAGS_TO_PASS = \
+ 	"GFORTRAN_FOR_TARGET=$(GFORTRAN_FOR_TARGET)" \
+ 	"GOC_FOR_TARGET=$(GOC_FOR_TARGET)" \
+ 	"GOCFLAGS_FOR_TARGET=$(GOCFLAGS_FOR_TARGET)" \
+-	"GDC_FOR_TARGET=$(GDC_FOR_TARGET)" \
++	"`echo 'GDC_FOR_TARGET=$(GDC_FOR_TARGET)' | sed -e 's/-idirafter [^ ]*//g'`" \
+ 	"GDCFLAGS_FOR_TARGET=$(GDCFLAGS_FOR_TARGET)" \
+ 	"LD_FOR_TARGET=$(LD_FOR_TARGET)" \
+ 	"LIPO_FOR_TARGET=$(LIPO_FOR_TARGET)" \
+@@ -890,7 +890,7 @@ EXTRA_HOST_FLAGS = \
+ 	'DLLTOOL=$(DLLTOOL)' \
+ 	'GFORTRAN=$(GFORTRAN)' \
+ 	'GOC=$(GOC)' \
+-	'GDC=$(GDC)' \
++	"`echo 'GDC=$(GDC)' | sed -e 's/-idirafter [^ ]*//g'`" \
+ 	'LD=$(LD)' \
+ 	'LIPO=$(LIPO)' \
+ 	'NM=$(NM)' \
+@@ -966,8 +966,11 @@ EXTRA_TARGET_FLAGS = \
+ 	'STAGE1_LDFLAGS=$$(POSTSTAGE1_LDFLAGS)' \
+ 	'STAGE1_LIBS=$$(POSTSTAGE1_LIBS)' \
+ 	"TFLAGS=$$TFLAGS"
++EXTRA_TARGET_FLAGS_D = \
++	"`echo $(EXTRA_TARGET_FLAGS) | sed -e 's/-idirafter [^ ]*//g'`"
+ 
+ TARGET_FLAGS_TO_PASS = $(BASE_FLAGS_TO_PASS) $(EXTRA_TARGET_FLAGS)
++TARGET_FLAGS_TO_PASS_D = $(BASE_FLAGS_TO_PASS) $(EXTRA_TARGET_FLAGS_D)
+ 
+ # Flags to pass down to gcc.  gcc builds a library, libgcc.a, so it
+ # unfortunately needs the native compiler and the target ar and
+@@ -47285,7 +47288,7 @@ check-target-libphobos:
+ 	s=`cd $(srcdir); ${PWD_COMMAND}`; export s; \
+ 	$(NORMAL_TARGET_EXPORTS) \
+ 	(cd $(TARGET_SUBDIR)/libphobos && \
+-	  $(MAKE) $(TARGET_FLAGS_TO_PASS)   check)
++	  $(MAKE) $(TARGET_FLAGS_TO_PASS_D)   check)
+ 
+ @endif target-libphobos
+ 
+@@ -47300,7 +47303,7 @@ install-target-libphobos: installdirs
+ 	s=`cd $(srcdir); ${PWD_COMMAND}`; export s; \
+ 	$(NORMAL_TARGET_EXPORTS) \
+ 	(cd $(TARGET_SUBDIR)/libphobos && \
+-	  $(MAKE) $(TARGET_FLAGS_TO_PASS)  install)
++	  $(MAKE) $(TARGET_FLAGS_TO_PASS_D)  install)
+ 
+ @endif target-libphobos
+ 
+@@ -47315,7 +47318,7 @@ install-strip-target-libphobos: installdirs
+ 	s=`cd $(srcdir); ${PWD_COMMAND}`; export s; \
+ 	$(NORMAL_TARGET_EXPORTS) \
+ 	(cd $(TARGET_SUBDIR)/libphobos && \
+-	  $(MAKE) $(TARGET_FLAGS_TO_PASS)  install-strip)
++	  $(MAKE) $(TARGET_FLAGS_TO_PASS_D)  install-strip)
+ 
+ @endif target-libphobos
+ 
+diff --git a/Makefile.tpl b/Makefile.tpl
+index 41cae58..b3d32e7 100644
+--- a/Makefile.tpl
++++ b/Makefile.tpl
+@@ -721,8 +721,11 @@ EXTRA_TARGET_FLAGS = \
+ 	'STAGE1_LDFLAGS=$$(POSTSTAGE1_LDFLAGS)' \
+ 	'STAGE1_LIBS=$$(POSTSTAGE1_LIBS)' \
+ 	"TFLAGS=$$TFLAGS"
++EXTRA_TARGET_FLAGS_D = \
++	"`echo $(EXTRA_TARGET_FLAGS) | sed -e 's/-idirafter [^ ]*//g'`"
+ 
+ TARGET_FLAGS_TO_PASS = $(BASE_FLAGS_TO_PASS) $(EXTRA_TARGET_FLAGS)
++TARGET_FLAGS_TO_PASS_D = $(BASE_FLAGS_TO_PASS) $(EXTRA_TARGET_FLAGS_D)
+ 
+ # Flags to pass down to gcc.  gcc builds a library, libgcc.a, so it
+ # unfortunately needs the native compiler and the target ar and
+diff --git a/libphobos/Makefile.in b/libphobos/Makefile.in
+index e894417..2d18dcb 100644
+--- a/libphobos/Makefile.in
++++ b/libphobos/Makefile.in
+@@ -365,6 +365,7 @@ AM_MAKEFLAGS = \
+ 	"LIBCFLAGS=$(LIBCFLAGS)" \
+ 	"LIBCFLAGS_FOR_TARGET=$(LIBCFLAGS_FOR_TARGET)" \
+ 	"MAKE=$(MAKE)" \
++	"`echo 'MAKEFLAGS=$(MAKEFLAGS)' | sed -e 's/-j[0-9]+/-j1/'`" \
+ 	"MAKEINFO=$(MAKEINFO) $(MAKEINFOFLAGS)" \
+ 	"PICFLAG=$(PICFLAG)" \
+ 	"PICFLAG_FOR_TARGET=$(PICFLAG_FOR_TARGET)" \
+@@ -694,6 +695,8 @@ uninstall-am:
+ 
+ .PRECIOUS: Makefile
+ 
++.NOTPARALLEL:
++
+ # GNU Make needs to see an explicit $(MAKE) variable in the command it
+ # runs to enable its job server during parallel builds.  Hence the
+ # comments below.
+diff --git a/libphobos/configure b/libphobos/configure
+index b3cb5f3..25adf2b 100755
+--- a/libphobos/configure
++++ b/libphobos/configure
+@@ -5122,6 +5122,7 @@ ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ ac_compiler_gnu=$ac_cv_c_compiler_gnu
+ 
++GDC=`$as_echo "$GDC" | sed -e 's/-idirafter [^ ]*//g'`
+ 
+ ac_ext=d
+ ac_compile='$GDC -c $GDCFLAGS conftest.$ac_ext >&5'

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8545,6 +8545,15 @@ in
   gcc-arm-embedded-9 = callPackage ../development/compilers/gcc-arm-embedded/9 {};
   gcc-arm-embedded = gcc-arm-embedded-9;
 
+  gdc = gdc9;
+  gdc9 = wrapCC (gcc9.cc.override {
+    name = "gdc";
+    langCC = false;
+    langC = false;
+    langD = true;
+    profiledCompiler = false;
+  });
+
   gforth = callPackage ../development/compilers/gforth {};
 
   gleam = callPackage ../development/compilers/gleam {
@@ -9324,7 +9333,7 @@ in
     isGNU = cc.isGNU or false;
     isClang = cc.isClang or false;
 
-    inherit cc bintools libc extraPackages;
+    inherit cc bintools libc extraPackages zlib;
   } // extraArgs; in self);
 
   wrapCC = cc: wrapCCWith {


### PR DESCRIPTION
###### Motivation for this change

As of version 9, GCC has a front-end for the [D language](https://dlang.org/), but the option to do so has not yet been included in nixpkgs. Packaging has been requested before and this is an attempt to move forward #68419 .

However, in the current state it doesn't work quite yet, so I would appreciate any help (I will also ask for help on the [Dlang GDC forum](https://forum.dlang.org/group/gdc)).

Inspiration for the flags that are set has been found in https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=gdc-git .

Issues I ran into when building with `nix-build -p gdc -K --cores 1`:
* When compiling without forcing `--disable-shared`, there are linker errors about needing to compile with `-fPIC`. It seems that some files are built using that flag, but not all, and I'm not sure how to go about forcing it for the rest.
* When invoking `nix-build` without specifying `--cores 1` there are problems when building `libphobos`; it looks like object files are moved before they are generated. This problem goes away when I build on a single core, but of course everything takes a very long time to try out.
* I have disabled bootstrapping for now to speed up the debugging process, hopefully it can be enabled again later on.
* In the current state of commit, when building with a single core, the process gets almost to the end but fails at the last part with

```
post-installation fixup
shrinking RPATHs of ELF executables and libraries in /nix/store/vgds3ba2r2s8fhqshqc6p0rc555fl8ns-gdc-wrapper-9.2.0
patching script interpreter paths in /nix/store/vgds3ba2r2s8fhqshqc6p0rc555fl8ns-gdc-wrapper-9.2.0
checking for references to /build/ in /nix/store/vgds3ba2r2s8fhqshqc6p0rc555fl8ns-gdc-wrapper-9.2.0...
building '/nix/store/7156ndb6f7a3jca8izbapdsmpd2v7llv-shell.drv'...
builder for '/nix/store/7156ndb6f7a3jca8izbapdsmpd2v7llv-shell.drv' failed to produce output path '/nix/store/rglh1pai765h6x1gjrrk4pbzq8vh1y09-shell'
note: keeping build directory '/tmp/nix-build-shell.drv-1'
error: build of '/nix/store/7156ndb6f7a3jca8izbapdsmpd2v7llv-shell.drv' failed
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @synthetica
