### PR TITLE
Clarissa: init at 1.0-80-g00c2581

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1007,6 +1007,7 @@
   ./services/networking/cloudflare-dyndns.nix
   ./services/networking/cloudflared.nix
   ./services/networking/cloudflare-warp.nix
+  ./services/networking/clarissa.nix
   ./services/networking/cntlm.nix
   ./services/networking/connman.nix
   ./services/networking/consul.nix

--- a/nixos/modules/services/networking/clarissa.nix
+++ b/nixos/modules/services/networking/clarissa.nix
@@ -1,0 +1,180 @@
+{ config, lib, pkgs, ...}:
+
+with lib;
+
+let
+
+  cfg = config.services.clarissa;
+
+in {
+
+  options.services.clarissa = {
+
+    enable = mkEnableOption ("The network census daemon.");
+
+    will = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Whether to leave a will file.";
+    };
+
+    quiet = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Whether not to nag timed out entries.";
+    };
+
+    buffer = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Whether to buffer the captured packets (not use immediate mode).";
+    };
+
+    promiscuous = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Whether to set the used interface to promiscuous mode.";
+    };
+
+    nags = mkOption {
+      type = types.ints.unsigned;
+      default = 4;
+      description = "How many times to send a frame to a timed out entry.";
+    };
+
+    timeout = mkOption {
+      type = types.ints.unsigned;
+      default = 5000;
+      description = "Time in ms to wait before nagging or culling an entry.";
+    };
+
+    interval = mkOption {
+      type = types.ints.unsigned;
+      default = 1250;
+      description = "How often to nag and cull the list entries (in ms).";
+    };
+
+    outputInterval = mkOption {
+      type = types.ints.unsigned;
+      default = 0;
+      description = "How often to update the outputFile.";
+    };
+
+    subnet = mkOption {
+      type = types.str;
+      default = "";
+      example = "192.168.0.0/16";
+      description = "Subnet to filter frames by (in CIDR notation).";
+    };
+
+    socket = mkOption {
+      type = types.str;
+      default = "";
+      example = "/var/run/clar/[dev]_[subnet]-[mask]";
+      description = "Full path to the output socket.";
+    };
+
+    interface = mkOption {
+      type = types.str;
+      default = "";
+      example = "eth0";
+      description = "Network interface to use instead of the automatically selected one.";
+    };
+
+    outputFile = mkOption {
+      type = types.str;
+      default = "";
+      example = "/var/run/clar/[dev_[subnet]-[mask].clar";
+      description = "Overwrite the default generated filename.";
+    };
+
+    extraOptions = mkOption {
+      type = types.str;
+      default = "";
+      example = "-vvv";
+      description = "Additional options passed to the command.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    users = {
+      users.clarissa = {
+        home = "/var/lib/clar";
+        isSystemUser = true;
+        group = "clarissa";
+        description = "network census daemon user";
+      };
+      groups.clarissa = { };
+    };
+
+    systemd.services.clarissa = {
+      description = "the network census daemon";
+      documentation = [ "man:clarissa(8)" ];
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+      postStop = "rm -f /var/lib/clar/*";
+      serviceConfig = rec {
+        User = "clarissa";
+        Group = "clarissa";
+        Restart = "always";
+        RestartSec = 1;
+        StartLimitBurst = 10;
+        ExecStart = "${pkgs.clarissa}/bin/clarissa "
+          + "--nags ${toString cfg.nags} "
+          + "--timeout ${toString cfg.timeout} "
+          + "--interval ${toString cfg.interval} "
+          + "--output_interval ${toString cfg.outputInterval} "
+          + (optionalString cfg.will "--will ")
+          + (optionalString cfg.quiet "--quiet ")
+          + (optionalString cfg.buffer "--buffer ")
+          + (optionalString (!cfg.promiscuous) "--abstemious ")
+          + (optionalString (cfg.subnet != "") "--cidr ${cfg.subnet} ")
+          + (optionalString (cfg.socket != "") "--socket ${cfg.socket} ")
+          + (optionalString (cfg.interface != "") "--interface ${cfg.interface} ")
+          + (optionalString (cfg.outputFile != "") "--output_file ${cfg.outputFile} ")
+          + "${cfg.extraOptions} ";
+        TimeoutStopSec = 7;
+
+        RuntimeDirectory = "clar";
+        StateDirectory = "clar";
+        AmbientCapabilities = [ "CAP_NET_RAW" ]
+          ++ optionals (cfg.promiscuous) [ "CAP_NET_ADMIN" ];
+        CapabilityBoundingSet = AmbientCapabilities;
+        IPAddressDeny= "any";
+        IPAddressAllow = [ "10.0.0.0/8" "172.16.0.0/12" "192.168.0.0/16" "fd00::/8" ];
+        NoNewPrivileges = true;
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        RemoveIPC = true;
+
+        PrivateDevices = true;
+        PrivateTmp = true;
+        PrivateUsers = false; # not sure why the service fails with this on true
+
+        ProtectSystem = "strict";
+        ProtectClock = true;
+        ProtectHostname = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectKernelLogs = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectProc = "noaccess"; # somehow still shows up as 0.1 exposure but no description
+        ProcSubset = "pid";
+
+        RestrictAddressFamilies = [ "AF_UNIX" "AF_INET" "AF_INET6" "AF_NETLINK" "AF_PACKET" ];
+        RestrictNamespaces = true;
+        RestrictSUIDSGID = true;
+        RestrictRealtime = true;
+
+        SystemCallFilter = [ "~@clock" "~@cpu-emulation" "~@debug" "~@module" "~@mount" "~@obsolete" "~@privileged" "~@ra" "-io" "~@reboot" "~@resources" "~@swap" ];
+        SystemCallArchitectures = "native";
+
+        UMask = "133";
+
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -202,6 +202,7 @@ in {
   cinnamon = handleTest ./cinnamon.nix {};
   cinnamon-wayland = handleTest ./cinnamon-wayland.nix {};
   cjdns = handleTest ./cjdns.nix {};
+  clarissa = handleTest ./clarissa.nix {};
   clatd = handleTest ./clatd.nix {};
   clickhouse = handleTest ./clickhouse.nix {};
   cloud-init = handleTest ./cloud-init.nix {};

--- a/nixos/tests/clarissa.nix
+++ b/nixos/tests/clarissa.nix
@@ -1,0 +1,40 @@
+import ./make-test-python.nix ({ pkgs, ...} : {
+  name = "clarissa";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ evils ];
+  };
+
+  nodes.censusTaker = { pkgs, ... }: {
+    environment.systemPackages = [ pkgs.clar ];
+    services.clarissa = {
+      enable = true;
+      extraOptions = "-vvv";
+    };
+    # required to get the hostname etc. of the other node
+    # unclear why that's not needed on the other node
+    networking = {
+      useDHCP = false;
+      useNetworkd = true;
+    };
+  };
+
+  nodes.hannibal = { pkgs, ... }: { environment.systemPackages = [ pkgs.iputils ]; };
+
+  testScript =
+    ''
+      start_all()
+      censusTaker.wait_for_unit("multi-user.target")
+      hannibal.wait_for_unit("multi-user.target")
+
+      # ensure censusTaker first sees a packet from hannibal
+      hannibal.wait_until_succeeds("ping -4c 1 censusTaker")
+
+      # check if censusTaker saw hannibal
+      # TODO: check for the actual MAC and IP address
+      censusTaker.succeed("clar show | tee /dev/stderr | grep -q 'hannibal'")
+
+      hannibal.shutdown()
+      censusTaker.shutdown()
+    '';
+})
+

--- a/pkgs/tools/networking/clarissa/clar.nix
+++ b/pkgs/tools/networking/clarissa/clar.nix
@@ -1,0 +1,44 @@
+{ lib, stdenv
+, clarissa
+, clar-oui
+, asciidoctor
+, dnsutils
+, makeWrapper
+}:
+
+stdenv.mkDerivation rec {
+
+  pname = "clar";
+  version = clarissa.version;
+
+  src = clarissa.src;
+
+  nativeBuildInputs = [ asciidoctor makeWrapper ];
+
+  outputs = [ "out" "man" ];
+
+  makeFlags = [ "DESTDIR=${placeholder "out"}" "PREFIX=" ];
+
+  dontBuild = true;
+  installTargets = [ "install-clar" ];
+  postInstall = ''
+    wrapProgram $out/bin/clar \
+      --prefix PATH : ${lib.makeBinPath [ clarissa dnsutils ]} \
+      --set CLAR_OUI ${clar-oui}/share/misc/clar_OUI.csv
+  '';
+
+  meta = with lib; {
+    description = "Utility for using clarissa's output";
+    longDescription = ''
+      This utility uses clarissa's output to provide a variety of formats and functions.
+      Such as: presenting the MAC and IP addresses along with an associated domain name
+      and the MAC vendor ID,
+      provide a near instantaneous arp-scan like output
+      and accessing clarissa's output without installing the daemon in the environment.
+    '';
+    homepage = "https://gitlab.com/evils/clarissa";
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.evils ];
+  };
+}

