### PR TITLE
Revert "perl-modules: do not create perllocal.pod, for determinism"

### DIFF
--- a/pkgs/development/perl-modules/generic/default.nix
+++ b/pkgs/development/perl-modules/generic/default.nix
@@ -22,9 +22,6 @@ toPerlModule(stdenv.mkDerivation (
     # Prevent CPAN downloads.
     PERL_AUTOINSTALL = "--skipdeps";
 
-    # Avoid creating perllocal.pod, which contains a timestamp
-    installTargets = "pure_install";
-
     # From http://wiki.cpantesters.org/wiki/CPANAuthorNotes: "allows
     # authors to skip certain tests (or include certain tests) when
     # the results are not being monitored by a human being."


### PR DESCRIPTION
This reverts commit d0bad145f5e78f2be6d745da305067398722df17.

I don’t think we need this any more, because the generated timestamps are
always set to 1970-01-01.

Reverting this will mean we get man pages for perl programs for free,
because those are generally part of the `install' target.