### PR TITLE
pythonPackages.supervisor: 3.3.5 -> 4.0.4

### DIFF
--- a/pkgs/development/python-modules/supervisor/default.nix
+++ b/pkgs/development/python-modules/supervisor/default.nix
@@ -1,27 +1,26 @@
 { lib, buildPythonPackage, isPy3k, fetchPypi
 , mock
 , meld3
+, setuptools
 }:
+
 buildPythonPackage rec {
   pname = "supervisor";
-  version = "3.3.5";
+  version = "4.0.4";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1w3ahridzbc6rxfpbyx8lij6pjlcgf2ymzyg53llkjqxalp6sk8v";
+    sha256 = "02pindhq84hb9a7ykyaqw8i2iqb21h69lpmclyqh7fm1446rji4n";
   };
 
   checkInputs = [ mock ];
 
-  propagatedBuildInputs = [ meld3 ];
+  propagatedBuildInputs = [ meld3 setuptools ];
 
-  # Supervisor requires Python 2.4 or later but does not work on any version of Python 3.  You are using version 3.6.5 (default, Mar 28 2018, 10:24:30)
-  disabled = isPy3k;
-
-  meta = {
+  meta = with lib; {
     description = "A system for controlling process state under UNIX";
     homepage = http://supervisord.org/;
-    license = lib.licenses.free; # http://www.repoze.org/LICENSE.txt
-    maintainers = with lib.maintainers; [ zimbatm ];
+    license = licenses.free; # http://www.repoze.org/LICENSE.txt
+    maintainers = with maintainers; [ zimbatm ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
noticed it needed setuptools when reviewingi #69918

also bumped the version again, and enabled support for python3.

closes #69918

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[1 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/70019
2 package were build:
python27Packages.supervisor python37Packages.supervisor
```
```
[nix-shell:~/.cache/nix-review/pr-70019]$ ./results/python37Packages.supervisor/bin/supervisorctl --help
supervisorctl -- control applications run by supervisord from the cmd line.
...
```
