### PR TITLE
python3Packages.dotnetcore2: 2.1.8.1 -> 2.1.9

### DIFF
--- a/pkgs/development/python-modules/dotnetcore2/default.nix
+++ b/pkgs/development/python-modules/dotnetcore2/default.nix
@@ -7,7 +7,7 @@
 
 buildPythonPackage rec {
   pname = "dotnetcore2";
-  version = "2.1.8.1";
+  version = "2.1.9";
   format = "wheel";
   disabled = isPy27;
 
@@ -15,7 +15,7 @@ buildPythonPackage rec {
     inherit pname version format;
     python = "py3";
     platform = "manylinux1_x86_64";
-    sha256 = "13zrff5j767d3f8drl397sjhl28winsrfa8pa20svf00xfcsy34s";
+    sha256 = "0h1igixk84md68z7gwj1vd6ki4d5drxh0ih5zww8xcr3qh5r0drb";
   };
 
   nativeBuildInputs = [ unzip ];

--- a/pkgs/development/python-modules/dotnetcore2/runtime.patch
+++ b/pkgs/development/python-modules/dotnetcore2/runtime.patch
@@ -1,7 +1,8 @@
-diff a/dotnetcore2/runtime.py b/dotnetcore2/runtime.py
+diff --git a/dotnetcore2/runtime.py b/dotnetcore2/runtime.py
+index 475e2b4..5b578ec 100644
 --- a/dotnetcore2/runtime.py
 +++ b/dotnetcore2/runtime.py
-@@ -39,13 +39,13 @@ def _get_bin_folder() -> str:
+@@ -41,6 +41,7 @@ def _get_bin_folder() -> str:
  
  
  def get_runtime_path():
@@ -9,6 +10,8 @@ diff a/dotnetcore2/runtime.py b/dotnetcore2/runtime.py
      search_string = os.path.join(_get_bin_folder(), 'dotnet*')
      matches = [f for f in glob.glob(search_string, recursive=True)]
      return matches[0]
+@@ -96,8 +97,7 @@ class _FileLock():
+ 
  
  def ensure_dependencies() -> Optional[str]:
 -    if dist is None:


### PR DESCRIPTION
###### Motivation for this change
need it for work... they updated it in the past 48 hours since the original PR landed :(

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[1 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/69680
1 package were build:
python37Packages.dotnetcore2
```