### PR TITLE
pythonPackages.ephem: 3.7.6.0 -> 3.7.7.0

### DIFF
--- a/pkgs/development/python-modules/ephem/default.nix
+++ b/pkgs/development/python-modules/ephem/default.nix
@@ -3,11 +3,11 @@
 
 buildPythonPackage rec {
   pname = "ephem";
-  version = "3.7.6.0";
+  version = "3.7.7.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "7a4c82b1def2893e02aec0394f108d24adb17bd7b0ca6f4bc78eb7120c0212ac";
+    sha256 = "0dj4kk325b01s7q1zkwpm9rrzl7n1jf7fr92wcajjhc5kx14hwb0";
   };
 
   patchFlags = "-p0";
@@ -16,11 +16,6 @@ buildPythonPackage rec {
   checkPhase = ''
     LC_ALL="en_US.UTF-8" py.test --pyargs ephem.tests -k "not JPLTest"
   '';
-
-  # Unfortunately, the tests are broken for Python 3 in 3.7.6.0. They have been
-  # fixed in https://github.com/brandon-rhodes/pyephem/commit/c8633854e2d251a198b0f701d0528b508baa2411
-  # but there has not been a new release since then.
-  doCheck = !isPy3k;
 
   meta = with stdenv.lib; {
     description = "Compute positions of the planets and stars";


### PR DESCRIPTION
###### Motivation for this change
noticed a comment about tests being disabled until a patch was released, so I updated the expression to run tests again.

closes #69790

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[1 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/70139
2 package were build:
python27Packages.ephem python37Packages.ephem
```