### PR TITLE
Update some mate packages patch version

### DIFF
--- a/pkgs/desktops/mate/caja-extensions/default.nix
+++ b/pkgs/desktops/mate/caja-extensions/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "caja-extensions";
-  version = "1.22.0";
+  version = "1.22.1";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1h866jmdd3qpjzi7wjj11krwiaadnlf21844g1zqfb4jgrzj773p";
+    sha256 = "0xzhphzvaxbwyyp242pnhl5zjrkiznj90i0xjmy7pvi155pmp16h";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/caja/default.nix
+++ b/pkgs/desktops/mate/caja/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "caja";
-  version = "1.22.1";
+  version = "1.22.2";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "10b7yjimblymp1fpsrl4jb2k7kbhla2izsj3njfmg2n6fv9fy9iv";
+    sha256 = "1c5yr4b8pzd7nz7g7ln9jwp4fx6qgq8vgbv4spfryy53il3gv75h";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/eom/default.nix
+++ b/pkgs/desktops/mate/eom/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "eom";
-  version = "1.22.1";
+  version = "1.22.2";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "03lpxqvyaqhz4wmi07nxcyn5q73ym3dzm41cdid53f2dp9lk1mv4";
+    sha256 = "0za1lw4awg1i0ls0r9iw0ail2hqa34y1dx65b50bw9kx9kbfyl9l";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/libmateweather/default.nix
+++ b/pkgs/desktops/mate/libmateweather/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "libmateweather";
-  version = "1.22.0";
+  version = "1.22.1";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1ribgcwl4ncfbcf9bkcbxrgc7yzajdnxg12837psngymkqswlp6a";
+    sha256 = "1y3z82ymc7q6z8ly9f6nys0hbs373fjnvr6j7zwlgf6zc88f71h3";
   };
 
   nativeBuildInputs = [ pkgconfig intltool ];

--- a/pkgs/desktops/mate/marco/default.nix
+++ b/pkgs/desktops/mate/marco/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "marco";
-  version = "1.22.2";
+  version = "1.22.3";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0sc7x14229yj22ka1vlzbaqndwcgh6idypjmm9rydkj4n968jwry";
+    sha256 = "0faiqj9i1mqqy1v4jdcwy8nsbkkvs0cwd2dqypgscmcqpbq7jf8a";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/mate-applets/default.nix
+++ b/pkgs/desktops/mate/mate-applets/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "mate-applets";
-  version = "1.22.1";
+  version = "1.22.2";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "19sjm2180ir8a264rz8m528qaqjpl3q3cq095ab0sbkp2igksrfx";
+    sha256 = "1c32rkkry6kka2arrx5psjj037j79icp5jr1s0qh596dvsgxciqc";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/mate-calc/default.nix
+++ b/pkgs/desktops/mate/mate-calc/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "mate-calc";
-  version = "1.22.1";
+  version = "1.22.2";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0zin3w03zrkpb12rvay23bfk9fnjpybkr5mqzkpn9xfnqamhk8ld";
+    sha256 = "1as4gshydcf84vynq8ijd9n8pslz5jpw6aj18ri4bdc91a6q3rpg";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/mate-control-center/default.nix
+++ b/pkgs/desktops/mate/mate-control-center/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   pname = "mate-control-center";
-  version = "1.22.1";
+  version = "1.22.2";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0w9w3wkxksbhzyd96y1x6yxb0q5lkp16y8i42564b6njvwqch5a0";
+    sha256 = "1ybdjibi6wgqn3587a66ckxp2qkvl4mcvv2smhflyxksl5djrjgh";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/mate-desktop/default.nix
+++ b/pkgs/desktops/mate/mate-desktop/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "mate-desktop";
-  version = "1.22.1";
+  version = "1.22.2";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1hr4r69855csqrcaqpbcyplsy4cwjfz7gabps2pzkh5132jycfr0";
+    sha256 = "18w5r9p3bqpvxqqy2am7z686xf65cz5vhj247kki8s2yvvap6rlh";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/mate-icon-theme/default.nix
+++ b/pkgs/desktops/mate/mate-icon-theme/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "mate-icon-theme";
-  version = "1.22.1";
+  version = "1.22.2";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1pn1xbmr4w4mi45nwk1qh18z9rlngmkhp9bw671yn4k6sii8fi3k";
+    sha256 = "0r2bk4flb6kjj97badj2lnml4lfwpl2ym5hkf7r6f7cj8g6pzc4r";
   };
 
   nativeBuildInputs = [ pkgconfig intltool iconnamingutils ];

