### PR TITLE
doc : improved and cleanup of submitting-changes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,3 @@
 - [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
 - [ ] Ensured that relevant documentation is up to date
 - [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
-
-###### Notify maintainers
-
-cc @

--- a/doc/contributing/submitting-changes.xml
+++ b/doc/contributing/submitting-changes.xml
@@ -13,7 +13,7 @@
    </listitem>
    <listitem>
     <para>
-     Fork the repository on GitHub.
+     Fork <link xlink:href="https://github.com/nixos/nixpkgs/">the Nixpkgs repository</link> on GitHub.
     </para>
    </listitem>
    <listitem>
@@ -22,15 +22,10 @@
      <itemizedlist>
       <listitem>
        <para>
-        You can make branch from a commit of your local <command>nixos-version</command>. That will help you to avoid additional local compilations. Because you will receive packages from binary cache.
-        <itemizedlist>
-         <listitem>
-          <para>
-           For example: <command>nixos-version</command> returns <command>15.05.git.0998212 (Dingo)</command>. So you can do:
-          </para>
-         </listitem>
-        </itemizedlist>
+        You can make branch from a commit of your local <command>nixos-version</command>. That will help you to avoid additional local compilations. Because you will receive packages from binary cache. For example
 <screen>
+<prompt>$ </prompt>nixos-version --hash
+0998212
 <prompt>$ </prompt>git checkout 0998212
 <prompt>$ </prompt>git checkout -b 'fix/pkg-name-update'
 </screen>
@@ -47,13 +42,11 @@
    <listitem>
     <para>
      Make commits of logical units.
-     <itemizedlist>
-      <listitem>
-       <para>
-        If you removed pkgs, made some major NixOS changes etc., write about them in <command>nixos/doc/manual/release-notes/rl-unstable.xml</command>.
-       </para>
-      </listitem>
-     </itemizedlist>
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     If you removed pkgs or made some major NixOS changes, write about it in the release notes for the next stable release. For example <command>nixos/doc/manual/release-notes/rl-2003.xml</command>.
     </para>
    </listitem>
    <listitem>
@@ -178,7 +171,7 @@ Additional information.
    </listitem>
    <listitem>
     <para>
-     Rebase you branch against current <command>master</command>.
+     <link xlink:href="https://git-scm.com/book/en/v2/Git-Branching-Rebasing">Rebase</link> your branch against current <command>master</command>.
     </para>
    </listitem>
   </itemizedlist>
@@ -194,36 +187,12 @@ Additional information.
    </listitem>
    <listitem>
     <para>
-     Create pull request:
-     <itemizedlist>
-      <listitem>
-       <para>
-        Write the title in format <command>(pkg-name | nixos/&lt;module>): improvement</command>.
-        <itemizedlist>
-         <listitem>
-          <para>
-           If you update the pkg, write versions <command>from -> to</command>.
-          </para>
-         </listitem>
-        </itemizedlist>
-       </para>
-      </listitem>
-      <listitem>
-       <para>
-        Write in comment if you have tested your patch. Do not rely much on <command>TravisCI</command>.
-       </para>
-      </listitem>
-      <listitem>
-       <para>
-        If you make an improvement, write about your motivation.
-       </para>
-      </listitem>
-      <listitem>
-       <para>
-        Notify maintainers of the package. For example add to the message: <command>cc @jagajaga @domenkozar</command>.
-       </para>
-      </listitem>
-     </itemizedlist>
+     Create the pull request
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Follow <link xlink:href="https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md#submitting-changes">the contribution guidelines</link>.
     </para>
    </listitem>
   </itemizedlist>


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Some documentation refactoring

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

I don't know 

cc @
