### PR TITLE
nixos/gnome-settings-daemon: move systemd config here

### DIFF
--- a/nixos/modules/services/desktops/gnome3/gnome-settings-daemon.nix
+++ b/nixos/modules/services/desktops/gnome3/gnome-settings-daemon.nix
@@ -43,6 +43,32 @@ in
       pkgs.gnome3.gnome-settings-daemon
     ];
 
+    systemd.packages = [
+      pkgs.gnome3.gnome-settings-daemon
+    ];
+
+    systemd.user.targets."gnome-session-initialized".wants = [
+      "gsd-color.target"
+      "gsd-datetime.target"
+      "gsd-keyboard.target"
+      "gsd-media-keys.target"
+      "gsd-print-notifications.target"
+      "gsd-rfkill.target"
+      "gsd-screensaver-proxy.target"
+      "gsd-sharing.target"
+      "gsd-smartcard.target"
+      "gsd-sound.target"
+      "gsd-wacom.target"
+      "gsd-wwan.target"
+      "gsd-a11y-settings.target"
+      "gsd-housekeeping.target"
+      "gsd-power.target"
+    ];
+
+    systemd.user.targets."gnome-session-x11-services".wants = [
+      "gsd-xsettings.target"
+    ];
+
   };
 
 }

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -230,22 +230,7 @@ in
       services.system-config-printer.enable = (mkIf config.services.printing.enable (mkDefault true));
       services.telepathy.enable = mkDefault true;
 
-      systemd.packages = with pkgs.gnome3; [ vino gnome-session gnome-settings-daemon ];
-
-      # gnome-settings-daemon.nix is shared between several desktop
-      # environments (eg. mate and pantheon) so specify these gnome-shell specific
-      # service dependencies here instead.
-      systemd.user.targets."gnome-session-initialized".wants = [
-        "gsd-a11y-settings.target" "gsd-housekeeping.target" "gsd-power.target"
-        "gsd-color.target" "gsd-keyboard.target" "gsd-print-notifications.target"
-        "gsd-datetime.target" "gsd-media-keys.target" "gsd-rfkill.target"
-        "gsd-screensaver-proxy.target" "gsd-sound.target" "gsd-smartcard.target"
-        "gsd-sharing.target" "gsd-wacom.target" "gsd-wwan.target"
-      ];
-
-      systemd.user.targets."gnome-session-x11-services".wants = [
-        "gsd-xsettings.target"
-      ];
+      systemd.packages = with pkgs.gnome3; [ vino gnome-session ];
 
       services.avahi.enable = mkDefault true;
 


### PR DESCRIPTION
As I've decided that it doesn't make sense for the module to be shared [0]
we can move this config here.

[0]: 68ab37aa4491c8f870483c9eff888dc5fc88d2c8

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
