### PR TITLE
pythonPackages.poetry: fix python2 build

### DIFF
--- a/pkgs/development/python-modules/poetry/default.nix
+++ b/pkgs/development/python-modules/poetry/default.nix
@@ -10,6 +10,7 @@
 , pkginfo
 , html5lib
 , shellingham
+, subprocess32
 , tomlkit
 , typing
 , pathlib2
@@ -63,7 +64,7 @@ in buildPythonPackage rec {
     shellingham
     tomlkit
   ] ++ lib.optionals (isPy27 || isPy34) [ typing pathlib2 glob2 ]
-    ++ lib.optionals isPy27 [ virtualenv functools32 ];
+    ++ lib.optionals isPy27 [ virtualenv functools32 subprocess32 ];
 
   postInstall = ''
     mkdir -p "$out/share/bash-completion/completions"


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken reviewing other packages

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[2 built, 2 copied (0.8 MiB), 0.2 MiB DL]
https://github.com/NixOS/nixpkgs/pull/70225
1 package were build:
python27Packages.poetry
```