### PR TITLE
spring-boot: init at 2.1.9

### DIFF
--- a/pkgs/development/tools/spring-boot/default.nix
+++ b/pkgs/development/tools/spring-boot/default.nix
@@ -1,0 +1,46 @@
+{ stdenv, fetchzip, jdk, makeWrapper, installShellFiles }:
+
+stdenv.mkDerivation rec {
+  pname = "spring-boot";
+  version = "2.1.9";
+
+  src = fetchzip {
+    url = "https://repo.spring.io/release/org/springframework/boot/${pname}-cli/${version}.RELEASE/${pname}-cli-${version}.RELEASE-bin.zip";
+    sha256 = "03iphh5l9w9sizksidkv217qnqx3nh1zpw6kdjnn40j3mlabfb7j";
+  };
+
+  nativeBuildInputs = [ makeWrapper installShellFiles ];
+
+  installPhase = ''
+    runHook preInstall
+    rm bin/spring.bat
+    installShellCompletion --bash shell-completion/bash/spring
+    installShellCompletion --zsh shell-completion/zsh/_spring
+    rm -r shell-completion
+    cp -r . $out
+    wrapProgram $out/bin/spring \
+      --prefix JAVA_HOME : ${jdk}
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = ''
+      CLI which makes it easy to create spring-based applications
+    '';
+    longDescription = ''
+      Spring Boot makes it easy to create stand-alone, production-grade 
+      Spring-based Applications that you can run. We take an opinionated view 
+      of the Spring platform and third-party libraries, so that you can get 
+      started with minimum fuss. Most Spring Boot applications need very 
+      little Spring configuration.
+
+      You can use Spring Boot to create Java applications that can be started 
+      by using java -jar or more traditional war deployments. We also provide 
+      a command line tool that runs “spring scripts”.
+    '';
+    homepage = https://spring.io/projects/spring-boot;
+    license = licenses.asl20;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ moaxcp ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15255,6 +15255,8 @@ in
 
   spawn_fcgi = callPackage ../servers/http/spawn-fcgi { };
 
+  spring-boot = callPackage ../development/tools/spring-boot { };
+
   squid = callPackage ../servers/squid { };
 
   sslh = callPackage ../servers/sslh { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Adding spring-boot cli

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
