### PR TITLE
work-sans: init at 1.6

### DIFF
--- a/pkgs/data/fonts/work-sans/default.nix
+++ b/pkgs/data/fonts/work-sans/default.nix
@@ -1,0 +1,29 @@
+{ lib, fetchFromGitHub }:
+
+let
+  version = "1.6";
+in fetchFromGitHub {
+  name = "work-sans-${version}";
+
+  owner = "weiweihuanghuang";
+  repo = "Work-Sans";
+  rev = "v${version}";
+
+  postFetch = ''
+    tar xf $downloadedFile --strip=1
+    install -m444 -Dt $out/share/fonts/opentype/ fonts/desktop/*.otf
+    install -m444 -Dt $out/share/fonts/truetype/ fonts/webfonts/ttf/*.ttf
+    install -m444 -Dt $out/share/fonts/woff/     fonts/webfonts/woff/*.woff
+    install -m444 -Dt $out/share/fonts/woff2/    fonts/webfonts/woff2/*.woff2
+  '';
+
+  sha256 = "01kjidk6zv80rqxapcdwhd9wxzrjfc6lj4gkf6dwa4sskw5x3b8a";
+
+  meta = with lib; {
+    description = "A grotesque sans";
+    homepage = "https://weiweihuanghuang.github.io/Work-Sans/";
+    license = licenses.ofl;
+    maintainers = [ maintainers.marsam ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17269,6 +17269,8 @@ in
 
   wireless-regdb = callPackage ../data/misc/wireless-regdb { };
 
+  work-sans  = callPackage ../data/fonts/work-sans { };
+
   wqy_microhei = callPackage ../data/fonts/wqy-microhei { };
 
   wqy_zenhei = callPackage ../data/fonts/wqy-zenhei { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add Work-Sans https://github.com/weiweihuanghuang/Work-Sans

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
