### PR TITLE
kernel/modules-closure.sh v2: fix the modules closure

### DIFF
--- a/pkgs/build-support/kernel/modules-closure.sh
+++ b/pkgs/build-support/kernel/modules-closure.sh
@@ -22,10 +22,13 @@ echo "kernel version is $version"
 closure=
 for module in $rootModules; do
     echo "root module: $module"
-    deps=$(modprobe --config no-config -d $kernel --set-version "$version" --show-depends "$module" \
-        | sed 's/^insmod //') \
-        || if test -z "$allowMissing"; then exit 1; fi
+    # Obtain the module dependencies with modprobe.
+    rawdeps=$(modprobe --config no-config -d "$kernel" --set-version "$version" --show-depends "$module") \
+     || if test -z "$allowMissing"; then exit 1; fi
+
     if [[ "$deps" != builtin* ]]; then
+        # Extract the module name from modprobe output and throws away the insmod part and the module arguments.
+        deps=$(printf '%s' "$rawdeps" | sed 's/^insmod \([^ ]*\).*/\1/')
         closure="$closure $deps"
     fi
 done

--- a/pkgs/build-support/kernel/modules-closure.sh
+++ b/pkgs/build-support/kernel/modules-closure.sh
@@ -26,7 +26,7 @@ for module in $rootModules; do
     rawdeps=$(modprobe --config no-config -d "$kernel" --set-version "$version" --show-depends "$module") \
      || if test -z "$allowMissing"; then exit 1; fi
 
-    if [[ "$deps" != builtin* ]]; then
+    if [[ "$rawdeps" != builtin* ]]; then
         # Extract the module name from modprobe output and throws away the insmod part and the module arguments.
         deps=$(printf '%s' "$rawdeps" | sed 's/^insmod \([^ ]*\).*/\1/')
         closure="$closure $deps"


### PR DESCRIPTION
Prior to this commit the modules closure could reference nonsensical
pieces of data in to form of module parameters. These were treated
as seperate modules.

"modprobe --show-depends" outputs a line of the form
"insmod module_name module_args", we are only interested in the
module name, so we extract it with sed.

Also fixes a bug in the original implementation where the check for missing modules did not work as indended (the exit status of
modprobe was ignored due to a pipe).
