### PR TITLE
nixos/system-environment: fix variable substitution

### DIFF
--- a/nixos/modules/config/system-environment.nix
+++ b/nixos/modules/config/system-environment.nix
@@ -78,7 +78,9 @@ in
         # We're trying to use the same syntax for PAM variables and env variables.
         # That means we need to map the env variables that people might use to their
         # equivalent PAM variable.
-        replaceEnvVars = replaceStrings ["$HOME" "$USER"] ["@{HOME}" "@{PAM_USER}"]
+        # Note: PAM_USER is a PAM_ITEM, HOME is an environment variable, they have 
+        # different syntax.
+        replaceEnvVars = replaceStrings ["$HOME" "$USER"] ["\${HOME}" "@{PAM_USER}"];
 
         pamVariable = n: v:
           ''${n}   DEFAULT="${concatStringsSep ":" (map replaceEnvVars (toList v))}"'';

--- a/nixos/modules/config/system-environment.nix
+++ b/nixos/modules/config/system-environment.nix
@@ -8,11 +8,6 @@ let
 
   cfg = config.environment;
 
-  pamProfiles =
-    map
-      (replaceStrings ["$HOME" "$USER"] ["@{HOME}" "@{PAM_USER}"])
-      cfg.profiles;
-
 in
 
 {
@@ -75,13 +70,18 @@ in
       let
         suffixedVariables =
           flip mapAttrs cfg.profileRelativeSessionVariables (envVar: suffixes:
-            flip concatMap pamProfiles (profile:
+            flip concatMap cfg.profiles (profile:
               map (suffix: "${profile}${suffix}") suffixes
             )
           );
 
+        # We're trying to use the same syntax for PAM variables and env variables.
+        # That means we need to map the env variables that people might use to their
+        # equivalent PAM variable.
+        replaceEnvVars = replaceStrings ["$HOME" "$USER"] ["@{HOME}" "@{PAM_USER}"]
+
         pamVariable = n: v:
-          ''${n}   DEFAULT="${concatStringsSep ":" (toList v)}"'';
+          ''${n}   DEFAULT="${concatStringsSep ":" (map replaceEnvVars (toList v))}"'';
 
         pamVariables =
           concatStringsSep "\n"


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
There were two issues:
- Variables weren't being replaced in the *values* of variables, only in the *profiles*.
- `HOME` isn't a `PAM_ITEM` so we need to use `${HOME}`.

Fixes https://github.com/NixOS/nixpkgs/issues/69316.

Someone other than me should also test this!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @worldofpeace 
