### PR TITLE
rx: init at 0.2.0

### DIFF
--- a/pkgs/applications/graphics/rx/default.nix
+++ b/pkgs/applications/graphics/rx/default.nix
@@ -1,0 +1,58 @@
+{ stdenv, rustPlatform, fetchFromGitHub, makeWrapper
+, cmake, pkgconfig
+, xorg ? null
+, vulkan-loader ? null }:
+
+assert stdenv.isLinux -> xorg != null;
+assert stdenv.isLinux -> vulkan-loader != null;
+
+let
+    graphicsBackend = if stdenv.isDarwin then "metal" else "vulkan";
+in
+  with stdenv.lib;
+  rustPlatform.buildRustPackage rec {
+    pname = "rx";
+    version = "0.2.0";
+
+    src = fetchFromGitHub {
+      owner = "cloudhead";
+      repo = pname;
+      rev = "v${version}";
+      sha256 = "0f6cw8zqr45bprj8ibhp89bb2a077g4zinfrdn943csdmh47qzcl";
+    };
+
+    cargoSha256 = "05bqsw0nw24xysq86qa3hx9b5ncf50wfxsgpy388yrs2dfnphwlx";
+
+    nativeBuildInputs = [ cmake pkgconfig makeWrapper ];
+
+    buildInputs = optionals stdenv.isLinux
+    (with xorg; [
+      # glfw-sys dependencies:
+      libX11 libXrandr libXinerama libXcursor libXi libXext
+    ]);
+
+    cargoBuildFlags = [ "--features=${graphicsBackend}" ];
+
+    # TODO: better to factor that into the rust platform
+    checkPhase = ''
+      runHook preCheck
+      echo "Running cargo test"
+      cargo test --features=${graphicsBackend}
+      runHook postCheck
+    '';
+
+    postInstall = optional stdenv.isLinux ''
+      mkdir -p $out/share/applications
+      cp $src/rx.desktop $out/share/applications
+      wrapProgram $out/bin/rx --prefix LD_LIBRARY_PATH : ${vulkan-loader}/lib
+    '';
+
+    meta = {
+      description = "Modern and extensible pixel editor implemented in Rust";
+      homepage = "https://cloudhead.io/rx/";
+      license = licenses.gpl3;
+      maintainers = with maintainers; [ minijackson ];
+      platforms   = with platforms; (linux ++ darwin ++ windows);
+      inherit version;
+    };
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5812,6 +5812,8 @@ in
 
   recordmydesktop = callPackage ../applications/video/recordmydesktop { };
 
+  rx = callPackage ../applications/graphics/rx { };
+
   gtk-recordmydesktop = callPackage ../applications/video/recordmydesktop/gtk.nix {
     jack2 = jack2Full;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

rx: a modern and extensible pixel editor implemented in Rust

- Website: https://cloudhead.io/rx/
- Source code: https://github.com/cloudhead/rx/blob/master/Cargo.toml

I have tested it on NixOS, and it works pretty well, but I need help testing it on macOS (I don't have anything running macOS)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).