### PR TITLE
python3Packages.keyring: 19.1.0 -> 19.2.0

### DIFF
--- a/pkgs/development/python-modules/keyring/default.nix
+++ b/pkgs/development/python-modules/keyring/default.nix
@@ -1,14 +1,15 @@
-{ stdenv, buildPythonPackage, fetchPypi
+{ stdenv, buildPythonPackage, fetchPypi, isPy27
 , dbus-python, setuptools_scm, entrypoints, secretstorage
 , pytest, pytest-flake8 }:
 
 buildPythonPackage rec {
   pname = "keyring";
-  version = "19.1.0";
+  version = "19.2.0";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "13frfmws03jdyz9wxb4ylkvk80qiyb6a3h3sn7wx3ry97bn5li3a";
+    sha256 = "1cvlm48fggl12m19j9vcnrlplidr2sjf8h3pdyki58f9y357q0wi";
   };
 
   nativeBuildInputs = [ setuptools_scm ];


### PR DESCRIPTION
###### Motivation for this change
noticed `ERROR: Package 'keyring' requires a different Python: 2.7.16 not in '>=3.5'` while reviewing another PR of mine.

decided to bump it while disabling python2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[21 built, 94 copied (306.1 MiB), 45.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/69676
2 package are marked as broken and were skipped:
backintime backintime-qt4

21 package were build:
aws-google-auth backintime-common bonfire coursera-dl gajim i3pystatus jira-cli jrnl ledger-autosync maestral maestral-gui nagstamon pgcli python37Packages.astroquery python37Packages.browser-cookie3 python37Packages.bugwarrior python37Packages.keyring python37Packages.keyrings-alt python37Packages.ofxclient spyder urlwatch
```