### PR TITLE
retroarch: 1.7.5 -> 1.7.8.4

### DIFF
--- a/pkgs/misc/emulators/retroarch/default.nix
+++ b/pkgs/misc/emulators/retroarch/default.nix
@@ -27,12 +27,12 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "retroarch-bare";
-  version = "1.7.5";
+  version = "1.7.8.4";
 
   src = fetchFromGitHub {
     owner = "libretro";
     repo = "RetroArch";
-    sha256 = "1jfpgl34jjxn3dvxd1kd564swkw7v98hnn562v998b7vllz3dxdm";
+    sha256 = "1i3i23xwvmck8k2fpalr49np7xjzfg507243mybqrljawlnbxvph";
     rev = "v${version}";
   };
 

--- a/pkgs/tools/X11/xdg-utils/default.nix
+++ b/pkgs/tools/X11/xdg-utils/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, fetchFromGitHub
 , file, libxslt, docbook_xml_dtd_412, docbook_xsl, xmlto
-, w3m, gnugrep, gnused, coreutils, xset
+, w3m, gnugrep, gnused, coreutils, xset, perlPackages
 , mimiSupport ? false, gawk ? null }:
 
 assert mimiSupport -> gawk != null;
@@ -13,6 +13,11 @@ let
     rev = "8e0070f17bcd3612ee83cb84e663e7c7fabcca3d";
     sha256 = "15gw2nyrqmdsdin8gzxihpn77grhk9l97jp7s7pr7sl4n9ya2rpj";
   };
+
+  perlPath = with perlPackages; makePerlPath [
+    NetDBus XMLTwig XMLParser X11Protocol
+  ];
+
 in
 
 stdenv.mkDerivation rec {
@@ -39,6 +44,7 @@ stdenv.mkDerivation rec {
     awk()   { ${gawk}/bin/awk       "$@"; }\
     sort()  { ${coreutils}/bin/sort "$@"; }\
     xset()  { ${xset}/bin/xset      "$@"; }\
+    perl()  { PERL5LIB=${perlPath} ${perlPackages.perl}/bin/perl "$@"; }\
     &#' -i "$out"/bin/*
 
     substituteInPlace $out/bin/xdg-open \


### PR DESCRIPTION
###### Motivation for this change
Updating retroarch fixes the missing GUI elements / icons. Also add missing perl dependency to xdg-utils, as it was found missing during testing of retroarch. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after): retroarch +2 MiB, xdg-utils +66 MiB.
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
