### PR TITLE
kafka: Fix stop script in pure environments

### DIFF
--- a/pkgs/servers/apache-kafka/default.nix
+++ b/pkgs/servers/apache-kafka/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre, makeWrapper, bash, coreutils, gnugrep, gnused,
+{ stdenv, fetchurl, jre, makeWrapper, bash, coreutils, gnugrep, gnused, ps,
   majorVersion ? "1.0" }:
 
 let
@@ -62,7 +62,7 @@ stdenv.mkDerivation rec {
     inherit sha256;
   };
 
-  buildInputs = [ jre makeWrapper bash gnugrep gnused coreutils ];
+  buildInputs = [ jre makeWrapper bash gnugrep gnused coreutils ps ];
 
   installPhase = ''
     mkdir -p $out
@@ -75,6 +75,9 @@ stdenv.mkDerivation rec {
     # allow us the specify logging directory using env
     substituteInPlace $out/bin/kafka-run-class.sh \
       --replace 'LOG_DIR="$base_dir/logs"' 'LOG_DIR="$KAFKA_LOG_DIR"'
+
+    substituteInPlace $out/bin/kafka-server-stop.sh \
+      --replace 'ps' '${ps}/bin/ps'
 
     for p in $out/bin\/*.sh; do
       wrapProgram $p \


### PR DESCRIPTION
##### Motivation for this change
The stop script was not working in pure environments (``nix-shell --pure -p apacheKafka``) due to the missing ``ps`` command.

###### Things done

Added explicit dependency on ``ps``.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @NeQuissimus 