--- a/pkgs/tools/networking/clarissa/default.nix
+++ b/pkgs/tools/networking/clarissa/default.nix
@@ -1,0 +1,46 @@
+{ lib, stdenv
+, fetchFromGitLab
+, libpcap, perl
+, asciidoctor
+}:
+
+stdenv.mkDerivation rec {
+
+  pname = "clarissa";
+  version = "1.0-80-g00c2581";
+
+  outputs = [ "out" "man" ];
+  separateDebugInfo = true;
+
+  src = fetchFromGitLab {
+    owner = "evils";
+    repo = "clarissa";
+    rev = "00c258184642f62d7ce151bcf7ce5e13e72ce681";
+    hash = "sha256-YQzsZ9rooCTUaGG7GVAmN0aTmNHzPHARHWhwXSgWUHU=";
+  };
+
+  nativeBuildInputs = [ asciidoctor ];
+  buildInputs = [ libpcap ];
+
+  installTargets = "install-clarissa";
+
+  checkInputs = [ perl ];
+  makeFlags = [ "DESTDIR=${placeholder "out"}" "PREFIX=" ];
+
+  checkTarget = "test";
+  doCheck = true;
+
+  dontBuild = true;
+
+  meta = with lib; {
+    description = "Near-real-time network census daemon";
+    longDescription = ''
+      Clarissa is a daemon which keeps track of connected MAC addresses on a network.
+      It can report these with sub-second resolution and can monitor passively.
+    '';
+    homepage = "https://gitlab.com/evils/clarissa";
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.evils ];
+  };
+}

