### PR TITLE
pythonPackages.cassandra-driver: 3.18.0 -> 3.19.0

### DIFF
--- a/pkgs/development/python-modules/cassandra-driver/default.nix
+++ b/pkgs/development/python-modules/cassandra-driver/default.nix
@@ -1,70 +1,46 @@
-{ stdenv
-, libev
-, buildPythonPackage
-, fetchPypi
+{ stdenv, lib, buildPythonPackage, fetchPypi, python, pythonOlder
 , cython
-, futures
-, six
-, python
-, scales
 , eventlet
-, twisted
+, futures
+, libev
 , mock
-, gevent
 , nose
+, pytest
 , pytz
 , pyyaml
+, scales
+, six
 , sure
-, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "cassandra-driver";
-  version = "3.18.0";
+  version = "3.19.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1w9a7fdl626m977cjj9zclh4a0mr3s4q9jpwm1fsmpi7v3gbribi";
+    sha256 = "1vy9yzsd9c29irq99m8lpkgnc634waai2phvr6b89pmmdirp2wm9";
   };
 
-  buildInputs = [
-    libev
-  ];
-
-  nativeBuildInputs = [
-    # NOTE: next version will work with cython 0.29
-    # Requires 'Cython!=0.25,<0.29,>=0.20'
-    (cython.overridePythonAttrs(old: rec {
-      pname = "Cython";
-      version = "0.28.3";
-      src = fetchPypi {
-        inherit pname version;
-        sha256 = "1aae6d6e9858888144cea147eb5e677830f45faaff3d305d77378c3cba55f526";
-      };
-    }))
-  ];
-
+  nativeBuildInputs = [ cython ];
+  buildInputs = [ libev ];
   propagatedBuildInputs = [ six ]
-    ++ stdenv.lib.optionals (pythonOlder "3.4") [ futures ];
+    ++ lib.optionals (pythonOlder "3.4") [ futures ];
 
-  postPatch = ''
-    sed -i "s/<=1.0.1//" setup.py
-  '';
+  checkInputs = [ eventlet mock nose pytest pytz pyyaml sure ];
 
+  # ignore test files which try to do socket.getprotocolname('tcp')
+  # as it fails in sandbox mode due to lack of a /etc/protocols file
   checkPhase = ''
-    ${python.interpreter} setup.py gevent_nosetests
-    ${python.interpreter} setup.py eventlet_nosetests
+    pytest tests/unit \
+      --ignore=tests/unit/io/test_libevreactor.py \
+      --ignore=tests/unit/io/test_eventletreactor.py \
+      --ignore=tests/unit/io/test_asyncorereactor.py
   '';
 
-  checkInputs = [ scales eventlet twisted mock gevent nose pytz pyyaml sure ];
-
-  # Could not get tests running
-  doCheck = false;
-
-  meta = with stdenv.lib; {
-    homepage = http://datastax.github.io/python-driver/;
+  meta = with lib; {
     description = "A Python client driver for Apache Cassandra";
+    homepage = "http://datastax.github.io/python-driver";
     license = licenses.asl20;
   };
-
 }


### PR DESCRIPTION
###### Motivation for this change
while reviewing #69775 I noticed it could be cleaned up and tests should be enabled.

closes #69775

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
