### PR TITLE
pythonPackages.qds_sdk: init at 1.12.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5807,6 +5807,12 @@
     githubId = 1151264;
     name = "Sebastian Graf";
   };
+  shahrukh330 = {
+    email = "shahrukh330@gmail.com";
+    github = "shahrukh330";
+    githubId = 1588288;
+    name = "Shahrukh Khan";
+  };
   shanemikel = {
     email = "shanemikel1@gmail.com";
     github = "shanemikel";

--- a/pkgs/development/python-modules/qds_sdk/default.nix
+++ b/pkgs/development/python-modules/qds_sdk/default.nix
@@ -1,0 +1,43 @@
+{ lib,
+ fetchFromGitHub,
+ buildPythonPackage,
+ boto,
+ inflection,
+ pytest,
+ mock,
+ requests,
+ six,
+ urllib3 }:
+
+buildPythonPackage rec {
+  pname = "qds_sdk";
+  version = "1.12.0";
+
+  # pypi does not contain tests, using github sources instead
+  src = fetchFromGitHub {
+    owner = "qubole";
+    repo = "qds-sdk-py";
+    rev = "V${version}";
+    sha256 = "18xhvlcfki8llv7fw2r5yfk20zds3gr78b4klwm9mkvhlhwds9rx";
+  };
+
+  propagatedBuildInputs = [ 
+    boto
+    inflection
+    requests
+    six 
+    urllib3 
+  ];
+
+  checkInputs = [ pytest mock ];
+  checkPhase = ''
+    py.test --disable-pytest-warnings tests
+  '';
+ 
+  meta = with lib; {
+    description = "A Python module that provides the tools you need to authenticate with, and use the Qubole Data Service API";
+    homepage = "https://github.com/qubole/qds-sdk-py";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ shahrukh330 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4683,6 +4683,8 @@ in {
 
   qdarkstyle = callPackage ../development/python-modules/qdarkstyle { };
 
+  qds_sdk = callPackage ../development/python-modules/qds_sdk { };
+
   quamash = callPackage ../development/python-modules/quamash { };
 
   quandl = callPackage ../development/python-modules/quandl { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add Qubole Data Service Python SDK to nixpkgs. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @kalbasit 
