### PR TITLE
generic-extlinux-compatible: generate build-time and host-time extlinux builders

### DIFF
--- a/nixos/modules/system/boot/loader/generic-extlinux-compatible/extlinux-conf-builder.nix
+++ b/nixos/modules/system/boot/loader/generic-extlinux-compatible/extlinux-conf-builder.nix
@@ -1,8 +1,8 @@
-{ pkgs }:
+{ substituteAll, bash, coreutils, gnused, gnugrep }:
 
-pkgs.substituteAll {
+substituteAll {
   src = ./extlinux-conf-builder.sh;
   isExecutable = true;
-  path = [pkgs.coreutils pkgs.gnused pkgs.gnugrep];
-  inherit (pkgs) bash;
+  path = [coreutils gnused gnugrep];
+  inherit bash;
 }


### PR DESCRIPTION
##### Motivation for this change

When cross compiling NixOS one cannot build extlinux bootloaders. This change creates a second script called `installBootLoaderNative` that is able to run on the build platform and does the boot loader install during cross compilation. `installBootLoader` is still done with the host's package set.

###### Things done

Tested both versions by making an image for my BeagleBone green and updating it via NixOps (thus creating a new bootloader entry). Not sure if `installBootLoaderNative` is a good name or not.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc  @dezgeg 
