### PR TITLE
giflib: fix build on darwin by patch submitted upstream

### DIFF
--- a/pkgs/development/libraries/giflib/default.nix
+++ b/pkgs/development/libraries/giflib/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, xmlto, docbook_xml_dtd_412, docbook_xsl, libxml2 }:
+{ stdenv, fetchurl, fetchpatch, xmlto, docbook_xml_dtd_412, docbook_xsl, libxml2 }:
 
 stdenv.mkDerivation rec {
   name = "giflib-5.2.1";
@@ -6,6 +6,15 @@ stdenv.mkDerivation rec {
     url = "mirror://sourceforge/giflib/${name}.tar.gz";
     sha256 = "1gbrg03z1b6rlrvjyc6d41bc8j1bsr7rm8206gb1apscyii5bnii";
   };
+
+  patches = stdenv.lib.optional stdenv.hostPlatform.isDarwin
+    (fetchpatch {
+      # https://sourceforge.net/p/giflib/bugs/133/
+      name = "darwin-soname.patch";
+      url = "https://sourceforge.net/p/giflib/bugs/_discuss/thread/4e811ad29b/c323/attachment/Makefile.patch";
+      sha256 = "12afkqnlkl3n1hywwgx8sqnhp3bz0c5qrwcv8j9hifw1lmfhv67r";
+      extraPrefix = "./";
+    });
 
   postPatch = ''
     substituteInPlace Makefile \


### PR DESCRIPTION
It broke by the update in 3605f128.  The patch seems OK on a quick look.