### PR TITLE
virtualbox: Temporary fix for kernel >= 5.3

### DIFF
--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -92,6 +92,9 @@ in stdenv.mkDerivation {
     })
   ++ [
     ./qtx11extras.patch
+    # Kernel 5.3 fix, should be fixed with VirtualBox 6.0.14
+    # https://www.virtualbox.org/ticket/18911
+    ./kernel-5.3-fix.patch
   ];
 
   postPatch = ''

--- a/pkgs/applications/virtualization/virtualbox/kernel-5.3-fix.patch
+++ b/pkgs/applications/virtualization/virtualbox/kernel-5.3-fix.patch
@@ -1,0 +1,72 @@
+--- a/src/VBox/HostDrivers/VBoxNetFlt/linux/VBoxNetFlt-linux.c
++++ b/src/VBox/HostDrivers/VBoxNetFlt/linux/VBoxNetFlt-linux.c
+@@ -2123,7 +2123,9 @@
+ #endif
+     if (in_dev != NULL)
+     {
+-        for_ifa(in_dev) {
++        struct in_ifaddr *ifa;
++
++        for (ifa = in_dev->ifa_list; ifa; ifa = ifa->ifa_next) {
+             if (VBOX_IPV4_IS_LOOPBACK(ifa->ifa_address))
+                 return NOTIFY_OK;
+
+@@ -2137,7 +2139,7 @@
+
+             pThis->pSwitchPort->pfnNotifyHostAddress(pThis->pSwitchPort,
+                 /* :fAdded */ true, kIntNetAddrType_IPv4, &ifa->ifa_address);
+-        } endfor_ifa(in_dev);
++        }
+     }
+
+     /*
+--- a/src/VBox/Runtime/r0drv/linux/mp-r0drv-linux.c
++++ a/src/VBox/Runtime/r0drv/linux/mp-r0drv-linux.c
+@@ -283,12 +283,15 @@
+     if (RTCpuSetCount(&OnlineSet) > 1)
+     {
+         /* Fire the function on all other CPUs without waiting for completion. */
+-# if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 27)
++# if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 3, 0)
++        smp_call_function(rtmpLinuxAllWrapper, &Args, 0 /* wait */);
++# elif LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 27)
+         int rc = smp_call_function(rtmpLinuxAllWrapper, &Args, 0 /* wait */);
++        Assert(!rc); NOREF(rc);
+ # else
+         int rc = smp_call_function(rtmpLinuxAllWrapper, &Args, 0 /* retry */, 0 /* wait */);
+-# endif
+         Assert(!rc); NOREF(rc);
++# endif
+     }
+ #endif
+
+@@ -326,7 +329,6 @@
+ {
+ #ifdef CONFIG_SMP
+     IPRT_LINUX_SAVE_EFL_AC();
+-    int rc;
+     RTMPARGS Args;
+
+     RTTHREADPREEMPTSTATE PreemptState = RTTHREADPREEMPTSTATE_INITIALIZER;
+@@ -337,14 +339,17 @@
+     Args.cHits = 0;
+
+     RTThreadPreemptDisable(&PreemptState);
+-# if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 27)
+-    rc = smp_call_function(rtmpLinuxWrapper, &Args, 1 /* wait */);
++# if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 3, 0)
++    smp_call_function(rtmpLinuxWrapper, &Args, 1 /* wait */);
++# elif LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 27)
++    int rc = smp_call_function(rtmpLinuxWrapper, &Args, 1 /* wait */);
++    Assert(rc == 0); NOREF(rc);
+ # else /* older kernels */
+-    rc = smp_call_function(rtmpLinuxWrapper, &Args, 0 /* retry */, 1 /* wait */);
++    int rc = smp_call_function(rtmpLinuxWrapper, &Args, 0 /* retry */, 1 /* wait */);
++    Assert(rc == 0); NOREF(rc);
+ # endif /* older kernels */
+     RTThreadPreemptRestore(&PreemptState);
+
+-    Assert(rc == 0); NOREF(rc);
+     IPRT_LINUX_RESTORE_EFL_AC();
+ #else
+     RT_NOREF(pfnWorker, pvUser1, pvUser2);


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
VirtualBox does not build with kernel 5.3 which is default with linuxPackages_latest. 

###### Things done

Found a fix that hasn't yet been released for VirutalBox at https://www.virtualbox.org/ticket/18911 and added as a patch to the build.

Running nix-review but it's compiling several kernel versions at once so it may take a while.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @flokli
