### PR TITLE
pythonPackages.jenkins-job-builder: 3.0.1 -> 3.0.2

### DIFF
--- a/pkgs/development/python-modules/jenkins-job-builder/default.nix
+++ b/pkgs/development/python-modules/jenkins-job-builder/default.nix
@@ -1,37 +1,32 @@
-{ stdenv
-, buildPythonPackage
-, fetchPypi
+{ lib, buildPythonPackage, fetchPypi, isPy27
+, fasteners
+, jinja2
 , pbr
-, mock
 , python-jenkins
 , pyyaml
 , six
 , stevedore
-, isPy27
-, fasteners
-, jinja2
 }:
 
 buildPythonPackage rec {
   pname = "jenkins-job-builder";
-  version = "3.0.1";
-  disabled = !isPy27;
+  version = "3.0.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "16x97pdr90x3xsc1xl66l7q77pgja5dzsk921by2h09k7dvxaqmh";
+    sha256 = "02ggscsyrrqk06w9lb43km77qgcj8cixrrm5mkigr4gz2pzdjhmf";
   };
 
   postPatch = ''
     export HOME=$TMPDIR
   '';
 
-  propagatedBuildInputs = [ pbr mock python-jenkins pyyaml six stevedore fasteners jinja2 ];
+  propagatedBuildInputs = [ pbr python-jenkins pyyaml six stevedore fasteners jinja2 ];
 
-  # Need to fix test deps
-  doCheck = false;
+  # Need to fix test deps, relies on stestr and a few other packages that aren't available on nixpkgs
+  checkPhase = ''$out/bin/jenkins-jobs --help'';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Jenkins Job Builder is a system for configuring Jenkins jobs using simple YAML files stored in Git";
     homepage = "https://docs.openstack.org/infra/system-config/jjb.html";
     license = licenses.asl20;

--- a/pkgs/development/python-modules/stevedore/default.nix
+++ b/pkgs/development/python-modules/stevedore/default.nix
@@ -1,17 +1,17 @@
-{ stdenv, buildPythonPackage, fetchPypi, pbr, six }:
+{ stdenv, buildPythonPackage, fetchPypi, pbr, setuptools, six }:
 
 buildPythonPackage rec {
   pname = "stevedore";
-  version = "1.30.1";
+  version = "1.31.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1860zslirsqskc2iifljxcyly28zqgjpmkm7k3bj6zyqagzriq3v";
+    sha256 = "054apq55yg7058pmbnyc8jhrcpi9clmi0sm7znhwg0d676brywz0";
   };
 
   doCheck = false;
 
-  propagatedBuildInputs = [ pbr six ];
+  propagatedBuildInputs = [ pbr setuptools six ];
 
   meta = with stdenv.lib; {
     description = "Manage dynamic plugins for Python applications";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9756,7 +9756,7 @@ in
 
   jenkins = callPackage ../development/tools/continuous-integration/jenkins { };
 
-  jenkins-job-builder = pythonPackages.jenkins-job-builder;
+  jenkins-job-builder = with python3Packages; toPythonApplication jenkins-job-builder;
 
   kafkacat = callPackage ../development/tools/kafkacat { };
 


### PR DESCRIPTION
###### Motivation for this change
was reviewing #69825 and noticed:
```
nix-shell:/home/jon/.cache/nix-review/pr-69825]$ ./results/jenkins-job-builder/bin/jenkins-jobs --help
Traceback (most recent call last):
  File "/nix/store/glxjcxidj9lkaf484kmsq9ww67r773jd-python2.7-jenkins-job-builder-3.0.2/bin/.jenkins-jobs-wrapped", line 7, in <module>
    from jenkins_jobs.cli.entry import main
  File "/nix/store/glxjcxidj9lkaf484kmsq9ww67r773jd-python2.7-jenkins-job-builder-3.0.2/lib/python2.7/site-packages/jenkins_jobs/cli/entry.py", line 21, in <module>
    from stevedore import extension
  File "/nix/store/rvbwxscav32rf453ff53586ndfiynmnc-python2.7-stevedore-1.30.1/lib/python2.7/site-packages/stevedore/__init__.py", line 11, in <module>
    from .extension import ExtensionManager
  File "/nix/store/rvbwxscav32rf453ff53586ndfiynmnc-python2.7-stevedore-1.30.1/lib/python2.7/site-packages/stevedore/extension.py", line 17, in <module>
    import pkg_resources
ImportError: No module named pkg_resources
```

Actions:
 - added setuptools to stevedore
 - bumped stevedore version
 - bumped jenkins-job-builder
 - added limited test to jenkins-job-builder
 - made jenkins-job-builder application use python3

closes #69825

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

no regressions:
```
[14 built, 10 copied (4.9 MiB), 2.3 MiB DL]
https://github.com/NixOS/nixpkgs/pull/70057
12 package were build:
jenkins-job-builder python27Packages.doc8 python27Packages.jenkins-job-builder python27Packages.stevedore python27Packages.subliminal python27Packages.virtualenvwrapper python37Packages.cliff python37Packages.doc8 python37Packages.optuna python37Packages.stevedore python37Packages.subliminal python37Packages.virtualenvwrapper
```