### PR TITLE
python37Packages.pyrsistent: 0.15.2 -> 0.15.4

### DIFF
--- a/pkgs/development/python-modules/pyrsistent/default.nix
+++ b/pkgs/development/python-modules/pyrsistent/default.nix
@@ -9,16 +9,20 @@
 
 buildPythonPackage rec {
   pname = "pyrsistent";
-  version = "0.15.2";
+  version = "0.15.4";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0fjwnxg7q1b02j7hk1wqm5xdn7wck9j2g3ggkkizab6l77kjws8n";
+    sha256 = "0cv5xvhfhlj88pb0ghdwivkfcmgi6503qjwxx4r6n06nd6hpzd1l";
   };
 
   propagatedBuildInputs = [ six ];
 
   checkInputs = [ pytestrunner pytest hypothesis ];
+
+  postPatch = ''
+    substituteInPlace setup.py --replace 'pytest<5' 'pytest'
+  '';
 
   meta = with stdenv.lib; {
     homepage = https://github.com/tobgu/pyrsistent/;


### PR DESCRIPTION
###### Motivation for this change
Some tests are broken on 0.15.2 if used with pytest 5+ as discussed
in #64145. The issue is fixed in tobgu/pyrsistent#175 and released in
0.15.4.
As this package is a required dependency to build `poetry` this fix takes use one step closer to be able to build poetry on unstable, however it is not enough as poetry now fails to build with the following error:
> ERROR: Invalid requirement: ''
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"` **NOTE** _poetry and python27Packages.poetry still fails to build_
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @desiderius
