### PR TITLE
httpie: run tests

### DIFF
--- a/pkgs/tools/networking/httpie/default.nix
+++ b/pkgs/tools/networking/httpie/default.nix
@@ -1,17 +1,35 @@
-{ stdenv, fetchurl, python3Packages }:
+{ stdenv, fetchFromGitHub, python3Packages, docutils, }:
 
 python3Packages.buildPythonApplication rec {
   pname = "httpie";
   version = "1.0.3";
 
-  src = python3Packages.fetchPypi {
-    inherit pname version;
-    sha256 = "103fcigpxf4nqmrdqjnyz7d9n4n16906slwmmqqc0gkxv8hnw6vd";
+  src = fetchFromGitHub {
+    owner = "jakubroztocil";
+    repo = "httpie";
+    rev = version;
+    sha256 = "0y30sp0x3nmgzi4dqw1rc3705hnn36ij0zlyyx7g6fqdq8bd8p5q";
   };
 
   propagatedBuildInputs = with python3Packages; [ pygments requests setuptools ];
+  dontUseSetuptoolsCheck = true;
 
-  doCheck = false;
+  disabledTests = [
+    "test_current_version"
+    "test_error"
+  ];
+
+  checkInputs = with python3Packages; [
+    mock
+    pytest
+    pytest-httpbin
+    pytestCheckHook
+  ];
+
+  # the tests call rst2pseudoxml.py from docutils
+  preCheck = ''
+    export PATH=${docutils}/bin:$PATH
+  '';
 
   meta = {
     description = "A command line HTTP client whose goal is to make CLI human-friendly";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
