### PR TITLE
python3Packages.flit: fix tests and packaging

### DIFF
--- a/pkgs/development/interpreters/python/hooks/flit-build-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/flit-build-hook.sh
@@ -3,9 +3,9 @@ echo "Sourcing flit-build-hook"
 
 flitBuildPhase () {
     echo "Executing flitBuildPhase"
-    preBuild
+    runHook preBuild
     @pythonInterpreter@ -m flit build --format wheel
-    postBuild
+    runHook postBuild
     echo "Finished executing flitBuildPhase"
 }
 

--- a/pkgs/development/python-modules/flit/default.nix
+++ b/pkgs/development/python-modules/flit/default.nix
@@ -7,7 +7,7 @@
 , requests_download
 , zipfile36
 , pythonOlder
-, pytest
+, pytest_4
 , testpath
 , responses
 , pytoml
@@ -21,17 +21,17 @@
 buildPythonPackage rec {
   pname = "flit";
   version = "1.3";
+  disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "6f6f0fb83c51ffa3a150fa41b5ac118df9ea4a87c2c06dff4ebf9adbe7b52b36";
   };
 
-  disabled = !isPy3k;
   propagatedBuildInputs = [ docutils requests requests_download pytoml ]
     ++ lib.optional (pythonOlder "3.6") zipfile36;
 
-  checkInputs = [ pytest testpath responses ];
+  checkInputs = [ pytest_4 testpath responses ];
 
   # Disable test that needs some ini file.
   # Disable test that wants hg
@@ -39,10 +39,10 @@ buildPythonPackage rec {
     HOME=$(mktemp -d) pytest -k "not test_invalid_classifier and not test_build_sdist"
   '';
 
-  meta = {
+  meta = with lib; {
     description = "A simple packaging tool for simple packages";
     homepage = https://github.com/takluyver/flit;
-    license = lib.licenses.bsd3;
-    maintainers = [ lib.maintainers.fridh ];
+    license = licenses.bsd3;
+    maintainers = [ maintainers.fridh ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Noticed during #69433 that we couldn't build a flit package because this package was broken.

For one of the tests, it uses `str(exception)` which isn't compatible with pytest5 

For the flit setup-hook, i needed to add `runHook` before calling the hooks, otherwise they failed if someone actually used them (e.g. python3Packages.bash_kernel)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @zimbatm (python3Packages.bash_kernel got fixed)

```
$ nix build -f . python3Packages.flit python35Packages.flit python36Packages.flit
[43 built, 127 copied (211.5 MiB), 74.5 MiB DL]
```
nix-review failed on creating the nix-shell "env", because it tried to execute the flitBuildHook
```
[7 built (1 failed), 20 copied (12.0 MiB), 7.7 MiB DL]
error: build of '/nix/store/p6qdqk77nd6qappspfrz658lq61lm32b-env.drv' failed
https://github.com/NixOS/nixpkgs/pull/69546
3 package were build:
python37Packages.bash_kernel python37Packages.flit python37Packages.flitBuildHook
```
