### PR TITLE
obitools3: init at 3.0.0-beta14

### DIFF
--- a/pkgs/applications/science/biology/obitools/obitools3.nix
+++ b/pkgs/applications/science/biology/obitools/obitools3.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchurl, python3Packages, cmake, python3 }:
+
+let
+  pythonPackages = python3Packages;
+in
+
+pythonPackages.buildPythonApplication rec {
+  pname = "obitools3";
+  version = "3.0.0-beta14";
+
+  src = fetchurl {
+    url = "https://git.metabarcoding.org/obitools/${pname}/repository/v${version}/archive.tar.gz";
+    sha256 = "17krklxfvxl6baf2m394gm1a88y0lg0bwqx20cf5q39zyw04z442";
+  };
+
+  preBuild = ''
+    substituteInPlace src/CMakeLists.txt --replace \$'{PYTHONLIB}' "$out/lib/${python3.libPrefix}/site-packages";
+    export NIX_CFLAGS_COMPILE="-L $out/lib/${python3.libPrefix}/site-packages $NIX_CFLAGS_COMPILE"
+  '';
+
+  disabled = !pythonPackages.isPy3k;
+
+  nativeBuildInputs = [ pythonPackages.cython cmake ];
+
+  dontConfigure = true;
+
+  doCheck = true;
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib ; {
+    description = "Management of analyses and data in DNA metabarcoding";
+    homepage = "https://git.metabarcoding.org/obitools/obitools3";
+    license = licenses.cecill20;
+    maintainers = [ maintainers.bzizou ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24435,6 +24435,8 @@ in
 
   manta = callPackage ../applications/science/biology/manta { };
 
+  obitools3 = callPackage ../applications/science/biology/obitools/obitools3.nix { };
+
   octopus-caller = callPackage ../applications/science/biology/octopus { };
 
   paml = callPackage ../applications/science/biology/paml { };


### PR DESCRIPTION

###### Motivation for this change
Obitools is an application developped into my lab and we would be very glad to have it available as a nix package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
