### PR TITLE
pythonPackages.hcloud: init at 1.6.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3587,6 +3587,12 @@
     githubId = 307589;
     name = "Nathaniel Baxter";
   };
+  liff = {
+    email = "liff@iki.fi";
+    github = "liff";
+    githubId = 124475;
+    name = "Olli Helenius";
+  };
   lightbulbjim = {
     email = "chris@killred.net";
     github = "lightbulbjim";

--- a/pkgs/development/python-modules/hcloud/default.nix
+++ b/pkgs/development/python-modules/hcloud/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, future
+, requests
+, python-dateutil
+, flake8
+, isort
+, mock
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "hcloud";
+  version = "1.6.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1skqq36k1dm7mngfg9c93pb1rdvmbapc0cv8zj00hnm63r67hmrj";
+  };
+
+  propagatedBuildInputs = [ future requests python-dateutil ];
+
+  checkInputs = [ flake8 isort mock pytest ];
+
+  # Skip integration tests since they require a separate external fake API endpoint.
+  checkPhase = ''
+    pytest --ignore=tests/integration
+  '';
+
+  meta = with lib; {
+    description = "Official Hetzner Cloud python library";
+    homepage = "https://github.com/hetznercloud/hcloud-python";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ liff ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6268,6 +6268,8 @@ in {
   runway-python = callPackage ../development/python-modules/runway-python { };
 
   pyprof2calltree = callPackage ../development/python-modules/pyprof2calltree { };
+
+  hcloud = callPackage ../development/python-modules/hcloud { };
 });
 
 in fix' (extends overrides packages)


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add this Python package: https://pypi.org/project/hcloud

As well as being useful for Python scripts that use the hcloud API it is also used by Ansible’s [‘hcloud’ cloud module](https://docs.ansible.com/ansible/latest/modules/list_of_cloud_modules.html#hcloud).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
