### PR TITLE
gst-plugins-base: apply patch for CVE-2019-9928

### DIFF
--- a/pkgs/development/libraries/gstreamer/legacy/gst-plugins-base/default.nix
+++ b/pkgs/development/libraries/gstreamer/legacy/gst-plugins-base/default.nix
@@ -18,11 +18,18 @@ stdenv.mkDerivation rec {
     sha256 = "0jp6hjlra98cnkal4n6bdmr577q8mcyp3c08s3a02c4hjhw5rr0z";
   };
 
-  patchPhase = ''
+  patches = [
+    ./gcc-4.9.patch
+    (fetchurl {
+      url = "https://gitlab.freedesktop.org/gstreamer/gst-plugins-base/commit/f672277509705c4034bc92a141eefee4524d15aa.patch";
+      name = "CVE-2019-9928.patch";
+      sha256 = "0hz3lsq3ppmaf329sbyi05y1qniqfj9vlp2f3z918383pvrcms4i";
+    })
+  ];
+
+  postPatch = ''
     sed -i 's@/bin/echo@echo@g' configure
     sed -i -e 's/^   /\t/' docs/{libs,plugins}/Makefile.in
-
-    patch -p1 < ${./gcc-4.9.patch}
   '';
 
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
###### Motivation for this change

Refactor the patchPhase management for the package along the way to
something more standard.

#70097 (security bug)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).