### PR TITLE
qubes-core-vchan-xen: init at 4.1.2

### DIFF
--- a/pkgs/applications/qubes/qubes-core-vchan-xen/default.nix
+++ b/pkgs/applications/qubes/qubes-core-vchan-xen/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, xen_4_10 }:
+
+stdenv.mkDerivation rec {
+  pname = "qubes-core-vchan-xen";
+  version = "4.1.2";
+
+  src = fetchFromGitHub {
+    owner = "QubesOS";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1wj4vv8nkzzig52r2nzkd4jy0cwznfkyddx379hfsdl4pzsp55mj";
+  };
+
+  buildInputs = [ xen_4_10 ];
+  buildPhase = ''
+    make all PREFIX=/
+  '';
+  installPhase = ''
+    make install DESTDIR=$out PREFIX=/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Libraries required for the higher-level Qubes daemons and tools";
+    homepage = "https://qubes-os.org";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ "0x4A6F" ];
+    platforms = platforms.linux;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24985,4 +24985,6 @@ in
 
   wifi-password = callPackage ../os-specific/darwin/wifi-password {};
 
+  qubes-core-vchan-xen = callPackage ../applications/qubes/qubes-core-vchan-xen {};
+
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Adding core QubesOS services for better integration.

During CCCamp19 we (@erictapen, +others) sat down with @marmarek and talked about NixOS Integration in QubesOS.

This package is a dependency for qubes-core-qrexec.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @