### PR TITLE
simplenote: 1.1.3 -> 1.8.0

### DIFF
--- a/pkgs/applications/misc/simplenote/default.nix
+++ b/pkgs/applications/misc/simplenote/default.nix
@@ -1,64 +1,75 @@
-{ fetchurl, stdenv, lib, zlib, glib, alsaLib, dbus, gtk2, atk, pango, freetype, fontconfig
-, libgnome-keyring3, gdk-pixbuf, cairo, cups, expat, libgpgerror, nspr
-, nss, xorg, libcap, systemd, libnotify ,libXScrnSaver, gnome2 }:
+{ atomEnv, autoPatchelfHook, dpkg, fetchurl, makeDesktopItem, makeWrapper
+, stdenv, udev, wrapGAppsHook }:
 
-stdenv.mkDerivation rec {
+let
+  inherit (stdenv.hostPlatform) system;
 
-  name = "simplenote-${pkgver}";
-  pkgver = "1.1.3";
+  pname = "simplenote";
 
-  src = fetchurl {
-    url = "https://github.com/Automattic/simplenote-electron/releases/download/v${pkgver}/Simplenote-linux-${pkgver}.tar.gz";
-    sha256 = "1z92yyjmg3bgfqfdpnysf98h9hhhnqzdqqigwlmdmn3d7fy49kcf";
-  };
+  version = "1.8.0";
 
-  buildCommand = let
-
-    packages = [
-      stdenv.cc.cc zlib glib dbus gtk2 atk pango freetype libgnome-keyring3
-      fontconfig gdk-pixbuf cairo cups expat libgpgerror alsaLib nspr nss
-      xorg.libXrender xorg.libX11 xorg.libXext xorg.libXdamage xorg.libXtst
-      xorg.libXcomposite xorg.libXi xorg.libXfixes xorg.libXrandr
-      xorg.libXcursor libcap systemd libnotify libXScrnSaver gnome2.GConf
-      xorg.libxcb
-    ];
-
-    libPathNative = lib.makeLibraryPath packages;
-    libPath64 = lib.makeSearchPathOutput "lib" "lib64" packages;
-    libPath = "${libPathNative}:${libPath64}";
-
-  in ''
-    mkdir -p $out/share/
-    mkdir -p $out/bin
-    tar xvzf $src -C $out/share/
-    mv $out/share/Simplenote-linux-x64 $out/share/simplenote
-    mv $out/share/simplenote/Simplenote $out/share/simplenote/simplenote
-    mkdir -p $out/share/applications
-
-    cat > $out/share/applications/simplenote.desktop << EOF
-    [Desktop Entry]
-    Name=Simplenote
-    Comment=Simplenote for Linux
-    Exec=$out/bin/simplenote
-    Icon=$out/share/simplenote/Simplenote.png
-    Type=Application
-    StartupNotify=true
-    Categories=Development;
-    EOF
-
-    fixupPhase
-
-    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-      --set-rpath "${libPath}:$out/share/simplenote" \
-      $out/share/simplenote/simplenote
-
-    ln -s $out/share/simplenote/simplenote $out/bin/simplenote
-  '';
+  sha256 = {
+    x86_64-linux = "066gr1awdj5nwdr1z57mmvx7dd1z19g0wzsgbnrrb89bqfj67ykl";
+  }.${system};
 
   meta = with stdenv.lib; {
     description = "The simplest way to keep notes";
-    homepage = https://github.com/Automattic/simplenote-electron;
-    license = licenses.lgpl2;
+    homepage = "https://github.com/Automattic/simplenote-electron";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ kiwi ];
     platforms = [ "x86_64-linux" ];
   };
-}
+
+  linux = stdenv.mkDerivation rec {
+    inherit pname version meta;
+
+    src = fetchurl {
+      url =
+        "https://github.com/Automattic/simplenote-electron/releases/download/"
+        + "v${version}/Simplenote-linux-${version}-amd64.deb";
+      inherit sha256;
+    };
+
+    desktopItem = makeDesktopItem {
+      name = "simplenote";
+      comment = "Simplenote for Linux";
+      exec = "simplenote %U";
+      icon = "simplenote";
+      type = "Application";
+      startupNotify = "true";
+      desktopName = "Simplenote";
+      categories = "Development";
+    };
+
+    dontBuild = true;
+    dontConfigure = true;
+    dontPatchELF = true;
+    dontWrapGApps = true;
+
+    buildInputs = atomEnv.packages;
+
+    nativeBuildInputs = [ dpkg makeWrapper autoPatchelfHook wrapGAppsHook ];
+
+    unpackPhase = "dpkg-deb -x $src .";
+
+    installPhase = ''
+      mkdir -p "$out/bin"
+      cp -R "opt" "$out"
+      cp -R "usr/share" "$out/share"
+      chmod -R g-w "$out"
+
+      mkdir -p "$out/share/applications"
+      cp "${desktopItem}/share/applications/"* "$out/share/applications"
+    '';
+
+    runtimeDependencies = [ udev.lib ];
+
+    postFixup = ''
+      ls -ahl $out
+      makeWrapper $out/opt/Simplenote/simplenote $out/bin/simplenote \
+      "''${gappsWrapperArgs[@]}"
+    '';
+  };
+
+in
+  linux


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
I wanted to take a look at Simplenote and the first thing it did was say there was a new version I needed to download manually (1.3.0, iirc). So I check the website, and it's up to 1.8.0! And then I checked nixpkgs issues to make sure nobody else had already submitted one before I wasted time (wouldn't be the first time, not even the first time this week...) and the latest [was an unmerged 1.5.0 from April](https://github.com/NixOS/nixpkgs/pull/59418)

###### Things done
I did not run nix-review because it is [broken for me right now??](https://gist.github.com/Kiwi/b36e78849c3064eda892180c8690194b)
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @worldofpeace 
