### PR TITLE
ghostscript: 9.26 -> 9.27, patch CVE-2019-10216, CVE-2019-14811, CVE-2019-14812, CVE-2019-14813 and most of CVE-2019-14817

### DIFF
--- a/pkgs/development/libraries/jbig2dec/default.nix
+++ b/pkgs/development/libraries/jbig2dec/default.nix
@@ -1,19 +1,21 @@
-{ stdenv, fetchurl, python }:
+{ stdenv, fetchurl, python, autoconf }:
 
 stdenv.mkDerivation rec {
-  name = "jbig2dec-0.14";
+  name = "jbig2dec-0.16";
 
   src = fetchurl {
-    url = "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs922/${name}.tar.gz";
-    sha256 = "0k01hp0q4275fj4rbr1gy64svfraw5w7wvwl08yjhvsnpb1rid11";
+    url = "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs927/${name}.tar.gz";
+    sha256 = "00h61y7bh3z6mqfzxyb318gyh0f8jwarg4hvlrm83rqps8avzxm4";
   };
 
   postPatch = ''
     patchShebangs test_jbig2dec.py
   '';
 
+  buildInputs = [ autoconf ];
+
   checkInputs = [ python ];
-  doCheck = false; # fails 1 of 4 tests
+  doCheck = true;
 
   meta = {
     homepage = https://www.jbig2dec.com/;

--- a/pkgs/misc/ghostscript/default.nix
+++ b/pkgs/misc/ghostscript/default.nix
@@ -47,6 +47,24 @@ stdenv.mkDerivation rec {
   patches = [
     ./urw-font-files.patch
     ./doc-no-ref.diff
+    (fetchpatch {
+        name = "CVE-2019-10216.patch";
+        url = "https://git.ghostscript.com/?p=ghostpdl.git;a=patch;h=5b85ddd19a8420a1bd2d5529325be35d78e94234";
+        sha256 = "165svml4knq1xlysfvj7vc07h68bhv3rgvl83xrhxsxdzs1ign31";
+    })
+    (fetchpatch {
+        name = "CVE-2019-14811.CVE-2019-14812.CVE-2019-14813.patch";
+        url = "https://git.ghostscript.com/?p=ghostpdl.git;a=patch;h=885444fcbe10dc42787ecb76686c8ee4dd33bf33";
+        sha256 = "19928sr7xpx7iibk9gn127g0r1yv2lcfpwgk2ipzz4wgrs3f5j70";
+    })
+    (fetchpatch {
+        name = "CVE-2019-14817-partial.patch";
+        url = "https://git.ghostscript.com/?p=ghostpdl.git;a=patch;h=cd1b1cacadac2479e291efe611979bdc1b3bdb19";
+        # patch doesn't apply cleanly to all files, but at least partially applying it fixes
+        # *most* of the problematic sites.
+        excludes = ["Resource/Init/pdf_font.ps"];
+        sha256 = "0f8qgdqpv7bldc9akvjj10af2h2876cvnz4q3nvg4a00rk5i05wn";
+    })
   ];
 
   outputs = [ "out" "man" "doc" ];

--- a/pkgs/misc/ghostscript/default.nix
+++ b/pkgs/misc/ghostscript/default.nix
@@ -10,8 +10,8 @@ assert cupsSupport -> cups != null;
 
 let
   version = "9.${ver_min}";
-  ver_min = "26";
-  sha512 = "0z2mvsh06qgnxl7p9isw7swg8jp8xcx3rnbqk727avw7ammvfh8785d2bn5i4fhz8y45ka3cpgp7b598m06yq5zawijhcnzkq187nrx";
+  ver_min = "27";
+  sha512 = "00m8pfvvg4dzvrzk66myr8kid76x44sgqk84m9562g4viv9zbw759l8q9qg64mgvbajzn78zpqfgdlgz9nwgcdb1vpwc08gm12ssrsy";
 
   fonts = stdenv.mkDerivation {
     name = "ghostscript-fonts";
@@ -47,21 +47,6 @@ stdenv.mkDerivation rec {
   patches = [
     ./urw-font-files.patch
     ./doc-no-ref.diff
-    (fetchpatch {
-      name = "CVE-2019-6116";
-      url = "http://git.ghostscript.com/?p=ghostpdl.git;a=patch;h=d3537a54740d78c5895ec83694a07b3e4f616f61";
-      sha256 = "1hr8bpi87bbg1kvv28kflmfh1dhzxw66p9q0ddvbrj72qd86p3kx";
-    })
-    (fetchpatch {
-      name = "CVE-2019-3839-part-1";
-      url = "http://git.ghostscript.com/?p=ghostpdl.git;a=patch;h=4ec9ca74bed49f2a82acb4bf430eae0d8b3b75c9";
-      sha256 = "0gn1n9fq5msrxxzspidcnmykp1iv3yvx5485fddmgrslr52ngcf9";
-    })
-    (fetchpatch {
-      name = "CVE-2019-3839-part-2";
-      url = "http://git.ghostscript.com/?p=ghostpdl.git;a=patch;h=db24f253409d5d085c2760c814c3e1d3fa2dac59";
-      sha256 = "1h6kpwc6ryr6jlxjr6bfnvmmf8x0kqmyjlx3hggqjs23n0wsr9p9";
-    })
   ];
 
   outputs = [ "out" "man" "doc" ];


### PR DESCRIPTION
###### Motivation for this change
https://www.openwall.com/lists/oss-security/2019/08/12/4

A prerequisite for bumping ghostscript to 9.27 is bumping `jbig2dec` to 0.16.

Re-targeted at staging due to large number of rebuilds.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
