### PR TITLE
ruby: 2.4.7 -> 2.4.9, 2.5.6 -> 2.5.7, 2.6.4 -> 2.6.5

### DIFF
--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -228,10 +228,10 @@ in {
   };
 
   ruby_2_6 = generic {
-    version = rubyVersion "2" "6" "4" "";
+    version = rubyVersion "2" "6" "5" "";
     sha256 = {
-      src = "0dvrw4g2igvjclxk9bmb9pf6mzxwm22zqvqa0abkfnshfnxdihag";
-      git = "1h4z66amjykpzl6lxx6yad2yfpwnwix4sw19bd96jnwg248kviqf";
+      src = "0zgdrgylq6avbblf78kpaf0k2xnkpc3jng3wkd7x67ycdrqnp5v6";
+      git = "0pay6ic22ag3bnvxffhgwp7z6clkd0p93944a1l4lvc5hxc8v77j";
     };
   };
 }

--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -220,10 +220,10 @@ in {
   };
 
   ruby_2_5 = generic {
-    version = rubyVersion "2" "5" "6" "";
+    version = rubyVersion "2" "5" "7" "";
     sha256 = {
-      src = "19xy6rf138ys4qycv0ibsycqwbjmf1j6iv9plw9cs81hcxnd0zhx";
-      git = "067gyy7149m6vk9dfyx22mghm2gbgy7snfa7df4ddrvr1pqffqmz";
+      src = "1m6nmnj9shifp8g3yh7aimac01vl035bzcc19x2spdji6ig0sb8b";
+      git = "0wppf82c9ccdbnvj30mppr5a3mc7sxm05diahjdw7hhk29n43knp";
     };
   };
 

--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -212,10 +212,10 @@ let
 
 in {
   ruby_2_4 = generic {
-    version = rubyVersion "2" "4" "7" "";
+    version = rubyVersion "2" "4" "9" "";
     sha256 = {
-      src = "12cbyf7zai8mi3mxffm5ynq3mmkcbvs7kb1bbrs259m61irgqvnd";
-      git = "1dgch9xz4wdcncb6pf2dvijm10yk6mbw2wfdrj7d3wazrjzh305z";
+      src = "1bn6n5b920qy3lsx99jr8495jkc3sg89swgb96d5fgd579g6p6zr";
+      git = "066kb1iki7mx7qkm10xhj5b6v8s47wg68v43l3nc36y2hyim1w2c";
     };
   };
 

--- a/pkgs/development/interpreters/ruby/patchsets.nix
+++ b/pkgs/development/interpreters/ruby/patchsets.nix
@@ -6,7 +6,7 @@
     "${patchSet}/patches/ruby/2.4/head/railsexpress/02-improve-gc-stats.patch"
     "${patchSet}/patches/ruby/2.4/head/railsexpress/03-display-more-detailed-stack-trace.patch"
   ];
-  "2.5.6" = ops useRailsExpress [
+  "2.5.7" = ops useRailsExpress [
     "${patchSet}/patches/ruby/2.5/head/railsexpress/01-fix-broken-tests-caused-by-ad.patch"
     "${patchSet}/patches/ruby/2.5/head/railsexpress/02-improve-gc-stats.patch"
     "${patchSet}/patches/ruby/2.5/head/railsexpress/03-more-detailed-stacktrace.patch"

--- a/pkgs/development/interpreters/ruby/patchsets.nix
+++ b/pkgs/development/interpreters/ruby/patchsets.nix
@@ -11,12 +11,7 @@
     "${patchSet}/patches/ruby/2.5/head/railsexpress/02-improve-gc-stats.patch"
     "${patchSet}/patches/ruby/2.5/head/railsexpress/03-more-detailed-stacktrace.patch"
   ];
-  "2.6.4" = [
-    (fetchpatch {
-      url = "https://git.ruby-lang.org/ruby.git/patch/?id=ade1283ca276f7d589ffd3539fbc7b9817f682d5";
-      sha256 = "1vgrckmzz0ykyxgzyp8fcifa93xz2hvyfil79bw1gc3xx94wnnxd";
-    })
-  ] ++ ops useRailsExpress [
+  "2.6.5" = ops useRailsExpress [
     "${patchSet}/patches/ruby/2.6/head/railsexpress/01-fix-broken-tests-caused-by-ad.patch"
     "${patchSet}/patches/ruby/2.6/head/railsexpress/02-improve-gc-stats.patch"
     "${patchSet}/patches/ruby/2.6/head/railsexpress/03-more-detailed-stacktrace.patch"

--- a/pkgs/development/interpreters/ruby/patchsets.nix
+++ b/pkgs/development/interpreters/ruby/patchsets.nix
@@ -1,11 +1,6 @@
 { patchSet, useRailsExpress, ops, patchLevel, fetchpatch }:
 
 {
-  "2.3.8" = ops useRailsExpress [
-    "${patchSet}/patches/ruby/2.3/head/railsexpress/01-skip-broken-tests.patch"
-    "${patchSet}/patches/ruby/2.3/head/railsexpress/02-improve-gc-stats.patch"
-    "${patchSet}/patches/ruby/2.3/head/railsexpress/03-display-more-detailed-stack-trace.patch"
-  ];
   "2.4.7" = ops useRailsExpress [
     "${patchSet}/patches/ruby/2.4/head/railsexpress/01-skip-broken-tests.patch"
     "${patchSet}/patches/ruby/2.4/head/railsexpress/02-improve-gc-stats.patch"

--- a/pkgs/development/interpreters/ruby/patchsets.nix
+++ b/pkgs/development/interpreters/ruby/patchsets.nix
@@ -1,7 +1,7 @@
 { patchSet, useRailsExpress, ops, patchLevel, fetchpatch }:
 
 {
-  "2.4.7" = ops useRailsExpress [
+  "2.4.9" = ops useRailsExpress [
     "${patchSet}/patches/ruby/2.4/head/railsexpress/01-skip-broken-tests.patch"
     "${patchSet}/patches/ruby/2.4/head/railsexpress/02-improve-gc-stats.patch"
     "${patchSet}/patches/ruby/2.4/head/railsexpress/03-display-more-detailed-stack-trace.patch"


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
CVE-2019-16255: A code injection vulnerability of Shell#[] and Shell#test
CVE-2019-16254: HTTP response splitting in WEBrick (Additional fix)
CVE-2019-15845: A NUL injection vulnerability of File.fnmatch and File.fnmatch?
CVE-2019-16201: Regular Expression Denial of Service vulnerability of WEBrick’s Digest access authentication

+ 2.6.5 https://www.ruby-lang.org/en/news/2019/10/01/ruby-2-6-5-released/
+ 2.5.7 https://www.ruby-lang.org/en/news/2019/10/01/ruby-2-5-7-released/
+ 2.4.9
  - https://www.ruby-lang.org/en/news/2019/10/01/ruby-2-4-8-released/
  - https://www.ruby-lang.org/en/news/2019/10/02/ruby-2-4-9-released/

~note: I haven't included 2.4.8, because the released tarball doesn’t install under non-root user https://bugs.ruby-lang.org/issues/16197~
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
