### PR TITLE
kernel/common-config: enable SCHED_DEBUG

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -42,6 +42,8 @@ let
       CRASH_DUMP                = option no;
       # Easier debugging of NFS issues.
       SUNRPC_DEBUG              = yes;
+      # Provide access to tunables like sched_migration_cost_ns
+      SCHED_DEBUG               = yes;
     };
 
     power-management = {


### PR DESCRIPTION
###### Motivation for this change

This makes `/proc/sys/kernel/sched_migration_cost_ns` and [other tunables](https://github.com/torvalds/linux/blob/5184d449600f501a8688069f35c138c6b3bf8b94/kernel/sysctl.c#L326) available for configuring the scheduler. These tunables are mentioned in many places around the web, and it is surprising to not have them in NixOS. I checked the Debian kernel and it enables this option. I also confirmed that the oldest kernel that nixpkgs carries (4.4) has this option.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I booted into a 4.19 kernel with this option enabled and it seemed to work fine. `/proc/sys/kernel/sched_migration_cost_ns` became available.

###### Notify maintainers

cc @thoughtpolice

@delroth may also want this

If accepted, please cherry-pick to staging-19.09 or let me know you want a backport PR.