### PR TITLE
redo-apenwarr: fix source URL

### DIFF
--- a/pkgs/development/tools/build-managers/redo-apenwarr/default.nix
+++ b/pkgs/development/tools/build-managers/redo-apenwarr/default.nix
@@ -17,10 +17,10 @@ in stdenv.mkDerivation rec {
   pname = "redo-apenwarr";
   version = "0.42";
 
-  src = fetchFromGitHub {
+  src = fetchFromGitHub rec {
     owner = "apenwarr";
-    repo = pname;
-    rev = "${pname}-${version}";
+    repo = "redo";
+    rev = "${repo}-${version}";
     sha256 = "1060yb7hrxm8c7bfvb0y4j0acpxsj6hbykw1d9549zpkxxr9nsgm";
   };
 


### PR DESCRIPTION
###### Motivation for this change

Fixes build regression from #65457

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
