### PR TITLE
zfsStable: don't throw with incompatible kernels

### DIFF
--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -26,10 +26,11 @@ let
     if buildKernel &&
       (incompatibleKernelVersion != null) &&
         versionAtLeast kernel.version incompatibleKernelVersion then
-       throw ''
+       warn ''
          Linux v${kernel.version} is not yet supported by zfsonlinux v${version}.
          ${stdenv.lib.optionalString (!isUnstable) "Try zfsUnstable or set the NixOS option boot.zfs.enableUnstable."}
        ''
+       null
     else stdenv.mkDerivation {
       name = "zfs-${configFile}-${version}${optionalString buildKernel "-${kernel.version}"}";
 


### PR DESCRIPTION
kernel packages get evaluated because of mergeEqualOption. The current
throw prevents from installing 5.3. I replaced it with a warning
instead.

```
x:371:8:
while evaluating anonymous function at /home/teto/nixpkgs/lib/options.nix:110:23, called from /home/teto/nixpkgs/lib/options.nix:110:10:
while evaluating the attribute 'zfsStable' at /home/teto/nixpkgs/pkgs/os-specific/linux/zfs/default.nix:152:3:
while evaluating 'common' at /home/teto/nixpkgs/pkgs/os-specific/linux/zfs/default.nix:20:12, called from /home/teto/nixpkgs/pkgs/os-specific/linux/zfs/default.nix:152:15:
Linux v5.3 is not yet supported by zfsonlinux v0.8.1.
Try zfsUnstable or set the NixOS option boot.zfs.enableUnstable.
```

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
