### PR TITLE
z-lua: fix build on darwin

### DIFF
--- a/pkgs/tools/misc/z-lua/default.nix
+++ b/pkgs/tools/misc/z-lua/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, lua }:
+{ stdenv, fetchFromGitHub, lua52Packages, makeWrapper }:
 
 stdenv.mkDerivation rec {
   pname = "z-lua";
@@ -13,10 +13,17 @@ stdenv.mkDerivation rec {
 
   dontBuild = true;
 
-  buildInputs = [ (lua.withPackages (p: with p; [ luafilesystem ])) ];
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [ lua52Packages.lua ];
 
   installPhase = ''
+    runHook preInstall
+
     install -Dm755 z.lua $out/bin/z
+    wrapProgram $out/bin/z --set LUA_CPATH "${lua52Packages.luafilesystem}/lib/lua/5.2/lfs.so" --set _ZL_USE_LFS 1;
+
+    runHook postInstall
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
wrap LUA_CPATH manually instead of lua.withPackages. We can't use lua.withPackages, because on darwin shebangs can't point to interpreted (shebang'd) scripts. See https://github.com/NixOS/nixpkgs/issues/23018
supersedes and closes https://github.com/NixOS/nixpkgs/pull/68920
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
