### PR TITLE
treewide: remove empty buildInputs

### DIFF
--- a/pkgs/applications/science/logic/potassco/clingo.nix
+++ b/pkgs/applications/science/logic/potassco/clingo.nix
@@ -9,8 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "01czx26p8gv81ahrh650x208hjhd8bx1kb688fmk1m4pw4yg5bfv";
   };
 
-  buildInputs = [];
-  nativeBuildInputs = [cmake];
+  nativeBuildInputs = [ cmake ];
 
   cmakeFlags = [ "-DCLINGO_BUILD_WITH_PYTHON=OFF" ];
 

--- a/pkgs/applications/science/math/nauty/default.nix
+++ b/pkgs/applications/science/math/nauty/default.nix
@@ -19,7 +19,6 @@ stdenv.mkDerivation rec {
     sandybridge    = [ "--disable-clz" ];
     ivybridge      = [ "--disable-clz" ];
   }.${stdenv.hostPlatform.platform.gcc.arch or "default"} or [];
-  buildInputs = [];
   installPhase = ''
     mkdir -p "$out"/{bin,share/doc/nauty} "$dev"/{lib,include/nauty}
 

--- a/pkgs/development/libraries/safefile/default.nix
+++ b/pkgs/development/libraries/safefile/default.nix
@@ -8,8 +8,6 @@ stdenv.mkDerivation rec {
     sha256 = "1y0gikds2nr8jk8smhrl617njk23ymmpxyjb2j1xbj0k82xspv78";
   };
 
-  buildInputs = [];
-
   passthru = {
     updateScript = ''
       #!${runtimeShell}

--- a/pkgs/development/libraries/spandsp/default.nix
+++ b/pkgs/development/libraries/spandsp/default.nix
@@ -6,7 +6,6 @@ stdenv.mkDerivation rec {
     url = "https://www.soft-switch.org/downloads/spandsp/spandsp-${version}.tar.gz";
     sha256 = "0rclrkyspzk575v8fslzjpgp4y2s4x7xk3r55ycvpi4agv33l1fc";
   };
-  buildInputs = [];
   propagatedBuildInputs = [audiofile libtiff];
   meta = {
     homepage = http://www.creytiv.com/baresip.html;
@@ -18,4 +17,3 @@ stdenv.mkDerivation rec {
     updateWalker = true;
   };
 }
-

--- a/pkgs/development/python-modules/graph_nets/default.nix
+++ b/pkgs/development/python-modules/graph_nets/default.nix
@@ -20,8 +20,6 @@ buildPythonPackage rec {
     sha256 = "6f27f0358a477d4ec3ab300bf09944b4dfdd5c10b0a5f7ac06bcb32d1327ebe1";
   };
 
-  buildInputs = [];
-
   postPatch = ''
     # https://github.com/deepmind/graph_nets/issues/63
     sed -i 's/dm-sonnet==1.23/dm-sonnet/' setup.py

--- a/pkgs/development/python-modules/pulp/default.nix
+++ b/pkgs/development/python-modules/pulp/default.nix
@@ -9,7 +9,6 @@ buildPythonPackage rec {
     sha256 = "1irzpfnnm5f0qf8y9ddxi489nwixyj0q4zlvqafm621bijkxdv6g";
   };
 
-  buildInputs = [];
   propagatedBuildInputs = [ pyparsing ];
 
   # only one test that requires an extra

--- a/pkgs/tools/misc/clac/default.nix
+++ b/pkgs/tools/misc/clac/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchFromGitHub}:
+{ stdenv, fetchFromGitHub }:
 stdenv.mkDerivation rec {
   pname = "clac";
   version = "0.0.0.20170503";
@@ -10,8 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "0j8p1npgq32s377c9lw959h5i2csq4yb27cvg7av17bji46816bv";
   };
 
-  buildInputs = [];
-  makeFlags = ["PREFIX=$(out)"];
+  makeFlags = [ "PREFIX=$(out)" ];
 
   postInstall = ''
     mkdir -p "$out/share/doc/${pname}"


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
