### PR TITLE
python3Packages.joblib: add setuptools dependency

### DIFF
--- a/pkgs/development/python-modules/joblib/default.nix
+++ b/pkgs/development/python-modules/joblib/default.nix
@@ -3,10 +3,11 @@
 , fetchPypi
 , fetchpatch
 , stdenv
-, sphinx
 , numpydoc
 , pytest
 , python-lz4
+, setuptools
+, sphinx
 }:
 
 
@@ -37,7 +38,7 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [ sphinx numpydoc pytest ];
-  propagatedBuildInputs = [ python-lz4 ];
+  propagatedBuildInputs = [ python-lz4 setuptools ];
 
   # test_disk_used is broken: https://github.com/joblib/joblib/issues/57
   # test_dispatch_multiprocessing is broken only on Darwin.


### PR DESCRIPTION
###### Motivation for this change
closes #69522

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
$ python
Python 3.7.4 (default, Jul  8 2019, 18:31:06)
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import sklearn
>>>
```