### PR TITLE
Revert "nixos/desktop-managers/xterm: Disable by default"

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1909.xml
+++ b/nixos/doc/manual/release-notes/rl-1909.xml
@@ -448,13 +448,6 @@
      </para>
    </listitem>
    <listitem>
-     <para>
-       <option>services.xserver.desktopManager.xterm</option> is now disabled by default if <literal>stateVersion</literal> is 19.09 or higher.
-       Previously the xterm desktopManager was enabled when xserver was enabled, but it isn't useful for all people so it didn't make sense to
-       have any desktopManager enabled default.
-     </para>
-   </listitem>
-   <listitem>
     <para>
      The WeeChat plugin <literal>pkgs.weechatScripts.weechat-xmpp</literal> has been removed as it doesn't receive
      any updates from upstream and depends on outdated Python2-based modules.

--- a/nixos/modules/services/x11/desktop-managers/xterm.nix
+++ b/nixos/modules/services/x11/desktop-managers/xterm.nix
@@ -5,7 +5,7 @@ with lib;
 let
 
   cfg = config.services.xserver.desktopManager.xterm;
-  xSessionEnabled = config.services.xserver.enable;
+  xserverEnabled = config.services.xserver.enable;
 
 in
 
@@ -14,8 +14,8 @@ in
 
     services.xserver.desktopManager.xterm.enable = mkOption {
       type = types.bool;
-      default = (versionOlder config.system.stateVersion "19.09") && xSessionEnabled;
-      defaultText = if versionOlder config.system.stateVersion "19.09" then "config.services.xserver.enable" else "false";
+      default = xserverEnabled;
+      defaultText = "config.services.xserver.enable";
       description = "Enable a xterm terminal as a desktop manager.";
     };
 


### PR DESCRIPTION
This reverts commit f140dfb161804871048c00f2c51485dd55b50efa.
This reverts commit cf56cefd95eb6f0ead3856ed69299b8ae7153712.
This reverts commit 456c42c3e8787d83d577526af90263de9b3d512d.

This has caused more issues than originally intended. It looks like many configurations rely on xterm being set to work correctly. This includes when you are starting a WM without going through a DE. We shouldn't break these setups (if stateVersion is unset). To make matters worse, most users don't actually know they are relying on xterm. LightDM seems to be the main one effected for now:

- #68360
- #70142

I expect more issues to come up as users of 19.03 upgrade to 19.09.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
