### PR TITLE
pythonPackages.prompt_toolkit: 2.0.9 -> 2.0.10

### DIFF
--- a/pkgs/development/python-modules/prompt_toolkit/default.nix
+++ b/pkgs/development/python-modules/prompt_toolkit/default.nix
@@ -8,11 +8,11 @@
 
 buildPythonPackage rec {
   pname = "prompt_toolkit";
-  version = "2.0.9";
+  version = "2.0.10";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "2519ad1d8038fd5fc8e770362237ad0364d16a7650fb5724af6997ed5515e3c1";
+    sha256 = "1nr990i4b04rnlw1ghd0xmgvvvhih698mb6lb6jylr76cs7zcnpi";
   };
   checkPhase = ''
     py.test -k 'not test_pathcompleter_can_expanduser'


### PR DESCRIPTION
###### Motivation for this change
was trying to fix another review, and just settled with bumping this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[76 built (6 failed), 84 copied (902.8 MiB), 212.7 MiB DL]
error: build of '/nix/store/9cmh5njnilllv21ixznvbzzz5fgwxmvd-env.drv' failed
https://github.com/NixOS/nixpkgs/pull/70367
2 package are marked as broken and were skipped:
ihaskell pyre

6 package failed to build:
litecli mycli python37Packages.cufflinks python37Packages.datashader python37Packages.yt xonsh

76 package were build:
adafruit-ampy fdroidserver gnome3.accerciser jira-cli jupyter paperless papis pgcli python37Packages.Nikola python37Packages.Pweave python37Packages.altair python37Packages.androguard python37Packages.ansible-kernel python37Packages.bash_kernel python37Packages.caffe python37Packages.click-repl python37Packages.colorcet python37Packages.dftfit python37Packages.google_cloud_bigquery python37Packages.greatfet python37Packages.holoviews python37Packages.hvplot python37Packages.intake python37Packages.ipdb python37Packages.ipdbplugin python37Packages.ipykernel python37Packages.ipyparallel python37Packages.ipython python37Packages.ipywidgets python37Packages.jira python37Packages.jupyter python37Packages.jupyter_client python37Packages.jupyter_console python37Packages.jupyter_core python37Packages.jupyterhub python37Packages.jupyterhub-ldapauthenticator python37Packages.jupyterlab python37Packages.jupyterlab_launcher python37Packages.jupyterlab_server python37Packages.jupytext python37Packages.kmapper python37Packages.line_profiler python37Packages.modeled python37Packages.moretools python37Packages.nbconvert python37Packages.nbformat python37Packages.nbmerge python37Packages.nbsmoke python37Packages.nbsphinx python37Packages.nbval python37Packages.notebook python37Packages.oauthenticator python37Packages.optuna python37Packages.plotly python37Packages.prompt_toolkit python37Packages.ptpython python37Packages.pygmo python37Packages.python-dotenv python37Packages.qtconsole python37Packages.robotframework-tools python37Packages.runway-python python37Packages.scapy python37Packages.scikit-bio python37Packages.scikit-tda python37Packages.sopel spyder python37Packages.spyder-kernels python37Packages.starfish python37Packages.vega python37Packages.widgetsnbextension python37Packages.zetup sage sageWithDoc theharvester todoman topydo
```