### PR TITLE
tks: init at 1.0.32 

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3754,6 +3754,16 @@
     githubId = 689294;
     name = "Daiderd Jordan";
   };
+  l0b0 = {
+    email = "victor.engmark@gmail.com";
+    github = "l0b0";
+    # gitlab = "victor-engmark";
+    name = "Victor Engmark";
+    keys = [{
+      longkeyid = "rsa4096/0xEC92D395260D3194";
+      fingerprint = "E5D2 3A00 D8C6 93B4 C2AC  D93C EC92 D395 260D 3194";
+    }];
+  };
   lo1tuma = {
     email = "schreck.mathias@gmail.com";
     github = "lo1tuma";

--- a/pkgs/applications/office/tks/default.nix
+++ b/pkgs/applications/office/tks/default.nix
@@ -1,0 +1,94 @@
+{ dpkg, fetchurl, makeWrapper, perl, stdenv }:
+
+let
+  perlEnv = perl.withPackages (p: with p; [
+    CarpClan
+    ClassLoad
+    ClassLoadXS
+    ClassMethodMaker
+    ConfigIniFiles
+    DataOptList
+    DateCalc
+    DBDSQLite
+    DBI
+    DevelGlobalDestruction
+    DevelOverloadInfo
+    EncodeLocale
+    EvalClosure
+    ExporterTiny
+    FileSlurp
+    HTMLForm
+    HTMLParser
+    HTMLTagset
+    HTTPCookies
+    HTTPDate
+    HTTPMessage
+    IPCSystemSimple
+    JSON
+    JSONXS
+    ListMoreUtils
+    LWP
+    LWPProtocolHttps
+    ModernPerl
+    ModuleImplementation
+    ModuleRuntime
+    Moose
+    MROCompat
+    PackageDeprecationManager
+    PackageStash
+    ParamsUtil
+    SubExporter
+    SubExporterProgressive
+    SubIdentify
+    SubInstall
+    SubName
+    TermProgressBar
+    TermReadKey
+    TermReadLineGnu
+    TimeDate
+    TryTiny
+    URI
+    WWWMechanize
+    XMLLibXML
+    XMLSAXBase
+  ]);
+in
+
+stdenv.mkDerivation rec {
+  pname = "tks";
+  version = "1.0.32";
+
+  src = fetchurl {
+    url = "https://debian.catalyst.net.nz/catalyst/dists/stable/catalyst/binary-amd64/tks_${version}_all.deb";
+    sha256 = "b4e288fd1068adbe0cbef12e0a916df20a785d90f7773e862b3c9f3b9528afb6";
+  };
+
+  nativeBuildInputs = [ dpkg makeWrapper ];
+  buildInputs = [ perlEnv ];
+
+  unpackPhase = "dpkg-deb -x ${src} .";
+
+  preConfigure = ''
+    patchShebangs usr/bin/*
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/${perl.libPrefix}
+
+    cp -r usr/bin $out/
+    cp -r usr/share/perl5/TKS $out/${perl.libPrefix}
+
+    sed -i "s|.\+bin/perl|#!${perlEnv}/bin/perl -I $out/${perl.libPrefix}|" $out/bin/*
+    sed -i "s|/usr/bin|$out/bin|g" $out/bin/*
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Timekeeping sucks, TKS makes it suck less";
+    license = stdenv.lib.licenses.gpl3;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.l0b0 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6519,6 +6519,8 @@ in
 
   tio = callPackage ../tools/misc/tio { };
 
+  tks = callPackage ../applications/office/tks { };
+
   tldr = callPackage ../tools/misc/tldr { };
 
   tldr-hs = haskellPackages.tldr;


### PR DESCRIPTION
###### Motivation for this change

Add TKS, a command line tool and more for managing time sheets for work.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)) *N/A*
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"` *N/A*
- [x] Tested execution of all binary files (usually in `./result/bin/`). `tks-weekly-prep` does not run due to a missing Scriptalicious.pm, but that can be fixed at a later time.
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).