### PR TITLE
bpm-tools: init at 0.3

### DIFF
--- a/pkgs/tools/audio/bpm-tools/default.nix
+++ b/pkgs/tools/audio/bpm-tools/default.nix
@@ -1,0 +1,32 @@
+{
+  stdenv,
+  fetchurl,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "bpm-tools";
+  version = "0.3";
+
+  src = fetchurl {
+    url = "http://www.pogo.org.uk/~mark/bpm-tools/releases/bpm-tools-${version}.tar.gz";
+    sha256 = "151vfbs8h3cibs7kbdps5pqrsxhpjv16y2iyfqbxzsclylgfivrp";
+  };
+
+  patchPhase = ''
+    patchShebangs bpm-tag
+    patchShebangs bpm-graph
+  '';
+
+  installFlags = [
+    "PREFIX=${placeholder "out"}"
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "http://www.pogo.org.uk/~mark/bpm-tools/";
+    description = "Automatically calculate BPM (tempo) of music files";
+    license = licenses.gpl2;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ doronbehar ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9284,6 +9284,8 @@ in
 
   bpftool = callPackage ../os-specific/linux/bpftool { };
 
+  bpm-tools = callPackage ../tools/audio/bpm-tools { };
+
   byacc = callPackage ../development/tools/parsing/byacc { };
 
   cadre = callPackage ../development/tools/cadre { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @