### PR TITLE
plantuml-syntax: add vim plugin

### DIFF
--- a/pkgs/misc/vim-plugins/generated.nix
+++ b/pkgs/misc/vim-plugins/generated.nix
@@ -2003,6 +2003,17 @@ let
     };
   };
 
+  plantuml-syntax = buildVimPluginFrom2Nix {
+    pname = "plantuml-syntax";
+    version = "2019-07-18";
+    src = fetchFromGitHub {
+      owner = "aklt";
+      repo = "plantuml-syntax";
+      rev = "0024021f01c349c2828aeb50a1e131997adea066";
+      sha256 = "1abqpbgz0d0ik4w5frha62i0s3f2w5xsgfa34c0jbwzzq0fkvkk7";
+    };
+  };
+
   pony-vim-syntax = buildVimPluginFrom2Nix {
     pname = "pony-vim-syntax";
     version = "2017-09-26";

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -2,6 +2,7 @@
 airblade/vim-gitgutter
 airblade/vim-rooter
 ajh17/Spacegray.vim
+aklt/plantuml-syntax
 albfan/nerdtree-git-plugin
 altercation/vim-colors-solarized
 alvan/vim-closetag


### PR DESCRIPTION
Add https://github.com/aklt/plantuml-syntax to vim-plugins

Signed-off-by: Sirio Balmelli <sirio@b-ad.ch>

###### Motivation for this change
Wanted plantuml syntax highlighting in Vim

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
    ```bash
    - system: `"x86_64-darwin"`
    - host os: `Darwin 16.7.0, macOS 10.12.6`
    - multi-user?: `no`
    - sandbox: `no`
    - version: `nix-env (Nix) 2.3`
    - channels(siriobalmelli): `"nixpkgs"`
    - nixpkgs: `/Users/siriobalmelli/.nix-defexpr/channels/nixpkgs`
    ```
   - [x] other Linux distributions
    ```bash
     - system: `"x86_64-linux"`
     - host os: `Linux 4.15.0-45-generic, Ubuntu, 18.04.3 LTS (Bionic Beaver)`
     - multi-user?: `no`
     - sandbox: `yes`
     - version: `nix-env (Nix) 2.3`
     - channels(admlocal): `"nixpkgs, sirio.tar.gz"`
     - nixpkgs: `/home/admlocal/.nix-defexpr/channels/nixpkgs`
    ```
- [ n/a ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ n/a ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ n/a ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
