### PR TITLE
jotta-cli: init at 0.6.18626

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2067,6 +2067,12 @@
     githubId = 195032;
     name = "Eric Evenchick";
   };
+  evenbrenden = {
+    email = "evenbrenden@gmail.com";
+    github = "evenbrenden";
+    githubId = 2512008;
+    name = "Even Brenden";
+  };
   exfalso = {
     email = "0slemi0@gmail.com";
     github = "exfalso";

--- a/pkgs/applications/misc/jotta-cli/default.nix
+++ b/pkgs/applications/misc/jotta-cli/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchzip }:
+
+let
+  arch = "amd64";
+in
+stdenv.mkDerivation rec {
+  pname = "jotta-cli";
+  version = "0.6.18626";
+  src =
+    fetchzip {
+      url = "https://repo.jotta.us/archives/linux/${arch}/jotta-cli-${version}_linux_${arch}.tar.gz";
+      sha256 = "0v9bw0f2mcvmzp7v8gs6q4p1q54rflqnbjv5sw7h1kyfwznmflzj";
+      stripRoot = false;
+    };
+
+  installPhase = ''
+    install -D usr/bin/jotta-cli usr/bin/jottad -t $out/bin/
+    mkdir -p $out/share/bash-completion/completions
+  '';
+
+  postFixup = ''
+    patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) $out/bin/jotta-cli
+    patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) $out/bin/jottad
+    $out/bin/jotta-cli completion > $out/share/bash-completion/completions/jotta-cli.bash
+  '';
+
+  meta = with stdenv.lib; {
+    description  = "Jottacloud CLI";
+    homepage     = https://www.jottacloud.com/;
+    downloadPage = https://repo.jotta.us/archives/linux/;
+    maintainers  = with maintainers; [ evenbrenden ];
+    license      = licenses.unfree;
+    platforms    = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1759,6 +1759,8 @@ in
 
   jellyfin = callPackage ../servers/jellyfin { };
 
+  jotta-cli = callPackage ../applications/misc/jotta-cli { };
+
   kapacitor = callPackage ../servers/monitoring/kapacitor { };
 
   kisslicer = callPackage ../tools/misc/kisslicer { };


### PR DESCRIPTION
- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).