### PR TITLE
pythonPackages.streamz: 0.5.1 -> 0.5.2

### DIFF
--- a/pkgs/development/python-modules/streamz/default.nix
+++ b/pkgs/development/python-modules/streamz/default.nix
@@ -5,28 +5,37 @@
 , toolz
 , zict
 , six
-, pytest
+, pytest_4
 , networkx
 , distributed
 , confluent-kafka
 , graphviz
+, requests
 }:
 
 buildPythonPackage rec {
   pname = "streamz";
-  version = "0.5.1";
+  version = "0.5.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "80c9ded1d6e68d3b78339deb6e9baf93a633d84b4a8875221e337ac06890103f";
+    sha256 = "127rpdjgkcyjifmkqbhmqfbzlgi32n54rybrdxja610qr906y40c";
   };
 
-  checkInputs = [ pytest networkx distributed confluent-kafka graphviz ];
   propagatedBuildInputs = [
     tornado
     toolz
     zict
     six
+  ];
+
+  checkInputs = [
+    confluent-kafka
+    distributed
+    graphviz
+    networkx
+    pytest_4
+    requests
   ];
 
   # Disable test_tcp_async because fails on sandbox build
@@ -37,7 +46,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Pipelines to manage continuous streams of data";
-    homepage = https://github.com/mrocklin/streamz/;
+    homepage = "https://github.com/mrocklin/streamz";
     license = licenses.bsd3;
     maintainers = [ maintainers.costrouc ];
   };


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken while reviewing another package.

bumped it while fixing it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[1 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/69681
1 package were build:
python37Packages.streamz
```