### PR TITLE
breeze-plymouth: allow usage of custom logo

### DIFF
--- a/nixos/modules/system/boot/plymouth.nix
+++ b/nixos/modules/system/boot/plymouth.nix
@@ -5,17 +5,20 @@ with lib;
 let
 
   inherit (pkgs) plymouth;
+  inherit (pkgs) nixos-icons;
 
   cfg = config.boot.plymouth;
 
-  breezePlymouth = pkgs.breeze-plymouth.override {
-    nixosBranding = true;
-    nixosVersion = config.system.nixos.release;
+  nixosBreezePlymouth = pkgs.breeze-plymouth.override {
+    logoFile = cfg.logo;
+    logoName = "nixos";
+    osName = "NixOS";
+    osVersion = config.system.nixos.release;
   };
 
   themesEnv = pkgs.buildEnv {
     name = "plymouth-themes";
-    paths = [ plymouth breezePlymouth ] ++ cfg.themePackages;
+    paths = [ plymouth ] ++ cfg.themePackages;
   };
 
   configFile = pkgs.writeText "plymouthd.conf" ''
@@ -35,7 +38,7 @@ in
       enable = mkEnableOption "Plymouth boot splash screen";
 
       themePackages = mkOption {
-        default = [];
+        default = [ nixosBreezePlymouth ];
         type = types.listOf types.package;
         description = ''
           Extra theme packages for plymouth.
@@ -52,10 +55,7 @@ in
 
       logo = mkOption {
         type = types.path;
-        default = pkgs.fetchurl {
-          url = "https://nixos.org/logo/nixos-hires.png";
-          sha256 = "1ivzgd7iz0i06y36p8m5w48fd8pjqwxhdaavc0pxs7w1g7mcy5si";
-        };
+        default = "${nixos-icons}/share/icons/hicolor/128x128/apps/nix-snowflake.png";
         defaultText = ''pkgs.fetchurl {
           url = "https://nixos.org/logo/nixos-hires.png";
           sha256 = "1ivzgd7iz0i06y36p8m5w48fd8pjqwxhdaavc0pxs7w1g7mcy5si";

--- a/pkgs/desktops/plasma-5/breeze-plymouth/default.nix
+++ b/pkgs/desktops/plasma-5/breeze-plymouth/default.nix
@@ -8,37 +8,42 @@
   imagemagick,
   netpbm,
   perl,
-  # these will typically need to be set via an override
-  # in a NixOS context
-  nixosBranding ? false,
-  nixosName ? "NixOS",
-  nixosVersion ? "",
+  logoName ? null,
+  logoFile ? null,
+  osName ? null,
+  osVersion ? null,
   topColor ? "black",
   bottomColor ? "black"
 }:
 
-let
-  logoName = "nixos";
+let 
+  validColors = [ "black" "cardboard_grey" "charcoal_grey" "icon_blue" "paper_white" "plasma_blue" "neon_blue" "neon_green" ];
+  resolvedLogoName = if (logoFile != null && logoName == null) then lib.strings.removeSuffix ".png" (baseNameOf(toString logoFile)) else logoName;
 in
+  assert lib.asserts.assertOneOf "topColor" topColor validColors;
+  assert lib.asserts.assertOneOf "bottomColor" bottomColor validColors;
+  
+
 mkDerivation {
   name = "breeze-plymouth";
   nativeBuildInputs = [ extra-cmake-modules ];
-  buildInputs = [ plymouth ] ++ lib.optionals nixosBranding [ imagemagick netpbm perl ];
+  buildInputs = [ plymouth ] ++ lib.optionals (logoFile != null) [ imagemagick netpbm perl ];
   patches = copyPathsToStore (lib.readPathsFromFile ./. ./series);
-  cmakeFlags = lib.optionals nixosBranding [
-    "-DDISTRO_NAME=${nixosName}"
-    "-DDISTRO_VERSION=${nixosVersion}"
-    "-DDISTRO_LOGO=${logoName}"
-    "-DBACKGROUND_TOP_COLOR=${topColor}"
-    "-DBACKGROUND_BOTTOM_COLOR=${bottomColor}"
-  ];
+  cmakeFlags = []
+    ++ lib.optional (osName      != null) "-DDISTRO_NAME=${osName}"
+    ++ lib.optional (osVersion   != null) "-DDISTRO_VERSION=${osVersion}"
+    ++ lib.optional (logoName    != null) "-DDISTRO_LOGO=${logoName}"
+    ++ lib.optional (topColor    != null) "-DBACKGROUND_TOP_COLOR=${topColor}"
+    ++ lib.optional (bottomColor != null) "-DBACKGROUND_BOTTOM_COLOR=${bottomColor}"
+  ;
+  
   postPatch = ''
       substituteInPlace cmake/FindPlymouth.cmake --subst-var out
-  '' + lib.optionalString nixosBranding ''
-      cp ${nixos-icons}/share/icons/hicolor/128x128/apps/nix-snowflake.png breeze/images/${logoName}.logo.png
+  '' + lib.optionalString (logoFile != null) ''
+      cp ${logoFile} breeze/images/${resolvedLogoName}.logo.png
 
       # conversion for 16bit taken from the breeze-plymouth readme
-      convert ${nixos-icons}/share/icons/hicolor/128x128/apps/nix-snowflake.png -alpha Background -background "#000000" -fill "#000000" -flatten tmp.png
-      pngtopnm tmp.png | pnmquant 16 | pnmtopng > breeze/images/16bit/${logoName}.logo.png
+      convert ${logoFile} -alpha Background -background "#000000" -fill "#000000" -flatten tmp.png
+      pngtopnm tmp.png | pnmquant 16 | pnmtopng > breeze/images/16bit/${resolvedLogoName}.logo.png
   '';
 }


### PR DESCRIPTION
###### Motivation for this change
Default plymouth theme was changed to breeze by: michaelpj@96da47ddfb44c352b8e3fc1155ba37373a607537.

IMHO this new default look way nicer than the "fade-in" theme. However, this modification breaks the logo option from the plymouth package.

Breeze-Plymouth have been modified to accept more customization throught overridde. 

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via plasma5.nix NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @michaelpj @orivej 
