### PR TITLE
openems: init at 0.35.0

### DIFF
--- a/pkgs/applications/science/electronics/appcsxcad/default.nix
+++ b/pkgs/applications/science/electronics/appcsxcad/default.nix
@@ -1,0 +1,54 @@
+{ stdenv
+, mkDerivation
+, fetchFromGitHub
+, cmake
+, csxcad
+, qcsxcad
+, hdf5
+, vtkWithQt5
+, qtbase
+, wrapQtAppsHook
+, fparser
+, tinyxml
+, cgal
+, boost
+}:
+
+mkDerivation {
+  pname = "appcsxcad";
+  version = "unstable-2020-01-04";
+
+  src = fetchFromGitHub {
+    owner = "thliebig";
+    repo = "AppCSXCAD";
+    rev = "de8c271ec8b57e80233cb2a432e3d7fd54d30876";
+    sha256 = "0shnfa0if3w588a68gr82qi6k7ldg1j2921fnzji90mmay21birp";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    csxcad
+    qcsxcad
+    hdf5
+    vtkWithQt5
+    qtbase
+    fparser
+    tinyxml
+    cgal
+    boost
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Minimal Application using the QCSXCAD library";
+    homepage = "https://github.com/thliebig/AppCSXCAD";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ matthuszagh ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/science/electronics/openems/default.nix
+++ b/pkgs/applications/science/electronics/openems/default.nix
@@ -1,0 +1,75 @@
+{ stdenv
+, fetchFromGitHub
+, csxcad
+, fparser
+, tinyxml
+, hdf5
+, vtk
+, boost
+, zlib
+, cmake
+, octave
+, gl2ps
+, withQcsxcad ? true
+, withMPI ? false
+, withHyp2mat ? true
+, qcsxcad ? null
+, openmpi ? null
+, hyp2mat ? null
+}:
+
+assert withQcsxcad -> qcsxcad != null;
+assert withMPI -> openmpi != null;
+assert withHyp2mat -> hyp2mat != null;
+
+stdenv.mkDerivation {
+  pname = "openems";
+  version = "unstable-2020-02-15";
+
+  src = fetchFromGitHub {
+    owner = "thliebig";
+    repo = "openEMS";
+    rev = "ba793ac84e2f78f254d6d690bb5a4c626326bbfd";
+    sha256 = "1dca6b6ccy771irxzsj075zvpa3dlzv4mjb8xyg9d889dqlgyl45";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  cmakeFlags = stdenv.lib.optionals withMPI [ "-DWITH_MPI=ON" ];
+
+  buildInputs = [
+    fparser
+    tinyxml
+    hdf5
+    vtk
+    boost
+    zlib
+    csxcad
+    (octave.override { inherit gl2ps hdf5; })
+    (if withQcsxcad then qcsxcad else null)
+    (if withMPI then openmpi else null)
+    (if withHyp2mat then hyp2mat else null)
+  ];
+
+  postFixup = ''
+    substituteInPlace $out/share/openEMS/matlab/setup.m \
+      --replace /usr/lib ${hdf5}/lib \
+      --replace /usr/include ${hdf5}/include
+
+    ${octave}/bin/mkoctfile -L${hdf5}/lib -I${hdf5}/include \
+      -lhdf5 $out/share/openEMS/matlab/h5readatt_octave.cc \
+      -o $out/share/openEMS/matlab/h5readatt_octave.oct
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Open Source Electromagnetic Field Solver";
+    homepage = http://openems.de/index.php/Main_Page.html;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ matthuszagh ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/science/electronics/qcsxcad/default.nix
+++ b/pkgs/applications/science/electronics/qcsxcad/default.nix
@@ -1,0 +1,50 @@
+{ stdenv
+, mkDerivation
+, fetchFromGitHub
+, cmake
+, csxcad
+, tinyxml
+, vtkWithQt5
+, wrapQtAppsHook
+, qtbase
+}:
+
+mkDerivation {
+  pname = "qcsxcad";
+  version = "unstable-2020-01-04";
+
+  src = fetchFromGitHub {
+    owner = "thliebig";
+    repo = "QCSXCAD";
+    rev = "0dabbaf2bc1190adec300871cf309791af842c8e";
+    sha256 = "11kbh0mxbdfh7s5azqin3i2alic5ihmdfj0jwgnrhlpjk4cbf9rn";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    wrapQtAppsHook
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_INSTALL_PREFIX=${placeholder "out"}"
+    "-DCSXCAD_ROOT_DIR=${csxcad}"
+    "-DENABLE_RPATH=OFF"
+  ];
+
+  buildInputs = [
+    csxcad
+    tinyxml
+    vtkWithQt5
+    qtbase
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Qt-GUI for CSXCAD";
+    homepage = "https://github.com/thliebig/QCSXCAD";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ matthuszagh ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/python-csxcad/default.nix
+++ b/pkgs/development/python-modules/python-csxcad/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub
+, python, pythonPackages, cython
+, openems, csxcad
+}:
+
+buildPythonPackage rec {
+  pname = "python-csxcad";
+  version = "0.6.2";
+
+  src = fetchFromGitHub {
+    owner = "thliebig";
+    repo = "CSXCAD";
+    rev = "55899d0fc3dbfc2eb3ec60af9783925926e661a9";
+    sha256 = "18h10575c8k0bx7l0pk5ksqfc1vvnsg98br2987y8x4jmrw2jy50";
+  };
+
+  sourceRoot = "source/python";
+
+  buildInputs = [
+    cython
+  ];
+
+  propagatedBuildInputs = [
+    openems
+    csxcad
+    python
+    pythonPackages.numpy
+    pythonPackages.matplotlib
+  ];
+
+  setupPyBuildFlags = "-I${openems}/include -L${openems}/lib -R${openems}/lib";
+
+  meta = with stdenv.lib; {
+    description = "Python interface to CSXCAD";
+    homepage = http://openems.de/index.php/Main_Page.html;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ matthuszagh ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/python-openems/default.nix
+++ b/pkgs/development/python-modules/python-openems/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub
+, python, pythonPackages, cython
+, openems, csxcad, boost
+}:
+
+buildPythonPackage rec {
+  pname = "python-openems";
+  version = "0.0.33";
+
+  src = fetchFromGitHub {
+    owner = "thliebig";
+    repo = "openEMS";
+    rev = "ffcf5ee0a64b2c64be306a3154405b0f13d5fbba";
+    sha256 = "1c8wlv0caxlhpicji26k93i9797f1alz6g2kc3fi18id0b0bjgha";
+  };
+
+  sourceRoot = "source/python";
+
+  buildInputs = [
+    cython
+    boost
+  ];
+
+  propagatedBuildInputs = [
+    openems
+    csxcad
+    python
+    pythonPackages.python-csxcad
+    pythonPackages.numpy
+    pythonPackages.h5py
+  ];
+
+  setupPyBuildFlags = "-I${openems}/include -L${openems}/lib -R${openems}/lib";
+
+  meta = with stdenv.lib; {
+    description = "Python interface to OpenEMS";
+    homepage = http://openems.de/index.php/Main_Page.html;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ matthuszagh ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25770,6 +25770,10 @@ in
 
   pcb = callPackage ../applications/science/electronics/pcb { };
 
+  qcsxcad = libsForQt5.callPackage ../applications/science/electronics/qcsxcad {
+    inherit (qt5) wrapQtAppsHook qtbase;
+  };
+
   qucs = callPackage ../applications/science/electronics/qucs { };
 
   xcircuit = callPackage ../applications/science/electronics/xcircuit { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25772,6 +25772,8 @@ in
 
   ngspice = callPackage ../applications/science/electronics/ngspice { };
 
+  openems = callPackage ../applications/science/electronics/openems { };
+
   pcb = callPackage ../applications/science/electronics/pcb { };
 
   qcsxcad = libsForQt5.callPackage ../applications/science/electronics/qcsxcad {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25726,6 +25726,10 @@ in
 
   adms = callPackage ../applications/science/electronics/adms { };
 
+  appcsxcad = libsForQt5.callPackage ../applications/science/electronics/appcsxcad {
+    inherit (qt5) qtbase wrapQtAppsHook;
+  };
+
   # Since version 8 Eagle requires an Autodesk account and a subscription
   # in contrast to single payment for the charged editions.
   # This is the last version with the old model.

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4544,6 +4544,8 @@ in {
 
   python-oauth2 = callPackage ../development/python-modules/python-oauth2 { };
 
+  python-openems = callPackage ../development/python-modules/python-openems { };
+
   python-csxcad = callPackage ../development/python-modules/python-csxcad { };
 
   python_openzwave = callPackage ../development/python-modules/python_openzwave {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4544,6 +4544,8 @@ in {
 
   python-oauth2 = callPackage ../development/python-modules/python-oauth2 { };
 
+  python-csxcad = callPackage ../development/python-modules/python-csxcad { };
+
   python_openzwave = callPackage ../development/python-modules/python_openzwave {
     inherit (pkgs) pkgconfig;
   };


### PR DESCRIPTION
[OpenEMS](http://openems.de/index.php/Main_Page.html) is an open-source electromagnetic field solver that uses the FDTD method.

This commit adds a number of related packages as dependencies for OpenEMS, including appcsxcad, csxcad, fparser, hyp2mat, and qcsxcad.

Additionally, it makes a few changes to existing, dependent packages:

1. Adds QT GUI support to VTK.
2. Adds gl2ps as an optional dependency of octave, which is needed for certain OpenEMS plots.
3. Adds openmpi C++ libraries.
4. Makes cgal headers and libraries discoverable by OpenEMS.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
