### PR TITLE
mp3gain: 1.5.2 -> 1.6.2

### DIFF
--- a/pkgs/applications/audio/mp3gain/default.nix
+++ b/pkgs/applications/audio/mp3gain/default.nix
@@ -1,13 +1,13 @@
-{ stdenv, fetchurl, unzip }:
+{ stdenv, fetchurl, unzip, mpg123 }:
 
 stdenv.mkDerivation {
-  name = "mp3gain-1.5.2";
+  name = "mp3gain-1.6.2";
   src = fetchurl {
-    url = "mirror://sourceforge/mp3gain/mp3gain-1_5_2-src.zip";
-    sha256 = "1jkgry59m8cnnfq05b9y1h4x4wpy3iq8j68slb9qffwa3ajcgbfv";
+    url = "mirror://sourceforge/mp3gain/mp3gain-1_6_2-src.zip";
+    sha256 = "0varr6y7k8zarr56b42r0ad9g3brhn5vv3xjg1c0v19jxwr4gh2w";
   };
 
-  buildInputs = [ unzip ];
+  buildInputs = [ unzip mpg123 ];
 
   sourceRoot = ".";
 


### PR DESCRIPTION
###### Motivation for this change
Version update

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
