### PR TITLE
mkRemovedOptionModule: assert on removed options

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -592,11 +592,14 @@ rec {
     { options = setAttrByPath optionName (mkOption {
         visible = false;
       });
-      config.warnings =
-        let opt = getAttrFromPath optionName options; in
-        optional opt.isDefined ''
+      config.assertions =
+        let opt = getAttrFromPath optionName options; in [{
+          assertion = !opt.isDefined;
+          message = ''
             The option definition `${showOption optionName}' in ${showFiles opt.files} no longer has any effect; please remove it.
-            ${replacementInstructions}'';
+            ${replacementInstructions}
+          '';
+        }];
     };
 
   /* Return a module that causes a warning to be shown if the

--- a/nixos/modules/services/monitoring/prometheus/exporters/nginx.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/nginx.nix
@@ -49,6 +49,6 @@ in
     (mkRemovedOptionModule [ "insecure" ] ''
       This option was replaced by 'prometheus.exporters.nginx.sslVerify'.
     '')
-    ({ options.warnings = options.warnings; })
+    ({ options.warnings = options.warnings; options.assertions = options.assertions; })
   ];
 }

--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -305,7 +305,7 @@ let
             optional (defined ipv6Address && defined ipv6PrefixLength)
             { address = ipv6Address; prefixLength = ipv6PrefixLength; }))
 
-        ({ options.warnings = options.warnings; })
+        ({ options.warnings = options.warnings; options.assertions = options.assertions; })
       ];
 
   };


### PR DESCRIPTION
We don't want to ignore config that can mess up machines. In general
this should always fail evaluation, as you think you are changing
behaviour and don't, which can easily create run-time errors we can
catch early.

cc @disassembler @lheckemann @grahamc @fpletz @samueldr @flokli @arianvp 

PS. Those `options.assertions` passthroughs are weird submodule cases.