### PR TITLE
nodePackages: Use repo tree as nixpkgs

### DIFF
--- a/pkgs/development/node-packages/generate.sh
+++ b/pkgs/development/node-packages/generate.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env nix-shell
-#! nix-shell -i bash -p nodePackages.node2nix
+#! nix-shell -I nixpkgs=../../.. -i bash -p nodePackages.node2nix
+# NOTE: Script must be run from the node-packages directory
 
 set -eu -o pipefail
 


### PR DESCRIPTION
This will make sure that generate.sh uses the correct version of
node2nix when building nodePackages, since the current version on 19.03
is 1.6.0 and the tree should be built with 1.7.0.

###### Motivation for this change
I accidentally built nodePackages with 1.6.0 before realizing my mistake, and this would fix that for the future.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).