### PR TITLE
dotnet-runtime{,_2}: init at 3 and 2.2.7

### DIFF
--- a/pkgs/development/tools/dotnet/runtime/2.nix
+++ b/pkgs/development/tools/dotnet/runtime/2.nix
@@ -1,0 +1,53 @@
+{ stdenv, fetchurl
+, autoPatchelfHook
+, curl
+, libkrb5
+, libunwind
+, lttng-ust
+, zlib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "dotnet-runtime";
+  version = "2.2.7";
+
+  src = fetchurl {
+    url = "https://download.visualstudio.microsoft.com/download/pr/dc8dd18d-e165-4f58-a821-d657eea08bf1/efd846172658c27dde2d9eafa7d0082e/dotnet-runtime-${version}-linux-x64.tar.gz";
+    sha256 = "11zcikd38k6x0paszfp582pzhsfzvj5kn7yl25n1m09wpp8yhqwd";
+  };
+
+  sourceRoot = ".";
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    curl
+    libkrb5
+    libunwind
+    lttng-ust
+    stdenv.cc.cc
+    zlib
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp -r ./ $out/bin
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/dotnet --info
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://dotnet.github.io/;
+    description = ".NET Core runtime v${version}";
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ jonringer ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/tools/dotnet/runtime/default.nix
+++ b/pkgs/development/tools/dotnet/runtime/default.nix
@@ -1,0 +1,53 @@
+{ stdenv, fetchurl
+, autoPatchelfHook
+, curl
+, libkrb5
+, libunwind
+, lttng-ust
+, zlib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "dotnet-runtime";
+  version = "3.0.0";
+
+  src = fetchurl {
+    url = "https://download.visualstudio.microsoft.com/download/pr/a5ff9cbb-d558-49d1-9fd2-410cb1c8b095/a940644f4133b81446cb3733a620983a/dotnet-runtime-${version}-linux-x64.tar.gz";
+    sha256 = "18gz9xa79scdfglxyy1yy0ag5nvv6h0abff4yd1c00mi7jf7p86y";
+  };
+
+  sourceRoot = ".";
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    curl
+    libkrb5
+    libunwind
+    lttng-ust
+    stdenv.cc.cc
+    zlib
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp -r ./ $out/bin
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/dotnet --info
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://dotnet.github.io/;
+    description = ".NET Core runtime v${version}";
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ jonringer ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -211,6 +211,10 @@ in
 
   dotnetbuildhelpers = callPackage ../build-support/dotnetbuildhelpers { };
 
+  dotnet-runtime = dotnet-runtime_3;
+
+  dotnet-runtime_3 = callPackage ../development/tools/dotnet/runtime/default.nix { };
+
   dotnet-sdk = callPackage ../development/compilers/dotnet/sdk { };
 
   dispad = callPackage ../tools/X11/dispad { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -215,6 +215,8 @@ in
 
   dotnet-runtime_3 = callPackage ../development/tools/dotnet/runtime/default.nix { };
 
+  dotnet-runtime_2 = callPackage ../development/tools/dotnet/runtime/2.nix { };
+
   dotnet-sdk = callPackage ../development/compilers/dotnet/sdk { };
 
   dispad = callPackage ../tools/X11/dispad { };


### PR DESCRIPTION
###### Motivation for this change

https://devblogs.microsoft.com/dotnet/announcing-net-core-3-0/

noticed there was a `dotnet-sdk` package, but not a runtime package (way smaller size foot-print). So, this is to remedy that issue.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
# sdk size
$ nix path-info -Sh ./result
/nix/store/89di93ibgvdzykyj4g5xmc4f9i5v6k0k-dotnet-sdk-2.2.401   770.9M
# runtimes
$ nix path-info -Sh ./result
/nix/store/jckkgjkkaacaz21yl5aap2x80xxrnr4z-dotnet-runtime-2.2.7         391.0M
$ nix path-info -Sh ./result
/nix/store/303pc0ibq8k4i837ka56zl7lwhxkh2cm-dotnet-runtime-3.0.0         393.8M
```
```
[2 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/69382
2 package were build:
dotnet-runtime dotnet-runtime_2
```
