### PR TITLE
libpcap, tcpdump: 1.9.1 and 4.9.3 for many security fixes

### DIFF
--- a/pkgs/development/libraries/libpcap/default.nix
+++ b/pkgs/development/libraries/libpcap/default.nix
@@ -1,11 +1,12 @@
-{ stdenv, fetchurl, fetchpatch, flex, bison }:
+{ stdenv, fetchurl, flex, bison }:
 
 stdenv.mkDerivation rec {
-  name = "libpcap-1.9.0";
+  pname = "libpcap";
+  version = "1.9.1";
 
   src = fetchurl {
-    url = "https://www.tcpdump.org/release/${name}.tar.gz";
-    sha256 = "06bhydl4vr4z9c3vahl76f2j96z1fbrcl7wwismgs4sris08inrf";
+    url = "https://www.tcpdump.org/release/${pname}-${version}.tar.gz";
+    sha256 = "153h1378diqyc27jjgz6gg5nxmb4ddk006d9xg69nqavgiikflk3";
   };
 
   nativeBuildInputs = [ flex bison ];
@@ -26,15 +27,6 @@ stdenv.mkDerivation rec {
   prePatch = stdenv.lib.optionalString stdenv.isDarwin ''
     substituteInPlace configure --replace " -arch i386" ""
   '';
-
-  patches = [
-    # https://github.com/the-tcpdump-group/libpcap/pull/735
-    (fetchpatch {
-      name = "add-missing-limits-h-include-pr735.patch";
-      url = https://github.com/the-tcpdump-group/libpcap/commit/aafa3512b7b742f5e66a5543e41974cc5e7eebfa.patch;
-      sha256 = "05zb4hx9g24gx07bi02rprk2rn7fdc1ss3249dv5x36qkasnfhvf";
-    })
-  ];
 
   meta = with stdenv.lib; {
     homepage = https://www.tcpdump.org;

--- a/pkgs/tools/networking/tcpdump/default.nix
+++ b/pkgs/tools/networking/tcpdump/default.nix
@@ -1,20 +1,13 @@
 { stdenv, fetchurl, libpcap, perl }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "tcpdump";
-  version = "4.9.2";
+  version = "4.9.3";
 
-  # leaked embargoed security update
   src = fetchurl {
-    url = "https://src.fedoraproject.org/lookaside/pkgs/tcpdump/tcpdump-4.9.2.tar.gz/sha512/e1bc19a5867d6e3628f3941bdf3ec831bf13784f1233ca1bccc46aac1702f47ee9357d7ff0ca62cddf211b3c8884488c21144cabddd92c861e32398cd8f7c44b/tcpdump-4.9.2.tar.gz";
-    sha256 = "0ygy0layzqaj838r5xd613iraz09wlfgpyh7pc6cwclql8v3b2vr";
+    url = "http://www.tcpdump.org/release/${pname}-${version}.tar.gz";
+    sha256 = "0434vdcnbqaia672rggjzdn4bb8p8dchz559yiszzdk0sjrprm1c";
   };
-  # src = fetchFromGitHub rec {
-  #   owner = "the-tcpdump-group";
-  #   repo = "tcpdump";
-  #   rev = "${repo}-${version}";
-  #   sha256 = "1vzrvn1q7x28h18yskqc390y357pzpg5xd3pzzj4xz3llnvsr64p";
-  # };
 
   postPatch = ''
     patchShebangs tests


### PR DESCRIPTION
###### Motivation for this change

See linked notes for CVE's and other changes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @