### PR TITLE
firecracker: 0.15.2 -> 0.18.0

### DIFF
--- a/pkgs/applications/virtualization/firecracker/default.nix
+++ b/pkgs/applications/virtualization/firecracker/default.nix
@@ -1,7 +1,7 @@
 { fetchurl, stdenv }:
 
 let
-  version = "0.15.2";
+  version = "0.18.0";
   baseurl = "https://github.com/firecracker-microvm/firecracker/releases/download";
 
   fetchbin = name: sha256: fetchurl {
@@ -9,8 +9,8 @@ let
     inherit sha256;
   };
 
-  firecracker-bin = fetchbin "firecracker" "11g0iz1krsm6gzhvf0fb4101c6qyk6bl8j3kjidbb52x9i4aqsxk";
-  jailer-bin      = fetchbin "jailer"      "0j1gc1cdsfsi82fkvvxla25791lcvk6vmp46i82f0ms9xm7xhswz";
+  firecracker-bin = fetchbin "firecracker" "140g93z0k8yd9lr049ps4dj0psb9ac1v7g5zs7lzpws9rj8shmgh";
+  jailer-bin      = fetchbin "jailer"      "0sk1zm1fx0zdy5il8vyygzads72ni2lcil42wv59j8b2bg8p7fwd";
 in
 stdenv.mkDerivation {
   name = "firecracker-${version}";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @thoughtpolice