### PR TITLE
dotnet-sdk_3: init at 3.0.100

### DIFF
--- a/pkgs/development/compilers/dotnet/sdk/3.nix
+++ b/pkgs/development/compilers/dotnet/sdk/3.nix
@@ -1,0 +1,60 @@
+{ stdenv
+, fetchurl
+, libunwind
+, openssl
+, icu
+, libuuid
+, zlib
+, curl
+}:
+
+let
+  rpath = stdenv.lib.makeLibraryPath [ stdenv.cc.cc libunwind libuuid icu openssl zlib curl ];
+in
+  stdenv.mkDerivation rec {
+    version = "3.0.100";
+    netCoreVersion = "3.0.0";
+    pname = "dotnet-sdk";
+
+    src = fetchurl {
+      url = "https://dotnetcli.azureedge.net/dotnet/Sdk/${version}/${pname}-${version}-linux-x64.tar.gz";
+      # use sha512 from the download page
+      sha512 = "3vxhwqv78z8s9pzq19gn0d35g4340m3zvnv70pglk1cgnk02k9hbh51dsf2j6bgcmdxay8q2719ll7baj1sc7n9287vzkqbk8gs6vbn";
+    };
+
+    sourceRoot = ".";
+
+    dontBuild = true;
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/bin
+      cp -r ./ $out
+      ln -s $out/dotnet $out/bin/dotnet
+      runHook postInstall
+    '';
+
+    dontPatchelf = true;
+
+    # the dotnet executable cannot be wrapped, must use patchelf.
+    # autoPatchelf isn't able to be used as libicu* and other's aren't
+    # listed under typical binary section
+    postFixup = ''
+      patchelf --set-interpreter "${stdenv.cc.bintools.dynamicLinker}" $out/dotnet
+      patchelf --set-rpath "${rpath}" $out/dotnet
+      find $out -type f -name "*.so" -exec patchelf --set-rpath '$ORIGIN:${rpath}' {} \;
+    '';
+
+    doInstallCheck = true;
+    installCheckPhase = ''
+      $out/bin/dotnet --info
+    '';
+
+    meta = with stdenv.lib; {
+      homepage = https://dotnet.github.io/;
+      description = ".NET Core SDK ${version} with .NET Core ${netCoreVersion}";
+      platforms = [ "x86_64-linux" ];
+      maintainers = with maintainers; [ jonringer ];
+      license = licenses.mit;
+    };
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -213,6 +213,8 @@ in
 
   dotnet-sdk = callPackage ../development/compilers/dotnet/sdk { };
 
+  dotnet-sdk_3 = callPackage ../development/compilers/dotnet/sdk/3.nix { };
+
   dispad = callPackage ../tools/X11/dispad { };
 
   dump1090 = callPackage ../applications/radio/dump1090 { };


### PR DESCRIPTION
###### Motivation for this change
https://devblogs.microsoft.com/dotnet/announcing-net-core-3-0/

leaving the previous dotnet-sdk as everything that use the dotnet-clr will likely need it still.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
