### PR TITLE
newsboat: 2.16.1 -> 2.17.1

### DIFF
--- a/pkgs/applications/networking/feedreaders/newsboat/default.nix
+++ b/pkgs/applications/networking/feedreaders/newsboat/default.nix
@@ -3,14 +3,14 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "newsboat";
-  version = "2.16.1";
+  version = "2.17.1";
 
   src = fetchurl {
     url = "https://newsboat.org/releases/${version}/${pname}-${version}.tar.xz";
-    sha256 = "0lxdsfcwa4byhfnn0gv34w3rr531f4nfqgi8j4qqmh3gncbwh8s0";
+    sha256 = "15qr2y35yvl0hzsf34d863n8v042v78ks6ksh5p1awvi055x5sy1";
   };
 
-  cargoSha256 = "0ck2dgfk4fay4cjl66wqkbnq4rqrd717jl63l1mvqmvad9i19igm";
+  cargoSha256 = "0db4j6y43gacazrvcmq823fzl5pdfdlg8mkjpysrw6h9fxisq83f";
 
   postPatch = ''
     substituteInPlace Makefile --replace "|| true" ""


### PR DESCRIPTION
###### Motivation for this change

[CHANGELOG](https://github.com/newsboat/newsboat/blob/master/CHANGELOG.md#2171---2019-10-02)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```sh
$ nix path-info -Sh /nix/store/y0cq1ym29a4lwn72r9ylia31xppsviv4-newsboat-2.16.1
/nix/store/y0cq1ym29a4lwn72r9ylia31xppsviv4-newsboat-2.16.1	  84.0M
$ nix path-info -Sh /nix/store/yf82cazi7jhfp7baqq58xchmzqmq647h-newsboat-2.17.1
/nix/store/yf82cazi7jhfp7baqq58xchmzqmq647h-newsboat-2.17.1	  84.8M
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @dotlambda, @nicknovitski, @dywedir 
