### PR TITLE
riot-{web,desktop}: 1.3.5 -> 1.4.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/riot/riot-desktop-package.json
+++ b/pkgs/applications/networking/instant-messengers/riot/riot-desktop-package.json
@@ -2,7 +2,7 @@
   "name": "riot-web",
   "productName": "Riot",
   "main": "src/electron-main.js",
-  "version": "1.3.5",
+  "version": "1.4.0",
   "description": "A feature-rich client for Matrix.org",
   "author": "New Vector Ltd.",
   "dependencies": {

--- a/pkgs/applications/networking/instant-messengers/riot/riot-desktop.nix
+++ b/pkgs/applications/networking/instant-messengers/riot/riot-desktop.nix
@@ -6,12 +6,12 @@
 
 let
   executableName = "riot-desktop";
-  version = "1.3.5";
+  version = "1.4.0";
   riot-web-src = fetchFromGitHub {
     owner = "vector-im";
     repo = "riot-web";
     rev = "v${version}";
-    sha256 = "05xwp6062lvjsy539swa6dxj3k3dw1667nkx8ffwdl1dg17wphy8";
+    sha256 = "1p8bl7v2214shywn53fpcb27vvvdjrs3kcys3f045v2l5fg5xhsa";
   };
 
 in yarn2nix-moretea.mkYarnPackage rec {

--- a/pkgs/applications/networking/instant-messengers/riot/riot-web.nix
+++ b/pkgs/applications/networking/instant-messengers/riot/riot-web.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   pname = "riot-web";
-  version = "1.3.5";
+  version = "1.4.0";
 
   src = fetchurl {
     url = "https://github.com/vector-im/riot-web/releases/download/v${version}/riot-v${version}.tar.gz";
-    sha256 = "0vpfv5rvrhrws52j4lxnj1qyagf9894znpxkdnkp72g19qsjn66g";
+    sha256 = "1si11hxkfn6sqaq1hddm5vkfrd0pghzwqld1wv4vxlb5jyn32qqk";
   };
 
   installPhase = let


### PR DESCRIPTION
###### Motivation for this change

This PR updates `riot-web` and `riot-desktop` to the latest version.


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`): could succesfully start and use the electron app
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @worldofpeace @bachp 
