### PR TITLE
NixOS 19.03: Fix kdelibs and kconfig patch names for vulnix

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/kconfig.nix
+++ b/pkgs/development/libraries/kde-frameworks/kconfig.nix
@@ -11,7 +11,7 @@ mkDerivation {
     (fetchpatch {
       url = "https://cgit.kde.org/kconfig.git/patch/?id=5d3e71b1d2ecd2cb2f910036e614ffdfc895aa22";
       sha256 = "0vzrwkv3l8dlr786l6h0hqq208i6i1fbnsifi5b36d3732fqbq89";
-      name = "kconfig-D22979.patch";
+      name = "CVE-2019-14744.patch";
     })
   ];
   nativeBuildInputs = [ extra-cmake-modules ];

--- a/pkgs/development/python-modules/pykde4/default.nix
+++ b/pkgs/development/python-modules/pykde4/default.nix
@@ -35,6 +35,7 @@ in stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     platforms = platforms.linux;
+    hydraPlatforms = platforms.none;
     description = "Python bindings for KDE";
     license = with licenses; [ gpl2 lgpl2 ];
     homepage = https://api.kde.org/pykde-4.3-api/;

--- a/pkgs/development/python-modules/pykde4/kdelibs.nix
+++ b/pkgs/development/python-modules/pykde4/kdelibs.nix
@@ -40,6 +40,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     platforms = platforms.linux;
+    hydraPlatforms = platforms.none;
     homepage = http://www.kde.org;
     license = with licenses; [ gpl2 fdl12 lgpl21 ];
   };

--- a/pkgs/development/python-modules/pykde4/kdelibs.nix
+++ b/pkgs/development/python-modules/pykde4/kdelibs.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       url = "https://cgit.kde.org/kdelibs.git/patch/?id=2c3762feddf7e66cf6b64d9058f625a715694a00";
       sha256 = "1wbzywh8lcc66n6y3pxs18h7cwkq6g216faz27san33jpl8ra1i9";
-      name = "kdelibs-D22989.patch";
+      name = "CVE-2019-14744.patch";
     })
   ];
 


### PR DESCRIPTION

###### Motivation for this change

Follow up to #70263. See also: #70102.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
