### PR TITLE
Revert systemd interface version to 2 [19.09 backport]

### DIFF
--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -223,7 +223,7 @@ in stdenv.mkDerivation {
   # in a backwards-incompatible way.  If the interface version of two
   # systemd builds is the same, then we can switch between them at
   # runtime; otherwise we can't and we need to reboot.
-  passthru.interfaceVersion = 3;
+  passthru.interfaceVersion = 2;
 
   meta = with stdenv.lib; {
     homepage = http://www.freedesktop.org/wiki/Software/systemd;


### PR DESCRIPTION
This backports https://github.com/NixOS/nixpkgs/pull/68906 to 19.09. It prevents users having to reboot when upgrading to 19.09.