### PR TITLE
pythonPackages.tensorflow: fix for bazel settings for intel mkl, dnnl

### DIFF
--- a/pkgs/development/python-modules/tensorflow/1/default.nix
+++ b/pkgs/development/python-modules/tensorflow/1/default.nix
@@ -18,6 +18,7 @@
 # it would also make the default tensorflow package unfree. See
 # https://groups.google.com/a/tensorflow.org/forum/#!topic/developers/iRCt5m4qUz0
 , cudaSupport ? false, nvidia_x11 ? null, cudatoolkit ? null, cudnn ? null, nccl ? null
+, mklSupport ? false, mkl ? null
 # XLA without CUDA is broken
 , xlaSupport ? cudaSupport
 # Default from ./configure script
@@ -35,6 +36,8 @@ assert cudaSupport -> nvidia_x11 != null
 
 # unsupported combination
 assert ! (stdenv.isDarwin && cudaSupport);
+
+assert mklSupport -> mkl != null;
 
 let
   withTensorboard = pythonOlder "3.6";
@@ -167,6 +170,8 @@ let
       cudatoolkit
       cudnn
       nvidia_x11
+    ] ++ lib.optionals mklSupport [
+      mkl
     ] ++ lib.optionals stdenv.isDarwin [
       Foundation
       Security
@@ -284,7 +289,8 @@ let
     ];
     bazelBuildFlags = [
       "--config=opt" # optimize using the flags set in the configure phase
-    ];
+    ]
+    ++ lib.optionals (mklSupport) [ "--config=mkl" ];
 
     bazelTarget = "//tensorflow/tools/pip_package:build_pip_package //tensorflow/tools/lib_package:libtensorflow";
 


### PR DESCRIPTION
	modified:   pkgs/development/python-modules/tensorflow/default.nix

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Nix Tensorflow does not support optionally using the Intel provided optimizations for Intel MKL, which must be enabled through additional compile flags.

On modern Intel processors, this will generally provide improved performance and is  recommended in [Tensorflow's performance guide](https://www.tensorflow.org/guide/performance/overview).

NOTE: This change depends on MKL-DNN, the open PR found here: #68014 

I've tested the changes on Linux with the above mentioned PR applied, both with an without Intel MKL enabled to confirm it works in both cases.  I do not have access to test on darwin, but believe that redirects to binary versions.  I would appreciate if someone could test with cuda, as this may need to be disabled when cudaSupport is enabled (I can make the change, but not test that myself).

With MKL enabled tensorflow.python.framework.test_util.IsMklEnabled() returns _True_

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @jyp @abbradar 
