### PR TITLE
xprite-editor: init at 2019-09-22

### DIFF
--- a/pkgs/tools/misc/xprite-editor/default.nix
+++ b/pkgs/tools/misc/xprite-editor/default.nix
@@ -1,0 +1,43 @@
+{ stdenv
+, fetchFromGitHub
+, rustPlatform
+, gtk3
+, AppKit
+, pkg-config
+, python3
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "xprite-editor-unstable";
+  version = "2019-09-22";
+
+  src = fetchFromGitHub {
+    owner = "rickyhan";
+    repo = "xprite-editor";
+    rev = "7f899dff982642927024540e4bafd74e4ea5e52a";
+    sha256 = "1k6k8y8gg1vdmyjz27q689q9rliw0rrnzwlpjcd4vlc6swaq9ahx";
+    fetchSubmodules = true;
+    # Rename unicode file name which leads to different checksums on HFS+
+    # vs. other filesystems because of unicode normalization.
+    postFetch = ''
+      mv $out/config/palettes/Sweet\ Guaran*.hex $out/config/palettes/Sweet\ Guarana.hex
+    '';
+  };
+
+  buildInputs = stdenv.lib.optionals stdenv.isLinux [ gtk3 ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ AppKit ];
+
+  nativeBuildInputs = stdenv.lib.optionals stdenv.isLinux [ pkg-config python3 ];
+
+  cargoSha256 = "0cd58888l7pjmghin31ha780yhs2pz67b10jysyasdw0a88m0dwy";
+
+  cargoBuildFlags = [ "--bin" "xprite-native" ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/rickyhan/xprite-editor";
+    description = "Pixel art editor";
+    license = licenses.gpl3;
+    maintainers = [ maintainers.marsam ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7130,6 +7130,10 @@ in
 
   xorriso = callPackage ../tools/cd-dvd/xorriso { };
 
+  xprite-editor = callPackage ../tools/misc/xprite-editor {
+    inherit (darwin.apple_sdk.frameworks) AppKit;
+  };
+
   xpf = callPackage ../tools/text/xml/xpf {
     libxml2 = libxml2Python;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add https://github.com/rickyhan/xprite-editor

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
