### PR TITLE
kicad: 5.1.2 -> 5.1.4

### DIFF
--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -28,11 +28,11 @@ let
 in stdenv.mkDerivation rec {
   pname = "kicad";
   series = "5.0";
-  version = "5.1.2";
+  version = "5.1.4";
 
   src = fetchurl {
     url = "https://launchpad.net/kicad/${series}/${version}/+download/kicad-${version}.tar.xz";
-    sha256 = "12kp82ms2dwqkhilmh3mbhg5rsj5ykk99pnkhp4sx89nni86qdw4";
+    sha256 = "1r60dgh6aalbpq1wsmpyxkz0nn4ck8ydfdjcrblpl69k5rks5k2j";
   };
 
   postPatch = ''
@@ -73,22 +73,22 @@ in stdenv.mkDerivation rec {
   dontWrapGApps = true;
 
   passthru = {
-    i18n = mkLib version "i18n" "08a8lpz2j7bhwn155s0ii538qlynnnvq6fmdw1dxjfgmfy7y3r66" {
+    i18n = mkLib version "i18n" "1dk7wis4cncmihl8fnic3jyhqcdzpifchzsp7hmf214h0vp199zr" {
       buildInputs = [
         gettext
       ];
       meta.license = licenses.gpl2; # https://github.com/KiCad/kicad-i18n/issues/3
     };
-    symbols = mkLib version "symbols" "0l5r53wcv0518x2kl0fh1zi0d50cckc7z1739fp9z3k5a4ddk824" {
+    symbols = mkLib version "symbols" "1lna4xlvzrxif3569pkp6mrg7fj62z3a3ri5j97lnmnnzhiddnh3" {
       meta.license = licenses.cc-by-sa-40;
     };
-    footprints = mkLib version "footprints" "0q7y7m10pav6917ri37pzjvyh71c8lf4lh9ch258pdpl3w481zk6" {
+    footprints = mkLib version "footprints" "0c0kcywxlaihzzwp9bi0dsr2v9j46zcdr85xmfpivmrk19apss6a" {
       meta.license = licenses.cc-by-sa-40;
     };
-    templates = mkLib version "templates" "1nva4ckq0l2lrah0l05355cawlwd7qfxcagcv32m8hcrn781455q" {
+    templates = mkLib version "templates" "1bagb0b94cjh7zp9z0h23b60j45kwxbsbb7b2bdk98dmph8lmzbb" {
       meta.license = licenses.cc-by-sa-40;
     };
-    packages3d = mkLib version "packages3d" "0xla9k1rnrs00fink90y9qz766iks5lyqwnf1h2i508djqhqm5zi" {
+    packages3d = mkLib version "packages3d" "1xla9k1rnrs00fink90y9qz766iks5lyqwnf1h2i508djqhqm5zi" {
       hydraPlatforms = []; # this is a ~1 GiB download, occupies ~5 GiB in store
       meta.license = licenses.cc-by-sa-40;
     };

--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -107,7 +107,7 @@ in stdenv.mkDerivation rec {
     buildPythonPath "$out $pythonPath"
     gappsWrapperArgs+=(--set PYTHONPATH "$program_PYTHONPATH")
 
-    wrapGApp "$out/bin/kicad"
+    wrapGApp "$out/bin/kicad" --prefix LD_LIBRARY_PATH : "${libngspice}/lib"
   '';
 
   meta = {

--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -88,7 +88,7 @@ in stdenv.mkDerivation rec {
     templates = mkLib version "templates" "1bagb0b94cjh7zp9z0h23b60j45kwxbsbb7b2bdk98dmph8lmzbb" {
       meta.license = licenses.cc-by-sa-40;
     };
-    packages3d = mkLib version "packages3d" "1xla9k1rnrs00fink90y9qz766iks5lyqwnf1h2i508djqhqm5zi" {
+    packages3d = mkLib version "packages3d" "0h2qjj8vf33jz6jhqdz90c80h5i1ydgfqnns7rn0fqphlnscb45g" {
       hydraPlatforms = []; # this is a ~1 GiB download, occupies ~5 GiB in store
       meta.license = licenses.cc-by-sa-40;
     };

--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -116,5 +116,6 @@ in stdenv.mkDerivation rec {
     license = licenses.gpl2;
     maintainers = with maintainers; [ berce ];
     platforms = with platforms; linux;
+    broken = stdenv.isAarch64;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update kicad and provide a partial fix for the ngspice issue.
With this the ngspice gui in eeschema Tools -> Simulation will open.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @berce 
