### PR TITLE
djvulibre: add {lib, man} outputs

### DIFF
--- a/pkgs/by-name/dj/djvulibre/package.nix
+++ b/pkgs/by-name/dj/djvulibre/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     sha256 = "1p1fiygq9ny8aimwc4vxwjc6k9ykgdsq1sq06slfbzalfvm0kl7w";
   };
 
-  outputs = [ "bin" "dev" "out" ];
+  outputs = [ "bin" "out" "dev" "lib" "man" ];
 
   strictDeps = true;
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

Split-package a `lib` and `man`.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).