### PR TITLE
kernel/common-config: enable INET_{TCP,UDP,RAW}_DIAG and INET_DIAG_DESTROY

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -149,6 +149,13 @@ let
       NF_TABLES_ARP               = whenAtLeast "4.17" yes;
       NF_TABLES_IPV6              = whenAtLeast "4.17" yes;
       NF_TABLES_BRIDGE            = whenBetween "4.17" "5.3" yes;
+
+      # needed for ss
+      INET_DIAG         = yes;
+      INET_TCP_DIAG     = module;
+      INET_UDP_DIAG     = module;
+      INET_RAW_DIAG     = whenAtLeast "4.14" module;
+      INET_DIAG_DESTROY = whenAtLeast "4.9" yes;
     };
 
     wireless = {


### PR DESCRIPTION
###### Motivation for this change

These are required for some [ss](http://man7.org/linux/man-pages/man8/ss.8.html) functionality. `ss -K` is particularly useful for killing connections and requires `INET_DIAG_DESTROY`. As far as I know, this is the only reliable way to kill stuck connections on Linux.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @thoughtpolice

I tested on 4.19.75-hardened and confirmed that `ss -K dst SOME_IP_ADDRESS dport = 80` did not work before this change, and did work after this change.