### PR TITLE
apt: 1.4.6 -> 1.8.4

### DIFF
--- a/pkgs/tools/package-management/apt/default.nix
+++ b/pkgs/tools/package-management/apt/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, lib, fetchzip, pkgconfig, cmake, perlPackages, curl, gtest, lzma, bzip2, lz4
+{ stdenv, lib, fetchurl, pkgconfig, cmake, ninja, perlPackages, curl, gtest
+, gnutls, lzma, bzip2, lz4, zstd, libseccomp, udev
 , db, dpkg, libxslt, docbook_xsl, docbook_xml_dtd_45
 
 # used when WITH_DOC=ON
@@ -16,17 +17,17 @@
 stdenv.mkDerivation rec {
   pname = "apt";
 
-  version = "1.4.6";
+  version = "1.8.4";
 
-  src = fetchzip {
-    url = "https://launchpad.net/ubuntu/+archive/primary/+files/apt_${version}.tar.xz";
-    sha256 = "0ahwhmscrmnpvl1r732wg93dzkhv8c1sph2yrqgsrhr73c1616ix";
+  src = fetchurl {
+    url = "http://deb.debian.org/debian/pool/main/a/apt/apt_${version}.tar.xz";
+    sha256 = "0gn4srqaaym85gc8nldqkv01477kdwr136an2nlpbdrsbx3y83zl";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig cmake ninja ];
 
   buildInputs = [
-    cmake perlPackages.perl curl gtest lzma bzip2 lz4 db dpkg libxslt.bin
+    perlPackages.perl curl gtest gnutls lzma bzip2 lz4 zstd libseccomp udev db dpkg libxslt.bin
   ] ++ lib.optionals withDocs [
     doxygen perlPackages.Po4a w3m docbook_xml_dtd_45
   ] ++ lib.optionals withNLS [
@@ -36,6 +37,7 @@ stdenv.mkDerivation rec {
   preConfigure = ''
     cmakeFlagsArray+=(
       -DBERKELEY_DB_INCLUDE_DIRS=${db.dev}/include
+      -DGNUTLS_INCLUDE_DIR=${gnutls.dev}/include
       -DDOCBOOK_XSL="${docbook_xsl}"/share/xml/docbook-xsl
       -DROOT_GROUP=root
       -DWITH_DOC=${if withDocs then "ON" else "OFF"}

--- a/pkgs/tools/package-management/apt/default.nix
+++ b/pkgs/tools/package-management/apt/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, lib, fetchurl, pkgconfig, cmake, ninja, perlPackages, curl, gtest
-, gnutls, lzma, bzip2, lz4, zstd, libseccomp, udev
+{ stdenv, lib, fetchurl, pkgconfig, cmake, perlPackages, curl, gtest
+, gnutls, libtasn1, lzma, bzip2, lz4, zstd, libseccomp, udev
 , db, dpkg, libxslt, docbook_xsl, docbook_xml_dtd_45
 
 # used when WITH_DOC=ON
@@ -23,10 +23,10 @@ stdenv.mkDerivation rec {
     sha256 = "0gn4srqaaym85gc8nldqkv01477kdwr136an2nlpbdrsbx3y83zl";
   };
 
-  nativeBuildInputs = [ pkgconfig cmake ninja gtest libxslt.bin ];
+  nativeBuildInputs = [ pkgconfig cmake gtest libxslt.bin ];
 
   buildInputs = [
-    perlPackages.perl curl gnutls lzma bzip2 lz4 zstd libseccomp udev db dpkg
+    perlPackages.perl curl gnutls libtasn1 lzma bzip2 lz4 zstd libseccomp udev db dpkg
   ] ++ lib.optionals withDocs [
     doxygen perlPackages.Po4a w3m docbook_xml_dtd_45
   ] ++ lib.optionals withNLS [

--- a/pkgs/tools/package-management/apt/default.nix
+++ b/pkgs/tools/package-management/apt/default.nix
@@ -16,40 +16,37 @@
 
 stdenv.mkDerivation rec {
   pname = "apt";
-
   version = "1.8.4";
 
   src = fetchurl {
-    url = "http://deb.debian.org/debian/pool/main/a/apt/apt_${version}.tar.xz";
+    url = "mirror://debian/pool/main/a/apt/apt_${version}.tar.xz";
     sha256 = "0gn4srqaaym85gc8nldqkv01477kdwr136an2nlpbdrsbx3y83zl";
   };
 
-  nativeBuildInputs = [ pkgconfig cmake ninja ];
+  nativeBuildInputs = [ pkgconfig cmake ninja gtest libxslt.bin ];
 
   buildInputs = [
-    perlPackages.perl curl gtest gnutls lzma bzip2 lz4 zstd libseccomp udev db dpkg libxslt.bin
+    perlPackages.perl curl gnutls lzma bzip2 lz4 zstd libseccomp udev db dpkg
   ] ++ lib.optionals withDocs [
     doxygen perlPackages.Po4a w3m docbook_xml_dtd_45
   ] ++ lib.optionals withNLS [
     gettext
   ];
 
-  preConfigure = ''
-    cmakeFlagsArray+=(
-      -DBERKELEY_DB_INCLUDE_DIRS=${db.dev}/include
-      -DGNUTLS_INCLUDE_DIR=${gnutls.dev}/include
-      -DDOCBOOK_XSL="${docbook_xsl}"/share/xml/docbook-xsl
-      -DROOT_GROUP=root
-      -DWITH_DOC=${if withDocs then "ON" else "OFF"}
-      -DUSE_NLS=${if withNLS then "ON" else "OFF"}
-    )
-  '';
+  cmakeFlags = [
+    "-DBERKELEY_DB_INCLUDE_DIRS=${db.dev}/include"
+    "-DGNUTLS_INCLUDE_DIR=${gnutls.dev}/include"
+    "-DDOCBOOK_XSL=${docbook_xsl}/share/xml/docbook-xsl"
+    "-DROOT_GROUP=root"
+    "-DWITH_DOC=${if withDocs then "ON" else "OFF"}"
+    "-DUSE_NLS=${if withNLS then "ON" else "OFF"}"
+  ];
 
   enableParallelBuilding = true;
 
   meta = with lib; {
-    description = "";
-    homepage = https://launchpad.net/ubuntu/+source/apt;
+    description = "Command-line package management tools used on Debian-based systems";
+    homepage = https://salsa.debian.org/apt-team/apt;
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ cstrahan ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```
/nix/store/p8dkrms4nijj7gvcvfk9v2hm1acv2kcd-apt-1.4.6	  136146232
/nix/store/h9zk42aqcab4z2gj1j2hy9gy8vbfz6hn-apt-1.8.4	  148277800
```
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
