### PR TITLE
Replace uses of splitString for splitting version strings

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -134,5 +134,7 @@ let
       mergeAttrsByFuncDefaultsClean mergeAttrBy
       fakeSha256 fakeSha512
       nixType imap;
+    inherit (versions)
+      splitVersion;
   });
 in lib

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -102,6 +102,21 @@ runTests {
     expected = [ "2001" "db8" "0" "0042" "" "8a2e" "370" "" ];
   };
 
+  testSplitVersionSingle = {
+    expr = versions.splitVersion "1";
+    expected = [ "1" ];
+  };
+
+  testSplitVersionDouble = {
+    expr = versions.splitVersion "1.2";
+    expected = [ "1" "2" ];
+  };
+
+  testSplitVersionTriple = {
+    expr = versions.splitVersion "1.2.3";
+    expected = [ "1" "2" "3" ];
+  };
+
   testIsStorePath =  {
     expr =
       let goodPath =

--- a/lib/versions.nix
+++ b/lib/versions.nix
@@ -1,13 +1,15 @@
 /* Version string functions. */
 { lib }:
 
-let
+rec {
 
+  /* Break a version string into its component parts.
+
+     Example:
+       splitVersion "1.2.3"
+       => ["1" "2" "3"]
+  */
   splitVersion = builtins.splitVersion or (lib.splitString ".");
-
-in
-
-{
 
   /* Get the major version string from a string.
 

--- a/nixos/modules/services/web-servers/apache-httpd/default.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/default.nix
@@ -12,7 +12,7 @@ let
 
   php = mainCfg.phpPackage.override { apacheHttpd = httpd.dev; /* otherwise it only gets .out */ };
 
-  phpMajorVersion = head (splitString "." php.version);
+  phpMajorVersion = lib.versions.major (lib.getVersion php);
 
   mod_perl = pkgs.apacheHttpdPackages.mod_perl.override { apacheHttpd = httpd; };
 

--- a/pkgs/applications/misc/mupdf/default.nix
+++ b/pkgs/applications/misc/mupdf/default.nix
@@ -9,8 +9,7 @@ let
 
   # OpenJPEG version is hardcoded in package source
   openJpegVersion = with stdenv;
-    lib.concatStringsSep "." (lib.lists.take 2
-      (lib.splitString "." (lib.getVersion openjpeg)));
+    lib.versions.majorMinor (lib.getVersion openjpeg);
 
 
 in stdenv.mkDerivation rec {

--- a/pkgs/applications/misc/workrave/default.nix
+++ b/pkgs/applications/misc/workrave/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   in fetchFromGitHub {
     sha256 = "0v2mx2idaxlsyv5w66b7pknlill9j9i2gqcs3vq54gak7ix9fj1p";
     rev = with stdenv.lib;
-      "v" + concatStringsSep "_" (splitString "." version);
+      "v" + concatStringsSep "_" (splitVersion version);
     repo = "workrave";
     owner = "rcaelers";
   };

--- a/pkgs/applications/networking/cluster/openshift/default.nix
+++ b/pkgs/applications/networking/cluster/openshift/default.nix
@@ -10,7 +10,7 @@ with lib;
 
 let
   version = "3.11.0";
-  ver = stdenv.lib.elemAt (stdenv.lib.splitString "." version);
+  ver = stdenv.lib.elemAt (stdenv.lib.splitVersion version);
   versionMajor = ver 0;
   versionMinor = ver 1;
   versionPatch = ver 2;

--- a/pkgs/applications/science/logic/yices/default.nix
+++ b/pkgs/applications/science/logic/yices/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   # Includes a fix for the embedded soname being libyices.so.2.5, but
   # only installing the libyices.so.2.5.x file.
   installPhase = let
-    ver_XdotY = builtins.concatStringsSep "." (stdenv.lib.take 2 (stdenv.lib.splitString "." version));
+    ver_XdotY = stdenv.lib.versions.majorMinor version;
   in ''
       make install LDCONFIG=true
       ln -sfr $out/lib/libyices.so.{${version},${ver_XdotY}}

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
@@ -3,7 +3,7 @@
 
 let
   version = virtualbox.version;
-  xserverVListFunc = builtins.elemAt (stdenv.lib.splitString "." xorg.xorgserver.version);
+  xserverVListFunc = builtins.elemAt (stdenv.lib.splitVersion xorg.xorgserver.version);
 
   # Forced to 1.18 in <nixpkgs/nixos/modules/services/x11/xserver.nix>
   # as it even fails to build otherwise.  Still, override this even here,

--- a/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
@@ -21,7 +21,7 @@
 , workspace_member }:
 let version_ = lib.splitString "-" crateVersion;
     versionPre = if lib.tail version_ == [] then "" else builtins.elemAt version_ 1;
-    version = lib.splitString "." (lib.head version_);
+    version = lib.splitVersion (lib.head version_);
     rustcOpts = lib.lists.foldl' (opts: opt: opts + " " + opt)
         (if release then "-C opt-level=3" else "-C debuginfo=2")
         (["-C codegen-units=$NIX_BUILD_CORES"] ++ extraRustcOpts);
@@ -150,4 +150,3 @@ in ''
   fi
   runHook postConfigure
 ''
-

--- a/pkgs/development/compilers/cudatoolkit/default.nix
+++ b/pkgs/development/compilers/cudatoolkit/default.nix
@@ -180,9 +180,7 @@ let
       '';
       passthru = {
         cc = gcc;
-        majorVersion =
-          let versionParts = lib.splitString "." version;
-          in "${lib.elemAt versionParts 0}.${lib.elemAt versionParts 1}";
+        majorVersion = lib.versions.majorMinor version;
       };
 
       meta = with stdenv.lib; {

--- a/pkgs/development/compilers/llvm/3.9/llvm.nix
+++ b/pkgs/development/compilers/llvm/3.9/llvm.nix
@@ -22,7 +22,7 @@ assert (stdenv.hostPlatform != stdenv.buildPlatform) -> !enableSharedLibraries;
 let
   # Used when creating a versioned symlinks of libLLVM.dylib
   versionSuffixes = with stdenv.lib;
-    let parts = splitString "." version; in
+    let parts = splitVersion version; in
     imap (i: _: concatStringsSep "." (take i parts)) parts;
 in
 

--- a/pkgs/development/compilers/llvm/4/llvm.nix
+++ b/pkgs/development/compilers/llvm/4/llvm.nix
@@ -19,7 +19,7 @@
 let
   # Used when creating a versioned symlinks of libLLVM.dylib
   versionSuffixes = with stdenv.lib;
-    let parts = splitString "." release_version; in
+    let parts = splitVersion release_version; in
     imap (i: _: concatStringsSep "." (take i parts)) parts;
 in
 

--- a/pkgs/development/compilers/llvm/5/llvm.nix
+++ b/pkgs/development/compilers/llvm/5/llvm.nix
@@ -18,7 +18,7 @@
 let
   # Used when creating a versioned symlinks of libLLVM.dylib
   versionSuffixes = with stdenv.lib;
-    let parts = splitString "." release_version; in
+    let parts = splitVersion release_version; in
     imap (i: _: concatStringsSep "." (take i parts)) parts;
 in
 

--- a/pkgs/development/compilers/llvm/6/llvm.nix
+++ b/pkgs/development/compilers/llvm/6/llvm.nix
@@ -21,7 +21,7 @@ let
 
   # Used when creating a versioned symlinks of libLLVM.dylib
   versionSuffixes = with stdenv.lib;
-    let parts = splitString "." release_version; in
+    let parts = splitVersion release_version; in
     imap (i: _: concatStringsSep "." (take i parts)) parts;
 in
 

--- a/pkgs/development/compilers/llvm/7/llvm.nix
+++ b/pkgs/development/compilers/llvm/7/llvm.nix
@@ -26,7 +26,7 @@ let
 
   # Used when creating a versioned symlinks of libLLVM.dylib
   versionSuffixes = with stdenv.lib;
-    let parts = splitString "." release_version; in
+    let parts = splitVersion release_version; in
     imap (i: _: concatStringsSep "." (take i parts)) parts;
 
 in stdenv.mkDerivation ({

--- a/pkgs/development/compilers/llvm/8/llvm.nix
+++ b/pkgs/development/compilers/llvm/8/llvm.nix
@@ -25,7 +25,7 @@ let
 
   # Used when creating a version-suffixed symlink of libLLVM.dylib
   shortVersion = with stdenv.lib;
-    concatStringsSep "." (take 1 (splitString "." release_version));
+    concatStringsSep "." (take 1 (splitVersion release_version));
 
 in stdenv.mkDerivation ({
   name = "llvm-${version}";

--- a/pkgs/development/interpreters/lfe/generic-builder.nix
+++ b/pkgs/development/interpreters/lfe/generic-builder.nix
@@ -9,9 +9,9 @@
 }:
 
 let
-  inherit (stdenv.lib) getVersion versionAtLeast splitString head;
+  inherit (stdenv.lib) getVersion versionAtLeast versions;
 
-  mainVersion = head (splitString "." (getVersion erlang));
+  mainVersion = versions.major (getVersion erlang);
 
   proper = buildHex {
     name = "proper";

--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -28,7 +28,7 @@ with stdenv.lib;
 
 let
   version = "19.1.5";
-  branch  = head (splitString "." version);
+  branch  = versions.major version;
 in
 
 stdenv.mkDerivation {

--- a/pkgs/development/libraries/science/math/cudnn/generic.nix
+++ b/pkgs/development/libraries/science/math/cudnn/generic.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation {
 
   passthru = {
     inherit cudatoolkit;
-    majorVersion = lib.head (lib.splitString "." version);
+    majorVersion = lib.versions.major version;
   };
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/sqlite/archive-version.nix
+++ b/pkgs/development/libraries/sqlite/archive-version.nix
@@ -1,9 +1,9 @@
 lib: version:
 
 with lib;
-  
+
 let
-  fragments = splitString "." version;
+  fragments = splitVersion version;
   major = head fragments;
   minor = concatMapStrings (fixedWidthNumber 2) (tail fragments);
 in

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -29,7 +29,7 @@ with super;
     # Parse out a version number without the Lua version inserted
     version = with pkgs.lib; let
       version' = super.cqueues.version;
-      rel = splitString "." version';
+      rel = splitVersion version';
       date = head rel;
       rev = last (splitString "-" (last rel));
     in "${date}-${rev}";

--- a/pkgs/games/dwarf-fortress/game.nix
+++ b/pkgs/games/dwarf-fortress/game.nix
@@ -26,7 +26,7 @@ let
     i686-cygwin = "win32";
   };
 
-  dfVersionTriple = splitString "." dfVersion;
+  dfVersionTriple = splitVersion dfVersion;
   baseVersion = elemAt dfVersionTriple 1;
   patchVersion = elemAt dfVersionTriple 2;
 

--- a/pkgs/misc/emulators/epsxe/default.nix
+++ b/pkgs/misc/emulators/epsxe/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
   version = "2.0.5";
 
   src = let
-    version2 = concatStrings (splitString "." version);
+    version2 = replaceStrings ["."] [""] version;
     platform = "linux" + (optionalString stdenv.is64bit "_x64");
   in fetchurl {
     url = "https://www.epsxe.com/files/ePSXe${version2}${platform}.zip";

--- a/pkgs/os-specific/bsd/netbsd/default.nix
+++ b/pkgs/os-specific/bsd/netbsd/default.nix
@@ -68,9 +68,9 @@ let
   } // lib.optionalAttrs stdenv'.isDarwin {
     MKRELRO = "no";
   } // lib.optionalAttrs (stdenv'.cc.isClang or false) {
-    HAVE_LLVM = lib.head (lib.splitString "." (lib.getVersion stdenv'.cc.cc));
+    HAVE_LLVM = lib.versions.major (lib.getVersion stdenv'.cc.cc);
   } // lib.optionalAttrs (stdenv'.cc.isGNU or false) {
-    HAVE_GCC = lib.head (lib.splitString "." (lib.getVersion stdenv'.cc.cc));
+    HAVE_GCC = lib.versions.major (lib.getVersion stdenv'.cc.cc);
   } // lib.optionalAttrs (attrs.headersOnly or false) {
     installPhase = "includesPhase";
     dontBuild = true;

--- a/pkgs/os-specific/linux/kernel/linux-4.14.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.14.nix
@@ -6,10 +6,10 @@ buildLinux (args // rec {
   version = "4.14.145";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
-  modDirVersion = if (modDirVersionArg == null) then concatStrings (intersperse "." (take 3 (splitString "." "${version}.0"))) else modDirVersionArg;
+  modDirVersion = if (modDirVersionArg == null) then concatStringsSep "." (take 3 (splitVersion "${version}.0")) else modDirVersionArg;
 
   # branchVersion needs to be x.y
-  extraMeta.branch = concatStrings (intersperse "." (take 2 (splitString "." version)));
+  extraMeta.branch = versions.majorMinor version;
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";

--- a/pkgs/os-specific/linux/kernel/linux-4.19.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.19.nix
@@ -6,10 +6,10 @@ buildLinux (args // rec {
   version = "4.19.74";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
-  modDirVersion = if (modDirVersionArg == null) then concatStrings (intersperse "." (take 3 (splitString "." "${version}.0"))) else modDirVersionArg;
+  modDirVersion = if (modDirVersionArg == null) then concatStringsSep "." (take 3 (splitVersion "${version}.0")) else modDirVersionArg;
 
   # branchVersion needs to be x.y
-  extraMeta.branch = concatStrings (intersperse "." (take 2 (splitString "." version)));
+  extraMeta.branch = versions.majorMinor version;
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";

--- a/pkgs/os-specific/linux/kernel/linux-5.2.nix
+++ b/pkgs/os-specific/linux/kernel/linux-5.2.nix
@@ -6,10 +6,10 @@ buildLinux (args // rec {
   version = "5.2.16";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
-  modDirVersion = if (modDirVersionArg == null) then concatStrings (intersperse "." (take 3 (splitString "." "${version}.0"))) else modDirVersionArg;
+  modDirVersion = if (modDirVersionArg == null) then concatStringsSep "." (take 3 (splitVersion "${version}.0")) else modDirVersionArg;
 
   # branchVersion needs to be x.y
-  extraMeta.branch = concatStrings (intersperse "." (take 2 (splitString "." version)));
+  extraMeta.branch = versions.majorMinor version;
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v5.x/linux-${version}.tar.xz";

--- a/pkgs/os-specific/linux/kernel/linux-5.3.nix
+++ b/pkgs/os-specific/linux/kernel/linux-5.3.nix
@@ -6,10 +6,10 @@ buildLinux (args // rec {
   version = "5.3";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
-  modDirVersion = if (modDirVersionArg == null) then concatStrings (intersperse "." (take 3 (splitString "." "${version}.0"))) else modDirVersionArg;
+  modDirVersion = if (modDirVersionArg == null) then concatStringsSep "." (take 3 (splitVersion "${version}.0")) else modDirVersionArg;
 
   # branchVersion needs to be x.y
-  extraMeta.branch = concatStrings (intersperse "." (take 2 (splitString "." version)));
+  extraMeta.branch = versions.majorMinor version;
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v5.x/linux-${version}.tar.xz";

--- a/pkgs/os-specific/linux/prl-tools/default.nix
+++ b/pkgs/os-specific/linux/prl-tools/default.nix
@@ -8,8 +8,8 @@ assert (!libsOnly) -> kernel != null;
 # Disable for kernels 4.15 and above due to compatibility issues
 assert kernel != null -> stdenv.lib.versionOlder kernel.version "4.15";
 
-let xorgFullVer = (builtins.parseDrvName xorg.xorgserver.name).version;
-    xorgVer = lib.concatStringsSep "." (lib.take 2 (lib.splitString "." xorgFullVer));
+let xorgFullVer = lib.getVersion xorg.xorgserver;
+    xorgVer = lib.versions.majorMinor xorgFullVer;
     x64 = if stdenv.hostPlatform.system == "x86_64-linux" then true
           else if stdenv.hostPlatform.system == "i686-linux" then false
           else throw "Parallels Tools for Linux only support {x86-64,i686}-linux targets";


### PR DESCRIPTION
Quoting from the splitString docstring:

   > NOTE: this function is not performant and should never be used.

This replaces trivial uses of splitString for splitting version
strings with the (potentially builtin) splitVersion.

I believe all the substitutions to be equivalent but have yet to verify.