### PR TITLE
gotify-client: init at 2.1.1

### DIFF
--- a/pkgs/applications/networking/gotify-client/default.nix
+++ b/pkgs/applications/networking/gotify-client/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  version = "2.1.1";
+  pname = "gotify-client";
+
+  src = fetchFromGitHub {
+    owner = "gotify";
+    repo = "cli";
+    rev = "v${version}";
+    sha256 = "131gs6xzfggnrzq5jgyky23zvcmhx3q3hd17xvqxd02s2i9x1mg4";
+  };
+
+  modSha256 = "1lrsg33zd7m24za2gv407hz02n3lmz9qljfk82whlj44hx7kim1z";
+
+  # Based on upstream's makefile
+  buildPhase = ''
+    go build -ldflags="-X main.Version=${version}" cli.go
+  '';
+  installPhase = ''
+    mkdir -p ${placeholder "out"}/bin/
+    cp cli ${placeholder "out"}/bin/gotify-cli
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A command line interface for pushing messages to gotify/server";
+    homepage = "https://github.com/gotify/cli";
+    license = licenses.mit;
+    maintainers = with maintainers; [ doronbehar ];
+    platforms = platforms.all;
+  };
+}
+
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9641,6 +9641,8 @@ in
 
   gotty = callPackage ../servers/gotty { };
 
+  gotify-client = callPackage ../applications/networking/gotify-client { };
+
   gputils = callPackage ../development/tools/misc/gputils { };
 
   gradleGen = callPackage ../development/tools/build-managers/gradle {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @