### PR TITLE
rofi-mpd: init at 1.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2836,6 +2836,12 @@
     githubId = 820715;
     name = "Jake Logemann";
   };
+  jakestanger = {
+    email = "mail@jstanger.dev";
+    github = "JakeStanger";
+    githubId = 5057870;
+    name = "Jake Stanger";
+  };
   jakewaksbaum = {
     email = "jake.waksbaum@gmail.com";
     github = "jbaum98";

--- a/pkgs/applications/audio/rofi-mpd/default.nix
+++ b/pkgs/applications/audio/rofi-mpd/default.nix
@@ -1,0 +1,26 @@
+{ lib, python3Packages, fetchFromGitHub }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "rofi-mpd";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "JakeStanger";
+    repo = "Rofi_MPD";
+    rev = "v${version}";
+    sha256 = "0pdra1idgas3yl9z9v7b002igwg2c1mv0yw2ffb8rsbx88x4gbai";
+  };
+
+  propagatedBuildInputs = with python3Packages; [ mutagen mpd2 ];
+
+  # upstream doesn't contain a test suite
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A rofi menu for interacting with MPD written in Python";
+    homepage = "https://github.com/JakeStanger/Rofi_MPD";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jakestanger ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19517,6 +19517,8 @@ in
 
   ncmpcpp = callPackage ../applications/audio/ncmpcpp { };
 
+  rofi-mpd = callPackage ../applications/audio/rofi-mpd { };
+
   ympd = callPackage ../applications/audio/ympd { };
 
   nload = callPackage ../applications/networking/nload { };


### PR DESCRIPTION
###### Motivation for this change

Adds package.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