--- a/pkgs/desktops/mate/mate-indicator-applet/default.nix
+++ b/pkgs/desktops/mate/mate-indicator-applet/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "mate-indicator-applet";
-  version = "1.22.0";
+  version = "1.22.1";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0zad81qvcin4m329hfxhv4a5j8gf4gj8944mvjrdgdh71bzan2x1";
+    sha256 = "05j5s6r4kx1rbz0j7a7xv38d0kbdi1r8iv8b6nx3lkbkdzq1x0w2";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/mate-media/default.nix
+++ b/pkgs/desktops/mate/mate-media/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "mate-media";
-  version = "1.22.1";
+  version = "1.22.2";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "13g1n2ddgr1yxgl4fsqj3sgb9344b756kam9v3sq6vh0bxlr4yf2";
+    sha256 = "0m8q2rqbxzvh82yj63syd8sbfjrc8y4a8caa42zs66j9x60d1agw";
   };
 
   buildInputs = [

--- a/pkgs/desktops/mate/mate-menus/default.nix
+++ b/pkgs/desktops/mate/mate-menus/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "mate-menus";
-  version = "1.22.0";
+  version = "1.22.1";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1lkakbf2f1815c146z4xp5f0h4lim6jzr02681wbvzalc6k97v5c";
+    sha256 = "0kh6y76f1rhp3nr22rp93bx77wcgqnygag2ir076cqkppayjc3c0";
   };
 
   nativeBuildInputs = [ pkgconfig intltool gobject-introspection ];

