### PR TITLE
kati: 2017-05-23 -> 2019-09-23

### DIFF
--- a/pkgs/development/tools/build-managers/kati/default.nix
+++ b/pkgs/development/tools/build-managers/kati/default.nix
@@ -1,14 +1,14 @@
-{ fetchgit, stdenv }:
+{ stdenv, fetchFromGitHub }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "kati-unstable";
-  version = "2017-05-23";
-  rev = "2dde61e46ab789f18956ff3b7c257dd8eb97993f";
+  version = "2019-09-23";
 
-  src = fetchgit {
-    inherit rev;
-    url = "https://github.com/google/kati.git";
-    sha256 = "1das1fvycra546lmh72cr5qpgblhbzqqy7gfywiijjgx160l75vq";
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "kati";
+    rev = "9da3296746a0cd55b38ebebf91e7f57105a4c36f";
+    sha256 = "0s5dfhgpcbx12b1fqmm8p0jpvrhgrnl9qywv1ksbwhw3pfp7j866";
   };
 
   patches = [ ./version.patch ];
@@ -17,10 +17,11 @@ stdenv.mkDerivation rec {
     install -D ckati $out/bin/ckati
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "An experimental GNU make clone";
     homepage = https://github.com/google/kati;
-    platforms = stdenv.lib.platforms.all;
-    license = stdenv.lib.licenses.asl20;
+    platforms = platforms.all;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ danielfullmer ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update to the most recent commit. Upstream doesn't seem to do releases. I'll adopt this package as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).