### PR TITLE
check-openvpn: init at 0.0.1

### DIFF
--- a/pkgs/servers/monitoring/plugins/openvpn.nix
+++ b/pkgs/servers/monitoring/plugins/openvpn.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchFromGitHub, python3Packages }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "check-openvpn";
+  version = "0.0.1";
+
+  src = fetchFromGitHub {
+    owner = "liquidat";
+    repo = "nagios-icinga-openvpn";
+    rev = version;
+    sha256 = "1vz3p7nckc5k5f06nm1xfzpykhyndh2dzyagmifrzg5k478p1lpm";
+  };
+
+  # no tests
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "A sensu plugin for OpenVPN";
+    license = licenses.mit;
+    maintainers = with maintainers; [ peterhoeg ];
+  };
+}

--- a/pkgs/servers/monitoring/plugins/openvpn.nix
+++ b/pkgs/servers/monitoring/plugins/openvpn.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, python3Packages }:
+{ lib, fetchFromGitHub, python3Packages }:
 
 python3Packages.buildPythonApplication rec {
   pname = "check-openvpn";
@@ -14,8 +14,8 @@ python3Packages.buildPythonApplication rec {
   # no tests
   doCheck = false;
 
-  meta = with stdenv.lib; {
-    description = "A sensu plugin for OpenVPN";
+  meta = with lib; {
+    description = "A nagios/icinga/sensu check plugin for OpenVPN";
     license = licenses.mit;
     maintainers = with maintainers; [ peterhoeg ];
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14946,6 +14946,8 @@ in
     check-nwc-health
     check-ups-health;
 
+  check-openvpn = callPackage ../servers/monitoring/plugins/openvpn.nix { };
+
   checkSSLCert = callPackage ../servers/monitoring/nagios/plugins/check_ssl_cert.nix { };
 
   neo4j = callPackage ../servers/nosql/neo4j { };


### PR DESCRIPTION
###### Motivation for this change

Check for openvpn. Been using this for a long time.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
