### PR TITLE
Unset unused variables in setup.sh

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -280,6 +280,8 @@ for i in $initialPath; do
     fi
 done
 
+unset i
+
 if (( "${NIX_DEBUG:-0}" >= 1 )); then
     echo "initial path: $PATH"
 fi
@@ -309,11 +311,11 @@ declare -a pkgsBuildBuild pkgsBuildHost pkgsBuildTarget
 declare -a pkgsHostHost pkgsHostTarget
 declare -a pkgsTargetTarget
 
-declare -ra pkgBuildAccumVars=(pkgsBuildBuild pkgsBuildHost pkgsBuildTarget)
-declare -ra pkgHostAccumVars=(pkgsHostHost pkgsHostTarget)
-declare -ra pkgTargetAccumVars=(pkgsTargetTarget)
+declare -a pkgBuildAccumVars=(pkgsBuildBuild pkgsBuildHost pkgsBuildTarget)
+declare -a pkgHostAccumVars=(pkgsHostHost pkgsHostTarget)
+declare -a pkgTargetAccumVars=(pkgsTargetTarget)
 
-declare -ra pkgAccumVarVars=(pkgBuildAccumVars pkgHostAccumVars pkgTargetAccumVars)
+declare -a pkgAccumVarVars=(pkgBuildAccumVars pkgHostAccumVars pkgTargetAccumVars)
 
 
 # Hooks
@@ -322,11 +324,11 @@ declare -a envBuildBuildHooks envBuildHostHooks envBuildTargetHooks
 declare -a envHostHostHooks envHostTargetHooks
 declare -a envTargetTargetHooks
 
-declare -ra pkgBuildHookVars=(envBuildBuildHook envBuildHostHook envBuildTargetHook)
-declare -ra pkgHostHookVars=(envHostHostHook envHostTargetHook)
-declare -ra pkgTargetHookVars=(envTargetTargetHook)
+declare -a pkgBuildHookVars=(envBuildBuildHook envBuildHostHook envBuildTargetHook)
+declare -a pkgHostHookVars=(envHostHostHook envHostTargetHook)
+declare -a pkgTargetHookVars=(envTargetTargetHook)
 
-declare -ra pkgHookVarVars=(pkgBuildHookVars pkgHostHookVars pkgTargetHookVars)
+declare -a pkgHookVarVars=(pkgBuildHookVars pkgHostHookVars pkgTargetHookVars)
 
 # Add env hooks for all sorts of deps with the specified host offset.
 addEnvHooks() {
@@ -342,26 +344,26 @@ addEnvHooks() {
 
 # Propagated dep files
 
-declare -ra propagatedBuildDepFiles=(
+declare -a propagatedBuildDepFiles=(
     propagated-build-build-deps
     propagated-native-build-inputs # Legacy name for back-compat
     propagated-build-target-deps
 )
-declare -ra propagatedHostDepFiles=(
+declare -a propagatedHostDepFiles=(
     propagated-host-host-deps
     propagated-build-inputs # Legacy name for back-compat
 )
-declare -ra propagatedTargetDepFiles=(
+declare -a propagatedTargetDepFiles=(
     propagated-target-target-deps
 )
-declare -ra propagatedDepFilesVars=(
+declare -a propagatedDepFilesVars=(
     propagatedBuildDepFiles
     propagatedHostDepFiles
     propagatedTargetDepFiles
 )
 
 # Platform offsets: build = -1, host = 0, target = 1
-declare -ra allPlatOffsets=(-1 0 1)
+declare -a allPlatOffsets=(-1 0 1)
 
 
 # Mutually-recursively find all build inputs. See the dependency section of the
@@ -603,6 +605,13 @@ _addToEnv() {
 
 # Run the package-specific hooks set by the setup-hook scripts.
 _addToEnv
+
+
+# Unset setup-specific declared variables
+unset allPlatOffsets
+unset pkgBuildAccumVars pkgHostAccumVars pkgTargetAccumVars pkgAccumVarVars
+unset pkgBuildHookVars pkgHostHookVars pkgTargetHookVars pkgHookVarVars
+unset propagatedBuildDepFiles propagatedHostDepFiles propagatedTargetDepFiles propagatedDepFilesVars
 
 
 _addRpathPrefix "$out"


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
