### PR TITLE
hachoir: init at 3.1.1

### DIFF
--- a/pkgs/development/python-modules/hachoir/default.nix
+++ b/pkgs/development/python-modules/hachoir/default.nix
@@ -1,0 +1,53 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchPypi
+, urwid
+, wxPython_4_0
+, six
+, flake8
+, sphinx
+, pygobject3
+, pyqt4
+
+# The following options control GUI functionality. Disabling them results in parts
+# of the library and certain user-facing scripts not working. They are here if
+# you need to avoid the dependencies these features pull in (e.g. in a headless
+# scenario).
+, urwidSupport ? true
+, wxPythonSupport ? true
+, gtkSupport ? true
+, qtSupport ? true
+}:
+
+assert urwidSupport -> urwid != null;
+assert wxPythonSupport -> wxPython_4_0 != null;
+
+with stdenv.lib;
+buildPythonPackage rec {
+  pname = "hachoir";
+  version = "3.1.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "030lffprlw371ciplsf2mszc55jx2pyzx192j1jkwbf3z0wim9qa";
+  };
+
+  # setuptoolsCheckPhase is broken, tox and runtests.py fail only when run from
+  # nix check phase
+  doCheck = false;
+
+  checkInputs = [ flake8 sphinx ];
+  propagatedBuildInputs = [ six ]
+      ++ (optional urwidSupport urwid)
+      ++ (optional wxPythonSupport wxPython_4_0)
+      ++ (optional gtkSupport pygobject3)
+      ++ (optional qtSupport pyqt4);
+
+  meta = with lib; {
+    description = "Package of Hachoir parsers used to open binary files";
+    homepage    = "http://hachoir.readthedocs.io/en/latest/install.html";
+    license     = lib.licenses.gpl2;
+    maintainers = with maintainers; [ dadada ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -740,6 +740,8 @@ in
 
   havoc = callPackage ../applications/terminal-emulators/havoc { };
 
+  hachoir = with python3Packages; toPythonApplication hachoir;
+
   hyper = callPackage ../applications/terminal-emulators/hyper { };
 
   iterm2 = callPackage ../applications/terminal-emulators/iterm2 {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15,7 +15,6 @@
 with lib;
 
 self:
-
 let
   inherit (self) callPackage;
   inherit (python.passthru) isPy27 isPy35 isPy36 isPy37 isPy38 isPy39 isPy3k isPyPy pythonAtLeast pythonOlder;
@@ -31,37 +30,40 @@ let
       ff = f origArgs;
       overrideWith = newArgs: origArgs // (if pkgs.lib.isFunction newArgs then newArgs origArgs else newArgs);
     in
-      if builtins.isAttrs ff then (ff // {
+    if builtins.isAttrs ff then
+      (ff // {
         overridePythonAttrs = newArgs: makeOverridablePythonPackage f (overrideWith newArgs);
       })
-      else if builtins.isFunction ff then {
-        overridePythonAttrs = newArgs: makeOverridablePythonPackage f (overrideWith newArgs);
-        __functor = self: ff;
-      }
-      else ff;
+    else if builtins.isFunction ff then {
+      overridePythonAttrs = newArgs: makeOverridablePythonPackage f (overrideWith newArgs);
+      __functor = self: ff;
+    }
+    else ff;
 
-  buildPythonPackage = makeOverridablePythonPackage ( makeOverridable (callPackage ../development/interpreters/python/mk-python-derivation.nix {
-    inherit namePrefix;     # We want Python libraries to be named like e.g. "python3.6-${name}"
-    inherit toPythonModule; # Libraries provide modules
+  buildPythonPackage = makeOverridablePythonPackage (makeOverridable (callPackage ../development/interpreters/python/mk-python-derivation.nix {
+    inherit namePrefix;# We want Python libraries to be named like e.g. "python3.6-${name}"
+    inherit toPythonModule;# Libraries provide modules
   }));
 
-  buildPythonApplication = makeOverridablePythonPackage ( makeOverridable (callPackage ../development/interpreters/python/mk-python-derivation.nix {
-    namePrefix = "";        # Python applications should not have any prefix
-    toPythonModule = x: x;  # Application does not provide modules.
+  buildPythonApplication = makeOverridablePythonPackage (makeOverridable (callPackage ../development/interpreters/python/mk-python-derivation.nix {
+    namePrefix = ""; # Python applications should not have any prefix
+    toPythonModule = x: x; # Application does not provide modules.
   }));
 
   # See build-setupcfg/default.nix for documentation.
   buildSetupcfg = import ../build-support/build-setupcfg self;
 
-  fetchPypi = callPackage ../development/interpreters/python/fetchpypi.nix {};
+  fetchPypi = callPackage ../development/interpreters/python/fetchpypi.nix { };
 
   # Check whether a derivation provides a Python module.
   hasPythonModule = drv: drv?pythonModule && drv.pythonModule == python;
 
   # Get list of required Python modules given a list of derivations.
-  requiredPythonModules = drvs: let
-    modules = filter hasPythonModule drvs;
-  in unique ([python] ++ modules ++ concatLists (catAttrs "requiredPythonModules" modules));
+  requiredPythonModules = drvs:
+    let
+      modules = filter hasPythonModule drvs;
+    in
+    unique ([ python ] ++ modules ++ concatLists (catAttrs "requiredPythonModules" modules));
 
   # Create a PYTHONPATH from a list of derivations. This function recurses into the items to find derivations
   # providing Python modules.
@@ -72,9 +74,9 @@ let
 
   # Convert derivation to a Python module.
   toPythonModule = drv:
-    drv.overrideAttrs( oldAttrs: {
+    drv.overrideAttrs (oldAttrs: {
       # Use passthru in order to prevent rebuilds when possible.
-      passthru = (oldAttrs.passthru or {})// {
+      passthru = (oldAttrs.passthru or { }) // {
         pythonModule = python;
         pythonPath = [ ]; # Deprecated, for compatibility.
         requiredPythonModules = requiredPythonModules drv.propagatedBuildInputs;
@@ -83,8 +85,8 @@ let
 
   # Convert a Python library to an application.
   toPythonApplication = drv:
-    drv.overrideAttrs( oldAttrs: {
-      passthru = (oldAttrs.passthru or {}) // {
+    drv.overrideAttrs (oldAttrs: {
+      passthru = (oldAttrs.passthru or { }) // {
         # Remove Python prefix from name so we have a "normal" name.
         # While the prefix shows up in the store path, it won't be
         # used by `nix-env`.
@@ -96,7 +98,8 @@ let
   disabledIf = x: drv:
     if x then throw "${removePythonPrefix (drv.pname or drv.name)} not supported for interpreter ${python.executable}" else drv;
 
-in {
+in
+{
 
   inherit (python.passthru) isPy27 isPy35 isPy36 isPy37 isPy38 isPy39 isPy3k isPyPy pythonAtLeast pythonOlder;
   inherit python bootstrapped-pip buildPythonPackage buildPythonApplication;
@@ -126,7 +129,7 @@ in {
 
   # helpers
 
-  wrapPython = callPackage ../development/interpreters/python/wrap-python.nix {inherit python; inherit (pkgs) makeSetupHook makeWrapper; };
+  wrapPython = callPackage ../development/interpreters/python/wrap-python.nix { inherit python;inherit (pkgs) makeSetupHook makeWrapper; };
 
   # Dont take pythonPackages from "global" pkgs scope to avoid mixing python versions
   pythonPackages = self;
@@ -135,10 +138,11 @@ in {
 
   recursivePthLoader = callPackage ../development/python-modules/recursive-pth-loader { };
 
-  setuptools = if isPy27 then
-    callPackage ../development/python-modules/setuptools/44.0.nix { }
-  else
-    callPackage ../development/python-modules/setuptools { };
+  setuptools =
+    if isPy27 then
+      callPackage ../development/python-modules/setuptools/44.0.nix { }
+    else
+      callPackage ../development/python-modules/setuptools { };
 
   aadict = callPackage ../development/python-modules/aadict { };
 
@@ -426,10 +430,11 @@ in {
 
   asdf = callPackage ../development/python-modules/asdf { };
 
-  ase = if isPy27 then
-    callPackage ../development/python-modules/ase/3.17.nix { }
-  else
-    callPackage ../development/python-modules/ase { };
+  ase =
+    if isPy27 then
+      callPackage ../development/python-modules/ase/3.17.nix { }
+    else
+      callPackage ../development/python-modules/ase { };
 
   asgi-csrf = callPackage ../development/python-modules/asgi-csrf { };
 
@@ -445,10 +450,11 @@ in {
 
   astral = callPackage ../development/python-modules/astral { };
 
-  astroid = if isPy3k then
-    callPackage ../development/python-modules/astroid { }
-  else
-    callPackage ../development/python-modules/astroid/1.6.nix { };
+  astroid =
+    if isPy3k then
+      callPackage ../development/python-modules/astroid { }
+    else
+      callPackage ../development/python-modules/astroid/1.6.nix { };
 
   astropy = callPackage ../development/python-modules/astropy { };
 
@@ -866,10 +872,11 @@ in {
 
   bcdoc = callPackage ../development/python-modules/bcdoc { };
 
-  bcrypt = if pythonOlder "3.6" then
-    callPackage ../development/python-modules/bcrypt/3_1.nix { }
-  else
-    callPackage ../development/python-modules/bcrypt { };
+  bcrypt =
+    if pythonOlder "3.6" then
+      callPackage ../development/python-modules/bcrypt/3_1.nix { }
+    else
+      callPackage ../development/python-modules/bcrypt { };
 
   beaker = callPackage ../development/python-modules/beaker { };
 
@@ -1089,16 +1096,18 @@ in {
 
   cachelib = callPackage ../development/python-modules/cachelib { };
 
-  cachetools = let
-    cachetools' = callPackage ../development/python-modules/cachetools { };
-    cachetools_2 = cachetools'.overridePythonAttrs (oldAttrs: rec {
-      version = "3.1.1";
-      src = oldAttrs.src.override {
-        inherit version;
-        sha256 = "16m69l6n6y1r1y7cklm92rr7v69ldig2n3lbl3j323w5jz7d78lf";
-      };
-    });
-  in if isPy3k then cachetools' else cachetools_2;
+  cachetools =
+    let
+      cachetools' = callPackage ../development/python-modules/cachetools { };
+      cachetools_2 = cachetools'.overridePythonAttrs (oldAttrs: rec {
+        version = "3.1.1";
+        src = oldAttrs.src.override {
+          inherit version;
+          sha256 = "16m69l6n6y1r1y7cklm92rr7v69ldig2n3lbl3j323w5jz7d78lf";
+        };
+      });
+    in
+    if isPy3k then cachetools' else cachetools_2;
 
   cachy = callPackage ../development/python-modules/cachy { };
 
@@ -1111,15 +1120,17 @@ in {
     inherit (self) python numpy boost;
   });
 
-  cairocffi = if isPy3k then
-    callPackage ../development/python-modules/cairocffi { }
-  else
-    callPackage ../development/python-modules/cairocffi/0_9.nix { };
+  cairocffi =
+    if isPy3k then
+      callPackage ../development/python-modules/cairocffi { }
+    else
+      callPackage ../development/python-modules/cairocffi/0_9.nix { };
 
-  cairosvg = if isPy3k then
-    callPackage ../development/python-modules/cairosvg { }
-  else
-    callPackage ../development/python-modules/cairosvg/1_x.nix { };
+  cairosvg =
+    if isPy3k then
+      callPackage ../development/python-modules/cairosvg { }
+    else
+      callPackage ../development/python-modules/cairosvg/1_x.nix { };
 
   caldav = callPackage ../development/python-modules/caldav { };
 
@@ -1229,10 +1240,11 @@ in {
 
   cheroot = callPackage ../development/python-modules/cheroot { };
 
-  cherrypy = if isPy3k then
-    callPackage ../development/python-modules/cherrypy { }
-  else
-    callPackage ../development/python-modules/cherrypy/17.nix { };
+  cherrypy =
+    if isPy3k then
+      callPackage ../development/python-modules/cherrypy { }
+    else
+      callPackage ../development/python-modules/cherrypy/17.nix { };
 
   chevron = callPackage ../development/python-modules/chevron { };
 
@@ -1284,9 +1296,9 @@ in {
 
   click-threading = callPackage ../development/python-modules/click-threading { };
 
-  clickhouse-cityhash = callPackage ../development/python-modules/clickhouse-cityhash {};
+  clickhouse-cityhash = callPackage ../development/python-modules/clickhouse-cityhash { };
 
-  clickhouse-driver = callPackage ../development/python-modules/clickhouse-driver {};
+  clickhouse-driver = callPackage ../development/python-modules/clickhouse-driver { };
 
   cliff = callPackage ../development/python-modules/cliff { };
 
@@ -1384,10 +1396,11 @@ in {
 
   configobj = callPackage ../development/python-modules/configobj { };
 
-  configparser = if pythonOlder "3.6" then
-    callPackage ../development/python-modules/configparser/4.nix { }
-  else
-    callPackage ../development/python-modules/configparser { };
+  configparser =
+    if pythonOlder "3.6" then
+      callPackage ../development/python-modules/configparser/4.nix { }
+    else
+      callPackage ../development/python-modules/configparser { };
 
   configshell = callPackage ../development/python-modules/configshell { };
 
@@ -1465,15 +1478,17 @@ in {
 
   cryptacular = callPackage ../development/python-modules/cryptacular { };
 
-  cryptography = if isPy27 then
-    callPackage ../development/python-modules/cryptography/3.3.nix { }
-  else
-    callPackage ../development/python-modules/cryptography { };
+  cryptography =
+    if isPy27 then
+      callPackage ../development/python-modules/cryptography/3.3.nix { }
+    else
+      callPackage ../development/python-modules/cryptography { };
 
-  cryptography_vectors = if isPy27 then
-    callPackage ../development/python-modules/cryptography/vectors-3.3.nix { }
-  else
-    callPackage ../development/python-modules/cryptography/vectors.nix { };
+  cryptography_vectors =
+    if isPy27 then
+      callPackage ../development/python-modules/cryptography/vectors-3.3.nix { }
+    else
+      callPackage ../development/python-modules/cryptography/vectors.nix { };
 
   crytic-compile = callPackage ../development/python-modules/crytic-compile { };
 
@@ -1866,10 +1881,11 @@ in {
 
   dnslib = callPackage ../development/python-modules/dnslib { };
 
-  dnspython = if isPy3k then
-    callPackage ../development/python-modules/dnspython { }
-  else
-    self.dnspython_1;
+  dnspython =
+    if isPy3k then
+      callPackage ../development/python-modules/dnspython { }
+    else
+      self.dnspython_1;
 
   dnspython_1 = callPackage ../development/python-modules/dnspython/1.nix { };
 
@@ -1941,10 +1957,11 @@ in {
 
   dugong = callPackage ../development/python-modules/dugong { };
 
-  dulwich = if isPy3k then
-    callPackage ../development/python-modules/dulwich { }
-  else
-    callPackage ../development/python-modules/dulwich/0_19.nix { };
+  dulwich =
+    if isPy3k then
+      callPackage ../development/python-modules/dulwich { }
+    else
+      callPackage ../development/python-modules/dulwich/0_19.nix { };
 
   dyn = callPackage ../development/python-modules/dyn { };
 
@@ -2140,10 +2157,11 @@ in {
 
   fasttext = callPackage ../development/python-modules/fasttext { };
 
-  faulthandler = if !isPy3k then
-    callPackage ../development/python-modules/faulthandler { }
-  else
-    throw "faulthandler is built into ${python.executable}";
+  faulthandler =
+    if !isPy3k then
+      callPackage ../development/python-modules/faulthandler { }
+    else
+      throw "faulthandler is built into ${python.executable}";
 
   favicon = callPackage ../development/python-modules/favicon { };
 
@@ -2155,10 +2173,11 @@ in {
 
   feedgenerator = callPackage ../development/python-modules/feedgenerator { inherit (pkgs) glibcLocales; };
 
-  feedparser = if isPy3k then
-    callPackage ../development/python-modules/feedparser { }
-  else
-    callPackage ../development/python-modules/feedparser/5.nix { };
+  feedparser =
+    if isPy3k then
+      callPackage ../development/python-modules/feedparser { }
+    else
+      callPackage ../development/python-modules/feedparser/5.nix { };
 
   fenics = callPackage ../development/libraries/science/math/fenics {
     inherit (pkgs) pkg-config;
@@ -2370,7 +2389,8 @@ in {
 
   freetype-py = callPackage ../development/python-modules/freetype-py { };
 
-  freezegun = if isPy27 then
+  freezegun =
+    if isPy27 then
       callPackage ../development/python-modules/freezegun/0.3.nix { }
     else
       callPackage ../development/python-modules/freezegun { };
@@ -2477,10 +2497,11 @@ in {
 
   geopandas = callPackage ../development/python-modules/geopandas { };
 
-  geopy = if isPy3k then
-    callPackage ../development/python-modules/geopy { }
-  else
-    callPackage ../development/python-modules/geopy/2.nix { };
+  geopy =
+    if isPy3k then
+      callPackage ../development/python-modules/geopy { }
+    else
+      callPackage ../development/python-modules/geopy/2.nix { };
 
   getmac = callPackage ../development/python-modules/getmac { };
 
@@ -2557,7 +2578,8 @@ in {
 
   google_api_python_client =
     let google_api_python_client = callPackage ../development/python-modules/google-api-python-client { };
-    in if isPy3k then
+    in
+    if isPy3k then
       google_api_python_client
     else # Python 2.7 support was deprecated but is still needed by weboob and duplicity
       google_api_python_client.overridePythonAttrs (old: rec {
@@ -2757,10 +2779,11 @@ in {
 
   grpcio-tools = callPackage ../development/python-modules/grpcio-tools { };
 
-  gsd = if isPy27 then
-    callPackage ../development/python-modules/gsd/1.7.nix { }
-  else
-    callPackage ../development/python-modules/gsd { };
+  gsd =
+    if isPy27 then
+      callPackage ../development/python-modules/gsd/1.7.nix { }
+    else
+      callPackage ../development/python-modules/gsd { };
 
   gspread = callPackage ../development/python-modules/gspread { };
 
@@ -2783,21 +2806,23 @@ in {
 
   gumath = callPackage ../development/python-modules/gumath { };
 
-  gunicorn = if isPy27 then
-    callPackage ../development/python-modules/gunicorn/19.nix { }
-  else
-    callPackage ../development/python-modules/gunicorn { };
+  gunicorn =
+    if isPy27 then
+      callPackage ../development/python-modules/gunicorn/19.nix { }
+    else
+      callPackage ../development/python-modules/gunicorn { };
 
-  gurobipy = if stdenv.hostPlatform.system == "x86_64-darwin" then
-    callPackage ../development/python-modules/gurobipy/darwin.nix { inherit (pkgs.darwin) cctools insert_dylib; }
-  else if stdenv.hostPlatform.system == "x86_64-linux" then
-    callPackage ../development/python-modules/gurobipy/linux.nix { }
-  else
-    throw "gurobipy not yet supported on ${stdenv.hostPlatform.system}";
+  gurobipy =
+    if stdenv.hostPlatform.system == "x86_64-darwin" then
+      callPackage ../development/python-modules/gurobipy/darwin.nix { inherit (pkgs.darwin) cctools insert_dylib; }
+    else if stdenv.hostPlatform.system == "x86_64-linux" then
+      callPackage ../development/python-modules/gurobipy/linux.nix { }
+    else
+      throw "gurobipy not yet supported on ${stdenv.hostPlatform.system}";
 
   guzzle_sphinx_theme = callPackage ../development/python-modules/guzzle_sphinx_theme { };
 
-  gviz-api = callPackage ../development/python-modules/gviz-api {};
+  gviz-api = callPackage ../development/python-modules/gviz-api { };
 
   gwyddion = disabledIf isPy3k (toPythonModule (pkgs.gwyddion.override {
     pythonSupport = true;
@@ -2821,6 +2846,8 @@ in {
   h5py-mpi = self.h5py.override { hdf5 = pkgs.hdf5-mpi; };
 
   habanero = callPackage ../development/python-modules/habanero { };
+
+  hachoir = callPackage ../development/python-modules/hachoir { };
 
   ha-ffmpeg = callPackage ../development/python-modules/ha-ffmpeg { };
 
@@ -2908,10 +2935,11 @@ in {
 
   hstspreload = callPackage ../development/python-modules/hstspreload { };
 
-  html2text = if isPy3k then
-    callPackage ../development/python-modules/html2text { }
-  else
-    callPackage ../development/python-modules/html2text/2018.nix { };
+  html2text =
+    if isPy3k then
+      callPackage ../development/python-modules/html2text { }
+    else
+      callPackage ../development/python-modules/html2text/2018.nix { };
 
   html5lib = callPackage ../development/python-modules/html5lib { };
 
@@ -2939,10 +2967,11 @@ in {
 
   http-parser = callPackage ../development/python-modules/http-parser { };
 
-  httpretty = if isPy3k then
-    callPackage ../development/python-modules/httpretty { }
-  else
-    callPackage ../development/python-modules/httpretty/0.nix { };
+  httpretty =
+    if isPy3k then
+      callPackage ../development/python-modules/httpretty { }
+    else
+      callPackage ../development/python-modules/httpretty/0.nix { };
 
   httpserver = callPackage ../development/python-modules/httpserver { };
 
@@ -3049,10 +3078,11 @@ in {
 
   imaplib2 = callPackage ../development/python-modules/imaplib2 { };
 
-  imbalanced-learn = if isPy27 then
-    callPackage ../development/python-modules/imbalanced-learn/0.4.nix { }
-  else
-    callPackage ../development/python-modules/imbalanced-learn { };
+  imbalanced-learn =
+    if isPy27 then
+      callPackage ../development/python-modules/imbalanced-learn/0.4.nix { }
+    else
+      callPackage ../development/python-modules/imbalanced-learn { };
 
   imdbpy = callPackage ../development/python-modules/imdbpy { };
 
@@ -3137,10 +3167,11 @@ in {
 
   ipydatawidgets = callPackage ../development/python-modules/ipydatawidgets { };
 
-  ipykernel = if pythonOlder "3.4" then
-    callPackage ../development/python-modules/ipykernel/4.nix { }
-  else
-    callPackage ../development/python-modules/ipykernel { };
+  ipykernel =
+    if pythonOlder "3.4" then
+      callPackage ../development/python-modules/ipykernel/4.nix { }
+    else
+      callPackage ../development/python-modules/ipykernel { };
 
   ipympl = callPackage ../development/python-modules/ipympl { };
 
@@ -3148,12 +3179,13 @@ in {
 
   ipython_genutils = callPackage ../development/python-modules/ipython_genutils { };
 
-  ipython = if isPy27 then
-    callPackage ../development/python-modules/ipython/5.nix { }
-  else if isPy36 then
-    callPackage ../development/python-modules/ipython/7.16.nix { }
-  else
-    callPackage ../development/python-modules/ipython { };
+  ipython =
+    if isPy27 then
+      callPackage ../development/python-modules/ipython/5.nix { }
+    else if isPy36 then
+      callPackage ../development/python-modules/ipython/7.16.nix { }
+    else
+      callPackage ../development/python-modules/ipython { };
 
   ipyvue = callPackage ../development/python-modules/ipyvue { };
 
@@ -3181,11 +3213,11 @@ in {
 
   isodate = callPackage ../development/python-modules/isodate { };
 
-  isort = if isPy3k then
-    callPackage ../development/python-modules/isort { }
-  else
-    callPackage ../development/python-modules/isort/4.nix {
-  };
+  isort =
+    if isPy3k then
+      callPackage ../development/python-modules/isort { }
+    else
+      callPackage ../development/python-modules/isort/4.nix { };
 
   isoweek = callPackage ../development/python-modules/isoweek { };
 
@@ -3211,19 +3243,21 @@ in {
 
   jaraco_collections = callPackage ../development/python-modules/jaraco_collections { };
 
-  jaraco_functools = if pythonOlder "3.6" then
-    callPackage ../development/python-modules/jaraco_functools/2.nix { }
-  else
-    callPackage ../development/python-modules/jaraco_functools { };
+  jaraco_functools =
+    if pythonOlder "3.6" then
+      callPackage ../development/python-modules/jaraco_functools/2.nix { }
+    else
+      callPackage ../development/python-modules/jaraco_functools { };
 
   jaraco_itertools = callPackage ../development/python-modules/jaraco_itertools { };
 
   jaraco_logging = callPackage ../development/python-modules/jaraco_logging { };
 
-  jaraco_stream = if pythonOlder "3.6" then
-    callPackage ../development/python-modules/jaraco_stream/2.nix { }
-  else
-    callPackage ../development/python-modules/jaraco_stream { };
+  jaraco_stream =
+    if pythonOlder "3.6" then
+      callPackage ../development/python-modules/jaraco_stream/2.nix { }
+    else
+      callPackage ../development/python-modules/jaraco_stream { };
 
   jaraco_text = callPackage ../development/python-modules/jaraco_text { };
 
@@ -3339,15 +3373,17 @@ in {
 
   jupyter-c-kernel = callPackage ../development/python-modules/jupyter-c-kernel { };
 
-  jupyter_client = if isPy3k then
-    callPackage ../development/python-modules/jupyter_client { }
-  else
-    callPackage ../development/python-modules/jupyter_client/5.nix { };
+  jupyter_client =
+    if isPy3k then
+      callPackage ../development/python-modules/jupyter_client { }
+    else
+      callPackage ../development/python-modules/jupyter_client/5.nix { };
 
-  jupyter_console = if pythonOlder "3.5" then
-    callPackage ../development/python-modules/jupyter_console/5.nix { }
-  else
-    callPackage ../development/python-modules/jupyter_console { };
+  jupyter_console =
+    if pythonOlder "3.5" then
+      callPackage ../development/python-modules/jupyter_console/5.nix { }
+    else
+      callPackage ../development/python-modules/jupyter_console { };
 
   jupyter_core = callPackage ../development/python-modules/jupyter_core { };
 
@@ -3416,10 +3452,11 @@ in {
 
   kerberos = callPackage ../development/python-modules/kerberos { inherit (pkgs) kerberos; };
 
-  keyring = if isPy3k then
-    callPackage ../development/python-modules/keyring { }
-  else
-    callPackage ../development/python-modules/keyring/2.nix { };
+  keyring =
+    if isPy3k then
+      callPackage ../development/python-modules/keyring { }
+    else
+      callPackage ../development/python-modules/keyring/2.nix { };
 
   keyrings-alt = callPackage ../development/python-modules/keyrings-alt { };
 
@@ -3431,10 +3468,11 @@ in {
 
   kitchen = callPackage ../development/python-modules/kitchen { };
 
-  kiwisolver = if isPy3k then
-    callPackage ../development/python-modules/kiwisolver { }
-  else
-    callPackage ../development/python-modules/kiwisolver/1_1.nix { };
+  kiwisolver =
+    if isPy3k then
+      callPackage ../development/python-modules/kiwisolver { }
+    else
+      callPackage ../development/python-modules/kiwisolver/1_1.nix { };
 
   klaus = callPackage ../development/python-modules/klaus { };
 
@@ -3534,10 +3572,11 @@ in {
 
   libasyncns = callPackage ../development/python-modules/libasyncns { inherit (pkgs) libasyncns pkgconfig; };
 
-  libcloud = if isPy27 then
-    callPackage ../development/python-modules/libcloud/2.nix { }
-  else
-    callPackage ../development/python-modules/libcloud { };
+  libcloud =
+    if isPy27 then
+      callPackage ../development/python-modules/libcloud/2.nix { }
+    else
+      callPackage ../development/python-modules/libcloud { };
 
   libcst = callPackage ../development/python-modules/libcst { };
 
@@ -3582,15 +3621,17 @@ in {
 
   libnacl = callPackage ../development/python-modules/libnacl { inherit (pkgs) libsodium; };
 
-  libnl-python = disabledIf isPy3k (toPythonModule (pkgs.libnl.override {
-    pythonSupport = true;
-    inherit python;
-  })).py;
+  libnl-python = disabledIf isPy3k
+    (toPythonModule (pkgs.libnl.override {
+      pythonSupport = true;
+      inherit python;
+    })).py;
 
-  libplist = disabledIf isPy3k (toPythonModule (pkgs.libplist.override {
-    enablePython = true;
-    inherit python;
-  })).py;
+  libplist = disabledIf isPy3k
+    (toPythonModule (pkgs.libplist.override {
+      enablePython = true;
+      inherit python;
+    })).py;
 
   libredwg = toPythonModule (pkgs.libredwg.override {
     enablePython = true;
@@ -3633,22 +3674,24 @@ in {
 
   libtmux = callPackage ../development/python-modules/libtmux { };
 
-  libtorrent-rasterbar = if isPy27 then
-    (toPythonModule (pkgs.libtorrent-rasterbar-1_2_x.override { inherit python; })).python
-  else
-    (toPythonModule (pkgs.libtorrent-rasterbar.override { inherit python; })).python;
+  libtorrent-rasterbar =
+    if isPy27 then
+      (toPythonModule (pkgs.libtorrent-rasterbar-1_2_x.override { inherit python; })).python
+    else
+      (toPythonModule (pkgs.libtorrent-rasterbar.override { inherit python; })).python;
 
   libusb1 = callPackage ../development/python-modules/libusb1 { inherit (pkgs) libusb1; };
 
   libversion = callPackage ../development/python-modules/libversion { inherit (pkgs) libversion pkgconfig; };
 
-  libvirt = if isPy3k then
-    (callPackage ../development/python-modules/libvirt { inherit (pkgs) libvirt pkgconfig; })
-  else
-    (callPackage ../development/python-modules/libvirt/5.9.0.nix {
-      inherit (pkgs) pkgconfig;
-      libvirt = pkgs.libvirt_5_9_0;
-    });
+  libvirt =
+    if isPy3k then
+      (callPackage ../development/python-modules/libvirt { inherit (pkgs) libvirt pkgconfig; })
+    else
+      (callPackage ../development/python-modules/libvirt/5.9.0.nix {
+        inherit (pkgs) pkgconfig;
+        libvirt = pkgs.libvirt_5_9_0;
+      });
 
   libxml2 = (toPythonModule (pkgs.libxml2.override {
     pythonSupport = true;
@@ -3850,10 +3893,11 @@ in {
 
   markdown2 = callPackage ../development/python-modules/markdown2 { };
 
-  markdown = if isPy3k then
-    callPackage ../development/python-modules/markdown { }
-  else
-    callPackage ../development/python-modules/markdown/3_1.nix { };
+  markdown =
+    if isPy3k then
+      callPackage ../development/python-modules/markdown { }
+    else
+      callPackage ../development/python-modules/markdown/3_1.nix { };
 
   markdown-it-py = callPackage ../development/python-modules/markdown-it-py { };
 
@@ -3881,16 +3925,19 @@ in {
 
   mathlibtools = callPackage ../development/python-modules/mathlibtools { };
 
-  matplotlib = let
-    path = if isPy3k then
-      ../development/python-modules/matplotlib/default.nix
-    else
-      ../development/python-modules/matplotlib/2.nix;
-  in callPackage path {
-    stdenv = if stdenv.isDarwin then pkgs.clangStdenv else pkgs.stdenv;
-    inherit (pkgs.darwin.apple_sdk.frameworks) Cocoa;
-    inherit (pkgs) pkgconfig;
-  };
+  matplotlib =
+    let
+      path =
+        if isPy3k then
+          ../development/python-modules/matplotlib/default.nix
+        else
+          ../development/python-modules/matplotlib/2.nix;
+    in
+    callPackage path {
+      stdenv = if stdenv.isDarwin then pkgs.clangStdenv else pkgs.stdenv;
+      inherit (pkgs.darwin.apple_sdk.frameworks) Cocoa;
+      inherit (pkgs) pkgconfig;
+    };
 
   matrix-client = callPackage ../development/python-modules/matrix-client { };
 
@@ -3944,7 +3991,8 @@ in {
   meshlabxml = callPackage ../development/python-modules/meshlabxml { };
 
   meson = disabledIf (pythonOlder "3.5") (toPythonModule ((pkgs.meson.override { python3 = python; }).overrideAttrs
-    (oldAttrs: { # We do not want the setup hook in Python packages because the build is performed differently.
+    (oldAttrs: {
+      # We do not want the setup hook in Python packages because the build is performed differently.
       setupHook = null;
     })));
 
@@ -4008,10 +4056,11 @@ in {
 
   mocket = callPackage ../development/python-modules/mocket { };
 
-  mock = if pythonOlder "3.6" then
-    callPackage ../development/python-modules/mock/2.nix { }
-  else
-    callPackage ../development/python-modules/mock { };
+  mock =
+    if pythonOlder "3.6" then
+      callPackage ../development/python-modules/mock/2.nix { }
+    else
+      callPackage ../development/python-modules/mock { };
 
   mockito = callPackage ../development/python-modules/mockito { };
 
@@ -4045,10 +4094,11 @@ in {
 
   monty = callPackage ../development/python-modules/monty { };
 
-  more-itertools = if isPy27 then
-    callPackage ../development/python-modules/more-itertools/2.7.nix { }
-  else
-    callPackage ../development/python-modules/more-itertools { };
+  more-itertools =
+    if isPy27 then
+      callPackage ../development/python-modules/more-itertools/2.7.nix { }
+    else
+      callPackage ../development/python-modules/more-itertools { };
 
   moretools = callPackage ../development/python-modules/moretools { };
 
@@ -4152,10 +4202,11 @@ in {
 
   mutag = callPackage ../development/python-modules/mutag { };
 
-  mutagen = if isPy27 then
-    callPackage ../development/python-modules/mutagen/1.43.nix { }
-  else
-    callPackage ../development/python-modules/mutagen { };
+  mutagen =
+    if isPy27 then
+      callPackage ../development/python-modules/mutagen/1.43.nix { }
+    else
+      callPackage ../development/python-modules/mutagen { };
 
   mutatormath = callPackage ../development/python-modules/mutatormath { };
 
@@ -4219,10 +4270,11 @@ in {
 
   nbdime = callPackage ../development/python-modules/nbdime { };
 
-  nbformat = if isPy3k then
-    callPackage ../development/python-modules/nbformat { }
-  else
-    callPackage ../development/python-modules/nbformat/2.nix { };
+  nbformat =
+    if isPy3k then
+      callPackage ../development/python-modules/nbformat { }
+    else
+      callPackage ../development/python-modules/nbformat/2.nix { };
 
   nbmerge = callPackage ../development/python-modules/nbmerge { };
 
@@ -4258,10 +4310,11 @@ in {
 
   netifaces = callPackage ../development/python-modules/netifaces { };
 
-  networkx = if isPy3k then
-    callPackage ../development/python-modules/networkx { }
-  else
-    callPackage ../development/python-modules/networkx/2.2.nix { };
+  networkx =
+    if isPy3k then
+      callPackage ../development/python-modules/networkx { }
+    else
+      callPackage ../development/python-modules/networkx/2.2.nix { };
 
   neuron-mpi = pkgs.neuron-mpi.override { inherit python; };
 
@@ -4360,10 +4413,11 @@ in {
 
   nosexcover = callPackage ../development/python-modules/nosexcover { };
 
-  notebook = if isPy3k then
-    callPackage ../development/python-modules/notebook { }
-  else
-    callPackage ../development/python-modules/notebook/2.nix { };
+  notebook =
+    if isPy3k then
+      callPackage ../development/python-modules/notebook { }
+    else
+      callPackage ../development/python-modules/notebook/2.nix { };
 
   notedown = callPackage ../development/python-modules/notedown { };
 
@@ -4400,10 +4454,11 @@ in {
 
   numpydoc = callPackage ../development/python-modules/numpydoc { };
 
-  numpy = if pythonOlder "3.5" then
-    callPackage ../development/python-modules/numpy/1.16.nix { }
-  else
-    callPackage ../development/python-modules/numpy { };
+  numpy =
+    if pythonOlder "3.5" then
+      callPackage ../development/python-modules/numpy/1.16.nix { }
+    else
+      callPackage ../development/python-modules/numpy { };
 
   numpy-stl = callPackage ../development/python-modules/numpy-stl { };
 
@@ -4427,10 +4482,11 @@ in {
 
   oauthenticator = callPackage ../development/python-modules/oauthenticator { };
 
-  oauthlib = if isPy27 then
-    callPackage ../development/python-modules/oauthlib/3.1.nix { }
-  else
-    callPackage ../development/python-modules/oauthlib { };
+  oauthlib =
+    if isPy27 then
+      callPackage ../development/python-modules/oauthlib/3.1.nix { }
+    else
+      callPackage ../development/python-modules/oauthlib { };
 
   obfsproxy = callPackage ../development/python-modules/obfsproxy { };
 
@@ -4479,10 +4535,11 @@ in {
 
   openidc-client = callPackage ../development/python-modules/openidc-client { };
 
-  openpyxl = if pythonAtLeast "3.6" then
-    callPackage ../development/python-modules/openpyxl { }
-  else
-    callPackage ../development/python-modules/openpyxl/2.nix { };
+  openpyxl =
+    if pythonAtLeast "3.6" then
+      callPackage ../development/python-modules/openpyxl { }
+    else
+      callPackage ../development/python-modules/openpyxl/2.nix { };
 
   openrazer = callPackage ../development/python-modules/openrazer/pylib.nix { };
 
@@ -4500,10 +4557,11 @@ in {
 
   openwrt-luci-rpc = disabledIf (!isPy3k) (callPackage ../development/python-modules/openwrt-luci-rpc { });
 
-  opt-einsum = if isPy27 then
-    callPackage ../development/python-modules/opt-einsum/2.nix { }
-  else
-    callPackage ../development/python-modules/opt-einsum { };
+  opt-einsum =
+    if isPy27 then
+      callPackage ../development/python-modules/opt-einsum/2.nix { }
+    else
+      callPackage ../development/python-modules/opt-einsum { };
 
   optuna = callPackage ../development/python-modules/optuna { };
 
@@ -4545,7 +4603,8 @@ in {
 
   oyaml = callPackage ../development/python-modules/oyaml { };
 
-  packaging = if isPy3k
+  packaging =
+    if isPy3k
     then callPackage ../development/python-modules/packaging { }
     else callPackage ../development/python-modules/packaging/2.nix { };
 
@@ -4568,10 +4627,11 @@ in {
 
   pamqp = callPackage ../development/python-modules/pamqp { };
 
-  pandas = if isPy3k then
-    callPackage ../development/python-modules/pandas { }
-  else
-    callPackage ../development/python-modules/pandas/2.nix { };
+  pandas =
+    if isPy3k then
+      callPackage ../development/python-modules/pandas { }
+    else
+      callPackage ../development/python-modules/pandas/2.nix { };
 
   pandas-datareader = callPackage ../development/python-modules/pandas-datareader { };
 
@@ -4649,10 +4709,11 @@ in {
 
   pathos = callPackage ../development/python-modules/pathos { };
 
-  pathpy = if isPy3k then
-    callPackage ../development/python-modules/path.py { }
-  else
-    callPackage ../development/python-modules/path.py/2.nix { };
+  pathpy =
+    if isPy3k then
+      callPackage ../development/python-modules/path.py { }
+    else
+      callPackage ../development/python-modules/path.py/2.nix { };
 
   pathspec = callPackage ../development/python-modules/pathspec { };
 
@@ -4779,16 +4840,18 @@ in {
 
   pillowfight = callPackage ../development/python-modules/pillowfight { };
 
-  pillow = if isPy27 then
-    callPackage ../development/python-modules/pillow/6.nix {
-      inherit (pkgs) freetype libjpeg zlib libtiff libwebp tcl lcms2 tk;
-      inherit (pkgs.xorg) libX11;
-    }
-  else
-    callPackage ../development/python-modules/pillow {
-      inherit (pkgs) freetype libjpeg zlib libtiff libwebp tcl lcms2 tk;
-      inherit (pkgs.xorg) libX11;
-    };
+  pillow =
+    if isPy27 then
+      callPackage ../development/python-modules/pillow/6.nix
+        {
+          inherit (pkgs) freetype libjpeg zlib libtiff libwebp tcl lcms2 tk;
+          inherit (pkgs.xorg) libX11;
+        }
+    else
+      callPackage ../development/python-modules/pillow {
+        inherit (pkgs) freetype libjpeg zlib libtiff libwebp tcl lcms2 tk;
+        inherit (pkgs.xorg) libX11;
+      };
 
   pims = callPackage ../development/python-modules/pims { };
 
@@ -4936,10 +4999,11 @@ in {
 
   prawcore = callPackage ../development/python-modules/prawcore { };
 
-  praw = if isPy3k then
-    callPackage ../development/python-modules/praw { }
-  else
-    callPackage ../development/python-modules/praw/6.3.nix { };
+  praw =
+    if isPy3k then
+      callPackage ../development/python-modules/praw { }
+    else
+      callPackage ../development/python-modules/praw/6.3.nix { };
 
   precis-i18n = callPackage ../development/python-modules/precis-i18n { };
 
@@ -4955,10 +5019,11 @@ in {
 
   pretend = callPackage ../development/python-modules/pretend { };
 
-  prettytable = if isPy3k then
-    callPackage ../development/python-modules/prettytable { }
-  else
-    callPackage ../development/python-modules/prettytable/1.nix { };
+  prettytable =
+    if isPy3k then
+      callPackage ../development/python-modules/prettytable { }
+    else
+      callPackage ../development/python-modules/prettytable/1.nix { };
 
   primer3 = callPackage ../development/python-modules/primer3 { };
 
@@ -4989,12 +5054,15 @@ in {
 
   promise = callPackage ../development/python-modules/promise { };
 
-  prompt_toolkit = let
-    filename = if isPy3k then
-      ../development/python-modules/prompt_toolkit
-    else
-      ../development/python-modules/prompt_toolkit/1.nix;
-  in callPackage filename { };
+  prompt_toolkit =
+    let
+      filename =
+        if isPy3k then
+          ../development/python-modules/prompt_toolkit
+        else
+          ../development/python-modules/prompt_toolkit/1.nix;
+    in
+    callPackage filename { };
 
   property-manager = callPackage ../development/python-modules/property-manager { };
 
@@ -5242,15 +5310,18 @@ in {
 
   pydispatcher = callPackage ../development/python-modules/pydispatcher { };
 
-  pydns = let
-    py3 = callPackage ../development/python-modules/py3dns { };
-    py2 = callPackage ../development/python-modules/pydns { };
-  in if isPy3k then py3 else py2;
+  pydns =
+    let
+      py3 = callPackage ../development/python-modules/py3dns { };
+      py2 = callPackage ../development/python-modules/pydns { };
+    in
+    if isPy3k then py3 else py2;
 
-  pydocstyle = if isPy27 then
-    callPackage ../development/python-modules/pydocstyle/2.nix { }
-  else
-    callPackage ../development/python-modules/pydocstyle { };
+  pydocstyle =
+    if isPy27 then
+      callPackage ../development/python-modules/pydocstyle/2.nix { }
+    else
+      callPackage ../development/python-modules/pydocstyle { };
 
   pydocumentdb = callPackage ../development/python-modules/pydocumentdb { };
 
@@ -5358,10 +5429,11 @@ in {
 
   pygments-better-html = callPackage ../development/python-modules/pygments-better-html { };
 
-  pygments = if isPy3k then
-    callPackage ../development/python-modules/Pygments { }
-  else
-    callPackage ../development/python-modules/Pygments/2_5.nix { };
+  pygments =
+    if isPy3k then
+      callPackage ../development/python-modules/Pygments { }
+    else
+      callPackage ../development/python-modules/Pygments/2_5.nix { };
 
   pygments-markdown-lexer = callPackage ../development/python-modules/pygments-markdown-lexer { };
 
@@ -5371,10 +5443,11 @@ in {
 
   pygobject2 = callPackage ../development/python-modules/pygobject { inherit (pkgs) pkgconfig; };
 
-  pygobject3 = if isPy3k then
-    callPackage ../development/python-modules/pygobject/3.nix { inherit (pkgs) meson pkgconfig; }
-  else
-    callPackage ../development/python-modules/pygobject/3.36.nix { inherit (pkgs) meson pkgconfig; };
+  pygobject3 =
+    if isPy3k then
+      callPackage ../development/python-modules/pygobject/3.nix { inherit (pkgs) meson pkgconfig; }
+    else
+      callPackage ../development/python-modules/pygobject/3.36.nix { inherit (pkgs) meson pkgconfig; };
 
   pygogo = callPackage ../development/python-modules/pygogo { };
 
@@ -5401,10 +5474,11 @@ in {
 
   pygtrie = callPackage ../development/python-modules/pygtrie { };
 
-  pyhamcrest = if isPy3k then
-    callPackage ../development/python-modules/pyhamcrest { }
-  else
-    callPackage ../development/python-modules/pyhamcrest/1.nix { };
+  pyhamcrest =
+    if isPy3k then
+      callPackage ../development/python-modules/pyhamcrest { }
+    else
+      callPackage ../development/python-modules/pyhamcrest/1.nix { };
 
   pyhaversion = callPackage ../development/python-modules/pyhaversion { };
 
@@ -5470,10 +5544,11 @@ in {
 
   pylev = callPackage ../development/python-modules/pylev { };
 
-  pylibacl = if isPy3k then
-    callPackage ../development/python-modules/pylibacl { }
-  else
-    callPackage ../development/python-modules/pylibacl/0.5.nix { };
+  pylibacl =
+    if isPy3k then
+      callPackage ../development/python-modules/pylibacl { }
+    else
+      callPackage ../development/python-modules/pylibacl/0.5.nix { };
 
   pylibconfig2 = callPackage ../development/python-modules/pylibconfig2 { };
 
@@ -5491,10 +5566,11 @@ in {
 
   pylint-flask = callPackage ../development/python-modules/pylint-flask { };
 
-  pylint = if isPy3k then
-    callPackage ../development/python-modules/pylint { }
-  else
-    callPackage ../development/python-modules/pylint/1.9.nix { };
+  pylint =
+    if isPy3k then
+      callPackage ../development/python-modules/pylint { }
+    else
+      callPackage ../development/python-modules/pylint/1.9.nix { };
 
   pylint-plugin-utils = callPackage ../development/python-modules/pylint-plugin-utils { };
 
@@ -5598,10 +5674,11 @@ in {
 
   pynzb = callPackage ../development/python-modules/pynzb { };
 
-  pyobjc = if stdenv.isDarwin then
-    callPackage ../development/python-modules/pyobjc { }
-  else
-    throw "pyobjc can only be built on Mac OS";
+  pyobjc =
+    if stdenv.isDarwin then
+      callPackage ../development/python-modules/pyobjc { }
+    else
+      throw "pyobjc can only be built on Mac OS";
 
   pyocr = callPackage ../development/python-modules/pyocr {
     tesseract = pkgs.tesseract4;
@@ -5923,17 +6000,22 @@ in {
   pytest = if isPy3k then self.pytest_6 else self.pytest_4;
 
   pytest_4 = callPackage
-    ../development/python-modules/pytest/4.nix { # hypothesis tests require pytest that causes dependency cycle
+    ../development/python-modules/pytest/4.nix
+    {
+      # hypothesis tests require pytest that causes dependency cycle
       hypothesis = self.hypothesis.override { doCheck = false; };
     };
 
   pytest_5 = callPackage
-    ../development/python-modules/pytest/5.nix { # hypothesis tests require pytest that causes dependency cycle
+    ../development/python-modules/pytest/5.nix
+    {
+      # hypothesis tests require pytest that causes dependency cycle
       hypothesis = self.hypothesis.override { doCheck = false; };
     };
 
   pytest_6 =
-    callPackage ../development/python-modules/pytest { # hypothesis tests require pytest that causes dependency cycle
+    callPackage ../development/python-modules/pytest {
+      # hypothesis tests require pytest that causes dependency cycle
       hypothesis = self.hypothesis.override { doCheck = false; };
     };
 
@@ -6017,10 +6099,11 @@ in {
 
   pytest-metadata = callPackage ../development/python-modules/pytest-metadata { };
 
-  pytest-mock = if isPy3k then
-    callPackage ../development/python-modules/pytest-mock { }
-  else
-    callPackage ../development/python-modules/pytest-mock/2.nix { };
+  pytest-mock =
+    if isPy3k then
+      callPackage ../development/python-modules/pytest-mock { }
+    else
+      callPackage ../development/python-modules/pytest-mock/2.nix { };
 
   pytest-mpl = callPackage ../development/python-modules/pytest-mpl { };
 
@@ -6100,10 +6183,11 @@ in {
   pytest-watch = callPackage ../development/python-modules/pytest-watch { };
 
   pytest-xdist = self.pytest_xdist; # added 2021-01-04
-  pytest_xdist = if isPy27 then
-    callPackage ../development/python-modules/pytest-xdist/1.nix { }
-  else
-    callPackage ../development/python-modules/pytest-xdist { };
+  pytest_xdist =
+    if isPy27 then
+      callPackage ../development/python-modules/pytest-xdist/1.nix { }
+    else
+      callPackage ../development/python-modules/pytest-xdist { };
 
   pytest-xprocess = callPackage ../development/python-modules/pytest-xprocess { };
 
@@ -6232,7 +6316,9 @@ in {
   python-nest = callPackage ../development/python-modules/python-nest { };
 
   pythonnet = callPackage
-    ../development/python-modules/pythonnet { # `mono >= 4.6` required to prevent crashes encountered with earlier versions.
+    ../development/python-modules/pythonnet
+    {
+      # `mono >= 4.6` required to prevent crashes encountered with earlier versions.
       mono = pkgs.mono4;
       inherit (pkgs) pkgconfig;
     };
@@ -6364,7 +6450,9 @@ in {
   pyu2f = callPackage ../development/python-modules/pyu2f { };
 
   pyuavcan = callPackage
-    ../development/python-modules/pyuavcan { # this version pinpoint to anold version is necessary due to a regression
+    ../development/python-modules/pyuavcan
+    {
+      # this version pinpoint to anold version is necessary due to a regression
       nunavut = self.nunavut.overridePythonAttrs (old: rec {
         version = "0.2.3";
         src = old.src.override {
@@ -6433,16 +6521,18 @@ in {
 
   pywizlight = callPackage ../development/python-modules/pywizlight { };
 
-  pyxattr = let
-    pyxattr' = callPackage ../development/python-modules/pyxattr { };
-    pyxattr_2 = pyxattr'.overridePythonAttrs (oldAttrs: rec {
-      version = "0.6.1";
-      src = oldAttrs.src.override {
-        inherit version;
-        sha256 = "b525843f6b51036198b3b87c4773a5093d6dec57d60c18a1f269dd7059aa16e3";
-      };
-    });
-  in if isPy3k then pyxattr' else pyxattr_2;
+  pyxattr =
+    let
+      pyxattr' = callPackage ../development/python-modules/pyxattr { };
+      pyxattr_2 = pyxattr'.overridePythonAttrs (oldAttrs: rec {
+        version = "0.6.1";
+        src = oldAttrs.src.override {
+          inherit version;
+          sha256 = "b525843f6b51036198b3b87c4773a5093d6dec57d60c18a1f269dd7059aa16e3";
+        };
+      });
+    in
+    if isPy3k then pyxattr' else pyxattr_2;
 
   pyx = callPackage ../development/python-modules/pyx { };
 
@@ -6688,7 +6778,7 @@ in {
   robomachine = callPackage ../development/python-modules/robomachine { };
 
   roboschool = callPackage ../development/python-modules/roboschool {
-    inherit (pkgs) pkgconfig; # use normal pkgconfig, not the python package
+    inherit (pkgs) pkgconfig;# use normal pkgconfig, not the python package
     inherit (pkgs.qt5) qtbase;
   };
 
@@ -6740,19 +6830,21 @@ in {
 
   rpmfluff = callPackage ../development/python-modules/rpmfluff { };
 
-  rpy2 = if isPy3k then
-    callPackage ../development/python-modules/rpy2 { }
-  else
-    callPackage ../development/python-modules/rpy2/2.nix { };
+  rpy2 =
+    if isPy3k then
+      callPackage ../development/python-modules/rpy2 { }
+    else
+      callPackage ../development/python-modules/rpy2/2.nix { };
 
   rpyc = callPackage ../development/python-modules/rpyc { };
 
   rq = callPackage ../development/python-modules/rq { };
 
-  rsa = if isPy3k then
-    callPackage ../development/python-modules/rsa { }
-  else
-    callPackage ../development/python-modules/rsa/4_0.nix { };
+  rsa =
+    if isPy3k then
+      callPackage ../development/python-modules/rsa { }
+    else
+      callPackage ../development/python-modules/rsa/4_0.nix { };
 
   rtmidi-python = callPackage ../development/python-modules/rtmidi-python { };
 
@@ -6846,11 +6938,13 @@ in {
 
   scikitimage = callPackage ../development/python-modules/scikit-image { };
 
-  scikitlearn = let args = { inherit (pkgs) gfortran glibcLocales; };
-  in if isPy3k then
-    callPackage ../development/python-modules/scikitlearn args
-  else
-    callPackage ../development/python-modules/scikitlearn/0.20.nix args;
+  scikitlearn =
+    let args = { inherit (pkgs) gfortran glibcLocales; };
+    in
+    if isPy3k then
+      callPackage ../development/python-modules/scikitlearn args
+    else
+      callPackage ../development/python-modules/scikitlearn/0.20.nix args;
 
   scikit-optimize = callPackage ../development/python-modules/scikit-optimize { };
 
@@ -6878,16 +6972,18 @@ in {
     disabled = !isPy3k;
   });
 
-  scipy = let
-    scipy_ = callPackage ../development/python-modules/scipy { };
-    scipy_1_2 = scipy_.overridePythonAttrs (oldAttrs: rec {
-      version = "1.2.2";
-      src = oldAttrs.src.override {
-        inherit version;
-        sha256 = "a4331e0b8dab1ff75d2c67b5158a8bb9a83c799d7140094dda936d876c7cfbb1";
-      };
-    });
-  in if pythonOlder "3.5" then scipy_1_2 else scipy_;
+  scipy =
+    let
+      scipy_ = callPackage ../development/python-modules/scipy { };
+      scipy_1_2 = scipy_.overridePythonAttrs (oldAttrs: rec {
+        version = "1.2.2";
+        src = oldAttrs.src.override {
+          inherit version;
+          sha256 = "a4331e0b8dab1ff75d2c67b5158a8bb9a83c799d7140094dda936d876c7cfbb1";
+        };
+      });
+    in
+    if pythonOlder "3.5" then scipy_1_2 else scipy_;
 
   scour = callPackage ../development/python-modules/scour { };
 
@@ -6911,10 +7007,11 @@ in {
 
   sdnotify = callPackage ../development/python-modules/sdnotify { };
 
-  seaborn = if isPy3k then
-    callPackage ../development/python-modules/seaborn { }
-  else
-    callPackage ../development/python-modules/seaborn/0.9.1.nix { };
+  seaborn =
+    if isPy3k then
+      callPackage ../development/python-modules/seaborn { }
+    else
+      callPackage ../development/python-modules/seaborn/0.9.1.nix { };
 
   seabreeze = callPackage ../development/python-modules/seabreeze { };
 
@@ -6922,10 +7019,11 @@ in {
 
   secp256k1 = callPackage ../development/python-modules/secp256k1 { inherit (pkgs) secp256k1 pkgconfig; };
 
-  secretstorage = if isPy3k then
-    callPackage ../development/python-modules/secretstorage { }
-  else
-    callPackage ../development/python-modules/secretstorage/2.nix { };
+  secretstorage =
+    if isPy3k then
+      callPackage ../development/python-modules/secretstorage { }
+    else
+      callPackage ../development/python-modules/secretstorage/2.nix { };
 
   secure = callPackage ../development/python-modules/secure { };
 
@@ -7174,10 +7272,11 @@ in {
 
   soundfile = callPackage ../development/python-modules/soundfile { };
 
-  soupsieve = if isPy3k then
-    callPackage ../development/python-modules/soupsieve { }
-  else
-    callPackage ../development/python-modules/soupsieve/1.nix { };
+  soupsieve =
+    if isPy3k then
+      callPackage ../development/python-modules/soupsieve { }
+    else
+      callPackage ../development/python-modules/soupsieve/1.nix { };
 
   spacy = callPackage ../development/python-modules/spacy { };
 
@@ -7240,15 +7339,17 @@ in {
     texLive = pkgs.texlive.combine { inherit (pkgs.texlive) scheme-small standalone pgfplots; };
   };
 
-  sphinxcontrib-websupport = if isPy3k then
-    callPackage ../development/python-modules/sphinxcontrib-websupport { }
-  else
-    callPackage ../development/python-modules/sphinxcontrib-websupport/1_1.nix { };
+  sphinxcontrib-websupport =
+    if isPy3k then
+      callPackage ../development/python-modules/sphinxcontrib-websupport { }
+    else
+      callPackage ../development/python-modules/sphinxcontrib-websupport/1_1.nix { };
 
-  sphinx = if isPy3k then
-    callPackage ../development/python-modules/sphinx { }
-  else
-    callPackage ../development/python-modules/sphinx/2.nix { };
+  sphinx =
+    if isPy3k then
+      callPackage ../development/python-modules/sphinx { }
+    else
+      callPackage ../development/python-modules/sphinx/2.nix { };
 
   sphinx-argparse = callPackage ../development/python-modules/sphinx-argparse { };
 
@@ -7431,10 +7532,11 @@ in {
 
   symengine = callPackage ../development/python-modules/symengine { symengine = pkgs.symengine; };
 
-  sympy = if isPy3k then
-    callPackage ../development/python-modules/sympy { }
-  else
-    callPackage ../development/python-modules/sympy/1_5.nix { };
+  sympy =
+    if isPy3k then
+      callPackage ../development/python-modules/sympy { }
+    else
+      callPackage ../development/python-modules/sympy/1_5.nix { };
 
   systemd = callPackage ../development/python-modules/systemd { inherit (pkgs) pkgconfig systemd; };
 
@@ -7442,10 +7544,11 @@ in {
 
   tableaudocumentapi = callPackage ../development/python-modules/tableaudocumentapi { };
 
-  tables = if isPy3k then
-    callPackage ../development/python-modules/tables { hdf5 = pkgs.hdf5.override { zlib = pkgs.zlib; }; }
-  else
-    callPackage ../development/python-modules/tables/3.5.nix { hdf5 = pkgs.hdf5.override { zlib = pkgs.zlib; }; };
+  tables =
+    if isPy3k then
+      callPackage ../development/python-modules/tables { hdf5 = pkgs.hdf5.override { zlib = pkgs.zlib; }; }
+    else
+      callPackage ../development/python-modules/tables/3.5.nix { hdf5 = pkgs.hdf5.override { zlib = pkgs.zlib; }; };
 
   tablib = callPackage ../development/python-modules/tablib { };
 
@@ -7483,7 +7586,7 @@ in {
 
   tensorboard-plugin-profile = callPackage ../development/python-modules/tensorboard-plugin-profile { };
 
-  tensorboard-plugin-wit = callPackage ../development/python-modules/tensorboard-plugin-wit {};
+  tensorboard-plugin-wit = callPackage ../development/python-modules/tensorboard-plugin-wit { };
 
   tensorboardx = callPackage ../development/python-modules/tensorboardx { };
 
@@ -7600,9 +7703,11 @@ in {
 
   thumborPexif = callPackage ../development/python-modules/thumborpexif { };
 
-  tkinter = let
-    py = python.override{x11Support=true;};
-  in callPackage ../development/python-modules/tkinter { py = py; };
+  tkinter =
+    let
+      py = python.override { x11Support = true; };
+    in
+    callPackage ../development/python-modules/tkinter { py = py; };
 
   tidylib = callPackage ../development/python-modules/pytidylib { };
 
@@ -7660,10 +7765,11 @@ in {
 
   tomlkit = callPackage ../development/python-modules/tomlkit { };
 
-  toolz = if isPy3k then
-    callPackage ../development/python-modules/toolz { }
-  else
-    callPackage ../development/python-modules/toolz/2.nix { };
+  toolz =
+    if isPy3k then
+      callPackage ../development/python-modules/toolz { }
+    else
+      callPackage ../development/python-modules/toolz/2.nix { };
 
   toonapi = callPackage ../development/python-modules/toonapi { };
 
@@ -7675,10 +7781,11 @@ in {
 
   torchvision = callPackage ../development/python-modules/torchvision { };
 
-  tornado = if isPy3k then
-    callPackage ../development/python-modules/tornado { }
-  else
-    callPackage ../development/python-modules/tornado/5.nix { };
+  tornado =
+    if isPy3k then
+      callPackage ../development/python-modules/tornado { }
+    else
+      callPackage ../development/python-modules/tornado/5.nix { };
 
   # Used by circus and grab-site, 2020-08-29
   tornado_4 = callPackage ../development/python-modules/tornado/4.nix { };
@@ -7698,10 +7805,11 @@ in {
 
   trackpy = callPackage ../development/python-modules/trackpy { };
 
-  traitlets = if pythonOlder "3.7" then
-    callPackage ../development/python-modules/traitlets/4.nix { }
-  else
-    callPackage ../development/python-modules/traitlets { };
+  traitlets =
+    if pythonOlder "3.7" then
+      callPackage ../development/python-modules/traitlets/4.nix { }
+    else
+      callPackage ../development/python-modules/traitlets { };
 
   traits = callPackage ../development/python-modules/traits { };
 
@@ -7829,10 +7937,11 @@ in {
 
   ufoprocessor = callPackage ../development/python-modules/ufoprocessor { };
 
-  ujson = if isPy27 then
-    callPackage ../development/python-modules/ujson/2.nix { }
-  else
-    callPackage ../development/python-modules/ujson { };
+  ujson =
+    if isPy27 then
+      callPackage ../development/python-modules/ujson/2.nix { }
+    else
+      callPackage ../development/python-modules/ujson { };
 
   ukpostcodeparser = callPackage ../development/python-modules/ukpostcodeparser { };
 
@@ -8152,10 +8261,11 @@ in {
 
   wsnsimpy = callPackage ../development/python-modules/wsnsimpy { };
 
-  wsproto = if (pythonAtLeast "3.6") then
-    callPackage ../development/python-modules/wsproto { }
-  else
-    callPackage ../development/python-modules/wsproto/0.14.nix { };
+  wsproto =
+    if (pythonAtLeast "3.6") then
+      callPackage ../development/python-modules/wsproto { }
+    else
+      callPackage ../development/python-modules/wsproto/0.14.nix { };
 
   wtforms = callPackage ../development/python-modules/wtforms { };
 
@@ -8375,10 +8485,11 @@ in {
 
   zipfile36 = callPackage ../development/python-modules/zipfile36 { };
 
-  zipp = if pythonOlder "3.6" then
-    callPackage ../development/python-modules/zipp/1.nix { }
-  else
-    callPackage ../development/python-modules/zipp { };
+  zipp =
+    if pythonOlder "3.6" then
+      callPackage ../development/python-modules/zipp/1.nix { }
+    else
+      callPackage ../development/python-modules/zipp { };
 
   zipstream = callPackage ../development/python-modules/zipstream { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This module provides the hachoir, a Python library to view and edit a binary stream field by field.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @vstinner
