### PR TITLE
python: get rid of msgpack-python, fixes #48864

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pybitmessage/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pybitmessage/default.nix
@@ -12,14 +12,15 @@ python2Packages.buildPythonApplication rec {
     sha256 = "1lmhbpwsqh1v93krlqqhafw2pc3y0qp8zby186yllbph6s8kdp35";
   };
 
-  propagatedBuildInputs = with python2Packages; [ msgpack pyqt4 numpy pyopencl ] ++ [ openssl ];
+  propagatedBuildInputs = with python2Packages; [ msgpack pyqt4 numpy pyopencl setuptools ] ++ [ openssl ];
 
   preConfigure = ''
     # Remove interaction and misleading output
     substituteInPlace setup.py \
       --replace "nothing = raw_input()" pass \
       --replace 'print "It looks like building the package failed.\n" \' pass \
-      --replace '    "You may be missing a C++ compiler and the OpenSSL headers."' pass
+      --replace '    "You may be missing a C++ compiler and the OpenSSL headers."' pass \
+      --replace 'msgpack-python' 'msgpack'
 
     substituteInPlace src/pyelliptic/openssl.py \
       --replace "libdir.append(find_library('ssl'))" "libdir.append('${openssl.out}/lib/libssl.so')"

--- a/pkgs/applications/networking/instant-messengers/pybitmessage/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pybitmessage/default.nix
@@ -12,7 +12,7 @@ python2Packages.buildPythonApplication rec {
     sha256 = "1lmhbpwsqh1v93krlqqhafw2pc3y0qp8zby186yllbph6s8kdp35";
   };
 
-  propagatedBuildInputs = with python2Packages; [ msgpack-python pyqt4 numpy pyopencl ] ++ [ openssl ];
+  propagatedBuildInputs = with python2Packages; [ msgpack pyqt4 numpy pyopencl ] ++ [ openssl ];
 
   preConfigure = ''
     # Remove interaction and misleading output

--- a/pkgs/development/python-modules/cachy/default.nix
+++ b/pkgs/development/python-modules/cachy/default.nix
@@ -1,7 +1,7 @@
 { lib, buildPythonPackage, fetchPypi
 , redis
 , memcached
-, msgpack-python
+, msgpack
 }:
 
 buildPythonPackage rec {
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     redis
     memcached
-    msgpack-python
+    msgpack
   ];
 
   # The Pypi tarball doesn't include tests, and the GitHub source isn't

--- a/pkgs/development/python-modules/intake/default.nix
+++ b/pkgs/development/python-modules/intake/default.nix
@@ -7,7 +7,7 @@
 , hvplot
 , jinja2
 , msgpack-numpy
-, msgpack-python
+, msgpack
 , numpy
 , pandas
 , panel
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     hvplot
     jinja2
     msgpack-numpy
-    msgpack-python
+    msgpack
     numpy
     pandas
     panel

--- a/pkgs/development/python-modules/monty/default.nix
+++ b/pkgs/development/python-modules/monty/default.nix
@@ -5,7 +5,7 @@
 , numpy
 , six
 , ruamel_yaml
-, msgpack-python
+, msgpack
 , coverage
 , coveralls
 , pymongo
@@ -24,7 +24,7 @@ buildPythonPackage rec {
     sha256 = "0vqaaz0dw0ypl6sfwbycpb0qs3ap04c4ghbggklxih66spdlggh6";
   };
 
-  checkInputs = [ lsof nose numpy msgpack-python coverage coveralls pymongo];
+  checkInputs = [ lsof nose numpy msgpack coverage coveralls pymongo];
   propagatedBuildInputs = [ six ruamel_yaml ];
 
   preCheck = ''

--- a/pkgs/development/python-modules/spacy/default.nix
+++ b/pkgs/development/python-modules/spacy/default.nix
@@ -15,7 +15,7 @@
 , regex
 , cymem
 , pathlib
-, msgpack-python
+, msgpack
 , msgpack-numpy
 , jsonschema
 , blis
@@ -49,7 +49,7 @@ buildPythonPackage rec {
    requests
    regex
    ftfy
-   msgpack-python
+   msgpack
    msgpack-numpy
    jsonschema
    blis

--- a/pkgs/development/python-modules/thinc/default.nix
+++ b/pkgs/development/python-modules/thinc/default.nix
@@ -8,7 +8,7 @@
 , cymem
 , darwin
 , msgpack-numpy
-, msgpack-python
+, msgpack
 , preshed
 , numpy
 , murmurhash
@@ -44,7 +44,7 @@ buildPythonPackage rec {
    cython
    cymem
    msgpack-numpy
-   msgpack-python
+   msgpack
    preshed
    numpy
    murmurhash

--- a/pkgs/development/python-modules/zerorpc/default.nix
+++ b/pkgs/development/python-modules/zerorpc/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "zerorpc";
-  version = "0.6.1";
+  version = "0.6.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "14d0nmprs0nm17d8kg2f7qalsi8x7c4damsccqgncylj7mpnk9hh";
+    sha256 = "d2ee247a566fc703f29c277d767f6f61f1e12f76d0402faea4bd815f32cbf37f";
   };
 
   propagatedBuildInputs = [ future gevent msgpack pyzmq ];

--- a/pkgs/development/python-modules/zerorpc/default.nix
+++ b/pkgs/development/python-modules/zerorpc/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, future, gevent, msgpack-python, pyzmq }:
+{ lib, buildPythonPackage, fetchPypi, future, gevent, msgpack, pyzmq }:
 
 buildPythonPackage rec {
   pname = "zerorpc";
@@ -9,7 +9,7 @@ buildPythonPackage rec {
     sha256 = "14d0nmprs0nm17d8kg2f7qalsi8x7c4damsccqgncylj7mpnk9hh";
   };
 
-  propagatedBuildInputs = [ future gevent msgpack-python pyzmq ];
+  propagatedBuildInputs = [ future gevent msgpack pyzmq ];
 
   doCheck = false; # pypi version doesn't include tests
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3836,13 +3836,6 @@ in {
 
   msgpack-numpy = callPackage ../development/python-modules/msgpack-numpy {};
 
-  msgpack-python = self.msgpack.overridePythonAttrs {
-    pname = "msgpack-python";
-    postPatch = ''
-      substituteInPlace setup.py --replace "TRANSITIONAL = False" "TRANSITIONAL = True"
-    '';
-  };
-
   msrplib = callPackage ../development/python-modules/msrplib { };
 
   multipledispatch = callPackage ../development/python-modules/multipledispatch { };


### PR DESCRIPTION
We already have msgpack, which is the same. Building a Python env with
`spacy` resulted in a collision between an `.so` provided through both
`msgpack` and `msgpack-python`.

I don't know why `transitional = True` was set. These kind of things
should be documented!

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
