### PR TITLE
[staging]texinfo: 6.5 -> 6.7

### DIFF
--- a/pkgs/development/tools/misc/texinfo/6.5.nix
+++ b/pkgs/development/tools/misc/texinfo/6.5.nix
@@ -1,4 +1,0 @@
-import ./common.nix {
-  version = "6.5";
-  sha256 = "0qjzvbvnv9003xdrcpi3jp7y68j4hq2ciw9frh2hghh698zlnxvp";
-}

--- a/pkgs/development/tools/misc/texinfo/6.nix
+++ b/pkgs/development/tools/misc/texinfo/6.nix
@@ -1,0 +1,4 @@
+import ./common.nix {
+  version = "6.7";
+  sha256 = "1aicn1v3czqii08wc91jw089n1x3gfchkf808q2as59dak0h714q";
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10662,7 +10662,7 @@ in
   texinfo413 = callPackage ../development/tools/misc/texinfo/4.13a.nix { };
   texinfo4 = texinfo413;
   texinfo5 = callPackage ../development/tools/misc/texinfo/5.2.nix { };
-  texinfo6 = callPackage ../development/tools/misc/texinfo/6.5.nix { };
+  texinfo6 = callPackage ../development/tools/misc/texinfo/6.nix { };
   texinfo = texinfo6;
   texinfoInteractive = appendToName "interactive" (
     texinfo.override { interactive = true; }


### PR DESCRIPTION
###### Motivation for this change
noticed it failed update in @r-ryantm logs

renamed 6.5.nix to 6.nix while under active development

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
