### PR TITLE
x11spice: init at 2019-08-20

### DIFF
--- a/pkgs/tools/X11/x11spice/default.nix
+++ b/pkgs/tools/X11/x11spice/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitLab, autoreconfHook, pkgconfig
+, xorg, gtk2, spice, spice-protocol
+}:
+
+stdenv.mkDerivation rec {
+  pname = "x11spice";
+  version = "2019-08-20";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "spice";
+    repo = "x11spice";
+    rev = "51d2a8ba3813469264959bb3ba2fc6fe08097be6";
+    sha256 = "0va5ix14vnqch59gq8wvrhw6q0w0n27sy70xx5kvfj2cl0h1xpg8";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+
+  buildInputs = [
+    xorg.libxcb xorg.xcbutil xorg.utilmacros
+    gtk2 spice spice-protocol
+  ];
+
+  NIX_LDFLAGS = "-lpthread";
+
+  meta = with stdenv.lib; {
+    description = ''
+      x11spice will enable a running X11 desktop to be available
+      via a Spice server
+    '';
+    homepage = https://gitlab.freedesktop.org/spice/x11spice;
+    platforms = platforms.linux;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ rnhmjoj ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21366,6 +21366,8 @@ in
 
   x11vnc = callPackage ../tools/X11/x11vnc { };
 
+  x11spice = callPackage ../tools/X11/x11spice { };
+
   x2goclient = libsForQt5.callPackage ../applications/networking/remote/x2goclient { };
 
   x2goserver = callPackage ../applications/networking/remote/x2goserver { };


### PR DESCRIPTION
###### Motivation for this change

SPICE is a protocol generally used for virtual machines but it's also useful as a remote desktop: it's much faster than regular VNC.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change (new package)
- [ ] Tested execution of all binary files
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).