### PR TITLE
peek: 1.3.1 -> 1.4.0

### DIFF
--- a/pkgs/applications/video/peek/default.nix
+++ b/pkgs/applications/video/peek/default.nix
@@ -1,45 +1,76 @@
-{ stdenv, fetchFromGitHub, cmake, gettext, libxml2, pkgconfig, txt2man, vala_0_40, wrapGAppsHook
-, gsettings-desktop-schemas, gtk3, keybinder3, ffmpeg
+{ stdenv
+, fetchFromGitHub
+, meson
+, ninja
+, gettext
+, desktop-file-utils
+, appstream-glib
+, pkgconfig
+, txt2man
+, gzip
+, vala
+, wrapGAppsHook
+, gsettings-desktop-schemas
+, gtk3
+, glib
+, cairo
+, keybinder3
+, ffmpeg
+, python3
+, libxml2
+, gst_all_1
 }:
 
 stdenv.mkDerivation rec {
   pname = "peek";
-  version = "1.3.1";
+  version = "1.4.0";
 
   src = fetchFromGitHub {
     owner = "phw";
-    repo = pname;
+    repo = "peek";
     rev = version;
-    sha256 = "1fnvlklmg6s5rs3ql74isa5fgdkqqrpsyf8k2spxj520239l4vgb";
+    sha256 = "0q70hz9anqywqgksd43i8v9ijwy6djyzwnzzd94j44xqwsk9zdbb";
   };
 
-  preConfigure = ''
-    gappsWrapperArgs+=(--prefix PATH : ${stdenv.lib.makeBinPath [ ffmpeg ]})
-  '';
-
   nativeBuildInputs = [
-    cmake
+    appstream-glib
+    desktop-file-utils
     gettext
+    gzip
+    meson
+    ninja
+    libxml2
     pkgconfig
-    libxml2.bin
     txt2man
-    vala_0_40 # See https://github.com/NixOS/nixpkgs/issues/58433
+    python3
+    vala
     wrapGAppsHook
   ];
 
   buildInputs = [
+    cairo
+    glib
     gsettings-desktop-schemas
     gtk3
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-ugly
     keybinder3
   ];
 
-  enableParallelBuilding = true;
+  postPatch = ''
+    patchShebangs build-aux/meson/postinstall.py data/man/build_man.sh
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(--prefix PATH : ${stdenv.lib.makeBinPath [ ffmpeg ]})
+  '';
 
   meta = with stdenv.lib; {
-    homepage    = https://github.com/phw/peek;
+    homepage = https://github.com/phw/peek;
     description = "Simple animated GIF screen recorder with an easy to use interface";
-    license     = licenses.gpl3;
-    maintainers = with maintainers; [ puffnfresh ];
-    platforms   = platforms.linux;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ puffnfresh worldofpeace ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/video/peek/default.nix
+++ b/pkgs/applications/video/peek/default.nix
@@ -19,6 +19,8 @@
 , python3
 , libxml2
 , gst_all_1
+, which
+, gifski
 }:
 
 stdenv.mkDerivation rec {
@@ -63,7 +65,7 @@ stdenv.mkDerivation rec {
   '';
 
   preFixup = ''
-    gappsWrapperArgs+=(--prefix PATH : ${stdenv.lib.makeBinPath [ ffmpeg ]})
+    gappsWrapperArgs+=(--prefix PATH : ${stdenv.lib.makeBinPath [ which ffmpeg gifski ]})
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/graphics/gifski/default.nix
+++ b/pkgs/tools/graphics/gifski/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "gifski";
-  version = "0.8.7";
+  version = "0.9.1";
 
   src = fetchFromGitHub {
     owner = "ImageOptim";
     repo = "gifski";
     rev = version;
-    sha256 = "0x41gyc5jk45jlx0hcq80j5gj1f66lcmbclqyx70l43ggslsi26f";
+    sha256 = "0dl5725imb2a2s0fskdqlnh2207ryyi2v5gz37cr5mf6khz898p2";
   };
 
-  cargoSha256 = "1pik6jcxg3amb5widpxn8j9szghbrhl0wsxjisizas3033xzrhcf";
+  cargoSha256 = "0wngsd0pmmxlwzxmyp8pvphh1ijs5s9k1mkkv688xpc4b8w0z10j";
 
   nativeBuildInputs = [ pkgconfig ];
 


### PR DESCRIPTION
###### Motivation for this change
See commit messages.

Note that https://github.com/NixOS/nixpkgs/commit/c5df3a63e3a90f8d8c13196ec5769f947149d949 doesn't actually force gifski post-processing, it's still an option you have to enable in the preferences dialog.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

