### PR TITLE
librsvg: 2.44.15 -> 2.46.0

### DIFF
--- a/pkgs/development/libraries/librsvg/default.nix
+++ b/pkgs/development/libraries/librsvg/default.nix
@@ -5,14 +5,14 @@
 
 let
   pname = "librsvg";
-  version = "2.44.15";
+  version = "2.46.0";
 in
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1p4cifnxppz2qwsk2wvn2a6c7dpvgfrsf5vlhdkmsd373czm9396";
+    sha256 = "1la3az2af2ccm6rp86b6wh0kq7kxzl4n8pli5qxhyic1rd91xj4n";
   };
 
   outputs = [ "out" "dev" "installedTests" ];


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken when reviewing a few other packages. Bumping it seems to fix the build.

should help with #70056 #69837

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
