### PR TITLE
sonic-pi: add midi support

### DIFF
--- a/pkgs/applications/audio/sonic-pi/default.nix
+++ b/pkgs/applications/audio/sonic-pi/default.nix
@@ -14,6 +14,7 @@
 , supercollider
 , qscintilla
 , qwt
+, osmid
 }:
 
 let
@@ -59,6 +60,10 @@ mkDerivation rec {
   buildPhase = ''
     export SONIC_PI_HOME=$TMPDIR
     export AUBIO_LIB=${aubio}/lib/libaubio.so
+    export OSMID_DIR=app/server/native/osmid
+
+    mkdir -p $OSMID_DIR
+    cp ${osmid}/bin/{m2o,o2m} $OSMID_DIR
 
     pushd app/server/ruby/bin
       ./compile-extensions.rb
@@ -95,11 +100,10 @@ mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://sonic-pi.net/;
+    homepage = "https://sonic-pi.net/";
     description = "Free live coding synth for everyone originally designed to support computing and music lessons within schools";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ Phlogistique kamilchm ];
     platforms = lib.platforms.linux;
-    broken = true;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20616,7 +20616,9 @@ in
 
   wavebox = callPackage ../applications/networking/instant-messengers/wavebox { };
 
-  sonic-pi = libsForQt5.callPackage ../applications/audio/sonic-pi { };
+  sonic-pi = libsForQt5.callPackage ../applications/audio/sonic-pi {
+    ruby = ruby_2_4;  # sonic-pi build breaks with ruby 2.5 and 2.6
+  };
 
   st = callPackage ../applications/misc/st {
     conf = config.st.conf or null;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This PR adds MIDI support to Sonic PI through the use of the `osmid` dependency. By using `osmid` Sonic Pi finds attached MIDI devices and shows them in the interface (see https://sonic-pi.net/tutorial.html#section-11). Tested with a https://www.akaipro.com/kb/akai-pro-midimix-setup-with-logic-pro-x/

Also pinned the ruby version to `ruby_2_4` as the package fails to build with the latest `ruby`. This should fix https://github.com/NixOS/nixpkgs/issues/68361

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
