### PR TITLE
vscode-extensions.python-language-server: init

### DIFF
--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -2,6 +2,19 @@
 
 let
   inherit (vscode-utils) buildVscodeMarketplaceExtension;
+
+  # The arch tag comes from 'PlatformName' defined here:
+  # https://github.com/Microsoft/vscode-python/blob/master/src/client/activation/types.ts
+  arch =
+    if stdenv.isLinux && stdenv.isx86_64 then "linux-x64"
+    else if stdenv.isDarwin then "osx-x64"
+    else throw "Only x86_64 Linux and Darwin are supported.";
+
+  python-language-server = callPackage ./python/language-server.nix {
+    extractNuGet = callPackage ./python/extract-nuget.nix {};
+    inherit arch;
+  };
+
 in
 #
 # Unless there is a good reason not to, we attempt to use the same name as the
@@ -63,8 +76,11 @@ in
   ms-vscode.cpptools = callPackage ./cpptools {};
 
   ms-python.python = callPackage ./python {
+    languageServer = python-language-server;
     extractNuGet = callPackage ./python/extract-nuget.nix { };
   };
+
+  inherit python-language-server;
 
   vscodevim.vim = buildVscodeMarketplaceExtension {
     mktplcRef = {

--- a/pkgs/misc/vscode-extensions/python/default.nix
+++ b/pkgs/misc/vscode-extensions/python/default.nix
@@ -6,6 +6,7 @@
 , ctagsUseFixed ? true, ctags     # When `true`, the ctags default setting will be fixed to specified.
                                   # Use version from `PATH` for default setting otherwise.
                                   # Defaults to `true` as usually not defined on a per projet basis.
+, languageServer
 }:
 
 assert pythonUseFixed -> null != python;
@@ -15,28 +16,6 @@ let
   pythonDefaultsTo = if pythonUseFixed then "${python}/bin/python" else "python";
   ctagsDefaultsTo = if ctagsUseFixed then "${ctags}/bin/ctags" else "ctags";
 
-  # The arch tag comes from 'PlatformName' defined here:
-  # https://github.com/Microsoft/vscode-python/blob/master/src/client/activation/types.ts
-  arch =
-    if stdenv.isLinux && stdenv.isx86_64 then "linux-x64"
-    else if stdenv.isDarwin then "osx-x64"
-    else throw "Only x86_64 Linux and Darwin are supported.";
-
-  languageServerSha256 = {
-    linux-x64 = "0j9251f8dfccmg0x9gzg1cai4k5zd0alcfpb0443gs4jqakl0lr2";
-    osx-x64 = "070qwwl08fa24rsnln4i5x9mfriqaw920l6v2j8d1r0zylxnyjsa";
-  }.${arch};
-
-  # version is languageServerVersion in the package.json
-  languageServer = extractNuGet rec {
-    name = "Python-Language-Server";
-    version = "0.3.40";
-
-    src = fetchurl {
-      url = "https://pvsc.azureedge.net/python-language-server-stable/${name}-${arch}.${version}.nupkg";
-      sha256 = languageServerSha256;
-    };
-  };
 in vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     name = "python";

--- a/pkgs/misc/vscode-extensions/python/extract-nuget.nix
+++ b/pkgs/misc/vscode-extensions/python/extract-nuget.nix
@@ -1,15 +1,21 @@
 { stdenv, unzip }:
-{ name, version, src, ... }:
+{ name, version, src, ... } @ args:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation ({
   inherit name version src;
 
   buildInputs = [ unzip ];
   dontBuild = true;
-  unpackPhase = "unzip $src";
+  unpackPhase = ''
+    runHook preUnpack
+    unzip $src
+    runHook postUnpack
+  '';
   installPhase = ''
+    runHook preInstall
     mkdir -p "$out"
     chmod -R +w .
     find . -mindepth 1 -maxdepth 1 | xargs cp -a -t "$out"
+    runHook postInstall
   '';
-}
+} // args)

--- a/pkgs/misc/vscode-extensions/python/language-server.nix
+++ b/pkgs/misc/vscode-extensions/python/language-server.nix
@@ -1,4 +1,6 @@
-{ fetchurl, extractNuGet, arch }:
+{ gcc-unwrapped, curl, fetchurl, extractNuGet, arch, autoPatchelfHook, unzip
+, lttng-ust
+}:
 let
 
   languageServerSha256 = {
@@ -11,13 +13,11 @@ in
     name = "Python-Language-Server";
     version = "0.4.24";
 
+    buildInputs = [ autoPatchelfHook curl unzip gcc-unwrapped.lib lttng-ust ];
     src = fetchurl {
       url = "https://pvsc.azureedge.net/python-language-server-stable/${name}-${arch}.${version}.nupkg";
       sha256 = languageServerSha256;
     };
 
-    preInstall = ''
-      patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" Microsoft.Python.LanguageServer
-    '';
   }
 

--- a/pkgs/misc/vscode-extensions/python/language-server.nix
+++ b/pkgs/misc/vscode-extensions/python/language-server.nix
@@ -15,5 +15,9 @@ in
       url = "https://pvsc.azureedge.net/python-language-server-stable/${name}-${arch}.${version}.nupkg";
       sha256 = languageServerSha256;
     };
+
+    preInstall = ''
+      patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" Microsoft.Python.LanguageServer
+    '';
   }
 

--- a/pkgs/misc/vscode-extensions/python/language-server.nix
+++ b/pkgs/misc/vscode-extensions/python/language-server.nix
@@ -1,0 +1,19 @@
+{ fetchurl, extractNuGet, arch }:
+let
+
+  languageServerSha256 = {
+    linux-x64 = "1w3y0sn6ijk1vspi4lailg1q1iy9lwslhx92c7jbrrkiaszvaqwn";
+    osx-x64 = "11l4fic8cvgh1l3dq6qxi51pwhcic79zf13rhyajl5w5g13caafp";
+  }.${arch};
+in
+  # version is languageServerVersion in the package.json
+  extractNuGet rec {
+    name = "Python-Language-Server";
+    version = "0.4.24";
+
+    src = fetchurl {
+      url = "https://pvsc.azureedge.net/python-language-server-stable/${name}-${arch}.${version}.nupkg";
+      sha256 = languageServerSha256;
+    };
+  }
+


### PR DESCRIPTION
It was already defined in nix but not referencable.
I make it accessible so that one can reuse it for instance in coc-python (which otherwise installs its version in $HOME/.config/coc/extensions/coc-python-data/languageServer.0.4.24/)

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
