### PR TITLE
piper: temporarily propagate gobject-introspection [19.09 backport]

### DIFF
--- a/pkgs/os-specific/linux/piper/default.nix
+++ b/pkgs/os-specific/linux/piper/default.nix
@@ -16,8 +16,12 @@ python3.pkgs.buildPythonApplication rec {
   };
 
   nativeBuildInputs = [ meson ninja gettext pkgconfig wrapGAppsHook desktop-file-utils appstream-glib gobject-introspection ];
-  buildInputs = [ gtk3 glib gnome3.adwaita-icon-theme python3 ];
-  propagatedBuildInputs = with python3.pkgs; [ lxml evdev pygobject3 ];
+  buildInputs = [
+    gtk3 glib gnome3.adwaita-icon-theme python3
+  ];
+  propagatedBuildInputs = with python3.pkgs; [ lxml evdev pygobject3 ] ++ [
+    gobject-introspection # fixes https://github.com/NixOS/nixpkgs/issues/56943 for now
+  ];
 
   postPatch = ''
     chmod +x meson_install.sh # patchShebangs requires executable file


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

Piper in 19.09 is currently affected by #56943, so propagate gobject-introspection as a temporariy workaround.

This is the same workaround merged into master in #69120 by @Mic92.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @mvnetbiz 
