### PR TITLE
friture: init at 0.36

### DIFF
--- a/pkgs/applications/audio/friture/default.nix
+++ b/pkgs/applications/audio/friture/default.nix
@@ -1,0 +1,44 @@
+{ lib, fetchFromGitHub, python3Packages, wrapQtAppsHook }:
+
+let
+  py = python3Packages;
+in py.buildPythonApplication rec {
+  pname = "friture";
+  version = "0.36";
+
+  src = fetchFromGitHub {
+    owner = "tlecomte";
+    repo = "friture";
+    rev = "v${version}";
+    sha256 = "1pz8v0qbzqq3ig9w33cp027s6c8rj316x5sy8pqs5nsiny9ddnk6";
+  };
+
+  # module imports scipy.misc.factorial, but it has been removed since scipy
+  # 1.3.0; use scipy.special.factorial instead
+  patches = [ ./factorial.patch ];
+
+  nativeBuildInputs = (with py; [ numpy cython scipy ]) ++
+    [ wrapQtAppsHook ];
+
+  propagatedBuildInputs = with py; [
+    sounddevice
+    pyopengl
+    docutils
+    numpy
+    pyqt5
+    appdirs
+    pyrr
+  ];
+
+  postFixup = ''
+    wrapQtApp $out/bin/friture
+    wrapQtApp $out/bin/.friture-wrapped
+  '';
+
+  meta = with lib; {
+    description = "A real-time audio analyzer";
+    homepage = http://friture.org/;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.laikq ];
+  };
+}

--- a/pkgs/applications/audio/friture/factorial.patch
+++ b/pkgs/applications/audio/friture/factorial.patch
@@ -1,0 +1,13 @@
+diff --git a/friture/filter_design.py b/friture/filter_design.py
+index 9876c43..1cc749a 100644
+--- a/friture/filter_design.py
++++ b/friture/filter_design.py
+@@ -2,7 +2,7 @@
+ from numpy import pi, exp, arange, cos, sin, sqrt, zeros, ones, log, arange, set_printoptions
+ # the three following lines are a workaround for a bug with scipy and py2exe
+ # together. See http://www.pyinstaller.org/ticket/83 for reference.
+-from scipy.misc import factorial
++from scipy.special import factorial
+ import scipy
+ scipy.factorial = factorial
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18518,6 +18518,8 @@ in
 
   freerdpUnstable = freerdp;
 
+  friture = libsForQt5.callPackage ../applications/audio/friture { };
+
   fte = callPackage ../applications/editors/fte { };
 
   game-music-emu = callPackage ../applications/audio/game-music-emu { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
Note: `scipy` was not listed in the requirements of `setup.py` in the repository, but the package won't build without it.

###### Motivation for this change
Theoretically, it should be possible to "install" Friture via an AppImage. However, I could not get this to work, neither with `appimage-run` nor `appimageTools.wrapType2` (`OS Error: PortAudio library not found`). Building this package from source requires a lot of machine resources, but at least it works. There are instructions on reducing the package size in `setup.py`, but I tried to keep the build as simple as possible because I'm a complete newbie to building packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Maintainers

I could of course try to maintain the package, but I was hesitant to add myself to the maintainers list.