### PR TITLE
Refactor Synapse plugins, add matrix-synapse-pam

### DIFF
--- a/pkgs/development/python-modules/python-pam/default.nix
+++ b/pkgs/development/python-modules/python-pam/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildPythonPackage, fetchPypi, pam }:
+
+buildPythonPackage rec {
+  pname = "python-pam";
+  version = "1.8.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "16whhc0vr7gxsbzvsnq65nq8fs3wwmx755cavm8kkczdkz4djmn8";
+  };
+
+  postPatch = ''
+    substituteInPlace pam.py --replace 'find_library("pam")' \
+      '"${pam}/lib/libpam${stdenv.hostPlatform.extensions.sharedLibrary}"'
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Python PAM module using ctypes";
+    homepage = "https://github.com/FirefighterBlu3/python-pam";
+    maintainers = with maintainers; [ abbradar ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/servers/matrix-synapse/default.nix
+++ b/pkgs/servers/matrix-synapse/default.nix
@@ -5,23 +5,9 @@
 with python3.pkgs;
 
 let
-  matrix-synapse-ldap3 = buildPythonPackage rec {
-    pname = "matrix-synapse-ldap3";
-    version = "0.1.4";
-
-    src = fetchPypi {
-      inherit pname version;
-      sha256 = "01bms89sl16nyh9f141idsz4mnhxvjrc3gj721wxh1fhikps0djx";
-    };
-
-    propagatedBuildInputs = [ service-identity ldap3 twisted ];
-
-    # ldaptor is not ready for py3 yet
-    doCheck = !isPy3k;
-    checkInputs = [ ldaptor mock ];
-  };
-
-in buildPythonApplication rec {
+  plugins = python3.pkgs.callPackage ./plugins { };
+in
+buildPythonApplication rec {
   pname = "matrix-synapse";
   version = "1.14.0";
 
@@ -45,7 +31,6 @@ in buildPythonApplication rec {
     jinja2
     jsonschema
     lxml
-    matrix-synapse-ldap3
     msgpack
     netaddr
     phonenumbers
@@ -79,11 +64,13 @@ in buildPythonApplication rec {
 
   doCheck = !stdenv.isDarwin;
 
-  passthru.tests = { inherit (nixosTests) matrix-synapse; };
-
   checkPhase = ''
     PYTHONPATH=".:$PYTHONPATH" ${python3.interpreter} -m twisted.trial tests
   '';
+
+  passthru.tests = { inherit (nixosTests) matrix-synapse; };
+  passthru.plugins = plugins;
+  passthru.python = python3;
 
   meta = with stdenv.lib; {
     homepage = "https://matrix.org";

--- a/pkgs/servers/matrix-synapse/plugins/default.nix
+++ b/pkgs/servers/matrix-synapse/plugins/default.nix
@@ -2,4 +2,5 @@
 
 {
   matrix-synapse-ldap3 = callPackage ./ldap3.nix { };
+  matrix-synapse-pam = callPackage ./pam.nix { };
 }

--- a/pkgs/servers/matrix-synapse/plugins/default.nix
+++ b/pkgs/servers/matrix-synapse/plugins/default.nix
@@ -1,0 +1,5 @@
+{ callPackage }:
+
+{
+  matrix-synapse-ldap3 = callPackage ./ldap3.nix { };
+}

--- a/pkgs/servers/matrix-synapse/plugins/ldap3.nix
+++ b/pkgs/servers/matrix-synapse/plugins/ldap3.nix
@@ -1,0 +1,17 @@
+{ isPy3k, buildPythonPackage, fetchPypi, service-identity, ldap3, twisted, ldaptor, mock }:
+
+buildPythonPackage rec {
+  pname = "matrix-synapse-ldap3";
+  version = "0.1.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "01bms89sl16nyh9f141idsz4mnhxvjrc3gj721wxh1fhikps0djx";
+  };
+
+  propagatedBuildInputs = [ service-identity ldap3 twisted ];
+
+  # ldaptor is not ready for py3 yet
+  doCheck = !isPy3k;
+  checkInputs = [ ldaptor mock ];
+}

--- a/pkgs/servers/matrix-synapse/plugins/pam.nix
+++ b/pkgs/servers/matrix-synapse/plugins/pam.nix
@@ -1,0 +1,15 @@
+{ buildPythonPackage, fetchFromGitHub, twisted, python-pam }:
+
+buildPythonPackage rec {
+  pname = "matrix-synapse-pam";
+  version = "0.1.2";
+
+  src = fetchFromGitHub {
+    owner = "14mRh4X0r";
+    repo = "matrix-synapse-pam";
+    rev = "v${version}";
+    sha256 = "10byma9hxz3g4sirw5sa4pvljn83h9vs7zc15chhpl2n14bdx45l";
+  };
+
+  propagatedBuildInputs = [ twisted python-pam ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4706,6 +4706,8 @@ in
     (https://github.com/NixOS/nixpkgs/issues/76093) */
   matrix-synapse = callPackage ../servers/matrix-synapse { /*python3 = python38;*/ };
 
+  matrix-synapse-plugins = recurseIntoAttrs matrix-synapse.plugins;
+
   matrix-appservice-slack = callPackage ../servers/matrix-synapse/matrix-appservice-slack {};
 
   mautrix-telegram = recurseIntoAttrs (callPackage ../servers/mautrix-telegram { });

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3316,6 +3316,8 @@ in {
 
   python-axolotl-curve25519 = callPackage ../development/python-modules/python-axolotl-curve25519 { };
 
+  python-pam = callPackage ../development/python-modules/python-pam { };
+
   pythonix = callPackage ../development/python-modules/pythonix {
     inherit (pkgs) meson pkgconfig;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Avoid having the core server depend on plugins. Also introduce a new one.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
