### PR TITLE
python3Packages.lammps-cython: fix tests

### DIFF
--- a/pkgs/development/python-modules/lammps-cython/default.nix
+++ b/pkgs/development/python-modules/lammps-cython/default.nix
@@ -9,7 +9,7 @@
 , pymatgen
 , ase
 , pytestrunner
-, pytest
+, pytest_4
 , pytestcov
 , isPy3k
 , openssh
@@ -26,7 +26,7 @@ buildPythonPackage rec {
   };
 
   buildInputs = [ cython pytestrunner ];
-  checkInputs = [ pytest pytestcov openssh ];
+  checkInputs = [ pytest_4 pytestcov openssh ];
   propagatedBuildInputs = [ mpi4py pymatgen ase numpy ];
 
   preBuild = ''


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken while reviewing another package of mine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[2 built, 1 copied (22.8 MiB), 4.2 MiB DL]
https://github.com/NixOS/nixpkgs/pull/69678
2 package were build:
python37Packages.dftfit python37Packages.lammps-cython
```