### PR TITLE
HTSeq: init at 0.11.2

### DIFF
--- a/pkgs/development/python-modules/HTSeq/default.nix
+++ b/pkgs/development/python-modules/HTSeq/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, buildPythonPackage, fetchPypi, cython, numpy, pysam, matplotlib
+}:
+buildPythonPackage rec {
+  version = "0.11.2";
+  pname = "HTSeq";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "65c4c13968506c7df92e97124df96fdd041c4476c12a548d67350ba8b436bcfc";
+  };
+
+  buildInputs = [ cython numpy pysam ];
+  propagatedBuildInputs = [ numpy pysam matplotlib ];
+
+  meta = with stdenv.lib; {
+    description = "A framework to work with high-throughput sequencing data";
+    maintainers = with maintainers; [ unode ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1698,6 +1698,8 @@ in {
     inherit (pkgs) pkgconfig;
   };
 
+  HTSeq = callPackage ../development/python-modules/HTSeq { };
+
   httpserver = callPackage ../development/python-modules/httpserver {};
 
   bleach = callPackage ../development/python-modules/bleach { };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).