### PR TITLE
radeon-profile: 20170714 -> 20190903 [19.09 backport]

### DIFF
--- a/pkgs/tools/misc/radeon-profile/default.nix
+++ b/pkgs/tools/misc/radeon-profile/default.nix
@@ -5,7 +5,7 @@
 mkDerivation rec {
 
   pname = "radeon-profile";
-  version = "20170714";
+  version = "20190903";
 
   nativeBuildInputs = [ qmake ];
   buildInputs = [ qtbase qtcharts libXrandr libdrm ];
@@ -14,12 +14,12 @@ mkDerivation rec {
     owner  = "marazmista";
     repo   = "radeon-profile";
     rev    = version;
-    sha256 = "08fv824iq00zbl9xk9zsfs8gkk8rsy6jlxbmszrjfx7ji28hansd";
+    sha256 = "0ax5417q03xjwi3pn7yyjdb90ssaygdprfgb1pz9nkyk6773ckx5";
   }) + "/radeon-profile";
 
-  postInstall = ''
-    mkdir -p $out/bin
-    cp ./radeon-profile $out/bin/radeon-profile
+  preConfigure = ''
+    substituteInPlace radeon-profile.pro \
+      --replace "/usr/" "$out/"
   '';
 
   meta = with lib; {

--- a/pkgs/tools/misc/radeon-profile/default.nix
+++ b/pkgs/tools/misc/radeon-profile/default.nix
@@ -1,6 +1,8 @@
-{ stdenv, fetchFromGitHub, qtbase, qtcharts, qmake, libXrandr, libdrm }:
+{ lib, mkDerivation, fetchFromGitHub
+, qtbase, qtcharts, qmake, libXrandr, libdrm
+}:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
 
   pname = "radeon-profile";
   version = "20170714";
@@ -20,7 +22,7 @@ stdenv.mkDerivation rec {
     cp ./radeon-profile $out/bin/radeon-profile
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Application to read current clocks of AMD Radeon cards";
     homepage    = https://github.com/marazmista/radeon-profile;
     license     = licenses.gpl2Plus;


### PR DESCRIPTION
###### Motivation for this change
Backport of #69248

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change
- [x] Tested execution of all binary files (just radeon-profile)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
