### PR TITLE
qtbase: Disable QAppleTestLogger on Darwin

### DIFF
--- a/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0002-qtbase-mac.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0002-qtbase-mac.patch
@@ -1,11 +1,16 @@
-From e32f2e184bf2adce216351b2a1e7390e8d9c31b9 Mon Sep 17 00:00:00 2001
+From 203c9338dc92c2c36007cfe6633387348976637e Mon Sep 17 00:00:00 2001
 From: Thomas Tuegel <ttuegel@mailbox.org>
 Date: Tue, 17 Sep 2019 05:37:15 -0500
 Subject: [PATCH 02/11] qtbase-mac
 
 ---
  src/corelib/kernel/qcore_mac_p.h | 16 ++++++++++++++--
- 1 file changed, 14 insertions(+), 2 deletions(-)
+ src/testlib/qappletestlogger.cpp |  2 +-
+ src/testlib/qappletestlogger_p.h |  2 +-
+ src/testlib/qtestcase.cpp        |  2 +-
+ src/testlib/qtestlog.cpp         |  2 +-
+ src/testlib/qtestlog_p.h         |  2 +-
+ 6 files changed, 19 insertions(+), 7 deletions(-)
 
 diff --git a/src/corelib/kernel/qcore_mac_p.h b/src/corelib/kernel/qcore_mac_p.h
 index f96e7358..650946b7 100644
@@ -41,6 +46,71 @@ index f96e7358..650946b7 100644
  
  // -------------------------------------------------------------------------
  
+diff --git a/src/testlib/qappletestlogger.cpp b/src/testlib/qappletestlogger.cpp
+index dfeadebd..2a74330c 100644
+--- a/src/testlib/qappletestlogger.cpp
++++ b/src/testlib/qappletestlogger.cpp
+@@ -43,7 +43,7 @@
+ 
+ QT_BEGIN_NAMESPACE
+ 
+-#if defined(QT_USE_APPLE_UNIFIED_LOGGING)
++#if defined(QT_USE_APPLE_UNIFIED_LOGGING) && 0
+ 
+ using namespace QTestPrivate;
+ 
+diff --git a/src/testlib/qappletestlogger_p.h b/src/testlib/qappletestlogger_p.h
+index 62c6d95c..f8e0a3b7 100644
+--- a/src/testlib/qappletestlogger_p.h
++++ b/src/testlib/qappletestlogger_p.h
+@@ -57,7 +57,7 @@
+ 
+ QT_BEGIN_NAMESPACE
+ 
+-#if defined(QT_USE_APPLE_UNIFIED_LOGGING)
++#if defined(QT_USE_APPLE_UNIFIED_LOGGING) && 0
+ class QAppleTestLogger : public QAbstractTestLogger
+ {
+ public:
+diff --git a/src/testlib/qtestcase.cpp b/src/testlib/qtestcase.cpp
+index 0c935a1f..22f2d75d 100644
+--- a/src/testlib/qtestcase.cpp
++++ b/src/testlib/qtestcase.cpp
+@@ -850,7 +850,7 @@ Q_TESTLIB_EXPORT void qtest_qParseArgs(int argc, char *argv[], bool qml)
+ 
+     bool addFallbackLogger = !explicitLoggerRequested;
+ 
+-#if defined(QT_USE_APPLE_UNIFIED_LOGGING)
++#if defined(QT_USE_APPLE_UNIFIED_LOGGING) && 0
+     // Any explicitly requested loggers will be added by now, so we can check if they use stdout
+     const bool safeToAddAppleLogger = !AppleUnifiedLogger::willMirrorToStderr() || !QTestLog::loggerUsingStdout();
+     if (safeToAddAppleLogger && QAppleTestLogger::debugLoggingEnabled()) {
+diff --git a/src/testlib/qtestlog.cpp b/src/testlib/qtestlog.cpp
+index 57bb7d95..33fb8162 100644
+--- a/src/testlib/qtestlog.cpp
++++ b/src/testlib/qtestlog.cpp
+@@ -460,7 +460,7 @@ void QTestLog::addLogger(LogMode mode, const char *filename)
+     case QTestLog::TAP:
+         logger = new QTapTestLogger(filename);
+         break;
+-#if defined(QT_USE_APPLE_UNIFIED_LOGGING)
++#if defined(QT_USE_APPLE_UNIFIED_LOGGING) && 0
+     case QTestLog::Apple:
+         logger = new QAppleTestLogger;
+         break;
+diff --git a/src/testlib/qtestlog_p.h b/src/testlib/qtestlog_p.h
+index e63e89a7..213b6945 100644
+--- a/src/testlib/qtestlog_p.h
++++ b/src/testlib/qtestlog_p.h
+@@ -68,7 +68,7 @@ class Q_TESTLIB_EXPORT QTestLog
+ public:
+     enum LogMode {
+         Plain = 0, XML, LightXML, XunitXML, CSV, TeamCity, TAP
+-#if defined(QT_USE_APPLE_UNIFIED_LOGGING)
++#if defined(QT_USE_APPLE_UNIFIED_LOGGING) && 0
+         , Apple
+ #endif
+ #if defined(HAVE_XCTEST)
 -- 
-2.22.1
+2.23.0
 


### PR DESCRIPTION

###### Motivation for this change

This pull request regenerates the patches for `qtbase` on macOS including disabling `QAppleTestLogger`, which causes build failures. The build on Linux should not be affected.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
