### PR TITLE
apacheHttpdPackages.mod_tile: init at unstable-2017-01-08

### DIFF
--- a/pkgs/servers/http/apache-modules/mod_tile/default.nix
+++ b/pkgs/servers/http/apache-modules/mod_tile/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, apacheHttpd, apr, cairo, iniparser, mapnik }:
+
+stdenv.mkDerivation rec {
+  pname = "mod_tile";
+  version = "unstable-2017-01-08";
+
+  src = fetchFromGitHub {
+    owner = "openstreetmap";
+    repo = "mod_tile";
+    rev = "e25bfdba1c1f2103c69529f1a30b22a14ce311f1";
+    sha256 = "12c96avka1dfb9wxqmjd57j30w9h8yx4y4w34kyq6xnf6lwnkcxp";
+  };
+
+  nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = [ apacheHttpd apr cairo iniparser mapnik ];
+
+  configureFlags = [
+    "--with-apxs=${apacheHttpd.dev}/bin/apxs"
+  ];
+
+  installPhase = ''
+    mkdir -p $out/modules
+    make install-mod_tile DESTDIR=$out
+    mv $out${apacheHttpd}/* $out
+    rm -rf $out/nix
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/openstreetmap/mod_tile";
+    description = "Efficiently render and serve OpenStreetMap tiles using Apache and Mapnik";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ jglukasik ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14552,6 +14552,8 @@ in
 
     mod_python = callPackage ../servers/http/apache-modules/mod_python { };
 
+    mod_tile = callPackage ../servers/http/apache-modules/mod_tile { };
+
     mod_wsgi  = self.mod_wsgi2;
     mod_wsgi2 = callPackage ../servers/http/apache-modules/mod_wsgi { python = python2; ncurses = null; };
     mod_wsgi3 = callPackage ../servers/http/apache-modules/mod_wsgi { python = python3; };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Continuing my OSM tools packaging. Changes to the httpd nixos service to "enableTile" like you can "enablePerl" will be coming later, i thought it would be best to do just the nixpkgs for now.

A release for this package hasn't been cut in a long time, so i'm following the naming convention for specifying the latest commit as documented here: https://nixos.org/nixpkgs/manual/#sec-package-naming

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
