### PR TITLE
libpfm: enable static build

### DIFF
--- a/pkgs/development/libraries/libpfm/default.nix
+++ b/pkgs/development/libraries/libpfm/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, enableShared ? true }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (rec {
   version = "4.10.1";
   pname = "libpfm";
 
@@ -30,4 +30,8 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.pierron ];
     platforms = platforms.linux;
   };
+} // stdenv.lib.optionalAttrs ( ! enableShared )
+{
+  CONFIG_PFMLIB_SHARED = "n";
 }
+)

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -95,6 +95,9 @@ in {
   libiberty = super.libiberty.override {
     staticBuild = true;
   };
+  libpfm = super.libpfm.override {
+    enableShared = false;
+  };
   ipmitool = super.ipmitool.override {
     static = true;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The `pkgsStatic` build on Linux fails with the following:

```
$ nix-build pkgsStatic.libpfm
...
/nix/store/gkq6rh8nj8i7prh4c9rawhwrk5g20cfx-x86_64-unknown-linux-musl-binutils-2.31.1/bin/x86_64-unknown-linux-musl-ld: /nix/store/c2yk9q5j6h15rvw83ry99df8lzak0bkx-gcc-debug-8.3.0-x86_64-unknown-linux-musl-stage-final/lib/gcc/x86_64-unknown-linux-musl/8.3.0/crtbeginT.o: relocation R_X86_64_32 against hidden symbol `__TMC_END__' can not be used when making a shared object
/nix/store/gkq6rh8nj8i7prh4c9rawhwrk5g20cfx-x86_64-unknown-linux-musl-binutils-2.31.1/bin/x86_64-unknown-linux-musl-ld: /nix/store/c2yk9q5j6h15rvw83ry99df8lzak0bkx-gcc-debug-8.3.0-x86_64-unknown-linux-musl-stage-final/lib/gcc/x86_64-unknown-linux-musl/8.3.0/crtend.o: relocation R_X86_64_32 against `.ctors' can not be used when making a shared object; recompile with -fPIC
/nix/store/gkq6rh8nj8i7prh4c9rawhwrk5g20cfx-x86_64-unknown-linux-musl-binutils-2.31.1/bin/x86_64-unknown-linux-musl-ld: final link failed: nonrepresentable section on output
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:380: libpfm.so.4.10.1] Error 1
make[1]: Leaving directory '/build/libpfm-4.10.1/lib'
make: *** [Makefile:49: all] Error 2
builder for '/nix/store/378h35wdwnmxkkkzbjv86m0jcdnh61rw-libpfm-4.10.1-x86_64-unknown-linux-musl.drv' failed with exit code 2
error: build of '/nix/store/378h35wdwnmxkkkzbjv86m0jcdnh61rw-libpfm-4.10.1-x86_64-unknown-linux-musl.drv' on 'ssh://nicolas@zrh-3' failed: builder for '/nix/store/378h35wdwnmxkkkzbjv86m0jcdnh61rw-libpfm-4.10.1-x86_64-unknown-linux-musl.drv' failed with exit code 2
builder for '/nix/store/378h35wdwnmxkkkzbjv86m0jcdnh61rw-libpfm-4.10.1-x86_64-unknown-linux-musl.drv' failed with exit code 1
error: build of '/nix/store/378h35wdwnmxkkkzbjv86m0jcdnh61rw-libpfm-4.10.1-x86_64-unknown-linux-musl.drv' failed
```

By specifying `CONFIG_PFMLIB_SHARED=n` we [disable the shared libraries](https://sourceforge.net/p/perfmon2/libpfm4/ci/master/tree/Makefile#l83).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @nbp 
