### PR TITLE
maven: 3.6.1 -> 3.6.2

### DIFF
--- a/pkgs/development/tools/build-managers/apache-maven/default.nix
+++ b/pkgs/development/tools/build-managers/apache-maven/default.nix
@@ -2,7 +2,7 @@
 
 assert jdk != null;
 
-let version = "3.6.1"; in
+let version = "3.6.2"; in
 stdenv.mkDerivation rec {
   pname = "apache-maven";
   inherit version;
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://apache/maven/maven-3/${version}/binaries/${pname}-${version}-bin.tar.gz";
-    sha256 = "1rv97g9qr6sifl88rxbsqnz5i79m6ifs36srri08j3y3k5dc6a15";
+    sha256 = "1p6z6bmjfzda8kxy73jjg03yfkbssbb3vgvzspxxd0hljv8r5g1z";
   };
 
   buildInputs = [ makeWrapper ];


### PR DESCRIPTION
#### Motivation for this change 
Updating Apache Maven


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

