### PR TITLE
gitAndTools.git-extras: 4.7.0 -> 5.0.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-extras/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-extras/default.nix
@@ -1,19 +1,26 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchzip, unixtools, which }:
 
 stdenv.mkDerivation rec {
   pname = "git-extras";
-  version = "4.7.0";
+  version = "5.0.0";
 
-  src = fetchurl {
+  src = fetchzip {
     url = "https://github.com/tj/git-extras/archive/${version}.tar.gz";
-    sha256 = "0pab4f5kmmcn333aswkgndf1fgilc41h8h0rk3lviz0yi8j59vaq";
+    sha256 = "0c839kc5mhi1iqhc696p4dj67i5hm2gi4d8cvdpskaapb124mj2f";
   };
+
+  nativeBuildInputs = [ unixtools.column which ];
 
   dontBuild = true;
 
-  installFlags = [ "DESTDIR=${placeholder "out"}" "PREFIX=" ];
+  preInstall = ''
+    patchShebangs .
+  '';
+
+  installFlags = [ "PREFIX=${placeholder "out"}" ];
 
   postInstall = ''
+    # bash completion is already handled by make install
     install -D etc/git-extras-completion.zsh $out/share/zsh/site-functions/_git_extras
   '';
 


### PR DESCRIPTION
###### Motivation for this change 
Update to latest version

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
