### PR TITLE
sourcehut.*: 2019.10.02

### DIFF
--- a/pkgs/applications/version-management/sourcehut/builds.nix
+++ b/pkgs/applications/version-management/sourcehut/builds.nix
@@ -4,7 +4,7 @@
 , srht, redis, celery, pyyaml, markdown }:
 
 let
-  version = "0.45.13";
+  version = "0.47.8";
 
   buildWorker = src: buildGoModule {
     inherit src version;
@@ -20,7 +20,7 @@ in buildPythonPackage rec {
   src = fetchgit {
     url = "https://git.sr.ht/~sircmpwn/builds.sr.ht";
     rev = version;
-    sha256 = "002pcj2a98gbmv77a10449w1q6iqhqjz4fim8hm4qm7vn6bwp0hz";
+    sha256 = "0agnxf118nlfykxbja8mnk4cal56rb2z8mhvyphnxm0ac28iq6jx";
   };
 
   patches = [

--- a/pkgs/applications/version-management/sourcehut/core.nix
+++ b/pkgs/applications/version-management/sourcehut/core.nix
@@ -6,12 +6,12 @@
 
 buildPythonPackage rec {
   pname = "srht";
-  version = "0.52.13";
+  version = "0.54.2";
 
   src = fetchgit {
     url = "https://git.sr.ht/~sircmpwn/core.sr.ht";
     rev = version;
-    sha256 = "0i7gd2rkq4y4lffxsgb3mql9ddmk3vqckan29w266imrqs6p8c0z";
+    sha256 = "1m9nblm0ygjjdzcf79jk5v8p74dgyby15mqkggw9i3smz9r3afim";
   };
 
   node_modules = fetchNodeModules {

--- a/pkgs/applications/version-management/sourcehut/core.nix
+++ b/pkgs/applications/version-management/sourcehut/core.nix
@@ -55,7 +55,6 @@ buildPythonPackage rec {
     cp -r ${node_modules} srht/node_modules
   '';
 
-  # No actual? tests but seems like it needs this anyway
   preCheck = let
     config = writeText "config.ini" ''
       [webhooks]
@@ -65,10 +64,7 @@ buildPythonPackage rec {
       origin=http://meta.sr.ht.local
     '';
   in ''
-    # Validation needs config option(s)
-    # webhooks <- ( private-key )
-    # meta.sr.ht <- ( origin )
-    cp ${config} config.ini
+    cp -f ${config} config.ini
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/version-management/sourcehut/core.nix
+++ b/pkgs/applications/version-management/sourcehut/core.nix
@@ -71,7 +71,6 @@ buildPythonPackage rec {
     homepage = https://git.sr.ht/~sircmpwn/srht;
     description = "Core modules for sr.ht";
     license = licenses.bsd3;
-    broken = true;
     maintainers = with maintainers; [ eadwu ];
   };
 }

--- a/pkgs/applications/version-management/sourcehut/dispatch.nix
+++ b/pkgs/applications/version-management/sourcehut/dispatch.nix
@@ -4,12 +4,12 @@
 
 buildPythonPackage rec {
   pname = "dispatchsrht";
-  version = "0.11.0";
+  version = "0.11.1";
 
   src = fetchgit {
     url = "https://git.sr.ht/~sircmpwn/dispatch.sr.ht";
     rev = version;
-    sha256 = "1kahl2gy5a5li79djwkzkglkw2s7pl4d29bzqp8c53r0xvx4sqkz";
+    sha256 = "1bi7vn0yr326mf2c63f2fahdlrx2c6a8d6p6bzy2ym2835qfcc0v";
   };
 
   patches = [

--- a/pkgs/applications/version-management/sourcehut/git.nix
+++ b/pkgs/applications/version-management/sourcehut/git.nix
@@ -4,7 +4,7 @@
 , srht, pygit2, scmsrht }:
 
 let
-  version = "0.32.3";
+  version = "0.33.1";
 
   buildDispatcher = src: buildGoModule {
     inherit src version;
@@ -20,7 +20,7 @@ in buildPythonPackage rec {
   src = fetchgit {
     url = "https://git.sr.ht/~sircmpwn/git.sr.ht";
     rev = version;
-    sha256 = "0grycmblhm9dnhcf1kcmn6bclgb9znahk2026dan58m9j9pja5vw";
+    sha256 = "0vwjkpvgscr01xhbzmhizqmg1wjhnj7jw9qcsv0s190fqach7ml8";
   };
 
   patches = [

--- a/pkgs/applications/version-management/sourcehut/git.nix
+++ b/pkgs/applications/version-management/sourcehut/git.nix
@@ -40,7 +40,6 @@ in buildPythonPackage rec {
     export SRHT_PATH=${srht}/${python.sitePackages}/srht
   '';
 
-  # TODO: Remove redundant mkdir?
   postInstall = ''
     mkdir -p $out/bin
     cp ${buildDispatcher "${src}/gitsrht-dispatch"}/bin/gitsrht-dispatch $out/bin/gitsrht-dispatch

--- a/pkgs/applications/version-management/sourcehut/hg.nix
+++ b/pkgs/applications/version-management/sourcehut/hg.nix
@@ -4,12 +4,12 @@
 
 buildPythonPackage rec {
   pname = "hgsrht";
-  version = "0.13.0";
+  version = "0.15.2";
 
   src = fetchhg {
     url = "https://hg.sr.ht/~sircmpwn/hg.sr.ht";
     rev = version;
-    sha256 = "0qkknvja0pyk69fvzqafj3x8hi5miw22nmksvifbrjcqph8jknqg";
+    sha256 = "097ikrr8bks4lag1lbaznj0zr1c56lmm5lgm5rfjq0k20l7n2bk0";
   };
 
   patches = [

--- a/pkgs/applications/version-management/sourcehut/lists.nix
+++ b/pkgs/applications/version-management/sourcehut/lists.nix
@@ -4,12 +4,12 @@
 
 buildPythonPackage rec {
   pname = "listssrht";
-  version = "0.36.3";
+  version = "0.38.1";
 
   src = fetchgit {
     url = "https://git.sr.ht/~sircmpwn/lists.sr.ht";
     rev = version;
-    sha256 = "1q2z2pjwz4zifsrkxab9b9jh1vzayjqych1cx3i4859f1swl2gwa";
+    sha256 = "02nfl9xnqx0p98kmcy8bzdwzlnl57k5a04i6gnvimc84c11a9chz";
   };
 
   patches = [

--- a/pkgs/applications/version-management/sourcehut/man.nix
+++ b/pkgs/applications/version-management/sourcehut/man.nix
@@ -4,12 +4,12 @@
 
 buildPythonPackage rec {
   pname = "mansrht";
-  version = "0.12.4";
+  version = "0.13.5";
 
   src = fetchgit {
     url = "https://git.sr.ht/~sircmpwn/man.sr.ht";
     rev = version;
-    sha256 = "1csnw71yh5zw7l17xmmxyskwiqbls0ynbbjrg45y5k1i3622mhiy";
+    sha256 = "1hfxhczppn8yng6m3kdzj9rn6zjhwpm6dq3pzaiaii92b3d4cyh3";
   };
 
   patches = [

--- a/pkgs/applications/version-management/sourcehut/meta.nix
+++ b/pkgs/applications/version-management/sourcehut/meta.nix
@@ -5,12 +5,12 @@
 
 buildPythonPackage rec {
   pname = "metasrht";
-  version = "0.34.3";
+  version = "0.35.2";
 
   src = fetchgit {
     url = "https://git.sr.ht/~sircmpwn/meta.sr.ht";
     rev = version;
-    sha256 = "1yj3npw1vlqawzj6q1mh6qryx009dg5prja9fn6rasfmxjn2gr7v";
+    sha256 = "10x00lydnrcgk7s27fddbrdb8bwc5ivwlpswkcrsi302qcjdff9w";
   };
 
   nativeBuildInputs = srht.nativeBuildInputs;

--- a/pkgs/applications/version-management/sourcehut/paste.nix
+++ b/pkgs/applications/version-management/sourcehut/paste.nix
@@ -4,12 +4,12 @@
 
 buildPythonPackage rec {
   pname = "pastesrht";
-  version = "0.5.1";
+  version = "0.5.2";
 
   src = fetchgit {
     url = "https://git.sr.ht/~sircmpwn/paste.sr.ht";
     rev = version;
-    sha256 = "0bzw03hcwi1pw16kliqjsr7kphqq3qw0pbpdjqkcs7jdr0a59vny";
+    sha256 = "16d0qviw3qifyqn94fj03mwxd65abf8bhrvn1fn6ramaq8zpx794";
   };
 
   patches = [

--- a/pkgs/applications/version-management/sourcehut/scm.nix
+++ b/pkgs/applications/version-management/sourcehut/scm.nix
@@ -4,12 +4,12 @@
 
 buildPythonPackage rec {
   pname = "scmsrht";
-  version = "0.13.3";
+  version = "0.14.2";
 
   src = fetchgit {
     url = "https://git.sr.ht/~sircmpwn/scm.sr.ht";
     rev = version;
-    sha256 = "0bapddgfqrs27y6prd6kwpz6jdlr33zdqr6ci6ixi584a7z8z7d6";
+    sha256 = "1xi4l1ycdglfm22ybawh5nbwgday0nfb1vqsjqvp2y7ysizwdxc1";
   };
 
   nativeBuildInputs = srht.nativeBuildInputs;

--- a/pkgs/applications/version-management/sourcehut/scm.nix
+++ b/pkgs/applications/version-management/sourcehut/scm.nix
@@ -39,11 +39,7 @@ buildPythonPackage rec {
       origin=http://meta.sr.ht.local
     '';
   in ''
-    # Validation needs config option(s)
-    # webhooks <- ( private-key )
-    # meta.sr.ht <- ( origin )
-    # builds.sr.ht <- ( origin, oauth-client-id )
-    cp ${config} config.ini
+    cp -f ${config} config.ini
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/version-management/sourcehut/todo.nix
+++ b/pkgs/applications/version-management/sourcehut/todo.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchgit, buildPythonPackage
 , python
-, srht, redis, alembic, pystache }:
+, srht, redis, alembic, pystache
+, pytest, factory_boy, writeText }:
 
 buildPythonPackage rec {
   pname = "todosrht";
@@ -30,8 +31,33 @@ buildPythonPackage rec {
     export SRHT_PATH=${srht}/${python.sitePackages}/srht
   '';
 
-  # Tests require a network connection
-  doCheck = false;
+  checkInputs = [
+    pytest
+    factory_boy
+  ];
+
+  installCheckPhase = let
+    config = writeText "config.ini" ''
+      [webhooks]
+      private-key=K6JupPpnr0HnBjelKTQUSm3Ro9SgzEA2T2Zv472OvzI=
+
+      [todo.sr.ht]
+      origin=http://todo.sr.ht.local
+      oauth-client-id=
+      oauth-client-secret=
+
+      [todo.sr.ht::mail]
+      posting-domain=
+
+      [meta.sr.ht]
+      origin=http://meta.sr.ht.local
+    '';
+  in ''
+    cp -f ${config} config.ini
+
+    # pytest tests fail
+    # pytest tests/
+  '';
 
   meta = with stdenv.lib; {
     homepage = https://todo.sr.ht/~sircmpwn/todo.sr.ht;

--- a/pkgs/applications/version-management/sourcehut/todo.nix
+++ b/pkgs/applications/version-management/sourcehut/todo.nix
@@ -4,12 +4,12 @@
 
 buildPythonPackage rec {
   pname = "todosrht";
-  version = "0.46.8";
+  version = "0.51.11";
 
   src = fetchgit {
     url = "https://git.sr.ht/~sircmpwn/todo.sr.ht";
     rev = version;
-    sha256 = "17nqqy81535jnkidjiqv8v2301w5wzbbvx4czib69aagw1l85gnn";
+    sha256 = "0x4aray1dappalmn2f4wqrhpa5k1idccnafbfhsnfi6nj718i33a";
   };
 
   patches = [


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
Builds after #69066 or should build after #70256 as well.
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
