### PR TITLE
haskellPackages.OpenAL: link with the OpenAL framework on Darwin

### DIFF
--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -100,7 +100,9 @@ self: super: builtins.intersectAttrs super {
   niv = enableSeparateBinOutput super.niv;
 
   # Ensure the necessary frameworks for Darwin.
-  OpenAL = addExtraLibrary super.OpenAL (pkgs.lib.optional pkgs.stdenv.isDarwin pkgs.darwin.apple_sdk.frameworks.OpenAL);
+  OpenAL = if pkgs.stdenv.isDarwin
+    then addExtraLibrary super.OpenAL pkgs.darwin.apple_sdk.frameworks.OpenAL
+    else super.OpenAL;
 
   ghcid = enableSeparateBinOutput super.ghcid;
 

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -100,10 +100,7 @@ self: super: builtins.intersectAttrs super {
   niv = enableSeparateBinOutput super.niv;
 
   # Ensure the necessary frameworks for Darwin.
-  OpenAL = overrideCabal super.OpenAL (drv: {
-    librarySystemDepends = drv.librarySystemDepends
-      ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [ pkgs.darwin.apple_sdk.frameworks.OpenAL ];
-  });
+  OpenAL = addExtraLibrary super.OpenAL ([] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [ pkgs.darwin.apple_sdk.frameworks.OpenAL ]);
 
   ghcid = enableSeparateBinOutput super.ghcid;
 

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -100,7 +100,7 @@ self: super: builtins.intersectAttrs super {
   niv = enableSeparateBinOutput super.niv;
 
   # Ensure the necessary frameworks for Darwin.
-  OpenAL = addExtraLibrary super.OpenAL ([] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [ pkgs.darwin.apple_sdk.frameworks.OpenAL ]);
+  OpenAL = addExtraLibrary super.OpenAL (pkgs.lib.optional pkgs.stdenv.isDarwin [ pkgs.darwin.apple_sdk.frameworks.OpenAL ]);
 
   ghcid = enableSeparateBinOutput super.ghcid;
 

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -99,6 +99,12 @@ self: super: builtins.intersectAttrs super {
 
   niv = enableSeparateBinOutput super.niv;
 
+  # Ensure the necessary frameworks for Darwin.
+  OpenAL = overrideCabal super.OpenAL (drv: {
+    librarySystemDepends = drv.librarySystemDepends
+      ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [ pkgs.darwin.apple_sdk.frameworks.OpenAL ];
+  });
+
   ghcid = enableSeparateBinOutput super.ghcid;
 
   hzk = overrideCabal super.hzk (drv: {

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -100,7 +100,7 @@ self: super: builtins.intersectAttrs super {
   niv = enableSeparateBinOutput super.niv;
 
   # Ensure the necessary frameworks for Darwin.
-  OpenAL = addExtraLibrary super.OpenAL (pkgs.lib.optional pkgs.stdenv.isDarwin [ pkgs.darwin.apple_sdk.frameworks.OpenAL ]);
+  OpenAL = addExtraLibrary super.OpenAL (pkgs.lib.optional pkgs.stdenv.isDarwin pkgs.darwin.apple_sdk.frameworks.OpenAL);
 
   ghcid = enableSeparateBinOutput super.ghcid;
 


### PR DESCRIPTION


###### Motivation for this change
The missing framework caused a build failure on Darwin. see #68306

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS (`nix-env -f./nixpkgs -iA haskellPackages.OpenAL`)
   - [X] other Linux distributions (`nix-env -f./nixpkgs -iA haskellPackages.OpenAL`)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
