### PR TITLE
boringtun: 20190407 -> 0.2.0

### DIFF
--- a/pkgs/tools/networking/boringtun/default.nix
+++ b/pkgs/tools/networking/boringtun/default.nix
@@ -2,24 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "boringtun";
-  # "boringtun" is still undergoing review for security concerns.
-  # The GitHub page does not show any release yet,
-  # use 20190407 as version number to indicate that it is an unstable version.
-  version = "20190407";
+  version = "0.2.0";
 
   src = fetchFromGitHub {
     owner = "cloudflare";
     repo = pname;
-    rev = "b040eb4fd1591b1d5ceb07c6cbb0856553f50adc";
-    sha256 = "04i53dvxld2a0xzr0gfl895rcwfvisj1rfs7rl0444gml8s8xyb3";
+    rev = "v${version}";
+    sha256 = "1mijy51hd8c4as9g4ivpfxismc9m5m3nhibfvclh3wrlcmp1ha9c";
   };
 
   cargoSha256 = "1gvmshwg9b486933vfgkg2r8nn6w6dyz42hqjy74p785fcg0v5hs";
-
-  # To prevent configuration phase error that is caused by
-  # lacking a new line in file ".cargo/config",
-  # we append a new line to the end of file.
-  preConfigure = "echo '' >> .cargo/config";
 
   buildInputs = stdenv.lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Security;
 

--- a/pkgs/tools/networking/boringtun/default.nix
+++ b/pkgs/tools/networking/boringtun/default.nix
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage rec {
     description = "Userspace WireGuard® implementation in Rust";
     homepage = https://github.com/cloudflare/boringtun;
     license = licenses.bsd3;
-    maintainers = with maintainers; [ xrelkd ];
+    maintainers = with maintainers; [ xrelkd marsam ];
     platforms = platforms.linux ++ platforms.darwin;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @xrelkd
