### PR TITLE
nim: 0.20.2 -> 1.0.0

### DIFF
--- a/pkgs/development/compilers/nim/default.nix
+++ b/pkgs/development/compilers/nim/default.nix
@@ -1,15 +1,15 @@
 # based on https://github.com/nim-lang/Nim/blob/v0.18.0/.travis.yml
 
-{ stdenv, lib, fetchurl, makeWrapper, nodejs-slim-11_x, openssl, pcre, readline,
+{ stdenv, lib, fetchurl, makeWrapper, nodejs-slim, openssl, pcre, readline,
   boehmgc, sfml, tzdata, coreutils, sqlite }:
 
 stdenv.mkDerivation rec {
   pname = "nim";
-  version = "0.20.2";
+  version = "1.0.0";
 
   src = fetchurl {
     url = "https://nim-lang.org/download/${pname}-${version}.tar.xz";
-    sha256 = "0pibil10x0c181kw705phlwk8bn8dy5ghqd9h9fm6i9afrz5ryp1";
+    sha256 = "1pg0lxahis8zfk6rdzdj281bahl8wglpjgngkc4vg1pc9p61fj03";
   };
 
   doCheck = !stdenv.isDarwin;
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   #    as part of building it, so it cannot be read-only
 
   checkInputs = [
-    nodejs-slim-11_x tzdata coreutils
+    nodejs-slim tzdata coreutils
   ];
 
   nativeBuildInputs = [
@@ -64,9 +64,6 @@ stdenv.mkDerivation rec {
       substituteInPlace ./tests/osproc/tworkingdir.nim --replace "/usr/bin" "${coreutils}/bin"
       substituteInPlace ./tests/stdlib/ttimes.nim --replace "/usr/share/zoneinfo" "${tzdata}/share/zoneinfo"
 
-      # reported upstream: https://github.com/nim-lang/Nim/issues/11435
-      ${disableTest} ./tests/misc/tstrace.nim
-
       # runs out of memory on a machine with 8GB RAM
       ${disableTest} ./tests/system/t7894.nim
 
@@ -80,11 +77,20 @@ stdenv.mkDerivation rec {
       ${disableCompile} ./lib/nimhcr.nim
       ${disableTest} ./tests/dll/nimhcr_unit.nim
       ${disableTest} ./tests/dll/nimhcr_integration.nim
+
+      # reported upstream: https://github.com/nim-lang/Nim/issues/12262
+      ${disableTest} ./tests/range/tcompiletime_range_checks.nim
+
+      # requires "immintrin.h" which is available only on x86
+      ${disableTest} ./tests/misc/tsizeof3.nim
     '';
 
   checkPhase = ''
     runHook preCheck
 
+    # Fortify hardening breaks tests
+    # https://github.com/nim-lang/Nim/issues/11435#issuecomment-534545696
+    NIX_HARDENING_ENABLE=''${NIX_HARDENING_ENABLE/fortify/} \
     ./koch tests --nim:bin/nim all
 
     runHook postCheck
@@ -97,7 +103,10 @@ stdenv.mkDerivation rec {
     ./koch install $out
     mv $out/nim/bin/* $out/bin/ && rmdir $out/nim/bin
     mv $out/nim/*     $out/     && rmdir $out/nim
+
+    # Fortify hardening appends -O2 to gcc flags which is unwanted for unoptimized nim builds.
     wrapProgram $out/bin/nim \
+      --run 'NIX_HARDENING_ENABLE=''${NIX_HARDENING_ENABLE/fortify/}' \
       --suffix PATH : ${lib.makeBinPath [ stdenv.cc ]}
 
     runHook postInstall
@@ -107,7 +116,7 @@ stdenv.mkDerivation rec {
     description = "Statically typed, imperative programming language";
     homepage = "https://nim-lang.org/";
     license = licenses.mit;
-    maintainers = with maintainers; [ ehmry peterhoeg ];
+    maintainers = with maintainers; [ ehmry ];
     platforms = with platforms; linux ++ darwin; # arbitrary
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

https://nim-lang.org/blog/2019/09/23/version-100-released.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @ehmry @peterhoeg
