### PR TITLE
Reduce closure size of Qt applications

### DIFF
--- a/pkgs/applications/kde/kate.nix
+++ b/pkgs/applications/kde/kate.nix
@@ -15,8 +15,8 @@ mkDerivation {
   };
 
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
-  buildInputs = [ libgit2 ];
-  propagatedBuildInputs = [
+  buildInputs = [
+    libgit2
     kactivities ki18n kio ktexteditor kwindowsystem plasma-framework
     qtscript kconfig kcrash kguiaddons kiconthemes kinit kjobwidgets kparts
     kxmlgui kdbusaddons kwallet kitemmodels knotifications threadweaver

--- a/pkgs/applications/kde/konsole.nix
+++ b/pkgs/applications/kde/konsole.nix
@@ -1,5 +1,5 @@
 {
-  mkDerivation, lib, makeWrapper,
+  mkDerivation, lib,
   extra-cmake-modules, kdoctools,
   kbookmarks, kcompletion, kconfig, kconfigwidgets, kcoreaddons, kguiaddons,
   ki18n, kiconthemes, kinit, kdelibs4support, kio, knotifications,
@@ -18,12 +18,7 @@ mkDerivation {
     kbookmarks kcompletion kconfig kconfigwidgets kcoreaddons kdelibs4support
     kguiaddons ki18n kiconthemes kinit kio knotifications knotifyconfig kparts kpty
     kservice ktextwidgets kwidgetsaddons kwindowsystem kxmlgui qtscript knewstuff
-    makeWrapper
   ];
-
-  postInstall = ''
-    wrapProgram $out/bin/konsole --prefix XDG_DATA_DIRS ":" $out/share
-  '';
 
   propagatedUserEnvPkgs = [ (lib.getBin kinit) ];
 }

--- a/pkgs/development/libraries/kde-frameworks/extra-cmake-modules/setup-hook.sh
+++ b/pkgs/development/libraries/kde-frameworks/extra-cmake-modules/setup-hook.sh
@@ -53,12 +53,11 @@ ecmPostHook() {
 }
 postHooks+=(ecmPostHook)
 
-xdgDataSubdirs=(
-    "doc" "config.kcfg" "kconf_update" "kservices5" "kservicetypes5" \
+xdgDataSubdirs=( \
+    "config.kcfg" "kconf_update" "kservices5" "kservicetypes5" \
     "kxmlgui5" "knotifications5" "icons" "locale" "sounds" "templates" \
     "wallpapers" "applications" "desktop-directories" "mime" "appdata" "dbus-1" \
 )
-
 
 ecmHostPathSeen=( )
 
@@ -103,6 +102,11 @@ ecmHostPathHook() {
     if [ -d "$infoDir" ]
     then
         qtWrapperArgs+=(--prefix INFOPATH : "$infoDir")
+    fi
+
+    if [ -d "$1/dbus-1" ]
+    then
+        propagatedUserEnvPkgs+=" $1"
     fi
 }
 addEnvHooks "$hostOffset" ecmHostPathHook

--- a/pkgs/development/libraries/kde-frameworks/extra-cmake-modules/setup-hook.sh
+++ b/pkgs/development/libraries/kde-frameworks/extra-cmake-modules/setup-hook.sh
@@ -109,4 +109,4 @@ ecmHostPathHook() {
         propagatedUserEnvPkgs+=" $1"
     fi
 }
-addEnvHooks "$hostOffset" ecmHostPathHook
+addEnvHooks "$targetOffset" ecmHostPathHook

--- a/pkgs/development/libraries/spandsp/default.nix
+++ b/pkgs/development/libraries/spandsp/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
     url = "https://www.soft-switch.org/downloads/spandsp/spandsp-${version}.tar.gz";
     sha256 = "0rclrkyspzk575v8fslzjpgp4y2s4x7xk3r55ycvpi4agv33l1fc";
   };
-  buildInputs = [];
+  outputs = [ "out" "dev" ];
   propagatedBuildInputs = [audiofile libtiff];
   meta = {
     homepage = http://www.creytiv.com/baresip.html;
@@ -18,4 +18,3 @@ stdenv.mkDerivation rec {
     updateWalker = true;
   };
 }
-

--- a/pkgs/development/libraries/srtp/default.nix
+++ b/pkgs/development/libraries/srtp/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
     sha256 = "1ac7xs1djb03j131f1gmqyfmrplblid9qqyxahs0shdy707r5ll6";
   };
 
+  outputs = [ "out" "dev" ];
+
   nativeBuildInputs = [ pkgconfig ];
 
   # libsrtp.pc references -lcrypto -lpcap without -L

--- a/pkgs/development/libraries/tremor/default.nix
+++ b/pkgs/development/libraries/tremor/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation {
     sha256 = "0m07gq4zfgigsiz8b518xyb19v7qqp76qmp7lb262825vkqzl3zq";
   };
 
+  outputs = [ "out" "dev" ];
+
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
   propagatedBuildInputs = [ libogg ];
 

--- a/pkgs/tools/inputmethods/ibus/default.nix
+++ b/pkgs/tools/inputmethods/ibus/default.nix
@@ -98,6 +98,8 @@ stdenv.mkDerivation rec {
     })
   ];
 
+  outputs = [ "out" "dev" ];
+
   postPatch = ''
     echo \#!${runtimeShell} > data/dconf/make-dconf-override-db.sh
     cp ${buildPackages.gtk-doc}/share/gtk-doc/data/gtk-doc.make .

--- a/pkgs/tools/misc/hdf5/default.nix
+++ b/pkgs/tools/misc/hdf5/default.nix
@@ -28,6 +28,8 @@ stdenv.mkDerivation rec {
     inherit mpi;
   };
 
+  outputs = [ "out" "dev" ];
+
   nativeBuildInputs = [ removeReferencesTo ];
 
   buildInputs = []
@@ -51,6 +53,7 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     find "$out" -type f -exec remove-references-to -t ${stdenv.cc} '{}' +
+    moveToOutput bin/h5cc "''${!outputDev}"
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Fixes: #69272

This removes all the `-dev` outputs from the runtime closure of Qt applications that I found by looking at the closure of the graphical installer ISO. There may yet be others, but I think this is enough to remove the blocker once backported to NixOS 19.09.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

CC: @lovek323 (SDL), @7c6f434c (spandsp), @yegortimoshenko (ibus)
