### PR TITLE
solo-python: init at 0.0.15

### DIFF
--- a/pkgs/development/python-modules/solo-python/default.nix
+++ b/pkgs/development/python-modules/solo-python/default.nix
@@ -1,0 +1,37 @@
+{ lib, buildPythonPackage, fetchFromGitHub
+, click, ecdsa, fido2, intelhex, pyserial, pyusb, requests}:
+
+ buildPythonPackage rec {
+  pname = "solo-python";
+  version = "0.0.15";
+  format = "flit";
+
+  src = fetchFromGitHub {
+    owner = "solokeys";
+    repo = pname;
+    rev = version;
+    sha256 = "14na9s65hxzx141bdv0j7rx1wi3cv85jzpdivsq1rwp6hdhiazr1";
+  };
+
+  # TODO: remove ASAP
+  patchPhase = ''
+    substituteInPlace pyproject.toml --replace "fido2 == 0.7.0" "fido2 >= 0.7.0"
+  '';
+
+  propagatedBuildInputs = [
+    click
+    ecdsa
+    fido2
+    intelhex
+    pyserial
+    pyusb
+    requests
+  ];
+
+  meta = with lib; {
+    description = "Python tool and library for SoloKeys";
+    homepage = "https://github.com/solokeys/solo-python";
+    maintainers = with maintainers; [ wucke13 ];
+    license = with licenses; [ asl20 mit ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6036,6 +6036,8 @@ in {
 
   yarl = callPackage ../development/python-modules/yarl { };
 
+  solo-python = disabledIf (! pythonAtLeast "3.6") (callPackage ../development/python-modules/solo-python { });
+
   suseapi = callPackage ../development/python-modules/suseapi { };
 
   typed-ast = callPackage ../development/python-modules/typed-ast { };


### PR DESCRIPTION
Support for solokeys U2F tokens

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
I got one of these tokens and wanted to tinker around with it. Unfortunately, their tool was not part of nixpkgs yet.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
