### PR TITLE
zbar: disable Qt assertions

### DIFF
--- a/pkgs/tools/graphics/zbar/default.nix
+++ b/pkgs/tools/graphics/zbar/default.nix
@@ -50,6 +50,9 @@ stdenv.mkDerivation rec {
     qtx11extras
   ];
 
+  # Disable assertions which include -dev QtBase file paths.
+  NIX_CFLAGS_COMPILE = [ "-DQT_NO_DEBUG" ];
+
   configureFlags = [
     "--without-python"
   ] ++ (if enableDbus then [


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Greatly decreases zbar-lib transitive closure size: assertion messages
contain paths to Qt header files, causing zbar-lib to depend on
qtbase-dev.

The Qt specific mkDerivation normally does this automatically, but we
can't use it here due to having only a small part of the project being
Qt related.

Before/after:
```
$ nix path-info -Sh /nix/store/yxcljqcpg03qrgp9cagvclkwx0rllq7m-zbar-0.23-lib
/nix/store/yxcljqcpg03qrgp9cagvclkwx0rllq7m-zbar-0.23-lib          1.1G
$ nix path-info -Sh /nix/store/864nvvs52wcplg8xslzhc54l5msiyngq-zbar-0.23-lib
/nix/store/864nvvs52wcplg8xslzhc54l5msiyngq-zbar-0.23-lib        493.0M
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).