### PR TITLE
[r19.09] qemu: add patches for CVE-2019-13164 & CVE-2019-14378

### DIFF
--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -83,6 +83,16 @@ stdenv.mkDerivation rec {
       name = "CVE-2019-12155.patch";
       sha256 = "0h2q71mcz3gvlrbfkqcgla74jdg73hvzcrwr4max2ckpxx8x9207";
     })
+    (fetchpatch {
+      url = "https://sources.debian.org/data/main/q/qemu/1:3.1+dfsg-8+deb10u2/debian/patches/slirp-fix-heap-overflow-in-ip_reass-on-big-packet-input-CVE-2019-14378.patch";
+      sha256 = "0f3jabl6x6slpnz5pg6fv1k9vfmrkd482z9vqm3adn6mka8lfimb";
+      extraPrefix = "slirp/src/";
+      stripLen = 2;
+    })
+    (fetchpatch {
+      url = "https://sources.debian.org/data/main/q/qemu/1:3.1+dfsg-8+deb10u2/debian/patches/qemu-bridge-helper-restrict-interface-name-to-IFNAMSIZ-CVE-2019-13164.patch";
+      sha256 = "1ypcdlpg3nap0kg9xkrgrqw33j5ah4j7l4i2cp6d5ap8vrw9nn3l";
+    })
   ] ++ optional nixosTestRunner ./force-uid0-on-9p.patch
     ++ optionals stdenv.hostPlatform.isMusl [
     (fetchpatch {


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2019-14378
https://nvd.nist.gov/vuln/detail/CVE-2019-13164

`master` is fine, having `4.1.0`. Luckily debian has patches that work against `4.0.0`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
