### PR TITLE
clipman: init at 1.0.1

### DIFF
--- a/pkgs/tools/misc/clipman/default.nix
+++ b/pkgs/tools/misc/clipman/default.nix
@@ -1,0 +1,30 @@
+{ buildGoModule, fetchFromGitHub, lib, wl-clipboard, makeWrapper }:
+
+buildGoModule rec {
+  pname = "clipman";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "yory8";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1qv7mncb8ggyxrxqxax3gbcfxzk8b4zj2n8rp2xpghsynw4j740w";
+  };
+
+  modSha256 = "0qwrj6wqy32v65k3sbp24frhrcq6wfk38ckmy6wfmhgcix47fzj2";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = ''
+    wrapProgram $out/bin/clipman \
+      --prefix PATH : ${lib.makeBinPath [ wl-clipboard ]}
+  '';
+
+  meta = with lib; {
+    homepage = https://github.com/yory8/clipman;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ ma27 ];
+    description = "A simple clipboard manager for Wayland";
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1401,6 +1401,8 @@ in
 
   chntpw = callPackage ../tools/security/chntpw { };
 
+  clipman = callPackage ../tools/misc/clipman { };
+
   clipster = callPackage ../tools/misc/clipster { };
 
   coprthr = callPackage ../development/libraries/coprthr { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Simple clipboard manager for wayland: https://github.com/yory8/clipman

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
