### PR TITLE
tamarin-prover: mark as broken because upstream is broken

### DIFF
--- a/pkgs/applications/science/logic/tamarin-prover/default.nix
+++ b/pkgs/applications/science/logic/tamarin-prover/default.nix
@@ -104,4 +104,6 @@ mkDerivation (common "tamarin-prover" src // {
           tamarin-prover-term
           tamarin-prover-theory
         ];
+
+  broken = true;
 })


### PR DESCRIPTION
#### Motivation for this change
tamarin-prover is packaged twice in nixpkgs: the first one taken from hackage (`haskellPackages.tamarin-prover`), the second one taken from its github repository (`tamarin-prover`). So apparently, they broke their newest release (1.4.1). The corresponding haskellPackages package is already marked as broken whereas the package from github is not. This makes hydra try evaluating it and fail.

@NixOS/backports #68361

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers
cc @thoughtpolice 