### PR TITLE
hdf5: Fix dependencies and flavors with multiple outputs

### DIFF
--- a/pkgs/development/python-modules/netcdf4/default.nix
+++ b/pkgs/development/python-modules/netcdf4/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, isPyPy, pytest
+{ stdenv, lib, buildPythonPackage, fetchPypi, isPyPy, pytest
 , numpy, zlib, netcdf, hdf5, curl, libjpeg, cython, cftime
 }:
 buildPythonPackage rec {
@@ -37,7 +37,7 @@ buildPythonPackage rec {
 
   # Variables used to configure the build process
   USE_NCCONFIG="0";
-  HDF5_DIR=hdf5;
+  HDF5_DIR = lib.getDev hdf5;
   NETCDF4_DIR=netcdf;
   CURL_DIR=curl.dev;
   JPEG_DIR=libjpeg.dev;

--- a/pkgs/development/python-modules/tables/default.nix
+++ b/pkgs/development/python-modules/tables/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchPypi, python, buildPythonPackage
+{ stdenv, lib, fetchPypi, python, buildPythonPackage
 , cython, bzip2, lzo, numpy, numexpr, hdf5, six, c-blosc, mock }:
 
 buildPythonPackage rec {
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   # The setup script complains about missing run-paths, but they are
   # actually set.
   setupPyBuildFlags =
-    [ "--hdf5=${hdf5}"
+    [ "--hdf5=${lib.getDev hdf5}"
       "--lzo=${lzo}"
       "--bzip2=${bzip2.dev}"
       "--blosc=${c-blosc}"

--- a/pkgs/tools/misc/hdf5/default.nix
+++ b/pkgs/tools/misc/hdf5/default.nix
@@ -53,7 +53,10 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     find "$out" -type f -exec remove-references-to -t ${stdenv.cc} '{}' +
-    moveToOutput bin/h5cc "''${!outputDev}"
+    moveToOutput 'bin/h5cc' "''${!outputDev}"
+    moveToOutput 'bin/h5c++' "''${!outputDev}"
+    moveToOutput 'bin/h5fc' "''${!outputDev}"
+    moveToOutput 'bin/h5pcc' "''${!outputDev}"
   '';
 
   meta = {


### PR DESCRIPTION

###### Motivation for this change

See #69642.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
