### PR TITLE
Fix certain desktop managers building together

### DIFF
--- a/nixos/modules/services/desktops/gnome3/gnome-settings-daemon.nix
+++ b/nixos/modules/services/desktops/gnome3/gnome-settings-daemon.nix
@@ -12,6 +12,12 @@ in
 
 {
 
+  imports = [
+    (mkRemovedOptionModule
+      ["services" "gnome3" "gnome-settings-daemon" "package"]
+      "")
+  ];
+
   ###### interface
 
   options = {
@@ -19,13 +25,6 @@ in
     services.gnome3.gnome-settings-daemon = {
 
       enable = mkEnableOption "GNOME Settings Daemon";
-
-      # There are many forks of gnome-settings-daemon
-      package = mkOption {
-        type = types.package;
-        default = pkgs.gnome3.gnome-settings-daemon;
-        description = "Which gnome-settings-daemon package to use.";
-      };
 
     };
 
@@ -36,9 +35,13 @@ in
 
   config = mkIf cfg.enable {
 
-    environment.systemPackages = [ cfg.package ];
+    environment.systemPackages = [
+      pkgs.gnome3.gnome-settings-daemon
+    ];
 
-    services.udev.packages = [ cfg.package ];
+    services.udev.packages = [
+      pkgs.gnome3.gnome-settings-daemon
+    ];
 
   };
 

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -209,14 +209,6 @@ in
 
       networking.networkmanager.enable = mkDefault true;
 
-      # Use the correct gnome3 packageSet
-      networking.networkmanager.basePackages = {
-        inherit (pkgs) networkmanager modemmanager wpa_supplicant crda;
-        inherit (pkgs.gnome3) networkmanager-openvpn networkmanager-vpnc
-        networkmanager-openconnect networkmanager-fortisslvpn
-        networkmanager-iodine networkmanager-l2tp;
-      };
-
       services.xserver.updateDbusEnvironment = true;
 
       # Needed for themes and backgrounds

--- a/nixos/modules/services/x11/desktop-managers/mate.nix
+++ b/nixos/modules/services/x11/desktop-managers/mate.nix
@@ -85,6 +85,7 @@ in
         pkgs.gtk3.out
         pkgs.shared-mime-info
         pkgs.xdg-user-dirs # Update user dirs as described in https://freedesktop.org/wiki/Software/xdg-user-dirs/
+        pkgs.mate.mate-settings-daemon
       ];
 
     programs.dconf.enable = true;
@@ -98,7 +99,7 @@ in
     services.gnome3.at-spi2-core.enable = true;
     services.gnome3.gnome-keyring.enable = true;
     services.gnome3.gnome-settings-daemon.enable = true;
-    services.gnome3.gnome-settings-daemon.package = pkgs.mate.mate-settings-daemon;
+    services.udev.packages = [ pkgs.mate.mate-settings-daemon ];
     services.gvfs.enable = true;
     services.upower.enable = config.powerManagement.enable;
 

--- a/nixos/modules/services/x11/desktop-managers/pantheon.nix
+++ b/nixos/modules/services/x11/desktop-managers/pantheon.nix
@@ -154,11 +154,6 @@ in
     qt5.style = "adwaita";
 
     networking.networkmanager.enable = mkDefault true;
-    networking.networkmanager.basePackages =
-      { inherit (pkgs) networkmanager modemmanager wpa_supplicant crda;
-        inherit (pkgs.gnome3) networkmanager-openvpn networkmanager-vpnc
-                              networkmanager-openconnect networkmanager-fortisslvpn
-                              networkmanager-iodine networkmanager-l2tp; };
 
     # Override GSettings schemas
     environment.sessionVariables.NIX_GSETTINGS_OVERRIDES_DIR = "${nixos-gsettings-desktop-schemas}/share/gsettings-schemas/nixos-gsettings-overrides/glib-2.0/schemas";

--- a/nixos/modules/services/x11/desktop-managers/pantheon.nix
+++ b/nixos/modules/services/x11/desktop-managers/pantheon.nix
@@ -119,7 +119,7 @@ in
     # TODO: gnome-keyring's xdg autostarts will still be in the environment (from elementary-session-settings) if disabled forcefully
     services.gnome3.gnome-keyring.enable = true;
     services.gnome3.gnome-settings-daemon.enable = true;
-    services.gnome3.gnome-settings-daemon.package = pkgs.pantheon.elementary-settings-daemon;
+    services.udev.packages = [ pkgs.pantheon.elementary-settings-daemon ];
     services.gvfs.enable = true;
     services.gnome3.rygel.enable = mkDefault true;
     services.gsignond.enable = mkDefault true;

--- a/nixos/modules/services/x11/desktop-managers/xfce4-14.nix
+++ b/nixos/modules/services/x11/desktop-managers/xfce4-14.nix
@@ -108,14 +108,6 @@ in
       "/share/gtksourceview-4.0"
     ];
 
-    # Use the correct gnome3 packageSet
-    networking.networkmanager.basePackages = mkIf config.networking.networkmanager.enable {
-      inherit (pkgs) networkmanager modemmanager wpa_supplicant crda;
-      inherit (pkgs.gnome3) networkmanager-openvpn networkmanager-vpnc
-      networkmanager-openconnect networkmanager-fortisslvpn
-      networkmanager-iodine networkmanager-l2tp;
-    };
-
     services.xserver.desktopManager.session = [{
       name = "xfce4-14";
       bgSupport = true;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Fixes #69208

Thanks @Infinisil for being my rubber duck, turns out the `basePackages` internal option is void.

The only other error is
```
error: The unique option `services.gvfs.package' is defined multiple times, in:
 - /alt/nixpkgs-channels/nixos/modules/services/x11/desktop-managers/lxqt.nix
 - /alt/nixpkgs-channels/nixos/modules/services/x11/desktop-managers/xfce4-14.nix.
```

The is because we have these definitions:
```
# for xfce4-14
services.gvfs.package = pkgs.xfce.gvfs;

# for lxqt
services.gvfs.package = pkgs.gvfs;
```

In this case, I think it would make sense for `pkgs.gvfs` definition to win.
The xfce version just isn't built with samba, which TBH could be a defunct config at this point.

I'm in favor of backporting, this probably could have broken someone's multi-de setup.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
