### PR TITLE
write_stylus: fix error "cannot download icon.tar.gz from any mirror"

### DIFF
--- a/pkgs/applications/graphics/write_stylus/default.nix
+++ b/pkgs/applications/graphics/write_stylus/default.nix
@@ -1,4 +1,12 @@
 { stdenv, lib, qtbase, qtsvg, libglvnd, fetchurl, makeDesktopItem }:
+let
+  # taken from: https://www.iconfinder.com/icons/50835/edit_pencil_write_icon
+  # license: Free for commercial use
+  desktopIcon = fetchurl {
+    url = "https://www.iconfinder.com/icons/50835/download/png/256";
+    sha256 = "0abdya42yf9alxbsmc2nf8jwld50zfria6z3d4ncvp1zw2a9jhb8";
+  };
+in
 stdenv.mkDerivation rec {
   pname = "write_stylus";
   version = "209";
@@ -7,7 +15,7 @@ stdenv.mkDerivation rec {
     name = "Write";
     exec = "Write";
     comment = "A word processor for handwriting";
-    icon = "write_stylus";
+    icon = desktopIcon;
     desktopName = "Write";
     genericName = "Write";
     categories = "Office;Graphics";
@@ -16,13 +24,6 @@ stdenv.mkDerivation rec {
   src = fetchurl {
     url = "http://www.styluslabs.com/write/write${version}.tar.gz";
     sha256 = "1p6glp4vdpwl8hmhypayc4cvs3j9jfmjfhhrgqm2xkgl5bfbv2qd";
-  };
-
-  # taken from: https://www.iconfinder.com/icons/50835/edit_pencil_write_icon
-  # license: Free for commercial use
-  icon = fetchurl {
-    url = "https://oyra.eu/write/icon.tar.gz";
-    sha256 = "1zd98g63apwi17qc1hm1g14maain5d18g4afadxm30qjz2s0mvs8";
   };
 
   sourceRoot = ".";
@@ -34,9 +35,6 @@ stdenv.mkDerivation rec {
     cp -R Write $out/
     # symlink the binary to bin/
     ln -s $out/Write/Write $out/bin/Write
-
-    # untar icons
-    tar -xzf ${icon} *.tar.gz -C $out/
 
     mkdir -p $out/share/applications
     ln -s ${desktopItem}/share/applications/* $out/share/applications/


### PR DESCRIPTION
error message was 

```
trying https://oyra.eu/write/icon.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404 Not Found
error: cannot download icon.tar.gz from any mirror
```

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
