### PR TITLE
nerdfonts: Use patchShebangs

### DIFF
--- a/pkgs/data/fonts/nerdfonts/default.nix
+++ b/pkgs/data/fonts/nerdfonts/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, bash, which, withFont ? "" }:
+{ stdenv, fetchFromGitHub, which, withFont ? "" }:
 
 stdenv.mkDerivation rec {
   version = "2.0.0";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   dontPatchShebangs = true;
   buildInputs = [ which ];
   patchPhase = ''
-    sed -i -e 's|/bin/bash|${bash}/bin/bash|g' install.sh
+    patchShebangs install.sh
     sed -i -e 's|font_dir="\$HOME/.local/share/fonts|font_dir="$out/share/fonts/truetype|g' install.sh
   '';
   installPhase = ''


### PR DESCRIPTION
In commit e8e191a1be9d after v2.0.0, nerdfonts switched from #!/bin/bash
to #!/usr/bin/env bash.  Rather than synchronizing this patching with
that change, just use patchShebangs which handles both cases.

1. When the next version is released, bumping the version number will Just Work.
2. In the meantime, this makes it easier to use pre-release versions by bumping the version in an overlay.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).