### PR TITLE
home-assistant: add support for python_script component

### DIFF
--- a/pkgs/development/python-modules/restrictedpython/default.nix
+++ b/pkgs/development/python-modules/restrictedpython/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+
+# Test dependencies
+, pytest, pytest-mock
+}:
+
+buildPythonPackage rec {
+  pname = "RestrictedPython";
+  version = "5.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1g0sffn6ifkl1w8gq15rpaqm8c7l68bsnm77wcd3flyzzydmd050";
+  };
+
+  #propagatedBuildInputs = [ xmltodict requests ifaddr ];
+
+  checkInputs = [
+    pytest pytest-mock
+  ];
+
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = {
+    homepage = https://github.com/zopefoundation/RestrictedPython;
+    description = "A restricted execution environment for Python to run untrusted code";
+    license = lib.licenses.zpl21;
+    maintainers = with lib.maintainers; [ juaningan ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -583,7 +583,7 @@
     "pushsafer" = ps: with ps; [  ];
     "pvoutput" = ps: with ps; [  ];
     "pyload" = ps: with ps; [  ];
-    "python_script" = ps: with ps; [  ];
+    "python_script" = ps: with ps; [ restrictedpython ];
     "qbittorrent" = ps: with ps; [  ];
     "qld_bushfire" = ps: with ps; [  ];
     "qnap" = ps: with ps; [  ];
@@ -814,7 +814,7 @@
     "vicare" = ps: with ps; [  ];
     "vivotek" = ps: with ps; [  ];
     "vizio" = ps: with ps; [  ];
-    "vlc" = ps: with ps; [  ];
+    "vlc" = ps: with ps; [ python-vlc ];
     "vlc_telnet" = ps: with ps; [  ];
     "voicerss" = ps: with ps; [  ];
     "volkszaehler" = ps: with ps; [  ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4864,6 +4864,8 @@ in {
 
   repocheck = callPackage ../development/python-modules/repocheck { };
 
+  restrictedpython = callPackage ../development/python-modules/restrictedpython { };
+
   restview = callPackage ../development/python-modules/restview { };
 
   readme = callPackage ../development/python-modules/readme { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @dotlambda 
