### PR TITLE
osxsnarf: init at 0.1.0

### DIFF
--- a/pkgs/os-specific/darwin/osxsnarf/default.nix
+++ b/pkgs/os-specific/darwin/osxsnarf/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, lib, fetchFromGitHub, plan9port, darwin, ... }:
+
+stdenv.mkDerivation rec {
+  pname = "osxsnarf";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "eraserhd";
+    repo = "osxsnarf";
+    rev = "v${version}";
+    sha256 = "1vpg39mpc5avnv1j0yfx0x2ncvv38slmm83zv6nmm7alfwfjr2ss";
+  };
+
+  buildInputs = [ plan9port darwin.apple_sdk.frameworks.Carbon ];
+  makeFlags = [ "prefix=${placeholder "out"}" ];
+
+  meta = with lib; {
+    description = "A Plan 9-inspired way to share your OS X clipboard.";
+    homepage = https://github.com/eraserhd/osxsnarf;
+    license = licenses.unlicense;
+    platforms = platforms.darwin;
+    maintainers = [ maintainers.eraserhd ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15895,6 +15895,8 @@ in
 
   osxfuse = callPackage ../os-specific/darwin/osxfuse { };
 
+  osxsnarf = callPackage ../os-specific/darwin/osxsnarf { };
+
   power-calibrate = callPackage ../os-specific/linux/power-calibrate { };
 
   powerstat = callPackage ../os-specific/linux/powerstat { };


### PR DESCRIPTION
###### Motivation for this change

New package.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).