### PR TITLE
noto-fonts-emoji-blob-bin: init at 2019-06-14-Emoji-12

### DIFF
--- a/pkgs/data/fonts/noto-fonts/default.nix
+++ b/pkgs/data/fonts/noto-fonts/default.nix
@@ -2,6 +2,7 @@
 , stdenvNoCC
 , lib
 , fetchFromGitHub
+, fetchurl
 , fetchzip
 , optipng
 , cairo
@@ -144,6 +145,30 @@ in
       license = with licenses; [ ofl asl20 ];
       platforms = platforms.all;
       maintainers = with maintainers; [ mathnerd314 ];
+    };
+  };
+
+  noto-fonts-emoji-blob-bin = stdenv.mkDerivation rec {
+    pname = "noto-fonts-emoji-blob-bin";
+    version = "2019-06-14-Emoji-12";
+
+    src = fetchurl {
+      url = "https://github.com/C1710/blobmoji/releases/download/v${version}/Blobmoji.ttf";
+      sha256 = "0snvymglmvpnfgsriw2cnnqm0f4llav0jvzir6mpd17mqqhhabbh";
+    };
+
+    dontUnpack = true;
+
+    installPhase = ''
+      install -D $src $out/share/fonts/blobmoji/Blobmoji.ttf
+    '';
+
+    meta = with stdenv.lib; {
+      description = "Noto Emoji with extended Blob support";
+      homepage = https://github.com/C1710/blobmoji;
+      license = with licenses; [ ofl asl20 ];
+      platforms = platforms.all;
+      maintainers = with maintainers; [ rileyinman ];
     };
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17806,7 +17806,7 @@ in
   nordic-polar = callPackage ../data/themes/nordic-polar { };
 
   inherit (callPackages ../data/fonts/noto-fonts {})
-    noto-fonts noto-fonts-cjk noto-fonts-emoji noto-fonts-extra;
+    noto-fonts noto-fonts-cjk noto-fonts-emoji noto-fonts-emoji-blob-bin noto-fonts-extra;
 
   nullmailer = callPackage ../servers/mail/nullmailer {
     stdenv = gccStdenv;


### PR DESCRIPTION
###### Motivation for this change
I like the blob emoji more than the new Noto style (and I know some other people do too!) and having this fork available seems like a good idea :)

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Mathnerd314 