### PR TITLE
djvulibre: {adopt, clean-up, upd description}

### DIFF
--- a/pkgs/applications/misc/djvulibre/default.nix
+++ b/pkgs/applications/misc/djvulibre/default.nix
@@ -1,22 +1,34 @@
-{ stdenv, fetchurl, libjpeg, libtiff, librsvg, libiconv }:
+{ stdenv
+, fetchurl
+, libjpeg
+, libtiff
+, librsvg
+, libiconv
+}:
 
 stdenv.mkDerivation rec {
-  name = "djvulibre-3.5.27";
+  pname = "djvulibre";
+  version = "3.5.27";
 
   src = fetchurl {
-    url = "mirror://sourceforge/djvu/${name}.tar.gz";
+    url = "mirror://sourceforge/djvu/${pname}-${version}.tar.gz";
     sha256 = "0psh3zl9dj4n4r3lx25390nx34xz0bg0ql48zdskhq354ljni5p6";
   };
 
   outputs = [ "bin" "dev" "out" ];
 
-  buildInputs = [ libjpeg libtiff librsvg libiconv ];
+  buildInputs = [
+    libjpeg
+    libtiff
+    librsvg
+    libiconv
+  ];
 
   meta = with stdenv.lib; {
-    description = "A library and viewer for the DJVU file format for scanned images";
-    homepage = http://djvu.sourceforge.net;
+    description = "The big set of CLI tools to make/modify/optimize/show/export DJVU files";
+    homepage = "http://djvu.sourceforge.net";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ Anton-Latukha ];
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

1. Old description said that there is a viewer - it is not here, - in the `djview` package. But there is all other tools for management.
2. Old description said there is library in package - the fact there is none. Most document utils I am aware of ship with own copy of `djvulibre` and often statically include it, and most utils seems to depend on `djvulibre` binaries that are very unix-like flexible.

The value of package is all utils for DJVU management.
New description of the package much more on point, package has a set of binaries and mans for them.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).