### PR TITLE
catfish: 1.4.7 -> 1.4.10

### DIFF
--- a/pkgs/applications/search/catfish/default.nix
+++ b/pkgs/applications/search/catfish/default.nix
@@ -5,13 +5,13 @@
 
 pythonPackages.buildPythonApplication rec {
   majorver = "1.4";
-  minorver = "7";
+  minorver = "10";
   version = "${majorver}.${minorver}";
   pname = "catfish";
 
   src = fetchurl {
     url = "https://archive.xfce.org/src/apps/${pname}/${majorver}/${pname}-${version}.tar.bz2";
-    sha256 = "1s97jb1r07ff40jnz8zianpn1f0c67hssn8ywdi2g7njfb4amjj8";
+    sha256 = "0g9l5sv5d7wmyb23cvpz5mpvjnxiqjh25v9gr5qzhcah202a0wr5";
   };
 
   nativeBuildInputs = [
@@ -19,7 +19,7 @@ pythonPackages.buildPythonApplication rec {
     file
     which
     intltool
-    gobject-introspection
+    gobject-introspection # for setup hook populating GI_TYPELIB_PATH
     wrapGAppsHook
   ];
 
@@ -30,9 +30,11 @@ pythonPackages.buildPythonApplication rec {
     pythonPackages.ptyprocess
     pythonPackages.pycairo
     hicolor-icon-theme
+    gobject-introspection # Temporary fix, see https://github.com/NixOS/nixpkgs/issues/56943
   ];
 
   propagatedBuildInputs = [
+    pythonPackages.dbus-python
     pythonPackages.pygobject3
     pythonPackages.pexpect
     xdg_utils
@@ -53,7 +55,7 @@ pythonPackages.buildPythonApplication rec {
 
   meta = with stdenv.lib; {
     homepage = https://docs.xfce.org/apps/catfish/start;
-    description = "A handy file search tool";
+    description = "Handy file search tool";
     longDescription = ''
       Catfish is a handy file searching tool. The interface is
       intentionally lightweight and simple, using only GTK 3.


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

- Update to version [1.4.10](https://bluesabre.org/2019/09/13/catfish-1-4-10-released/)
- Add a new dependence on python-dbus

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).