### PR TITLE
OCaml: make version 4.07 the default one

### DIFF
--- a/pkgs/development/coq-modules/contribs/default.nix
+++ b/pkgs/development/coq-modules/contribs/default.nix
@@ -42,7 +42,7 @@ let mkContrib = repo: revs: param:
     sha256 = "18f5vbq6nx9gz2gcj5p7v2gmjczpspc5dmlj6by4jqv07iirzsz2";
   };
 
-  additions = mkContrib "additions" [ "8.6" "8.7" ] {
+  additions = mkContrib "additions" [ "8.6" ] {
     version = "v8.5.0-9-gbec504e";
     rev = "bec504e7822747376159aaa2156cf7453dbbd2b4";
     sha256 = "1vvkqjnqrf6m726krhlm2viza64ha2081xgc5wb9y5sygd0baaz7";

--- a/pkgs/tools/misc/patdiff/default.nix
+++ b/pkgs/tools/misc/patdiff/default.nix
@@ -4,8 +4,8 @@ with ocamlPackages;
 
 janePackage {
   pname = "patdiff";
-  hash = "02cdn5j5brbp4n2rpxprzxfakjbl7n2llixg7m632bih3ppmfcq1";
-  buildInputs = [ core_extended expect_test_helpers patience_diff ocaml_pcre ];
+  hash = "04krzn6rj2r81z55pms5ayk6bxhlxrm006cbhy0m6rc69a0h00lh";
+  buildInputs = [ core_extended expect_test_helpers patience_diff ocaml_pcre shell ];
   meta = {
     description = "File Diff using the Patience Diff algorithm";
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19326,7 +19326,7 @@ in
 
   linuxsampler = callPackage ../applications/audio/linuxsampler { };
 
-  llpp = ocaml-ng.ocamlPackages_4_07.callPackage ../applications/misc/llpp { };
+  llpp = ocamlPackages.callPackage ../applications/misc/llpp { };
 
   lmms = libsForQt5.callPackage ../applications/audio/lmms {
     lame = null;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11653,7 +11653,7 @@ in
   libb2 = callPackage ../development/libraries/libb2 { };
 
   libbap = callPackage ../development/libraries/libbap {
-    inherit (ocamlPackages) bap ocaml findlib ctypes;
+    inherit (ocaml-ng.ocamlPackages_4_06) bap ocaml findlib ctypes;
   };
 
   libbass = (callPackage ../development/libraries/audio/libbass { }).bass;

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -829,13 +829,15 @@ let
 
     # Jane Street
 
-    janePackage = callPackage ../development/ocaml-modules/janestreet/janePackage.nix {};
+    janePackage =
+      if lib.versionOlder "4.07" ocaml.version
+      then callPackage ../development/ocaml-modules/janestreet/janePackage_0_12.nix {}
+      else callPackage ../development/ocaml-modules/janestreet/janePackage.nix {};
 
     janeStreet =
     if lib.versionOlder "4.07" ocaml.version
     then import ../development/ocaml-modules/janestreet/0.12.nix {
-      janePackage = callPackage ../development/ocaml-modules/janestreet/janePackage_0_12.nix {};
-      inherit ctypes num octavius ppxlib re;
+      inherit ctypes janePackage num octavius ppxlib re;
       inherit (pkgs) openssl;
     }
     else import ../development/ocaml-modules/janestreet {
@@ -1137,5 +1139,5 @@ in let inherit (pkgs) callPackage; in rec
 
   ocamlPackages_latest = ocamlPackages_4_09;
 
-  ocamlPackages = ocamlPackages_4_06;
+  ocamlPackages = ocamlPackages_4_07;
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -416,7 +416,7 @@ in {
   backports-shutil-which = callPackage ../development/python-modules/backports-shutil-which {};
 
   bap = callPackage ../development/python-modules/bap {
-    bap = pkgs.ocamlPackages.bap;
+    bap = pkgs.ocaml-ng.ocamlPackages_4_06.bap;
   };
 
   baselines = callPackage ../development/python-modules/baselines { };


### PR DESCRIPTION
###### Motivation for this change

Intermediate step before 4.08 can be used as default.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
