### PR TITLE
python3Packages.opt-einsum: 2.3.2 -> 3.0.1

### DIFF
--- a/pkgs/development/python-modules/opt-einsum/2.nix
+++ b/pkgs/development/python-modules/opt-einsum/2.nix
@@ -1,26 +1,30 @@
 { buildPythonPackage, fetchPypi, lib, numpy, pytest_4 }:
 
 buildPythonPackage rec {
-  version = "3.0.1";
+  version = "2.3.2";
   pname = "opt_einsum";
 
   src = fetchPypi {
     inherit version pname;
-    sha256 = "1agyvq26x0zd6j3wzgczl4apx8v7cb9w1z50azn8c3pq9jphgfla";
+    sha256 = "0ny3v8x83mzpwmqjdzqhzy2pzwyy4wx01r1h9i29xw3yvas69m6k";
   };
 
-  propagatedBuildInputs = [ numpy ];
-
-  checkInputs = [ pytest_4 ];
+  checkInputs = [
+    pytest_4
+  ];
 
   checkPhase = ''
     pytest
   '';
 
-  meta = with lib; {
+  propagatedBuildInputs = [
+    numpy
+  ];
+
+  meta = {
     description = "Optimizing NumPy's einsum function with order optimization and GPU support.";
     homepage = http://optimized-einsum.readthedocs.io;
-    license = licenses.mit;
-    maintainers = with maintainers; [ teh ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ teh ];
   };
 }

--- a/pkgs/development/python-modules/opt-einsum/default.nix
+++ b/pkgs/development/python-modules/opt-einsum/default.nix
@@ -1,4 +1,5 @@
-{ buildPythonPackage, fetchPypi, lib, numpy, pytest, pytestpep8, pytestcov }:
+{ buildPythonPackage, fetchPypi, lib, numpy, pytest_4 }:
+
 buildPythonPackage rec {
   version = "2.3.2";
   pname = "opt_einsum";
@@ -9,9 +10,7 @@ buildPythonPackage rec {
   };
 
   checkInputs = [
-    pytest
-    pytestpep8
-    pytestcov
+    pytest_4
   ];
 
   checkPhase = ''

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3165,7 +3165,10 @@ in {
 
   pyro-ppl = callPackage ../development/python-modules/pyro-ppl {};
 
-  opt-einsum = callPackage ../development/python-modules/opt-einsum {};
+  opt-einsum = if isPy27 then
+      callPackage ../development/python-modules/opt-einsum/2.nix {}
+    else
+      callPackage ../development/python-modules/opt-einsum {};
 
   pytorchWithCuda = self.pytorch.override {
     cudaSupport = true;


### PR DESCRIPTION
###### Motivation for this change
saw it was broken, fixed the build, then bumped the python3 version as v3+ dropped support for python2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

pyro-ppl package is broken due to pytorch being broken on master. Which is being addressed #69947
```
[0 built (2 failed), 0.0 MiB DL]
error: build of '/nix/store/9l85dy86fczxyfpw08nhl50m85ny4kaa-env.drv' failed
https://github.com/NixOS/nixpkgs/pull/69967
2 package failed to build:
python27Packages.pyro-ppl python37Packages.pyro-ppl

2 package were build:
python27Packages.opt-einsum python37Packages.opt-einsum
```