### PR TITLE
nix: allow static compilation

### DIFF
--- a/pkgs/development/libraries/libexecinfo/default.nix
+++ b/pkgs/development/libraries/libexecinfo/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch }:
+{ stdenv, fetchurl, fetchpatch, enableStatic ? true, enableShared ? true }:
 
 stdenv.mkDerivation rec {
   pname = "libexecinfo";
@@ -29,12 +29,19 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "CC:=$(CC)" "AR:=$(AR)" ];
 
+  buildFlags =
+      stdenv.lib.optional enableStatic "static"
+   ++ stdenv.lib.optional enableShared "dynamic";
+
   patchFlags = [ "-p0" ];
 
   installPhase = ''
     install -Dm644 execinfo.h stacktraverse.h -t $out/include
-    install -Dm755 libexecinfo.{a,so.1} -t $out/lib
+  '' + stdenv.lib.optionalString enableShared ''
+    install -Dm755 libexecinfo.so.1 -t $out/lib
     ln -s $out/lib/libexecinfo.so{.1,}
+  '' + stdenv.lib.optionalString enableStatic ''
+    install -Dm755 libexecinfo.a -t $out/lib
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -21,8 +21,8 @@ common =
   , stateDir
   , confDir
   , withLibseccomp ? lib.any (lib.meta.platformMatch stdenv.hostPlatform) libseccomp.meta.platforms, libseccomp
-  , withAWS ? stdenv.isLinux || stdenv.isDarwin, aws-sdk-cpp
-
+  , withAWS ? !enableStatic && (stdenv.isLinux || stdenv.isDarwin), aws-sdk-cpp
+  , enableStatic ? false
   , name, suffix ? "", src, crates ? null
 
   }:
@@ -65,12 +65,21 @@ common =
       propagatedBuildInputs = [ boehmgc ];
 
       # Seems to be required when using std::atomic with 64-bit types
-      NIX_LDFLAGS = lib.optionalString (stdenv.hostPlatform.system == "armv5tel-linux" || stdenv.hostPlatform.system == "armv6l-linux") "-latomic";
+      NIX_LDFLAGS =
+        # need to list libraries individually until
+        # https://github.com/NixOS/nix/commit/3e85c57a6cbf46d5f0fe8a89b368a43abd26daba
+        # is in a release
+          lib.optionalString enableStatic "-lssl -lbrotlicommon -lssh2 -lz -lnghttp2 -lcrypto"
+
+        # need to detect it here until
+        # https://github.com/NixOS/nix/commits/74b4737d8f0e1922ef5314a158271acf81cd79f8
+        # is in a release
+        + lib.optionalString (stdenv.hostPlatform.system == "armv5tel-linux" || stdenv.hostPlatform.system == "armv6l-linux") "-latomic";
 
       preConfigure =
         # Copy libboost_context so we don't get all of Boost in our closure.
         # https://github.com/NixOS/nixpkgs/issues/45462
-        ''
+        lib.optionalString (!enableStatic) ''
           mkdir -p $out/lib
           cp -pd ${boost}/lib/{libboost_context*,libboost_thread*,libboost_system*} $out/lib
           rm -f $out/lib/*.a

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -159,7 +159,7 @@ in {
     enableShared = false;
   };
   mkl = super.mkl.override { enableStatic = true; };
-  nix = super.nix.override { withAWS = false; };
+  nix = super.nix.override { enableStatic = true; };
   openssl = (super.openssl_1_1.override { static = true; }).overrideAttrs (o: {
     # OpenSSL doesn't like the `--enable-static` / `--disable-shared` flags.
     configureFlags = (removeUnknownConfigureFlags o.configureFlags);

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -274,4 +274,6 @@ in {
 
 
   libev = super.libev.override { static = true; };
+
+  libexecinfo = super.libexecinfo.override { enableShared = false; };
 }


### PR DESCRIPTION
Continuation of https://github.com/NixOS/nixpkgs/pull/56281

Nix compiles statically, but not everything is included:

```
$ nix-store -qR /nix/store/51sl3macs7bjrx8lfck8pmlcnq01hpyd-nix-2.3-x86_64-unknown-linux-musl
/nix/store/6yaj6n8l925xxfbcd65gzqx3dz7idrnn-glibc-2.27
/nix/store/kn9w6k46qmzrv3hgzs1csrrs3dcad7h6-attr-2.4.48
/nix/store/08al8hwj0hvqahb0yibslsmsvj50b1qz-acl-2.2.53
/nix/store/11kmi14g34nfb54d2bnv7q8mg17vn98h-nix-2.3-x86_64-unknown-linux-musl-man
/nix/store/5dn03xfw3wimm78nfpg67p1zj1025sbc-bzip2-1.0.6.0.1
/nix/store/440vkrx6mf7v4j4z88vjcp6pavk05lig-bzip2-1.0.6.0.1-bin
/nix/store/a66s8hzy6w34dlh6ahgfdwaiglpcny65-gnutar-1.32
/nix/store/yk8lp0x7sml42gaf9gfkr6cwx99glz7b-xz-5.2.4
/nix/store/jryr8hdk55jrmmicyz5j9shyvzqydfk8-xz-5.2.4-bin
/nix/store/kq5axl0hwrnxm1ri3dc7dgmnx7pwn9xc-busybox-1.30.1-x86_64-unknown-linux-musl
/nix/store/kx56d14p0qm2awn0qrqrv4rb8xdhvhpi-coreutils-8.31
/nix/store/l6h4ya0wzb4b8mr0y58k2gh2nhfql4sn-bash-4.4-p23
/nix/store/sgganmpm2bbnqmgz35hrgp4d0cvml6ir-gzip-1.10
/nix/store/k99c3nzlhg3znrjj5h3s03ckbb898rn0-musl-1.1.22-x86_64-unknown-linux-musl
/nix/store/xrkb0djwxjqciyk7ikgk2fxrk1dj0226-openssl-1.0.2t-x86_64-unknown-linux-musl
/nix/store/51sl3macs7bjrx8lfck8pmlcnq01hpyd-nix-2.3-x86_64-unknown-linux-musl
```

- [ ] openssl builds also shared libs and those are linked instead of static
- [ ] [nix config depends on some binaries (gnutar, ...)](https://github.com/NixOS/nix/pull/2748)
- [ ] [support https based stores](https://github.com/NixOS/nix/pull/2698)