### PR TITLE
pythonPackages.cairocffi: v1.0.2 -> v.1.1.0

### DIFF
--- a/pkgs/development/python-modules/cairocffi/default.nix
+++ b/pkgs/development/python-modules/cairocffi/default.nix
@@ -19,8 +19,8 @@
 }@args:
 
 import ./generic.nix ({
-  version = "1.0.2";
-  sha256 = "01ac51ae12c4324ca5809ce270f9dd1b67f5166fe63bd3e497e9ea3ca91946ff";
+  version = "1.1.0";
+  sha256 = "1nq53f5jipgy9jgyfxp43j40qfbmrhgn1cj8bp5rrb3liy3wbh7i";
   dlopen_patch = ./dlopen-paths.patch;
   disabled = pythonOlder "3.5";
   inherit withXcffib;

--- a/pkgs/development/python-modules/cairocffi/dlopen-paths.patch
+++ b/pkgs/development/python-modules/cairocffi/dlopen-paths.patch
@@ -1,46 +1,61 @@
-commit 0435bc2577d4b18f54b78b2f5185abb2b2005982
-Author: Alexander V. Nikolaev <avn@avnik.info>
-Date:   Sat Feb 6 08:09:06 2016 +0200
+Patch dlopen() to allow direct paths to all required libs
 
-    Patch dlopen() to allow direct paths to all required libs
+This is an update of the patch submitted in
+https://github.com/NixOS/nixpkgs/commit/b13e44e094989d3a902f8c73b22e8d3c0cc7acf4
+by Alexander V. Nikolaev <avn@avnik.info>
 
-    This patch is NixOS specific
+---
+ cairocffi/__init__.py | 34 ++++++++++++++++------------------
+ 1 file changed, 16 insertions(+), 18 deletions(-)
 
 diff --git a/cairocffi/__init__.py b/cairocffi/__init__.py
-index 6061973..3538a58 100644
+index 307d58c..43c29e3 100644
 --- a/cairocffi/__init__.py
 +++ b/cairocffi/__init__.py
-@@ -21,19 +21,22 @@ VERSION = __version__ = (Path(__file__).parent / 'VERSION').read_text().strip()
- version = '1.16.0'
- version_info = (1, 16, 0)
+@@ -21,28 +21,26 @@ VERSION = __version__ = (Path(__file__).parent / 'VERSION').read_text().strip()
+ version = '1.17.2'
+ version_info = (1, 17, 2)
 
-+# Use hardcoded soname, because ctypes.util use gcc/objdump which shouldn't be required for runtime
++# Use hardcoded soname, because ctypes.util use gcc/objdump which shouldn't be
++# required for runtime
 +_LIBS = {
 +    'cairo': '@cairo@/lib/libcairo@ext@',
 +    'glib-2.0': '@glib@/lib/libglib-2.0@ext@',
 +    'gobject-2.0': '@glib@/lib/libgobject-2.0@ext@',
 +    'gdk_pixbuf-2.0': '@gdk_pixbuf@/lib/libgdk_pixbuf-2.0@ext@',
 +}
++
 
--def dlopen(ffi, *names):
-+def dlopen(ffi, name, *names):
+ def dlopen(ffi, library_names, filenames):
      """Try various names for the same library, for different platforms."""
--    for name in names:
--        for lib_name in (name, 'lib' + name):
--            try:
--                path = ctypes.util.find_library(lib_name)
--                lib = ffi.dlopen(path or lib_name)
--                if lib:
--                    return lib
--            except OSError:
--                pass
--    raise OSError("dlopen() failed to load a library: %s" % ' / '.join(names))
-+    path = _LIBS.get(name, None)
-+    if path:
-+        lib = ffi.dlopen(path)
-+        if lib:
-+            return lib
-+    raise OSError("dlopen() failed to load a library: %s as %s" % (name, path))
+-    exceptions = []
+-
+     for library_name in library_names:
+-        library_filename = find_library(library_name)
+-        if library_filename:
+-            filenames = (library_filename,) + filenames
+-        else:
+-            exceptions.append(
+-                'no library called "{}" was found'.format(library_name))
+-
+-    for filename in filenames:
+-        try:
+-            return ffi.dlopen(filename)
+-        except OSError as exception:  # pragma: no cover
+-            exceptions.append(exception)
+-
+-    error_message = '\n'.join(  # pragma: no cover
+-        str(exception) for exception in exceptions)
+-    raise OSError(error_message)  # pragma: no cover
++        path = _LIBS.get(library_name, None)
++        if path:
++            lib = ffi.dlopen(path)
++            if lib:
++                return lib
++
++    raise OSError("dlopen() failed to load a library: %s as %s" % (library_name, path))
 
 
- cairo = dlopen(ffi, 'cairo', 'cairo-2', 'cairo-gobject-2', 'cairo.so.2')
+ cairo = dlopen(
+--
+2.19.2


### PR DESCRIPTION
###### Motivation for this change

Fixes: https://github.com/NixOS/nixpkgs/issues/69126
Related to: https://github.com/NixOS/nixpkgs/issues/68361

The tests were failing due the switch to pytest5.
This issue has been addressed upstream in
https://github.com/Kozea/cairocffi/commit/a500f208660ba9861828a2a92b32c33565ee18fd
which is included in v.1.1.0, so bumping the version and
updating the old patch.

Hydra log of the failure:
https://hydra.nixos.org/build/100785460/nixlog/6

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @avnik 
