### PR TITLE
kafka: Remove old versions

### DIFF
--- a/nixos/tests/kafka.nix
+++ b/nixos/tests/kafka.nix
@@ -80,12 +80,8 @@ let
   }) {});
 
 in with pkgs; {
-  kafka_0_9  = makeKafkaTest "kafka_0_9"  apacheKafka_0_9;
-  kafka_0_10 = makeKafkaTest "kafka_0_10" apacheKafka_0_10;
   kafka_0_11 = makeKafkaTest "kafka_0_11" apacheKafka_0_11;
-  kafka_1_0  = makeKafkaTest "kafka_1_0"  apacheKafka_1_0;
   kafka_1_1  = makeKafkaTest "kafka_1_1"  apacheKafka_1_1;
-  kafka_2_0  = makeKafkaTest "kafka_2_0"  apacheKafka_2_0;
   kafka_2_1  = makeKafkaTest "kafka_2_1"  apacheKafka_2_1;
   kafka_2_2  = makeKafkaTest "kafka_2_2"  apacheKafka_2_2;
   kafka_2_3  = makeKafkaTest "kafka_2_3"  apacheKafka_2_3;

--- a/pkgs/servers/apache-kafka/default.nix
+++ b/pkgs/servers/apache-kafka/default.nix
@@ -1,37 +1,17 @@
 { stdenv, fetchurl, jre, makeWrapper, bash, coreutils, gnugrep, gnused, ps,
-  majorVersion ? "1.0" }:
+  majorVersion ? "2.2" }:
 
 let
   versionMap = {
-    "0.9" = {
-      kafkaVersion = "0.9.0.1";
-      scalaVersion = "2.11";
-      sha256 = "0ykcjv5dz9i5bws9my2d60pww1g9v2p2nqr67h0i2xrjm7az8a6v";
-    };
-    "0.10" = {
-      kafkaVersion = "0.10.2.2";
-      scalaVersion = "2.12";
-      sha256 = "13wibnz7n7znv2g13jlpkz1r0y73qy5b02pdqhsq7cl72h9s6wms";
-    };
     "0.11" = {
       kafkaVersion = "0.11.0.3";
       scalaVersion = "2.12";
       sha256 = "0zkzp9a8lcfcpavks131119v10hpn90sc0pw4f90jc4zn2yw3rgd";
     };
-    "1.0" = {
-      kafkaVersion = "1.0.2";
-      scalaVersion = "2.12";
-      sha256 = "0cmq8ww1lbkp3ipy9d1q8c1yz4kfwj0v4ynnhsk1i48sqlmvwybj";
-    };
     "1.1" = {
       kafkaVersion = "1.1.1";
       scalaVersion = "2.12";
       sha256 = "13vg0wm2fsd06pfw05m4bhcgbjmb2bmd4i31zfs48w0f7hjc8qf2";
-    };
-    "2.0" = {
-      kafkaVersion = "2.0.1";
-      scalaVersion = "2.12";
-      sha256 = "0i62q3542cznf711kiskaa30l06gq9ckszlxja4k1vs1flxz5khl";
     };
     "2.1" = {
       kafkaVersion = "2.1.1";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9671,12 +9671,8 @@ in
   ant = apacheAnt;
 
   apacheKafka = apacheKafka_2_4;
-  apacheKafka_0_9 = callPackage ../servers/apache-kafka { majorVersion = "0.9"; };
-  apacheKafka_0_10 = callPackage ../servers/apache-kafka { majorVersion = "0.10"; };
   apacheKafka_0_11 = callPackage ../servers/apache-kafka { majorVersion = "0.11"; };
-  apacheKafka_1_0 = callPackage ../servers/apache-kafka { majorVersion = "1.0"; };
   apacheKafka_1_1 = callPackage ../servers/apache-kafka { majorVersion = "1.1"; };
-  apacheKafka_2_0 = callPackage ../servers/apache-kafka { majorVersion = "2.0"; };
   apacheKafka_2_1 = callPackage ../servers/apache-kafka { majorVersion = "2.1"; };
   apacheKafka_2_2 = callPackage ../servers/apache-kafka { majorVersion = "2.2"; };
   apacheKafka_2_3 = callPackage ../servers/apache-kafka { majorVersion = "2.3"; };


### PR DESCRIPTION
Keeping latest two + latest 0.x and latest 1.x

Removed 0.9, 0.10, 1.0, 2.0

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

