### PR TITLE
gnomeExtensions.drop-down-terminal: init at v24

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1997,6 +1997,11 @@
     githubId = 4828;
     name = "Eric Merritt";
   };
+  ericdallo = {
+    email = "ercdll1337@gmail.com";
+    github = "ericdallo";
+    name = "Eric Dallo";
+  };
   ericsagnes = {
     email = "eric.sagnes@gmail.com";
     github = "ericsagnes";

--- a/pkgs/desktops/gnome-3/extensions/drop-down-terminal/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/drop-down-terminal/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, substituteAll, gnome3, vte }:
+
+stdenv.mkDerivation rec {
+  pname = "gnome-shell-extension-drop-down-terminal";
+  version = "24";
+
+  src = fetchFromGitHub {
+    owner = "zzrough";
+    repo = "gs-extensions-drop-down-terminal";
+    rev = "v${version}";
+    sha256 = "1gda56xzwsa5pgmgpb7lhb3i3gqishvn84282inwvqm86afks73r";
+  };
+
+  uuid = "drop-down-terminal@gs-extensions.zzrough.org";
+
+  patches = [
+    (substituteAll {
+      src = ./fix_vte_and_gjs.patch;
+      inherit vte;
+      gjs = gnome3.gjs;
+    })
+  ];
+
+  installPhase = ''
+    mkdir -p $out/share/gnome-shell/extensions
+    cp -r ${uuid} $out/share/gnome-shell/extensions/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Configurable drop down terminal shell";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ ericdallo ];
+    homepage = https://github.com/zzrough/gs-extensions-drop-down-terminal;
+  };
+}

--- a/pkgs/desktops/gnome-3/extensions/drop-down-terminal/fix_vte_and_gjs.patch
+++ b/pkgs/desktops/gnome-3/extensions/drop-down-terminal/fix_vte_and_gjs.patch
@@ -1,0 +1,32 @@
+--- a/drop-down-terminal@gs-extensions.zzrough.org/extension.js
++++ b/drop-down-terminal@gs-extensions.zzrough.org/extension.js
+@@ -15,6 +15,8 @@
+ 
+ // Author: Stéphane Démurget <stephane.demurget@free.fr>
+ 
++imports.gi.GIRepository.Repository.prepend_search_path('@vte@/lib/girepository-1.0')
++
+ const Lang = imports.lang;
+ const Gettext = imports.gettext.domain("drop-down-terminal");
+ const Mainloop = imports.mainloop;
+@@ -653,7 +655,7 @@ const DropDownTerminalExtension = new Lang.Class({
+         this._killingChild = false;
+ 
+         // finds the forking arguments
+-        let args = ["gjs", GLib.build_filenamev([Me.path, "terminal.js"]), Me.path];
++        let args = ["@gjs@/bin/gjs", GLib.build_filenamev([Me.path, "terminal.js"]), Me.path];
+ 
+         // forks the process
+         debug("forking '" + args.join(" ") + "'");
+--- a/drop-down-terminal@gs-extensions.zzrough.org/terminal.js
++++ b/drop-down-terminal@gs-extensions.zzrough.org/terminal.js
+@@ -14,6 +14,9 @@
+ // along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ 
+ // Author: Stéphane Démurget <stephane.demurget@free.fr>
++
++imports.gi.GIRepository.Repository.prepend_search_path('@vte@/lib/girepository-1.0')
++
+ const Lang = imports.lang;
+ 
+ const Pango = imports.gi.Pango;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22654,6 +22654,7 @@ in
     clipboard-indicator = callPackage ../desktops/gnome-3/extensions/clipboard-indicator { };
     dash-to-dock = callPackage ../desktops/gnome-3/extensions/dash-to-dock { };
     dash-to-panel = callPackage ../desktops/gnome-3/extensions/dash-to-panel { };
+    drop-down-terminal = callPackage ../desktops/gnome-3/extensions/drop-down-terminal { };
     gsconnect = callPackage ../desktops/gnome-3/extensions/gsconnect { };
     icon-hider = callPackage ../desktops/gnome-3/extensions/icon-hider { };
     impatience = callPackage ../desktops/gnome-3/extensions/impatience.nix { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add the drop down terminal GNOME shell extension.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
