### PR TITLE
ocamlformat: 0.8 → 0.11.0

### DIFF
--- a/pkgs/development/tools/ocaml/ocamlformat/default.nix
+++ b/pkgs/development/tools/ocaml/ocamlformat/default.nix
@@ -1,35 +1,33 @@
-{ stdenv, fetchFromGitHub, ocamlPackages }:
+{ lib, fetchFromGitHub, ocamlPackages }:
 
 with ocamlPackages; buildDunePackage rec {
   pname = "ocamlformat";
-  version = "0.8";
+  version = "0.11.0";
 
-  minimumOCamlVersion = "4.05";
+  minimumOCamlVersion = "4.06";
 
   src = fetchFromGitHub {
     owner = "ocaml-ppx";
     repo = pname;
     rev = version;
-    sha256 = "1i7rsbs00p43362yv7z7dw0qsnv7vjf630qk676qvfg7kg422w6j";
+    sha256 = "0zvjn71jd4d3znnpgh0yphb2w8ggs457b6bl6cg1fmpdgxnds6yx";
   };
 
   buildInputs = [
-    base
     cmdliner
     fpath
     ocaml-migrate-parsetree
+    odoc
+    re
     stdio
+    uuseg
+    uutf
   ];
-
-  configurePhase = ''
-    patchShebangs tools/gen_version.sh
-    tools/gen_version.sh src/Version.ml version
-  '';
 
   meta = {
     inherit (src.meta) homepage;
     description = "Auto-formatter for OCaml code";
-    maintainers = [ stdenv.lib.maintainers.Zimmi48 ];
-    license = stdenv.lib.licenses.mit;
+    maintainers = [ lib.maintainers.Zimmi48 ];
+    license = lib.licenses.mit;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Compatibility with OCaml 4.07.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Zimmi48 
