### PR TITLE
home-assistant: 0.96.2 -> 0.99.2

### DIFF
--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "0.96.2";
+  version = "0.99.2";
   components = {
     "abode" = ps: with ps; [  ];
     "acer_projector" = ps: with ps; [ pyserial ];
@@ -28,6 +28,7 @@
     "androidtv" = ps: with ps; [  ];
     "anel_pwrctrl" = ps: with ps; [  ];
     "anthemav" = ps: with ps; [  ];
+    "apache_kafka" = ps: with ps; [  ];
     "apcupsd" = ps: with ps; [  ];
     "api" = ps: with ps; [ aiohttp-cors ];
     "apns" = ps: with ps; [  ];
@@ -44,12 +45,14 @@
     "asterisk_cdr" = ps: with ps; [  ];
     "asterisk_mbox" = ps: with ps; [  ];
     "asuswrt" = ps: with ps; [  ];
+    "atome" = ps: with ps; [  ];
     "august" = ps: with ps; [  ];
     "aurora" = ps: with ps; [  ];
     "aurora_abb_powerone" = ps: with ps; [  ];
     "auth" = ps: with ps; [ aiohttp-cors ];
     "automatic" = ps: with ps; [ aiohttp-cors ];
     "automation" = ps: with ps; [ aiohttp-cors ];
+    "avea" = ps: with ps; [  ];
     "avion" = ps: with ps; [  ];
     "awair" = ps: with ps; [  ];
     "aws" = ps: with ps; [  ];
@@ -59,6 +62,7 @@
     "bayesian" = ps: with ps; [  ];
     "bbb_gpio" = ps: with ps; [  ];
     "bbox" = ps: with ps; [  ];
+    "beewi_smartclim" = ps: with ps; [  ];
     "bh1750" = ps: with ps; [  ];
     "binary_sensor" = ps: with ps; [  ];
     "bitcoin" = ps: with ps; [  ];
@@ -131,6 +135,7 @@
     "decora" = ps: with ps; [  ];
     "decora_wifi" = ps: with ps; [  ];
     "default_config" = ps: with ps; [ pynacl aiohttp-cors distro netdisco sqlalchemy zeroconf ];
+    "delijn" = ps: with ps; [  ];
     "deluge" = ps: with ps; [ deluge-client ];
     "demo" = ps: with ps; [ aiohttp-cors ];
     "denon" = ps: with ps; [  ];
@@ -173,7 +178,6 @@
     "ecovacs" = ps: with ps; [  ];
     "eddystone_temperature" = ps: with ps; [ construct ];
     "edimax" = ps: with ps; [  ];
-    "edp_redy" = ps: with ps; [  ];
     "ee_brightbox" = ps: with ps; [  ];
     "efergy" = ps: with ps; [  ];
     "egardia" = ps: with ps; [  ];
@@ -222,6 +226,7 @@
     "fints" = ps: with ps; [ fints ];
     "fitbit" = ps: with ps; [ aiohttp-cors fitbit ];
     "fixer" = ps: with ps; [  ];
+    "fleetgo" = ps: with ps; [  ];
     "flexit" = ps: with ps; [  ];
     "flic" = ps: with ps; [  ];
     "flock" = ps: with ps; [  ];
@@ -231,6 +236,8 @@
     "folder" = ps: with ps; [  ];
     "folder_watcher" = ps: with ps; [ watchdog ];
     "foobot" = ps: with ps; [  ];
+    "fortigate" = ps: with ps; [  ];
+    "fortios" = ps: with ps; [  ];
     "foscam" = ps: with ps; [  ];
     "foursquare" = ps: with ps; [ aiohttp-cors ];
     "free_mobile" = ps: with ps; [  ];
@@ -256,6 +263,7 @@
     "geo_location" = ps: with ps; [  ];
     "geo_rss_events" = ps: with ps; [  ];
     "geofency" = ps: with ps; [ aiohttp-cors ];
+    "geonetnz_quakes" = ps: with ps; [  ];
     "github" = ps: with ps; [ PyGithub ];
     "gitlab_ci" = ps: with ps; [ python-gitlab ];
     "gitter" = ps: with ps; [  ];
@@ -272,7 +280,6 @@
     "google_translate" = ps: with ps; [ gtts-token ];
     "google_travel_time" = ps: with ps; [  ];
     "google_wifi" = ps: with ps; [  ];
-    "googlehome" = ps: with ps; [  ];
     "gpmdp" = ps: with ps; [ websocket_client ];
     "gpsd" = ps: with ps; [  ];
     "gpslogger" = ps: with ps; [ aiohttp-cors ];
@@ -280,6 +287,7 @@
     "greeneye_monitor" = ps: with ps; [  ];
     "greenwave" = ps: with ps; [  ];
     "group" = ps: with ps; [  ];
+    "growatt_server" = ps: with ps; [  ];
     "gstreamer" = ps: with ps; [  ];
     "gtfs" = ps: with ps; [  ];
     "gtt" = ps: with ps; [  ];
@@ -323,6 +331,7 @@
     "hydroquebec" = ps: with ps; [  ];
     "hyperion" = ps: with ps; [  ];
     "ialarm" = ps: with ps; [  ];
+    "iaqualink" = ps: with ps; [  ];
     "icloud" = ps: with ps; [  ];
     "idteck_prox" = ps: with ps; [  ];
     "ifttt" = ps: with ps; [ aiohttp-cors pyfttt ];
@@ -357,6 +366,7 @@
     "joaoapps_join" = ps: with ps; [  ];
     "juicenet" = ps: with ps; [  ];
     "kankun" = ps: with ps; [  ];
+    "keba" = ps: with ps; [  ];
     "keenetic_ndms2" = ps: with ps; [  ];
     "keyboard" = ps: with ps; [  ];
     "keyboard_remote" = ps: with ps; [ evdev ];
@@ -402,7 +412,7 @@
     "london_underground" = ps: with ps; [  ];
     "loopenergy" = ps: with ps; [  ];
     "lovelace" = ps: with ps; [  ];
-    "luci" = ps: with ps; [  ];
+    "luci" = ps: with ps; [ packaging ];
     "luftdaten" = ps: with ps; [ luftdaten ];
     "lupusec" = ps: with ps; [  ];
     "lutron" = ps: with ps; [  ];
@@ -440,6 +450,7 @@
     "mikrotik" = ps: with ps; [  ];
     "mill" = ps: with ps; [  ];
     "min_max" = ps: with ps; [  ];
+    "minio" = ps: with ps; [ minio ];
     "mitemp_bt" = ps: with ps; [  ];
     "mjpeg" = ps: with ps; [  ];
     "mobile_app" = ps: with ps; [ pynacl aiohttp-cors ];
@@ -497,9 +508,11 @@
     "nuimo_controller" = ps: with ps; [  ];
     "nuki" = ps: with ps; [  ];
     "nut" = ps: with ps; [  ];
+    "nws" = ps: with ps; [  ];
     "nx584" = ps: with ps; [  ];
     "nzbget" = ps: with ps; [  ];
     "oasa_telematics" = ps: with ps; [  ];
+    "obihai" = ps: with ps; [  ];
     "octoprint" = ps: with ps; [  ];
     "oem" = ps: with ps; [  ];
     "ohmconnect" = ps: with ps; [ defusedxml ];
@@ -546,6 +559,7 @@
     "plaato" = ps: with ps; [ aiohttp-cors ];
     "plant" = ps: with ps; [  ];
     "plex" = ps: with ps; [  ];
+    "plugwise" = ps: with ps; [  ];
     "plum_lightpad" = ps: with ps; [  ];
     "pocketcasts" = ps: with ps; [  ];
     "point" = ps: with ps; [ aiohttp-cors ];
@@ -578,6 +592,7 @@
     "radiotherm" = ps: with ps; [  ];
     "rainbird" = ps: with ps; [  ];
     "raincloud" = ps: with ps; [  ];
+    "rainforest_eagle" = ps: with ps; [  ];
     "rainmachine" = ps: with ps; [  ];
     "random" = ps: with ps; [  ];
     "raspihats" = ps: with ps; [  ];
@@ -597,7 +612,6 @@
     "rfxtrx" = ps: with ps; [  ];
     "ring" = ps: with ps; [ ha-ffmpeg ];
     "ripple" = ps: with ps; [  ];
-    "ritassist" = ps: with ps; [  ];
     "rmvtransport" = ps: with ps; [  ];
     "rocketchat" = ps: with ps; [  ];
     "roku" = ps: with ps; [  ];
@@ -613,7 +627,6 @@
     "rtorrent" = ps: with ps; [  ];
     "russound_rio" = ps: with ps; [  ];
     "russound_rnet" = ps: with ps; [  ];
-    "ruter" = ps: with ps; [  ];
     "sabnzbd" = ps: with ps; [  ];
     "samsungtv" = ps: with ps; [ wakeonlan ];
     "satel_integra" = ps: with ps; [  ];
@@ -647,6 +660,7 @@
     "skybell" = ps: with ps; [  ];
     "slack" = ps: with ps; [  ];
     "sleepiq" = ps: with ps; [  ];
+    "slide" = ps: with ps; [  ];
     "sma" = ps: with ps; [  ];
     "smappee" = ps: with ps; [  ];
     "smarthab" = ps: with ps; [  ];
@@ -689,6 +703,7 @@
     "stream" = ps: with ps; [ aiohttp-cors av ];
     "streamlabswater" = ps: with ps; [  ];
     "stride" = ps: with ps; [  ];
+    "suez_water" = ps: with ps; [  ];
     "sun" = ps: with ps; [  ];
     "supervisord" = ps: with ps; [  ];
     "supla" = ps: with ps; [  ];
@@ -724,7 +739,7 @@
     "telnet" = ps: with ps; [  ];
     "temper" = ps: with ps; [  ];
     "template" = ps: with ps; [  ];
-    "tensorflow" = ps: with ps; [ numpy pillow protobuf ];
+    "tensorflow" = ps: with ps; [ numpy pillow protobuf tensorflow ];
     "tesla" = ps: with ps; [  ];
     "tfiac" = ps: with ps; [  ];
     "thermoworks_smoke" = ps: with ps; [ stringcase ];
@@ -748,7 +763,7 @@
     "touchline" = ps: with ps; [  ];
     "tplink" = ps: with ps; [  ];
     "tplink_lte" = ps: with ps; [  ];
-    "traccar" = ps: with ps; [ stringcase ];
+    "traccar" = ps: with ps; [ aiohttp-cors stringcase ];
     "trackr" = ps: with ps; [  ];
     "tradfri" = ps: with ps; [  ];
     "trafikverket_train" = ps: with ps; [  ];
@@ -759,6 +774,7 @@
     "trend" = ps: with ps; [ numpy ];
     "tts" = ps: with ps; [ aiohttp-cors mutagen ];
     "tuya" = ps: with ps; [  ];
+    "twentemilieu" = ps: with ps; [  ];
     "twilio" = ps: with ps; [ aiohttp-cors twilio ];
     "twilio_call" = ps: with ps; [ aiohttp-cors twilio ];
     "twilio_sms" = ps: with ps; [ aiohttp-cors twilio ];
@@ -771,7 +787,7 @@
     "unifi" = ps: with ps; [ aiounifi ];
     "unifi_direct" = ps: with ps; [ pexpect ];
     "universal" = ps: with ps; [  ];
-    "upc_connect" = ps: with ps; [ defusedxml ];
+    "upc_connect" = ps: with ps; [  ];
     "upcloud" = ps: with ps; [  ];
     "updater" = ps: with ps; [ distro ];
     "upnp" = ps: with ps; [  ];
@@ -794,6 +810,8 @@
     "version" = ps: with ps; [  ];
     "vesync" = ps: with ps; [  ];
     "viaggiatreno" = ps: with ps; [  ];
+    "vicare" = ps: with ps; [  ];
+    "vivotek" = ps: with ps; [  ];
     "vizio" = ps: with ps; [  ];
     "vlc" = ps: with ps; [  ];
     "vlc_telnet" = ps: with ps; [  ];
@@ -819,6 +837,7 @@
     "whois" = ps: with ps; [  ];
     "wink" = ps: with ps; [  ];
     "wirelesstag" = ps: with ps; [  ];
+    "withings" = ps: with ps; [ aiohttp-cors ];
     "workday" = ps: with ps; [  ];
     "worldclock" = ps: with ps; [  ];
     "worldtidesinfo" = ps: with ps; [  ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -98,7 +98,7 @@ let
   extraBuildInputs = extraPackages py.pkgs;
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "0.96.2";
+  hassVersion = "0.99.2";
 
 in with py.pkgs; buildPythonApplication rec {
   pname = "homeassistant";

--- a/pkgs/servers/home-assistant/parse-requirements.py
+++ b/pkgs/servers/home-assistant/parse-requirements.py
@@ -33,7 +33,9 @@ PKG_SET = 'python3Packages'
 # the following can be used to choose one of them
 PKG_PREFERENCES = {
     # Use python3Packages.youtube-dl-light instead of python3Packages.youtube-dl
-    'youtube-dl': 'youtube-dl-light'
+    'youtube-dl': 'youtube-dl-light',
+    'tensorflow-bin': 'tensorflow',
+    'tensorflowWithoutCuda': 'tensorflow'
 }
 
 def get_version():


### PR DESCRIPTION
###### Motivation for this change

https://www.home-assistant.io/blog/2019/09/18/release-99/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @dotlambda 
