### PR TITLE
[wip] wafHook: don’t depend directly on python

### DIFF
--- a/pkgs/development/tools/build-managers/wafHook/default.nix
+++ b/pkgs/development/tools/build-managers/wafHook/default.nix
@@ -1,9 +1,9 @@
-{ lib, stdenv, pkgs, python, makeSetupHook, waf }:
+{ lib, stdenv, pkgs, python3, makeSetupHook, waf }:
 
 makeSetupHook {
-  deps = [ python ];
   substitutions = {
     inherit waf;
+    python = python3;
     crossFlags = lib.optionalString (stdenv.hostPlatform.system != stdenv.targetPlatform.system)
       ''--cross-compile "--cross-execute=${stdenv.targetPlatform.emulator pkgs}"'';
   };

--- a/pkgs/development/tools/build-managers/wafHook/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/wafHook/setup-hook.sh
@@ -10,6 +10,11 @@ wafConfigurePhase() {
         wafConfigureFlags="${prefixKey:---prefix=}$prefix $wafConfigureFlags"
     fi
 
+    if ! command -v python >/dev/null 2>&1; then
+	echo "Adding python to path"
+        PATH="@python@/bin:$PATH"
+    fi
+
     local flagsArray=(
         @crossFlags@
         "${flagsArray[@]}"


### PR DESCRIPTION
Uses python as fallback when it is not in the environment.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
