### PR TITLE
nixos/postgresql: switch default 9.6 -> 11

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1909.xml
+++ b/nixos/doc/manual/release-notes/rl-1909.xml
@@ -34,6 +34,13 @@
     </para>
    </listitem>
    <listitem>
+    <para>
+     Postgresql for NixOS service now defaults to v11. <literal>pkgs.postgresql</literal> is still 9.6, but
+     may be updated in future release. To prevent future update problems replace <literal>pkgs.postgresql</literal>
+     with an explicitly versioned <literal>pkgs.postgresql_9_6</literal>.
+    </para>
+   </listitem>
+   <listitem>
      <para>
        The binfmt module is now easier to use. Additional systems can
        be added through <option>boot.binfmt.emulatedSystems</option>.

--- a/nixos/doc/manual/release-notes/rl-1909.xml
+++ b/nixos/doc/manual/release-notes/rl-1909.xml
@@ -34,13 +34,6 @@
     </para>
    </listitem>
    <listitem>
-    <para>
-     Postgresql for NixOS service now defaults to v11. <literal>pkgs.postgresql</literal> is still 9.6, but
-     may be updated in future release. To prevent future update problems replace <literal>pkgs.postgresql</literal>
-     with an explicitly versioned <literal>pkgs.postgresql_9_6</literal>.
-    </para>
-   </listitem>
-   <listitem>
      <para>
        The binfmt module is now easier to use. Additional systems can
        be added through <option>boot.binfmt.emulatedSystems</option>.

--- a/nixos/doc/manual/release-notes/rl-2003.xml
+++ b/nixos/doc/manual/release-notes/rl-2003.xml
@@ -23,6 +23,11 @@
      Support is planned until the end of October 2020, handing over to 20.09.
     </para>
    </listitem>
+   <listitem>
+    <para>
+     Postgresql for NixOS service now defaults to v11.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -226,7 +226,8 @@ in
       # Note: when changing the default, make it conditional on
       # ‘system.stateVersion’ to maintain compatibility with existing
       # systems!
-      mkDefault (if versionAtLeast config.system.stateVersion "17.09" then pkgs.postgresql_9_6
+      mkDefault (if versionAtLeast config.system.stateVersion "19.09" then pkgs.postgresql_11
+            else if versionAtLeast config.system.stateVersion "17.09" then pkgs.postgresql_9_6
             else if versionAtLeast config.system.stateVersion "16.03" then pkgs.postgresql_9_5
             else throw "postgresql_9_4 was removed, please upgrade your postgresql version.");
 

--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -226,7 +226,7 @@ in
       # Note: when changing the default, make it conditional on
       # ‘system.stateVersion’ to maintain compatibility with existing
       # systems!
-      mkDefault (if versionAtLeast config.system.stateVersion "19.09" then pkgs.postgresql_11
+      mkDefault (if versionAtLeast config.system.stateVersion "20.03" then pkgs.postgresql_11
             else if versionAtLeast config.system.stateVersion "17.09" then pkgs.postgresql_9_6
             else if versionAtLeast config.system.stateVersion "16.03" then pkgs.postgresql_9_5
             else throw "postgresql_9_4 was removed, please upgrade your postgresql version.");


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/issues/69141

This is designed to be merged fast for 19.09 release. 20.03 or 20.09 should then include PG12.

This *may* break beta-19.09 and nixos-unstable, but it shouldn't be a problem *after* 19.09 release.
I should have this done before 19.03 was branched off. Maybe we should learn from this and already declare 20.09 as Pg12.

cc @peti @disassembler 