### PR TITLE
Add lib.kernel

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -52,6 +52,9 @@ let
     # back-compat aliases
     platforms = systems.doubles;
 
+    # linux kernel configuration
+    kernel = callLibs ./kernel.nix;
+
     inherit (builtins) add addErrorContext attrNames concatLists
       deepSeq elem elemAt filter genericClosure genList getAttr
       hasAttr head isAttrs isBool isInt isList isString length

--- a/lib/kernel.nix
+++ b/lib/kernel.nix
@@ -1,12 +1,7 @@
-{ lib, version }:
+{ lib }:
 
 with lib;
 {
-  # Common patterns/legacy
-  whenAtLeast = ver: mkIf (versionAtLeast version ver);
-  whenOlder   = ver: mkIf (versionOlder version ver);
-  # range is (inclusive, exclusive)
-  whenBetween = verLow: verHigh: mkIf (versionAtLeast version verLow && versionOlder version verHigh);
 
 
   # Keeping these around in case we decide to change this horrible implementation :)

--- a/lib/kernel.nix
+++ b/lib/kernel.nix
@@ -13,4 +13,14 @@ with lib;
   module   = { tristate    = "m"; };
   freeform = x: { freeform = x; };
 
+  /*
+    Common patterns/legacy used in common-config/hardened-config.nix
+   */
+  whenHelpers = version: {
+    whenAtLeast = ver: mkIf (versionAtLeast version ver);
+    whenOlder   = ver: mkIf (versionOlder version ver);
+    # range is (inclusive, exclusive)
+    whenBetween = verLow: verHigh: mkIf (versionAtLeast version verLow && versionOlder version verHigh);
+  };
+
 }

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -17,13 +17,9 @@
 
 with stdenv.lib;
 with stdenv.lib.kernel;
+with (stdenv.lib.kernel.whenHelpers version);
 
 let
-  # Common patterns/legacy
-  whenAtLeast = ver: mkIf (versionAtLeast version ver);
-  whenOlder   = ver: mkIf (versionOlder version ver);
-  # range is (inclusive, exclusive)
-  whenBetween = verLow: verHigh: mkIf (versionAtLeast version verLow && versionOlder version verHigh);
 
 
   # configuration items have to be part of a subattrs

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -16,10 +16,15 @@
 }:
 
 with stdenv.lib;
-
-  with import ../../../../lib/kernel.nix { inherit (stdenv) lib; inherit version; };
+with stdenv.lib.kernel;
 
 let
+  # Common patterns/legacy
+  whenAtLeast = ver: mkIf (versionAtLeast version ver);
+  whenOlder   = ver: mkIf (versionOlder version ver);
+  # range is (inclusive, exclusive)
+  whenBetween = verLow: verHigh: mkIf (versionAtLeast version verLow && versionOlder version verHigh);
+
 
   # configuration items have to be part of a subattrs
   flattenKConf =  nested: mapAttrs (_: head) (zipAttrs (attrValues nested));

--- a/pkgs/os-specific/linux/kernel/hardened-config.nix
+++ b/pkgs/os-specific/linux/kernel/hardened-config.nix
@@ -11,8 +11,7 @@
 { stdenv, version }:
 
 with stdenv.lib;
-with import ../../../../lib/kernel.nix { inherit (stdenv) lib; inherit version; };
-
+with stdenv.lib.kernel;
 assert (versionAtLeast version "4.9");
 
 optionalAttrs (stdenv.hostPlatform.platform.kernelArch == "x86_64") {

--- a/pkgs/os-specific/linux/kernel/hardened-config.nix
+++ b/pkgs/os-specific/linux/kernel/hardened-config.nix
@@ -12,6 +12,8 @@
 
 with stdenv.lib;
 with stdenv.lib.kernel;
+with (stdenv.lib.kernel.whenHelpers version);
+
 assert (versionAtLeast version "4.9");
 
 optionalAttrs (stdenv.hostPlatform.platform.kernelArch == "x86_64") {

--- a/pkgs/os-specific/linux/kernel/mptcp-config.nix
+++ b/pkgs/os-specific/linux/kernel/mptcp-config.nix
@@ -1,5 +1,5 @@
 { stdenv }:
-with import ../../../../lib/kernel.nix { inherit (stdenv) lib; version = null; };
+with stdenv.lib.kernel;
 {
     # DRM_AMDGPU = yes;
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
I would like to improve the kernel configuration system, https://github.com/NixOS/nixpkgs/pull/69013 looks blocked so I extracted what I believed is less controversial here.
I would like afterwards to get rid  of the string format
```
extraConfig=''
OPENVSWITCH ?y
''
```
in favor of the more powerful `structuredExtraConfig` that is not documented (and thus not used) because it is presently too hard to use:
- you either have to import lib/kernel.nix yourself
- or understand or how the `kernelItem` submodule

Merging this will help move forward with https://github.com/NixOS/nixpkgs/issues/69014

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
