### PR TITLE
dxx-rebirth: build with gcc6 as gcc8 is not supported

### DIFF
--- a/pkgs/games/dxx-rebirth/default.nix
+++ b/pkgs/games/dxx-rebirth/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, scons, pkgconfig
+{ gcc6Stdenv, fetchurl, fetchpatch, scons, pkgconfig
 , SDL, SDL_mixer, libGLU_combined, physfs
 }:
 
@@ -8,7 +8,7 @@ let
     sha256 = "05mz77vml396mff43dbs50524rlm4fyds6widypagfbh5hc55qdc";
   };
 
-in stdenv.mkDerivation rec {
+in gcc6Stdenv.mkDerivation rec {
   pname = "dxx-rebirth";
   version = "0.59.100";
 
@@ -44,9 +44,9 @@ in stdenv.mkDerivation rec {
     install -Dm644 -t $out/share/doc/dxx-rebirth *.txt
   '';
 
-  meta = with stdenv.lib; {
+  meta = with gcc6Stdenv.lib; {
     description = "Source Port of the Descent 1 and 2 engines";
-    homepage = https://www.dxx-rebirth.com/;
+    homepage = "https://www.dxx-rebirth.com/";
     license = licenses.free;
     maintainers = with maintainers; [ peterhoeg ];
     platforms = with platforms; linux;


### PR DESCRIPTION
###### Motivation for this change

building with gcc8 is not supported by upstream so fix it to gcc6 to at least make things run again.

Needed for #68361

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
