### PR TITLE
vala: 0.46.1 -> 0.46.2

### DIFF
--- a/pkgs/applications/networking/browsers/midori/default.nix
+++ b/pkgs/applications/networking/browsers/midori/default.nix
@@ -4,7 +4,7 @@
 , ninja
 , pkgconfig
 , intltool
-, vala_0_44
+, vala
 , wrapGAppsHook
 , gcr
 , libpeas
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     intltool
     ninja
     pkgconfig
-    vala_0_44
+    vala
     wrapGAppsHook
   ];
 

--- a/pkgs/development/compilers/vala/default.nix
+++ b/pkgs/development/compilers/vala/default.nix
@@ -83,12 +83,12 @@ let
     doCheck = false; # fails, requires dbus daemon
 
     # Wait for PR #59372
-    #passthru = {
+    # passthru = {
     #  updateScript = gnome3.updateScript {
     #    attrPath = "${pname}_${lib.versions.major version}_${lib.versions.minor version}";
     #    packageName = pname;
     #  };
-    #};
+    # };
 
     meta = with stdenv.lib; {
       description = "Compiler for GObject type system";
@@ -111,8 +111,8 @@ in rec {
   };
 
   vala_0_44 = generic {
-    version = "0.44.7";
-    sha256 = "0z5xy4qc95rm2gj7s2k14xm1xp3mrf0yz64fx4kddqjxkpsz87xz";
+    version = "0.44.8";
+    sha256 = "0f7pc496zvxfhbkhg8ayxykjas6f55mgv452wsnh0bz5zbxm8xrl";
   };
 
   vala_0_46 = generic {

--- a/pkgs/development/compilers/vala/default.nix
+++ b/pkgs/development/compilers/vala/default.nix
@@ -116,8 +116,8 @@ in rec {
   };
 
   vala_0_46 = generic {
-    version = "0.46.1";
-    sha256 = "10czkhclnisdz6k5qfiicmvx47m9177l5dkhjn29g43khnmpkr8l";
+    version = "0.46.2";
+    sha256 = "1g20fzcwh3j7ab46jalabyi005h2in0cp7xj0yga4b8hx29h61wj";
   };
 
   vala = vala_0_46;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
See commit messages for News.
This allows us to build midori with latest vala.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
