### PR TITLE
Update a few mate packages

### DIFF
--- a/pkgs/desktops/mate/mate-common/default.nix
+++ b/pkgs/desktops/mate/mate-common/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "mate-common";
-  version = "1.22.0";
+  version = "1.22.2";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "11lwckndizawbq993ws8lqp59vsc873zri0m8s1i5zyc4qx9f69z";
+    sha256 = "1xx7qrw8kc6355r1a1nybncf8s2rxjb2nqzw0gv2r5j5sqx8fzgf";
   };
 
   meta = {

--- a/pkgs/desktops/mate/mate-utils/default.nix
+++ b/pkgs/desktops/mate/mate-utils/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "mate-utils";
-  version = "1.22.1";
+  version = "1.22.2";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0768y6x33ljc9dxjlfmvplsn4lrxj5xhjddbyab9h6pqav8527rg";
+    sha256 = "1i6fnm3y1hj8r57x4jpc4ixqs77zln8f7477d0haypflxm3s4kjr";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/mozo/default.nix
+++ b/pkgs/desktops/mate/mozo/default.nix
@@ -2,14 +2,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "mozo";
-  version = "1.22.1";
+  version = "1.22.2";
 
   format = "other";
   doCheck = false;
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0yffp7p3b6ynpf7ck21klym7h09l35amnyahm71dxbv2kzj6hlqh";
+    sha256 = "1lzcwsz940v218frwzhpywp1an9x3cgfvqr7r8dplpdapvd0khrs";
   };
 
   nativeBuildInputs = [ pkgconfig intltool gobject-introspection wrapGAppsHook ];

--- a/pkgs/desktops/mate/pluma/default.nix
+++ b/pkgs/desktops/mate/pluma/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "pluma";
-  version = "1.22.1";
+  version = "1.22.2";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "14d5c5fg31d7br9h1y3gdcr53j4sxlgybf326jvdcw8mgy91k3dg";
+    sha256 = "1gsj8grdhzb1jvl5zwd8zjc9cj9ys2ndny04gy4bbh80sjaj6xva";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/python-caja/default.nix
+++ b/pkgs/desktops/mate/python-caja/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "python-caja";
-  version = "1.22.0";
+  version = "1.22.1";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1zwdjvxci72j0181nlfq6912lw3aq8j3746brlp7wlzn22qp7b0k";
+    sha256 = "07hkvs4a6anrvh28zjsrj8anbcz32p19hslhq66yhcvh0hh4kvqk";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update some mate packages to the latest stable release.

mate.mate-common: 1.22.0 -> [1.22.2](https://github.com/mate-desktop/mate-common/releases/tag/v1.22.2)
mate.mate-utils: 1.22.1 -> [1.22.2](https://github.com/mate-desktop/mate-utils/releases/tag/v1.22.2)
mate.mozo: 1.22.1 -> [1.22.2](https://github.com/mate-desktop/mozo/releases/tag/v1.22.2)
mate.pluma: 1.22.1 -> [1.22.2](https://github.com/mate-desktop/pluma/releases/tag/v1.22.2)
mate.python-caja: 1.22.0 -> [1.22.1](https://github.com/mate-desktop/python-caja/releases/tag/v1.22.1)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).