### PR TITLE
libcerf: 1.5 -> 1.13

### DIFF
--- a/pkgs/development/libraries/libcerf/default.nix
+++ b/pkgs/development/libraries/libcerf/default.nix
@@ -1,16 +1,19 @@
-{ stdenv, lib, fetchurl }:
+{ stdenv, lib, fetchurl, cmake, perl }:
 
-stdenv.mkDerivation {
-  name = "libcerf-1.5";
+stdenv.mkDerivation rec {
+  pname = "libcerf";
+  version = "1.13";
 
   src = fetchurl {
-    url = "http://apps.jcns.fz-juelich.de/src/libcerf/libcerf-1.5.tgz";
-    sha256 = "11jwr8ql4a9kmv04ycgwk4dsqnlv4l65a8aa0x1i3y7zwx3w2vg3";
+    url = "https://jugit.fz-juelich.de/mlz/libcerf/-/archive/v${version}/libcerf-v${version}.tar.gz";
+    sha256 = "01d3fr4qa0080xdgp66mjbsa884qivn9y83p7rdyz2l3my0rysg4";
   };
+
+  nativeBuildInputs = [ cmake perl ];
 
   meta = with lib; {
     description = "Complex error (erf), Dawson, Faddeeva, and Voigt function library";
-    homepage = http://apps.jcns.fz-juelich.de/doku/sc/libcerf;
+    homepage = https://jugit.fz-juelich.de/mlz/libcerf;
     license = licenses.mit;
     maintainers = with maintainers; [ orivej ];
     platforms = platforms.all;


### PR DESCRIPTION
Upstream has moved the src tarball download location and homepage for `libcerf`,
so the current package is broken. While fixing it, let's upgrade to the latest
version, which is built with cmake now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @orivej 
