### PR TITLE
librseq: init at 0.1pre54_1526001

### DIFF
--- a/pkgs/development/libraries/librseq/default.nix
+++ b/pkgs/development/libraries/librseq/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub
+, autoreconfHook, linuxHeaders
+}:
+
+stdenv.mkDerivation rec {
+  pname = "librseq";
+  version = "0.1.0pre54_${builtins.substring 0 7 src.rev}";
+
+  src = fetchFromGitHub {
+    owner  = "compudj";
+    repo   = "librseq";
+    rev    = "152600188dd214a0b2c6a8c66380e50c6ad27154";
+    sha256 = "0mivjmgdkgrr6z2gz3k6q6wgnvyvw9xzy65f6ipvqva68sxhk0mx";
+  };
+
+  outputs = [ "out" "dev" ];
+  nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = [ linuxHeaders ];
+
+  separateDebugInfo = true;
+  enableParallelBuilding = true;
+
+  # The share/ subdir only contains a doc/ with a README.md that just describes
+  # how to compile the library, which clearly isn't very useful! So just get
+  # rid of it anyway.
+  postInstall = ''
+    rm -rf $out/share
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Userspace library for the Linux Restartable Sequence API";
+    homepage    = "https://github.com/compudj/librseq";
+    license     = licenses.lgpl21;
+    platforms   = platforms.linux;
+    maintainers = with maintainers; [ thoughtpolice ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11876,6 +11876,8 @@ in
 
   liburing = callPackage ../development/libraries/liburing { };
 
+  librseq = callPackage ../development/libraries/librseq { };
+
   libseccomp = callPackage ../development/libraries/libseccomp { };
 
   libsecret = callPackage ../development/libraries/libsecret { };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] other Linux distributions