### PR TITLE
pythonPackages.supervisor: fix tests

### DIFF
--- a/pkgs/development/python-modules/supervisor/default.nix
+++ b/pkgs/development/python-modules/supervisor/default.nix
@@ -1,6 +1,7 @@
-{ lib, buildPythonPackage, isPy3k, fetchPypi
+{ stdenv, lib, buildPythonPackage, isPy3k, fetchPypi
 , mock
 , meld3
+, pytest
 , setuptools
 }:
 
@@ -13,7 +14,13 @@ buildPythonPackage rec {
     sha256 = "02pindhq84hb9a7ykyaqw8i2iqb21h69lpmclyqh7fm1446rji4n";
   };
 
-  checkInputs = [ mock ];
+  # wants to write to /tmp/foo which is likely already owned by another
+  # nixbld user on hydra
+  doCheck = !stdenv.isDarwin;
+  checkInputs = [ mock pytest ];
+  checkPhase = ''
+    pytest
+  '';
 
   propagatedBuildInputs = [ meld3 setuptools ];
 


### PR DESCRIPTION
###### Motivation for this change
was able to build the package fine at home, but was brought up on #70019 and in hydra that it has some issues. Was able to reproduce the issue at work, and it seems using pytest as the test runner fixes the issue.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Taneb (brought up build issue originally)

```
[2 built, 1 copied (0.2 MiB), 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/70073
2 package were build:
python27Packages.supervisor python37Packages.supervisor
```