### PR TITLE
Mark some Plasma packages broken with Qt < 5.12.0

### DIFF
--- a/pkgs/desktops/plasma-5/kdecoration.nix
+++ b/pkgs/desktops/plasma-5/kdecoration.nix
@@ -2,6 +2,9 @@
 
 mkDerivation {
   name = "kdecoration";
+  meta = {
+    broken = builtins.compareVersions qtbase.version "5.12.0" < 0;
+  };
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ qtbase ki18n ];
   outputs = [ "out" "dev" ];

--- a/pkgs/desktops/plasma-5/libkscreen/default.nix
+++ b/pkgs/desktops/plasma-5/libkscreen/default.nix
@@ -1,11 +1,14 @@
 {
   mkDerivation, lib, copyPathsToStore, propagate,
   extra-cmake-modules,
-  kwayland, libXrandr, qtx11extras
+  kwayland, libXrandr, qtbase, qtx11extras
 }:
 
 mkDerivation {
   name = "libkscreen";
+  meta = {
+    broken = builtins.compareVersions qtbase.version "5.12.0" < 0;
+  };
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ kwayland libXrandr qtx11extras ];
   outputs = [ "out" "dev" ];


### PR DESCRIPTION

###### Motivation for this change

These builds are failing on Hydra with Qt 5.11 because the packages require at least Qt 5.12.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
