### PR TITLE
IPMIView: 2.14.0 --> 2.16.0, fix iKVM console

### DIFF
--- a/pkgs/applications/misc/ipmiview/default.nix
+++ b/pkgs/applications/misc/ipmiview/default.nix
@@ -1,33 +1,33 @@
 { stdenv, fetchurl, patchelf, makeWrapper, xorg, gcc, gcc-unwrapped }:
 
 stdenv.mkDerivation rec {
-   pname = "IPMIView";
-   version = "2.14.0";
-   buildVersion = "180213";
+  pname = "IPMIView";
+  version = "2.14.0";
+  buildVersion = "180213";
 
-   src = fetchurl {
+  src = fetchurl {
     url = "ftp://ftp.supermicro.com/utility/IPMIView/Linux/IPMIView_${version}_build.${buildVersion}_bundleJRE_Linux_x64.tar.gz";
     sha256 = "1wp22wm7smlsb25x0cck4p660cycfczxj381930crd1qrf68mw4h";
   };
 
-   nativeBuildInputs = [ patchelf makeWrapper ];
+  nativeBuildInputs = [ patchelf makeWrapper ];
 
-   buildPhase = with xorg; ''
-     patchelf --set-rpath "${stdenv.lib.makeLibraryPath [ libX11 libXext libXrender libXtst libXi ]}" ./jre/lib/amd64/xawt/libmawt.so
-     patchelf --set-rpath "${gcc-unwrapped.lib}/lib" ./libiKVM64.so
-     patchelf --set-rpath "${stdenv.lib.makeLibraryPath [ libXcursor libX11 libXext libXrender libXtst libXi ]}" --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" ./jre/bin/javaws
-     patchelf --set-rpath "${gcc.cc}/lib:$out/jre/lib/amd64/jli" --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" ./jre/bin/java
-   '';
+  buildPhase = with xorg; ''
+    patchelf --set-rpath "${stdenv.lib.makeLibraryPath [ libX11 libXext libXrender libXtst libXi ]}" ./jre/lib/amd64/xawt/libmawt.so
+    patchelf --set-rpath "${gcc-unwrapped.lib}/lib" ./libiKVM64.so
+    patchelf --set-rpath "${stdenv.lib.makeLibraryPath [ libXcursor libX11 libXext libXrender libXtst libXi ]}" --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" ./jre/bin/javaws
+    patchelf --set-rpath "${gcc.cc}/lib:$out/jre/lib/amd64/jli" --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" ./jre/bin/java
+  '';
 
-   installPhase = ''
-     mkdir -p $out/bin
-     cp -R . $out/
-     makeWrapper $out/jre/bin/java $out/bin/IPMIView \
-       --prefix PATH : "$out/jre/bin" \
-       --add-flags "-jar $out/IPMIView20.jar"
-   '';
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -R . $out/
+    makeWrapper $out/jre/bin/java $out/bin/IPMIView \
+      --prefix PATH : "$out/jre/bin" \
+      --add-flags "-jar $out/IPMIView20.jar"
+  '';
 
-   meta = with stdenv.lib; {
+  meta = with stdenv.lib; {
     license = licenses.unfree;
-   };
-  }
+  };
+}

--- a/pkgs/applications/misc/ipmiview/default.nix
+++ b/pkgs/applications/misc/ipmiview/default.nix
@@ -1,33 +1,37 @@
-{ stdenv, fetchurl, patchelf, makeWrapper, xorg, gcc, gcc-unwrapped }:
+{ stdenv, fetchurl, patchelf, makeWrapper, xorg, fontconfig, freetype, gcc, gcc-unwrapped }:
 
 stdenv.mkDerivation rec {
   pname = "IPMIView";
-  version = "2.14.0";
-  buildVersion = "180213";
+  version = "2.16.0";
+  buildVersion = "190815";
 
   src = fetchurl {
-    url = "ftp://ftp.supermicro.com/utility/IPMIView/Linux/IPMIView_${version}_build.${buildVersion}_bundleJRE_Linux_x64.tar.gz";
-    sha256 = "1wp22wm7smlsb25x0cck4p660cycfczxj381930crd1qrf68mw4h";
+    url = "https://www.supermicro.com/wftp/utility/IPMIView/Linux/IPMIView_${version}_build.${buildVersion}_bundleJRE_Linux_x64.tar.gz";
+    sha256 = "0qw9zfnj0cyvab7ndamlw2y0gpczjhh1jkz8340kl42r2xmhkvpl";
   };
 
   nativeBuildInputs = [ patchelf makeWrapper ];
 
   buildPhase = with xorg; ''
-    patchelf --set-rpath "${stdenv.lib.makeLibraryPath [ libX11 libXext libXrender libXtst libXi ]}" ./jre/lib/amd64/xawt/libmawt.so
+    patchelf --set-rpath "${stdenv.lib.makeLibraryPath [ libX11 libXext libXrender libXtst libXi ]}" ./jre/lib/amd64/libawt_xawt.so
+    patchelf --set-rpath "${stdenv.lib.makeLibraryPath [ freetype ]}" ./jre/lib/amd64/libfontmanager.so
     patchelf --set-rpath "${gcc-unwrapped.lib}/lib" ./libiKVM64.so
-    patchelf --set-rpath "${stdenv.lib.makeLibraryPath [ libXcursor libX11 libXext libXrender libXtst libXi ]}" --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" ./jre/bin/javaws
     patchelf --set-rpath "${gcc.cc}/lib:$out/jre/lib/amd64/jli" --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" ./jre/bin/java
   '';
 
   installPhase = ''
     mkdir -p $out/bin
     cp -R . $out/
+
+    # LD_LIBRARY_PATH: fontconfig is used from java code
     makeWrapper $out/jre/bin/java $out/bin/IPMIView \
+      --set LD_LIBRARY_PATH "${stdenv.lib.makeLibraryPath [ fontconfig ]}" \
       --prefix PATH : "$out/jre/bin" \
-      --add-flags "-jar $out/IPMIView20.jar"
+      --add-flags "-jar $out/IPMIView20.jar" \
   '';
 
   meta = with stdenv.lib; {
     license = licenses.unfree;
+    maintainers = with maintainers; [ vlaci ];
   };
 }

