### PR TITLE
libcxx: fix build on linux musl

### DIFF
--- a/pkgs/development/compilers/llvm/7/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/7/libc++/default.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv, fetch, cmake, python, libcxxabi, fixDarwinDylibNames, version }:
+{ lib, stdenv, fetch, cmake, python, libcxxabi, fixDarwinDylibNames, version
+, enableShared ? ! stdenv.hostPlatform.isMusl }:
 
 stdenv.mkDerivation {
   pname = "libc++";
@@ -31,7 +32,8 @@ stdenv.mkDerivation {
     "-DLIBCXX_LIBCXXABI_LIB_PATH=${libcxxabi}/lib"
     "-DLIBCXX_LIBCPPABI_VERSION=2"
     "-DLIBCXX_CXX_ABI=libcxxabi"
-  ] ++ stdenv.lib.optional stdenv.hostPlatform.isMusl "-DLIBCXX_HAS_MUSL_LIBC=1";
+  ] ++ stdenv.lib.optional stdenv.hostPlatform.isMusl "-DLIBCXX_HAS_MUSL_LIBC=1"
+  ++ stdenv.lib.optional (!enableShared) "-DLIBCXX_ENABLE_SHARED=OFF" ;
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/compilers/llvm/7/libc++abi.nix
+++ b/pkgs/development/compilers/llvm/7/libc++abi.nix
@@ -1,4 +1,6 @@
-{ stdenv, cmake, fetch, libcxx, llvm, version }:
+{ stdenv, cmake, fetch, libcxx, llvm, version
+  # on musl the shared objects don't build
+, enableShared ? ! stdenv.hostPlatform.isMusl }:
 
 stdenv.mkDerivation {
   pname = "libc++abi";
@@ -11,12 +13,14 @@ stdenv.mkDerivation {
   postUnpack = ''
     unpackFile ${libcxx.src}
     unpackFile ${llvm.src}
-    export cmakeFlags="-DLLVM_PATH=$PWD/$(ls -d llvm-*) -DLIBCXXABI_LIBCXX_PATH=$PWD/$(ls -d libcxx-*)"
+    cmakeFlagsArray=($cmakeFlagsArray -DLLVM_PATH=$PWD/$(ls -d llvm-*) -DLIBCXXABI_LIBCXX_PATH=$PWD/$(ls -d libcxx-*) )
   '' + stdenv.lib.optionalString stdenv.isDarwin ''
     export TRIPLE=x86_64-apple-darwin
   '' + stdenv.lib.optionalString stdenv.hostPlatform.isMusl ''
     patch -p1 -d $(ls -d libcxx-*) -i ${../libcxx-0001-musl-hacks.patch}
   '';
+
+  cmakeFlags = stdenv.lib.optional (!enableShared) "-DLIBCXXABI_ENABLE_SHARED=OFF";
 
   installPhase = if stdenv.isDarwin
     then ''
@@ -34,10 +38,10 @@ stdenv.mkDerivation {
     else ''
       install -d -m 755 $out/include $out/lib
       install -m 644 lib/libc++abi.a $out/lib
-      install -m 644 lib/libc++abi.so.1.0 $out/lib
+      ${stdenv.lib.optionalString enableShared "install -m 644 lib/libc++abi.so.1.0 $out/lib"}
       install -m 644 ../include/cxxabi.h $out/include
-      ln -s libc++abi.so.1.0 $out/lib/libc++abi.so
-      ln -s libc++abi.so.1.0 $out/lib/libc++abi.so.1
+      ${stdenv.lib.optionalString enableShared "ln -s libc++abi.so.1.0 $out/lib/libc++abi.so"}
+      ${stdenv.lib.optionalString enableShared "ln -s libc++abi.so.1.0 $out/lib/libc++abi.so.1"}
     '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Before this, `libunwind`, `libcxxabi` and `libcxx` failed to build on x86_64-linux-musl.

On current master with

>  for attr in libunwind libcxx libcxxabi; do for platform in linux; do for pkgs in pkgs pkgsStatic; do echo -n "$attr $platform $pkgs "; nix-build -A $pkgs.$attr --argstr system x86_64-$platform  &> /dev/null  && echo success || echo failure ; done; done; done | column -t

```
libunwind  linux  pkgs        success
libunwind  linux  pkgsStatic  failure
libcxx     linux  pkgs        success
libcxx     linux  pkgsStatic  failure
libcxxabi  linux  pkgs        success
libcxxabi  linux  pkgsStatic  failure
```

on this branch:

```
libunwind  linux  pkgs        success
libunwind  linux  pkgsStatic  success
libcxx     linux  pkgs        success
libcxx     linux  pkgsStatic  success
libcxxabi  linux  pkgs        success
libcxxabi  linux  pkgsStatic  success
```

I have _not_, I repeat _not_, built the `pkgsStatic` versions on darwin, although the `pkgs` versions do still work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @basvandijk 