### PR TITLE
libtiff: patch for CVE-2019-6128, CVE-2019-14973

### DIFF
--- a/pkgs/development/libraries/libtiff/CVE-2019-14973.patch
+++ b/pkgs/development/libraries/libtiff/CVE-2019-14973.patch
@@ -1,0 +1,384 @@
+diff -ru tiff-4.0.10-orig/libtiff/tif_aux.c tiff-4.0.10/libtiff/tif_aux.c
+--- tiff-4.0.10-orig/libtiff/tif_aux.c	2017-12-02 16:21:47.305709555 +0100
++++ tiff-4.0.10/libtiff/tif_aux.c	2019-10-02 22:35:17.392184463 +0200
+@@ -57,18 +57,57 @@
+ 	return bytes;
+ }
+ 
++tmsize_t
++_TIFFMultiplySSize(TIFF* tif, tmsize_t first, tmsize_t second, const char* where)
++{
++    if( first <= 0 || second <= 0 )
++    {
++        if( tif != NULL && where != NULL )
++        {
++            TIFFErrorExt(tif->tif_clientdata, where,
++                        "Invalid argument to _TIFFMultiplySSize() in %s", where);
++        }
++        return 0;
++    }
++
++    if( first > TIFF_TMSIZE_T_MAX / second )
++    {
++        if( tif != NULL && where != NULL )
++        {
++            TIFFErrorExt(tif->tif_clientdata, where,
++                        "Integer overflow in %s", where);
++        }
++        return 0;
++    }
++    return first * second;
++}
++
++tmsize_t _TIFFCastUInt64ToSSize(TIFF* tif, uint64 val, const char* module)
++{
++    if( val > (uint64)TIFF_TMSIZE_T_MAX )
++    {
++        if( tif != NULL && module != NULL )
++        {
++            TIFFErrorExt(tif->tif_clientdata,module,"Integer overflow");
++        }
++        return 0;
++    }
++    return (tmsize_t)val;
++}
++
+ void*
+ _TIFFCheckRealloc(TIFF* tif, void* buffer,
+ 		  tmsize_t nmemb, tmsize_t elem_size, const char* what)
+ {
+ 	void* cp = NULL;
+-	tmsize_t bytes = nmemb * elem_size;
+-
++        tmsize_t count = _TIFFMultiplySSize(tif, nmemb, elem_size, NULL);
+ 	/*
+-	 * XXX: Check for integer overflow.
++	 * Check for integer overflow.
+ 	 */
+-	if (nmemb && elem_size && bytes / elem_size == nmemb)
+-		cp = _TIFFrealloc(buffer, bytes);
++	if (count != 0)
++	{
++		cp = _TIFFrealloc(buffer, count);
++	}
+ 
+ 	if (cp == NULL) {
+ 		TIFFErrorExt(tif->tif_clientdata, tif->tif_name,
+diff -ru tiff-4.0.10-orig/libtiff/tiffiop.h tiff-4.0.10/libtiff/tiffiop.h
+--- tiff-4.0.10-orig/libtiff/tiffiop.h	2018-11-03 15:28:37.748910968 +0100
++++ tiff-4.0.10/libtiff/tiffiop.h	2019-10-02 22:35:17.396184535 +0200
+@@ -77,6 +77,9 @@
+ #define	FALSE	0
+ #endif
+ 
++#define TIFF_SIZE_T_MAX ((size_t) ~ ((size_t)0))
++#define TIFF_TMSIZE_T_MAX (tmsize_t)(TIFF_SIZE_T_MAX >> 1)
++
+ typedef struct client_info {
+     struct client_info *next;
+     void *data;
+@@ -258,7 +261,7 @@
+ #define TIFFhowmany8_64(x) (((x)&0x07)?((uint64)(x)>>3)+1:(uint64)(x)>>3)
+ #define TIFFroundup_64(x, y) (TIFFhowmany_64(x,y)*(y))
+ 
+-/* Safe multiply which returns zero if there is an integer overflow */
++/* Safe multiply which returns zero if there is an *unsigned* integer overflow. This macro is not safe for *signed* integer types */
+ #define TIFFSafeMultiply(t,v,m) ((((t)(m) != (t)0) && (((t)(((v)*(m))/(m))) == (t)(v))) ? (t)((v)*(m)) : (t)0)
+ 
+ #define TIFFmax(A,B) ((A)>(B)?(A):(B))
+@@ -368,6 +371,8 @@
+ 
+ extern uint32 _TIFFMultiply32(TIFF*, uint32, uint32, const char*);
+ extern uint64 _TIFFMultiply64(TIFF*, uint64, uint64, const char*);
++extern tmsize_t _TIFFMultiplySSize(TIFF*, tmsize_t, tmsize_t, const char*);
++extern tmsize_t _TIFFCastUInt64ToSSize(TIFF*, uint64, const char*);
+ extern void* _TIFFCheckMalloc(TIFF*, tmsize_t, tmsize_t, const char*);
+ extern void* _TIFFCheckRealloc(TIFF*, void*, tmsize_t, tmsize_t, const char*);
+ 
+diff -ru tiff-4.0.10-orig/libtiff/tif_getimage.c tiff-4.0.10/libtiff/tif_getimage.c
+--- tiff-4.0.10-orig/libtiff/tif_getimage.c	2017-12-02 16:21:47.654716127 +0100
++++ tiff-4.0.10/libtiff/tif_getimage.c	2019-10-02 22:35:17.393184481 +0200
+@@ -755,9 +755,8 @@
+ 	uint32 leftmost_tw;
+ 
+ 	tilesize = TIFFTileSize(tif);  
+-	bufsize = TIFFSafeMultiply(tmsize_t,alpha?4:3,tilesize);
++	bufsize = _TIFFMultiplySSize(tif, alpha?4:3,tilesize, "gtTileSeparate");
+ 	if (bufsize == 0) {
+-		TIFFErrorExt(tif->tif_clientdata, TIFFFileName(tif), "Integer overflow in %s", "gtTileSeparate");
+ 		return (0);
+ 	}
+ 
+@@ -1019,9 +1018,8 @@
+         uint16 colorchannels;
+ 
+ 	stripsize = TIFFStripSize(tif);  
+-	bufsize = TIFFSafeMultiply(tmsize_t,alpha?4:3,stripsize);
++	bufsize = _TIFFMultiplySSize(tif,alpha?4:3,stripsize, "gtStripSeparate");
+ 	if (bufsize == 0) {
+-		TIFFErrorExt(tif->tif_clientdata, TIFFFileName(tif), "Integer overflow in %s", "gtStripSeparate");
+ 		return (0);
+ 	}
+ 
+diff -ru tiff-4.0.10-orig/libtiff/tif_luv.c tiff-4.0.10/libtiff/tif_luv.c
+--- tiff-4.0.10-orig/libtiff/tif_luv.c	2018-05-05 15:50:35.884596907 +0200
++++ tiff-4.0.10/libtiff/tif_luv.c	2019-10-02 22:35:17.393184481 +0200
+@@ -1264,16 +1264,10 @@
+ 	return (SGILOGDATAFMT_UNKNOWN);
+ }
+ 
+-
+-#define TIFF_SIZE_T_MAX ((size_t) ~ ((size_t)0))
+-#define TIFF_TMSIZE_T_MAX (tmsize_t)(TIFF_SIZE_T_MAX >> 1)
+-
+ static tmsize_t
+ multiply_ms(tmsize_t m1, tmsize_t m2)
+ {
+-        if( m1 == 0 || m2 > TIFF_TMSIZE_T_MAX / m1 )
+-            return 0;
+-        return m1 * m2;
++        return _TIFFMultiplySSize(NULL, m1, m2, NULL);
+ }
+ 
+ static int
+diff -ru tiff-4.0.10-orig/libtiff/tif_pixarlog.c tiff-4.0.10/libtiff/tif_pixarlog.c
+--- tiff-4.0.10-orig/libtiff/tif_pixarlog.c	2017-12-02 16:21:47.841162432 +0100
++++ tiff-4.0.10/libtiff/tif_pixarlog.c	2019-10-02 22:36:01.223970118 +0200
+@@ -634,15 +634,10 @@
+ 	return guess;
+ }
+ 
+-#define TIFF_SIZE_T_MAX ((size_t) ~ ((size_t)0))
+-#define TIFF_TMSIZE_T_MAX (tmsize_t)(TIFF_SIZE_T_MAX >> 1)
+-
+ static tmsize_t
+ multiply_ms(tmsize_t m1, tmsize_t m2)
+ {
+-        if( m1 == 0 || m2 > TIFF_TMSIZE_T_MAX / m1 )
+-            return 0;
+-        return m1 * m2;
++        return _TIFFMultiplySSize(NULL, m1, m2, NULL);
+ }
+ 
+ static tmsize_t
+diff -ru tiff-4.0.10-orig/libtiff/tif_read.c tiff-4.0.10/libtiff/tif_read.c
+--- tiff-4.0.10-orig/libtiff/tif_read.c	2018-10-14 21:15:27.551093695 +0200
++++ tiff-4.0.10/libtiff/tif_read.c	2019-10-02 22:41:09.387290927 +0200
+@@ -29,9 +29,6 @@
+ #include "tiffiop.h"
+ #include <stdio.h>
+ 
+-#define TIFF_SIZE_T_MAX ((size_t) ~ ((size_t)0))
+-#define TIFF_TMSIZE_T_MAX (tmsize_t)(TIFF_SIZE_T_MAX >> 1)
+-
+ int TIFFFillStrip(TIFF* tif, uint32 strip);
+ int TIFFFillTile(TIFF* tif, uint32 tile);
+ static int TIFFStartStrip(TIFF* tif, uint32 strip);
+@@ -49,6 +46,8 @@
+ #define THRESHOLD_MULTIPLIER 10
+ #define MAX_THRESHOLD (THRESHOLD_MULTIPLIER * THRESHOLD_MULTIPLIER * THRESHOLD_MULTIPLIER * INITIAL_THRESHOLD)
+ 
++#define TIFF_INT64_MAX ((((int64)0x7FFFFFFF) << 32) | 0xFFFFFFFF)
++
+ /* Read 'size' bytes in tif_rawdata buffer starting at offset 'rawdata_offset'
+  * Returns 1 in case of success, 0 otherwise. */
+ static int TIFFReadAndRealloc( TIFF* tif, tmsize_t size,
+@@ -734,23 +733,8 @@
+ 		return ((tmsize_t)(-1));
+ 	}
+ 	bytecount = td->td_stripbytecount[strip];
+-	if ((int64)bytecount <= 0) {
+-#if defined(__WIN32__) && (defined(_MSC_VER) || defined(__MINGW32__))
+-		TIFFErrorExt(tif->tif_clientdata, module,
+-			     "%I64u: Invalid strip byte count, strip %lu",
+-			     (unsigned __int64) bytecount,
+-			     (unsigned long) strip);
+-#else
+-		TIFFErrorExt(tif->tif_clientdata, module,
+-			     "%llu: Invalid strip byte count, strip %lu",
+-			     (unsigned long long) bytecount,
+-			     (unsigned long) strip);
+-#endif
+-		return ((tmsize_t)(-1));
+-	}
+-	bytecountm = (tmsize_t)bytecount;
+-	if ((uint64)bytecountm!=bytecount) {
+-		TIFFErrorExt(tif->tif_clientdata, module, "Integer overflow");
++	bytecountm =  _TIFFCastUInt64ToSSize(tif, bytecount, module);
++	if (bytecountm == 0) {
+ 		return ((tmsize_t)(-1));
+ 	}
+ 	if (size != (tmsize_t)(-1) && size < bytecountm)
+@@ -774,7 +758,7 @@
+ 	if ((tif->tif_flags&TIFF_NOREADRAW)==0)
+ 	{
+ 		uint64 bytecount = td->td_stripbytecount[strip];
+-		if ((int64)bytecount <= 0) {
++		if( bytecount == 0 || bytecount > (uint64)TIFF_INT64_MAX ) {
+ #if defined(__WIN32__) && (defined(_MSC_VER) || defined(__MINGW32__))
+ 			TIFFErrorExt(tif->tif_clientdata, module,
+ 				"Invalid strip byte count %I64u, strip %lu",
+@@ -801,7 +785,7 @@
+ 			    (bytecount - 4096) / 10 > (uint64)stripsize  )
+ 			{
+ 				uint64 newbytecount = (uint64)stripsize * 10 + 4096;
+-				if( (int64)newbytecount >= 0 )
++				if( newbytecount == 0 || newbytecount > (uint64)TIFF_INT64_MAX )
+ 				{
+ #if defined(__WIN32__) && (defined(_MSC_VER) || defined(__MINGW32__))
+ 					TIFFWarningExt(tif->tif_clientdata, module,
+@@ -1196,10 +1180,8 @@
+ 	bytecount64 = td->td_stripbytecount[tile];
+ 	if (size != (tmsize_t)(-1) && (uint64)size < bytecount64)
+ 		bytecount64 = (uint64)size;
+-	bytecountm = (tmsize_t)bytecount64;
+-	if ((uint64)bytecountm!=bytecount64)
+-	{
+-		TIFFErrorExt(tif->tif_clientdata,module,"Integer overflow");
++	bytecountm = _TIFFCastUInt64ToSSize(tif, bytecount64, module);
++        if( bytecountm == 0 ) {
+ 		return ((tmsize_t)(-1));
+ 	}
+ 	return (TIFFReadRawTile1(tif, tile, buf, bytecountm, module));
+@@ -1221,7 +1203,7 @@
+ 	if ((tif->tif_flags&TIFF_NOREADRAW)==0)
+ 	{
+ 		uint64 bytecount = td->td_stripbytecount[tile];
+-		if ((int64)bytecount <= 0) {
++		if( bytecount == 0 || bytecount > (uint64)TIFF_INT64_MAX ) {
+ #if defined(__WIN32__) && (defined(_MSC_VER) || defined(__MINGW32__))
+ 			TIFFErrorExt(tif->tif_clientdata, module,
+ 				"%I64u: Invalid tile byte count, tile %lu",
+@@ -1248,7 +1230,7 @@
+ 			    (bytecount - 4096) / 10 > (uint64)stripsize  )
+ 			{
+ 				uint64 newbytecount = (uint64)stripsize * 10 + 4096;
+-				if( (int64)newbytecount >= 0 )
++				if( newbytecount == 0 || newbytecount > (uint64)TIFF_INT64_MAX )
+ 				{
+ #if defined(__WIN32__) && (defined(_MSC_VER) || defined(__MINGW32__))
+ 					TIFFWarningExt(tif->tif_clientdata, module,
+diff -ru tiff-4.0.10-orig/libtiff/tif_strip.c tiff-4.0.10/libtiff/tif_strip.c
+--- tiff-4.0.10-orig/libtiff/tif_strip.c	2017-12-02 16:21:47.947867167 +0100
++++ tiff-4.0.10/libtiff/tif_strip.c	2019-10-02 22:35:17.395184517 +0200
+@@ -129,15 +129,8 @@
+ {
+ 	static const char module[] = "TIFFVStripSize";
+ 	uint64 m;
+-	tmsize_t n;
+ 	m=TIFFVStripSize64(tif,nrows);
+-	n=(tmsize_t)m;
+-	if ((uint64)n!=m)
+-	{
+-		TIFFErrorExt(tif->tif_clientdata,module,"Integer overflow");
+-		n=0;
+-	}
+-	return(n);
++        return _TIFFCastUInt64ToSSize(tif, m, module);
+ }
+ 
+ /*
+@@ -211,15 +204,8 @@
+ {
+ 	static const char module[] = "TIFFStripSize";
+ 	uint64 m;
+-	tmsize_t n;
+ 	m=TIFFStripSize64(tif);
+-	n=(tmsize_t)m;
+-	if ((uint64)n!=m)
+-	{
+-		TIFFErrorExt(tif->tif_clientdata,module,"Integer overflow");
+-		n=0;
+-	}
+-	return(n);
++	return _TIFFCastUInt64ToSSize(tif, m, module);
+ }
+ 
+ /*
+@@ -330,14 +316,8 @@
+ {
+ 	static const char module[] = "TIFFScanlineSize";
+ 	uint64 m;
+-	tmsize_t n;
+ 	m=TIFFScanlineSize64(tif);
+-	n=(tmsize_t)m;
+-	if ((uint64)n!=m) {
+-		TIFFErrorExt(tif->tif_clientdata,module,"Integer arithmetic overflow");
+-		n=0;
+-	}
+-	return(n);
++	return _TIFFCastUInt64ToSSize(tif, m, module);
+ }
+ 
+ /*
+@@ -366,15 +346,8 @@
+ {
+ 	static const char module[] = "TIFFRasterScanlineSize";
+ 	uint64 m;
+-	tmsize_t n;
+ 	m=TIFFRasterScanlineSize64(tif);
+-	n=(tmsize_t)m;
+-	if ((uint64)n!=m)
+-	{
+-		TIFFErrorExt(tif->tif_clientdata,module,"Integer arithmetic overflow");
+-		n=0;
+-	}
+-	return(n);
++	return _TIFFCastUInt64ToSSize(tif, m, module);
+ }
+ 
+ /* vim: set ts=8 sts=8 sw=8 noet: */
+diff -ru tiff-4.0.10-orig/libtiff/tif_tile.c tiff-4.0.10/libtiff/tif_tile.c
+--- tiff-4.0.10-orig/libtiff/tif_tile.c	2017-12-02 16:21:47.993972977 +0100
++++ tiff-4.0.10/libtiff/tif_tile.c	2019-10-02 22:35:17.395184517 +0200
+@@ -181,15 +181,8 @@
+ {
+ 	static const char module[] = "TIFFTileRowSize";
+ 	uint64 m;
+-	tmsize_t n;
+ 	m=TIFFTileRowSize64(tif);
+-	n=(tmsize_t)m;
+-	if ((uint64)n!=m)
+-	{
+-		TIFFErrorExt(tif->tif_clientdata,module,"Integer overflow");
+-		n=0;
+-	}
+-	return(n);
++	return _TIFFCastUInt64ToSSize(tif, m, module);
+ }
+ 
+ /*
+@@ -248,15 +241,8 @@
+ {
+ 	static const char module[] = "TIFFVTileSize";
+ 	uint64 m;
+-	tmsize_t n;
+ 	m=TIFFVTileSize64(tif,nrows);
+-	n=(tmsize_t)m;
+-	if ((uint64)n!=m)
+-	{
+-		TIFFErrorExt(tif->tif_clientdata,module,"Integer overflow");
+-		n=0;
+-	}
+-	return(n);
++	return _TIFFCastUInt64ToSSize(tif, m, module);
+ }
+ 
+ /*
+@@ -272,15 +258,8 @@
+ {
+ 	static const char module[] = "TIFFTileSize";
+ 	uint64 m;
+-	tmsize_t n;
+ 	m=TIFFTileSize64(tif);
+-	n=(tmsize_t)m;
+-	if ((uint64)n!=m)
+-	{
+-		TIFFErrorExt(tif->tif_clientdata,module,"Integer overflow");
+-		n=0;
+-	}
+-	return(n);
++	return _TIFFCastUInt64ToSSize(tif, m, module);
+ }
+ 
+ /*

--- a/pkgs/development/libraries/libtiff/default.nix
+++ b/pkgs/development/libraries/libtiff/default.nix
@@ -17,6 +17,16 @@ stdenv.mkDerivation rec {
     sha256 = "1r4np635gr6zlc0bic38dzvxia6iqzcrary4n1ylarzpr8fd2lic";
   };
 
+  patches = [
+    (fetchurl {
+      url = "https://gitlab.com/libtiff/libtiff/commit/0c74a9f49b8d7a36b17b54a7428b3526d20f88a8.patch";
+      name = "CVE-2019-6128.patch";
+      sha256 = "03yvsfq6dxjd3v8ypfwz6cpz2iymqwcbawqqlmkh40dayi7fgizr";
+    })
+    # Manual backport of https://gitlab.com/libtiff/libtiff/commit/1b5e3b6a23827c33acf19ad50ce5ce78f12b3773.patch
+    ./CVE-2019-14973.patch
+  ];
+
   outputs = [ "bin" "dev" "out" "man" "doc" ];
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change

CVE-2019-14973.patch is a manually backported of the upstream patch to
work around some minor merge conflicts.

#70108 (security bug)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).