--- a/pkgs/applications/misc/ipmiview/default.nix
+++ b/pkgs/applications/misc/ipmiview/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , fetchurl
+, makeDesktopItem
 , makeWrapper
 , patchelf
 , fontconfig
@@ -35,9 +36,19 @@ stdenv.mkDerivation rec {
     patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" ./BMCSecurity/${stunnelBinary}
   '';
 
+  desktopItem = makeDesktopItem rec {
+    name = "IPMIView";
+    exec = "IPMIView";
+    desktopName = name;
+    genericName = "Supermicro BMC manager";
+    categories = "Network;Configuration";
+  };
+
   installPhase = ''
     mkdir -p $out/bin
     cp -R . $out/
+
+    ln -s ${desktopItem}/share $out/share
 
     # LD_LIBRARY_PATH: fontconfig is used from java code
     # PATH: iputils is used for ping, and psmisc is for killall

--- a/pkgs/applications/misc/ipmiview/default.nix
+++ b/pkgs/applications/misc/ipmiview/default.nix
@@ -1,4 +1,14 @@
-{ stdenv, fetchurl, patchelf, makeWrapper, xorg, fontconfig, freetype, gcc, gcc-unwrapped }:
+{ stdenv
+, fetchurl
+, makeWrapper
+, patchelf
+, fontconfig
+, freetype
+, gcc
+, gcc-unwrapped
+, iputils
+, psmisc
+, xorg }:
 
 stdenv.mkDerivation rec {
   pname = "IPMIView";
@@ -11,12 +21,18 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ patchelf makeWrapper ];
-
-  buildPhase = with xorg; ''
+  buildPhase = with xorg;
+    let
+      stunnelBinary = if stdenv.hostPlatform.system == "x86_64-linux" then "linux/stunnel64"
+      else if stdenv.hostPlatform.system == "i686-linux" then "linux/stunnel32"
+      else throw "IPMIView is not supported on this platform";
+    in
+  ''
     patchelf --set-rpath "${stdenv.lib.makeLibraryPath [ libX11 libXext libXrender libXtst libXi ]}" ./jre/lib/amd64/libawt_xawt.so
     patchelf --set-rpath "${stdenv.lib.makeLibraryPath [ freetype ]}" ./jre/lib/amd64/libfontmanager.so
     patchelf --set-rpath "${gcc-unwrapped.lib}/lib" ./libiKVM64.so
     patchelf --set-rpath "${gcc.cc}/lib:$out/jre/lib/amd64/jli" --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" ./jre/bin/java
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" ./BMCSecurity/${stunnelBinary}
   '';
 
   installPhase = ''
@@ -24,14 +40,22 @@ stdenv.mkDerivation rec {
     cp -R . $out/
 
     # LD_LIBRARY_PATH: fontconfig is used from java code
+    # PATH: iputils is used for ping, and psmisc is for killall
+    # WORK_DIR: unfortunately the ikvm related binaries are loaded from
+    #           and user configuration is written to files in the CWD
     makeWrapper $out/jre/bin/java $out/bin/IPMIView \
       --set LD_LIBRARY_PATH "${stdenv.lib.makeLibraryPath [ fontconfig ]}" \
-      --prefix PATH : "$out/jre/bin" \
+      --prefix PATH : "$out/jre/bin:${iputils}/bin:${psmisc}/bin" \
       --add-flags "-jar $out/IPMIView20.jar" \
+      --run 'WORK_DIR=''${XDG_DATA_HOME:-~/.local/share}/ipmiview
+             mkdir -p $WORK_DIR
+             ln -snf '$out'/iKVM.jar '$out'/libiKVM* '$out'/libSharedLibrary* $WORK_DIR
+             cd $WORK_DIR'
   '';
 
   meta = with stdenv.lib; {
     license = licenses.unfree;
     maintainers = with maintainers; [ vlaci ];
+    platforms = [ "x86_64-linux" "i686-linux" ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
This PR fixes #26650

###### Things done
First of all package has to be updated  because the previous URL is no longer
accessible.  As the bundled JRE is newer the build process needed to be adjusted too.

The main problem was that the iKVM related libraries are always loaded
from the current working directory. The bundled wrapper script makes
sure to CD to the package root folder. This is a no-go in nix as the
application writes its settings in the current working directory and the
store is read-only.

Workaround: create a directory in the users home, where the required
binaries are symlinked and is writable for the current user.

There was an additional issue that for some BMCs IPMIView relies on
the bundled `stunnel` binary to wrap the iKVM traffic in a TLS tunnel.
Therefore it has to be patched to make it executable and the `killall`
command is needed on the PATH because it is used to terminate the
`stunnel` process upon exit.



- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @domenkozar based on his work on the original issue
