### PR TITLE
nixos/gitlab: Update release notes and documentation

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1909.xml
+++ b/nixos/doc/manual/release-notes/rl-1909.xml
@@ -505,6 +505,13 @@
        becomes <literal>services.gitlab.databasePasswordFile = "/path/to/secret_file"</literal> where the
        file <literal>secret_file</literal> contains the string <literal>supersecurepassword</literal>.
      </para>
+     <para>
+       The state path (<option>services.gitlab.statePath</option>) now has the following restriction:
+       no parent directory can be owned by any other user than <literal>root</literal> or the user
+       specified in <option>services.gitlab.user</option>; i.e. if <option>services.gitlab.statePath</option>
+       is set to <literal>/var/lib/gitlab/state</literal>, <literal>gitlab</literal> and all parent directories
+       must be owned by either <literal>root</literal> or the user specified in <option>services.gitlab.user</option>.
+     </para>
    </listitem>
   </itemizedlist>
  </section>

--- a/nixos/doc/manual/release-notes/rl-1909.xml
+++ b/nixos/doc/manual/release-notes/rl-1909.xml
@@ -484,6 +484,28 @@
        (<literal>citrix_workspace</literal>).
      </para>
    </listitem>
+   <listitem>
+     <para>
+       The <literal>services.gitlab</literal> module has had its literal secret options (<option>services.gitlab.smtp.password</option>,
+       <option>services.gitlab.databasePassword</option>,
+       <option>services.gitlab.initialRootPassword</option>,
+       <option>services.gitlab.secrets.secret</option>,
+       <option>services.gitlab.secrets.db</option>,
+       <option>services.gitlab.secrets.otp</option> and
+       <option>services.gitlab.secrets.jws</option>) replaced by file-based versions (<option>services.gitlab.smtp.passwordFile</option>,
+       <option>services.gitlab.databasePasswordFile</option>,
+       <option>services.gitlab.initialRootPasswordFile</option>,
+       <option>services.gitlab.secrets.secretFile</option>,
+       <option>services.gitlab.secrets.dbFile</option>,
+       <option>services.gitlab.secrets.otpFile</option> and
+       <option>services.gitlab.secrets.jwsFile</option>). This was done so that secrets aren't stored
+       in the world-readable nix store, but means that for each option you'll have to create a file with
+       the same exact string, add "File" to the end of the option name, and change the definition to a
+       string pointing to the corresponding file; e.g. <literal>services.gitlab.databasePassword = "supersecurepassword"</literal>
+       becomes <literal>services.gitlab.databasePasswordFile = "/path/to/secret_file"</literal> where the
+       file <literal>secret_file</literal> contains the string <literal>supersecurepassword</literal>.
+     </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/modules/services/misc/gitlab.nix
+++ b/nixos/modules/services/misc/gitlab.nix
@@ -223,7 +223,15 @@ in {
       statePath = mkOption {
         type = types.str;
         default = "/var/gitlab/state";
-        description = "Gitlab state directory, logs are stored here.";
+        description = ''
+          Gitlab state directory. Configuration, repositories and
+          logs, among other things, are stored here.
+
+          The directory will be created automatically if it doesn't
+          exist already. Its parent directories must be owned by
+          either <literal>root</literal> or the user set in
+          <option>services.gitlab.user</option>.
+        '';
       };
 
       backupPath = mkOption {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
- Mention the switch from literal secrets to file-based ones in the release notes
- Document the restriction imposed on `services.gitlab.statePath` in both its description and the release notes

This addresses issues raised in #68841 and #68972. This should be pulled into 19.09.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @globin @flokli @aanderse @schneefux @mawis
