### PR TITLE
linux_rpi1: fix Raspberry Pi Zero device tree file name

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-rpi.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rpi.nix
@@ -49,8 +49,8 @@ lib.overrideDerivation (buildLinux (args // {
       cp -v "$dtbDir/$1" "$dtbDir/$2"
     }
   '' + lib.optionalString (lib.elem stdenv.hostPlatform.system ["armv6l-linux"]) ''
-    copyDTB bcm2708-rpi-0-w.dtb bcm2835-rpi-zero.dtb
-    copyDTB bcm2708-rpi-0-w.dtb bcm2835-rpi-zero-w.dtb
+    copyDTB bcm2708-rpi-zero-w.dtb bcm2835-rpi-zero.dtb
+    copyDTB bcm2708-rpi-zero-w.dtb bcm2835-rpi-zero-w.dtb
     copyDTB bcm2708-rpi-b.dtb bcm2835-rpi-a.dtb
     copyDTB bcm2708-rpi-b.dtb bcm2835-rpi-b.dtb
     copyDTB bcm2708-rpi-b.dtb bcm2835-rpi-b-rev2.dtb


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

With the latest update to the Raspberry Pi kernel, the device tree for the Raspberry Pi Zero was renamed, but the package was not updated to account for this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @samueldr @tkerber 
