### PR TITLE
epson-escpr2: 1.0.29 -> 1.1.1 

### DIFF
--- a/pkgs/misc/drivers/epson-escpr2/default.nix
+++ b/pkgs/misc/drivers/epson-escpr2/default.nix
@@ -2,11 +2,14 @@
 
 stdenv.mkDerivation rec {
   pname = "epson-inkjet-printer-escpr2";
-  version = "1.0.29";
+  version = "1.1.1";
 
   src = fetchurl {
-    url = "https://download3.ebz.epson.net/dsc/f/03/00/09/02/31/a332507b6398c6e2e007c05477dd6c3d5a8e50eb/${pname}-${version}-1lsb3.2.src.rpm";
-    sha256 = "064br52akpw5yrxb2wqw2klv4jrvyipa7w0rjj974xgyi781lqs5";
+    # To find new versions, visit http://download.ebz.epson.net/dsc/search/01/search/?OSC=LX
+    # and search for some printer like for instance "WF-7210" to get to the most recent version.
+    # NOTE: keep in mind that many parts of the URL change and not just version.
+    url = "https://download3.ebz.epson.net/dsc/f/03/00/09/72/04/c6d928e83e558c4ba1e7e8bcb5c1fe080b8095eb/${pname}-${version}-1lsb3.2.src.rpm";
+    sha256 = "02vdlhvinsx6vsjq172b2c1vrfzkg0w9j5lbsnjvj6yq3yqz5b5q";
   };
 
   patches = [ ./cups-filter-ppd-dirs.patch ];


### PR DESCRIPTION
###### Motivation for this change

The build was failing because the source rpm does not exist
on epsons servers anymore.

Thus bumping it to an existing version
https://hydra.nixos.org/build/101990975/nixlog/5

Related: https://github.com/NixOS/nixpkgs/issues/68361

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @ma9e 

