### PR TITLE
Add ledger_agent, trezor_agent and keepkey_agent packages

### DIFF
--- a/pkgs/development/python-modules/keepkey_agent/default.nix
+++ b/pkgs/development/python-modules/keepkey_agent/default.nix
@@ -1,0 +1,29 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, keepkey
+, setuptools
+, libagent
+, wheel
+}:
+
+buildPythonPackage rec {
+  pname = "keepkey_agent";
+  version = "0.9.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "03779gvlx70i0nnry98i4pl1d92604ix5x6jgdfkrdgzqbh5vj27";
+  };
+
+  propagatedBuildInputs = [
+    keepkey libagent setuptools wheel
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Using KeepKey as hardware-based SSH/PGP agent";
+    homepage = https://github.com/romanz/trezor-agent;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ hkjn np mmahut ];
+  };
+}

--- a/pkgs/development/python-modules/ledger_agent/default.nix
+++ b/pkgs/development/python-modules/ledger_agent/default.nix
@@ -1,0 +1,29 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, ledgerblue
+, setuptools
+, libagent
+, wheel
+}:
+
+buildPythonPackage rec {
+  pname = "ledger_agent";
+  version = "0.9.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "03zj602m2rln9yvr08dswy56vzkbldp8b074ixwzz525dafblr92";
+  };
+
+  propagatedBuildInputs = [
+    ledgerblue libagent setuptools wheel
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Using Ledger as hardware-based SSH/PGP agent";
+    homepage = https://github.com/romanz/trezor-agent;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ hkjn np mmahut ];
+  };
+}

--- a/pkgs/development/python-modules/trezor_agent/default.nix
+++ b/pkgs/development/python-modules/trezor_agent/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec{
     description = "Using Trezor as hardware SSH agent";
     homepage = "https://github.com/romanz/trezor-agent";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ np mmahut ];
+    maintainers = with maintainers; [ hkjn np mmahut ];
   };
 
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6711,6 +6711,8 @@ in
 
   trezord = callPackage ../servers/trezord { };
 
+  trezor_agent = with python3Packages; toPythonApplication trezor_agent;
+
   tthsum = callPackage ../applications/misc/tthsum { };
 
   chaps = callPackage ../tools/security/chaps { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4274,6 +4274,8 @@ in
 
   kexectools = callPackage ../os-specific/linux/kexectools { };
 
+  keepkey_agent = with python3Packages; toPythonApplication keepkey_agent;
+
   kexpand = callPackage ../development/tools/kexpand { };
 
   keybase = callPackage ../tools/security/keybase {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22249,6 +22249,8 @@ in
     inherit (darwin.apple_sdk.frameworks) IOKit;
   };
 
+  ledger_agent = with python3Packages; toPythonApplication ledger_agent;
+
   ledger-live-desktop = callPackage ../applications/blockchains/ledger-live-desktop { };
 
   litecoin  = callPackage ../applications/blockchains/litecoin.nix {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6001,6 +6001,8 @@ in {
 
   libagent = callPackage ../development/python-modules/libagent { };
 
+  ledger_agent = callPackage ../development/python-modules/ledger_agent { };
+
   ledgerblue = callPackage ../development/python-modules/ledgerblue { };
 
   ecpy = callPackage ../development/python-modules/ecpy { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5999,6 +5999,8 @@ in {
 
   keepkey = callPackage ../development/python-modules/keepkey { };
 
+  keepkey_agent = callPackage ../development/python-modules/keepkey_agent { };
+
   libagent = callPackage ../development/python-modules/libagent { };
 
   ledger_agent = callPackage ../development/python-modules/ledger_agent { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add new `ledger_agent`, `trezor_agent` and `keepkey_agent` packages, providing the binaries:

* `ledger-agent`
* `ledger-gpg`
* `trezor-agent`
* `trezor-gpg`
* `keepkey-agent`

Also add hkjn as initial maintainer for `pythonPackages.trezor_agent`.

_Edit:_ Updated description after changes from review feedback.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @mmahut @np 