### PR TITLE
f2fs-tools: 1.11.0 -> 1.13.0

### DIFF
--- a/pkgs/tools/filesystems/f2fs-tools/default.nix
+++ b/pkgs/tools/filesystems/f2fs-tools/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   pname = "f2fs-tools";
-  version = "1.11.0";
+  version = "1.13.0";
 
   src = fetchgit {
     url = "https://git.kernel.org/pub/scm/linux/kernel/git/jaegeuk/f2fs-tools.git";
     rev = "refs/tags/v${version}";
-    sha256 = "188yv77ga466wpzbirsx6vspym8idaschgi7cx92z4jwqpnkk5gv";
+    sha256 = "0h6wincsvg6s232ajxblg66r5nx87v00a4w7xkbxgbl1qyny477j";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];

--- a/pkgs/tools/filesystems/f2fs-tools/f2fs-tools-cross-fix.patch
+++ b/pkgs/tools/filesystems/f2fs-tools/f2fs-tools-cross-fix.patch
@@ -1,25 +1,27 @@
---- f2fs-tools/configure.ac.orig	2018-11-29 05:05:57.154988687 +0300
-+++ f2fs-tools/configure.ac	2018-11-29 05:06:12.667316101 +0300
-@@ -20,14 +20,16 @@
+diff --git a/configure.ac b/configure.ac
+index 9b0e872..0108219 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -20,14 +20,16 @@ AC_DEFINE([F2FS_MINOR_VERSION], m4_bpatsubst(f2fs_tools_version,
  				[\([0-9]*\).\([0-9]*\)\(\w\|\W\)*], [\2]),
  				[Minor version for f2fs-tools])
  
--AC_CHECK_FILE(.git,
+-AS_IF([test -d .git],[
 -	AC_DEFINE([F2FS_TOOLS_DATE],
 -		"m4_bpatsubst(f2fs_tools_gitdate,
 -		[\([0-9-]*\)\(\w\|\W\)*], [\1])",
--		[f2fs-tools date based on Git commits]),
+-		[f2fs-tools date based on Git commits])],[
 -	AC_DEFINE([F2FS_TOOLS_DATE],
 -		"f2fs_tools_date",
--		[f2fs-tools date based on Source releases]))
-+dnl AC_CHECK_FILE(.git,
-+dnl 	AC_DEFINE([F2FS_TOOLS_DATE],
-+dnl 		"m4_bpatsubst(f2fs_tools_gitdate,
-+dnl 		[\([0-9-]*\)\(\w\|\W\)*], [\1])",
-+dnl 		[f2fs-tools date based on Git commits]),
-+dnl 	AC_DEFINE([F2FS_TOOLS_DATE],
-+dnl 		"f2fs_tools_date",
-+dnl 		[f2fs-tools date based on Source releases]))
+-		[f2fs-tools date based on Source releases])])
++dnl AS_IF([test -d .git],[
++dnl	AC_DEFINE([F2FS_TOOLS_DATE],
++dnl		"m4_bpatsubst(f2fs_tools_gitdate,
++dnl		[\([0-9-]*\)\(\w\|\W\)*], [\1])",
++dnl		[f2fs-tools date based on Git commits])],[
++dnl	AC_DEFINE([F2FS_TOOLS_DATE],
++dnl		"f2fs_tools_date",
++dnl		[f2fs-tools date based on Source releases])])
 +
 +AC_DEFINE([F2FS_TOOLS_DATE], "f2fs_tools_date", [f2fs-tools date based on Source releases])
  


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
