### PR TITLE
kakounePlugins.kak-plumb: init at 0.1.1

### DIFF
--- a/pkgs/applications/editors/kakoune/plugins/default.nix
+++ b/pkgs/applications/editors/kakoune/plugins/default.nix
@@ -7,6 +7,7 @@
   kak-auto-pairs = pkgs.callPackage ./kak-auto-pairs.nix { };
   kak-buffers = pkgs.callPackage ./kak-buffers.nix { };
   kak-fzf = pkgs.callPackage ./kak-fzf.nix { };
+  kak-plumb = pkgs.callPackage ./kak-plumb.nix { };
   kak-powerline = pkgs.callPackage ./kak-powerline.nix { };
   kak-vertical-selection = pkgs.callPackage ./kak-vertical-selection.nix { };
 }

--- a/pkgs/applications/editors/kakoune/plugins/kak-plumb.nix
+++ b/pkgs/applications/editors/kakoune/plugins/kak-plumb.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, kakoune-unwrapped, plan9port, ... }:
+
+stdenv.mkDerivation rec {
+  pname = "kak-plumb";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "eraserhd";
+    repo = "kak-plumb";
+    rev = "v${version}";
+    sha256 = "1rz6pr786slnf1a78m3sj09axr4d2lb5rg7sfa4mfg1zcjh06ps6";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share/kak/autoload/plugins/
+    substitute rc/plumb.kak $out/share/kak/autoload/plugins/plumb.kak \
+      --replace '9 plumb' '${plan9port}/bin/9 plumb'
+    substitute edit-client $out/bin/edit-client \
+      --replace '9 9p' '${plan9port}/bin/9 9p' \
+      --replace 'kak -p' '${kakoune-unwrapped}/bin/kak -p'
+    chmod +x $out/bin/edit-client
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Kakoune integration with the Plan 9 plumber";
+    homepage = "https://github.com/eraserhd/kak-plumb";
+    license = licenses.unlicense;
+    maintainers = with maintainers; [ eraserhd ];
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

New plugin for Kakoune

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).