### PR TITLE
youtube-dl-gui: init at 0.4

### DIFF
--- a/pkgs/development/python-modules/twodict/default.nix
+++ b/pkgs/development/python-modules/twodict/default.nix
@@ -1,0 +1,18 @@
+{ lib, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "twodict";
+  version = "1.2";
+
+  src = fetchPypi {
+    inherit version pname;
+    sha256 = "0ifv7dv18jn2lg0a3l6zdlvmmlda2ivixfjbsda58a2ay6kxznr0";
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/MrS0m30n3/twodict/wiki";
+    description = "Two way ordered dictionary";
+    license = licenses.unlicense;
+    maintainers = with maintainers; [ alexarice ];
+  };
+}

--- a/pkgs/tools/misc/youtube-dl-gui/default.nix
+++ b/pkgs/tools/misc/youtube-dl-gui/default.nix
@@ -1,0 +1,34 @@
+{ lib, buildPythonPackage, fetchFromGitHub,
+  ffmpegSupport ? false, ffmpeg_4,
+  wxPython, gettext, twodict, youtube-dl }:
+
+buildPythonPackage rec {
+  pname = "youtube-dl-gui";
+  version = "0.4";
+
+  src = fetchFromGitHub {
+    owner = "MrS0m30n3";
+    repo = "youtube-dl-gui";
+    rev = version;
+    sha256 = "1znnjd3ks8r5bsdg9k94yjpwcynlif6l4c07lmlby8vkgpgn0hyj";
+  };
+
+  preBuild = ''
+    export HOME=$NIX_BUILD_TOP
+  '';
+
+  propagatedBuildInputs = [ wxPython twodict youtube-dl ];
+
+  nativeBuildInputs = [ gettext ];
+
+  doCheck = false; # tests rely on display
+
+  makeWrapperArgs = lib.optional ffmpegSupport ''--prefix PATH : "${lib.makeBinPath [ ffmpeg_4 ]}"'';
+
+  meta = with lib; {
+    description = "A cross platform front-end GUI of the popular youtube-dl written in wxPython";
+    homepage = "https://mrs0m30n3.github.io/youtube-dl-gui/";
+    license = licenses.unlicense;
+    maintainers = with maintainers; [ alexarice ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21608,6 +21608,8 @@ in
 
   youtube-dl-light = with python3Packages; toPythonApplication youtube-dl-light;
 
+  youtube-dl-gui = with python2Packages; toPythonApplication youtube-dl-gui;
+
   youtube-viewer = perlPackages.WWWYoutubeViewer;
 
   ytcc = callPackage ../tools/networking/ytcc { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1228,6 +1228,8 @@ in {
 
   trio = callPackage ../development/python-modules/trio {};
 
+  twodict = callPackage ../development/python-modules/twodict {};
+
   sniffio = callPackage ../development/python-modules/sniffio { };
 
   spyder-kernels = callPackage ../development/python-modules/spyder-kernels {};
@@ -5136,6 +5138,8 @@ in {
     ffmpegSupport = false;
     phantomjsSupport = false;
   };
+
+  youtube-dl-gui = callPackage ../tools/misc/youtube-dl-gui {};
 
   zconfig = callPackage ../development/python-modules/zconfig { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Fixes  #69334

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@davidak 
