### PR TITLE
vcv-rack: 1.1.4 -> 1.1.5

### DIFF
--- a/pkgs/applications/audio/vcv-rack/default.nix
+++ b/pkgs/applications/audio/vcv-rack/default.nix
@@ -1,6 +1,6 @@
 { stdenv, makeWrapper, fetchFromBitbucket, fetchFromGitHub, pkgconfig
 , alsaLib, curl, glew, glfw, gtk2-x11, jansson, libjack2, libXext, libXi
-, libzip, rtaudio, rtmidi, speex }:
+, libzip, rtaudio, rtmidi, speex, libsamplerate }:
 
 let
   glfw-git = glfw.overrideAttrs (oldAttrs: rec {
@@ -28,13 +28,13 @@ let
 in
 with stdenv.lib; stdenv.mkDerivation rec {
   pname = "VCV-Rack";
-  version = "1.1.4";
+  version = "1.1.5";
 
   src = fetchFromGitHub {
     owner = "VCVRack";
     repo = "Rack";
     rev = "v${version}";
-    sha256 = "04kg0nm7w19s2zfrsxjfl3bs4sy3bzf28kzl4hayzwv480667ybx";
+    sha256 = "172v66v2vb6l9dpsq6fb6xn035igwhpjci8w3kz2na3rvmz1bc5w";
     fetchSubmodules = true;
   };
 
@@ -58,7 +58,7 @@ with stdenv.lib; stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   nativeBuildInputs = [ makeWrapper pkgconfig ];
-  buildInputs = [ glfw-git alsaLib curl glew gtk2-x11 jansson libjack2 libzip rtaudio rtmidi speex ];
+  buildInputs = [ glfw-git alsaLib curl glew gtk2-x11 jansson libjack2 libzip rtaudio rtmidi speex libsamplerate ];
 
   buildFlags = "Rack";
 

--- a/pkgs/applications/audio/vcv-rack/rack-minimize-vendoring.patch
+++ b/pkgs/applications/audio/vcv-rack/rack-minimize-vendoring.patch
@@ -5,10 +5,9 @@ diff -ru a/Makefile b/Makefile
  build/dep/osdialog/osdialog_gtk2.c.o: FLAGS += $(shell pkg-config --cflags gtk+-2.0)
  
  	LDFLAGS += -rdynamic \
--		dep/lib/libglfw3.a dep/lib/libGLEW.a dep/lib/libjansson.a dep/lib/libspeexdsp.a dep/lib/libzip.a dep/lib/libz.a dep/lib/librtmidi.a dep/lib/librtaudio.a dep/lib/libcurl.a dep/lib/libssl.a dep/lib/libcrypto.a \
--		-lpthread -lGL -ldl -lX11 -lasound -ljack \
-+		-lGLEW -ljansson -lspeexdsp -lzip -lz -lrtmidi -lrtaudio -lcurl -lssl -lcrypto \
-+		-lpthread -lGL -ldl -lX11 -lasound -ljack -lglfw \
+-		dep/lib/libGLEW.a dep/lib/libglfw3.a dep/lib/libjansson.a dep/lib/libcurl.a dep/lib/libssl.a dep/lib/libcrypto.a dep/lib/libzip.a dep/lib/libz.a dep/lib/libspeexdsp.a dep/lib/libsamplerate.a dep/lib/librtmidi.a dep/lib/librtaudio.a \
++		-lGLEW -lglfw -ljansson -lcurl -lssl -lcrypto -lzip -lz -lspeexdsp -lsamplerate -lrtmidi -lrtaudio \
+		-lpthread -lGL -ldl -lX11 -lasound -ljack \
  		$(shell pkg-config --libs gtk+-2.0)
  	TARGET := Rack
  endif


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

