### PR TITLE
gtk3-nocsd: init at 3.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4888,6 +4888,12 @@
     github = "pcarrier";
     name = "Pierre Carrier";
   };
+  peanutbutter144 = {
+    email = "tom@ient.me";
+    github = "peanutbutter144";
+    githubID = 43531981;
+    name = "Tom Ient";
+  };
   periklis = {
     email = "theopompos@gmail.com";
     github = "periklis";

--- a/pkgs/development/libraries/gtk3-nocsd/default.nix
+++ b/pkgs/development/libraries/gtk3-nocsd/default.nix
@@ -11,18 +11,23 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "ZaWertun";
-    repo = "${pname}";
+    repo = pname;
     rev = "v${version}";
     sha256 = "035rrn9jq9bdfkmmj6xl4q8paqx7xf3hxsw6gslgk86sh7x56lvi";
   };
 
-  nativeBuildInputs = [
-    pkgconfig
+  buildInputs = [
     gtk3
     gobject-introspection
   ];
 
-  makeFlags = [ "prefix=$(out)" ];
+  nativeBuildInputs = [
+    pkgconfig
+  ];
+
+  makeFlags = [
+    "prefix=${placeholder "out"}"
+  ];
 
   meta = with stdenv.lib; {
     description = "A hack to disable gtk+ 3 client side decoration";

--- a/pkgs/development/libraries/gtk3-nocsd/default.nix
+++ b/pkgs/development/libraries/gtk3-nocsd/default.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gtk3-nocsd";
-  version = "3";
+  version = "3.0.1";
 
   src = fetchFromGitHub {
-    owner = "PCMan";
-    repo = "gtk3-nocsd";
+    owner = "ZaWertun";
+    repo = "${pname}";
     rev = "v${version}";
-    sha256 = "1x3bk03qilnvbrg7xgw26his5w21lwsbvy4ll23inqfyh4rszllb";
+    sha256 = "035rrn9jq9bdfkmmj6xl4q8paqx7xf3hxsw6gslgk86sh7x56lvi";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/gtk3-nocsd/default.nix
+++ b/pkgs/development/libraries/gtk3-nocsd/default.nix
@@ -1,0 +1,34 @@
+{ stdenv
+, fetchFromGitHub
+, pkgconfig
+, gtk3
+, gobject-introspection
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gtk3-nocsd";
+  version = "3";
+
+  src = fetchFromGitHub {
+    owner = "PCMan";
+    repo = "gtk3-nocsd";
+    rev = "v${version}";
+    sha256 = "1x3bk03qilnvbrg7xgw26his5w21lwsbvy4ll23inqfyh4rszllb";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    gtk3
+    gobject-introspection
+  ];
+
+  makeFlags = [ "prefix=$(out)" ];
+
+  meta = with stdenv.lib; {
+    description = "A hack to disable gtk+ 3 client side decoration";
+    homepage = https://github.com/PCMan/gtk3-nocsd;
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ peanutbutter144 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11247,6 +11247,8 @@ in
     inherit (darwin.apple_sdk.frameworks) AppKit Cocoa;
   };
 
+  gtk3-nocsd = callPackage ../development/libraries/gtk3-nocsd { };
+
   # On darwin gtk uses cocoa by default instead of x11.
   gtk3-x11 = gtk3.override {
     cairo = cairo.override { x11Support = true; };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
