### PR TITLE
pantheon.elementary-greeter: hardcode fallback wallpaper

### DIFF
--- a/pkgs/desktops/pantheon/desktop/elementary-greeter/default.nix
+++ b/pkgs/desktops/pantheon/desktop/elementary-greeter/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , fetchFromGitHub
 , linkFarm
+, substituteAll
 , elementary-greeter
 , pantheon
 , pkgconfig
@@ -86,6 +87,11 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./sysconfdir-install.patch
+    # Needed until https://github.com/elementary/greeter/issues/360 is fixed
+    (substituteAll {
+      src = ./hardcode-fallback-background.patch;
+      default_wallpaper = "${nixos-artwork.wallpapers.simple-dark-gray}/share/artwork/gnome/nix-wallpaper-simple-dark-gray.png";
+    })
   ];
 
   preFixup = ''

--- a/pkgs/desktops/pantheon/desktop/elementary-greeter/hardcode-fallback-background.patch
+++ b/pkgs/desktops/pantheon/desktop/elementary-greeter/hardcode-fallback-background.patch
@@ -1,0 +1,22 @@
+diff --git a/src/Cards/BackgroundImage.vala b/src/Cards/BackgroundImage.vala
+index b57fb4d..ddfd56c 100644
+--- a/src/Cards/BackgroundImage.vala
++++ b/src/Cards/BackgroundImage.vala
+@@ -9,7 +9,7 @@ public class Greeter.BackgroundImage : Gtk.EventBox {
+ 
+     public BackgroundImage (string? path) {
+         if (path == null) {
+-            path = "/usr/share/backgrounds/elementaryos-default";
++            path = "@default_wallpaper@";
+         }
+ 
+         try {
+@@ -19,7 +19,7 @@ public class Greeter.BackgroundImage : Gtk.EventBox {
+             critical ("Fallback to default wallpaper");
+ 
+             try {
+-                full_pixbuf = new Gdk.Pixbuf.from_file ("/usr/share/backgrounds/elementaryos-default");
++                full_pixbuf = new Gdk.Pixbuf.from_file ("@default_wallpaper");
+             } catch (GLib.Error e) {
+                 critical (e.message);
+             }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Workaround https://github.com/elementary/greeter/issues/360

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
