### PR TITLE
python3Packages.gsd: 1.7.0 -> 1.9.1

### DIFF
--- a/pkgs/development/python-modules/gsd/1.7.nix
+++ b/pkgs/development/python-modules/gsd/1.7.nix
@@ -1,0 +1,27 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, numpy
+}:
+
+buildPythonPackage rec {
+  version = "1.7.0";
+  pname = "gsd";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0fpk69wachyydpk9cbs901m7hkwrrvq24ykxsrz62km9ql8lr2vp";
+  };
+
+  propagatedBuildInputs = [ numpy ];
+
+  # tests not packaged with gsd
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://bitbucket.org/glotzer/gsd;
+    description = "General simulation data file format";
+    license = licenses.bsd2;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/gsd/default.nix
+++ b/pkgs/development/python-modules/gsd/default.nix
@@ -1,26 +1,30 @@
-{ stdenv
-, buildPythonPackage
-, fetchPypi
+{ lib, buildPythonPackage, fetchFromGitHub, isPy27
 , numpy
+, pytest
 }:
 
 buildPythonPackage rec {
-  version = "1.7.0";
+  version = "1.9.3";
   pname = "gsd";
+  disabled = isPy27;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "0fpk69wachyydpk9cbs901m7hkwrrvq24ykxsrz62km9ql8lr2vp";
+  src = fetchFromGitHub {
+    owner = "glotzerlab";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "07hw29r2inyp493dia4fx3ysfr1wxi2jb3n9cmwdi0l54s2ahqvf";
   };
 
   propagatedBuildInputs = [ numpy ];
 
-  # tests not packaged with gsd
-  doCheck = false;
+  checkInputs = [ pytest ];
+  checkPhase = ''
+    pytest
+  '';
 
-  meta = with stdenv.lib; {
-    homepage = https://bitbucket.org/glotzer/gsd;
+  meta = with lib; {
     description = "General simulation data file format";
+    homepage = "https://github.com/glotzerlab/gsd";
     license = licenses.bsd2;
     maintainers = [ maintainers.costrouc ];
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -631,7 +631,10 @@ in {
     inherit (pkgs) graphviz;
   };
 
-  gsd = callPackage ../development/python-modules/gsd { };
+  gsd = if isPy27 then
+      callPackage ../development/python-modules/gsd/1.7.nix { }
+    else
+      callPackage ../development/python-modules/gsd { };
 
   gssapi = callPackage ../development/python-modules/gssapi {
     inherit (pkgs) darwin krb5Full;


### PR DESCRIPTION
###### Motivation for this change
noticed a regression #69783

Actions:
 - froze gsd for python2
 - added tests for python3
 - bumped python3 version to 1.9.1

closes #69783
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[2 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/70064
1 package were build:
python37Packages.gsd
```