### PR TITLE
halide new release 2018/02/15 -> 2019/08/27

### DIFF
--- a/pkgs/development/compilers/halide/default.nix
+++ b/pkgs/development/compilers/halide/default.nix
@@ -3,7 +3,7 @@
 }:
 
 let
-  version = "2018_02_15";
+  version = "2019_08_27";
 
 in llvmPackages.stdenv.mkDerivation {
 
@@ -13,7 +13,7 @@ in llvmPackages.stdenv.mkDerivation {
     owner = "halide";
     repo = "Halide";
     rev = "release_${version}";
-    sha256 = "14lmpbxydx7ii0pxds6rgq5vw4i6yfjsq0bai1l5wwpv1rnwmbxd";
+    sha256 = "09xf8v9zyxx2fn6s1yzjkyzcf9zyzrg3x5vivgd2ljzbfhm8wh7n";
   };
 
   patches = [ ./nix.patch ];

--- a/pkgs/development/compilers/halide/default.nix
+++ b/pkgs/development/compilers/halide/default.nix
@@ -58,7 +58,7 @@ in llvmPackages.stdenv.mkDerivation {
     description = "C++ based language for image processing and computational photography";
     homepage = "https://halide-lang.org";
     license = licenses.mit;
-    platforms = platforms.linux;
+    platforms = [ "i686-linux" "x86_64-linux" ];
     maintainers = [ maintainers.ck3d ];
   };
 }

--- a/pkgs/development/compilers/halide/nix.patch
+++ b/pkgs/development/compilers/halide/nix.patch
@@ -1,11 +1,11 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 40a685b7e..c452efd09 100644
+index 4ba384324..7e23038f7 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -49,10 +49,10 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
-
+@@ -75,10 +75,10 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
+ 
  set(LLVM_VERSION "${LLVM_VERSION_MAJOR}${LLVM_VERSION_MINOR}")
-
+ 
 -file(TO_NATIVE_PATH "${LLVM_TOOLS_BINARY_DIR}/llvm-as${CMAKE_EXECUTABLE_SUFFIX}" LLVM_AS)
 -file(TO_NATIVE_PATH "${LLVM_TOOLS_BINARY_DIR}/llvm-nm${CMAKE_EXECUTABLE_SUFFIX}" LLVM_NM)
 -file(TO_NATIVE_PATH "${LLVM_TOOLS_BINARY_DIR}/clang${CMAKE_EXECUTABLE_SUFFIX}" CLANG)
@@ -14,7 +14,7 @@ index 40a685b7e..c452efd09 100644
 +find_program(LLVM_NM llvm-nm HINTS ${LLVM_TOOLS_BINARY_DIR})
 +find_program(CLANG clang HINTS ${LLVM_TOOLS_BINARY_DIR})
 +find_program(LLVM_CONFIG llvm-config HINTS ${LLVM_TOOLS_BINARY_DIR})
-
+ 
  # LLVM doesn't appear to expose --system-libs via its CMake interface,
  # so we must shell out to llvm-config to find this info
 diff --git a/apps/linear_algebra/CMakeLists.txt b/apps/linear_algebra/CMakeLists.txt
@@ -27,7 +27,7 @@ index 132c80e6a..36ce865f2 100644
    set(OpenBLAS_EXTRA_LIBS)
 -  set(BLAS_VENDORS OpenBLAS ATLAS)
 +  set(BLAS_VENDORS OpenBLAS)
-
+ 
    # TODO
    # there are more vendors we could add here that support the cblas interface
 @@ -41,6 +41,7 @@ if (CBLAS_FOUND)
@@ -39,17 +39,18 @@ index 132c80e6a..36ce865f2 100644
      endif()
    endforeach()
 diff --git a/apps/linear_algebra/tests/CMakeLists.txt b/apps/linear_algebra/tests/CMakeLists.txt
-index 4b95eb3bb..1daa97437 100644
+index cc02eb0a4..c20419a0d 100644
 --- a/apps/linear_algebra/tests/CMakeLists.txt
 +++ b/apps/linear_algebra/tests/CMakeLists.txt
-@@ -19,6 +19,6 @@ target_compile_options(test_halide_blas PRIVATE -Wno-unused-variable)
+@@ -19,7 +19,7 @@ target_compile_options(test_halide_blas PRIVATE -Wno-unused-variable)
  target_link_libraries(test_halide_blas
    PRIVATE
     halide_blas
 -   cblas # XXX fragile
 +   ${BLAS_LIBRARIES}
-    Halide
+    ${HALIDE_COMPILER_LIB}
  )
---
-2.15.0
+ 
+-- 
+2.23.0
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3745,7 +3745,7 @@ in
 
   halibut = callPackage ../tools/typesetting/halibut { };
 
-  halide = callPackage ../development/compilers/halide { llvmPackages=llvmPackages_6; };
+  halide = callPackage ../development/compilers/halide { };
 
   ham = pkgs.perlPackages.ham;
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
updated to new release

###### Things done
compiled and run my own halide projects.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @markuskowa 
