### PR TITLE
pim-data-exporter: Add missing dependencies

### DIFF
--- a/pkgs/applications/kde/pim-data-exporter.nix
+++ b/pkgs/applications/kde/pim-data-exporter.nix
@@ -1,10 +1,10 @@
 {
   mkDerivation, lib, kdepimTeam,
   extra-cmake-modules, kdoctools,
-  akonadi, kcmutils, kcrash, kdbusaddons, kidentitymanagement, kldap,
-  kmailtransport, knewstuff, knotifications, knotifyconfig, kparts, kross, ktexteditor,
-  kwallet, libkdepim, libkleo, pimcommon, qttools,
-  karchive, mailcommon, messagelib
+  akonadi, akonadi-notes, kcalcore, kcmutils, kcrash, kdbusaddons,
+  kidentitymanagement, kldap, kmailtransport, knewstuff, knotifications,
+  knotifyconfig, kparts, kross, ktexteditor, kwallet, libkdepim, libkleo,
+  pimcommon, qttools, karchive, mailcommon, messagelib
 }:
 
 mkDerivation {
@@ -15,8 +15,9 @@ mkDerivation {
   };
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [
-    akonadi kcmutils kcrash kdbusaddons kidentitymanagement kldap kmailtransport
-    knewstuff knotifications knotifyconfig kparts kross ktexteditor kwallet libkdepim
-    libkleo pimcommon qttools karchive mailcommon messagelib
+    akonadi akonadi-notes kcalcore kcmutils kcrash kdbusaddons
+    kidentitymanagement kldap kmailtransport knewstuff knotifications
+    knotifyconfig kparts kross ktexteditor kwallet libkdepim libkleo pimcommon
+    qttools karchive mailcommon messagelib
   ];
 }


### PR DESCRIPTION
###### Motivation for this change

Fixes failing build of `kdeApplications.pim-data-exporter`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
