### PR TITLE
firefoxPackages.tor-browser: 8.5.4 -> 8.5.6

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -265,17 +265,17 @@ in rec {
     gtk3Support = false;
   };
 
-  tor-browser-8-5 = tbcommon {
-    ffversion = "60.8.0esr";
-    tbversion = "8.5.4";
+  tor-browser-8-5 = tbcommon rec {
+    ffversion = "60.9.0esr";
+    tbversion = "8.5.6";
 
     # FIXME: fetchFromGitHub is not ideal, unpacked source is >900Mb
     src = fetchFromGitHub {
       owner = "SLNOS";
       repo  = "tor-browser";
-      # branch "tor-browser-60.8.0esr-8.5-1-slnos"
-      rev   = "9ec7e4832a68ba3a77f5e8e21dc930a25757f55d";
-      sha256 = "10x9h2nm1p8cs0qnd8yjp7ly5raxagqyfjn4sj2y3i86ya5zygb9";
+      # branch "tor-browser-60.9.0esr-8.5-2-slnos"
+      rev   = "0489ae3158cd8c0e16c2e78b94083d8cbf0209dc";
+      sha256 = "0y5s7d8pg8ak990dp8d801j9823igaibfhv9hsa79nib5yllifzs";
     };
 
     patches = [


### PR DESCRIPTION
# `git log`

- firefoxPackages.tor-browser: 8.5.4 -> 8.5.6

# `nix-instantiate` environment

- Host OS: Linux 4.9, SLNOS 19.09
- Nix: nix-env (Nix) 2.2.2
- Multi-user: yes
- Sandbox: yes
- NIXPKGS_CONFIG:

```nix
{
  checkMeta = true;
  doCheckByDefault = true;
}
```

# `nix-env -qaP` diffs

- On x86_64-linux:
  - Updated (2):
    - firefoxPackages.tor-browser
    - tor-browser-bundle
- On aarch64-linux: ditto
- On x86_64-darwin:
  - Updated (1):
    - firefoxPackages.tor-browser

/cc @joachifm