### PR TITLE
python3Packages.cnvkit: fix build

### DIFF
--- a/pkgs/development/python-modules/cnvkit/default.nix
+++ b/pkgs/development/python-modules/cnvkit/default.nix
@@ -39,6 +39,11 @@ buildPythonPackage rec {
     pomegranate
   ];
 
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "pandas >= 0.20.1, < 0.25.0" "pandas"
+  '';
+
   meta = with lib; {
     homepage = "https://cnvkit.readthedocs.io";
     description = "A Python library and command-line software toolkit to infer and visualize copy number from high-throughput DNA sequencing data";


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken while reviewing another PR

cnvkit master removed the upper bounds on pandas, but they haven't cut a new release yet. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
