### PR TITLE
 thunderbird, thunderbird-bin: 68.1.0 -> 68.1.1 

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,615 +1,615 @@
 {
-  version = "68.1.0";
+  version = "68.1.1";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/ar/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/ar/thunderbird-68.1.1.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "b9bb22bdbe013358c03e804e3c51ad387dca503b9e0074db70494eb3f331d72bd8679db929972e75b39f2464d384753bcab9947d1a843a69167d7b3706952c35";
+      sha512 = "33accd6fe1f83fc47a34df038f4257571f42281a89f9aab2f54514443856b71aaa2ee81abe98331ecdbbf026a09eea31fb2c5eb72044347c54f51a6ac1e0bfd4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/ast/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/ast/thunderbird-68.1.1.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "e00382241343bbd8a86e31dfcf5bbb060b46e5db6211cfa54c7192361353e2c4fe3d0ad3f4e0319ec1a0dc1f4590b7bc0271e5658bc468986d8e27a64d9924da";
+      sha512 = "1e32c40cd198b51a5836c2ad9a6331c0b3028e57d62e5e057990a48ab80b9fd5bd1290a268da29dc5a45c61e712bf0345f85d0ca43c18b2236c0f4bac7b9328f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/be/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/be/thunderbird-68.1.1.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "f043c8aa5dac0d5e2f9da628d6659f654cc39726677424e4b5e5005e97bf202575f569ebdee346d37cc8d4d59da188e6cfe1bd6bf7df1acafe26b489242b4a9f";
+      sha512 = "0f86506a7cf72c75712f6b507fda6e39da9520865dea5eb4fbfdb78531dc88116d4e8227dd91e8f1fb4dff9ed3e4eb7e118b5a4dde3860ec00c3bca625478a21";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/bg/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/bg/thunderbird-68.1.1.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "61fcf864145fb4fd4a05bff47bd23a7be8444f9d067eec246399c3a7ce48db8744ba4a9cb42e28a215a5bb1b336a57c51d1a32e6564f42c8b9fd4dba5f629d9f";
+      sha512 = "f25c07ee41767fc1ec9381291662ce5bf269971f3542b4c2427da7240c13cfe44f006b8995e6474309bb6330e21626ca7e3e7463452ddd5d7e0128b799f6f566";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/br/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/br/thunderbird-68.1.1.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "1cdc9b2a8ee82bb087a51ac013644ff3da5f1e161fca23fb24feae8076cef6c5aff5316f83a8ecfa4f08c3a8642501a333d3ef95b46b8f899ce78b79d027af4c";
+      sha512 = "c57c207922aa0f1534fd6925305effdea2f09ee83ddfe7eed62d30b91494ddbf6ade0c0cba2e7332c876e10e15593ad985deaec769525fd3a19b21d048383690";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/ca/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/ca/thunderbird-68.1.1.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "1b73ca87f3067ec2a84990c7c58060b11286dd653f4b8b4c18a44f5540ea195d25f995539de39b6e1de6cbbe54c890bf30f6d88157e000e30c69f4d32a4ae8f0";
+      sha512 = "4fb66d8e9285cb40cf42f626d38eecabe489fa5311a25ce2e687483b6624819674b0b4a41f486a0ea98edbe27cea2f7f156368516f70afd4f78629aef93cb94f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/cak/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/cak/thunderbird-68.1.1.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "1b2ec85786a842c7554f52b1ff72c4e5611a76bca94c4b8e9a79604d6b85d7f2deba906bbeca355dfd0c5a6c241d9bd397f4e0dfebd802cdb0c35162a02fd879";
+      sha512 = "2c591767d09c3af59dcda7c44937f012cc14695a7744bca49d2b5788cd44953a85b8cc0005efa4db3daeb6c5f553ead9d15239af37b1c7686e5331cf9bb09ee5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/cs/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/cs/thunderbird-68.1.1.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "69df6542c5037815d3a80be764eaa809dd351f75417e4362a258df5e17e36aef6d8f8653429f4218f196ff096252e0304c2cca1cccbf8693d119bc05f1072067";
+      sha512 = "62d58fd817b235d8afea65212f527b99cf67d882a3fef592c2499881d659837ed90f5192111edef9b7d00e37ea5b1becc9fed00eb4af063ffa4ece160996a73b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/cy/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/cy/thunderbird-68.1.1.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "5dc63d2746475f0045f7749e45bbc3f755b187521b0ca877ffab9386bb1bbe9b4fd66f9cc6bdac516ba591e71d71f02a75b5c965a610a3efbee3b59815d8deda";
+      sha512 = "7df64966340aed43c1411abeef18ade4891c2d64361d3952967529ea487dbccf6ec4d824f85a740ed4d54bda188acf9992ba9623a72c139268f09efaaa27eb89";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/da/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/da/thunderbird-68.1.1.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "89427a2b66dbd71cdfbb299a14ce7ed61ab4836e473854ea8b2ec522de64870f8886f6ae86428c9b1c86733aaa4ac7c732a708fccdd70d3e112d2f651c0dc762";
+      sha512 = "7bc7c0b44e981f74119cb19f4d27e260a2df53b9188364c367752ca4fa461b1c003ea58d4eb14fd9d9b64ab1cec5cbef6e68080da180ca6e904bc6bed0dea924";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/de/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/de/thunderbird-68.1.1.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "34130ec994f6ee6a407313ccc61d43b0375046f59f75d4fb619776d5c880993802c16a3b8ec28dc7053b4ae89f91f1c2046da7d884d150aa7c3b65edd1650b21";
+      sha512 = "6879addb03511e1fa18696069251a3649865fa2410b2503f8588d06e3ad8fe9d127ef414cfa977a323468e037f7fa06d7dbf306bb98608ecc21acedb68e2784d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/dsb/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/dsb/thunderbird-68.1.1.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "0b9c02a1e31f8f3120fb9ed520c53505dc247440ba2e189cbc58569be5ce6e0c33de220ebda17754338aa680cf5c8aac3ad7f5da14e0cbefc29f32db2446618a";
+      sha512 = "ab82cc4b35e0bc9bca7611cc9b17cc383e7489f54e976074d34deca5ddf83d380b85ef3db5b35611d59500ba8c421848ca9d0e4e8dc4f8dbbd0b9fabfd13eada";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/el/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/el/thunderbird-68.1.1.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "1d8e2efc2c9a7375a2ce0f2137165756800a680209d18612420581963f13774fc7780ac0ccda24a485996531d1e82e027b42a671f1c8fce5e8ccf0887f72ac6f";
+      sha512 = "b8aba262bd82149ec9213d0a307ca6579c64b7afa084a251f35efb68384df55c220fe71bbef1741514ddd45c284e669fd4062ce5202f9ba91622b88dd48d5304";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/en-GB/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/en-GB/thunderbird-68.1.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "79684a833afe5d1025088d6f91e023c81832e9df83751926c5d9bc05fecb7f53d6efd096f55d65d45fa07309497cf5bed2e3b00cc4a80cc1e4ed2a0fe44d02a8";
+      sha512 = "b16a859480d9cc2f2ae2bf644bdff72e5b272a91cd311684012b4f364f7a06742ceac37a1821cd37e5749e6bc7c12b737e35f226c0694710140b154d931d5610";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/en-US/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/en-US/thunderbird-68.1.1.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "7a29cf0a238e44a2051b53e5476bc8f622dffd088251b66d951ad6874fba5fba180f440c80c7d5ae154c688d3e29fcc6c889f0031d81a018b7fd1dfd53f112a5";
+      sha512 = "3046e6826e5df839ec1e572784bf333f72c5deb3dd472a17f0fdae5ce33bad3980a7f39eddaf99e680084053d66dfe83dace788c392ef027116f03ef49e05d33";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/es-AR/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/es-AR/thunderbird-68.1.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "d9d62f94af40ba69240b792b3ef2d93efef20b01b4289e992f7d1192147029574f86fa21aed5ad54489d1e5ec1f3b80cd9601e71e2ba9c903582ccd7aed278a8";
+      sha512 = "8e7ddd969487ec21ec2b4ad50e0757595d05f44972427d6c7243da15a433d16b14dcf6128f9ef96711bf8ac5353df3c3fb7a844a8f69ceb3761b023b22728f7e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/es-ES/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/es-ES/thunderbird-68.1.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "d720320494b2c8431004e0d1ac24ff8fef83bc0977f44653d0fdab99fbc9a1aee6d5aecd7cbf6002e3746d04156f47aeb57367f2b30f4690efba36c3297fbeb0";
+      sha512 = "7e59701093cd6c34498b9439d50bb1d03a2089366e793ef3d205dedeb14427d0f2306d18c5c0423a3a7d349006e3986d2c4977a996b3ebe3fed5d79d4a00035d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/et/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/et/thunderbird-68.1.1.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "8d9ba13604fab4eb9a3dec8894b04d52f9677d5f82695512680ff03740a66e96786f69476071741c8086a09070fd03786e8fae7f94bb3bec9075331fe4dc144b";
+      sha512 = "851ed5a2289682a658eb69dbc2e5bab05199b08a3ee53a5d57bc8dbf0bc7882170697b1b382c9abc6f8fd6674c132bdf83f2b05aceeb4edeab57eb510f95f64a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/eu/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/eu/thunderbird-68.1.1.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "e40110a94b3d7fb42707287dc695ea09b082fa3262d05b39a0c09002c32722630711f1b0131441c919b23130ed133338239060726cfc9d6c0b49822558081313";
+      sha512 = "b006a9d2ca2510ce975509fa505200e3ad66dbc21a3e029007b01b60ea0021c34056b5972e7610ffbbd1d083e70745328ad36d7c64d97fab9973ffe2458d7c94";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/fi/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/fi/thunderbird-68.1.1.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "d8778ddba26f544a4721b9118ce5726b04fdf09758272b35ca16c14aea61d0b8271888344e742feb4d4e758182e97b01758acd53ad622a66117e3eb0d4a6d336";
+      sha512 = "c08b0567e22048a36ed6838464af84867cf6119130a5c1aa01e093bc7b564cc5d12d22bd530de6aab4e247ffdca1a3757b22dbe2be65edf846026733a8ab6cbb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/fr/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/fr/thunderbird-68.1.1.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "2cd546d40bedf09b58703b0b11a5c9349d702540ae714942e0152a19cbecee51f37c7e217fadfc719ecfebf914f9ffad6b3070bb6471d395e8f5ff8ada754551";
+      sha512 = "0dc66c2136f6bdd0d11d450603f13f9c3822f3a50ecfa0d8f0173475243ca145dd1082fac9f8b9a25e7e6d4e0f19cb127510c40c86bc721074b301536aa114df";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/fy-NL/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/fy-NL/thunderbird-68.1.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "03f52224f145917f64e8962b68bcf3810543b5bf0508dca7965c5a385c4f87bc7d236dac217594fdd2a10afe31da8aadc674eaf7b226e189b598011a8b9e223a";
+      sha512 = "685f664ebb6545f85d52604ea9e26477ba7ab6b36b2cb26fa81caccabe42e99c4cf57de40ce0615e830b0199b1317764e90f2d112fde42344606a39eaf454c1c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/ga-IE/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/ga-IE/thunderbird-68.1.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "931257466ce7134b9852c2627f34efebc031b3dfc9fb7b5e344665da7fa52ac1fcd12a8848fd9a264a900e98ee3383d3ee6c251de58c1432127a8ce8f1c100e1";
+      sha512 = "ecc63d373496bbef6992dd619d637956ce9d753f2eeadb0b2d45d11c11b71e9018c33d6deed7bddb1781285949dfa8f245b99d881126a8076db403e9036ac39c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/gd/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/gd/thunderbird-68.1.1.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "ee3573fe9af5fae39aa053061ef82207ae6669e6764637f6ddef5f8ee3cebf362dfecf5cf5e9e208392f3fe79a0c1a56aba28f372e2e279b33a1f1e3a58851f3";
+      sha512 = "9cc2e9a105b2e1d3410fbde8d06c3340ba2d50ef8790b31c928385607baa8735bfe02ff6010315c1068d7585ac94bd9fa002cdc27c30007e6be44b37a6ebb6e1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/gl/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/gl/thunderbird-68.1.1.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "73ba3965d522aac8f9d5af87856a7e2f71cb7ed850f240be56eab9426f91e5356810a12da7cb91bc223cb14eeae3ecb89a2afeca48641ce4debefdaed05aeed6";
+      sha512 = "223c36a2ac4b02e991b90134deb0ac6d2a18d77bf0e8b8627b0cc5c0af49e0d9b10b06c05efb31b93aad90a75792ecf4f803a2fc5471595612697f92e1d3aaf0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/he/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/he/thunderbird-68.1.1.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "abd4f47d571037c4340dd3118a517f3421a3e3597efa1ad7ab14cf537d4b4e226144beb0a6c54a45ec272ab428ee8ed95083d31554ef2aa0022712dd832a1585";
+      sha512 = "865fff7acc60d6b4c19bda1ea38e532e96e0cfde18c441970389c34dd1e6f90f635202f4d98457d2373d42cd47cb3462b2ce0a3d7a385593be654edc54f2b756";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/hr/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/hr/thunderbird-68.1.1.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "32a18d8666fc2b7566807a010d94bf5503b375c5330687aa58efc2bc6464e4f910947ea513a6ebb6b7eadef0e552138a5349583e6894b3166ef6f8d53d5cf67b";
+      sha512 = "34c410ab7a1b16c2c172a0c45fcf69d9e2b4462f98f926c391b71eacac351162dfb55f29728627ed2fef28ef7ba40530b899d637690926297e797a3a2be5ceb3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/hsb/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/hsb/thunderbird-68.1.1.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "58794aecdb5f3824e94f2bde4e4080d4922648bac632cfdffbc5304329af64f9e5ef01fc587c4e19e88f206004cc4254503513d7bfddecdb6778de89e4ca6bc5";
+      sha512 = "f885d2b366fdf1806dd8e882fdabf8994e56471cf01cc0c6ef6d1e1d4972186dc8ec5d35b18ceab8f7982d45724544f4f20afb4621499d9543eb98a3d87a9e43";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/hu/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/hu/thunderbird-68.1.1.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "c7881770fc75a6b1eecc5c481e2de134a241b7a497e19ff2abf08aaecf65006f054090a53b028202becf7776d3939742fa71156e6761f981ff7a00ca0d1d7d3f";
+      sha512 = "e66ac6ad21527936f65e82be605d061b9b93688e94ef35d85699e2ac03d639e00db07d113071af08f11ac1742d811d66048e1d6de4ecfc01e25e325788fdc208";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/hy-AM/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/hy-AM/thunderbird-68.1.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "80f5fd19da8e07a6d40c19c645eb8fd6964f9904cd14df36374170c4d395146d168728953d1619965f04b3f2295df3d379650e97f8320587816ee088e2f17a9e";
+      sha512 = "fa959b64625773fdca62414269f1b3d0eb369d1e4d3d45b260d4ebfc367a156f70bda5b13d30a0fb4d576ff96bea5712edde51eab62db211fe636340b73999e2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/id/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/id/thunderbird-68.1.1.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "efffdd32086ca57e93b1ebcb40484a3c2243d6b088c70d7b20bcdb38925e7fb64be4446c98980a53738f54dadb54a2d17016adc69bd2a47a9719bb7bb982f729";
+      sha512 = "b20294eb413344fc550200ecf6780c79a919e9d4498bfb97c660cffc14ef18e1d38ad5033b6ecca703467f832c40d4ed4022e335cf3e28e12b43e7c6321fc1a5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/is/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/is/thunderbird-68.1.1.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "277d1137675c6304b28f43273c5a3fbcdf0d2188cbaa38911d784df98b3429eb6d2667b818a292e4c3bd4019b2b682463c2d01faa0a034cb4fc1dd49ba8aab33";
+      sha512 = "99c70cf0baed763feaa41799a51a15ecac4190131d74996101b00e99c2b4b674cdcfd0896573bd5fe4e22a25067f6c0dc3c19ecdc2706e010719d19f97aef20f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/it/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/it/thunderbird-68.1.1.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "6932697d769f98dcd32f3dcda57dfa154314e29bfd2c1b11a2b9a8aeb8395f00fdb0d1c71b8e9d405d1540cde21547a910a55024b799e270759d8638a3d11512";
+      sha512 = "b711ad04c405b7cf0796f242bcc08cb5906a8b4fea4b2655251b135347a4539e974606f88626093376ce16a11995d23c6dfb16fbea38842a0b9dbcd8ce2a93a5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/ja/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/ja/thunderbird-68.1.1.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "034021e89c471429367807f04d79dbe877d0ebc94f584fa6c0bec3a29f279f1d6dfc85f709b26e9d11c8ebcc1f42adb9a458137c032a73ae2b69f7238d31ce76";
+      sha512 = "bad79952ae19ee63892c357ca2e55e0ee220532fa2d28836a15866f7549c82448196ddb51b91eb2abe75d87188fc1139c886c24f66a557f87253c843622fad64";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/ka/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/ka/thunderbird-68.1.1.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "7af1caeda9babac2a4c9b456233e86be32bcd14b6dd81cc18a1874dafe86c5b80099d0ce388a70fe6e74bb7b0d00d3b7ce810ffcbae143eadf6d8c4367567c27";
+      sha512 = "f129b230d2572b25e289a7b8c1f1b4be71a8f57b639d0264cc50068a2767af8fbb64ffc0c4ae7d50cb489015fe9a810e34682cf351f6711d40a333c2fcbf9493";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/kab/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/kab/thunderbird-68.1.1.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "d8e7e7d423f36d40ce05cf1378278c47049fca0ba415466028dd821b12970fb78fbadfbb7b7390ec446aede490f07f979b94ef890a43a710e3a1f66a0c68937a";
+      sha512 = "2346f5acab924faf1eda887f29777dbdccd4569a3163f385dbd3ff8fd7be9767df4c19496ac7a550426784a04f1cea6a4370288eb8d12e3cb93abf8b0726979d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/kk/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/kk/thunderbird-68.1.1.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "339c8e86693a34c8a2da5e47924e545f0fa55d5314db73c6bb23df3eabed29dd6cf47662a8c4e43c381ede5098aba72887739993b4e71db75e41de3d1d777c3a";
+      sha512 = "12a7dfe909bf22a2a2906cd749aa409e023a777defeab4a28d4456e76e84a24d10c8a6cd1dfe54371b110acbb04c89c3259341ebd6e0ad497d175d1f9eb8c871";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/ko/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/ko/thunderbird-68.1.1.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "ba80df01778f8fa95dd32bf0af55afe7fa828a489c4682e6a8891636281031170b9fff77ae4f2e4bbaae9124946b0429e55bbed741973d80da868d94e29991e8";
+      sha512 = "7a3ec307a546c9adbf56a0b41c7b900edb76b0e52a773b486997c1f294abfd7262208a9717936e4e6ccdf109d20cdacd4cc5b4aefec30e82e23c6080154174e9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/lt/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/lt/thunderbird-68.1.1.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "32e93ec3203b70c2dced59a376bf7379879b5361f55a396d533e1f10727482b357344c9890864279eff9aa6d75feb1b36a67f2293c51d3a3222183f62c51e477";
+      sha512 = "3f0cbd3e185594fb16694020788b22aec01c12682aea86ede1052d766da797b24b9b99b8ecb44dee008cfcd7a10ea36e7e1bbd39842fa416b8e69eea0bd831a4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/ms/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/ms/thunderbird-68.1.1.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "29190352e1bbfe30b1e98d2a7fa20268488d82aefbdb4de1f8c2e197ed9f196be8256050f48d71ec6475b707d93d0570002fb175cd88fac89aca5e7140a7cbfe";
+      sha512 = "cb70f35114b3fb3c0324b80ece639a4bf733abe15b74bf0f04201e272703eecdffe66a2cd50e66d986332b40d3ba7dee04cf7624cea48e9925294437def77853";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/nb-NO/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/nb-NO/thunderbird-68.1.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "8e076d0967b0b79ac2cc9ade63e1bea4d27db1c050f792f1d1da01758a576fad884fdda32a02d58d45cf4c615f38c44bebc80c6e864ee076212f280398602892";
+      sha512 = "3bd4914a8b0cad71622a79e34d182aa7c1aa115780980c29f732454ec219a19ca4d1af3f61693595842b27cac7c64138c094dbb13b0329950d79ef8674ea610d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/nl/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/nl/thunderbird-68.1.1.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "7bee338542f949d86700d9b67d26c059232ba96cba991e491e6380f1ef914e7ee2747c9c73907e393bcc83c7f05ec6e656d869980c2c03ba0a548ae120793030";
+      sha512 = "3335baf0974932247e73704a5272d3bb4b182908a76e9e3e0f15bc0c40fca7763a3fe1f4303b3f3374a0f758bb00d6639595b8cfe9c03999f3bfefd8b6f0153c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/nn-NO/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/nn-NO/thunderbird-68.1.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "33b67ce4100a61461a238189e06b623a067e5f1b550fe5f20b5686f597408f3d7eaf45c92bbf5ffe58ff96c99fac9b9e282b024e40829d4d9d4422e54cb7293b";
+      sha512 = "b9c93af9d330bec6f7182163fc680161a138a99691897263b74e81d9a30c6d892c4639aa28d0b311ac51800b72de9e092065ce03cd7683b86bd571c7e394a49b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/pl/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/pl/thunderbird-68.1.1.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "860c606fffb3ae85193b4c919783c94ea1a84c2579316cef98adc247d7d595b01dc6c2e84662641c7285dfc65097f710d7d2605efd960847739ab4acfc296836";
+      sha512 = "3f66d17f0e231c608b1f45dd51cdb231826a3159ce188e9036cae8f45486d38d95d9878429dc1f15a90df3a91069b4c4c5d64ba9d35ca071cc7c1383d6c89239";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/pt-BR/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/pt-BR/thunderbird-68.1.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "3093207072a79d9556c4e1ca2fa75d990a3952d583f0a4fe8c850a4911b1af19e3ac08a357d239d66b22c397f6722b8625fee03ca1f2b6a8f21dc61fca348541";
+      sha512 = "dfa439f4decb4bd22945584772d837acc79ac9227763ffe061a551d334b4ab5b8479516ece0c32ae5d7b05c7168c7ab32b390a83edb61f5d33e20cad965e6b75";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/pt-PT/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/pt-PT/thunderbird-68.1.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "5d29ed9a8e8c768a3749801dc191b27aecf7994a4afa02e70de823ed1eabe4e936bd7686830359aa48321681396aff29ead762ab28c7bda6f8aec36117e8cadc";
+      sha512 = "79dcbab7997b1610a33db0654d5e2a831e63dc1e5be7794105bf3d9739d749b75ee56a9892c112d1da5fa5c5bcd76b945b1fb7532ef2b075f1c09706abe64165";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/rm/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/rm/thunderbird-68.1.1.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "cf342acfbb9ab92b7bf483ad3227730dc3923ee107ae42a0fb05c6070256e43a4d3c1647c1fa2c4dec7adbc8c018a185bd3d91e598d09eac43ec679d3c25063b";
+      sha512 = "e79789f61bd59fcad82e25b62e4a324476d48297e826118352f9a8cbfb3b6807cf565fbcdc49fb1c90f22595f5d5e9b41c67b994d83a15f0bfd8b98645552b35";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/ro/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/ro/thunderbird-68.1.1.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "ae13fc229198a5c5327dd4d9d948f1a5eaf699877c48c1c961ca084e79075f479f4b270fed1c9ce22f420fecd4332a30594d4d2dc87bb114d1e3518e3a4a7071";
+      sha512 = "77e7deeb8e0fb2d77e7a672d0ef77acf171b602036fc14f8685c3b247b42d953dc18e816812067d025f17ec64daf1895508c11ce27de1f55cca7474377eadb6d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/ru/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/ru/thunderbird-68.1.1.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "f51b1f99c16af5f24702f0bfd433c71c7ae899ded5f101aea2dcdc16f1cc9e1b7b18f26a4fd0ca9296c5e9007067e35bd9cc322bddfe07f58795147547fc0c56";
+      sha512 = "74993af15f9afbe5034966d2c5ed17d1f1d43a47422acd7e671b4cbb8176ad845b1bf26d45d81a05e6cb4e6f7cb1be0dcec38d22ec4ef82aca45db49a22de1f8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/si/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/si/thunderbird-68.1.1.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "26bc664b1623523d644ee231666a4489421ba31d1f0b52b5f4a4164343672333070c3781c577e370e7d97d42b61783077c74d1f38d37565776c752a2310c3a1c";
+      sha512 = "a2feda066e1cac0e3d4e9ae5837cae50ec864190b9620694817eb7659a1292b488b820aefc2c3e11393ac52934827c368d379f9a74babe53dcbc48c447cfb538";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/sk/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/sk/thunderbird-68.1.1.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "46470afe078d1ef2e48b3732fdc02ff3c9104a727b4d94cae1b9c54f6d2b4771e5784cfb3e6350ab8a205f8ba010a82a2b2fe92313eb351496a19a99df75179a";
+      sha512 = "ecf370133d0fcda81c9caed13f5307bf27b50e85f255a5c13cb37da4466ca60cceceabe8463dbec3b2e4e7349c92c759803eb2ec01448dce1778d2bcfd2d9fac";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/sl/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/sl/thunderbird-68.1.1.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "9bb5b0c979fede4dfdaf8f4965bfed1ad78d14168efb797fc216ac2527434047c3e6b65eb9dd1e607f55b22f6f28e49b0ff58c272c0708cf5ae1f9ce96b2c796";
+      sha512 = "2fd49d0f88c145ab65ba3887363b969da2b6ca141de373fe7b3fe95cb1af27cd4fcc1e21b146e241c312862736aebeb8ddf813548e7e5e133188eaeb94933124";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/sq/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/sq/thunderbird-68.1.1.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "440870b75e47aa277c5453bd997709d2f9e59e0aa86e2fa7f5aa95ad39b139d8e9b7b8a7dd44765d8f8d5ec18c5ce6a284ab40d4aca01b251bcd9e2183be4976";
+      sha512 = "4adb9557d053c8485dd2abb89285c3559004653d4200025205758f54bf349d79f4a1db8229af5a2fbb7598554e47ebd7f6b1823f3a1cd0bff53a6080d17ed363";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/sr/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/sr/thunderbird-68.1.1.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "bced610dbc95e7cab982f40376fb7cce8e672f8533a66816f01667ba69d73dfcb00e95a80b42273c1ec7ada9cef8c14af1c426cda2f8425e3f77a3a0e393a611";
+      sha512 = "4132d8b2470b50d3565d4ab32ce23eae77874b6cba8451c06a10cf5e10d0f1d03170004985d61cc9d7ce4f1c5c31f017b7ed8392ac070e63227d996b0d9cabbf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/sv-SE/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/sv-SE/thunderbird-68.1.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "af139912f563710b05c274d1b89012e27a3997b582d379e3561011fed7c77994447c3054433e0fd4b5db8417d5b43b63e840d313cef1fc7a8aa7baf0655982e1";
+      sha512 = "7d24c7ab6f7cb5fd6cfffa21b1d55040a626109ed2cff7859dc8c28b78b2dfc40b7b3c9a5ed12aafbc15368f294990a35d172bfa69aeddf8b65505f65f38898c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/tr/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/tr/thunderbird-68.1.1.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "50693e4638f8fea5a7f609924ef65c8d7ea4f4ffff79320651481e1a7f5cdf69edc2fd987137a0d655077959cbd8f32218d2f78fd55790084e2d46d3ecd70cf6";
+      sha512 = "17393c5c522cb0fb6de9c9fc13a2ed0743f995cb51d852ebffcaa03e59b39d93c2137e62aadc70131bc8fd61f2d6c3c70baddfae299e2244109f35b4f7443572";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/uk/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/uk/thunderbird-68.1.1.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "c24943567c110ce8cff6da066d0bd0081621d8c397e6569c57b63eef3098963a55215083aa655fa9c98adf9babfcedecfd72204c1a68604c851e1a5c1a1b0102";
+      sha512 = "e8dad1bfa1b118141e65198014cc405a3041fc552cd1bf4186b22877433805357fe39a5adc6cdb9b9afaa86493442bf32ee73bf2c2859f8ad535c7996744f60c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/uz/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/uz/thunderbird-68.1.1.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "e02a86c848a013a84824246db3e29e889e1f5cc1b743a3a9b567b914a46100a808779fc13b897b04e8c698e14cf474fcea907e25e937e5c8b4ccb997f06d8e85";
+      sha512 = "5a99a2ec1539f452db613f7fef10d180bb57c642e0098ecb234fe03521f1ac9c781cce50eb025d8a5adae280b466dbcdbc08be08a0106c6d8ad99ff250eec4e4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/vi/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/vi/thunderbird-68.1.1.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "de6d6794796f5b60cfffa9eee92906237fd692b21ffc3925c7866ea9660d26366f5fd3c847b2dfecc418b631c6241dad4e509e58e391c414a37587c6185c2655";
+      sha512 = "fc39ef4d2bdd5791cd8661a522f74b2a1f9f3b534968f10b3abfaaa287a160d01debc56c9cd416c35e50b38f80d2a1b5ba10f4134e9fac3ac32748e3891f4026";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/zh-CN/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/zh-CN/thunderbird-68.1.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "d5835538fe615544a07e93a2088b65eae6c3c36b75ca2b9f6605974d929a36dd226d848e2394611809538106f56c1703ebedb5c0776593e998935bd322a4e27d";
+      sha512 = "96e2cb653a93d788a7e721bf6677e7dd50ad67e4e173bcfc23dbf190440a35ec2349241adbe7bb1a74c4732f3990a15636a0563448cd90b7526c06bc106d083b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-x86_64/zh-TW/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/zh-TW/thunderbird-68.1.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "9dfaa7dc83725fa795cf1b2e45e7af760dc6c38999b05a0968e46d4b5676a4b9f705ebb63ff400ec6600d83a6be26eb4c2638671a539b59b6ea37002ea9b97ac";
+      sha512 = "c9d720e70d55998343c4d20257a0385e3764da751e57eb992d7ddf2723f565099d6e8c880ec009f9ea71609ddbf172a8ee7f82e603f42529388d0627e882ce79";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/ar/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/ar/thunderbird-68.1.1.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "17733249e5c2c33899fde89a5b2dea2592fe0414419c235f4d853917990a05664d52a05f1f1a290ece4bdb3646008b0aa0af1e495e5b8af0c08f5b9962bed5aa";
+      sha512 = "79e4d01a88156ddbc1db2afd10b83e6e069a69df8cedfb0e247706aebbb8053ae68bf44b0ab1849e859ae15d8a6332c4e795033ce7e3385210cf9c12e4f3c37b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/ast/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/ast/thunderbird-68.1.1.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "95b40d08b988146db7175232c9d9be92175cc3fdd73ba5e205e6543dbdb9e6e33579edeec73b6961a7ace574d3466c162d0665ffbd3705de15b7ea4cf6d7b77d";
+      sha512 = "72f4ac14a13e364e4ab66d9659845abd4be47f07311cc79d71e05dedea1aa796a8e6d5772faef836e2eae410c1f8ea2b7b1bb460ccd60a0cd2bc7d48f511cd2b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/be/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/be/thunderbird-68.1.1.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "d2f4ad38d81306c1637ae8612221bb462409373b3cfa70a08d0f2872aceccd8087835eccc014f4009680e9e36b6cfecc9bcb95328dcb8f6c9ef11c432e2d3c6f";
+      sha512 = "aaef151a1ac5b0f4adcb1d708925f5d6452f04fe3f73617bd2a5fd0e2a54e48229c9fc27ec48d5d9ebe8db9e1925b2df7542cd543cf9f312ea7e65ece10d44ce";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/bg/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/bg/thunderbird-68.1.1.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "f2c74a0609eff929202d13719fce167577b2ae0e1a0c98b75b359bfcddcb531907a466e184ece24d904bd592ab41654f2dcc2500defece0aede3be3826dcc8eb";
+      sha512 = "28c9f71d5674a21785656309f40876917c27d979f082269f8b32f1600664fa10a3689abf856aa391cb42776fd2d2af18731e4af22fb1c5e75f3616c44772e54f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/br/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/br/thunderbird-68.1.1.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "1f1ff89743c398443a18230ec0eadeb51a8d57633bb7c242f7003e472b0ea206dde50a9d20880ddfbc9ee36a3ca28135662ed21d6e8cb779627120c70f0aedea";
+      sha512 = "08d2e1186d18f3dd80282597927c7c747152d13d2511eea5169b2b42eb4318a817261a2518509f8b26ac83d770d0e70e3ca0521fed8c3f253b5e6f211424ef6c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/ca/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/ca/thunderbird-68.1.1.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "608232b5bc7a93cd786d84662e59e3b186bb1de51cbe0f720cf4e80e65a93e09a24f06abfba63785c0cdba997a6fa871497998f1953f57a98ea6b9e224235ffe";
+      sha512 = "d6c0a548b4eaee0c0ab8f7f03e3cf329d353f7e0d2403796b7db8f1693afdcb8454715e4d0e0d2e1f074cd816b2c9ec9be5ccc76b4d7f0d00f8615bfce4f193b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/cak/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/cak/thunderbird-68.1.1.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "5e77fc07093e5b2cbb345f21b48415a5c7d987ab0a82540f398ef33c7051f1917fb448fe23401ec3683c87379aeecb287be5ffcf6a124df9a464401f242d1e3c";
+      sha512 = "3bd32854eccddf411c294bf0dee5f3d945a1016d1ede639ab8c1e2e86ca97b9866f1e4149f1fb0402fe3ebb148e8f34f7b12ede4853c6cd2edb87d9e822d1e27";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/cs/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/cs/thunderbird-68.1.1.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "036304985db3ecccbe50a9b3d8c19dcc269f7c6987c1101c9443ea5fb2d14e71390ccdf6f0000c972af631863398a02cba1c05566c6be4ab3e79396c049e0e16";
+      sha512 = "33c87e9a016097991fdee92d5f8813b4cdeab355ddd5d65d25a017640bd50dba94d5936148e0873ea596fdab2e214eb70bafeb5edb6576397ba300eacbd873c0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/cy/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/cy/thunderbird-68.1.1.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "4de3a065234e921f9ae7250409ba24bc54230af61b4993c3686a77e1e165874995f7c60b45ab136c6b3f3047461e86c19207952b870019df06dd164054b65dc2";
+      sha512 = "f28f46b5d8004ade5b91e3fa10659ab87c85f33faef90c534a5c4c0680d11dc0f013abc28003b1a7111b4f67040ba54a4616c85cf9c906e52048ceaf6d9de7b2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/da/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/da/thunderbird-68.1.1.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "69e190f9263438c88b445821b56b93c052613fd67a1f1918b135c719e4358bea46d3a79bc135d50b254fa686d8cba013daf89d40ccc5212062cb177bdab4d667";
+      sha512 = "21eafecbc13e8f63f36386a64fd947ca566ff6878e96a6ccbd124e1020a62ecede74f8578b56c66b13ef63a4197f527d406aaea6559b833017bb3e1931052dfa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/de/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/de/thunderbird-68.1.1.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "ce4cf8c1e11f4813ce173bd08ceed9ef26b2117771ca87ef16c001e1a49f5385a6a3ecf4bf7561d48aa6c7e63d307c2fbde77ef8a51fa0aa9b66f4f98386bff3";
+      sha512 = "5c7c528fbff84823ffa46300081f2d5352bfc5316af574d39e020ca53e9b61b1c5784ec7b863fb095645d908ca18862610babf31f7e094d1e0280ce8069573bc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/dsb/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/dsb/thunderbird-68.1.1.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "9007c92825220ff9685c599b1c6e39fe3e96888621ce5dd15f5ef9d812c09a29ef72a6eb2f68cd8eab78b5519b6c26cc957ed04f3c9798ea0305fa4f5c8bb962";
+      sha512 = "f18ab27c8bf26e2ee2feb2007cfab28622c9df0f03facb20f0ee581d6bc33c67227a2422f9bda7edd5cec8fc1ce0096764e26d35262559162a3a37481a92ac3f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/el/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/el/thunderbird-68.1.1.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "e619576813260ec68a26226a83a540c58aea7e87d3b0ca35f6ae7bd9e0dcaaf54ab12f57cebf669060191e3affc42df1585a3ce4aa18f82f6afe469b85de495c";
+      sha512 = "f3fb8cca78a51fa0b855c8e112625af364b59a6ef2c05c7712da6451790a8749f26260aec716943a785c6006582977ebd950f09cfee8ed9041a875f9ffb632f7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/en-GB/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/en-GB/thunderbird-68.1.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "0810f25326d8a08628aa55d5c15e6144f833454019087fa20f2c128bbaa4380f9f2a07714b0d8ac0f3fabb5b6065e7b2efe6e80975e5e47e81749da9f4e6be94";
+      sha512 = "5d53ae6575e6f3580dab921cc2ee11c00834fee39cd321c906b81103fa14b82e4e129d48642aa9b857921abb11a6877b774ad685069a921d417fd93d25ab2198";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/en-US/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/en-US/thunderbird-68.1.1.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "adc1dddf36116435b3948810cd9d647febfc97d62443032100b0f2d722913aa051d44244f057c29cb8c6cf494fc67b3044b83ebfd5eacbc36b6cd9c88361078e";
+      sha512 = "9a4ead1f16785db8778ead96eb4ed21c5d52e9d3669d2d3bbded0d616e6b57d0649347b067d48437b769c51093627b47503408aa109dc899d62ace8fed83f62f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/es-AR/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/es-AR/thunderbird-68.1.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "a9433a5de45477f432c6906b640909880650443e5e3a65a839e9c055d887befedc8c22c76675700886dc128ad190fa0ecdbbf2c5f18e650219b33a78105eac63";
+      sha512 = "15e85f3f51409fac915b095310158a5313dcd82f66470c85874e4306f1efa70e63bc4b39b615dd8e1eeda22b863c6fe0c5ba15bbc6dd94b6fb4a0859f22ceea3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/es-ES/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/es-ES/thunderbird-68.1.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "a128e46d7d2cce449a261f857a221232d2d89a7d999bc074ad5d1aec741f766516f3882cc2603d6284458208c2ed36dcb81e214039222c9c15450e96e73d0283";
+      sha512 = "b136302034d987594f65e68564eb1e6b1713d79be39e7b90f8ca73c74faba06d97afd60253ca34f15a415575c412be6ec1113598e86b0b7c4d8ddba35301cbe5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/et/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/et/thunderbird-68.1.1.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "521d004b432fd27ed6b167263253b3a3c89aa22ee5e06a4a434da6948a8c2af4fe27e17a1ef962e7caedf7d15ab27b98384545069abfaaf41871cd5878fdbf72";
+      sha512 = "5a344c70202d884827231d0a7ba06703c7a265fd3ad59f1442b7d4bdb57fed06b8d6aabff4a5d6193a7b62027e243cfd27cbcafcdc1ce97baa7e0f3317f64e49";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/eu/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/eu/thunderbird-68.1.1.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "df8afc11cddf0c06d05bee455833bc5d786789a709baeade7b64e8f815c42f399fca1442a8b64271fea7e45fed4408ee923293cec953e0406b093f0b94120861";
+      sha512 = "ae417ccef00a3c5a2fd33ca653d35575126d18cd991ae32e25bbcd8f6d8a85f282929c2f2c78ae0f12ccf85a418cbd9518f6d28f89d6bf38c41d3509801caf45";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/fi/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/fi/thunderbird-68.1.1.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "51e05f21e01dfa0fc3c5d0463d80e87a38e50dff612a7632f9a5cd440f037a438a555e3640cdddd794ebe04eb2cc15c549db7ac829c91ac488b73b66808496a9";
+      sha512 = "2046eda267c49edb5bdf268265dd02f638670c8d6f1310fcc496c1acab2c777e39c5a974dedbb7bb1305f7a9ecf11c64303f8857aa7fba66f76a62cb89e45b23";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/fr/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/fr/thunderbird-68.1.1.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "9448860f48fd93383a24fead6af1102af855270749e817f720e2afac152949e47fcc9ce6fd0d2c60d3dd958c855af47a54a38e85975acf05496a7f67d2af72fa";
+      sha512 = "f483c884064d13d11d4085a72c8805b5c10564f2926182c649c5422c31c8014a75948d2dbaa612f29b1f64b615e6e9bbdb2c4c1c406c8b57f13498ec1f29674d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/fy-NL/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/fy-NL/thunderbird-68.1.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "e9a27da8b86e2ec3593056a19001dd656b8bde07edc918ec18f266de377c697eb0ea3a10fedb223e58db53ae5970d2b9753b46fa87db938e5568283ba136bd2b";
+      sha512 = "b8fc327bb911c25be29c8ae5a664a2b000ee08183388dea6b75f56105365f541a5f81f6d00089868ad20037809c2e4a33dfcc988567fbec187f41abf66d4d6d6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/ga-IE/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/ga-IE/thunderbird-68.1.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "b346fe3863ab7944ac33a8204eea7a458a0131c879eae26be66928bed930aa29ba74a5b0e39aa939f0320fb8e5fb0a5e31599235daed526f920b92240763633f";
+      sha512 = "4c456ec8474109c7b136b14ba49ec8b155f6b7194ca4db618a3daa7affb7dab4b757a8536798cd59241425f4b2404a28f6f3d99969beeb9448192a8faf8fa324";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/gd/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/gd/thunderbird-68.1.1.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "e921a3c2720aad333febe7e1d69579eeda4f641fe32c1b6235fb6c01480ab7c87bcb47020b0dc2e4225746b277d8c6b288aaec86125ad48da9fbe3452f30e01a";
+      sha512 = "d126c7f9c29102392c8bf2643130f7cca7add29e60d540bdd344f54bc7535b10e70b224ff6adb0d1f8eebb86b933f1f232b768ce65cbb0cda68347dccd8fe373";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/gl/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/gl/thunderbird-68.1.1.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "dd581aab660e96d7b0283bacab74d5635610301fbf40e95bc85edb5e177492f2a9c786a4fa722024fd57e2f2158fa339c161fba605ae428b5c03fa983b70d176";
+      sha512 = "35c855e9d0df8030e455af1fc1c704ef12f598f598f15b2951b412f9147ad5f3dc129c7ce7b4d3757ab67773e9af75459bc4acc07fdd1390c0d080214840d903";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/he/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/he/thunderbird-68.1.1.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "2ab68acb57eadab585bedaef3f79369cd7a0c08030d24bc3361a0e08ff796f28f345cae15fbd78bd1fe2c275f8d4fb7058194ef44dcddd3e8f92b69f92482321";
+      sha512 = "361df030e5bd3e876865fe727e41885cc063f1091e0fb6ed71530aaf2cb88b8ed02c6d762939668cc2bd2fc7d861ef0e737dbd7c7ace9a859158c978f87fa6c3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/hr/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/hr/thunderbird-68.1.1.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "975be725774e200f39b77cbb16ad364fb5d901ef46a85da9f297b61140e5be61cbf48de9f2ea0236d4580a27be97e87c195b92d9286133ac5aac2a35b1b7e5f7";
+      sha512 = "92bc3303a6a0bfde8c287e98593f3a88ed1b44257dd660cfc418beae15780c06919509c48498633ee85fff990ae447f71916bffbdbd1a5eb691fe8d880052c4c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/hsb/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/hsb/thunderbird-68.1.1.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "5d501e9b7a39a518da0a82c1a89f398adaa449753b4dadc6ff8fa610bfc152016e6f70c1a944cc85e72fcaea5aba21a04d5abea2f2e045ca1c9212a37d31c461";
+      sha512 = "6a18e62fe60fe7694fbe305a65a497987934af299c83ea0410b08fd139cb988640f511595340b4522fa64550616864060df7423bb0e23696a29dcf274c5987af";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/hu/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/hu/thunderbird-68.1.1.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "4cf2c82e4d965c3ff51e40823f876811834cf7602d9cca30011346c2bdb6e222b7d37f28db79b6507350cd833db312aaf30c13ae245c93a6b1118d9abb132571";
+      sha512 = "f6a4e4844eb10964c95e0cd6a143128e970f40bda283d63ca542ad707c8818c47106e638fe2cd0e5c88420d31fcb7dd86888fa764ccf4d6de009841dd06bef65";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/hy-AM/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/hy-AM/thunderbird-68.1.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "d13d91b889903bdbbae1e12b96f07bfc6f5a6cb734a45fb87402ac44df9fcca703e067b1d1554a41c9b7e2e31703021eeeedd3ecd8b27536b548a3b2d89a1f27";
+      sha512 = "1ab27605d214695d3db36d337ecd33853cad37b2355c5a5a89da995c3fe655f25f3a1f7e01a9903e5628061bd65d0fe43c49e93558939d152449a81cc91916fc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/id/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/id/thunderbird-68.1.1.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "7c199788cead727742dfebbcdf6ddfe4491be31a3f4dcc7ae05d25413101036cad7fae399f6b390002f55f60214ea66399d5bfdc515557351b309d174b83fa55";
+      sha512 = "330f0b9b8c854c37250679ce6e9cf3882153dec717b3b0e6a29524967c5e75c6c784547e9055aae232156c6e0aa0cf833060ea9e192746185c472b1289c662cf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/is/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/is/thunderbird-68.1.1.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "33ac7dae65efc4792f92fed4eb0062302ef601f6bceef4d1eaa6b4a7fd75427607e8ebd7f6df70073bcbcc89f057b0689e365cea960428b5e57f9f1e810d6e48";
+      sha512 = "e8856b72d2950238ea82095fe96fb93872ff6ca8da2ccc666386ce08700f7fc137fb3957ac75c90872b7db3b15095892a3bf39d4169d364c93b79abffcec0588";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/it/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/it/thunderbird-68.1.1.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "231acc8648e2e377a8ca6d22c273957506fd1c21f226ddd681fd3a91940cb151df4f0eb05885ec0325629bb0cfdd3ed500af6047970b43b898a37586e4612502";
+      sha512 = "75c7cbd7659f5b2156ee6ff05fad47f8c0e9e41461a79ec1f9c35bf15d696f9526789a6192e3dc32b36851d17958351f65f76be50ab70309fd8bfedfcf579e64";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/ja/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/ja/thunderbird-68.1.1.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "90b8ca0d72fef8fbeae34027c95e3391452d72b53b40ecd59b1d2d2b07c6ef2e4d787bb2e927bf3d4b7837ea4cf2f10a0d3ccb0a6c98992e6fd857717c8ab04a";
+      sha512 = "ad790fdab0bed7a4828e3654999e3c3b04dc51f04ba4ca12e60d9c70b44236e6902b0dfaa70842db661c5fefc28eb7f2045d78ff5df82224d7e0550dca516f95";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/ka/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/ka/thunderbird-68.1.1.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "271415dafa136d326b89ea3a58b852e2526c86f45d63f383fa250ace14f71b1b915dac3810a04507d9ca4437c640065520f9f3d9d032cb7eb84aad1f7b3517ba";
+      sha512 = "371fb961b63f170ab0521bd2fd590244966a8ce9935f5352baaa244922425ddd46f40fc6f8d5512fb7b61c12d01e8d050fe53e77bd7c69f7b6a9135bdeb81e3d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/kab/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/kab/thunderbird-68.1.1.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "c0b4fe65e9937bf897e7512ff6f267993c324c772232317e1314ce035a282f313b8385eee8c13e7b131eb0fabaa1b62345fbcd6289a5172d78aa3abf7f716bb2";
+      sha512 = "a1e6fa908913e56e17272545765092f3cb32d6f5807db7b7bf02d3eaceac37a76136cbfdf0c11e274c7a59b8a1db8d8b54ddea6bdda75d0b1e9f869eb62d8fbe";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/kk/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/kk/thunderbird-68.1.1.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "b8c7ddd098540ef8354eda1f2a3a06987d11cb7e0c4af4e170d507ec540e743a7d2527188c18e045df99576ed44990a800e7f7ce212042eb03b02339be9f86af";
+      sha512 = "2953c0e23c7153e96cde831a607e688540522698649bed526066bdd527ab8024e6007842ce8cc2f6681ab6de81250e63f52c3a0bd51f9ce1a495d19f2446b2e0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/ko/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/ko/thunderbird-68.1.1.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "a33dbf6ef3aef69644261ea1c1cf3986fcda5c9d0b28996c46e3d8e53d3d7f8e9e6b62f1b03f2816267b483a84295ad99e888cf76c5c192e9a9dbadd78ce7d8b";
+      sha512 = "bbae4b68e771c5416285edf8bd5e8d9f117d5bb9b5da4b4d2d4a90e89dc74e0be32b53f123426bf356749dcb3077f3c28fff47037df2a4afde90d08899794e01";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/lt/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/lt/thunderbird-68.1.1.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "3bf1cd599707a2728fbf46beadb7d8d1832c0c271e98647ac7d2de1be78b8c1b5d0af4ac246af01eaf4b2a57154f6068065fbbb2019346b663cafeb40edd5b71";
+      sha512 = "a074abc38275119652bbd69765fa36d3865253f32ca7efaaf628aea94ba6316fb581d083eb0284eeba530bbbd8f2613ea43ef6cbec6090c377449e16a1cab272";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/ms/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/ms/thunderbird-68.1.1.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "563c413b21e2fda6f412a1826b1191097d4df1ade8d12e031522e122bedea6ae23a2d3b047e870030c9b4901a5869c9439107d8a7ebc6380c758bd741e0b4128";
+      sha512 = "a956870831e313917eb15e836aa1c3b5f774afce7a1962f0041c07008b627d5dc12821c091e4777181a15de94d62df565caff10c620cf48d08db0fe2391ec8d8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/nb-NO/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/nb-NO/thunderbird-68.1.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "c9062949faf5cbfe8bde2b0f330f76b438e1606360364a90f0e35026fd52952d6aff7c6925fd1ce569b24f41409d0b63540dbeb0ae82260604d5faaee723bc2e";
+      sha512 = "425ba2a0e7401d83a4f98389e108eeb85ffafe685a748526012a47c07768278879d0a9795da0bfca5a955f607afdfb5243a4a5980d85d0f827d0253c5f84daa8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/nl/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/nl/thunderbird-68.1.1.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "b8b385db8fd2385a88d12c1ba23bf812592beca14e44d9c33456ebad16a40db8e7d886779565a4d617fc56f7a6d651dc8da171b1c727481895d05777bc0eb3c1";
+      sha512 = "dd05524929e09c8459ea9bde675e645af56e516cfe087862d4b869401b54fea9766553de4edf340ae936d9db169861fe655b3e258cb2f824237de68ba087088e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/nn-NO/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/nn-NO/thunderbird-68.1.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "3c88ea8dffc71524402416d9222c859dafc5bd5799651a948bb318a7d2f91ca2c00fa4158e6019949f9a1d72a2d85a0c9d2a3c9a8caf052e8743fcb5dd0dccb6";
+      sha512 = "5d74324cdc78563e109f0dd151dd90133baa3d93ecd7c24e3ab8d0b36a402f524e97c58889a4d5ad2bbf5ca08d785b45c660099777b9706441bd7fe5b8c508d1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/pl/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/pl/thunderbird-68.1.1.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "c6ba1f98ebc44af63d8cd8052fd306d3a8920c33eb5b3be563c0fe203d5d07806bc5db7ff88847c3ee2d82c62d0811a086fa91e8253eec3a3977091569f40a20";
+      sha512 = "09521b3fb8f49631c318f6bd1e8bad27f9b75994c3b1e8b57014d9b290cf6cf338ea30ff46c6b07fb2dfd456fbca18cb609696341417bfb39740253be2a9f678";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/pt-BR/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/pt-BR/thunderbird-68.1.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "cbd4c0f1b14cb04b98ef6f2e4ce53d655b58ae9a11047eeb1959ac1c4ef4370507194dd1149372fd1dad4ceedf91c39f3bde4fdf07b5d925f27dc8eb5041be67";
+      sha512 = "9a5c096a5e2bf3d3446c0de33fb92995ca71e994e40fb5b66001f7afe5d0e196a7b3b0088b8e51fa8e079af42095c321ebf9acf367408d9c99c33ecdc90dd57b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/pt-PT/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/pt-PT/thunderbird-68.1.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "ec08c628708a7bbcb00df2122e5fc463e1b0e1c031e9130369ddfee12db3cfe9219f7939756fc47abab8514c6cea642bb653ee420818ad625a33caada7005993";
+      sha512 = "c19d39ace2beb65123f09129545cdddd303726c2efce12b57f5919435cd6d432c592c5fe48f86ede44a949edf1a1a995b3094f26266baf18cabb79188b00ad58";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/rm/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/rm/thunderbird-68.1.1.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "4520dfb1529220e40cf2e1aca44cbc2af750fcceee3639d7ef334e9488034b18bc6e73b5b7a37204346da53a44da099f4f7f65d5b3dbdeac6d6934918c02cca3";
+      sha512 = "839f4e56a788762578de09a74ce8974573b575eb0e0f641f36d2d6086eae08e2a0cb6a610f4ee2ce00db0b8f0549c9cdc3ea433ba3e0a1eb5f6a9093542b94d1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/ro/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/ro/thunderbird-68.1.1.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "49e54dd1cca8038ab6c34e9980b6b36117aa157b6555ba440f0d7c8c4d909253989b9a50d25c7c18529136fa26d0ff94474d17e43156afba171948c9c05e16a6";
+      sha512 = "0ae5d25b55971b41594676678dfeed2c5f0c89c3f4c8b2649ce2a1ae9183c1518a07410e46b9fa86d5f09f18f53f4a6c37ecf1e4e72d6414b065dbe3f46d0d6e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/ru/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/ru/thunderbird-68.1.1.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "6d297592bcf0c9b97c40f1053a95385e6c2510aa0ddfafd25085bc6a954fb5460f59f18f65477d8c93af829cd2a053b389b5dcec35a7ac7766d72c29064e5687";
+      sha512 = "fc00117c0caffb90ee70583692add1a0aadb8a03970c8cf501aeb248bf4abe1d8d8046c2c170b42248d0f1f11241067508e35aeb0db320579882905156827527";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/si/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/si/thunderbird-68.1.1.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "f602557748517324943b5ff276f4efdeca1c5083662bc9f0b0bdba8c10510cee834b3883870a98d51d406f58e338a09d0589b3bc0891bfbd88b895cca02fd360";
+      sha512 = "6345bfa3abf1ec899320696b10553f0a75b48f2f2dc317c5d6ac10ddaf09a7269353a73aec84ef4d7501d064e409d434054711441da3698f1ed5af653de4970f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/sk/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/sk/thunderbird-68.1.1.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "7b6980d2b5131bd9a43a29efa2f1e97c60e15410a63224d839548d777fd8b4c4d65ccfc7756227cf900f7420b12231c3d48f062133cb6f21bbdcdcdb179f2e47";
+      sha512 = "745514c55e85f71cf07bda02a842c8452c454a80a10bfea20e9c5750f1702809b4c589a2c1d3127c599a91ac0fab458de8c4d66afc8511e64278f02638fff63c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/sl/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/sl/thunderbird-68.1.1.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "ecc38fb4fde66b7b213b1cfeb8ab170b3e685d0a28c7e071e19a85509ec74e79fb6eb61104c47f0eef1a77e1e1a52b292469a364747eeccc701c522452c58351";
+      sha512 = "2449333ceec017fd3b6e3bf673c3aa553b9c52c07a09e02e773e42e2c6acec60573183d6a09c5c085ed9389c1d48c4f02acf50d83499421bedb3094823ddb34d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/sq/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/sq/thunderbird-68.1.1.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "3ff668c6ed28bdb2f3d388ab8ecb1bf3b2b38bb29046b8559f7b9f9c6fa32db226c4620f472ba5a982b473e3e3f4aee04aa3746e57738b512dcb37fdfd5ecfc5";
+      sha512 = "7a2ac8f6c04cbdbc222ea1218dcc64928b6d5038381a7655db34cd568717854197fe4b77645b2ea07b4b76a724c2e8196db693c5e367d09367edf1af471f358e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/sr/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/sr/thunderbird-68.1.1.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "4c71511375333802f903cb632963933054a969c02a3fb23f4416e0cb3c21e18147bbffb28572f8ac90aa5bc3c4138b25590c42610c20a14b5e8eddb1edf28c28";
+      sha512 = "06db22ff1ed32c1311d62d1cb860bb22686d5893985bf16fe2effaff864b4352788889d5e2f2ff6c450edd4be9d9c1f33ddcff513d5eb2cc3e88fe5e50c33485";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/sv-SE/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/sv-SE/thunderbird-68.1.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "5d7d569f4eb9ed738f54139a90e9a01e9e771a553af193357d45765bd54815a096ddc31ac69620d6f14516e8f41f1c0fb8f16a848e13273d0c18b9c047d85fb4";
+      sha512 = "f1a43a44dc155a01cda07041f554eb3474c35621ee8d8c7596aeee2746da12aa934d94f436014218a360b7848888d0e49285ca66cca8209b7b02d044c29571f4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/tr/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/tr/thunderbird-68.1.1.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "fc8892f85032d9fcce76c3fa971531f4039b8bb9e1812776bb3e7c5b68474543b5db4007f79e81abc1685c74f0574201236aab8a2df05ac10fcaade7c57ca3c2";
+      sha512 = "e430c26852fd2cc3b9afabe9f8c3e1480e3454614bd90c766dce2b2cf652fe526146f79bdc0e25a1ce4979c1e22c0af90540659df5fdae89b0498428a61e0d1b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/uk/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/uk/thunderbird-68.1.1.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "80335f326bde31f4b1e269cd756b4b41ff3a632023f09447abf6d1964381f8f9657a4f47ed6af63a3eb0cd4e84e5bced595eec07cc0a9e30ad8d3cf3d08026df";
+      sha512 = "d6717aee4e1367ba031d03a90fc46ef397f9bbe6ef1d2a5537df77dca1d042e83c6fb44baef9ab01dc47de0f481742186220542831bfb6670c7a756a77eddfad";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/uz/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/uz/thunderbird-68.1.1.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "2434a8a063b0d1019220579bc83160217d5c269b24ad83a9ed0969425a1fc9d9ed8b190c291d87c34379928aa6c2329d3b5ad287b44177dd61f680081cd7caf9";
+      sha512 = "58ba68d642eeb1700c6d0994260bb16028fd15b49697c6e99e61e73d90275e0e4d2e6957c2af60122ca7be8804c1ddeb15dc38090287335a674104da3cd1cb47";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/vi/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/vi/thunderbird-68.1.1.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "0e33f1a2f8cd67bdb523180af0b8afa5fbbb3628b0b9407f2a4ae609c7155b33fd85a1f23d9b74097fefb045fd0b437f58971cc4c4d5f391398d6ea7429b921e";
+      sha512 = "9968cf02fe2b58f21e228b9292b48fcf9df5beb805335e7c77332231690b2bfcea29a4abfe9e834a85c2e4f79fe55df4590a2ec17676712c1b30736f48704bf8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/zh-CN/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/zh-CN/thunderbird-68.1.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "27d1d9b3c30ab1dd863362139f91b79ffb7e36e87ff1f7f07162ea3e86a58962136e43cca3212e4263908f63dfe3a3c53bb3db3085e5b4bf07e0ff88408822d8";
+      sha512 = "41369b102e82285050147d0e883fc20c6b7d311a1a8cef2efd31480a6eeee8c3ea5e0a9e9968c3d903d1fd92aeec331ade3cbcedd16cb254a74c6049ec0ab410";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.0/linux-i686/zh-TW/thunderbird-68.1.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/zh-TW/thunderbird-68.1.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "2141f0ad5d11daf3a94f3a737801ec0234a7f2d869320d4859d771ab92a6e59bf13139b4048a7239640635051a9228e6cbf55746402ed35cb398d93a3d129439";
+      sha512 = "37e07f78c2ab67d040d6cd4a511fb3e6a641ca00dd659b51d5d320e79251bb2096dd6719da819c22306e10af9fc88389212129d20064ce110d06d49bf01545b5";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -25,11 +25,11 @@ let
   gcc = if stdenv.cc.isGNU then stdenv.cc.cc else stdenv.cc.cc.gcc;
 in stdenv.mkDerivation rec {
   pname = "thunderbird";
-  version = "68.1.0";
+  version = "68.1.1";
 
   src = fetchurl {
     url = "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
-    sha512 = "06036nawpm987q33567nhz55qybbcl55h5rdhjbhck5qmyj1qi383xqac5niwyk7c0gaq4ygwc5a24pysf85crjdway2zmqyjxp2apb";
+    sha512 = "2ng5wwd7fn9247ggzlxx96scc2nalaahzvxkzvb87mp9fbfcsi3v9dh370cm42px8hrknnsp2lrfk9hqx4287zyn9pl3k9vr6a9cswl";
   };
 
   # from firefox, but without sound libraries


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

- Bug fixes

https://www.thunderbird.net/en-US/thunderbird/68.1.1/releasenotes/

The release notes mentions “Various security fixes”, but security advisories are not available.
https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird68.1.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Fuuzetsu, @nbp, @edolstra
