### PR TITLE
nvidia-x11: Make vulkan library path absolute for >= 435.

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/builder.sh
+++ b/pkgs/os-specific/linux/nvidia-x11/builder.sh
@@ -59,15 +59,24 @@ installPhase() {
         mv $i/lib/libvdpau* $i/lib/vdpau
 
         # Install ICDs, make absolute paths.
+        # Be careful not to modify any original files because this runs twice.
+
+        # OpenCL
         sed -E "s#(libnvidia-opencl)#$i/lib/\\1#" nvidia.icd > nvidia.icd.fixed
         install -Dm644 nvidia.icd.fixed $i/etc/OpenCL/vendors/nvidia.icd
-        if [ -e nvidia_icd.json.template ]; then
-            # template patching for version < 435
-            sed "s#__NV_VK_ICD__#$i/lib/libGLX_nvidia.so#" nvidia_icd.json.template > nvidia_icd.json
+
+        # Vulkan
+        if [ -e nvidia_icd.json.template ] || [ -e nvidia_icd.json ]; then
+            if [ -e nvidia_icd.json.template ]; then
+                # template patching for version < 435
+                sed "s#__NV_VK_ICD__#$i/lib/libGLX_nvidia.so#" nvidia_icd.json.template > nvidia_icd.json.fixed
+            else
+                sed -E "s#(libGLX_nvidia)#$i/lib/\\1#" nvidia_icd.json > nvidia_icd.json.fixed
+            fi
+            install -Dm644 nvidia_icd.json.fixed $i/share/vulkan/icd.d/nvidia.json
         fi
-        if [ -e nvidia_icd.json ]; then
-            install -Dm644 nvidia_icd.json $i/share/vulkan/icd.d/nvidia.json
-        fi
+
+        # EGL
         if [ "$useGLVND" = "1" ]; then
             sed -E "s#(libEGL_nvidia)#$i/lib/\\1#" 10_nvidia.json > 10_nvidia.json.fixed
             install -Dm644 10_nvidia.json.fixed $i/share/glvnd/egl_vendor.d/nvidia.json


### PR DESCRIPTION
The original file contains just a library name, which does not work when LD_LIBRARY_PATH does not contain /run/opengl-driver/lib, as is the case in unstable NixOS.

Fixes https://github.com/NixOS/nixpkgs/issues/69264

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The PR https://github.com/NixOS/nixpkgs/pull/68024 did not realize that the path is supposed to be absolute, as already indicated in a comment. Due to this it still did not fix Vulkan for nixos-unstable, where `LD_LIBRARY_PATH` is normally not set to `/run/opengl-driver/lib`.

###### Things done

Tested that vulkaninfo now works when it did not before, both 64- and 32-bit version.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @FRidh @abbradar 
