### PR TITLE
elm.elmPackages: Cleanup code

### DIFF
--- a/pkgs/development/node-packages/node-packages-v10.json
+++ b/pkgs/development/node-packages/node-packages-v10.json
@@ -1,7 +1,7 @@
 [
   "@angular/cli"
 , "@antora/cli"
-, "@antora/site-generator-default" 
+, "@antora/site-generator-default"
 , "@vue/cli"
 , "@webassemblyjs/cli"
 , "@webassemblyjs/repl"
@@ -32,7 +32,6 @@
 , "dnschain"
 , "dockerfile-language-server-nodejs"
 , "elasticdump"
-, "elm-live"
 , "elm-oracle"
 , "emoj"
 , "emojione"


### PR DESCRIPTION
*Be aware that this is chore so it's probably low-priority PR*

Cleaning up the mess I made over several months adding elm tooling to hopefully easier to understand and more maitainable structure.

- separation of HS and node based tools
- removal of `elm-live` from `nodeModules`
- expose `elmPackages.lib.patchBinwrap`

**This will need a code quality review**

- Is this separation of node and elm based packages what we want?
- Is it ok to just remove `elm-live` from nodePackages (maybe we should first mark it as deprecated?)
- Is it fine to expose `lib.patchBinwrap`

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @domenkozar 
