### PR TITLE
riot-{web,desktop}: 1.4.0 -> 1.4.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/riot/riot-desktop-package.json
+++ b/pkgs/applications/networking/instant-messengers/riot/riot-desktop-package.json
@@ -2,7 +2,7 @@
   "name": "riot-web",
   "productName": "Riot",
   "main": "src/electron-main.js",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "A feature-rich client for Matrix.org",
   "author": "New Vector Ltd.",
   "dependencies": {

--- a/pkgs/applications/networking/instant-messengers/riot/riot-desktop.nix
+++ b/pkgs/applications/networking/instant-messengers/riot/riot-desktop.nix
@@ -6,12 +6,12 @@
 
 let
   executableName = "riot-desktop";
-  version = "1.4.0";
+  version = "1.4.1";
   riot-web-src = fetchFromGitHub {
     owner = "vector-im";
     repo = "riot-web";
     rev = "v${version}";
-    sha256 = "1p8bl7v2214shywn53fpcb27vvvdjrs3kcys3f045v2l5fg5xhsa";
+    sha256 = "0w4w39smak6hp65vam5rrz6l48rb4yzszzyn1yjhr1m8w8j9bvfl";
   };
 
 in yarn2nix-moretea.mkYarnPackage rec {

--- a/pkgs/applications/networking/instant-messengers/riot/riot-web.nix
+++ b/pkgs/applications/networking/instant-messengers/riot/riot-web.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   pname = "riot-web";
-  version = "1.4.0";
+  version = "1.4.1";
 
   src = fetchurl {
     url = "https://github.com/vector-im/riot-web/releases/download/v${version}/riot-v${version}.tar.gz";
-    sha256 = "1si11hxkfn6sqaq1hddm5vkfrd0pghzwqld1wv4vxlb5jyn32qqk";
+    sha256 = "16lgxyqxs6vpjcfdr4j7gnn7h8gyi6b5520b8nq8hxynh24iyhcq";
   };
 
   installPhase = let


### PR DESCRIPTION
###### Motivation for this change

This PR updates Riot to the latest version.

They're making new releases annoyingly fast.
Is there a way to automate updates for this package through the package update bot?


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`): _could start the electron app and chat_
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @worldofpeace @bachp 
