### PR TITLE
mysqltuner: 1.7.13 -> 1.7.17

### DIFF
--- a/pkgs/tools/misc/mysqltuner/default.nix
+++ b/pkgs/tools/misc/mysqltuner/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "mysqltuner";
-  version = "1.7.13";
+  version = "1.7.17";
 
   src = fetchFromGitHub {
     owner  = "major";
     repo   = "MySQLTuner-perl";
     rev    = version;
-    sha256 = "0zxm2hjvgznbbmsqb8bpcgzc0yq1ikxz1gckirp95ibxid3jdham";
+    sha256 = "0wjdqraa6r6kd6rsgrn177dq6xsnnr1sgnbs9whknjbs4fn3wwl5";
   };
 
   buildInputs = [ perl ];


### PR DESCRIPTION
##### Motivation for this change
Version update

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
