### PR TITLE
pgmodeler: init at 0.9.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2045,6 +2045,12 @@
     github = "ertes";
     name = "Ertugrul Söylemez";
   };
+  esclear = {
+    email = "esclear@users.noreply.github.com";
+    github = "esclear";
+    githubId = 7432848;
+    name = "Daniel Albert";
+  };
   Esteth = {
     email = "adam.copp@gmail.com";
     name = "Adam Copp";

--- a/pkgs/applications/misc/pgmodeler/default.nix
+++ b/pkgs/applications/misc/pgmodeler/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, lib, fetchFromGitHub, pkgconfig, qmake, mkDerivation,
+  qtsvg,
+  libxml2, postgresql }:
+
+mkDerivation rec {
+  pname = "pgmodeler";
+  version = "0.9.1";
+
+  src = fetchFromGitHub {
+    owner = "pgmodeler";
+    repo = "pgmodeler";
+    rev = "v${version}";
+    sha256 = "15isnbli9jj327r6sj7498nmhgf1mzdyhc1ih120ibw4900aajiv";
+  };
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [ pkgconfig qmake ];
+  qmakeFlags = [ "pgmodeler.pro" "CONFIG+=release" ];
+
+  # todo: libpq would suffice here. Unfortunately this won't work, if one uses only postgresql.lib here.
+  buildInputs = [ postgresql qtsvg ];
+
+  meta = with stdenv.lib; {
+    description = "A database modeling tool for PostgreSQL";
+    longDescription = ''pgModeler (PostgreSQL Database Modeler) is an open source database modeling tool designed for PostgreSQL.'';
+    homepage = https://pgmodeler.io/;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.esclear ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24297,6 +24297,8 @@ in
     openssl = openssl_1_0_2;
   };
 
+  pgmodeler = libsForQt5.callPackage ../applications/misc/pgmodeler { };
+
   pgf = pgf2;
 
   # Keep the old PGF since some documents don't render properly with


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
[pgModeler](https://pgmodeler.io/) (PostgreSQL Database Modeler) is an open source database modeling tool designed for PostgreSQL.
It is not packaged for NixOS yet, so I did that.

I'm a bit unsure about whether the complete postgresql package is needed as a dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
  (No dependencies)
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  (+ 563.73 MB)
- [x] Ensured that relevant documentation is up to date
  (No relevant documentation)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers
That'd be me :)
