### PR TITLE
wireguard-go: 0.0.20190517 -> 0.0.20190908

### DIFF
--- a/pkgs/tools/networking/wireguard-go/default.nix
+++ b/pkgs/tools/networking/wireguard-go/default.nix
@@ -2,13 +2,13 @@
 
 buildGoPackage rec {
   pname = "wireguard-go";
-  version = "0.0.20190517";
+  version = "0.0.20190908";
 
-  goPackagePath = "git.zx2c4.com/wireguard-go";
+  goPackagePath = "golang.zx2c4.com/wireguard";
 
   src = fetchzip {
     url = "https://git.zx2c4.com/wireguard-go/snapshot/wireguard-go-${version}.tar.xz";
-    sha256 = "0ir3dp13vkkqr76q0jvw610qw40053ngk51psqhqxfaw3jicdqgr";
+    sha256 = "1jsch0157nk86krdknij7dsvg6i7ar0ydhy07r40drhxqyp3q0hx";
   };
 
   goDeps = ./deps.nix;
@@ -20,6 +20,5 @@ buildGoPackage rec {
     homepage = https://git.zx2c4.com/wireguard-go/about/;
     license = licenses.gpl2;
     maintainers = with maintainers; [ elseym kirelagin yegortimoshenko zx2c4 ];
-    platforms = platforms.darwin;
   };
 }

--- a/pkgs/tools/networking/wireguard-go/deps.nix
+++ b/pkgs/tools/networking/wireguard-go/deps.nix
@@ -1,30 +1,12 @@
 # file generated from go.mod using vgo2nix (https://github.com/adisbladis/vgo2nix)
 [
   {
-    goPackagePath = "github.com/Microsoft/go-winio";
-    fetch = {
-      type = "git";
-      url = "https://github.com/Microsoft/go-winio";
-      rev = "v0.4.12";
-      sha256 = "10v2f1xaw2cc97mjqnxzgs9ydpqv71f0ynp1spcywqw97la56zqw";
-    };
-  }
-  {
-    goPackagePath = "github.com/pkg/errors";
-    fetch = {
-      type = "git";
-      url = "https://github.com/pkg/errors";
-      rev = "v0.8.1";
-      sha256 = "0g5qcb4d4fd96midz0zdk8b9kz8xkzwfa8kr1cliqbg8sxsy5vd1";
-    };
-  }
-  {
     goPackagePath = "golang.org/x/crypto";
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/crypto";
-      rev = "a29dc8fdc734";
-      sha256 = "07f0jj4haqs0ywc1akk1qjwn5msl2j0pry1rxjkkbfcq4r6ihc1p";
+      rev = "9756ffdc2472";
+      sha256 = "0q7hxaaq6lp0v8qqzifvysl47z5rfdlrxkh3d29vsl3wyby3dxl8";
     };
   }
   {
@@ -32,8 +14,8 @@
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/net";
-      rev = "7f726cade0ab";
-      sha256 = "0zv5var5agbhd2mcn7lciwip0j49gxka73f0csvh3hvb1di068gn";
+      rev = "ba9fcec4b297";
+      sha256 = "1hbqvy6r0s5h0dpdqw8fynl3cq0acin3iyqki9xvl5r8h33yb9bx";
     };
   }
   {
@@ -41,8 +23,8 @@
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/sys";
-      rev = "a43fa875dd82";
-      sha256 = "0xvwwaqcj02a9n8izs4zrlg8vvz7wffli955i93nc34m1f0w8vyg";
+      rev = "19e00faab6ad";
+      sha256 = "0znjx9xbyjdvk8cafdc1jl22gg29asxl5yl7mi3yz6zx3h39rm8y";
     };
   }
   {
@@ -50,8 +32,17 @@
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/text";
-      rev = "v0.3.0";
-      sha256 = "0r6x6zjzhr8ksqlpiwm5gdd7s209kwk5p4lw54xjvz10cs3qlq19";
+      rev = "v0.3.2";
+      sha256 = "0flv9idw0jm5nm8lx25xqanbkqgfiym6619w575p7nrdh0riqwqh";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/tools";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/tools";
+      rev = "90fa682c2a6e";
+      sha256 = "03ic2xsy51jw9749wl7gszdbz99iijbd2bckgygl6cm9w5m364ak";
     };
   }
 ]


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Fixes https://github.com/NixOS/nixpkgs/issues/70350
cc: @lilyball
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
