### PR TITLE
[19.09] transifex-client: Add missing setuptools dependency

### DIFF
--- a/pkgs/tools/text/transifex-client/default.nix
+++ b/pkgs/tools/text/transifex-client/default.nix
@@ -1,12 +1,12 @@
 { stdenv, buildPythonApplication, fetchPypi
-, python-slugify, requests, urllib3, six }:
+, python-slugify, requests, urllib3, six, setuptools }:
 
 buildPythonApplication rec {
   pname = "transifex-client";
   version = "0.13.6";
 
   propagatedBuildInputs = [
-    urllib3 requests python-slugify six
+    urllib3 requests python-slugify six setuptools
   ];
 
   src = fetchPypi {
@@ -24,7 +24,7 @@ buildPythonApplication rec {
   doCheck = false;
 
   meta = with stdenv.lib; {
-    homepage = https://www.transifex.com/;
+    homepage = "https://www.transifex.com/";
     license = licenses.gpl2;
     description = "Transifex translation service client";
     maintainers = [ maintainers.etu ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
(cherry picked from commit d1a8006b89bdfb511450316e5088a179a8e69d78)

Follow up from #70170.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
