### PR TITLE
ocamlPackages.patience_diff: init at 0.12.0 for OCaml ≥ 4.07 and related additions

### DIFF
--- a/pkgs/development/ocaml-modules/janestreet/0.12.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.12.nix
@@ -451,6 +451,13 @@ rec {
     propagatedBuildInputs = [ async expect_test_helpers_kernel ];
   };
 
+  patience_diff = janePackage {
+    pname = "patience_diff";
+    hash = "055kd3piadjnplip8c8q99ssh79d4irmhg2wng7aida5pbqp2p9f";
+    meta.description = "Diff library using Bram Cohen's patience diff algorithm";
+    propagatedBuildInputs = [ core_kernel ];
+  };
+
   ### Packages at version 0.11, with dependencies at version 0.12
 
   configurator = janePackage {

--- a/pkgs/development/ocaml-modules/janestreet/0.12.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.12.nix
@@ -436,6 +436,14 @@ rec {
     propagatedBuildInputs = [ ppx_base re sexplib ];
   };
 
+  expect_test_helpers_kernel = janePackage {
+    pname = "expect_test_helpers_kernel";
+    hash = "18ya187y2i2hfxr771sd9vy5jdsa30vhs56yjdhwk06v01b2fzbq";
+    meta.description = "Helpers for writing expectation tests";
+    buildInputs = [ ppx_jane ];
+    propagatedBuildInputs = [ core_kernel sexp_pretty ];
+  };
+
   ### Packages at version 0.11, with dependencies at version 0.12
 
   configurator = janePackage {

--- a/pkgs/development/ocaml-modules/janestreet/0.12.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.12.nix
@@ -444,6 +444,13 @@ rec {
     propagatedBuildInputs = [ core_kernel sexp_pretty ];
   };
 
+  expect_test_helpers = janePackage {
+    pname = "expect_test_helpers";
+    hash = "0ixqck2lnsmz107yw0q2sr8va80skjpldx7lz4ymjiq2vsghk0rb";
+    meta.description = "Async helpers for writing expectation tests";
+    propagatedBuildInputs = [ async expect_test_helpers_kernel ];
+  };
+
   ### Packages at version 0.11, with dependencies at version 0.12
 
   configurator = janePackage {

--- a/pkgs/development/ocaml-modules/janestreet/0.12.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.12.nix
@@ -429,6 +429,13 @@ rec {
     propagatedBuildInputs = [ core ];
   };
 
+  sexp_pretty = janePackage {
+    pname = "sexp_pretty";
+    hash = "06hdsaszc5cd7fphiblbn4r1sh36xgjwf2igzr2rvlzqs7jiv2v4";
+    meta.description = "S-expression pretty-printer";
+    propagatedBuildInputs = [ ppx_base re sexplib ];
+  };
+
   ### Packages at version 0.11, with dependencies at version 0.12
 
   configurator = janePackage {


### PR DESCRIPTION
###### Motivation for this change

Dependencies of `patdiff` at version 0.12.0, compatible with OCaml ≥ 4.07

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
