### PR TITLE
setuptools-build-hook: fix the develop mode

### DIFF
--- a/pkgs/development/interpreters/python/hooks/setuptools-build-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/setuptools-build-hook.sh
@@ -29,7 +29,7 @@ setuptoolsShellHook() {
         export PATH="$tmp_path/bin:$PATH"
         export PYTHONPATH="@pythonSitePackages@:$PYTHONPATH"
         mkdir -p "$tmp_path/@pythonSitePackages@"
-        eval "@pythonInterpreter@ -m pip -e . --prefix $tmp_path >&2"
+        @pythonInterpreter@ -m pip -e . --prefix $tmp_path >&2
     fi
 
     runHook postShellHook


### PR DESCRIPTION
I have tested with several packages and develop mode would
systematically trigger.

these paths will be fetched (0.02 MiB download, 0.16 MiB unpacked):
  /nix/store/j7bms8a3r2pxl31x7nq9hzjzxzkfkwfk-source
copying path '/nix/store/j7bms8a3r2pxl31x7nq9hzjzxzkfkwfk-source' from 'https://cache.nixos.org'...
Sourcing python-catch-conflicts-hook.sh
Sourcing python-remove-bin-bytecode-hook.sh
Sourcing setuptools-build-hook
Using setuptoolsBuildPhase
Using setuptoolsShellHook
Sourcing pip-install-hook
Using pipInstallPhase
Sourcing python-imports-check-hook.sh
Using pythonImportsCheckPhase
Sourcing setuptools-check-hook
Using setuptoolsCheckPhase
Executing setuptoolsShellHook

Usage:
  /nix/store/k0igqpz995nmxwf6piyd5jjpcc7gcnyc-python3-3.7.4/bin/python3.7 -m pip <command> [options]

no such option: -e
Finished executing setuptoolsShellHook

There doesn't seem to be a need for eval in the setuptools-build-hook, especially as
other hooks don't have it.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @FRidh 
