### PR TITLE
nixos/nix-daemon: Prevent network warning when checking config

### DIFF
--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -11,6 +11,7 @@ let
   nixVersion = getVersion nix;
 
   isNix20 = versionAtLeast nixVersion "2.0pre";
+  isNix23 = versionAtLeast nixVersion "2.3pre";
 
   makeNixBuildUser = nr:
     { name = "nixbld${toString nr}";
@@ -63,7 +64,7 @@ let
           builders =
         ''}
         system-features = ${toString cfg.systemFeatures}
-        ${optionalString (versionAtLeast nixVersion "2.3pre") ''
+        ${optionalString isNix23 ''
           sandbox-fallback = false
         ''}
         $extraOptions
@@ -74,7 +75,7 @@ let
             '' else ''
               echo "Checking that Nix can read nix.conf..."
               ln -s $out ./nix.conf
-              NIX_CONF_DIR=$PWD ${cfg.package}/bin/nix show-config >/dev/null
+              NIX_CONF_DIR=$PWD ${cfg.package}/bin/nix show-config ${optionalString isNix23 "--no-net"} >/dev/null
             '')
       );
 


### PR DESCRIPTION
###### Motivation for this change

Since version 2.3 (https://github.com/NixOS/nix/pull/2949 which was
cherry-picked to master) Nix issues a warning when --no-net wasn't
passed and there is no network interface. This commit adds the --no-net
flag to the nix.conf check such that no warning is issued.

For reference, the warning is
```
warning: you don't have Internet access; disabling some network-dependent features
```

This is a purely cosmetic change.

Ping @edolstra @volth 

###### Things done

- [x] Checked with `nix-build nixos -A 'config.environment.etc."nix/nix.conf".source'` that no warning is issued anymore
- [x] Checked with `nix-build nixos -A 'config.environment.etc."nix/nix.conf".source' --arg configuration '{ pkgs, ... }: { nix.package = pkgs.nix.overrideAttrs (old: rec { name = "nix-${version}"; version = "2.2.2"; src = pkgs.fetchurl { url = "https://nixos.org/releases/nix/${name}/${name}.tar.xz"; sha256 = "f80a1b4f9837a8d33209f0b7769d5038335459ff4303eccf3e9217a9eca8594c"; }; }); }'` that an version <2.3 still works.