### PR TITLE
linuxPackages.virtualboxGuestAdditions: apply mp-r0drv-linux.c patch

### DIFF
--- a/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, lib, patchelf, cdrkit, kernel, which, makeWrapper
-, zlib, xorg, dbus, virtualbox }:
+, zlib, xorg, dbus, virtualbox, dos2unix }:
 
 let
   version = virtualbox.version;
@@ -32,9 +32,6 @@ in stdenv.mkDerivation {
   KERN_DIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
   KERN_INCL = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/source/include";
 
-  # If you add a patch you probably need this.
-  #patchFlags = [ "-p1" "-d" "install/src/vboxguest-${version}" ];
-
   hardeningDisable = [ "pic" ];
 
   NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types -Wno-error=implicit-function-declaration";
@@ -42,10 +39,17 @@ in stdenv.mkDerivation {
   nativeBuildInputs = [ patchelf makeWrapper ];
   buildInputs = [ cdrkit ] ++ kernel.moduleBuildDependencies;
 
-  postPatch = ''
+
+  prePatch = ''
     substituteInPlace src/vboxguest-${version}/vboxvideo/vbox_ttm.c \
       --replace "<ttm/" "<drm/ttm/"
+    ${dos2unix}/bin/dos2unix src/vboxguest-${version}/vboxguest/r0drv/linux/mp-r0drv-linux.c
   '';
+
+  patchFlags = [ "-p1" "-d" "src/vboxguest-${version}" ];
+  # Kernel 5.3 fix, should be fixed with VirtualBox 6.0.14
+  # https://www.virtualbox.org/ticket/18911
+  patches = [ ./kernel-5.3-fix.patch ];
 
   unpackPhase = ''
     ${if stdenv.hostPlatform.system == "i686-linux" || stdenv.hostPlatform.system == "x86_64-linux" then ''

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/kernel-5.3-fix.patch
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/kernel-5.3-fix.patch
@@ -1,0 +1,50 @@
+--- a/vboxguest/r0drv/linux/mp-r0drv-linux.c
++++ a/vboxguest/r0drv/linux/mp-r0drv-linux.c
+@@ -283,12 +283,15 @@
+     if (RTCpuSetCount(&OnlineSet) > 1)
+     {
+         /* Fire the function on all other CPUs without waiting for completion. */
+-# if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 27)
++# if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 3, 0)
++        smp_call_function(rtmpLinuxAllWrapper, &Args, 0 /* wait */);
++# elif LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 27)
+         int rc = smp_call_function(rtmpLinuxAllWrapper, &Args, 0 /* wait */);
++        Assert(!rc); NOREF(rc);
+ # else
+         int rc = smp_call_function(rtmpLinuxAllWrapper, &Args, 0 /* retry */, 0 /* wait */);
+-# endif
+         Assert(!rc); NOREF(rc);
++# endif
+     }
+ #endif
+
+@@ -326,7 +329,6 @@
+ {
+ #ifdef CONFIG_SMP
+     IPRT_LINUX_SAVE_EFL_AC();
+-    int rc;
+     RTMPARGS Args;
+
+     RTTHREADPREEMPTSTATE PreemptState = RTTHREADPREEMPTSTATE_INITIALIZER;
+@@ -337,14 +339,17 @@
+     Args.cHits = 0;
+
+     RTThreadPreemptDisable(&PreemptState);
+-# if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 27)
+-    rc = smp_call_function(rtmpLinuxWrapper, &Args, 1 /* wait */);
++# if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 3, 0)
++    smp_call_function(rtmpLinuxWrapper, &Args, 1 /* wait */);
++# elif LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 27)
++    int rc = smp_call_function(rtmpLinuxWrapper, &Args, 1 /* wait */);
++    Assert(rc == 0); NOREF(rc);
+ # else /* older kernels */
+-    rc = smp_call_function(rtmpLinuxWrapper, &Args, 0 /* retry */, 1 /* wait */);
++    int rc = smp_call_function(rtmpLinuxWrapper, &Args, 0 /* retry */, 1 /* wait */);
++    Assert(rc == 0); NOREF(rc);
+ # endif /* older kernels */
+     RTThreadPreemptRestore(&PreemptState);
+
+-    Assert(rc == 0); NOREF(rc);
+     IPRT_LINUX_RESTORE_EFL_AC();
+ #else
+     RT_NOREF(pfnWorker, pvUser1, pvUser2);


### PR DESCRIPTION
These don't use a the virtualbox sources, but an iso as `src`, and we need
to add the kernel 5.3 patch aswell.

As for some reason the source files are present on the .iso with Windows
Line endings (sic!), call `dos2unix` first.

Unfortunately, we can't use the same `kernel-5.3-fix.patch` as `virtualbox`
itself, as some files are missing and paths are different.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Fixes https://github.com/NixOS/nixpkgs/issues/65689.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @wkral @ambrop72 
