### PR TITLE
thinkfan: 0.9.3 -> 1.0.2 (replaces #55895)

### DIFF
--- a/pkgs/tools/system/thinkfan/default.nix
+++ b/pkgs/tools/system/thinkfan/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmakeCurses, libyamlcpp, pkgconfig
+{ stdenv, fetchFromGitHub, cmake, libyamlcpp, pkgconfig
 , smartSupport ? false, libatasmart }:
 
 stdenv.mkDerivation rec {
@@ -12,18 +12,14 @@ stdenv.mkDerivation rec {
     sha256 = "107vw0962hrwva3wra9n3hxlbfzg82ldc10qssv3dspja88g8psr";
   };
 
-  configureFlags = [
+  cmakeFlags = [
     "-DCMAKE_INSTALL_DOCDIR=share/doc/${pname}"
     "-DUSE_NVML=OFF"
-    "-DUSE_ATASMART=ON"
-    "-DUSE_YAML=ON"
-  ];
+  ] ++ stdenv.lib.optional smartSupport "-DUSE_ATASMART=ON";
 
-  nativeBuildInputs = [ cmakeCurses pkgconfig ];
+  nativeBuildInputs = [ cmake pkgconfig ];
 
-  buildInputs = [libyamlcpp] ++ stdenv.lib.optional smartSupport libatasmart;
-
-  cmakeFlags = stdenv.lib.optional smartSupport "-DUSE_ATASMART=ON";
+  buildInputs = [ libyamlcpp ] ++ stdenv.lib.optional smartSupport libatasmart;
 
   installPhase = ''
     install -Dm755 {.,$out/bin}/thinkfan
@@ -34,10 +30,10 @@ stdenv.mkDerivation rec {
     install -Dm644 {src,$out/share/man/man1}/thinkfan.1
   '';
 
-  meta = {
-    license = stdenv.lib.licenses.gpl3;
-    homepage = https://github.com/vmatare/thinkfan;
-    maintainers = with stdenv.lib.maintainers; [ domenkozar ];
-    platforms = stdenv.lib.platforms.linux;
+  meta = with stdenv.lib; {
+    license = licenses.gpl3;
+    homepage = "https://github.com/vmatare/thinkfan";
+    maintainers = with maintainers; [ domenkozar ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/system/thinkfan/default.nix
+++ b/pkgs/tools/system/thinkfan/default.nix
@@ -31,6 +31,9 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
+    description = "A minimalist fan control program. Originally designed
+specifically for IBM/Lenovo Thinkpads, it now supports any kind of system via
+the sysfs hwmon interface (/sys/class/hwmon).";
     license = licenses.gpl3;
     homepage = "https://github.com/vmatare/thinkfan";
     maintainers = with maintainers; [ domenkozar ];

--- a/pkgs/tools/system/thinkfan/default.nix
+++ b/pkgs/tools/system/thinkfan/default.nix
@@ -22,12 +22,16 @@ stdenv.mkDerivation rec {
   buildInputs = [ libyamlcpp ] ++ stdenv.lib.optional smartSupport libatasmart;
 
   installPhase = ''
+    runHook preInstall
+
     install -Dm755 {.,$out/bin}/thinkfan
 
     cd "$NIX_BUILD_TOP"; cd "$sourceRoot" # attempt to be a bit robust
     install -Dm644 {.,$out/share/doc/thinkfan}/README
     cp -R examples $out/share/doc/thinkfan
     install -Dm644 {src,$out/share/man/man1}/thinkfan.1
+
+    runHook postInstall
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/system/thinkfan/default.nix
+++ b/pkgs/tools/system/thinkfan/default.nix
@@ -8,12 +8,12 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "vmatare";
     repo = "thinkfan";
-    rev = "${version}";
+    rev = version;
     sha256 = "1983p8aryfgpyhflh5r5xz27y136a4vvm7plgrg44q4aicqbcp8j";
   };
 
   configureFlags = [
-    "-DCMAKE_INSTALL_DOCDIR==share/doc/${pname}"
+    "-DCMAKE_INSTALL_DOCDIR=share/doc/${pname}"
     "-DUSE_NVML=OFF"
     "-DUSE_ATASMART=ON"
     "-DUSE_YAML=ON"

--- a/pkgs/tools/system/thinkfan/default.nix
+++ b/pkgs/tools/system/thinkfan/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   pname = "thinkfan";
-  version = "1.0.1";
+  version = "1.0.2";
 
   src = fetchFromGitHub {
     owner = "vmatare";
     repo = "thinkfan";
     rev = version;
-    sha256 = "1983p8aryfgpyhflh5r5xz27y136a4vvm7plgrg44q4aicqbcp8j";
+    sha256 = "107vw0962hrwva3wra9n3hxlbfzg82ldc10qssv3dspja88g8psr";
   };
 
   configureFlags = [

--- a/pkgs/tools/system/thinkfan/default.nix
+++ b/pkgs/tools/system/thinkfan/default.nix
@@ -1,18 +1,27 @@
-{ stdenv, fetchurl, cmake
+{ stdenv, fetchFromGitHub, cmakeCurses, libyamlcpp, pkgconfig
 , smartSupport ? false, libatasmart }:
 
 stdenv.mkDerivation rec {
   pname = "thinkfan";
-  version = "0.9.3";
+  version = "1.0.1";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/thinkfan/thinkfan-${version}.tar.gz";
-    sha256 = "0nz4c48f0i0dljpk5y33c188dnnwg8gz82s4grfl8l64jr4n675n";
+  src = fetchFromGitHub {
+    owner = "vmatare";
+    repo = "thinkfan";
+    rev = "${version}";
+    sha256 = "1983p8aryfgpyhflh5r5xz27y136a4vvm7plgrg44q4aicqbcp8j";
   };
 
-  nativeBuildInputs = [ cmake ];
+  configureFlags = [
+    "-DCMAKE_INSTALL_DOCDIR==share/doc/${pname}"
+    "-DUSE_NVML=OFF"
+    "-DUSE_ATASMART=ON"
+    "-DUSE_YAML=ON"
+  ];
 
-  buildInputs = stdenv.lib.optional smartSupport libatasmart;
+  nativeBuildInputs = [ cmakeCurses pkgconfig ];
+
+  buildInputs = [libyamlcpp] ++ stdenv.lib.optional smartSupport libatasmart;
 
   cmakeFlags = stdenv.lib.optional smartSupport "-DUSE_ATASMART=ON";
 
@@ -27,7 +36,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     license = stdenv.lib.licenses.gpl3;
-    homepage = http://thinkfan.sourceforge.net/;
+    homepage = https://github.com/vmatare/thinkfan;
     maintainers = with stdenv.lib.maintainers; [ domenkozar ];
     platforms = stdenv.lib.platforms.linux;
   };


### PR DESCRIPTION
###### Motivation for this change
#55895(thinkfan: 0.9.3 -> 1.0.1) wasn't merged due to some remarks and some merge conflicts with master. This PR incorporates the changes from #55895, addresses the remarks and adds an update to 1.0.2.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @domenkozar
