### PR TITLE
sndpeek: init at 1.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3495,6 +3495,11 @@
     githubId = 1362179;
     name = "Kyle Lacy";
   };
+  laikq = {
+    email = "gwen@quasebarth.de";
+    github = "laikq";
+    name = "Gwendolyn Quasebarth";
+  };
   lasandell = {
     email = "lasandell@gmail.com";
     github = "lasandell";

--- a/pkgs/applications/audio/sndpeek/default.nix
+++ b/pkgs/applications/audio/sndpeek/default.nix
@@ -1,0 +1,56 @@
+{ stdenv, fetchurl, libsndfile, freeglut, alsaLib, mesa, libGLU, libX11, libXmu
+, libXext, libXi }:
+
+stdenv.mkDerivation rec {
+  pname = "sndpeek";
+  version = "1.4";
+
+  src = fetchurl {
+    url = "https://soundlab.cs.princeton.edu/software/sndpeek/files/sndpeek-${version}.tgz";
+    sha256 = "2d86cf74854fa00dcdc05a35dd92bc4cf6115e87102b17023be5cba9ead8eedf";
+  };
+  sourceRoot = "sndpeek-${version}/src/sndpeek";
+
+  # this patch adds -lpthread to the list of libraries, without it a
+  # symbol-not-found-error is thrown
+  patches = [ ./pthread.patch ];
+
+  buildInputs = [
+    freeglut
+    alsaLib
+    mesa
+    libGLU
+    libsndfile
+    libX11
+    libXmu
+    libXext
+    libXi
+  ];
+  buildFlags = "linux-alsa";
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mv sndpeek $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Real-time 3D animated audio display/playback";
+    longDescription = ''
+       sndpeek is just what it sounds (and looks) like:
+         * real-time 3D animated display/playback
+         * can use mic-input or wav/aiff/snd/raw/mat file (with playback)
+         * time-domain waveform
+         * FFT magnitude spectrum
+         * 3D waterfall plot
+         * lissajous! (interchannel correlation)
+         * rotatable and scalable display
+         * freeze frame! (for didactic purposes)
+         * real-time spectral feature extraction (centroid, rms, flux, rolloff)
+         * available on MacOS X, Linux, and Windows under GPL
+         * part of the sndtools distribution.
+    '';
+    homepage = https://soundlab.cs.princeton.edu/software/sndpeek/;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.laikq ];
+  };
+}

--- a/pkgs/applications/audio/sndpeek/pthread.patch
+++ b/pkgs/applications/audio/sndpeek/pthread.patch
@@ -1,0 +1,13 @@
+diff --git a/makefile.alsa b/makefile.alsa
+index 34fb848..cdaeaec 100644
+--- a/makefile.alsa
++++ b/makefile.alsa
+@@ -4,7 +4,7 @@ CPP=g++
+ INCLUDES=-I../marsyas/
+ MARSYAS_DIR=../marsyas/
+ CFLAGS=-D__LINUX_ALSA__ -D__LITTLE_ENDIAN__ $(INCLUDES) -O3 -c
+-LIBS=-L/usr/X11R6/lib -lglut -lGL -lGLU -lasound -lXmu -lX11 -lXext -lXi -lm -lsndfile
++LIBS=-L/usr/X11R6/lib -lglut -lGL -lGLU -lasound -lXmu -lX11 -lXext -lXi -lm -lsndfile -lpthread
+ 
+ OBJS=chuck_fft.o RtAudio.o Thread.o sndpeek.o Stk.o \
+ 	Centroid.o DownSampler.o Flux.o LPC.o MFCC.o RMS.o Rolloff.o \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19750,6 +19750,8 @@ in
 
   sidplayfp = callPackage ../applications/audio/sidplayfp { };
 
+  sndpeek = callPackage ../applications/audio/sndpeek { };
+
   sxhkd = callPackage ../applications/window-managers/sxhkd { };
 
   mpop = callPackage ../applications/networking/mpop {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
