### PR TITLE
soulseekqt: fix build

### DIFF
--- a/pkgs/applications/networking/p2p/soulseekqt/default.nix
+++ b/pkgs/applications/networking/p2p/soulseekqt/default.nix
@@ -1,53 +1,47 @@
-{ stdenv
-, fetchurl
+{ stdenv, lib, fetchurl, mkDerivation
+, autoPatchelfHook
 , dbus
-, zlib, fontconfig
-, qtbase, qtmultimedia
-, libjson, libgpgerror
-, libX11, libxcb, libXau, libXdmcp, freetype, libbsd
-, pythonPackages, squashfsTools, desktop-file-utils
+, desktop-file-utils
+, fontconfig
+, libjson
+, pythonPackages
+, qtmultimedia
+, squashfsTools
+, zlib
 }:
 
-with stdenv.lib;
-let
-  libPath = makeLibraryPath
-    [ stdenv.cc.cc qtbase qtmultimedia dbus libX11 zlib libX11 libxcb libXau libXdmcp freetype fontconfig libbsd libjson libgpgerror];
-
+mkDerivation rec {
+  pname = "soulseekqt";
   version = "2018-1-30";
 
-  mainbin = "SoulseekQt-" + (version) +"-"+ (if stdenv.is64bit then "64bit" else "32bit");
-  srcs = {
-    x86_64-linux = fetchurl {
-      url = "https://www.dropbox.com/s/0vi87eef3ooh7iy/${mainbin}.tgz";
+  src = fetchurl {
+      urls = [
+        "https://www.dropbox.com/s/0vi87eef3ooh7iy/SoulseekQt-${version}.tgz"
+        "https://www.slsknet.org/SoulseekQt/Linux/SoulseekQt-${version}-64bit-appimage.tgz"
+      ];
       sha256 = "0d1cayxr1a4j19bc5a3qp9pg22ggzmd55b6f5av3lc6lvwqqg4w6";
     };
-  };
-
-in stdenv.mkDerivation rec {
-
-  pname = "soulseekqt";
-  inherit version;
-  src = srcs.${stdenv.hostPlatform.system} or (throw "unsupported system: ${stdenv.hostPlatform.system}");
 
   dontBuild = true;
 
-  buildInputs = [ pythonPackages.binwalk squashfsTools desktop-file-utils ];
+  nativeBuildInputs = [ autoPatchelfHook pythonPackages.binwalk squashfsTools desktop-file-utils ];
+  buildInputs = [ qtmultimedia stdenv.cc.cc ];
 
-  # avoid usage of appimage's runner option --appimage-extract 
+  # avoid usage of appimage's runner option --appimage-extract
   unpackCmd = ''
     export HOME=$(pwd) # workaround for binwalk
     appimage=$(tar xvf $curSrc) && binwalk --quiet \
        $appimage -D 'squashfs:squashfs:unsquashfs %e'
     '';
-  
+
   patchPhase = ''
     cd squashfs-root/
     binary="$(readlink AppRun)"
-  
+
     # fixup desktop file
     desktop-file-edit --set-key Exec --set-value $binary default.desktop
     desktop-file-edit --set-key Comment --set-value "${meta.description}" default.desktop
-    desktop-file-edit --set-key Categories --set-value Network default.desktop   
+    desktop-file-edit --set-key Categories --set-value Network default.desktop
   '';
 
   installPhase = ''
@@ -57,13 +51,7 @@ in stdenv.mkDerivation rec {
     cp $binary $out/bin/
   '';
 
-  fixupPhase = ''
-    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-             --set-rpath ${libPath} \
-             $out/bin/$binary
-  '';
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Official Qt SoulSeek client";
     homepage = http://www.soulseekqt.net;
     license = licenses.unfree;


### PR DESCRIPTION
###### Motivation for this change
saw it was broken while doing a review of #70235

 - updated the urls
 - fixed the qt runtime
 - cleaned up the expression a bit.

would like for a user to verify that the app doesn't do any `dlopen`'s to libraries I removed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
$ nix path-info -Sh ./result
/nix/store/yqb1k52v822qpffh1xc7fiic8ykzds5l-soulseekqt-2018-1-30         310.0M
```