### PR TITLE
ocamlPackages.ptmap: 2.0.3 → 2.0.4

### DIFF
--- a/pkgs/development/ocaml-modules/ptmap/default.nix
+++ b/pkgs/development/ocaml-modules/ptmap/default.nix
@@ -1,13 +1,22 @@
 { stdenv, fetchzip, ocaml, findlib, obuild }:
 
-let version = "2.0.3"; in
+let param =
+  if stdenv.lib.versionAtLeast ocaml.version "4.07"
+  then {
+    version = "2.0.4";
+    sha256 = "05a391m1l04zigi6ghywj7f5kxy2w6186221k7711wmg56m94yjw";
+  } else {
+    version = "2.0.3";
+    sha256 = "19xykhqk7q25r1pj8rpfj53j2r9ls8mxi1w5m2wqshrf20gf078h";
+  }
+; in
 
 stdenv.mkDerivation {
-  name = "ocaml${ocaml.version}-ptmap-${version}";
+  name = "ocaml${ocaml.version}-ptmap-${param.version}";
 
   src = fetchzip {
-    url = "https://github.com/backtracking/ptmap/archive/v${version}.tar.gz";
-    sha256 = "19xykhqk7q25r1pj8rpfj53j2r9ls8mxi1w5m2wqshrf20gf078h";
+    url = "https://github.com/backtracking/ptmap/archive/v${param.version}.tar.gz";
+    inherit (param) sha256;
   };
 
   buildInputs = [ ocaml findlib obuild ];


### PR DESCRIPTION
Ensures compatibility with OCaml 4.07

The old version (2.0.3) is kept for OCaml ≤ 4.06

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

