### PR TITLE
peepdf: init at 0.4.2

### DIFF
--- a/pkgs/tools/security/peepdf/default.nix
+++ b/pkgs/tools/security/peepdf/default.nix
@@ -1,0 +1,34 @@
+{ lib, python3Packages }:
+
+with lib;
+
+let
+  pythonaes = python3Packages.buildPythonPackage rec {
+    pname = "pythonaes";
+    version = "1.0";
+    src = python3Packages.fetchPypi {
+      inherit pname version;
+      sha256 = "0rwzmwdfslzkabvsxgcg630x27favh1pdwc3dyhcpf006p033pbi";
+    };
+  };
+in python3Packages.buildPythonApplication rec {
+  pname = "peepdf";
+  version = "0.4.2";
+
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "1sblv9dsfvh773qmjpxpzlcxibms6kq2x0rkyh55q8njxh16v1kx";
+  };
+
+  postPatch = "sed -i 's/==/>=/' setup.py";
+
+  propagatedBuildInputs =
+    with python3Packages; [ jsbeautifier colorama future pillow pythonaes ];
+
+  meta = {
+    description = "Powerful Python tool to analyze PDF documents ";
+    homepage = https://eternal-todo.com/tools/peepdf-pdf-analysis-tool;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ offline ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5441,6 +5441,8 @@ in
 
   peco = callPackage ../tools/text/peco { };
 
+  peepdf = callPackage ../tools/security/peepdf { };
+
   pg_top = callPackage ../tools/misc/pg_top { };
 
   pgcenter = callPackage ../tools/misc/pgcenter { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Packaged peepdf for pdf forensics

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
