### PR TITLE
afew: propagate setuptools

### DIFF
--- a/pkgs/applications/networking/mailreaders/afew/default.nix
+++ b/pkgs/applications/networking/mailreaders/afew/default.nix
@@ -12,7 +12,7 @@ pythonPackages.buildPythonApplication rec {
   nativeBuildInputs = with pythonPackages; [ sphinx setuptools_scm ];
 
   propagatedBuildInputs = with pythonPackages; [
-    pythonPackages.notmuch chardet dkimpy
+    pythonPackages.setuptools pythonPackages.notmuch chardet dkimpy
   ] ++ stdenv.lib.optional (!pythonPackages.isPy3k) subprocess32;
 
   makeWrapperArgs = [


### PR DESCRIPTION
###### Motivation for this change
afew fails to run on current master, as setuptools isn't propagated anymore

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