--- a/pkgs/tools/networking/clarissa/default.nix
+++ b/pkgs/tools/networking/clarissa/default.nix
@@ -2,6 +2,7 @@
 , fetchFromGitLab
 , libpcap, perl
 , asciidoctor
+, nixosTests
 }:
 
 stdenv.mkDerivation rec {
@@ -31,6 +32,8 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   dontBuild = true;
+
+  passthru.tests = nixosTests.clarissa;
 
   meta = with lib; {
     description = "Near-real-time network census daemon";

--- a/pkgs/tools/networking/clarissa/oui.nix
+++ b/pkgs/tools/networking/clarissa/oui.nix
@@ -1,0 +1,32 @@
+{ lib, stdenv
+, clarissa
+, wget
+, cacert
+}:
+
+stdenv.mkDerivation rec {
+
+  pname = "clar-oui";
+  version = clarissa.version;
+
+  src = clarissa.src;
+
+  outputHashMode = "recursive";
+  outputHashAlgo = "sha256";
+  outputHash = "07b9gpjknrgyb0a9fr1sr3mkm3cgr566zjd1jz1iyy2fxb5a3ik5";
+
+  nativeBuildInputs = [ wget cacert ];
+
+  makeFlags = [ "DESTDIR=${placeholder "out"}" "PREFIX=" ];
+
+  dontBuild = true;
+  installTargets = [ "clean" "install-oui" ];
+
+  meta = with lib; {
+    description = "Organizationally Unique Identifier (OUI) file for use with the clar utility";
+    homepage = "https://gitlab.com/evils/clarissa";
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.evils ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1853,9 +1853,11 @@ with pkgs;
     withDriver = false;
   };
 
-  clarissa = callPackage ../tools/networking/clarissa { };
-  clar = callPackage ../tools/networking/clarissa/clar.nix { };
-  clar-oui = callPackage ../tools/networking/clarissa/oui.nix { };
+  inherit ({ # workaround for keeping the packages in 1 directory outside of by-name
+    clarissa = callPackage ../tools/networking/clarissa { };
+    clar = callPackage ../tools/networking/clarissa/clar.nix { };
+    clar-oui = callPackage ../tools/networking/clarissa/oui.nix { };
+  }) clarissa clar clar-oui;
 
   fedora-backgrounds = callPackage ../data/misc/fedora-backgrounds { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1854,7 +1854,7 @@ with pkgs;
   };
 
   clarissa = callPackage ../tools/networking/clarissa { };
-
+  clar = callPackage ../tools/networking/clarissa/clar.nix { };
   clar-oui = callPackage ../tools/networking/clarissa/oui.nix { };
 
   fedora-backgrounds = callPackage ../data/misc/fedora-backgrounds { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1853,6 +1853,8 @@ with pkgs;
     withDriver = false;
   };
 
+  clarissa = callPackage ../tools/networking/clarissa { };
+
   fedora-backgrounds = callPackage ../data/misc/fedora-backgrounds { };
 
   coconut = with python3Packages; toPythonApplication coconut;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1855,6 +1855,8 @@ with pkgs;
 
   clarissa = callPackage ../tools/networking/clarissa { };
 
+  clar-oui = callPackage ../tools/networking/clarissa/oui.nix { };
+
   fedora-backgrounds = callPackage ../data/misc/fedora-backgrounds { };
 
   coconut = with python3Packages; toPythonApplication coconut;


### PR DESCRIPTION
###### Motivation for this change
I want to share my tool.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - `36910136`
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).