### PR TITLE
corebird: move deprecation warning to aliases and release notes

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1909.xml
+++ b/nixos/doc/manual/release-notes/rl-1909.xml
@@ -513,6 +513,12 @@
        must be owned by either <literal>root</literal> or the user specified in <option>services.gitlab.user</option>.
      </para>
    </listitem>
+   <listitem>
+     <para>
+       The Twitter client <literal>corebird</literal> has been dropped as <link xlink:href="https://www.patreon.com/posts/corebirds-future-18921328">it is discontinued and does not work against the new Twitter API</link>.
+       Please use the fork <literal>cawbird</literal> instead which has been adapted to the API changes and is still maintained.
+     </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -67,6 +67,7 @@ mapAliases ({
   compton-git = compton; # added 2019-05-20
   conntrack_tools = conntrack-tools; # added 2018-05
   cool-old-term = cool-retro-term; # added 2015-01-31
+  corebird = throw "deprecated 2019-10-02: See https://www.patreon.com/posts/corebirds-future-18921328. Please use Cawbird as replacement.";
   cpp-gsl = microsoft_gsl; # added 2019-05-24
   cupsBjnp = cups-bjnp; # added 2016-01-02
   cups_filters = cups-filters; # added 2016-08

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1381,8 +1381,6 @@ in
 
   copyright-update = callPackage ../tools/text/copyright-update { };
 
-  corebird = throw "corebird has been discontinued, use cawbird instead";
-
   inherit (callPackage ../tools/misc/coreboot-utils { })
     msrtool
     cbmem


### PR DESCRIPTION
Follow-up to #70168: The deprecation warnings needed to be moved to the appropriate places as discussed in #70287

/cc @worldofpeace 