### PR TITLE
[19.09] libproxy: build with spidermonkey_60

### DIFF
--- a/pkgs/development/libraries/libproxy/default.nix
+++ b/pkgs/development/libraries/libproxy/default.nix
@@ -6,7 +6,7 @@
 , fetchpatch
 , dbus
 , networkmanager
-, spidermonkey_38
+, spidermonkey_60
 , pcre
 , gsettings-desktop-schemas
 , glib
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
     JavaScriptCore
   ] else [
     glib
-    spidermonkey_38
+    spidermonkey_60
     dbus
     networkmanager
   ]);
@@ -59,7 +59,21 @@ stdenv.mkDerivation rec {
     "-DPYTHON3_SITEPKG_DIR=${placeholder "py3"}/${python3.sitePackages}"
   ];
 
-  patches = stdenv.lib.optionals stdenv.isDarwin [
+  patches = [
+    # Make build with spidermonkey_60
+    (fetchpatch {
+      url = "https://github.com/libproxy/libproxy/pull/86.patch";
+      sha256 = "17c06ilinrnzr7xnnmw9pc6zrncyaxcdd6r6k1ah5p156skbykfs";
+    })
+    (fetchpatch {
+      url = "https://github.com/libproxy/libproxy/pull/87.patch";
+      sha256 = "0sagzfwm16f33inbkwsp88w9wmrd034rjmw0y8d122f7k1qfx6zc";
+    })
+    (fetchpatch {
+      url = "https://github.com/libproxy/libproxy/pull/95.patch";
+      sha256 = "18vyr6wlis9zfwml86606jpgb9mss01l9aj31iiciml8p857aixi";
+    })
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [
     (fetchpatch {
       url = "https://github.com/libproxy/libproxy/commit/44158f03f8522116758d335688ed840dfcb50ac8.patch";
       sha256 = "0axfvb6j7gcys6fkwi9dkn006imhvm3kqr83gpwban8419n0q5v1";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
ZHF: https://github.com/NixOS/nixpkgs/issues/68361

This fixes a lot of stuff on i686-linux.

(note this patch isn't going to master because it's in gnome-3.34 branch https://github.com/NixOS/nixpkgs/pull/68608/commits/c3204b3203c32dd28e623dbba03458b1dabc7913)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
