### PR TITLE
unit: 1.10.0 -> 1.11.0

### DIFF
--- a/pkgs/servers/http/unit/default.nix
+++ b/pkgs/servers/http/unit/default.nix
@@ -14,14 +14,14 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  version = "1.10.0";
+  version = "1.11.0";
   pname = "unit";
 
   src = fetchFromGitHub {
     owner = "nginx";
     repo = "unit";
     rev = version;
-    sha256 = "00y7hc6bzn38f9mcqxnzddnwwsiba4ss9vwd9vgc95sj0yvv885a";
+    sha256 = "05qplbwki8kcj0xy9d39gf8lhwwg2cx24waxd1q5cb0fq9a5hprm";
   };
 
   nativeBuildInputs = [ which ];


### PR DESCRIPTION
###### Motivation for this change
Update package to version 1.11.0
Chengelog:
 - Feature: basic support for serving static files.
 - Feature: isolation of application processes with Linux namespaces.
 - Feature: built-in WebSocket server implementation for Java Servlet Containers.
 - Feature: direct addressing of API configuration options containing slashes "/" using URI encoding (%2F).
 - Bugfix: segmentation fault might have occurred in Go applications under high load.
 - Bugfix: WebSocket support was broken if Unit was built with some linkers other than GNU ld (e.g. gold or LLD).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
