### PR TITLE
cwm: 5.6 -> 6.3, and myself as maintainer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4217,6 +4217,15 @@
     githubId = 5698461;
     name = "Maciej Kazulak";
   };
+  mkf = {
+    email = "m@mikf.pl";
+    github = "mkf";
+    name = "Michał Krzysztof Feiler";
+    keys = [{
+      longkeyid = "rsa4096/0xE35C2D7C2C6AC724";
+      fingerprint = "1E36 9940 CC7E 01C4 CFE8  F20A E35C 2D7C 2C6A C724";
+    }];
+  };
   mkg = {
     email = "mkg@vt.edu";
     github = "mkgvt";

--- a/pkgs/applications/window-managers/cwm/default.nix
+++ b/pkgs/applications/window-managers/cwm/default.nix
@@ -1,13 +1,15 @@
 { stdenv, fetchFromGitHub, libX11, libXinerama, libXrandr, libXft, yacc, pkgconfig }:
 
-stdenv.mkDerivation {
-  name = "cwm-5.6";
+stdenv.mkDerivation rec {
+
+  pname = "cwm";
+  version = "6.3";
 
   src = fetchFromGitHub {
-      owner = "chneukirchen";
-      repo = "cwm";
-      rev = "b7a8c11750d11721a897fdb8442d52f15e7a24a0";
-      sha256 = "0a0x8rgqif4kxy7hj70hck7jma6c8jy4428ybl8fz9qxgxh014ml";
+    owner = "leahneukirchen";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1m08gd6nscwfx6040zbg2zl89m4g73im68iflzcihd6pdc8rzzs4";
   };
 
   nativeBuildInputs = [ pkgconfig ];
@@ -17,9 +19,9 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     description = "A lightweight and efficient window manager for X11";
-    homepage = https://github.com/chneukirchen/cwm;
-    maintainers = [];
-    license     = licenses.isc;
-    platforms   = platforms.linux;
+    homepage = "https://github.com/leahneukirchen/cwm";
+    maintainers = with maintainers; [ "0x4A6F" ];
+    license = licenses.isc;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/window-managers/cwm/default.nix
+++ b/pkgs/applications/window-managers/cwm/default.nix
@@ -19,9 +19,9 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A lightweight and efficient window manager for X11";
-    homepage = "https://github.com/leahneukirchen/cwm";
-    maintainers = with maintainers; [ "0x4A6F" ];
-    license = licenses.isc;
-    platforms = platforms.linux;
+    homepage    = "https://github.com/leahneukirchen/cwm";
+    maintainers = with maintainers; [ "0x4A6F" mkf ];
+    license     = licenses.isc;
+    platforms   = platforms.linux;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

There were huge changes in the syntax and feature set of the cwmrc language, cwm users coming from distros of it such as archlinux or openbsd that have it up-to-date faced the necessity to either abandon cwm and their cwmrc, or to install newer cwm privately if savvy enough, or to rework their whole cwmrc and get used to lack of features and outdated way of operation, from before changes made over a time of something like five years.

###### Things done

`cwm: 5.6 -> 6.3-80-g4154b9b`, and i added myself as the sole maintainer, adding myself to maintainers-list for that.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).