### PR TITLE
racerd: 2019-03-20 -> unstable-2019-09-02

### DIFF
--- a/pkgs/development/tools/rust/racerd/default.nix
+++ b/pkgs/development/tools/rust/racerd/default.nix
@@ -4,12 +4,12 @@ with rustPlatform;
 
 buildRustPackage rec {
   pname = "racerd";
-  version = "2019-03-20";
+  version = "unstable-2019-09-02";
   src = fetchFromGitHub {
     owner = "jwilm";
     repo = "racerd";
-    rev = "6f74488e58e42314a36ff000bae796fe54c1bdd1";
-    sha256 = "1lg7j2plxpn5l65jxhsm99vmy08ljdb666hm0y1nnmmzalrakrg1";
+    rev = "e3d380b9a1d3f3b67286d60465746bc89fea9098";
+    sha256 = "13jqdvjk4savcl03mrn2vzgdsd7vxv2racqbyavrxp2cm9h6cjln";
   };
 
   # a nightly compiler is required unless we use this cheat code.
@@ -17,7 +17,7 @@ buildRustPackage rec {
 
   doCheck = false;
 
-  cargoSha256 = "15894qr0kpp5kivx0p71zmmfhfh8in0ydkvfirxh2r12x0r2jhdd";
+  cargoSha256 = "07130587drrdkrk7aqb8pl8i3p485qr6xh1m86630ydlnb9z6s6i";
 
   buildInputs = [ makeWrapper ]
                 ++ stdenv.lib.optional stdenv.isDarwin Security;


### PR DESCRIPTION
###### Motivation for this change
while reviewing #70309 I noticed it was broken, most likely from the rustc bump.

Updating the project seems to have fixed the build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[2 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/70313
3 package were build:
rustracerd vimPlugins.YouCompleteMe ycmd
```