### PR TITLE
haskellPackages.pinboard-notes-backup: mark not broken

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -7824,7 +7824,6 @@ broken-packages:
   - pier-core
   - piet
   - pig
-  - pinboard-notes-backup
   - pinchot
   - ping
   - pinpon


### PR DESCRIPTION
##### Motivation for this change

Marks the pinboard-notes-backup Hackage package as not broken.

I’m the maintainer of this package; it broke in the LTS Haskell 13 to 14 transition because its dependencies could no longer be satisfied. I updated the package and published the update to Hackage. That updated version is now in Nixpkgs master so this package can be marked as unbroken.

###### Things done

- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions

###### Notify maintainers

cc @peti
