### PR TITLE
gajim: add missing setuptools dependency

### DIFF
--- a/pkgs/applications/networking/instant-messengers/gajim/default.nix
+++ b/pkgs/applications/networking/instant-messengers/gajim/default.nix
@@ -44,7 +44,7 @@ python3.pkgs.buildPythonApplication rec {
   ];
 
   propagatedBuildInputs = with python3.pkgs; [
-    nbxmpp pyasn1 pygobject3 dbus-python pillow cssutils precis-i18n keyring
+    nbxmpp pyasn1 pygobject3 dbus-python pillow cssutils precis-i18n keyring setuptools
   ] ++ lib.optionals enableE2E [ pycrypto python-gnupg ]
     ++ lib.optional enableRST docutils
     ++ lib.optionals enableOmemoPluginDependencies [ python-axolotl qrcode ]


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Gajim crashes because of missing `pkg_resources` module which part of `setuptools`:

```
Traceback (most recent call last):
  File "/nix/store/21glmpkw51vm6pjfw6khj5szl05rczpi-gajim-1.1.3/bin/..gajim-wrapped-wrapped", line 11, in <module>
    sys.exit(main())
  File "/nix/store/21glmpkw51vm6pjfw6khj5szl05rczpi-gajim-1.1.3/lib/python3.7/site-packages/gajim/gajim.py", line 123, in main
    _init_gui('GTK')
  File "/nix/store/21glmpkw51vm6pjfw6khj5szl05rczpi-gajim-1.1.3/lib/python3.7/site-packages/gajim/gajim.py", line 49, in _init_gui
    _init_gtk()
  File "/nix/store/21glmpkw51vm6pjfw6khj5szl05rczpi-gajim-1.1.3/lib/python3.7/site-packages/gajim/gajim.py", line 70, in _init_gtk
    from gajim import gtkexcepthook
  File "/nix/store/21glmpkw51vm6pjfw6khj5szl05rczpi-gajim-1.1.3/lib/python3.7/site-packages/gajim/gtkexcepthook.py", line 42, in <module>
    from gajim.common import configpaths
  File "/nix/store/21glmpkw51vm6pjfw6khj5szl05rczpi-gajim-1.1.3/lib/python3.7/site-packages/gajim/common/configpaths.py", line 242, in <module>
    _paths = ConfigPaths()
  File "/nix/store/21glmpkw51vm6pjfw6khj5szl05rczpi-gajim-1.1.3/lib/python3.7/site-packages/gajim/common/configpaths.py", line 131, in __init__
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'

```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @raskin @aszlig @abbradar 