### PR TITLE
NixOS 19.03: Patches for CVE-2019-14744

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/kconfig.nix
+++ b/pkgs/development/libraries/kde-frameworks/kconfig.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, lib, extra-cmake-modules, qtbase, qttools }:
+{ mkDerivation, lib, fetchpatch, extra-cmake-modules, qtbase, qttools }:
 
 mkDerivation {
   name = "kconfig";
@@ -6,6 +6,14 @@ mkDerivation {
     maintainers = [ lib.maintainers.ttuegel ];
     broken = builtins.compareVersions qtbase.version "5.7.0" < 0;
   };
+  patches = [
+    # https://phabricator.kde.org/D22979
+    (fetchpatch {
+      url = "https://cgit.kde.org/kconfig.git/patch/?id=5d3e71b1d2ecd2cb2f910036e614ffdfc895aa22";
+      sha256 = "0vzrwkv3l8dlr786l6h0hqq208i6i1fbnsifi5b36d3732fqbq89";
+      name = "kconfig-D22979.patch";
+    })
+  ];
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ qttools ];
   propagatedBuildInputs = [ qtbase ];

--- a/pkgs/development/python-modules/pykde4/kdelibs.nix
+++ b/pkgs/development/python-modules/pykde4/kdelibs.nix
@@ -1,5 +1,5 @@
 {
-  stdenv, fetchurl,
+  stdenv, fetchurl, fetchpatch,
   automoc4, cmake_2_8, libxslt, perl, pkgconfig, shared-mime-info,
   attica, docbook_xml_dtd_42, docbook_xsl, giflib,
   libdbusmenu_qt, libjpeg, phonon, qt4
@@ -12,6 +12,14 @@ stdenv.mkDerivation rec {
     url = "mirror://kde/stable/applications/17.08.3/src/${name}.tar.xz";
     sha256 = "1zn3yb09sd22bm54is0rn98amj0398zybl550dp406419sil7z9p";
   };
+  patches = [
+    # https://phabricator.kde.org/D22989
+    (fetchpatch {
+      url = "https://cgit.kde.org/kdelibs.git/patch/?id=2c3762feddf7e66cf6b64d9058f625a715694a00";
+      sha256 = "1wbzywh8lcc66n6y3pxs18h7cwkq6g216faz27san33jpl8ra1i9";
+      name = "kdelibs-D22989.patch";
+    })
+  ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

See also: #70102 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
