### PR TITLE
pythonPackages.tensorflow: fix build with CUDA

### DIFF
--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, pkgs, buildBazelPackage, lib, fetchFromGitHub, fetchpatch, symlinkJoin
+{ stdenv, gcc7Stdenv, pkgs, buildBazelPackage, lib, fetchFromGitHub
+, fetchpatch, symlinkJoin
 # Python deps
 , buildPythonPackage, isPy3k, pythonOlder, pythonAtLeast, python
 # Python libraries
@@ -76,7 +77,12 @@ let
     mock
   ]);
 
-  bazel-build = buildBazelPackage {
+  bazel-build = buildBazelPackage.override {
+    stdenv = if cudaSupport then
+      gcc7Stdenv
+    else
+      stdenv;
+  } {
     name = "${pname}-${version}";
 
     src = fetchFromGitHub {
@@ -264,7 +270,7 @@ let
 
       # cudaSupport causes fetch of ncclArchive, resulting in different hashes
       sha256 = if cudaSupport then
-        "196pm3ynfafqlcxah07hkvphf536hpix1ydgsynr1yg08aynlvvx"
+        "12bgxq4arxacak4h2lynbz44yqzwjz2aq361z4bgz48c4mk31agd"
       else
         "138r85n27ijzwxfwb5pcfyb79v14368jpckw0vmciz6pwf11bd9g";
     };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The Tensorflow package fails to build for two reasons:

1. The hash for Tensorflow with CUDA support mismatches.
2. With GCC 8, the build fails with the following error:

```
/nix/store/b2svf6rl14n8yvfzb6r1yl8snbz1mblp-cudatoolkit-10.0.130-merged/bin/..//include/crt/host_config.h:129:2:
error: #error -- unsupported GNU version! gcc versions later than 7 are not supported!
```

This change fixes both issues.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @jyp @abbradar
