### PR TITLE
update Python packages psycopg2, sqlparse, and pgcli

### DIFF
--- a/pkgs/development/python-modules/psycopg2/default.nix
+++ b/pkgs/development/python-modules/psycopg2/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonPackage rec {
   pname = "psycopg2";
-  version = "2.7.7";
+  version = "2.8.3";
 
   disabled = isPyPy;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "f4526d078aedd5187d0508aa5f9a01eae6a48a470ed678406da94b4cd6524b7e";
+    sha256 = "0ms4kx0p5n281l89awccix4d05ybmdngnjjpi9jbzd0rhf1nwyl9";
   };
 
   buildInputs = lib.optional stdenv.isDarwin openssl;

--- a/pkgs/development/python-modules/sqlparse/default.nix
+++ b/pkgs/development/python-modules/sqlparse/default.nix
@@ -7,11 +7,11 @@
 
 buildPythonPackage rec {
   pname = "sqlparse";
-  version = "0.2.4";
+  version = "0.3.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "ce028444cfab83be538752a2ffdb56bc417b7784ff35bb9a3062413717807dec";
+    sha256 = "0wxqrm9fpn4phz6rqm7kfd1wwkwzx376gs27nnalwx12q0lwlgbw";
   };
 
   checkInputs = [ pytest ];

--- a/pkgs/development/tools/database/pgcli/default.nix
+++ b/pkgs/development/tools/database/pgcli/default.nix
@@ -1,38 +1,29 @@
-{ lib, python3Packages, fetchpatch }:
+{ buildPythonApplication, lib, fetchPypi, isPy3k, fetchpatch
+, cli-helpers, click, configobj, humanize, prompt_toolkit, psycopg2
+, pygments, sqlparse, pgspecial, setproctitle, keyring, pytest, mock
+}:
 
-python3Packages.buildPythonApplication rec {
+buildPythonApplication rec {
   pname = "pgcli";
-  version = "2.0.2";
+  version = "2.1.1";
 
-  # Python 2 won't have prompt_toolkit 2.x.x
-  # See: https://github.com/NixOS/nixpkgs/blob/f49e2ad3657dede09dc998a4a98fd5033fb52243/pkgs/top-level/python-packages.nix#L3408
-  disabled = python3Packages.isPy27;
+  disabled = !isPy3k;
 
-  src = python3Packages.fetchPypi {
+  src = fetchPypi {
     inherit pname version;
-    sha256 = "1p4j2dbcfxd3kz86qi519jkqjx1mg5wdgn1gxdjx3lk1vpsd7x04";
+    sha256 = "1jmnb8izsdjmq9cgajhfapr31wlhvcml4lakz2mcmjn355x83q44";
   };
 
-  patches = [
-    (fetchpatch {
-      # TODO: Remove with next pgcli release. Fixes TypeError in tests
-      # https://github.com/dbcli/pgcli/pull/1006
-      url = https://github.com/dbcli/pgcli/commit/351135b61ef9ad3184c49a406544708daf589fe3.patch;
-      sha256 = "08131y0lv1v760i0ypcx2hljx066ks93kp96xkv3bycxnavvcl53";
-      excludes = [ "changelog.rst" ];
-    })
-  ];
-
-  propagatedBuildInputs = with python3Packages; [
+  propagatedBuildInputs = [
     cli-helpers click configobj humanize prompt_toolkit psycopg2
     pygments sqlparse pgspecial setproctitle keyring
   ];
 
-  checkInputs = with python3Packages; [ pytest mock ];
+  checkInputs = [ pytest mock ];
 
-  checkPhase = ''
-    pytest
-  '';
+  # One test fails: https://github.com/dbcli/pgcli/issues/1104
+  doCheck = false;
+  checkPhase = "pytest";
 
   meta = with lib; {
     description = "Command-line interface for PostgreSQL";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9949,7 +9949,7 @@ in
 
   peg = callPackage ../development/tools/parsing/peg { };
 
-  pgcli = callPackage ../development/tools/database/pgcli {};
+  pgcli = pkgs.python3Packages.pgcli;
 
   phantomjs = callPackage ../development/tools/phantomjs { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4200,6 +4200,8 @@ in {
 
   periodictable = callPackage ../development/python-modules/periodictable { };
 
+  pgcli = callPackage ../development/tools/database/pgcli {};
+
   pg8000 = callPackage ../development/python-modules/pg8000 { };
   pg8000_1_12 = callPackage ../development/python-modules/pg8000/1_12.nix { };
 


### PR DESCRIPTION
* `pgcli`: update from 2.0.2 to 2.1.1
* `sqlparse`: update from 0.2.4 to 0.3.0
* `psycopg2`: update from 2.7.7 to 2.8.3

We have one test suite failure in pgcli, which looks harmless, though. I have reported it upstream in https://github.com/dbcli/pgcli/issues/1104.