### PR TITLE
ycmd: 2018-09-20 -> 2019-09-19; add optional golang completion

### DIFF
--- a/pkgs/development/tools/misc/ycmd/default.nix
+++ b/pkgs/development/tools/misc/ycmd/default.nix
@@ -7,12 +7,12 @@
 
 stdenv.mkDerivation {
   pname = "ycmd";
-  version = "2018-09-20";
+  version = "2019-09-19";
 
   src = fetchgit {
     url = "https://github.com/Valloric/ycmd.git";
-    rev = "bf658fd78722c517674c0aaf2381e199bca8f163";
-    sha256 = "1lwa8xr76vapfpncvp81cn3m9219yw14fl7fzk5gnly60zkphbbl";
+    rev = "c6d360775b0c5c82e2513dce7b625f8bf3812702";
+    sha256 = "19rxlval20gg65xc5p7q9cnzfm9zw2j0m6vxxk0vqlalcyh0rnzd";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/tools/misc/ycmd/default.nix
+++ b/pkgs/development/tools/misc/ycmd/default.nix
@@ -51,16 +51,17 @@ stdenv.mkDerivation {
 
     mkdir -p $out/lib/ycmd/third_party/{gocode,godef,racerd/target/release}
 
-    for p in jedi waitress frozendict bottle parso python-future requests; do
-      cp -r third_party/$p $out/lib/ycmd/third_party
-    done
+    # Copy everything: the structure of third_party has been known to change.
+    # When linking our own libraries below, do so with '-f'
+    # to clobber anything we may have copied here.
+    cp -r third_party/* $out/lib/ycmd/third_party/
 
   '' + lib.optionalString (gocode != null) ''
-    ln -s ${gocode}/bin/gocode $out/lib/ycmd/third_party/gocode
+    ln -sf ${gocode}/bin/gocode $out/lib/ycmd/third_party/gocode
   '' + lib.optionalString (godef != null) ''
-    ln -s ${godef}/bin/godef $out/lib/ycmd/third_party/godef
+    ln -sf ${godef}/bin/godef $out/lib/ycmd/third_party/godef
   '' + lib.optionalString (rustracerd != null) ''
-    ln -s ${rustracerd}/bin/racerd $out/lib/ycmd/third_party/racerd/target/release
+    ln -sf ${rustracerd}/bin/racerd $out/lib/ycmd/third_party/racerd/target/release
   '';
 
   # fixup the argv[0] and replace __file__ with the corresponding path so

--- a/pkgs/development/tools/misc/ycmd/default.nix
+++ b/pkgs/development/tools/misc/ycmd/default.nix
@@ -1,6 +1,7 @@
 { stdenv, lib, fetchgit, cmake, llvmPackages, boost, python
 , gocode ? null
 , godef ? null
+, gotools ? null
 , rustracerd ? null
 , fixDarwinDylibNames, Cocoa ? null
 }:
@@ -49,19 +50,28 @@ stdenv.mkDerivation {
     mkdir -p $out/bin
     ln -s $out/lib/ycmd/ycmd/__main__.py $out/bin/ycmd
 
-    mkdir -p $out/lib/ycmd/third_party/{gocode,godef,racerd/target/release}
-
     # Copy everything: the structure of third_party has been known to change.
     # When linking our own libraries below, do so with '-f'
     # to clobber anything we may have copied here.
+    mkdir -p $out/lib/ycmd/third_party
     cp -r third_party/* $out/lib/ycmd/third_party/
 
   '' + lib.optionalString (gocode != null) ''
-    ln -sf ${gocode}/bin/gocode $out/lib/ycmd/third_party/gocode
+    TARGET=$out/lib/ycmd/third_party/gocode
+    mkdir -p $TARGET
+    ln -sf ${gocode}/bin/gocode $TARGET
   '' + lib.optionalString (godef != null) ''
-    ln -sf ${godef}/bin/godef $out/lib/ycmd/third_party/godef
+    TARGET=$out/lib/ycmd/third_party/godef
+    mkdir -p $TARGET
+    ln -sf ${godef}/bin/godef $TARGET
+  '' + lib.optionalString (gotools != null) ''
+    TARGET=$out/lib/ycmd/third_party/go/src/golang.org/x/tools/cmd/gopls
+    mkdir -p $TARGET
+    ln -sf ${gotools}/bin/gopls $TARGET
   '' + lib.optionalString (rustracerd != null) ''
-    ln -sf ${rustracerd}/bin/racerd $out/lib/ycmd/third_party/racerd/target/release
+    TARGET=$out/lib/ycmd/third_party/racerd/target/release
+    mkdir -p $TARGET
+    ln -sf ${rustracerd}/bin/racerd $TARGET
   '';
 
   # fixup the argv[0] and replace __file__ with the corresponding path so


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Needed golang support for ycmd.

###### Things done
1. Fix ycmd build (see dfc7bdb)
2. Update ycmd to 2019-09-19 (see 7d21d6a)
3. Add golang completer support (see dee0cb7)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions : ubuntu-18.04
- [ n/a ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
    ```
    /nix/store/5xbbjfriyy7kmfkpwklls3418h9i7spx-ycmd-2019-09-19	 2122140720
    /nix/store/njw3hsp4pgm78nvx6m65avrvy416yma9-ycmd-2018-09-20	 1838635488
    ```
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
