### PR TITLE
linuxPackages_5_3.openafs_1_8: fix build

### DIFF
--- a/pkgs/servers/openafs/1.8/module.nix
+++ b/pkgs/servers/openafs/1.8/module.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, which, autoconf, automake, flex, yacc
-, kernel, glibc, perl, libtool_2, kerberos }:
+, kernel, glibc, perl, libtool_2, kerberos, fetchpatch }:
 
 with (import ./srcs.nix { inherit fetchurl; });
 
@@ -10,6 +10,20 @@ let
 in stdenv.mkDerivation {
   name = "openafs-${version}-${kernel.modDirVersion}";
   inherit version src;
+
+  patches = [
+    # Linux 5.3
+    (fetchpatch {
+      name = "openafs_1_8-recurse-keyring_search.patch";
+      url = "http://git.openafs.org/?p=openafs.git;a=patch;h=02d82275c17284d04629282aa374bb39f511c989";
+      sha256 = "03pkldwf6i67yf6i1705qp18rx5b0b342ryda8vfjw9lnvpinygs";
+    })
+    (fetchpatch {
+      name = "openafs_1_8-send-sig.patch";
+      url = "http://git.openafs.org/?p=openafs.git;a=patch;h=2b7af1243f46496c0b5973b3fa2a6396243f7613";
+      sha256 = "13gyh5ncpp15dl7056gdzl5xhp2bmafc557bd2a4bwx9nyj53bag";
+    })
+  ];
 
   nativeBuildInputs = [ autoconf automake flex libtool_2 perl which yacc ]
     ++ kernel.moduleBuildDependencies;


### PR DESCRIPTION
This update cherry-picks patches necessary to build the OpenAFS kernel
module from the OpenAFS master branch. This commit does not fix OpenAFS
1.6.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

OpenAFS failed to build


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @spacefrogg @maggesi 