--- a/pkgs/desktops/mate/mate-notification-daemon/default.nix
+++ b/pkgs/desktops/mate/mate-notification-daemon/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   pname = "mate-notification-daemon";
-  version = "1.22.0";
+  version = "1.22.1";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "06z3xczhz5diy4kk7b8lrzljrnql6fz0n1jyy916cf8pnnanpg0j";
+    sha256 = "0f8m3m94iqj2x61dzwwvwq2qlsl2ma8pqr6rfns5pzd0nj0waz0m";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/mate-panel/default.nix
+++ b/pkgs/desktops/mate/mate-panel/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "mate-panel";
-  version = "1.22.1";
+  version = "1.22.2";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0pb9dpgsfjp6gsldg4ad2jz23xdvjfarmz4cjwkpakygkq5i6dma";
+    sha256 = "1sm0fniywcxg8rbakhhc37bamwq1x3jqqyaqcvqwxvm6jg1hc97y";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/mate-power-manager/default.nix
+++ b/pkgs/desktops/mate/mate-power-manager/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "mate-power-manager";
-  version = "1.22.1";
+  version = "1.22.2";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "06vs2w44l1s25j0mifkid02yncw0nvdxw8r4pp2jm18kxan4frms";
+    sha256 = "12pnj7y01k1fhfhswxmf6q9yyb0772am5anm338hzfhjp0lcxlbn";
   };
 
   buildInputs = [

--- a/pkgs/desktops/mate/mate-screensaver/default.nix
+++ b/pkgs/desktops/mate/mate-screensaver/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "mate-screensaver";
-  version = "1.22.1";
+  version = "1.22.2";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0c4qq5szsbfrz8hgkmlby2k7f1qs8kgqf2shd63z0pc8p6f47vvc";
+    sha256 = "1y8828g4bys8y4r5y478z6i7dgdqm2wkymi5fq75vxx4lzq919cb";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/mate-session-manager/default.nix
+++ b/pkgs/desktops/mate/mate-session-manager/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   pname = "mate-session-manager";
-  version = "1.22.1";
+  version = "1.22.2";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1ix8picxgc28m5zd0ww3zvzw6rz38wvzsrbqw28hghrfg926h6ig";
+    sha256 = "1v0a9jbsmf9axfqm2cnsqp5ihwffw7rl0z77dyw0m4j2pmyb0558";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/mate-settings-daemon/default.nix
+++ b/pkgs/desktops/mate/mate-settings-daemon/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   pname = "mate-settings-daemon";
-  version = "1.22.0";
+  version = "1.22.1";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0yr5v6b9hdk20j29smbw1k4fkyg82i5vlflmgly0vi5whgc74gym";
+    sha256 = "0idw02z0iig0pfxvlhc4dq4sr7kl1w50xscvg0jzzswnxid2l4ip";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/mate-system-monitor/default.nix
+++ b/pkgs/desktops/mate/mate-system-monitor/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "mate-system-monitor";
-  version = "1.22.1";
+  version = "1.22.2";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0yh1sh5snd7ivchh6l9rbn1s7ia4j5ihhzhqkyjnhr8ln59dvcbm";
+    sha256 = "1d4l5rv01343jf8bk2j5hxvrbp3d705nd4v2pdrjn4h5dw8nxsl1";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/mate-user-guide/default.nix
+++ b/pkgs/desktops/mate/mate-user-guide/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "mate-user-guide";
-  version = "1.22.2";
+  version = "1.22.3";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "01kcszsjiriqp4hf1k4fhazi2yfqlkn415sfgx0jw0p821bzqf2h";
+    sha256 = "0zv8arsxnbab0qk3ck9i1wp3d4gfclcv6vq6nh5i8zjz6rpp9cjs";
   };
 
   nativeBuildInputs = [ itstool intltool libxml2 ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update some mate packages patch version:

mate.mate-user-guide: 1.22.2 -> [1.22.3](https://github.com/mate-desktop/mate-user-guide/releases/tag/v1.22.3)
mate.mate-system-monitor: 1.22.1 -> [1.22.2](https://github.com/mate-desktop/mate-system-monitor/releases/tag/v1.22.2)
mate.mate-settings-daemon: 1.22.0 -> [1.22.1](https://github.com/mate-desktop/mate-settings-daemon/releases/tag/v1.22.1)
mate.mate-session-manager: 1.22.1 -> [1.22.2](https://github.com/mate-desktop/mate-session-manager/releases/tag/v1.22.2)
mate.mate-screensaver: 1.22.1 -> [1.22.2](https://github.com/mate-desktop/mate-screensaver/releases/tag/v1.22.2)
mate.mate-power-manager: 1.22.1 -> [1.22.2](https://github.com/mate-desktop/mate-power-manager/releases/tag/v1.22.2)
mate.mate-panel: 1.22.1 -> [1.22.2](https://github.com/mate-desktop/mate-panel/releases/tag/v1.22.2)
mate.mate-notification-daemon: 1.22.0 -> [1.22.1](https://github.com/mate-desktop/mate-notification-daemon/releases/tag/v1.22.1)
mate.mate-menus: 1.22.0 -> [1.22.1](https://github.com/mate-desktop/mate-menus/releases/tag/v1.22.1)
mate.mate-media: 1.22.1 -> [1.22.2](https://github.com/mate-desktop/mate-media/releases/tag/v1.22.2)
mate.mate-indicator-applet: 1.22.0 -> [1.22.1](https://github.com/mate-desktop/mate-indicator-applet/releases/tag/v1.22.1)
mate.mate-icon-theme: 1.22.1 -> [1.22.2](https://github.com/mate-desktop/mate-icon-theme/releases/tag/v1.22.2)
mate.mate-desktop: 1.22.1 -> [1.22.2](https://github.com/mate-desktop/mate-desktop/releases/tag/v1.22.2)
mate.mate-control-center: 1.22.1 -> [1.22.2](https://github.com/mate-desktop/mate-control-center/releases/tag/v1.22.2)
mate.mate-calc: 1.22.1 -> [1.22.2](https://github.com/mate-desktop/mate-calc/releases/tag/v1.22.2)
mate.mate-applets: 1.22.1 -> [1.22.2](https://github.com/mate-desktop/mate-applets/releases/tag/v1.22.2)
mate.marco: 1.22.2 -> [1.22.3](https://github.com/mate-desktop/marco/releases/tag/v1.22.3)
mate.libmateweather: 1.22.0 -> [1.22.1](https://github.com/mate-desktop/libmateweather/releases/tag/v1.22.1)
mate.eom: 1.22.1 -> [1.22.2](https://github.com/mate-desktop/eom/releases/tag/v1.22.2)
mate.caja-extensions: 1.22.0 -> [1.22.1](https://github.com/mate-desktop/caja-extensions/releases/tag/v1.22.1)

Tested on a VM.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).