### PR TITLE
nixos/mailcatcher: add bind capabilities

### DIFF
--- a/nixos/modules/services/mail/mailcatcher.nix
+++ b/nixos/modules/services/mail/mailcatcher.nix
@@ -3,7 +3,7 @@
 let
   cfg = config.services.mailcatcher;
 
-  inherit (lib) mkEnableOption mkIf mkOption types;
+  inherit (lib) mkEnableOption mkIf mkOption types optionalString;
 in
 {
   # interface
@@ -54,6 +54,7 @@ in
         DynamicUser = true;
         Restart = "always";
         ExecStart = "${pkgs.mailcatcher}/bin/mailcatcher --foreground --no-quit --http-ip ${cfg.http.ip} --http-port ${toString cfg.http.port} --smtp-ip ${cfg.smtp.ip} --smtp-port ${toString cfg.smtp.port}";
+        AmbientCapabilities = optionalString (cfg.http.port < 1024 || cfg.smtp.port < 1024) "cap_net_bind_service";
       };
     };
   };


### PR DESCRIPTION
allow `mailcatcher` to bind to privileged ports 