### PR TITLE
nixos/zabbixServer: move pid file from default (/tmp) to /run/zabbix …

### DIFF
--- a/nixos/modules/services/monitoring/zabbix-server.nix
+++ b/nixos/modules/services/monitoring/zabbix-server.nix
@@ -30,6 +30,7 @@ let
     DBUser = ${cfg.database.user}
     ${optionalString (cfg.database.passwordFile != null) "Include ${passwordFile}"}
     ${optionalString (mysqlLocal && cfg.database.socket != null) "DBSocket = ${cfg.database.socket}"}
+    PidFile = ${runtimeDir}/zabbix_server.pid
     SocketDir = ${runtimeDir}
     FpingLocation = /run/wrappers/bin/fping
     ${optionalString (cfg.modules != {}) "LoadModulePath = ${moduleEnv}/lib"}


### PR DESCRIPTION
…to avoid issues with PrivateTmp=true

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
```
sudo -u zabbix /nix/store/c2byq8pqcka13mgzj38cnapvsl8f0byh-zabbix-server-4.2.3/sbin/zabbix_server -R log_level_increase="http poller"
zabbix_server [110889]: cannot open PID file [/tmp/zabbix_server.pid]: [2] No such file or directory
```

Due to usage of `PrivateTmp=true` in the `systemd` service `zabbix` behavior cannot be modified at runtime.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
