### PR TITLE
Cypress 3.4.1: Fix files used for verification.

### DIFF
--- a/pkgs/development/web/cypress/default.nix
+++ b/pkgs/development/web/cypress/default.nix
@@ -26,7 +26,11 @@ stdenv.mkDerivation rec{
     mkdir -p $out/bin $out/opt/cypress
     cp -vr * $out/opt/cypress/
     # Let's create the file binary_state ourselves to make the npm package happy on initial verification.
-    echo '{"verified": true}' > $out/opt/cypress/binary_state.json
+    # Cypress now verifies version by reading bin/resources/app/package.json
+    mkdir -p $out/bin/resources/app
+    echo '{"version":"3.4.1"}' > $out/bin/resources/app/package.json
+    # Cypress now looks for binary_state.json in bin
+    echo '{"verified": true}' > $out/bin/binary_state.json
     ln -s $out/opt/cypress/Cypress $out/bin/Cypress
   '';
 

--- a/pkgs/development/web/cypress/default.nix
+++ b/pkgs/development/web/cypress/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec{
   pname = "cypress";
-  version = "3.4.1";
+  version = "3.5.0";
 
   src = fetchzip {
     url = "https://cdn.cypress.io/desktop/${version}/linux-x64/cypress.zip";
-    sha256 = "1gyl5c86gr5sv6z5rkg0afdxqrmsxmyrimm1p5q6jlrlyzki1bfs";
+    sha256 = "1w1nqa0j3bzjr000d4jlr34d1asdc1fv81pq831s3wl55hyqbij6";
   };
 
   # don't remove runtime deps
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec{
     # Let's create the file binary_state ourselves to make the npm package happy on initial verification.
     # Cypress now verifies version by reading bin/resources/app/package.json
     mkdir -p $out/bin/resources/app
-    echo '{"version":"3.4.1"}' > $out/bin/resources/app/package.json
+    printf '{"version":"%b"}' $version > $out/bin/resources/app/package.json
     # Cypress now looks for binary_state.json in bin
     echo '{"verified": true}' > $out/bin/binary_state.json
     ln -s $out/opt/cypress/Cypress $out/bin/Cypress


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Cypress 3.4.1 fails to run giving verification errors.
To reproduce:

  1. Install cypress from `nixpkgs` --> gets version 3.4.1
  2. In project package directory, install cypress with `CYPRESS_INSTALL_BINARY=0 npm install cypress@3.4.1`
  3. run ``CYPRESS_RUN_BINARY=`which Cypress` $(npm bin)/cypress open``
  
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
