### PR TITLE
luaPackages.pulseaudio: init at 0.1

### DIFF
--- a/maintainers/scripts/luarocks-packages.csv
+++ b/maintainers/scripts/luarocks-packages.csv
@@ -68,3 +68,4 @@ say,,,,,
 std__debug,std._debug,,,,
 std_normalize,std.normalize,,,,
 stdlib,,,,,vyp
+pulseaudio,,,,,doronbehar

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -132,6 +132,39 @@ with self; {
     };
   };
 
+  pulseaudio = buildLuaPackage rec {
+    pname = "pulseaudio";
+    version = "0.1";
+    name = "pulseaudio-${version}";
+
+    src = fetchFromGitHub {
+      owner = "doronbehar";
+      repo = "lua-pulseaudio";
+      rev = "v${version}";
+      sha256 = "0vldm34m3ysgn8gvwfdglpw4jl5680fvfay7pzs14gzkzcvgv25b";
+    };
+    disabled = (luaOlder "5.1") || (luaAtLeast "5.5");
+    buildInputs = [ pkgs.libpulseaudio ];
+    propagatedBuildInputs = [ lua ];
+    nativeBuildInputs = [ pkgs.pulseaudio pkgconfig ];
+
+    makeFlags = [
+      "INST_LIBDIR=${placeholder "out"}/lib/lua/${lua.luaversion}"
+      "INST_LUADIR=${placeholder "out"}/share/lua/${lua.luaversion}"
+      "LUA_BINDIR=${placeholder "out"}/bin"
+    ];
+    preBuild = ''
+      mkdir -p ${placeholder "out"}/lib/lua/${lua.luaversion}
+    '';
+
+    meta = with stdenv.lib; {
+      homepage = "https://github.com/doronbehar/lua-pulseaudio";
+      description = "Libpulse Lua bindings";
+      maintainers = with maintainers; [ doronbehar ];
+      license = licenses.lgpl21;
+    };
+  };
+
   vicious = toLuaModule(stdenv.mkDerivation rec {
     pname = "vicious";
     version = "2.3.1";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).