### PR TITLE
lsd2dsl: init at 0.4.1

### DIFF
--- a/pkgs/applications/misc/lsd2dsl/default.nix
+++ b/pkgs/applications/misc/lsd2dsl/default.nix
@@ -1,0 +1,36 @@
+{ mkDerivation, lib, fetchFromGitHub, cmake
+, boost, libvorbis, libsndfile, minizip, gtest }:
+
+mkDerivation rec {
+  pname = "lsd2dsl";
+  version = "0.4.1";
+
+  src = fetchFromGitHub {
+    owner = "nongeneric";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "15xjp5xxvl0qc4zp553n7djrbvdp63sfjw406idgxqinfmkqkqdr";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ boost libvorbis libsndfile minizip gtest ];
+
+  NIX_CFLAGS_COMPILE = "-Wno-error=unused-result";
+
+  installPhase = ''
+    install -Dm755 lsd2dsl $out/bin/lsd2dsl
+    install -m755 qtgui/lsd2dsl-qtgui $out/bin/lsd2dsl-qtgui
+  '';
+
+  meta = with lib; {
+    homepage = "https://rcebits.com/lsd2dsl/";
+    description = "Lingvo dictionaries decompiler";
+    longDescription = ''
+      A decompiler for ABBYY Lingvo’s proprietary dictionaries.
+    '';
+    license = licenses.mit;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19246,6 +19246,8 @@ in
 
   loxodo = callPackage ../applications/misc/loxodo { };
 
+  lsd2dsl = libsForQt5.callPackage ../applications/misc/lsd2dsl { };
+
   lrzsz = callPackage ../tools/misc/lrzsz { };
 
   lsp-plugins = callPackage ../applications/audio/lsp-plugins { };


### PR DESCRIPTION
###### Motivation for this change

**[lsd2dsl](https://rcebits.com/lsd2dsl/)** is a decompiler for ABBYY Lingvo’s proprietary dictionaries.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```sh
$ nix path-info -Sh /nix/store/4cqj9g0hpm1q0kkjyzg8ll6nnjsqbza8-lsd2dsl-0.4.1/
/nix/store/4cqj9g0hpm1q0kkjyzg8ll6nnjsqbza8-lsd2dsl-0.4.1	 543.6M
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
