### PR TITLE
kernel: build initrd and modules tree locally

### DIFF
--- a/pkgs/build-support/kernel/make-initrd.nix
+++ b/pkgs/build-support/kernel/make-initrd.nix
@@ -28,6 +28,8 @@ in stdenv.mkDerivation rec {
 
   builder = ./make-initrd.sh;
 
+  preferLocalBuild = true;
+
   makeUInitrd = stdenv.hostPlatform.platform.kernelTarget == "uImage";
 
   nativeBuildInputs = [ perl cpio ]

--- a/pkgs/build-support/kernel/modules-closure.nix
+++ b/pkgs/build-support/kernel/modules-closure.nix
@@ -9,6 +9,7 @@
 stdenvNoCC.mkDerivation {
   name = kernel.name + "-shrunk";
   builder = ./modules-closure.sh;
+  preferLocalBuild = true;
   nativeBuildInputs = [ nukeReferences kmod ];
   inherit kernel firmware rootModules allowMissing;
   allowedReferences = ["out"];


### PR DESCRIPTION
###### Motivation for this change

morph was spending too much time building these remotely. I confirmed that it started building locally.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @thoughtpolice 

If accepted, please cherry-pick to 19.09 or let me know you want a backport PR.