### PR TITLE
makeWrapper: Remove unused extraFlagsArray feature

### DIFF
--- a/pkgs/build-support/setup-hooks/make-wrapper.sh
+++ b/pkgs/build-support/setup-hooks/make-wrapper.sh
@@ -19,9 +19,6 @@ assertExecutable() {
 #                         the environment
 # --unset       VAR     : remove VAR from the environment
 # --run         COMMAND : run command before the executable
-#                         The command can push extra flags to a magic list
-#                         variable extraFlagsArray, which are then added to
-#                         the invocation of the executable
 # --add-flags   FLAGS   : add FLAGS to invocation of executable
 
 # --prefix          ENV SEP VAL   : suffix/prefix ENV with VAL, separated by SEP
@@ -109,12 +106,8 @@ makeWrapper() {
         fi
     done
 
-    # Note: extraFlagsArray is an array containing additional flags
-    # that may be set by --run actions.
-    # Silence warning about unexpanded extraFlagsArray:
-    # shellcheck disable=SC2016
     echo exec ${argv0:+-a \"$argv0\"} \""$original"\" \
-         "$flagsBefore" '"${extraFlagsArray[@]}"' '"$@"' >> "$wrapper"
+         "$flagsBefore" '"$@"' >> "$wrapper"
 
     chmod +x "$wrapper"
 }

--- a/pkgs/desktops/gnustep/make/builder.sh
+++ b/pkgs/desktops/gnustep/make/builder.sh
@@ -16,7 +16,7 @@ wrapGSMake() {
 
 export GNUSTEP_CONFIG_FILE="$config"
 
-exec "$wrapped" "\$@" "\${extraFlagsArray[@]}"
+exec "$wrapped" "\$@"
 EOF
     chmod +x "$program"
 }

--- a/pkgs/development/tools/misc/ccls/wrapper
+++ b/pkgs/development/tools/misc/ccls/wrapper
@@ -9,4 +9,4 @@ fi
 
 initString+="]}}"
 
-exec -a "$0" "@out@/bin/@wrapped@" "${initString}" "${extraFlagsArray[@]}" "$@"
+exec -a "$0" "@out@/bin/@wrapped@" "${initString}" "$@"

--- a/pkgs/development/tools/misc/cquery/wrapper
+++ b/pkgs/development/tools/misc/cquery/wrapper
@@ -9,4 +9,4 @@ fi
 
 initString+="]}"
 
-exec -a "$0" "@out@/bin/@wrapped@" "${initString}" "${extraFlagsArray[@]}" "$@"
+exec -a "$0" "@out@/bin/@wrapped@" "${initString}" "$@"

--- a/pkgs/games/simutrans/default.nix
+++ b/pkgs/games/simutrans/default.nix
@@ -97,7 +97,7 @@ let
       cat > "$out/bin/simutrans" <<EOF
       #!${runtimeShell}
       cd "$out"/share/simutrans
-      exec "${binaries}/bin/simutrans" -use_workdir "\''${extraFlagsArray[@]}" "\$@"
+      exec "${binaries}/bin/simutrans" -use_workdir "\$@"
       EOF
       chmod +x "$out/bin/simutrans"
     '';


### PR DESCRIPTION
##### Motivation for this change
There is a bug in this feature: It allows extra arguments to leak in
from the environment. For example:

`$ export extraFlagsArray=date`
`$ man ls`

Note that you get the man page for `date` rather than for `ls`. This happens
because `man` happens to use a wrapper (to add groff to its PATH).

An attempt to fix this was made in 5ae18574fce in PR #19328 for
issue #2537, but 1. That change didn't actually fix the problem because
it addressed makeWrapper's environment during the build process, not the
constructed wrapper script's environment after installation, and 2. That
change was apparently accidentally lost when merged with 7ff6eec5fd8.

Rather than trying to fix the bug again, we remove the extraFlagsArray
feature, since it has never been used in the public repo in the ten
years it has been available.

wrapAclocal continues to use its own, separate flavor of extraFlagsArray
in a more limited context. The analogous bug there was fixed in
4d7d10da6b1 in 2011.



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
   - [x] Tested compilation of all pkgs that depend on this change _that are installed on my machine -- about 1000 packages_
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
   - [x] Ran my personal computer with this change for a week
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
