### PR TITLE
imagescan: init at 3.59.2

### DIFF
--- a/pkgs/misc/drivers/imagescan/default.nix
+++ b/pkgs/misc/drivers/imagescan/default.nix
@@ -1,0 +1,51 @@
+{ stdenv, fetchFromGitLab, pkgconfig, patchelf, boost, udev, libusb, imagemagick
+, sane-backends, gtkmm2 }:
+
+stdenv.mkDerivation rec {
+  pname = "imagescan";
+  version = "3.59.2";
+
+  src = fetchFromGitLab{
+    owner = "utsushi";
+    repo = pname;
+    rev = version;
+    sha256 = "06gp97dfnf43l6kb988scmm66q9n5rc7ndwv3rykrdpyhy8rbi05";
+  };
+
+  configureFlags = [ 
+    "--with-boost-libdir=${boost}/lib"
+    "--with-sane-confdir=${placeholder "out"}/etc/sane.d"
+    "--with-udev-confdir=${placeholder "out"}/etc/udev"
+    "--with-gtkmm"
+    "--with-jpeg"
+    "--with-magick"
+    "--with-sane"
+    "--with-tiff"
+  ];
+
+  NIX_CFLAGS_COMPILE = [ "-Wno-error=unused-variable" "-Wno-error=parentheses" ];
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ udev libusb.dev boost imagemagick sane-backends gtkmm2 ];
+  enableParallelBuilding = true;
+
+  installFlags = [ "SANE_BACKENDDIR=${placeholder "out"}/lib/sane" ];
+  doInstallCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "A Next Generation Image Acquisition & Epson scanner driver";
+    longDescription = ''
+      This software provides applications to easily turn hard-copy
+      documents and imagery into formats that are more amenable to
+      computer processing.
+
+      Included are a native driver for a number of EPSON scanners
+      and a compatibility driver to interface with software built
+      around the SANE standard.
+    '';
+    homepage = "https://gitlab.com/utsushi/imagescan";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ wucke13 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23917,6 +23917,8 @@ in
   illum = callPackage ../tools/system/illum { };
 
   image_optim = callPackage ../applications/graphics/image_optim { inherit (nodePackages) svgo; };
+  
+  imagescan = callPackage ../misc/drivers/imagescan { };
 
   # using the new configuration style proposal which is unstable
   jack1 = callPackage ../misc/jackaudio/jack1.nix { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
