### PR TITLE
pythonPackages.cufflinks: 0.15 -> 0.16

### DIFF
--- a/pkgs/development/python-modules/chart-studio/default.nix
+++ b/pkgs/development/python-modules/chart-studio/default.nix
@@ -1,0 +1,44 @@
+{ lib, buildPythonPackage, fetchFromGitHub
+, mock
+, nose
+, plotly
+, pytest
+, requests
+, retrying
+, six
+}:
+
+buildPythonPackage rec {
+  pname = "chart-studio";
+  version = "1.0.0";
+
+  # chart-studio was split from plotly
+  src = fetchFromGitHub {
+    owner = "plotly";
+    repo = "plotly.py";
+    rev = "${pname}-v${version}";
+    sha256 = "14lyqbjdffnlnkzlfnn60k7yxjd99vx3hfcs23apsiyinzipjlbf";
+  };
+
+  sourceRoot = "source/packages/python/chart-studio";
+
+  propagatedBuildInputs = [
+    plotly
+    requests
+    retrying
+    six
+  ];
+
+  checkInputs = [ mock nose pytest ];
+  # most tests talk to a service
+  checkPhase = ''
+    HOME=$TMPDIR pytest chart_studio/tests/test_core chart_studio/tests/test_plot_ly/test_api
+  '';
+
+  meta = with lib; {
+    description = "Utilities for interfacing with Plotly's Chart Studio service";
+    homepage = "https://github.com/plotly/plotly.py/tree/master/packages/python/chart-studio";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/development/python-modules/cufflinks/default.nix
+++ b/pkgs/development/python-modules/cufflinks/default.nix
@@ -1,29 +1,48 @@
-{ buildPythonPackage, stdenv, fetchPypi, fetchpatch
-, numpy, pandas, plotly, six, colorlover
-, ipython, ipywidgets, nose
+{ lib, buildPythonPackage, fetchPypi, fetchpatch
+, chart-studio
+, colorlover
+, ipython
+, ipywidgets
+, nose
+, numpy
+, pandas
+, six
+, statsmodels
 }:
 
 buildPythonPackage rec {
   pname = "cufflinks";
-  version = "0.15";
+  version = "0.16";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "014098a4568199957198c0a7fe3dbeb3b4010b6de8d692a41fe3b3ac107b660e";
+    sha256 = "163lag5g4micpqm3m4qy9b5r06a7pw45nq80x4skxc7dcrly2ygd";
   };
 
   propagatedBuildInputs = [
-    numpy pandas plotly six colorlover
-    ipython ipywidgets
+    chart-studio
+    colorlover
+    ipython
+    ipywidgets
+    numpy
+    pandas
+    six
+    statsmodels
   ];
 
   patches = [
-    # Plotly 3.8 compatibility. Remove with the next release. See https://github.com/santosjorge/cufflinks/pull/178
+    # Plotly 4 compatibility. Remove with next release, assuming it gets merged.
     (fetchpatch {
-      url = "https://github.com/santosjorge/cufflinks/commit/cc4c23c2b45b870f6801d1cb0312948e1f73f424.patch";
-      sha256 = "1psl2h7vscpzvb4idr6s175v8znl2mfhkcyhb1926p4saswmghw1";
+      url = "https://github.com/santosjorge/cufflinks/pull/202/commits/e291dce14181858cb457404adfdaf2624b6d0594.patch";
+      sha256 = "1l0dahwqn3cxg49v3i3amwi80dmx2bi5zrazmgzpwsfargmk2kd1";
     })
   ];
+
+  # in plotly4+, the plotly.plotly module was moved to chart-studio.plotly
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace "plotly>=3.0.0,<4.0.0a0" "chart-studio"
+  '';
 
   checkInputs = [ nose ];
 
@@ -31,10 +50,10 @@ buildPythonPackage rec {
     nosetests -xv tests.py
   '';
 
-  meta = {
-    homepage = https://github.com/santosjorge/cufflinks;
+  meta = with lib; {
     description = "Productivity Tools for Plotly + Pandas";
-    license = stdenv.lib.licenses.mit;
-    maintainers = with stdenv.lib.maintainers; [ globin ];
+    homepage = "https://github.com/santosjorge/cufflinks";
+    license = licenses.mit;
+    maintainers = with maintainers; [ globin ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1800,6 +1800,8 @@ in {
 
   characteristic = callPackage ../development/python-modules/characteristic { };
 
+  chart-studio = callPackage ../development/python-modules/chart-studio { };
+
   cheetah = callPackage ../development/python-modules/cheetah { };
 
   cherrypy = if isPy3k then


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken on master with:
```
$ nix-build -A pythonPackages.cufflinks
...
ImportError:
The plotly.plotly module is deprecated,
please install the chart-studio package and use the
chart_studio.plotly module instead.
```
so I did the following:
 - Added the chart-studio package
 - Added patch which gave support to the new plotly version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

closure includes numpy, expected to be large:
```
$ nix path-info -Sh ./result
/nix/store/r48nwnlgvv45fy6f0qar7lklflc59hfi-python2.7-cufflinks-0.16     564.8M
```
```
[3 built, 2 copied (37.1 MiB), 7.2 MiB DL]
https://github.com/NixOS/nixpkgs/pull/70220
4 package were build:
python27Packages.chart-studio python27Packages.cufflinks python37Packages.chart-studio python37Packages.cufflinks
```