### PR TITLE
komodo-python3-dbgp: init at 11.1.1

### DIFF
--- a/pkgs/development/tools/komodo-python3-dbgp/default.nix
+++ b/pkgs/development/tools/komodo-python3-dbgp/default.nix
@@ -1,0 +1,23 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  python3Packages
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "komodo-python3-dbgp";
+  version = "11.1.1";
+
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "11ndpihpass7bpq5v61klvkhvnydqkr8mpdl24bkw2h6k46dzlci";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/agroszer/komodo-python3-dbgp";
+    description = "ActiveState Komodo's PyDBGp server";
+    # https://github.com/agroszer/komodo-python3-dbgp/blob/master/LICENSE.txt#L27
+    license = licenses.mit;
+    maintainers = with maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17730,6 +17730,8 @@ in
 
   das_watchdog = callPackage ../tools/system/das_watchdog { };
 
+  komodo-python3-dbgp = callPackage ../development/tools/komodo-python3-dbgp {};
+
   dbvisualizer = callPackage ../applications/misc/dbvisualizer {};
 
   dd-agent = callPackage ../tools/networking/dd-agent/5.nix { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).