### PR TITLE
dotnet-sdk: 2.2.401 -> 2.2.402

### DIFF
--- a/pkgs/development/compilers/dotnet/sdk/default.nix
+++ b/pkgs/development/compilers/dotnet/sdk/default.nix
@@ -12,29 +12,19 @@ let
   rpath = stdenv.lib.makeLibraryPath [ stdenv.cc.cc libunwind libuuid icu openssl zlib curl ];
 in
   stdenv.mkDerivation rec {
-    version = "2.2.401";
-    netCoreVersion = "2.2.6";
+    version = "2.2.402";
+    netCoreVersion = "2.2.7";
     pname = "dotnet-sdk";
 
     src = fetchurl {
       url = "https://dotnetcli.azureedge.net/dotnet/Sdk/${version}/${pname}-${version}-linux-x64.tar.gz";
       # use sha512 from the download page
-      sha512 = "05w3zk7bcd8sv3k4kplf20j906and2006g1fggq7y6kaxrlhdnpd6jhy6idm8v5bz48wfxga5b4yys9qx0fp3p8yl7wi67qljpzrq88";
+      sha512 = "129pnngq2c16cy58zdh47grkf36k9kj39l3zpr8jxapzlin85i3wwwglwv97jp758bd0q5syvprvg84kv7x2difnkikgs2fhzh7v4w1";
     };
 
     sourceRoot = ".";
 
-    buildPhase = ''
-      runHook preBuild
-      patchelf --set-interpreter "${stdenv.cc.bintools.dynamicLinker}" ./dotnet
-      patchelf --set-rpath "${rpath}" ./dotnet
-      find -type f -name "*.so" -exec patchelf --set-rpath '$ORIGIN:${rpath}' {} \;
-      echo -n "dotnet-sdk version: "
-      ./dotnet --version
-      runHook postBuild
-    '';
-
-    dontPatchELF = true;
+    dontBuild = true;
 
     installPhase = ''
       runHook preInstall
@@ -42,6 +32,22 @@ in
       cp -r ./ $out
       ln -s $out/dotnet $out/bin/dotnet
       runHook postInstall
+    '';
+
+    dontPatchelf = true;
+
+    # the dotnet executable cannot be wrapped, must use patchelf.
+    # autoPatchelf isn't able to be used as libicu* and other's aren't
+    # listed under typical binary section
+    postFixup = ''
+      patchelf --set-interpreter "${stdenv.cc.bintools.dynamicLinker}" $out/dotnet
+      patchelf --set-rpath "${rpath}" $out/dotnet
+      find $out -type f -name "*.so" -exec patchelf --set-rpath '$ORIGIN:${rpath}' {} \;
+    '';
+
+    doInstallCheck = true;
+    installCheckPhase = ''
+      $out/bin/dotnet --info
     '';
 
     meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

https://github.com/dotnet/core/blob/master/release-notes/2.2/2.2.7/2.2.7.md

also cleaned up the expression a bit.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
https://github.com/NixOS/nixpkgs/pull/69391
7 package were build:
dotnet-sdk eventstore fsharp41 jellyfin msbuild python37Packages.dotnetcore2 wasabiwallet
```