### PR TITLE
pythonPackages.py-wmi-client: init at unstable-20160601

### DIFF
--- a/pkgs/development/python-modules/impacket/default.nix
+++ b/pkgs/development/python-modules/impacket/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildPythonPackage, fetchPypi, isPy3k }:
+
+buildPythonPackage rec {
+  pname = "impacket";
+  version = "0.9.15";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1sq1698g7wqj731h24f7gr4lc0fz0mxrqv6mm3j4hm2j6h3rrbr6";
+  };
+
+  disabled = isPy3k;
+
+  # no tests
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Network protocols Constructors and Dissectors";
+    homepage = "https://github.com/CoreSecurity/impacket";
+    # Modified Apache Software License, Version 1.1
+    license = licenses.free;
+    maintainers = with maintainers; [ peterhoeg ];
+  };
+}

--- a/pkgs/tools/networking/py-wmi-client/default.nix
+++ b/pkgs/tools/networking/py-wmi-client/default.nix
@@ -1,0 +1,25 @@
+{ lib, pythonPackages, fetchFromGitHub }:
+
+pythonPackages.buildPythonApplication rec {
+  pname = "py-wmi-client";
+  version = "unstable-20160601";
+
+  src = fetchFromGitHub {
+    owner = "dlundgren";
+    repo = pname;
+    rev = "9702b036df85c3e0ecdde84a753b353069f58208";
+    sha256 = "1kd12gi1knqv477f1shzqr0h349s5336vzp3fpfp3xl0b502ld8d";
+  };
+
+  propagatedBuildInputs = with pythonPackages; [ impacket natsort pyasn1 pycrypto ];
+
+  # no tests
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Python WMI Client implementation";
+    homepage = "https://github.com/dlundgren/py-wmi-client";
+    license = licenses.mit;
+    maintainers = with maintainers; [ peterhoeg ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24211,6 +24211,8 @@ in
 
   qMasterPassword = libsForQt5.callPackage ../applications/misc/qMasterPassword { };
 
+  py-wmi-client = callPackage ../tools/networking/py-wmi-client { };
+
   redprl = callPackage ../applications/science/logic/redprl { };
 
   retroarchBare = callPackage ../misc/emulators/retroarch {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1898,6 +1898,8 @@ in {
 
   eth-utils = callPackage ../development/python-modules/eth-utils { };
 
+  impacket = callPackage ../development/python-modules/impacket { };
+
   jsonrpc-async = callPackage ../development/python-modules/jsonrpc-async { };
 
   jsonrpc-base = callPackage ../development/python-modules/jsonrpc-base { };


### PR DESCRIPTION
###### Motivation for this change

wmic client written in python for use by check-wmiplus.

Also includes the required impacket dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
