### PR TITLE
lib.mkRemovedOptionModule: Show replacement for option usage too

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -591,6 +591,7 @@ rec {
     { options, ... }:
     { options = setAttrByPath optionName (mkOption {
         visible = false;
+        apply = x: throw "The option `${showOption optionName}' can no longer be used since it's been removed. ${replacementInstructions}";
       });
       config.warnings =
         let opt = getAttrFromPath optionName options; in


### PR DESCRIPTION
###### Motivation for this change

Previously `mkRemovedOptionModule` would only show the replacement
instructions when the removed option was *defined*. With this change, it
also does so when an option is *used*.

This is essential for options that are only intended to be used such as
`security.acme.directory`, whose replacement instructions would never
trigger without this change because almost everybody only uses the
option and isn't defining it.

This was discovered while I updated to nixos-unstable where I got the following error for my usage of `security.acme.directory`, even though replacement instructions were defined in https://github.com/NixOS/nixpkgs/blob/6fd3fea4db261f52e0b5422219d41adaf884a422/nixos/modules/rename.nix#L265
```
error: The option `security.acme.directory' is used but not defined.
```

With this change I get the expected error of
```
error: The option `security.acme.directory' can no longer be used since it's been removed.
  ACME Directory is now hardcoded to /var/lib/acme and its permisisons are managed by 
  systemd. See https://github.com/NixOS/nixpkgs/issues/53852 for more info.
```

One concern with this is that replacement instructions might not have been written with both defining and using the option in mind, but I'd say any replacement instructions are better than none.

To my amusement, this change can only even have this effect because of my recent https://github.com/NixOS/nixpkgs/pull/66407, which I originally didn't think could be this useful.

See also https://github.com/NixOS/nixpkgs/pull/60219 which removed the `security.acme.directory` option.

Ping @rycee @nbp @Profpatsch @samueldr @worldofpeace 

###### Things done

- [x] Tested that this indeed has the desired effect with `nix-build nixos -A config.security.acme.directory`