### PR TITLE
cabal2nix: fix build

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-8.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.6.x.nix
@@ -95,7 +95,11 @@ self: super: {
   # Newer versions don't compile.
   resolv = self.resolv_0_1_1_2;
 
-  # cabal2nix needs the latest version of Cabal.
-  cabal2nix = super.cabal2nix.overrideScope (self: super: { Cabal = self.Cabal_3_0_0_0; });
+  # cabal2nix needs the latest version of Cabal, and the one
+  # hackage-db uses must match, so take the latest
+  cabal2nix = super.cabal2nix.overrideScope (self: super: {
+    Cabal = self.Cabal_3_0_0_0;
+    hackage-db = self.hackage-db_2_1_0;
+  });
 
 }


### PR DESCRIPTION
###### Motivation for this change

Without this change, the build fails with:

```
Warning:
    This package indirectly depends on multiple versions of the same package. This is very likely to cause a compile failure.
      package hackage-db (hackage-db-2.0.1-AliTRXEJBGFAEMpONOEnbV) requires Cabal-2.4.0.1
      package hpack (hpack-0.32.0-1iJuukTWmC4EGkYhAiFeII) requires Cabal-3.0.0.0-CD1INMNwoxXIKVgcu1nec5
      package distribution-nixpkgs (distribution-nixpkgs-1.3.1-82Z2DCdLAUs8Q2gjtlPLz5) requires Cabal-3.0.0.0-CD1INMNwoxXIKVgcu1nec5
      package cabal2nix (cabal2nix-2.15.0) requires Cabal-3.0.0.0-CD1INMNwoxXIKVgcu1nec5
      package cabal2nix (cabal2nix-2.15.0) requires Cabal-3.0.0.0-CD1INMNwoxXIKVgcu1nec5
      package cabal2nix (cabal2nix-2.15.0) requires Cabal-3.0.0.0-CD1INMNwoxXIKVgcu1nec5
```

(See https://nix-cache.s3.amazonaws.com/log/xsvv9fcsblqk34hr3j2bznim9c4c9rc2-cabal2nix-2.15.0.drv for a full sample)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @peti 
