### PR TITLE
hugo: 0.58.0 -> 0.58.3

### DIFF
--- a/pkgs/applications/misc/hugo/default.nix
+++ b/pkgs/applications/misc/hugo/default.nix
@@ -2,18 +2,18 @@
 
 buildGoModule rec {
   pname = "hugo";
-  version = "0.58.0";
+  version = "0.58.3";
 
   goPackagePath = "github.com/gohugoio/hugo";
 
   src = fetchFromGitHub {
     owner  = "gohugoio";
-    repo   = "hugo";
+    repo   = pname;
     rev    = "v${version}";
-    sha256 = "0971li0777c1s67w72wl1y0b58ky93dw05hbk3s4kqys0acanc2d";
+    sha256 = "00dhb6xilkwr9yhncpyc6alzqw77ch3vd85dc7lzsmhw1c80n0lc";
   };
 
-  modSha256 = "14ylbh2hx14swcqvawprbx5gynkwyb0nlp5acr4fjy1zl0ifc790";
+  modSha256 = "0d6zc7hxb246zsvwsjz4ds6gdd2m95x6l3djh3mmciwfg9cd7prx";
 
   buildFlags = "-tags extended";
 


### PR DESCRIPTION
###### Motivation for this change

[Hugo 0.58.1: A couple of Bug Fixes](https://gohugo.io/news/0.58.1-relnotes/)
[Hugo 0.58.2: A couple of Bug Fixes](https://gohugo.io/news/0.58.2-relnotes/)
[Hugo 0.58.3: A couple of Bug Fixes](https://gohugo.io/news/0.58.3-relnotes/)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```sh
$ nix path-info -Sh /nix/store/z6ydympl9ljaizcml66vk2vyrn10pn53-hugo-0.58.0
/nix/store/z6ydympl9ljaizcml66vk2vyrn10pn53-hugo-0.58.0	  77.1M
$ nix path-info -Sh /nix/store/3vl1jflw8xm9js4cfl3vz8chfv6p837g-hugo-0.58.3
/nix/store/3vl1jflw8xm9js4cfl3vz8chfv6p837g-hugo-0.58.3	  77.1M
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @schneefux
