### PR TITLE
qremotecontrol-server: init at 2.4.1

### DIFF
--- a/pkgs/servers/misc/qremotecontrol-server/default.nix
+++ b/pkgs/servers/misc/qremotecontrol-server/default.nix
@@ -1,0 +1,46 @@
+{ stdenv
+, fetchurl
+, qmake4Hook
+, qt4
+, xorg
+}:
+
+stdenv.mkDerivation rec {
+  pname = "qremotecontrol-server";
+  version = "2.4.1";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/project/qrc/${version}/qremotecontrol-${version}.tar.bz2";
+    sha256 = "07hzc9959a56b49jgmcv8ry8b9sppklvqs9kns3qjj3v9d22nbrp";
+  };
+
+  nativeBuildInputs = [ qmake4Hook ];
+  buildInputs = [ qt4 xorg.libXtst ];
+
+  postPatch = ''
+    substituteInPlace QRemoteControl-Server.pro \
+      --replace /usr $out
+  '';
+
+  meta = with stdenv.lib; {
+    license = licenses.gpl3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ fgaz ];
+    homepage = "https://qremote.org/";
+    downloadPage = "https://qremote.org/download.php#Download";
+    description = "Remote control your desktop from your mobile";
+    longDescription = ''
+      With QRemoteControl installed on your desktop you can easily control
+      your computer via WiFi from your mobile. By using the touch pad of your
+      Phone you can for example open the internet browser and navigate to
+      the pages you want to visit, use the music player or your media center
+      without being next to your PC or laptop. Summarizing QRemoteControl
+      allows you to do almost everything you would be able to do with a
+      mouse and a keyboard, but from a greater distance. To make these
+      replacements possible QRemoteControl offers you a touch pad, a
+      keyboard, multimedia keys and buttons for starting applications. Even
+      powering on the computer via Wake On Lan is supported.
+    '';
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15126,6 +15126,8 @@ in
     inherit (pythonPackages) buildPythonPackage qpid-python;
   };
 
+  qremotecontrol-server = callPackage ../servers/misc/qremotecontrol-server { };
+
   quagga = callPackage ../servers/quagga { };
 
   rabbitmq-server = callPackage ../servers/amqp/rabbitmq-server {
@@ -15477,11 +15479,11 @@ in
   bridge-utils = callPackage ../os-specific/linux/bridge-utils { };
 
   busybox = callPackage ../os-specific/linux/busybox { };
-  busybox-sandbox-shell = callPackage ../os-specific/linux/busybox/sandbox-shell.nix { 
+  busybox-sandbox-shell = callPackage ../os-specific/linux/busybox/sandbox-shell.nix {
     # musl roadmap has RISC-V support projected for 1.1.20
     busybox = if !stdenv.hostPlatform.isRiscV && stdenv.hostPlatform.libc != "bionic"
               then pkgsStatic.busybox
-              else busybox; 
+              else busybox;
   };
 
   cachefilesd = callPackage ../os-specific/linux/cachefilesd { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
