### PR TITLE
zfsnap: init at 2.0.0-beta3

### DIFF
--- a/pkgs/tools/backup/zfsnap/default.nix
+++ b/pkgs/tools/backup/zfsnap/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchFromGitHub, coreutils, installShellFiles }:
+
+stdenv.mkDerivation rec {
+  version = "2.0.0-beta3";
+  pname = "zfsnap";
+
+  src = fetchFromGitHub {
+    owner = "zfsnap";
+    repo = "zfsnap";
+    rev = "v${version}";
+    sha256 = "0670a5sghvqx32c9gfsird15mg9nqcvwxsrfcjrwc0sj7br9bd2g";
+  };
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postPatch = ''
+    # Use zfs binaries from PATH, because often the zfs package from nixpkgs is
+    # not the one that should be used
+    substituteInPlace share/zfsnap/core.sh \
+      --replace "ZFS_CMD='/sbin/zfs'" "ZFS_CMD='zfs'" \
+      --replace "ZPOOL_CMD='/sbin/zpool'" "ZPOOL_CMD='zpool'"
+
+    substituteInPlace sbin/zfsnap.sh \
+      --replace "/bin/ls" "${coreutils}/bin/ls"
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mv sbin/zfsnap.sh $out/bin/zfsnap
+    mv share $out
+    installManPage man/*/*
+    installShellCompletion completion/*.{bash,zsh}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A portable, performant script to make rolling ZFS snapshots easy";
+    homepage = "https://github.com/zfsnap/zfsnap";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ woffs ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7223,6 +7223,8 @@ in
 
   zfstools = callPackage ../tools/filesystems/zfstools { };
 
+  zfsnap = callPackage ../tools/backup/zfsnap { };
+
   zile = callPackage ../applications/editors/zile { };
 
   zinnia = callPackage ../tools/inputmethods/zinnia { };


### PR DESCRIPTION
###### Motivation for this change
make zfs snapshots with timestamps and let them expire

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
