### PR TITLE
pythonPackages.rasterio: add setuptools

### DIFF
--- a/pkgs/development/python-modules/rasterio/default.nix
+++ b/pkgs/development/python-modules/rasterio/default.nix
@@ -1,5 +1,5 @@
 { buildPythonPackage, lib, fetchFromGitHub, isPy3k
-, cython
+, cython, setuptools
 , numpy, affine, attrs, cligj, click-plugins, snuggs, gdal
 , pytest, pytestcov, packaging, hypothesis, boto3, mock
 }:
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   checkInputs = [ boto3 pytest pytestcov packaging hypothesis ] ++ lib.optional (!isPy3k) mock;
   nativeBuildInputs = [ cython gdal ];
-  propagatedBuildInputs = [ gdal numpy attrs affine cligj click-plugins snuggs ];
+  propagatedBuildInputs = [ gdal numpy attrs affine cligj click-plugins snuggs setuptools ];
 
   meta = with lib; {
     description = "Python package to read and write geospatial raster data";


### PR DESCRIPTION

###### Motivation for this change
noticed it was broken while reviewing #69801

previous behavior:
```
$ ./result/bin/rio
proj_create: init=epsg:/init=IGNF: syntax not supported in non-PROJ4 emulation mode
Traceback (most recent call last):
  File "/nix/store/ffv9d9pifmip3x24ymxf4nkdfw7jggsl-python3.7-rasterio-1.0.28/bin/.rio-wrapped", line 7, in <module>
    from rasterio.rio.main import main_group
  File "/nix/store/ffv9d9pifmip3x24ymxf4nkdfw7jggsl-python3.7-rasterio-1.0.28/lib/python3.7/site-packages/rasterio/rio/main.py", line 35, in <module>
    from pkg_resources import iter_entry_points
ModuleNotFoundError: No module named 'pkg_resources'
```
current:
```
$ ./result/bin/rio --help
proj_create: init=epsg:/init=IGNF: syntax not supported in non-PROJ4 emulation mode
Usage: rio [OPTIONS] COMMAND [ARGS]...

  Rasterio command line interface.
...
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
