### PR TITLE
linkFarmFromDrvs: Add a trivial builder to create a linkFarm from a list of derivations

### DIFF
--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -234,17 +234,48 @@ rec {
     '';
 
   /*
-  * Create a forest of symlinks to the files in `paths'.
-  *
-  * Examples:
-  * # adds symlinks of hello to current build.
-  * { symlinkJoin, hello }:
-  * symlinkJoin { name = "myhello"; paths = [ hello ]; }
-  *
-  * # adds symlinks of hello to current build and prints "links added"
-  * { symlinkJoin, hello }:
-  * symlinkJoin { name = "myhello"; paths = [ hello ]; postBuild = "echo links added"; }
-  */
+   * Create a forest of symlinks to the files in `paths'.
+   *
+   * This creates a single derivation that replicates the directory structure
+   * of all the input paths.
+   *
+   * Examples:
+   * # adds symlinks of hello to current build.
+   * symlinkJoin { name = "myhello"; paths = [ pkgs.hello ]; }
+   *
+   * # adds symlinks of hello and stack to current build and prints "links added"
+   * symlinkJoin { name = "myexample"; paths = [ pkgs.hello pkgs.stack ]; postBuild = "echo links added"; }
+   *
+   * This creates a derivation with a directory structure like the following:
+   *
+   * /nix/store/sglsr5g079a5235hy29da3mq3hv8sjmm-myexample
+   * |-- bin
+   * |   |-- hello -> /nix/store/qy93dp4a3rqyn2mz63fbxjg228hffwyw-hello-2.10/bin/hello
+   * |   `-- stack -> /nix/store/6lzdpxshx78281vy056lbk553ijsdr44-stack-2.1.3.1/bin/stack
+   * `-- share
+   *     |-- bash-completion
+   *     |   `-- completions
+   *     |       `-- stack -> /nix/store/6lzdpxshx78281vy056lbk553ijsdr44-stack-2.1.3.1/share/bash-completion/completions/stack
+   *     |-- fish
+   *     |   `-- vendor_completions.d
+   *     |       `-- stack.fish -> /nix/store/6lzdpxshx78281vy056lbk553ijsdr44-stack-2.1.3.1/share/fish/vendor_completions.d/stack.fish
+   * ...
+   *
+   * symlinkJoin and linkFarm are similar functions, but they output
+   * derivations with different structure.
+   *
+   * symlinkJoin is used to create a derivation with a familiar directory
+   * structure (top-level bin/, share/, etc), but with all actual files being symlinks to
+   * the files in the input derivations.
+   *
+   * symlinkJoin is used many places in nixpkgs to create a single derivation
+   * that appears to contain binaries, libraries, documentation, etc from
+   * multiple input derivations.
+   *
+   * linkFarm is instead used to create a simple derivation with symlinks to
+   * other derivations.  A derivation created with linkFarm is often used in CI
+   * as a easy way to build multiple derivations at once.
+   */
   symlinkJoin =
     args_@{ name
          , paths
@@ -264,6 +295,60 @@ rec {
         done
         ${postBuild}
       '';
+
+  /*
+   * Quickly create a set of symlinks to derivations.
+   *
+   * This creates a simple derivation with symlinks to all inputs.
+   *
+   * entries is a list of attribute sets like
+   * { name = "name" ; path = "/nix/store/..."; }
+   *
+   * Example:
+   *
+   * # Symlinks hello and stack paths in store to current $out/hello-test and
+   * # $out/foobar.
+   * linkFarm "myexample" [ { name = "hello-test"; path = pkgs.hello; } { name = "foobar"; path = pkgs.stack; } ]
+   *
+   * This creates a derivation with a directory structure like the following:
+   *
+   * /nix/store/qc5728m4sa344mbks99r3q05mymwm4rw-myexample
+   * |-- foobar -> /nix/store/6lzdpxshx78281vy056lbk553ijsdr44-stack-2.1.3.1
+   * `-- hello-test -> /nix/store/qy93dp4a3rqyn2mz63fbxjg228hffwyw-hello-2.10
+   *
+   * See the note on symlinkJoin for the difference between linkFarm and symlinkJoin.
+   */
+  linkFarm = name: entries: runCommand name { preferLocalBuild = true; allowSubstitutes = false; }
+    ''mkdir -p $out
+      cd $out
+      ${lib.concatMapStrings (x: ''
+          mkdir -p "$(dirname ${lib.escapeShellArg x.name})"
+          ln -s ${lib.escapeShellArg x.path} ${lib.escapeShellArg x.name}
+      '') entries}
+    '';
+
+  /*
+   * Easily create a linkFarm from a set of derivations.
+   *
+   * This calls linkFarm with a list of entries created from the list of input
+   * derivations.  It turns each input derivation into an attribute set
+   * like { name = drv.name ; path = drv }, and passes this to linkFarm.
+   *
+   * Example:
+   *
+   * # Symlinks the hello, gcc, and ghc derivations in $out
+   * linkFarmFromDrvs "myexample" [ pkgs.hello pkgs.gcc pkgs.ghc ]
+   *
+   * This creates a derivation with a directory structure like the following:
+   *
+   * /nix/store/m3s6wkjy9c3wy830201bqsb91nk2yj8c-myexample
+   * |-- gcc-wrapper-9.2.0 -> /nix/store/fqhjxf9ii4w4gqcsx59fyw2vvj91486a-gcc-wrapper-9.2.0
+   * |-- ghc-8.6.5 -> /nix/store/gnf3s07bglhbbk4y6m76sbh42siym0s6-ghc-8.6.5
+   * `-- hello-2.10 -> /nix/store/k0ll91c4npk4lg8lqhx00glg2m735g74-hello-2.10
+   */
+  linkFarmFromDrvs = name: drvs:
+    let mkEntryFromDrv = drv: { name = drv.name; path = drv; };
+    in linkFarm name (map mkEntryFromDrv drvs);
 
 
   /*
@@ -311,42 +396,6 @@ rec {
       done < graph
     '';
 
-
-  /*
-   * Quickly create a set of symlinks to derivations.
-   * entries is a list of attribute sets like
-   * { name = "name" ; path = "/nix/store/..."; }
-   *
-   * Example:
-   *
-   * # Symlinks hello path in store to current $out/hello
-   * linkFarm "hello" [ { name = "hello"; path = pkgs.hello; } ];
-   *
-   */
-  linkFarm = name: entries: runCommand name { preferLocalBuild = true; allowSubstitutes = false; }
-    ''mkdir -p $out
-      cd $out
-      ${lib.concatMapStrings (x: ''
-          mkdir -p "$(dirname ${lib.escapeShellArg x.name})"
-          ln -s ${lib.escapeShellArg x.path} ${lib.escapeShellArg x.name}
-      '') entries}
-    '';
-
-  /*
-   * Easily create a linkFarm from a set of derivations.
-   *
-   * This calls linkFarm with a list of entries created from the list of input
-   * derivations.  It turns each input derivation into an attribute set
-   * like { name = drv.name ; path = drv }, and passes this to linkFarm.
-   *
-   * Example:
-   *
-   * # Symlinks the hello, gcc, and ghc derivations in $out
-   * linkFarmFromDrvs "example" [ pkgs.hello pkgs.gcc pkgs.ghc ]
-   */
-  linkFarmFromDrvs = name: drvs:
-    let mkEntryFromDrv = drv: { name = drv.name; path = drv; };
-    in linkFarm name (map mkEntryFromDrv drvs);
 
   /* Print an error message if the file with the specified name and
    * hash doesn't exist in the Nix store. This function should only

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -332,6 +332,21 @@ rec {
       '') entries}
     '';
 
+  /*
+   * Easily create a linkFarm from a set of derivations.
+   *
+   * This calls linkFarm with a list of entries created from the list of input
+   * derivations.  It turns each input derivation into an attribute set
+   * like { name = drv.name ; path = drv }, and passes this to linkFarm.
+   *
+   * Example:
+   *
+   * # Symlinks the hello, gcc, and ghc derivations in $out
+   * linkFarmFromDrvs "example" [ pkgs.hello pkgs.gcc pkgs.ghc ]
+   */
+  linkFarmFromDrvs = name: drvs:
+    let mkEntryFromDrv = drv: { name = drv.name; path = drv; };
+    in linkFarm name (map mkEntryFromDrv drvs);
 
   /* Print an error message if the file with the specified name and
    * hash doesn't exist in the Nix store. This function should only


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This PR adds a trivial builder called `linkFarmFromDrvs`.  It is similar to `linkFarm`, but it is a easier to use if you just want directory with a bunch of links to derivations, but you're fine with links just being the name of the derivation.

We use this in a couple places in our nix code-base at work, and we thought it could be helpful to other nix users.

Here's an example of using it:

```console
$ nix-build -E 'with (import ./. {}); linkFarmFromDrvs "example" [ pkgs.hello pkgs.gcc pkgs.xterm ]'
...
/nix/store/hsi98apxc80l8r3lpi13hzc3lk8i8623-example
$ ls -l result/
lrwxrwxrwx 1 root root 61 Jan  1  1970 gcc-wrapper-8.3.0 -> /nix/store/7hzmz83nv8khpwsk858yaac7y3idh0a7-gcc-wrapper-8.3.0
lrwxrwxrwx 1 root root 54 Jan  1  1970 hello-2.10 -> /nix/store/rr3y0c6zyk7kjjl8y19s4lsrhn4aiq1z-hello-2.10
lrwxrwxrwx 1 root root 53 Jan  1  1970 xterm-348 -> /nix/store/y0cz7w39v4sb743mix5qps3kc2ra9b72-xterm-348
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
