### PR TITLE
WIP: xfce4-screensaver: init at 0.1.8

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/xfce4-14.nix
+++ b/nixos/modules/services/x11/desktop-managers/xfce4-14.nix
@@ -87,7 +87,10 @@ in
     ] # TODO: NetworkManager doesn't belong here
       ++ optional config.networking.networkmanager.enable networkmanagerapplet
       ++ optional config.hardware.pulseaudio.enable xfce4-pulseaudio-plugin
-      ++ optional config.powerManagement.enable xfce4-power-manager
+      ++ optionals config.powerManagement.enable [
+        xfce4-power-manager
+        xfce4-screensaver
+      ]
       ++ optional cfg.enableXfwm xfwm4
       ++ optionals (!cfg.noDesktop) [
         xfce4-panel
@@ -139,6 +142,7 @@ in
     services.tumbler.enable = true;
     services.system-config-printer.enable = (mkIf config.services.printing.enable (mkDefault true));
     services.xserver.libinput.enable = mkDefault true; # used in xfce4-settings-manager
+    services.dbus.packages = optional (config.powerManagement.enable) pkgs.xfce4-14.xfce4-screensaver;
 
     # Enable default programs
     programs.dconf.enable = true;

--- a/pkgs/desktops/xfce4-14/default.nix
+++ b/pkgs/desktops/xfce4-14/default.nix
@@ -72,6 +72,8 @@ makeScope newScope (self: with self; {
     inherit (gnome3) libsoup;
   };
 
+  xfce4-screensaver = callPackage ./xfce4-screensaver { };
+
   xfce4-session = callPackage ./xfce4-session { };
   xinitrc = "${xfce4-session}/etc/xdg/xfce4/xinitrc";
 

--- a/pkgs/desktops/xfce4-14/xfce4-screensaver/default.nix
+++ b/pkgs/desktops/xfce4-14/xfce4-screensaver/default.nix
@@ -1,0 +1,20 @@
+{ mkXfceDerivation, python3, exo, gtk3, libxfce4ui, dbus-glib, libxklavier, gobject-introspection, xorg, xfconf, garcon, libwnck3, xrandr, pam, systemd }:
+
+mkXfceDerivation {
+  category = "apps";
+  pname = "xfce4-screensaver";
+  version = "0.1.8";
+
+  sha256 = "09asaha1d65965abxmxhrjb0mmz5ig0c2642lcb09kn22jsg7iw5";
+
+  prePatch = ''
+    sed -i "s@^DBUS_SESSION_SERVICE_DIR=.*@DBUS_SESSION_SERVICE_DIR=$out/share/dbus-1/services@" configure.ac
+  '';
+
+  buildInputs = [ 
+    (python3.withPackages(ps: [ps.pygobject3])) gobject-introspection
+    exo gtk3 dbus-glib libxklavier libxfce4ui xfconf garcon xorg.libXScrnSaver libwnck3 xrandr
+    # optional
+    pam systemd
+  ];
+}


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I was chasing a bug with xfce4-14 automatic screen locking so I thought it was related to the missing screensaver component. The bug was solved by an upgrade, so the hypothesis was wrong.

It turned out xfce-screensaver password prompt to unlock sometimes flickers which makes it difficult to login again. The error messages I get are unhelpful at best:
```
pam_warn(xfce4-screensaver:auth): function=[pam_sm_authenticate] flags=0 service=[xfce4-screensaver] terminal=[:0.0] user=[jane] ruser=[<unknown>] rhost=[<unknown>]
```
Googling yields nothing and https://bugzilla.xfce.org/ seems down so I cannot even file an issue.
Anyhow I spent more time on this than I originally intended and the PR as is as broken. Either someone has an idea to solve the aforementioned problem or we drop the PR or we disable pam support. You still get a nice screensaver but no password prompt to unlock  ¯\\_(ツ)_/¯ 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

tested in a vm

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
