### PR TITLE
nixos/systemd: pick more upstream tmpfiles confs

### DIFF
--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -742,13 +742,6 @@ in
     environment.etc =
       mapAttrsToList (n: v: makePAMService v) config.security.pam.services;
 
-    systemd.tmpfiles.rules = optionals
-      (any (s: s.updateWtmp) (attrValues config.security.pam.services))
-      [
-        "f /var/log/wtmp"
-        "f /var/log/lastlog"
-      ];
-
     security.pam.services =
       { other.text =
           ''

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -858,7 +858,12 @@ in
       "sysctl.d/50-coredump.conf".source = "${systemd}/example/sysctl.d/50-coredump.conf";
       "sysctl.d/50-default.conf".source = "${systemd}/example/sysctl.d/50-default.conf";
 
+      "tmpfiles.d/journal-nocow.conf".source = "${systemd}/example/tmpfiles.d/journal-nocow.conf";
+      "tmpfiles.d/static-nodes-permissions.conf".source = "${systemd}/example/tmpfiles.d/static-nodes-permissions.conf";
       "tmpfiles.d/systemd.conf".source = "${systemd}/example/tmpfiles.d/systemd.conf";
+      "tmpfiles.d/systemd-nspawn.conf".source = "${systemd}/example/tmpfiles.d/system-nspawn.conf";
+      "tmpfiles.d/systemd-tmp.conf".source = "${systemd}/example/tmpfiles.d/system-tmp.conf";
+      "tmpfiles.d/var.conf".source = "${systemd}/example/tmpfiles.d/var.conf";
       "tmpfiles.d/x11.conf".source = "${systemd}/example/tmpfiles.d/x11.conf";
 
       "tmpfiles.d/nixos.conf".text = ''


### PR DESCRIPTION
###### Motivation for this change

In #68792 it was discovered that /dev/fuse doesn't have
wordl-read-writeable permissions anymore. The cause of this is that the
tmpfiles examples in systemd were reorganized and split into more files.
We thus lost some of the configuration we were depending on.

In this commit some of the new tmpfiles configuration that are
applicable to us are added which also makes wtmp/lastlog in the pam
module not necessary anymore.

Rationale for the new tmpfile configs:

  - `journal-nowcow.conf`: Contains chattr +C for journald logs which
  makes sense on copy-on-write filesystems like Btrfs. Other filesystems
  shouldn't do anything funny when that flag is set.

  - `static-nodes-permissions.conf`: Contains some permission overrides
  for some device nodes like audio, loop, tun, fuse and kvm.

  - `systemd-nspawn.conf`: Makes sure `/var/lib/machines` exists and old
  snapshots are properly removed.

  - `systemd-tmp.conf`: Removes systemd services related private tmp
  folders and temporary coredump files.

  - `var.conf`: Creates some useful directories in `/var` which we would
  create anyway at some point. Also includes
  `/var/log/{wtmp,btmp,lastlog}`.

Fixes #68792.

###### Things done

Ran systemd & installer tests successfully.
